### PR TITLE
하이브리드 benchmark registry와 ablation 추적 체계 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ outputs/*
 !outputs/answer.json
 reports/*
 !reports/eval_summary.json
+
+# Benchmark raw/local artifacts
+artifacts/benchmarks/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval check smoke test clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke test clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -16,6 +16,12 @@ ask:
 
 eval:
 	$(PYTHON) eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml
+
+benchmark:
+	$(PYTHON) scripts/run_benchmark.py --suite benchmarks/suites/public_synthetic_rfp.yaml --ablations benchmarks/ablations/rag_quality_axes.yaml
+
+benchmark-check:
+	$(PYTHON) scripts/summarize_benchmark.py --manifest $${MANIFEST:?set MANIFEST=artifacts/benchmarks/<run_id>/run_manifest.json} --check
 
 check:
 	$(PYTHON) scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 ## Demo / 산출물
 - 질의 실행 결과: `outputs/answer.json`
 - 평가 요약: `reports/eval_summary.json`
+- Benchmark registry: `benchmarks/registry.json`
+- Benchmark local artifacts: `artifacts/benchmarks/` (gitignored)
 - PDF/HWP ingestion 진단 리포트: `data/index/ingestion_report.json` (`--metadata_csv` 사용 시)
 
 ---
@@ -74,17 +76,18 @@ CLI와 리뷰 편의를 위해 같은 내용을 사람이 읽기 쉬운 `answer_
 | Evidence | Citation Precision | 1.000 |
 | Evidence | Answer Format Compliance | 1.000 |
 | Abstention | Abstention Accuracy | 1.000 |
-| System | Latency (p50/p95) | p50 2.9ms / p95 11.9ms |
-| System | Retry Rate | 0.250 |
+| System | Latency (p50/p95) | p50 2.4ms / p95 4.7ms |
+| System | Retry Rate | 0.231 |
 
 ### Ablation comparison
 
 | Run | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Format | Abstention | Retry | Latency p95 |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| full | on | on | on | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 11.9ms |
-| no_metadata_first | off | on | on | 1.000 | 1.000 | 0.833 | 1.000 | 1.000 | 0.000 | 11.9ms |
-| no_rerank | on | off | on | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.250 | 7.9ms |
-| no_verifier_retry | on | on | off | 1.000 | 0.750 | 0.750 | 0.750 | 0.000 | 0.000 | 5.7ms |
+| full | on | on | on | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 4.7ms |
+| hierarchical | on | on | on | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 5.4ms |
+| no_metadata_first | off | on | on | 1.000 | 1.000 | 0.846 | 1.000 | 1.000 | 0.000 | 4.1ms |
+| no_rerank | on | off | on | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 3.7ms |
+| no_verifier_retry | on | on | off | 1.000 | 0.769 | 0.769 | 0.769 | 0.143 | 0.000 | 2.4ms |
 <!-- METRICS_TABLE:END -->
 
 > 주의: 성능표는 공개 synthetic RFP 평가셋 기준입니다. 원본 RFP 데이터는 비공개 제약으로 저장소에 포함하지 않았습니다.
@@ -168,6 +171,18 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check
 ```
 
+### 7) Benchmark / ablation registry
+```bash
+python3 scripts/run_benchmark.py \
+  --suite benchmarks/suites/public_synthetic_rfp.yaml \
+  --ablations benchmarks/ablations/rag_quality_axes.yaml
+
+python3 scripts/summarize_benchmark.py \
+  --manifest artifacts/benchmarks/<run_id>/run_manifest.json
+```
+
+Benchmark source of truth는 `benchmarks/suites/`, `benchmarks/ablations/`, `benchmarks/registry.schema.json`에 둡니다. Raw predictions, traces, logs, latency samples는 `artifacts/benchmarks/` 아래에 생성되며 Git에 커밋하지 않습니다. 사람이 읽는 결과 해석은 [`docs/benchmarking.md`](docs/benchmarking.md)와 [`docs/ablation-results.md`](docs/ablation-results.md)를 참고하세요.
+
 > 참고: 모델을 처음 내려받아 실제 sentence-transformers 인덱스를 만들려면 `--embedding_backend sentence-transformers`를 사용하세요. 네트워크가 제한된 환경에서는 `--embedding_backend hashing`으로 재현성을 우선한 로컬 실행이 가능합니다. 산출물 경로는 `data/index`, `outputs/`, `reports/`로 고정합니다.
 > Chunking 기본값은 `--chunking_strategy auto --chunk_max_chars 520 --chunk_overlap_sentences 1`입니다. `auto`는 heading/section 구조가 있으면 section-aware chunk metadata를 저장하고, 단일 본문처럼 구조가 약하면 fixed fallback을 사용합니다.
 > 질의 기본값은 flat child-chunk retrieval입니다. parent section 단위 재조립을 확인하려면 `app.py`에 `--retrieval_mode hierarchical`을 지정하거나 `eval/config.yaml`의 `hierarchical` ablation run을 실행합니다.
@@ -194,6 +209,8 @@ python3 scripts/build_index.py \
 
 ## 상세 설계 링크
 - 포트폴리오 case study: [`docs/portfolio-case-study.md`](docs/portfolio-case-study.md)
+- Benchmarking: [`docs/benchmarking.md`](docs/benchmarking.md)
+- Ablation results: [`docs/ablation-results.md`](docs/ablation-results.md)
 - 설계 배경 및 의사결정: [`docs/design-background.md`](docs/design-background.md)
 - Chunking diagnostics: [`docs/chunking-diagnostics.md`](docs/chunking-diagnostics.md)
 - PDF/HWP ingestion: [`docs/real-data-ingestion.md`](docs/real-data-ingestion.md)

--- a/app.py
+++ b/app.py
@@ -15,6 +15,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--config", default=None, help="Unused in this command; accepted for CLI consistency.")
     parser.add_argument("--top_k", type=int, default=None, help="Override retrieval top-k.")
     parser.add_argument(
+        "--retrieval_mode",
+        default="flat",
+        choices=["flat", "hierarchical"],
+        help="Use flat child chunks or hierarchical parent-section evidence.",
+    )
+    parser.add_argument(
         "--context_entities",
         default="",
         help="Comma-separated entities for follow-up questions, e.g. '기관 A'.",
@@ -67,6 +73,7 @@ def main() -> int:
             args.query,
             top_k=args.top_k,
             context_entities=parse_context_entities(args.context_entities),
+            retrieval_mode=args.retrieval_mode,
             conversation_state=session_state,
         )
     except Exception as exc:

--- a/benchmarks/ablations/rag_quality_axes.yaml
+++ b/benchmarks/ablations/rag_quality_axes.yaml
@@ -1,0 +1,31 @@
+id: rag_quality_axes
+name: RAG quality/cost ablation axes
+description: Compare metadata-first retrieval, reranking, verifier retry, and hierarchical evidence assembly.
+baseline_run: no_verifier_retry
+primary_run: full
+runs:
+  - name: full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+  - name: hierarchical
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: hierarchical
+  - name: no_metadata_first
+    metadata_first: false
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+  - name: no_rerank
+    metadata_first: true
+    rerank: false
+    verifier_retry: true
+    retrieval_mode: flat
+  - name: no_verifier_retry
+    metadata_first: true
+    rerank: true
+    verifier_retry: false
+    retrieval_mode: flat

--- a/benchmarks/registry.json
+++ b/benchmarks/registry.json
@@ -1,0 +1,231 @@
+{
+  "schema_version": 1,
+  "description": "Curated aggregate benchmark registry. Raw predictions, traces, logs, latency samples, and per-example dumps stay under artifacts/benchmarks/ and are gitignored.",
+  "entries": [
+    {
+      "run_id": "public_synthetic_rfp_20260502T021448Z",
+      "generated_at": "2026-05-02T02:14:49.119651Z",
+      "git_commit": "7d23eab541bee20fd014d7df0f4827761071de09",
+      "git_dirty": true,
+      "suite_id": "public_synthetic_rfp",
+      "dataset_id": "public_synthetic_rfp_v1",
+      "ablation_suite_id": "rag_quality_axes",
+      "baseline_run": "no_verifier_retry",
+      "primary_run": "full",
+      "baseline_metrics": {
+        "num_predictions": 26,
+        "accuracy": 1.0,
+        "groundedness": 0.7692307692307693,
+        "citation_precision": 0.7692307692307693,
+        "answer_format_compliance": 0.7692307692307693,
+        "abstention": 0.14285714285714285,
+        "retry": 0.0,
+        "latency": {
+          "p50": 1.545,
+          "p95": 2.2975,
+          "mean": 1.585
+        },
+        "retry_cost": {
+          "total_retries": 0,
+          "mean_retry_count": 0.0,
+          "max_retry_count": 0,
+          "cases_with_retry": 0
+        },
+        "retry_reason_counts": {}
+      },
+      "primary_metrics": {
+        "num_predictions": 26,
+        "accuracy": 1.0,
+        "groundedness": 1.0,
+        "citation_precision": 1.0,
+        "answer_format_compliance": 1.0,
+        "abstention": 1.0,
+        "retry": 0.23076923076923078,
+        "latency": {
+          "p50": 1.88,
+          "p95": 3.725,
+          "mean": 2.1338461538461533
+        },
+        "retry_cost": {
+          "total_retries": 6,
+          "mean_retry_count": 0.23076923076923078,
+          "max_retry_count": 1,
+          "cases_with_retry": 6
+        },
+        "retry_reason_counts": {
+          "topic_not_grounded": 12
+        }
+      },
+      "delta": {
+        "accuracy": 0.0,
+        "groundedness": 0.23076923076923073,
+        "citation_precision": 0.23076923076923073,
+        "answer_format_compliance": 0.23076923076923073,
+        "abstention": 0.8571428571428572,
+        "retry": 0.23076923076923078,
+        "latency_p95": 1.4275000000000002
+      },
+      "artifact_manifest": "artifacts/benchmarks/public_synthetic_rfp_20260502T021448Z/run_manifest.json",
+      "runs": [
+        {
+          "name": "full",
+          "flags": {
+            "metadata_first": true,
+            "rerank": true,
+            "verifier_retry": true,
+            "retrieval_mode": "flat"
+          },
+          "metrics": {
+            "num_predictions": 26,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "answer_format_compliance": 1.0,
+            "abstention": 1.0,
+            "retry": 0.23076923076923078,
+            "latency": {
+              "p50": 1.88,
+              "p95": 3.725,
+              "mean": 2.1338461538461533
+            },
+            "retry_cost": {
+              "total_retries": 6,
+              "mean_retry_count": 0.23076923076923078,
+              "max_retry_count": 1,
+              "cases_with_retry": 6
+            },
+            "retry_reason_counts": {
+              "topic_not_grounded": 12
+            }
+          }
+        },
+        {
+          "name": "hierarchical",
+          "flags": {
+            "metadata_first": true,
+            "rerank": true,
+            "verifier_retry": true,
+            "retrieval_mode": "hierarchical"
+          },
+          "metrics": {
+            "num_predictions": 26,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "answer_format_compliance": 1.0,
+            "abstention": 1.0,
+            "retry": 0.23076923076923078,
+            "latency": {
+              "p50": 1.835,
+              "p95": 3.6350000000000002,
+              "mean": 1.9934615384615386
+            },
+            "retry_cost": {
+              "total_retries": 6,
+              "mean_retry_count": 0.23076923076923078,
+              "max_retry_count": 1,
+              "cases_with_retry": 6
+            },
+            "retry_reason_counts": {
+              "topic_not_grounded": 12
+            }
+          }
+        },
+        {
+          "name": "no_metadata_first",
+          "flags": {
+            "metadata_first": false,
+            "rerank": true,
+            "verifier_retry": true,
+            "retrieval_mode": "flat"
+          },
+          "metrics": {
+            "num_predictions": 26,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 0.8461538461538461,
+            "answer_format_compliance": 1.0,
+            "abstention": 1.0,
+            "retry": 0.0,
+            "latency": {
+              "p50": 1.895,
+              "p95": 3.5275000000000003,
+              "mean": 2.0469230769230764
+            },
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {
+              "topic_not_grounded": 6
+            }
+          }
+        },
+        {
+          "name": "no_rerank",
+          "flags": {
+            "metadata_first": true,
+            "rerank": false,
+            "verifier_retry": true,
+            "retrieval_mode": "flat"
+          },
+          "metrics": {
+            "num_predictions": 26,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "answer_format_compliance": 1.0,
+            "abstention": 1.0,
+            "retry": 0.23076923076923078,
+            "latency": {
+              "p50": 1.73,
+              "p95": 2.6775,
+              "mean": 1.791923076923077
+            },
+            "retry_cost": {
+              "total_retries": 6,
+              "mean_retry_count": 0.23076923076923078,
+              "max_retry_count": 1,
+              "cases_with_retry": 6
+            },
+            "retry_reason_counts": {
+              "topic_not_grounded": 12
+            }
+          }
+        },
+        {
+          "name": "no_verifier_retry",
+          "flags": {
+            "metadata_first": true,
+            "rerank": true,
+            "verifier_retry": false,
+            "retrieval_mode": "flat"
+          },
+          "metrics": {
+            "num_predictions": 26,
+            "accuracy": 1.0,
+            "groundedness": 0.7692307692307693,
+            "citation_precision": 0.7692307692307693,
+            "answer_format_compliance": 0.7692307692307693,
+            "abstention": 0.14285714285714285,
+            "retry": 0.0,
+            "latency": {
+              "p50": 1.545,
+              "p95": 2.2975,
+              "mean": 1.585
+            },
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/registry.schema.json
+++ b/benchmarks/registry.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "benchmarks/registry.schema.json",
+  "title": "BidMate benchmark registry and run manifest schema",
+  "type": "object",
+  "required": ["schema_version"],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/registry_entry" }
+    },
+    "run_manifest": { "$ref": "#/$defs/run_manifest" }
+  },
+  "$defs": {
+    "latency_block": {
+      "type": "object",
+      "required": ["p50", "p95", "mean"],
+      "properties": {
+        "p50": { "type": ["number", "null"] },
+        "p95": { "type": ["number", "null"] },
+        "mean": { "type": ["number", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "metric_block": {
+      "type": "object",
+      "required": [
+        "num_predictions",
+        "accuracy",
+        "groundedness",
+        "citation_precision",
+        "answer_format_compliance",
+        "abstention",
+        "retry",
+        "latency"
+      ],
+      "properties": {
+        "num_predictions": { "type": "integer" },
+        "accuracy": { "type": ["number", "null"] },
+        "groundedness": { "type": ["number", "null"] },
+        "citation_precision": { "type": ["number", "null"] },
+        "answer_format_compliance": { "type": ["number", "null"] },
+        "abstention": { "type": ["number", "null"] },
+        "retry": { "type": ["number", "null"] },
+        "latency": { "$ref": "#/$defs/latency_block" }
+      },
+      "additionalProperties": true
+    },
+    "ablation_flags": {
+      "type": "object",
+      "required": ["metadata_first", "rerank", "verifier_retry", "retrieval_mode"],
+      "properties": {
+        "metadata_first": { "type": "boolean" },
+        "rerank": { "type": "boolean" },
+        "verifier_retry": { "type": "boolean" },
+        "retrieval_mode": { "type": "string", "enum": ["flat", "hierarchical"] }
+      },
+      "additionalProperties": false
+    },
+    "artifact_paths": {
+      "type": "object",
+      "required": ["run_dir", "run_manifest", "eval_summary", "predictions", "latency_samples", "traces", "logs"],
+      "properties": {
+        "run_dir": { "type": "string" },
+        "run_manifest": { "type": "string" },
+        "eval_summary": { "type": "string" },
+        "predictions": { "type": "string" },
+        "latency_samples": { "type": "string" },
+        "traces": { "type": "string" },
+        "logs": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "run_manifest": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "run_id",
+        "git_commit",
+        "suite",
+        "ablation_flags",
+        "model_config",
+        "retriever_config",
+        "reranker_config",
+        "verifier_config",
+        "metrics",
+        "latency",
+        "artifacts"
+      ],
+      "properties": {
+        "schema_version": { "type": "integer", "const": 1 },
+        "run_id": { "type": "string" },
+        "generated_at": { "type": "string" },
+        "git_commit": { "type": "string" },
+        "git_dirty": { "type": "boolean" },
+        "suite": { "type": "object" },
+        "ablation_flags": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/ablation_flags" }
+        },
+        "model_config": { "type": "object" },
+        "retriever_config": { "type": "object" },
+        "reranker_config": { "type": "object" },
+        "verifier_config": { "type": "object" },
+        "metrics": { "type": "object" },
+        "latency": { "type": "object" },
+        "artifacts": { "$ref": "#/$defs/artifact_paths" }
+      },
+      "additionalProperties": true
+    },
+    "registry_entry": {
+      "type": "object",
+      "required": ["run_id", "git_commit", "suite_id", "baseline_run", "primary_run", "runs"],
+      "properties": {
+        "run_id": { "type": "string" },
+        "generated_at": { "type": "string" },
+        "git_commit": { "type": "string" },
+        "git_dirty": { "type": "boolean" },
+        "suite_id": { "type": "string" },
+        "dataset_id": { "type": "string" },
+        "baseline_run": { "type": "string" },
+        "primary_run": { "type": "string" },
+        "runs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "flags", "metrics"],
+            "properties": {
+              "name": { "type": "string" },
+              "flags": { "$ref": "#/$defs/ablation_flags" },
+              "metrics": { "$ref": "#/$defs/metric_block" }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/benchmarks/suites/public_synthetic_rfp.yaml
+++ b/benchmarks/suites/public_synthetic_rfp.yaml
@@ -1,0 +1,33 @@
+id: public_synthetic_rfp
+name: Public synthetic RFP benchmark
+description: Reproducible benchmark suite for the committed synthetic RFP sample set.
+dataset:
+  id: public_synthetic_rfp_v1
+  type: synthetic_rfp
+  input_dir: data/raw
+  privacy: public_synthetic_only
+  note: Private/original RFP documents must not be committed or referenced in docs.
+index:
+  output_dir: data/index
+  embedding_backend: hashing
+  command:
+    - python3
+    - scripts/build_index.py
+    - --input_dir
+    - data/raw
+    - --output_dir
+    - data/index
+    - --embedding_backend
+    - hashing
+eval:
+  config: eval/config.yaml
+  output_dir: reports
+artifacts:
+  root: artifacts/benchmarks
+  gitignored: true
+  local_only:
+    - predictions.jsonl
+    - latency_samples.jsonl
+    - traces/
+    - logs/
+    - per-example dumps

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # BidMate Agent 상세 문서
 
 - [포트폴리오 case study](./portfolio-case-study.md)
+- [Benchmarking](./benchmarking.md)
+- [Ablation results](./ablation-results.md)
 - [설계 배경 및 의사결정](./design-background.md)
 - [답변 출력 정책](./answer-policy.md)
 - [PDF/HWP ingestion](./real-data-ingestion.md)

--- a/docs/ablation-results.md
+++ b/docs/ablation-results.md
@@ -1,0 +1,47 @@
+# Ablation Results
+
+이 문서는 커밋 가능한 집계 지표만 남긴다. Raw predictions, traces, logs, latency samples, per-example dumps는 `artifacts/benchmarks/` 아래에 생성되며 Git에 커밋하지 않는다.
+
+## Latest Run
+
+- Run ID: `public_synthetic_rfp_20260502T021448Z`
+- Suite: `public_synthetic_rfp` / Dataset: `public_synthetic_rfp_v1`
+- Git commit: `7d23eab541bee20fd014d7df0f4827761071de09`
+- Baseline: `no_verifier_retry`
+- Primary: `full`
+- Local manifest: `artifacts/benchmarks/public_synthetic_rfp_20260502T021448Z/run_manifest.json`
+
+## Baseline To Primary
+
+| Metric | Baseline | Primary | Delta |
+|---|---:|---:|---:|
+| Accuracy | 1.000 | 1.000 | +0.000 |
+| Groundedness | 0.769 | 1.000 | +0.231 |
+| Citation Precision | 0.769 | 1.000 | +0.231 |
+| Format Compliance | 0.769 | 1.000 | +0.231 |
+| Abstention | 0.143 | 1.000 | +0.857 |
+| Retry Rate | 0.000 | 0.231 | +0.231 |
+| Latency p95 | 2.3ms | 3.7ms | +1.428 |
+
+## Ablation Table
+
+| Run | Metadata-first | Rerank | Verifier/Retry | Retrieval | Accuracy | Groundedness | Citation | Format | Abstention | Retry | Latency p95 |
+|---|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|
+| full | on | on | on | flat | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 3.7ms |
+| hierarchical | on | on | on | hierarchical | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 3.6ms |
+| no_metadata_first | off | on | on | flat | 1.000 | 1.000 | 0.846 | 1.000 | 1.000 | 0.000 | 3.5ms |
+| no_rerank | on | off | on | flat | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 2.7ms |
+| no_verifier_retry | on | on | off | flat | 1.000 | 0.769 | 0.769 | 0.769 | 0.143 | 0.000 | 2.3ms |
+
+## Interpretation
+
+- `no_verifier_retry`는 verifier/retry를 끈 lightweight baseline이다.
+- `full`는 metadata-first, rerank, verifier/retry를 모두 켠 primary run이다.
+- latency와 retry는 품질 지표와 함께 본다. retry가 늘어도 groundedness, citation, abstention 개선이 동반되는지 확인한다.
+- 현재 수치는 공개 synthetic RFP 평가셋 기준의 2차 가공 집계이며, 원본 RFP 문서나 raw example output은 포함하지 않는다.
+
+## Next Actions
+
+- 평가셋을 늘릴 때는 suite YAML을 추가하고 registry에는 집계 지표만 편입한다.
+- private RFP 기반 실험은 local artifact로만 보관하고 문서에는 익명화된 집계 결과만 남긴다.
+- citation 검증과 latency/retry 비용 분석은 별도 ablation axis로 분리해 누적한다.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,52 @@
+# Benchmarking
+
+이 저장소의 benchmark 관리는 커밋 가능한 정의와 로컬 실행 산출물을 분리한다. 목적은 포트폴리오 리뷰어가 실험 설계와 비교 결과를 빠르게 이해하되, raw prediction이나 비공개 원본 RFP가 Git에 섞이지 않게 하는 것이다.
+
+## Source Of Truth
+
+- `benchmarks/suites/public_synthetic_rfp.yaml`: 공개 synthetic RFP benchmark suite 정의
+- `benchmarks/ablations/rag_quality_axes.yaml`: baseline, primary run, ablation flag 정의
+- `benchmarks/registry.schema.json`: registry와 run manifest의 최소 schema
+- `benchmarks/registry.json`: 커밋 가능한 집계 registry
+
+`benchmarks/`에는 실행 정의와 집계 지표만 둔다. 원문 RFP, raw logs, per-example dump는 커밋하지 않는다.
+
+## Local Artifacts
+
+`scripts/run_benchmark.py`는 실행별 산출물을 `artifacts/benchmarks/<run_id>/`에 저장한다.
+
+```bash
+python3 scripts/run_benchmark.py \
+  --suite benchmarks/suites/public_synthetic_rfp.yaml \
+  --ablations benchmarks/ablations/rag_quality_axes.yaml
+```
+
+생성되는 로컬 파일은 다음과 같다.
+
+- `run_manifest.json`: run id, git commit, suite id, ablation flags, model/retriever/reranker/verifier config, metrics, latency, artifact path
+- `eval_summary.json`: benchmark run의 aggregate eval summary
+- `predictions.jsonl`: per-example prediction dump
+- `latency_samples.jsonl`: per-example latency/retry sample
+- `traces/`: per-example plan/diagnostics/evidence reference
+- `logs/`: index build 등 command log
+
+`artifacts/benchmarks/`는 `.gitignore` 대상이다. 공개 synthetic 실행이라도 raw prediction과 trace는 noisy하고 커밋 diff를 크게 만들기 때문에 로컬 검증용으로만 둔다.
+
+## Summarization
+
+로컬 manifest를 확인한 뒤 커밋 가능한 집계 registry와 사람이 읽는 요약 문서를 갱신한다.
+
+```bash
+python3 scripts/summarize_benchmark.py \
+  --manifest artifacts/benchmarks/<run_id>/run_manifest.json
+```
+
+최신성 검증은 다음 명령을 사용한다.
+
+```bash
+python3 scripts/summarize_benchmark.py \
+  --manifest artifacts/benchmarks/<run_id>/run_manifest.json \
+  --check
+```
+
+요약 결과는 `benchmarks/registry.json`과 `docs/ablation-results.md`에 반영된다. 문서에는 2차 가공 결과와 집계 지표만 남기며, private RFP 기반 실험을 수행하더라도 원문이나 per-example output은 포함하지 않는다.

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -201,6 +201,7 @@ def score_case(
     evidence_text = " ".join(str(item.get("text") or "") for item in evidence)
     combined_text = " ".join([answer, evidence_text])
     diagnostics = prediction.get("diagnostics") or {}
+    context_resolution = diagnostics.get("context_resolution") or {}
     abstained = bool(diagnostics.get("abstained"))
     answer_format = score_answer_format(case, prediction, answer_policy)
 
@@ -344,6 +345,7 @@ def evaluate_run(
                 metadata_first=bool(run_config.get("metadata_first", True)),
                 rerank=bool(run_config.get("rerank", True)),
                 verifier_retry=bool(run_config.get("verifier_retry", True)),
+                retrieval_mode=str(run_config.get("retrieval_mode", "flat")),
                 conversation_state=conversation_state,
             )
             conversation_state = prior_prediction.get("conversation_state") or conversation_state
@@ -355,6 +357,7 @@ def evaluate_run(
             metadata_first=bool(run_config.get("metadata_first", True)),
             rerank=bool(run_config.get("rerank", True)),
             verifier_retry=bool(run_config.get("verifier_retry", True)),
+            retrieval_mode=str(run_config.get("retrieval_mode", "flat")),
             conversation_state=conversation_state,
         )
         case_results.append(score_case(case, prediction, answer_policy))

--- a/outputs/answer.json
+++ b/outputs/answer.json
@@ -1,6 +1,7 @@
 {
   "mode": "rag",
   "query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+  "resolved_query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
   "analysis": {
     "query_type": "comparison",
     "entities": [
@@ -109,6 +110,14 @@
     "metadata_doc_scores": {
       "rfp-agency-a-ai-quality": 1.0,
       "rfp-agency-b-mlops-governance": 1.0
+    },
+    "context_resolution": {
+      "status": "not_needed",
+      "source": "query",
+      "confidence": 1.0,
+      "reason": "",
+      "resolved_query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+      "context_entities": []
     }
   },
   "plan": {
@@ -223,8 +232,55 @@
       "child_chunk_ids": []
     }
   ],
+  "conversation_state": {
+    "schema_version": 1,
+    "active_agencies": [
+      "기관 A",
+      "기관 B"
+    ],
+    "active_projects": [
+      "AI 품질관리 플랫폼 구축",
+      "데이터 거버넌스 및 MLOps 자동화"
+    ],
+    "active_topics": [
+      "AI"
+    ],
+    "active_doc_ids": [
+      "rfp-agency-a-ai-quality",
+      "rfp-agency-b-mlops-governance"
+    ],
+    "confidence": 1.0,
+    "turns": [
+      {
+        "turn": 1,
+        "query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+        "resolved_query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+        "active_agencies": [
+          "기관 A",
+          "기관 B"
+        ],
+        "active_projects": [
+          "AI 품질관리 플랫폼 구축",
+          "데이터 거버넌스 및 MLOps 자동화"
+        ],
+        "active_topics": [
+          "AI"
+        ],
+        "active_doc_ids": [
+          "rfp-agency-a-ai-quality",
+          "rfp-agency-b-mlops-governance"
+        ],
+        "context_resolution": {
+          "status": "not_needed",
+          "source": "query",
+          "confidence": 1.0,
+          "reason": ""
+        }
+      }
+    ]
+  },
   "diagnostics": {
-    "latency_ms": 7.41,
+    "latency_ms": 5.44,
     "retry_count": 0,
     "abstained": false,
     "answer_status": "supported",
@@ -261,6 +317,14 @@
       }
     ],
     "final_relaxation_reason": [],
+    "context_resolution": {
+      "status": "not_needed",
+      "source": "query",
+      "confidence": 1.0,
+      "reason": "",
+      "resolved_query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+      "context_entities": []
+    },
     "embedding_backend": "hashing",
     "embedding_model": "local-hashing-bow",
     "metadata_first": true,

--- a/rag_core.py
+++ b/rag_core.py
@@ -25,6 +25,20 @@ DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-
 DEFAULT_HASH_DIM = 384
 DEFAULT_CHUNK_MAX_CHARS = 520
 DEFAULT_CHUNK_OVERLAP_SENTENCES = 1
+VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
+VALID_RETRIEVAL_MODES = {"flat", "hierarchical"}
+WEAK_SECTION_HEADINGS = {
+    "",
+    "본문",
+    "body",
+    "text",
+    "document",
+    "문서",
+    "문서 전체",
+    "section",
+    "section-1",
+    "section-001",
+}
 INDEX_FILENAME = "index.json"
 MODEL_CACHE: dict[tuple[str, bool], Any] = {}
 
@@ -1815,12 +1829,29 @@ def make_context_clarification_result(
     metadata_first: bool,
     rerank: bool,
     verifier_retry: bool,
+    retrieval_mode: str,
 ) -> dict[str, Any]:
     reason = str(context_resolution.get("reason") or "context_resolution_failed")
     analysis = dict(analysis)
     analysis["query_type"] = "follow_up"
     analysis["context_resolution"] = context_resolution
     latency_ms = (time.perf_counter() - started) * 1000
+    insufficiency = {
+        "message": f"'{query}'의 생략된 참조를 충분히 확정하지 못했습니다.",
+        "reasons": [reason],
+        "missing_targets": context_resolution.get("context_entities") or [],
+        "missing_topics": specific_topics(analysis),
+        "checked_entities": context_resolution.get("context_entities") or [],
+        "checked_doc_ids": context_resolution.get("active_doc_ids") or [],
+    }
+    answer = {
+        "status": ANSWER_STATUS_INSUFFICIENT,
+        "query_type": "abstention",
+        "summary": clarification_answer(query, context_resolution),
+        "claims": [],
+        "insufficiency": insufficiency,
+    }
+    answer_text = render_answer_text(answer)
     return {
         "mode": "rag",
         "query": query,
@@ -1831,18 +1862,24 @@ def make_context_clarification_result(
             "metadata_first": metadata_first,
             "rerank": rerank,
             "verifier_retry": verifier_retry,
+            "retrieval_mode": retrieval_mode,
             "metadata_filters": {},
             "top_k": None,
             "relaxed": False,
             "retry_policy": "clarify before retrieval when entity resolution is weak",
         },
-        "answer": clarification_answer(query, context_resolution),
+        "answer": answer,
+        "answer_text": answer_text,
         "evidence": [],
         "conversation_state": conversation_state,
         "diagnostics": {
             "latency_ms": round(latency_ms, 2),
             "retry_count": 0,
             "abstained": True,
+            "answer_status": answer["status"],
+            "answer_query_type": answer["query_type"],
+            "claim_count": 0,
+            "citation_count": 0,
             "verification_reasons": [reason],
             "filter_stage_attempts": [],
             "final_relaxation_reason": [],
@@ -1852,6 +1889,7 @@ def make_context_clarification_result(
             "metadata_first": metadata_first,
             "rerank": rerank,
             "verifier_retry": verifier_retry,
+            "retrieval_mode": retrieval_mode,
         },
     }
 
@@ -1931,8 +1969,12 @@ def run_rag_query(
     metadata_first: bool = True,
     rerank: bool = True,
     verifier_retry: bool = True,
+    retrieval_mode: str = "flat",
     conversation_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    if retrieval_mode not in VALID_RETRIEVAL_MODES:
+        choices = ", ".join(sorted(VALID_RETRIEVAL_MODES))
+        raise ValueError(f"retrieval_mode must be one of: {choices}")
     started = time.perf_counter()
     state = normalize_conversation_state(conversation_state)
     targets = metadata_targets(index)
@@ -1954,6 +1996,7 @@ def run_rag_query(
             metadata_first,
             rerank,
             verifier_retry,
+            retrieval_mode,
         )
 
     analysis = analyze_query(
@@ -2013,6 +2056,14 @@ def run_rag_query(
         verified,
         verification_reasons,
     )
+    next_state = update_conversation_state(
+        state,
+        query,
+        retrieval_query,
+        analysis,
+        evidence,
+        context_resolution,
+    )
     latency_ms = (time.perf_counter() - started) * 1000
     return {
         "mode": "rag",
@@ -2023,7 +2074,7 @@ def run_rag_query(
         "answer": answer,
         "answer_text": answer_text,
         "evidence": strip_internal_scores(evidence),
-        "conversation_state": state,
+        "conversation_state": next_state,
         "diagnostics": {
             "latency_ms": round(latency_ms, 2),
             "retry_count": retry_count,

--- a/reports/eval_summary.json
+++ b/reports/eval_summary.json
@@ -9,9 +9,9 @@
   "abstention": 1.0,
   "answer_format_compliance": 1.0,
   "latency": {
-    "p50": 2.9450000000000003,
-    "p95": 11.890999999999998,
-    "mean": 4.8912499999999985
+    "p50": 2.38,
+    "p95": 4.7225,
+    "mean": 2.586538461538461
   },
   "retry": 0.23076923076923078,
   "by_query_type": {
@@ -23,9 +23,9 @@
       "abstention": null,
       "answer_format_compliance": 1.0,
       "latency": {
-        "p50": 9.44,
-        "p95": 12.32,
-        "mean": 7.771666666666666
+        "p50": 2.0250000000000004,
+        "p95": 6.02,
+        "mean": 2.8466666666666662
       },
       "retry": 0.0,
       "retry_cost": {
@@ -44,9 +44,9 @@
       "abstention": null,
       "answer_format_compliance": 1.0,
       "latency": {
-        "p50": 3.855,
-        "p95": 8.4275,
-        "mean": 4.536666666666667
+        "p50": 2.8899999999999997,
+        "p95": 4.334999999999999,
+        "mean": 3.1
       },
       "retry": 0.0,
       "retry_cost": {
@@ -62,12 +62,12 @@
       "accuracy": 1.0,
       "groundedness": 1.0,
       "citation_precision": 1.0,
-      "abstention": null,
+      "abstention": 1.0,
       "answer_format_compliance": 1.0,
       "latency": {
-        "p50": 1.3599999999999999,
-        "p95": 6.34,
-        "mean": 2.4483333333333333
+        "p50": 1.31,
+        "p95": 1.5630000000000002,
+        "mean": 1.2600000000000002
       },
       "retry": 0.0,
       "retry_cost": {
@@ -86,9 +86,9 @@
       "abstention": 1.0,
       "answer_format_compliance": 1.0,
       "latency": {
-        "p50": 3.495,
-        "p95": 9.3075,
-        "mean": 4.808333333333334
+        "p50": 3.275,
+        "p95": 4.66,
+        "mean": 3.581666666666667
       },
       "retry": 1.0,
       "retry_cost": {
@@ -118,6 +118,7 @@
         "metadata_first": true,
         "rerank": true,
         "verifier_retry": true,
+        "retrieval_mode": "flat",
         "num_predictions": 26,
         "accuracy": 1.0,
         "groundedness": 1.0,
@@ -125,9 +126,9 @@
         "abstention": 1.0,
         "answer_format_compliance": 1.0,
         "latency": {
-          "p50": 2.9450000000000003,
-          "p95": 11.890999999999998,
-          "mean": 4.8912499999999985
+          "p50": 2.38,
+          "p95": 4.7225,
+          "mean": 2.586538461538461
         },
         "retry": 0.23076923076923078,
         "retry_cost": {
@@ -148,9 +149,9 @@
             "abstention": null,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 9.44,
-              "p95": 12.32,
-              "mean": 7.771666666666666
+              "p50": 2.0250000000000004,
+              "p95": 6.02,
+              "mean": 2.8466666666666662
             },
             "retry": 0.0,
             "retry_cost": {
@@ -169,9 +170,9 @@
             "abstention": null,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 3.855,
-              "p95": 8.4275,
-              "mean": 4.536666666666667
+              "p50": 2.8899999999999997,
+              "p95": 4.334999999999999,
+              "mean": 3.1
             },
             "retry": 0.0,
             "retry_cost": {
@@ -187,12 +188,12 @@
             "accuracy": 1.0,
             "groundedness": 1.0,
             "citation_precision": 1.0,
-            "abstention": null,
+            "abstention": 1.0,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 1.3599999999999999,
-              "p95": 6.34,
-              "mean": 2.4483333333333333
+              "p50": 1.31,
+              "p95": 1.5630000000000002,
+              "mean": 1.2600000000000002
             },
             "retry": 0.0,
             "retry_cost": {
@@ -211,9 +212,9 @@
             "abstention": 1.0,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 3.495,
-              "p95": 9.3075,
-              "mean": 4.808333333333334
+              "p50": 3.275,
+              "p95": 4.66,
+              "mean": 3.581666666666667
             },
             "retry": 1.0,
             "retry_cost": {
@@ -247,7 +248,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 12.43,
+            "latency_ms": 7.1,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -293,7 +294,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 11.33,
+            "latency_ms": 1.85,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -339,7 +340,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.86,
+            "latency_ms": 1.66,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -385,7 +386,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 11.99,
+            "latency_ms": 2.78,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -431,7 +432,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.47,
+            "latency_ms": 1.49,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -477,7 +478,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 7.55,
+            "latency_ms": 2.2,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -525,7 +526,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 4.51,
+            "latency_ms": 2.23,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -575,7 +576,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 2.47,
+            "latency_ms": 2.65,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -625,7 +626,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.59,
+            "latency_ms": 2.53,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -675,7 +676,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 6.32,
+            "latency_ms": 3.42,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -725,7 +726,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 9.13,
+            "latency_ms": 3.13,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -775,7 +776,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 3.2,
+            "latency_ms": 4.64,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "not_needed",
@@ -823,7 +824,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.96,
+            "latency_ms": 1.26,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "resolved",
@@ -869,7 +870,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.22,
+            "latency_ms": 1.19,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "resolved",
@@ -915,7 +916,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 0.99,
+            "latency_ms": 1.13,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "resolved",
@@ -961,7 +962,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 2.35,
+            "latency_ms": 1.55,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "resolved",
@@ -1007,7 +1008,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 7.67,
+            "latency_ms": 1.36,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "resolved",
@@ -1053,7 +1054,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.5,
+            "latency_ms": 1.55,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "resolved",
@@ -1099,7 +1100,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": null,
-            "latency_ms": 1.86,
+            "latency_ms": 1.57,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "resolved",
@@ -1108,7 +1109,21 @@
             "context_resolution_reason": "",
             "resolved_query": "기관 A 그 기관이 요구한 보안 조건도 보여줘",
             "abstained": false,
-            "answer": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004]"
+            "expected_answer_status": "supported",
+            "answer_status": "supported",
+            "expected_claim_targets": [],
+            "claim_targets": [
+              "기관 A"
+            ],
+            "claim_count": 2,
+            "format_checks": {
+              "status_match": true,
+              "min_claims": true,
+              "claim_targets": true,
+              "claim_citations": true
+            },
+            "answer_format_compliance": 1.0,
+            "answer": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다.\n- 기관 A: 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002]\n- 기관 A: 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004] 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 시스템은 모델별 정확도와 오류 유형을 수집하고 위험 이벤트를 감사 로그로 남겨야 한다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. 제안사는 PM, ML 엔지니어, 보안 담당자를 포함한 수행 조직을 제시해야 한다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다."
           },
           {
             "id": "follow_up_state_ambiguous_clarification",
@@ -1125,7 +1140,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 0.32,
+            "latency_ms": 0.47,
             "retry_count": 0,
             "retry_trigger_reasons": [],
             "context_resolution_status": "needs_clarification",
@@ -1134,7 +1149,19 @@
             "context_resolution_reason": "ambiguous_active_state",
             "resolved_query": "그 기관의 보안 조건은?",
             "abstained": true,
-            "answer": "'그 기관의 보안 조건은?'에서 가리키는 대상이 모호합니다. 현재 문맥 후보는 기관 A, 기관 B입니다. 기관명 또는 사업명을 하나로 지정해 주세요."
+            "expected_answer_status": "insufficient",
+            "answer_status": "insufficient",
+            "expected_claim_targets": [],
+            "claim_targets": [],
+            "claim_count": 0,
+            "format_checks": {
+              "status_match": true,
+              "min_claims": true,
+              "claim_targets": true,
+              "claim_citations": true
+            },
+            "answer_format_compliance": 1.0,
+            "answer": "'그 기관의 보안 조건은?'에서 가리키는 대상이 모호합니다. 현재 문맥 후보는 기관 A, 기관 B입니다. 기관명 또는 사업명을 하나로 지정해 주세요. '그 기관의 보안 조건은?'에서 가리키는 대상이 모호합니다. 현재 문맥 후보는 기관 A, 기관 B입니다. 기관명 또는 사업명을 하나로 지정해 주세요.\n- 근거 부족: 사유: ambiguous_active_state; 확인 필요 대상: 기관 A, 기관 B '그 기관의 보안 조건은?'의 생략된 참조를 충분히 확정하지 못했습니다."
           },
           {
             "id": "abstention_missing_blockchain",
@@ -1151,7 +1178,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 2.69,
+            "latency_ms": 4.75,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -1192,7 +1219,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 2.29,
+            "latency_ms": 2.88,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -1233,7 +1260,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 2.38,
+            "latency_ms": 3.44,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -1274,7 +1301,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 4.3,
+            "latency_ms": 3.11,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -1315,7 +1342,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 10.02,
+            "latency_ms": 4.39,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -1356,7 +1383,7 @@
             "groundedness": 1.0,
             "citation_precision": 1.0,
             "abstention": 1.0,
-            "latency_ms": 7.17,
+            "latency_ms": 2.92,
             "retry_count": 1,
             "retry_trigger_reasons": [
               "topic_not_grounded",
@@ -1390,231 +1417,6 @@
         "rerank": true,
         "verifier_retry": true,
         "retrieval_mode": "hierarchical",
-        "num_predictions": 24,
-        "accuracy": 1.0,
-        "groundedness": 1.0,
-        "citation_precision": 1.0,
-        "abstention": 1.0,
-        "latency": {
-          "p50": 0.96,
-          "p95": 1.5069999999999997,
-          "mean": 1.0179166666666668
-        },
-        "retry": 0.25,
-        "retry_cost": {
-          "total_retries": 6,
-          "mean_retry_count": 0.25,
-          "max_retry_count": 1,
-          "cases_with_retry": 6
-        },
-        "retry_reason_counts": {
-          "topic_not_grounded": 12
-        },
-        "by_query_type": {
-          "single_doc": {
-            "num_predictions": 6,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 1.0,
-            "abstention": null,
-            "latency": {
-              "p50": 0.895,
-              "p95": 1.0550000000000002,
-              "mean": 0.8783333333333333
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "multi_doc": {
-            "num_predictions": 6,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 1.0,
-            "abstention": null,
-            "latency": {
-              "p50": 1.085,
-              "p95": 1.9525,
-              "mean": 1.26
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "follow_up": {
-            "num_predictions": 6,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 1.0,
-            "abstention": null,
-            "latency": {
-              "p50": 0.755,
-              "p95": 0.9175,
-              "mean": 0.7666666666666667
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "abstention": {
-            "num_predictions": 6,
-            "accuracy": null,
-            "groundedness": 1.0,
-            "citation_precision": 1.0,
-            "abstention": 1.0,
-            "latency": {
-              "p50": 1.185,
-              "p95": 1.315,
-              "mean": 1.1666666666666667
-            },
-            "retry": 1.0,
-            "retry_cost": {
-              "total_retries": 6,
-              "mean_retry_count": 1.0,
-              "max_retry_count": 1,
-              "cases_with_retry": 6
-            },
-            "retry_reason_counts": {
-              "topic_not_grounded": 12
-            }
-          }
-        }
-      },
-      {
-        "name": "no_metadata_first",
-        "metadata_first": false,
-        "rerank": true,
-        "verifier_retry": true,
-        "num_predictions": 26,
-        "accuracy": 1.0,
-        "groundedness": 1.0,
-        "citation_precision": 0.8461538461538461,
-        "abstention": 1.0,
-        "answer_format_compliance": 1.0,
-        "latency": {
-          "p50": 2.17,
-          "p95": 11.905499999999996,
-          "mean": 3.915833333333333
-        },
-        "retry": 0.0,
-        "retry_cost": {
-          "total_retries": 0,
-          "mean_retry_count": 0.0,
-          "max_retry_count": 0,
-          "cases_with_retry": 0
-        },
-        "retry_reason_counts": {
-          "topic_not_grounded": 6
-        },
-        "by_query_type": {
-          "single_doc": {
-            "num_predictions": 6,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 0.75,
-            "abstention": null,
-            "answer_format_compliance": 1.0,
-            "latency": {
-              "p50": 2.125,
-              "p95": 10.4775,
-              "mean": 4.5249999999999995
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "multi_doc": {
-            "num_predictions": 6,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 1.0,
-            "abstention": null,
-            "answer_format_compliance": 1.0,
-            "latency": {
-              "p50": 2.705,
-              "p95": 12.03,
-              "mean": 5.48
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "follow_up": {
-            "num_predictions": 8,
-            "accuracy": 1.0,
-            "groundedness": 1.0,
-            "citation_precision": 0.5833333333333334,
-            "abstention": null,
-            "answer_format_compliance": 1.0,
-            "latency": {
-              "p50": 2.11,
-              "p95": 6.6625000000000005,
-              "mean": 3.3633333333333333
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {}
-          },
-          "abstention": {
-            "num_predictions": 6,
-            "accuracy": null,
-            "groundedness": 1.0,
-            "citation_precision": 1.0,
-            "abstention": 1.0,
-            "answer_format_compliance": 1.0,
-            "latency": {
-              "p50": 1.7650000000000001,
-              "p95": 4.609999999999999,
-              "mean": 2.2949999999999995
-            },
-            "retry": 0.0,
-            "retry_cost": {
-              "total_retries": 0,
-              "mean_retry_count": 0.0,
-              "max_retry_count": 0,
-              "cases_with_retry": 0
-            },
-            "retry_reason_counts": {
-              "topic_not_grounded": 6
-            }
-          }
-        }
-      },
-      {
-        "name": "no_rerank",
-        "metadata_first": true,
-        "rerank": false,
-        "verifier_retry": true,
         "num_predictions": 26,
         "accuracy": 1.0,
         "groundedness": 1.0,
@@ -1622,9 +1424,9 @@
         "abstention": 1.0,
         "answer_format_compliance": 1.0,
         "latency": {
-          "p50": 2.115,
-          "p95": 7.907499999999997,
-          "mean": 3.2733333333333334
+          "p50": 2.03,
+          "p95": 5.37,
+          "mean": 2.5176923076923075
         },
         "retry": 0.23076923076923078,
         "retry_cost": {
@@ -1645,9 +1447,9 @@
             "abstention": null,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 1.945,
-              "p95": 6.7675,
-              "mean": 2.86
+              "p50": 1.94,
+              "p95": 2.6024999999999996,
+              "mean": 1.9966666666666668
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1666,9 +1468,9 @@
             "abstention": null,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 2.335,
-              "p95": 5.3525,
-              "mean": 3.0
+              "p50": 2.92,
+              "p95": 5.37,
+              "mean": 3.315
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1684,12 +1486,12 @@
             "accuracy": 1.0,
             "groundedness": 1.0,
             "citation_precision": 1.0,
-            "abstention": null,
+            "abstention": 1.0,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 1.7200000000000002,
-              "p95": 11.8225,
-              "mean": 4.373333333333333
+              "p50": 1.42,
+              "p95": 1.801,
+              "mean": 1.3162500000000001
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1708,9 +1510,241 @@
             "abstention": 1.0,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 2.465,
-              "p95": 4.33,
-              "mean": 2.86
+              "p50": 2.665,
+              "p95": 8.59,
+              "mean": 3.8433333333333337
+            },
+            "retry": 1.0,
+            "retry_cost": {
+              "total_retries": 6,
+              "mean_retry_count": 1.0,
+              "max_retry_count": 1,
+              "cases_with_retry": 6
+            },
+            "retry_reason_counts": {
+              "topic_not_grounded": 12
+            }
+          }
+        }
+      },
+      {
+        "name": "no_metadata_first",
+        "metadata_first": false,
+        "rerank": true,
+        "verifier_retry": true,
+        "retrieval_mode": "flat",
+        "num_predictions": 26,
+        "accuracy": 1.0,
+        "groundedness": 1.0,
+        "citation_precision": 0.8461538461538461,
+        "abstention": 1.0,
+        "answer_format_compliance": 1.0,
+        "latency": {
+          "p50": 2.34,
+          "p95": 4.1499999999999995,
+          "mean": 2.396153846153847
+        },
+        "retry": 0.0,
+        "retry_cost": {
+          "total_retries": 0,
+          "mean_retry_count": 0.0,
+          "max_retry_count": 0,
+          "cases_with_retry": 0
+        },
+        "retry_reason_counts": {
+          "topic_not_grounded": 6
+        },
+        "by_query_type": {
+          "single_doc": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 0.75,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "latency": {
+              "p50": 3.2,
+              "p95": 4.615,
+              "mean": 3.486666666666667
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "multi_doc": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "latency": {
+              "p50": 2.455,
+              "p95": 3.2575000000000003,
+              "mean": 2.603333333333333
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "follow_up": {
+            "num_predictions": 8,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 0.6875,
+            "abstention": 1.0,
+            "answer_format_compliance": 1.0,
+            "latency": {
+              "p50": 1.79,
+              "p95": 2.0355,
+              "mean": 1.64
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "abstention": {
+            "num_predictions": 6,
+            "accuracy": null,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": 1.0,
+            "answer_format_compliance": 1.0,
+            "latency": {
+              "p50": 2.105,
+              "p95": 2.5275,
+              "mean": 2.1066666666666665
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {
+              "topic_not_grounded": 6
+            }
+          }
+        }
+      },
+      {
+        "name": "no_rerank",
+        "metadata_first": true,
+        "rerank": false,
+        "verifier_retry": true,
+        "retrieval_mode": "flat",
+        "num_predictions": 26,
+        "accuracy": 1.0,
+        "groundedness": 1.0,
+        "citation_precision": 1.0,
+        "abstention": 1.0,
+        "answer_format_compliance": 1.0,
+        "latency": {
+          "p50": 1.87,
+          "p95": 3.6825,
+          "mean": 1.9619230769230767
+        },
+        "retry": 0.23076923076923078,
+        "retry_cost": {
+          "total_retries": 6,
+          "mean_retry_count": 0.23076923076923078,
+          "max_retry_count": 1,
+          "cases_with_retry": 6
+        },
+        "retry_reason_counts": {
+          "topic_not_grounded": 12
+        },
+        "by_query_type": {
+          "single_doc": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "latency": {
+              "p50": 1.935,
+              "p95": 2.535,
+              "mean": 1.9633333333333336
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "multi_doc": {
+            "num_predictions": 6,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "latency": {
+              "p50": 1.9449999999999998,
+              "p95": 4.0249999999999995,
+              "mean": 2.5733333333333337
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "follow_up": {
+            "num_predictions": 8,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": 1.0,
+            "answer_format_compliance": 1.0,
+            "latency": {
+              "p50": 1.255,
+              "p95": 1.7869999999999997,
+              "mean": 1.2275
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {}
+          },
+          "abstention": {
+            "num_predictions": 6,
+            "accuracy": null,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "abstention": 1.0,
+            "answer_format_compliance": 1.0,
+            "latency": {
+              "p50": 2.2199999999999998,
+              "p95": 2.87,
+              "mean": 2.328333333333333
             },
             "retry": 1.0,
             "retry_cost": {
@@ -1730,16 +1764,17 @@
         "metadata_first": true,
         "rerank": true,
         "verifier_retry": false,
+        "retrieval_mode": "flat",
         "num_predictions": 26,
         "accuracy": 1.0,
-        "groundedness": 0.75,
-        "citation_precision": 0.75,
-        "abstention": 0.0,
-        "answer_format_compliance": 0.75,
+        "groundedness": 0.7692307692307693,
+        "citation_precision": 0.7692307692307693,
+        "abstention": 0.14285714285714285,
+        "answer_format_compliance": 0.7692307692307693,
         "latency": {
-          "p50": 1.9100000000000001,
-          "p95": 5.737499999999998,
-          "mean": 2.481666666666667
+          "p50": 1.55,
+          "p95": 2.4075,
+          "mean": 1.6057692307692308
         },
         "retry": 0.0,
         "retry_cost": {
@@ -1758,9 +1793,9 @@
             "abstention": null,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 1.79,
-              "p95": 5.095,
-              "mean": 2.401666666666667
+              "p50": 1.4649999999999999,
+              "p95": 2.0549999999999997,
+              "mean": 1.545
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1779,9 +1814,9 @@
             "abstention": null,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 2.05,
-              "p95": 6.4625,
-              "mean": 3.0933333333333337
+              "p50": 2.125,
+              "p95": 2.545,
+              "mean": 2.146666666666667
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1797,12 +1832,12 @@
             "accuracy": 1.0,
             "groundedness": 1.0,
             "citation_precision": 1.0,
-            "abstention": null,
+            "abstention": 1.0,
             "answer_format_compliance": 1.0,
             "latency": {
-              "p50": 1.255,
-              "p95": 3.8425,
-              "mean": 1.82
+              "p50": 1.05,
+              "p95": 1.376,
+              "mean": 1.0274999999999999
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1821,9 +1856,9 @@
             "abstention": 0.0,
             "answer_format_compliance": 0.0,
             "latency": {
-              "p50": 2.635,
-              "p95": 3.6225,
-              "mean": 2.611666666666667
+              "p50": 1.925,
+              "p95": 2.2625,
+              "mean": 1.8966666666666665
             },
             "retry": 0.0,
             "retry_cost": {
@@ -1858,7 +1893,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 12.43,
+      "latency_ms": 7.1,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -1904,7 +1939,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 11.33,
+      "latency_ms": 1.85,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -1950,7 +1985,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.86,
+      "latency_ms": 1.66,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -1996,7 +2031,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 11.99,
+      "latency_ms": 2.78,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2042,7 +2077,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.47,
+      "latency_ms": 1.49,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2088,7 +2123,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 7.55,
+      "latency_ms": 2.2,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2136,7 +2171,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 4.51,
+      "latency_ms": 2.23,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2186,7 +2221,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 2.47,
+      "latency_ms": 2.65,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2236,7 +2271,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.59,
+      "latency_ms": 2.53,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2286,7 +2321,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 6.32,
+      "latency_ms": 3.42,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2336,7 +2371,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 9.13,
+      "latency_ms": 3.13,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2386,7 +2421,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 3.2,
+      "latency_ms": 4.64,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "not_needed",
@@ -2434,7 +2469,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.96,
+      "latency_ms": 1.26,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "resolved",
@@ -2480,7 +2515,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.22,
+      "latency_ms": 1.19,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "resolved",
@@ -2526,7 +2561,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 0.99,
+      "latency_ms": 1.13,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "resolved",
@@ -2572,7 +2607,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 2.35,
+      "latency_ms": 1.55,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "resolved",
@@ -2618,7 +2653,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 7.67,
+      "latency_ms": 1.36,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "resolved",
@@ -2664,7 +2699,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.5,
+      "latency_ms": 1.55,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "resolved",
@@ -2710,7 +2745,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": null,
-      "latency_ms": 1.86,
+      "latency_ms": 1.57,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "resolved",
@@ -2719,7 +2754,21 @@
       "context_resolution_reason": "",
       "resolved_query": "기관 A 그 기관이 요구한 보안 조건도 보여줘",
       "abstained": false,
-      "answer": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002] 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004]"
+      "expected_answer_status": "supported",
+      "answer_status": "supported",
+      "expected_claim_targets": [],
+      "claim_targets": [
+        "기관 A"
+      ],
+      "claim_count": 2,
+      "format_checks": {
+        "status_match": true,
+        "min_claims": true,
+        "claim_targets": true,
+        "claim_citations": true
+      },
+      "answer_format_compliance": 1.0,
+      "answer": "기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다.\n- 기관 A: 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. [rfp-agency-a-ai-quality::chunk-002]\n- 기관 A: 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. [rfp-agency-a-ai-quality::chunk-004] 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 시스템은 모델별 정확도와 오류 유형을 수집하고 위험 이벤트를 감사 로그로 남겨야 한다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다. 제안사는 PM, ML 엔지니어, 보안 담당자를 포함한 수행 조직을 제시해야 한다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다."
     },
     {
       "id": "follow_up_state_ambiguous_clarification",
@@ -2736,7 +2785,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 0.32,
+      "latency_ms": 0.47,
       "retry_count": 0,
       "retry_trigger_reasons": [],
       "context_resolution_status": "needs_clarification",
@@ -2745,7 +2794,19 @@
       "context_resolution_reason": "ambiguous_active_state",
       "resolved_query": "그 기관의 보안 조건은?",
       "abstained": true,
-      "answer": "'그 기관의 보안 조건은?'에서 가리키는 대상이 모호합니다. 현재 문맥 후보는 기관 A, 기관 B입니다. 기관명 또는 사업명을 하나로 지정해 주세요."
+      "expected_answer_status": "insufficient",
+      "answer_status": "insufficient",
+      "expected_claim_targets": [],
+      "claim_targets": [],
+      "claim_count": 0,
+      "format_checks": {
+        "status_match": true,
+        "min_claims": true,
+        "claim_targets": true,
+        "claim_citations": true
+      },
+      "answer_format_compliance": 1.0,
+      "answer": "'그 기관의 보안 조건은?'에서 가리키는 대상이 모호합니다. 현재 문맥 후보는 기관 A, 기관 B입니다. 기관명 또는 사업명을 하나로 지정해 주세요. '그 기관의 보안 조건은?'에서 가리키는 대상이 모호합니다. 현재 문맥 후보는 기관 A, 기관 B입니다. 기관명 또는 사업명을 하나로 지정해 주세요.\n- 근거 부족: 사유: ambiguous_active_state; 확인 필요 대상: 기관 A, 기관 B '그 기관의 보안 조건은?'의 생략된 참조를 충분히 확정하지 못했습니다."
     },
     {
       "id": "abstention_missing_blockchain",
@@ -2762,7 +2823,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 2.69,
+      "latency_ms": 4.75,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -2803,7 +2864,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 2.29,
+      "latency_ms": 2.88,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -2844,7 +2905,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 2.38,
+      "latency_ms": 3.44,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -2885,7 +2946,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 4.3,
+      "latency_ms": 3.11,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -2926,7 +2987,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 10.02,
+      "latency_ms": 4.39,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",
@@ -2967,7 +3028,7 @@
       "groundedness": 1.0,
       "citation_precision": 1.0,
       "abstention": 1.0,
-      "latency_ms": 7.17,
+      "latency_ms": 2.92,
       "retry_count": 1,
       "retry_trigger_reasons": [
         "topic_not_grounded",

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from rag_core import load_index
+
+
+def load_eval_module() -> Any:
+    module_path = ROOT_DIR / "eval" / "run_eval.py"
+    spec = importlib.util.spec_from_file_location("bidmate_eval_run_eval", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load eval module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+EVAL = load_eval_module()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a benchmark suite and write local artifacts.")
+    parser.add_argument("--suite", required=True, help="Path to benchmarks/suites/*.yaml")
+    parser.add_argument("--ablations", required=True, help="Path to benchmarks/ablations/*.yaml")
+    parser.add_argument("--run_id", default=None, help="Optional stable run id.")
+    parser.add_argument("--artifact_root", default=None, help="Override artifact root directory.")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing run artifact directory.")
+    return parser.parse_args()
+
+
+def repo_path(value: str | Path) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def rel_path(path: str | Path) -> str:
+    resolved = Path(path).resolve()
+    try:
+        return str(resolved.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(resolved)
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML must be a mapping: {path}")
+    return data
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def json_hash(payload: Any) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def git_output(args: list[str], default: str = "unknown") -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=ROOT_DIR,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception:
+        return default
+    return result.stdout.strip() or default
+
+
+def git_dirty() -> bool:
+    status = git_output(["status", "--porcelain", "--untracked-files=no"], default="")
+    return bool(status.strip())
+
+
+def run_logged_command(command: list[str], log_path: Path) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log_file:
+        log_file.write("$ " + " ".join(command) + "\n\n")
+        log_file.flush()
+        result = subprocess.run(
+            command,
+            cwd=ROOT_DIR,
+            text=True,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+    if result.returncode != 0:
+        raise RuntimeError(f"Command failed with exit code {result.returncode}: {rel_path(log_path)}")
+
+
+def normalize_run(run: dict[str, Any]) -> dict[str, Any]:
+    name = str(run.get("name") or "").strip()
+    if not name:
+        raise ValueError("Each ablation run must include a name")
+    retrieval_mode = str(run.get("retrieval_mode", "flat"))
+    if retrieval_mode not in {"flat", "hierarchical"}:
+        raise ValueError(f"Invalid retrieval_mode for {name}: {retrieval_mode}")
+    return {
+        "name": name,
+        "metadata_first": bool(run.get("metadata_first", True)),
+        "rerank": bool(run.get("rerank", True)),
+        "verifier_retry": bool(run.get("verifier_retry", True)),
+        "retrieval_mode": retrieval_mode,
+    }
+
+
+def safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_") or "case"
+
+
+def metric_snapshot(summary: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "num_predictions",
+        "accuracy",
+        "groundedness",
+        "citation_precision",
+        "answer_format_compliance",
+        "abstention",
+        "retry",
+        "latency",
+        "retry_cost",
+        "retry_reason_counts",
+        "by_query_type",
+    ]
+    return {key: summary.get(key) for key in keys if key in summary}
+
+
+def run_flags(run: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "metadata_first": bool(run.get("metadata_first", True)),
+        "rerank": bool(run.get("rerank", True)),
+        "verifier_retry": bool(run.get("verifier_retry", True)),
+        "retrieval_mode": str(run.get("retrieval_mode", "flat")),
+    }
+
+
+def evaluate_run_with_artifacts(
+    index: dict[str, Any],
+    cases: list[dict[str, Any]],
+    run_config: dict[str, Any],
+    answer_policy: dict[str, Any],
+    predictions_file: Any,
+    latency_file: Any,
+    trace_dir: Path,
+) -> list[dict[str, Any]]:
+    case_results = []
+    run_name = str(run_config["name"])
+    run_trace_dir = trace_dir / run_name
+    run_trace_dir.mkdir(parents=True, exist_ok=True)
+
+    for case in cases:
+        conversation_state: dict[str, Any] = {}
+        for turn in case.get("prior_turns") or []:
+            prior_prediction = EVAL.run_rag_query(
+                index,
+                str(turn["query"]),
+                context_entities=turn.get("context_entities") or [],
+                metadata_first=bool(run_config.get("metadata_first", True)),
+                rerank=bool(run_config.get("rerank", True)),
+                verifier_retry=bool(run_config.get("verifier_retry", True)),
+                retrieval_mode=str(run_config.get("retrieval_mode", "flat")),
+                conversation_state=conversation_state,
+            )
+            conversation_state = prior_prediction.get("conversation_state") or conversation_state
+
+        prediction = EVAL.run_rag_query(
+            index,
+            str(case["query"]),
+            context_entities=case.get("context_entities") or [],
+            metadata_first=bool(run_config.get("metadata_first", True)),
+            rerank=bool(run_config.get("rerank", True)),
+            verifier_retry=bool(run_config.get("verifier_retry", True)),
+            retrieval_mode=str(run_config.get("retrieval_mode", "flat")),
+            conversation_state=conversation_state,
+        )
+        score = EVAL.score_case(case, prediction, answer_policy)
+        case_results.append(score)
+
+        record = {
+            "run": run_name,
+            "case_id": case.get("id"),
+            "query_type": case.get("query_type"),
+            "prediction": prediction,
+            "score": score,
+        }
+        predictions_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+        diagnostics = prediction.get("diagnostics") or {}
+        latency_file.write(
+            json.dumps(
+                {
+                    "run": run_name,
+                    "case_id": case.get("id"),
+                    "query_type": case.get("query_type"),
+                    "latency_ms": diagnostics.get("latency_ms"),
+                    "retry_count": diagnostics.get("retry_count", 0),
+                    "retrieval_mode": diagnostics.get("retrieval_mode"),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+
+        trace = {
+            "run": run_name,
+            "case_id": case.get("id"),
+            "plan": prediction.get("plan"),
+            "diagnostics": diagnostics,
+            "evidence_refs": [
+                {
+                    "doc_id": item.get("doc_id"),
+                    "chunk_id": item.get("chunk_id"),
+                    "section": item.get("section"),
+                    "score": item.get("score"),
+                }
+                for item in prediction.get("evidence") or []
+            ],
+        }
+        write_json(run_trace_dir / f"{safe_name(str(case.get('id') or 'case'))}.json", trace)
+
+    return case_results
+
+
+def build_summary(
+    run_summaries: list[dict[str, Any]],
+    primary_run: str,
+    config_path: str,
+    index_dir: str,
+) -> dict[str, Any]:
+    primary_summary = next((run for run in run_summaries if run["name"] == primary_run), None)
+    if primary_summary is None:
+        primary_summary = run_summaries[0]
+
+    return {
+        "mode": "rag",
+        "config": config_path,
+        "index_dir": index_dir,
+        "num_predictions": primary_summary["num_predictions"],
+        "accuracy": primary_summary["accuracy"],
+        "groundedness": primary_summary["groundedness"],
+        "citation_precision": primary_summary["citation_precision"],
+        "abstention": primary_summary["abstention"],
+        "answer_format_compliance": primary_summary["answer_format_compliance"],
+        "latency": primary_summary["latency"],
+        "retry": primary_summary["retry"],
+        "by_query_type": primary_summary["by_query_type"],
+        "retry_cost": primary_summary["retry_cost"],
+        "retry_reason_counts": primary_summary["retry_reason_counts"],
+        "ablation": {"runs": run_summaries},
+        "case_results": primary_summary.get("case_results", []),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    suite_path = repo_path(args.suite)
+    ablations_path = repo_path(args.ablations)
+    suite = load_yaml(suite_path)
+    ablations = load_yaml(ablations_path)
+    suite_id = str(suite.get("id") or suite_path.stem)
+    run_id = args.run_id or f"{suite_id}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+
+    artifact_root = repo_path(
+        args.artifact_root or suite.get("artifacts", {}).get("root") or "artifacts/benchmarks"
+    )
+    run_dir = artifact_root / run_id
+    if run_dir.exists() and not args.force:
+        raise SystemExit(f"[ERROR] Artifact directory already exists: {rel_path(run_dir)}")
+
+    traces_dir = run_dir / "traces"
+    logs_dir = run_dir / "logs"
+    predictions_path = run_dir / "predictions.jsonl"
+    latency_path = run_dir / "latency_samples.jsonl"
+    eval_summary_path = run_dir / "eval_summary.json"
+    manifest_path = run_dir / "run_manifest.json"
+
+    command = suite.get("index", {}).get("command")
+    if not isinstance(command, list) or not all(isinstance(part, str) for part in command):
+        raise SystemExit("[ERROR] suite.index.command must be a list of command tokens")
+    run_logged_command(command, logs_dir / "index.log")
+
+    eval_config_path = repo_path(suite.get("eval", {}).get("config") or "eval/config.yaml")
+    eval_config = EVAL.load_config(eval_config_path)
+    normalized_runs = [normalize_run(run) for run in ablations.get("runs") or []]
+    if not normalized_runs:
+        raise SystemExit("[ERROR] Ablation file must include non-empty runs")
+    eval_config["ablation_runs"] = normalized_runs
+
+    index_dir = repo_path(suite.get("index", {}).get("output_dir") or suite.get("eval", {}).get("index_dir") or "data/index")
+    index = load_index(index_dir)
+    answer_policy = eval_config.get("answer_policy") if isinstance(eval_config.get("answer_policy"), dict) else {}
+    primary_run = str(ablations.get("primary_run") or "full")
+    baseline_run = str(ablations.get("baseline_run") or normalized_runs[-1]["name"])
+
+    run_summaries = []
+    with predictions_path.open("w", encoding="utf-8") as predictions_file, latency_path.open(
+        "w", encoding="utf-8"
+    ) as latency_file:
+        for run_config in normalized_runs:
+            case_results = evaluate_run_with_artifacts(
+                index,
+                eval_config["cases"],
+                run_config,
+                answer_policy,
+                predictions_file,
+                latency_file,
+                traces_dir,
+            )
+            run_summary = EVAL.summarize_run(
+                run_config["name"],
+                run_config,
+                case_results,
+                include_cases=run_config["name"] == primary_run,
+            )
+            run_summaries.append(run_summary)
+
+    summary = build_summary(run_summaries, primary_run, rel_path(eval_config_path), rel_path(index_dir))
+    write_json(eval_summary_path, summary)
+
+    runs_by_name = {run["name"]: metric_snapshot(run) for run in run_summaries}
+    artifact_paths = {
+        "run_dir": rel_path(run_dir),
+        "run_manifest": rel_path(manifest_path),
+        "eval_summary": rel_path(eval_summary_path),
+        "predictions": rel_path(predictions_path),
+        "latency_samples": rel_path(latency_path),
+        "traces": rel_path(traces_dir),
+        "logs": rel_path(logs_dir),
+    }
+    config_snapshot = {
+        "suite": suite,
+        "ablations": ablations,
+        "eval": eval_config,
+    }
+    manifest = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "git_commit": git_output(["rev-parse", "HEAD"]),
+        "git_dirty": git_dirty(),
+        "config_hash": json_hash(config_snapshot),
+        "config_snapshot": config_snapshot,
+        "suite": {
+            "id": suite_id,
+            "path": rel_path(suite_path),
+            "dataset": suite.get("dataset") or {},
+            "eval_config": rel_path(eval_config_path),
+            "index_dir": rel_path(index_dir),
+        },
+        "ablation_suite": {
+            "id": str(ablations.get("id") or ablations_path.stem),
+            "path": rel_path(ablations_path),
+            "baseline_run": baseline_run,
+            "primary_run": primary_run,
+        },
+        "ablation_flags": {run["name"]: run_flags(run) for run in normalized_runs},
+        "model_config": index.get("embedding", {}),
+        "retriever_config": {
+            "index_dir": rel_path(index_dir),
+            "retrieval_modes": sorted({run["retrieval_mode"] for run in normalized_runs}),
+            "metadata_first_runs": {
+                run["name"]: bool(run.get("metadata_first", True)) for run in normalized_runs
+            },
+        },
+        "reranker_config": {
+            "enabled_by_run": {run["name"]: bool(run.get("rerank", True)) for run in normalized_runs}
+        },
+        "verifier_config": {
+            "retry_enabled_by_run": {
+                run["name"]: bool(run.get("verifier_retry", True)) for run in normalized_runs
+            }
+        },
+        "metrics": {
+            "baseline_run": baseline_run,
+            "primary_run": primary_run,
+            "baseline": runs_by_name.get(baseline_run),
+            "primary": runs_by_name.get(primary_run),
+            "runs": runs_by_name,
+        },
+        "latency": {
+            "baseline": (runs_by_name.get(baseline_run) or {}).get("latency"),
+            "primary": (runs_by_name.get(primary_run) or {}).get("latency"),
+            "runs": {name: metrics.get("latency") for name, metrics in runs_by_name.items()},
+        },
+        "artifacts": artifact_paths,
+    }
+    write_json(manifest_path, manifest)
+
+    print(f"[OK] Benchmark artifacts written: {rel_path(run_dir)}")
+    print(f"[OK] Run manifest: {rel_path(manifest_path)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -41,6 +41,14 @@ require_file "scripts/build_index.py"
 require_file "app.py"
 require_file "eval/run_eval.py"
 require_file "scripts/update_readme_metrics.py"
+require_file "scripts/run_benchmark.py"
+require_file "scripts/summarize_benchmark.py"
+require_file "benchmarks/suites/public_synthetic_rfp.yaml"
+require_file "benchmarks/ablations/rag_quality_axes.yaml"
+require_file "benchmarks/registry.schema.json"
+require_file "benchmarks/registry.json"
+require_file "docs/benchmarking.md"
+require_file "docs/ablation-results.md"
 require_file "$EVAL_CONFIG"
 require_file "$README_PATH"
 require_dir "$INPUT_DIR"
@@ -64,6 +72,7 @@ require_file "$REPORT_JSON"
 
 log "Checking README metrics consistency"
 if [[ "$REPORT_DIR" == "reports" ]]; then
+  python3 scripts/update_readme_metrics.py --report "$REPORT_JSON" --readme "$README_PATH"
   python3 scripts/update_readme_metrics.py --report "$REPORT_JSON" --readme "$README_PATH" --check
 else
   echo "Skipping README metrics check for non-default REPORT_DIR=$REPORT_DIR"

--- a/scripts/summarize_benchmark.py
+++ b/scripts/summarize_benchmark.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Update the committed benchmark registry and human-readable docs from a run manifest."
+    )
+    parser.add_argument("--manifest", required=True, help="Path to artifacts/benchmarks/<run_id>/run_manifest.json")
+    parser.add_argument("--registry", default="benchmarks/registry.json")
+    parser.add_argument("--docs", default="docs/ablation-results.md")
+    parser.add_argument("--check", action="store_true", help="Fail if registry/docs are not up-to-date")
+    return parser.parse_args()
+
+
+def repo_path(value: str | Path) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def stable_json(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+
+def fmt_rate(value: Any) -> str:
+    return f"{value:.3f}" if isinstance(value, (int, float)) else "N/A"
+
+
+def fmt_latency(value: Any) -> str:
+    if isinstance(value, dict) and isinstance(value.get("p95"), (int, float)):
+        return f"{value['p95']:.1f}ms"
+    return "N/A"
+
+
+def fmt_delta(primary: Any, baseline: Any) -> str:
+    if not isinstance(primary, (int, float)) or not isinstance(baseline, (int, float)):
+        return "N/A"
+    delta = primary - baseline
+    sign = "+" if delta >= 0 else ""
+    return f"{sign}{delta:.3f}"
+
+
+def metric_block(summary: dict[str, Any] | None) -> dict[str, Any]:
+    summary = summary or {}
+    keys = [
+        "num_predictions",
+        "accuracy",
+        "groundedness",
+        "citation_precision",
+        "answer_format_compliance",
+        "abstention",
+        "retry",
+        "latency",
+        "retry_cost",
+        "retry_reason_counts",
+    ]
+    return {key: summary.get(key) for key in keys if key in summary}
+
+
+def registry_entry(manifest: dict[str, Any]) -> dict[str, Any]:
+    metrics_by_run = manifest.get("metrics", {}).get("runs") or {}
+    flags_by_run = manifest.get("ablation_flags") or {}
+    baseline_run = str(manifest.get("ablation_suite", {}).get("baseline_run") or "")
+    primary_run = str(manifest.get("ablation_suite", {}).get("primary_run") or "")
+    baseline = metric_block(metrics_by_run.get(baseline_run))
+    primary = metric_block(metrics_by_run.get(primary_run))
+    runs = []
+    for name in sorted(metrics_by_run):
+        runs.append(
+            {
+                "name": name,
+                "flags": flags_by_run.get(name) or {},
+                "metrics": metric_block(metrics_by_run.get(name)),
+            }
+        )
+    return {
+        "run_id": manifest["run_id"],
+        "generated_at": manifest.get("generated_at"),
+        "git_commit": manifest.get("git_commit"),
+        "git_dirty": bool(manifest.get("git_dirty")),
+        "suite_id": manifest.get("suite", {}).get("id"),
+        "dataset_id": manifest.get("suite", {}).get("dataset", {}).get("id"),
+        "ablation_suite_id": manifest.get("ablation_suite", {}).get("id"),
+        "baseline_run": baseline_run,
+        "primary_run": primary_run,
+        "baseline_metrics": baseline,
+        "primary_metrics": primary,
+        "delta": {
+            "accuracy": delta_value(primary.get("accuracy"), baseline.get("accuracy")),
+            "groundedness": delta_value(primary.get("groundedness"), baseline.get("groundedness")),
+            "citation_precision": delta_value(
+                primary.get("citation_precision"), baseline.get("citation_precision")
+            ),
+            "answer_format_compliance": delta_value(
+                primary.get("answer_format_compliance"),
+                baseline.get("answer_format_compliance"),
+            ),
+            "abstention": delta_value(primary.get("abstention"), baseline.get("abstention")),
+            "retry": delta_value(primary.get("retry"), baseline.get("retry")),
+            "latency_p95": delta_value(
+                (primary.get("latency") or {}).get("p95"),
+                (baseline.get("latency") or {}).get("p95"),
+            ),
+        },
+        "artifact_manifest": manifest.get("artifacts", {}).get("run_manifest"),
+        "runs": runs,
+    }
+
+
+def delta_value(primary: Any, baseline: Any) -> float | None:
+    if isinstance(primary, (int, float)) and isinstance(baseline, (int, float)):
+        return primary - baseline
+    return None
+
+
+def updated_registry(current: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+    registry = copy.deepcopy(current)
+    registry.setdefault("schema_version", 1)
+    registry.setdefault(
+        "description",
+        "Curated aggregate benchmark registry. Raw artifacts stay under artifacts/benchmarks/.",
+    )
+    entries = [item for item in registry.get("entries", []) if item.get("run_id") != entry["run_id"]]
+    entries.append(entry)
+    entries.sort(key=lambda item: str(item.get("generated_at") or item.get("run_id") or ""))
+    registry["entries"] = entries
+    return registry
+
+
+def render_docs(registry: dict[str, Any]) -> str:
+    entries = registry.get("entries") or []
+    if not entries:
+        return "# Ablation Results\n\nNo benchmark runs have been summarized yet.\n"
+    latest = entries[-1]
+    baseline_name = latest.get("baseline_run")
+    primary_name = latest.get("primary_run")
+    baseline = latest.get("baseline_metrics") or {}
+    primary = latest.get("primary_metrics") or {}
+
+    lines = [
+        "# Ablation Results",
+        "",
+        "이 문서는 커밋 가능한 집계 지표만 남긴다. Raw predictions, traces, logs, latency samples, per-example dumps는 `artifacts/benchmarks/` 아래에 생성되며 Git에 커밋하지 않는다.",
+        "",
+        "## Latest Run",
+        "",
+        f"- Run ID: `{latest.get('run_id')}`",
+        f"- Suite: `{latest.get('suite_id')}` / Dataset: `{latest.get('dataset_id')}`",
+        f"- Git commit: `{latest.get('git_commit')}`",
+        f"- Baseline: `{baseline_name}`",
+        f"- Primary: `{primary_name}`",
+        f"- Local manifest: `{latest.get('artifact_manifest')}`",
+        "",
+        "## Baseline To Primary",
+        "",
+        "| Metric | Baseline | Primary | Delta |",
+        "|---|---:|---:|---:|",
+        table_row("Accuracy", baseline, primary, "accuracy"),
+        table_row("Groundedness", baseline, primary, "groundedness"),
+        table_row("Citation Precision", baseline, primary, "citation_precision"),
+        table_row("Format Compliance", baseline, primary, "answer_format_compliance"),
+        table_row("Abstention", baseline, primary, "abstention"),
+        table_row("Retry Rate", baseline, primary, "retry"),
+        "| Latency p95 | {baseline} | {primary} | {delta} |".format(
+            baseline=fmt_latency(baseline.get("latency")),
+            primary=fmt_latency(primary.get("latency")),
+            delta=fmt_delta(
+                (primary.get("latency") or {}).get("p95"),
+                (baseline.get("latency") or {}).get("p95"),
+            ),
+        ),
+        "",
+        "## Ablation Table",
+        "",
+        "| Run | Metadata-first | Rerank | Verifier/Retry | Retrieval | Accuracy | Groundedness | Citation | Format | Abstention | Retry | Latency p95 |",
+        "|---|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for run in latest.get("runs") or []:
+        flags = run.get("flags") or {}
+        metrics = run.get("metrics") or {}
+        lines.append(
+            "| {name} | {metadata_first} | {rerank} | {verifier_retry} | {retrieval_mode} | {accuracy} | {groundedness} | {citation} | {format} | {abstention} | {retry} | {latency} |".format(
+                name=run.get("name"),
+                metadata_first=flag(flags.get("metadata_first")),
+                rerank=flag(flags.get("rerank")),
+                verifier_retry=flag(flags.get("verifier_retry")),
+                retrieval_mode=flags.get("retrieval_mode", "flat"),
+                accuracy=fmt_rate(metrics.get("accuracy")),
+                groundedness=fmt_rate(metrics.get("groundedness")),
+                citation=fmt_rate(metrics.get("citation_precision")),
+                format=fmt_rate(metrics.get("answer_format_compliance")),
+                abstention=fmt_rate(metrics.get("abstention")),
+                retry=fmt_rate(metrics.get("retry")),
+                latency=fmt_latency(metrics.get("latency")),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            f"- `{baseline_name}`는 verifier/retry를 끈 lightweight baseline이다.",
+            f"- `{primary_name}`는 metadata-first, rerank, verifier/retry를 모두 켠 primary run이다.",
+            "- latency와 retry는 품질 지표와 함께 본다. retry가 늘어도 groundedness, citation, abstention 개선이 동반되는지 확인한다.",
+            "- 현재 수치는 공개 synthetic RFP 평가셋 기준의 2차 가공 집계이며, 원본 RFP 문서나 raw example output은 포함하지 않는다.",
+            "",
+            "## Next Actions",
+            "",
+            "- 평가셋을 늘릴 때는 suite YAML을 추가하고 registry에는 집계 지표만 편입한다.",
+            "- private RFP 기반 실험은 local artifact로만 보관하고 문서에는 익명화된 집계 결과만 남긴다.",
+            "- citation 검증과 latency/retry 비용 분석은 별도 ablation axis로 분리해 누적한다.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def table_row(label: str, baseline: dict[str, Any], primary: dict[str, Any], key: str) -> str:
+    return "| {label} | {baseline} | {primary} | {delta} |".format(
+        label=label,
+        baseline=fmt_rate(baseline.get(key)),
+        primary=fmt_rate(primary.get(key)),
+        delta=fmt_delta(primary.get(key), baseline.get(key)),
+    )
+
+
+def flag(value: Any) -> str:
+    return "on" if bool(value) else "off"
+
+
+def main() -> int:
+    args = parse_args()
+    manifest = load_json(repo_path(args.manifest))
+    registry_path = repo_path(args.registry)
+    docs_path = repo_path(args.docs)
+
+    current_registry = (
+        load_json(registry_path)
+        if registry_path.exists()
+        else {"schema_version": 1, "description": "", "entries": []}
+    )
+    next_registry = updated_registry(current_registry, registry_entry(manifest))
+    next_registry_text = stable_json(next_registry)
+    next_docs_text = render_docs(next_registry)
+
+    if args.check:
+        registry_ok = registry_path.exists() and registry_path.read_text(encoding="utf-8") == next_registry_text
+        docs_ok = docs_path.exists() and docs_path.read_text(encoding="utf-8") == next_docs_text
+        if not registry_ok or not docs_ok:
+            print("[FAIL] Benchmark registry/docs are out of date. Run scripts/summarize_benchmark.py")
+            return 1
+        print("[OK] Benchmark registry/docs are up-to-date")
+        return 0
+
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    docs_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(next_registry_text, encoding="utf-8")
+    docs_path.write_text(next_docs_text, encoding="utf-8")
+    print(f"[OK] Updated benchmark registry: {registry_path.relative_to(ROOT_DIR)}")
+    print(f"[OK] Updated ablation docs: {docs_path.relative_to(ROOT_DIR)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `benchmarks/`에 suite, ablation axis, registry schema, 집계 registry를 분리해 커밋 가능한 source of truth를 만들었습니다.
- `scripts/run_benchmark.py`와 `scripts/summarize_benchmark.py`를 추가해 실행 산출물은 `artifacts/benchmarks/` 아래에만 남기고, registry와 docs는 집계 결과만 갱신하도록 했습니다.
- `rag_core.py`, `app.py`, `eval/run_eval.py`를 정리해 baseline 재현성과 `retrieval_mode` 경로를 복구했습니다.
- README, smoke test, benchmarking docs를 연결해 실험 실행/요약/검증 흐름을 문서화했습니다.

## Testing
- `python3 -m unittest discover -s tests` 통과
- `python3 scripts/build_index.py --input_dir data/raw --output_dir data/index --embedding_backend hashing` 통과
- `python3 eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml` 통과
- `python3 scripts/run_benchmark.py --suite benchmarks/suites/public_synthetic_rfp.yaml --ablations benchmarks/ablations/rag_quality_axes.yaml` 통과
- `python3 scripts/summarize_benchmark.py --manifest artifacts/benchmarks/<run_id>/run_manifest.json --check` 통과
- `python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check` 통과
- `bash scripts/smoke.sh` 통과