### PR TITLE
Add PR eval delta CI workflow

### DIFF
--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -1,0 +1,119 @@
+name: PR Eval Delta
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  EMBEDDING_BACKEND: hashing
+  PYTHONDONTWRITEBYTECODE: "1"
+
+jobs:
+  test:
+    name: Pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run pytest
+        run: bash scripts/test.sh
+
+  eval-delta:
+    name: Eval delta vs base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          path: pr
+
+      - name: Checkout base ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: base
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pr/requirements.txt
+
+      - name: Install dependencies (PR)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r pr/requirements.txt
+
+      - name: Build CI eval config (full pipeline only) — PR
+        working-directory: pr
+        run: |
+          python -c "import yaml; c=yaml.safe_load(open('eval/config.yaml')); c['primary_run']='full'; c['ablation_runs']=[r for r in c['ablation_runs'] if r['name']=='full']; open('eval/config.ci.yaml','w').write(yaml.safe_dump(c, allow_unicode=True, sort_keys=False))"
+
+      - name: Build CI eval config (full pipeline only) — base
+        working-directory: base
+        run: |
+          python -c "import yaml; c=yaml.safe_load(open('eval/config.yaml')); c['primary_run']='full'; c['ablation_runs']=[r for r in c['ablation_runs'] if r['name']=='full']; open('eval/config.ci.yaml','w').write(yaml.safe_dump(c, allow_unicode=True, sort_keys=False))"
+
+      - name: Build index — PR
+        working-directory: pr
+        run: python scripts/build_index.py --input_dir data/raw --output_dir data/index --embedding_backend hashing
+
+      - name: Run eval — PR
+        working-directory: pr
+        run: python eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.ci.yaml
+
+      - name: Build index — base
+        working-directory: base
+        run: python scripts/build_index.py --input_dir data/raw --output_dir data/index --embedding_backend hashing
+
+      - name: Run eval — base
+        working-directory: base
+        run: python eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.ci.yaml
+
+      - name: Render delta table
+        run: |
+          python pr/scripts/compare_eval.py \
+            --base base/reports/eval_summary.json \
+            --head pr/reports/eval_summary.json \
+            --title "Eval delta — \`full\` pipeline" > delta.md
+          cat delta.md
+
+      - name: Upload eval summaries
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-summaries
+          path: |
+            pr/reports/eval_summary.json
+            base/reports/eval_summary.json
+
+      - name: Upsert PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          marker="<!-- eval-delta-bot -->"
+          body="$(printf '%s\n\n%s\n' "$marker" "$(cat delta.md)")"
+          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" >/dev/null
+            echo "Updated existing comment $existing"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+          fi

--- a/scripts/compare_eval.py
+++ b/scripts/compare_eval.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Render a markdown delta table comparing two eval_summary.json files.
+
+Used by the PR eval workflow to post a base-vs-head comparison comment.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+# (dotted_path, label, higher_is_better)
+METRICS: list[tuple[str, str, bool]] = [
+    ("accuracy", "accuracy", True),
+    ("groundedness", "groundedness", True),
+    ("citation_precision", "citation_precision", True),
+    ("citation_grounding", "citation_grounding", True),
+    ("claim_citation_alignment", "claim_citation_alignment", True),
+    ("answer_format_compliance", "answer_format_compliance", True),
+    ("abstention", "abstention (unanswerable cases)", True),
+    ("retry", "retry_rate", False),
+    ("latency.p50", "latency_p50_ms", False),
+    ("latency.p95", "latency_p95_ms", False),
+]
+
+
+def get_path(data: Any, path: str) -> Any:
+    cur = data
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def fmt_value(value: Any) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def fmt_delta(base: Any, head: Any, higher_is_better: bool) -> str:
+    if not isinstance(base, (int, float)) or not isinstance(head, (int, float)):
+        return "—"
+    delta = float(head) - float(base)
+    if abs(delta) < 5e-4:
+        return "·"
+    sign = "+" if delta > 0 else ""
+    improved = (delta > 0) if higher_is_better else (delta < 0)
+    flag = " ✅" if improved else " ⚠️"
+    return f"{sign}{delta:.3f}{flag}"
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", required=True, help="Base (main) eval_summary.json")
+    ap.add_argument("--head", required=True, help="Head (PR) eval_summary.json")
+    ap.add_argument("--title", default="Eval delta")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    base = json.loads(Path(args.base).read_text(encoding="utf-8"))
+    head = json.loads(Path(args.head).read_text(encoding="utf-8"))
+
+    lines: list[str] = []
+    lines.append(f"### {args.title}")
+    lines.append("")
+    lines.append(
+        f"- pipeline: `{head.get('pipeline', '?')}` "
+        f"(primary run: `{head.get('primary_run', '?')}`)"
+    )
+    lines.append(
+        f"- cases: base={base.get('num_predictions', '?')} · "
+        f"head={head.get('num_predictions', '?')}"
+    )
+    lines.append("")
+    lines.append("| metric | main | PR | Δ |")
+    lines.append("|---|---|---|---|")
+    for path, label, higher in METRICS:
+        b = get_path(base, path)
+        h = get_path(head, path)
+        lines.append(f"| {label} | {fmt_value(b)} | {fmt_value(h)} | {fmt_delta(b, h, higher)} |")
+    lines.append("")
+    lines.append(
+        "_✅ direction-of-improvement; ⚠️ direction-of-regression. "
+        "Soft check — does not fail CI._"
+    )
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- New GitHub Actions workflow runs `pytest` and an eval delta (PR vs base) on every PR targeting `main`.
- Renders a markdown comparison table from two `eval_summary.json` files and upserts it as a PR comment (no comment-spam on rerun).
- Soft check only — no thresholds yet. Goal is to observe metric noise across a few PRs before turning on hard gates.

## Design notes
- Runs the `full` pipeline ablation only (1 of 6) to keep CI tractable; the CI config is derived from `eval/config.yaml` inline so we don't fork the case list.
- Uses `EMBEDDING_BACKEND=hashing` so no API keys / network calls are needed.
- Pip cache enabled to amortize the heavy deps (`sentence-transformers`, `opencv-python-headless`, etc.) after the first run.
- Both `eval_summary.json` files are uploaded as the `eval-summaries` artifact for offline inspection.

## Files
- `.github/workflows/pr-eval.yml` — workflow.
- `scripts/compare_eval.py` — renders the delta table; smoke-tested locally with synthetic input.

## Test plan
- [ ] Workflow runs to completion on this PR.
- [ ] Eval delta comment appears on the PR with all metrics at `·` (since this PR doesn't touch RAG code).
- [ ] Re-running the workflow updates the existing comment instead of posting a new one.
- [ ] `eval-summaries` artifact is downloadable and contains both JSON files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)