### PR TITLE
Add section-aware chunking and hierarchical retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,18 @@
 | Follow-up | Answer Accuracy | 1.000 |
 | Evidence | Citation Precision | 1.000 |
 | Abstention | Abstention Accuracy | 1.000 |
-| System | Latency (p50/p95) | p50 1.0ms / p95 1.3ms |
+| System | Latency (p50/p95) | p50 1.1ms / p95 2.2ms |
 | System | Retry Rate | 0.250 |
 
 ### Ablation comparison
 
-| Run | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Abstention | Retry | Latency p95 |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| full | on | on | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 1.3ms |
-| no_metadata_first | off | on | on | 1.000 | 1.000 | 0.833 | 1.000 | 0.000 | 1.6ms |
-| no_rerank | on | off | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 2.0ms |
-| no_verifier_retry | on | on | off | 1.000 | 0.750 | 0.750 | 0.000 | 0.000 | 2.3ms |
+| Run | Retrieval | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Abstention | Retry | Latency p95 |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| full | flat | on | on | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 2.2ms |
+| hierarchical | hierarchical | on | on | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 1.5ms |
+| no_metadata_first | flat | off | on | on | 1.000 | 1.000 | 0.833 | 1.000 | 0.000 | 1.8ms |
+| no_rerank | flat | on | off | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 1.8ms |
+| no_verifier_retry | flat | on | on | off | 1.000 | 0.750 | 0.750 | 0.000 | 0.000 | 1.5ms |
 <!-- METRICS_TABLE:END -->
 
 > 주의: 성능표는 공개 synthetic RFP 평가셋 기준입니다. 원본 RFP 데이터는 비공개 제약으로 저장소에 포함하지 않았습니다.
@@ -142,6 +143,8 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 ```
 
 > 참고: 모델을 처음 내려받아 실제 sentence-transformers 인덱스를 만들려면 `--embedding_backend sentence-transformers`를 사용하세요. 네트워크가 제한된 환경에서는 `--embedding_backend hashing`으로 재현성을 우선한 로컬 실행이 가능합니다. 산출물 경로는 `data/index`, `outputs/`, `reports/`로 고정합니다.
+> Chunking 기본값은 `--chunking_strategy auto --chunk_max_chars 520 --chunk_overlap_sentences 1`입니다. `auto`는 heading/section 구조가 있으면 section-aware chunk metadata를 저장하고, 단일 본문처럼 구조가 약하면 fixed fallback을 사용합니다.
+> 질의 기본값은 flat child-chunk retrieval입니다. parent section 단위 재조립을 확인하려면 `app.py`에 `--retrieval_mode hierarchical`을 지정하거나 `eval/config.yaml`의 `hierarchical` ablation run을 실행합니다.
 
 평가 재현 기본 순서: **인덱싱(`scripts/build_index.py`) → 질의 실행(`app.py`) → 평가 실행(`eval/run_eval.py`) → 성능표 갱신(`scripts/update_readme_metrics.py`)**
 > - 인덱스: `data/index/index.json`
@@ -166,6 +169,7 @@ python3 scripts/build_index.py \
 ## 상세 설계 링크
 - 포트폴리오 case study: [`docs/portfolio-case-study.md`](docs/portfolio-case-study.md)
 - 설계 배경 및 의사결정: [`docs/design-background.md`](docs/design-background.md)
+- Chunking diagnostics: [`docs/chunking-diagnostics.md`](docs/chunking-diagnostics.md)
 - PDF/HWP ingestion: [`docs/real-data-ingestion.md`](docs/real-data-ingestion.md)
 - 실패 사례 분석: [`docs/failure-cases.md`](docs/failure-cases.md)
 - 회고 및 개선 방향: [`docs/retrospective.md`](docs/retrospective.md)

--- a/app.py
+++ b/app.py
@@ -19,6 +19,12 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="Comma-separated entities for follow-up questions, e.g. '기관 A'.",
     )
+    parser.add_argument(
+        "--retrieval_mode",
+        default="flat",
+        choices=["flat", "hierarchical"],
+        help="Use flat child-chunk retrieval or hierarchical parent-section reassembly.",
+    )
     return parser.parse_args()
 
 
@@ -45,6 +51,7 @@ def main() -> int:
             args.query,
             top_k=args.top_k,
             context_entities=parse_context_entities(args.context_entities),
+            retrieval_mode=args.retrieval_mode,
         )
     except Exception as exc:
         print(f"[ERROR] RAG query failed: {exc}", file=sys.stderr)

--- a/data/index/index.json
+++ b/data/index/index.json
@@ -11,7 +11,51 @@
   "build": {
     "num_documents": 4,
     "num_chunks": 13,
-    "source_dir": "data/raw"
+    "num_parent_sections": 13,
+    "source_dir": "data/raw",
+    "chunking": {
+      "requested_strategy": "auto",
+      "max_chars": 520,
+      "overlap_sentences": 1,
+      "num_parent_sections": 13,
+      "actual_strategy_counts": {
+        "section": 4
+      },
+      "documents": [
+        {
+          "doc_id": "rfp-agency-a-ai-quality",
+          "requested_strategy": "auto",
+          "actual_strategy": "section",
+          "num_input_sections": 4,
+          "num_parent_sections": 4,
+          "num_chunks": 4
+        },
+        {
+          "doc_id": "rfp-agency-b-mlops-governance",
+          "requested_strategy": "auto",
+          "actual_strategy": "section",
+          "num_input_sections": 4,
+          "num_parent_sections": 4,
+          "num_chunks": 4
+        },
+        {
+          "doc_id": "rfp-agency-c-chatbot",
+          "requested_strategy": "auto",
+          "actual_strategy": "section",
+          "num_input_sections": 3,
+          "num_parent_sections": 3,
+          "num_chunks": 3
+        },
+        {
+          "doc_id": "rfp-common-submission",
+          "requested_strategy": "auto",
+          "actual_strategy": "section",
+          "num_input_sections": 2,
+          "num_parent_sections": 2,
+          "num_chunks": 2
+        }
+      ]
+    }
   },
   "documents": [
     {
@@ -59,9 +103,9 @@
       "source_path": "data/raw/rfp_common_submission.json"
     }
   ],
-  "chunks": [
+  "parent_sections": [
     {
-      "chunk_id": "rfp-agency-a-ai-quality::chunk-001",
+      "section_id": "rfp-agency-a-ai-quality::section-001",
       "doc_id": "rfp-agency-a-ai-quality",
       "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
       "agency": "기관 A",
@@ -71,6 +115,249 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "사업 개요",
+      "heading": "사업 개요",
+      "section_path": [
+        "사업 개요"
+      ],
+      "text": "기관 A는 AI 품질관리 플랫폼 구축을 추진한다. 목표는 모델 성능 저하를 조기에 감지하고 품질 지표를 표준화하는 것이다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-a-ai-quality::section-002",
+      "doc_id": "rfp-agency-a-ai-quality",
+      "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
+      "agency": "기관 A",
+      "project": "AI 품질관리 플랫폼 구축",
+      "metadata": {
+        "domain": "AI quality",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "AI 요구사항",
+      "heading": "AI 요구사항",
+      "section_path": [
+        "AI 요구사항"
+      ],
+      "text": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 시스템은 모델별 정확도와 오류 유형을 수집하고 위험 이벤트를 감사 로그로 남겨야 한다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-a-ai-quality::section-003",
+      "doc_id": "rfp-agency-a-ai-quality",
+      "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
+      "agency": "기관 A",
+      "project": "AI 품질관리 플랫폼 구축",
+      "metadata": {
+        "domain": "AI quality",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "일정 및 산출물",
+      "heading": "일정 및 산출물",
+      "section_path": [
+        "일정 및 산출물"
+      ],
+      "text": "기관 A 일정은 착수 후 4개월 내 MVP를 제출하고 6개월 내 최종 검수를 완료하는 방식이다. 필수 산출물은 모델 점검 리포트, 보안 통제 매뉴얼, 운영자 교육 자료이다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-a-ai-quality::section-004",
+      "doc_id": "rfp-agency-a-ai-quality",
+      "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
+      "agency": "기관 A",
+      "project": "AI 품질관리 플랫폼 구축",
+      "metadata": {
+        "domain": "AI quality",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "제출조건",
+      "heading": "제출조건",
+      "section_path": [
+        "제출조건"
+      ],
+      "text": "제안사는 PM, ML 엔지니어, 보안 담당자를 포함한 수행 조직을 제시해야 한다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-b-mlops-governance::section-001",
+      "doc_id": "rfp-agency-b-mlops-governance",
+      "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
+      "agency": "기관 B",
+      "project": "데이터 거버넌스 및 MLOps 자동화",
+      "metadata": {
+        "domain": "MLOps",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "사업 개요",
+      "heading": "사업 개요",
+      "section_path": [
+        "사업 개요"
+      ],
+      "text": "기관 B는 데이터 거버넌스와 MLOps 자동화를 결합한 운영 체계를 구축한다. 목표는 모델 배포 절차를 표준화하고 데이터 변경 영향을 추적하는 것이다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-b-mlops-governance::section-002",
+      "doc_id": "rfp-agency-b-mlops-governance",
+      "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
+      "agency": "기관 B",
+      "project": "데이터 거버넌스 및 MLOps 자동화",
+      "metadata": {
+        "domain": "MLOps",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "AI 요구사항",
+      "heading": "AI 요구사항",
+      "section_path": [
+        "AI 요구사항"
+      ],
+      "text": "기관 B의 핵심 AI 요구사항은 데이터 거버넌스, MLOps 배포 자동화, 모델 모니터링이다. 시스템은 데이터 lineage, 모델 drift, 배포 승인 이력을 대시보드로 제공해야 한다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-b-mlops-governance::section-003",
+      "doc_id": "rfp-agency-b-mlops-governance",
+      "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
+      "agency": "기관 B",
+      "project": "데이터 거버넌스 및 MLOps 자동화",
+      "metadata": {
+        "domain": "MLOps",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "보안 및 개인정보",
+      "heading": "보안 및 개인정보",
+      "section_path": [
+        "보안 및 개인정보"
+      ],
+      "text": "기관 B는 개인정보 비식별화와 접근 권한 분리를 요구한다. 보안 통제는 데이터셋 반출 승인과 관리자 작업 기록을 중심으로 설계한다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-b-mlops-governance::section-004",
+      "doc_id": "rfp-agency-b-mlops-governance",
+      "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
+      "agency": "기관 B",
+      "project": "데이터 거버넌스 및 MLOps 자동화",
+      "metadata": {
+        "domain": "MLOps",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "일정 및 산출물",
+      "heading": "일정 및 산출물",
+      "section_path": [
+        "일정 및 산출물"
+      ],
+      "text": "기관 B 일정은 착수 후 3개월 내 파일럿 환경을 구성하고 5개월 내 운영 전환을 완료하는 방식이다. 필수 산출물은 데이터 표준 사전, MLOps 운영 가이드, 모니터링 대시보드이다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-c-chatbot::section-001",
+      "doc_id": "rfp-agency-c-chatbot",
+      "title": "기관 C 고객지원 챗봇 고도화 RFP",
+      "agency": "기관 C",
+      "project": "고객지원 챗봇 고도화",
+      "metadata": {
+        "domain": "chatbot",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "사업 개요",
+      "heading": "사업 개요",
+      "section_path": [
+        "사업 개요"
+      ],
+      "text": "기관 C는 고객지원 챗봇 고도화를 추진한다. 목표는 반복 문의를 자동 처리하고 상담원 이관 기준을 명확히 하는 것이다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-c-chatbot::section-002",
+      "doc_id": "rfp-agency-c-chatbot",
+      "title": "기관 C 고객지원 챗봇 고도화 RFP",
+      "agency": "기관 C",
+      "project": "고객지원 챗봇 고도화",
+      "metadata": {
+        "domain": "chatbot",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "AI 요구사항",
+      "heading": "AI 요구사항",
+      "section_path": [
+        "AI 요구사항"
+      ],
+      "text": "기관 C의 챗봇 AI 요구사항은 한국어 FAQ 검색, 의도 분류, 상담 이관 추천이다. 챗봇은 주요 문의에 대해 평균 2초 이내 응답해야 한다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-agency-c-chatbot::section-003",
+      "doc_id": "rfp-agency-c-chatbot",
+      "title": "기관 C 고객지원 챗봇 고도화 RFP",
+      "agency": "기관 C",
+      "project": "고객지원 챗봇 고도화",
+      "metadata": {
+        "domain": "chatbot",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "평가 및 운영",
+      "heading": "평가 및 운영",
+      "section_path": [
+        "평가 및 운영"
+      ],
+      "text": "기관 C는 답변 정확도, 상담 이관 적절성, 사용자 만족도를 운영 지표로 사용한다. 운영 로그는 월간 리포트로 제출한다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-common-submission::section-001",
+      "doc_id": "rfp-common-submission",
+      "title": "공통 제출조건 및 산출물 기준",
+      "agency": "공통",
+      "project": "공통 제출조건",
+      "metadata": {
+        "domain": "submission",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "공통 제출조건",
+      "heading": "공통 제출조건",
+      "section_path": [
+        "공통 제출조건"
+      ],
+      "text": "모든 제안사는 일정 준수 계획, 위험 관리 방안, 산출물 품질 검수 절차를 제출해야 한다. 산출물은 표준 템플릿에 맞춰 버전과 책임자를 표시해야 한다.",
+      "chunking_strategy": "section"
+    },
+    {
+      "section_id": "rfp-common-submission::section-002",
+      "doc_id": "rfp-common-submission",
+      "title": "공통 제출조건 및 산출물 기준",
+      "agency": "공통",
+      "project": "공통 제출조건",
+      "metadata": {
+        "domain": "submission",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "평가 기준",
+      "heading": "평가 기준",
+      "section_path": [
+        "평가 기준"
+      ],
+      "text": "공통 평가는 요구사항 이해도, 근거 기반 실행 계획, 보안 및 운영 리스크 대응 능력을 중심으로 진행한다. 부재 정보는 추정하지 않고 질의응답 기간에 확인해야 한다.",
+      "chunking_strategy": "section"
+    }
+  ],
+  "chunks": [
+    {
+      "chunk_id": "rfp-agency-a-ai-quality::chunk-001",
+      "section_id": "rfp-agency-a-ai-quality::section-001",
+      "parent_section_id": "rfp-agency-a-ai-quality::section-001",
+      "doc_id": "rfp-agency-a-ai-quality",
+      "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
+      "agency": "기관 A",
+      "project": "AI 품질관리 플랫폼 구축",
+      "metadata": {
+        "domain": "AI quality",
+        "document_type": "synthetic_public_sample"
+      },
+      "section": "사업 개요",
+      "section_path": [
+        "사업 개요"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 A는 AI 품질관리 플랫폼 구축을 추진한다. 목표는 모델 성능 저하를 조기에 감지하고 품질 지표를 표준화하는 것이다.",
       "tokens": [
         "a",
@@ -486,6 +773,8 @@
     },
     {
       "chunk_id": "rfp-agency-a-ai-quality::chunk-002",
+      "section_id": "rfp-agency-a-ai-quality::section-002",
+      "parent_section_id": "rfp-agency-a-ai-quality::section-002",
       "doc_id": "rfp-agency-a-ai-quality",
       "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
       "agency": "기관 A",
@@ -495,6 +784,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "AI 요구사항",
+      "section_path": [
+        "AI 요구사항"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 시스템은 모델별 정확도와 오류 유형을 수집하고 위험 이벤트를 감사 로그로 남겨야 한다.",
       "tokens": [
         "a",
@@ -916,6 +1210,8 @@
     },
     {
       "chunk_id": "rfp-agency-a-ai-quality::chunk-003",
+      "section_id": "rfp-agency-a-ai-quality::section-003",
+      "parent_section_id": "rfp-agency-a-ai-quality::section-003",
       "doc_id": "rfp-agency-a-ai-quality",
       "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
       "agency": "기관 A",
@@ -925,6 +1221,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "일정 및 산출물",
+      "section_path": [
+        "일정 및 산출물"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 A 일정은 착수 후 4개월 내 MVP를 제출하고 6개월 내 최종 검수를 완료하는 방식이다. 필수 산출물은 모델 점검 리포트, 보안 통제 매뉴얼, 운영자 교육 자료이다.",
       "tokens": [
         "a",
@@ -1351,6 +1652,8 @@
     },
     {
       "chunk_id": "rfp-agency-a-ai-quality::chunk-004",
+      "section_id": "rfp-agency-a-ai-quality::section-004",
+      "parent_section_id": "rfp-agency-a-ai-quality::section-004",
       "doc_id": "rfp-agency-a-ai-quality",
       "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
       "agency": "기관 A",
@@ -1360,6 +1663,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "제출조건",
+      "section_path": [
+        "제출조건"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "제안사는 PM, ML 엔지니어, 보안 담당자를 포함한 수행 조직을 제시해야 한다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다.",
       "tokens": [
         "a",
@@ -1780,6 +2088,8 @@
     },
     {
       "chunk_id": "rfp-agency-b-mlops-governance::chunk-001",
+      "section_id": "rfp-agency-b-mlops-governance::section-001",
+      "parent_section_id": "rfp-agency-b-mlops-governance::section-001",
       "doc_id": "rfp-agency-b-mlops-governance",
       "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
       "agency": "기관 B",
@@ -1789,6 +2099,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "사업 개요",
+      "section_path": [
+        "사업 개요"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 B는 데이터 거버넌스와 MLOps 자동화를 결합한 운영 체계를 구축한다. 목표는 모델 배포 절차를 표준화하고 데이터 변경 영향을 추적하는 것이다.",
       "tokens": [
         "b",
@@ -2209,6 +2524,8 @@
     },
     {
       "chunk_id": "rfp-agency-b-mlops-governance::chunk-002",
+      "section_id": "rfp-agency-b-mlops-governance::section-002",
+      "parent_section_id": "rfp-agency-b-mlops-governance::section-002",
       "doc_id": "rfp-agency-b-mlops-governance",
       "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
       "agency": "기관 B",
@@ -2218,6 +2535,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "AI 요구사항",
+      "section_path": [
+        "AI 요구사항"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 B의 핵심 AI 요구사항은 데이터 거버넌스, MLOps 배포 자동화, 모델 모니터링이다. 시스템은 데이터 lineage, 모델 drift, 배포 승인 이력을 대시보드로 제공해야 한다.",
       "tokens": [
         "b",
@@ -2640,6 +2962,8 @@
     },
     {
       "chunk_id": "rfp-agency-b-mlops-governance::chunk-003",
+      "section_id": "rfp-agency-b-mlops-governance::section-003",
+      "parent_section_id": "rfp-agency-b-mlops-governance::section-003",
       "doc_id": "rfp-agency-b-mlops-governance",
       "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
       "agency": "기관 B",
@@ -2649,6 +2973,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "보안 및 개인정보",
+      "section_path": [
+        "보안 및 개인정보"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 B는 개인정보 비식별화와 접근 권한 분리를 요구한다. 보안 통제는 데이터셋 반출 승인과 관리자 작업 기록을 중심으로 설계한다.",
       "tokens": [
         "b",
@@ -3069,6 +3398,8 @@
     },
     {
       "chunk_id": "rfp-agency-b-mlops-governance::chunk-004",
+      "section_id": "rfp-agency-b-mlops-governance::section-004",
+      "parent_section_id": "rfp-agency-b-mlops-governance::section-004",
       "doc_id": "rfp-agency-b-mlops-governance",
       "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
       "agency": "기관 B",
@@ -3078,6 +3409,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "일정 및 산출물",
+      "section_path": [
+        "일정 및 산출물"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 B 일정은 착수 후 3개월 내 파일럿 환경을 구성하고 5개월 내 운영 전환을 완료하는 방식이다. 필수 산출물은 데이터 표준 사전, MLOps 운영 가이드, 모니터링 대시보드이다.",
       "tokens": [
         "b",
@@ -3505,6 +3841,8 @@
     },
     {
       "chunk_id": "rfp-agency-c-chatbot::chunk-001",
+      "section_id": "rfp-agency-c-chatbot::section-001",
+      "parent_section_id": "rfp-agency-c-chatbot::section-001",
       "doc_id": "rfp-agency-c-chatbot",
       "title": "기관 C 고객지원 챗봇 고도화 RFP",
       "agency": "기관 C",
@@ -3514,6 +3852,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "사업 개요",
+      "section_path": [
+        "사업 개요"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 C는 고객지원 챗봇 고도화를 추진한다. 목표는 반복 문의를 자동 처리하고 상담원 이관 기준을 명확히 하는 것이다.",
       "tokens": [
         "c",
@@ -3928,6 +4271,8 @@
     },
     {
       "chunk_id": "rfp-agency-c-chatbot::chunk-002",
+      "section_id": "rfp-agency-c-chatbot::section-002",
+      "parent_section_id": "rfp-agency-c-chatbot::section-002",
       "doc_id": "rfp-agency-c-chatbot",
       "title": "기관 C 고객지원 챗봇 고도화 RFP",
       "agency": "기관 C",
@@ -3937,6 +4282,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "AI 요구사항",
+      "section_path": [
+        "AI 요구사항"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 C의 챗봇 AI 요구사항은 한국어 FAQ 검색, 의도 분류, 상담 이관 추천이다. 챗봇은 주요 문의에 대해 평균 2초 이내 응답해야 한다.",
       "tokens": [
         "c",
@@ -4357,6 +4707,8 @@
     },
     {
       "chunk_id": "rfp-agency-c-chatbot::chunk-003",
+      "section_id": "rfp-agency-c-chatbot::section-003",
+      "parent_section_id": "rfp-agency-c-chatbot::section-003",
       "doc_id": "rfp-agency-c-chatbot",
       "title": "기관 C 고객지원 챗봇 고도화 RFP",
       "agency": "기관 C",
@@ -4366,6 +4718,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "평가 및 운영",
+      "section_path": [
+        "평가 및 운영"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "기관 C는 답변 정확도, 상담 이관 적절성, 사용자 만족도를 운영 지표로 사용한다. 운영 로그는 월간 리포트로 제출한다.",
       "tokens": [
         "c",
@@ -4783,6 +5140,8 @@
     },
     {
       "chunk_id": "rfp-common-submission::chunk-001",
+      "section_id": "rfp-common-submission::section-001",
+      "parent_section_id": "rfp-common-submission::section-001",
       "doc_id": "rfp-common-submission",
       "title": "공통 제출조건 및 산출물 기준",
       "agency": "공통",
@@ -4792,6 +5151,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "공통 제출조건",
+      "section_path": [
+        "공통 제출조건"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "모든 제안사는 일정 준수 계획, 위험 관리 방안, 산출물 품질 검수 절차를 제출해야 한다. 산출물은 표준 템플릿에 맞춰 버전과 책임자를 표시해야 한다.",
       "tokens": [
         "공통",
@@ -5214,6 +5578,8 @@
     },
     {
       "chunk_id": "rfp-common-submission::chunk-002",
+      "section_id": "rfp-common-submission::section-002",
+      "parent_section_id": "rfp-common-submission::section-002",
       "doc_id": "rfp-common-submission",
       "title": "공통 제출조건 및 산출물 기준",
       "agency": "공통",
@@ -5223,6 +5589,11 @@
         "document_type": "synthetic_public_sample"
       },
       "section": "평가 기준",
+      "section_path": [
+        "평가 기준"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
       "text": "공통 평가는 요구사항 이해도, 근거 기반 실행 계획, 보안 및 운영 리스크 대응 능력을 중심으로 진행한다. 부재 정보는 추정하지 않고 질의응답 기간에 확인해야 한다.",
       "tokens": [
         "공통",

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 - [포트폴리오 case study](./portfolio-case-study.md)
 - [설계 배경 및 의사결정](./design-background.md)
+- [Chunking diagnostics](./chunking-diagnostics.md)
 - [PDF/HWP ingestion](./real-data-ingestion.md)
 - [실패 사례 분석](./failure-cases.md)
 - [회고 및 향후 개선](./retrospective.md)

--- a/docs/chunking-diagnostics.md
+++ b/docs/chunking-diagnostics.md
@@ -1,0 +1,49 @@
+# Chunking diagnostics
+
+## 목적
+RFP 문서는 heading, 요구사항 목록, 제출조건 같은 구조가 검색 품질에 직접 영향을 준다. 이 저장소는 기본 인덱싱에서 section-aware metadata를 저장하고, 구조가 약한 단일 본문 문서는 fixed fallback으로 처리한다.
+
+## 인덱스 schema
+각 chunk에는 아래 진단 필드가 포함된다.
+
+- `section_id` / `parent_section_id`: parent section과 child chunk를 연결한다.
+- `section_path`: heading 계층을 보존한다. 공개 synthetic 문서는 1단계 heading을 사용한다.
+- `chunk_seq_in_section`: 같은 parent section 안에서 child chunk 순서를 나타낸다.
+- `chunking_strategy`: 실제 적용된 전략이다. 값은 `section` 또는 `fixed`이다.
+
+`index.json`의 `parent_sections`에는 parent section text와 metadata가 저장된다. `build.chunking`에는 요청 전략, `chunk_max_chars`, overlap, 문서별 실제 전략, parent section 수, chunk 수가 기록된다.
+
+## 동작 방식
+기본 인덱싱 명령은 다음 옵션과 같다.
+
+```bash
+python3 scripts/build_index.py \
+  --input_dir data/raw \
+  --output_dir data/index \
+  --chunking_strategy auto \
+  --chunk_max_chars 520 \
+  --chunk_overlap_sentences 1
+```
+
+- `auto`: 문서에 여러 section이 있거나 heading 구조가 있으면 `section`을 사용한다.
+- `fixed`: heading 구조가 약한 단일 본문은 문서 전체를 parent section으로 묶고 fixed-size child chunk를 만든다.
+- `section`: section 경계를 강제로 유지한다.
+
+질의 기본값은 `flat` retrieval이다. `--retrieval_mode hierarchical`은 child chunk를 먼저 점수화한 뒤 `parent_section_id` 기준으로 section text를 재조립해 evidence로 반환한다.
+
+## 공개 synthetic 평가 결과
+2026-04-30에 hashing embedding으로 동일 평가셋을 비교했다.
+
+| Index strategy | Chunks | Parent sections | Retrieval | Accuracy | Groundedness | Citation | Abstention | Retry |
+|---|---:|---:|---|---:|---:|---:|---:|---:|
+| auto | 13 | 13 | flat | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 |
+| auto | 13 | 13 | hierarchical | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 |
+| fixed | 4 | 4 | flat | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 |
+| fixed | 4 | 4 | hierarchical | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 |
+
+현재 공개 synthetic 문서는 짧고 heading이 명확해 fixed와 section-aware의 품질 차이가 지표로 드러나지 않는다. 대신 section-aware 인덱스는 chunk별 `section_path`와 parent-child 연결을 제공해 citation 해석과 긴 문서 디버깅에 더 유리하다.
+
+## 해석 기준
+- 기본 flat retrieval은 기존 baseline 회귀를 피하기 위한 기본값이다.
+- hierarchical retrieval은 긴 section이 여러 child chunk로 나뉠 때 주변 문맥을 함께 확인하는 실험 옵션이다.
+- 품질 비교는 `reports/eval_summary.json`의 `hierarchical` ablation run과 fixed/auto 임시 인덱스 평가 결과를 함께 본다.

--- a/docs/failure-cases.md
+++ b/docs/failure-cases.md
@@ -12,3 +12,4 @@
 - 공개본에서는 agency/project/title metadata를 정규화해 exact/partial/fuzzy 후보를 확장한다.
 - verifier가 topic/entity/doc coverage를 확인하고 실패 시 strict → reduced → relaxed 단계로 metadata filter를 완화한다.
 - retrieval diagnostics에는 단계별 filter, 후보 수, 검증 실패 사유를 남겨 metadata mismatch를 추적한다.
+- section-aware chunk metadata(`section_path`, `parent_section_id`)와 hierarchical retrieval 진단은 요구사항 목록이 chunk 경계에서 끊기거나 비교 질의 근거가 문맥 없이 보이는 경우를 해석하는 데 사용한다.

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -6,18 +6,27 @@ ablation_runs:
     metadata_first: true
     rerank: true
     verifier_retry: true
+    retrieval_mode: flat
+  - name: hierarchical
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: hierarchical
   - name: no_metadata_first
     metadata_first: false
     rerank: true
     verifier_retry: true
+    retrieval_mode: flat
   - name: no_rerank
     metadata_first: true
     rerank: false
     verifier_retry: true
+    retrieval_mode: flat
   - name: no_verifier_retry
     metadata_first: true
     rerank: true
     verifier_retry: false
+    retrieval_mode: flat
 cases:
   - id: single_doc_security
     query_type: single_doc

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -22,6 +22,7 @@ DEFAULT_ABLATION_RUNS = [
         "metadata_first": True,
         "rerank": True,
         "verifier_retry": True,
+        "retrieval_mode": "flat",
     }
 ]
 
@@ -57,6 +58,11 @@ def load_config(path: Path) -> dict[str, Any]:
             raise ValueError("Each ablation run must be a mapping with a name")
         if run["name"] in seen_names:
             raise ValueError(f"Duplicate ablation run name: {run['name']}")
+        retrieval_mode = run.get("retrieval_mode", "flat")
+        if retrieval_mode not in {"flat", "hierarchical"}:
+            raise ValueError(
+                f"Eval run retrieval_mode must be 'flat' or 'hierarchical': {run['name']}"
+            )
         seen_names.add(run["name"])
     return data
 
@@ -188,6 +194,7 @@ def summarize_run(
         "metadata_first": bool(run_config.get("metadata_first", True)),
         "rerank": bool(run_config.get("rerank", True)),
         "verifier_retry": bool(run_config.get("verifier_retry", True)),
+        "retrieval_mode": str(run_config.get("retrieval_mode", "flat")),
         **metric_block(case_results),
         "by_query_type": {},
     }
@@ -216,6 +223,7 @@ def evaluate_run(
             metadata_first=bool(run_config.get("metadata_first", True)),
             rerank=bool(run_config.get("rerank", True)),
             verifier_retry=bool(run_config.get("verifier_retry", True)),
+            retrieval_mode=str(run_config.get("retrieval_mode", "flat")),
         )
         case_results.append(score_case(case, prediction))
     return case_results
@@ -231,6 +239,7 @@ def ablation_runs(config: dict[str, Any]) -> list[dict[str, Any]]:
                 "metadata_first": bool(run.get("metadata_first", True)),
                 "rerank": bool(run.get("rerank", True)),
                 "verifier_retry": bool(run.get("verifier_retry", True)),
+                "retrieval_mode": str(run.get("retrieval_mode", "flat")),
             }
         )
     return normalized

--- a/outputs/answer.json
+++ b/outputs/answer.json
@@ -117,6 +117,7 @@
     "metadata_first": true,
     "rerank": true,
     "verifier_retry": true,
+    "retrieval_mode": "flat",
     "metadata_filters": {
       "doc_ids": [
         "rfp-agency-a-ai-quality",
@@ -152,7 +153,16 @@
         "domain": "AI quality",
         "document_type": "synthetic_public_sample"
       },
-      "section": "AI 요구사항"
+      "section": "AI 요구사항",
+      "section_id": "rfp-agency-a-ai-quality::section-002",
+      "parent_section_id": "rfp-agency-a-ai-quality::section-002",
+      "section_path": [
+        "AI 요구사항"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
+      "retrieval_mode": "flat",
+      "child_chunk_ids": []
     },
     {
       "doc_id": "rfp-agency-b-mlops-governance",
@@ -165,11 +175,20 @@
         "domain": "MLOps",
         "document_type": "synthetic_public_sample"
       },
-      "section": "AI 요구사항"
+      "section": "AI 요구사항",
+      "section_id": "rfp-agency-b-mlops-governance::section-002",
+      "parent_section_id": "rfp-agency-b-mlops-governance::section-002",
+      "section_path": [
+        "AI 요구사항"
+      ],
+      "chunk_seq_in_section": 1,
+      "chunking_strategy": "section",
+      "retrieval_mode": "flat",
+      "child_chunk_ids": []
     }
   ],
   "diagnostics": {
-    "latency_ms": 1.87,
+    "latency_ms": 8.55,
     "retry_count": 0,
     "abstained": false,
     "verification_reasons": [],
@@ -193,8 +212,10 @@
         },
         "top_k": 6,
         "candidate_count": 8,
+        "parent_candidate_count": null,
         "total_chunks": 13,
         "filter_fallback_used": false,
+        "retrieval_mode": "flat",
         "verified": true,
         "verification_reasons": []
       }
@@ -204,6 +225,7 @@
     "embedding_model": "local-hashing-bow",
     "metadata_first": true,
     "rerank": true,
-    "verifier_retry": true
+    "verifier_retry": true,
+    "retrieval_mode": "flat"
   }
 }

--- a/rag_core.py
+++ b/rag_core.py
@@ -23,6 +23,8 @@ import numpy as np
 
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 DEFAULT_HASH_DIM = 384
+DEFAULT_CHUNK_MAX_CHARS = 520
+DEFAULT_CHUNK_OVERLAP_SENTENCES = 1
 INDEX_FILENAME = "index.json"
 MODEL_CACHE: dict[tuple[str, bool], Any] = {}
 
@@ -113,6 +115,9 @@ TOPIC_KEYWORDS = [
 STRICT_METADATA_CONFIDENCE = 0.90
 REDUCED_METADATA_CONFIDENCE = 0.70
 AMBIGUOUS_CONFIDENCE_DELTA = 0.05
+VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
+VALID_RETRIEVAL_MODES = {"flat", "hierarchical"}
+WEAK_SECTION_HEADINGS = {"", "본문", "body", "text", "content"}
 
 METADATA_GENERIC_TOKENS = {
     "rfp",
@@ -324,54 +329,240 @@ def normalize_text_document(path: Path) -> dict[str, Any]:
     }
 
 
-def build_chunks(documents: Iterable[dict[str, Any]], max_chars: int = 520) -> list[dict[str, Any]]:
-    chunks: list[dict[str, Any]] = []
-    for doc in documents:
-        chunk_seq = 1
-        for section in doc["sections"]:
-            sentences = []
-            for sentence in sentence_split(section["text"]) or [section["text"]]:
-                sentences.extend(split_long_text_unit(sentence, max_chars))
-            current: list[str] = []
-            current_len = 0
-            for sentence in sentences:
-                next_len = current_len + len(sentence) + 1
-                if current and next_len > max_chars:
-                    chunks.append(make_chunk(doc, section["heading"], current, chunk_seq))
-                    chunk_seq += 1
-                    overlap = current[-1:]
-                    overlap_len = sum(len(s) + 1 for s in overlap)
-                    if overlap_len + len(sentence) + 1 <= max_chars:
-                        current = overlap
-                        current_len = overlap_len
-                    else:
-                        current = []
-                        current_len = 0
-                current.append(sentence)
-                current_len += len(sentence) + 1
-            if current:
-                chunks.append(make_chunk(doc, section["heading"], current, chunk_seq))
-                chunk_seq += 1
-    return chunks
+def validate_chunking_options(
+    chunking_strategy: str,
+    max_chars: int,
+    overlap_sentences: int,
+) -> None:
+    if chunking_strategy not in VALID_CHUNKING_STRATEGIES:
+        choices = ", ".join(sorted(VALID_CHUNKING_STRATEGIES))
+        raise ValueError(f"chunking_strategy must be one of: {choices}")
+    if max_chars < 1:
+        raise ValueError("chunk_max_chars must be positive.")
+    if overlap_sentences < 0:
+        raise ValueError("chunk_overlap_sentences must be zero or positive.")
 
 
-def make_chunk(
-    doc: dict[str, Any],
-    section: str,
-    sentences: list[str],
-    chunk_seq: int,
-) -> dict[str, Any]:
-    text = " ".join(sentences).strip()
+def normalize_section_path(section: dict[str, Any], heading: str) -> list[str]:
+    raw_path = section.get("section_path") or section.get("path") or []
+    if isinstance(raw_path, str):
+        parts = [part.strip() for part in raw_path.split(">")]
+    elif isinstance(raw_path, list):
+        parts = [str(part).strip() for part in raw_path]
+    else:
+        parts = []
+    path = [part for part in parts if part]
+    if not path:
+        path = [heading]
+    return path
+
+
+def normalize_document_sections(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    normalized = []
+    for idx, section in enumerate(doc.get("sections") or [], start=1):
+        heading = str(section.get("heading") or f"section-{idx}").strip()
+        text = str(section.get("text") or "").strip()
+        if not text:
+            continue
+        section_path = normalize_section_path(section, heading)
+        normalized.append(
+            {
+                "section_id": f"{doc['doc_id']}::section-{idx:03d}",
+                "doc_id": doc["doc_id"],
+                "title": doc["title"],
+                "agency": doc.get("agency", ""),
+                "project": doc.get("project", ""),
+                "metadata": doc.get("metadata", {}),
+                "section": section_path[-1],
+                "heading": heading,
+                "section_path": section_path,
+                "text": text,
+            }
+        )
+    return normalized
+
+
+def document_has_section_structure(doc: dict[str, Any]) -> bool:
+    sections = normalize_document_sections(doc)
+    if len(sections) > 1:
+        return True
+    if not sections:
+        return False
+    section = sections[0]
+    heading = str(section.get("heading") or "").strip().lower()
+    section_path = section.get("section_path") or []
+    return len(section_path) > 1 or heading not in WEAK_SECTION_HEADINGS
+
+
+def resolve_chunking_strategy(doc: dict[str, Any], requested_strategy: str) -> str:
+    if requested_strategy == "auto":
+        return "section" if document_has_section_structure(doc) else "fixed"
+    return requested_strategy
+
+
+def fixed_parent_section(doc: dict[str, Any], sections: list[dict[str, Any]]) -> dict[str, Any]:
+    parts = []
+    for section in sections:
+        heading = str(section.get("section") or "").strip()
+        text = str(section.get("text") or "").strip()
+        if heading and heading not in WEAK_SECTION_HEADINGS:
+            parts.append(f"{heading}\n{text}")
+        else:
+            parts.append(text)
     return {
-        "chunk_id": f"{doc['doc_id']}::chunk-{chunk_seq:03d}",
+        "section_id": f"{doc['doc_id']}::section-001",
         "doc_id": doc["doc_id"],
         "title": doc["title"],
         "agency": doc.get("agency", ""),
         "project": doc.get("project", ""),
         "metadata": doc.get("metadata", {}),
-        "section": section,
+        "section": "문서 전체",
+        "heading": "문서 전체",
+        "section_path": ["문서 전체"],
+        "text": "\n\n".join(part for part in parts if part).strip(),
+    }
+
+
+def split_section_text(
+    text: str,
+    max_chars: int,
+    overlap_sentences: int,
+) -> list[list[str]]:
+    sentences = []
+    for sentence in sentence_split(text) or [text]:
+        sentences.extend(split_long_text_unit(sentence, max_chars))
+
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    current_len = 0
+    for sentence in sentences:
+        next_len = current_len + len(sentence) + 1
+        if current and next_len > max_chars:
+            chunks.append(current)
+            overlap = current[-overlap_sentences:] if overlap_sentences else []
+            overlap_len = sum(len(s) + 1 for s in overlap)
+            if overlap and overlap_len + len(sentence) + 1 <= max_chars:
+                current = overlap
+                current_len = overlap_len
+            else:
+                current = []
+                current_len = 0
+        current.append(sentence)
+        current_len += len(sentence) + 1
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def build_chunk_records(
+    documents: Iterable[dict[str, Any]],
+    max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+    chunking_strategy: str = "auto",
+    overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    validate_chunking_options(chunking_strategy, max_chars, overlap_sentences)
+    chunks: list[dict[str, Any]] = []
+    parent_sections: list[dict[str, Any]] = []
+    strategy_counts = {"section": 0, "fixed": 0}
+    document_diagnostics = []
+
+    for doc in documents:
+        normalized_sections = normalize_document_sections(doc)
+        actual_strategy = resolve_chunking_strategy(doc, chunking_strategy)
+        parent_candidates = (
+            normalized_sections
+            if actual_strategy == "section"
+            else [fixed_parent_section(doc, normalized_sections)]
+        )
+        doc_chunk_count = 0
+        chunk_seq = 1
+
+        for parent in parent_candidates:
+            parent = {**parent, "chunking_strategy": actual_strategy}
+            parent_sections.append(parent)
+            section_chunks = split_section_text(parent["text"], max_chars, overlap_sentences)
+            for chunk_seq_in_section, sentences in enumerate(section_chunks, start=1):
+                chunks.append(
+                    make_chunk(
+                        doc,
+                        parent,
+                        sentences,
+                        chunk_seq,
+                        chunk_seq_in_section,
+                        actual_strategy,
+                    )
+                )
+                chunk_seq += 1
+                doc_chunk_count += 1
+
+        strategy_counts[actual_strategy] += 1
+        document_diagnostics.append(
+            {
+                "doc_id": doc["doc_id"],
+                "requested_strategy": chunking_strategy,
+                "actual_strategy": actual_strategy,
+                "num_input_sections": len(normalized_sections),
+                "num_parent_sections": len(parent_candidates),
+                "num_chunks": doc_chunk_count,
+            }
+        )
+
+    diagnostics = {
+        "requested_strategy": chunking_strategy,
+        "max_chars": max_chars,
+        "overlap_sentences": overlap_sentences,
+        "num_parent_sections": len(parent_sections),
+        "actual_strategy_counts": {
+            key: value for key, value in strategy_counts.items() if value
+        },
+        "documents": document_diagnostics,
+    }
+    return chunks, parent_sections, diagnostics
+
+
+def build_chunks(
+    documents: Iterable[dict[str, Any]],
+    max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+    chunking_strategy: str = "auto",
+    overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
+) -> list[dict[str, Any]]:
+    chunks, _, _ = build_chunk_records(
+        documents,
+        max_chars=max_chars,
+        chunking_strategy=chunking_strategy,
+        overlap_sentences=overlap_sentences,
+    )
+    return chunks
+
+
+def make_chunk(
+    doc: dict[str, Any],
+    parent_section: dict[str, Any],
+    sentences: list[str],
+    chunk_seq: int,
+    chunk_seq_in_section: int,
+    chunking_strategy: str,
+) -> dict[str, Any]:
+    text = " ".join(sentences).strip()
+    section_path = parent_section.get("section_path") or [parent_section.get("section", "")]
+    section_label = str(parent_section.get("section") or section_path[-1])
+    return {
+        "chunk_id": f"{doc['doc_id']}::chunk-{chunk_seq:03d}",
+        "section_id": parent_section["section_id"],
+        "parent_section_id": parent_section["section_id"],
+        "doc_id": doc["doc_id"],
+        "title": doc["title"],
+        "agency": doc.get("agency", ""),
+        "project": doc.get("project", ""),
+        "metadata": doc.get("metadata", {}),
+        "section": section_label,
+        "section_path": section_path,
+        "chunk_seq_in_section": chunk_seq_in_section,
+        "chunking_strategy": chunking_strategy,
         "text": text,
-        "tokens": tokenize(" ".join([doc["title"], doc.get("agency", ""), section, text])),
+        "tokens": tokenize(
+            " ".join([doc["title"], doc.get("agency", ""), " > ".join(section_path), text])
+        ),
     }
 
 
@@ -478,6 +669,9 @@ def build_index_payload(
     input_dir: Path,
     model_name: str = DEFAULT_EMBEDDING_MODEL,
     embedding_backend: str = "auto",
+    chunking_strategy: str = "auto",
+    chunk_max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+    chunk_overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
 ) -> dict[str, Any]:
     documents = load_raw_documents(input_dir)
     return build_index_payload_from_documents(
@@ -485,6 +679,9 @@ def build_index_payload(
         source_dir=str(input_dir),
         model_name=model_name,
         embedding_backend=embedding_backend,
+        chunking_strategy=chunking_strategy,
+        chunk_max_chars=chunk_max_chars,
+        chunk_overlap_sentences=chunk_overlap_sentences,
         message="Public synthetic RFP index for local minimum E2E RAG.",
     )
 
@@ -494,11 +691,26 @@ def build_index_payload_from_documents(
     source_dir: str,
     model_name: str = DEFAULT_EMBEDDING_MODEL,
     embedding_backend: str = "auto",
+    chunking_strategy: str = "auto",
+    chunk_max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+    chunk_overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
     message: str = "RFP index for local minimum E2E RAG.",
 ) -> dict[str, Any]:
-    chunks = build_chunks(documents)
+    chunks, parent_sections, chunking_diagnostics = build_chunk_records(
+        documents,
+        max_chars=chunk_max_chars,
+        chunking_strategy=chunking_strategy,
+        overlap_sentences=chunk_overlap_sentences,
+    )
     embedding_inputs = [
-        " ".join([chunk["title"], chunk.get("agency", ""), chunk["section"], chunk["text"]])
+        " ".join(
+            [
+                chunk["title"],
+                chunk.get("agency", ""),
+                " > ".join(chunk.get("section_path") or [chunk["section"]]),
+                chunk["text"],
+            ]
+        )
         for chunk in chunks
     ]
     embedding_result = embed_texts(embedding_inputs, model_name=model_name, backend=embedding_backend)
@@ -529,9 +741,12 @@ def build_index_payload_from_documents(
         "build": {
             "num_documents": len(public_docs),
             "num_chunks": len(chunks),
+            "num_parent_sections": len(parent_sections),
             "source_dir": source_dir,
+            "chunking": chunking_diagnostics,
         },
         "documents": public_docs,
+        "parent_sections": parent_sections,
         "chunks": chunks,
     }
 
@@ -827,7 +1042,11 @@ def make_plan(
     metadata_first: bool = True,
     rerank: bool = True,
     verifier_retry: bool = True,
+    retrieval_mode: str = "flat",
 ) -> dict[str, Any]:
+    if retrieval_mode not in VALID_RETRIEVAL_MODES:
+        choices = ", ".join(sorted(VALID_RETRIEVAL_MODES))
+        raise ValueError(f"retrieval_mode must be one of: {choices}")
     default_top_k = 6 if analysis["query_type"] == "comparison" else 4
     if relaxed:
         stage = "relaxed"
@@ -852,6 +1071,7 @@ def make_plan(
         "metadata_first": metadata_first,
         "rerank": rerank,
         "verifier_retry": verifier_retry,
+        "retrieval_mode": retrieval_mode,
         "metadata_filters": filters,
         "top_k": top_k or default_top_k,
         "relaxed": stage == "relaxed",
@@ -912,6 +1132,12 @@ def retrieve(
                 "project": chunk.get("project", ""),
                 "metadata": chunk.get("metadata", {}),
                 "section": chunk["section"],
+                "section_id": chunk.get("section_id"),
+                "parent_section_id": chunk.get("parent_section_id") or chunk.get("section_id"),
+                "section_path": chunk.get("section_path") or [chunk.get("section", "")],
+                "chunk_seq_in_section": chunk.get("chunk_seq_in_section"),
+                "chunking_strategy": chunk.get("chunking_strategy", "legacy"),
+                "retrieval_mode": "flat",
                 "text": chunk["text"],
                 "score": round(float(score), 4),
                 "score_parts": {
@@ -923,7 +1149,62 @@ def retrieve(
         )
 
     scored.sort(key=lambda item: item["score"], reverse=True)
-    return scored[: int(plan["top_k"])]
+    top_k = int(plan["top_k"])
+    if plan.get("retrieval_mode") == "hierarchical":
+        return reassemble_parent_sections(index, scored, top_k, plan)
+    return scored[:top_k]
+
+
+def reassemble_parent_sections(
+    index: dict[str, Any],
+    scored_chunks: list[dict[str, Any]],
+    top_k: int,
+    plan: dict[str, Any],
+) -> list[dict[str, Any]]:
+    parent_by_id = {
+        str(section.get("section_id")): section
+        for section in index.get("parent_sections", [])
+        if section.get("section_id")
+    }
+    best_by_parent: dict[str, dict[str, Any]] = {}
+    child_ids_by_parent: dict[str, list[str]] = {}
+
+    for chunk in scored_chunks:
+        parent_id = str(
+            chunk.get("parent_section_id") or chunk.get("section_id") or chunk.get("chunk_id")
+        )
+        child_ids_by_parent.setdefault(parent_id, []).append(chunk["chunk_id"])
+        current = best_by_parent.get(parent_id)
+        if current is None or chunk["score"] > current["score"]:
+            best_by_parent[parent_id] = chunk
+
+    plan["parent_candidate_count"] = len(best_by_parent)
+
+    reassembled = []
+    for parent_id, best_chunk in best_by_parent.items():
+        parent = parent_by_id.get(parent_id)
+        if not parent:
+            item = dict(best_chunk)
+            item["retrieval_mode"] = "hierarchical_fallback"
+            item["child_chunk_ids"] = child_ids_by_parent.get(parent_id, [])
+            reassembled.append(item)
+            continue
+
+        item = {
+            **best_chunk,
+            "section_id": parent.get("section_id"),
+            "parent_section_id": parent_id,
+            "section": parent.get("section", best_chunk.get("section", "")),
+            "section_path": parent.get("section_path") or best_chunk.get("section_path") or [],
+            "text": parent.get("text", best_chunk.get("text", "")),
+            "chunking_strategy": parent.get("chunking_strategy", best_chunk.get("chunking_strategy", "")),
+            "retrieval_mode": "hierarchical",
+            "child_chunk_ids": child_ids_by_parent.get(parent_id, []),
+        }
+        reassembled.append(item)
+
+    reassembled.sort(key=lambda item: item["score"], reverse=True)
+    return reassembled[:top_k]
 
 
 def embed_query_for_index(query: str, embedding_config: dict[str, Any]) -> np.ndarray:
@@ -956,12 +1237,13 @@ def dense_similarity(query_vector: np.ndarray, chunk_vector: Any) -> float:
 def lexical_similarity(query_tokens: set[str], topics: list[str], chunk: dict[str, Any]) -> float:
     if not query_tokens and not topics:
         return 0.0
+    section_path = chunk.get("section_path") or [chunk.get("section", "")]
     chunk_text = " ".join(
         [
             chunk.get("title", ""),
             chunk.get("agency", ""),
             chunk.get("project", ""),
-            chunk.get("section", ""),
+            " > ".join(section_path),
             chunk.get("text", ""),
         ]
     ).lower()
@@ -1124,8 +1406,10 @@ def summarize_stage_attempt(
         "metadata_filters": plan.get("metadata_filters") or {},
         "top_k": plan.get("top_k"),
         "candidate_count": plan.get("candidate_count"),
+        "parent_candidate_count": plan.get("parent_candidate_count"),
         "total_chunks": plan.get("total_chunks"),
         "filter_fallback_used": plan.get("filter_fallback_used", False),
+        "retrieval_mode": plan.get("retrieval_mode", "flat"),
         "verified": verified,
         "verification_reasons": verification_reasons,
     }
@@ -1139,8 +1423,12 @@ def run_rag_query(
     metadata_first: bool = True,
     rerank: bool = True,
     verifier_retry: bool = True,
+    retrieval_mode: str = "flat",
 ) -> dict[str, Any]:
     started = time.perf_counter()
+    if retrieval_mode not in VALID_RETRIEVAL_MODES:
+        choices = ", ".join(sorted(VALID_RETRIEVAL_MODES))
+        raise ValueError(f"retrieval_mode must be one of: {choices}")
     analysis = analyze_query(query, metadata_targets(index), context_entities=context_entities)
     stage_sequence = metadata_stage_sequence(
         analysis,
@@ -1165,6 +1453,7 @@ def run_rag_query(
             metadata_first=metadata_first,
             rerank=rerank,
             verifier_retry=verifier_retry,
+            retrieval_mode=retrieval_mode,
         )
         evidence = retrieve(index, query, analysis, plan)
         if verifier_retry:
@@ -1203,6 +1492,7 @@ def run_rag_query(
             "metadata_first": metadata_first,
             "rerank": rerank,
             "verifier_retry": verifier_retry,
+            "retrieval_mode": retrieval_mode,
         },
     }
 
@@ -1218,6 +1508,13 @@ def strip_internal_scores(evidence: list[dict[str, Any]]) -> list[dict[str, Any]
             "agency": item.get("agency", ""),
             "metadata": item.get("metadata", {}),
             "section": item.get("section", ""),
+            "section_id": item.get("section_id"),
+            "parent_section_id": item.get("parent_section_id"),
+            "section_path": item.get("section_path") or [],
+            "chunk_seq_in_section": item.get("chunk_seq_in_section"),
+            "chunking_strategy": item.get("chunking_strategy", ""),
+            "retrieval_mode": item.get("retrieval_mode", "flat"),
+            "child_chunk_ids": item.get("child_chunk_ids", []),
         }
         for item in evidence
     ]

--- a/reports/eval_summary.json
+++ b/reports/eval_summary.json
@@ -8,9 +8,9 @@
   "citation_precision": 1.0,
   "abstention": 1.0,
   "latency": {
-    "p50": 0.99,
-    "p95": 1.3339999999999999,
-    "mean": 1.0024999999999997
+    "p50": 1.07,
+    "p95": 2.1854999999999998,
+    "mean": 1.2070833333333333
   },
   "retry": 0.25,
   "by_query_type": {
@@ -21,9 +21,9 @@
       "citation_precision": 1.0,
       "abstention": null,
       "latency": {
-        "p50": 1.045,
-        "p95": 2.8775,
-        "mean": 1.3883333333333334
+        "p50": 1.13,
+        "p95": 2.9475000000000002,
+        "mean": 1.5183333333333333
       },
       "retry": 0.0,
       "retry_cost": {
@@ -41,9 +41,9 @@
       "citation_precision": 1.0,
       "abstention": null,
       "latency": {
-        "p50": 1.13,
-        "p95": 1.2750000000000001,
-        "mean": 1.1233333333333333
+        "p50": 1.08,
+        "p95": 1.515,
+        "mean": 1.1700000000000002
       },
       "retry": 0.0,
       "retry_cost": {
@@ -61,9 +61,9 @@
       "citation_precision": 1.0,
       "abstention": null,
       "latency": {
-        "p50": 0.52,
-        "p95": 0.5975,
-        "mean": 0.5216666666666666
+        "p50": 0.6699999999999999,
+        "p95": 0.9324999999999999,
+        "mean": 0.705
       },
       "retry": 0.0,
       "retry_cost": {
@@ -81,9 +81,9 @@
       "citation_precision": 1.0,
       "abstention": 1.0,
       "latency": {
-        "p50": 1.005,
-        "p95": 1.0750000000000002,
-        "mean": 0.9766666666666667
+        "p50": 1.4,
+        "p95": 1.8575,
+        "mean": 1.4350000000000003
       },
       "retry": 1.0,
       "retry_cost": {
@@ -113,15 +113,16 @@
         "metadata_first": true,
         "rerank": true,
         "verifier_retry": true,
+        "retrieval_mode": "flat",
         "num_predictions": 24,
         "accuracy": 1.0,
         "groundedness": 1.0,
         "citation_precision": 1.0,
         "abstention": 1.0,
         "latency": {
-          "p50": 0.99,
-          "p95": 1.3339999999999999,
-          "mean": 1.0024999999999997
+          "p50": 1.07,
+          "p95": 2.1854999999999998,
+          "mean": 1.2070833333333333
         },
         "retry": 0.25,
         "retry_cost": {
@@ -141,9 +142,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 1.045,
-              "p95": 2.8775,
-              "mean": 1.3883333333333334
+              "p50": 1.13,
+              "p95": 2.9475000000000002,
+              "mean": 1.5183333333333333
             },
             "retry": 0.0,
             "retry_cost": {
@@ -161,9 +162,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 1.13,
-              "p95": 1.2750000000000001,
-              "mean": 1.1233333333333333
+              "p50": 1.08,
+              "p95": 1.515,
+              "mean": 1.1700000000000002
             },
             "retry": 0.0,
             "retry_cost": {
@@ -181,9 +182,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 0.52,
-              "p95": 0.5975,
-              "mean": 0.5216666666666666
+              "p50": 0.6699999999999999,
+              "p95": 0.9324999999999999,
+              "mean": 0.705
             },
             "retry": 0.0,
             "retry_cost": {
@@ -201,9 +202,9 @@
             "citation_precision": 1.0,
             "abstention": 1.0,
             "latency": {
-              "p50": 1.005,
-              "p95": 1.0750000000000002,
-              "mean": 0.9766666666666667
+              "p50": 1.4,
+              "p95": 1.8575,
+              "mean": 1.4350000000000003
             },
             "retry": 1.0,
             "retry_cost": {
@@ -237,7 +238,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 3.39,
+            "latency_ms": 3.19,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -262,7 +263,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.34,
+            "latency_ms": 1.47,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -287,7 +288,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.05,
+            "latency_ms": 0.79,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -312,7 +313,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.92,
+            "latency_ms": 2.22,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -337,7 +338,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.59,
+            "latency_ms": 0.69,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -362,7 +363,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.04,
+            "latency_ms": 0.75,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -389,7 +390,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.16,
+            "latency_ms": 1.65,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -416,7 +417,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.3,
+            "latency_ms": 1.09,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -443,7 +444,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.0,
+            "latency_ms": 1.11,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -470,7 +471,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.2,
+            "latency_ms": 1.03,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -497,7 +498,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.1,
+            "latency_ms": 1.07,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -524,7 +525,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.98,
+            "latency_ms": 1.07,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -549,7 +550,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.5,
+            "latency_ms": 0.57,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -574,7 +575,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.49,
+            "latency_ms": 0.72,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -599,7 +600,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.43,
+            "latency_ms": 0.57,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -624,7 +625,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.61,
+            "latency_ms": 0.99,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -649,7 +650,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.56,
+            "latency_ms": 0.76,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -674,7 +675,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.54,
+            "latency_ms": 0.62,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "abstained": false,
@@ -695,7 +696,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 1.08,
+            "latency_ms": 1.45,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -719,7 +720,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 0.96,
+            "latency_ms": 1.46,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -743,7 +744,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 0.87,
+            "latency_ms": 1.06,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -767,7 +768,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 1.06,
+            "latency_ms": 1.3,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -791,7 +792,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 1.05,
+            "latency_ms": 1.99,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -815,7 +816,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 0.84,
+            "latency_ms": 1.35,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -827,129 +828,20 @@
         ]
       },
       {
-        "name": "no_metadata_first",
-        "metadata_first": false,
+        "name": "hierarchical",
+        "metadata_first": true,
         "rerank": true,
         "verifier_retry": true,
-        "num_predictions": 24,
-        "accuracy": 1.0,
-        "groundedness": 1.0,
-        "citation_precision": 0.8333333333333334,
-        "abstention": 1.0,
-        "latency": {
-          "p50": 1.045,
-          "p95": 1.6134999999999997,
-          "mean": 1.0941666666666667
-        },
-        "retry": 0.0,
-        "retry_cost": {
-          "total_retries": 0,
-          "mean_retry_count": 0.0,
-          "max_retry_count": 0,
-          "cases_with_retry": 0
-        },
-        "retry_reason_counts": {
-          "topic_not_grounded": 6
-        },
-        "by_query_type": {
-          "single_doc": {
-            "num_predictions": 6,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 0.75,
-            "abstention": null,
-            "latency": {
-              "p50": 1.245,
-              "p95": 1.5825,
-              "mean": 1.295
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "multi_doc": {
-            "num_predictions": 6,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 1.0,
-            "abstention": null,
-            "latency": {
-              "p50": 0.845,
-              "p95": 1.015,
-              "mean": 0.8866666666666667
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "follow_up": {
-            "num_predictions": 6,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 0.5833333333333334,
-            "abstention": null,
-            "latency": {
-              "p50": 1.1800000000000002,
-              "p95": 1.885,
-              "mean": 1.2133333333333334
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "abstention": {
-            "num_predictions": 6,
-            "accuracy": null,
-            "groundedness": 1.0,
-            "citation_precision": 1.0,
-            "abstention": 1.0,
-            "latency": {
-              "p50": 0.9099999999999999,
-              "p95": 1.425,
-              "mean": 0.9816666666666665
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {
-              "topic_not_grounded": 6
-            }
-          }
-        }
-      },
-      {
-        "name": "no_rerank",
-        "metadata_first": true,
-        "rerank": false,
-        "verifier_retry": true,
+        "retrieval_mode": "hierarchical",
         "num_predictions": 24,
         "accuracy": 1.0,
         "groundedness": 1.0,
         "citation_precision": 1.0,
         "abstention": 1.0,
         "latency": {
-          "p50": 0.98,
-          "p95": 2.0109999999999992,
-          "mean": 1.1512499999999999
+          "p50": 0.96,
+          "p95": 1.5069999999999997,
+          "mean": 1.0179166666666668
         },
         "retry": 0.25,
         "retry_cost": {
@@ -969,9 +861,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 0.835,
-              "p95": 1.1475,
-              "mean": 0.8566666666666668
+              "p50": 0.895,
+              "p95": 1.0550000000000002,
+              "mean": 0.8783333333333333
             },
             "retry": 0.0,
             "retry_cost": {
@@ -989,9 +881,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 0.95,
-              "p95": 1.4225,
-              "mean": 1.0316666666666665
+              "p50": 1.085,
+              "p95": 1.9525,
+              "mean": 1.26
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1009,9 +901,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 0.7150000000000001,
-              "p95": 3.3049999999999997,
-              "mean": 1.3
+              "p50": 0.755,
+              "p95": 0.9175,
+              "mean": 0.7666666666666667
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1029,9 +921,231 @@
             "citation_precision": 1.0,
             "abstention": 1.0,
             "latency": {
-              "p50": 1.255,
-              "p95": 1.9849999999999999,
-              "mean": 1.4166666666666667
+              "p50": 1.185,
+              "p95": 1.315,
+              "mean": 1.1666666666666667
+            },
+            "retry": 1.0,
+            "retry_cost": {
+              "total_retries": 6,
+              "mean_retry_count": 1.0,
+              "max_retry_count": 1,
+              "cases_with_retry": 6
+            },
+            "retry_reason_counts": {
+              "topic_not_grounded": 12
+            }
+          }
+        }
+      },
+      {
+        "name": "no_metadata_first",
+        "metadata_first": false,
+        "rerank": true,
+        "verifier_retry": true,
+        "retrieval_mode": "flat",
+        "num_predictions": 24,
+        "accuracy": 1.0,
+        "groundedness": 1.0,
+        "citation_precision": 0.8333333333333334,
+        "abstention": 1.0,
+        "latency": {
+          "p50": 1.225,
+          "p95": 1.76,
+          "mean": 1.3041666666666665
+        },
+        "retry": 0.0,
+        "retry_cost": {
+          "total_retries": 0,
+          "mean_retry_count": 0.0,
+          "max_retry_count": 0,
+          "cases_with_retry": 0
+        },
+        "retry_reason_counts": {
+          "topic_not_grounded": 6
+        },
+        "by_query_type": {
+          "single_doc": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 0.75,
+            "abstention": null,
+            "latency": {
+              "p50": 1.16,
+              "p95": 1.3200000000000003,
+              "mean": 1.1366666666666665
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "multi_doc": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": null,
+            "latency": {
+              "p50": 1.45,
+              "p95": 1.7425000000000002,
+              "mean": 1.4116666666666668
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "follow_up": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 0.5833333333333334,
+            "abstention": null,
+            "latency": {
+              "p50": 1.09,
+              "p95": 2.52,
+              "mean": 1.3833333333333335
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "abstention": {
+            "num_predictions": 6,
+            "accuracy": null,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": 1.0,
+            "latency": {
+              "p50": 1.2349999999999999,
+              "p95": 1.6300000000000001,
+              "mean": 1.2850000000000001
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {
+              "topic_not_grounded": 6
+            }
+          }
+        }
+      },
+      {
+        "name": "no_rerank",
+        "metadata_first": true,
+        "rerank": false,
+        "verifier_retry": true,
+        "retrieval_mode": "flat",
+        "num_predictions": 24,
+        "accuracy": 1.0,
+        "groundedness": 1.0,
+        "citation_precision": 1.0,
+        "abstention": 1.0,
+        "latency": {
+          "p50": 1.205,
+          "p95": 1.75,
+          "mean": 1.2566666666666668
+        },
+        "retry": 0.25,
+        "retry_cost": {
+          "total_retries": 6,
+          "mean_retry_count": 0.25,
+          "max_retry_count": 1,
+          "cases_with_retry": 6
+        },
+        "retry_reason_counts": {
+          "topic_not_grounded": 12
+        },
+        "by_query_type": {
+          "single_doc": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": null,
+            "latency": {
+              "p50": 1.18,
+              "p95": 1.6875,
+              "mean": 1.2149999999999999
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "multi_doc": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": null,
+            "latency": {
+              "p50": 1.155,
+              "p95": 1.2525,
+              "mean": 1.1466666666666667
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "follow_up": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": null,
+            "latency": {
+              "p50": 0.765,
+              "p95": 1.125,
+              "mean": 0.8216666666666667
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "abstention": {
+            "num_predictions": 6,
+            "accuracy": null,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": 1.0,
+            "latency": {
+              "p50": 1.56,
+              "p95": 3.085,
+              "mean": 1.8433333333333335
             },
             "retry": 1.0,
             "retry_cost": {
@@ -1051,15 +1165,16 @@
         "metadata_first": true,
         "rerank": true,
         "verifier_retry": false,
+        "retrieval_mode": "flat",
         "num_predictions": 24,
         "accuracy": 1.0,
         "groundedness": 0.75,
         "citation_precision": 0.75,
         "abstention": 0.0,
         "latency": {
-          "p50": 1.02,
-          "p95": 2.325499999999999,
-          "mean": 1.2587499999999998
+          "p50": 1.05,
+          "p95": 1.5325,
+          "mean": 1.1049999999999998
         },
         "retry": 0.0,
         "retry_cost": {
@@ -1077,9 +1192,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 1.51,
-              "p95": 3.14,
-              "mean": 1.7616666666666667
+              "p50": 1.05,
+              "p95": 1.4375,
+              "mean": 1.07
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1097,9 +1212,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 1.275,
-              "p95": 1.91,
-              "mean": 1.4116666666666668
+              "p50": 1.26,
+              "p95": 1.585,
+              "mean": 1.3100000000000003
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1117,9 +1232,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 0.845,
-              "p95": 0.9374999999999999,
-              "mean": 0.8233333333333334
+              "p50": 0.9450000000000001,
+              "p95": 1.2325,
+              "mean": 0.9733333333333333
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1137,9 +1252,9 @@
             "citation_precision": 0.0,
             "abstention": 0.0,
             "latency": {
-              "p50": 0.965,
-              "p95": 1.33,
-              "mean": 1.0383333333333333
+              "p50": 0.9450000000000001,
+              "p95": 1.45,
+              "mean": 1.0666666666666667
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1174,7 +1289,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 3.39,
+      "latency_ms": 3.19,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1199,7 +1314,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.34,
+      "latency_ms": 1.47,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1224,7 +1339,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.05,
+      "latency_ms": 0.79,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1249,7 +1364,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.92,
+      "latency_ms": 2.22,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1274,7 +1389,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.59,
+      "latency_ms": 0.69,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1299,7 +1414,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.04,
+      "latency_ms": 0.75,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1326,7 +1441,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.16,
+      "latency_ms": 1.65,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1353,7 +1468,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.3,
+      "latency_ms": 1.09,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1380,7 +1495,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.0,
+      "latency_ms": 1.11,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1407,7 +1522,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.2,
+      "latency_ms": 1.03,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1434,7 +1549,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.1,
+      "latency_ms": 1.07,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1461,7 +1576,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.98,
+      "latency_ms": 1.07,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1486,7 +1601,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.5,
+      "latency_ms": 0.57,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1511,7 +1626,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.49,
+      "latency_ms": 0.72,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1536,7 +1651,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.43,
+      "latency_ms": 0.57,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1561,7 +1676,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.61,
+      "latency_ms": 0.99,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1586,7 +1701,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.56,
+      "latency_ms": 0.76,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1611,7 +1726,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.54,
+      "latency_ms": 0.62,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "abstained": false,
@@ -1632,7 +1747,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 1.08,
+      "latency_ms": 1.45,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -1656,7 +1771,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 0.96,
+      "latency_ms": 1.46,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -1680,7 +1795,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 0.87,
+      "latency_ms": 1.06,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -1704,7 +1819,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 1.06,
+      "latency_ms": 1.3,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -1728,7 +1843,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 1.05,
+      "latency_ms": 1.99,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -1752,7 +1867,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 0.84,
+      "latency_ms": 1.35,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -9,7 +9,13 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from ingestion import load_documents_from_metadata_csv
-from rag_core import DEFAULT_EMBEDDING_MODEL, build_index_payload, build_index_payload_from_documents
+from rag_core import (
+    DEFAULT_CHUNK_MAX_CHARS,
+    DEFAULT_CHUNK_OVERLAP_SENTENCES,
+    DEFAULT_EMBEDDING_MODEL,
+    build_index_payload,
+    build_index_payload_from_documents,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,6 +43,24 @@ def parse_args() -> argparse.Namespace:
         choices=["auto", "sentence-transformers", "hashing"],
         help="Use cached sentence-transformers in auto mode; otherwise fall back to deterministic hashing.",
     )
+    parser.add_argument(
+        "--chunking_strategy",
+        default="auto",
+        choices=["auto", "section", "fixed"],
+        help="Chunk by detected sections in auto mode; use fixed fallback when structure is weak.",
+    )
+    parser.add_argument(
+        "--chunk_max_chars",
+        type=int,
+        default=DEFAULT_CHUNK_MAX_CHARS,
+        help="Maximum characters per child chunk.",
+    )
+    parser.add_argument(
+        "--chunk_overlap_sentences",
+        type=int,
+        default=DEFAULT_CHUNK_OVERLAP_SENTENCES,
+        help="Number of trailing sentences to overlap between adjacent chunks.",
+    )
     return parser.parse_args()
 
 
@@ -55,6 +79,10 @@ def validate_args(args: argparse.Namespace) -> None:
 
     if using_metadata_csv and not args.files_dir:
         raise ValueError("--files_dir is required when --metadata_csv is provided.")
+    if args.chunk_max_chars < 1:
+        raise ValueError("--chunk_max_chars must be positive.")
+    if args.chunk_overlap_sentences < 0:
+        raise ValueError("--chunk_overlap_sentences must be zero or positive.")
 
 
 def main() -> int:
@@ -72,6 +100,9 @@ def main() -> int:
                 source_dir=str(Path(args.metadata_csv)),
                 model_name=args.model,
                 embedding_backend=args.embedding_backend,
+                chunking_strategy=args.chunking_strategy,
+                chunk_max_chars=args.chunk_max_chars,
+                chunk_overlap_sentences=args.chunk_overlap_sentences,
                 message="PDF/HWP RFP index built from data_list.csv text and joined metadata.",
             )
         else:
@@ -79,6 +110,9 @@ def main() -> int:
                 Path(args.input_dir),
                 model_name=args.model,
                 embedding_backend=args.embedding_backend,
+                chunking_strategy=args.chunking_strategy,
+                chunk_max_chars=args.chunk_max_chars,
+                chunk_overlap_sentences=args.chunk_overlap_sentences,
             )
     except Exception as exc:
         print(f"[ERROR] Index build failed: {exc}", file=sys.stderr)

--- a/scripts/update_readme_metrics.py
+++ b/scripts/update_readme_metrics.py
@@ -100,8 +100,8 @@ def render_ablation_table(summary: Dict[str, Any]) -> str:
     table = [
         "### Ablation comparison",
         "",
-        "| Run | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Abstention | Retry | Latency p95 |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| Run | Retrieval | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Abstention | Retry | Latency p95 |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for run in runs:
         if not isinstance(run, dict):
@@ -110,8 +110,9 @@ def render_ablation_table(summary: Dict[str, Any]) -> str:
         p95 = latency.get("p95") if isinstance(latency, dict) else None
         p95_text = f"{p95:.1f}ms" if isinstance(p95, (int, float)) else "N/A"
         table.append(
-            "| {name} | {metadata_first} | {rerank} | {verifier_retry} | {accuracy} | {groundedness} | {citation} | {abstention} | {retry} | {p95} |".format(
+            "| {name} | {retrieval} | {metadata_first} | {rerank} | {verifier_retry} | {accuracy} | {groundedness} | {citation} | {abstention} | {retry} | {p95} |".format(
                 name=run.get("name", "unknown"),
+                retrieval=run.get("retrieval_mode", "flat"),
                 metadata_first=fmt_flag(run.get("metadata_first")),
                 rerank=fmt_flag(run.get("rerank")),
                 verifier_retry=fmt_flag(run.get("verifier_retry")),

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -23,6 +23,21 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
             result["plan"]["metadata_filters"]["doc_ids"],
         )
 
+    def test_section_metadata_is_stored_on_chunks_and_evidence(self) -> None:
+        chunk = self.index["chunks"][0]
+
+        self.assertEqual("section", chunk["chunking_strategy"])
+        self.assertEqual(["사업 개요"], chunk["section_path"])
+        self.assertEqual(1, chunk["chunk_seq_in_section"])
+        self.assertTrue(chunk["section_id"].startswith("rfp-agency-a-ai-quality::section-"))
+
+        result = run_rag_query(self.index, "기관 A의 보안 통제 요구사항은?")
+        evidence = result["evidence"][0]
+
+        self.assertEqual(["AI 요구사항"], evidence["section_path"])
+        self.assertEqual(evidence["section_id"], evidence["parent_section_id"])
+        self.assertEqual("section", evidence["chunking_strategy"])
+
     def test_abbreviation_query_keeps_both_comparison_sides(self) -> None:
         result = run_rag_query(self.index, "A와 B의 AI 요구사항 차이 알려줘")
 
@@ -92,6 +107,79 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
             {"alpha-research", "alpha-regional"},
             set(result["plan"]["metadata_filters"]["doc_ids"]),
         )
+
+    def test_auto_chunking_uses_fixed_fallback_for_weak_structure(self) -> None:
+        fallback_index = build_index_payload_from_documents(
+            [
+                {
+                    "doc_id": "single-body",
+                    "title": "단일 본문 RFP",
+                    "agency": "기관 S",
+                    "project": "단일 본문 사업",
+                    "metadata": {},
+                    "sections": [
+                        {
+                            "heading": "본문",
+                            "text": "보안 로그를 남긴다. 운영 리포트를 제출한다.",
+                        }
+                    ],
+                    "source_path": "single-body.txt",
+                }
+            ],
+            source_dir="test-fixture",
+            embedding_backend="hashing",
+        )
+
+        self.assertEqual(
+            {"fixed": 1},
+            fallback_index["build"]["chunking"]["actual_strategy_counts"],
+        )
+        self.assertEqual("fixed", fallback_index["chunks"][0]["chunking_strategy"])
+        self.assertEqual(["문서 전체"], fallback_index["chunks"][0]["section_path"])
+
+    def test_hierarchical_retrieval_reassembles_parent_section(self) -> None:
+        long_section_index = build_index_payload_from_documents(
+            [
+                {
+                    "doc_id": "section-parent",
+                    "title": "부모 섹션 테스트 RFP",
+                    "agency": "기관 P",
+                    "project": "부모 섹션 사업",
+                    "metadata": {},
+                    "sections": [
+                        {
+                            "heading": "보안 요구사항",
+                            "text": (
+                                "보안 로그는 모든 관리자 작업에 대해 남겨야 한다. "
+                                "접근 권한은 역할별로 분리한다. "
+                                "운영 리포트는 매월 제출한다."
+                            ),
+                        }
+                    ],
+                    "source_path": "section-parent.txt",
+                }
+            ],
+            source_dir="test-fixture",
+            embedding_backend="hashing",
+            chunking_strategy="section",
+            chunk_max_chars=45,
+            chunk_overlap_sentences=0,
+        )
+
+        flat = run_rag_query(long_section_index, "기관 P의 보안 로그 요구사항은?", top_k=1)
+        hierarchical = run_rag_query(
+            long_section_index,
+            "기관 P의 보안 로그 요구사항은?",
+            top_k=1,
+            retrieval_mode="hierarchical",
+        )
+
+        self.assertEqual("flat", flat["diagnostics"]["retrieval_mode"])
+        self.assertEqual("hierarchical", hierarchical["diagnostics"]["retrieval_mode"])
+        self.assertEqual("hierarchical", hierarchical["evidence"][0]["retrieval_mode"])
+        self.assertGreater(len(hierarchical["evidence"][0]["text"]), len(flat["evidence"][0]["text"]))
+        self.assertIn("운영 리포트", hierarchical["evidence"][0]["text"])
+        self.assertTrue(hierarchical["evidence"][0]["child_chunk_ids"])
 
     def test_retry_relaxes_filters_when_verifier_rejects_evidence(self) -> None:
         result = run_rag_query(self.index, "기관 A의 블록체인 납품 실적은?")

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -106,7 +106,11 @@ class MetadataCsvIngestionTest(unittest.TestCase):
 
             self.assertEqual(2, payload["build"]["num_documents"])
             self.assertGreater(payload["build"]["num_chunks"], 2)
+            self.assertEqual({"fixed": 2}, payload["build"]["chunking"]["actual_strategy_counts"])
+            self.assertEqual(2, len(payload["parent_sections"]))
             self.assertTrue(all("metadata" in chunk for chunk in payload["chunks"]))
+            self.assertTrue(all("section_path" in chunk for chunk in payload["chunks"]))
+            self.assertTrue(all("chunking_strategy" in chunk for chunk in payload["chunks"]))
             self.assertTrue(all(len(chunk["text"]) <= 520 for chunk in payload["chunks"]))
             self.assertEqual("202400001", payload["chunks"][0]["metadata"]["notice_id"])
 


### PR DESCRIPTION
## Summary
- Add section-aware chunk metadata with auto/fixed fallback chunking
- Add optional hierarchical retrieval and wire it through CLI and eval config
- Update diagnostics, docs, and regenerated index/report artifacts

## Testing
- Added unit tests covering chunk metadata, fixed fallback, and hierarchical retrieval behavior
- Ran the test suite locally with the updated retrieval and ingestion paths