### PR TITLE
Harden planner / query-rewrite trace artifacts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Benchmarking](./benchmarking.md)
 - [Retrieval hardening milestone](./retrieval-hardening.md)
 - [Grounding/eval hardening](./grounding-eval-hardening.md)
+- [Planner & query-rewrite trace schema](./planner-trace.md)
 - [Reproducible harness](./harness.md)
 - [Private hard-case benchmark](./private-hardcase-benchmark.md)
 - [Private 100-doc experiments](./private-100-doc-experiments.md)

--- a/docs/grounding-eval-hardening.md
+++ b/docs/grounding-eval-hardening.md
@@ -7,8 +7,8 @@
 - Public eval slice를 `single_doc`, `comparison`, `follow_up`, `abstention`으로 표준화했다. 기존 `multi_doc` config 값은 호환 alias로 계속 읽는다.
 - 공개 eval에 claim-level citation spec과 partial comparison 케이스를 추가했다.
 - `answer` 객체를 schema v2로 고정하고 `schema_version`, `status_reason`을 추가했다.
-- `run_rag_query` 결과에 `trace`를 추가해 planner 선택과 query rewrite/context resolution을 한 곳에서 볼 수 있게 했다.
-- `eval/run_eval.py`는 각 run/case의 trace를 `reports/traces/<run>/<case>.trace.json`에 쓴다. `reports/`는 gitignored라 private/local trace가 커밋되지 않는다.
+- `run_rag_query` 결과에 `trace`를 추가해 planner 선택과 query rewrite/context resolution을 한 곳에서 볼 수 있게 했다. 필드 정의와 해석 가이드는 [planner-trace.md](./planner-trace.md) 참고.
+- `eval/run_eval.py`는 각 run/case의 trace를 `reports/traces/<run>/<case>.trace.json`에 쓴다. `reports/`는 gitignored라 private/local trace가 커밋되지 않는다. `--redact_trace` 플래그로 doc ID / entity 마스킹을 켤 수 있다.
 - `claim_citation_alignment`과 `claim_citation_error_counts`를 추가해 whole-answer citation precision과 claim-level drift를 분리했다.
 
 ## Why it changed

--- a/docs/planner-trace.md
+++ b/docs/planner-trace.md
@@ -1,0 +1,107 @@
+# Planner & Query-Rewrite Trace Schema (v1)
+
+This document is the reviewer-facing reference for the local trace artifacts produced by `run_rag_query` and persisted under `reports/traces/<run>/<case_id>.trace.json` by `eval/run_eval.py`.
+
+The goal is that a reviewer can open one `.trace.json` file and reconstruct *what the planner decided, why it rewrote (or didn't rewrite) the query, and where time was spent* — without having to re-run the pipeline.
+
+Builders live in [rag_core.py](../rag_core.py): `build_query_rewrite_trace`, `build_planner_trace`, `build_result_trace`.
+
+## Top-level shape
+
+```jsonc
+{
+  "schema_version": 1,
+  "query_rewrite": { ... },
+  "planner":       { ... },
+  "answer_schema": { ... }
+}
+```
+
+`schema_version` is currently `1`. Field additions that are backward-compatible (new optional keys) do not bump this; a breaking shape change will (paired with `#63` answer-schema v2).
+
+## `query_rewrite`
+
+Captures conversational context resolution and any prefix injection done before retrieval.
+
+| Field | Type | Notes |
+|---|---|---|
+| `original_query` | str | Verbatim user query for this turn. |
+| `resolved_query` | str | Query actually sent to retrieval. Equals `original_query` when no rewrite occurred. |
+| `rewritten` | bool | True iff `resolved_query != original_query`. |
+| `rewrite_type` | str | One of `conversation_state_prefix`, `explicit_context`, `clarification_required`, `none`. |
+| `context_source` | str | Origin of resolution signal: `conversation_state`, `context_entities`, `query`, or `none`. |
+| `context_status` | str | `resolved`, `needs_clarification`, `not_needed`, etc. |
+| `context_resolution_confidence` | float (0.0–1.0) | Confidence of the resolution decision. Below `CONTEXT_RESOLUTION_THRESHOLD` triggers clarification. |
+| `reason` | str | Diagnostic tag (e.g. `weak_active_state`, `ambiguous_active_state`, `no_active_state`). |
+| `context_entities` | list[str] | Carried-over agency / entity names. |
+| `context_projects` | list[str] | Carried-over project names. |
+| `active_doc_ids` | list[str] | Doc IDs in the active conversation state. |
+| `readable_summary` | str | Single-line human description of the rewrite outcome. |
+
+### Reading tips
+
+- A follow-up that abstained with `rewrite_type=clarification_required` and low `context_resolution_confidence` is the textbook "we couldn't pin down the referent" path.
+- `rewrite_type=conversation_state_prefix` + non-empty `context_entities` means a prior turn's agency/project was prepended to the query.
+
+## `planner`
+
+Captures the retrieval/answer plan and per-stage attempts.
+
+| Field | Type | Notes |
+|---|---|---|
+| `query_type` | str | `single_doc`, `comparison`, `follow_up`, `abstention`. |
+| `pipeline` | str | Active pipeline name (e.g. `agentic_full`, `naive`). |
+| `prompt_profile` | str | Prompt profile selected for this run. |
+| `strategy` | str | High-level retrieval strategy label. |
+| `retrieval_mode` | str | `flat` or hierarchical mode. |
+| `metadata_first` | bool | Whether the metadata-first path was taken. |
+| `rerank` | bool | Reranker enabled. |
+| `verifier_retry` | bool | Verifier-driven retry enabled. |
+| `stage_sequence` | list[str] | Filter stages attempted in order (e.g. `["strict", "reduced", "relaxed"]`). |
+| `selected_stage` | str | Final filter stage that produced the answer. |
+| `selected_top_k` | int \| null | Final top-k used. |
+| `retrieval_budget` | object | Top-k planning details (defaults, query-type override, reason). |
+| `metadata_candidate_count` | int \| null | Candidate doc count from metadata resolution. |
+| `metadata_selected_doc_ids` | list[str] | Doc IDs selected by metadata-first resolution. |
+| `metadata_ambiguous` | bool | Metadata resolution flagged ambiguity. |
+| `comparison_coverage` | object \| null | Comparison coverage diagnostics (when applicable). |
+| `stage_latencies_ms` | object | `{query_analysis_ms, context_resolution_ms, answer_generation_ms}`. |
+| `attempts` | list[object] | Per-stage attempt records: `stage`, `top_k`, `verified`, `verification_reasons`, `metadata_doc_ids`. |
+| `readable_summary` | str | Single-line plan summary, e.g. `single_doc planned with agentic_full stage=strict top_k=4 metadata_docs=['rfp-agency-a-ai-quality']`. |
+
+### Reading tips
+
+- Walk `attempts` in order to see retry chain. The first `verified=true` is what fed answer generation.
+- Stage-level `retrieve_ms` / `verify_ms` live inside each attempt entry; the top-level `stage_latencies_ms` covers analysis / context resolution / answer generation.
+- Pair `metadata_selected_doc_ids` with `query_rewrite.active_doc_ids` to see whether the planner respected the active conversation context.
+
+## `answer_schema`
+
+Mirrors the answer envelope (`schema_version`, `status`, `status_reason`, `query_type`, `claim_count`) so a reviewer can decide whether the verifier abstained without opening the answer file.
+
+## Privacy & redaction
+
+Traces contain document IDs, agency names, and project names from the indexed corpus. They are written to **local files only** (`reports/traces/...`) and are not uploaded by any code path in this repo.
+
+For reviewer hand-off where document IDs / entities are sensitive:
+
+```bash
+# mask both doc IDs and entities
+python eval/run_eval.py --config eval/dev_config.yaml --redact_trace all
+
+# mask only doc IDs
+python eval/run_eval.py --config eval/dev_config.yaml --redact_trace doc_ids
+```
+
+Redaction replaces each list entry with the literal `"<redacted>"` while preserving list length, so structural shape (e.g. "two doc IDs were selected") is still inspectable. The in-memory result returned by `run_rag_query` is never mutated — redaction applies only at the trace-write boundary.
+
+The `eval_summary.json` records the effective redaction state under `trace_redaction`.
+
+## Regression coverage
+
+`tests/test_fuzzy_retrieval.py` enforces:
+
+- Schema version 1.
+- Required field sets on `query_rewrite` and `planner` (so a future PR cannot silently drop a field).
+- `stage_latencies_ms` keys present and numeric.
+- `redact_trace` masks list fields without mutating the input or losing length.

--- a/docs/planner-trace.md
+++ b/docs/planner-trace.md
@@ -93,7 +93,7 @@ python eval/run_eval.py --config eval/dev_config.yaml --redact_trace all
 python eval/run_eval.py --config eval/dev_config.yaml --redact_trace doc_ids
 ```
 
-Redaction replaces each list entry with the literal `"<redacted>"` while preserving list length, so structural shape (e.g. "two doc IDs were selected") is still inspectable. The in-memory result returned by `run_rag_query` is never mutated — redaction applies only at the trace-write boundary.
+Redaction replaces each list entry with the literal `"<redacted>"` while preserving list length, so structural shape (e.g. "two doc IDs were selected") is still inspectable. `planner.readable_summary` is rewritten in lockstep so it cannot leak the selected doc IDs via its summary string. The in-memory result returned by `run_rag_query` is never mutated — redaction applies only at the trace-write boundary.
 
 The `eval_summary.json` records the effective redaction state under `trace_redaction`.
 

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -19,6 +19,7 @@ from rag_core import (
     load_index,
     percentile,
     rate,
+    redact_trace,
     resolve_pipeline_config,
     run_rag_query,
 )
@@ -67,7 +68,28 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Directory for local planner/rewrite trace JSON files. Defaults to <output_dir>/traces.",
     )
+    parser.add_argument(
+        "--redact_trace",
+        choices=("doc_ids", "entities", "all"),
+        action="append",
+        default=None,
+        help=(
+            "Mask sensitive list fields in written traces. Pass once per category "
+            "(doc_ids|entities) or 'all' to mask both. Default: no redaction."
+        ),
+    )
     return parser.parse_args()
+
+
+def trace_redact_options(values: list[str] | None) -> dict[str, bool]:
+    """Translate CLI --redact_trace selections into redact_trace kwargs."""
+    selected = set(values or [])
+    if "all" in selected:
+        selected.update({"doc_ids", "entities"})
+    return {
+        "include_doc_ids": "doc_ids" not in selected,
+        "include_entities": "entities" not in selected,
+    }
 
 
 def normalize_run_config(run: dict[str, Any]) -> dict[str, Any]:
@@ -1013,8 +1035,12 @@ def prediction_trace_payload(
     case: dict[str, Any],
     run_config: dict[str, Any],
     prediction: dict[str, Any],
+    *,
+    redact_options: dict[str, bool] | None = None,
 ) -> dict[str, Any]:
     trace = prediction.get("trace") if isinstance(prediction.get("trace"), dict) else {}
+    if redact_options and isinstance(trace, dict):
+        trace = redact_trace(trace, **redact_options)
     return {
         "schema_version": 1,
         "case_id": case.get("id"),
@@ -1032,6 +1058,8 @@ def write_prediction_trace(
     case: dict[str, Any],
     run_config: dict[str, Any],
     prediction: dict[str, Any],
+    *,
+    redact_options: dict[str, bool] | None = None,
 ) -> str | None:
     if trace_dir is None:
         return None
@@ -1040,7 +1068,12 @@ def write_prediction_trace(
     path = run_dir / f"{safe_path_part(str(case.get('id') or 'case'))}.trace.json"
     path.write_text(
         json.dumps(
-            prediction_trace_payload(case, run_config, prediction),
+            prediction_trace_payload(
+                case,
+                run_config,
+                prediction,
+                redact_options=redact_options,
+            ),
             ensure_ascii=False,
             indent=2,
         ),
@@ -1055,6 +1088,7 @@ def evaluate_run(
     run_config: dict[str, Any],
     answer_policy: dict[str, Any] | None = None,
     trace_dir: Path | None = None,
+    redact_options: dict[str, bool] | None = None,
 ) -> list[dict[str, Any]]:
     case_results = []
     for case in cases:
@@ -1088,7 +1122,13 @@ def evaluate_run(
             prompt_profile=str(run_config.get("prompt_profile") or ""),
             conversation_state=conversation_state,
         )
-        trace_path = write_prediction_trace(trace_dir, case, run_config, prediction)
+        trace_path = write_prediction_trace(
+            trace_dir,
+            case,
+            run_config,
+            prediction,
+            redact_options=redact_options,
+        )
         result = score_case(case, prediction, answer_policy)
         if trace_path:
             result["trace_path"] = trace_path
@@ -1117,6 +1157,7 @@ def main() -> int:
     primary_summary = None
     primary_run_name = str(config.get("primary_run") or DEFAULT_CLI_PIPELINE_NAME)
     trace_root = Path(args.trace_dir) if args.trace_dir else Path(args.output_dir) / "traces"
+    redact_options = trace_redact_options(args.redact_trace)
     try:
         for run_config in ablation_runs(config):
             case_results = evaluate_run(
@@ -1125,6 +1166,7 @@ def main() -> int:
                 run_config,
                 config.get("answer_policy") if isinstance(config.get("answer_policy"), dict) else {},
                 trace_dir=trace_root,
+                redact_options=redact_options,
             )
             is_primary = run_config["name"] == primary_run_name
             run_summary = summarize_run(
@@ -1174,6 +1216,10 @@ def main() -> int:
         "citation_grounding_error_counts": primary_summary["citation_grounding_error_counts"],
         "claim_citation_error_counts": primary_summary["claim_citation_error_counts"],
         "trace_dir": str(trace_root),
+        "trace_redaction": {
+            "include_doc_ids": redact_options["include_doc_ids"],
+            "include_entities": redact_options["include_entities"],
+        },
         "ablation": {"runs": run_summaries},
         "case_results": primary_summary.get("case_results", []),
     }

--- a/rag_core.py
+++ b/rag_core.py
@@ -7,6 +7,7 @@ generation is extractive, and external LLM/API calls are not required.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 import difflib
 import hashlib
@@ -2595,6 +2596,9 @@ def build_query_rewrite_trace(
         "rewrite_type": rewrite_type,
         "context_source": source,
         "context_status": status,
+        "context_resolution_confidence": round(
+            float(context_resolution.get("confidence") or 0.0), 3
+        ),
         "reason": context_resolution.get("reason", ""),
         "context_entities": context_resolution.get("context_entities") or [],
         "context_projects": context_resolution.get("context_projects") or [],
@@ -2613,6 +2617,8 @@ def build_planner_trace(
     metadata_resolution: dict[str, Any],
     stage_sequence: list[str],
     stage_attempts: list[dict[str, Any]],
+    *,
+    stage_latencies_ms: dict[str, float] | None = None,
 ) -> dict[str, Any]:
     attempts = [
         {
@@ -2628,6 +2634,14 @@ def build_planner_trace(
     query_type = str(analysis.get("query_type") or "")
     filter_stage = str(plan.get("filter_stage") or "")
     top_k = plan.get("top_k")
+    latencies = {
+        key: round(float((stage_latencies_ms or {}).get(key, 0.0)), 2)
+        for key in (
+            "query_analysis_ms",
+            "context_resolution_ms",
+            "answer_generation_ms",
+        )
+    }
     return {
         "query_type": query_type,
         "pipeline": plan.get("pipeline"),
@@ -2645,6 +2659,7 @@ def build_planner_trace(
         "metadata_selected_doc_ids": selected_doc_ids,
         "metadata_ambiguous": bool(analysis.get("metadata_ambiguous")),
         "comparison_coverage": plan.get("comparison_coverage"),
+        "stage_latencies_ms": latencies,
         "attempts": attempts,
         "readable_summary": (
             f"{query_type} planned with {plan.get('pipeline')} "
@@ -2664,6 +2679,8 @@ def build_result_trace(
     stage_sequence: list[str],
     stage_attempts: list[dict[str, Any]],
     answer: dict[str, Any],
+    *,
+    stage_latencies_ms: dict[str, float] | None = None,
 ) -> dict[str, Any]:
     return {
         "schema_version": TRACE_SCHEMA_VERSION,
@@ -2678,6 +2695,7 @@ def build_result_trace(
             metadata_resolution,
             stage_sequence,
             stage_attempts,
+            stage_latencies_ms=stage_latencies_ms,
         ),
         "answer_schema": {
             "schema_version": answer.get("schema_version"),
@@ -2687,6 +2705,52 @@ def build_result_trace(
             "claim_count": len(answer.get("claims") or []),
         },
     }
+
+
+REDACTED_LIST_PLACEHOLDER = "<redacted>"
+
+
+def redact_trace(
+    trace: dict[str, Any],
+    *,
+    include_doc_ids: bool = True,
+    include_entities: bool = True,
+) -> dict[str, Any]:
+    """Return a deep copy of `trace` with sensitive list fields masked.
+
+    `include_doc_ids=False` masks active doc ids in query_rewrite, planner
+    metadata selections, and per-attempt metadata filters. `include_entities=False`
+    masks context entity / project lists. Counts are preserved so reviewers can
+    still see structural shape.
+    """
+    if not isinstance(trace, dict):
+        return trace
+    redacted = copy.deepcopy(trace)
+
+    def _mask(values: Any) -> list[str]:
+        items = values if isinstance(values, list) else []
+        return [REDACTED_LIST_PLACEHOLDER] * len(items)
+
+    rewrite = redacted.get("query_rewrite")
+    if isinstance(rewrite, dict):
+        if not include_entities:
+            rewrite["context_entities"] = _mask(rewrite.get("context_entities"))
+            rewrite["context_projects"] = _mask(rewrite.get("context_projects"))
+        if not include_doc_ids:
+            rewrite["active_doc_ids"] = _mask(rewrite.get("active_doc_ids"))
+
+    planner = redacted.get("planner")
+    if isinstance(planner, dict) and not include_doc_ids:
+        planner["metadata_selected_doc_ids"] = _mask(
+            planner.get("metadata_selected_doc_ids")
+        )
+        attempts = planner.get("attempts")
+        if isinstance(attempts, list):
+            for attempt in attempts:
+                if isinstance(attempt, dict):
+                    attempt["metadata_doc_ids"] = _mask(attempt.get("metadata_doc_ids"))
+
+    return redacted
 
 
 def clarification_answer(query: str, context_resolution: dict[str, Any]) -> str:
@@ -2796,6 +2860,7 @@ def make_context_clarification_result(
         [],
         [],
         answer,
+        stage_latencies_ms=stage_timings,
     )
     return {
         "mode": "rag",
@@ -2937,6 +3002,7 @@ def make_metadata_clarification_result(
         [],
         [],
         answer,
+        stage_latencies_ms=stage_timings,
     )
     return {
         "mode": "rag",
@@ -3258,6 +3324,7 @@ def run_rag_query(
         stage_sequence,
         stage_attempts,
         answer,
+        stage_latencies_ms=stage_latency,
     )
     return {
         "mode": "rag",

--- a/rag_core.py
+++ b/rag_core.py
@@ -2741,14 +2741,21 @@ def redact_trace(
 
     planner = redacted.get("planner")
     if isinstance(planner, dict) and not include_doc_ids:
-        planner["metadata_selected_doc_ids"] = _mask(
-            planner.get("metadata_selected_doc_ids")
-        )
+        masked_selected = _mask(planner.get("metadata_selected_doc_ids"))
+        planner["metadata_selected_doc_ids"] = masked_selected
         attempts = planner.get("attempts")
         if isinstance(attempts, list):
             for attempt in attempts:
                 if isinstance(attempt, dict):
                     attempt["metadata_doc_ids"] = _mask(attempt.get("metadata_doc_ids"))
+        # readable_summary embeds the selected doc IDs verbatim; rebuild it
+        # so masking is consistent with the structured fields.
+        planner["readable_summary"] = (
+            f"{planner.get('query_type', '')} planned with {planner.get('pipeline')} "
+            f"stage={planner.get('selected_stage') or 'none'} "
+            f"top_k={planner.get('selected_top_k')} "
+            f"metadata_docs={masked_selected or 'none'}"
+        )
 
     return redacted
 

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -2,13 +2,59 @@ import unittest
 from pathlib import Path
 
 from rag_core import (
+    REDACTED_LIST_PLACEHOLDER,
     analyze_query,
     build_index_payload,
     build_index_payload_from_documents,
     metadata_stage_sequence,
     metadata_targets,
+    redact_trace,
     run_rag_query,
 )
+
+
+REQUIRED_QUERY_REWRITE_FIELDS = {
+    "original_query",
+    "resolved_query",
+    "rewritten",
+    "rewrite_type",
+    "context_source",
+    "context_status",
+    "context_resolution_confidence",
+    "reason",
+    "context_entities",
+    "context_projects",
+    "active_doc_ids",
+    "readable_summary",
+}
+
+REQUIRED_PLANNER_FIELDS = {
+    "query_type",
+    "pipeline",
+    "prompt_profile",
+    "strategy",
+    "retrieval_mode",
+    "metadata_first",
+    "rerank",
+    "verifier_retry",
+    "stage_sequence",
+    "selected_stage",
+    "selected_top_k",
+    "retrieval_budget",
+    "metadata_candidate_count",
+    "metadata_selected_doc_ids",
+    "metadata_ambiguous",
+    "comparison_coverage",
+    "stage_latencies_ms",
+    "attempts",
+    "readable_summary",
+}
+
+REQUIRED_LATENCY_KEYS = {
+    "query_analysis_ms",
+    "context_resolution_ms",
+    "answer_generation_ms",
+}
 
 
 class FuzzyMetadataRetrievalTest(unittest.TestCase):
@@ -513,6 +559,63 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
         self.assertEqual("single_doc", trace["planner"]["query_type"])
         self.assertEqual("agentic_full", trace["planner"]["pipeline"])
         self.assertIn("stage=", trace["planner"]["readable_summary"])
+
+        self.assertEqual(
+            REQUIRED_QUERY_REWRITE_FIELDS,
+            set(trace["query_rewrite"].keys()),
+        )
+        self.assertEqual(REQUIRED_PLANNER_FIELDS, set(trace["planner"].keys()))
+        latencies = trace["planner"]["stage_latencies_ms"]
+        self.assertEqual(REQUIRED_LATENCY_KEYS, set(latencies.keys()))
+        for key in REQUIRED_LATENCY_KEYS:
+            self.assertIsInstance(latencies[key], (int, float))
+            self.assertGreaterEqual(latencies[key], 0.0)
+        self.assertIsInstance(
+            trace["query_rewrite"]["context_resolution_confidence"], (int, float)
+        )
+
+    def test_redact_trace_masks_doc_ids_and_entities_but_preserves_shape(self) -> None:
+        first = run_rag_query(
+            self.index,
+            "기관 A의 AI 요구사항은?",
+            conversation_state={},
+        )
+        follow_up = run_rag_query(
+            self.index,
+            "그 기관이 요구한 보안 조건도 보여줘",
+            conversation_state=first["conversation_state"],
+        )
+        trace = follow_up["trace"]
+        original_active = list(trace["query_rewrite"]["active_doc_ids"])
+        original_entities = list(trace["query_rewrite"]["context_entities"])
+        original_selected = list(trace["planner"]["metadata_selected_doc_ids"])
+        self.assertTrue(original_active, "fixture should produce active_doc_ids")
+
+        redacted = redact_trace(trace, include_doc_ids=False, include_entities=False)
+
+        self.assertEqual(
+            [REDACTED_LIST_PLACEHOLDER] * len(original_active),
+            redacted["query_rewrite"]["active_doc_ids"],
+        )
+        self.assertEqual(
+            [REDACTED_LIST_PLACEHOLDER] * len(original_entities),
+            redacted["query_rewrite"]["context_entities"],
+        )
+        self.assertEqual(
+            [REDACTED_LIST_PLACEHOLDER] * len(original_selected),
+            redacted["planner"]["metadata_selected_doc_ids"],
+        )
+        # original trace is unchanged (deep copy)
+        self.assertEqual(original_active, trace["query_rewrite"]["active_doc_ids"])
+        # non-list scalar fields preserved
+        self.assertEqual(
+            trace["query_rewrite"]["rewrite_type"],
+            redacted["query_rewrite"]["rewrite_type"],
+        )
+        self.assertEqual(
+            trace["planner"]["stage_latencies_ms"],
+            redacted["planner"]["stage_latencies_ms"],
+        )
 
     def test_multi_step_follow_up_preserves_agency_and_project_context(self) -> None:
         first = run_rag_query(

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -616,6 +616,14 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
             trace["planner"]["stage_latencies_ms"],
             redacted["planner"]["stage_latencies_ms"],
         )
+        # readable_summary embeds the selected doc IDs; redaction must rewrite it
+        # so doc IDs do not leak via the summary string.
+        for doc_id in original_selected:
+            self.assertNotIn(doc_id, redacted["planner"]["readable_summary"])
+        self.assertIn(
+            REDACTED_LIST_PLACEHOLDER,
+            redacted["planner"]["readable_summary"],
+        )
 
     def test_multi_step_follow_up_preserves_agency_and_project_context(self) -> None:
         first = run_rag_query(


### PR DESCRIPTION
## Summary
- Adds `stage_latencies_ms` (analysis / context resolution / answer generation) and `context_resolution_confidence` to the trace schema v1 — backward-compatible field additions sourced from existing diagnostics, no new measurement code.
- Adds `redact_trace()` plus `eval/run_eval.py --redact_trace {doc_ids|entities|all}` for length-preserving masking of doc IDs and entity / project lists at the trace-write boundary; in-memory result is unchanged. `eval_summary.json` records the effective redaction state under `trace_redaction`.
- New [docs/planner-trace.md](https://github.com/hskim-solv/BidMate-DocAgent/blob/feat/60-followup-planner-trace-hardening/docs/planner-trace.md) — reviewer-facing field reference + privacy guidance, linked from `docs/README.md` and `docs/grounding-eval-hardening.md`.
- Strengthens `tests/test_fuzzy_retrieval.py` with required-field-set assertions and a redaction shape test, so a future PR cannot silently drop trace fields.

Follow-up to closed #60 — fills the reviewer-facing gaps surfaced after that issue shipped.

## Test plan
- [x] `python3 -m pytest -x -q` (81 passed)
- [x] Inline smoke: `run_rag_query` follow-up turn shows populated `stage_latencies_ms`, `context_resolution_confidence`, and `redact_trace(...)` masks `active_doc_ids` / `context_entities` / `metadata_selected_doc_ids` while preserving length.
- [x] CLI parse check: `--redact_trace all` → `{include_doc_ids: False, include_entities: False}`; default → both `True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)