### PR TITLE
Add P0 retrieval-loop regression guards (#68)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -34,6 +34,11 @@ harness-smoke:
 
 test:
 	bash scripts/test.sh
+
+# Fast P0 regression guards for the retrieval loop and answerable smoke path.
+# Run before any change to rag_core retrieval/verification or the eval pipeline.
+test-regression:
+	$(PYTHON) -m pytest tests/test_retrieval_loop_regression.py -q
 
 clean:
 	rm -rf data/index outputs reports

--- a/docs/grounding-eval-hardening.md
+++ b/docs/grounding-eval-hardening.md
@@ -30,6 +30,7 @@ python3 app.py --input_dir data/index --output_dir outputs --query "기관 A와 
 python3 eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml
 python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check
 python3 -m pytest tests/test_eval_metrics.py tests/test_fuzzy_retrieval.py
+make test-regression  # P0 retrieval-loop / answerable-smoke regression guards (#68)
 ```
 
 Inspect these artifacts:

--- a/tests/test_retrieval_loop_regression.py
+++ b/tests/test_retrieval_loop_regression.py
@@ -1,0 +1,100 @@
+"""P0 regression guards for the retrieval loop and answerable smoke path.
+
+Covers two real-data regressions documented in
+``docs/real-data-failure-taxonomy.md`` and tracked under issue #68 / #49:
+
+* **R2** — retrieval loop body (`retrieve` / `verify_evidence` /
+  ``stage_attempts.append``) was lost in a merge, causing every answerable
+  query to abstain with empty evidence.
+* **R1** — ``IndexError`` when reading ``final_relaxation_reason`` with
+  ``retry_count > 0`` but ``len(stage_attempts) < 2``.
+
+These tests are intentionally lightweight (hashing embedding backend, the
+existing ``data/raw`` fixture) so they can be run on every change without
+slowing down the dev loop. See ``make test-regression``.
+"""
+
+import unittest
+from pathlib import Path
+
+from rag_core import build_index_payload, run_rag_query
+
+
+ANSWERABLE_QUERY = "기관 A의 보안 통제 요구사항은?"
+OUT_OF_CORPUS_QUERY = "외계 행성의 우주선 검수 절차는?"
+
+
+class RetrievalLoopRegressionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index = build_index_payload(
+            Path("data/raw"),
+            embedding_backend="hashing",
+        )
+
+    def test_answerable_single_doc_returns_non_empty_evidence(self) -> None:
+        """R2 guard: answerable single-doc query must not silently abstain.
+
+        If the retrieval loop body is deleted again, this assertion fails fast.
+        """
+        result = run_rag_query(self.index, ANSWERABLE_QUERY)
+
+        diagnostics = result["diagnostics"]
+        self.assertFalse(
+            diagnostics["abstained"],
+            "answerable query unexpectedly abstained — retrieval loop may be broken",
+        )
+        self.assertGreater(
+            len(result["evidence"]),
+            0,
+            "answerable query returned empty evidence",
+        )
+        attempts = diagnostics["filter_stage_attempts"]
+        self.assertGreaterEqual(
+            len(attempts),
+            1,
+            "stage_attempts must be appended on each retrieval iteration",
+        )
+        self.assertTrue(
+            attempts[-1]["verified"],
+            "final stage attempt must be verified for an answerable query",
+        )
+        self.assertEqual("supported", result["answer"]["status"])
+
+    def test_diagnostics_block_safe_for_single_attempt_verified_path(self) -> None:
+        """R1 guard: diagnostics must build cleanly when only one attempt ran.
+
+        On a single verified attempt, ``retry_count == 0`` and
+        ``final_relaxation_reason`` must be an empty list — not raise IndexError
+        and not be ``None``.
+        """
+        result = run_rag_query(self.index, ANSWERABLE_QUERY)
+
+        diagnostics = result["diagnostics"]
+        self.assertEqual(0, diagnostics["retry_count"])
+        self.assertIsInstance(diagnostics["final_relaxation_reason"], list)
+        self.assertEqual([], diagnostics["final_relaxation_reason"])
+
+    def test_out_of_corpus_query_exits_loop_without_indexerror(self) -> None:
+        """R1 guard for the retry/abstention path.
+
+        Out-of-corpus queries exercise the retry path. Regardless of how many
+        attempts run, the diagnostics dict must be well-formed:
+        ``final_relaxation_reason`` is a list and ``filter_stage_attempts`` is
+        non-empty.
+        """
+        result = run_rag_query(self.index, OUT_OF_CORPUS_QUERY)
+
+        diagnostics = result["diagnostics"]
+        self.assertIsInstance(diagnostics["final_relaxation_reason"], list)
+        attempts = diagnostics["filter_stage_attempts"]
+        self.assertGreaterEqual(len(attempts), 1)
+        # Every appended attempt carries a stage label and verified flag,
+        # which proves the loop body ran end-to-end.
+        for attempt in attempts:
+            self.assertIn("stage", attempt)
+            self.assertIn("verified", attempt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #68. Tracked under #49 Phase 1.

## Summary
- Add `tests/test_retrieval_loop_regression.py` with three fast guards covering the two real-data regressions documented in `docs/real-data-failure-taxonomy.md`:
  - **R2** — retrieval loop body lost in merge → answerable queries silently abstain. Guard: an answerable single-doc smoke query must produce non-empty evidence and a verified final stage attempt.
  - **R1** — `IndexError` on `final_relaxation_reason` when `retry_count > 0` but `len(stage_attempts) < 2`. Guard: diagnostics block must build cleanly on both the single-verified-attempt path and the out-of-corpus retry path.
- Add `make test-regression` target so the guards can be run quickly (~0.1s) before any retrieval/eval change.
- Link the target from `docs/grounding-eval-hardening.md` so reviewers see it in the validation checklist.

## Why
`docs/real-data-failure-taxonomy.md` flags R1 and R2 as P0 regressions and explicitly recommends a regression test so the same class of breakage is caught before merge. R2 was already detectable via `eval/run_eval.py` but had no fast unit-level guard.

## Reviewer notes
- Tests use the existing `data/raw` fixture and `embedding_backend="hashing"` for deterministic, CI-friendly runs.
- No production code changes — pure test/Makefile/doc additions.

## Test plan
- [x] `make test-regression` → 3 passed in 0.08s
- [x] `python3 -m pytest tests/ -q` → 83 passed (was 80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)