### PR TITLE
Add optional real-data profile for private RFP smoke and evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ venv/
 data/files/
 data/data_list.csv
 data/data_list.xlsx
+eval/*.local.yaml
 원본 데이터/
 
 # Generated artifacts: keep committed portfolio samples, ignore extra outputs

--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ python3 scripts/build_index.py \
 
 이 모드는 `data/index/index.json`과 함께 `data/index/ingestion_report.json`을 생성합니다. 리포트에는 문서별 indexed/failed 상태와 `missing_file`, `empty_text`, `unsupported_file_format`, `duplicate_doc_id` 같은 실패 사유가 기록됩니다.
 
+#### Optional real-data profile
+
+공개 synthetic baseline과 성능표는 그대로 유지하고, 로컬 private 실데이터는 별도 profile로 실행합니다.
+
+```bash
+bash scripts/smoke_real.sh
+```
+
+기본 입력은 `data/data_list.csv`와 `data/files/`이며, 산출물은 `data/index/real100/`, `outputs/real100/`, `reports/real100/`에 생성됩니다. `eval/real_config.local.yaml`이 있으면 실데이터 gold 평가까지 실행하고, 없으면 인덱싱과 대표 질의까지만 실행합니다. 로컬 평가 파일은 `eval/real_config.example.yaml`을 복사해 만들며, `eval/*.local.yaml`은 Git 추적 대상이 아닙니다.
+
 ### 선택) Document visual parsing v2
 원본 PDF/이미지 문서를 직접 파싱해 page/bbox/region metadata가 포함된 v2 artifact를 만들 수 있습니다. PDF는 text layer block을 우선 사용하고, text가 부족한 page 또는 이미지 파일은 OCR adapter를 사용합니다. HWP는 이번 v2에서 native visual parsing 대상이 아니며, metadata CSV visual mode에서는 기존 `텍스트` 컬럼으로 fallback하고 `visual_fallback_hwp`로 표시합니다.
 

--- a/docs/real-data-ingestion.md
+++ b/docs/real-data-ingestion.md
@@ -17,9 +17,27 @@ python3 scripts/build_index.py \
   --embedding_backend hashing
 ```
 
+## Optional real-data profile
+공개 baseline은 `data/raw` synthetic 흐름으로 유지한다. 로컬에 비공개 원본과 `data_list.csv`가 있는 환경에서는 다음 smoke profile로 실데이터 end-to-end를 확인한다.
+
+```bash
+bash scripts/smoke_real.sh
+```
+
+기본값은 다음과 같다.
+- 입력: `data/data_list.csv`, `data/files/`
+- 인덱스: `data/index/real100/`
+- 질의 출력: `outputs/real100/answer.json`
+- 평가 출력: `reports/real100/eval_summary.json`
+- 평가 설정: `eval/real_config.local.yaml`
+
+`eval/real_config.local.yaml`이 없으면 인덱싱과 대표 질의까지만 실행하고, 실데이터 gold 평가를 건너뛴다. 새 환경에서는 `eval/real_config.example.yaml`을 복사해 로컬 expected doc id/term/target을 채운다. `eval/*.local.yaml`, 실데이터 원본, 실데이터 산출물은 Git 추적 대상이 아니다.
+
 ## 출력
 - `data/index/index.json`: 기존 RAG index schema를 유지하되, 문서와 chunk에 normalized metadata를 포함한다.
 - `data/index/ingestion_report.json`: CSV row별 `indexed` 또는 `failed` 상태와 실패 사유를 기록한다.
+
+optional profile을 사용할 때도 index schema는 동일하며, 기본 경로만 `data/index/real100/`로 분리한다.
 
 ## v1 / v2 비교
 - v1 기본값은 `--ingestion_mode csv-text`이며, CSV의 `텍스트` 컬럼을 본문으로 사용한다.
@@ -36,3 +54,6 @@ python3 scripts/build_index.py \
 - 동일 `doc_id`가 반복되는 경우: `duplicate_doc_id`
 
 단, 성공적으로 인덱싱 가능한 문서가 0개이면 입력 오류로 보고 빌드를 실패시킨다.
+
+## 현재 로컬 검증 기준
+현재 로컬 실데이터 샘플은 100개 row로 구성되며, CSV 텍스트 기반 v1 경로에서 100개 문서가 모두 인덱싱된다. 이 수치는 private local data 기준이므로 공개 README 성능표에는 반영하지 않는다.

--- a/eval/real_config.example.yaml
+++ b/eval/real_config.example.yaml
@@ -1,0 +1,37 @@
+mode: rag
+description: Local-only real RFP evaluation template. Copy to eval/real_config.local.yaml and fill with private expected values.
+index_dir: data/index/real100
+answer_policy:
+  answerable_status: supported
+  unanswerable_status: insufficient
+  min_claims_answerable: 1
+  require_claim_citations: true
+ablation_runs:
+  - name: full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+cases:
+  - id: replace_single_doc_budget_schedule
+    query_type: single_doc
+    query: "발주기관명 사업명의 사업기간과 사업예산 알려줘"
+    expected_doc_ids:
+      - replace-with-real-doc-id
+    expected_terms:
+      - "replace-with-budget-term"
+      - "replace-with-schedule-term"
+    expected_citation_terms:
+      - "replace-with-budget-term"
+    expected_claim_targets:
+      - "replace-with-agency"
+    answerable: true
+
+  - id: replace_absent_fact
+    query_type: abstention
+    query: "발주기관명 사업명의 문서에 없는 조건을 알려줘"
+    expected_doc_ids: []
+    expected_terms: []
+    expected_citation_terms: []
+    expected_claim_targets: []
+    answerable: false

--- a/rag_core.py
+++ b/rag_core.py
@@ -191,6 +191,22 @@ METADATA_EVIDENCE_LABELS = {
     "summary": ("요약", "사업 요약"),
 }
 
+METADATA_CLAIM_LABELS = {
+    "budget": "사업예산",
+    "published_at": "공개 일자",
+    "bid_start_at": "입찰 시작일",
+    "bid_deadline_at": "입찰 마감일",
+    "summary": "사업 요약",
+}
+
+METADATA_CLAIM_TOPIC_LABELS = {
+    "budget": ("예산", "사업예산", "사업금액", "금액"),
+    "published_at": ("공개", "일자", "공개일자", "공고일"),
+    "bid_start_at": ("입찰", "시작일", "입찰시작일", "입찰참여시작일", "일정"),
+    "bid_deadline_at": ("입찰", "마감일", "입찰마감일", "입찰참여마감일", "일정"),
+    "summary": ("요약", "사업요약", "사업기간", "기간"),
+}
+
 KOREAN_PARTICLE_SUFFIXES = (
     "으로",
     "에서",
@@ -1308,7 +1324,7 @@ def analyze_query(
     matched_agencies = ordered_unique(match["agency"] for match in reduced_matches)
     matched_projects = ordered_unique(match["project"] for match in reduced_matches)
     has_comparison_term = any(term in normalized_query for term in comparison_terms)
-    has_multi_target_joiner = len(matched_doc_ids) > 1 and any(
+    has_multi_target_joiner = len(matched_agencies) > 1 and any(
         joiner in normalized_query for joiner in comparison_joiners
     )
     if has_comparison_term or has_multi_target_joiner:
@@ -1742,7 +1758,29 @@ def build_extract_claims(analysis: dict[str, Any], evidence: list[dict[str, Any]
     selected = []
     seen = set()
     for item in evidence:
+        metadata_sentences = metadata_claim_sentences(item, analysis)
+        for metadata_sentence in metadata_sentences:
+            key = (item["chunk_id"], metadata_sentence)
+            if key in seen:
+                continue
+            seen.add(key)
+            selected.append(
+                make_claim(
+                    claim_target(item),
+                    item,
+                    analysis,
+                    sentence=metadata_sentence,
+                    support=metadata_sentence,
+                )
+            )
+            if len(selected) >= 2:
+                break
+        if len(selected) >= 2:
+            break
+
         sentence = best_sentence(item["text"], analysis.get("topics", []), analysis.get("tokens", []))
+        if metadata_sentences and not sentence_has_verification_topic(sentence, analysis):
+            continue
         key = (item["chunk_id"], sentence)
         if key in seen:
             continue
@@ -1758,12 +1796,13 @@ def make_claim(
     item: dict[str, Any],
     analysis: dict[str, Any],
     sentence: str | None = None,
+    support: str | None = None,
 ) -> dict[str, Any]:
     claim_text = sentence or best_sentence(item["text"], analysis.get("topics", []), analysis.get("tokens", []))
     return {
         "target": target,
         "claim": claim_text,
-        "support": item["text"],
+        "support": support or item["text"],
         "citations": [make_citation(item)],
     }
 
@@ -1891,6 +1930,54 @@ def best_sentence(text: str, topics: list[str], query_tokens: list[str]) -> str:
         scored.append((topic_hits * 3 + token_hits, len(sentence), sentence))
     scored.sort(key=lambda item: (item[0], -item[1]), reverse=True)
     return scored[0][2]
+
+
+def metadata_claim_sentences(item: dict[str, Any], analysis: dict[str, Any]) -> list[str]:
+    metadata = item.get("metadata")
+    if not isinstance(metadata, dict):
+        return []
+
+    sentences = []
+    for key in METADATA_CLAIM_LABELS:
+        value = metadata.get(key)
+        if value is None or value == "":
+            continue
+        if not metadata_field_requested(key, value, analysis):
+            continue
+        sentences.append(f"{METADATA_CLAIM_LABELS[key]}: {format_metadata_claim_value(key, value)}")
+    return ordered_unique(sentences)
+
+
+def metadata_field_requested(key: str, value: Any, analysis: dict[str, Any]) -> bool:
+    terms = [term for term in verification_topics(analysis) if term]
+    if not terms:
+        return False
+
+    labels = METADATA_CLAIM_TOPIC_LABELS.get(key) or METADATA_EVIDENCE_LABELS.get(key, (key,))
+    label_text = " ".join(str(label) for label in labels)
+    value_text = str(value)
+    searchable = compact_metadata_text(" ".join([label_text, value_text]))
+    for term in terms:
+        compact_term = compact_metadata_text(str(term))
+        if compact_term and compact_term in searchable:
+            return True
+    return False
+
+
+def format_metadata_claim_value(key: str, value: Any) -> str:
+    if key == "budget" and isinstance(value, (int, float)):
+        if isinstance(value, float) and not value.is_integer():
+            return f"{value:,.2f}원"
+        return f"{int(value):,}원"
+    return str(value)
+
+
+def sentence_has_verification_topic(sentence: str, analysis: dict[str, Any]) -> bool:
+    topics = verification_topics(analysis)
+    if not topics:
+        return True
+    lowered = sentence.lower()
+    return any(topic.lower() in lowered for topic in topics)
 
 
 def select_supporting_evidence(

--- a/scripts/smoke_real.sh
+++ b/scripts/smoke_real.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local-only smoke test for private real RFP data.
+# Run from the repository root:
+#   bash scripts/smoke_real.sh
+# Optional overrides:
+#   METADATA_CSV=data/data_list.csv FILES_DIR=data/files INDEX_DIR=data/index/real100 bash scripts/smoke_real.sh
+
+METADATA_CSV="${METADATA_CSV:-data/data_list.csv}"
+FILES_DIR="${FILES_DIR:-data/files}"
+INDEX_DIR="${INDEX_DIR:-data/index/real100}"
+OUTPUT_DIR="${OUTPUT_DIR:-outputs/real100}"
+REPORT_DIR="${REPORT_DIR:-reports/real100}"
+QUERY="${QUERY:-한영대학교 특성화 맞춤형 교육환경 구축 사업의 사업기간과 사업예산 알려줘}"
+EVAL_CONFIG="${EVAL_CONFIG:-eval/real_config.local.yaml}"
+EMBEDDING_BACKEND="${EMBEDDING_BACKEND:-hashing}"
+INGESTION_MODE="${INGESTION_MODE:-csv-text}"
+
+log() {
+  printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$1"
+}
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "Missing required file: $path" >&2
+    exit 1
+  fi
+}
+
+require_dir() {
+  local path="$1"
+  if [[ ! -d "$path" ]]; then
+    echo "Missing required directory: $path" >&2
+    exit 1
+  fi
+}
+
+require_file "scripts/build_index.py"
+require_file "app.py"
+require_file "eval/run_eval.py"
+require_file "$METADATA_CSV"
+require_dir "$FILES_DIR"
+
+mkdir -p "$INDEX_DIR" "$OUTPUT_DIR" "$REPORT_DIR"
+
+log "Building real-data index"
+python3 scripts/build_index.py \
+  --metadata_csv "$METADATA_CSV" \
+  --files_dir "$FILES_DIR" \
+  --ingestion_mode "$INGESTION_MODE" \
+  --output_dir "$INDEX_DIR" \
+  --embedding_backend "$EMBEDDING_BACKEND"
+
+log "Running real-data sample query"
+python3 app.py --input_dir "$INDEX_DIR" --output_dir "$OUTPUT_DIR" --query "$QUERY"
+
+if [[ ! -f "$EVAL_CONFIG" ]]; then
+  log "Skipping real-data eval"
+  echo "Local eval config not found: $EVAL_CONFIG"
+  echo "Create it from eval/real_config.example.yaml to run real-data gold evaluation."
+  echo "Generated artifacts:"
+  echo "- Index dir:   $INDEX_DIR"
+  echo "- Outputs dir: $OUTPUT_DIR"
+  exit 0
+fi
+
+log "Running real-data evaluation"
+python3 eval/run_eval.py --index_dir "$INDEX_DIR" --output_dir "$REPORT_DIR" --config "$EVAL_CONFIG"
+
+REPORT_JSON="$REPORT_DIR/eval_summary.json"
+require_file "$REPORT_JSON"
+
+log "Real-data smoke test completed successfully"
+echo "Generated artifacts:"
+echo "- Index dir:   $INDEX_DIR"
+echo "- Outputs dir: $OUTPUT_DIR"
+echo "- Report file: $REPORT_JSON"

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -118,6 +118,36 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
             set(result["plan"]["metadata_filters"]["doc_ids"]),
         )
 
+    def test_single_agency_schedule_and_budget_query_is_not_comparison(self) -> None:
+        same_agency_index = build_index_payload_from_documents(
+            [
+                {
+                    "doc_id": "agency-x-main",
+                    "title": "기관 X 시스템 기능개선",
+                    "agency": "기관 X",
+                    "project": "시스템 기능개선",
+                    "metadata": {},
+                    "sections": [{"heading": "본문", "text": "사업기간은 3개월이고 사업금액은 1억원이다."}],
+                    "source_path": "agency-x-main.txt",
+                },
+                {
+                    "doc_id": "agency-x-extra",
+                    "title": "기관 X 포털 기능개선",
+                    "agency": "기관 X",
+                    "project": "포털 기능개선",
+                    "metadata": {},
+                    "sections": [{"heading": "본문", "text": "포털 기능개선은 별도 유지관리 사업이다."}],
+                    "source_path": "agency-x-extra.txt",
+                },
+            ],
+            source_dir="test-fixture",
+            embedding_backend="hashing",
+        )
+
+        result = run_rag_query(same_agency_index, "기관 X의 사업기간과 사업금액은?")
+
+        self.assertEqual("single_doc", result["analysis"]["query_type"])
+
     def test_partial_comparison_keeps_supported_claims_and_missing_target(self) -> None:
         partial_index = build_index_payload_from_documents(
             [
@@ -253,6 +283,37 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
             follow_up["diagnostics"]["context_resolution"]["source"],
         )
         self.assertIn("사업예산", follow_up["diagnostics"]["verification_topics"])
+
+    def test_metadata_only_budget_claim_does_not_emit_unrelated_body_sentence(self) -> None:
+        real_like_index = build_index_payload_from_documents(
+            [
+                {
+                    "doc_id": "agency-x-budget",
+                    "title": "기관 X 예산 사업",
+                    "agency": "기관 X",
+                    "project": "예산 사업",
+                    "metadata": {"budget": 130000000},
+                    "sections": [
+                        {
+                            "heading": "본문",
+                            "text": "기관 X는 사용자 교육과 운영 지원을 제공한다.",
+                        }
+                    ],
+                    "source_path": "agency-x.hwp",
+                }
+            ],
+            source_dir="test-fixture",
+            embedding_backend="hashing",
+        )
+
+        result = run_rag_query(real_like_index, "기관 X의 사업예산 알려줘")
+
+        self.assertEqual("supported", result["answer"]["status"])
+        self.assertFalse(result["diagnostics"]["abstained"])
+        self.assertEqual(1, len(result["answer"]["claims"]))
+        self.assertIn("사업예산", result["answer"]["claims"][0]["claim"])
+        self.assertIn("130,000,000원", result["answer"]["claims"][0]["claim"])
+        self.assertNotIn("운영 지원", result["answer"]["summary"])
 
     def test_metadata_first_can_be_disabled_for_ablation(self) -> None:
         result = run_rag_query(


### PR DESCRIPTION
## Summary
- Add a local-only real-data smoke path that builds the `data/data_list.csv` index, runs a representative query, and optionally runs gold evaluation when `eval/real_config.local.yaml` is present.
- Document the optional real-data workflow in `README.md` and `docs/real-data-ingestion.md` without changing the public synthetic baseline flow.
- Tighten verifier and claim generation so metadata-backed answers produce grounded claims instead of unrelated body sentences.
- Add regression coverage for metadata-only budget answers and a single-agency schedule/budget query that should not be treated as a comparison.

## Testing
- `python3 -m unittest discover -s tests`
- Synthetic baseline smoke: index build, sample query, and eval run completed successfully.
- Real-data smoke: local `data/data_list.csv` index build, representative query, and optional local evaluation completed successfully.
- README metrics consistency check passed against the committed public evaluation summary.