### PR TITLE
Refine verifier topic grounding for real 100-document RAG

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -169,10 +169,35 @@ METADATA_GENERIC_TOKENS = {
     "시스템",
 }
 
+VERIFICATION_INTENT_TOKENS = {
+    "간단히",
+    "관련",
+    "내용",
+    "대해",
+    "알려줘",
+    "요약",
+    "요약해줘",
+    "정리",
+    "정리해줘",
+    "주요",
+    "확인",
+}
+
+METADATA_EVIDENCE_LABELS = {
+    "budget": ("예산", "사업예산", "사업 금액"),
+    "published_at": ("공개 일자", "공고일"),
+    "bid_start_at": ("입찰", "입찰 시작일", "입찰 참여 시작일"),
+    "bid_deadline_at": ("입찰", "마감일", "입찰 마감일", "입찰 참여 마감일"),
+    "summary": ("요약", "사업 요약"),
+}
+
 KOREAN_PARTICLE_SUFFIXES = (
     "으로",
     "에서",
     "에게",
+    "도",
+    "만",
+    "나",
     "과",
     "와",
     "의",
@@ -1568,11 +1593,8 @@ def verify_evidence(analysis: dict[str, Any], evidence: list[dict[str, Any]]) ->
     if evidence[0]["score"] < 0.18:
         reasons.append("low_top_score")
 
-    combined = " ".join(
-        " ".join([item.get("title", ""), item.get("section", ""), item["text"]])
-        for item in evidence
-    ).lower()
-    topics = specific_topics(analysis)
+    combined = " ".join(evidence_text_for_verification(item) for item in evidence).lower()
+    topics = verification_topics(analysis)
     if topics and not all(topic.lower() in combined for topic in topics):
         reasons.append("topic_not_grounded")
 
@@ -1602,11 +1624,62 @@ def verify_evidence(analysis: dict[str, Any], evidence: list[dict[str, Any]]) ->
 
 
 def specific_topics(analysis: dict[str, Any]) -> list[str]:
-    return [topic for topic in analysis.get("topics", []) if topic.lower() not in {"ai"}]
+    return verification_topics(analysis)
+
+
+def verification_topics(analysis: dict[str, Any]) -> list[str]:
+    metadata_terms = metadata_terms_for_verification(analysis)
+    keyword_terms = {
+        normalize_metadata_token(keyword)
+        for keyword in TOPIC_KEYWORDS
+        if normalize_metadata_token(keyword).lower() != "ai"
+    }
+    topics = []
+    for topic in analysis.get("topics", []):
+        normalized = normalize_metadata_token(str(topic))
+        if not normalized or normalized.lower() == "ai":
+            continue
+        if normalized in metadata_terms and normalized not in keyword_terms:
+            continue
+        if normalized in METADATA_GENERIC_TOKENS or normalized in VERIFICATION_INTENT_TOKENS:
+            continue
+        topics.append(normalized)
+    return ordered_unique(topics)
+
+
+def metadata_terms_for_verification(analysis: dict[str, Any]) -> set[str]:
+    values: list[str] = []
+    for key in ("entities", "matched_agencies", "matched_projects", "context_entities"):
+        values.extend(str(value) for value in analysis.get(key) or [])
+    for match in analysis.get("metadata_matches") or []:
+        values.extend(
+            str(match.get(key) or "")
+            for key in ("agency", "project", "value")
+        )
+        values.extend(str(term) for term in match.get("matched_terms") or [])
+    return set(metadata_tokens(" ".join(values)))
+
+
+def evidence_text_for_verification(item: dict[str, Any]) -> str:
+    parts = [
+        item.get("title", ""),
+        item.get("agency", ""),
+        item.get("project", ""),
+        item.get("section", ""),
+        item.get("text", ""),
+    ]
+    metadata = item.get("metadata")
+    if isinstance(metadata, dict):
+        for key, value in metadata.items():
+            if value is None or value == "":
+                continue
+            parts.extend(METADATA_EVIDENCE_LABELS.get(str(key), (str(key),)))
+            parts.append(str(value))
+    return " ".join(str(part) for part in parts if str(part).strip())
 
 
 def evidence_has_topic(item: dict[str, Any], topics: list[str]) -> bool:
-    text = " ".join([item.get("title", ""), item.get("section", ""), item.get("text", "")]).lower()
+    text = evidence_text_for_verification(item).lower()
     return any(topic.lower() in text for topic in topics)
 
 
@@ -1824,11 +1897,11 @@ def select_supporting_evidence(
     analysis: dict[str, Any],
     evidence: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    topics = [topic.lower() for topic in specific_topics(analysis)]
+    topics = [topic.lower() for topic in verification_topics(analysis)]
     topic_matched = [
         item
         for item in evidence
-        if not topics or any(topic in item["text"].lower() for topic in topics)
+        if not topics or any(topic in evidence_text_for_verification(item).lower() for topic in topics)
     ]
 
     if analysis.get("query_type") == "comparison" and len(analysis.get("entities", [])) > 1:
@@ -2173,6 +2246,7 @@ def run_rag_query(
             "claim_count": len(answer["claims"]),
             "citation_count": sum(len(claim.get("citations") or []) for claim in answer["claims"]),
             "verification_reasons": verification_reasons,
+            "verification_topics": verification_topics(analysis),
             "filter_stage_attempts": stage_attempts,
             "final_relaxation_reason": stage_attempts[-2]["verification_reasons"] if retry_count else [],
             "context_resolution": context_resolution,

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -166,6 +166,94 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
         )
         self.assertEqual("relaxed", result["plan"]["filter_stage"])
 
+    def test_verifier_ignores_metadata_and_intent_tokens_for_real_like_summary(self) -> None:
+        real_like_index = build_index_payload_from_documents(
+            [
+                {
+                    "doc_id": "bonghwa-disaster",
+                    "title": "봉화군 재난통합관리시스템 고도화 사업",
+                    "agency": "경상북도 봉화군",
+                    "project": "봉화군 재난통합관리시스템 고도화 사업",
+                    "metadata": {
+                        "summary": "사업범위: 재난통합관리시스템 고도화 및 개선",
+                    },
+                    "sections": [
+                        {
+                            "heading": "본문",
+                            "text": (
+                                "사업내용 및 범위는 재난 상황관리 기능 개선과 "
+                                "시스템 연계 고도화를 포함한다."
+                            ),
+                        }
+                    ],
+                    "source_path": "bonghwa.hwp",
+                }
+            ],
+            source_dir="test-fixture",
+            embedding_backend="hashing",
+        )
+
+        result = run_rag_query(
+            real_like_index,
+            "경상북도 봉화군 봉화군 재난통합관리시스템 고도화 사업의 주요 요구사항과 사업 범위를 요약해줘",
+        )
+
+        self.assertEqual("supported", result["answer"]["status"])
+        self.assertFalse(result["diagnostics"]["abstained"])
+        self.assertEqual({"bonghwa-disaster"}, {item["doc_id"] for item in result["evidence"]})
+
+    def test_follow_up_budget_particle_normalization_uses_conversation_state(self) -> None:
+        real_like_index = build_index_payload_from_documents(
+            [
+                {
+                    "doc_id": "hanyeong-track",
+                    "title": "한영대학교 특성화 맞춤형 교육환경 구축 사업",
+                    "agency": "한영대학",
+                    "project": "한영대학교 특성화 맞춤형 교육환경 구축 - 트랙운영 학사정보시스템 고도화",
+                    "metadata": {
+                        "budget": 130000000,
+                        "summary": "사업예산 130,000,000원, 사업기간 계약일로부터 3개월",
+                    },
+                    "sections": [
+                        {
+                            "heading": "사업 안내",
+                            "text": (
+                                "사업예산은 130,000,000원 범위 내이다. "
+                                "사업기간은 계약일로부터 3개월이다. "
+                                "트랙기반 교육과정 운영 관리 체계를 지원한다."
+                            ),
+                        }
+                    ],
+                    "source_path": "hanyeong.hwp",
+                }
+            ],
+            source_dir="test-fixture",
+            embedding_backend="hashing",
+        )
+        first = run_rag_query(
+            real_like_index,
+            "한영대학교 특성화 맞춤형 교육환경 구축 사업의 주요 요구사항은?",
+            conversation_state={},
+        )
+
+        follow_up = run_rag_query(
+            real_like_index,
+            "그 사업의 사업기간과 사업예산도 알려줘",
+            conversation_state=first["conversation_state"],
+        )
+
+        self.assertEqual("supported", follow_up["answer"]["status"])
+        self.assertFalse(follow_up["diagnostics"]["abstained"])
+        self.assertEqual(
+            "resolved",
+            follow_up["diagnostics"]["context_resolution"]["status"],
+        )
+        self.assertEqual(
+            "conversation_state",
+            follow_up["diagnostics"]["context_resolution"]["source"],
+        )
+        self.assertIn("사업예산", follow_up["diagnostics"]["verification_topics"])
+
     def test_metadata_first_can_be_disabled_for_ablation(self) -> None:
         result = run_rag_query(
             self.index,


### PR DESCRIPTION
## Summary
- Split verification-time topic checks from retrieval topics so the verifier no longer treats intent words and metadata-derived tokens as mandatory ground truth.
- Expanded evidence grounding to include metadata fields like budget, bid dates, and summary text, which reduces false `insufficient` answers on real 100-document queries.
- Added regression coverage for real-like summary and follow-up cases, while preserving comparison partial/abstention safety.

## Testing
- `pytest -q` passed (`24 passed`).
- Re-ran the public synthetic evaluation and restored the expected metrics to `1.0` across accuracy, groundedness, citation precision, format compliance, and abstention.
- Rebuilt the real 100-document index and rechecked the previously failing queries; both now return `supported` with citations.