### PR TITLE
Add parser-stage metrics evaluation for visual parsing v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - Benchmark local artifacts: `artifacts/benchmarks/` (gitignored)
 - PDF/HWP ingestion 진단 리포트: `data/index/ingestion_report.json` (`--metadata_csv` 사용 시)
 - Visual parsing v2 artifact: `data/index/visual_artifacts/*.visual.json` (`--visual_input_dir` 또는 `--ingestion_mode visual` 사용 시)
+- Parser-stage 평가 리포트: `reports/parser_eval_summary.json` (`eval/run_parser_eval.py` 사용 시)
 
 ---
 
@@ -240,6 +241,19 @@ python3 scripts/build_index.py \
 ```
 
 이 모드는 `data/index/index.json`, `data/index/ingestion_report.json`, `data/index/visual_artifacts/*.visual.json`을 생성합니다. OCR에는 Python 패키지(`pymupdf`, `pdfplumber`, `pytesseract`, `Pillow`, `opencv-python-headless`)와 시스템 Tesseract 설치가 필요합니다. OCR 엔진이 없으면 text-layer PDF는 계속 처리할 수 있지만 image-only 문서는 `ocr_unavailable`로 실패합니다.
+
+visual parsing 품질은 QA 평가와 별도로 parser-stage 평가로 확인합니다. 이 평가는 이미 생성된 `*.visual.json` artifact와 gold 기대값을 비교하며 OCR text, layout block, section boundary, table, field, bbox/page-region 지표를 `reports/parser_eval_summary.json`에 기록합니다. 공개 fixture로 먼저 실행해 report 형태를 확인할 수 있습니다.
+
+```bash
+python3 eval/run_parser_eval.py \
+  --artifact_dir eval/fixtures/parser_visual_v2 \
+  --gold eval/parser_visual_v2_gold.yaml \
+  --output_dir reports \
+  --run_name visual_v2_fixture \
+  --parser_version 2
+```
+
+실제 visual ingestion 산출물을 비교할 때는 같은 gold 형식에서 `doc_id`와 artifact 이름을 맞춘 뒤 `--artifact_dir data/index/visual_artifacts`를 지정합니다. README의 핵심 성능표는 기존 QA 평가(`reports/eval_summary.json`) 기준으로 유지하고, parser-stage 지표는 별도 리포트로 관리합니다.
 
 ---
 

--- a/docs/failure-cases.md
+++ b/docs/failure-cases.md
@@ -6,6 +6,10 @@
 3. 후속 질문에서 문맥 엔터티 소실
 4. 근거가 부족한 질문에서 unsupported claim 생성
 5. claim과 citation chunk가 같은 내용을 직접 지지하지 않는 citation drift
+6. OCR 누락으로 parser artifact의 본문 text가 retrieval 후보에 들어오지 않는 경우
+7. layout/section boundary 오류로 heading과 본문이 잘못 묶여 chunk가 노이즈를 포함하는 경우
+8. table/field 추출 오류로 요구사항 표나 key-value 사실이 누락 또는 오인식되는 경우
+9. bbox/page-region 누락 또는 오정렬로 citation이 원문 위치까지 설명하지 못하는 경우
 
 ## 대응 전략
 - 필터 완화 + 질의 재작성
@@ -16,3 +20,5 @@
 - retrieval diagnostics에는 단계별 filter, 후보 수, 검증 실패 사유를 남겨 metadata mismatch를 추적한다.
 - 최종 답변은 `supported`/`partial`/`insufficient` 상태를 명시하고, claim마다 citation을 연결한다.
 - 근거가 없으면 `claims`를 비우고 `insufficiency`에 missing target/topic과 검증 실패 사유를 남긴다.
+- visual parsing v2는 `eval/run_parser_eval.py`로 QA 이전 단계의 OCR/layout/section/table/field/bbox 오류를 분리해 기록한다.
+- parser failure taxonomy는 downstream 실패와 연결해 해석한다. 예를 들어 `ocr_missing_text`는 retrieval miss, `section_boundary_missing`은 noisy chunking, `table_cell_mismatch`는 표 기반 요구사항 누락, `field_value_mismatch`는 잘못된 metadata-like claim, `bbox_missing`/`bbox_misaligned`는 약한 citation grounding으로 이어질 수 있다.

--- a/docs/visual-ingestion-v2.md
+++ b/docs/visual-ingestion-v2.md
@@ -16,6 +16,7 @@
 - `index.json`: 기존 RAG index schema를 유지하면서 section/chunk/evidence/citation에 `regions`와 `page_span`을 선택적으로 포함한다.
 - `ingestion_report.json`: 문서별 `parsed`, `partial`, `fallback`, `failed` 상태와 실패 사유를 기록한다.
 - `*.visual.json`: `schema_version: 2` artifact. `pages[*].blocks[*]`, `tables`, `field_candidates`, `sections`, `diagnostics`를 포함한다.
+- `parser_eval_summary.json`: parser-stage gold와 artifact를 비교한 OCR/layout/section/table/field/bbox 평가 리포트다.
 
 ## Parser stages
 - PDF text layer: PyMuPDF로 page block, bbox, layout type을 추출한다.
@@ -31,6 +32,30 @@
 - `visual_fallback_hwp`: HWP native visual parsing은 후속 과제로 남기고 CSV `텍스트` 컬럼을 사용함.
 
 OCR 품질은 자동으로 개선되었다고 간주하지 않는다. v2의 1차 성공 기준은 page/bbox region artifact 생성, 기존 retrieval 호환성, v1/v2 비교 가능성이다.
+
+## Parser-stage evaluation
+QA end-to-end 지표만으로는 parser 품질 저하가 retrieval 문제인지, OCR/layout/table/field 단계 문제인지 분리하기 어렵다. `eval/run_parser_eval.py`는 이미 생성된 `*.visual.json` artifact를 gold YAML과 비교해 parser 단계별 지표를 독립적으로 기록한다.
+
+```bash
+python3 eval/run_parser_eval.py \
+  --artifact_dir eval/fixtures/parser_visual_v2 \
+  --gold eval/parser_visual_v2_gold.yaml \
+  --output_dir reports \
+  --run_name visual_v2_fixture \
+  --parser_version 2
+```
+
+실제 visual ingestion 결과를 비교할 때는 `--artifact_dir data/index/visual_artifacts`를 사용하고, gold의 `doc_id`와 artifact 파일명을 해당 run에 맞춘다. report schema는 `eval/parser_metrics.schema.json`에 둔다.
+
+주요 지표는 다음과 같다.
+- OCR: gold text snippet recall과 normalized char-F1 proxy.
+- Layout: block text/type/page 기준 precision, recall, F1.
+- Section: heading과 `page_span` 기준 boundary recall.
+- Table: cell, row, column-count reconstruction F1.
+- Field: key-value candidate precision, recall, F1.
+- Bbox/page-region: anchor block의 bbox 존재율과, gold bbox가 있을 때 IoU threshold 충족률.
+
+실패 taxonomy는 `ocr_missing_text`, `layout_type_mismatch`, `section_boundary_missing`, `table_cell_mismatch`, `field_missing`, `field_value_mismatch`, `bbox_missing`, `bbox_misaligned`를 포함한다. 이 코드는 downstream 분석에서 retrieval miss, noisy chunking, wrong field grounding, weak bbox citation 같은 QA 실패 원인과 연결한다.
 
 ## 실행 예시
 ```bash
@@ -57,6 +82,6 @@ python3 -m unittest discover -s tests -q
 python3 scripts/build_index.py --input_dir data/raw --output_dir /private/tmp/agentic-vlm-index --embedding_backend hashing
 python3 app.py --input_dir /private/tmp/agentic-vlm-index --output_dir /private/tmp/agentic-vlm-outputs --query "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
 python3 eval/run_eval.py --index_dir /private/tmp/agentic-vlm-index --output_dir /private/tmp/agentic-vlm-reports --config eval/config.yaml
+python3 eval/run_parser_eval.py --artifact_dir eval/fixtures/parser_visual_v2 --gold eval/parser_visual_v2_gold.yaml --output_dir /private/tmp/agentic-vlm-parser-reports --run_name visual_v2_fixture --parser_version 2
 python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check
 ```
-

--- a/eval/fixtures/parser_visual_v2/parser-fixture-doc.visual.json
+++ b/eval/fixtures/parser_visual_v2/parser-fixture-doc.visual.json
@@ -1,0 +1,143 @@
+{
+  "schema_version": 2,
+  "doc_id": "parser-fixture-doc",
+  "title": "시각 파싱 평가 사업",
+  "agency": "공개기관",
+  "project": "시각 파싱 평가 사업",
+  "source_path": "eval/fixtures/parser_visual_v2/parser-fixture-doc.pdf",
+  "file_format": "pdf",
+  "metadata": {
+    "file_format": "pdf",
+    "file_name": "parser-fixture-doc.pdf",
+    "document_type": "visual_parsing_v2"
+  },
+  "pages": [
+    {
+      "page_number": 1,
+      "width": 400.0,
+      "height": 600.0,
+      "blocks": [
+        {
+          "block_id": "parser-fixture-doc::p001::b001",
+          "text": "1. 사업 개요",
+          "type": "heading",
+          "page_number": 1,
+          "bbox": [10, 10, 120, 30],
+          "confidence": 1.0,
+          "source": "pdf_text_layer"
+        },
+        {
+          "block_id": "parser-fixture-doc::p001::b002",
+          "text": "사업명: 시각 파싱 평가 사업\n기관: 공개기관\n보안 요구사항은 접근 통제입니다.",
+          "type": "text",
+          "page_number": 1,
+          "bbox": [10, 40, 280, 100],
+          "confidence": 1.0,
+          "source": "pdf_text_layer"
+        },
+        {
+          "block_id": "parser-fixture-doc::p001::b003",
+          "text": "항목 | 값\n보안 | 접근 통제\n로그 | 감사 추적",
+          "type": "table",
+          "page_number": 1,
+          "bbox": [10, 120, 300, 190],
+          "confidence": 0.95,
+          "source": "layout_heuristic"
+        }
+      ]
+    }
+  ],
+  "tables": [
+    {
+      "table_id": "parser-fixture-doc::p001::heuristic001",
+      "page_number": 1,
+      "bbox": [10, 120, 300, 190],
+      "rows": [
+        ["항목", "값"],
+        ["보안", "접근 통제"],
+        ["로그", "감사 추적"]
+      ],
+      "source": "layout_heuristic",
+      "confidence": 0.45
+    }
+  ],
+  "field_candidates": [
+    {
+      "field_id": "field-001",
+      "key": "사업명",
+      "value": "시각 파싱 평가 사업",
+      "page_number": 1,
+      "bbox": [10, 40, 280, 100],
+      "source": "pdf_text_layer",
+      "confidence": 1.0
+    },
+    {
+      "field_id": "field-002",
+      "key": "기관",
+      "value": "공개기관",
+      "page_number": 1,
+      "bbox": [10, 40, 280, 100],
+      "source": "pdf_text_layer",
+      "confidence": 1.0
+    }
+  ],
+  "sections": [
+    {
+      "heading": "1. 사업 개요",
+      "section_path": ["1. 사업 개요"],
+      "text": "사업명: 시각 파싱 평가 사업\n기관: 공개기관\n보안 요구사항은 접근 통제입니다.\n항목 | 값\n보안 | 접근 통제\n로그 | 감사 추적",
+      "page_span": [1, 1],
+      "regions": [
+        {
+          "page_number": 1,
+          "bbox": [10, 10, 120, 30],
+          "source": "pdf_text_layer",
+          "type": "heading",
+          "block_id": "parser-fixture-doc::p001::b001"
+        },
+        {
+          "page_number": 1,
+          "bbox": [10, 40, 280, 100],
+          "source": "pdf_text_layer",
+          "type": "text",
+          "block_id": "parser-fixture-doc::p001::b002"
+        },
+        {
+          "page_number": 1,
+          "bbox": [10, 120, 300, 190],
+          "source": "layout_heuristic",
+          "type": "table",
+          "block_id": "parser-fixture-doc::p001::b003"
+        }
+      ]
+    }
+  ],
+  "diagnostics": {
+    "status": "parsed",
+    "reasons": [],
+    "stages": [
+      {
+        "name": "pdf_text_layer",
+        "status": "ok",
+        "blocks": 3
+      },
+      {
+        "name": "ocr",
+        "status": "skipped",
+        "reason": "text_layer_sufficient"
+      },
+      {
+        "name": "table_extraction",
+        "status": "ok",
+        "tables": 1
+      }
+    ],
+    "summary": {
+      "pages": 1,
+      "blocks": 3,
+      "tables": 1,
+      "field_candidates": 2,
+      "sections": 1
+    }
+  }
+}

--- a/eval/parser_metrics.schema.json
+++ b/eval/parser_metrics.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Visual Parser Stage Evaluation Report",
+  "type": "object",
+  "required": ["mode", "schema_version", "run", "summary", "documents", "failure_taxonomy"],
+  "properties": {
+    "mode": { "const": "parser" },
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "run": {
+      "type": "object",
+      "required": ["name", "parser_version", "artifact_dir", "gold"],
+      "properties": {
+        "name": { "type": "string" },
+        "parser_version": { "type": "string" },
+        "artifact_dir": { "type": "string" },
+        "gold": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "summary": {
+      "type": "object",
+      "required": ["num_documents", "num_documents_with_errors", "metrics", "failure_counts"],
+      "properties": {
+        "num_documents": { "type": "integer", "minimum": 0 },
+        "num_documents_with_errors": { "type": "integer", "minimum": 0 },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "maximum": 1
+          }
+        },
+        "failure_counts": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "documents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["doc_id", "artifact_path", "parser_status", "metrics", "errors"],
+        "properties": {
+          "doc_id": { "type": "string" },
+          "artifact_path": { "type": "string" },
+          "parser_status": { "type": "string" },
+          "metrics": {
+            "type": "object",
+            "additionalProperties": {
+              "type": ["number", "null"],
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["code", "stage", "message"],
+              "properties": {
+                "code": { "type": "string" },
+                "stage": { "type": "string" },
+                "message": { "type": "string" },
+                "expected": {},
+                "actual": {}
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "failure_taxonomy": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["stage", "downstream_risk"],
+        "properties": {
+          "stage": { "type": "string" },
+          "downstream_risk": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/eval/parser_visual_v2_gold.yaml
+++ b/eval/parser_visual_v2_gold.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+description: Public synthetic parser-stage gold fixture for visual parsing v2.
+documents:
+  - doc_id: parser-fixture-doc
+    artifact: parser-fixture-doc.visual.json
+    ocr_text:
+      snippets:
+        - "1. 사업 개요"
+        - "사업명: 시각 파싱 평가 사업"
+        - "기관: 공개기관"
+        - "보안 요구사항은 접근 통제입니다."
+        - "항목 | 값"
+        - "보안 | 접근 통제"
+        - "로그 | 감사 추적"
+    layout_blocks:
+      - text: "1. 사업 개요"
+        type: heading
+        page_number: 1
+      - text: "사업명: 시각 파싱 평가 사업"
+        type: text
+        page_number: 1
+      - text: "항목 | 값"
+        type: table
+        page_number: 1
+    sections:
+      - heading: "1. 사업 개요"
+        page_span: [1, 1]
+    tables:
+      - rows:
+          - ["항목", "값"]
+          - ["보안", "접근 통제"]
+          - ["로그", "감사 추적"]
+    fields:
+      - key: "사업명"
+        value: "시각 파싱 평가 사업"
+      - key: "기관"
+        value: "공개기관"
+    bbox_anchors:
+      - text: "사업명: 시각 파싱 평가 사업"
+        page_number: 1
+        bbox: [10, 40, 280, 100]
+        min_iou: 0.9
+      - text: "항목 | 값"
+        page_number: 1
+        bbox: [10, 120, 300, 190]
+        min_iou: 0.9

--- a/eval/run_parser_eval.py
+++ b/eval/run_parser_eval.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+"""Run parser-stage evaluation for visual parsing v2 artifacts.
+
+This evaluator compares already generated ``*.visual.json`` artifacts against a
+small gold file. It does not rerun OCR, PDF parsing, indexing, or QA eval.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+import yaml
+
+
+REPORT_SCHEMA_VERSION = 1
+
+METRIC_KEYS = (
+    "ocr_text_recall",
+    "ocr_char_f1",
+    "layout_block_precision",
+    "layout_block_recall",
+    "layout_block_f1",
+    "section_boundary_recall",
+    "table_cell_f1",
+    "table_row_f1",
+    "table_column_f1",
+    "field_precision",
+    "field_recall",
+    "field_f1",
+    "bbox_alignment_rate",
+)
+
+FAILURE_TAXONOMY = {
+    "artifact_missing": {
+        "stage": "artifact",
+        "downstream_risk": "Parser run cannot be compared for this document.",
+    },
+    "ocr_missing_text": {
+        "stage": "ocr",
+        "downstream_risk": "Important text may be absent from retrieval candidates.",
+    },
+    "layout_block_missing": {
+        "stage": "layout",
+        "downstream_risk": "Chunking and section grouping may lose document structure.",
+    },
+    "layout_type_mismatch": {
+        "stage": "layout",
+        "downstream_risk": "Headings, tables, and body text may be grouped incorrectly.",
+    },
+    "section_boundary_missing": {
+        "stage": "section",
+        "downstream_risk": "Section-aware chunks may become noisy or incomplete.",
+    },
+    "table_cell_mismatch": {
+        "stage": "table",
+        "downstream_risk": "Tabular requirements may be flattened or misread.",
+    },
+    "field_missing": {
+        "stage": "field",
+        "downstream_risk": "Metadata-like facts may not be available for filtering or answers.",
+    },
+    "field_value_mismatch": {
+        "stage": "field",
+        "downstream_risk": "Extracted key-value facts may support wrong claims.",
+    },
+    "bbox_missing": {
+        "stage": "bbox",
+        "downstream_risk": "Citations cannot point back to page regions.",
+    },
+    "bbox_misaligned": {
+        "stage": "bbox",
+        "downstream_risk": "Page-region citations may point to the wrong visual evidence.",
+    },
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run parser-stage metrics over visual parsing v2 artifacts."
+    )
+    parser.add_argument(
+        "--artifact_dir",
+        required=True,
+        help="Directory containing generated *.visual.json artifacts.",
+    )
+    parser.add_argument("--gold", required=True, help="Parser-stage gold YAML file.")
+    parser.add_argument(
+        "--output_dir",
+        default="reports",
+        help="Directory to save parser_eval_summary.json.",
+    )
+    parser.add_argument("--run_name", default="visual_v2", help="Stable parser run name.")
+    parser.add_argument(
+        "--parser_version",
+        default="2",
+        help="Parser version label to record in the report.",
+    )
+    return parser.parse_args()
+
+
+def load_gold(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Parser gold must be a mapping: {path}")
+    documents = data.get("documents")
+    if not isinstance(documents, list) or not documents:
+        raise ValueError("Parser gold must include a non-empty documents list")
+    seen_doc_ids: set[str] = set()
+    for document in documents:
+        if not isinstance(document, dict):
+            raise ValueError("Each parser gold document must be a mapping")
+        doc_id = str(document.get("doc_id") or "").strip()
+        if not doc_id:
+            raise ValueError("Each parser gold document must include doc_id")
+        if doc_id in seen_doc_ids:
+            raise ValueError(f"Duplicate parser gold doc_id: {doc_id}")
+        seen_doc_ids.add(doc_id)
+    return data
+
+
+def load_artifact(artifact_dir: Path, gold_doc: dict[str, Any]) -> tuple[Path, dict[str, Any] | None]:
+    doc_id = str(gold_doc["doc_id"])
+    artifact_name = str(gold_doc.get("artifact") or f"{doc_id}.visual.json")
+    artifact_path = Path(artifact_name)
+    if not artifact_path.is_absolute():
+        artifact_path = artifact_dir / artifact_path
+    if not artifact_path.exists():
+        return artifact_path, None
+    data = json.loads(artifact_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Visual artifact must be a JSON object: {artifact_path}")
+    return artifact_path, data
+
+
+def normalize_text(value: Any) -> str:
+    text = str(value or "").lower()
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def text_chars(value: Any) -> Counter[str]:
+    return Counter(char for char in normalize_text(value) if not char.isspace())
+
+
+def round_score(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(float(value), 3)
+
+
+def safe_rate(values: list[float | None]) -> float | None:
+    present = [float(value) for value in values if value is not None]
+    if not present:
+        return None
+    return round_score(sum(present) / len(present))
+
+
+def prf(matched: int, predicted_total: int, expected_total: int) -> dict[str, float | None]:
+    if expected_total == 0:
+        return {"precision": None, "recall": None, "f1": None}
+    precision = matched / predicted_total if predicted_total else 0.0
+    recall = matched / expected_total
+    f1 = 0.0 if precision + recall == 0 else 2 * precision * recall / (precision + recall)
+    return {
+        "precision": round_score(precision),
+        "recall": round_score(recall),
+        "f1": round_score(f1),
+    }
+
+
+def counter_prf(predicted: Counter[Any], expected: Counter[Any]) -> dict[str, float | None]:
+    expected_total = sum(expected.values())
+    predicted_total = sum(predicted.values())
+    if expected_total == 0:
+        return {"precision": None, "recall": None, "f1": None}
+    matched = sum((predicted & expected).values())
+    return prf(matched, predicted_total, expected_total)
+
+
+def add_error(
+    errors: list[dict[str, Any]],
+    code: str,
+    message: str,
+    expected: Any = None,
+    actual: Any = None,
+) -> None:
+    taxonomy = FAILURE_TAXONOMY[code]
+    error = {
+        "code": code,
+        "stage": taxonomy["stage"],
+        "message": message,
+    }
+    if expected is not None:
+        error["expected"] = expected
+    if actual is not None:
+        error["actual"] = actual
+    errors.append(error)
+
+
+def all_blocks(artifact: dict[str, Any]) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = []
+    for page in artifact.get("pages") or []:
+        if isinstance(page, dict):
+            page_blocks = page.get("blocks") or []
+            blocks.extend(block for block in page_blocks if isinstance(block, dict))
+    return blocks
+
+
+def artifact_text(artifact: dict[str, Any]) -> str:
+    return "\n".join(str(block.get("text") or "") for block in all_blocks(artifact))
+
+
+def find_block(
+    blocks: list[dict[str, Any]],
+    expected_text: str,
+    page_number: int | None = None,
+) -> dict[str, Any] | None:
+    expected = normalize_text(expected_text)
+    if not expected:
+        return None
+    for block in blocks:
+        if page_number is not None and block.get("page_number") != page_number:
+            continue
+        if expected in normalize_text(block.get("text")):
+            return block
+    return None
+
+
+def score_ocr(gold_doc: dict[str, Any], artifact: dict[str, Any], errors: list[dict[str, Any]]) -> dict[str, Any]:
+    expected = gold_doc.get("ocr_text") or {}
+    snippets = [str(item) for item in expected.get("snippets") or []]
+    full_expected = " ".join(snippets)
+    predicted_text = artifact_text(artifact)
+
+    matched_snippets = 0
+    for snippet in snippets:
+        if normalize_text(snippet) in normalize_text(predicted_text):
+            matched_snippets += 1
+        else:
+            add_error(
+                errors,
+                "ocr_missing_text",
+                "Expected OCR/text snippet was not found in artifact blocks.",
+                expected=snippet,
+            )
+
+    expected_chars = text_chars(full_expected)
+    predicted_chars = text_chars(predicted_text)
+    char_scores = counter_prf(predicted_chars, expected_chars)
+    return {
+        "ocr_text_recall": round_score(matched_snippets / len(snippets)) if snippets else None,
+        "ocr_char_f1": char_scores["f1"],
+    }
+
+
+def score_layout(
+    gold_doc: dict[str, Any], artifact: dict[str, Any], errors: list[dict[str, Any]]
+) -> dict[str, Any]:
+    expected_blocks = [item for item in gold_doc.get("layout_blocks") or [] if isinstance(item, dict)]
+    blocks = all_blocks(artifact)
+    matched = 0
+    for expected in expected_blocks:
+        expected_text = str(expected.get("text") or "")
+        page_number = expected.get("page_number")
+        if not isinstance(page_number, int):
+            page_number = None
+        block = find_block(blocks, expected_text, page_number)
+        if block is None:
+            add_error(
+                errors,
+                "layout_block_missing",
+                "Expected layout block text was not found.",
+                expected=expected,
+            )
+            continue
+        expected_type = str(expected.get("type") or "")
+        actual_type = str(block.get("type") or "")
+        if expected_type and actual_type != expected_type:
+            add_error(
+                errors,
+                "layout_type_mismatch",
+                "Expected layout block was found with a different type.",
+                expected=expected,
+                actual={"type": actual_type, "block_id": block.get("block_id")},
+            )
+            continue
+        matched += 1
+
+    scores = prf(matched, len(blocks), len(expected_blocks))
+    return {
+        "layout_block_precision": scores["precision"],
+        "layout_block_recall": scores["recall"],
+        "layout_block_f1": scores["f1"],
+    }
+
+
+def score_sections(
+    gold_doc: dict[str, Any], artifact: dict[str, Any], errors: list[dict[str, Any]]
+) -> dict[str, Any]:
+    expected_sections = [item for item in gold_doc.get("sections") or [] if isinstance(item, dict)]
+    actual_sections = [item for item in artifact.get("sections") or [] if isinstance(item, dict)]
+    matched = 0
+    for expected in expected_sections:
+        expected_heading = normalize_text(expected.get("heading"))
+        expected_page_span = expected.get("page_span")
+        found = None
+        for section in actual_sections:
+            if expected_heading != normalize_text(section.get("heading")):
+                continue
+            if expected_page_span and section.get("page_span") != expected_page_span:
+                continue
+            found = section
+            break
+        if found is None:
+            add_error(
+                errors,
+                "section_boundary_missing",
+                "Expected section heading/page span was not found.",
+                expected=expected,
+            )
+        else:
+            matched += 1
+    return {
+        "section_boundary_recall": (
+            round_score(matched / len(expected_sections)) if expected_sections else None
+        )
+    }
+
+
+def rows_from_tables(tables: list[Any]) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for table in tables:
+        if not isinstance(table, dict):
+            continue
+        for row in table.get("rows") or []:
+            if isinstance(row, list):
+                normalized_row = [normalize_text(cell) for cell in row if normalize_text(cell)]
+                if normalized_row:
+                    rows.append(normalized_row)
+    return rows
+
+
+def row_counter(rows: list[list[str]]) -> Counter[str]:
+    return Counter("\t".join(row) for row in rows)
+
+
+def cell_counter(rows: list[list[str]]) -> Counter[str]:
+    return Counter(cell for row in rows for cell in row)
+
+
+def column_counter(rows: list[list[str]]) -> Counter[int]:
+    return Counter(len(row) for row in rows if row)
+
+
+def score_tables(
+    gold_doc: dict[str, Any], artifact: dict[str, Any], errors: list[dict[str, Any]]
+) -> dict[str, Any]:
+    expected_rows = rows_from_tables(gold_doc.get("tables") or [])
+    actual_rows = rows_from_tables(artifact.get("tables") or [])
+    cell_scores = counter_prf(cell_counter(actual_rows), cell_counter(expected_rows))
+    row_scores = counter_prf(row_counter(actual_rows), row_counter(expected_rows))
+    column_scores = counter_prf(column_counter(actual_rows), column_counter(expected_rows))
+
+    if expected_rows and cell_scores["f1"] != 1.0:
+        add_error(
+            errors,
+            "table_cell_mismatch",
+            "Expected table rows/cells were not fully reconstructed.",
+            expected=expected_rows,
+            actual=actual_rows,
+        )
+
+    return {
+        "table_cell_f1": cell_scores["f1"],
+        "table_row_f1": row_scores["f1"],
+        "table_column_f1": column_scores["f1"],
+    }
+
+
+def normalize_field(field: dict[str, Any]) -> tuple[str, str]:
+    return normalize_text(field.get("key")), normalize_text(field.get("value"))
+
+
+def value_matches(expected: str, actual: str) -> bool:
+    if not expected:
+        return True
+    return expected == actual or expected in actual or actual in expected
+
+
+def score_fields(
+    gold_doc: dict[str, Any], artifact: dict[str, Any], errors: list[dict[str, Any]]
+) -> dict[str, Any]:
+    expected_fields = [item for item in gold_doc.get("fields") or [] if isinstance(item, dict)]
+    actual_fields = [item for item in artifact.get("field_candidates") or [] if isinstance(item, dict)]
+    matched = 0
+    used_actual: set[int] = set()
+    for expected in expected_fields:
+        expected_key, expected_value = normalize_field(expected)
+        same_key = [
+            (idx, field)
+            for idx, field in enumerate(actual_fields)
+            if idx not in used_actual and normalize_text(field.get("key")) == expected_key
+        ]
+        if not same_key:
+            add_error(
+                errors,
+                "field_missing",
+                "Expected key-value field was not extracted.",
+                expected=expected,
+            )
+            continue
+        matching_value = [
+            (idx, field)
+            for idx, field in same_key
+            if value_matches(expected_value, normalize_text(field.get("value")))
+        ]
+        if not matching_value:
+            add_error(
+                errors,
+                "field_value_mismatch",
+                "Expected field key was found with a different value.",
+                expected=expected,
+                actual=[field for _, field in same_key],
+            )
+            continue
+        used_actual.add(matching_value[0][0])
+        matched += 1
+
+    scores = prf(matched, len(actual_fields), len(expected_fields))
+    return {
+        "field_precision": scores["precision"],
+        "field_recall": scores["recall"],
+        "field_f1": scores["f1"],
+    }
+
+
+def is_bbox(value: Any) -> bool:
+    if not isinstance(value, list) or len(value) != 4:
+        return False
+    try:
+        [float(part) for part in value]
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def bbox_iou(left: list[Any], right: list[Any]) -> float:
+    l0, t0, l1, b1 = [float(part) for part in left]
+    r0, u0, r1, d1 = [float(part) for part in right]
+    inter_w = max(0.0, min(l1, r1) - max(l0, r0))
+    inter_h = max(0.0, min(b1, d1) - max(t0, u0))
+    intersection = inter_w * inter_h
+    left_area = max(0.0, l1 - l0) * max(0.0, b1 - t0)
+    right_area = max(0.0, r1 - r0) * max(0.0, d1 - u0)
+    union = left_area + right_area - intersection
+    return 0.0 if union <= 0 else intersection / union
+
+
+def score_bboxes(
+    gold_doc: dict[str, Any], artifact: dict[str, Any], errors: list[dict[str, Any]]
+) -> dict[str, Any]:
+    anchors = [item for item in gold_doc.get("bbox_anchors") or [] if isinstance(item, dict)]
+    if not anchors:
+        return {"bbox_alignment_rate": None}
+
+    blocks = all_blocks(artifact)
+    aligned = 0
+    for anchor in anchors:
+        page_number = anchor.get("page_number")
+        if not isinstance(page_number, int):
+            page_number = None
+        block_id = str(anchor.get("block_id") or "")
+        if block_id:
+            block = next((item for item in blocks if item.get("block_id") == block_id), None)
+        else:
+            block = find_block(blocks, str(anchor.get("text") or ""), page_number)
+
+        if block is None:
+            add_error(
+                errors,
+                "bbox_missing",
+                "Expected page-region anchor block was not found.",
+                expected=anchor,
+            )
+            continue
+
+        actual_bbox = block.get("bbox")
+        if not is_bbox(actual_bbox):
+            add_error(
+                errors,
+                "bbox_missing",
+                "Expected page-region anchor has no bbox.",
+                expected=anchor,
+                actual={"block_id": block.get("block_id"), "bbox": actual_bbox},
+            )
+            continue
+
+        expected_bbox = anchor.get("bbox")
+        if is_bbox(expected_bbox):
+            min_iou = float(anchor.get("min_iou", 0.5))
+            iou = bbox_iou(actual_bbox, expected_bbox)
+            if iou < min_iou:
+                add_error(
+                    errors,
+                    "bbox_misaligned",
+                    "Expected bbox anchor did not meet the IoU threshold.",
+                    expected=anchor,
+                    actual={
+                        "block_id": block.get("block_id"),
+                        "bbox": actual_bbox,
+                        "iou": round_score(iou),
+                    },
+                )
+                continue
+        aligned += 1
+
+    return {"bbox_alignment_rate": round_score(aligned / len(anchors))}
+
+
+def score_document(
+    gold_doc: dict[str, Any],
+    artifact: dict[str, Any] | None,
+    artifact_path: Path,
+) -> dict[str, Any]:
+    doc_id = str(gold_doc["doc_id"])
+    errors: list[dict[str, Any]] = []
+    metrics = {key: None for key in METRIC_KEYS}
+
+    if artifact is None:
+        add_error(errors, "artifact_missing", "Expected visual artifact file is missing.")
+        return {
+            "doc_id": doc_id,
+            "artifact_path": str(artifact_path),
+            "parser_status": "missing",
+            "metrics": metrics,
+            "errors": errors,
+        }
+
+    metrics.update(score_ocr(gold_doc, artifact, errors))
+    metrics.update(score_layout(gold_doc, artifact, errors))
+    metrics.update(score_sections(gold_doc, artifact, errors))
+    metrics.update(score_tables(gold_doc, artifact, errors))
+    metrics.update(score_fields(gold_doc, artifact, errors))
+    metrics.update(score_bboxes(gold_doc, artifact, errors))
+
+    diagnostics = artifact.get("diagnostics") or {}
+    return {
+        "doc_id": doc_id,
+        "artifact_path": str(artifact_path),
+        "parser_status": str(diagnostics.get("status") or "unknown"),
+        "metrics": metrics,
+        "errors": errors,
+    }
+
+
+def summarize_documents(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    metrics = {
+        key: safe_rate([doc.get("metrics", {}).get(key) for doc in documents])
+        for key in METRIC_KEYS
+    }
+    failure_counts = Counter(
+        error["code"]
+        for document in documents
+        for error in document.get("errors") or []
+        if error.get("code")
+    )
+    return {
+        "num_documents": len(documents),
+        "num_documents_with_errors": sum(1 for doc in documents if doc.get("errors")),
+        "metrics": metrics,
+        "failure_counts": dict(sorted(failure_counts.items())),
+    }
+
+
+def build_report(
+    artifact_dir: Path,
+    gold_path: Path,
+    gold: dict[str, Any],
+    run_name: str,
+    parser_version: str,
+) -> dict[str, Any]:
+    document_results = []
+    for gold_doc in sorted(gold["documents"], key=lambda item: str(item["doc_id"])):
+        artifact_path, artifact = load_artifact(artifact_dir, gold_doc)
+        document_results.append(score_document(gold_doc, artifact, artifact_path))
+
+    return {
+        "mode": "parser",
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "run": {
+            "name": run_name,
+            "parser_version": str(parser_version),
+            "artifact_dir": str(artifact_dir),
+            "gold": str(gold_path),
+        },
+        "summary": summarize_documents(document_results),
+        "documents": document_results,
+        "failure_taxonomy": FAILURE_TAXONOMY,
+    }
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        artifact_dir = Path(args.artifact_dir)
+        gold_path = Path(args.gold)
+        if not artifact_dir.exists() or not artifact_dir.is_dir():
+            raise ValueError(f"--artifact_dir must be an existing directory: {artifact_dir}")
+        if not gold_path.exists() or not gold_path.is_file():
+            raise ValueError(f"--gold must be an existing file: {gold_path}")
+        gold = load_gold(gold_path)
+        report = build_report(
+            artifact_dir=artifact_dir,
+            gold_path=gold_path,
+            gold=gold,
+            run_name=args.run_name,
+            parser_version=args.parser_version,
+        )
+    except Exception as exc:
+        print(f"[ERROR] Parser eval failed: {exc}", file=sys.stderr)
+        return 2
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "parser_eval_summary.json"
+    output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"[OK] Parser eval summary written: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_parser_eval.py
+++ b/tests/test_parser_eval.py
@@ -1,0 +1,116 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from eval.run_parser_eval import (
+    build_report,
+    load_gold,
+    score_document,
+)
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = ROOT_DIR / "eval" / "fixtures" / "parser_visual_v2"
+GOLD_PATH = ROOT_DIR / "eval" / "parser_visual_v2_gold.yaml"
+
+
+class ParserEvalTest(unittest.TestCase):
+    def test_scores_clean_fixture_without_errors(self) -> None:
+        gold = load_gold(GOLD_PATH)
+        artifact_path = FIXTURE_DIR / "parser-fixture-doc.visual.json"
+        artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+        result = score_document(gold["documents"][0], artifact, artifact_path)
+
+        self.assertEqual("parser-fixture-doc", result["doc_id"])
+        self.assertEqual([], result["errors"])
+        self.assertEqual(1.0, result["metrics"]["ocr_text_recall"])
+        self.assertEqual(1.0, result["metrics"]["ocr_char_f1"])
+        self.assertEqual(1.0, result["metrics"]["layout_block_f1"])
+        self.assertEqual(1.0, result["metrics"]["field_f1"])
+        self.assertEqual(1.0, result["metrics"]["bbox_alignment_rate"])
+
+    def test_scores_missing_field_and_bbox_errors(self) -> None:
+        gold = {
+            "doc_id": "broken-doc",
+            "ocr_text": {"snippets": ["사업명: 오류 사례"]},
+            "layout_blocks": [{"text": "사업명: 오류 사례", "type": "text", "page_number": 1}],
+            "fields": [{"key": "사업명", "value": "오류 사례"}],
+            "bbox_anchors": [{"text": "사업명: 오류 사례", "page_number": 1}],
+        }
+        artifact = {
+            "doc_id": "broken-doc",
+            "pages": [
+                {
+                    "page_number": 1,
+                    "blocks": [
+                        {
+                            "text": "사업명: 오류 사례",
+                            "type": "text",
+                            "page_number": 1,
+                            "bbox": None,
+                        }
+                    ],
+                }
+            ],
+            "field_candidates": [],
+            "sections": [],
+            "tables": [],
+            "diagnostics": {"status": "parsed"},
+        }
+
+        result = score_document(gold, artifact, Path("broken-doc.visual.json"))
+        codes = {error["code"] for error in result["errors"]}
+
+        self.assertIn("field_missing", codes)
+        self.assertIn("bbox_missing", codes)
+        self.assertEqual(0.0, result["metrics"]["field_recall"])
+        self.assertEqual(0.0, result["metrics"]["bbox_alignment_rate"])
+
+    def test_build_report_includes_summary_and_taxonomy(self) -> None:
+        gold = load_gold(GOLD_PATH)
+        report = build_report(FIXTURE_DIR, GOLD_PATH, gold, "unit", "2")
+
+        self.assertEqual("parser", report["mode"])
+        self.assertEqual(1, report["summary"]["num_documents"])
+        self.assertEqual(0, report["summary"]["num_documents_with_errors"])
+        self.assertEqual(1.0, report["summary"]["metrics"]["field_f1"])
+        self.assertIn("ocr_missing_text", report["failure_taxonomy"])
+        self.assertIn("bbox_misaligned", report["failure_taxonomy"])
+
+    def test_cli_writes_parser_eval_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT_DIR / "eval" / "run_parser_eval.py"),
+                    "--artifact_dir",
+                    str(FIXTURE_DIR),
+                    "--gold",
+                    str(GOLD_PATH),
+                    "--output_dir",
+                    tmp_dir,
+                    "--run_name",
+                    "fixture",
+                    "--parser_version",
+                    "2",
+                ],
+                cwd=ROOT_DIR,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            out_path = Path(tmp_dir) / "parser_eval_summary.json"
+            self.assertTrue(out_path.exists())
+            report = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertEqual("fixture", report["run"]["name"])
+            self.assertEqual({}, report["summary"]["failure_counts"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added an independent parser-stage evaluator for visual parsing v2 artifacts with a new `eval/run_parser_eval.py` CLI.
- Introduced a compact gold fixture and report schema for OCR, layout, section, table, field, and bbox/page-region metrics.
- Added a public synthetic parser fixture and unit tests for metric scoring and report generation.
- Updated README and docs to explain parser-stage evaluation flow and failure taxonomy.

## Testing
- Added new unit tests for parser-stage metric helpers and CLI output.
- Ran the full test suite and local evaluation flow to verify the new parser report path and preserve the existing QA evaluation baseline.