### PR TITLE
Add engineering governance: ADRs, CLAUDE.md rules, workflow doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,114 @@ This repository is an RFP-focused DocAgent system.
 Core product flow:
 ingestion -> metadata normalization -> chunking -> retrieval -> reranking/planning -> evidence aggregation -> grounded answer -> verification -> evaluation -> reviewer-facing docs
 
-Rules:
-- Treat this as a Bid/RFP document intelligence system, not a generic AI playground.
+This file is the **enforceable** governance layer for AI-assisted work
+on this repo. The rules below are not aspirational — every change is
+expected to satisfy them or to call out, in the PR, exactly which rule
+is being waived and why.
+
+For the broader workflow that ties this file together with ADRs,
+tests, eval, and reviewer artifacts, see
+[`docs/engineering-governance.md`](docs/engineering-governance.md).
+
+---
+
+## Product rules
+
+- Treat this as a Bid/RFP document intelligence system, not a generic
+  AI playground.
 - Preserve a naive baseline before adding advanced retrieval methods.
+  See [ADR 0001](docs/adr/0001-preserve-naive-baseline.md).
 - Prefer metadata-aware retrieval where appropriate.
+  See [ADR 0002](docs/adr/0002-metadata-first-retrieval.md).
 - Keep answers grounded in retrieved evidence.
+  The grounded answer / citation contract is fixed by
+  [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md);
+  every behavior change that touches answers must respect it.
 - Favor reproducible evaluation and reviewer-friendly artifacts.
-- Avoid unrelated abstractions and broad rewrites.
-- Before coding, inspect the current implementation and explain what already exists.
-- When changing code, name files affected, risks, and verification steps.
-- Add or update tests when behavior changes.
-- Keep backward compatibility unless there is a strong reason not to.
+  Public vs private eval split is fixed by
+  [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md).
+
+## Change rules
+
+- **Before coding**, inspect the current implementation and explain
+  what already exists. Search for reusable functions / utilities
+  before proposing new code. Most changes should reuse, not invent.
+- **When changing code**, name in the PR: files affected, risks,
+  verification steps. "It works on my machine" is not a verification
+  step.
+- **Add or update tests when behavior changes.** Behavior changes
+  without test changes are presumed accidental; if intentional,
+  justify in the PR.
+- **Keep backward compatibility** unless there is a strong, stated
+  reason not to. Breaking the answer contract (ADR 0003) is the
+  highest-cost break and requires bumping `schema_version`.
+- **Avoid unrelated abstractions and broad rewrites.** One PR, one
+  concern. If you find a worthwhile fix outside the current scope,
+  open an issue instead of expanding the diff.
+- **ADR threshold.** Open an ADR when a change removes or replaces a
+  load-bearing decision (baseline / pipeline / answer contract /
+  eval surface). See [`docs/adr/README.md`](docs/adr/README.md).
+
+## Pre-PR review checklist
+
+Every PR description must answer these, in order:
+
+1. **What changed and why.** One paragraph. Link the issue.
+2. **Files affected.** A bulleted list; flag anything in
+   `rag_core.py`, `eval/`, `api/`, or `docs/adr/` as load-bearing.
+3. **Risks.** What is the most likely way this breaks? What
+   specifically did you check to rule that out?
+4. **Tests.** Which tests exercise the new behavior? If none, why is
+   that acceptable?
+5. **Eval impact.** What do you expect the CI eval delta to show?
+   ("All `·`" is a valid answer for non-RAG changes — say so.)
+6. **Backward compatibility.** Anything that breaks an existing
+   contract, schema, CLI flag, or doc link? If yes, what's the
+   migration?
+7. **Out of scope.** Anything you noticed and deliberately did not
+   fix.
+
+## Testing rules
+
+- `bash scripts/test.sh` (i.e. `pytest -q`) must pass locally before
+  push. CI runs the same command and is the gate.
+- Behavior changes in retrieval, verification, answer assembly, or
+  citation grounding **must** add at least one test that fails before
+  the change and passes after.
+- Regression tests for shipped bugs go in `tests/test_*_regression.py`
+  with a docstring linking the originating issue or taxonomy entry.
+  See `tests/test_retrieval_loop_regression.py` for the pattern.
+- Heavy-dep tests (visual ingestion, sentence-transformers) are fine
+  but must use the hashing embedding backend wherever the test is
+  about retrieval / verifier logic rather than the embedding itself.
+
+## Reproducibility & performance expectations
+
+- Public synthetic eval must runnable on every PR via the eval delta
+  workflow without network access or paid APIs. Anything that breaks
+  that constraint is a stop-the-line bug.
+- The CLI `make smoke` flow stays under a few minutes on a developer
+  laptop using `EMBEDDING_BACKEND=hashing`. Significant new latency
+  in that path needs justification in the PR.
+- API demo (`api/main.py`, `docker-entrypoint.sh`) must remain
+  one-command startable. Don't add required setup steps without
+  updating [`docs/api-demo.md`](docs/api-demo.md).
+- Latency numbers reported in PR descriptions should come from the
+  `stage_latency` block in `reports/eval_summary.json`, not ad-hoc
+  measurement.
+
+## Prohibited shortcuts
+
+- Do **not** remove the naive baseline or its eval ablation. See
+  ADR 0001.
+- Do **not** delete or rename ADRs even when superseded. Mark
+  status; keep the file.
+- Do **not** skip pre-commit hooks (`--no-verify`,
+  `--no-gpg-sign`) without explicit user approval.
+- Do **not** commit anything from `data/files/`, `data/data_list.csv`,
+  `eval/*.local.yaml`, or `reports/real*/`. These are the private
+  side of the eval split (ADR 0005) and stay out of git.
+- Do **not** introduce a parallel pydantic / TypedDict model that
+  shadows the `run_rag_query` answer dict. The dict is the contract.
+- Do **not** broaden a PR mid-review by adding unrelated commits.
+  Open a follow-up.

--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ python3 eval/run_parser_eval.py \
 - Grounding/eval hardening: [`docs/grounding-eval-hardening.md`](docs/grounding-eval-hardening.md)
 - Reproducible harness: [`docs/harness.md`](docs/harness.md)
 - API demo (FastAPI + container): [`docs/api-demo.md`](docs/api-demo.md)
+- Architecture Decision Records: [`docs/adr/README.md`](docs/adr/README.md)
+- Engineering governance (workflow map): [`docs/engineering-governance.md`](docs/engineering-governance.md)
 - 답변 출력 정책: [`docs/answer-policy.md`](docs/answer-policy.md)
 - 실패 사례 분석: [`docs/failure-cases.md`](docs/failure-cases.md)
 - 회고 및 개선 방향: [`docs/retrospective.md`](docs/retrospective.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # BidMate Agent 상세 문서
 
+- [Engineering governance (workflow map)](./engineering-governance.md)
+- [Architecture Decision Records](./adr/README.md)
 - [Reviewer evidence pack](./reviewer-evidence-pack.md)
 - [포트폴리오 case study](./portfolio-case-study.md)
 - [Benchmarking](./benchmarking.md)

--- a/docs/adr/0001-preserve-naive-baseline.md
+++ b/docs/adr/0001-preserve-naive-baseline.md
@@ -1,0 +1,58 @@
+# 0001: Preserve a naive baseline alongside the agentic pipeline
+
+- **Status**: accepted
+- **Date**: 2026-05-11
+- **Related**: [`CLAUDE.md`](../../CLAUDE.md), [`docs/ablation-results.md`](../ablation-results.md), [`eval/config.yaml`](../../eval/config.yaml)
+
+## Context
+
+The system ships an "agentic" full pipeline (metadata-first retrieval,
+reranker, verifier-driven retry, structured answer/citation contract).
+Every advanced component adds latency, complexity, and a surface for
+regressions. Without a side-by-side comparison run on the same cases,
+it is impossible to tell whether the extra machinery actually improves
+quality on a given query slice — or just shifts the failure mode.
+
+## Decision
+
+Keep a runnable `naive_baseline` pipeline preset alongside
+`agentic_full` for the lifetime of the project. The CLI default
+remains `naive_baseline` so that the most reproducible path is the
+simplest one. Both presets appear as ablation runs in
+[`eval/config.yaml`](../../eval/config.yaml) and are measured on
+every eval invocation.
+
+The knob: `pipeline_cli_choices()` in
+[`rag_core.py`](../../rag_core.py) is the source of truth for which
+presets exist; removing `naive_baseline` from that list is the
+explicit signal that this ADR is being revisited.
+
+## Consequences
+
+**Wins**
+
+- Every ablation report includes a baseline column, so quality wins
+  from advanced components are demonstrable, not asserted.
+- Reviewers can run the simplest path (`make ask`) end-to-end without
+  understanding the agentic stack.
+- Regressions in the agentic pipeline that drag it below baseline are
+  detected by the eval delta job, not by anecdote.
+- Issue triage gains a fast question: *does it reproduce on
+  `naive_baseline`?*
+
+**Costs**
+
+- Two code paths must keep working. The CLI surface (`app.py`), the
+  API surface (`api/main.py`), and `eval/run_eval.py` all carry the
+  abstraction.
+- The README's headline metrics need to make the baseline-vs-full gap
+  explicit, or the system looks weaker than it is.
+
+## Alternatives considered
+
+- **Drop the baseline once the agentic pipeline ships.** Rejected:
+  there would be no defensible answer to *"is the extra complexity
+  earning its keep?"* on any future change.
+- **Keep the baseline in code but stop running it in eval.** Rejected:
+  silent baselines rot. If we are not measuring it, we are not
+  preserving it.

--- a/docs/adr/0002-metadata-first-retrieval.md
+++ b/docs/adr/0002-metadata-first-retrieval.md
@@ -1,0 +1,67 @@
+# 0002: Metadata-first retrieval strategy
+
+- **Status**: accepted
+- **Date**: 2026-05-11
+- **Related**: [`rag_core.py`](../../rag_core.py), [`docs/design-background.md`](../design-background.md), [`docs/real-data-failure-taxonomy.md`](../real-data-failure-taxonomy.md)
+
+## Context
+
+RFP queries are usually about *a specific agency / project / section*
+(e.g. "기관 A의 보안 통제 요구사항"). Generic dense or BM25 retrieval
+returns lexically similar chunks across the corpus and frequently
+mixes the wrong agency's content with the right one. The failure mode
+is silent: the answer can look plausible while citing the wrong
+document, which is exactly what a reviewer cannot accept.
+
+The corpus, by contrast, carries reliable metadata: `agency`,
+`project`, `section`, document type. Anchoring retrieval to those
+facets first turns out to be the cheapest large win available.
+
+## Decision
+
+The default retrieval strategy resolves a metadata target (agency /
+project / section) **before** ranking chunks by content similarity.
+When metadata is resolvable, retrieval is filtered to the matching
+slice; only within that slice are content scores used. When metadata
+is ambiguous, the system surfaces the ambiguity rather than picking
+silently. When no metadata signal applies, retrieval falls back to
+content-only ranking.
+
+The knob: the `metadata_first` flag in the pipeline preset. It is
+`true` for `agentic_full` and `false` for `naive_baseline`, which
+makes the contribution measurable as an ablation
+(`no_metadata_first`).
+
+## Consequences
+
+**Wins**
+
+- Cross-agency contamination drops sharply on the comparison and
+  single-doc query types where it dominated the failure mix.
+- The `citation_doc_precision` metric, which previously punished
+  metadata-blind retrievals, becomes usable as a quality signal
+  rather than a noise floor.
+- Reviewer-facing artifacts (`outputs/answer.json`,
+  `reports/eval_summary.json`) include a metadata-resolution
+  diagnostic block, so failures are debuggable without re-running
+  the query.
+
+**Costs**
+
+- Retrieval quality is now bounded by metadata-extraction quality.
+  When the corpus has imperfect metadata, this strategy concentrates
+  the damage instead of averaging it out.
+- A whole new failure category emerges — *metadata ambiguity* — that
+  requires its own handling (see issue #72). The system must surface
+  the ambiguity rather than guessing, which complicates the answer
+  contract (ADR 0003).
+
+## Alternatives considered
+
+- **Content-only retrieval with reranker.** Rejected as the default:
+  it still mixes agencies on the queries that matter most.
+  Preserved as an ablation (`naive_baseline`, `no_metadata_first`)
+  for comparison.
+- **Hybrid scoring with a metadata bonus term.** Rejected: harder to
+  reason about, harder to ablate cleanly, and prone to silent failure
+  when the bonus is tuned wrong.

--- a/docs/adr/0003-structured-answer-citation-contract.md
+++ b/docs/adr/0003-structured-answer-citation-contract.md
@@ -1,0 +1,74 @@
+# 0003: Structured answer / citation contract (`schema_version: 2`)
+
+- **Status**: accepted
+- **Date**: 2026-05-11
+- **Related**: [`docs/answer-policy.md`](../answer-policy.md), [`docs/citation-grounding-eval.md`](../citation-grounding-eval.md), [`eval/run_eval.py`](../../eval/run_eval.py)
+
+## Context
+
+A grounded RAG system is only as trustworthy as its citations. Early
+iterations returned free-text answers with informal "(see chunk 3)"
+references; this was fine for a demo and useless for evaluation.
+Anything we wanted to measure — citation precision, claim alignment,
+correct abstention — required parsing those informal answers heuristically,
+which made every metric brittle and every regression invisible.
+
+The system also needs a clear way to say *"I do not have evidence"*
+without producing a plausible-sounding hallucination. That signal must
+be a value in the response, not absence of text, so callers can act on
+it programmatically.
+
+## Decision
+
+Every answer is a JSON object with `schema_version: 2`. The contract:
+
+- `status` is one of `supported`, `partial`, `insufficient`. Other
+  values are not permitted.
+- `claims` is a list of `{target, claim, support, citations[]}`.
+  Each `citation` has a `doc_id` and `chunk_id` that points back into
+  the `evidence` list at the top level. Without those, the claim is
+  unsupported by construction.
+- `status_reason` is machine-readable: `{code, verified,
+  verification_reasons[]}`. The eval pipeline keys off these.
+- `evidence` at the top level holds the actual retrieved chunks with
+  `doc_id`, `chunk_id`, `text`, and the metadata used to resolve
+  them. Citations resolve into this list.
+- `answer_text` is a human-readable summary. It is **not** part of
+  the verifiable contract; tooling must not key off it.
+- Insufficient answers carry an `insufficiency` block with
+  `missing_targets` and a human-readable message, instead of a fake
+  answer.
+
+[`docs/answer-policy.md`](../answer-policy.md) is the working
+reference; this ADR is the load-bearing decision behind it.
+
+## Consequences
+
+**Wins**
+
+- Eval metrics (`citation_grounding`, `claim_citation_alignment`,
+  `answer_format_compliance`) can be computed mechanically; the
+  numbers in `reports/eval_summary.json` are real, not best-effort.
+- The API demo can return `run_rag_query`'s dict verbatim
+  (ADR-aligned with the FastAPI surface) because the response *is*
+  the contract.
+- Abstention becomes a first-class signal. Issue #69's work on
+  partial-topic grounding has somewhere to put its decision
+  (`partial` vs `insufficient`).
+
+**Costs**
+
+- Every behavior change that touches answers must consider whether
+  it breaks this contract. The `schema_version` bump exists exactly
+  so that incompatible changes are explicit.
+- Free-text-only models cannot be dropped in without a wrapper that
+  emits this shape.
+
+## Alternatives considered
+
+- **Free-text answer with inline citations parsed by regex.**
+  Rejected: every metric becomes brittle and every reviewer
+  inspection becomes manual.
+- **Use a generic LangChain / agent-framework response model.**
+  Rejected: those models change on someone else's schedule, and we
+  need stability for the eval delta job to mean anything.

--- a/docs/adr/0004-verifier-retry-policy.md
+++ b/docs/adr/0004-verifier-retry-policy.md
@@ -1,0 +1,84 @@
+# 0004: Verifier-driven retry with strict → relaxed staging
+
+- **Status**: accepted
+- **Date**: 2026-05-11
+- **Related**: [`rag_core.py`](../../rag_core.py) (`verify_evidence`, `L1843` / `L2053`), [`docs/real-data-failure-taxonomy.md`](../real-data-failure-taxonomy.md), [`docs/grounding-eval-hardening.md`](../grounding-eval-hardening.md)
+
+## Context
+
+Even with metadata-first retrieval (ADR 0002), the top-k chunks for a
+query are sometimes only partially on-topic. A pipeline that always
+trusts the first retrieval pass produces confident-sounding but
+weakly-grounded answers, which is the failure mode this project most
+wants to avoid. The opposite extreme — refusing to answer whenever
+evidence is imperfect — produces excessive false abstention, which
+`docs/real-data-failure-taxonomy.md` C6 identified as the dominant
+remaining failure on real corpora.
+
+There needs to be a structured way to ask *"is this evidence good
+enough?"* and to take a second shot when it isn't, without unbounded
+loops or unverifiable answers.
+
+## Decision
+
+Answer generation is gated by `verify_evidence`. The retrieval loop
+runs in **stages**:
+
+1. **Strict stage.** Full topic / entity / comparison-coverage
+   checks. Evidence must satisfy all required signals or the stage
+   fails with explicit `verification_reasons` (e.g.
+   `topic_not_grounded`, `missing_comparison_entity:*`).
+2. **Relaxed stage** (one retry). Retrieval re-runs with widened
+   parameters; the verifier accepts evidence that meets a documented,
+   weaker bar. The relaxation is recorded in
+   `diagnostics.filter_stage_attempts` so every answer carries its
+   own evidence-quality trail.
+3. **Abstain.** If the relaxed stage still fails, the answer becomes
+   `insufficient` (or `partial` for comparison queries that have only
+   some targets — see ADR 0003). No third retry.
+
+The knobs:
+
+- `verifier_retry: bool` per pipeline preset. `agentic_full` has it
+  on; `naive_baseline` has it off; `no_verifier_retry` is a
+  first-class ablation.
+- The strict / relaxed thresholds live in `verify_evidence` and
+  related helpers in `rag_core.py`. Changes that move these
+  thresholds must update the eval delta and call out the trade-off
+  in the PR.
+
+## Consequences
+
+**Wins**
+
+- Abstention is auditable: every abstained answer carries the
+  `verification_reasons` that led there, which is what makes the
+  taxonomy-driven backlog (#69, #70, #72) actionable.
+- Retry cost is bounded (one extra retrieval at most), so the
+  latency / cost story stays simple.
+- Each component is independently ablatable
+  (`metadata_first`, `rerank`, `verifier_retry`), and the eval
+  config exposes each as a named run.
+
+**Costs**
+
+- The strict vs relaxed thresholds are policy decisions, not derived
+  from first principles. Issue #69 exists precisely because the
+  default policy errs strict and produces false abstentions on real
+  data.
+- Every new failure mode tends to want its own verification reason
+  string. The list in `eval/run_eval.py`'s `retry_reason_counts` is
+  the source of truth for what is currently tracked.
+
+## Alternatives considered
+
+- **No verifier; always answer with the top-k.** Rejected: this is
+  the `naive_baseline` behavior and is preserved for ablation, not
+  as the default. It is unsafe for reviewer-facing claims.
+- **Unbounded retries with score-based stopping.** Rejected: latency
+  is unbounded, and the failure cases that motivate retry are
+  exactly the ones where higher scores do not mean better grounding.
+- **LLM-as-judge verifier.** Rejected for the public path: it adds
+  an external dependency, costs tokens per query, and makes
+  reproducible eval much harder. May be reconsidered if the
+  deterministic verifier hits a ceiling.

--- a/docs/adr/0005-eval-split-public-synthetic-private-local.md
+++ b/docs/adr/0005-eval-split-public-synthetic-private-local.md
@@ -1,0 +1,77 @@
+# 0005: Eval split — public synthetic vs private local
+
+- **Status**: accepted
+- **Date**: 2026-05-11
+- **Related**: [`eval/config.yaml`](../../eval/config.yaml), [`eval/real_config.example.yaml`](../../eval/real_config.example.yaml), [`docs/private-100-doc-experiments.md`](../private-100-doc-experiments.md), [`docs/private-hardcase-benchmark.md`](../private-hardcase-benchmark.md), [`docs/real-data-failure-taxonomy.md`](../real-data-failure-taxonomy.md)
+
+## Context
+
+The system has two evaluation needs that pull in opposite directions:
+
+- **Public reproducibility.** Anyone cloning the repo must be able to
+  run a meaningful eval without secrets, paid APIs, or data we cannot
+  redistribute. README metrics must be backed by a public artifact.
+- **Honest signal.** Synthetic RFPs do not exercise the failure modes
+  that show up on real procurement documents — ambiguous metadata,
+  scanned PDFs, off-distribution phrasing. Real-data eval is where the
+  failure taxonomy actually comes from.
+
+A single eval set cannot do both jobs. Anything we publish gets
+optimized against, and anything we cannot publish cannot anchor
+public claims.
+
+## Decision
+
+Maintain two eval surfaces side-by-side:
+
+- **Public synthetic** (`eval/config.yaml`, `data/raw/`). Committed,
+  CI-runnable on every PR (`make eval`, the eval delta workflow),
+  drives README metrics. Source of truth for *"is the system still
+  shipping the contract it claims?"*. Uses the hashing embedding
+  backend so it runs offline.
+- **Private local** (`eval/real_config.example.yaml` as the
+  scaffold; the actual config and corpus stay out of git). Run
+  locally on real procurement documents. Source of truth for *"what
+  failure modes are real?"*. Outputs (`reports/real100/`) and inputs
+  (`data/files/`, `data/data_list.csv`, the local config) are
+  `.gitignore`d.
+
+The boundary is enforced by the example-file convention
+(`*.example.yaml`) and by `.gitignore`. Any new eval surface picks a
+side: public-redistributable, or strictly local.
+
+## Consequences
+
+**Wins**
+
+- The CI eval delta job (`.github/workflows/pr-eval.yml`) can be
+  honest about what it does and does not cover — it measures the
+  public synthetic surface only.
+- Failure taxonomies and prioritized backlog items can be grounded
+  in real-data observations without leaking the documents.
+- Confidentiality is not a per-file judgment call; the example /
+  gitignore split is the convention.
+
+**Costs**
+
+- Two configs to keep in shape. When the schema of a case evolves
+  (new required field, new metric key), both must update or the
+  private surface silently drifts.
+- README metrics under-report the failure rate that real-data work
+  actually sees. Aggregate-delta reports
+  (`docs/private-100-doc-experiments.md`) are needed to bridge that
+  honestly.
+- Reviewers cannot reproduce private-surface numbers. They must trust
+  the aggregate / delta reports plus the public-surface
+  reproducibility.
+
+## Alternatives considered
+
+- **Public-only.** Rejected: synthetic data hides the failure modes
+  that matter; we would be optimizing for the wrong thing.
+- **Private-only.** Rejected: nothing reproducible to publish; no
+  reviewer can validate any claim.
+- **One config with a private-cases extension loaded conditionally.**
+  Considered. Rejected because the two surfaces have different
+  purposes (PR gating vs. real-data taxonomy), and conflating them
+  makes both harder to defend in review.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,70 @@
+# Architecture Decision Records (ADR)
+
+This directory holds the **load-bearing decisions** for BidMate-DocAgent
+— the ones that, if reversed, would force significant rework or
+invalidate published evaluation results.
+
+## When to write an ADR
+
+Write one when a change:
+
+- Removes, replaces, or fundamentally alters a baseline / pipeline /
+  evaluation contract that other parts of the system depend on.
+- Picks between two viable approaches whose trade-off you will need to
+  defend later (in review, in an interview, or to your future self).
+- Establishes a new convention that future changes must follow.
+
+Do **not** write one for routine code changes, bug fixes, refactors,
+or doc edits. Those go straight into the PR description.
+
+## File layout
+
+```
+docs/adr/
+├── README.md           # this file
+├── _template.md        # copy this when starting a new ADR
+└── NNNN-slug.md        # one ADR per file
+```
+
+- `NNNN` is a 4-digit zero-padded sequence, e.g. `0001`, `0023`.
+- Numbers are **never reused or renumbered**, even if an ADR is later
+  superseded. Continuity matters more than tidiness.
+- `slug` is short, kebab-case, and stable. Pick a name you will not
+  want to rename later (e.g. `metadata-first-retrieval`, not
+  `retrieval-changes-v2`).
+
+## Status lifecycle
+
+| status | meaning |
+|---|---|
+| `proposed` | Decision drafted but not yet implemented or merged. Open for change. |
+| `accepted` | Reflected in code / docs / tests. Treated as the current convention. |
+| `superseded by NNNN` | Replaced by a later ADR. The old file stays; the new one links back. |
+| `deprecated` | No longer applies but no replacement exists. Rare. |
+
+Always update the status header when status changes. Do not delete
+old ADRs even when superseded — their existence is part of the
+project record.
+
+## Authoring conventions
+
+- Keep each ADR short. One screen is the target. If you need more
+  room, the decision probably needs to be split or the context
+  belongs in a regular design doc.
+- Use the section headings from [`_template.md`](./_template.md):
+  **Context**, **Decision**, **Consequences**, **Alternatives
+  considered**.
+- Reference concrete code paths (`rag_core.py:L1843`) and existing
+  docs rather than restating their content.
+- Cross-link from any prose doc that previously held the rationale,
+  so the ADR becomes the canonical source.
+
+## Index
+
+| # | Status | Title |
+|---|---|---|
+| [0001](./0001-preserve-naive-baseline.md) | accepted | Preserve a naive baseline alongside the agentic pipeline |
+| [0002](./0002-metadata-first-retrieval.md) | accepted | Metadata-first retrieval strategy |
+| [0003](./0003-structured-answer-citation-contract.md) | accepted | Structured answer / citation contract (`schema_version: 2`) |
+| [0004](./0004-verifier-retry-policy.md) | accepted | Verifier-driven retry with strict → relaxed staging |
+| [0005](./0005-eval-split-public-synthetic-private-local.md) | accepted | Eval split: public synthetic vs private local |

--- a/docs/adr/_template.md
+++ b/docs/adr/_template.md
@@ -1,0 +1,32 @@
+# NNNN: <decision title>
+
+- **Status**: proposed | accepted | superseded by NNNN | deprecated
+- **Date**: YYYY-MM-DD
+- **Deciders**: <names or roles>
+- **Related**: <issue / PR / doc links, optional>
+
+## Context
+
+What problem or constraint forced a decision? Keep this factual and
+specific to this repo — link concrete files (`rag_core.py:L1843`) or
+existing docs rather than re-explaining them. Three paragraphs max.
+
+## Decision
+
+The chosen approach, stated as one direct sentence followed by the
+specifics needed to act on it. If the decision has a knob (threshold,
+toggle, default), name it here so future readers know what to change
+if they want to revisit.
+
+## Consequences
+
+What becomes easier, harder, or constrained because of this decision?
+List both the wins and the costs. Include any contract this locks in
+(e.g., a schema field other code relies on, a default that other ADRs
+assume).
+
+## Alternatives considered
+
+Brief notes on the options that were not chosen and why. One or two
+bullets each. The goal is to make the trade-off legible, not to
+re-litigate it.

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -1,0 +1,122 @@
+# Engineering governance
+
+This page is the **single navigation point** for how engineering work
+flows through this repo. It ties together the rule book
+([`CLAUDE.md`](../CLAUDE.md)), decision records
+([`docs/adr/`](./adr/README.md)), tests, evaluation, and
+reviewer-facing artifacts.
+
+If you are new to the repo or onboarding a reviewer, start here.
+
+## Where each thing lives
+
+| Concern | Source of truth | Notes |
+|---|---|---|
+| Coding & review rules | [`CLAUDE.md`](../CLAUDE.md) | Pre-PR checklist, prohibited shortcuts, performance expectations. |
+| Load-bearing decisions | [`docs/adr/`](./adr/README.md) | One short file per decision; status-tracked. |
+| Behavior contracts | [ADR 0003](./adr/0003-structured-answer-citation-contract.md), [`docs/answer-policy.md`](./answer-policy.md) | Answer JSON shape, `schema_version`, status values. |
+| Eval surfaces | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`eval/config.yaml`](../eval/config.yaml), `eval/*.example.yaml` | Public synthetic is committed; private local is `.gitignore`d. |
+| Reviewer-facing metrics | `reports/eval_summary.json`, README headline table | The PR eval delta workflow upserts a PR comment with the diff. |
+| Failure analysis | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), [`docs/failure-cases.md`](./failure-cases.md) | Drives the prioritized backlog. |
+| API demo | [`docs/api-demo.md`](./api-demo.md), `api/main.py` | Reviewer playground; never the source of truth for measurement. |
+
+## Change lifecycle
+
+The expected flow for any non-trivial change, written as a checklist
+a contributor (human or AI) can walk through:
+
+1. **Open or pick an issue.** Real-data failure taxonomy entries
+   (`docs/real-data-failure-taxonomy.md`) and the prioritized backlog
+   are the primary feed.
+2. **Decide if it needs an ADR.** Use the criteria in
+   [`docs/adr/README.md`](./adr/README.md). Most changes do **not**;
+   when in doubt, ask in the issue.
+3. **Inspect what exists.** Per `CLAUDE.md` ("Before coding,
+   inspect..."). Name the files you read, the functions you intend
+   to reuse, and what you found that surprised you.
+4. **Branch + worktree if parallel.** Two independent tracks → two
+   worktrees, two PRs. Coupled tracks → one PR, one branch.
+5. **Make the change.** Reuse over invent. One concern per PR.
+6. **Add or update tests.** Behavior change without a test is
+   presumed accidental. Regressions get a guard test in
+   `tests/test_*_regression.py`.
+7. **Run the eval locally if relevant.** `make eval` for the public
+   synthetic surface. Compare against `main`'s
+   `reports/eval_summary.json` if you have it.
+8. **Push, open PR.** PR body answers the pre-PR checklist in
+   `CLAUDE.md` (what / files / risks / tests / eval impact / back-compat / out-of-scope).
+9. **CI verifies.** `Pytest` job + `Eval delta vs base` job. The
+   delta job upserts a comment with the metrics table; expect `·`
+   across the board for non-RAG changes.
+10. **Address review.** No mid-review scope creep — open a follow-up
+    issue instead.
+11. **Merge.** Squash-merge, delete the branch, remove the worktree
+    if used.
+12. **Update docs** if the change changed something a reviewer needs
+    to know (README headline metrics, ADR status, taxonomy entry).
+
+## How the documents reinforce each other
+
+```
+                ┌───────────────────────────┐
+                │        CLAUDE.md          │  (the rules)
+                └─────────────┬─────────────┘
+                              │
+              ┌───────────────┼────────────────┐
+              ▼               ▼                ▼
+        ┌──────────┐    ┌──────────┐     ┌──────────┐
+        │  ADRs    │    │  Tests   │     │   Eval   │
+        │ (why)    │    │ (guard)  │     │ (proof)  │
+        └────┬─────┘    └────┬─────┘     └────┬─────┘
+             │               │                │
+             └───────────────┼────────────────┘
+                             ▼
+                ┌───────────────────────────┐
+                │ Reviewer-facing artifacts │
+                │ (README, docs/*, PR diff) │
+                └───────────────────────────┘
+```
+
+- **CLAUDE.md** says what every change must satisfy.
+- **ADRs** record why a load-bearing choice was made, so future
+  changes don't unknowingly invert it.
+- **Tests** prevent the rules and decisions from silently rotting.
+- **Eval** turns the rules and decisions into numbers a reviewer can
+  read.
+- **Reviewer artifacts** (README, design docs, PR descriptions,
+  ablation reports) point back into the above so the system can be
+  understood end-to-end without DM'ing the author.
+
+## Anti-patterns this governance is designed to prevent
+
+- Silent contract drift — an answer field disappears and no test
+  catches it. *Prevented by:* ADR 0003 + `score_answer_format` in
+  `eval/run_eval.py`.
+- Headline-metric inflation — README claims a number that no
+  artifact backs. *Prevented by:* `scripts/update_readme_metrics.py
+  --check` in `make check`, plus the public/private eval split (ADR
+  0005).
+- Baseline rot — the naive baseline still imports but no one runs
+  it. *Prevented by:* `naive_baseline` is a named ablation in
+  `eval/config.yaml`; every eval run reports it.
+- Decision laundering — a load-bearing choice is buried in a
+  refactor PR. *Prevented by:* ADR threshold in `CLAUDE.md`; the
+  pre-PR checklist forces the question.
+- Review-time scope creep — a PR grows to include "while I was
+  here" fixes. *Prevented by:* "one PR, one concern" in
+  `CLAUDE.md`; spawn a follow-up issue instead.
+
+## Onboarding shortcuts
+
+Reading order for a new contributor:
+
+1. [`CLAUDE.md`](../CLAUDE.md) — the rules.
+2. This file — how the rules connect.
+3. [`docs/adr/README.md`](./adr/README.md) and skim the 5 current
+   ADRs — the load-bearing decisions.
+4. [`docs/portfolio-case-study.md`](./portfolio-case-study.md) — the
+   narrative.
+5. [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md)
+   — what the backlog comes from.
+
+A reviewer who has 10 minutes should start at step 3.


### PR DESCRIPTION
Closes #74, closes #77, closes #78.

## Summary
Bundles three governance issues into one **documentation-only** PR since they describe complementary pieces of the same workflow:

- **#74 — ADR structure**: new `docs/adr/` with conventions, template, and **five initial ADRs** covering the load-bearing decisions already reflected in the system.
- **#77 — Hardened `CLAUDE.md`**: from a short orientation note into an enforceable governance layer (pre-PR checklist, testing rules, reproducibility expectations, prohibited shortcuts, ADR threshold).
- **#78 — `docs/engineering-governance.md`**: a single navigation point that ties `CLAUDE.md`, ADRs, tests, eval, and reviewer artifacts into one change-lifecycle flow.

## Files affected
- New: `docs/adr/README.md`, `docs/adr/_template.md`, `docs/adr/0001-…` through `0005-…`, `docs/engineering-governance.md`
- Modified: `CLAUDE.md` (full rewrite into governance form), `README.md` and `docs/README.md` (index links)
- No code touched.

## Initial ADRs
| # | Title |
|---|---|
| 0001 | Preserve a naive baseline alongside the agentic pipeline |
| 0002 | Metadata-first retrieval strategy |
| 0003 | Structured answer / citation contract (`schema_version: 2`) |
| 0004 | Verifier-driven retry with strict → relaxed staging |
| 0005 | Eval split — public synthetic vs private local |

## Risks
- Low. Pure docs.
- Most likely failure mode: a link drifts. The README index links and inter-ADR references were authored together to avoid that.
- Future code PRs are now expected to follow the pre-PR checklist in `CLAUDE.md`; this changes contributor expectations but does not change any current behavior.

## Tests
- N/A (docs-only). `pytest -q` locally: **90 passed**, no regressions.

## Eval impact
- Expected: **all `·`** in the eval delta comment. RAG code untouched.

## Backward compatibility
- The original `CLAUDE.md` rules are preserved inside the new layout (Product rules + Change rules sections). No prior link is broken.

## Out of scope
- Backfilling ADRs for every decision in the repo. Five high-leverage ones first; more can land as separate ADR-only PRs when new load-bearing choices appear.
- Auto-linting of ADR status / numbering — overkill for the current volume.

## Test plan
- [ ] `Pytest` CI green.
- [ ] `Eval delta vs base` CI green; comment shows `·` across the board.
- [ ] Spot-check rendered ADRs and the governance doc on GitHub for link integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)