### PR TITLE
후속 질문용 대화 상태와 세션 저장을 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,17 @@
 | Follow-up | Answer Accuracy | 1.000 |
 | Evidence | Citation Precision | 1.000 |
 | Abstention | Abstention Accuracy | 1.000 |
-| System | Latency (p50/p95) | p50 1.0ms / p95 1.3ms |
-| System | Retry Rate | 0.250 |
+| System | Latency (p50/p95) | p50 1.4ms / p95 3.6ms |
+| System | Retry Rate | 0.231 |
 
 ### Ablation comparison
 
 | Run | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Abstention | Retry | Latency p95 |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| full | on | on | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 1.3ms |
-| no_metadata_first | off | on | on | 1.000 | 1.000 | 0.833 | 1.000 | 0.000 | 1.6ms |
-| no_rerank | on | off | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 2.0ms |
-| no_verifier_retry | on | on | off | 1.000 | 0.750 | 0.750 | 0.000 | 0.000 | 2.3ms |
+| full | on | on | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 3.6ms |
+| no_metadata_first | off | on | on | 1.000 | 1.000 | 0.846 | 1.000 | 0.000 | 3.0ms |
+| no_rerank | on | off | on | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 2.8ms |
+| no_verifier_retry | on | on | off | 1.000 | 0.769 | 0.769 | 0.143 | 0.000 | 2.4ms |
 <!-- METRICS_TABLE:END -->
 
 > 주의: 성능표는 공개 synthetic RFP 평가셋 기준입니다. 원본 RFP 데이터는 비공개 제약으로 저장소에 포함하지 않았습니다.
@@ -124,6 +124,23 @@ python3 scripts/build_index.py --input_dir data/raw --output_dir data/index
 ### 3) 질의 실행
 ```bash
 python3 app.py --input_dir data/index --output_dir outputs --query "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
+```
+
+후속 질문을 재현하려면 세션 상태 파일을 명시적으로 지정합니다. 상태에는 현재 활성 agency/project/topic/doc id와 최근 턴 요약이 JSON으로 저장되며, 생략된 참조가 모호하면 답을 추정하지 않고 clarification 응답으로 중단합니다.
+
+```bash
+python3 app.py \
+  --input_dir data/index \
+  --output_dir outputs \
+  --query "기관 A의 AI 요구사항은?" \
+  --session_state outputs/session_state.json \
+  --reset_session
+
+python3 app.py \
+  --input_dir data/index \
+  --output_dir outputs \
+  --query "그 기관이 요구한 보안 조건도 보여줘" \
+  --session_state outputs/session_state.json
 ```
 
 ### 4) 평가 실행

--- a/app.py
+++ b/app.py
@@ -19,6 +19,16 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="Comma-separated entities for follow-up questions, e.g. '기관 A'.",
     )
+    parser.add_argument(
+        "--session_state",
+        default=None,
+        help="Optional JSON file used to persist conversational entity state across runs.",
+    )
+    parser.add_argument(
+        "--reset_session",
+        action="store_true",
+        help="Start with an empty conversational state before saving --session_state.",
+    )
     return parser.parse_args()
 
 
@@ -35,16 +45,29 @@ def parse_context_entities(value: str) -> list[str]:
     return [part.strip() for part in value.split(",") if part.strip()]
 
 
+def load_session_state(path: Path, reset: bool = False) -> dict:
+    if reset or not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"--session_state must contain a JSON object: {path}")
+    return data
+
+
 def main() -> int:
     try:
         args = parse_args()
         validate_args(args)
         index = load_index(Path(args.input_dir))
+        session_state = None
+        if args.session_state:
+            session_state = load_session_state(Path(args.session_state), reset=args.reset_session)
         answer = run_rag_query(
             index,
             args.query,
             top_k=args.top_k,
             context_entities=parse_context_entities(args.context_entities),
+            conversation_state=session_state,
         )
     except Exception as exc:
         print(f"[ERROR] RAG query failed: {exc}", file=sys.stderr)
@@ -55,6 +78,15 @@ def main() -> int:
     out_path = out_dir / "answer.json"
     out_path.write_text(json.dumps(answer, ensure_ascii=False, indent=2), encoding="utf-8")
     print(f"[OK] Answer written: {out_path}")
+
+    if args.session_state:
+        session_path = Path(args.session_state)
+        session_path.parent.mkdir(parents=True, exist_ok=True)
+        session_path.write_text(
+            json.dumps(answer.get("conversation_state", {}), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"[OK] Session state written: {session_path}")
 
     if args.config:
         print("[INFO] --config is accepted for interface consistency but unused here.")

--- a/docs/failure-cases.md
+++ b/docs/failure-cases.md
@@ -12,3 +12,8 @@
 - 공개본에서는 agency/project/title metadata를 정규화해 exact/partial/fuzzy 후보를 확장한다.
 - verifier가 topic/entity/doc coverage를 확인하고 실패 시 strict → reduced → relaxed 단계로 metadata filter를 완화한다.
 - retrieval diagnostics에는 단계별 filter, 후보 수, 검증 실패 사유를 남겨 metadata mismatch를 추적한다.
+
+## 후속 질문 문맥 해석 예시
+- 성공 예시: `기관 A의 AI 요구사항은?` 이후 `그 기관이 요구한 보안 조건도 보여줘`는 session state의 `active_agencies=["기관 A"]`, `active_doc_ids=["rfp-agency-a-ai-quality"]`를 사용해 `기관 A 그 기관이 요구한 보안 조건도 보여줘`로 해석한다.
+- 실패 방지 예시: `기관 A와 기관 B의 보안 요구사항 차이를 비교해줘` 이후 `그 기관의 보안 조건은?`은 활성 기관이 둘이라 `ambiguous_active_state`로 clarification 처리한다.
+- 한계: session state는 명시한 JSON 파일 안에서만 유지된다. 파일을 지정하지 않거나 `--reset_session`을 사용하면 이전 턴은 이어지지 않는다.

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -283,6 +283,30 @@ cases:
       - "사용자 만족도"
     answerable: true
 
+  - id: follow_up_state_a_security
+    query_type: follow_up
+    prior_turns:
+      - query: "기관 A의 AI 요구사항은?"
+    query: "그 기관이 요구한 보안 조건도 보여줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "보안 통제"
+      - "로그"
+    expected_citation_terms:
+      - "보안 통제"
+      - "로그"
+    answerable: true
+
+  - id: follow_up_state_ambiguous_clarification
+    query_type: follow_up
+    prior_turns:
+      - query: "기관 A와 기관 B의 보안 요구사항 차이를 비교해줘"
+    query: "그 기관의 보안 조건은?"
+    expected_doc_ids: []
+    expected_terms: []
+    answerable: false
+
   - id: abstention_missing_blockchain
     query_type: abstention
     query: "기관 A의 블록체인 납품 실적은?"

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -47,6 +47,12 @@ def load_config(path: Path) -> dict[str, Any]:
         query_type = case.get("query_type")
         if query_type not in QUERY_TYPES:
             raise ValueError(f"Eval case must include query_type in {QUERY_TYPES}: {case.get('id')}")
+        prior_turns = case.get("prior_turns") or []
+        if not isinstance(prior_turns, list):
+            raise ValueError(f"Eval case prior_turns must be a list: {case.get('id')}")
+        for turn in prior_turns:
+            if not isinstance(turn, dict) or not str(turn.get("query") or "").strip():
+                raise ValueError(f"Each prior turn must include a query: {case.get('id')}")
 
     runs = data.get("ablation_runs", DEFAULT_ABLATION_RUNS)
     if not isinstance(runs, list) or not runs:
@@ -91,6 +97,7 @@ def score_case(case: dict[str, Any], prediction: dict[str, Any]) -> dict[str, An
     combined_text = " ".join([answer, evidence_text])
     diagnostics = prediction.get("diagnostics") or {}
     abstained = bool(diagnostics.get("abstained"))
+    context_resolution = diagnostics.get("context_resolution") or {}
 
     citation_doc_precision = 0.0
     if evidence_doc_ids:
@@ -134,6 +141,11 @@ def score_case(case: dict[str, Any], prediction: dict[str, Any]) -> dict[str, An
         "latency_ms": diagnostics.get("latency_ms"),
         "retry_count": diagnostics.get("retry_count", 0),
         "retry_trigger_reasons": retry_trigger_reasons(prediction),
+        "context_resolution_status": context_resolution.get("status"),
+        "context_resolution_source": context_resolution.get("source"),
+        "context_resolution_confidence": context_resolution.get("confidence"),
+        "context_resolution_reason": context_resolution.get("reason"),
+        "resolved_query": prediction.get("resolved_query"),
         "abstained": abstained,
         "answer": answer,
     }
@@ -209,6 +221,19 @@ def evaluate_run(
 ) -> list[dict[str, Any]]:
     case_results = []
     for case in cases:
+        conversation_state: dict[str, Any] = {}
+        for turn in case.get("prior_turns") or []:
+            prior_prediction = run_rag_query(
+                index,
+                str(turn["query"]),
+                context_entities=turn.get("context_entities") or [],
+                metadata_first=bool(run_config.get("metadata_first", True)),
+                rerank=bool(run_config.get("rerank", True)),
+                verifier_retry=bool(run_config.get("verifier_retry", True)),
+                conversation_state=conversation_state,
+            )
+            conversation_state = prior_prediction.get("conversation_state") or conversation_state
+
         prediction = run_rag_query(
             index,
             str(case["query"]),
@@ -216,6 +241,7 @@ def evaluate_run(
             metadata_first=bool(run_config.get("metadata_first", True)),
             rerank=bool(run_config.get("rerank", True)),
             verifier_retry=bool(run_config.get("verifier_retry", True)),
+            conversation_state=conversation_state,
         )
         case_results.append(score_case(case, prediction))
     return case_results

--- a/rag_core.py
+++ b/rag_core.py
@@ -32,6 +32,7 @@ SENTENCE_RE = re.compile(r"(?<=[.!?。])\s+")
 
 STOPWORDS = {
     "그럼",
+    "그",
     "그리고",
     "어떻게",
     "알려줘",
@@ -42,14 +43,18 @@ STOPWORDS = {
     "비교해줘",
     "기관",
     "요구",
+    "요구한",
     "요구가",
     "요구사항",
+    "조건",
+    "조건도",
     "기능",
     "목표",
     "성능",
     "초점",
     "필수",
     "그중",
+    "보여줘",
     "어떤",
     "누가",
     "포함돼야",
@@ -113,6 +118,24 @@ TOPIC_KEYWORDS = [
 STRICT_METADATA_CONFIDENCE = 0.90
 REDUCED_METADATA_CONFIDENCE = 0.70
 AMBIGUOUS_CONFIDENCE_DELTA = 0.05
+CONVERSATION_STATE_SCHEMA_VERSION = 1
+MAX_CONVERSATION_TURNS = 12
+CONTEXT_RESOLUTION_THRESHOLD = 0.70
+
+IMPLICIT_REFERENCE_PATTERNS = (
+    "그 기관",
+    "그 사업",
+    "그 시스템",
+    "그 문서",
+    "그 프로젝트",
+    "해당 기관",
+    "해당 사업",
+    "해당 시스템",
+    "이 기관",
+    "이 사업",
+    "그럼",
+    "그중",
+)
 
 METADATA_GENERIC_TOKENS = {
     "rfp",
@@ -191,6 +214,48 @@ def ordered_unique(values: Iterable[str]) -> list[str]:
             seen.add(value)
             ordered.append(value)
     return ordered
+
+
+def coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return ordered_unique(str(item).strip() for item in value if str(item).strip())
+
+
+def empty_conversation_state() -> dict[str, Any]:
+    return {
+        "schema_version": CONVERSATION_STATE_SCHEMA_VERSION,
+        "active_agencies": [],
+        "active_projects": [],
+        "active_topics": [],
+        "active_doc_ids": [],
+        "confidence": 0.0,
+        "turns": [],
+    }
+
+
+def normalize_conversation_state(state: dict[str, Any] | None) -> dict[str, Any]:
+    normalized = empty_conversation_state()
+    if not isinstance(state, dict):
+        return normalized
+
+    normalized["schema_version"] = int(
+        state.get("schema_version") or CONVERSATION_STATE_SCHEMA_VERSION
+    )
+    normalized["active_agencies"] = coerce_string_list(state.get("active_agencies"))
+    normalized["active_projects"] = coerce_string_list(state.get("active_projects"))
+    normalized["active_topics"] = coerce_string_list(state.get("active_topics"))
+    normalized["active_doc_ids"] = coerce_string_list(state.get("active_doc_ids"))
+    try:
+        normalized["confidence"] = round(float(state.get("confidence") or 0.0), 3)
+    except (TypeError, ValueError):
+        normalized["confidence"] = 0.0
+
+    turns = state.get("turns") if isinstance(state.get("turns"), list) else []
+    normalized["turns"] = [
+        turn for turn in turns[-MAX_CONVERSATION_TURNS:] if isinstance(turn, dict)
+    ]
+    return normalized
 
 
 def tokenize(text: str) -> list[str]:
@@ -747,6 +812,140 @@ def is_metadata_ambiguous(matches: list[dict[str, Any]], query_type: str) -> boo
     return len(close_doc_ids) > 1
 
 
+def has_implicit_reference(query: str) -> bool:
+    normalized_query = normalize_entity(query)
+    return any(pattern in normalized_query for pattern in IMPLICIT_REFERENCE_PATTERNS)
+
+
+def has_comparison_request(query: str) -> bool:
+    comparison_terms = ("차이", "비교", "각각", "대비")
+    return any(term in normalize_entity(query) for term in comparison_terms)
+
+
+def active_state_terms(state: dict[str, Any]) -> list[str]:
+    terms = state.get("active_agencies") or state.get("active_projects") or []
+    if terms:
+        return coerce_string_list(terms)
+    return coerce_string_list(state.get("active_doc_ids"))
+
+
+def active_state_size(state: dict[str, Any]) -> int:
+    return max(
+        len(state.get("active_agencies") or []),
+        len(state.get("active_projects") or []),
+        len(state.get("active_doc_ids") or []),
+    )
+
+
+def make_context_resolution(
+    status: str,
+    source: str,
+    confidence: float,
+    reason: str = "",
+    resolved_query: str | None = None,
+    context_entities: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "source": source,
+        "confidence": round(float(confidence), 3),
+        "reason": reason,
+        "resolved_query": resolved_query,
+        "context_entities": context_entities or [],
+    }
+
+
+def resolve_conversation_context(
+    query: str,
+    initial_analysis: dict[str, Any],
+    conversation_state: dict[str, Any],
+    context_entities: list[str] | None = None,
+) -> tuple[str, list[str], dict[str, Any]]:
+    explicit_context = coerce_string_list(context_entities or [])
+    if explicit_context:
+        return (
+            query,
+            explicit_context,
+            make_context_resolution(
+                "resolved",
+                "context_entities",
+                1.0,
+                resolved_query=query,
+                context_entities=explicit_context,
+            ),
+        )
+
+    if initial_analysis.get("matched_doc_ids"):
+        return (
+            query,
+            [],
+            make_context_resolution("not_needed", "query", 1.0, resolved_query=query),
+        )
+
+    if not has_implicit_reference(query):
+        return (
+            query,
+            [],
+            make_context_resolution("not_needed", "none", 0.0, resolved_query=query),
+        )
+
+    state_terms = active_state_terms(conversation_state)
+    if not state_terms:
+        return (
+            query,
+            [],
+            make_context_resolution(
+                "needs_clarification",
+                "conversation_state",
+                0.0,
+                reason="no_active_state",
+                resolved_query=query,
+            ),
+        )
+
+    state_confidence = float(conversation_state.get("confidence") or 0.0)
+    if state_confidence < CONTEXT_RESOLUTION_THRESHOLD:
+        return (
+            query,
+            [],
+            make_context_resolution(
+                "needs_clarification",
+                "conversation_state",
+                state_confidence,
+                reason="weak_active_state",
+                resolved_query=query,
+                context_entities=state_terms,
+            ),
+        )
+
+    if active_state_size(conversation_state) > 1 and not has_comparison_request(query):
+        return (
+            query,
+            [],
+            make_context_resolution(
+                "needs_clarification",
+                "conversation_state",
+                state_confidence,
+                reason="ambiguous_active_state",
+                resolved_query=query,
+                context_entities=state_terms,
+            ),
+        )
+
+    resolved_query = " ".join([*state_terms, query])
+    return (
+        resolved_query,
+        state_terms,
+        make_context_resolution(
+            "resolved",
+            "conversation_state",
+            state_confidence,
+            resolved_query=resolved_query,
+            context_entities=state_terms,
+        ),
+    )
+
+
 def analyze_query(
     query: str,
     entities: list[Any],
@@ -1131,6 +1330,143 @@ def summarize_stage_attempt(
     }
 
 
+def clarification_answer(query: str, context_resolution: dict[str, Any]) -> str:
+    reason = context_resolution.get("reason")
+    if reason == "no_active_state":
+        return (
+            f"'{query}'는 이전 문맥의 기관이나 사업을 확인해야 답할 수 있습니다. "
+            "기관명 또는 사업명을 포함해 다시 질문해 주세요."
+        )
+    if reason == "ambiguous_active_state":
+        entities = ", ".join(context_resolution.get("context_entities") or [])
+        return (
+            f"'{query}'에서 가리키는 대상이 모호합니다. "
+            f"현재 문맥 후보는 {entities}입니다. 기관명 또는 사업명을 하나로 지정해 주세요."
+        )
+    return (
+        f"'{query}'의 생략된 참조를 충분히 확정하지 못했습니다. "
+        "기관명 또는 사업명을 포함해 다시 질문해 주세요."
+    )
+
+
+def make_context_clarification_result(
+    index: dict[str, Any],
+    query: str,
+    analysis: dict[str, Any],
+    conversation_state: dict[str, Any],
+    context_resolution: dict[str, Any],
+    started: float,
+    metadata_first: bool,
+    rerank: bool,
+    verifier_retry: bool,
+) -> dict[str, Any]:
+    reason = str(context_resolution.get("reason") or "context_resolution_failed")
+    analysis = dict(analysis)
+    analysis["query_type"] = "follow_up"
+    analysis["context_resolution"] = context_resolution
+    latency_ms = (time.perf_counter() - started) * 1000
+    return {
+        "mode": "rag",
+        "query": query,
+        "resolved_query": context_resolution.get("resolved_query") or query,
+        "analysis": analysis,
+        "plan": {
+            "strategy": "conversation-state clarification",
+            "metadata_first": metadata_first,
+            "rerank": rerank,
+            "verifier_retry": verifier_retry,
+            "metadata_filters": {},
+            "top_k": None,
+            "relaxed": False,
+            "retry_policy": "clarify before retrieval when entity resolution is weak",
+        },
+        "answer": clarification_answer(query, context_resolution),
+        "evidence": [],
+        "conversation_state": conversation_state,
+        "diagnostics": {
+            "latency_ms": round(latency_ms, 2),
+            "retry_count": 0,
+            "abstained": True,
+            "verification_reasons": [reason],
+            "filter_stage_attempts": [],
+            "final_relaxation_reason": [],
+            "context_resolution": context_resolution,
+            "embedding_backend": index.get("embedding", {}).get("backend"),
+            "embedding_model": index.get("embedding", {}).get("model"),
+            "metadata_first": metadata_first,
+            "rerank": rerank,
+            "verifier_retry": verifier_retry,
+        },
+    }
+
+
+def update_conversation_state(
+    conversation_state: dict[str, Any],
+    original_query: str,
+    resolved_query: str,
+    analysis: dict[str, Any],
+    evidence: list[dict[str, Any]],
+    context_resolution: dict[str, Any],
+) -> dict[str, Any]:
+    active_doc_ids = ordered_unique(
+        [
+            *coerce_string_list(analysis.get("matched_doc_ids")),
+            *(item.get("doc_id", "") for item in evidence),
+        ]
+    )
+    active_agencies = ordered_unique(
+        [
+            *coerce_string_list(analysis.get("entities")),
+            *(item.get("agency", "") for item in evidence),
+        ]
+    )
+    active_projects = ordered_unique(
+        [
+            *coerce_string_list(analysis.get("matched_projects")),
+            *(item.get("project", "") for item in evidence),
+        ]
+    )
+    active_topics = coerce_string_list(analysis.get("topics"))
+
+    if not (active_doc_ids or active_agencies or active_projects):
+        return conversation_state
+
+    metadata_confidence = float(analysis.get("metadata_confidence") or 0.0)
+    resolution_confidence = float(context_resolution.get("confidence") or 0.0)
+    confidence = max(metadata_confidence, resolution_confidence, 0.85)
+    if analysis.get("metadata_ambiguous"):
+        confidence = min(confidence, 0.65)
+
+    turns = list(conversation_state.get("turns") or [])
+    turns.append(
+        {
+            "turn": len(turns) + 1,
+            "query": original_query,
+            "resolved_query": resolved_query,
+            "active_agencies": active_agencies,
+            "active_projects": active_projects,
+            "active_topics": active_topics,
+            "active_doc_ids": active_doc_ids,
+            "context_resolution": {
+                "status": context_resolution.get("status"),
+                "source": context_resolution.get("source"),
+                "confidence": context_resolution.get("confidence"),
+                "reason": context_resolution.get("reason", ""),
+            },
+        }
+    )
+
+    return {
+        "schema_version": CONVERSATION_STATE_SCHEMA_VERSION,
+        "active_agencies": active_agencies,
+        "active_projects": active_projects,
+        "active_topics": active_topics,
+        "active_doc_ids": active_doc_ids,
+        "confidence": round(float(confidence), 3),
+        "turns": turns[-MAX_CONVERSATION_TURNS:],
+    }
+
+
 def run_rag_query(
     index: dict[str, Any],
     query: str,
@@ -1139,9 +1475,40 @@ def run_rag_query(
     metadata_first: bool = True,
     rerank: bool = True,
     verifier_retry: bool = True,
+    conversation_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     started = time.perf_counter()
-    analysis = analyze_query(query, metadata_targets(index), context_entities=context_entities)
+    state = normalize_conversation_state(conversation_state)
+    targets = metadata_targets(index)
+    initial_analysis = analyze_query(query, targets)
+    retrieval_query, effective_context_entities, context_resolution = resolve_conversation_context(
+        query,
+        initial_analysis,
+        state,
+        context_entities=context_entities,
+    )
+    if context_resolution["status"] == "needs_clarification":
+        return make_context_clarification_result(
+            index,
+            query,
+            initial_analysis,
+            state,
+            context_resolution,
+            started,
+            metadata_first,
+            rerank,
+            verifier_retry,
+        )
+
+    analysis = analyze_query(
+        retrieval_query,
+        targets,
+        context_entities=effective_context_entities,
+    )
+    if context_resolution["source"] in {"conversation_state", "context_entities"}:
+        analysis["query_type"] = "follow_up"
+        analysis["context_used"] = True
+    analysis["context_resolution"] = context_resolution
     stage_sequence = metadata_stage_sequence(
         analysis,
         metadata_first=metadata_first,
@@ -1166,7 +1533,7 @@ def run_rag_query(
             rerank=rerank,
             verifier_retry=verifier_retry,
         )
-        evidence = retrieve(index, query, analysis, plan)
+        evidence = retrieve(index, retrieval_query, analysis, plan)
         if verifier_retry:
             verified, verification_reasons = verify_evidence(analysis, evidence)
         else:
@@ -1182,15 +1549,25 @@ def run_rag_query(
         evidence = []
     else:
         evidence = select_supporting_evidence(analysis, evidence)
+        state = update_conversation_state(
+            state,
+            query,
+            retrieval_query,
+            analysis,
+            evidence,
+            context_resolution,
+        )
     answer, abstained = generate_answer(query, analysis, evidence, verified)
     latency_ms = (time.perf_counter() - started) * 1000
     return {
         "mode": "rag",
         "query": query,
+        "resolved_query": retrieval_query,
         "analysis": analysis,
         "plan": plan,
         "answer": answer,
         "evidence": strip_internal_scores(evidence),
+        "conversation_state": state,
         "diagnostics": {
             "latency_ms": round(latency_ms, 2),
             "retry_count": retry_count,
@@ -1198,6 +1575,7 @@ def run_rag_query(
             "verification_reasons": verification_reasons,
             "filter_stage_attempts": stage_attempts,
             "final_relaxation_reason": stage_attempts[-2]["verification_reasons"] if retry_count else [],
+            "context_resolution": context_resolution,
             "embedding_backend": index.get("embedding", {}).get("backend"),
             "embedding_model": index.get("embedding", {}).get("model"),
             "metadata_first": metadata_first,

--- a/reports/eval_summary.json
+++ b/reports/eval_summary.json
@@ -2,17 +2,17 @@
   "mode": "rag",
   "config": "eval/config.yaml",
   "index_dir": "data/index",
-  "num_predictions": 24,
+  "num_predictions": 26,
   "accuracy": 1.0,
   "groundedness": 1.0,
   "citation_precision": 1.0,
   "abstention": 1.0,
   "latency": {
-    "p50": 0.99,
-    "p95": 1.3339999999999999,
-    "mean": 1.0024999999999997
+    "p50": 1.42,
+    "p95": 3.5525,
+    "mean": 1.7780769230769233
   },
-  "retry": 0.25,
+  "retry": 0.23076923076923078,
   "by_query_type": {
     "single_doc": {
       "num_predictions": 6,
@@ -21,9 +21,9 @@
       "citation_precision": 1.0,
       "abstention": null,
       "latency": {
-        "p50": 1.045,
-        "p95": 2.8775,
-        "mean": 1.3883333333333334
+        "p50": 1.625,
+        "p95": 5.51,
+        "mean": 2.4699999999999998
       },
       "retry": 0.0,
       "retry_cost": {
@@ -41,9 +41,9 @@
       "citation_precision": 1.0,
       "abstention": null,
       "latency": {
-        "p50": 1.13,
-        "p95": 1.2750000000000001,
-        "mean": 1.1233333333333333
+        "p50": 2.03,
+        "p95": 3.42,
+        "mean": 2.183333333333333
       },
       "retry": 0.0,
       "retry_cost": {
@@ -55,15 +55,15 @@
       "retry_reason_counts": {}
     },
     "follow_up": {
-      "num_predictions": 6,
+      "num_predictions": 8,
       "accuracy": 1.0,
       "groundedness": 1.0,
       "citation_precision": 1.0,
-      "abstention": null,
+      "abstention": 1.0,
       "latency": {
-        "p50": 0.52,
-        "p95": 0.5975,
-        "mean": 0.5216666666666666
+        "p50": 1.0050000000000001,
+        "p95": 1.7759999999999998,
+        "mean": 1.0975
       },
       "retry": 0.0,
       "retry_cost": {
@@ -81,9 +81,9 @@
       "citation_precision": 1.0,
       "abstention": 1.0,
       "latency": {
-        "p50": 1.005,
-        "p95": 1.0750000000000002,
-        "mean": 0.9766666666666667
+        "p50": 1.445,
+        "p95": 2.145,
+        "mean": 1.5883333333333336
       },
       "retry": 1.0,
       "retry_cost": {
@@ -99,7 +99,7 @@
   },
   "retry_cost": {
     "total_retries": 6,
-    "mean_retry_count": 0.25,
+    "mean_retry_count": 0.23076923076923078,
     "max_retry_count": 1,
     "cases_with_retry": 6
   },
@@ -113,20 +113,20 @@
         "metadata_first": true,
         "rerank": true,
         "verifier_retry": true,
-        "num_predictions": 24,
+        "num_predictions": 26,
         "accuracy": 1.0,
         "groundedness": 1.0,
         "citation_precision": 1.0,
         "abstention": 1.0,
         "latency": {
-          "p50": 0.99,
-          "p95": 1.3339999999999999,
-          "mean": 1.0024999999999997
+          "p50": 1.42,
+          "p95": 3.5525,
+          "mean": 1.7780769230769233
         },
-        "retry": 0.25,
+        "retry": 0.23076923076923078,
         "retry_cost": {
           "total_retries": 6,
-          "mean_retry_count": 0.25,
+          "mean_retry_count": 0.23076923076923078,
           "max_retry_count": 1,
           "cases_with_retry": 6
         },
@@ -141,9 +141,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 1.045,
-              "p95": 2.8775,
-              "mean": 1.3883333333333334
+              "p50": 1.625,
+              "p95": 5.51,
+              "mean": 2.4699999999999998
             },
             "retry": 0.0,
             "retry_cost": {
@@ -161,9 +161,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 1.13,
-              "p95": 1.2750000000000001,
-              "mean": 1.1233333333333333
+              "p50": 2.03,
+              "p95": 3.42,
+              "mean": 2.183333333333333
             },
             "retry": 0.0,
             "retry_cost": {
@@ -175,15 +175,15 @@
             "retry_reason_counts": {}
           },
           "follow_up": {
-            "num_predictions": 6,
+            "num_predictions": 8,
             "accuracy": 1.0,
             "groundedness": 1.0,
             "citation_precision": 1.0,
-            "abstention": null,
+            "abstention": 1.0,
             "latency": {
-              "p50": 0.52,
-              "p95": 0.5975,
-              "mean": 0.5216666666666666
+              "p50": 1.0050000000000001,
+              "p95": 1.7759999999999998,
+              "mean": 1.0975
             },
             "retry": 0.0,
             "retry_cost": {
@@ -201,9 +201,9 @@
             "citation_precision": 1.0,
             "abstention": 1.0,
             "latency": {
-              "p50": 1.005,
-              "p95": 1.0750000000000002,
-              "mean": 0.9766666666666667
+              "p50": 1.445,
+              "p95": 2.145,
+              "mean": 1.5883333333333336
             },
             "retry": 1.0,
             "retry_cost": {
@@ -237,9 +237,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 3.39,
+            "latency_ms": 6.35,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A의 보안 통제 요구사항은?",
             "abstained": false,
             "answer": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004]"
           },
@@ -262,9 +267,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.34,
+            "latency_ms": 2.99,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 C의 챗봇 응답 시간 목표는?",
             "abstained": false,
             "answer": "챗봇은 주요 문의에 대해 평균 2초 이내 응답해야 한다. [rfp-agency-c-chatbot::chunk-002] 기관 C는 고객지원 챗봇 고도화를 추진한다. [rfp-agency-c-chatbot::chunk-001]"
           },
@@ -287,9 +297,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.05,
+            "latency_ms": 1.13,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 B의 개인정보 보안 요구사항은?",
             "abstained": false,
             "answer": "기관 B는 개인정보 비식별화와 접근 권한 분리를 요구한다. [rfp-agency-b-mlops-governance::chunk-003]"
           },
@@ -312,9 +327,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.92,
+            "latency_ms": 2.09,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "공통 제출조건에서 모든 제안사가 제출해야 하는 것은?",
             "abstained": false,
             "answer": "모든 제안사는 일정 준수 계획, 위험 관리 방안, 산출물 품질 검수 절차를 제출해야 한다. [rfp-common-submission::chunk-001] 공통 평가는 요구사항 이해도, 근거 기반 실행 계획, 보안 및 운영 리스크 대응 능력을 중심으로 진행한다. [rfp-common-submission::chunk-002]"
           },
@@ -337,9 +357,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.59,
+            "latency_ms": 1.1,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A의 필수 산출물은?",
             "abstained": false,
             "answer": "필수 산출물은 모델 점검 리포트, 보안 통제 매뉴얼, 운영자 교육 자료이다. [rfp-agency-a-ai-quality::chunk-003]"
           },
@@ -362,9 +387,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.04,
+            "latency_ms": 1.16,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 B 일정과 필수 산출물은?",
             "abstained": false,
             "answer": "기관 B 일정은 착수 후 3개월 내 파일럿 환경을 구성하고 5개월 내 운영 전환을 완료하는 방식이다. [rfp-agency-b-mlops-governance::chunk-004]"
           },
@@ -389,9 +419,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.16,
+            "latency_ms": 1.68,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
             "abstained": false,
             "answer": "기관 A: 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 기관 B: 기관 B의 핵심 AI 요구사항은 데이터 거버넌스, MLOps 배포 자동화, 모델 모니터링이다. [rfp-agency-b-mlops-governance::chunk-002]"
           },
@@ -416,9 +451,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.3,
+            "latency_ms": 1.36,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A와 기관 B의 보안 요구사항 차이를 비교해줘",
             "abstained": false,
             "answer": "기관 A: 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004] 기관 B: 보안 통제는 데이터셋 반출 승인과 관리자 작업 기록을 중심으로 설계한다. [rfp-agency-b-mlops-governance::chunk-003]"
           },
@@ -443,9 +483,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.0,
+            "latency_ms": 1.48,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A와 기관 B의 일정 차이를 비교해줘",
             "abstained": false,
             "answer": "기관 A: 기관 A 일정은 착수 후 4개월 내 MVP를 제출하고 6개월 내 최종 검수를 완료하는 방식이다. [rfp-agency-a-ai-quality::chunk-003] 기관 B: 기관 B 일정은 착수 후 3개월 내 파일럿 환경을 구성하고 5개월 내 운영 전환을 완료하는 방식이다. [rfp-agency-b-mlops-governance::chunk-004]"
           },
@@ -470,9 +515,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.2,
+            "latency_ms": 3.74,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A와 기관 C의 AI 요구사항 초점 차이는?",
             "abstained": false,
             "answer": "기관 A: 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 기관 C: 기관 C의 챗봇 AI 요구사항은 한국어 FAQ 검색, 의도 분류, 상담 이관 추천이다. [rfp-agency-c-chatbot::chunk-002]"
           },
@@ -497,9 +547,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.1,
+            "latency_ms": 2.46,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 B와 기관 C의 운영 지표나 모니터링 요구를 비교해줘",
             "abstained": false,
             "answer": "기관 B: 필수 산출물은 데이터 표준 사전, MLOps 운영 가이드, 모니터링 대시보드이다. [rfp-agency-b-mlops-governance::chunk-004] 기관 C: 기관 C는 답변 정확도, 상담 이관 적절성, 사용자 만족도를 운영 지표로 사용한다. [rfp-agency-c-chatbot::chunk-003]"
           },
@@ -524,9 +579,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.98,
+            "latency_ms": 2.38,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A 제출조건과 공통 평가 기준을 비교해줘",
             "abstained": false,
             "answer": "기관 A: 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004] 공통: 공통 평가는 요구사항 이해도, 근거 기반 실행 계획, 보안 및 운영 리스크 대응 능력을 중심으로 진행한다. [rfp-common-submission::chunk-002]"
           },
@@ -549,9 +609,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.5,
+            "latency_ms": 1.09,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "resolved",
+            "context_resolution_source": "context_entities",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "그럼 일정은 어떻게 돼?",
             "abstained": false,
             "answer": "기관 A 일정은 착수 후 4개월 내 MVP를 제출하고 6개월 내 최종 검수를 완료하는 방식이다. [rfp-agency-a-ai-quality::chunk-003]"
           },
@@ -574,9 +639,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.49,
+            "latency_ms": 1.62,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "resolved",
+            "context_resolution_source": "context_entities",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "필수 산출물은 뭐야?",
             "abstained": false,
             "answer": "필수 산출물은 데이터 표준 사전, MLOps 운영 가이드, 모니터링 대시보드이다. [rfp-agency-b-mlops-governance::chunk-004]"
           },
@@ -599,9 +669,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.43,
+            "latency_ms": 0.9,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "resolved",
+            "context_resolution_source": "context_entities",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "응답 성능 목표는?",
             "abstained": false,
             "answer": "챗봇은 주요 문의에 대해 평균 2초 이내 응답해야 한다. [rfp-agency-c-chatbot::chunk-002]"
           },
@@ -624,9 +699,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.61,
+            "latency_ms": 1.22,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "resolved",
+            "context_resolution_source": "context_entities",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "평가 기준은 무엇을 중심으로 진행해?",
             "abstained": false,
             "answer": "공통 평가는 요구사항 이해도, 근거 기반 실행 계획, 보안 및 운영 리스크 대응 능력을 중심으로 진행한다. [rfp-common-submission::chunk-002]"
           },
@@ -649,9 +729,14 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.56,
+            "latency_ms": 0.92,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "resolved",
+            "context_resolution_source": "context_entities",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "수행 조직에는 누가 포함돼야 해?",
             "abstained": false,
             "answer": "제안사는 PM, ML 엔지니어, 보안 담당자를 포함한 수행 조직을 제시해야 한다. [rfp-agency-a-ai-quality::chunk-004]"
           },
@@ -674,11 +759,72 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.54,
+            "latency_ms": 0.85,
             "retry_count": 0,
             "retry_trigger_reasons": [],
+            "context_resolution_status": "resolved",
+            "context_resolution_source": "context_entities",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "운영 지표로 무엇을 사용해?",
             "abstained": false,
             "answer": "기관 C는 답변 정확도, 상담 이관 적절성, 사용자 만족도를 운영 지표로 사용한다. [rfp-agency-c-chatbot::chunk-003]"
+          },
+          {
+            "id": "follow_up_state_a_security",
+            "query_type": "follow_up",
+            "query": "그 기관이 요구한 보안 조건도 보여줘",
+            "answerable": true,
+            "expected_doc_ids": [
+              "rfp-agency-a-ai-quality"
+            ],
+            "evidence_doc_ids": [
+              "rfp-agency-a-ai-quality"
+            ],
+            "doc_match": true,
+            "term_match": true,
+            "citation_term_match": true,
+            "citation_doc_precision": 1.0,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": null,
+            "latency_ms": 1.86,
+            "retry_count": 0,
+            "retry_trigger_reasons": [],
+            "context_resolution_status": "resolved",
+            "context_resolution_source": "conversation_state",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A 그 기관이 요구한 보안 조건도 보여줘",
+            "abstained": false,
+            "answer": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004]"
+          },
+          {
+            "id": "follow_up_state_ambiguous_clarification",
+            "query_type": "follow_up",
+            "query": "그 기관의 보안 조건은?",
+            "answerable": false,
+            "expected_doc_ids": [],
+            "evidence_doc_ids": [],
+            "doc_match": true,
+            "term_match": true,
+            "citation_term_match": false,
+            "citation_doc_precision": 0.0,
+            "accuracy": null,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": 1.0,
+            "latency_ms": 0.32,
+            "retry_count": 0,
+            "retry_trigger_reasons": [],
+            "context_resolution_status": "needs_clarification",
+            "context_resolution_source": "conversation_state",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "ambiguous_active_state",
+            "resolved_query": "그 기관의 보안 조건은?",
+            "abstained": true,
+            "answer": "'그 기관의 보안 조건은?'에서 가리키는 대상이 모호합니다. 현재 문맥 후보는 기관 A, 기관 B입니다. 기관명 또는 사업명을 하나로 지정해 주세요."
           },
           {
             "id": "abstention_missing_blockchain",
@@ -695,12 +841,17 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 1.08,
+            "latency_ms": 2.24,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
               "topic_not_grounded"
             ],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A의 블록체인 납품 실적은?",
             "abstained": true,
             "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 A의 블록체인 납품 실적은?'에 답할 수 있는 내용을 찾지 못했습니다."
           },
@@ -719,12 +870,17 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 0.96,
+            "latency_ms": 1.29,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
               "topic_not_grounded"
             ],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 B의 드론 영상분석 요구사항은?",
             "abstained": true,
             "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 B의 드론 영상분석 요구사항은?'에 답할 수 있는 내용을 찾지 못했습니다."
           },
@@ -743,12 +899,17 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 0.87,
+            "latency_ms": 1.3,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
               "topic_not_grounded"
             ],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 C의 결제 기능 연동 요구사항은?",
             "abstained": true,
             "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 C의 결제 기능 연동 요구사항은?'에 답할 수 있는 내용을 찾지 못했습니다."
           },
@@ -767,12 +928,17 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 1.06,
+            "latency_ms": 1.86,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
               "topic_not_grounded"
             ],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "공통 제출조건에 OCR 자동인식 기능 요구가 있나?",
             "abstained": true,
             "answer": "제공된 공개 샘플 RFP 근거에서는 '공통 제출조건에 OCR 자동인식 기능 요구가 있나?'에 답할 수 있는 내용을 찾지 못했습니다."
           },
@@ -791,12 +957,17 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 1.05,
+            "latency_ms": 1.59,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
               "topic_not_grounded"
             ],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 A의 생성형 AI 상담 기능 요구사항은?",
             "abstained": true,
             "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 A의 생성형 AI 상담 기능 요구사항은?'에 답할 수 있는 내용을 찾지 못했습니다."
           },
@@ -815,12 +986,17 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 0.84,
+            "latency_ms": 1.25,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
               "topic_not_grounded"
             ],
+            "context_resolution_status": "not_needed",
+            "context_resolution_source": "query",
+            "context_resolution_confidence": 1.0,
+            "context_resolution_reason": "",
+            "resolved_query": "기관 B의 양자암호 연동 요구사항은?",
             "abstained": true,
             "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 B의 양자암호 연동 요구사항은?'에 답할 수 있는 내용을 찾지 못했습니다."
           }
@@ -831,15 +1007,15 @@
         "metadata_first": false,
         "rerank": true,
         "verifier_retry": true,
-        "num_predictions": 24,
+        "num_predictions": 26,
         "accuracy": 1.0,
         "groundedness": 1.0,
-        "citation_precision": 0.8333333333333334,
+        "citation_precision": 0.8461538461538461,
         "abstention": 1.0,
         "latency": {
-          "p50": 1.045,
-          "p95": 1.6134999999999997,
-          "mean": 1.0941666666666667
+          "p50": 1.6349999999999998,
+          "p95": 2.9775,
+          "mean": 1.6900000000000002
         },
         "retry": 0.0,
         "retry_cost": {
@@ -859,9 +1035,9 @@
             "citation_precision": 0.75,
             "abstention": null,
             "latency": {
-              "p50": 1.245,
-              "p95": 1.5825,
-              "mean": 1.295
+              "p50": 1.755,
+              "p95": 2.6149999999999998,
+              "mean": 1.8116666666666665
             },
             "retry": 0.0,
             "retry_cost": {
@@ -879,9 +1055,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 0.845,
-              "p95": 1.015,
-              "mean": 0.8866666666666667
+              "p50": 1.85,
+              "p95": 3.405,
+              "mean": 2.2199999999999998
             },
             "retry": 0.0,
             "retry_cost": {
@@ -893,15 +1069,15 @@
             "retry_reason_counts": {}
           },
           "follow_up": {
-            "num_predictions": 6,
+            "num_predictions": 8,
             "accuracy": 1.0,
             "groundedness": 1.0,
-            "citation_precision": 0.5833333333333334,
-            "abstention": null,
+            "citation_precision": 0.6875,
+            "abstention": 1.0,
             "latency": {
-              "p50": 1.1800000000000002,
-              "p95": 1.885,
-              "mean": 1.2133333333333334
+              "p50": 1.38,
+              "p95": 1.6364999999999998,
+              "mean": 1.2775
             },
             "retry": 0.0,
             "retry_cost": {
@@ -919,9 +1095,9 @@
             "citation_precision": 1.0,
             "abstention": 1.0,
             "latency": {
-              "p50": 0.9099999999999999,
-              "p95": 1.425,
-              "mean": 0.9816666666666665
+              "p50": 1.605,
+              "p95": 2.0025,
+              "mean": 1.5883333333333336
             },
             "retry": 0.0,
             "retry_cost": {
@@ -941,20 +1117,20 @@
         "metadata_first": true,
         "rerank": false,
         "verifier_retry": true,
-        "num_predictions": 24,
+        "num_predictions": 26,
         "accuracy": 1.0,
         "groundedness": 1.0,
         "citation_precision": 1.0,
         "abstention": 1.0,
         "latency": {
-          "p50": 0.98,
-          "p95": 2.0109999999999992,
-          "mean": 1.1512499999999999
+          "p50": 1.29,
+          "p95": 2.845,
+          "mean": 1.4426923076923073
         },
-        "retry": 0.25,
+        "retry": 0.23076923076923078,
         "retry_cost": {
           "total_retries": 6,
-          "mean_retry_count": 0.25,
+          "mean_retry_count": 0.23076923076923078,
           "max_retry_count": 1,
           "cases_with_retry": 6
         },
@@ -969,9 +1145,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 0.835,
-              "p95": 1.1475,
-              "mean": 0.8566666666666668
+              "p50": 1.07,
+              "p95": 2.7675,
+              "mean": 1.5499999999999998
             },
             "retry": 0.0,
             "retry_cost": {
@@ -989,9 +1165,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 0.95,
-              "p95": 1.4225,
-              "mean": 1.0316666666666665
+              "p50": 1.51,
+              "p95": 1.83,
+              "mean": 1.5433333333333332
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1003,15 +1179,15 @@
             "retry_reason_counts": {}
           },
           "follow_up": {
-            "num_predictions": 6,
+            "num_predictions": 8,
             "accuracy": 1.0,
             "groundedness": 1.0,
             "citation_precision": 1.0,
-            "abstention": null,
+            "abstention": 1.0,
             "latency": {
-              "p50": 0.7150000000000001,
-              "p95": 3.3049999999999997,
-              "mean": 1.3
+              "p50": 0.935,
+              "p95": 2.241999999999999,
+              "mean": 1.0975000000000001
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1029,9 +1205,9 @@
             "citation_precision": 1.0,
             "abstention": 1.0,
             "latency": {
-              "p50": 1.255,
-              "p95": 1.9849999999999999,
-              "mean": 1.4166666666666667
+              "p50": 1.52,
+              "p95": 2.5725000000000002,
+              "mean": 1.6950000000000003
             },
             "retry": 1.0,
             "retry_cost": {
@@ -1051,15 +1227,15 @@
         "metadata_first": true,
         "rerank": true,
         "verifier_retry": false,
-        "num_predictions": 24,
+        "num_predictions": 26,
         "accuracy": 1.0,
-        "groundedness": 0.75,
-        "citation_precision": 0.75,
-        "abstention": 0.0,
+        "groundedness": 0.7692307692307693,
+        "citation_precision": 0.7692307692307693,
+        "abstention": 0.14285714285714285,
         "latency": {
-          "p50": 1.02,
-          "p95": 2.325499999999999,
-          "mean": 1.2587499999999998
+          "p50": 1.2,
+          "p95": 2.3600000000000003,
+          "mean": 1.4384615384615385
         },
         "retry": 0.0,
         "retry_cost": {
@@ -1077,9 +1253,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 1.51,
-              "p95": 3.14,
-              "mean": 1.7616666666666667
+              "p50": 1.115,
+              "p95": 2.24,
+              "mean": 1.3766666666666667
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1097,9 +1273,9 @@
             "citation_precision": 1.0,
             "abstention": null,
             "latency": {
-              "p50": 1.275,
-              "p95": 1.91,
-              "mean": 1.4116666666666668
+              "p50": 1.8250000000000002,
+              "p95": 2.0725,
+              "mean": 1.7916666666666667
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1111,15 +1287,15 @@
             "retry_reason_counts": {}
           },
           "follow_up": {
-            "num_predictions": 6,
+            "num_predictions": 8,
             "accuracy": 1.0,
             "groundedness": 1.0,
             "citation_precision": 1.0,
-            "abstention": null,
+            "abstention": 1.0,
             "latency": {
-              "p50": 0.845,
-              "p95": 0.9374999999999999,
-              "mean": 0.8233333333333334
+              "p50": 0.9450000000000001,
+              "p95": 1.1624999999999999,
+              "mean": 0.9099999999999999
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1137,9 +1313,9 @@
             "citation_precision": 0.0,
             "abstention": 0.0,
             "latency": {
-              "p50": 0.965,
-              "p95": 1.33,
-              "mean": 1.0383333333333333
+              "p50": 1.4,
+              "p95": 3.6675,
+              "mean": 1.8516666666666666
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1174,9 +1350,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 3.39,
+      "latency_ms": 6.35,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A의 보안 통제 요구사항은?",
       "abstained": false,
       "answer": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004]"
     },
@@ -1199,9 +1380,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.34,
+      "latency_ms": 2.99,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 C의 챗봇 응답 시간 목표는?",
       "abstained": false,
       "answer": "챗봇은 주요 문의에 대해 평균 2초 이내 응답해야 한다. [rfp-agency-c-chatbot::chunk-002] 기관 C는 고객지원 챗봇 고도화를 추진한다. [rfp-agency-c-chatbot::chunk-001]"
     },
@@ -1224,9 +1410,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.05,
+      "latency_ms": 1.13,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 B의 개인정보 보안 요구사항은?",
       "abstained": false,
       "answer": "기관 B는 개인정보 비식별화와 접근 권한 분리를 요구한다. [rfp-agency-b-mlops-governance::chunk-003]"
     },
@@ -1249,9 +1440,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.92,
+      "latency_ms": 2.09,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "공통 제출조건에서 모든 제안사가 제출해야 하는 것은?",
       "abstained": false,
       "answer": "모든 제안사는 일정 준수 계획, 위험 관리 방안, 산출물 품질 검수 절차를 제출해야 한다. [rfp-common-submission::chunk-001] 공통 평가는 요구사항 이해도, 근거 기반 실행 계획, 보안 및 운영 리스크 대응 능력을 중심으로 진행한다. [rfp-common-submission::chunk-002]"
     },
@@ -1274,9 +1470,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.59,
+      "latency_ms": 1.1,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A의 필수 산출물은?",
       "abstained": false,
       "answer": "필수 산출물은 모델 점검 리포트, 보안 통제 매뉴얼, 운영자 교육 자료이다. [rfp-agency-a-ai-quality::chunk-003]"
     },
@@ -1299,9 +1500,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.04,
+      "latency_ms": 1.16,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 B 일정과 필수 산출물은?",
       "abstained": false,
       "answer": "기관 B 일정은 착수 후 3개월 내 파일럿 환경을 구성하고 5개월 내 운영 전환을 완료하는 방식이다. [rfp-agency-b-mlops-governance::chunk-004]"
     },
@@ -1326,9 +1532,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.16,
+      "latency_ms": 1.68,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
       "abstained": false,
       "answer": "기관 A: 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 기관 B: 기관 B의 핵심 AI 요구사항은 데이터 거버넌스, MLOps 배포 자동화, 모델 모니터링이다. [rfp-agency-b-mlops-governance::chunk-002]"
     },
@@ -1353,9 +1564,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.3,
+      "latency_ms": 1.36,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A와 기관 B의 보안 요구사항 차이를 비교해줘",
       "abstained": false,
       "answer": "기관 A: 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004] 기관 B: 보안 통제는 데이터셋 반출 승인과 관리자 작업 기록을 중심으로 설계한다. [rfp-agency-b-mlops-governance::chunk-003]"
     },
@@ -1380,9 +1596,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.0,
+      "latency_ms": 1.48,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A와 기관 B의 일정 차이를 비교해줘",
       "abstained": false,
       "answer": "기관 A: 기관 A 일정은 착수 후 4개월 내 MVP를 제출하고 6개월 내 최종 검수를 완료하는 방식이다. [rfp-agency-a-ai-quality::chunk-003] 기관 B: 기관 B 일정은 착수 후 3개월 내 파일럿 환경을 구성하고 5개월 내 운영 전환을 완료하는 방식이다. [rfp-agency-b-mlops-governance::chunk-004]"
     },
@@ -1407,9 +1628,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.2,
+      "latency_ms": 3.74,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A와 기관 C의 AI 요구사항 초점 차이는?",
       "abstained": false,
       "answer": "기관 A: 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 기관 C: 기관 C의 챗봇 AI 요구사항은 한국어 FAQ 검색, 의도 분류, 상담 이관 추천이다. [rfp-agency-c-chatbot::chunk-002]"
     },
@@ -1434,9 +1660,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.1,
+      "latency_ms": 2.46,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 B와 기관 C의 운영 지표나 모니터링 요구를 비교해줘",
       "abstained": false,
       "answer": "기관 B: 필수 산출물은 데이터 표준 사전, MLOps 운영 가이드, 모니터링 대시보드이다. [rfp-agency-b-mlops-governance::chunk-004] 기관 C: 기관 C는 답변 정확도, 상담 이관 적절성, 사용자 만족도를 운영 지표로 사용한다. [rfp-agency-c-chatbot::chunk-003]"
     },
@@ -1461,9 +1692,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.98,
+      "latency_ms": 2.38,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A 제출조건과 공통 평가 기준을 비교해줘",
       "abstained": false,
       "answer": "기관 A: 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004] 공통: 공통 평가는 요구사항 이해도, 근거 기반 실행 계획, 보안 및 운영 리스크 대응 능력을 중심으로 진행한다. [rfp-common-submission::chunk-002]"
     },
@@ -1486,9 +1722,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.5,
+      "latency_ms": 1.09,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "resolved",
+      "context_resolution_source": "context_entities",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "그럼 일정은 어떻게 돼?",
       "abstained": false,
       "answer": "기관 A 일정은 착수 후 4개월 내 MVP를 제출하고 6개월 내 최종 검수를 완료하는 방식이다. [rfp-agency-a-ai-quality::chunk-003]"
     },
@@ -1511,9 +1752,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.49,
+      "latency_ms": 1.62,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "resolved",
+      "context_resolution_source": "context_entities",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "필수 산출물은 뭐야?",
       "abstained": false,
       "answer": "필수 산출물은 데이터 표준 사전, MLOps 운영 가이드, 모니터링 대시보드이다. [rfp-agency-b-mlops-governance::chunk-004]"
     },
@@ -1536,9 +1782,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.43,
+      "latency_ms": 0.9,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "resolved",
+      "context_resolution_source": "context_entities",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "응답 성능 목표는?",
       "abstained": false,
       "answer": "챗봇은 주요 문의에 대해 평균 2초 이내 응답해야 한다. [rfp-agency-c-chatbot::chunk-002]"
     },
@@ -1561,9 +1812,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.61,
+      "latency_ms": 1.22,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "resolved",
+      "context_resolution_source": "context_entities",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "평가 기준은 무엇을 중심으로 진행해?",
       "abstained": false,
       "answer": "공통 평가는 요구사항 이해도, 근거 기반 실행 계획, 보안 및 운영 리스크 대응 능력을 중심으로 진행한다. [rfp-common-submission::chunk-002]"
     },
@@ -1586,9 +1842,14 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.56,
+      "latency_ms": 0.92,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "resolved",
+      "context_resolution_source": "context_entities",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "수행 조직에는 누가 포함돼야 해?",
       "abstained": false,
       "answer": "제안사는 PM, ML 엔지니어, 보안 담당자를 포함한 수행 조직을 제시해야 한다. [rfp-agency-a-ai-quality::chunk-004]"
     },
@@ -1611,11 +1872,72 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.54,
+      "latency_ms": 0.85,
       "retry_count": 0,
       "retry_trigger_reasons": [],
+      "context_resolution_status": "resolved",
+      "context_resolution_source": "context_entities",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "운영 지표로 무엇을 사용해?",
       "abstained": false,
       "answer": "기관 C는 답변 정확도, 상담 이관 적절성, 사용자 만족도를 운영 지표로 사용한다. [rfp-agency-c-chatbot::chunk-003]"
+    },
+    {
+      "id": "follow_up_state_a_security",
+      "query_type": "follow_up",
+      "query": "그 기관이 요구한 보안 조건도 보여줘",
+      "answerable": true,
+      "expected_doc_ids": [
+        "rfp-agency-a-ai-quality"
+      ],
+      "evidence_doc_ids": [
+        "rfp-agency-a-ai-quality"
+      ],
+      "doc_match": true,
+      "term_match": true,
+      "citation_term_match": true,
+      "citation_doc_precision": 1.0,
+      "accuracy": 1.0,
+      "groundedness": 1.0,
+      "citation_precision": 1.0,
+      "abstention": null,
+      "latency_ms": 1.86,
+      "retry_count": 0,
+      "retry_trigger_reasons": [],
+      "context_resolution_status": "resolved",
+      "context_resolution_source": "conversation_state",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A 그 기관이 요구한 보안 조건도 보여줘",
+      "abstained": false,
+      "answer": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004]"
+    },
+    {
+      "id": "follow_up_state_ambiguous_clarification",
+      "query_type": "follow_up",
+      "query": "그 기관의 보안 조건은?",
+      "answerable": false,
+      "expected_doc_ids": [],
+      "evidence_doc_ids": [],
+      "doc_match": true,
+      "term_match": true,
+      "citation_term_match": false,
+      "citation_doc_precision": 0.0,
+      "accuracy": null,
+      "groundedness": 1.0,
+      "citation_precision": 1.0,
+      "abstention": 1.0,
+      "latency_ms": 0.32,
+      "retry_count": 0,
+      "retry_trigger_reasons": [],
+      "context_resolution_status": "needs_clarification",
+      "context_resolution_source": "conversation_state",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "ambiguous_active_state",
+      "resolved_query": "그 기관의 보안 조건은?",
+      "abstained": true,
+      "answer": "'그 기관의 보안 조건은?'에서 가리키는 대상이 모호합니다. 현재 문맥 후보는 기관 A, 기관 B입니다. 기관명 또는 사업명을 하나로 지정해 주세요."
     },
     {
       "id": "abstention_missing_blockchain",
@@ -1632,12 +1954,17 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 1.08,
+      "latency_ms": 2.24,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
         "topic_not_grounded"
       ],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A의 블록체인 납품 실적은?",
       "abstained": true,
       "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 A의 블록체인 납품 실적은?'에 답할 수 있는 내용을 찾지 못했습니다."
     },
@@ -1656,12 +1983,17 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 0.96,
+      "latency_ms": 1.29,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
         "topic_not_grounded"
       ],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 B의 드론 영상분석 요구사항은?",
       "abstained": true,
       "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 B의 드론 영상분석 요구사항은?'에 답할 수 있는 내용을 찾지 못했습니다."
     },
@@ -1680,12 +2012,17 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 0.87,
+      "latency_ms": 1.3,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
         "topic_not_grounded"
       ],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 C의 결제 기능 연동 요구사항은?",
       "abstained": true,
       "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 C의 결제 기능 연동 요구사항은?'에 답할 수 있는 내용을 찾지 못했습니다."
     },
@@ -1704,12 +2041,17 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 1.06,
+      "latency_ms": 1.86,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
         "topic_not_grounded"
       ],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "공통 제출조건에 OCR 자동인식 기능 요구가 있나?",
       "abstained": true,
       "answer": "제공된 공개 샘플 RFP 근거에서는 '공통 제출조건에 OCR 자동인식 기능 요구가 있나?'에 답할 수 있는 내용을 찾지 못했습니다."
     },
@@ -1728,12 +2070,17 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 1.05,
+      "latency_ms": 1.59,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
         "topic_not_grounded"
       ],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 A의 생성형 AI 상담 기능 요구사항은?",
       "abstained": true,
       "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 A의 생성형 AI 상담 기능 요구사항은?'에 답할 수 있는 내용을 찾지 못했습니다."
     },
@@ -1752,12 +2099,17 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 0.84,
+      "latency_ms": 1.25,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
         "topic_not_grounded"
       ],
+      "context_resolution_status": "not_needed",
+      "context_resolution_source": "query",
+      "context_resolution_confidence": 1.0,
+      "context_resolution_reason": "",
+      "resolved_query": "기관 B의 양자암호 연동 요구사항은?",
       "abstained": true,
       "answer": "제공된 공개 샘플 RFP 근거에서는 '기관 B의 양자암호 연동 요구사항은?'에 답할 수 있는 내용을 찾지 못했습니다."
     }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 #   bash scripts/smoke.sh
 # Optional overrides:
 #   INPUT_DIR=data/raw INDEX_DIR=data/index OUTPUT_DIR=outputs REPORT_DIR=reports QUERY="..." bash scripts/smoke.sh
+#   EMBEDDING_BACKEND=auto bash scripts/smoke.sh
 
 INPUT_DIR="${INPUT_DIR:-data/raw}"
 INDEX_DIR="${INDEX_DIR:-data/index}"
@@ -14,6 +15,7 @@ REPORT_DIR="${REPORT_DIR:-reports}"
 QUERY="${QUERY:-기관 A와 기관 B의 AI 요구사항 차이 알려줘}"
 EVAL_CONFIG="${EVAL_CONFIG:-eval/config.yaml}"
 README_PATH="${README_PATH:-README.md}"
+EMBEDDING_BACKEND="${EMBEDDING_BACKEND:-hashing}"
 
 log() {
   printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$1"
@@ -46,7 +48,10 @@ require_dir "$INPUT_DIR"
 mkdir -p "$INDEX_DIR" "$OUTPUT_DIR" "$REPORT_DIR"
 
 log "Building index"
-python3 scripts/build_index.py --input_dir "$INPUT_DIR" --output_dir "$INDEX_DIR"
+python3 scripts/build_index.py \
+  --input_dir "$INPUT_DIR" \
+  --output_dir "$INDEX_DIR" \
+  --embedding_backend "$EMBEDDING_BACKEND"
 
 log "Running sample query"
 python3 app.py --input_dir "$INDEX_DIR" --output_dir "$OUTPUT_DIR" --query "$QUERY"
@@ -58,7 +63,11 @@ REPORT_JSON="$REPORT_DIR/eval_summary.json"
 require_file "$REPORT_JSON"
 
 log "Checking README metrics consistency"
-python3 scripts/update_readme_metrics.py --report "$REPORT_JSON" --readme "$README_PATH" --check
+if [[ "$REPORT_DIR" == "reports" ]]; then
+  python3 scripts/update_readme_metrics.py --report "$REPORT_JSON" --readme "$README_PATH" --check
+else
+  echo "Skipping README metrics check for non-default REPORT_DIR=$REPORT_DIR"
+fi
 
 log "Smoke test completed successfully"
 echo "Generated artifacts:"

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -137,6 +137,58 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
         self.assertEqual(0, result["diagnostics"]["retry_count"])
         self.assertTrue(result["evidence"])
 
+    def test_conversation_state_resolves_implicit_follow_up_entity(self) -> None:
+        first = run_rag_query(
+            self.index,
+            "기관 A의 AI 요구사항은?",
+            conversation_state={},
+        )
+
+        follow_up = run_rag_query(
+            self.index,
+            "그 기관이 요구한 보안 조건도 보여줘",
+            conversation_state=first["conversation_state"],
+        )
+
+        self.assertFalse(follow_up["diagnostics"]["abstained"])
+        self.assertEqual(
+            "resolved",
+            follow_up["diagnostics"]["context_resolution"]["status"],
+        )
+        self.assertEqual(
+            "conversation_state",
+            follow_up["diagnostics"]["context_resolution"]["source"],
+        )
+        self.assertIn("기관 A", follow_up["resolved_query"])
+        self.assertEqual(
+            {"rfp-agency-a-ai-quality"},
+            {item["doc_id"] for item in follow_up["evidence"]},
+        )
+
+    def test_conversation_state_clarifies_ambiguous_singular_reference(self) -> None:
+        first = run_rag_query(
+            self.index,
+            "기관 A와 기관 B의 보안 요구사항 차이를 비교해줘",
+            conversation_state={},
+        )
+
+        follow_up = run_rag_query(
+            self.index,
+            "그 기관의 보안 조건은?",
+            conversation_state=first["conversation_state"],
+        )
+
+        self.assertTrue(follow_up["diagnostics"]["abstained"])
+        self.assertEqual([], follow_up["evidence"])
+        self.assertEqual(
+            "needs_clarification",
+            follow_up["diagnostics"]["context_resolution"]["status"],
+        )
+        self.assertEqual(
+            "ambiguous_active_state",
+            follow_up["diagnostics"]["context_resolution"]["reason"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- 후속 질문에서 이전 턴의 agency/project/doc context를 재사용하도록 conversation state를 추가했습니다.
- `app.py`에 `--session_state`와 `--reset_session`을 넣어 CLI 실행 간 상태를 JSON으로 저장/로드할 수 있게 했습니다.
- eval에 multi-turn `prior_turns` 케이스를 추가하고, 모호한 생략 참조는 clarification-style abstain으로 처리하도록 검증을 강화했습니다.
- README와 실패 사례 문서를 갱신하고, 평가 결과와 성능표를 다시 생성했습니다.

## Testing
- `python3 -m unittest discover -s tests -v`
- `python3 eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml`
- `python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check`
- `bash scripts/smoke.sh` (임시 경로, `EMBEDDING_BACKEND=hashing`)