### PR TITLE
Add Phase 0 ingestion foundations for real-data roadmap (#49)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [설계 배경 및 의사결정](./design-background.md)
 - [답변 출력 정책](./answer-policy.md)
 - [PDF/HWP ingestion](./real-data-ingestion.md)
+- [Local gold authoring guide](./local-gold-authoring.md)
 - [Visual parsing v2](./visual-ingestion-v2.md)
 - [Citation grounding evaluation](./citation-grounding-eval.md)
 - [실패 사례 분석](./failure-cases.md)

--- a/docs/local-gold-authoring.md
+++ b/docs/local-gold-authoring.md
@@ -1,0 +1,176 @@
+# Local gold authoring guide
+
+이슈 [#50](https://github.com/hskim-solv/BidMate-DocAgent/issues/50)의 산출물. 비공개 실데이터(`data/files/`, `data/data_list.csv`) 위에서 답변 정확도와 abstention 동작을 검증할 때 사용하는 `eval/real_config.local.yaml`을 작성·유지하는 방법을 정리한다.
+
+## 무엇을 만드는 파일인가
+
+`eval/real_config.local.yaml`은 **비공개** 평가 입력이다. 다음을 적는다.
+
+- 어떤 질의를 던지는지
+- 어떤 답이 나와야 하는지(혹은 답이 없어야 하는지)
+- 어떤 문서·문구가 인용되어야 하는지
+
+이 파일이 있어야 [`scripts/smoke_real.sh`](../scripts/smoke_real.sh) 또는 직접 호출하는 `python3 eval/run_eval.py --config eval/real_config.local.yaml ...`이 gold 비교를 한다. 파일이 없으면 인덱싱과 대표 질의까지만 실행되고 평가는 건너뛴다.
+
+## 안전 원칙 (반드시 지킬 것)
+
+- `eval/*.local.yaml`은 [`.gitignore`](../.gitignore)에 등록되어 있다. 절대 git에 커밋하지 않는다.
+- 파일 내용에는 발주기관명, 사업명, 공고 번호, 문서 원문 일부 등 민감정보가 포함될 수 있다. PR 본문, 이슈 코멘트, 스크린샷, 외부 채널에 그대로 붙여 넣지 않는다.
+- 평가 결과(`reports/real100/eval_summary.json`)도 같은 이유로 git 추적 대상이 아니다. 공유가 필요하면 sanitized 요약(`docs/real-data-failure-taxonomy.md`처럼 카테고리별 빈도 + sanitized 증상)으로 옮긴다.
+- 공개 README의 성능 표는 실데이터 평가 결과로 갱신하지 않는다([이슈 #47 out-of-scope](real-data-failure-taxonomy.md)).
+
+## 어디서 시작하나
+
+[`eval/real_config.example.yaml`](../eval/real_config.example.yaml)을 같은 폴더에 `real_config.local.yaml`로 복사한 뒤 채운다.
+
+```bash
+cp eval/real_config.example.yaml eval/real_config.local.yaml
+```
+
+## 필수 필드
+
+최상위 키:
+
+| 키 | 의미 | 비고 |
+|---|---|---|
+| `mode` | 평가 모드. 항상 `rag`. | 다른 값은 지원하지 않는다. |
+| `description` | 사람이 읽는 한 줄 설명. | 자유롭게. |
+| `index_dir` | 사용할 인덱스 경로. | 보통 `data/index/real100`. |
+| `answer_policy` | 답변 가능/불가 케이스에 어떤 status를 기대하는지. | example과 동일하게 둔다. |
+| `ablation_runs` | 실행할 파이프라인 목록. 최소 1개. | 보통 `full` 하나로 충분. |
+| `cases` | 실제 케이스 목록. **이 부분이 핵심.** |  |
+
+각 case의 필수 필드:
+
+| 필드 | 의미 |
+|---|---|
+| `id` | 케이스 식별자. 다른 케이스와 겹치지 않도록 유니크하게 둔다. |
+| `query_type` | `single_doc`, `multi_doc`, `follow_up`, `abstention` 중 하나. |
+| `query` | 사용자가 입력하는 질의 본문. |
+| `expected_doc_ids` | 기대되는 정답 doc_id 목록. abstention 케이스에서는 `[]`. |
+| `expected_terms` | 답변 텍스트에 등장해야 하는 핵심 term들. |
+| `expected_citation_terms` | 인용 chunk 텍스트에 등장해야 하는 term들. |
+| `expected_claim_targets` | 답변 claim의 target(보통 발주기관명/사업명). abstention은 `[]`. |
+| `answerable` | `true` = 답이 나와야 함. `false` = abstention 케이스. |
+
+선택 필드(필요할 때만):
+
+- `prior_turns`: 후속 질의(follow_up)에서 직전 턴들을 시뮬레이션할 때 사용. 각 turn은 `query` 필드만 있으면 된다.
+- `context_entities`: 평가 시점에 강제로 주입할 발주기관/사업명. 보통은 비워둔다.
+- `hardcase_categories`: 카테고리별 슬라이스 메트릭에 포함시키고 싶을 때(예: `["C1", "C5"]`).
+- `expected_citation_pages`, `expected_citation_regions`: visual 인덱스에서 페이지·영역 단위 grounding을 검증할 때만.
+
+## doc_id를 어떻게 알아내나
+
+[`scripts/build_index.py`](../scripts/build_index.py) 실행 후 `data/index/real100/ingestion_report.json`에 모든 row의 `doc_id`가 기록된다. 보통 `<공고 번호>-<공고 차수>` 형태이며, 공고 번호가 비어 있을 때만 파일명 stem이 사용된다(자세한 규칙은 [PDF/HWP ingestion](./real-data-ingestion.md#canonical-doc_id-rule)).
+
+이 파일은 비공개이므로 평가 케이스 작성 외 용도로 외부에 공유하지 않는다.
+
+## 답변 가능(answerable) 케이스 예시
+
+PDF/HWP 인덱스의 한 사업에 대해 사업기간과 사업예산을 묻는 케이스.
+
+```yaml
+- id: single_doc_budget_schedule
+  query_type: single_doc
+  query: "발주기관명 사업명의 사업기간과 사업예산을 알려줘"
+  expected_doc_ids:
+    - 20240001-0
+  expected_terms:
+    - "1,200,000,000"
+    - "2024-03-01"
+  expected_citation_terms:
+    - "1,200,000,000"
+  expected_claim_targets:
+    - "발주기관명"
+  answerable: true
+```
+
+작성 가이드:
+
+- `query`는 사용자가 실제로 칠 만한 어순으로 둔다. 비교 질의면 `차이`/`비교`/`각각` 중 하나를 포함시키는 것이 좋다.
+- `expected_terms`에는 답변 텍스트에 반드시 들어가야 하는 핵심 토큰만 넣는다(금액 숫자, 일자, 명사구). 자유 문장 전체를 넣지 않는다.
+- `expected_citation_terms`는 인용 chunk 본문에 그대로 등장해야 하는 토큰이다. metadata-derived claim(예: 사업금액이 metadata에서만 나오는 경우)은 citation chunk에 그 숫자가 없을 수 있으므로 보수적으로 둔다(자세한 사례: [`docs/real-data-failure-taxonomy.md` C5](./real-data-failure-taxonomy.md#c5-인용-불일치약한-근거-빈도-412-impact-h-effort-s)).
+
+### 후속 질의(follow_up) 변형
+
+```yaml
+- id: follow_up_same_project_schedule
+  query_type: follow_up
+  prior_turns:
+    - query: "발주기관명 사업명에 대해 알려줘"
+  query: "그 사업의 일정은?"
+  expected_doc_ids:
+    - 20240001-0
+  expected_terms:
+    - "2024-03-01"
+  expected_citation_terms:
+    - "2024-03-01"
+  expected_claim_targets:
+    - "발주기관명"
+  answerable: true
+```
+
+`prior_turns`이 conversation state를 채우고, `query`는 그 위에서 follow-up 동작을 검증한다. C4 카테고리 회복 추적용으로 1~2개 두는 것이 좋다.
+
+## 의도된 abstention 케이스 예시
+
+코퍼스에 없는 사실을 물어 시스템이 정상적으로 답을 거부하는지 본다.
+
+```yaml
+- id: abstention_unrelated_topic
+  query_type: abstention
+  query: "발주기관명 사업명에서 블록체인 인증 요구사항 알려줘"
+  expected_doc_ids: []
+  expected_terms: []
+  expected_citation_terms: []
+  expected_claim_targets: []
+  answerable: false
+```
+
+작성 가이드:
+
+- "그 사업이 다루지 않을 법한 키워드"를 고른다. 단, 코퍼스 어디에도 등장하지 않는 토큰을 골라야 false abstention과 구분된다.
+- abstention 케이스가 너무 많으면 `abstention_recall`만 부풀려진다. 답변 가능 케이스 대비 1:3~1:4 비율을 권장한다.
+
+## 케이스 작성 후 검증
+
+1. 인덱스부터 갱신한다.
+   ```bash
+   python3 scripts/build_index.py \
+     --metadata_csv data/data_list.csv \
+     --files_dir data/files \
+     --output_dir data/index/real100 \
+     --embedding_backend hashing
+   ```
+2. CSV 자체에 column / null / duplicate 문제가 없는지 먼저 본다.
+   ```bash
+   python3 scripts/validate_data_list.py \
+     --metadata_csv data/data_list.csv \
+     --files_dir data/files \
+     --output_path reports/real100/data_list_validation.json
+   ```
+   exit code가 0이 아니면 인덱스 빌드 전에 fix한다(이슈 [#51](https://github.com/hskim-solv/BidMate-DocAgent/issues/51)).
+3. gold를 적용해 평가한다.
+   ```bash
+   python3 eval/run_eval.py \
+     --config eval/real_config.local.yaml \
+     --index_dir data/index/real100 \
+     --output_dir reports/real100
+   ```
+4. `reports/real100/eval_summary.json`의 `by_query_type`과 `case_results`를 확인한다. 슬라이스별 빈도와 실패 패턴은 [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md)와 동일한 분류 체계로 정리하면 트래킹이 쉽다.
+
+## 자주 막히는 지점
+
+- **`expected_doc_ids`가 틀려서 정답인데도 fail로 잡힘** — `ingestion_report.json`의 doc_id를 그대로 복사한다. 공고 번호 차수(`0`/`0.0`)가 잘 맞는지 한 번 더 본다.
+- **`expected_terms`에 너무 긴 문장을 넣어서 정답이 fail로 잡힘** — 답변 생성 형식과 어순이 달라서이다. 명사·숫자·일자 단위로 쪼갠다.
+- **abstention 케이스가 false negative로 잡힘** — 그 키워드가 다른 row의 `텍스트`에 우연히 등장하는 경우이다. 코퍼스에 정말 없는 키워드인지 `grep` 한 번 해본다.
+- **follow_up이 abstain으로 빠짐** — 현재 구현은 1단계 follow-up까지만 강하게 처리한다(C4-1, 이슈 [#57](https://github.com/hskim-solv/BidMate-DocAgent/issues/57)). 2단계 implicit chain은 보수적으로 케이스에서 빼두는 것을 권장한다.
+
+## 참고
+
+- [PDF/HWP ingestion](./real-data-ingestion.md)
+- [실데이터 실패 분류 및 우선순위 백로그](./real-data-failure-taxonomy.md)
+- [답변 정책](./answer-policy.md)
+- [Citation grounding evaluation](./citation-grounding-eval.md)
+- [Private hard-case benchmark](./private-hardcase-benchmark.md)

--- a/docs/real-data-ingestion.md
+++ b/docs/real-data-ingestion.md
@@ -3,10 +3,43 @@
 이 문서는 비공개 PDF/HWP 원본과 `data_list.csv`를 로컬에서 인덱싱하는 v1 경로를 설명한다. 공개 baseline인 `data/raw` synthetic RFP 실행 흐름은 그대로 유지한다. 원본 PDF/image를 직접 파싱하는 v2 경로는 [`visual-ingestion-v2.md`](./visual-ingestion-v2.md)에 별도로 정리한다.
 
 ## 입력
-- `data/data_list.csv`: `공고 번호`, `공고 차수`, `사업명`, `사업 금액`, `발주 기관`, 날짜 필드, `사업 요약`, `파일형식`, `파일명`, `텍스트` 컬럼을 사용한다.
+- `data/data_list.csv`: `공고 번호`, `공고 차수`, `사업명`, `사업 금액`, `발주 기관`, 날짜 필드, `사업 요약`, `파일형식`, `파일명`, `텍스트` 컬럼을 사용한다. 컬럼 audits는 [pre-flight 검증](#pre-flight-검증-issue-51)으로 분리해 본다.
 - `data/files/`: CSV의 `파일명`이 가리키는 PDF/HWP 파일 디렉터리다.
 - v1은 PDF/HWP 바이너리를 직접 파싱하지 않고, CSV의 `텍스트` 컬럼을 본문 소스로 사용한다.
-- `공고 번호`가 비어 있으면 파일명 stem을 `doc_id`로 사용하고, 이 사실은 metadata의 `doc_id_source`에 기록한다.
+- `공고 번호`가 비어 있으면 파일명 stem을 `doc_id`로 사용하고, 이 사실은 metadata의 `doc_id_source`에 기록한다([canonical doc_id rule](#canonical-doc_id-rule)).
+
+## Canonical doc_id rule
+([이슈 #52](https://github.com/hskim-solv/BidMate-DocAgent/issues/52))
+
+`ingestion.canonical_doc_id`가 모든 ingestion 경로에서 단일 규칙으로 doc_id를 생성한다.
+
+1. **우선순위 1** — `공고 번호`가 비어 있지 않으면 `slug(공고 번호)[-slug(공고 차수)]`. 차수가 비어 있으면 공고 번호만 사용한다. 예: `20240001-0`, `20240003-1.0`.
+2. **우선순위 2** — 공고 번호가 비어 있을 때만 `slug(파일명 stem)`. 이 사실은 `metadata.doc_id_source = "file_name"`에 기록되어 평가 단계에서 추적할 수 있다.
+3. 두 경로 모두 NFC 정규화 + 내부 공백 collapse를 적용해, 같은 row가 OS·plaftform 차이와 무관하게 같은 doc_id를 만든다.
+4. 둘 다 비어 있으면 row는 `missing_doc_id`로 실패 처리한다.
+
+### 중복 doc_id 처리
+같은 base doc_id가 두 row에서 발생하면 두 가지 정책 중 하나로 처리한다.
+
+- `on_duplicate_doc_id="fail"` (기본): 두 번째 row는 `duplicate_doc_id`로 실패 처리되고, `record.duplicate_resolution`에 `first_seen_row`, `suggested_doc_id`(`<base>-2` 등)가 기록된다.
+- `on_duplicate_doc_id="suffix"` (옵트인): 두 번째 row의 doc_id를 deterministic suffix(`<base>-2`, `<base>-3`, ...)로 자동 부여한다. 부여 결과는 row metadata에 `doc_id_resolution=suffix`, `doc_id_base=<base>`로 함께 기록되어 downstream 평가에서 추적 가능하다.
+
+`build_index.py`는 v1에서 기본값(`fail`)으로 동작한다. 자동 suffix는 라이브러리 호출(`load_documents_from_metadata_csv(..., on_duplicate_doc_id="suffix")`)에서만 활성화된다.
+
+## Pre-flight 검증 (issue #51)
+
+인덱싱을 돌리기 전에 CSV 자체의 schema/필수값/중복을 먼저 잡고 싶을 때는 [`scripts/validate_data_list.py`](../scripts/validate_data_list.py)를 사용한다. 이 스크립트는 본문 텍스트는 로드하지 않고 row별 메타데이터만 audits한다.
+
+```bash
+python3 scripts/validate_data_list.py \
+  --metadata_csv data/data_list.csv \
+  --files_dir data/files \
+  --output_path reports/real100/data_list_validation.json
+```
+
+- exit code: 0 = 통과 / 1 = row-level 실패 또는 schema 위반 / 2 = CLI/입력 오류.
+- 출력 JSON에는 `summary.failure_reasons`, `summary.failure_examples`, `summary.duplicate_doc_ids`, `summary.blank_field_warnings`가 포함되어 있어 어떤 row가 어떤 사유로 실패했는지를 한눈에 본다.
+- `--on_duplicate_doc_id suffix`를 주면 어떤 doc_id가 자동 suffix로 들어가는지 미리 미리보기 할 수 있다.
 
 ## 실행
 ```bash
@@ -31,7 +64,7 @@ bash scripts/smoke_real.sh
 - 평가 출력: `reports/real100/eval_summary.json`
 - 평가 설정: `eval/real_config.local.yaml`
 
-`eval/real_config.local.yaml`이 없으면 인덱싱과 대표 질의까지만 실행하고, 실데이터 gold 평가를 건너뛴다. 새 환경에서는 `eval/real_config.example.yaml`을 복사해 로컬 expected doc id/term/target을 채운다. `eval/*.local.yaml`, 실데이터 원본, 실데이터 산출물은 Git 추적 대상이 아니다.
+`eval/real_config.local.yaml`이 없으면 인덱싱과 대표 질의까지만 실행하고, 실데이터 gold 평가를 건너뛴다. 새 환경에서는 `eval/real_config.example.yaml`을 복사해 로컬 expected doc id/term/target을 채운다(상세 가이드: [`docs/local-gold-authoring.md`](./local-gold-authoring.md)). `eval/*.local.yaml`, 실데이터 원본, 실데이터 산출물은 Git 추적 대상이 아니다.
 
 ## 출력
 - `data/index/index.json`: 기존 RAG index schema를 유지하되, 문서와 chunk에 normalized metadata를 포함한다.
@@ -46,14 +79,39 @@ optional profile을 사용할 때도 index schema는 동일하며, 기본 경로
 - HWP fallback 문서는 metadata에 `visual_fallback_reason: visual_fallback_hwp`, `text_source: data_list_csv_text`를 유지한다.
 - 두 모드 모두 기본 산출물 경로는 `data/index/index.json`과 `data/index/ingestion_report.json`이다. v2는 추가로 `data/index/visual_artifacts/*.visual.json`을 생성한다.
 
-## 실패 처리
+## 실패 처리 (issue #53)
 다음 row는 전체 인덱싱을 중단하지 않고 리포트에 실패로 남긴다.
-- 원본 파일이 없는 경우: `missing_file`
-- CSV 텍스트가 비어 있는 경우: `empty_text`
-- `pdf`, `hwp` 외 형식인 경우: `unsupported_file_format`
-- 동일 `doc_id`가 반복되는 경우: `duplicate_doc_id`
 
-단, 성공적으로 인덱싱 가능한 문서가 0개이면 입력 오류로 보고 빌드를 실패시킨다.
+| reason | stage | downstream 영향 |
+|---|---|---|
+| `missing_file_name` | row | row를 어떤 source 파일에도 매칭할 수 없다. |
+| `missing_doc_id` | row | 안정적인 식별자가 없어 평가가 row를 참조할 수 없다. |
+| `duplicate_doc_id` | row | 두 row가 인덱스에서 충돌하므로 뒤 row를 drop한다. |
+| `unsupported_file_format` | row | v1은 `pdf`, `hwp`만 지원한다. |
+| `missing_file` | filesystem | CSV가 가리키는 원본 파일이 디스크에 없다. |
+| `empty_text` | text | 본문 텍스트가 비어 있어 chunking·embedding 대상이 없다. |
+
+이 표는 `ingestion_report.json`의 `failure_taxonomy` 필드와 동일한 키를 사용한다(`ingestion.FAILURE_TAXONOMY`). reviewer가 산출물을 읽을 때 별도 코드 검색 없이 의미를 파악할 수 있다.
+
+`ingestion_report.json`의 `summary` 섹션은 다음을 노출한다.
+- `failure_reasons`: reason → count.
+- `failure_examples`: reason → 최대 3개의 예시 row(row_number, doc_id, file_name, file_format).
+- `doc_id_sources`: `notice_id` / `file_name` 분포.
+- `file_formats`: 형식별 row 수.
+- `duplicate_doc_ids`: base doc_id → 충돌한 row_number 목록.
+- `on_duplicate_doc_id`: 이번 실행에서 적용된 정책(`fail` 또는 `suffix`).
+
+성공적으로 인덱싱 가능한 문서가 0개이면 입력 오류로 보고 빌드를 실패시킨다.
+
+## 회귀 보호 (issue #54)
+v1 PDF/HWP 혼합 ingestion 경로는 [`tests/test_mixed_format_ingestion_regression.py`](../tests/test_mixed_format_ingestion_regression.py)가 회귀 가드 역할을 한다. 다음을 assert한다.
+
+- PDF + HWP 성공 row가 안정적인 doc_id로 인덱싱된다.
+- 한 mixed corpus에서 `missing_file` / `unsupported_file_format` / `duplicate_doc_id` 세 가지 실패 reason이 grouped count로 잡힌다.
+- `on_duplicate_doc_id="suffix"` 옵트인은 두 번째 row를 정상 인덱싱하고 metadata에 resolution 흔적을 남긴다.
+- `validate_data_list.py` CLI는 실패가 있으면 exit code 1, clean하면 0을 반환한다.
+
+새로운 fixture를 추가할 때는 이 파일의 `_build_mixed_corpus`를 모방하면 된다. 실데이터 원본을 그대로 옮겨오지 말고, 의도하는 실패 패턴을 만족하는 최소 stub만 만든다(예: PDF 헤더 4 byte, 빈 본문 텍스트).
 
 ## 현재 로컬 검증 기준
 현재 로컬 실데이터 샘플은 100개 row로 구성되며, CSV 텍스트 기반 v1 경로에서 100개 문서가 모두 인덱싱된다. 이 수치는 private local data 기준이므로 공개 README 성능표에는 반영하지 않는다.

--- a/ingestion.py
+++ b/ingestion.py
@@ -204,8 +204,8 @@ def normalize_ingestion_row(
     else:
         existing_row = tracker.seen.get(base_doc_id)
         if existing_row is not None:
-            suggested = next_unique_doc_id(base_doc_id, tracker)
             if on_duplicate_doc_id == "suffix":
+                suggested = reserve_next_unique_doc_id(base_doc_id, tracker)
                 doc_id = suggested
                 duplicate_resolution = {
                     "policy": "suffix",
@@ -214,6 +214,10 @@ def normalize_ingestion_row(
                     "assigned_doc_id": suggested,
                 }
             else:
+                # Read-only peek: do not reserve the suggested id, otherwise a
+                # later row whose canonical doc_id is legitimately <base>-N
+                # would be falsely flagged as a duplicate.
+                suggested = peek_next_unique_doc_id(base_doc_id, tracker)
                 failure_reason = "duplicate_doc_id"
                 duplicate_resolution = {
                     "policy": "fail",
@@ -383,12 +387,37 @@ def slug_part(value: str) -> str:
     return normalized
 
 
-def next_unique_doc_id(base_doc_id: str, tracker: _DuplicateTracker) -> str:
+def _compute_next_unique_doc_id(
+    base_doc_id: str,
+    tracker: _DuplicateTracker,
+) -> tuple[str, int]:
     count = tracker.counts.get(base_doc_id, 1) + 1
     candidate = f"{base_doc_id}-{count}"
     while candidate in tracker.seen:
         count += 1
         candidate = f"{base_doc_id}-{count}"
+    return candidate, count
+
+
+def peek_next_unique_doc_id(base_doc_id: str, tracker: _DuplicateTracker) -> str:
+    """Compute the next available ``<base>-N`` id without mutating ``tracker``.
+
+    Used when ``on_duplicate_doc_id="fail"`` so the failure record can carry a
+    ``suggested_doc_id`` for diagnostics without reserving an id that no row
+    will ever take. A later row whose canonical doc_id is legitimately
+    ``<base>-N`` must remain free to claim it.
+    """
+    candidate, _ = _compute_next_unique_doc_id(base_doc_id, tracker)
+    return candidate
+
+
+def reserve_next_unique_doc_id(base_doc_id: str, tracker: _DuplicateTracker) -> str:
+    """Compute and reserve the next ``<base>-N`` id; mutates ``tracker``.
+
+    Used when ``on_duplicate_doc_id="suffix"`` to actually take the id for the
+    duplicate row.
+    """
+    candidate, count = _compute_next_unique_doc_id(base_doc_id, tracker)
     tracker.seen[candidate] = tracker.seen.get(base_doc_id, 0)
     tracker.counts[base_doc_id] = count
     return candidate
@@ -587,13 +616,15 @@ def audit_metadata_row(
     source_path = find_source_file(files_dir, file_name) if file_name else files_dir
     base_doc_id = canonical_doc_id(notice_id, notice_round, file_name)
 
+    # Track non-fatal warnings on fields ingestion accepts but downstream
+    # eval often relies on. Blank body text is NOT a warning: the ingestion
+    # path raises ``empty_text`` for that row, and the validator must
+    # report the same failure so a clean validator exit code can be trusted.
     messages: list[str] = []
     if not clean_cell(row.get("발주 기관")):
         messages.append("blank_agency")
     if not clean_cell(row.get("사업명")):
         messages.append("blank_project")
-    if not clean_cell(row.get("텍스트")):
-        messages.append("blank_text")
 
     duplicate_resolution: dict[str, Any] | None = None
     failure_reason: str | None = None
@@ -610,8 +641,8 @@ def audit_metadata_row(
     else:
         existing_row = tracker.seen.get(base_doc_id)
         if existing_row is not None:
-            suggested = next_unique_doc_id(base_doc_id, tracker)
             if on_duplicate_doc_id == "suffix":
+                suggested = reserve_next_unique_doc_id(base_doc_id, tracker)
                 doc_id = suggested
                 duplicate_resolution = {
                     "policy": "suffix",
@@ -620,6 +651,7 @@ def audit_metadata_row(
                     "assigned_doc_id": suggested,
                 }
             else:
+                suggested = peek_next_unique_doc_id(base_doc_id, tracker)
                 failure_reason = "duplicate_doc_id"
                 duplicate_resolution = {
                     "policy": "fail",
@@ -630,6 +662,8 @@ def audit_metadata_row(
         else:
             tracker.seen[base_doc_id] = row_number
             tracker.counts[base_doc_id] = 1
+            if not clean_cell(row.get("텍스트")):
+                failure_reason = "empty_text"
 
     return make_record(
         row_number,

--- a/ingestion.py
+++ b/ingestion.py
@@ -9,7 +9,8 @@ in the ingestion report.
 from __future__ import annotations
 
 import csv
-from dataclasses import asdict, dataclass
+from collections import OrderedDict
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 import re
 from typing import Any
@@ -26,6 +27,37 @@ REQUIRED_COLUMNS = [
     "텍스트",
 ]
 
+INGESTION_REPORT_SCHEMA_VERSION = 2
+
+# Public, reviewer-facing failure taxonomy for ingestion. Keep keys stable;
+# downstream tooling (eval/run_eval.py, docs, dashboards) reads them.
+FAILURE_TAXONOMY: dict[str, dict[str, str]] = {
+    "missing_file_name": {
+        "stage": "row",
+        "downstream_risk": "Row cannot be matched to any source file.",
+    },
+    "missing_doc_id": {
+        "stage": "row",
+        "downstream_risk": "Row produces no stable identifier; eval cannot reference it.",
+    },
+    "duplicate_doc_id": {
+        "stage": "row",
+        "downstream_risk": "Two rows would collide in the index; later row is dropped.",
+    },
+    "unsupported_file_format": {
+        "stage": "row",
+        "downstream_risk": "PDF/HWP path is the only supported v1 format.",
+    },
+    "missing_file": {
+        "stage": "filesystem",
+        "downstream_risk": "Source file is referenced but not present on disk.",
+    },
+    "empty_text": {
+        "stage": "text",
+        "downstream_risk": "CSV has no body text for this row; nothing to chunk or embed.",
+    },
+}
+
 
 @dataclass(frozen=True)
 class IngestionRecord:
@@ -36,6 +68,22 @@ class IngestionRecord:
     file_format: str
     source_path: str
     reason: str | None = None
+    duplicate_resolution: dict[str, Any] | None = None
+    messages: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    code: str
+    field: str
+    message: str
+    row_number: int | None = None
+
+
+@dataclass
+class _DuplicateTracker:
+    seen: dict[str, int] = field(default_factory=dict)
+    counts: dict[str, int] = field(default_factory=dict)
 
 
 class CsvTextDocumentLoader:
@@ -65,7 +113,14 @@ LOADERS: dict[str, CsvTextDocumentLoader] = {
 def load_documents_from_metadata_csv(
     metadata_csv: Path,
     files_dir: Path,
+    *,
+    on_duplicate_doc_id: str = "fail",
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if on_duplicate_doc_id not in {"fail", "suffix"}:
+        raise ValueError(
+            "on_duplicate_doc_id must be 'fail' or 'suffix'; got: "
+            f"{on_duplicate_doc_id}"
+        )
     if not metadata_csv.exists():
         raise ValueError(f"--metadata_csv does not exist: {metadata_csv}")
     if not metadata_csv.is_file():
@@ -77,17 +132,22 @@ def load_documents_from_metadata_csv(
 
     documents: list[dict[str, Any]] = []
     records: list[IngestionRecord] = []
-    seen_doc_ids: set[str] = set()
+    tracker = _DuplicateTracker()
 
     with metadata_csv.open("r", encoding="utf-8-sig", newline="") as file:
         reader = csv.DictReader(file)
         validate_fieldnames(reader.fieldnames or [], metadata_csv)
         for row_number, row in enumerate(reader, start=2):
-            document, record = normalize_ingestion_row(row, row_number, files_dir, seen_doc_ids)
+            document, record = normalize_ingestion_row(
+                row,
+                row_number,
+                files_dir,
+                tracker,
+                on_duplicate_doc_id=on_duplicate_doc_id,
+            )
             records.append(record)
             if document is not None:
                 documents.append(document)
-                seen_doc_ids.add(document["doc_id"])
 
     if not documents:
         failure_reasons = sorted({record.reason or record.status for record in records})
@@ -96,16 +156,13 @@ def load_documents_from_metadata_csv(
             f"{metadata_csv}. Failure reasons: {', '.join(failure_reasons) or 'none'}"
         )
 
-    report = {
-        "metadata_csv": str(metadata_csv),
-        "files_dir": str(files_dir),
-        "summary": {
-            "total_rows": len(records),
-            "indexed_documents": len(documents),
-            "failed_rows": sum(1 for record in records if record.status == "failed"),
-        },
-        "records": [asdict(record) for record in records],
-    }
+    report = build_ingestion_report(
+        metadata_csv=metadata_csv,
+        files_dir=files_dir,
+        records=records,
+        indexed_count=len(documents),
+        on_duplicate_doc_id=on_duplicate_doc_id,
+    )
     return documents, report
 
 
@@ -121,22 +178,53 @@ def normalize_ingestion_row(
     row: dict[str, str],
     row_number: int,
     files_dir: Path,
-    seen_doc_ids: set[str],
+    tracker: _DuplicateTracker,
+    *,
+    on_duplicate_doc_id: str = "fail",
 ) -> tuple[dict[str, Any] | None, IngestionRecord]:
     notice_id = clean_cell(row.get("공고 번호"))
     notice_round = clean_cell(row.get("공고 차수"))
     file_name = clean_cell(row.get("파일명"))
     file_format = normalize_file_format(row.get("파일형식"), file_name)
     source_path = find_source_file(files_dir, file_name) if file_name else files_dir
-    doc_id = make_doc_id(notice_id, notice_round) if notice_id else make_doc_id_from_file_name(file_name)
+    base_doc_id = canonical_doc_id(notice_id, notice_round, file_name)
 
-    failure_reason = validate_row_basics(
-        doc_id=doc_id,
-        file_name=file_name,
-        file_format=file_format,
-        source_path=source_path,
-        seen_doc_ids=seen_doc_ids,
-    )
+    duplicate_resolution: dict[str, Any] | None = None
+    failure_reason: str | None = None
+    doc_id = base_doc_id
+
+    if not file_name:
+        failure_reason = "missing_file_name"
+    elif not doc_id:
+        failure_reason = "missing_doc_id"
+    elif file_format not in SUPPORTED_FILE_FORMATS:
+        failure_reason = "unsupported_file_format"
+    elif not source_path.exists() or not source_path.is_file():
+        failure_reason = "missing_file"
+    else:
+        existing_row = tracker.seen.get(base_doc_id)
+        if existing_row is not None:
+            suggested = next_unique_doc_id(base_doc_id, tracker)
+            if on_duplicate_doc_id == "suffix":
+                doc_id = suggested
+                duplicate_resolution = {
+                    "policy": "suffix",
+                    "base_doc_id": base_doc_id,
+                    "first_seen_row": existing_row,
+                    "assigned_doc_id": suggested,
+                }
+            else:
+                failure_reason = "duplicate_doc_id"
+                duplicate_resolution = {
+                    "policy": "fail",
+                    "base_doc_id": base_doc_id,
+                    "first_seen_row": existing_row,
+                    "suggested_doc_id": suggested,
+                }
+        else:
+            tracker.seen[base_doc_id] = row_number
+            tracker.counts[base_doc_id] = 1
+
     if failure_reason:
         return None, make_record(
             row_number,
@@ -146,6 +234,7 @@ def normalize_ingestion_row(
             file_format,
             source_path,
             failure_reason,
+            duplicate_resolution=duplicate_resolution,
         )
 
     loader = LOADERS[file_format]
@@ -160,9 +249,14 @@ def normalize_ingestion_row(
             file_format,
             source_path,
             str(exc),
+            duplicate_resolution=duplicate_resolution,
         )
 
     metadata = normalize_metadata(row, file_format, file_name)
+    metadata["doc_id"] = doc_id
+    if duplicate_resolution and on_duplicate_doc_id == "suffix":
+        metadata["doc_id_resolution"] = duplicate_resolution["policy"]
+        metadata["doc_id_base"] = duplicate_resolution["base_doc_id"]
     document = {
         "doc_id": doc_id,
         "title": clean_cell(row.get("사업명")) or Path(file_name).stem,
@@ -179,27 +273,8 @@ def normalize_ingestion_row(
         file_name,
         file_format,
         source_path,
+        duplicate_resolution=duplicate_resolution,
     )
-
-
-def validate_row_basics(
-    doc_id: str | None,
-    file_name: str,
-    file_format: str,
-    source_path: Path,
-    seen_doc_ids: set[str],
-) -> str | None:
-    if not file_name:
-        return "missing_file_name"
-    if not doc_id:
-        return "missing_doc_id"
-    if doc_id in seen_doc_ids:
-        return "duplicate_doc_id"
-    if file_format not in SUPPORTED_FILE_FORMATS:
-        return "unsupported_file_format"
-    if not source_path.exists() or not source_path.is_file():
-        return "missing_file"
-    return None
 
 
 def make_record(
@@ -210,6 +285,9 @@ def make_record(
     file_format: str,
     source_path: Path,
     reason: str | None = None,
+    *,
+    duplicate_resolution: dict[str, Any] | None = None,
+    messages: tuple[str, ...] = (),
 ) -> IngestionRecord:
     return IngestionRecord(
         row_number=row_number,
@@ -219,6 +297,8 @@ def make_record(
         file_format=file_format,
         source_path=str(source_path),
         reason=reason,
+        duplicate_resolution=duplicate_resolution,
+        messages=messages,
     )
 
 
@@ -260,21 +340,58 @@ def find_source_file(files_dir: Path, file_name: str) -> Path:
     return candidate
 
 
+def canonical_doc_id(
+    notice_id: str | None,
+    notice_round: str | None,
+    file_name: str | None,
+) -> str | None:
+    """Single canonical doc_id rule used across ingestion paths.
+
+    Priority:
+      1. ``notice_id`` (+ optional ``notice_round``) if non-empty.
+      2. File-name stem fallback.
+    Both branches NFC-normalize, casefold, and collapse whitespace so the
+    same source row produces the same id across runs and platforms.
+    """
+    notice = clean_cell(notice_id)
+    if notice:
+        return make_doc_id(notice, clean_cell(notice_round))
+    return make_doc_id_from_file_name(clean_cell(file_name or ""))
+
+
 def make_doc_id(notice_id: str, notice_round: str) -> str:
     parts = [notice_id]
     if notice_round:
         parts.append(notice_round)
-    return "-".join(slug_part(part) for part in parts if part)
+    slugged = [slug_part(part) for part in parts if slug_part(part)]
+    return "-".join(slugged)
 
 
 def make_doc_id_from_file_name(file_name: str) -> str | None:
     if not file_name:
         return None
-    return slug_part(Path(file_name).stem)
+    stem = Path(file_name).stem
+    slug = slug_part(stem)
+    return slug or None
 
 
 def slug_part(value: str) -> str:
-    return re.sub(r"\s+", "-", value.strip())
+    if not value:
+        return ""
+    normalized = unicodedata.normalize("NFC", value).strip()
+    normalized = re.sub(r"\s+", "-", normalized)
+    return normalized
+
+
+def next_unique_doc_id(base_doc_id: str, tracker: _DuplicateTracker) -> str:
+    count = tracker.counts.get(base_doc_id, 1) + 1
+    candidate = f"{base_doc_id}-{count}"
+    while candidate in tracker.seen:
+        count += 1
+        candidate = f"{base_doc_id}-{count}"
+    tracker.seen[candidate] = tracker.seen.get(base_doc_id, 0)
+    tracker.counts[base_doc_id] = count
+    return candidate
 
 
 def parse_budget(value: str | None) -> int | float | str | None:
@@ -296,3 +413,292 @@ def clean_cell(value: str | None) -> str:
 
 def normalize_body_text(value: str | None) -> str:
     return clean_cell(value).replace("\r\n", "\n").replace("\r", "\n")
+
+
+def build_ingestion_report(
+    *,
+    metadata_csv: Path,
+    files_dir: Path,
+    records: list[IngestionRecord],
+    indexed_count: int,
+    on_duplicate_doc_id: str,
+) -> dict[str, Any]:
+    """Build the canonical ingestion_report.json payload."""
+    failure_reasons: dict[str, int] = OrderedDict()
+    failure_examples: dict[str, list[dict[str, Any]]] = OrderedDict()
+    doc_id_sources: dict[str, int] = OrderedDict()
+    file_formats: dict[str, int] = OrderedDict()
+    duplicate_groups: dict[str, list[int]] = OrderedDict()
+
+    for record in records:
+        if record.reason:
+            failure_reasons[record.reason] = failure_reasons.get(record.reason, 0) + 1
+            examples = failure_examples.setdefault(record.reason, [])
+            if len(examples) < 3:
+                examples.append(
+                    {
+                        "row_number": record.row_number,
+                        "doc_id": record.doc_id,
+                        "file_name": record.file_name,
+                        "file_format": record.file_format,
+                    }
+                )
+        fmt = record.file_format or "unknown"
+        file_formats[fmt] = file_formats.get(fmt, 0) + 1
+        if record.status == "indexed":
+            source = "notice_id" if _looks_like_notice_id_doc(record) else "file_name"
+            doc_id_sources[source] = doc_id_sources.get(source, 0) + 1
+        _accumulate_duplicate_group(duplicate_groups, record)
+
+    summary = {
+        "schema_version": INGESTION_REPORT_SCHEMA_VERSION,
+        "total_rows": len(records),
+        "indexed_documents": indexed_count,
+        "failed_rows": sum(1 for record in records if record.status == "failed"),
+        "failure_reasons": dict(failure_reasons),
+        "failure_examples": {k: v for k, v in failure_examples.items()},
+        "doc_id_sources": dict(doc_id_sources),
+        "file_formats": dict(file_formats),
+        "duplicate_doc_ids": {k: sorted(set(v)) for k, v in duplicate_groups.items()},
+        "on_duplicate_doc_id": on_duplicate_doc_id,
+    }
+    return {
+        "metadata_csv": str(metadata_csv),
+        "files_dir": str(files_dir),
+        "summary": summary,
+        "failure_taxonomy": FAILURE_TAXONOMY,
+        "records": [_record_to_dict(record) for record in records],
+    }
+
+
+def _accumulate_duplicate_group(
+    duplicate_groups: dict[str, list[int]],
+    record: IngestionRecord,
+) -> None:
+    """Add a record to ``duplicate_groups`` keyed by base_doc_id when applicable."""
+    if not record.duplicate_resolution:
+        return
+    base = str(record.duplicate_resolution.get("base_doc_id") or record.doc_id or "")
+    if not base:
+        return
+    duplicate_groups.setdefault(base, [])
+    duplicate_groups[base].append(record.row_number)
+    first_seen = record.duplicate_resolution.get("first_seen_row")
+    if isinstance(first_seen, int) and first_seen not in duplicate_groups[base]:
+        duplicate_groups[base].append(first_seen)
+
+
+def _looks_like_notice_id_doc(record: IngestionRecord) -> bool:
+    if not record.doc_id or not record.file_name:
+        return True
+    stem_slug = slug_part(Path(record.file_name).stem)
+    return record.doc_id != stem_slug
+
+
+def _record_to_dict(record: IngestionRecord) -> dict[str, Any]:
+    payload = asdict(record)
+    payload["messages"] = list(record.messages)
+    if record.duplicate_resolution is None:
+        payload.pop("duplicate_resolution", None)
+    return payload
+
+
+def validate_data_list_csv(
+    metadata_csv: Path,
+    files_dir: Path,
+    *,
+    on_duplicate_doc_id: str = "fail",
+) -> dict[str, Any]:
+    """Lightweight schema/audit pass over data_list.csv.
+
+    Mirrors the per-row checks of :func:`load_documents_from_metadata_csv`
+    but does not load body text or build documents. Returns a report
+    structurally compatible with ``ingestion_report.json``.
+    """
+    if on_duplicate_doc_id not in {"fail", "suffix"}:
+        raise ValueError(
+            "on_duplicate_doc_id must be 'fail' or 'suffix'; got: "
+            f"{on_duplicate_doc_id}"
+        )
+    if not metadata_csv.exists():
+        raise ValueError(f"metadata_csv does not exist: {metadata_csv}")
+    if not metadata_csv.is_file():
+        raise ValueError(f"metadata_csv must be a file: {metadata_csv}")
+    if not files_dir.exists():
+        raise ValueError(f"files_dir does not exist: {files_dir}")
+    if not files_dir.is_dir():
+        raise ValueError(f"files_dir must be a directory: {files_dir}")
+
+    schema_issues: list[ValidationIssue] = []
+    records: list[IngestionRecord] = []
+    tracker = _DuplicateTracker()
+
+    with metadata_csv.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+        missing = [column for column in REQUIRED_COLUMNS if column not in fieldnames]
+        for column in missing:
+            schema_issues.append(
+                ValidationIssue(
+                    code="missing_required_column",
+                    field=column,
+                    message=f"required column missing: {column}",
+                )
+            )
+        if missing:
+            return _build_validation_report(
+                metadata_csv=metadata_csv,
+                files_dir=files_dir,
+                records=records,
+                schema_issues=schema_issues,
+                on_duplicate_doc_id=on_duplicate_doc_id,
+            )
+        for row_number, row in enumerate(reader, start=2):
+            record = audit_metadata_row(
+                row,
+                row_number,
+                files_dir,
+                tracker,
+                on_duplicate_doc_id=on_duplicate_doc_id,
+            )
+            records.append(record)
+
+    return _build_validation_report(
+        metadata_csv=metadata_csv,
+        files_dir=files_dir,
+        records=records,
+        schema_issues=schema_issues,
+        on_duplicate_doc_id=on_duplicate_doc_id,
+    )
+
+
+def audit_metadata_row(
+    row: dict[str, str],
+    row_number: int,
+    files_dir: Path,
+    tracker: _DuplicateTracker,
+    *,
+    on_duplicate_doc_id: str = "fail",
+) -> IngestionRecord:
+    notice_id = clean_cell(row.get("공고 번호"))
+    notice_round = clean_cell(row.get("공고 차수"))
+    file_name = clean_cell(row.get("파일명"))
+    file_format = normalize_file_format(row.get("파일형식"), file_name)
+    source_path = find_source_file(files_dir, file_name) if file_name else files_dir
+    base_doc_id = canonical_doc_id(notice_id, notice_round, file_name)
+
+    messages: list[str] = []
+    if not clean_cell(row.get("발주 기관")):
+        messages.append("blank_agency")
+    if not clean_cell(row.get("사업명")):
+        messages.append("blank_project")
+    if not clean_cell(row.get("텍스트")):
+        messages.append("blank_text")
+
+    duplicate_resolution: dict[str, Any] | None = None
+    failure_reason: str | None = None
+    doc_id = base_doc_id
+
+    if not file_name:
+        failure_reason = "missing_file_name"
+    elif not doc_id:
+        failure_reason = "missing_doc_id"
+    elif file_format not in SUPPORTED_FILE_FORMATS:
+        failure_reason = "unsupported_file_format"
+    elif not source_path.exists() or not source_path.is_file():
+        failure_reason = "missing_file"
+    else:
+        existing_row = tracker.seen.get(base_doc_id)
+        if existing_row is not None:
+            suggested = next_unique_doc_id(base_doc_id, tracker)
+            if on_duplicate_doc_id == "suffix":
+                doc_id = suggested
+                duplicate_resolution = {
+                    "policy": "suffix",
+                    "base_doc_id": base_doc_id,
+                    "first_seen_row": existing_row,
+                    "assigned_doc_id": suggested,
+                }
+            else:
+                failure_reason = "duplicate_doc_id"
+                duplicate_resolution = {
+                    "policy": "fail",
+                    "base_doc_id": base_doc_id,
+                    "first_seen_row": existing_row,
+                    "suggested_doc_id": suggested,
+                }
+        else:
+            tracker.seen[base_doc_id] = row_number
+            tracker.counts[base_doc_id] = 1
+
+    return make_record(
+        row_number,
+        "failed" if failure_reason else "ok",
+        doc_id,
+        file_name,
+        file_format,
+        source_path,
+        failure_reason,
+        duplicate_resolution=duplicate_resolution,
+        messages=tuple(messages),
+    )
+
+
+def _build_validation_report(
+    *,
+    metadata_csv: Path,
+    files_dir: Path,
+    records: list[IngestionRecord],
+    schema_issues: list[ValidationIssue],
+    on_duplicate_doc_id: str,
+) -> dict[str, Any]:
+    failure_reasons: dict[str, int] = OrderedDict()
+    failure_examples: dict[str, list[dict[str, Any]]] = OrderedDict()
+    file_formats: dict[str, int] = OrderedDict()
+    duplicate_groups: dict[str, list[int]] = OrderedDict()
+    blank_field_counts: dict[str, int] = OrderedDict()
+
+    for record in records:
+        if record.reason:
+            failure_reasons[record.reason] = failure_reasons.get(record.reason, 0) + 1
+            examples = failure_examples.setdefault(record.reason, [])
+            if len(examples) < 3:
+                examples.append(
+                    {
+                        "row_number": record.row_number,
+                        "doc_id": record.doc_id,
+                        "file_name": record.file_name,
+                        "file_format": record.file_format,
+                    }
+                )
+        fmt = record.file_format or "unknown"
+        file_formats[fmt] = file_formats.get(fmt, 0) + 1
+        for message in record.messages:
+            blank_field_counts[message] = blank_field_counts.get(message, 0) + 1
+        _accumulate_duplicate_group(duplicate_groups, record)
+
+    ok_count = sum(1 for record in records if record.status == "ok")
+    failed_count = sum(1 for record in records if record.status == "failed")
+    schema_ok = not schema_issues
+    summary = {
+        "schema_version": INGESTION_REPORT_SCHEMA_VERSION,
+        "schema_ok": schema_ok,
+        "total_rows": len(records),
+        "ok_rows": ok_count,
+        "failed_rows": failed_count,
+        "failure_reasons": dict(failure_reasons),
+        "failure_examples": {k: v for k, v in failure_examples.items()},
+        "blank_field_warnings": dict(blank_field_counts),
+        "file_formats": dict(file_formats),
+        "duplicate_doc_ids": {k: sorted(set(v)) for k, v in duplicate_groups.items()},
+        "on_duplicate_doc_id": on_duplicate_doc_id,
+    }
+    return {
+        "mode": "validation",
+        "metadata_csv": str(metadata_csv),
+        "files_dir": str(files_dir),
+        "summary": summary,
+        "schema_issues": [asdict(issue) for issue in schema_issues],
+        "failure_taxonomy": FAILURE_TAXONOMY,
+        "records": [_record_to_dict(record) for record in records],
+    }

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -81,6 +81,16 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_CHUNK_OVERLAP_SENTENCES,
         help="Number of trailing sentences to overlap between adjacent chunks.",
     )
+    parser.add_argument(
+        "--on_duplicate_doc_id",
+        default="fail",
+        choices=["fail", "suffix"],
+        help=(
+            "How duplicate canonical doc_ids should be handled when ingesting "
+            "from --metadata_csv. 'fail' marks the later row as duplicate; "
+            "'suffix' deterministically appends -2/-3/... to keep both rows."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -145,6 +155,7 @@ def main() -> int:
                 documents, ingestion_report = load_documents_from_metadata_csv(
                     Path(args.metadata_csv),
                     Path(args.files_dir),
+                    on_duplicate_doc_id=args.on_duplicate_doc_id,
                 )
                 message = "PDF/HWP RFP index built from data_list.csv text and joined metadata."
             payload = build_index_payload_from_documents(

--- a/scripts/smoke_real.sh
+++ b/scripts/smoke_real.sh
@@ -38,12 +38,21 @@ require_dir() {
 }
 
 require_file "scripts/build_index.py"
+require_file "scripts/validate_data_list.py"
 require_file "app.py"
 require_file "eval/run_eval.py"
 require_file "$METADATA_CSV"
 require_dir "$FILES_DIR"
 
 mkdir -p "$INDEX_DIR" "$OUTPUT_DIR" "$REPORT_DIR"
+
+log "Validating data_list.csv schema"
+if ! python3 scripts/validate_data_list.py \
+  --metadata_csv "$METADATA_CSV" \
+  --files_dir "$FILES_DIR" \
+  --output_path "$REPORT_DIR/data_list_validation.json"; then
+  echo "[WARN] data_list.csv has row-level issues; review $REPORT_DIR/data_list_validation.json before proceeding." >&2
+fi
 
 log "Building real-data index"
 python3 scripts/build_index.py \

--- a/scripts/validate_data_list.py
+++ b/scripts/validate_data_list.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Standalone validator for ``data_list.csv`` (issue #51).
+
+Runs the same per-row schema audits as ``scripts/build_index.py`` but does
+not load body text, build chunks, or emit an index. The goal is to catch
+column / null / duplicate / format / missing-file problems **before** an
+indexing run, with a reviewer-friendly report.
+
+Exit codes:
+    0  validation passed (no schema issues, no failed rows)
+    1  validation surfaced row-level failures
+    2  CLI usage error or missing inputs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from ingestion import FAILURE_TAXONOMY, validate_data_list_csv
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a data_list.csv against the v1 RFP ingestion schema. "
+            "See docs/real-data-ingestion.md for column rules."
+        )
+    )
+    parser.add_argument("--metadata_csv", required=True, help="Path to data_list.csv.")
+    parser.add_argument(
+        "--files_dir",
+        required=True,
+        help="Directory holding the PDF/HWP files referenced by --metadata_csv.",
+    )
+    parser.add_argument(
+        "--output_path",
+        default=None,
+        help="Optional path to write the JSON validation report.",
+    )
+    parser.add_argument(
+        "--on_duplicate_doc_id",
+        default="fail",
+        choices=["fail", "suffix"],
+        help=(
+            "How duplicate doc_ids should be treated. 'fail' marks the later "
+            "row as a duplicate (current default). 'suffix' deterministically "
+            "renames the duplicate so downstream eval keeps a stable id."
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the summary text printed to stdout.",
+    )
+    return parser.parse_args()
+
+
+def render_summary(report: dict) -> str:
+    summary = report["summary"]
+    schema_issues = report.get("schema_issues") or []
+    lines: list[str] = []
+    lines.append(f"metadata_csv : {report['metadata_csv']}")
+    lines.append(f"files_dir    : {report['files_dir']}")
+    lines.append(
+        f"rows         : total={summary['total_rows']} "
+        f"ok={summary['ok_rows']} failed={summary['failed_rows']}"
+    )
+    lines.append(f"schema_ok    : {summary['schema_ok']}")
+    lines.append(f"on_duplicate : {summary['on_duplicate_doc_id']}")
+
+    if schema_issues:
+        lines.append("schema_issues:")
+        for issue in schema_issues:
+            lines.append(
+                f"  - {issue.get('code')}: {issue.get('field')} -> {issue.get('message')}"
+            )
+
+    if summary["failure_reasons"]:
+        lines.append("failure_reasons:")
+        for reason, count in sorted(summary["failure_reasons"].items()):
+            description = FAILURE_TAXONOMY.get(reason, {}).get("downstream_risk", "")
+            lines.append(f"  - {reason}: {count}  // {description}".rstrip())
+            for example in summary["failure_examples"].get(reason, []):
+                lines.append(
+                    f"      row={example['row_number']} "
+                    f"file={example['file_name'] or '-'} "
+                    f"doc_id={example['doc_id'] or '-'}"
+                )
+
+    if summary["blank_field_warnings"]:
+        lines.append("blank_field_warnings:")
+        for warning, count in sorted(summary["blank_field_warnings"].items()):
+            lines.append(f"  - {warning}: {count}")
+
+    if summary["duplicate_doc_ids"]:
+        lines.append("duplicate_doc_ids:")
+        for base, rows in summary["duplicate_doc_ids"].items():
+            lines.append(f"  - {base}: rows={rows}")
+
+    if summary["file_formats"]:
+        lines.append("file_formats:")
+        for fmt, count in sorted(summary["file_formats"].items()):
+            lines.append(f"  - {fmt}: {count}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        metadata_csv = Path(args.metadata_csv)
+        files_dir = Path(args.files_dir)
+        report = validate_data_list_csv(
+            metadata_csv,
+            files_dir,
+            on_duplicate_doc_id=args.on_duplicate_doc_id,
+        )
+    except ValueError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
+
+    if args.output_path:
+        output_path = Path(args.output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    if not args.quiet:
+        print(render_summary(report))
+        if args.output_path:
+            print(f"\n[OK] Validation report written: {args.output_path}")
+
+    summary = report["summary"]
+    if not summary["schema_ok"] or summary["failed_rows"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_data_list_validation.py
+++ b/tests/test_data_list_validation.py
@@ -209,7 +209,11 @@ class ValidateDataListCsvTest(unittest.TestCase):
             self.assertEqual(2, resolution["first_seen_row"])
             self.assertEqual("20240001-0-2", resolution["suggested_doc_id"])
 
-    def test_blank_required_field_warnings_are_separate_from_failures(self) -> None:
+    def test_blank_text_is_a_failure_not_a_warning(self) -> None:
+        # Mirrors the ingestion path which raises ``empty_text`` for blank
+        # body text. Validating a CSV where every row has empty text must
+        # not exit clean — otherwise the pre-flight check claims success
+        # for inputs that will fail the actual index build.
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             files_dir = root / "files"
@@ -233,12 +237,92 @@ class ValidateDataListCsvTest(unittest.TestCase):
                 ],
             )
             report = validate_data_list_csv(csv_path, files_dir)
-            self.assertEqual(1, report["summary"]["ok_rows"])
-            self.assertEqual(0, report["summary"]["failed_rows"])
-            warnings = report["summary"]["blank_field_warnings"]
+            self.assertEqual(0, report["summary"]["ok_rows"])
+            self.assertEqual(1, report["summary"]["failed_rows"])
             self.assertEqual(
-                {"blank_agency": 1, "blank_project": 1, "blank_text": 1},
-                warnings,
+                {"empty_text": 1},
+                report["summary"]["failure_reasons"],
+            )
+            warnings = report["summary"]["blank_field_warnings"]
+            self.assertEqual({"blank_agency": 1, "blank_project": 1}, warnings)
+            self.assertNotIn("blank_text", warnings)
+            self.assertIn("empty_text", report["failure_taxonomy"])
+
+    def test_fail_policy_does_not_reserve_suggested_doc_id(self) -> None:
+        # Regression for codex P1: under ``on_duplicate_doc_id="fail"`` the
+        # second collision row only *suggests* ``<base>-2`` for diagnostics.
+        # A later row whose canonical doc_id is legitimately ``<base>-2``
+        # must remain free to claim it instead of being flagged as a
+        # spurious duplicate.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files_dir = root / "files"
+            files_dir.mkdir()
+            for name in ("a.pdf", "b.pdf", "c.pdf"):
+                (files_dir / name).write_bytes(b"%PDF-1.4\n")
+            csv_path = root / "data_list.csv"
+            _write_csv(
+                csv_path,
+                rows=[
+                    _row(
+                        **{
+                            "공고 번호": "20240001",
+                            "공고 차수": "0",
+                            "사업명": "원본",
+                            "발주 기관": "기관 A",
+                            "파일형식": "pdf",
+                            "파일명": "a.pdf",
+                            "텍스트": "본문 가",
+                        }
+                    ),
+                    _row(
+                        **{
+                            "공고 번호": "20240001",
+                            "공고 차수": "0",
+                            "사업명": "충돌",
+                            "발주 기관": "기관 A",
+                            "파일형식": "pdf",
+                            "파일명": "b.pdf",
+                            "텍스트": "본문 나",
+                        }
+                    ),
+                    _row(
+                        **{
+                            "공고 번호": "20240001-0-2",
+                            "공고 차수": "",
+                            "사업명": "별개 공고",
+                            "발주 기관": "기관 B",
+                            "파일형식": "pdf",
+                            "파일명": "c.pdf",
+                            "텍스트": "본문 다",
+                        }
+                    ),
+                ],
+            )
+
+            report = validate_data_list_csv(csv_path, files_dir)
+            self.assertEqual(2, report["summary"]["ok_rows"])
+            self.assertEqual(1, report["summary"]["failed_rows"])
+            self.assertEqual(
+                {"duplicate_doc_id": 1},
+                report["summary"]["failure_reasons"],
+            )
+            ok_doc_ids = sorted(
+                record["doc_id"]
+                for record in report["records"]
+                if record["status"] == "ok"
+            )
+            self.assertEqual(["20240001-0", "20240001-0-2"], ok_doc_ids)
+
+            documents, ingestion_report = load_documents_from_metadata_csv(
+                csv_path,
+                files_dir,
+            )
+            indexed_doc_ids = sorted(doc["doc_id"] for doc in documents)
+            self.assertEqual(["20240001-0", "20240001-0-2"], indexed_doc_ids)
+            self.assertEqual(
+                {"duplicate_doc_id": 1},
+                ingestion_report["summary"]["failure_reasons"],
             )
 
 

--- a/tests/test_data_list_validation.py
+++ b/tests/test_data_list_validation.py
@@ -1,0 +1,304 @@
+"""Tests for issue #51 (data_list.csv validator) and #52 (canonical doc_id)."""
+
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from ingestion import (
+    FAILURE_TAXONOMY,
+    canonical_doc_id,
+    load_documents_from_metadata_csv,
+    make_doc_id,
+    make_doc_id_from_file_name,
+    validate_data_list_csv,
+)
+
+
+FIELDNAMES = [
+    "공고 번호",
+    "공고 차수",
+    "사업명",
+    "사업 금액",
+    "발주 기관",
+    "공개 일자",
+    "입찰 참여 시작일",
+    "입찰 참여 마감일",
+    "사업 요약",
+    "파일형식",
+    "파일명",
+    "텍스트",
+]
+
+
+def _row(**kwargs: str) -> dict[str, str]:
+    base = {column: "" for column in FIELDNAMES}
+    base.update(kwargs)
+    return base
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]], fieldnames: list[str] | None = None) -> None:
+    fieldnames = fieldnames or FIELDNAMES
+    with path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class CanonicalDocIdTest(unittest.TestCase):
+    """Issue #52 — deterministic doc_id generation."""
+
+    def test_notice_id_priority_over_file_name(self) -> None:
+        self.assertEqual(
+            "20240001-1",
+            canonical_doc_id("20240001", "1", "anything.pdf"),
+        )
+
+    def test_file_name_fallback_when_notice_id_missing(self) -> None:
+        self.assertEqual(
+            "교육과정-안내서",
+            canonical_doc_id("", "", "교육과정 안내서.pdf"),
+        )
+
+    def test_returns_none_when_no_signal(self) -> None:
+        self.assertIsNone(canonical_doc_id("", "", ""))
+
+    def test_canonical_normalization_is_idempotent(self) -> None:
+        first = canonical_doc_id("  20240001 ", "1.0", "Sample.pdf")
+        second = canonical_doc_id("20240001", "1.0", "Sample.pdf")
+        self.assertEqual(first, second)
+
+    def test_make_doc_id_collapses_internal_whitespace(self) -> None:
+        self.assertEqual("a-b-c", make_doc_id("a b", "c"))
+
+    def test_make_doc_id_from_file_name_handles_unicode(self) -> None:
+        self.assertEqual(
+            "사업-안내서",
+            make_doc_id_from_file_name("사업 안내서.pdf"),
+        )
+
+
+class ValidateDataListCsvTest(unittest.TestCase):
+    """Issue #51 — schema audit + #53 grouped diagnostics."""
+
+    def test_missing_required_column_is_a_schema_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "files").mkdir()
+            csv_path = root / "data_list.csv"
+            partial_fieldnames = [c for c in FIELDNAMES if c != "발주 기관"]
+            _write_csv(csv_path, rows=[], fieldnames=partial_fieldnames)
+            report = validate_data_list_csv(csv_path, root / "files")
+            self.assertFalse(report["summary"]["schema_ok"])
+            codes = {issue["code"] for issue in report["schema_issues"]}
+            self.assertIn("missing_required_column", codes)
+            fields = {issue["field"] for issue in report["schema_issues"]}
+            self.assertIn("발주 기관", fields)
+
+    def test_grouped_failure_reasons_with_examples(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files_dir = root / "files"
+            files_dir.mkdir()
+            (files_dir / "ok.pdf").write_bytes(b"%PDF-1.4\n")
+            csv_path = root / "data_list.csv"
+            _write_csv(
+                csv_path,
+                rows=[
+                    _row(
+                        **{
+                            "공고 번호": "1",
+                            "공고 차수": "0",
+                            "사업명": "정상 사업",
+                            "발주 기관": "기관 A",
+                            "파일형식": "pdf",
+                            "파일명": "ok.pdf",
+                            "텍스트": "본문",
+                        }
+                    ),
+                    _row(
+                        **{
+                            "공고 번호": "2",
+                            "공고 차수": "0",
+                            "사업명": "누락 사업",
+                            "발주 기관": "기관 B",
+                            "파일형식": "pdf",
+                            "파일명": "missing.pdf",
+                            "텍스트": "본문",
+                        }
+                    ),
+                    _row(
+                        **{
+                            "공고 번호": "3",
+                            "공고 차수": "0",
+                            "사업명": "지원되지 않는 형식",
+                            "발주 기관": "기관 C",
+                            "파일형식": "doc",
+                            "파일명": "weird.doc",
+                            "텍스트": "본문",
+                        }
+                    ),
+                ],
+            )
+            report = validate_data_list_csv(csv_path, files_dir)
+            self.assertTrue(report["summary"]["schema_ok"])
+            self.assertEqual(3, report["summary"]["total_rows"])
+            self.assertEqual(1, report["summary"]["ok_rows"])
+            self.assertEqual(2, report["summary"]["failed_rows"])
+            self.assertEqual(
+                {"missing_file": 1, "unsupported_file_format": 1},
+                report["summary"]["failure_reasons"],
+            )
+            self.assertEqual(
+                ["missing_file", "unsupported_file_format"],
+                sorted(report["summary"]["failure_examples"].keys()),
+            )
+            for examples in report["summary"]["failure_examples"].values():
+                self.assertGreaterEqual(len(examples), 1)
+            self.assertEqual(report["failure_taxonomy"], FAILURE_TAXONOMY)
+
+    def test_duplicate_resolution_explains_collision_under_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files_dir = root / "files"
+            files_dir.mkdir()
+            (files_dir / "a.pdf").write_bytes(b"%PDF-1.4\n")
+            (files_dir / "b.pdf").write_bytes(b"%PDF-1.4\n")
+            csv_path = root / "data_list.csv"
+            _write_csv(
+                csv_path,
+                rows=[
+                    _row(
+                        **{
+                            "공고 번호": "20240001",
+                            "공고 차수": "0",
+                            "사업명": "원본",
+                            "발주 기관": "기관",
+                            "파일형식": "pdf",
+                            "파일명": "a.pdf",
+                            "텍스트": "본문",
+                        }
+                    ),
+                    _row(
+                        **{
+                            "공고 번호": "20240001",
+                            "공고 차수": "0",
+                            "사업명": "충돌",
+                            "발주 기관": "기관",
+                            "파일형식": "pdf",
+                            "파일명": "b.pdf",
+                            "텍스트": "본문",
+                        }
+                    ),
+                ],
+            )
+            report = validate_data_list_csv(csv_path, files_dir)
+            self.assertEqual(
+                {"duplicate_doc_id": 1},
+                report["summary"]["failure_reasons"],
+            )
+            duplicates = report["summary"]["duplicate_doc_ids"]
+            self.assertIn("20240001-0", duplicates)
+            self.assertEqual([2, 3], duplicates["20240001-0"])
+            second_record = next(
+                record for record in report["records"] if record["row_number"] == 3
+            )
+            self.assertEqual("duplicate_doc_id", second_record["reason"])
+            resolution = second_record["duplicate_resolution"]
+            self.assertEqual("fail", resolution["policy"])
+            self.assertEqual(2, resolution["first_seen_row"])
+            self.assertEqual("20240001-0-2", resolution["suggested_doc_id"])
+
+    def test_blank_required_field_warnings_are_separate_from_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files_dir = root / "files"
+            files_dir.mkdir()
+            (files_dir / "a.pdf").write_bytes(b"%PDF-1.4\n")
+            csv_path = root / "data_list.csv"
+            _write_csv(
+                csv_path,
+                rows=[
+                    _row(
+                        **{
+                            "공고 번호": "1",
+                            "공고 차수": "0",
+                            "사업명": "",
+                            "발주 기관": "",
+                            "파일형식": "pdf",
+                            "파일명": "a.pdf",
+                            "텍스트": "",
+                        }
+                    ),
+                ],
+            )
+            report = validate_data_list_csv(csv_path, files_dir)
+            self.assertEqual(1, report["summary"]["ok_rows"])
+            self.assertEqual(0, report["summary"]["failed_rows"])
+            warnings = report["summary"]["blank_field_warnings"]
+            self.assertEqual(
+                {"blank_agency": 1, "blank_project": 1, "blank_text": 1},
+                warnings,
+            )
+
+
+class IngestionDuplicateResolutionTest(unittest.TestCase):
+    """Issue #52 — auto-suffix policy keeps the second row indexable."""
+
+    def test_suffix_policy_assigns_next_available_doc_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files_dir = root / "files"
+            files_dir.mkdir()
+            (files_dir / "a.pdf").write_bytes(b"%PDF-1.4\n")
+            (files_dir / "b.pdf").write_bytes(b"%PDF-1.4\n")
+            csv_path = root / "data_list.csv"
+            _write_csv(
+                csv_path,
+                rows=[
+                    _row(
+                        **{
+                            "공고 번호": "20240001",
+                            "공고 차수": "0",
+                            "사업명": "원본",
+                            "발주 기관": "기관",
+                            "파일형식": "pdf",
+                            "파일명": "a.pdf",
+                            "텍스트": "본문 가",
+                        }
+                    ),
+                    _row(
+                        **{
+                            "공고 번호": "20240001",
+                            "공고 차수": "0",
+                            "사업명": "복원",
+                            "발주 기관": "기관",
+                            "파일형식": "pdf",
+                            "파일명": "b.pdf",
+                            "텍스트": "본문 나",
+                        }
+                    ),
+                ],
+            )
+
+            documents, report = load_documents_from_metadata_csv(
+                csv_path,
+                files_dir,
+                on_duplicate_doc_id="suffix",
+            )
+
+            self.assertEqual(2, len(documents))
+            self.assertEqual("20240001-0", documents[0]["doc_id"])
+            self.assertEqual("20240001-0-2", documents[1]["doc_id"])
+            self.assertEqual("suffix", documents[1]["metadata"]["doc_id_resolution"])
+            self.assertEqual("20240001-0", documents[1]["metadata"]["doc_id_base"])
+            self.assertEqual(
+                {"20240001-0": [2, 3]},
+                report["summary"]["duplicate_doc_ids"],
+            )
+            self.assertEqual("suffix", report["summary"]["on_duplicate_doc_id"])
+            self.assertEqual({}, report["summary"]["failure_reasons"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mixed_format_ingestion_regression.py
+++ b/tests/test_mixed_format_ingestion_regression.py
@@ -1,0 +1,297 @@
+"""Mixed PDF/HWP ingestion regression suite (issue #54).
+
+Protects the v1 CSV-text path against regressions in:
+  * mixed PDF + HWP success rows producing stable doc_ids
+  * per-failure-reason grouped diagnostics in ingestion_report.json
+  * duplicate handling under both 'fail' and 'suffix' policies
+  * downstream RAG payload contract for the mixed corpus
+
+Tests deliberately use small text fixtures so the suite stays fast and
+CI-friendly. Extending the suite is documented in
+``docs/real-data-ingestion.md``.
+"""
+
+import csv
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from ingestion import (
+    INGESTION_REPORT_SCHEMA_VERSION,
+    load_documents_from_metadata_csv,
+)
+from rag_core import build_index_payload_from_documents
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+FIELDNAMES = [
+    "공고 번호",
+    "공고 차수",
+    "사업명",
+    "사업 금액",
+    "발주 기관",
+    "공개 일자",
+    "입찰 참여 시작일",
+    "입찰 참여 마감일",
+    "사업 요약",
+    "파일형식",
+    "파일명",
+    "텍스트",
+]
+
+
+def _row(**kwargs: str) -> dict[str, str]:
+    base = {column: "" for column in FIELDNAMES}
+    base.update(kwargs)
+    return base
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _build_mixed_corpus(root: Path) -> tuple[Path, Path, list[dict[str, str]]]:
+    files_dir = root / "files"
+    files_dir.mkdir()
+    (files_dir / "pdf-success.pdf").write_bytes(b"%PDF-1.4\n")
+    (files_dir / "hwp-success.hwp").write_bytes(b"HWP DOC")
+    (files_dir / "pdf-dup-a.pdf").write_bytes(b"%PDF-1.4\n")
+    (files_dir / "pdf-dup-b.pdf").write_bytes(b"%PDF-1.4\n")
+    (files_dir / "weird.doc").write_bytes(b"WORD")
+
+    csv_path = root / "data_list.csv"
+    rows = [
+        _row(
+            **{
+                "공고 번호": "20240001",
+                "공고 차수": "0",
+                "사업명": "PDF 사업",
+                "발주 기관": "기관 A",
+                "파일형식": "pdf",
+                "파일명": "pdf-success.pdf",
+                "텍스트": "PDF 본문 내용 보안 요구사항.",
+            }
+        ),
+        _row(
+            **{
+                "공고 번호": "20240002",
+                "공고 차수": "1",
+                "사업명": "HWP 사업",
+                "발주 기관": "기관 B",
+                "파일형식": "hwp",
+                "파일명": "hwp-success.hwp",
+                "텍스트": "HWP 본문 내용 일정 정보.",
+            }
+        ),
+        _row(
+            **{
+                "공고 번호": "20240003",
+                "공고 차수": "0",
+                "사업명": "누락 파일",
+                "발주 기관": "기관 C",
+                "파일형식": "pdf",
+                "파일명": "missing.pdf",
+                "텍스트": "본문이 있어도 파일이 없으면 인덱싱 실패.",
+            }
+        ),
+        _row(
+            **{
+                "공고 번호": "20240004",
+                "공고 차수": "0",
+                "사업명": "지원되지 않는 형식",
+                "발주 기관": "기관 D",
+                "파일형식": "doc",
+                "파일명": "weird.doc",
+                "텍스트": "본문",
+            }
+        ),
+        _row(
+            **{
+                "공고 번호": "20240005",
+                "공고 차수": "0",
+                "사업명": "원본",
+                "발주 기관": "기관 E",
+                "파일형식": "pdf",
+                "파일명": "pdf-dup-a.pdf",
+                "텍스트": "본문 가",
+            }
+        ),
+        _row(
+            **{
+                "공고 번호": "20240005",
+                "공고 차수": "0",
+                "사업명": "충돌",
+                "발주 기관": "기관 E",
+                "파일형식": "pdf",
+                "파일명": "pdf-dup-b.pdf",
+                "텍스트": "본문 나",
+            }
+        ),
+    ]
+    _write_csv(csv_path, rows)
+    return csv_path, files_dir, rows
+
+
+class MixedFormatIngestionTest(unittest.TestCase):
+    def test_default_fail_policy_indexes_three_and_reports_three_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csv_path, files_dir, _ = _build_mixed_corpus(root)
+            documents, report = load_documents_from_metadata_csv(csv_path, files_dir)
+
+            self.assertEqual(3, len(documents))
+            doc_ids = {doc["doc_id"] for doc in documents}
+            self.assertEqual(
+                {"20240001-0", "20240002-1", "20240005-0"},
+                doc_ids,
+            )
+
+            summary = report["summary"]
+            self.assertEqual(INGESTION_REPORT_SCHEMA_VERSION, summary["schema_version"])
+            self.assertEqual(6, summary["total_rows"])
+            self.assertEqual(3, summary["indexed_documents"])
+            self.assertEqual(3, summary["failed_rows"])
+            self.assertEqual(
+                {
+                    "missing_file": 1,
+                    "unsupported_file_format": 1,
+                    "duplicate_doc_id": 1,
+                },
+                summary["failure_reasons"],
+            )
+            self.assertEqual({"pdf": 4, "hwp": 1, "doc": 1}, summary["file_formats"])
+            self.assertEqual({"notice_id": 3}, summary["doc_id_sources"])
+            self.assertEqual(
+                {"20240005-0": [6, 7]},
+                summary["duplicate_doc_ids"],
+            )
+            for reason in ("missing_file", "unsupported_file_format", "duplicate_doc_id"):
+                examples = summary["failure_examples"].get(reason)
+                self.assertTrue(examples, f"missing examples for reason: {reason}")
+            taxonomy = report["failure_taxonomy"]
+            for reason in summary["failure_reasons"]:
+                self.assertIn(reason, taxonomy)
+
+    def test_suffix_policy_keeps_duplicate_row_indexable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csv_path, files_dir, _ = _build_mixed_corpus(root)
+            documents, report = load_documents_from_metadata_csv(
+                csv_path,
+                files_dir,
+                on_duplicate_doc_id="suffix",
+            )
+
+            self.assertEqual(4, len(documents))
+            doc_ids = [doc["doc_id"] for doc in documents]
+            self.assertIn("20240005-0", doc_ids)
+            self.assertIn("20240005-0-2", doc_ids)
+            second = next(d for d in documents if d["doc_id"] == "20240005-0-2")
+            self.assertEqual("suffix", second["metadata"]["doc_id_resolution"])
+            self.assertEqual("20240005-0", second["metadata"]["doc_id_base"])
+
+            summary = report["summary"]
+            self.assertEqual(2, summary["failed_rows"])
+            self.assertNotIn("duplicate_doc_id", summary["failure_reasons"])
+            self.assertEqual("suffix", summary["on_duplicate_doc_id"])
+
+    def test_rag_payload_chunks_carry_mixed_format_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csv_path, files_dir, _ = _build_mixed_corpus(root)
+            documents, _ = load_documents_from_metadata_csv(csv_path, files_dir)
+
+            payload = build_index_payload_from_documents(
+                documents,
+                source_dir=str(csv_path),
+                embedding_backend="hashing",
+            )
+
+            self.assertEqual(3, payload["build"]["num_documents"])
+            self.assertGreaterEqual(payload["build"]["num_chunks"], 3)
+            chunk_formats = {
+                chunk["metadata"]["file_format"] for chunk in payload["chunks"]
+            }
+            self.assertEqual({"pdf", "hwp"}, chunk_formats)
+            self.assertTrue(
+                all(chunk["metadata"]["text_source"] == "data_list_csv_text" for chunk in payload["chunks"])
+            )
+
+    def test_validate_data_list_cli_returns_exit_code_one_for_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csv_path, files_dir, _ = _build_mixed_corpus(root)
+            output_path = root / "validation.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "validate_data_list.py"),
+                    "--metadata_csv",
+                    str(csv_path),
+                    "--files_dir",
+                    str(files_dir),
+                    "--output_path",
+                    str(output_path),
+                    "--quiet",
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            self.assertEqual(1, result.returncode, result.stderr)
+            report = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual("validation", report["mode"])
+            self.assertTrue(report["summary"]["schema_ok"])
+            self.assertEqual(3, report["summary"]["failed_rows"])
+            self.assertIn("duplicate_doc_id", report["summary"]["failure_reasons"])
+
+    def test_validate_data_list_cli_returns_exit_code_zero_when_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files_dir = root / "files"
+            files_dir.mkdir()
+            (files_dir / "ok.pdf").write_bytes(b"%PDF-1.4\n")
+            csv_path = root / "data_list.csv"
+            _write_csv(
+                csv_path,
+                rows=[
+                    _row(
+                        **{
+                            "공고 번호": "1",
+                            "공고 차수": "0",
+                            "사업명": "정상",
+                            "발주 기관": "기관",
+                            "파일형식": "pdf",
+                            "파일명": "ok.pdf",
+                            "텍스트": "본문",
+                        }
+                    ),
+                ],
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "validate_data_list.py"),
+                    "--metadata_csv",
+                    str(csv_path),
+                    "--files_dir",
+                    str(files_dir),
+                    "--quiet",
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Resolves the ingestion-side Phase 0 children of [#49](https://github.com/hskim-solv/BidMate-DocAgent/issues/49) (real-data validation roadmap, follow-up to #47). Lays the foundation that the retrieval/eval Phase 0 children will build on; intentionally does **not** touch retrieval logic so the diff stays reviewable.

Closes [#50](https://github.com/hskim-solv/BidMate-DocAgent/issues/50), [#51](https://github.com/hskim-solv/BidMate-DocAgent/issues/51), [#52](https://github.com/hskim-solv/BidMate-DocAgent/issues/52), [#53](https://github.com/hskim-solv/BidMate-DocAgent/issues/53), [#54](https://github.com/hskim-solv/BidMate-DocAgent/issues/54).

## What's in this PR

### #52 — Canonical `doc_id` rule
- New `ingestion.canonical_doc_id(notice_id, notice_round, file_name)` enforces a single rule across ingestion paths: `notice_id [+ notice_round]` → `file_name` stem fallback. Both branches NFC-normalize and collapse internal whitespace so the same source row produces the same id across runs and platforms.
- New opt-in `on_duplicate_doc_id="suffix"` policy: deterministic `<base>-2`, `<base>-3` suffixes when duplicates appear, with `metadata.doc_id_resolution` / `metadata.doc_id_base` recorded for traceability. Default remains `"fail"` for backward compat (existing test still passes).
- `IngestionRecord` now carries `duplicate_resolution` (`first_seen_row`, `suggested_doc_id`) so failures are explainable.

### #53 — Ingestion report schema v2
- `INGESTION_REPORT_SCHEMA_VERSION = 2`. The `summary` block now exposes `failure_reasons`, `failure_examples` (max 3 per reason), `doc_id_sources`, `file_formats`, `duplicate_doc_ids`, and `on_duplicate_doc_id`.
- Added a public `ingestion.FAILURE_TAXONOMY` (mirroring `eval/run_parser_eval.py`) so reviewers can read the report without grepping code.

### #51 — `data_list.csv` validator + CLI
- New `ingestion.validate_data_list_csv()` runs the same per-row audits without loading body text or building documents.
- New `scripts/validate_data_list.py` CLI: JSON output with `--output_path`, taxonomy descriptions inline in stdout, exit codes 0/1/2.
- `scripts/smoke_real.sh` now calls the validator as a pre-flight step and writes `data_list_validation.json` next to eval outputs.

### #54 — Mixed PDF/HWP regression suite
- `tests/test_mixed_format_ingestion_regression.py` exercises a 6-row corpus (PDF + HWP success, missing file, unsupported format, duplicate pair) and asserts:
  - grouped failure counts in the report
  - `on_duplicate_doc_id="suffix"` keeps the duplicate row indexable with a stable id
  - downstream RAG payload preserves mixed-format metadata
  - validator CLI exit codes (0 clean, 1 with row failures)
- Fixture-extension guidance documented in `docs/real-data-ingestion.md`.

### #50 — Local gold authoring guide
- New [`docs/local-gold-authoring.md`](https://github.com/hskim-solv/BidMate-DocAgent/blob/feat/49-phase0-real-data-roadmap/docs/local-gold-authoring.md): required fields, answerable + abstention + follow-up examples, doc_id lookup flow, validation flow, confidentiality rules. Linked from `docs/README.md` and `docs/real-data-ingestion.md`.

### #49 status mapping

| # | Status |
|---|---|
| #50 docs guide | **fully resolved** |
| #51 csv validator | **fully resolved** |
| #52 canonical doc_id | **fully resolved** |
| #53 ingestion diagnostics | **fully resolved** |
| #54 mixed regression suite | **fully resolved** |
| #55 staged filter policy | deferred (retrieval PR) |
| #56 fuzzy / alias lexicon | deferred (retrieval PR) |
| #57 follow-up entity resolution | deferred (multi-turn PR after #56) |
| #58 public eval expansion | deferred (eval-only PR) |

Recommended split for the rest of #49: PR B (#55+#56), PR C (#57), PR D (#58).

## Why now

Phase 0 of #47/#49 prioritized ingestion-side foundations because the real-data failure taxonomy (`docs/real-data-failure-taxonomy.md`) traces several C1/C2/C6 retrieval misses back to inconsistent `doc_id` generation, weak duplicate handling, and coarse failure diagnostics. Hardening those primitives first makes the retrieval-side fixes (#55, #56) easier to evaluate cleanly.

## What's intentionally not in this PR

- No retrieval logic changes (no edits to `rag_core.py` `analyze_query`, `metadata_filters_from_matches`, `verify_evidence`, etc).
- No public eval set expansion or slice metric changes (already grouped `by_query_type`; expansion is content authoring).
- No README metrics table refresh — kept this PR focused on Phase 0 ingestion foundations.

## Test plan

- [x] `python3 -m pytest tests/` — 68 passed (52 prior + 16 new).
- [x] `bash scripts/smoke.sh` — public synthetic baseline still runs end-to-end.
- [x] `python3 scripts/validate_data_list.py --metadata_csv … --files_dir …` — manually tested with both clean (exit 0) and failure-rich (exit 1) fixtures, output renders grouped reasons with taxonomy descriptions inline.
- [ ] Reviewer: confirm doc cross-links resolve (`docs/README.md` → `docs/local-gold-authoring.md`, `docs/real-data-ingestion.md` → `local-gold-authoring.md`, validator script).
- [ ] Reviewer: confirm `eval/real_config.local.yaml` is still .gitignored after this PR (no new tracked private gold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)