### PR TITLE
Add FastAPI demo surface with containerized startup (#75)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# BidMate-DocAgent demo API container.
+#
+# One-shot reviewer flow:
+#   docker build -t bidmate-demo .
+#   docker run --rm -p 8000:8000 bidmate-demo
+#
+# The entrypoint builds the index from data/raw on first start if it is
+# missing, then launches uvicorn. Mount a volume on /app/data/index to
+# persist the index across runs.
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    BIDMATE_INDEX_DIR=/app/data/index \
+    EMBEDDING_BACKEND=hashing
+
+WORKDIR /app
+
+# OS deps needed by opencv-python-headless / pymupdf / pytesseract.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+        tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+    && pip install -r requirements.txt
+
+# Copy only the code/data needed at runtime. tests/, benchmarks/, eval/
+# are intentionally left out of the image to keep it small — they are
+# part of the CLI evaluation flow, not the demo surface.
+COPY rag_core.py ingestion.py visual_ingestion.py app.py ./
+COPY api/ ./api/
+COPY scripts/build_index.py ./scripts/build_index.py
+COPY data/raw/ ./data/raw/
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health',timeout=3).status==200 else 1)"
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -39,6 +39,17 @@ test:
 # Run before any change to rag_core retrieval/verification or the eval pipeline.
 test-regression:
 	$(PYTHON) -m pytest tests/test_retrieval_loop_regression.py -q
+
+# Run the FastAPI demo locally. Requires data/index to exist
+# (run `make index` first). See docs/api-demo.md for details.
+api:
+	$(PYTHON) -m uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload
+
+# Build and run the demo container. The entrypoint builds the index on
+# first start if data/index is empty inside the container.
+api-docker:
+	docker build -t bidmate-demo .
+	docker run --rm -p 8000:8000 bidmate-demo
 
 clean:
 	rm -rf data/index outputs reports

--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ Final Response (grounded)
 
 ## 실행 방법 (검증됨)
 
+두 가지 흐름을 제공합니다.
+
+- **CLI 평가 흐름 (source of truth)**: `scripts/build_index.py` → `app.py` → `eval/run_eval.py`. 재현 가능한 측정/벤치마크/ablation 보고서 생성용.
+- **API 데모 흐름 (리뷰어용)**: `make api` 또는 `make api-docker`로 FastAPI 서버를 띄워 `/health`, `/pipelines`, `POST /query` 엔드포인트로 RAG를 호출. 출력은 grounded answer/citation 계약을 그대로 보존. 자세한 내용은 [`docs/api-demo.md`](docs/api-demo.md).
+
 현재 공개본은 `data/raw`의 synthetic RFP 문서를 사용해 로컬에서 end-to-end RAG를 실행합니다. 기본 실행은 `naive_baseline` control이며, embedding `auto` 모드는 캐시된 `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` 모델을 우선 사용하고 모델을 사용할 수 없는 환경에서는 deterministic hashing embedding으로 자동 fallback합니다.
 
 ### 1) 환경 준비
@@ -316,6 +321,7 @@ python3 eval/run_parser_eval.py \
 - Citation grounding evaluation: [`docs/citation-grounding-eval.md`](docs/citation-grounding-eval.md)
 - Grounding/eval hardening: [`docs/grounding-eval-hardening.md`](docs/grounding-eval-hardening.md)
 - Reproducible harness: [`docs/harness.md`](docs/harness.md)
+- API demo (FastAPI + container): [`docs/api-demo.md`](docs/api-demo.md)
 - 답변 출력 정책: [`docs/answer-policy.md`](docs/answer-policy.md)
 - 실패 사례 분석: [`docs/failure-cases.md`](docs/failure-cases.md)
 - 회고 및 개선 방향: [`docs/retrospective.md`](docs/retrospective.md)

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,9 @@
+"""FastAPI demo surface for the BidMate-DocAgent RAG pipeline.
+
+This package is intentionally thin — see ``api/main.py`` for the app and
+``docs/api-demo.md`` for the end-to-end startup flow. The CLI evaluation
+flow (``scripts/build_index.py``, ``app.py``, ``eval/run_eval.py``) remains
+the source of truth; this package only wraps :func:`rag_core.run_rag_query`
+behind HTTP so reviewers can poke the system without stitching commands
+together.
+"""

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,175 @@
+"""FastAPI demo surface around :func:`rag_core.run_rag_query`.
+
+Goals (issue #75):
+* Reviewers can start the demo with a documented local container flow.
+* Health check and at least one representative query endpoint.
+* API output preserves the repo's grounded answer / citation contract
+  (we pass the raw ``run_rag_query`` dict through).
+* CLI evaluation flow stays the source of truth — this module never
+  builds an index itself; it only loads one prepared on disk.
+
+Environment variables:
+* ``BIDMATE_INDEX_DIR`` — directory containing ``index.json``.
+  Defaults to ``data/index``.
+* ``BIDMATE_DEFAULT_PIPELINE`` — pipeline name used when a request does
+  not specify one. Defaults to ``agentic_full`` (the full demo
+  pipeline), falling back to the CLI default if that name is not in the
+  registry.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+
+from rag_core import (
+    DEFAULT_CLI_PIPELINE_NAME,
+    load_index,
+    pipeline_cli_choices,
+    run_rag_query,
+)
+
+from .schemas import QueryRequest
+
+logger = logging.getLogger("bidmate.api")
+
+DEFAULT_INDEX_DIR = "data/index"
+DEFAULT_API_PIPELINE = "agentic_full"
+
+
+def _resolve_default_pipeline() -> str:
+    """Pick the default pipeline for unspecified requests.
+
+    Prefers ``BIDMATE_DEFAULT_PIPELINE`` from the environment, then
+    ``agentic_full``, then the CLI default. The fallback chain keeps the
+    API working even if the registry is reshuffled.
+    """
+    env = (os.environ.get("BIDMATE_DEFAULT_PIPELINE") or "").strip()
+    choices = set(pipeline_cli_choices())
+    for candidate in (env, DEFAULT_API_PIPELINE, DEFAULT_CLI_PIPELINE_NAME):
+        if candidate and candidate in choices:
+            return candidate
+    return DEFAULT_CLI_PIPELINE_NAME
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Load the index once at startup and stash it on ``app.state``.
+
+    Eager loading keeps per-request latency clean and makes ``/health``
+    a meaningful readiness signal. If the index is missing we still
+    start (so ``/health`` can report the failure) instead of crashing
+    the worker.
+    """
+    index_dir = Path(os.environ.get("BIDMATE_INDEX_DIR") or DEFAULT_INDEX_DIR)
+    app.state.index_dir = index_dir
+    app.state.default_pipeline = _resolve_default_pipeline()
+    app.state.index = None
+    app.state.index_load_error = None
+    try:
+        app.state.index = load_index(index_dir)
+        logger.info(
+            "Loaded RAG index from %s (chunks=%d, default_pipeline=%s)",
+            index_dir,
+            len(app.state.index.get("chunks") or []),
+            app.state.default_pipeline,
+        )
+    except Exception as exc:  # pragma: no cover - logged for operators
+        app.state.index_load_error = str(exc)
+        logger.exception("Failed to load RAG index from %s", index_dir)
+    yield
+
+
+app = FastAPI(
+    title="BidMate-DocAgent demo API",
+    description=(
+        "Thin HTTP surface around the RAG pipeline. See docs/api-demo.md "
+        "for the local + container startup flow."
+    ),
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+def get_index(request: Request) -> dict[str, Any]:
+    """Dependency that returns the loaded index or 503s."""
+    index = getattr(request.app.state, "index", None)
+    if index is None:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "index_not_loaded",
+                "index_dir": str(getattr(request.app.state, "index_dir", "")),
+                "load_error": getattr(request.app.state, "index_load_error", None),
+                "hint": "Run scripts/build_index.py or restart with BIDMATE_INDEX_DIR set.",
+            },
+        )
+    return index
+
+
+@app.get("/health")
+def health(request: Request) -> dict[str, Any]:
+    """Readiness probe: 200 once the index is loaded, otherwise 503.
+
+    The body is the same shape in both cases so operators can read the
+    status without parsing the HTTP code.
+    """
+    state = request.app.state
+    index = getattr(state, "index", None)
+    payload: dict[str, Any] = {
+        "status": "ok" if index is not None else "degraded",
+        "index_dir": str(getattr(state, "index_dir", "")),
+        "index_loaded": index is not None,
+        "default_pipeline": getattr(state, "default_pipeline", DEFAULT_CLI_PIPELINE_NAME),
+    }
+    if index is not None:
+        payload["chunk_count"] = len(index.get("chunks") or [])
+        payload["doc_count"] = len({c.get("doc_id") for c in index.get("chunks") or []})
+    else:
+        payload["load_error"] = getattr(state, "index_load_error", None)
+        raise HTTPException(status_code=503, detail=payload)
+    return payload
+
+
+@app.get("/pipelines")
+def pipelines(request: Request) -> dict[str, Any]:
+    """List pipeline presets accepted by ``POST /query``."""
+    return {
+        "default": getattr(request.app.state, "default_pipeline", DEFAULT_CLI_PIPELINE_NAME),
+        "available": pipeline_cli_choices(),
+    }
+
+
+@app.post("/query")
+def query(
+    body: QueryRequest,
+    request: Request,
+    index: dict[str, Any] = Depends(get_index),
+) -> dict[str, Any]:
+    """Run one RAG query and return the raw answer dict.
+
+    The response shape is intentionally **not** wrapped in a pydantic
+    model — it passes through whatever ``run_rag_query`` returns so the
+    API never drifts from the canonical answer / citation contract.
+    """
+    pipeline = body.pipeline or request.app.state.default_pipeline
+    try:
+        return run_rag_query(
+            index,
+            body.query,
+            pipeline=pipeline,
+            top_k=body.top_k,
+            context_entities=body.context_entities or [],
+            retrieval_mode=body.retrieval_mode,
+            conversation_state=body.conversation_state,
+        )
+    except Exception as exc:
+        logger.exception("RAG query failed for query=%r pipeline=%r", body.query, pipeline)
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "rag_query_failed", "message": str(exc)},
+        )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,50 @@
+"""Request schema for the API demo.
+
+The response is left as the raw ``run_rag_query`` dict so the API output
+preserves the repo's grounded answer / citation contract verbatim. If
+the underlying schema evolves, the API surface evolves with it without
+a parallel pydantic model to drift out of sync.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class QueryRequest(BaseModel):
+    """Request body for ``POST /query``.
+
+    Only ``query`` is required. Optional fields mirror the CLI flags of
+    :mod:`app` so a reviewer can switch pipelines / retrieval modes from
+    the HTTP surface without rebuilding anything.
+    """
+
+    query: str = Field(..., min_length=1, description="User query string.")
+    pipeline: str | None = Field(
+        default=None,
+        description=(
+            "Named RAG pipeline preset (e.g. 'naive_baseline', 'agentic_full'). "
+            "Defaults to the API's configured default pipeline."
+        ),
+    )
+    top_k: int | None = Field(
+        default=None,
+        ge=1,
+        description="Override retrieval top-k.",
+    )
+    context_entities: list[str] | None = Field(
+        default=None,
+        description="Entities to carry across turns for follow-up queries.",
+    )
+    retrieval_mode: Literal["flat", "hierarchical"] | None = Field(
+        default=None,
+        description="Override the pipeline retrieval mode.",
+    )
+    conversation_state: dict | None = Field(
+        default=None,
+        description=(
+            "Optional prior conversation state echoed back from a previous "
+            "response. Pass this through unchanged for multi-turn flows."
+        ),
+    )

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Entrypoint for the BidMate-DocAgent demo container.
+#
+# If no index.json is present under BIDMATE_INDEX_DIR, build one from
+# data/raw using the hashing embedding backend (no network needed),
+# then launch uvicorn. This keeps the reviewer flow to a single
+# ``docker run`` command without burying the index inside the image.
+set -euo pipefail
+
+INDEX_DIR="${BIDMATE_INDEX_DIR:-/app/data/index}"
+INPUT_DIR="${BIDMATE_RAW_DIR:-/app/data/raw}"
+EMBEDDING_BACKEND="${EMBEDDING_BACKEND:-hashing}"
+HOST="${BIDMATE_API_HOST:-0.0.0.0}"
+PORT="${BIDMATE_API_PORT:-8000}"
+
+mkdir -p "$INDEX_DIR"
+if [[ ! -f "$INDEX_DIR/index.json" ]]; then
+  echo "[entrypoint] No index.json under $INDEX_DIR; building from $INPUT_DIR (backend=$EMBEDDING_BACKEND)"
+  python scripts/build_index.py \
+    --input_dir "$INPUT_DIR" \
+    --output_dir "$INDEX_DIR" \
+    --embedding_backend "$EMBEDDING_BACKEND"
+else
+  echo "[entrypoint] Reusing existing index at $INDEX_DIR/index.json"
+fi
+
+echo "[entrypoint] Starting uvicorn on $HOST:$PORT"
+exec uvicorn api.main:app --host "$HOST" --port "$PORT"

--- a/docs/api-demo.md
+++ b/docs/api-demo.md
@@ -1,0 +1,102 @@
+# API demo (FastAPI + container)
+
+This page documents the **reviewer-facing demo surface** added in
+issue #75. It is intentionally separate from the CLI evaluation flow:
+
+| Flow | Entry point | What it's for |
+|---|---|---|
+| **CLI eval** | `scripts/build_index.py`, `app.py`, `eval/run_eval.py` | Reproducible measurement, ablations, benchmark reports. Source of truth. |
+| **API demo** | `api/main.py` (this doc) | Letting a reviewer poke the system over HTTP without stitching commands together. |
+
+The API never builds an index itself; it loads one prepared on disk
+and wraps `rag_core.run_rag_query` behind three small endpoints.
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/health` | Readiness probe. 200 once the index is loaded, 503 otherwise. Reports `chunk_count`, `doc_count`, `default_pipeline`. |
+| `GET` | `/pipelines` | Lists pipeline presets accepted by `POST /query`, plus the configured default. |
+| `POST` | `/query` | Runs one RAG query. Body matches the CLI flags in `app.py`. Response is the raw `run_rag_query` dict — same shape `outputs/answer.json` would have. |
+| `GET` | `/docs` | FastAPI's built-in Swagger UI (auto-generated). |
+
+### `POST /query` body
+
+```json
+{
+  "query": "기관 A의 보안 통제 요구사항은?",
+  "pipeline": "agentic_full",        // optional
+  "top_k": 8,                         // optional
+  "retrieval_mode": "flat",           // optional: "flat" | "hierarchical"
+  "context_entities": ["기관 A"],    // optional, for follow-up turns
+  "conversation_state": null          // optional, pass back the prior response's value
+}
+```
+
+Only `query` is required. The response preserves the grounded
+answer / citation contract — see `docs/answer-policy.md` and
+`docs/citation-grounding-eval.md` for the schema specifics.
+
+## Local startup (no Docker)
+
+```bash
+make index          # builds data/index from data/raw (one-time)
+make api            # uvicorn on :8000 with --reload
+```
+
+Then:
+
+```bash
+curl http://localhost:8000/health
+curl -X POST http://localhost:8000/query \
+  -H 'content-type: application/json' \
+  -d '{"query":"기관 A와 기관 B의 AI 요구사항 차이 알려줘"}'
+```
+
+## Container startup (single command)
+
+```bash
+make api-docker
+# equivalent to:
+#   docker build -t bidmate-demo .
+#   docker run --rm -p 8000:8000 bidmate-demo
+```
+
+`docker-entrypoint.sh` checks for `data/index/index.json` inside the
+container and builds it from `data/raw` on first start using the
+hashing embedding backend (no network needed). Subsequent starts
+reuse the existing index.
+
+To persist the index across runs, mount a host volume:
+
+```bash
+docker run --rm -p 8000:8000 -v "$(pwd)/data/index:/app/data/index" bidmate-demo
+```
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `BIDMATE_INDEX_DIR` | `data/index` (local), `/app/data/index` (container) | Where the API looks for `index.json`. |
+| `BIDMATE_DEFAULT_PIPELINE` | `agentic_full` | Pipeline used when a request omits `"pipeline"`. Falls back to the CLI default if the name is not registered. |
+| `BIDMATE_API_HOST` / `BIDMATE_API_PORT` | `0.0.0.0` / `8000` | Container entrypoint binding. |
+| `EMBEDDING_BACKEND` | `hashing` (container) | Passed to `scripts/build_index.py` when the entrypoint auto-builds the index. |
+
+## Expected artifacts
+
+A successful demo run produces:
+
+- A live HTTP server on `:8000` (`/health` returning 200).
+- `data/index/index.json` if the container built one on first start.
+- No `outputs/answer.json` is written — the API returns the answer
+  inline. Use `make ask` / `app.py` for the file-emitting CLI flow.
+
+## What this demo deliberately does **not** do
+
+- No authentication, rate limiting, or persistence layer — out of
+  scope for a reviewer-facing demo.
+- No HTML UI — the OpenAPI Swagger page at `/docs` is enough.
+- No multi-stage Docker build / image size optimization — tracked
+  separately if it becomes a concern.
+- The container does not run `make eval` or any benchmark. Those are
+  CLI evaluation concerns and stay there.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@
 # Keep this file focused on tools needed for local/Codex validation.
 
 pytest>=9.0.3
+# Required by fastapi.testclient (starlette.testclient) for tests/test_api.py.
+httpx>=0.27,<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pdfplumber>=0.11,<1.0
 pytesseract>=0.3,<1.0
 Pillow>=10.0
 opencv-python-headless>=4.9,<4.13
+fastapi>=0.110,<1.0
+uvicorn[standard]>=0.27,<1.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,94 @@
+"""Integration tests for the FastAPI demo surface (issue #75).
+
+These tests bypass uvicorn and use FastAPI's ``TestClient`` so they
+remain fast and offline. The index is built in-memory from the
+existing ``data/raw`` fixture using the hashing embedding backend,
+matching the pattern used by other retrieval regression tests.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from rag_core import build_index_payload
+
+
+class ApiSmokeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index = build_index_payload(Path("data/raw"), embedding_backend="hashing")
+
+    def _client(self, *, with_index: bool = True) -> TestClient:
+        client = TestClient(api_main.app)
+        # TestClient triggers lifespan, which tries to load_index() from
+        # disk. Override the loaded state with our in-memory index so we
+        # never depend on a prebuilt data/index dir.
+        client.__enter__()
+        self.addCleanup(client.__exit__, None, None, None)
+        if with_index:
+            api_main.app.state.index = self.index
+            api_main.app.state.index_load_error = None
+        else:
+            api_main.app.state.index = None
+            api_main.app.state.index_load_error = "forced for test"
+        return client
+
+    def test_health_reports_loaded_index(self) -> None:
+        client = self._client()
+        resp = client.get("/health")
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        self.assertEqual(body["status"], "ok")
+        self.assertTrue(body["index_loaded"])
+        self.assertGreater(body["chunk_count"], 0)
+        self.assertGreater(body["doc_count"], 0)
+
+    def test_health_reports_degraded_when_index_missing(self) -> None:
+        client = self._client(with_index=False)
+        resp = client.get("/health")
+        self.assertEqual(resp.status_code, 503)
+        detail = resp.json()["detail"]
+        self.assertFalse(detail["index_loaded"])
+        self.assertEqual(detail["load_error"], "forced for test")
+
+    def test_pipelines_lists_available_presets(self) -> None:
+        client = self._client()
+        resp = client.get("/pipelines")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertIn("default", body)
+        self.assertIsInstance(body["available"], list)
+        self.assertIn(body["default"], body["available"])
+
+    def test_query_returns_grounded_answer_contract(self) -> None:
+        client = self._client()
+        resp = client.post(
+            "/query",
+            json={"query": "기관 A의 보안 통제 요구사항은?"},
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        body = resp.json()
+        # The API must preserve the run_rag_query contract: at minimum
+        # an answer payload and an evidence list must be present.
+        self.assertIn("answer", body)
+        self.assertIn("evidence", body)
+        self.assertIsInstance(body["evidence"], list)
+
+    def test_query_rejects_empty_string(self) -> None:
+        client = self._client()
+        resp = client.post("/query", json={"query": ""})
+        # pydantic v2 returns 422 on min_length violations.
+        self.assertEqual(resp.status_code, 422)
+
+    def test_query_503s_when_index_not_loaded(self) -> None:
+        client = self._client(with_index=False)
+        resp = client.post("/query", json={"query": "anything"})
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.json()["detail"]["error"], "index_not_loaded")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #75.

## Summary
- Thin FastAPI wrapper around `rag_core.run_rag_query` so reviewers can poke the system over HTTP without stitching CLI commands together.
- Single `docker run` startup: entrypoint auto-builds the index from `data/raw` on first start, then launches `uvicorn`.
- CLI evaluation flow remains the source of truth — the API never builds an index, it only loads one prepared on disk.
- Response is the raw `run_rag_query` dict, so the grounded answer / citation contract is preserved verbatim (no parallel pydantic model to drift).

## Endpoints
| Method | Path | Notes |
|---|---|---|
| `GET` | `/health` | 200 with `index_loaded`, `chunk_count`, `doc_count`, `default_pipeline`. 503 when the index is missing. |
| `GET` | `/pipelines` | Resolved default + list from `pipeline_cli_choices()`. |
| `POST` | `/query` | Body mirrors `app.py` flags. Response is the canonical RAG dict. |
| `GET` | `/docs` | FastAPI's built-in Swagger UI. |

## Files
- `api/main.py`, `api/schemas.py`, `api/__init__.py`
- `Dockerfile`, `docker-entrypoint.sh`
- `tests/test_api.py` (6 tests via `TestClient`)
- `docs/api-demo.md` — endpoints, env vars, local + container flows, explicit non-goals
- `Makefile` — `make api`, `make api-docker`
- `requirements.txt` — `fastapi`, `uvicorn[standard]`
- `README.md` — short callout distinguishing CLI eval vs API demo

## Verification
- `pytest -q` → **90 passed** locally (was 84; +6 API tests; no regressions).
- Live local check (`uvicorn api.main:app`):
  - `GET /health` → 200, `index_loaded: true`, `default_pipeline: agentic_full`
  - `POST /query` with `\"query\":\"기관 A의 보안 통제 요구사항은?\"` → `answer.status: supported`, non-empty `evidence`
- Eval delta CI job is expected to report all `·` (no RAG code touched).

## Test plan
- [ ] `Pytest` CI job green (includes the new 6 API tests).
- [ ] `Eval delta vs base` CI job green; delta comment shows `·` across metrics.
- [ ] Optional manual: `make api-docker` builds and serves; `curl :8000/health` returns 200 after the first-start index build.

## Out of scope (explicit)
- Auth / rate limiting / persistence — demo-only surface.
- HTML UI (Swagger at `/docs` is enough).
- Docker multi-stage / image size optimization (tracked separately if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)