### PR TITLE
Phase 1: harden grounding and eval reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ### 3) 성과 (Outcome)
 - 평가 범위: 단일 문서 추출, 단일 문서 심화 탐색, 다문서 비교, 후속 질문, 부재 정보 판별
-- 핵심 지표: Answer Accuracy, Groundedness, Citation Precision, Abstention Accuracy, Latency, Retry Rate
+- 핵심 지표: Answer Accuracy, Groundedness, Citation Precision, Claim Citation Alignment, Abstention Accuracy, Latency, Retry Rate
 - 상세 수치/해석은 아래 성능표 및 `docs/` 문서 참고
 
 ### 4) 재현 (Reproducibility)
@@ -62,6 +62,7 @@
 ## Demo / 산출물
 - 질의 실행 결과: `outputs/answer.json`
 - 평가 요약: `reports/eval_summary.json`
+- Planner/rewrite trace: `reports/traces/<run>/<case>.trace.json` (`eval/run_eval.py` 실행 시 생성, Git 미추적)
 - Benchmark registry: `benchmarks/registry.json`
 - Benchmark local artifacts: `artifacts/benchmarks/` (gitignored)
 - PDF/HWP ingestion 진단 리포트: `data/index/ingestion_report.json` (`--metadata_csv` 사용 시)
@@ -72,9 +73,11 @@
 
 ## 답변 출력 정책
 
-`outputs/answer.json`의 `answer`는 구조화된 객체입니다. `status`는 `supported`, `partial`, `insufficient` 중 하나이며, `claims`의 각 항목은 `target`, `claim`, `support`, `citations`를 포함합니다. 근거가 부족하면 `claims`를 비우고 `insufficiency`에 사유와 확인 대상이 기록됩니다.
+`outputs/answer.json`의 `answer`는 `schema_version: 2`인 구조화 객체입니다. `status`는 `supported`, `partial`, `insufficient` 중 하나이며, `status_reason`은 machine-readable 사유를 담습니다. `claims`의 각 항목은 `target`, `claim`, `support`, `citations`를 포함합니다. 근거가 부족하면 `claims`를 비우고 `insufficiency`에 사유와 확인 대상이 기록됩니다.
 
 CLI와 리뷰 편의를 위해 같은 내용을 사람이 읽기 쉬운 `answer_text`로도 제공합니다. 자세한 예시는 [`docs/answer-policy.md`](docs/answer-policy.md)를 참고하세요.
+
+Planner와 query rewrite 결정은 `outputs/answer.json`의 `trace`와 eval 실행 후 `reports/traces/`에서 확인할 수 있습니다. Grounding/eval hardening 변경 사항과 trace 해석 방법은 [`docs/grounding-eval-hardening.md`](docs/grounding-eval-hardening.md)를 참고하세요.
 
 ## Baseline policy
 
@@ -89,26 +92,27 @@ CLI와 리뷰 편의를 위해 같은 내용을 사람이 읽기 쉬운 `answer_
 <!-- METRICS_TABLE:START -->
 | Category | Metric | Score |
 |---|---:|---:|
-| Overall | Answer Accuracy | 0.808 |
+| Overall | Answer Accuracy | 0.821 |
 | Single-doc extraction | Answer Accuracy | 1.000 |
-| Multi-doc comparison | Groundedness Rate | 0.667 |
+| Multi-doc comparison | Groundedness Rate | 0.700 |
 | Follow-up | Answer Accuracy | 0.750 |
-| Evidence | Citation Precision | 0.455 |
-| Evidence | Answer Format Compliance | 0.667 |
+| Evidence | Citation Precision | 0.471 |
+| Evidence | Claim Citation Alignment | 0.970 |
+| Evidence | Answer Format Compliance | 0.686 |
 | Abstention | Abstention Accuracy | 0.143 |
-| System | Latency (p50/p95) | p50 1.1ms / p95 1.9ms |
+| System | Latency (p50/p95) | p50 1.1ms / p95 1.8ms |
 | System | Retry Rate | 0.000 |
 
 ### Ablation comparison
 
-| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Format | Abstention | Retry | Latency p95 |
-|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| naive_baseline | naive_baseline | 4 | off | off | off | 0.808 | 0.667 | 0.455 | 0.667 | 0.143 | 0.000 | 1.9ms |
-| full | agentic_full | auto | on | on | on | 0.885 | 0.909 | 0.909 | 0.909 | 1.000 | 0.273 | 2.0ms |
-| hierarchical | agentic_full | auto | on | on | on | 0.885 | 0.909 | 0.909 | 0.909 | 1.000 | 0.273 | 1.9ms |
-| no_metadata_first | agentic_full | auto | off | on | on | 0.808 | 0.848 | 0.636 | 0.848 | 1.000 | 0.000 | 1.6ms |
-| no_rerank | agentic_full | auto | on | off | on | 0.885 | 0.909 | 0.909 | 0.909 | 1.000 | 0.273 | 1.9ms |
-| no_verifier_retry | agentic_full | auto | on | on | off | 0.885 | 0.727 | 0.727 | 0.727 | 0.143 | 0.000 | 1.5ms |
+| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Claim Align | Format | Abstention | Retry | Latency p95 |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| naive_baseline | naive_baseline | 4 | off | off | off | 0.821 | 0.686 | 0.471 | 0.970 | 0.686 | 0.143 | 0.000 | 1.8ms |
+| full | agentic_full | auto | on | on | on | 0.857 | 0.886 | 0.886 | 0.964 | 0.886 | 1.000 | 0.314 | 1.8ms |
+| hierarchical | agentic_full | auto | on | on | on | 0.857 | 0.886 | 0.886 | 0.964 | 0.886 | 1.000 | 0.314 | 2.0ms |
+| no_metadata_first | agentic_full | auto | off | on | on | 0.786 | 0.829 | 0.629 | 0.926 | 0.829 | 1.000 | 0.000 | 1.9ms |
+| no_rerank | agentic_full | auto | on | off | on | 0.857 | 0.886 | 0.886 | 0.964 | 0.886 | 1.000 | 0.314 | 1.7ms |
+| no_verifier_retry | agentic_full | auto | on | on | off | 0.893 | 0.743 | 0.743 | 1.000 | 0.743 | 0.143 | 0.000 | 1.5ms |
 <!-- METRICS_TABLE:END -->
 
 > 주의: 성능표는 공개 synthetic RFP 평가셋 기준입니다. 원본 RFP 데이터는 비공개 제약으로 저장소에 포함하지 않았습니다.
@@ -310,6 +314,7 @@ python3 eval/run_parser_eval.py \
 - PDF/HWP ingestion: [`docs/real-data-ingestion.md`](docs/real-data-ingestion.md)
 - Visual parsing v2: [`docs/visual-ingestion-v2.md`](docs/visual-ingestion-v2.md)
 - Citation grounding evaluation: [`docs/citation-grounding-eval.md`](docs/citation-grounding-eval.md)
+- Grounding/eval hardening: [`docs/grounding-eval-hardening.md`](docs/grounding-eval-hardening.md)
 - Reproducible harness: [`docs/harness.md`](docs/harness.md)
 - 답변 출력 정책: [`docs/answer-policy.md`](docs/answer-policy.md)
 - 실패 사례 분석: [`docs/failure-cases.md`](docs/failure-cases.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [포트폴리오 case study](./portfolio-case-study.md)
 - [Benchmarking](./benchmarking.md)
 - [Retrieval hardening milestone](./retrieval-hardening.md)
+- [Grounding/eval hardening](./grounding-eval-hardening.md)
 - [Reproducible harness](./harness.md)
 - [Private hard-case benchmark](./private-hardcase-benchmark.md)
 - [Private 100-doc experiments](./private-100-doc-experiments.md)

--- a/docs/answer-policy.md
+++ b/docs/answer-policy.md
@@ -10,13 +10,27 @@
 | `partial` | 비교 질문에서 일부 대상만 근거로 확인됨 | 확인된 대상만 있음 | 1개 이상 |
 | `insufficient` | 답변 가능한 근거를 찾지 못함 | 없음 | 없음 |
 
-`answer_text`는 사람이 빠르게 읽기 위한 요약이고, 검증 가능한 계약은 `answer.status`, `answer.claims`, `answer.insufficiency`, top-level `evidence`를 기준으로 본다.
+현재 답변 객체는 `schema_version: 2`를 사용한다. `answer_text`는 사람이 빠르게 읽기 위한 요약이고, 검증 가능한 계약은 `answer.schema_version`, `answer.status`, `answer.status_reason`, `answer.claims`, `answer.insufficiency`, top-level `evidence`를 기준으로 본다.
+
+`status_reason`은 machine-readable 진단 필드다.
+
+| field | 의미 |
+|---|---|
+| `code` | `verified`, `partial_comparison`, `insufficient_evidence`, `context_clarification`, `metadata_ambiguity_clarification` 중 하나 |
+| `verified` | verifier 기준 통과 여부. 단, 명시 요청된 비교 대상이 corpus에 없으면 verifier 설정과 무관하게 `partial`이 될 수 있음 |
+| `verification_reasons` | `topic_not_grounded`, `missing_comparison_doc:*`, `missing_requested_entity:*` 같은 근거 부족 사유 |
 
 ## 좋은 답변 예시
 
 ```json
 {
+  "schema_version": 2,
   "status": "supported",
+  "status_reason": {
+    "code": "verified",
+    "verified": true,
+    "verification_reasons": []
+  },
   "query_type": "comparison",
   "summary": "기관 A: ... 기관 B: ...",
   "claims": [
@@ -43,7 +57,13 @@
 
 ```json
 {
+  "schema_version": 2,
   "status": "supported",
+  "status_reason": {
+    "code": "verified",
+    "verified": true,
+    "verification_reasons": []
+  },
   "summary": "기관 A는 블록체인 납품 실적이 있습니다.",
   "claims": [],
   "insufficiency": null
@@ -58,7 +78,13 @@ unsupported 질문은 다음처럼 답한다.
 
 ```json
 {
+  "schema_version": 2,
   "status": "insufficient",
+  "status_reason": {
+    "code": "insufficient_evidence",
+    "verified": false,
+    "verification_reasons": ["topic_not_grounded"]
+  },
   "query_type": "abstention",
   "summary": "제공된 공개 샘플 RFP 근거에서는 '기관 A의 블록체인 납품 실적은?'에 답할 수 있는 내용을 찾지 못했습니다.",
   "claims": [],
@@ -70,7 +96,7 @@ unsupported 질문은 다음처럼 답한다.
 }
 ```
 
-비교 질문에서 한쪽만 확인되면 `partial`로 표시하고, 확인되지 않은 대상은 `missing_targets`에 남긴다. 이 경우 확인된 claim만 citation과 함께 제공하며, 빠진 대상을 추측해 채우지 않는다.
+비교 질문에서 한쪽만 확인되면 `partial`로 표시하고, 확인되지 않은 대상은 `missing_targets`에 남긴다. 명시적으로 요청된 기관이 corpus metadata에 없을 때도 `missing_requested_entity:*` 사유를 남겨 `partial`로 처리한다. 이 경우 확인된 claim만 citation과 함께 제공하며, 빠진 대상을 추측해 채우지 않는다.
 
 ## 실패 유형
 

--- a/docs/citation-grounding-eval.md
+++ b/docs/citation-grounding-eval.md
@@ -1,9 +1,10 @@
 # Citation grounding evaluation
 
-이 문서는 이슈 #26의 page/region-grounded citation 평가 기준을 정리한다. 기존 `citation_precision`은 문서/근거 term 중심 지표로 유지하고, visual parsing v2에서 page/bbox metadata가 있을 때만 추가 grounding 지표를 계산한다.
+이 문서는 citation 평가 기준을 정리한다. 기존 `citation_precision`은 whole-answer 문서/근거 term 중심 지표로 유지하고, `claim_citation_alignment`는 claim마다 citation chunk가 해당 claim을 직접 지지하는지 별도로 측정한다. visual parsing v2에서 page/bbox metadata가 있을 때는 page/region grounding 지표도 추가 계산한다.
 
 ## 목적
 - 답변 citation이 올바른 문서뿐 아니라 올바른 page/region을 가리키는지 분리해 측정한다.
+- whole-answer citation 품질과 claim-level citation drift를 분리한다.
 - text v1과 visual v2를 비교할 때 region metadata가 없는 경우와 잘못 정렬된 경우를 구분한다.
 - downstream citation drift를 parser-stage `bbox_missing`, `bbox_misaligned` 오류와 연결해 해석한다.
 
@@ -20,9 +21,16 @@ expected_citation_regions:
     page_number: 1
     bbox: [10, 40, 280, 100]
     min_iou: 0.5
+
+expected_claim_citations:
+  - target: 기관 A
+    expected_doc_ids: [rfp-agency-a-ai-quality]
+    expected_terms: ["보안 통제", "로그"]
 ```
 
 `expected_citation_pages`는 citation의 `page_span` 또는 `regions[*].page_number`와 비교한다. `expected_citation_regions`는 같은 `doc_id`와 `page_number`의 `regions[*].bbox`를 gold bbox와 IoU로 비교하며, `min_iou` 기본값은 `0.5`다.
+
+`expected_claim_citations`는 선택 필드다. 지정하면 해당 target claim의 citation이 기대 doc id와 expected terms를 직접 포함해야 한다. 지정하지 않은 claim도 기본적으로 claim text가 cited evidence text에 의해 지지되는지 token/substring 기반으로 점검한다.
 
 ## Report fields
 `reports/eval_summary.json`에는 다음 additive metric이 기록된다.
@@ -32,9 +40,11 @@ expected_citation_regions:
 | `citation_page_precision` | 기대 page anchor 중 citation page metadata가 맞은 비율 |
 | `citation_region_precision` | 기대 region anchor 중 citation bbox가 IoU 기준을 통과한 비율 |
 | `citation_grounding` | page/region grounding score의 평균. 둘 다 없으면 `null` |
+| `claim_citation_alignment` | claim별 citation chunk가 claim text와 기대 claim terms를 직접 지지한 비율 |
 | `citation_grounding_error_counts` | page/region grounding 실패 taxonomy count |
+| `claim_citation_error_counts` | claim-level citation alignment 실패 taxonomy count |
 
-case result에는 `citation_grounding_errors`가 포함된다.
+case result에는 `citation_grounding_errors`와 `claim_citation_errors`가 포함된다.
 
 | Code | Meaning |
 |---|---|
@@ -42,6 +52,17 @@ case result에는 `citation_grounding_errors`가 포함된다.
 | `page_mismatch` | page metadata는 있으나 기대 page와 불일치 |
 | `region_unavailable` | 기대 page의 bbox region metadata가 없음 |
 | `region_misaligned` | bbox가 있으나 IoU threshold 미달 |
+
+Claim-level 오류는 다음처럼 해석한다.
+
+| Code | Meaning |
+|---|---|
+| `claim_missing_citation` | claim에 citation이 없음 |
+| `citation_not_in_evidence` | claim citation chunk가 top-level evidence에 없음 |
+| `claim_text_not_supported_by_citation` | citation text가 claim text를 직접 지지하지 않음 |
+| `expected_claim_doc_mismatch` | target별 expected doc id와 citation doc id가 다름 |
+| `expected_claim_terms_missing` | target별 expected terms가 citation text에 없음 |
+| `expected_claim_missing` | expected target claim이 출력되지 않음 |
 
 ## Examples
 Correctly grounded citation:

--- a/docs/comparison-ranking.md
+++ b/docs/comparison-ranking.md
@@ -76,12 +76,12 @@ This is also surfaced in `diagnostics.filter_stage_attempts[].comparison_coverag
 
 ## Eval metric
 
-`eval/run_eval.py` computes two coverage metrics per `query_type == "multi_doc"` case with ≥2 expected doc_ids:
+`eval/run_eval.py` computes two coverage metrics per `query_type == "comparison"` case with ≥2 expected doc_ids. Older configs that still use `multi_doc` are normalized to the `comparison` slice:
 
 - `comparison_target_recall` = `|expected_doc_ids ∩ evidence_doc_ids| / |expected_doc_ids|` — measured against the FINAL evidence (post `select_supporting_evidence` topic-grounding trim). Sensitive to topic-grounding failures, not just retrieval coverage.
 - `comparison_pool_recall` = `|expected_doc_ids ∩ pool_doc_ids| / |expected_doc_ids|` — measured against the post-balance retrieval pool (read from `plan.comparison_coverage.after`). Isolates the effect of balancing from downstream verifier/topic trimming.
 
-Both are aggregated in `metric_block` as means plus a `*_full_coverage_rate` (fraction with recall == 1.0). They only appear under `by_query_type["multi_doc"]` and `by_hardcase_category["one_sided_comparison"]` (or any slice with qualifying cases) so headline numbers stay clean.
+Both are aggregated in `metric_block` as means plus a `*_full_coverage_rate` (fraction with recall == 1.0). They appear under `by_slice["comparison"]` / `by_query_type["comparison"]` and `by_hardcase_category["one_sided_comparison"]` (or any slice with qualifying cases) so headline numbers stay clean.
 
 `comparison_pool_recall` is the cleanest signal that the balanced top-k cut is doing its job; `comparison_target_recall` is the user-visible answer-quality signal that depends on both balancing and topic grounding.
 

--- a/docs/grounding-eval-hardening.md
+++ b/docs/grounding-eval-hardening.md
@@ -1,0 +1,58 @@
+# Grounding and eval hardening
+
+이 문서는 phase 1 grounding/eval hardening 변경을 리뷰어가 재현할 수 있도록 정리한다.
+
+## What changed
+
+- Public eval slice를 `single_doc`, `comparison`, `follow_up`, `abstention`으로 표준화했다. 기존 `multi_doc` config 값은 호환 alias로 계속 읽는다.
+- 공개 eval에 claim-level citation spec과 partial comparison 케이스를 추가했다.
+- `answer` 객체를 schema v2로 고정하고 `schema_version`, `status_reason`을 추가했다.
+- `run_rag_query` 결과에 `trace`를 추가해 planner 선택과 query rewrite/context resolution을 한 곳에서 볼 수 있게 했다.
+- `eval/run_eval.py`는 각 run/case의 trace를 `reports/traces/<run>/<case>.trace.json`에 쓴다. `reports/`는 gitignored라 private/local trace가 커밋되지 않는다.
+- `claim_citation_alignment`과 `claim_citation_error_counts`를 추가해 whole-answer citation precision과 claim-level drift를 분리했다.
+
+## Why it changed
+
+기존 report는 전체 답변의 expected term/doc match를 잘 보여줬지만, 다음 질문에는 답하기 어려웠다.
+
+- 비교 질문에서 어떤 target이 빠졌는가?
+- follow-up query가 실제로 어떤 query로 rewrite 되었는가?
+- `supported`, `partial`, `insufficient`가 같은 JSON 계약으로 안정적으로 나오는가?
+- 답변 전체는 맞아 보여도 claim이 엉뚱한 chunk를 citation으로 달고 있지 않은가?
+
+이번 변경은 retrieval/chunking 구조를 바꾸지 않고, reviewer가 위 질문을 report와 trace artifact에서 직접 확인하도록 만든다.
+
+## How to validate
+
+```bash
+python3 scripts/build_index.py --input_dir data/raw --output_dir data/index
+python3 app.py --input_dir data/index --output_dir outputs --query "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
+python3 eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml
+python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check
+python3 -m pytest tests/test_eval_metrics.py tests/test_fuzzy_retrieval.py
+```
+
+Inspect these artifacts:
+
+- `outputs/answer.json`: `answer.schema_version == 2`, `answer.status_reason`, `trace.planner`, `trace.query_rewrite`
+- `reports/eval_summary.json`: `by_slice`, `claim_citation_alignment`, `claim_citation_error_counts`, `case_results[*].trace_path`
+- `reports/traces/full/*.trace.json`: readable planner and rewrite traces for the stronger agentic run
+- `reports/traces/naive_baseline/*.trace.json`: baseline control traces for comparison
+
+## Interpreting failures
+
+- Low `citation_precision`: whole-answer evidence doc/term quality is weak.
+- Low `claim_citation_alignment`: at least one emitted claim is not directly supported by its cited chunk, even if the overall answer found the right document.
+- `expected_claim_missing`: a target-specific claim required by eval was not emitted.
+- `claim_text_not_supported_by_citation`: likely citation drift; inspect the case trace and the claim citation chunk.
+- `answer_format_compliance` failure with `status_match`: the answer schema status did not match expected `supported`, `partial`, or `insufficient`.
+- `trace.query_rewrite.rewritten == true`: follow-up context was used to rewrite the query. Check `rewrite_type`, `context_entities`, and `active_doc_ids`.
+
+## Issue coverage
+
+- #58: public eval has broader slice-aware reporting through `by_slice` plus expanded comparison/partial/claim cases.
+- #60: local planner/rewrite traces are emitted in both `outputs/answer.json` and `reports/traces/`.
+- #63: answer schema v2 explicitly represents `supported`, `partial`, and `insufficient` with machine-readable status reasons.
+- #64: claim-level citation alignment is measured separately from whole-answer citation precision.
+
+Out of scope remains chunking redesign (#62) and confidentiality/reporting flow (#65).

--- a/docs/local-gold-authoring.md
+++ b/docs/local-gold-authoring.md
@@ -45,7 +45,7 @@ cp eval/real_config.example.yaml eval/real_config.local.yaml
 | 필드 | 의미 |
 |---|---|
 | `id` | 케이스 식별자. 다른 케이스와 겹치지 않도록 유니크하게 둔다. |
-| `query_type` | `single_doc`, `multi_doc`, `follow_up`, `abstention` 중 하나. |
+| `query_type` | `single_doc`, `comparison`, `follow_up`, `abstention` 중 하나. 기존 `multi_doc` 값은 호환 alias로 읽힌다. |
 | `query` | 사용자가 입력하는 질의 본문. |
 | `expected_doc_ids` | 기대되는 정답 doc_id 목록. abstention 케이스에서는 `[]`. |
 | `expected_terms` | 답변 텍스트에 등장해야 하는 핵심 term들. |

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -54,6 +54,13 @@ cases:
       - "로그"
     expected_claim_targets:
       - "기관 A"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "보안 통제"
+          - "로그"
     answerable: true
 
   - id: single_doc_chatbot_latency
@@ -189,8 +196,31 @@ cases:
       - "기관 B"
     answerable: true
 
-  - id: multi_doc_ai_requirements
-    query_type: multi_doc
+  - id: single_doc_c_operation_metrics
+    query_type: single_doc
+    query: "기관 C가 운영 지표로 사용하는 항목은?"
+    expected_doc_ids:
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "답변 정확도"
+      - "상담 이관 적절성"
+      - "사용자 만족도"
+    expected_citation_terms:
+      - "답변 정확도"
+      - "사용자 만족도"
+    expected_claim_targets:
+      - "기관 C"
+    expected_claim_citations:
+      - target: "기관 C"
+        expected_doc_ids:
+          - rfp-agency-c-chatbot
+        expected_terms:
+          - "답변 정확도"
+          - "사용자 만족도"
+    answerable: true
+
+  - id: comparison_ai_requirements
+    query_type: comparison
     query: "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
     expected_doc_ids:
       - rfp-agency-a-ai-quality
@@ -204,10 +234,21 @@ cases:
     expected_claim_targets:
       - "기관 A"
       - "기관 B"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "품질관리"
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "MLOps"
     answerable: true
 
-  - id: multi_doc_security_controls
-    query_type: multi_doc
+  - id: comparison_security_controls
+    query_type: comparison
     query: "기관 A와 기관 B의 보안 요구사항 차이를 비교해줘"
     expected_doc_ids:
       - rfp-agency-a-ai-quality
@@ -221,10 +262,52 @@ cases:
     expected_claim_targets:
       - "기관 A"
       - "기관 B"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "보안 통제"
+          - "로그"
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "개인정보 비식별화"
+          - "접근 권한 분리"
     answerable: true
 
-  - id: multi_doc_schedule_compare
-    query_type: multi_doc
+  - id: comparison_partial_missing_agency_d
+    query_type: comparison
+    hardcase_categories:
+      - answer_schema_v2
+      - partial_comparison
+    query: "기관 A와 기관 D의 보안 요구사항 차이를 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "보안 통제"
+      - "로그"
+    expected_citation_terms:
+      - "보안 통제"
+      - "로그"
+    expected_claim_targets:
+      - "기관 A"
+    expected_missing_targets:
+      - "기관 D"
+    expected_answer_status: partial
+    min_claims: 1
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "보안 통제"
+          - "로그"
+    answerable: true
+
+  - id: comparison_schedule_compare
+    query_type: comparison
     query: "기관 A와 기관 B의 일정 차이를 비교해줘"
     expected_doc_ids:
       - rfp-agency-a-ai-quality
@@ -242,8 +325,8 @@ cases:
       - "기관 B"
     answerable: true
 
-  - id: multi_doc_a_c_ai_focus
-    query_type: multi_doc
+  - id: comparison_a_c_ai_focus
+    query_type: comparison
     query: "기관 A와 기관 C의 AI 요구사항 초점 차이는?"
     expected_doc_ids:
       - rfp-agency-a-ai-quality
@@ -260,8 +343,8 @@ cases:
       - "기관 C"
     answerable: true
 
-  - id: multi_doc_b_c_operations
-    query_type: multi_doc
+  - id: comparison_b_c_operations
+    query_type: comparison
     query: "기관 B와 기관 C의 운영 지표나 모니터링 요구를 비교해줘"
     expected_doc_ids:
       - rfp-agency-b-mlops-governance
@@ -278,8 +361,8 @@ cases:
       - "기관 C"
     answerable: true
 
-  - id: multi_doc_a_common_submission
-    query_type: multi_doc
+  - id: comparison_a_common_submission
+    query_type: comparison
     query: "기관 A 제출조건과 공통 평가 기준을 비교해줘"
     expected_doc_ids:
       - rfp-agency-a-ai-quality
@@ -296,8 +379,8 @@ cases:
       - "공통"
     answerable: true
 
-  - id: multi_doc_one_sided_quality_focus
-    query_type: multi_doc
+  - id: comparison_one_sided_quality_focus
+    query_type: comparison
     hardcase_categories:
       - one_sided_comparison
     query: "품질관리 관점에서 기관 A와 기관 B의 AI 요구사항 차이는?"
@@ -315,8 +398,8 @@ cases:
       - "기관 B"
     answerable: true
 
-  - id: multi_doc_one_sided_mlops_focus
-    query_type: multi_doc
+  - id: comparison_one_sided_mlops_focus
+    query_type: comparison
     hardcase_categories:
       - one_sided_comparison
     query: "MLOps 자동화 측면에서 기관 B와 기관 A는 어떻게 다른가?"
@@ -334,8 +417,8 @@ cases:
       - "기관 B"
     answerable: true
 
-  - id: multi_doc_one_sided_chatbot_focus
-    query_type: multi_doc
+  - id: comparison_one_sided_chatbot_focus
+    query_type: comparison
     hardcase_categories:
       - one_sided_comparison
     query: "사용자 만족도 측면에서 기관 C와 기관 B의 운영 지표는 어떻게 다른가?"
@@ -472,6 +555,15 @@ cases:
     expected_citation_terms:
       - "보안 통제"
       - "로그"
+    expected_claim_targets:
+      - "기관 A"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "보안 통제"
+          - "로그"
     answerable: true
 
   - id: follow_up_state_multi_step_a_deliverables

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -3,8 +3,10 @@ import argparse
 from collections import Counter, defaultdict
 import json
 from pathlib import Path
+import re
 import sys
 from typing import Any
+import unicodedata
 
 import yaml
 
@@ -22,7 +24,8 @@ from rag_core import (
 )
 
 
-QUERY_TYPES = ("single_doc", "multi_doc", "follow_up", "abstention")
+QUERY_TYPES = ("single_doc", "comparison", "follow_up", "abstention")
+QUERY_TYPE_ALIASES = {"multi_doc": "comparison"}
 DEFAULT_ABLATION_RUNS = [
     {
         "name": DEFAULT_CLI_PIPELINE_NAME,
@@ -47,6 +50,11 @@ def hardcase_categories(item: dict[str, Any]) -> list[str]:
     return normalized
 
 
+def canonical_query_type(query_type: Any) -> str:
+    value = str(query_type or "").strip()
+    return QUERY_TYPE_ALIASES.get(value, value)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run local RAG evaluation over configured cases.")
     parser.add_argument("--input_dir", default="outputs", help="Kept for CLI compatibility; not required.")
@@ -54,6 +62,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output_dir", default="reports", help="Directory to save eval summary.")
     parser.add_argument("--query", default=None, help="Unused in this command; accepted for CLI consistency.")
     parser.add_argument("--config", required=True, help="Path to eval config YAML file.")
+    parser.add_argument(
+        "--trace_dir",
+        default=None,
+        help="Directory for local planner/rewrite trace JSON files. Defaults to <output_dir>/traces.",
+    )
     return parser.parse_args()
 
 
@@ -82,9 +95,11 @@ def load_config(path: Path) -> dict[str, Any]:
     if not isinstance(cases, list) or not cases:
         raise ValueError("Eval config must include non-empty cases list")
     for case in cases:
-        query_type = case.get("query_type")
+        query_type = canonical_query_type(case.get("query_type"))
         if query_type not in QUERY_TYPES:
-            raise ValueError(f"Eval case must include query_type in {QUERY_TYPES}: {case.get('id')}")
+            accepted = tuple([*QUERY_TYPES, *QUERY_TYPE_ALIASES])
+            raise ValueError(f"Eval case must include query_type in {accepted}: {case.get('id')}")
+        case["query_type"] = query_type
         prior_turns = case.get("prior_turns") or []
         if not isinstance(prior_turns, list):
             raise ValueError(f"Eval case prior_turns must be a list: {case.get('id')}")
@@ -135,6 +150,24 @@ def load_config(path: Path) -> dict[str, Any]:
                 raise ValueError(
                     f"Each expected_citation_regions min_iou must be numeric: {case.get('id')}"
                 )
+        expected_claim_citations = case.get("expected_claim_citations") or []
+        if not isinstance(expected_claim_citations, list):
+            raise ValueError(f"Eval case expected_claim_citations must be a list: {case.get('id')}")
+        for expected_claim in expected_claim_citations:
+            if not isinstance(expected_claim, dict):
+                raise ValueError(
+                    f"Each expected_claim_citations item must be a mapping: {case.get('id')}"
+                )
+            if expected_claim.get("target") is not None and not str(expected_claim.get("target")).strip():
+                raise ValueError(
+                    f"expected_claim_citations target must be non-empty when provided: {case.get('id')}"
+                )
+            for field in ("expected_terms", "expected_doc_ids"):
+                values = expected_claim.get(field) or []
+                if not isinstance(values, list):
+                    raise ValueError(
+                        f"expected_claim_citations {field} must be a list: {case.get('id')}"
+                    )
 
     runs = data.get("ablation_runs", DEFAULT_ABLATION_RUNS)
     if not isinstance(runs, list) or not runs:
@@ -371,6 +404,214 @@ def score_citation_grounding(
     }
 
 
+ALIGN_TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]+")
+ALIGN_STOPWORDS = {
+    "기관",
+    "핵심",
+    "요구사항",
+    "요구",
+    "차이",
+    "비교",
+    "관련",
+    "확인",
+    "대상",
+    "한다",
+    "있다",
+    "이다",
+    "은",
+    "는",
+    "이",
+    "가",
+    "을",
+    "를",
+    "의",
+    "와",
+    "과",
+}
+
+
+def normalized_alignment_text(text: str) -> str:
+    normalized = unicodedata.normalize("NFC", text).lower()
+    return re.sub(r"[^0-9a-z가-힣]+", "", normalized)
+
+
+def alignment_tokens(text: str) -> list[str]:
+    tokens = []
+    for match in ALIGN_TOKEN_RE.finditer(unicodedata.normalize("NFC", text).lower()):
+        token = match.group(0)
+        if len(token) <= 1 or token in ALIGN_STOPWORDS:
+            continue
+        tokens.append(token)
+    return tokens
+
+
+def evidence_alignment_text(item: dict[str, Any]) -> str:
+    parts = [
+        item.get("title", ""),
+        item.get("agency", ""),
+        item.get("project", ""),
+        item.get("section", ""),
+        item.get("text", ""),
+    ]
+    metadata = item.get("metadata")
+    if isinstance(metadata, dict):
+        for key, value in sorted(metadata.items()):
+            if value is None or value == "":
+                continue
+            parts.append(str(key))
+            parts.append(str(value))
+    return " ".join(str(part) for part in parts if str(part).strip())
+
+
+def claim_text_supported_by_citation(claim: dict[str, Any], citation_text: str) -> bool:
+    claim_text = " ".join(
+        str(claim.get(key) or "") for key in ("claim", "support") if claim.get(key)
+    )
+    if not claim_text.strip() or not citation_text.strip():
+        return False
+
+    compact_claim = normalized_alignment_text(str(claim.get("claim") or ""))
+    compact_citation = normalized_alignment_text(citation_text)
+    if compact_claim and compact_claim in compact_citation:
+        return True
+
+    tokens = alignment_tokens(str(claim.get("claim") or ""))
+    if not tokens:
+        return bool(compact_claim and compact_claim in compact_citation)
+    citation_tokens = set(alignment_tokens(citation_text))
+    overlap = sum(1 for token in tokens if token in citation_tokens)
+    return (overlap / max(1, len(tokens))) >= 0.5
+
+
+def expected_claim_specs_for_target(
+    case: dict[str, Any],
+    target: str,
+) -> list[dict[str, Any]]:
+    specs = case.get("expected_claim_citations") or []
+    matched = []
+    for spec in specs:
+        if not isinstance(spec, dict):
+            continue
+        expected_target = str(spec.get("target") or "").strip()
+        if not expected_target or expected_target == target:
+            matched.append(spec)
+    return matched
+
+
+def score_claim_citation_alignment(
+    case: dict[str, Any],
+    prediction: dict[str, Any],
+) -> dict[str, Any]:
+    evidence_by_chunk = {
+        str(item.get("chunk_id")): item
+        for item in prediction.get("evidence") or []
+        if item.get("chunk_id")
+    }
+    claims = answer_claims(prediction)
+    expected_specs = [
+        spec for spec in case.get("expected_claim_citations") or [] if isinstance(spec, dict)
+    ]
+    errors: list[dict[str, Any]] = []
+    scores: list[float] = []
+    claim_targets = {str(claim.get("target") or "") for claim in claims}
+
+    for claim_index, claim in enumerate(claims):
+        target = str(claim.get("target") or "")
+        citations = [citation for citation in claim.get("citations") or [] if isinstance(citation, dict)]
+        if not citations:
+            scores.append(0.0)
+            errors.append(
+                {
+                    "code": "claim_missing_citation",
+                    "message": "Claim has no citation.",
+                    "claim_index": claim_index,
+                    "target": target,
+                }
+            )
+            continue
+
+        citation_items = []
+        missing_chunk_ids = []
+        for citation in citations:
+            chunk_id = str(citation.get("chunk_id") or "")
+            item = evidence_by_chunk.get(chunk_id)
+            if item is None:
+                missing_chunk_ids.append(chunk_id)
+                continue
+            citation_items.append(item)
+        citation_text = " ".join(evidence_alignment_text(item) for item in citation_items)
+        citation_doc_ids = {str(item.get("doc_id") or "") for item in citation_items}
+
+        claim_errors: list[dict[str, Any]] = []
+        if missing_chunk_ids and not citation_items:
+            claim_errors.append(
+                {
+                    "code": "citation_not_in_evidence",
+                    "message": "Claim citation chunk was not present in top-level evidence.",
+                    "claim_index": claim_index,
+                    "target": target,
+                    "chunk_ids": missing_chunk_ids,
+                }
+            )
+        elif not claim_text_supported_by_citation(claim, citation_text):
+            claim_errors.append(
+                {
+                    "code": "claim_text_not_supported_by_citation",
+                    "message": "Claim text was not directly supported by the cited evidence text.",
+                    "claim_index": claim_index,
+                    "target": target,
+                    "citation_chunk_ids": [item.get("chunk_id") for item in citation_items],
+                }
+            )
+
+        for spec in expected_claim_specs_for_target(case, target):
+            expected_doc_ids = {str(doc_id) for doc_id in spec.get("expected_doc_ids") or []}
+            expected_terms = [str(term) for term in spec.get("expected_terms") or []]
+            if expected_doc_ids and not (expected_doc_ids & citation_doc_ids):
+                claim_errors.append(
+                    {
+                        "code": "expected_claim_doc_mismatch",
+                        "message": "Claim citation doc_id did not match the expected claim-level doc.",
+                        "claim_index": claim_index,
+                        "target": target,
+                        "expected_doc_ids": sorted(expected_doc_ids),
+                        "actual_doc_ids": sorted(doc_id for doc_id in citation_doc_ids if doc_id),
+                    }
+                )
+            if expected_terms and not contains_all_terms(citation_text, expected_terms):
+                claim_errors.append(
+                    {
+                        "code": "expected_claim_terms_missing",
+                        "message": "Claim citation text missed expected claim-level terms.",
+                        "claim_index": claim_index,
+                        "target": target,
+                        "expected_terms": expected_terms,
+                    }
+                )
+
+        errors.extend(claim_errors)
+        scores.append(0.0 if claim_errors else 1.0)
+
+    for spec in expected_specs:
+        expected_target = str(spec.get("target") or "").strip()
+        if expected_target and expected_target not in claim_targets:
+            scores.append(0.0)
+            errors.append(
+                {
+                    "code": "expected_claim_missing",
+                    "message": "Expected claim target was not emitted.",
+                    "target": expected_target,
+                }
+            )
+
+    return {
+        "claim_citation_alignment": rate(scores) if scores else None,
+        "claim_citation_aligned": sum(1 for score in scores if score >= 1.0),
+        "claim_citation_checked": len(scores),
+        "claim_citation_errors": errors,
+    }
+
+
 def score_answer_format(
     case: dict[str, Any],
     prediction: dict[str, Any],
@@ -396,7 +637,11 @@ def score_answer_format(
         case.get("require_claim_citations", policy.get("require_claim_citations", True))
     )
     expected_targets = {str(target) for target in case.get("expected_claim_targets") or []}
+    expected_missing_targets = {
+        str(target) for target in case.get("expected_missing_targets") or []
+    }
 
+    payload = answer_payload(prediction)
     claims = answer_claims(prediction)
     claim_targets = {str(claim.get("target") or "") for claim in claims}
     citation_checks = []
@@ -417,17 +662,27 @@ def score_answer_format(
     elif require_claim_citations and int(min_claims) > 0:
         citations_ok = False
 
+    insufficiency = payload.get("insufficiency") if isinstance(payload, dict) else {}
+    if not isinstance(insufficiency, dict):
+        insufficiency = {}
+    missing_targets = {str(target) for target in insufficiency.get("missing_targets") or []}
+
     checks = {
+        "schema_version": int(payload.get("schema_version") or 0) >= 2,
         "status_match": answer_status(prediction) == str(expected_status),
         "min_claims": len(claims) >= int(min_claims),
         "claim_targets": expected_targets.issubset(claim_targets),
         "claim_citations": citations_ok,
     }
+    if expected_missing_targets:
+        checks["missing_targets"] = expected_missing_targets.issubset(missing_targets)
     return {
         "expected_answer_status": str(expected_status),
         "answer_status": answer_status(prediction),
         "expected_claim_targets": sorted(expected_targets),
         "claim_targets": sorted(target for target in claim_targets if target),
+        "expected_missing_targets": sorted(expected_missing_targets),
+        "missing_targets": sorted(target for target in missing_targets if target),
         "claim_count": len(claims),
         "format_checks": checks,
         "answer_format_compliance": 1.0 if all(checks.values()) else 0.0,
@@ -440,7 +695,7 @@ def score_case(
     answer_policy: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     answerable = bool(case.get("answerable", True))
-    query_type = str(case.get("query_type"))
+    query_type = canonical_query_type(case.get("query_type"))
     expected_doc_ids = set(case.get("expected_doc_ids") or [])
     expected_terms = [str(term) for term in case.get("expected_terms") or []]
     expected_citation_terms = [
@@ -460,6 +715,7 @@ def score_case(
     abstained = bool(diagnostics.get("abstained"))
     answer_format = score_answer_format(case, prediction, answer_policy)
     citation_grounding = score_citation_grounding(case, prediction)
+    claim_alignment = score_claim_citation_alignment(case, prediction)
 
     citation_doc_precision = 0.0
     if evidence_doc_ids:
@@ -472,7 +728,7 @@ def score_case(
 
     comparison_target_recall: float | None = None
     comparison_pool_recall: float | None = None
-    if query_type == "multi_doc" and len(expected_doc_ids) >= 2:
+    if query_type == "comparison" and len(expected_doc_ids) >= 2:
         covered = expected_doc_ids & evidence_doc_ids
         comparison_target_recall = len(covered) / len(expected_doc_ids)
         coverage_after = (
@@ -502,6 +758,7 @@ def score_case(
     return {
         "id": case.get("id"),
         "query_type": query_type,
+        "slice": query_type,
         "hardcase_categories": hardcase_categories(case),
         "query": case.get("query"),
         "answerable": answerable,
@@ -515,6 +772,7 @@ def score_case(
         "groundedness": groundedness,
         "citation_precision": citation_precision,
         **citation_grounding,
+        **claim_alignment,
         "abstention": abstention,
         "comparison_target_recall": comparison_target_recall,
         "comparison_pool_recall": comparison_pool_recall,
@@ -583,6 +841,11 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
     citation_grounding_scores = [
         r["citation_grounding"] for r in case_results if r.get("citation_grounding") is not None
     ]
+    claim_alignment_scores = [
+        r["claim_citation_alignment"]
+        for r in case_results
+        if r.get("claim_citation_alignment") is not None
+    ]
     abstention_scores = [r["abstention"] for r in case_results if r["abstention"] is not None]
     comparison_recall_scores = [
         r["comparison_target_recall"]
@@ -609,6 +872,12 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         error["code"]
         for result in case_results
         for error in result.get("citation_grounding_errors") or []
+        if isinstance(error, dict) and error.get("code")
+    )
+    claim_citation_error_counts = Counter(
+        error["code"]
+        for result in case_results
+        for error in result.get("claim_citation_errors") or []
         if isinstance(error, dict) and error.get("code")
     )
 
@@ -660,6 +929,7 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         "citation_page_precision": rate(citation_page_scores),
         "citation_region_precision": rate(citation_region_scores),
         "citation_grounding": rate(citation_grounding_scores),
+        "claim_citation_alignment": rate(claim_alignment_scores),
         "abstention": rate(abstention_scores),
         "answer_format_compliance": rate(format_scores),
         "latency": {
@@ -679,6 +949,7 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         },
         "retry_reason_counts": dict(sorted(retry_reason_counts.items())),
         "citation_grounding_error_counts": dict(sorted(citation_grounding_error_counts.items())),
+        "claim_citation_error_counts": dict(sorted(claim_citation_error_counts.items())),
     }
     if comparison_recall_scores:
         block["comparison_target_recall"] = rate(comparison_recall_scores)
@@ -710,13 +981,16 @@ def summarize_run(
         "prompt_profile": str(run_config.get("prompt_profile") or ""),
         **metric_block(case_results),
         "by_query_type": {},
+        "by_slice": {},
     }
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for result in case_results:
-        grouped[str(result["query_type"])].append(result)
+        grouped[canonical_query_type(result["query_type"])].append(result)
     for query_type in QUERY_TYPES:
         if query_type in grouped:
-            summary["by_query_type"][query_type] = metric_block(grouped[query_type])
+            block = metric_block(grouped[query_type])
+            summary["by_query_type"][query_type] = block
+            summary["by_slice"][query_type] = block
     hardcase_grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for result in case_results:
         for category in hardcase_categories(result):
@@ -731,11 +1005,56 @@ def summarize_run(
     return summary
 
 
+def safe_path_part(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_") or "unknown"
+
+
+def prediction_trace_payload(
+    case: dict[str, Any],
+    run_config: dict[str, Any],
+    prediction: dict[str, Any],
+) -> dict[str, Any]:
+    trace = prediction.get("trace") if isinstance(prediction.get("trace"), dict) else {}
+    return {
+        "schema_version": 1,
+        "case_id": case.get("id"),
+        "run": run_config.get("name"),
+        "pipeline": run_config.get("pipeline"),
+        "slice": canonical_query_type(case.get("query_type")),
+        "query": case.get("query"),
+        "answer_status": answer_status(prediction),
+        "trace": trace,
+    }
+
+
+def write_prediction_trace(
+    trace_dir: Path | None,
+    case: dict[str, Any],
+    run_config: dict[str, Any],
+    prediction: dict[str, Any],
+) -> str | None:
+    if trace_dir is None:
+        return None
+    run_dir = trace_dir / safe_path_part(str(run_config.get("name") or "run"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / f"{safe_path_part(str(case.get('id') or 'case'))}.trace.json"
+    path.write_text(
+        json.dumps(
+            prediction_trace_payload(case, run_config, prediction),
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
 def evaluate_run(
     index: dict[str, Any],
     cases: list[dict[str, Any]],
     run_config: dict[str, Any],
     answer_policy: dict[str, Any] | None = None,
+    trace_dir: Path | None = None,
 ) -> list[dict[str, Any]]:
     case_results = []
     for case in cases:
@@ -769,7 +1088,11 @@ def evaluate_run(
             prompt_profile=str(run_config.get("prompt_profile") or ""),
             conversation_state=conversation_state,
         )
-        case_results.append(score_case(case, prediction, answer_policy))
+        trace_path = write_prediction_trace(trace_dir, case, run_config, prediction)
+        result = score_case(case, prediction, answer_policy)
+        if trace_path:
+            result["trace_path"] = trace_path
+        case_results.append(result)
     return case_results
 
 
@@ -793,6 +1116,7 @@ def main() -> int:
     run_summaries = []
     primary_summary = None
     primary_run_name = str(config.get("primary_run") or DEFAULT_CLI_PIPELINE_NAME)
+    trace_root = Path(args.trace_dir) if args.trace_dir else Path(args.output_dir) / "traces"
     try:
         for run_config in ablation_runs(config):
             case_results = evaluate_run(
@@ -800,6 +1124,7 @@ def main() -> int:
                 config["cases"],
                 run_config,
                 config.get("answer_policy") if isinstance(config.get("answer_policy"), dict) else {},
+                trace_dir=trace_root,
             )
             is_primary = run_config["name"] == primary_run_name
             run_summary = summarize_run(
@@ -833,6 +1158,7 @@ def main() -> int:
         "citation_page_precision": primary_summary["citation_page_precision"],
         "citation_region_precision": primary_summary["citation_region_precision"],
         "citation_grounding": primary_summary["citation_grounding"],
+        "claim_citation_alignment": primary_summary["claim_citation_alignment"],
         "abstention": primary_summary["abstention"],
         "answer_format_compliance": primary_summary["answer_format_compliance"],
         "latency": primary_summary["latency"],
@@ -841,10 +1167,13 @@ def main() -> int:
         "cold_start_samples": primary_summary.get("cold_start_samples", {}),
         "retry": primary_summary["retry"],
         "by_query_type": primary_summary["by_query_type"],
+        "by_slice": primary_summary.get("by_slice", {}),
         "by_hardcase_category": primary_summary.get("by_hardcase_category", {}),
         "retry_cost": primary_summary["retry_cost"],
         "retry_reason_counts": primary_summary["retry_reason_counts"],
         "citation_grounding_error_counts": primary_summary["citation_grounding_error_counts"],
+        "claim_citation_error_counts": primary_summary["claim_citation_error_counts"],
+        "trace_dir": str(trace_root),
         "ablation": {"runs": run_summaries},
         "case_results": primary_summary.get("case_results", []),
     }

--- a/outputs/answer.json
+++ b/outputs/answer.json
@@ -8,6 +8,11 @@
       "기관 A",
       "기관 B"
     ],
+    "requested_entities": [
+      "기관 A",
+      "기관 B"
+    ],
+    "missing_requested_entities": [],
     "topics": [
       "AI"
     ],
@@ -130,55 +135,34 @@
     }
   },
   "plan": {
-    "strategy": "metadata-first dense + lexical + metadata rerank",
-    "pipeline": "agentic_full",
-    "prompt_profile": "structured_grounded_claims",
-    "filter_stage": "strict",
-    "metadata_first": true,
-    "rerank": true,
-    "verifier_retry": true,
+    "strategy": "dense",
+    "pipeline": "naive_baseline",
+    "prompt_profile": "minimal_grounded_extractive",
+    "filter_stage": "relaxed",
+    "metadata_first": false,
+    "rerank": false,
+    "verifier_retry": false,
     "retrieval_mode": "flat",
-    "metadata_filters": {
-      "doc_ids": [
-        "rfp-agency-a-ai-quality",
-        "rfp-agency-b-mlops-governance"
-      ],
-      "agencies": [
-        "기관 A",
-        "기관 B"
-      ],
-      "projects": [
-        "AI 품질관리 플랫폼 구축",
-        "데이터 거버넌스 및 MLOps 자동화"
-      ],
-      "confidence": 1.0
-    },
-    "top_k": 8,
+    "metadata_filters": {},
+    "top_k": 4,
     "retrieval_budget": {
-      "selected_top_k": 8,
+      "selected_top_k": 4,
       "query_type": "comparison",
-      "reason": "comparison_coverage_adaptive",
+      "reason": "pipeline_or_explicit_override",
       "defaults": {
         "single_doc": 4,
         "follow_up": 6,
         "comparison": 6
       }
     },
-    "relaxed": false,
+    "relaxed": true,
     "retry_policy": "try strict metadata filters, then reduced fuzzy filters, then relaxed retrieval",
-    "comparison_balance": {
-      "enabled": true,
-      "min_per_target": 1,
-      "k_per_target": 3,
-      "headroom": 2,
-      "max_top_k": 12
-    },
     "comparison_targets": [
       "rfp-agency-a-ai-quality",
       "rfp-agency-b-mlops-governance"
     ],
     "comparison_target_field": "doc_id",
-    "candidate_count": 2,
+    "candidate_count": 4,
     "total_chunks": 4,
     "filter_fallback_used": false,
     "comparison_coverage": {
@@ -195,12 +179,17 @@
         "rfp-agency-a-ai-quality": 1,
         "rfp-agency-b-mlops-governance": 1
       },
-      "balanced": true,
-      "min_per_target": 1
+      "balanced": false
     }
   },
   "answer": {
+    "schema_version": 2,
     "status": "supported",
+    "status_reason": {
+      "code": "verified",
+      "verified": true,
+      "verification_reasons": []
+    },
     "query_type": "comparison",
     "summary": "기관 A: 사업 개요\n기관 A는 AI 품질관리 플랫폼 구축을 추진한다. 기관 B: AI 요구사항\n기관 B의 핵심 AI 요구사항은 데이터 거버넌스, MLOps 배포 자동화, 모델 모니터링이다.",
     "claims": [
@@ -242,7 +231,7 @@
       "chunk_id": "rfp-agency-a-ai-quality::chunk-001",
       "title": "기관 A AI 품질관리 플랫폼 구축 RFP",
       "text": "사업 개요\n기관 A는 AI 품질관리 플랫폼 구축을 추진한다. 목표는 모델 성능 저하를 조기에 감지하고 품질 지표를 표준화하는 것이다. AI 요구사항\n기관 A의 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 시스템은 모델별 정확도와 오류 유형을 수집하고 위험 이벤트를 감사 로그로 남겨야 한다. 일정 및 산출물\n기관 A 일정은 착수 후 4개월 내 MVP를 제출하고 6개월 내 최종 검수를 완료하는 방식이다. 필수 산출물은 모델 점검 리포트, 보안 통제 매뉴얼, 운영자 교육 자료이다. 제출조건\n제안사는 PM, ML 엔지니어, 보안 담당자를 포함한 수행 조직을 제시해야 한다. 보안 통제 경험과 AI 품질관리 프로젝트 경험은 정성평가에 반영된다.",
-      "score": 0.6988,
+      "score": 0.5744,
       "agency": "기관 A",
       "metadata": {
         "domain": "AI quality",
@@ -268,7 +257,7 @@
       "chunk_id": "rfp-agency-b-mlops-governance::chunk-001",
       "title": "기관 B 데이터 거버넌스 및 MLOps 자동화 RFP",
       "text": "사업 개요\n기관 B는 데이터 거버넌스와 MLOps 자동화를 결합한 운영 체계를 구축한다. 목표는 모델 배포 절차를 표준화하고 데이터 변경 영향을 추적하는 것이다. AI 요구사항\n기관 B의 핵심 AI 요구사항은 데이터 거버넌스, MLOps 배포 자동화, 모델 모니터링이다. 시스템은 데이터 lineage, 모델 drift, 배포 승인 이력을 대시보드로 제공해야 한다. 보안 및 개인정보\n기관 B는 개인정보 비식별화와 접근 권한 분리를 요구한다. 보안 통제는 데이터셋 반출 승인과 관리자 작업 기록을 중심으로 설계한다. 일정 및 산출물\n기관 B 일정은 착수 후 3개월 내 파일럿 환경을 구성하고 5개월 내 운영 전환을 완료하는 방식이다. 필수 산출물은 데이터 표준 사전, MLOps 운영 가이드, 모니터링 대시보드이다.",
-      "score": 0.7092,
+      "score": 0.5916,
       "agency": "기관 B",
       "metadata": {
         "domain": "MLOps",
@@ -290,6 +279,87 @@
       "child_chunk_ids": []
     }
   ],
+  "trace": {
+    "schema_version": 1,
+    "query_rewrite": {
+      "original_query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+      "resolved_query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+      "rewritten": false,
+      "rewrite_type": "none",
+      "context_source": "query",
+      "context_status": "not_needed",
+      "reason": "",
+      "context_entities": [],
+      "context_projects": [],
+      "active_doc_ids": [],
+      "readable_summary": "none: query used without text rewrite"
+    },
+    "planner": {
+      "query_type": "comparison",
+      "pipeline": "naive_baseline",
+      "prompt_profile": "minimal_grounded_extractive",
+      "strategy": "dense",
+      "retrieval_mode": "flat",
+      "metadata_first": false,
+      "rerank": false,
+      "verifier_retry": false,
+      "stage_sequence": [
+        "relaxed"
+      ],
+      "selected_stage": "relaxed",
+      "selected_top_k": 4,
+      "retrieval_budget": {
+        "selected_top_k": 4,
+        "query_type": "comparison",
+        "reason": "pipeline_or_explicit_override",
+        "defaults": {
+          "single_doc": 4,
+          "follow_up": 6,
+          "comparison": 6
+        }
+      },
+      "metadata_candidate_count": 3,
+      "metadata_selected_doc_ids": [],
+      "metadata_ambiguous": false,
+      "comparison_coverage": {
+        "targets": [
+          "rfp-agency-a-ai-quality",
+          "rfp-agency-b-mlops-governance"
+        ],
+        "target_field": "doc_id",
+        "before": {
+          "rfp-agency-a-ai-quality": 1,
+          "rfp-agency-b-mlops-governance": 1
+        },
+        "after": {
+          "rfp-agency-a-ai-quality": 1,
+          "rfp-agency-b-mlops-governance": 1
+        },
+        "balanced": false
+      },
+      "attempts": [
+        {
+          "stage": "relaxed",
+          "top_k": 4,
+          "verified": true,
+          "verification_reasons": [],
+          "metadata_doc_ids": []
+        }
+      ],
+      "readable_summary": "comparison planned with naive_baseline stage=relaxed top_k=4 metadata_docs=none"
+    },
+    "answer_schema": {
+      "schema_version": 2,
+      "status": "supported",
+      "status_reason": {
+        "code": "verified",
+        "verified": true,
+        "verification_reasons": []
+      },
+      "query_type": "comparison",
+      "claim_count": 2
+    }
+  },
   "conversation_state": {
     "schema_version": 1,
     "active_agencies": [
@@ -354,7 +424,7 @@
     ]
   },
   "diagnostics": {
-    "latency_ms": 2.16,
+    "latency_ms": 1.91,
     "retry_count": 0,
     "abstained": false,
     "answer_status": "supported",
@@ -365,36 +435,22 @@
     "verification_topics": [],
     "filter_stage_attempts": [
       {
-        "stage": "strict",
-        "pipeline": "agentic_full",
-        "prompt_profile": "structured_grounded_claims",
-        "metadata_filters": {
-          "doc_ids": [
-            "rfp-agency-a-ai-quality",
-            "rfp-agency-b-mlops-governance"
-          ],
-          "agencies": [
-            "기관 A",
-            "기관 B"
-          ],
-          "projects": [
-            "AI 품질관리 플랫폼 구축",
-            "데이터 거버넌스 및 MLOps 자동화"
-          ],
-          "confidence": 1.0
-        },
-        "top_k": 8,
+        "stage": "relaxed",
+        "pipeline": "naive_baseline",
+        "prompt_profile": "minimal_grounded_extractive",
+        "metadata_filters": {},
+        "top_k": 4,
         "retrieval_budget": {
-          "selected_top_k": 8,
+          "selected_top_k": 4,
           "query_type": "comparison",
-          "reason": "comparison_coverage_adaptive",
+          "reason": "pipeline_or_explicit_override",
           "defaults": {
             "single_doc": 4,
             "follow_up": 6,
             "comparison": 6
           }
         },
-        "candidate_count": 2,
+        "candidate_count": 4,
         "parent_candidate_count": null,
         "total_chunks": 4,
         "filter_fallback_used": false,
@@ -402,7 +458,7 @@
         "verified": true,
         "verification_reasons": [],
         "retrieve_ms": 0.18,
-        "verify_ms": 0.13,
+        "verify_ms": 0.0,
         "comparison_coverage": {
           "targets": [
             "rfp-agency-a-ai-quality",
@@ -417,8 +473,7 @@
             "rfp-agency-a-ai-quality": 1,
             "rfp-agency-b-mlops-governance": 1
           },
-          "balanced": true,
-          "min_per_target": 1
+          "balanced": false
         }
       }
     ],
@@ -484,7 +539,7 @@
           ]
         }
       ],
-      "selected_stage": "strict",
+      "selected_stage": "relaxed",
       "selected_candidates_by_stage": {
         "strict": [
           {
@@ -558,38 +613,8 @@
         ],
         "relaxed": []
       },
-      "selected_candidates": [
-        {
-          "doc_id": "rfp-agency-a-ai-quality",
-          "field": "agency",
-          "value": "기관 A",
-          "agency": "기관 A",
-          "project": "AI 품질관리 플랫폼 구축",
-          "confidence": 1.0,
-          "stage": "strict",
-          "match_type": "compact_contains",
-          "matched_terms": [
-            "a"
-          ]
-        },
-        {
-          "doc_id": "rfp-agency-b-mlops-governance",
-          "field": "agency",
-          "value": "기관 B",
-          "agency": "기관 B",
-          "project": "데이터 거버넌스 및 MLOps 자동화",
-          "confidence": 1.0,
-          "stage": "strict",
-          "match_type": "compact_contains",
-          "matched_terms": [
-            "b"
-          ]
-        }
-      ],
-      "selected_doc_ids": [
-        "rfp-agency-a-ai-quality",
-        "rfp-agency-b-mlops-governance"
-      ],
+      "selected_candidates": [],
+      "selected_doc_ids": [],
       "matched_doc_ids": [
         "rfp-agency-a-ai-quality",
         "rfp-agency-b-mlops-governance"
@@ -604,18 +629,18 @@
         "decision_reason": "comparison_allows_multiple_targets"
       }
     },
-    "selected_top_k": 8,
+    "selected_top_k": 4,
     "embedding_backend": "hashing",
     "embedding_model": "local-hashing-bow",
-    "metadata_first": true,
-    "rerank": true,
-    "verifier_retry": true,
+    "metadata_first": false,
+    "rerank": false,
+    "verifier_retry": false,
     "retrieval_mode": "flat",
-    "pipeline": "agentic_full",
-    "prompt_profile": "structured_grounded_claims",
+    "pipeline": "naive_baseline",
+    "prompt_profile": "minimal_grounded_extractive",
     "cold_start": true,
     "stage_latency": {
-      "query_analysis_ms": 0.53,
+      "query_analysis_ms": 0.51,
       "context_resolution_ms": 0.0,
       "answer_generation_ms": 0.36
     }

--- a/rag_core.py
+++ b/rag_core.py
@@ -90,7 +90,7 @@ INDEX_FILENAME = "index.json"
 MODEL_CACHE: dict[tuple[str, bool], Any] = {}
 
 TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]+")
-ENTITY_RE = re.compile(r"기관\s*[A-Za-z0-9가-힣]+")
+ENTITY_RE = re.compile(r"기관\s*[-_]?\s*([A-Za-z0-9]+)", re.IGNORECASE)
 SENTENCE_RE = re.compile(r"(?<=[.!?。])\s+")
 
 STOPWORDS = {
@@ -181,6 +181,8 @@ TOPIC_KEYWORDS = [
 ANSWER_STATUS_SUPPORTED = "supported"
 ANSWER_STATUS_PARTIAL = "partial"
 ANSWER_STATUS_INSUFFICIENT = "insufficient"
+ANSWER_SCHEMA_VERSION = 2
+TRACE_SCHEMA_VERSION = 1
 
 STRICT_METADATA_CONFIDENCE = 0.90
 REDUCED_METADATA_CONFIDENCE = 0.70
@@ -1358,6 +1360,18 @@ def has_comparison_request(query: str) -> bool:
     return any(term in normalize_entity(query) for term in comparison_terms)
 
 
+def extract_requested_agencies(query: str) -> list[str]:
+    agencies = []
+    for match in ENTITY_RE.finditer(unicodedata.normalize("NFC", query)):
+        token = normalize_metadata_token(match.group(1))
+        if not token:
+            continue
+        if re.fullmatch(r"[a-z0-9]+", token):
+            token = token.upper()
+        agencies.append(f"기관 {token}")
+    return ordered_unique(agencies)
+
+
 def active_state_terms(state: dict[str, Any]) -> list[str]:
     terms = [
         *coerce_string_list(state.get("active_agencies")),
@@ -1506,6 +1520,7 @@ def analyze_query(
 ) -> dict[str, Any]:
     targets = coerce_metadata_targets(entities)
     normalized_query = normalize_entity(query)
+    requested_agencies = extract_requested_agencies(normalized_query)
     metadata_matches = match_metadata_targets(normalized_query, targets)
 
     context_used = False
@@ -1544,6 +1559,9 @@ def analyze_query(
         query_type = "follow_up"
     else:
         query_type = "single_doc"
+    analysis_entities = matched_agencies
+    if query_type == "comparison":
+        analysis_entities = ordered_unique([*requested_agencies, *matched_agencies])
 
     strict_matches = metadata_matches_for_stage(metadata_matches, "strict")
     strict_filters = metadata_filters_from_matches(strict_matches)
@@ -1552,7 +1570,11 @@ def analyze_query(
 
     return {
         "query_type": query_type,
-        "entities": matched_agencies,
+        "entities": analysis_entities,
+        "requested_entities": requested_agencies,
+        "missing_requested_entities": [
+            entity for entity in requested_agencies if entity not in matched_agencies
+        ],
         "topics": topics[:8],
         "context_entities": context_entities or [],
         "context_used": context_used,
@@ -2132,7 +2154,8 @@ def generate_answer(
     verification_reasons: list[str] | None = None,
 ) -> tuple[dict[str, Any], str, bool]:
     claims = build_claims(analysis, evidence)
-    status = answer_status(analysis, claims, verified, verification_reasons or [])
+    effective_reasons = answer_verification_reasons(analysis, verification_reasons or [])
+    status = answer_status(analysis, claims, verified, effective_reasons)
     insufficiency = None
     if status != ANSWER_STATUS_SUPPORTED:
         insufficiency = build_insufficiency(
@@ -2140,11 +2163,13 @@ def generate_answer(
             analysis,
             claims,
             verified,
-            verification_reasons or [],
+            effective_reasons,
         )
 
     answer = {
+        "schema_version": ANSWER_SCHEMA_VERSION,
         "status": status,
+        "status_reason": answer_status_reason(status, verified, effective_reasons),
         "query_type": answer_query_type(analysis, status),
         "summary": answer_summary(query, analysis, claims, status, insufficiency),
         "claims": claims,
@@ -2152,6 +2177,39 @@ def generate_answer(
     }
     answer_text = render_answer_text(answer)
     return answer, answer_text, status == ANSWER_STATUS_INSUFFICIENT
+
+
+def answer_verification_reasons(
+    analysis: dict[str, Any],
+    verification_reasons: list[str],
+) -> list[str]:
+    reasons = list(verification_reasons)
+    if analysis.get("query_type") == "comparison":
+        for entity in analysis.get("missing_requested_entities") or []:
+            reason = f"missing_requested_entity:{entity}"
+            if reason not in reasons:
+                reasons.append(reason)
+    return reasons
+
+
+def answer_status_reason(
+    status: str,
+    verified: bool,
+    verification_reasons: list[str],
+    code: str | None = None,
+) -> dict[str, Any]:
+    if code is None:
+        if status == ANSWER_STATUS_SUPPORTED:
+            code = "verified"
+        elif status == ANSWER_STATUS_PARTIAL:
+            code = "partial_comparison"
+        else:
+            code = "insufficient_evidence"
+    return {
+        "code": code,
+        "verified": bool(verified),
+        "verification_reasons": verification_reasons,
+    }
 
 
 def build_claims(analysis: dict[str, Any], evidence: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -2260,9 +2318,15 @@ def answer_status(
     verification_reasons: list[str],
 ) -> str:
     if verified:
-        return ANSWER_STATUS_SUPPORTED
+        has_missing_requested = any(
+            reason.startswith("missing_requested_entity") for reason in verification_reasons
+        )
+        if not has_missing_requested:
+            return ANSWER_STATUS_SUPPORTED
     has_partial_comparison_reason = any(
-        reason.startswith("missing_comparison") for reason in verification_reasons
+        reason.startswith("missing_comparison")
+        or reason.startswith("missing_requested_entity")
+        for reason in verification_reasons
     )
     if analysis.get("query_type") == "comparison" and claims and has_partial_comparison_reason:
         return ANSWER_STATUS_PARTIAL
@@ -2507,6 +2571,124 @@ def summarize_stage_attempt(
     return summary
 
 
+def build_query_rewrite_trace(
+    original_query: str,
+    resolved_query: str,
+    context_resolution: dict[str, Any],
+) -> dict[str, Any]:
+    rewritten = bool(resolved_query and resolved_query != original_query)
+    source = str(context_resolution.get("source") or "none")
+    status = str(context_resolution.get("status") or "")
+    if rewritten and source == "conversation_state":
+        rewrite_type = "conversation_state_prefix"
+    elif source == "context_entities":
+        rewrite_type = "explicit_context"
+    elif status == "needs_clarification":
+        rewrite_type = "clarification_required"
+    else:
+        rewrite_type = "none"
+
+    return {
+        "original_query": original_query,
+        "resolved_query": resolved_query or original_query,
+        "rewritten": rewritten,
+        "rewrite_type": rewrite_type,
+        "context_source": source,
+        "context_status": status,
+        "reason": context_resolution.get("reason", ""),
+        "context_entities": context_resolution.get("context_entities") or [],
+        "context_projects": context_resolution.get("context_projects") or [],
+        "active_doc_ids": context_resolution.get("active_doc_ids") or [],
+        "readable_summary": (
+            f"{rewrite_type}: {original_query} -> {resolved_query}"
+            if rewritten
+            else f"{rewrite_type}: query used without text rewrite"
+        ),
+    }
+
+
+def build_planner_trace(
+    analysis: dict[str, Any],
+    plan: dict[str, Any],
+    metadata_resolution: dict[str, Any],
+    stage_sequence: list[str],
+    stage_attempts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    attempts = [
+        {
+            "stage": attempt.get("stage"),
+            "top_k": attempt.get("top_k"),
+            "verified": bool(attempt.get("verified")),
+            "verification_reasons": attempt.get("verification_reasons") or [],
+            "metadata_doc_ids": (attempt.get("metadata_filters") or {}).get("doc_ids") or [],
+        }
+        for attempt in stage_attempts
+    ]
+    selected_doc_ids = metadata_resolution.get("selected_doc_ids") or []
+    query_type = str(analysis.get("query_type") or "")
+    filter_stage = str(plan.get("filter_stage") or "")
+    top_k = plan.get("top_k")
+    return {
+        "query_type": query_type,
+        "pipeline": plan.get("pipeline"),
+        "prompt_profile": plan.get("prompt_profile"),
+        "strategy": plan.get("strategy"),
+        "retrieval_mode": plan.get("retrieval_mode"),
+        "metadata_first": bool(plan.get("metadata_first")),
+        "rerank": bool(plan.get("rerank")),
+        "verifier_retry": bool(plan.get("verifier_retry")),
+        "stage_sequence": stage_sequence,
+        "selected_stage": filter_stage,
+        "selected_top_k": top_k,
+        "retrieval_budget": plan.get("retrieval_budget") or {},
+        "metadata_candidate_count": metadata_resolution.get("candidate_count"),
+        "metadata_selected_doc_ids": selected_doc_ids,
+        "metadata_ambiguous": bool(analysis.get("metadata_ambiguous")),
+        "comparison_coverage": plan.get("comparison_coverage"),
+        "attempts": attempts,
+        "readable_summary": (
+            f"{query_type} planned with {plan.get('pipeline')} "
+            f"stage={filter_stage or 'none'} top_k={top_k} "
+            f"metadata_docs={selected_doc_ids or 'none'}"
+        ),
+    }
+
+
+def build_result_trace(
+    original_query: str,
+    resolved_query: str,
+    analysis: dict[str, Any],
+    plan: dict[str, Any],
+    metadata_resolution: dict[str, Any],
+    context_resolution: dict[str, Any],
+    stage_sequence: list[str],
+    stage_attempts: list[dict[str, Any]],
+    answer: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": TRACE_SCHEMA_VERSION,
+        "query_rewrite": build_query_rewrite_trace(
+            original_query,
+            resolved_query,
+            context_resolution,
+        ),
+        "planner": build_planner_trace(
+            analysis,
+            plan,
+            metadata_resolution,
+            stage_sequence,
+            stage_attempts,
+        ),
+        "answer_schema": {
+            "schema_version": answer.get("schema_version"),
+            "status": answer.get("status"),
+            "status_reason": answer.get("status_reason") or {},
+            "query_type": answer.get("query_type"),
+            "claim_count": len(answer.get("claims") or []),
+        },
+    }
+
+
 def clarification_answer(query: str, context_resolution: dict[str, Any]) -> str:
     reason = context_resolution.get("reason")
     if reason == "no_active_state":
@@ -2571,40 +2753,60 @@ def make_context_clarification_result(
         "checked_doc_ids": context_resolution.get("active_doc_ids") or [],
     }
     answer = {
+        "schema_version": ANSWER_SCHEMA_VERSION,
         "status": ANSWER_STATUS_INSUFFICIENT,
+        "status_reason": answer_status_reason(
+            ANSWER_STATUS_INSUFFICIENT,
+            False,
+            [reason],
+            code="context_clarification",
+        ),
         "query_type": "abstention",
         "summary": clarification_answer(query, context_resolution),
         "claims": [],
         "insufficiency": insufficiency,
     }
     answer_text = render_answer_text(answer)
+    plan = {
+        "strategy": "conversation-state clarification",
+        "pipeline": pipeline,
+        "prompt_profile": prompt_profile,
+        "metadata_first": metadata_first,
+        "rerank": rerank,
+        "verifier_retry": verifier_retry,
+        "retrieval_mode": retrieval_mode,
+        "metadata_filters": {},
+        "top_k": None,
+        "retrieval_budget": {
+            "selected_top_k": None,
+            "query_type": "follow_up",
+            "reason": "clarification_before_retrieval",
+            "defaults": dict(QUERY_TYPE_TOP_K_DEFAULTS),
+        },
+        "relaxed": False,
+        "retry_policy": "clarify before retrieval when entity resolution is weak",
+    }
+    trace = build_result_trace(
+        query,
+        context_resolution.get("resolved_query") or query,
+        analysis,
+        plan,
+        metadata_resolution,
+        context_resolution,
+        [],
+        [],
+        answer,
+    )
     return {
         "mode": "rag",
         "query": query,
         "resolved_query": context_resolution.get("resolved_query") or query,
         "analysis": analysis,
-        "plan": {
-            "strategy": "conversation-state clarification",
-            "pipeline": pipeline,
-            "prompt_profile": prompt_profile,
-            "metadata_first": metadata_first,
-            "rerank": rerank,
-            "verifier_retry": verifier_retry,
-            "retrieval_mode": retrieval_mode,
-            "metadata_filters": {},
-            "top_k": None,
-            "retrieval_budget": {
-                "selected_top_k": None,
-                "query_type": "follow_up",
-                "reason": "clarification_before_retrieval",
-                "defaults": dict(QUERY_TYPE_TOP_K_DEFAULTS),
-            },
-            "relaxed": False,
-            "retry_policy": "clarify before retrieval when entity resolution is weak",
-        },
+        "plan": plan,
         "answer": answer,
         "answer_text": answer_text,
         "evidence": [],
+        "trace": trace,
         "conversation_state": conversation_state,
         "diagnostics": {
             "latency_ms": round(latency_ms, 2),
@@ -2692,40 +2894,60 @@ def make_metadata_clarification_result(
         "checked_doc_ids": analysis.get("matched_doc_ids") or [],
     }
     answer = {
+        "schema_version": ANSWER_SCHEMA_VERSION,
         "status": ANSWER_STATUS_INSUFFICIENT,
+        "status_reason": answer_status_reason(
+            ANSWER_STATUS_INSUFFICIENT,
+            False,
+            [reason],
+            code="metadata_ambiguity_clarification",
+        ),
         "query_type": "abstention",
         "summary": metadata_clarification_answer(query, analysis),
         "claims": [],
         "insufficiency": insufficiency,
     }
     answer_text = render_answer_text(answer)
+    plan = {
+        "strategy": "metadata ambiguity clarification",
+        "pipeline": pipeline,
+        "prompt_profile": prompt_profile,
+        "metadata_first": metadata_first,
+        "rerank": rerank,
+        "verifier_retry": verifier_retry,
+        "retrieval_mode": retrieval_mode,
+        "metadata_filters": {},
+        "top_k": None,
+        "retrieval_budget": {
+            "selected_top_k": None,
+            "query_type": analysis.get("query_type"),
+            "reason": "clarification_before_retrieval",
+            "defaults": dict(QUERY_TYPE_TOP_K_DEFAULTS),
+        },
+        "relaxed": False,
+        "retry_policy": "clarify before retrieval when metadata resolution is ambiguous",
+    }
+    trace = build_result_trace(
+        query,
+        retrieval_query,
+        analysis,
+        plan,
+        metadata_resolution,
+        context_resolution,
+        [],
+        [],
+        answer,
+    )
     return {
         "mode": "rag",
         "query": query,
         "resolved_query": retrieval_query,
         "analysis": analysis,
-        "plan": {
-            "strategy": "metadata ambiguity clarification",
-            "pipeline": pipeline,
-            "prompt_profile": prompt_profile,
-            "metadata_first": metadata_first,
-            "rerank": rerank,
-            "verifier_retry": verifier_retry,
-            "retrieval_mode": retrieval_mode,
-            "metadata_filters": {},
-            "top_k": None,
-            "retrieval_budget": {
-                "selected_top_k": None,
-                "query_type": analysis.get("query_type"),
-                "reason": "clarification_before_retrieval",
-                "defaults": dict(QUERY_TYPE_TOP_K_DEFAULTS),
-            },
-            "relaxed": False,
-            "retry_policy": "clarify before retrieval when metadata resolution is ambiguous",
-        },
+        "plan": plan,
         "answer": answer,
         "answer_text": answer_text,
         "evidence": [],
+        "trace": trace,
         "conversation_state": conversation_state,
         "diagnostics": {
             "latency_ms": round(latency_ms, 2),
@@ -3026,6 +3248,17 @@ def run_rag_query(
         analysis,
         selected_stage=str(plan.get("filter_stage") or ""),
     )
+    trace = build_result_trace(
+        query,
+        retrieval_query,
+        analysis,
+        plan,
+        metadata_resolution,
+        context_resolution,
+        stage_sequence,
+        stage_attempts,
+        answer,
+    )
     return {
         "mode": "rag",
         "query": query,
@@ -3035,6 +3268,7 @@ def run_rag_query(
         "answer": answer,
         "answer_text": answer_text,
         "evidence": strip_internal_scores(evidence),
+        "trace": trace,
         "conversation_state": next_state,
         "diagnostics": {
             "latency_ms": round(latency_ms, 2),
@@ -3044,7 +3278,7 @@ def run_rag_query(
             "answer_query_type": answer["query_type"],
             "claim_count": len(answer["claims"]),
             "citation_count": sum(len(claim.get("citations") or []) for claim in answer["claims"]),
-            "verification_reasons": verification_reasons,
+            "verification_reasons": (answer.get("status_reason") or {}).get("verification_reasons") or verification_reasons,
             "verification_topics": verification_topics(analysis),
             "filter_stage_attempts": stage_attempts,
             "final_relaxation_reason": stage_attempts[-2]["verification_reasons"] if retry_count and len(stage_attempts) >= 2 else [],

--- a/scripts/update_readme_metrics.py
+++ b/scripts/update_readme_metrics.py
@@ -11,6 +11,7 @@ REQUIRED_KEYS = [
     "accuracy",
     "groundedness",
     "citation_precision",
+    "claim_citation_alignment",
     "abstention",
     "answer_format_compliance",
     "latency",
@@ -47,10 +48,12 @@ def fmt_latency(value: Any) -> str:
 
 
 def metric_from_type(summary: Dict[str, Any], query_type: str, metric: str) -> Any:
-    by_type = summary.get("by_query_type")
+    by_type = summary.get("by_slice") or summary.get("by_query_type")
     if not isinstance(by_type, dict):
         return None
     block = by_type.get(query_type)
+    if block is None and query_type == "comparison":
+        block = by_type.get("multi_doc")
     if not isinstance(block, dict):
         return None
     return block.get(metric)
@@ -75,7 +78,7 @@ def render_main_table(summary: Dict[str, Any]) -> str:
         (
             "Multi-doc comparison",
             "Groundedness Rate",
-            fmt_rate(metric_from_type(summary, "multi_doc", "groundedness")),
+            fmt_rate(metric_from_type(summary, "comparison", "groundedness")),
         ),
         (
             "Follow-up",
@@ -83,6 +86,7 @@ def render_main_table(summary: Dict[str, Any]) -> str:
             fmt_rate(metric_from_type(summary, "follow_up", "accuracy")),
         ),
         ("Evidence", "Citation Precision", fmt_rate(summary.get("citation_precision"))),
+        ("Evidence", "Claim Citation Alignment", fmt_rate(summary.get("claim_citation_alignment"))),
         ("Evidence", "Answer Format Compliance", fmt_rate(summary.get("answer_format_compliance"))),
         (
             "Abstention",
@@ -106,8 +110,8 @@ def render_ablation_table(summary: Dict[str, Any]) -> str:
     table = [
         "### Ablation comparison",
         "",
-        "| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Format | Abstention | Retry | Latency p95 |",
-        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Claim Align | Format | Abstention | Retry | Latency p95 |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for run in runs:
         if not isinstance(run, dict):
@@ -116,7 +120,7 @@ def render_ablation_table(summary: Dict[str, Any]) -> str:
         p95 = latency.get("p95") if isinstance(latency, dict) else None
         p95_text = f"{p95:.1f}ms" if isinstance(p95, (int, float)) else "N/A"
         table.append(
-            "| {name} | {pipeline} | {top_k} | {metadata_first} | {rerank} | {verifier_retry} | {accuracy} | {groundedness} | {citation} | {format} | {abstention} | {retry} | {p95} |".format(
+            "| {name} | {pipeline} | {top_k} | {metadata_first} | {rerank} | {verifier_retry} | {accuracy} | {groundedness} | {citation} | {claim_align} | {format} | {abstention} | {retry} | {p95} |".format(
                 name=run.get("name", "unknown"),
                 pipeline=run.get("pipeline", ""),
                 top_k=fmt_top_k(run.get("top_k")),
@@ -126,6 +130,7 @@ def render_ablation_table(summary: Dict[str, Any]) -> str:
                 accuracy=fmt_rate(run.get("accuracy")),
                 groundedness=fmt_rate(run.get("groundedness")),
                 citation=fmt_rate(run.get("citation_precision")),
+                claim_align=fmt_rate(run.get("claim_citation_alignment")),
                 format=fmt_rate(run.get("answer_format_compliance")),
                 abstention=fmt_rate(run.get("abstention")),
                 retry=fmt_rate(run.get("retry")),

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -1,7 +1,9 @@
+import tempfile
 import unittest
 from pathlib import Path
 
-from eval.run_eval import load_config, score_case, summarize_run
+from eval.run_eval import evaluate_run, load_config, score_case, summarize_run
+from rag_core import build_index_payload
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -11,7 +13,13 @@ class EvalMetricsTest(unittest.TestCase):
     def prediction_with_citation(self, citation: dict) -> dict:
         return {
             "answer": {
+                "schema_version": 2,
                 "status": "supported",
+                "status_reason": {
+                    "code": "verified",
+                    "verified": True,
+                    "verification_reasons": [],
+                },
                 "claims": [
                     {
                         "target": "기관 V",
@@ -126,6 +134,7 @@ class EvalMetricsTest(unittest.TestCase):
                 "accuracy": 1.0,
                 "groundedness": 1.0,
                 "citation_precision": 0.5,
+                "claim_citation_alignment": 1.0,
                 "answer_format_compliance": 1.0,
                 "abstention": None,
                 "latency_ms": 10.0,
@@ -138,6 +147,7 @@ class EvalMetricsTest(unittest.TestCase):
                 "accuracy": 0.0,
                 "groundedness": 0.0,
                 "citation_precision": 0.0,
+                "claim_citation_alignment": 0.0,
                 "answer_format_compliance": 0.0,
                 "abstention": None,
                 "latency_ms": 20.0,
@@ -153,6 +163,98 @@ class EvalMetricsTest(unittest.TestCase):
         self.assertEqual(0.5, summary["by_hardcase_category"]["scanned_pdf"]["accuracy"])
         self.assertEqual(1, summary["by_hardcase_category"]["noisy_ocr"]["num_predictions"])
         self.assertEqual(1.0, summary["by_hardcase_category"]["noisy_ocr"]["retry"])
+
+    def test_scores_claim_citation_alignment_separately_from_whole_answer(self) -> None:
+        prediction = {
+            "answer": {
+                "schema_version": 2,
+                "status": "supported",
+                "status_reason": {
+                    "code": "verified",
+                    "verified": True,
+                    "verification_reasons": [],
+                },
+                "claims": [
+                    {
+                        "target": "기관 V",
+                        "claim": "기관 V의 보안 요구사항은 접근 통제입니다.",
+                        "support": "기관 V의 보안 요구사항은 접근 통제입니다.",
+                        "citations": [
+                            {
+                                "doc_id": "visual-doc",
+                                "chunk_id": "visual-doc::chunk-002",
+                            }
+                        ],
+                    }
+                ],
+            },
+            "answer_text": "기관 V의 보안 요구사항은 접근 통제입니다.",
+            "evidence": [
+                {
+                    "doc_id": "visual-doc",
+                    "chunk_id": "visual-doc::chunk-001",
+                    "text": "기관 V의 보안 요구사항은 접근 통제입니다.",
+                },
+                {
+                    "doc_id": "visual-doc",
+                    "chunk_id": "visual-doc::chunk-002",
+                    "text": "기관 V의 일정은 3개월입니다.",
+                },
+            ],
+            "diagnostics": {"latency_ms": 1.0, "retry_count": 0},
+        }
+
+        result = score_case(
+            self.visual_case(
+                expected_citation_pages=[],
+                expected_citation_regions=[],
+                expected_claim_citations=[
+                    {
+                        "target": "기관 V",
+                        "expected_doc_ids": ["visual-doc"],
+                        "expected_terms": ["보안 요구사항", "접근 통제"],
+                    }
+                ],
+            ),
+            prediction,
+        )
+
+        self.assertEqual(1.0, result["citation_precision"])
+        self.assertEqual(0.0, result["claim_citation_alignment"])
+        self.assertEqual(
+            "claim_text_not_supported_by_citation",
+            result["claim_citation_errors"][0]["code"],
+        )
+
+    def test_evaluate_run_writes_readable_trace_files(self) -> None:
+        index = build_index_payload(Path("data/raw"), embedding_backend="hashing")
+        case = {
+            "id": "trace-case",
+            "query_type": "single_doc",
+            "query": "기관 A의 보안 통제 요구사항은?",
+            "expected_doc_ids": ["rfp-agency-a-ai-quality"],
+            "expected_terms": ["보안 통제", "로그"],
+            "expected_claim_targets": ["기관 A"],
+            "answerable": True,
+        }
+        run_config = {
+            "name": "unit",
+            "pipeline": "agentic_full",
+            "top_k": None,
+            "metadata_first": True,
+            "rerank": True,
+            "verifier_retry": True,
+            "retrieval_mode": "flat",
+            "prompt_profile": "structured_grounded_claims",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            results = evaluate_run(index, [case], run_config, trace_dir=Path(tmp))
+            trace_path = Path(results[0]["trace_path"])
+            payload = trace_path.read_text(encoding="utf-8")
+
+        self.assertIn("planner", payload)
+        self.assertIn("query_rewrite", payload)
+        self.assertIn("readable_summary", payload)
 
     def test_private_hardcase_example_config_loads(self) -> None:
         config = load_config(ROOT_DIR / "eval" / "private_hardcase.example.yaml")

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -87,6 +87,8 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
 
         self.assertEqual("comparison", result["analysis"]["query_type"])
         self.assertEqual("supported", result["answer"]["status"])
+        self.assertEqual(2, result["answer"]["schema_version"])
+        self.assertEqual("verified", result["answer"]["status_reason"]["code"])
         self.assertEqual("comparison", result["answer"]["query_type"])
         self.assertIn("answer_text", result)
         self.assertEqual(
@@ -242,15 +244,32 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
         result = run_rag_query(partial_index, "기관 X와 기관 Y의 보안 요구사항 차이를 비교해줘")
 
         self.assertEqual("partial", result["answer"]["status"])
+        self.assertEqual(2, result["answer"]["schema_version"])
+        self.assertEqual("partial_comparison", result["answer"]["status_reason"]["code"])
         self.assertFalse(result["diagnostics"]["abstained"])
         self.assertEqual(["기관 Y"], result["answer"]["insufficiency"]["missing_targets"])
         self.assertEqual({"기관 X"}, {claim["target"] for claim in result["answer"]["claims"]})
+
+    def test_partial_comparison_records_unknown_requested_target(self) -> None:
+        result = run_rag_query(
+            self.index,
+            "기관 A와 기관 D의 보안 요구사항 차이를 비교해줘",
+            pipeline="agentic_full",
+        )
+
+        self.assertEqual("comparison", result["analysis"]["query_type"])
+        self.assertIn("기관 D", result["analysis"]["requested_entities"])
+        self.assertEqual("partial", result["answer"]["status"])
+        self.assertEqual(["기관 D"], result["answer"]["insufficiency"]["missing_targets"])
+        self.assertEqual({"기관 A"}, {claim["target"] for claim in result["answer"]["claims"]})
 
     def test_retry_relaxes_filters_when_verifier_rejects_evidence(self) -> None:
         result = run_rag_query(self.index, "기관 A의 블록체인 납품 실적은?")
 
         self.assertTrue(result["diagnostics"]["abstained"])
         self.assertEqual("insufficient", result["answer"]["status"])
+        self.assertEqual(2, result["answer"]["schema_version"])
+        self.assertEqual("insufficient_evidence", result["answer"]["status_reason"]["code"])
         self.assertEqual("abstention", result["answer"]["query_type"])
         self.assertEqual([], result["answer"]["claims"])
         self.assertTrue(result["answer"]["insufficiency"]["reasons"])
@@ -473,6 +492,27 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
         self.assertEqual(6, follow_up["plan"]["top_k"])
         self.assertEqual("follow_up_default", follow_up["plan"]["retrieval_budget"]["reason"])
         self.assertEqual(6, follow_up["diagnostics"]["selected_top_k"])
+        self.assertEqual(1, follow_up["trace"]["schema_version"])
+        self.assertTrue(follow_up["trace"]["query_rewrite"]["rewritten"])
+        self.assertEqual(
+            "conversation_state_prefix",
+            follow_up["trace"]["query_rewrite"]["rewrite_type"],
+        )
+        self.assertIn("readable_summary", follow_up["trace"]["planner"])
+
+    def test_planner_trace_is_readable_for_direct_query(self) -> None:
+        result = run_rag_query(
+            self.index,
+            "기관 A의 보안 통제 요구사항은?",
+            pipeline="agentic_full",
+        )
+
+        trace = result["trace"]
+        self.assertEqual(1, trace["schema_version"])
+        self.assertFalse(trace["query_rewrite"]["rewritten"])
+        self.assertEqual("single_doc", trace["planner"]["query_type"])
+        self.assertEqual("agentic_full", trace["planner"]["pipeline"])
+        self.assertIn("stage=", trace["planner"]["readable_summary"])
 
     def test_multi_step_follow_up_preserves_agency_and_project_context(self) -> None:
         first = run_rag_query(


### PR DESCRIPTION
Closes parts of #49 (Phase 1 backlog). Issue coverage: #58, #60, #63, #64. Out of scope: #62 (chunking), #65 (private/public delta flow).

## Summary

- **Slice naming standardized** to `single_doc`, `comparison`, `follow_up`, `abstention` across `eval/config.yaml`, `eval/run_eval.py`, README/docs, and `scripts/update_readme_metrics.py`. Old `multi_doc` configs are normalized to `comparison` and the README updater falls back to `by_query_type` so existing eval artifacts keep working.
- **Answer schema v2**: `outputs/answer.json` now carries `schema_version: 2` and a structured `status_reason` block (`code`, `verified`, `verification_reasons`). Verifier outcomes (`verified`, `topic_not_grounded`, `missing_comparison_doc:*`, `missing_requested_entity:*`) are machine-readable, and `partial` is now used for missing requested entities even when the verifier passes.
- **Planner / rewrite trace**: `run_rag_query` emits a `trace` block (planner choice, context resolution, query rewrite). `eval/run_eval.py` writes per-case traces to `reports/traces/<run>/<case>.trace.json` (gitignored) so reviewers can inspect agentic vs baseline behavior offline.
- **Claim-level citation alignment**: new aggregate metrics `claim_citation_alignment` and `claim_citation_error_counts`, new per-case `claim_citation_errors`, and new optional gold field `expected_claim_citations`. Six new failure codes separate citation drift from whole-answer citation precision.
- **README metrics regenerated** (all overall metrics held or improved; new "Claim Citation Alignment" column added to main and ablation tables).
- **Tests extended**: `tests/test_eval_metrics.py` (+slice naming, claim alignment, schema v2) and `tests/test_fuzzy_retrieval.py` (+missing requested entities path).
- **New doc** [`docs/grounding-eval-hardening.md`](docs/grounding-eval-hardening.md) — reviewer-facing summary, validation steps, failure-mode interpretation guide.

## Why

The prior eval surface answered "is the answer mostly right?" but not:
- which target failed in a comparison?
- what query did follow-up rewrite into?
- is `supported` / `partial` / `insufficient` produced via a stable contract?
- is each individual claim cited by a chunk that actually supports it?

This change adds the schema, traces, and metrics needed to answer those — without touching retrieval / chunking structure (deferred to #62).

## Reviewer notes

- `outputs/answer.json` was regenerated and now reflects a `naive_baseline` run (was `agentic_full` previously). The structural fields (`schema_version`, `status_reason`, `trace`) are the demo target. If the portfolio sample should stay on `agentic_full`, regenerating with `app.py --pipeline agentic_full` and recommitting is enough.
- The two compat layers (slice rename, README updater) are intentional — drop them only when no caller still emits `multi_doc`.
- Issue label hygiene: this PR addresses #58, #60, #63, #64. Closing those individually after merge is preferred over auto-close so each child can record its own commit pointer.

## Test plan

- [ ] `python3 -m pytest tests/test_eval_metrics.py tests/test_fuzzy_retrieval.py`
- [ ] `python3 eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml` produces `by_slice`, `claim_citation_alignment`, `case_results[*].trace_path`
- [ ] `python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check` passes
- [ ] `outputs/answer.json` shows `answer.schema_version == 2`, `answer.status_reason`, and a populated `trace` block
- [ ] `reports/traces/full/*.trace.json` and `reports/traces/naive_baseline/*.trace.json` exist after eval