### PR TITLE
비공개 hard-case 벤치마크 slice와 slice별 집계를 추가

### DIFF
--- a/benchmarks/registry.schema.json
+++ b/benchmarks/registry.schema.json
@@ -43,7 +43,11 @@
         "answer_format_compliance": { "type": ["number", "null"] },
         "abstention": { "type": ["number", "null"] },
         "retry": { "type": ["number", "null"] },
-        "latency": { "$ref": "#/$defs/latency_block" }
+        "latency": { "$ref": "#/$defs/latency_block" },
+        "by_hardcase_category": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/metric_block" }
+        }
       },
       "additionalProperties": true
     },

--- a/benchmarks/suites/private_hardcase_rfp.example.yaml
+++ b/benchmarks/suites/private_hardcase_rfp.example.yaml
@@ -1,0 +1,39 @@
+id: private_hardcase_rfp
+name: Private hard-case RFP benchmark template
+description: Local-only benchmark slice for scanned, rotated, table-heavy, mixed-layout, and noisy OCR RFP documents.
+dataset:
+  id: private_hardcase_rfp_v1
+  type: private_rfp_hardcase
+  input_dir: data/files
+  privacy: private_local_only
+  note: Do not commit raw private documents, raw private predictions, original file names, or source-specific identifiers.
+index:
+  output_dir: data/index-private-hardcase
+  embedding_backend: hashing
+  command:
+    - python3
+    - scripts/build_index.py
+    - --metadata_csv
+    - data/data_list.csv
+    - --files_dir
+    - data/files
+    - --ingestion_mode
+    - visual
+    - --output_dir
+    - data/index-private-hardcase
+    - --embedding_backend
+    - hashing
+eval:
+  config: eval/private_hardcase.local.yaml
+  output_dir: reports
+artifacts:
+  root: artifacts/benchmarks
+  gitignored: true
+  local_only:
+    - predictions.jsonl
+    - latency_samples.jsonl
+    - error_examples.jsonl
+    - traces/
+    - logs/
+    - private source documents
+    - per-example dumps

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 - [Reviewer evidence pack](./reviewer-evidence-pack.md)
 - [포트폴리오 case study](./portfolio-case-study.md)
 - [Benchmarking](./benchmarking.md)
+- [Private hard-case benchmark](./private-hardcase-benchmark.md)
 - [Ablation results](./ablation-results.md)
 - [설계 배경 및 의사결정](./design-background.md)
 - [답변 출력 정책](./answer-policy.md)

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -5,6 +5,7 @@
 ## Source Of Truth
 
 - `benchmarks/suites/public_synthetic_rfp.yaml`: 공개 synthetic RFP benchmark suite 정의
+- `benchmarks/suites/private_hardcase_rfp.example.yaml`: 비공개 hard-case benchmark용 local-only suite template
 - `benchmarks/ablations/rag_quality_axes.yaml`: `naive_baseline` control, primary run, ablation flag 정의
 - `benchmarks/registry.schema.json`: registry와 run manifest의 최소 schema
 - `benchmarks/registry.json`: 커밋 가능한 집계 registry
@@ -51,3 +52,9 @@ python3 scripts/summarize_benchmark.py \
 ```
 
 요약 결과는 `benchmarks/registry.json`과 `docs/ablation-results.md`에 반영된다. 문서에는 2차 가공 결과와 집계 지표만 남기며, private RFP 기반 실험을 수행하더라도 원문이나 per-example output은 포함하지 않는다.
+
+## Private Hard-case Slice
+
+이슈 #24의 private hard-case slice는 공개 benchmark를 대체하지 않고 현실적인 문서 조건에서 품질 하락을 분리하기 위한 보조 suite다. `eval/private_hardcase.example.yaml`은 익명 case list와 `hardcase_categories` 형식을 보여준다. 실제 실행 파일은 `eval/private_hardcase.local.yaml`처럼 `.gitignore` 대상 local YAML로 복사해 사용한다.
+
+`eval/run_eval.py`와 benchmark manifest는 `by_hardcase_category` 집계를 포함한다. 이 값만 registry/docs에 남기고 raw private prediction, trace, 원문 artifact는 `artifacts/benchmarks/` 아래 local-only 산출물로 유지한다. 운영 절차와 금지 항목은 [`docs/private-hardcase-benchmark.md`](private-hardcase-benchmark.md)에 정리했다.

--- a/docs/private-hardcase-benchmark.md
+++ b/docs/private-hardcase-benchmark.md
@@ -1,0 +1,83 @@
+# Private Hard-case Benchmark
+
+이 문서는 이슈 #24의 private hard-case benchmark 운영 기준을 정리한다. 목적은 공개 synthetic benchmark를 대체하는 것이 아니라, scanned PDF, rotated/skewed page, table-heavy page, mixed layout, noisy OCR 조건에서 parser/retrieval/answer failure가 얼마나 늘어나는지 aggregate로 비교하는 것이다.
+
+## Commit Boundary
+
+커밋 가능한 항목은 benchmark template, 익명 case id, aggregate metric, failure taxonomy, 실행 절차뿐이다.
+
+커밋하지 않는 항목은 다음과 같다.
+
+- 원본 private RFP 문서
+- 원본 파일명, 기관명, 사업명처럼 출처를 복원할 수 있는 식별자
+- raw private predictions, traces, per-example dumps
+- OCR로 추출된 원문 snippet을 포함한 private artifact
+
+로컬 입력은 `.gitignore` 대상인 `data/files/`, `data/data_list.csv`, `eval/*.local.yaml`을 사용한다. 실행 산출물은 `artifacts/benchmarks/` 아래에만 둔다.
+
+## Case List
+
+`eval/private_hardcase.example.yaml`을 `eval/private_hardcase.local.yaml`로 복사한 뒤 로컬 환경에서만 채운다. 각 case는 익명 ID와 difficulty slice만 남긴다.
+
+지원하는 기본 slice는 다음과 같다.
+
+- `scanned_pdf`
+- `rotated_or_skewed`
+- `table_heavy`
+- `mixed_layout`
+- `noisy_ocr`
+
+한 case는 여러 slice에 속할 수 있다. `eval/run_eval.py`는 `by_hardcase_category`를 생성해 전체 평균뿐 아니라 slice별 accuracy, groundedness, citation precision, answer format, abstention, retry를 함께 보고한다.
+
+## Running Locally
+
+private suite template은 그대로 실행하지 않고 로컬 파일로 복사해 경로를 맞춘다.
+
+```bash
+cp eval/private_hardcase.example.yaml eval/private_hardcase.local.yaml
+cp benchmarks/suites/private_hardcase_rfp.example.yaml benchmarks/suites/private_hardcase_rfp.local.yaml
+```
+
+v1 text ingestion과 v2 visual parsing을 비교하려면 같은 익명 case list를 사용하고 index build command만 바꾼 suite를 각각 실행한다.
+
+```bash
+python3 scripts/run_benchmark.py \
+  --suite benchmarks/suites/private_hardcase_rfp.local.yaml \
+  --ablations benchmarks/ablations/rag_quality_axes.yaml
+```
+
+생성된 `artifacts/benchmarks/<run_id>/run_manifest.json`을 확인한 뒤 aggregate만 registry/docs에 반영한다.
+
+```bash
+python3 scripts/summarize_benchmark.py \
+  --manifest artifacts/benchmarks/<run_id>/run_manifest.json
+```
+
+## Failure Analysis
+
+parser-stage 분석은 `eval/run_parser_eval.py`의 taxonomy를 사용한다. gold YAML도 private local 파일로만 유지하고, `hardcase_categories`를 문서 단위로 기록하면 report의 `summary.by_hardcase_category`에서 OCR/layout/table/field/bbox failure count가 slice별로 집계된다.
+
+```bash
+python3 eval/run_parser_eval.py \
+  --artifact_dir data/index-private-hardcase/visual_artifacts \
+  --gold eval/private_parser_gold.local.yaml \
+  --output_dir reports \
+  --run_name private_visual_v2 \
+  --parser_version 2
+```
+
+분석 문서에는 public synthetic benchmark와 private hard-case slice의 aggregate 차이만 적는다. 예를 들어 public에서는 citation precision이 유지되지만 `table_heavy`에서 table cell F1과 citation precision이 같이 떨어지면 table reconstruction failure가 grounded answer 품질에 미치는 영향으로 분류한다.
+
+## Aggregate Comparison Report
+
+실제 private 문서가 저장소에 없기 때문에 이 저장소에는 실측 private 수치를 커밋하지 않는다. private run 이후에는 아래 형식으로 aggregate만 남긴다.
+
+| Slice | Public primary | Private hard-case primary | Delta | Likely failure stage |
+|---|---:|---:|---:|---|
+| overall accuracy | public aggregate | private aggregate | private - public | parser/retrieval/answer |
+| citation precision | public aggregate | private aggregate | private - public | retrieval/citation grounding |
+| table_heavy citation precision | N/A or public proxy | private aggregate | N/A | table/parser |
+| noisy_ocr groundedness | N/A or public proxy | private aggregate | N/A | OCR/retrieval |
+| rotated_or_skewed bbox alignment | N/A or parser fixture | private aggregate | N/A | bbox/layout |
+
+failure increase는 `summary.by_hardcase_category`, `by_hardcase_category`, `failure_counts`, `retry_reason_counts`를 함께 보고 분류한다. private aggregate가 public 대비 악화되었지만 parser failure count가 늘지 않았다면 retrieval/rerank/answer policy 쪽을 우선 의심한다.

--- a/docs/visual-ingestion-v2.md
+++ b/docs/visual-ingestion-v2.md
@@ -57,6 +57,8 @@ python3 eval/run_parser_eval.py \
 
 실패 taxonomy는 `ocr_missing_text`, `layout_type_mismatch`, `section_boundary_missing`, `table_cell_mismatch`, `field_missing`, `field_value_mismatch`, `bbox_missing`, `bbox_misaligned`를 포함한다. 이 코드는 downstream 분석에서 retrieval miss, noisy chunking, wrong field grounding, weak bbox citation 같은 QA 실패 원인과 연결한다.
 
+private hard-case gold에는 문서별 `hardcase_categories`를 둘 수 있다. `eval/run_parser_eval.py`는 `summary.by_hardcase_category`를 생성해 scanned PDF, rotated/skewed, table-heavy, mixed-layout, noisy OCR 조건별 parser metric과 failure count를 분리한다. 비공개 원문과 raw artifact는 커밋하지 않고 aggregate만 [`docs/private-hardcase-benchmark.md`](private-hardcase-benchmark.md) 방식으로 기록한다.
+
 ## 실행 예시
 ```bash
 python3 scripts/build_index.py \

--- a/eval/parser_metrics.schema.json
+++ b/eval/parser_metrics.schema.json
@@ -34,6 +34,23 @@
         "failure_counts": {
           "type": "object",
           "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "by_hardcase_category": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["num_documents", "num_documents_with_errors", "metrics", "failure_counts"],
+            "properties": {
+              "num_documents": { "type": "integer", "minimum": 0 },
+              "num_documents_with_errors": { "type": "integer", "minimum": 0 },
+              "metrics": { "type": "object" },
+              "failure_counts": {
+                "type": "object",
+                "additionalProperties": { "type": "integer", "minimum": 0 }
+              }
+            },
+            "additionalProperties": true
+          }
         }
       },
       "additionalProperties": true
@@ -45,6 +62,10 @@
         "required": ["doc_id", "artifact_path", "parser_status", "metrics", "errors"],
         "properties": {
           "doc_id": { "type": "string" },
+          "hardcase_categories": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
           "artifact_path": { "type": "string" },
           "parser_status": { "type": "string" },
           "metrics": {

--- a/eval/private_hardcase.example.yaml
+++ b/eval/private_hardcase.example.yaml
@@ -1,0 +1,66 @@
+mode: rag
+description: Private hard-case RFP evaluation template. Copy to eval/private_hardcase.local.yaml before use.
+index_dir: data/index-private-hardcase
+primary_run: visual_v2_full
+answer_policy:
+  answerable_status: supported
+  unanswerable_status: insufficient
+  min_claims_answerable: 1
+  require_claim_citations: true
+ablation_runs:
+  - name: text_v1_full
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    prompt_profile: private_text_v1
+  - name: visual_v2_full
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: hierarchical
+    prompt_profile: private_visual_v2
+cases:
+  - id: private-hardcase-001
+    hardcase_categories:
+      - scanned_pdf
+      - noisy_ocr
+    query_type: single_doc
+    query: "익명 문서 001의 제출 마감 조건은?"
+    expected_doc_ids:
+      - private-hardcase-doc-001
+    expected_terms:
+      - "제출 마감"
+    expected_citation_terms:
+      - "제출 마감"
+    expected_claim_targets:
+      - "익명 문서 001"
+    answerable: true
+
+  - id: private-hardcase-002
+    hardcase_categories:
+      - rotated_or_skewed
+      - table_heavy
+    query_type: single_doc
+    query: "익명 문서 002의 정량 평가 배점 조건은?"
+    expected_doc_ids:
+      - private-hardcase-doc-002
+    expected_terms:
+      - "배점"
+    expected_citation_terms:
+      - "배점"
+    expected_claim_targets:
+      - "익명 문서 002"
+    answerable: true
+
+  - id: private-hardcase-003
+    hardcase_categories:
+      - mixed_layout
+    query_type: abstention
+    query: "익명 문서 003에 명시되지 않은 유지보수 예산은?"
+    expected_doc_ids: []
+    expected_terms: []
+    expected_claim_targets: []
+    answerable: false

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -31,6 +31,22 @@ DEFAULT_ABLATION_RUNS = [
 ]
 
 
+def hardcase_categories(item: dict[str, Any]) -> list[str]:
+    categories = item.get("hardcase_categories") or item.get("hardcase_category") or []
+    if isinstance(categories, str):
+        categories = [categories]
+    if not isinstance(categories, list):
+        return []
+    normalized = []
+    seen: set[str] = set()
+    for category in categories:
+        value = str(category).strip()
+        if value and value not in seen:
+            normalized.append(value)
+            seen.add(value)
+    return normalized
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run local RAG evaluation over configured cases.")
     parser.add_argument("--input_dir", default="outputs", help="Kept for CLI compatibility; not required.")
@@ -75,6 +91,11 @@ def load_config(path: Path) -> dict[str, Any]:
         for turn in prior_turns:
             if not isinstance(turn, dict) or not str(turn.get("query") or "").strip():
                 raise ValueError(f"Each prior turn must include a query: {case.get('id')}")
+        categories = case.get("hardcase_categories") or case.get("hardcase_category") or []
+        if isinstance(categories, str):
+            categories = [categories]
+        if not isinstance(categories, list):
+            raise ValueError(f"Eval case hardcase_categories must be a list: {case.get('id')}")
 
     runs = data.get("ablation_runs", DEFAULT_ABLATION_RUNS)
     if not isinstance(runs, list) or not runs:
@@ -247,6 +268,7 @@ def score_case(
     return {
         "id": case.get("id"),
         "query_type": query_type,
+        "hardcase_categories": hardcase_categories(case),
         "query": case.get("query"),
         "answerable": answerable,
         "expected_doc_ids": sorted(expected_doc_ids),
@@ -341,6 +363,15 @@ def summarize_run(
     for query_type in QUERY_TYPES:
         if query_type in grouped:
             summary["by_query_type"][query_type] = metric_block(grouped[query_type])
+    hardcase_grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for result in case_results:
+        for category in hardcase_categories(result):
+            hardcase_grouped[category].append(result)
+    if hardcase_grouped:
+        summary["by_hardcase_category"] = {
+            category: metric_block(hardcase_grouped[category])
+            for category in sorted(hardcase_grouped)
+        }
     if include_cases:
         summary["case_results"] = case_results
     return summary
@@ -450,6 +481,7 @@ def main() -> int:
         "latency": primary_summary["latency"],
         "retry": primary_summary["retry"],
         "by_query_type": primary_summary["by_query_type"],
+        "by_hardcase_category": primary_summary.get("by_hardcase_category", {}),
         "retry_cost": primary_summary["retry_cost"],
         "retry_reason_counts": primary_summary["retry_reason_counts"],
         "ablation": {"runs": run_summaries},

--- a/eval/run_parser_eval.py
+++ b/eval/run_parser_eval.py
@@ -121,7 +121,28 @@ def load_gold(path: Path) -> dict[str, Any]:
         if doc_id in seen_doc_ids:
             raise ValueError(f"Duplicate parser gold doc_id: {doc_id}")
         seen_doc_ids.add(doc_id)
+        categories = document.get("hardcase_categories") or document.get("hardcase_category") or []
+        if isinstance(categories, str):
+            categories = [categories]
+        if not isinstance(categories, list):
+            raise ValueError(f"Parser gold hardcase_categories must be a list: {doc_id}")
     return data
+
+
+def hardcase_categories(item: dict[str, Any]) -> list[str]:
+    categories = item.get("hardcase_categories") or item.get("hardcase_category") or []
+    if isinstance(categories, str):
+        categories = [categories]
+    if not isinstance(categories, list):
+        return []
+    normalized = []
+    seen: set[str] = set()
+    for category in categories:
+        value = str(category).strip()
+        if value and value not in seen:
+            normalized.append(value)
+            seen.add(value)
+    return normalized
 
 
 def load_artifact(artifact_dir: Path, gold_doc: dict[str, Any]) -> tuple[Path, dict[str, Any] | None]:
@@ -536,6 +557,7 @@ def score_document(
         add_error(errors, "artifact_missing", "Expected visual artifact file is missing.")
         return {
             "doc_id": doc_id,
+            "hardcase_categories": hardcase_categories(gold_doc),
             "artifact_path": str(artifact_path),
             "parser_status": "missing",
             "metrics": metrics,
@@ -552,6 +574,7 @@ def score_document(
     diagnostics = artifact.get("diagnostics") or {}
     return {
         "doc_id": doc_id,
+        "hardcase_categories": hardcase_categories(gold_doc),
         "artifact_path": str(artifact_path),
         "parser_status": str(diagnostics.get("status") or "unknown"),
         "metrics": metrics,
@@ -578,6 +601,17 @@ def summarize_documents(documents: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def summarize_by_hardcase_category(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for document in documents:
+        for category in hardcase_categories(document):
+            grouped.setdefault(category, []).append(document)
+    return {
+        category: summarize_documents(grouped[category])
+        for category in sorted(grouped)
+    }
+
+
 def build_report(
     artifact_dir: Path,
     gold_path: Path,
@@ -589,6 +623,8 @@ def build_report(
     for gold_doc in sorted(gold["documents"], key=lambda item: str(item["doc_id"])):
         artifact_path, artifact = load_artifact(artifact_dir, gold_doc)
         document_results.append(score_document(gold_doc, artifact, artifact_path))
+    summary = summarize_documents(document_results)
+    summary["by_hardcase_category"] = summarize_by_hardcase_category(document_results)
 
     return {
         "mode": "parser",
@@ -599,7 +635,7 @@ def build_report(
             "artifact_dir": str(artifact_dir),
             "gold": str(gold_path),
         },
-        "summary": summarize_documents(document_results),
+        "summary": summary,
         "documents": document_results,
         "failure_taxonomy": FAILURE_TAXONOMY,
     }

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -150,6 +150,7 @@ def metric_snapshot(summary: dict[str, Any]) -> dict[str, Any]:
         "retry_cost",
         "retry_reason_counts",
         "by_query_type",
+        "by_hardcase_category",
     ]
     return {key: summary.get(key) for key in keys if key in summary}
 
@@ -233,6 +234,7 @@ def evaluate_run_with_artifacts(
             "run": run_name,
             "case_id": case.get("id"),
             "query_type": case.get("query_type"),
+            "hardcase_categories": EVAL.hardcase_categories(case),
             "prediction": prediction,
             "score": score,
         }
@@ -247,6 +249,7 @@ def evaluate_run_with_artifacts(
                     "run": run_name,
                     "case_id": case.get("id"),
                     "query_type": case.get("query_type"),
+                    "hardcase_categories": EVAL.hardcase_categories(case),
                     "pipeline": diagnostics.get("pipeline"),
                     "top_k": (prediction.get("plan") or {}).get("top_k"),
                     "latency_ms": diagnostics.get("latency_ms"),
@@ -262,6 +265,7 @@ def evaluate_run_with_artifacts(
         trace = {
             "run": run_name,
             "case_id": case.get("id"),
+            "hardcase_categories": EVAL.hardcase_categories(case),
             "plan": prediction.get("plan"),
             "diagnostics": diagnostics,
             "evidence_refs": [
@@ -306,6 +310,7 @@ def build_summary(
         "latency": primary_summary["latency"],
         "retry": primary_summary["retry"],
         "by_query_type": primary_summary["by_query_type"],
+        "by_hardcase_category": primary_summary.get("by_hardcase_category", {}),
         "retry_cost": primary_summary["retry_cost"],
         "retry_reason_counts": primary_summary["retry_reason_counts"],
         "ablation": {"runs": run_summaries},

--- a/scripts/summarize_benchmark.py
+++ b/scripts/summarize_benchmark.py
@@ -66,6 +66,7 @@ def metric_block(summary: dict[str, Any] | None) -> dict[str, Any]:
         "latency",
         "retry_cost",
         "retry_reason_counts",
+        "by_hardcase_category",
     ]
     return {key: summary.get(key) for key in keys if key in summary}
 
@@ -210,6 +211,32 @@ def render_docs(registry: dict[str, Any]) -> str:
                 latency=fmt_latency(metrics.get("latency")),
             )
         )
+
+    hardcase_metrics = (primary.get("by_hardcase_category") or {})
+    if hardcase_metrics:
+        lines.extend(
+            [
+                "",
+                "## Hard-case Slices",
+                "",
+                "| Category | Cases | Accuracy | Groundedness | Citation | Format | Abstention | Retry |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for category in sorted(hardcase_metrics):
+            metrics = hardcase_metrics[category] or {}
+            lines.append(
+                "| {category} | {cases} | {accuracy} | {groundedness} | {citation} | {format} | {abstention} | {retry} |".format(
+                    category=category,
+                    cases=metrics.get("num_predictions", "N/A"),
+                    accuracy=fmt_rate(metrics.get("accuracy")),
+                    groundedness=fmt_rate(metrics.get("groundedness")),
+                    citation=fmt_rate(metrics.get("citation_precision")),
+                    format=fmt_rate(metrics.get("answer_format_compliance")),
+                    abstention=fmt_rate(metrics.get("abstention")),
+                    retry=fmt_rate(metrics.get("retry")),
+                )
+            )
 
     lines.extend(
         [

--- a/tests/test_benchmark_summary.py
+++ b/tests/test_benchmark_summary.py
@@ -1,0 +1,70 @@
+import unittest
+
+from scripts.summarize_benchmark import registry_entry, render_docs
+
+
+class BenchmarkSummaryTest(unittest.TestCase):
+    def test_registry_and_docs_preserve_hardcase_aggregate_only(self) -> None:
+        manifest = {
+            "run_id": "private_hardcase_unit",
+            "generated_at": "2026-05-08T00:00:00Z",
+            "git_commit": "abc123",
+            "git_dirty": False,
+            "suite": {
+                "id": "private_hardcase_rfp",
+                "dataset": {"id": "private_hardcase_rfp_v1"},
+            },
+            "ablation_suite": {
+                "baseline_run": "text_v1_full",
+                "primary_run": "visual_v2_full",
+            },
+            "ablation_flags": {
+                "visual_v2_full": {
+                    "pipeline": "agentic_full",
+                    "top_k": None,
+                    "metadata_first": True,
+                    "rerank": True,
+                    "verifier_retry": True,
+                    "retrieval_mode": "hierarchical",
+                    "prompt_profile": "private_visual_v2",
+                }
+            },
+            "metrics": {
+                "runs": {
+                    "visual_v2_full": {
+                        "num_predictions": 2,
+                        "accuracy": 0.5,
+                        "groundedness": 0.5,
+                        "citation_precision": 0.25,
+                        "answer_format_compliance": 0.5,
+                        "abstention": None,
+                        "retry": 0.5,
+                        "latency": {"p50": 1.0, "p95": 2.0, "mean": 1.5},
+                        "by_hardcase_category": {
+                            "table_heavy": {
+                                "num_predictions": 1,
+                                "accuracy": 0.0,
+                                "groundedness": 0.0,
+                                "citation_precision": 0.0,
+                                "answer_format_compliance": 0.0,
+                                "abstention": None,
+                                "retry": 1.0,
+                                "latency": {"p50": 2.0, "p95": 2.0, "mean": 2.0},
+                            }
+                        },
+                    }
+                }
+            },
+            "artifacts": {"run_manifest": "artifacts/benchmarks/private/run_manifest.json"},
+        }
+
+        entry = registry_entry(manifest)
+        docs = render_docs({"schema_version": 1, "entries": [entry]})
+
+        self.assertIn("by_hardcase_category", entry["primary_metrics"])
+        self.assertIn("## Hard-case Slices", docs)
+        self.assertIn("| table_heavy | 1 | 0.000 | 0.000 | 0.000 | 0.000 | N/A | 1.000 |", docs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -1,0 +1,58 @@
+import unittest
+from pathlib import Path
+
+from eval.run_eval import load_config, summarize_run
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+class EvalMetricsTest(unittest.TestCase):
+    def test_summarize_run_groups_metrics_by_hardcase_category(self) -> None:
+        case_results = [
+            {
+                "query_type": "single_doc",
+                "hardcase_categories": ["scanned_pdf", "noisy_ocr"],
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 0.5,
+                "answer_format_compliance": 1.0,
+                "abstention": None,
+                "latency_ms": 10.0,
+                "retry_count": 1,
+                "retry_trigger_reasons": ["topic_not_grounded"],
+            },
+            {
+                "query_type": "single_doc",
+                "hardcase_categories": ["scanned_pdf"],
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "answer_format_compliance": 0.0,
+                "abstention": None,
+                "latency_ms": 20.0,
+                "retry_count": 0,
+                "retry_trigger_reasons": [],
+            },
+        ]
+
+        summary = summarize_run("unit", {"pipeline": "agentic_full"}, case_results)
+
+        self.assertIn("by_hardcase_category", summary)
+        self.assertEqual(2, summary["by_hardcase_category"]["scanned_pdf"]["num_predictions"])
+        self.assertEqual(0.5, summary["by_hardcase_category"]["scanned_pdf"]["accuracy"])
+        self.assertEqual(1, summary["by_hardcase_category"]["noisy_ocr"]["num_predictions"])
+        self.assertEqual(1.0, summary["by_hardcase_category"]["noisy_ocr"]["retry"])
+
+    def test_private_hardcase_example_config_loads(self) -> None:
+        config = load_config(ROOT_DIR / "eval" / "private_hardcase.example.yaml")
+
+        self.assertEqual("visual_v2_full", config["primary_run"])
+        self.assertEqual(
+            ["scanned_pdf", "noisy_ocr"],
+            config["cases"][0]["hardcase_categories"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser_eval.py
+++ b/tests/test_parser_eval.py
@@ -81,6 +81,29 @@ class ParserEvalTest(unittest.TestCase):
         self.assertIn("ocr_missing_text", report["failure_taxonomy"])
         self.assertIn("bbox_misaligned", report["failure_taxonomy"])
 
+    def test_build_report_groups_by_hardcase_category(self) -> None:
+        gold = {
+            "documents": [
+                {
+                    "doc_id": "broken-doc",
+                    "hardcase_categories": ["table_heavy", "noisy_ocr"],
+                    "ocr_text": {"snippets": ["사업명: 오류 사례"]},
+                    "layout_blocks": [
+                        {"text": "사업명: 오류 사례", "type": "text", "page_number": 1}
+                    ],
+                    "fields": [{"key": "사업명", "value": "오류 사례"}],
+                    "bbox_anchors": [{"text": "사업명: 오류 사례", "page_number": 1}],
+                }
+            ]
+        }
+
+        report = build_report(Path("missing-artifacts"), Path("gold.yaml"), gold, "unit", "2")
+        by_category = report["summary"]["by_hardcase_category"]
+
+        self.assertEqual(1, by_category["table_heavy"]["num_documents"])
+        self.assertEqual(1, by_category["noisy_ocr"]["num_documents_with_errors"])
+        self.assertEqual({"artifact_missing": 1}, by_category["table_heavy"]["failure_counts"])
+
     def test_cli_writes_parser_eval_summary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             completed = subprocess.run(


### PR DESCRIPTION
## Summary
- private hard-case RFP용 `.example.yaml` 템플릿과 문서를 추가해 scanned/rotated/table-heavy/mixed-layout/noisy OCR slice를 익명 ID로 관리할 수 있게 했습니다.
- `eval/run_eval.py`, `eval/run_parser_eval.py`, `scripts/run_benchmark.py`, `scripts/summarize_benchmark.py`에 `by_hardcase_category` 집계를 추가해 public synthetic 결과와 별도로 slice별 품질 저하를 볼 수 있게 했습니다.
- registry/schema와 parser report schema를 확장하고, 관련 문서에 private 실험 경계와 실행 절차를 정리했습니다.
- slice별 집계와 private template 로딩을 검증하는 단위 테스트를 추가했습니다.

## Testing
- `python3 -m unittest discover -s tests -q` 통과
- `python3 -m py_compile eval/run_eval.py eval/run_parser_eval.py scripts/run_benchmark.py scripts/summarize_benchmark.py` 통과
- 로컬 baseline 재현: 인덱싱, 샘플 질의, eval, parser eval 통과
- `README` metrics check는 최신 eval 수치와의 latency drift로 실패했지만, 이번 변경 범위와 무관한 기존 성능표 불일치로 확인됨