### PR TITLE
Fix pytest collection in CI by adding pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- PR #83 added a CI `Pytest` job that fails on all 10 test modules with `ModuleNotFoundError` for top-level imports (`rag_core`, `ingestion`, `eval`).
- Root cause: repo has no `pyproject.toml` / `pytest.ini` / `conftest.py`, so pytest only puts `tests/` on `sys.path`, never the repo root.
- Fix: add a 3-line `pyproject.toml` with `pythonpath = ["."]`.

## Verification
- Locally: `pytest --collect-only -q` now collects **84 tests** (was 0 with 10 collection errors).
- This PR itself should now show the `Pytest` job green; the `Eval delta vs base` job should keep passing and the upserted delta comment should report `·` across the board (no RAG code touched).

## Test plan
- [ ] `Pytest` job goes green on this PR.
- [ ] `Eval delta vs base` job still passes.
- [ ] Delta comment is posted (or upserted) with all metrics at `·`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)