### PR TITLE
Add CLAUDE.md with RFP DocAgent guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md
+
+This repository is an RFP-focused DocAgent system.
+
+Core product flow:
+ingestion -> metadata normalization -> chunking -> retrieval -> reranking/planning -> evidence aggregation -> grounded answer -> verification -> evaluation -> reviewer-facing docs
+
+Rules:
+- Treat this as a Bid/RFP document intelligence system, not a generic AI playground.
+- Preserve a naive baseline before adding advanced retrieval methods.
+- Prefer metadata-aware retrieval where appropriate.
+- Keep answers grounded in retrieved evidence.
+- Favor reproducible evaluation and reviewer-friendly artifacts.
+- Avoid unrelated abstractions and broad rewrites.
+- Before coding, inspect the current implementation and explain what already exists.
+- When changing code, name files affected, risks, and verification steps.
+- Add or update tests when behavior changes.
+- Keep backward compatibility unless there is a strong reason not to.


### PR DESCRIPTION
## Summary
- Adds root `CLAUDE.md` describing the repo as an RFP-focused DocAgent system, the core product flow, and collaboration rules (preserve naive baseline, metadata-aware retrieval, grounded answers, reproducible eval, no broad rewrites).

## Test plan
- [ ] Confirm `CLAUDE.md` renders correctly on GitHub
- [ ] Verify no other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)