### PR TITLE
Fix --force overwrite for benchmark artifacts

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -8,6 +8,7 @@ import importlib.util
 import json
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 from typing import Any
@@ -286,11 +287,16 @@ def main() -> int:
         args.artifact_root or suite.get("artifacts", {}).get("root") or "artifacts/benchmarks"
     )
     run_dir = artifact_root / run_id
-    if run_dir.exists() and not args.force:
-        raise SystemExit(f"[ERROR] Artifact directory already exists: {rel_path(run_dir)}")
+    if run_dir.exists():
+        if not args.force:
+            raise SystemExit(f"[ERROR] Artifact directory already exists: {rel_path(run_dir)}")
+        shutil.rmtree(run_dir)
+
+    run_dir.mkdir(parents=True, exist_ok=True)
 
     traces_dir = run_dir / "traces"
     logs_dir = run_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
     predictions_path = run_dir / "predictions.jsonl"
     latency_path = run_dir / "latency_samples.jsonl"
     eval_summary_path = run_dir / "eval_summary.json"


### PR DESCRIPTION
## Summary
- Make `scripts/run_benchmark.py` actually overwrite an existing run directory when `--force` is set.
- Delete the existing `artifact_root / run_id` directory before recreating the run layout.
- Ensure `run_dir` and `logs_dir` are created explicitly before writing benchmark outputs.

## Testing
- `python3 -m py_compile scripts/run_benchmark.py`
- Verified the benchmark runner rejects an existing run directory without `--force`
- Verified rerunning with `--force` removes the old artifact directory and recreates the expected files