### PR TITLE
재현 가능한 실행 harness와 smoke artifact 레이아웃 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ reports/
 
 # Benchmark raw/local artifacts
 artifacts/benchmarks/
+artifacts/runs/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke test clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -28,6 +28,9 @@ check:
 
 smoke:
 	bash scripts/smoke.sh
+
+harness-smoke:
+	$(PYTHON) scripts/run_harness.py --config harness/smoke.yaml
 
 test:
 	bash scripts/test.sh

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ python3 scripts/summarize_benchmark.py \
 
 Benchmark source of truth는 `benchmarks/suites/`, `benchmarks/ablations/`, `benchmarks/registry.schema.json`에 둡니다. Raw predictions, traces, logs, latency samples, error examples는 `artifacts/benchmarks/` 아래에 생성되며 Git에 커밋하지 않습니다. 사람이 읽는 결과 해석은 [`docs/benchmarking.md`](docs/benchmarking.md)와 [`docs/ablation-results.md`](docs/ablation-results.md)를 참고하세요.
 
+### 선택) Harness smoke run
+재현 가능한 smoke 실행의 config snapshot, 로그, prediction, metric을 한 디렉터리에 모으려면 `python3 scripts/run_harness.py --config harness/smoke.yaml` 또는 `make harness-smoke`를 실행합니다. 산출물은 `artifacts/runs/<run_id>/` 아래에 생성되며 Git 추적 대상이 아닙니다. 자세한 흐름은 [`docs/harness.md`](docs/harness.md)를 참고하세요.
+
 > 참고: 모델을 처음 내려받아 실제 sentence-transformers 인덱스를 만들려면 `--embedding_backend sentence-transformers`를 사용하세요. 네트워크가 제한된 환경에서는 `--embedding_backend hashing`으로 재현성을 우선한 로컬 실행이 가능합니다. 산출물 경로는 `data/index`, `outputs/`, `reports/`로 고정합니다.
 > Chunking 기본값은 naive baseline 기준인 `--chunking_strategy fixed --chunk_max_chars 520 --chunk_overlap_sentences 1`입니다. section-aware 비교는 `--chunking_strategy auto` 또는 `section`으로 명시합니다.
 > 질의 기본값은 `--pipeline naive_baseline`의 flat dense top-k=4 retrieval입니다. parent section 단위 재조립을 확인하려면 `app.py`에 `--pipeline agentic_full --retrieval_mode hierarchical`을 지정하거나 `eval/config.yaml`의 `hierarchical` ablation run을 실행합니다.
@@ -292,6 +295,7 @@ python3 eval/run_parser_eval.py \
 - Chunking diagnostics: [`docs/chunking-diagnostics.md`](docs/chunking-diagnostics.md)
 - PDF/HWP ingestion: [`docs/real-data-ingestion.md`](docs/real-data-ingestion.md)
 - Visual parsing v2: [`docs/visual-ingestion-v2.md`](docs/visual-ingestion-v2.md)
+- Reproducible harness: [`docs/harness.md`](docs/harness.md)
 - 답변 출력 정책: [`docs/answer-policy.md`](docs/answer-policy.md)
 - 실패 사례 분석: [`docs/failure-cases.md`](docs/failure-cases.md)
 - 회고 및 개선 방향: [`docs/retrospective.md`](docs/retrospective.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 - [Reviewer evidence pack](./reviewer-evidence-pack.md)
 - [포트폴리오 case study](./portfolio-case-study.md)
 - [Benchmarking](./benchmarking.md)
+- [Reproducible harness](./harness.md)
 - [Private hard-case benchmark](./private-hardcase-benchmark.md)
 - [Ablation results](./ablation-results.md)
 - [설계 배경 및 의사결정](./design-background.md)

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -1,0 +1,81 @@
+# Reproducible Harness
+
+이 harness는 기존 README 기본 흐름을 바꾸지 않고, smoke 실행에 필요한 입력 config, 로그, 예측, 평가 요약을 run 단위 디렉터리에 묶는다. 목적은 benchmark/ablation 확장 전에도 한 명령으로 재현 가능한 작은 실행 단위를 남기는 것이다.
+
+## 실행
+
+```bash
+python3 scripts/run_harness.py --config harness/smoke.yaml
+```
+
+동일한 smoke harness는 Make target으로도 실행할 수 있다.
+
+```bash
+make harness-smoke
+```
+
+고정 run id를 사용하거나 기존 run을 덮어쓰려면 다음처럼 실행한다.
+
+```bash
+python3 scripts/run_harness.py \
+  --config harness/smoke.yaml \
+  --run_id issue25_smoke_test \
+  --force
+```
+
+## Run ID와 artifact layout
+
+`--run_id`를 생략하면 `<config_id>_YYYYMMDDTHHMMSSZ` 형식으로 생성한다. 기본 artifact root는 `artifacts/runs`이며, 전체 산출물은 `artifacts/runs/<run_id>/` 아래에 저장된다.
+
+```text
+artifacts/runs/<run_id>/
+  run_manifest.json
+  config_snapshot.json
+  summary.json
+  predictions.jsonl
+  errors.jsonl
+  index/index.json
+  outputs/answer.json
+  metrics/eval_summary.json
+  logs/index.log
+  logs/query.log
+  logs/eval.log
+```
+
+`artifacts/runs/`는 Git 추적 대상이 아니다. 공개 synthetic smoke라도 raw prediction과 로그는 로컬 검증 산출물로 유지한다.
+
+## 스키마
+
+`run_manifest.json`은 다음 필드를 포함한다.
+
+- `schema_version`: manifest schema version
+- `run_id`: 실행 식별자
+- `generated_at`: manifest 생성 시각
+- `git_commit`, `git_dirty`: 실행 시점의 Git 상태
+- `config_hash`: `config_snapshot.json`의 deterministic hash
+- `config_snapshot_path`: 저장된 config snapshot 경로
+- `artifacts`: 주요 산출물 경로
+- `commands`: index/query/eval에 사용한 실제 command token
+- `status`: `passed` 또는 `failed`
+- `metrics`: `metrics/eval_summary.json`의 핵심 metric snapshot
+
+`summary.json`은 다음 필드를 포함한다.
+
+- `run_id`
+- `status`
+- `started_at`, `ended_at`
+- `steps`: 각 단계 command, log path, return code, status
+- `artifact_dir`
+- `metrics_path`
+- `errors_path`
+
+`errors.jsonl`은 실패가 없어도 생성한다. 성공한 실행에서는 빈 파일이며, 실패한 실행에서는 실패 step, return code, log path, command를 JSONL로 기록한다.
+
+## Smoke 범위
+
+`harness/smoke.yaml`은 공개 synthetic RFP만 사용하고 hashing embedding으로 인덱스를 만든다. `harness/smoke_eval.yaml`은 작은 고정 case set만 포함한다.
+
+- 단일 문서 보안 요구사항
+- 기관 A/B AI 요구사항 비교
+
+전체 품질 평가는 계속 `eval/run_eval.py --config eval/config.yaml`과 benchmark flow가 담당한다.

--- a/harness/smoke.yaml
+++ b/harness/smoke.yaml
@@ -1,0 +1,15 @@
+id: public_synthetic_smoke
+description: Minimal reproducible smoke harness over committed synthetic RFP data.
+artifact_root: artifacts/runs
+dataset:
+  id: public_synthetic_rfp_v1
+  input_dir: data/raw
+  privacy: public_synthetic_only
+index:
+  embedding_backend: hashing
+  chunking_strategy: fixed
+query:
+  text: "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
+  pipeline: naive_baseline
+eval:
+  config: harness/smoke_eval.yaml

--- a/harness/smoke_eval.yaml
+++ b/harness/smoke_eval.yaml
@@ -1,0 +1,44 @@
+mode: rag
+description: Tiny fixed smoke evaluation set for the reproducible harness.
+index_dir: data/index
+primary_run: naive_baseline
+answer_policy:
+  answerable_status: supported
+  unanswerable_status: insufficient
+  min_claims_answerable: 1
+  require_claim_citations: true
+ablation_runs:
+  - name: naive_baseline
+    pipeline: naive_baseline
+cases:
+  - id: smoke_single_doc_security
+    query_type: single_doc
+    query: "기관 A의 보안 통제 요구사항은?"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "보안 통제"
+      - "로그"
+    expected_citation_terms:
+      - "보안 통제"
+      - "로그"
+    expected_claim_targets:
+      - "기관 A"
+    answerable: true
+
+  - id: smoke_multi_doc_ai_requirements
+    query_type: multi_doc
+    query: "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "품질관리"
+      - "MLOps"
+    expected_citation_terms:
+      - "품질관리"
+      - "MLOps"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 B"
+    answerable: true

--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a reproducible local harness.")
+    parser.add_argument("--config", required=True, help="Path to harness/*.yaml")
+    parser.add_argument("--run_id", default=None, help="Optional stable run id.")
+    parser.add_argument("--artifact_root", default=None, help="Override artifact root directory.")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing run directory.")
+    return parser.parse_args()
+
+
+def repo_path(value: str | Path) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def rel_path(path: str | Path) -> str:
+    resolved = Path(path).resolve()
+    try:
+        return str(resolved.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(resolved)
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML must be a mapping: {path}")
+    return data
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def json_hash(payload: Any) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def git_output(args: list[str], default: str = "unknown") -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=ROOT_DIR,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception:
+        return default
+    return result.stdout.strip() or default
+
+
+def git_dirty() -> bool:
+    status = git_output(["status", "--porcelain", "--untracked-files=no"], default="")
+    return bool(status.strip())
+
+
+def run_logged_command(command: list[str], log_path: Path) -> dict[str, Any]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    started_at = utc_now()
+    with log_path.open("w", encoding="utf-8") as log_file:
+        log_file.write("$ " + " ".join(command) + "\n\n")
+        log_file.flush()
+        result = subprocess.run(
+            command,
+            cwd=ROOT_DIR,
+            env=env,
+            text=True,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+    ended_at = utc_now()
+    return {
+        "command": command,
+        "log": rel_path(log_path),
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "returncode": result.returncode,
+        "status": "passed" if result.returncode == 0 else "failed",
+    }
+
+
+def require_mapping(config: dict[str, Any], key: str) -> dict[str, Any]:
+    value = config.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"Config must include mapping: {key}")
+    return value
+
+
+def command_failed(step: dict[str, Any]) -> bool:
+    return int(step.get("returncode", 1)) != 0
+
+
+def build_commands(config: dict[str, Any], run_dir: Path) -> dict[str, list[str]]:
+    dataset = require_mapping(config, "dataset")
+    index_config = require_mapping(config, "index")
+    query_config = require_mapping(config, "query")
+    eval_config = require_mapping(config, "eval")
+
+    input_dir = str(dataset.get("input_dir") or "data/raw")
+    index_dir = run_dir / "index"
+    output_dir = run_dir / "outputs"
+    metrics_dir = run_dir / "metrics"
+    eval_config_path = str(eval_config.get("config") or "harness/smoke_eval.yaml")
+
+    index_command = [
+        "python3",
+        "scripts/build_index.py",
+        "--input_dir",
+        input_dir,
+        "--output_dir",
+        rel_path(index_dir),
+        "--embedding_backend",
+        str(index_config.get("embedding_backend") or "hashing"),
+    ]
+    chunking_strategy = index_config.get("chunking_strategy")
+    if chunking_strategy:
+        index_command.extend(["--chunking_strategy", str(chunking_strategy)])
+
+    query_command = [
+        "python3",
+        "app.py",
+        "--input_dir",
+        rel_path(index_dir),
+        "--output_dir",
+        rel_path(output_dir),
+        "--query",
+        str(query_config.get("text") or ""),
+        "--pipeline",
+        str(query_config.get("pipeline") or "naive_baseline"),
+    ]
+
+    eval_command = [
+        "python3",
+        "eval/run_eval.py",
+        "--index_dir",
+        rel_path(index_dir),
+        "--output_dir",
+        rel_path(metrics_dir),
+        "--config",
+        eval_config_path,
+    ]
+
+    return {
+        "index": index_command,
+        "query": query_command,
+        "eval": eval_command,
+    }
+
+
+def metric_snapshot(metrics_path: Path) -> dict[str, Any]:
+    if not metrics_path.exists():
+        return {}
+    summary = json.loads(metrics_path.read_text(encoding="utf-8"))
+    keys = [
+        "num_predictions",
+        "accuracy",
+        "groundedness",
+        "citation_precision",
+        "answer_format_compliance",
+        "abstention",
+        "retry",
+        "latency",
+    ]
+    return {key: summary.get(key) for key in keys if key in summary}
+
+
+def write_predictions(answer_path: Path, predictions_path: Path, query: str) -> None:
+    predictions_path.parent.mkdir(parents=True, exist_ok=True)
+    if not answer_path.exists():
+        predictions_path.touch()
+        return
+    answer = json.loads(answer_path.read_text(encoding="utf-8"))
+    record = {
+        "source": "sample_query",
+        "query": query,
+        "prediction": answer,
+    }
+    predictions_path.write_text(json.dumps(record, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    started_at = utc_now()
+    config_path = repo_path(args.config)
+    config = load_yaml(config_path)
+    config_id = str(config.get("id") or config_path.stem)
+    run_id = args.run_id or f"{config_id}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    artifact_root = repo_path(args.artifact_root or config.get("artifact_root") or "artifacts/runs")
+    run_dir = artifact_root / run_id
+
+    if run_dir.exists():
+        if not args.force:
+            raise SystemExit(f"[ERROR] Artifact directory already exists: {rel_path(run_dir)}")
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    logs_dir = run_dir / "logs"
+    metrics_path = run_dir / "metrics" / "eval_summary.json"
+    answer_path = run_dir / "outputs" / "answer.json"
+    predictions_path = run_dir / "predictions.jsonl"
+    errors_path = run_dir / "errors.jsonl"
+    summary_path = run_dir / "summary.json"
+    manifest_path = run_dir / "run_manifest.json"
+    config_snapshot_path = run_dir / "config_snapshot.json"
+
+    eval_config_path = repo_path(require_mapping(config, "eval").get("config") or "harness/smoke_eval.yaml")
+    eval_config = load_yaml(eval_config_path)
+    config_snapshot = {
+        "harness": config,
+        "eval": eval_config,
+        "source_paths": {
+            "harness": rel_path(config_path),
+            "eval": rel_path(eval_config_path),
+        },
+    }
+    write_json(config_snapshot_path, config_snapshot)
+    errors_path.touch()
+
+    commands = build_commands(config, run_dir)
+    steps: list[dict[str, Any]] = []
+    status = "passed"
+    failure: dict[str, Any] | None = None
+
+    for name in ("index", "query", "eval"):
+        step = {"name": name, **run_logged_command(commands[name], logs_dir / f"{name}.log")}
+        steps.append(step)
+        if command_failed(step):
+            status = "failed"
+            failure = {
+                "step": name,
+                "returncode": step["returncode"],
+                "log": step["log"],
+                "command": step["command"],
+            }
+            append_jsonl(errors_path, failure)
+            break
+
+    write_predictions(
+        answer_path,
+        predictions_path,
+        str(require_mapping(config, "query").get("text") or ""),
+    )
+    metrics = metric_snapshot(metrics_path)
+    ended_at = utc_now()
+    artifact_paths = {
+        "run_dir": rel_path(run_dir),
+        "run_manifest": rel_path(manifest_path),
+        "config_snapshot": rel_path(config_snapshot_path),
+        "summary": rel_path(summary_path),
+        "predictions": rel_path(predictions_path),
+        "metrics": rel_path(metrics_path),
+        "errors": rel_path(errors_path),
+        "logs": rel_path(logs_dir),
+        "index": rel_path(run_dir / "index" / "index.json"),
+        "answer": rel_path(answer_path),
+    }
+
+    summary = {
+        "run_id": run_id,
+        "status": status,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "steps": steps,
+        "artifact_dir": rel_path(run_dir),
+        "metrics_path": rel_path(metrics_path),
+        "errors_path": rel_path(errors_path),
+    }
+    write_json(summary_path, summary)
+
+    manifest = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "generated_at": ended_at,
+        "git_commit": git_output(["rev-parse", "HEAD"]),
+        "git_dirty": git_dirty(),
+        "config_hash": json_hash(config_snapshot),
+        "config_snapshot_path": rel_path(config_snapshot_path),
+        "artifacts": artifact_paths,
+        "commands": commands,
+        "status": status,
+        "metrics": metrics,
+    }
+    if failure:
+        manifest["failure"] = failure
+    write_json(manifest_path, manifest)
+
+    print(f"[OK] Harness run written: {rel_path(run_dir)}")
+    print(f"[OK] Run manifest: {rel_path(manifest_path)}")
+    return 0 if status == "passed" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `scripts/run_harness.py`를 추가해 인덱싱, 샘플 질의, 평가를 한 번에 실행하고 run 단위 artifact를 `artifacts/runs/<run_id>/`에 저장하도록 했습니다.
- `harness/smoke.yaml`과 `harness/smoke_eval.yaml`로 공개 synthetic 데이터 기반의 작은 smoke 흐름을 분리했습니다.
- `run_manifest.json`, `config_snapshot.json`, `summary.json`, `predictions.jsonl`, `errors.jsonl`, 로그 및 metrics 경로를 표준화하고, `Makefile`에 `harness-smoke` 타깃을 추가했습니다.
- 관련 사용법과 산출물 구조를 `docs/harness.md`와 README에 문서화했습니다.

## Testing
- `python3 scripts/run_harness.py --config harness/smoke.yaml --run_id issue25_smoke_test --force`
- `make harness-smoke`
- 기존 baseline smoke 재실행
- `python3 -m pytest -q`