### PR TITLE
Add stage-level latency profiling and retry cost breakdown (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ CLI와 리뷰 편의를 위해 같은 내용을 사람이 읽기 쉬운 `answer_
 | System | Latency (p50/p95) | p50 1.5ms / p95 2.4ms |
 | System | Retry Rate | 0.000 |
 
+> Stage 단위 latency, retry 비용, cold-start 분리 해석은 [`docs/benchmarking.md`](docs/benchmarking.md#stage-latency--retry-cost)를 참고한다.
+
 ### Ablation comparison
 
 | Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Format | Abstention | Retry | Latency p95 |

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -58,3 +58,27 @@ python3 scripts/summarize_benchmark.py \
 이슈 #24의 private hard-case slice는 공개 benchmark를 대체하지 않고 현실적인 문서 조건에서 품질 하락을 분리하기 위한 보조 suite다. `eval/private_hardcase.example.yaml`은 익명 case list와 `hardcase_categories` 형식을 보여준다. 실제 실행 파일은 `eval/private_hardcase.local.yaml`처럼 `.gitignore` 대상 local YAML로 복사해 사용한다.
 
 `eval/run_eval.py`와 benchmark manifest는 `by_hardcase_category` 집계를 포함한다. 이 값만 registry/docs에 남기고 raw private prediction, trace, 원문 artifact는 `artifacts/benchmarks/` 아래 local-only 산출물로 유지한다. 운영 절차와 금지 항목은 [`docs/private-hardcase-benchmark.md`](private-hardcase-benchmark.md)에 정리했다.
+
+## Stage Latency & Retry Cost
+
+이슈 #32 이후 benchmark는 단일 `latency_ms` 외에 stage 단위 latency를 함께 기록한다. 목표는 reviewer가 "응답 시간이 어느 단계에서 쌓이는지"와 "verifier retry가 품질 개선만큼 latency 비용을 정당화하는지"를 동시에 판단할 수 있게 하는 것이다.
+
+`run_rag_query`의 diagnostics에 추가된 필드:
+
+- `stage_latency`: top-level stage별 ms — `query_analysis_ms`, `context_resolution_ms`, `answer_generation_ms`
+- `filter_stage_attempts[i].retrieve_ms` / `verify_ms`: strict → reduced → relaxed 각 retry 시도의 retrieval+rerank, verifier 비용
+- `cold_start`: 프로세스 첫 호출 여부. embedding/reranker lazy-load가 첫 query latency에 섞이는 것을 분리한다.
+
+`latency_samples.jsonl`은 위 필드를 row 단위로도 기록한다 (`stage_latency`, `attempt_latency`, `cold_start`). 기존 컬럼은 유지되며 추가 필드는 무시해도 안전하다.
+
+`eval_summary.json`에는 다음 집계 블록이 추가된다 (warm = `cold_start=false`인 case만).
+
+- `stage_latency.{stage}` → `{p50, p95, mean, count}`. `retrieve_ms` / `verify_ms`는 모든 retry 시도를 통합한 sample이다.
+- `latency_by_retry_count["0" | "1" | "2" | ...]` → retry 수별 case latency 분포. retry quality gain을 비교할 때 사용한다.
+- `cold_start_samples` → cold-start case 수와 latency. warm percentile에는 포함되지 않는다.
+
+같은 블록은 `by_query_type`과 `by_hardcase_category`에도 동일하게 propagate된다. Reviewer가 latency 트레이드오프를 읽을 때의 가이드:
+
+1. `latency.p95`가 늘어났다면 먼저 `stage_latency.retrieve_ms`/`verify_ms`를 보고 어느 단계가 원인인지 식별한다.
+2. `latency_by_retry_count["1+"]`의 p95와 `retry_cost.cases_with_retry`를 함께 보고, 같은 retry로 얻은 groundedness/citation/abstention gain (ablation 비교)이 latency 증가를 정당화하는지 판단한다.
+3. `cold_start_samples`는 별도로 기록되므로 warm steady-state 비교를 흐리지 않는다. CI/평가 환경에서는 첫 case의 cold_start 영향을 확인용으로만 사용한다.

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -501,6 +501,16 @@ def score_case(
         "latency_ms": diagnostics.get("latency_ms"),
         "retry_count": diagnostics.get("retry_count", 0),
         "retry_trigger_reasons": retry_trigger_reasons(prediction),
+        "cold_start": bool(diagnostics.get("cold_start", False)),
+        "stage_latency": dict(diagnostics.get("stage_latency") or {}),
+        "attempt_latency": [
+            {
+                "stage": attempt.get("stage"),
+                "retrieve_ms": attempt.get("retrieve_ms", 0.0),
+                "verify_ms": attempt.get("verify_ms", 0.0),
+            }
+            for attempt in diagnostics.get("filter_stage_attempts") or []
+        ],
         "context_resolution_status": context_resolution.get("status"),
         "context_resolution_source": context_resolution.get("source"),
         "context_resolution_confidence": context_resolution.get("confidence"),
@@ -509,6 +519,18 @@ def score_case(
         "abstained": abstained,
         **answer_format,
         "answer": answer,
+    }
+
+
+_TOP_LEVEL_STAGE_KEYS = ("query_analysis_ms", "context_resolution_ms", "answer_generation_ms")
+
+
+def _latency_summary(values: list[float]) -> dict[str, float | None]:
+    return {
+        "p50": percentile(values, 0.50),
+        "p95": percentile(values, 0.95),
+        "mean": rate(values),
+        "count": len(values),
     }
 
 
@@ -552,6 +574,46 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         if isinstance(error, dict) and error.get("code")
     )
 
+    warm_results = [r for r in case_results if not bool(r.get("cold_start"))]
+    cold_results = [r for r in case_results if bool(r.get("cold_start"))]
+
+    stage_buckets: dict[str, list[float]] = {key: [] for key in _TOP_LEVEL_STAGE_KEYS}
+    retrieve_samples: list[float] = []
+    verify_samples: list[float] = []
+    for result in warm_results:
+        stage_latency = result.get("stage_latency") or {}
+        for key in _TOP_LEVEL_STAGE_KEYS:
+            value = stage_latency.get(key)
+            if value is not None:
+                stage_buckets[key].append(float(value))
+        for attempt in result.get("attempt_latency") or []:
+            retrieve_samples.append(float(attempt.get("retrieve_ms") or 0.0))
+            verify_samples.append(float(attempt.get("verify_ms") or 0.0))
+
+    stage_latency_summary: dict[str, dict[str, float | None]] = {
+        key: _latency_summary(stage_buckets[key]) for key in _TOP_LEVEL_STAGE_KEYS
+    }
+    stage_latency_summary["retrieve_ms"] = _latency_summary(retrieve_samples)
+    stage_latency_summary["verify_ms"] = _latency_summary(verify_samples)
+
+    latency_by_retry_count: dict[str, dict[str, float | None]] = {}
+    grouped_latencies: dict[int, list[float]] = defaultdict(list)
+    for result in warm_results:
+        if result.get("latency_ms") is None:
+            continue
+        bucket = int(result.get("retry_count") or 0)
+        grouped_latencies[bucket].append(float(result["latency_ms"]))
+    for bucket in sorted(grouped_latencies):
+        latency_by_retry_count[str(bucket)] = _latency_summary(grouped_latencies[bucket])
+
+    cold_latencies = [
+        float(r["latency_ms"]) for r in cold_results if r.get("latency_ms") is not None
+    ]
+    cold_start_samples = {
+        "count": len(cold_results),
+        "latency_ms": _latency_summary(cold_latencies) if cold_latencies else None,
+    }
+
     return {
         "num_predictions": len(case_results),
         "accuracy": rate(accuracy_scores),
@@ -567,6 +629,9 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
             "p95": percentile(latencies, 0.95),
             "mean": rate(latencies),
         },
+        "stage_latency": stage_latency_summary,
+        "latency_by_retry_count": latency_by_retry_count,
+        "cold_start_samples": cold_start_samples,
         "retry": rate(retries),
         "retry_cost": {
             "total_retries": sum(retry_counts),
@@ -722,6 +787,9 @@ def main() -> int:
         "abstention": primary_summary["abstention"],
         "answer_format_compliance": primary_summary["answer_format_compliance"],
         "latency": primary_summary["latency"],
+        "stage_latency": primary_summary.get("stage_latency", {}),
+        "latency_by_retry_count": primary_summary.get("latency_by_retry_count", {}),
+        "cold_start_samples": primary_summary.get("cold_start_samples", {}),
         "retry": primary_summary["retry"],
         "by_query_type": primary_summary["by_query_type"],
         "by_hardcase_category": primary_summary.get("by_hardcase_category", {}),

--- a/rag_core.py
+++ b/rag_core.py
@@ -2124,12 +2124,37 @@ def metadata_stage_sequence(
     return stages
 
 
+_PROCESS_WARM = False
+
+
+class _StageTimer:
+    """Accumulate ``time.perf_counter`` deltas (ms) into a dict bucket.
+
+    Adds the elapsed milliseconds to ``bucket[key]`` so re-entering the same
+    key (e.g. a stage invoked twice) sums into a single total.
+    """
+
+    def __init__(self, bucket: dict[str, float], key: str) -> None:
+        self.bucket = bucket
+        self.key = key
+
+    def __enter__(self) -> "_StageTimer":
+        self._t0 = time.perf_counter()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        elapsed_ms = (time.perf_counter() - self._t0) * 1000
+        self.bucket[self.key] = self.bucket.get(self.key, 0.0) + elapsed_ms
+
+
 def summarize_stage_attempt(
     plan: dict[str, Any],
     verified: bool,
     verification_reasons: list[str],
+    *,
+    timings: dict[str, float] | None = None,
 ) -> dict[str, Any]:
-    return {
+    record = {
         "stage": plan.get("filter_stage"),
         "pipeline": plan.get("pipeline"),
         "prompt_profile": plan.get("prompt_profile"),
@@ -2142,7 +2167,10 @@ def summarize_stage_attempt(
         "retrieval_mode": plan.get("retrieval_mode", "flat"),
         "verified": verified,
         "verification_reasons": verification_reasons,
+        "retrieve_ms": round(float((timings or {}).get("retrieve_ms", 0.0)), 2),
+        "verify_ms": round(float((timings or {}).get("verify_ms", 0.0)), 2),
     }
+    return record
 
 
 def clarification_answer(query: str, context_resolution: dict[str, Any]) -> str:
@@ -2177,6 +2205,9 @@ def make_context_clarification_result(
     retrieval_mode: str,
     pipeline: str,
     prompt_profile: str,
+    *,
+    stage_timings: dict[str, float] | None = None,
+    cold_start: bool = False,
 ) -> dict[str, Any]:
     reason = str(context_resolution.get("reason") or "context_resolution_failed")
     analysis = dict(analysis)
@@ -2241,6 +2272,12 @@ def make_context_clarification_result(
             "retrieval_mode": retrieval_mode,
             "pipeline": pipeline,
             "prompt_profile": prompt_profile,
+            "cold_start": cold_start,
+            "stage_latency": {
+                "query_analysis_ms": round(float((stage_timings or {}).get("query_analysis_ms", 0.0)), 2),
+                "context_resolution_ms": round(float((stage_timings or {}).get("context_resolution_ms", 0.0)), 2),
+                "answer_generation_ms": round(float((stage_timings or {}).get("answer_generation_ms", 0.0)), 2),
+            },
         },
     }
 
@@ -2348,16 +2385,24 @@ def run_rag_query(
     pipeline_name = str(pipeline_config["pipeline"])
     prompt_profile = str(pipeline_config["prompt_profile"])
 
+    global _PROCESS_WARM
+    cold_start = not _PROCESS_WARM
+    if cold_start:
+        _PROCESS_WARM = True
+
     started = time.perf_counter()
+    stage_timings: dict[str, float] = {}
     state = normalize_conversation_state(conversation_state)
     targets = metadata_targets(index)
-    initial_analysis = analyze_query(query, targets)
-    retrieval_query, effective_context_entities, context_resolution = resolve_conversation_context(
-        query,
-        initial_analysis,
-        state,
-        context_entities=context_entities,
-    )
+    with _StageTimer(stage_timings, "query_analysis_ms"):
+        initial_analysis = analyze_query(query, targets)
+    with _StageTimer(stage_timings, "context_resolution_ms"):
+        retrieval_query, effective_context_entities, context_resolution = resolve_conversation_context(
+            query,
+            initial_analysis,
+            state,
+            context_entities=context_entities,
+        )
     if context_resolution["status"] == "needs_clarification":
         return make_context_clarification_result(
             index,
@@ -2372,13 +2417,16 @@ def run_rag_query(
             retrieval_mode,
             pipeline_name,
             prompt_profile,
+            stage_timings=stage_timings,
+            cold_start=cold_start,
         )
 
-    analysis = analyze_query(
-        retrieval_query,
-        targets,
-        context_entities=effective_context_entities,
-    )
+    with _StageTimer(stage_timings, "query_analysis_ms"):
+        analysis = analyze_query(
+            retrieval_query,
+            targets,
+            context_entities=effective_context_entities,
+        )
     if context_resolution["source"] in {"conversation_state", "context_entities"}:
         analysis["query_type"] = "follow_up"
         analysis["context_used"] = True
@@ -2399,24 +2447,29 @@ def run_rag_query(
         attempt_top_k = top_k
         if attempt_index > 0:
             attempt_top_k = max(top_k or 0, 8)
-        plan = make_plan(
-            analysis,
-            top_k=attempt_top_k,
-            stage=stage,
-            metadata_first=metadata_first,
-            rerank=rerank,
-            verifier_retry=verifier_retry,
-            retrieval_mode=retrieval_mode,
-            pipeline=pipeline_name,
-            prompt_profile=prompt_profile,
+        attempt_timings: dict[str, float] = {}
+        with _StageTimer(attempt_timings, "retrieve_ms"):
+            plan = make_plan(
+                analysis,
+                top_k=attempt_top_k,
+                stage=stage,
+                metadata_first=metadata_first,
+                rerank=rerank,
+                verifier_retry=verifier_retry,
+                retrieval_mode=retrieval_mode,
+                pipeline=pipeline_name,
+                prompt_profile=prompt_profile,
+            )
+            evidence = retrieve(index, retrieval_query, analysis, plan)
+        with _StageTimer(attempt_timings, "verify_ms"):
+            if verifier_retry:
+                verified, verification_reasons = verify_evidence(analysis, evidence)
+            else:
+                verified = bool(evidence)
+                verification_reasons = [] if verified else ["no_evidence"]
+        stage_attempts.append(
+            summarize_stage_attempt(plan, verified, verification_reasons, timings=attempt_timings)
         )
-        evidence = retrieve(index, retrieval_query, analysis, plan)
-        if verifier_retry:
-            verified, verification_reasons = verify_evidence(analysis, evidence)
-        else:
-            verified = bool(evidence)
-            verification_reasons = [] if verified else ["no_evidence"]
-        stage_attempts.append(summarize_stage_attempt(plan, verified, verification_reasons))
         if verified:
             break
         if attempt_index < len(stage_sequence) - 1:
@@ -2426,13 +2479,14 @@ def run_rag_query(
         evidence = select_supporting_evidence(analysis, evidence)
     else:
         evidence = []
-    answer, answer_text, abstained = generate_answer(
-        query,
-        analysis,
-        evidence,
-        verified,
-        verification_reasons,
-    )
+    with _StageTimer(stage_timings, "answer_generation_ms"):
+        answer, answer_text, abstained = generate_answer(
+            query,
+            analysis,
+            evidence,
+            verified,
+            verification_reasons,
+        )
     next_state = update_conversation_state(
         state,
         query,
@@ -2442,6 +2496,11 @@ def run_rag_query(
         context_resolution,
     )
     latency_ms = (time.perf_counter() - started) * 1000
+    stage_latency = {
+        "query_analysis_ms": round(stage_timings.get("query_analysis_ms", 0.0), 2),
+        "context_resolution_ms": round(stage_timings.get("context_resolution_ms", 0.0), 2),
+        "answer_generation_ms": round(stage_timings.get("answer_generation_ms", 0.0), 2),
+    }
     return {
         "mode": "rag",
         "query": query,
@@ -2473,6 +2532,8 @@ def run_rag_query(
             "retrieval_mode": retrieval_mode,
             "pipeline": pipeline_name,
             "prompt_profile": prompt_profile,
+            "cold_start": cold_start,
+            "stage_latency": stage_latency,
         },
     }
 

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -248,6 +248,14 @@ def evaluate_run_with_artifacts(
             error_examples_file.write(json.dumps(record, ensure_ascii=False) + "\n")
 
         diagnostics = prediction.get("diagnostics") or {}
+        attempt_latency = [
+            {
+                "stage": attempt.get("stage"),
+                "retrieve_ms": attempt.get("retrieve_ms", 0.0),
+                "verify_ms": attempt.get("verify_ms", 0.0),
+            }
+            for attempt in diagnostics.get("filter_stage_attempts") or []
+        ]
         latency_file.write(
             json.dumps(
                 {
@@ -261,6 +269,9 @@ def evaluate_run_with_artifacts(
                     "retry_count": diagnostics.get("retry_count", 0),
                     "retrieval_mode": diagnostics.get("retrieval_mode"),
                     "prompt_profile": diagnostics.get("prompt_profile"),
+                    "cold_start": bool(diagnostics.get("cold_start", False)),
+                    "stage_latency": diagnostics.get("stage_latency") or {},
+                    "attempt_latency": attempt_latency,
                 },
                 ensure_ascii=False,
             )
@@ -313,6 +324,9 @@ def build_summary(
         "abstention": primary_summary["abstention"],
         "answer_format_compliance": primary_summary["answer_format_compliance"],
         "latency": primary_summary["latency"],
+        "stage_latency": primary_summary.get("stage_latency", {}),
+        "latency_by_retry_count": primary_summary.get("latency_by_retry_count", {}),
+        "cold_start_samples": primary_summary.get("cold_start_samples", {}),
         "retry": primary_summary["retry"],
         "by_query_type": primary_summary["by_query_type"],
         "by_hardcase_category": primary_summary.get("by_hardcase_category", {}),

--- a/tests/test_latency_instrumentation.py
+++ b/tests/test_latency_instrumentation.py
@@ -1,0 +1,173 @@
+import time
+import unittest
+from pathlib import Path
+
+import rag_core
+from rag_core import _StageTimer, build_index_payload, run_rag_query
+from eval.run_eval import metric_block, summarize_run
+
+
+class StageTimerTest(unittest.TestCase):
+    def test_records_elapsed_milliseconds(self) -> None:
+        bucket: dict[str, float] = {}
+        with _StageTimer(bucket, "stage_ms"):
+            time.sleep(0.005)
+        self.assertIn("stage_ms", bucket)
+        self.assertGreater(bucket["stage_ms"], 0.0)
+
+    def test_reentry_accumulates(self) -> None:
+        bucket: dict[str, float] = {}
+        with _StageTimer(bucket, "stage_ms"):
+            time.sleep(0.001)
+        first = bucket["stage_ms"]
+        with _StageTimer(bucket, "stage_ms"):
+            time.sleep(0.001)
+        self.assertGreater(bucket["stage_ms"], first)
+
+
+class RunRagQueryTimingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index = build_index_payload(Path("data/raw"), embedding_backend="hashing")
+
+    def setUp(self) -> None:
+        rag_core._PROCESS_WARM = False
+
+    def test_diagnostics_include_stage_latency(self) -> None:
+        result = run_rag_query(self.index, "기관A의 보안 통제 요구사항은?")
+        diagnostics = result["diagnostics"]
+        self.assertIn("stage_latency", diagnostics)
+        self.assertIn("cold_start", diagnostics)
+        for key in ("query_analysis_ms", "context_resolution_ms", "answer_generation_ms"):
+            self.assertIn(key, diagnostics["stage_latency"])
+            self.assertGreaterEqual(diagnostics["stage_latency"][key], 0.0)
+
+    def test_filter_stage_attempts_have_per_attempt_timings(self) -> None:
+        result = run_rag_query(self.index, "기관A의 보안 통제 요구사항은?")
+        attempts = result["diagnostics"]["filter_stage_attempts"]
+        self.assertTrue(attempts)
+        for attempt in attempts:
+            self.assertIn("retrieve_ms", attempt)
+            self.assertIn("verify_ms", attempt)
+            self.assertGreaterEqual(attempt["retrieve_ms"], 0.0)
+            self.assertGreaterEqual(attempt["verify_ms"], 0.0)
+
+    def test_cold_start_flag_flips_after_first_call(self) -> None:
+        first = run_rag_query(self.index, "기관A의 보안 통제 요구사항은?")
+        second = run_rag_query(self.index, "기관A의 보안 통제 요구사항은?")
+        self.assertTrue(first["diagnostics"]["cold_start"])
+        self.assertFalse(second["diagnostics"]["cold_start"])
+
+    def test_retry_attempts_each_get_timings(self) -> None:
+        original_verify = rag_core.verify_evidence
+        calls = {"n": 0}
+
+        def always_fail(analysis, evidence):
+            calls["n"] += 1
+            return False, ["forced_failure"]
+
+        rag_core.verify_evidence = always_fail
+        try:
+            result = run_rag_query(self.index, "기관A의 보안 통제 요구사항은?")
+        finally:
+            rag_core.verify_evidence = original_verify
+
+        attempts = result["diagnostics"]["filter_stage_attempts"]
+        self.assertGreaterEqual(len(attempts), 2)
+        for attempt in attempts:
+            self.assertIn("retrieve_ms", attempt)
+            self.assertIn("verify_ms", attempt)
+        self.assertGreaterEqual(result["diagnostics"]["retry_count"], 1)
+
+
+class MetricBlockLatencyTest(unittest.TestCase):
+    def _case(
+        self,
+        *,
+        retry_count: int,
+        latency_ms: float,
+        cold_start: bool = False,
+        retrieve_ms: float = 5.0,
+        verify_ms: float = 1.0,
+    ) -> dict:
+        attempts = retry_count + 1
+        return {
+            "query_type": "single_doc",
+            "hardcase_categories": [],
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "answer_format_compliance": 1.0,
+            "abstention": None,
+            "latency_ms": latency_ms,
+            "retry_count": retry_count,
+            "retry_trigger_reasons": [],
+            "cold_start": cold_start,
+            "stage_latency": {
+                "query_analysis_ms": 2.0,
+                "context_resolution_ms": 1.0,
+                "answer_generation_ms": 3.0,
+            },
+            "attempt_latency": [
+                {"stage": "strict", "retrieve_ms": retrieve_ms, "verify_ms": verify_ms}
+            ]
+            * attempts,
+        }
+
+    def test_stage_latency_aggregations_present(self) -> None:
+        case_results = [
+            self._case(retry_count=0, latency_ms=10.0),
+            self._case(retry_count=1, latency_ms=20.0),
+            self._case(retry_count=2, latency_ms=30.0),
+        ]
+        block = metric_block(case_results)
+        self.assertIn("stage_latency", block)
+        for key in (
+            "query_analysis_ms",
+            "context_resolution_ms",
+            "answer_generation_ms",
+            "retrieve_ms",
+            "verify_ms",
+        ):
+            self.assertIn(key, block["stage_latency"])
+            self.assertEqual(2.0 if key == "query_analysis_ms" else block["stage_latency"][key]["mean"], block["stage_latency"][key]["mean"])
+            self.assertGreater(block["stage_latency"][key]["count"], 0)
+
+    def test_latency_by_retry_count_buckets(self) -> None:
+        case_results = [
+            self._case(retry_count=0, latency_ms=10.0),
+            self._case(retry_count=0, latency_ms=12.0),
+            self._case(retry_count=1, latency_ms=25.0),
+        ]
+        block = metric_block(case_results)
+        self.assertIn("0", block["latency_by_retry_count"])
+        self.assertIn("1", block["latency_by_retry_count"])
+        self.assertEqual(2, block["latency_by_retry_count"]["0"]["count"])
+        self.assertEqual(1, block["latency_by_retry_count"]["1"]["count"])
+
+    def test_cold_start_excluded_from_warm_aggregations(self) -> None:
+        case_results = [
+            self._case(retry_count=0, latency_ms=500.0, cold_start=True),
+            self._case(retry_count=0, latency_ms=10.0),
+            self._case(retry_count=0, latency_ms=12.0),
+        ]
+        block = metric_block(case_results)
+        # Warm bucket should not include the 500ms cold-start latency.
+        self.assertEqual(2, block["latency_by_retry_count"]["0"]["count"])
+        self.assertLess(block["latency_by_retry_count"]["0"]["p95"], 500.0)
+        self.assertEqual(1, block["cold_start_samples"]["count"])
+        self.assertIsNotNone(block["cold_start_samples"]["latency_ms"])
+
+    def test_summarize_run_propagates_stage_latency_to_query_type(self) -> None:
+        case_results = [
+            self._case(retry_count=0, latency_ms=10.0),
+            self._case(retry_count=1, latency_ms=20.0),
+        ]
+        summary = summarize_run("unit", {"pipeline": "agentic_full"}, case_results)
+        self.assertIn("stage_latency", summary)
+        self.assertIn("stage_latency", summary["by_query_type"]["single_doc"])
+        self.assertIn("latency_by_retry_count", summary["by_query_type"]["single_doc"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Decomposes `run_rag_query` latency into per-stage timings (query_analysis, context_resolution, retrieval, verifier, answer_generation) and per-attempt timings for the strict → reduced → relaxed retry chain.
- Adds a process-local `cold_start` flag so first-call embedding/reranker load cost is reported separately from warm steady-state percentiles.
- Extends `latency_samples.jsonl` and `eval_summary.json` with `stage_latency`, `latency_by_retry_count`, and `cold_start_samples` blocks (also propagated through `by_query_type` / `by_hardcase_category`) so reviewers can weigh retry quality gain against latency cost. New `docs/benchmarking.md` section explains the trade-off.

## Why
Closes [hskim-solv/BidMate-DocAgent#32](https://github.com/hskim-solv/BidMate-DocAgent/issues/32). Aggregate `latency_ms` was hiding where time is spent and whether verifier retries were paying for themselves. Treating latency as a first-class trade-off — per stage, per retry bucket, with cold-start excluded — lets the benchmark answer those questions directly.

## Notes for reviewers
- This is a **clean re-application** of the change that briefly landed via PR #42 on the wrong branch (`eval/27-...`). PR #43 reverted that merge; this PR re-introduces the same content on the properly-named `eval/32-...` branch.
- Schema changes are **additive**. Existing readers of `latency_samples.jsonl` / `eval_summary.json` keep working; existing `latency` p50/p95 field unchanged.
- `summarize_stage_attempt` gained a kwarg-only `timings=None` parameter — all current callers continue to work.
- Cold-start samples are excluded from warm percentiles and surfaced separately in `cold_start_samples`.

## Test plan
- [x] `python3 -m pytest tests/` — 46 passed, including 10 new tests in `tests/test_latency_instrumentation.py` covering the timer, real-query stage_latency population, per-attempt timings under forced retry, cold_start flag flip, retry-count buckets, and cold-start exclusion in aggregates.
- [ ] Reviewer end-to-end: `python3 scripts/run_benchmark.py --suite benchmarks/suites/public_synthetic_rfp.yaml --ablations benchmarks/ablations/rag_quality_axes.yaml`. First row of generated `latency_samples.jsonl` should have `cold_start=true` with populated `stage_latency` / `attempt_latency`; later rows `cold_start=false`. `eval_summary.json` should include `stage_latency`, `latency_by_retry_count`, and `cold_start_samples` at top level and inside `by_query_type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)