### PR TITLE
Add visual parsing v2 for PDF and image ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 - Benchmark registry: `benchmarks/registry.json`
 - Benchmark local artifacts: `artifacts/benchmarks/` (gitignored)
 - PDF/HWP ingestion 진단 리포트: `data/index/ingestion_report.json` (`--metadata_csv` 사용 시)
+- Visual parsing v2 artifact: `data/index/visual_artifacts/*.visual.json` (`--visual_input_dir` 또는 `--ingestion_mode visual` 사용 시)
 
 ---
 
@@ -217,6 +218,29 @@ python3 scripts/build_index.py \
 
 이 모드는 `data/index/index.json`과 함께 `data/index/ingestion_report.json`을 생성합니다. 리포트에는 문서별 indexed/failed 상태와 `missing_file`, `empty_text`, `unsupported_file_format`, `duplicate_doc_id` 같은 실패 사유가 기록됩니다.
 
+### 선택) Document visual parsing v2
+원본 PDF/이미지 문서를 직접 파싱해 page/bbox/region metadata가 포함된 v2 artifact를 만들 수 있습니다. PDF는 text layer block을 우선 사용하고, text가 부족한 page 또는 이미지 파일은 OCR adapter를 사용합니다. HWP는 이번 v2에서 native visual parsing 대상이 아니며, metadata CSV visual mode에서는 기존 `텍스트` 컬럼으로 fallback하고 `visual_fallback_hwp`로 표시합니다.
+
+```bash
+python3 scripts/build_index.py \
+  --visual_input_dir data/visual_samples \
+  --output_dir data/index \
+  --embedding_backend hashing
+```
+
+metadata CSV와 함께 v2를 비교하려면 다음처럼 실행합니다.
+
+```bash
+python3 scripts/build_index.py \
+  --metadata_csv data/data_list.csv \
+  --files_dir data/files \
+  --ingestion_mode visual \
+  --output_dir data/index \
+  --embedding_backend hashing
+```
+
+이 모드는 `data/index/index.json`, `data/index/ingestion_report.json`, `data/index/visual_artifacts/*.visual.json`을 생성합니다. OCR에는 Python 패키지(`pymupdf`, `pdfplumber`, `pytesseract`, `Pillow`, `opencv-python-headless`)와 시스템 Tesseract 설치가 필요합니다. OCR 엔진이 없으면 text-layer PDF는 계속 처리할 수 있지만 image-only 문서는 `ocr_unavailable`로 실패합니다.
+
 ---
 
 ## 상세 설계 링크
@@ -226,6 +250,7 @@ python3 scripts/build_index.py \
 - 설계 배경 및 의사결정: [`docs/design-background.md`](docs/design-background.md)
 - Chunking diagnostics: [`docs/chunking-diagnostics.md`](docs/chunking-diagnostics.md)
 - PDF/HWP ingestion: [`docs/real-data-ingestion.md`](docs/real-data-ingestion.md)
+- Visual parsing v2: [`docs/visual-ingestion-v2.md`](docs/visual-ingestion-v2.md)
 - 답변 출력 정책: [`docs/answer-policy.md`](docs/answer-policy.md)
 - 실패 사례 분석: [`docs/failure-cases.md`](docs/failure-cases.md)
 - 회고 및 개선 방향: [`docs/retrospective.md`](docs/retrospective.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,6 @@
 - [설계 배경 및 의사결정](./design-background.md)
 - [답변 출력 정책](./answer-policy.md)
 - [PDF/HWP ingestion](./real-data-ingestion.md)
+- [Visual parsing v2](./visual-ingestion-v2.md)
 - [실패 사례 분석](./failure-cases.md)
 - [회고 및 향후 개선](./retrospective.md)

--- a/docs/answer-policy.md
+++ b/docs/answer-policy.md
@@ -37,7 +37,7 @@
 }
 ```
 
-좋은 답변은 claim마다 citation이 있고, citation의 chunk text가 claim을 직접 지지한다. 비교 질문에서는 대상별 claim을 나눠 스캔 가능하게 유지한다.
+좋은 답변은 claim마다 citation이 있고, citation의 chunk text가 claim을 직접 지지한다. visual parsing v2 인덱스에서는 citation에 `page_span`과 `regions`가 추가될 수 있어 page/bbox 근거 위치까지 추적할 수 있다. 비교 질문에서는 대상별 claim을 나눠 스캔 가능하게 유지한다.
 
 ## 나쁜 답변 예시
 

--- a/docs/chunking-diagnostics.md
+++ b/docs/chunking-diagnostics.md
@@ -10,8 +10,9 @@ RFP 문서는 heading, 요구사항 목록, 제출조건 같은 구조가 검색
 - `section_path`: heading 계층을 보존한다. 공개 synthetic 문서는 1단계 heading을 사용한다.
 - `chunk_seq_in_section`: 같은 parent section 안에서 child chunk 순서를 나타낸다.
 - `chunking_strategy`: 실제 적용된 전략이다. 값은 `section` 또는 `fixed`이다.
+- `regions` / `page_span`: visual parsing v2 입력에서만 포함되는 page/bbox 근거 위치 metadata다.
 
-`index.json`의 `parent_sections`에는 parent section text와 metadata가 저장된다. `build.chunking`에는 요청 전략, `chunk_max_chars`, overlap, 문서별 실제 전략, parent section 수, chunk 수가 기록된다.
+`index.json`의 `parent_sections`에는 parent section text와 metadata가 저장된다. visual parsing v2 문서라면 parent section에도 `regions`와 `page_span`이 보존된다. `build.chunking`에는 요청 전략, `chunk_max_chars`, overlap, 문서별 실제 전략, parent section 수, chunk 수가 기록된다.
 
 ## 동작 방식
 기본 인덱싱 명령은 다음 옵션과 같다.

--- a/docs/real-data-ingestion.md
+++ b/docs/real-data-ingestion.md
@@ -1,6 +1,6 @@
 # PDF/HWP ingestion
 
-이 문서는 비공개 PDF/HWP 원본과 `data_list.csv`를 로컬에서 인덱싱하는 v1 경로를 설명한다. 공개 baseline인 `data/raw` synthetic RFP 실행 흐름은 그대로 유지한다.
+이 문서는 비공개 PDF/HWP 원본과 `data_list.csv`를 로컬에서 인덱싱하는 v1 경로를 설명한다. 공개 baseline인 `data/raw` synthetic RFP 실행 흐름은 그대로 유지한다. 원본 PDF/image를 직접 파싱하는 v2 경로는 [`visual-ingestion-v2.md`](./visual-ingestion-v2.md)에 별도로 정리한다.
 
 ## 입력
 - `data/data_list.csv`: `공고 번호`, `공고 차수`, `사업명`, `사업 금액`, `발주 기관`, 날짜 필드, `사업 요약`, `파일형식`, `파일명`, `텍스트` 컬럼을 사용한다.
@@ -20,6 +20,13 @@ python3 scripts/build_index.py \
 ## 출력
 - `data/index/index.json`: 기존 RAG index schema를 유지하되, 문서와 chunk에 normalized metadata를 포함한다.
 - `data/index/ingestion_report.json`: CSV row별 `indexed` 또는 `failed` 상태와 실패 사유를 기록한다.
+
+## v1 / v2 비교
+- v1 기본값은 `--ingestion_mode csv-text`이며, CSV의 `텍스트` 컬럼을 본문으로 사용한다.
+- v2는 `--ingestion_mode visual`을 명시했을 때만 활성화된다.
+- v2에서 PDF/image는 visual parser artifact를 만들고, HWP는 native visual parsing 대신 CSV 텍스트 fallback을 사용한다.
+- HWP fallback 문서는 metadata에 `visual_fallback_reason: visual_fallback_hwp`, `text_source: data_list_csv_text`를 유지한다.
+- 두 모드 모두 기본 산출물 경로는 `data/index/index.json`과 `data/index/ingestion_report.json`이다. v2는 추가로 `data/index/visual_artifacts/*.visual.json`을 생성한다.
 
 ## 실패 처리
 다음 row는 전체 인덱싱을 중단하지 않고 리포트에 실패로 남긴다.

--- a/docs/visual-ingestion-v2.md
+++ b/docs/visual-ingestion-v2.md
@@ -1,0 +1,62 @@
+# Visual parsing v2
+
+이 문서는 이슈 #14의 PDF/image visual parsing v2 경로를 설명한다. 기존 공개 baseline(`data/raw`)과 CSV-text v1 ingestion은 기본 동작으로 유지한다.
+
+## 목적
+- 원본 PDF/이미지에서 text, page, bbox, region metadata를 함께 추출한다.
+- parser artifact를 기존 RAG document schema로 정규화해 chunking, retrieval, citation 흐름에서 재사용한다.
+- HWP는 이번 단계에서 native visual parsing을 하지 않고 CSV 텍스트 fallback으로 비교 가능성을 유지한다.
+
+## 입력
+- `--visual_input_dir`: PDF 또는 이미지(`pdf`, `png`, `jpg`, `jpeg`, `tif`, `tiff`, `bmp`, `webp`) 파일 디렉터리.
+- `--metadata_csv --files_dir --ingestion_mode visual`: 기존 `data_list.csv` 메타데이터를 사용하되 PDF/image는 v2 parser로 처리하고 HWP는 v1 텍스트 fallback으로 처리한다.
+- `--visual_artifact_dir`: v2 artifact 저장 위치. 생략하면 `<output_dir>/visual_artifacts`를 사용한다.
+
+## 출력
+- `index.json`: 기존 RAG index schema를 유지하면서 section/chunk/evidence/citation에 `regions`와 `page_span`을 선택적으로 포함한다.
+- `ingestion_report.json`: 문서별 `parsed`, `partial`, `fallback`, `failed` 상태와 실패 사유를 기록한다.
+- `*.visual.json`: `schema_version: 2` artifact. `pages[*].blocks[*]`, `tables`, `field_candidates`, `sections`, `diagnostics`를 포함한다.
+
+## Parser stages
+- PDF text layer: PyMuPDF로 page block, bbox, layout type을 추출한다.
+- OCR: PDF page text가 부족하거나 이미지 입력일 때 OCR adapter를 호출한다.
+- Table candidates: pdfplumber table 추출과 layout text heuristic을 함께 사용한다.
+- Field candidates: `key: value`, `key=value` 형태의 line을 후보로 기록한다.
+- Section detection: heading-like block을 section boundary로 사용하고, 없으면 문서 전체 section으로 묶는다.
+
+## Failure policy
+- `pdf_parser_unavailable`: PyMuPDF를 사용할 수 없어 PDF를 열 수 없음.
+- `ocr_unavailable`: pytesseract 또는 시스템 Tesseract 실행이 불가능함.
+- `empty_visual_text`: text layer와 OCR 모두에서 인덱싱 가능한 text가 없음.
+- `visual_fallback_hwp`: HWP native visual parsing은 후속 과제로 남기고 CSV `텍스트` 컬럼을 사용함.
+
+OCR 품질은 자동으로 개선되었다고 간주하지 않는다. v2의 1차 성공 기준은 page/bbox region artifact 생성, 기존 retrieval 호환성, v1/v2 비교 가능성이다.
+
+## 실행 예시
+```bash
+python3 scripts/build_index.py \
+  --visual_input_dir data/visual_samples \
+  --output_dir data/index \
+  --embedding_backend hashing
+```
+
+```bash
+python3 scripts/build_index.py \
+  --metadata_csv data/data_list.csv \
+  --files_dir data/files \
+  --ingestion_mode visual \
+  --output_dir data/index \
+  --embedding_backend hashing
+```
+
+## 검증
+기본 회귀는 기존과 동일하게 유지한다.
+
+```bash
+python3 -m unittest discover -s tests -q
+python3 scripts/build_index.py --input_dir data/raw --output_dir /private/tmp/agentic-vlm-index --embedding_backend hashing
+python3 app.py --input_dir /private/tmp/agentic-vlm-index --output_dir /private/tmp/agentic-vlm-outputs --query "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
+python3 eval/run_eval.py --index_dir /private/tmp/agentic-vlm-index --output_dir /private/tmp/agentic-vlm-reports --config eval/config.yaml
+python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check
+```
+

--- a/rag_core.py
+++ b/rag_core.py
@@ -377,7 +377,16 @@ def normalize_json_document(data: dict[str, Any], path: Path) -> dict[str, Any]:
         heading = str(section.get("heading") or f"section-{idx}")
         text = str(section.get("text") or "").strip()
         if text:
-            normalized_sections.append({"heading": heading, "text": text})
+            normalized_section = {"heading": heading, "text": text}
+            if section.get("section_path"):
+                normalized_section["section_path"] = section.get("section_path")
+            regions = normalize_regions(section.get("regions"))
+            page_span = normalize_page_span(section.get("page_span"), regions)
+            if regions:
+                normalized_section["regions"] = regions
+            if page_span:
+                normalized_section["page_span"] = page_span
+            normalized_sections.append(normalized_section)
     if not normalized_sections:
         raise ValueError(f"Document has no text: {path}")
     metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
@@ -437,6 +446,48 @@ def normalize_section_path(section: dict[str, Any], heading: str) -> list[str]:
     return path
 
 
+def normalize_regions(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    regions = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        region: dict[str, Any] = {}
+        page_number = item.get("page_number")
+        if isinstance(page_number, int):
+            region["page_number"] = page_number
+        elif page_number is None:
+            region["page_number"] = None
+        bbox = item.get("bbox")
+        if isinstance(bbox, list) and len(bbox) == 4:
+            region["bbox"] = bbox
+        elif bbox is None:
+            region["bbox"] = None
+        for key in ("source", "type", "block_id"):
+            if item.get(key) is not None:
+                region[key] = str(item.get(key))
+        if region:
+            regions.append(region)
+    return regions
+
+
+def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] | None:
+    if isinstance(value, list) and len(value) == 2:
+        try:
+            return [int(value[0]), int(value[1])]
+        except (TypeError, ValueError):
+            pass
+    page_numbers = [
+        int(region["page_number"])
+        for region in regions
+        if isinstance(region.get("page_number"), int)
+    ]
+    if not page_numbers:
+        return None
+    return [min(page_numbers), max(page_numbers)]
+
+
 def normalize_document_sections(doc: dict[str, Any]) -> list[dict[str, Any]]:
     normalized = []
     for idx, section in enumerate(doc.get("sections") or [], start=1):
@@ -445,20 +496,25 @@ def normalize_document_sections(doc: dict[str, Any]) -> list[dict[str, Any]]:
         if not text:
             continue
         section_path = normalize_section_path(section, heading)
-        normalized.append(
-            {
-                "section_id": f"{doc['doc_id']}::section-{idx:03d}",
-                "doc_id": doc["doc_id"],
-                "title": doc["title"],
-                "agency": doc.get("agency", ""),
-                "project": doc.get("project", ""),
-                "metadata": doc.get("metadata", {}),
-                "section": section_path[-1],
-                "heading": heading,
-                "section_path": section_path,
-                "text": text,
-            }
-        )
+        regions = normalize_regions(section.get("regions"))
+        page_span = normalize_page_span(section.get("page_span"), regions)
+        normalized_section = {
+            "section_id": f"{doc['doc_id']}::section-{idx:03d}",
+            "doc_id": doc["doc_id"],
+            "title": doc["title"],
+            "agency": doc.get("agency", ""),
+            "project": doc.get("project", ""),
+            "metadata": doc.get("metadata", {}),
+            "section": section_path[-1],
+            "heading": heading,
+            "section_path": section_path,
+            "text": text,
+        }
+        if regions:
+            normalized_section["regions"] = regions
+        if page_span:
+            normalized_section["page_span"] = page_span
+        normalized.append(normalized_section)
     return normalized
 
 
@@ -482,14 +538,16 @@ def resolve_chunking_strategy(doc: dict[str, Any], requested_strategy: str) -> s
 
 def fixed_parent_section(doc: dict[str, Any], sections: list[dict[str, Any]]) -> dict[str, Any]:
     parts = []
+    regions = []
     for section in sections:
         heading = str(section.get("section") or "").strip()
         text = str(section.get("text") or "").strip()
+        regions.extend(normalize_regions(section.get("regions")))
         if heading and heading not in WEAK_SECTION_HEADINGS:
             parts.append(f"{heading}\n{text}")
         else:
             parts.append(text)
-    return {
+    parent = {
         "section_id": f"{doc['doc_id']}::section-001",
         "doc_id": doc["doc_id"],
         "title": doc["title"],
@@ -501,6 +559,12 @@ def fixed_parent_section(doc: dict[str, Any], sections: list[dict[str, Any]]) ->
         "section_path": ["문서 전체"],
         "text": "\n\n".join(part for part in parts if part).strip(),
     }
+    page_span = normalize_page_span(None, regions)
+    if regions:
+        parent["regions"] = regions
+    if page_span:
+        parent["page_span"] = page_span
+    return parent
 
 
 def split_section_text(
@@ -626,7 +690,9 @@ def make_chunk(
     text = " ".join(sentences).strip()
     section_path = parent_section.get("section_path") or [parent_section.get("section", "")]
     section_label = str(parent_section.get("section") or section_path[-1])
-    return {
+    regions = normalize_regions(parent_section.get("regions"))
+    page_span = normalize_page_span(parent_section.get("page_span"), regions)
+    chunk = {
         "chunk_id": f"{doc['doc_id']}::chunk-{chunk_seq:03d}",
         "section_id": parent_section["section_id"],
         "parent_section_id": parent_section["section_id"],
@@ -644,6 +710,11 @@ def make_chunk(
             " ".join([doc["title"], doc.get("agency", ""), " > ".join(section_path), text])
         ),
     }
+    if regions:
+        chunk["regions"] = regions
+    if page_span:
+        chunk["page_span"] = page_span
+    return chunk
 
 
 def embed_texts(
@@ -1337,30 +1408,35 @@ def retrieve(
             score = (0.70 * dense_score) + (0.30 * lexical_score)
         else:
             score = (0.60 * dense_score) + (0.25 * lexical_score) + (0.15 * metadata_score)
-        scored.append(
-            {
-                "doc_id": chunk["doc_id"],
-                "chunk_id": chunk["chunk_id"],
-                "title": chunk["title"],
-                "agency": chunk.get("agency", ""),
-                "project": chunk.get("project", ""),
-                "metadata": chunk.get("metadata", {}),
-                "section": chunk["section"],
-                "section_id": chunk.get("section_id"),
-                "parent_section_id": chunk.get("parent_section_id") or chunk.get("section_id"),
-                "section_path": chunk.get("section_path") or [chunk.get("section", "")],
-                "chunk_seq_in_section": chunk.get("chunk_seq_in_section"),
-                "chunking_strategy": chunk.get("chunking_strategy", "legacy"),
-                "retrieval_mode": "flat",
-                "text": chunk["text"],
-                "score": round(float(score), 4),
-                "score_parts": {
-                    "dense": round(float(dense_score), 4),
-                    "lexical": round(float(lexical_score), 4),
-                    "metadata": round(float(metadata_score), 4),
-                },
-            }
-        )
+        item = {
+            "doc_id": chunk["doc_id"],
+            "chunk_id": chunk["chunk_id"],
+            "title": chunk["title"],
+            "agency": chunk.get("agency", ""),
+            "project": chunk.get("project", ""),
+            "metadata": chunk.get("metadata", {}),
+            "section": chunk["section"],
+            "section_id": chunk.get("section_id"),
+            "parent_section_id": chunk.get("parent_section_id") or chunk.get("section_id"),
+            "section_path": chunk.get("section_path") or [chunk.get("section", "")],
+            "chunk_seq_in_section": chunk.get("chunk_seq_in_section"),
+            "chunking_strategy": chunk.get("chunking_strategy", "legacy"),
+            "retrieval_mode": "flat",
+            "text": chunk["text"],
+            "score": round(float(score), 4),
+            "score_parts": {
+                "dense": round(float(dense_score), 4),
+                "lexical": round(float(lexical_score), 4),
+                "metadata": round(float(metadata_score), 4),
+            },
+        }
+        regions = normalize_regions(chunk.get("regions"))
+        page_span = normalize_page_span(chunk.get("page_span"), regions)
+        if regions:
+            item["regions"] = regions
+        if page_span:
+            item["page_span"] = page_span
+        scored.append(item)
 
     scored.sort(key=lambda item: item["score"], reverse=True)
     top_k = int(plan["top_k"])
@@ -1415,6 +1491,12 @@ def reassemble_parent_sections(
             "retrieval_mode": "hierarchical",
             "child_chunk_ids": child_ids_by_parent.get(parent_id, []),
         }
+        parent_regions = normalize_regions(parent.get("regions"))
+        parent_page_span = normalize_page_span(parent.get("page_span"), parent_regions)
+        if parent_regions:
+            item["regions"] = parent_regions
+        if parent_page_span:
+            item["page_span"] = parent_page_span
         reassembled.append(item)
 
     reassembled.sort(key=lambda item: item["score"], reverse=True)
@@ -1618,13 +1700,20 @@ def claim_target(item: dict[str, Any]) -> str:
 
 
 def make_citation(item: dict[str, Any]) -> dict[str, Any]:
-    return {
+    citation = {
         "doc_id": item.get("doc_id", ""),
         "chunk_id": item.get("chunk_id", ""),
         "title": item.get("title", ""),
         "section": item.get("section", ""),
         "agency": item.get("agency", ""),
     }
+    regions = normalize_regions(item.get("regions"))
+    page_span = normalize_page_span(item.get("page_span"), regions)
+    if regions:
+        citation["regions"] = regions
+    if page_span:
+        citation["page_span"] = page_span
+    return citation
 
 
 def answer_status(
@@ -2098,8 +2187,9 @@ def run_rag_query(
 
 
 def strip_internal_scores(evidence: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        {
+    stripped = []
+    for item in evidence:
+        public_item = {
             "doc_id": item["doc_id"],
             "chunk_id": item["chunk_id"],
             "title": item["title"],
@@ -2116,8 +2206,14 @@ def strip_internal_scores(evidence: list[dict[str, Any]]) -> list[dict[str, Any]
             "retrieval_mode": item.get("retrieval_mode", "flat"),
             "child_chunk_ids": item.get("child_chunk_ids", []),
         }
-        for item in evidence
-    ]
+        regions = normalize_regions(item.get("regions"))
+        page_span = normalize_page_span(item.get("page_span"), regions)
+        if regions:
+            public_item["regions"] = regions
+        if page_span:
+            public_item["page_span"] = page_span
+        stripped.append(public_item)
+    return stripped
 
 
 def percentile(values: list[float], pct: float) -> float | None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
-numpy>=1.24
+numpy>=1.24,<2.3
 PyYAML>=6.0
 sentence-transformers>=2.7,<3.0
 transformers>=4.41,<5.0
+pymupdf>=1.24,<2.0
+pdfplumber>=0.11,<1.0
+pytesseract>=0.3,<1.0
+Pillow>=10.0
+opencv-python-headless>=4.9,<4.13

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -16,6 +16,10 @@ from rag_core import (
     build_index_payload,
     build_index_payload_from_documents,
 )
+from visual_ingestion import (
+    load_visual_documents_from_dir,
+    load_visual_documents_from_metadata_csv,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -23,6 +27,11 @@ def parse_args() -> argparse.Namespace:
         description="Build a local dense RAG index from synthetic or CSV-backed PDF/HWP RFP documents."
     )
     parser.add_argument("--input_dir", default=None, help="Path to raw JSON/Markdown/Text documents.")
+    parser.add_argument(
+        "--visual_input_dir",
+        default=None,
+        help="Path to original PDF/image documents for visual parsing v2.",
+    )
     parser.add_argument(
         "--metadata_csv",
         default=None,
@@ -32,6 +41,17 @@ def parse_args() -> argparse.Namespace:
         "--files_dir",
         default=None,
         help="Directory containing PDF/HWP files referenced by --metadata_csv.",
+    )
+    parser.add_argument(
+        "--ingestion_mode",
+        default="csv-text",
+        choices=["csv-text", "visual"],
+        help="Use CSV text v1 or visual parsing v2 when --metadata_csv is provided.",
+    )
+    parser.add_argument(
+        "--visual_artifact_dir",
+        default=None,
+        help="Directory to write visual parsing v2 artifacts. Defaults to <output_dir>/visual_artifacts.",
     )
     parser.add_argument("--output_dir", required=True, help="Path to write index.json.")
     parser.add_argument("--query", default=None, help="Unused in this command; accepted for CLI consistency.")
@@ -66,9 +86,10 @@ def parse_args() -> argparse.Namespace:
 
 def validate_args(args: argparse.Namespace) -> None:
     using_raw_dir = bool(args.input_dir)
+    using_visual_dir = bool(args.visual_input_dir)
     using_metadata_csv = bool(args.metadata_csv)
-    if using_raw_dir == using_metadata_csv:
-        raise ValueError("Provide exactly one of --input_dir or --metadata_csv.")
+    if sum([using_raw_dir, using_visual_dir, using_metadata_csv]) != 1:
+        raise ValueError("Provide exactly one of --input_dir, --visual_input_dir, or --metadata_csv.")
 
     if using_raw_dir:
         input_dir = Path(args.input_dir)
@@ -77,8 +98,21 @@ def validate_args(args: argparse.Namespace) -> None:
         if not input_dir.is_dir():
             raise ValueError(f"--input_dir must be a directory: {input_dir}")
 
+    if using_visual_dir:
+        visual_input_dir = Path(args.visual_input_dir)
+        if not visual_input_dir.exists():
+            raise ValueError(f"--visual_input_dir does not exist: {visual_input_dir}")
+        if not visual_input_dir.is_dir():
+            raise ValueError(f"--visual_input_dir must be a directory: {visual_input_dir}")
+
     if using_metadata_csv and not args.files_dir:
         raise ValueError("--files_dir is required when --metadata_csv is provided.")
+    if not using_metadata_csv and args.ingestion_mode != "csv-text":
+        raise ValueError("--ingestion_mode is only used with --metadata_csv.")
+    if args.visual_artifact_dir and not (
+        using_visual_dir or (using_metadata_csv and args.ingestion_mode == "visual")
+    ):
+        raise ValueError("--visual_artifact_dir is only used with visual ingestion.")
     if args.chunk_max_chars < 1:
         raise ValueError("--chunk_max_chars must be positive.")
     if args.chunk_overlap_sentences < 0:
@@ -90,11 +124,29 @@ def main() -> int:
     try:
         args = parse_args()
         validate_args(args)
+        output_dir = Path(args.output_dir)
+        visual_artifact_dir = (
+            Path(args.visual_artifact_dir)
+            if args.visual_artifact_dir
+            else output_dir / "visual_artifacts"
+        )
         if args.metadata_csv:
-            documents, ingestion_report = load_documents_from_metadata_csv(
-                Path(args.metadata_csv),
-                Path(args.files_dir),
-            )
+            if args.ingestion_mode == "visual":
+                documents, ingestion_report = load_visual_documents_from_metadata_csv(
+                    Path(args.metadata_csv),
+                    Path(args.files_dir),
+                    visual_artifact_dir,
+                )
+                message = (
+                    "PDF/image visual parsing v2 index with HWP CSV-text fallback "
+                    "and page/region metadata."
+                )
+            else:
+                documents, ingestion_report = load_documents_from_metadata_csv(
+                    Path(args.metadata_csv),
+                    Path(args.files_dir),
+                )
+                message = "PDF/HWP RFP index built from data_list.csv text and joined metadata."
             payload = build_index_payload_from_documents(
                 documents,
                 source_dir=str(Path(args.metadata_csv)),
@@ -103,7 +155,22 @@ def main() -> int:
                 chunking_strategy=args.chunking_strategy,
                 chunk_max_chars=args.chunk_max_chars,
                 chunk_overlap_sentences=args.chunk_overlap_sentences,
-                message="PDF/HWP RFP index built from data_list.csv text and joined metadata.",
+                message=message,
+            )
+        elif args.visual_input_dir:
+            documents, ingestion_report = load_visual_documents_from_dir(
+                Path(args.visual_input_dir),
+                visual_artifact_dir,
+            )
+            payload = build_index_payload_from_documents(
+                documents,
+                source_dir=str(Path(args.visual_input_dir)),
+                model_name=args.model,
+                embedding_backend=args.embedding_backend,
+                chunking_strategy=args.chunking_strategy,
+                chunk_max_chars=args.chunk_max_chars,
+                chunk_overlap_sentences=args.chunk_overlap_sentences,
+                message="PDF/image visual parsing v2 index with page/region metadata.",
             )
         else:
             payload = build_index_payload(
@@ -118,7 +185,6 @@ def main() -> int:
         print(f"[ERROR] Index build failed: {exc}", file=sys.stderr)
         return 2
 
-    output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / "index.json"
     out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/tests/test_visual_ingestion.py
+++ b/tests/test_visual_ingestion.py
@@ -1,0 +1,190 @@
+import csv
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+from rag_core import build_index_payload_from_documents, run_rag_query
+from visual_ingestion import (
+    extract_field_candidates,
+    extract_table_candidates,
+    load_visual_documents_from_metadata_csv,
+    parse_visual_document,
+)
+
+
+FIELDNAMES = [
+    "공고 번호",
+    "공고 차수",
+    "사업명",
+    "사업 금액",
+    "발주 기관",
+    "공개 일자",
+    "입찰 참여 시작일",
+    "입찰 참여 마감일",
+    "사업 요약",
+    "파일형식",
+    "파일명",
+    "텍스트",
+]
+
+
+class VisualIngestionTest(unittest.TestCase):
+    @unittest.skipIf(importlib.util.find_spec("fitz") is None, "pymupdf is not installed")
+    def test_parses_synthetic_pdf_to_v2_artifact(self) -> None:
+        import fitz  # type: ignore
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pdf_path = Path(tmp_dir) / "visual_sample.pdf"
+            doc = fitz.open()
+            page = doc.new_page()
+            page.insert_text((72, 72), "사업명: 시각 파싱 사업\n1. 보안 요구사항\n접근 통제를 포함합니다.")
+            doc.save(pdf_path)
+            doc.close()
+
+            document, artifact = parse_visual_document(
+                pdf_path,
+                doc_id="visual-pdf",
+                title="시각 파싱 사업",
+                agency="기관 V",
+                metadata={"file_format": "pdf", "file_name": pdf_path.name},
+            )
+
+            self.assertIsNotNone(document)
+            self.assertEqual(2, artifact["schema_version"])
+            self.assertEqual("parsed", artifact["diagnostics"]["status"])
+            self.assertTrue(artifact["pages"][0]["blocks"])
+            self.assertTrue(artifact["sections"])
+            self.assertEqual("visual_parsing_v2", document["metadata"]["text_source"])
+
+    @unittest.skipIf(importlib.util.find_spec("PIL") is None, "Pillow is not installed")
+    def test_image_ocr_path_uses_injected_provider(self) -> None:
+        from PIL import Image
+
+        def fake_ocr(_image):
+            return [
+                {
+                    "text": "사업명: 이미지 OCR 사업\n항목 | 값\n보안 | 접근통제",
+                    "bbox": [10, 10, 180, 90],
+                    "confidence": 0.91,
+                }
+            ]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            image_path = Path(tmp_dir) / "sample.png"
+            Image.new("RGB", (200, 100), "white").save(image_path)
+
+            document, artifact = parse_visual_document(
+                image_path,
+                doc_id="visual-image",
+                title="이미지 OCR 사업",
+                ocr_provider=fake_ocr,
+            )
+
+            self.assertIsNotNone(document)
+            self.assertEqual("parsed", artifact["diagnostics"]["status"])
+            self.assertEqual([1, 1], artifact["sections"][0]["page_span"])
+            self.assertTrue(artifact["field_candidates"])
+            self.assertTrue(artifact["tables"])
+            self.assertEqual("visual_parsing_v2", document["metadata"]["document_type"])
+
+    def test_extracts_table_and_field_candidates_from_layout_text(self) -> None:
+        blocks = [
+            {
+                "text": "사업명: 후보 추출 사업\n항목 | 요구사항\n보안 | 접근 통제\n로그 | 감사 추적",
+                "page_number": 3,
+                "bbox": [1, 2, 100, 120],
+                "source": "unit",
+                "confidence": 1.0,
+            }
+        ]
+
+        tables = extract_table_candidates(blocks, doc_id="candidate-doc")
+        fields = extract_field_candidates(blocks)
+
+        self.assertEqual(1, len(tables))
+        self.assertEqual(["항목", "요구사항"], tables[0]["rows"][0])
+        self.assertEqual("사업명", fields[0]["key"])
+        self.assertEqual("후보 추출 사업", fields[0]["value"])
+
+    def test_metadata_csv_visual_mode_falls_back_for_hwp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            files_dir = root / "files"
+            files_dir.mkdir()
+            (files_dir / "sample.hwp").write_bytes(b"HWP Document File")
+            metadata_csv = root / "data_list.csv"
+            with metadata_csv.open("w", encoding="utf-8-sig", newline="") as file:
+                writer = csv.DictWriter(file, fieldnames=FIELDNAMES)
+                writer.writeheader()
+                writer.writerow(
+                    {
+                        "공고 번호": "202400010",
+                        "공고 차수": "0.0",
+                        "사업명": "HWP fallback 사업",
+                        "사업 금액": "",
+                        "발주 기관": "기관 H",
+                        "공개 일자": "",
+                        "입찰 참여 시작일": "",
+                        "입찰 참여 마감일": "",
+                        "사업 요약": "",
+                        "파일형식": "hwp",
+                        "파일명": "sample.hwp",
+                        "텍스트": "HWP CSV 텍스트 본문입니다. 보안 요구사항을 포함합니다.",
+                    }
+                )
+
+            documents, report = load_visual_documents_from_metadata_csv(
+                metadata_csv,
+                files_dir,
+                root / "artifacts",
+            )
+
+            self.assertEqual(1, len(documents))
+            self.assertEqual("fallback", report["records"][0]["status"])
+            self.assertEqual(1, report["summary"]["fallback_documents"])
+            self.assertEqual("data_list_csv_text", documents[0]["metadata"]["text_source"])
+            self.assertEqual("visual_fallback_hwp", documents[0]["metadata"]["visual_fallback_reason"])
+
+    def test_region_metadata_reaches_chunks_evidence_and_citations(self) -> None:
+        region = {
+            "page_number": 2,
+            "bbox": [10, 20, 120, 160],
+            "source": "unit",
+            "type": "text",
+            "block_id": "block-1",
+        }
+        document = {
+            "doc_id": "visual-region-doc",
+            "title": "Region 보존 사업",
+            "agency": "기관 V",
+            "project": "Region 보존 사업",
+            "metadata": {"document_type": "visual_parsing_v2"},
+            "sections": [
+                {
+                    "heading": "보안 요구사항",
+                    "text": "보안 요구사항은 접근 통제와 감사 추적입니다.",
+                    "regions": [region],
+                    "page_span": [2, 2],
+                }
+            ],
+            "source_path": "visual-region.pdf",
+        }
+
+        index = build_index_payload_from_documents(
+            [document],
+            source_dir="unit",
+            embedding_backend="hashing",
+        )
+        result = run_rag_query(index, "기관 V의 보안 요구사항은?")
+
+        self.assertEqual([region], index["chunks"][0]["regions"])
+        self.assertEqual([2, 2], index["chunks"][0]["page_span"])
+        self.assertEqual([region], result["evidence"][0]["regions"])
+        citation = result["answer"]["claims"][0]["citations"][0]
+        self.assertEqual([region], citation["regions"])
+        self.assertEqual([2, 2], citation["page_span"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/visual_ingestion.py
+++ b/visual_ingestion.py
@@ -1,0 +1,1100 @@
+#!/usr/bin/env python3
+"""Visual parsing v2 ingestion for PDF/image RFP sources.
+
+The parser emits structured artifacts with page/block/region metadata and
+normalizes those artifacts into the existing RAG document shape. Heavy parser
+dependencies are imported lazily so the public CSV/text baseline keeps running
+in minimal environments.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import re
+from typing import Any, Callable
+
+from ingestion import (
+    clean_cell,
+    find_source_file,
+    make_doc_id,
+    make_doc_id_from_file_name,
+    normalize_body_text,
+    normalize_file_format,
+    normalize_metadata,
+    validate_fieldnames,
+)
+
+VISUAL_SCHEMA_VERSION = 2
+PDF_MIN_TEXT_CHARS_FOR_OCR = 24
+SUPPORTED_IMAGE_FORMATS = {"png", "jpg", "jpeg", "tif", "tiff", "bmp", "webp"}
+SUPPORTED_VISUAL_FORMATS = {"pdf", *SUPPORTED_IMAGE_FORMATS}
+VISUAL_METADATA_FORMATS = { *SUPPORTED_VISUAL_FORMATS, "hwp" }
+
+OcrProvider = Callable[[Any], str | list[dict[str, Any]]]
+
+
+class OcrUnavailable(RuntimeError):
+    """Raised when an OCR provider cannot be loaded or executed."""
+
+
+@dataclass(frozen=True)
+class VisualIngestionRecord:
+    row_number: int | None
+    status: str
+    doc_id: str | None
+    file_name: str
+    file_format: str
+    source_path: str
+    artifact_path: str | None = None
+    reason: str | None = None
+
+
+def load_visual_documents_from_dir(
+    input_dir: Path,
+    artifact_dir: Path,
+    ocr_provider: OcrProvider | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if not input_dir.exists():
+        raise ValueError(f"--visual_input_dir does not exist: {input_dir}")
+    if not input_dir.is_dir():
+        raise ValueError(f"--visual_input_dir must be a directory: {input_dir}")
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    documents: list[dict[str, Any]] = []
+    records: list[VisualIngestionRecord] = []
+
+    files = sorted(
+        path
+        for path in input_dir.iterdir()
+        if path.is_file() and normalize_file_format("", path.name) in SUPPORTED_VISUAL_FORMATS
+    )
+    for source_path in files:
+        doc_id = make_doc_id_from_file_name(source_path.name) or source_path.stem
+        metadata = {
+            "file_format": normalize_file_format("", source_path.name),
+            "file_name": source_path.name,
+            "doc_id_source": "file_name",
+        }
+        document, artifact = parse_visual_document(
+            source_path,
+            doc_id=doc_id,
+            title=source_path.stem,
+            metadata=metadata,
+            ocr_provider=ocr_provider,
+        )
+        artifact_path = write_visual_artifact(artifact, artifact_dir)
+        if document is not None:
+            attach_artifact_path(document, artifact_path)
+            documents.append(document)
+        records.append(record_from_artifact(artifact, artifact_path, row_number=None))
+
+    if not documents:
+        failure_reasons = sorted({record.reason or record.status for record in records})
+        raise ValueError(
+            "No visual PDF/image documents could be ingested from "
+            f"{input_dir}. Failure reasons: {', '.join(failure_reasons) or 'none'}"
+        )
+
+    return documents, make_visual_report(
+        source={"visual_input_dir": str(input_dir), "visual_artifact_dir": str(artifact_dir)},
+        records=records,
+    )
+
+
+def load_visual_documents_from_metadata_csv(
+    metadata_csv: Path,
+    files_dir: Path,
+    artifact_dir: Path,
+    ocr_provider: OcrProvider | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if not metadata_csv.exists():
+        raise ValueError(f"--metadata_csv does not exist: {metadata_csv}")
+    if not metadata_csv.is_file():
+        raise ValueError(f"--metadata_csv must be a file: {metadata_csv}")
+    if not files_dir.exists():
+        raise ValueError(f"--files_dir does not exist: {files_dir}")
+    if not files_dir.is_dir():
+        raise ValueError(f"--files_dir must be a directory: {files_dir}")
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    documents: list[dict[str, Any]] = []
+    records: list[VisualIngestionRecord] = []
+    seen_doc_ids: set[str] = set()
+
+    with metadata_csv.open("r", encoding="utf-8-sig", newline="") as file:
+        reader = csv.DictReader(file)
+        validate_fieldnames(reader.fieldnames or [], metadata_csv)
+        for row_number, row in enumerate(reader, start=2):
+            document, artifact, record = parse_visual_metadata_row(
+                row,
+                row_number,
+                files_dir,
+                seen_doc_ids,
+                ocr_provider=ocr_provider,
+            )
+            artifact_path = write_visual_artifact(artifact, artifact_dir)
+            record = replace_record_artifact_path(record, artifact_path)
+            if document is not None:
+                attach_artifact_path(document, artifact_path)
+                documents.append(document)
+                seen_doc_ids.add(document["doc_id"])
+            records.append(record)
+
+    if not documents:
+        failure_reasons = sorted({record.reason or record.status for record in records})
+        raise ValueError(
+            "No visual PDF/image/HWP-fallback documents could be ingested from "
+            f"{metadata_csv}. Failure reasons: {', '.join(failure_reasons) or 'none'}"
+        )
+
+    return documents, make_visual_report(
+        source={
+            "metadata_csv": str(metadata_csv),
+            "files_dir": str(files_dir),
+            "visual_artifact_dir": str(artifact_dir),
+        },
+        records=records,
+    )
+
+
+def parse_visual_metadata_row(
+    row: dict[str, str],
+    row_number: int,
+    files_dir: Path,
+    seen_doc_ids: set[str],
+    ocr_provider: OcrProvider | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any], VisualIngestionRecord]:
+    notice_id = clean_cell(row.get("공고 번호"))
+    notice_round = clean_cell(row.get("공고 차수"))
+    file_name = clean_cell(row.get("파일명"))
+    file_format = normalize_file_format(row.get("파일형식"), file_name)
+    source_path = find_source_file(files_dir, file_name) if file_name else files_dir
+    doc_id = make_doc_id(notice_id, notice_round) if notice_id else make_doc_id_from_file_name(file_name)
+
+    failure_reason = validate_visual_row_basics(
+        doc_id=doc_id,
+        file_name=file_name,
+        file_format=file_format,
+        source_path=source_path,
+        seen_doc_ids=seen_doc_ids,
+    )
+    if failure_reason:
+        artifact = failure_artifact(
+            doc_id=doc_id or make_doc_id_from_file_name(file_name) or f"row-{row_number}",
+            source_path=source_path,
+            file_format=file_format,
+            title=clean_cell(row.get("사업명")) or Path(file_name).stem,
+            metadata=normalize_metadata(row, file_format, file_name),
+            reason=failure_reason,
+        )
+        return None, artifact, record_from_artifact(artifact, None, row_number=row_number)
+
+    metadata = normalize_metadata(row, file_format, file_name)
+    title = clean_cell(row.get("사업명")) or Path(file_name).stem
+    agency = clean_cell(row.get("발주 기관"))
+    project = clean_cell(row.get("사업명"))
+
+    if file_format == "hwp":
+        document, artifact = make_hwp_fallback_document(
+            row=row,
+            doc_id=doc_id or Path(file_name).stem,
+            source_path=source_path,
+            file_format=file_format,
+            file_name=file_name,
+        )
+    else:
+        document, artifact = parse_visual_document(
+            source_path,
+            doc_id=doc_id,
+            title=title,
+            agency=agency,
+            project=project,
+            metadata=metadata,
+            ocr_provider=ocr_provider,
+        )
+    return document, artifact, record_from_artifact(artifact, None, row_number=row_number)
+
+
+def validate_visual_row_basics(
+    doc_id: str | None,
+    file_name: str,
+    file_format: str,
+    source_path: Path,
+    seen_doc_ids: set[str],
+) -> str | None:
+    if not file_name:
+        return "missing_file_name"
+    if not doc_id:
+        return "missing_doc_id"
+    if doc_id in seen_doc_ids:
+        return "duplicate_doc_id"
+    if file_format not in VISUAL_METADATA_FORMATS:
+        return "unsupported_file_format"
+    if not source_path.exists() or not source_path.is_file():
+        return "missing_file"
+    return None
+
+
+def parse_visual_document(
+    source_path: Path,
+    doc_id: str | None = None,
+    title: str | None = None,
+    agency: str = "",
+    project: str = "",
+    metadata: dict[str, Any] | None = None,
+    ocr_provider: OcrProvider | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    file_format = normalize_file_format("", source_path.name)
+    resolved_doc_id = doc_id or make_doc_id_from_file_name(source_path.name) or source_path.stem
+    resolved_title = title or source_path.stem
+    base_metadata = dict(metadata or {})
+    base_metadata.setdefault("file_format", file_format)
+    base_metadata.setdefault("file_name", source_path.name)
+
+    if file_format not in SUPPORTED_VISUAL_FORMATS:
+        artifact = failure_artifact(
+            resolved_doc_id,
+            source_path,
+            file_format,
+            resolved_title,
+            base_metadata,
+            "unsupported_file_format",
+            agency=agency,
+            project=project,
+        )
+        return None, artifact
+    if not source_path.exists() or not source_path.is_file():
+        artifact = failure_artifact(
+            resolved_doc_id,
+            source_path,
+            file_format,
+            resolved_title,
+            base_metadata,
+            "missing_file",
+            agency=agency,
+            project=project,
+        )
+        return None, artifact
+
+    if file_format == "pdf":
+        artifact = parse_pdf_artifact(
+            source_path,
+            resolved_doc_id,
+            resolved_title,
+            agency,
+            project,
+            base_metadata,
+            ocr_provider,
+        )
+    else:
+        artifact = parse_image_artifact(
+            source_path,
+            resolved_doc_id,
+            resolved_title,
+            agency,
+            project,
+            base_metadata,
+            ocr_provider,
+        )
+
+    finalize_visual_artifact(artifact)
+    if artifact["diagnostics"]["status"] == "failed":
+        return None, artifact
+    return artifact_to_document(artifact), artifact
+
+
+def parse_pdf_artifact(
+    source_path: Path,
+    doc_id: str,
+    title: str,
+    agency: str,
+    project: str,
+    metadata: dict[str, Any],
+    ocr_provider: OcrProvider | None,
+) -> dict[str, Any]:
+    artifact = base_visual_artifact(source_path, doc_id, "pdf", title, agency, project, metadata)
+    try:
+        import fitz  # type: ignore
+    except Exception as exc:
+        mark_failed(artifact, "pdf_parser_unavailable", {"dependency": "pymupdf", "error": str(exc)})
+        return artifact
+
+    try:
+        pdf_doc = fitz.open(str(source_path))
+    except Exception as exc:
+        mark_failed(artifact, "pdf_open_failed", {"error": str(exc)})
+        return artifact
+
+    text_block_count = 0
+    ocr_block_count = 0
+    with pdf_doc:
+        for page_index, page in enumerate(pdf_doc, start=1):
+            width = float(page.rect.width)
+            height = float(page.rect.height)
+            blocks = pdf_text_blocks(page, page_index, width, height, doc_id)
+            text_block_count += len(blocks)
+            page_text = "\n".join(block["text"] for block in blocks)
+            if len(page_text.strip()) < PDF_MIN_TEXT_CHARS_FOR_OCR:
+                ocr_blocks, ocr_reason = ocr_pdf_page(page, page_index, width, height, doc_id, ocr_provider)
+                if ocr_blocks:
+                    blocks.extend(ocr_blocks)
+                    ocr_block_count += len(ocr_blocks)
+                elif not page_text.strip():
+                    add_reason(artifact, ocr_reason or "ocr_unavailable")
+            artifact["pages"].append(
+                {
+                    "page_number": page_index,
+                    "width": width,
+                    "height": height,
+                    "blocks": blocks,
+                }
+            )
+
+    add_stage(artifact, "pdf_text_layer", "ok", {"blocks": text_block_count})
+    if ocr_block_count:
+        add_stage(artifact, "ocr", "ok", {"blocks": ocr_block_count})
+    elif artifact["diagnostics"]["reasons"]:
+        add_stage(artifact, "ocr", "failed", {"reason": "ocr_unavailable"})
+    else:
+        add_stage(artifact, "ocr", "skipped", {"reason": "text_layer_sufficient"})
+
+    artifact["tables"].extend(pdfplumber_tables(source_path, artifact))
+    return artifact
+
+
+def pdf_text_blocks(
+    page: Any,
+    page_number: int,
+    page_width: float,
+    page_height: float,
+    doc_id: str,
+) -> list[dict[str, Any]]:
+    try:
+        raw = page.get_text("dict")
+    except Exception:
+        return []
+
+    blocks = []
+    for block_index, block in enumerate(raw.get("blocks", []), start=1):
+        if block.get("type") != 0:
+            continue
+        text = text_from_pdf_block(block)
+        if not text:
+            continue
+        bbox = normalize_bbox(block.get("bbox"), page_width, page_height)
+        blocks.append(
+            {
+                "block_id": f"{doc_id}::p{page_number:03d}::b{block_index:03d}",
+                "text": text,
+                "type": classify_layout_block(text),
+                "page_number": page_number,
+                "bbox": bbox,
+                "confidence": 1.0,
+                "source": "pdf_text_layer",
+            }
+        )
+    return blocks
+
+
+def text_from_pdf_block(block: dict[str, Any]) -> str:
+    lines = []
+    for line in block.get("lines", []):
+        parts = [str(span.get("text") or "").strip() for span in line.get("spans", [])]
+        line_text = " ".join(part for part in parts if part).strip()
+        if line_text:
+            lines.append(line_text)
+    return normalize_body_text("\n".join(lines))
+
+
+def ocr_pdf_page(
+    page: Any,
+    page_number: int,
+    page_width: float,
+    page_height: float,
+    doc_id: str,
+    ocr_provider: OcrProvider | None,
+) -> tuple[list[dict[str, Any]], str | None]:
+    try:
+        import fitz  # type: ignore
+        from PIL import Image
+    except Exception:
+        return [], "ocr_unavailable"
+
+    try:
+        pixmap = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+        image = Image.frombytes("RGB", (pixmap.width, pixmap.height), pixmap.samples)
+        blocks = ocr_blocks_from_image(
+            image,
+            page_number=page_number,
+            width=float(pixmap.width),
+            height=float(pixmap.height),
+            doc_id=doc_id,
+            source="ocr_pdf_page",
+            ocr_provider=ocr_provider,
+        )
+        scale_x = page_width / max(1.0, float(pixmap.width))
+        scale_y = page_height / max(1.0, float(pixmap.height))
+        return [scale_block_bbox(block, scale_x, scale_y) for block in blocks], None
+    except OcrUnavailable:
+        return [], "ocr_unavailable"
+    except Exception:
+        return [], "ocr_failed"
+
+
+def parse_image_artifact(
+    source_path: Path,
+    doc_id: str,
+    title: str,
+    agency: str,
+    project: str,
+    metadata: dict[str, Any],
+    ocr_provider: OcrProvider | None,
+) -> dict[str, Any]:
+    file_format = normalize_file_format("", source_path.name)
+    artifact = base_visual_artifact(source_path, doc_id, file_format, title, agency, project, metadata)
+    try:
+        from PIL import Image
+    except Exception as exc:
+        mark_failed(artifact, "image_parser_unavailable", {"dependency": "pillow", "error": str(exc)})
+        return artifact
+
+    try:
+        with Image.open(source_path) as image:
+            width, height = image.size
+            blocks = ocr_blocks_from_image(
+                image.convert("RGB"),
+                page_number=1,
+                width=float(width),
+                height=float(height),
+                doc_id=doc_id,
+                source="ocr_image",
+                ocr_provider=ocr_provider,
+            )
+    except OcrUnavailable as exc:
+        mark_failed(artifact, "ocr_unavailable", {"error": str(exc)})
+        return artifact
+    except Exception as exc:
+        mark_failed(artifact, "image_open_failed", {"error": str(exc)})
+        return artifact
+
+    artifact["pages"].append(
+        {
+            "page_number": 1,
+            "width": float(width),
+            "height": float(height),
+            "blocks": blocks,
+        }
+    )
+    add_stage(artifact, "ocr", "ok", {"blocks": len(blocks)})
+    return artifact
+
+
+def ocr_blocks_from_image(
+    image: Any,
+    page_number: int,
+    width: float,
+    height: float,
+    doc_id: str,
+    source: str,
+    ocr_provider: OcrProvider | None,
+) -> list[dict[str, Any]]:
+    provider = ocr_provider or tesseract_ocr_provider
+    result = provider(image)
+    return normalize_ocr_result(result, page_number, width, height, doc_id, source)
+
+
+def tesseract_ocr_provider(image: Any) -> list[dict[str, Any]]:
+    try:
+        import pytesseract  # type: ignore
+    except Exception as exc:
+        raise OcrUnavailable(f"pytesseract_unavailable: {exc}") from exc
+
+    try:
+        data = pytesseract.image_to_data(image, output_type=pytesseract.Output.DICT)
+    except Exception as exc:
+        raise OcrUnavailable(f"tesseract_unavailable: {exc}") from exc
+
+    grouped: dict[tuple[int, int, int], dict[str, Any]] = {}
+    for idx, raw_text in enumerate(data.get("text", [])):
+        text = str(raw_text or "").strip()
+        if not text:
+            continue
+        try:
+            confidence = float(data.get("conf", [0])[idx])
+        except (TypeError, ValueError):
+            confidence = 0.0
+        if confidence < 0:
+            confidence = 0.0
+        key = (
+            int(data.get("block_num", [0])[idx]),
+            int(data.get("par_num", [0])[idx]),
+            int(data.get("line_num", [0])[idx]),
+        )
+        left = float(data.get("left", [0])[idx])
+        top = float(data.get("top", [0])[idx])
+        width = float(data.get("width", [0])[idx])
+        height = float(data.get("height", [0])[idx])
+        entry = grouped.setdefault(key, {"parts": [], "confidences": [], "boxes": []})
+        entry["parts"].append(text)
+        entry["confidences"].append(confidence / 100.0)
+        entry["boxes"].append([left, top, left + width, top + height])
+
+    blocks = []
+    for entry in grouped.values():
+        text = " ".join(entry["parts"]).strip()
+        if not text:
+            continue
+        confidences = entry["confidences"] or [0.0]
+        blocks.append(
+            {
+                "text": text,
+                "bbox": union_bboxes(entry["boxes"]),
+                "confidence": round(sum(confidences) / len(confidences), 3),
+            }
+        )
+    return blocks
+
+
+def normalize_ocr_result(
+    result: str | list[dict[str, Any]],
+    page_number: int,
+    width: float,
+    height: float,
+    doc_id: str,
+    source: str,
+) -> list[dict[str, Any]]:
+    if isinstance(result, str):
+        text = normalize_body_text(result)
+        if not text:
+            return []
+        result = [{"text": text, "bbox": [0.0, 0.0, width, height], "confidence": 1.0}]
+
+    blocks = []
+    for idx, block in enumerate(result, start=1):
+        text = normalize_body_text(str(block.get("text") or ""))
+        if not text:
+            continue
+        bbox = normalize_bbox(block.get("bbox"), width, height)
+        confidence = float(block.get("confidence", 1.0) or 0.0)
+        blocks.append(
+            {
+                "block_id": block.get("block_id") or f"{doc_id}::p{page_number:03d}::ocr{idx:03d}",
+                "text": text,
+                "type": str(block.get("type") or classify_layout_block(text)),
+                "page_number": int(block.get("page_number") or page_number),
+                "bbox": bbox,
+                "confidence": round(max(0.0, min(1.0, confidence)), 3),
+                "source": str(block.get("source") or source),
+            }
+        )
+    return blocks
+
+
+def pdfplumber_tables(source_path: Path, artifact: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        import pdfplumber  # type: ignore
+    except Exception:
+        add_stage(artifact, "table_extraction", "skipped", {"reason": "pdfplumber_unavailable"})
+        return []
+
+    tables = []
+    try:
+        with pdfplumber.open(str(source_path)) as pdf:
+            for page_number, page in enumerate(pdf.pages, start=1):
+                for table_index, table in enumerate(page.find_tables(), start=1):
+                    rows = table.extract() or []
+                    if not rows:
+                        continue
+                    tables.append(
+                        {
+                            "table_id": f"{artifact['doc_id']}::p{page_number:03d}::table{table_index:03d}",
+                            "page_number": page_number,
+                            "bbox": normalize_bbox(table.bbox, float(page.width), float(page.height)),
+                            "rows": rows,
+                            "source": "pdfplumber",
+                            "confidence": 0.8,
+                        }
+                    )
+    except Exception as exc:
+        add_stage(artifact, "table_extraction", "failed", {"error": str(exc)})
+        return []
+
+    add_stage(artifact, "table_extraction", "ok", {"tables": len(tables)})
+    return tables
+
+
+def finalize_visual_artifact(artifact: dict[str, Any]) -> None:
+    if artifact["diagnostics"]["status"] == "failed":
+        return
+
+    blocks = all_blocks(artifact)
+    if not blocks:
+        mark_failed(artifact, "empty_visual_text")
+        return
+
+    heuristic_tables = extract_table_candidates(blocks, doc_id=artifact["doc_id"])
+    if heuristic_tables:
+        artifact["tables"].extend(heuristic_tables)
+    artifact["field_candidates"] = extract_field_candidates(blocks)
+    artifact["sections"] = build_sections_from_blocks(blocks)
+
+    if not artifact["sections"]:
+        mark_failed(artifact, "empty_visual_text")
+        return
+
+    reasons = artifact["diagnostics"]["reasons"]
+    artifact["diagnostics"]["status"] = "partial" if reasons else "parsed"
+    artifact["diagnostics"]["summary"] = {
+        "pages": len(artifact["pages"]),
+        "blocks": len(blocks),
+        "tables": len(artifact["tables"]),
+        "field_candidates": len(artifact["field_candidates"]),
+        "sections": len(artifact["sections"]),
+    }
+
+
+def make_hwp_fallback_document(
+    row: dict[str, str],
+    doc_id: str,
+    source_path: Path,
+    file_format: str,
+    file_name: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    metadata = normalize_metadata(row, file_format, file_name)
+    metadata["visual_fallback_reason"] = "visual_fallback_hwp"
+    title = clean_cell(row.get("사업명")) or Path(file_name).stem
+    artifact = base_visual_artifact(
+        source_path=source_path,
+        doc_id=doc_id,
+        file_format=file_format,
+        title=title,
+        agency=clean_cell(row.get("발주 기관")),
+        project=clean_cell(row.get("사업명")),
+        metadata=metadata,
+    )
+    text = normalize_body_text(row.get("텍스트", ""))
+    if not text:
+        mark_failed(artifact, "empty_text")
+        return None, artifact
+
+    region = {
+        "page_number": None,
+        "bbox": None,
+        "source": "data_list_csv_text",
+        "type": "fallback_text",
+        "block_id": f"{doc_id}::fallback::text",
+    }
+    artifact["sections"] = [
+        {
+            "heading": "본문",
+            "section_path": ["본문"],
+            "text": text,
+            "page_span": None,
+            "regions": [region],
+        }
+    ]
+    artifact["diagnostics"]["status"] = "fallback"
+    artifact["diagnostics"]["reasons"] = ["visual_fallback_hwp"]
+    artifact["diagnostics"]["stages"].append(
+        {
+            "name": "hwp_visual_parsing",
+            "status": "fallback",
+            "reason": "HWP native visual parsing is out of scope for v2.",
+        }
+    )
+    artifact["diagnostics"]["summary"] = {
+        "pages": 0,
+        "blocks": 0,
+        "tables": 0,
+        "field_candidates": 0,
+        "sections": 1,
+    }
+    return artifact_to_document(artifact), artifact
+
+
+def artifact_to_document(artifact: dict[str, Any]) -> dict[str, Any]:
+    metadata = dict(artifact.get("metadata") or {})
+    metadata.setdefault("file_format", artifact["file_format"])
+    metadata["visual_schema_version"] = artifact["schema_version"]
+    if metadata.get("visual_fallback_reason") == "visual_fallback_hwp":
+        metadata["document_type"] = "private_hwp_csv_text_visual_fallback"
+        metadata["text_source"] = "data_list_csv_text"
+    else:
+        metadata["document_type"] = "visual_parsing_v2"
+        metadata["text_source"] = "visual_parsing_v2"
+    metadata["visual_parse_status"] = artifact["diagnostics"]["status"]
+
+    return {
+        "doc_id": artifact["doc_id"],
+        "title": artifact["title"],
+        "agency": artifact.get("agency", ""),
+        "project": artifact.get("project", ""),
+        "metadata": metadata,
+        "sections": artifact.get("sections", []),
+        "source_path": artifact["source_path"],
+    }
+
+
+def base_visual_artifact(
+    source_path: Path,
+    doc_id: str,
+    file_format: str,
+    title: str,
+    agency: str,
+    project: str,
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": VISUAL_SCHEMA_VERSION,
+        "doc_id": doc_id,
+        "title": title,
+        "agency": agency,
+        "project": project,
+        "source_path": str(source_path),
+        "file_format": file_format,
+        "metadata": dict(metadata),
+        "pages": [],
+        "tables": [],
+        "field_candidates": [],
+        "sections": [],
+        "diagnostics": {
+            "status": "parsed",
+            "reasons": [],
+            "stages": [],
+            "summary": {},
+        },
+    }
+
+
+def failure_artifact(
+    doc_id: str,
+    source_path: Path,
+    file_format: str,
+    title: str,
+    metadata: dict[str, Any],
+    reason: str,
+    agency: str = "",
+    project: str = "",
+) -> dict[str, Any]:
+    artifact = base_visual_artifact(source_path, doc_id, file_format, title, agency, project, metadata)
+    mark_failed(artifact, reason)
+    return artifact
+
+
+def mark_failed(artifact: dict[str, Any], reason: str, detail: dict[str, Any] | None = None) -> None:
+    artifact["diagnostics"]["status"] = "failed"
+    add_reason(artifact, reason)
+    stage = {"name": "visual_parsing", "status": "failed", "reason": reason}
+    if detail:
+        stage.update(detail)
+    artifact["diagnostics"]["stages"].append(stage)
+
+
+def add_reason(artifact: dict[str, Any], reason: str) -> None:
+    reasons = artifact["diagnostics"].setdefault("reasons", [])
+    if reason and reason not in reasons:
+        reasons.append(reason)
+
+
+def add_stage(
+    artifact: dict[str, Any],
+    name: str,
+    status: str,
+    detail: dict[str, Any] | None = None,
+) -> None:
+    stage = {"name": name, "status": status}
+    if detail:
+        stage.update(detail)
+    artifact["diagnostics"].setdefault("stages", []).append(stage)
+
+
+def all_blocks(artifact: dict[str, Any]) -> list[dict[str, Any]]:
+    blocks = []
+    for page in artifact.get("pages", []):
+        blocks.extend(page.get("blocks") or [])
+    return blocks
+
+
+def classify_layout_block(text: str) -> str:
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    compact = re.sub(r"\s+", "", first_line)
+    if re.match(r"^(제\s*\d+\s*[장절]|[IVXLC]+\.|\d+[\).]|[가-힣]\.)", first_line):
+        return "heading"
+    heading_keywords = (
+        "제안요청",
+        "사업개요",
+        "사업 개요",
+        "요구사항",
+        "과업내용",
+        "과업 내용",
+        "입찰",
+        "평가",
+        "목차",
+        "security requirements",
+        "requirements",
+    )
+    lowered = first_line.lower()
+    if (
+        0 < len(compact) <= 48
+        and ":" not in first_line
+        and not re.search(r"[.?!。]$", first_line)
+        and any(keyword in lowered for keyword in heading_keywords)
+    ):
+        return "heading"
+    if looks_like_table_line(first_line):
+        return "table"
+    return "text"
+
+
+def build_sections_from_blocks(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    sections: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+
+    for block in blocks:
+        text = normalize_body_text(block.get("text", ""))
+        if not text:
+            continue
+        block_type = block.get("type") or classify_layout_block(text)
+        is_heading = block_type == "heading"
+        if current is None or is_heading:
+            heading = first_non_empty_line(text) if is_heading else "문서 전체"
+            remainder = text_after_first_line(text) if is_heading else text
+            current = {
+                "heading": heading,
+                "section_path": [heading],
+                "text_parts": [remainder] if remainder else [],
+                "regions": [] if is_heading else [region_from_block(block)],
+            }
+            sections.append(current)
+            if is_heading:
+                current["regions"].append(region_from_block(block))
+            continue
+        current["text_parts"].append(text)
+        current["regions"].append(region_from_block(block))
+
+    normalized = []
+    for section in sections:
+        text = "\n".join(part for part in section.pop("text_parts", []) if part).strip()
+        if not text:
+            text = section["heading"]
+        regions = [region for region in section.get("regions", []) if region]
+        normalized.append(
+            {
+                "heading": section["heading"],
+                "section_path": section["section_path"],
+                "text": text,
+                "page_span": page_span_from_regions(regions),
+                "regions": regions,
+            }
+        )
+    return normalized
+
+
+def extract_table_candidates(
+    blocks: list[dict[str, Any]],
+    doc_id: str = "visual-doc",
+) -> list[dict[str, Any]]:
+    tables = []
+    table_seq = 1
+    for block in blocks:
+        lines = [line.strip() for line in str(block.get("text") or "").splitlines() if line.strip()]
+        table_lines = [line for line in lines if looks_like_table_line(line)]
+        if len(table_lines) < 2:
+            continue
+        rows = [split_table_line(line) for line in table_lines]
+        if max(len(row) for row in rows) < 2:
+            continue
+        tables.append(
+            {
+                "table_id": f"{doc_id}::p{int(block.get('page_number') or 1):03d}::heuristic{table_seq:03d}",
+                "page_number": block.get("page_number"),
+                "bbox": block.get("bbox"),
+                "rows": rows,
+                "source": "layout_heuristic",
+                "confidence": 0.45,
+            }
+        )
+        table_seq += 1
+    return tables
+
+
+def extract_field_candidates(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    candidates = []
+    field_seq = 1
+    for block in blocks:
+        for line in str(block.get("text") or "").splitlines():
+            match = re.match(r"^\s*([^:=：]{2,40})\s*[:=：]\s*(.{1,200})\s*$", line)
+            if not match:
+                continue
+            candidates.append(
+                {
+                    "field_id": f"field-{field_seq:03d}",
+                    "key": match.group(1).strip(),
+                    "value": match.group(2).strip(),
+                    "page_number": block.get("page_number"),
+                    "bbox": block.get("bbox"),
+                    "source": block.get("source", ""),
+                    "confidence": block.get("confidence", 1.0),
+                }
+            )
+            field_seq += 1
+    return candidates
+
+
+def looks_like_table_line(line: str) -> bool:
+    if "|" in line or "\t" in line:
+        return True
+    return bool(re.search(r"\S+\s{2,}\S+\s{2,}\S+", line))
+
+
+def split_table_line(line: str) -> list[str]:
+    if "|" in line:
+        parts = line.split("|")
+    elif "\t" in line:
+        parts = line.split("\t")
+    else:
+        parts = re.split(r"\s{2,}", line)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def first_non_empty_line(text: str) -> str:
+    return next((line.strip() for line in text.splitlines() if line.strip()), "문서 전체")
+
+
+def text_after_first_line(text: str) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if len(lines) <= 1:
+        return ""
+    return "\n".join(lines[1:]).strip()
+
+
+def region_from_block(block: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "page_number": block.get("page_number"),
+        "bbox": block.get("bbox"),
+        "source": block.get("source", ""),
+        "type": block.get("type", ""),
+        "block_id": block.get("block_id", ""),
+    }
+
+
+def page_span_from_regions(regions: list[dict[str, Any]]) -> list[int] | None:
+    page_numbers = [
+        int(region["page_number"])
+        for region in regions
+        if isinstance(region.get("page_number"), int)
+    ]
+    if not page_numbers:
+        return None
+    return [min(page_numbers), max(page_numbers)]
+
+
+def normalize_bbox(value: Any, width: float, height: float) -> list[float] | None:
+    if not isinstance(value, (list, tuple)) or len(value) != 4:
+        return None
+    try:
+        x0, y0, x1, y1 = [float(part) for part in value]
+    except (TypeError, ValueError):
+        return None
+    x0 = max(0.0, min(width, x0))
+    x1 = max(0.0, min(width, x1))
+    y0 = max(0.0, min(height, y0))
+    y1 = max(0.0, min(height, y1))
+    return [round(x0, 2), round(y0, 2), round(x1, 2), round(y1, 2)]
+
+
+def union_bboxes(boxes: list[list[float]]) -> list[float] | None:
+    if not boxes:
+        return None
+    return [
+        round(min(box[0] for box in boxes), 2),
+        round(min(box[1] for box in boxes), 2),
+        round(max(box[2] for box in boxes), 2),
+        round(max(box[3] for box in boxes), 2),
+    ]
+
+
+def scale_block_bbox(block: dict[str, Any], scale_x: float, scale_y: float) -> dict[str, Any]:
+    bbox = block.get("bbox")
+    if isinstance(bbox, list) and len(bbox) == 4:
+        block = dict(block)
+        block["bbox"] = [
+            round(float(bbox[0]) * scale_x, 2),
+            round(float(bbox[1]) * scale_y, 2),
+            round(float(bbox[2]) * scale_x, 2),
+            round(float(bbox[3]) * scale_y, 2),
+        ]
+    return block
+
+
+def write_visual_artifact(artifact: dict[str, Any], artifact_dir: Path) -> Path:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    out_path = artifact_dir / f"{safe_file_stem(artifact['doc_id'])}.visual.json"
+    out_path.write_text(json.dumps(artifact, ensure_ascii=False, indent=2), encoding="utf-8")
+    return out_path
+
+
+def attach_artifact_path(document: dict[str, Any], artifact_path: Path) -> None:
+    document.setdefault("metadata", {})["visual_artifact_path"] = str(artifact_path)
+
+
+def safe_file_stem(value: str) -> str:
+    return re.sub(r"[^0-9A-Za-z가-힣_.-]+", "-", value).strip("-") or "visual-artifact"
+
+
+def record_from_artifact(
+    artifact: dict[str, Any],
+    artifact_path: Path | None,
+    row_number: int | None,
+) -> VisualIngestionRecord:
+    reasons = artifact.get("diagnostics", {}).get("reasons") or []
+    return VisualIngestionRecord(
+        row_number=row_number,
+        status=str(artifact.get("diagnostics", {}).get("status") or "failed"),
+        doc_id=artifact.get("doc_id"),
+        file_name=str(artifact.get("metadata", {}).get("file_name") or Path(artifact["source_path"]).name),
+        file_format=str(artifact.get("file_format") or ""),
+        source_path=str(artifact.get("source_path") or ""),
+        artifact_path=str(artifact_path) if artifact_path else None,
+        reason=str(reasons[0]) if reasons else None,
+    )
+
+
+def replace_record_artifact_path(record: VisualIngestionRecord, artifact_path: Path) -> VisualIngestionRecord:
+    return VisualIngestionRecord(
+        row_number=record.row_number,
+        status=record.status,
+        doc_id=record.doc_id,
+        file_name=record.file_name,
+        file_format=record.file_format,
+        source_path=record.source_path,
+        artifact_path=str(artifact_path),
+        reason=record.reason,
+    )
+
+
+def make_visual_report(
+    source: dict[str, str],
+    records: list[VisualIngestionRecord],
+) -> dict[str, Any]:
+    status_counts = {
+        status: sum(1 for record in records if record.status == status)
+        for status in ("parsed", "partial", "fallback", "failed")
+    }
+    summary = {
+        "total_rows": len(records),
+        "indexed_documents": len(records) - status_counts["failed"],
+        "failed_rows": status_counts["failed"],
+        **{f"{status}_documents": count for status, count in status_counts.items()},
+    }
+    return {
+        "schema_version": VISUAL_SCHEMA_VERSION,
+        "ingestion_mode": "visual",
+        **source,
+        "summary": summary,
+        "records": [asdict(record) for record in records],
+    }
+


### PR DESCRIPTION
## Summary
- Add a new visual ingestion path for PDF and image sources with page, bbox, region, table, and field-candidate metadata.
- Extend the index build CLI to support `--visual_input_dir` and `--ingestion_mode visual` while keeping the existing CSV-text v1 baseline intact.
- Preserve region metadata through chunking, retrieval, evidence, and citations, and keep HWP on the v1 CSV-text fallback path.
- Update docs and requirements to describe v2 setup, execution, and known failure modes.

## Testing
- Added unit coverage for visual artifact generation, OCR injection, table/field candidate extraction, HWP fallback, and region metadata propagation.
- Ran the full test suite and local E2E smoke checks for the baseline and the new visual ingestion path.
- Verified README metrics stay in sync with the tracked evaluation summary.