### PR TITLE
Reduce false abstention via partial-topic grounding on relaxed stage (#69)

### DIFF
--- a/docs/answer-policy.md
+++ b/docs/answer-policy.md
@@ -7,7 +7,7 @@
 | status | 의미 | evidence | claims |
 |---|---|---|---|
 | `supported` | 모든 필수 대상과 주제가 근거로 확인됨 | 있음 | 1개 이상 |
-| `partial` | 비교 질문에서 일부 대상만 근거로 확인됨 | 확인된 대상만 있음 | 1개 이상 |
+| `partial` | (a) 비교 질문에서 일부 대상만 근거로 확인됨, 또는 (b) 검증 토픽 중 일부만 evidence에 매칭됨 (relaxed 단계의 partial-topic grounding) | 확인된 대상만 있음 | 1개 이상 |
 | `insufficient` | 답변 가능한 근거를 찾지 못함 | 없음 | 없음 |
 
 현재 답변 객체는 `schema_version: 2`를 사용한다. `answer_text`는 사람이 빠르게 읽기 위한 요약이고, 검증 가능한 계약은 `answer.schema_version`, `answer.status`, `answer.status_reason`, `answer.claims`, `answer.insufficiency`, top-level `evidence`를 기준으로 본다.
@@ -16,9 +16,9 @@
 
 | field | 의미 |
 |---|---|
-| `code` | `verified`, `partial_comparison`, `insufficient_evidence`, `context_clarification`, `metadata_ambiguity_clarification` 중 하나 |
-| `verified` | verifier 기준 통과 여부. 단, 명시 요청된 비교 대상이 corpus에 없으면 verifier 설정과 무관하게 `partial`이 될 수 있음 |
-| `verification_reasons` | `topic_not_grounded`, `missing_comparison_doc:*`, `missing_requested_entity:*` 같은 근거 부족 사유 |
+| `code` | `verified`, `partial_comparison`, `partial_topic_grounding`, `insufficient_evidence`, `context_clarification`, `metadata_ambiguity_clarification` 중 하나 |
+| `verified` | verifier 기준 통과 여부. 단, 명시 요청된 비교 대상이 corpus에 없으면 verifier 설정과 무관하게 `partial`이 될 수 있음. relaxed 단계의 partial-topic 매칭으로 통과한 경우 `verified=True`이지만 status는 `partial`로 surface된다 |
+| `verification_reasons` | `topic_not_grounded`, `partial_topic_grounding`, `missing_comparison_doc:*`, `missing_requested_entity:*` 같은 근거 부족 또는 약한 근거 사유 |
 
 ## 좋은 답변 예시
 

--- a/docs/grounding-eval-hardening.md
+++ b/docs/grounding-eval-hardening.md
@@ -55,5 +55,65 @@ Inspect these artifacts:
 - #60: local planner/rewrite traces are emitted in both `outputs/answer.json` and `reports/traces/`.
 - #63: answer schema v2 explicitly represents `supported`, `partial`, and `insufficient` with machine-readable status reasons.
 - #64: claim-level citation alignment is measured separately from whole-answer citation precision.
+- #69: partial-topic grounding on the relaxed (last-attempt) verifier stage — see below.
 
 Out of scope remains chunking redesign (#62) and confidentiality/reporting flow (#65).
+
+## Partial-topic grounding (issue #69)
+
+`docs/real-data-failure-taxonomy.md` C6 identified false abstention as
+the highest-impact remaining failure on real corpora: 9 of 12 real100
+misses ended with `retry_trigger_reason: topic_not_grounded × 2` —
+both the strict and relaxed stages rejected the same weak-but-usable
+evidence because the verifier required **every** verification topic to
+appear in the combined evidence text. The intended-abstention cases
+(P-13~15) were already robust; the failure was over-strict
+verification, not under-strict retrieval.
+
+### What changed
+
+- `verify_evidence(..., allow_partial_topic=False)` gained an explicit
+  flag. The retrieval loop sets it to `True` **only on the last
+  scheduled attempt** so the strict stages keep their current bar.
+- On the last attempt, when at least one topic and at least
+  `PARTIAL_TOPIC_GROUNDING_MIN_FRACTION` (currently `0.5`) of all
+  verification topics appear in the evidence, the verifier returns
+  `verified=True` with a non-blocking `partial_topic_grounding` reason.
+- `answer_status` maps that reason to `ANSWER_STATUS_PARTIAL` (not
+  `supported`), and `answer_status_reason` emits
+  `code: partial_topic_grounding` so the partial path is distinguishable
+  from the existing `partial_comparison` path. Both are documented in
+  [`answer-policy.md`](./answer-policy.md).
+- All other floors stay strict: `low_top_score`, comparison entity /
+  doc coverage, and the per-entity comparison topic check remain
+  blocking. Partial-topic grounding does not buy a free pass through
+  the hallucination floor.
+
+### Trade-off
+
+This is the strict-vs-relaxed knob anticipated in
+[ADR 0004](./adr/0004-verifier-retry-policy.md). The trade-off is
+explicit:
+
+- **Won**: meaningful share of false-abstention queries recover to
+  `partial` instead of `insufficient`. On the public synthetic eval,
+  the new `partial_topic_security_quantum` case ships as the in-tree
+  guard; real-data impact is expected on the C6 backlog (9 cases).
+- **Cost**: `citation_precision` may dip slightly because partial
+  answers can include citations to chunks that only ground some of
+  the requested topics. The status itself (`partial`) is the
+  contract telling callers the answer is not fully grounded.
+
+### How to validate locally
+
+```bash
+python3 scripts/build_index.py --input_dir data/raw --output_dir data/index --embedding_backend hashing
+python3 eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml
+python3 -m pytest tests/test_partial_topic_grounding.py -v
+```
+
+Look for `case_results[*].id == "partial_topic_security_quantum"` with
+`answer_status == "partial"` and `verification_reasons` containing
+`partial_topic_grounding`. The same eval must keep the
+`abstention` (intended-abstention) metric unchanged on the
+unanswerable slice.

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -647,3 +647,32 @@ cases:
     expected_terms:
       - "양자암호"
     answerable: false
+
+  # Issue #69 / docs/real-data-failure-taxonomy.md C6 — partial-topic
+  # recovery. "보안 통제" is documented for 기관 A; "양자암호" is not
+  # in the corpus. Before this change the strict-then-relaxed verifier
+  # abstained on `topic_not_grounded × 2`. After the change the relaxed
+  # (last-attempt) verifier accepts the partial match with a
+  # `partial_topic_grounding` reason and the answer surfaces as
+  # `partial` rather than an unconditional abstention. This case is the
+  # public synthetic guard that the policy stays in effect.
+  - id: partial_topic_security_quantum
+    query_type: single_doc
+    query: "기관 A의 보안 통제와 양자암호 적용 방안은?"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "보안 통제"
+    expected_citation_terms:
+      - "보안 통제"
+    expected_answer_status: partial
+    min_claims: 1
+    expected_claim_targets:
+      - "기관 A"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "보안 통제"
+    answerable: true

--- a/rag_core.py
+++ b/rag_core.py
@@ -2050,8 +2050,38 @@ def metadata_similarity(analysis: dict[str, Any], chunk: dict[str, Any]) -> floa
     return 1.0 if chunk.get("agency") in entities else 0.0
 
 
-def verify_evidence(analysis: dict[str, Any], evidence: list[dict[str, Any]]) -> tuple[bool, list[str]]:
-    reasons = []
+# Minimum fraction of verification topics that must appear in the
+# combined evidence text for a *relaxed* (last-attempt) verification
+# pass to accept partial-topic grounding instead of abstaining. See
+# issue #69 / docs/real-data-failure-taxonomy.md C6, and ADR 0004 for
+# the strict→relaxed staging policy this implements.
+PARTIAL_TOPIC_GROUNDING_MIN_FRACTION = 0.5
+PARTIAL_TOPIC_GROUNDING_REASON = "partial_topic_grounding"
+
+
+def verify_evidence(
+    analysis: dict[str, Any],
+    evidence: list[dict[str, Any]],
+    *,
+    allow_partial_topic: bool = False,
+) -> tuple[bool, list[str]]:
+    """Verify that ``evidence`` supports the query in ``analysis``.
+
+    When ``allow_partial_topic`` is ``True`` (caller signals this is the
+    last retrieval attempt), a partial topic match — at least one topic
+    and at least :data:`PARTIAL_TOPIC_GROUNDING_MIN_FRACTION` of all
+    topics present in the combined evidence text — is accepted with
+    ``verified=True`` and a non-blocking
+    :data:`PARTIAL_TOPIC_GROUNDING_REASON` in the reasons list. The
+    caller (see :func:`answer_status`) maps that reason to
+    ``ANSWER_STATUS_PARTIAL`` so the answer surfaces the weaker
+    grounding instead of abstaining outright.
+
+    All other checks (low top score, comparison entity / doc coverage)
+    remain strict — partial topic grounding does not bypass hallucination
+    floors or comparison contracts.
+    """
+    reasons: list[str] = []
     if not evidence:
         return False, ["no_evidence"]
     if evidence[0]["score"] < 0.18:
@@ -2059,8 +2089,18 @@ def verify_evidence(analysis: dict[str, Any], evidence: list[dict[str, Any]]) ->
 
     combined = " ".join(evidence_text_for_verification(item) for item in evidence).lower()
     topics = verification_topics(analysis)
-    if topics and not all(topic.lower() in combined for topic in topics):
-        reasons.append("topic_not_grounded")
+    if topics:
+        matched_topic_count = sum(1 for topic in topics if topic.lower() in combined)
+        if matched_topic_count < len(topics):
+            if (
+                allow_partial_topic
+                and matched_topic_count >= 1
+                and (matched_topic_count / len(topics)) >= PARTIAL_TOPIC_GROUNDING_MIN_FRACTION
+            ):
+                # Soft signal — caller surfaces this as `partial` status.
+                reasons.append(PARTIAL_TOPIC_GROUNDING_REASON)
+            else:
+                reasons.append("topic_not_grounded")
 
     entities = analysis.get("entities") or []
     if analysis.get("query_type") == "comparison" and len(entities) > 1:
@@ -2084,7 +2124,10 @@ def verify_evidence(analysis: dict[str, Any], evidence: list[dict[str, Any]]) ->
         if missing_doc_ids:
             reasons.append("missing_comparison_doc:" + ",".join(missing_doc_ids))
 
-    return not reasons, reasons
+    # `partial_topic_grounding` is non-blocking: it surfaces the weaker
+    # grounding to the answer layer without forcing an abstention.
+    blocking_reasons = [reason for reason in reasons if reason != PARTIAL_TOPIC_GROUNDING_REASON]
+    return not blocking_reasons, reasons
 
 
 def specific_topics(analysis: dict[str, Any]) -> list[str]:
@@ -2203,7 +2246,13 @@ def answer_status_reason(
         if status == ANSWER_STATUS_SUPPORTED:
             code = "verified"
         elif status == ANSWER_STATUS_PARTIAL:
-            code = "partial_comparison"
+            # Disambiguate between the two partial paths so the status
+            # reason is machine-readable: comparison-coverage partial
+            # vs partial-topic grounding (#69 / ADR 0004).
+            if PARTIAL_TOPIC_GROUNDING_REASON in verification_reasons:
+                code = "partial_topic_grounding"
+            else:
+                code = "partial_comparison"
         else:
             code = "insufficient_evidence"
     return {
@@ -2318,11 +2367,17 @@ def answer_status(
     verified: bool,
     verification_reasons: list[str],
 ) -> str:
+    has_partial_topic = PARTIAL_TOPIC_GROUNDING_REASON in verification_reasons
     if verified:
         has_missing_requested = any(
             reason.startswith("missing_requested_entity") for reason in verification_reasons
         )
-        if not has_missing_requested:
+        if has_partial_topic and claims:
+            # Verified via the relaxed-stage partial-topic path: surface
+            # the weaker grounding as ``partial`` rather than the
+            # unconditional ``supported`` that strict verification yields.
+            return ANSWER_STATUS_PARTIAL
+        if not has_missing_requested and not has_partial_topic:
             return ANSWER_STATUS_SUPPORTED
     has_partial_comparison_reason = any(
         reason.startswith("missing_comparison")
@@ -3278,7 +3333,16 @@ def run_rag_query(
             evidence = retrieve(index, retrieval_query, analysis, plan)
         with _StageTimer(attempt_timings, "verify_ms"):
             if verifier_retry:
-                verified, verification_reasons = verify_evidence(analysis, evidence)
+                # On the last scheduled attempt allow partial-topic
+                # grounding so weak-but-usable evidence surfaces as
+                # ``partial`` instead of an unconditional abstention
+                # (issue #69, ADR 0004).
+                is_last_attempt = attempt_index == len(stage_sequence) - 1
+                verified, verification_reasons = verify_evidence(
+                    analysis,
+                    evidence,
+                    allow_partial_topic=is_last_attempt,
+                )
             else:
                 verified = bool(evidence)
                 verification_reasons = [] if verified else ["no_evidence"]

--- a/tests/test_latency_instrumentation.py
+++ b/tests/test_latency_instrumentation.py
@@ -62,7 +62,7 @@ class RunRagQueryTimingTest(unittest.TestCase):
         original_verify = rag_core.verify_evidence
         calls = {"n": 0}
 
-        def always_fail(analysis, evidence):
+        def always_fail(analysis, evidence, **_kwargs):
             calls["n"] += 1
             return False, ["forced_failure"]
 

--- a/tests/test_partial_topic_grounding.py
+++ b/tests/test_partial_topic_grounding.py
@@ -1,0 +1,126 @@
+"""Behavioral guards for partial-topic grounding (issue #69).
+
+Covers two complementary expectations from ``docs/real-data-failure-taxonomy.md``
+C6 ("false abstention"):
+
+* **Recovery** — when verification topics are only partially matched in
+  the evidence, the *relaxed* (last-attempt) verifier accepts the result
+  with a non-blocking ``partial_topic_grounding`` reason, and the answer
+  surfaces as ``partial`` instead of an unconditional abstention.
+* **Preservation** — when no relevant evidence exists (out-of-corpus
+  query), abstention is preserved. Partial-topic mode must not turn
+  unanswerable queries into hallucinated ``partial`` answers.
+
+Both tests use the deterministic hashing embedding backend on the
+existing ``data/raw`` fixture, matching the pattern in
+``tests/test_retrieval_loop_regression.py``.
+"""
+
+import unittest
+from pathlib import Path
+
+from rag_core import (
+    PARTIAL_TOPIC_GROUNDING_MIN_FRACTION,
+    PARTIAL_TOPIC_GROUNDING_REASON,
+    build_index_payload,
+    verify_evidence,
+)
+
+
+class VerifyEvidencePartialTopicTest(unittest.TestCase):
+    """Unit-level checks against :func:`verify_evidence` semantics.
+
+    These do not need the index — they exercise the decision logic on
+    synthetic evidence/analysis dicts so the policy is locked in
+    independent of retrieval quality.
+    """
+
+    def _evidence(self, text: str, score: float = 0.5) -> list[dict]:
+        return [
+            {
+                "doc_id": "doc-x",
+                "chunk_id": "c1",
+                "score": score,
+                "text": text,
+            }
+        ]
+
+    def test_strict_rejects_partial_topic_match(self) -> None:
+        analysis = {"topics": ["보안 통제", "로그 추적"]}
+        evidence = self._evidence("이 문서는 보안 통제만 다룬다.")
+        verified, reasons = verify_evidence(analysis, evidence)
+        self.assertFalse(verified)
+        self.assertIn("topic_not_grounded", reasons)
+        self.assertNotIn(PARTIAL_TOPIC_GROUNDING_REASON, reasons)
+
+    def test_relaxed_accepts_partial_topic_match_above_threshold(self) -> None:
+        analysis = {"topics": ["보안 통제", "로그 추적"]}
+        evidence = self._evidence("이 문서는 보안 통제만 다룬다.")
+        verified, reasons = verify_evidence(
+            analysis, evidence, allow_partial_topic=True
+        )
+        # 1/2 == 0.5 == PARTIAL_TOPIC_GROUNDING_MIN_FRACTION → accepted.
+        self.assertGreaterEqual(1 / 2, PARTIAL_TOPIC_GROUNDING_MIN_FRACTION)
+        self.assertTrue(verified, f"reasons={reasons}")
+        self.assertIn(PARTIAL_TOPIC_GROUNDING_REASON, reasons)
+        self.assertNotIn("topic_not_grounded", reasons)
+
+    def test_relaxed_still_rejects_zero_topic_match(self) -> None:
+        analysis = {"topics": ["보안 통제", "로그 추적"]}
+        evidence = self._evidence("관련 없는 내용만 있는 문단이다.")
+        verified, reasons = verify_evidence(
+            analysis, evidence, allow_partial_topic=True
+        )
+        # No topic matched → strict reject even in relaxed stage so
+        # unanswerable / out-of-corpus queries keep abstaining.
+        self.assertFalse(verified)
+        self.assertIn("topic_not_grounded", reasons)
+        self.assertNotIn(PARTIAL_TOPIC_GROUNDING_REASON, reasons)
+
+    def test_relaxed_still_rejects_below_fraction(self) -> None:
+        analysis = {"topics": ["보안 통제", "로그 추적", "암호화", "감사"]}
+        evidence = self._evidence("이 문서는 보안 통제만 다룬다.")
+        verified, reasons = verify_evidence(
+            analysis, evidence, allow_partial_topic=True
+        )
+        # 1/4 == 0.25 < PARTIAL_TOPIC_GROUNDING_MIN_FRACTION (0.5).
+        self.assertLess(1 / 4, PARTIAL_TOPIC_GROUNDING_MIN_FRACTION)
+        self.assertFalse(verified)
+        self.assertIn("topic_not_grounded", reasons)
+
+    def test_low_top_score_still_blocking_in_relaxed_stage(self) -> None:
+        analysis = {"topics": ["보안 통제"]}
+        evidence = self._evidence("이 문서는 보안 통제를 다룬다.", score=0.05)
+        verified, reasons = verify_evidence(
+            analysis, evidence, allow_partial_topic=True
+        )
+        # Hallucination floor must hold even in relaxed mode.
+        self.assertFalse(verified)
+        self.assertIn("low_top_score", reasons)
+
+
+class OutOfCorpusAbstentionPreservedTest(unittest.TestCase):
+    """End-to-end guard: out-of-corpus queries still abstain.
+
+    This is the regression-safety side of issue #69 — the policy
+    change must not flip intended abstentions into ``partial`` answers.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index = build_index_payload(
+            Path("data/raw"), embedding_backend="hashing"
+        )
+
+    def test_out_of_corpus_query_still_abstains(self) -> None:
+        from rag_core import run_rag_query
+
+        result = run_rag_query(
+            self.index, "외계 행성의 우주선 검수 절차는?"
+        )
+        self.assertEqual(result["answer"]["status"], "insufficient")
+        self.assertEqual(result["evidence"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #69. Parent: #49.

## Summary
`docs/real-data-failure-taxonomy.md` C6 identified false abstention as the dominant remaining failure on real corpora — 9 of 12 real100 misses ended with `topic_not_grounded × 2` because the verifier required **every** verification topic to appear in the combined evidence text, in both the strict **and** the relaxed stages. The intended-abstention cases (P-13~15) were already robust; the failure was over-strict verification, not under-strict retrieval.

This implements the strict-vs-relaxed knob anticipated by [ADR 0004](docs/adr/0004-verifier-retry-policy.md), enabled on the **last scheduled attempt only** so strict stages keep their current bar.

## Files affected
- `rag_core.py` — `verify_evidence` gains `allow_partial_topic=False` (default keeps current behavior); `answer_status` and `answer_status_reason` thread the new `partial_topic_grounding` reason / code; retrieval loop sets the flag on `is_last_attempt`.
- `eval/config.yaml` — adds `partial_topic_security_quantum` case (one in-corpus topic + one out-of-corpus topic on the same agency) with `expected_answer_status: partial`.
- `tests/test_partial_topic_grounding.py` — **6 new tests** covering both recovery (relaxed acceptance at/above threshold) and preservation (strict rejection, zero-match abstention, `low_top_score` floor).
- `tests/test_latency_instrumentation.py` — stub `verify_evidence` now accepts `**kwargs` to match the new signature.
- `docs/answer-policy.md` — extended `partial` semantics; new `partial_topic_grounding` code documented.
- `docs/grounding-eval-hardening.md` — new section recording rationale, trade-off, and local validation steps.

## Risks
- **Hallucination floor.** Mitigated: `low_top_score` and all comparison checks remain blocking; only the topic-completeness rule is relaxed, and only on the last attempt. Test `test_low_top_score_still_blocking_in_relaxed_stage` guards this.
- **False positive on out-of-corpus queries.** Mitigated: zero-match still rejects (`test_relaxed_still_rejects_zero_topic_match`); end-to-end out-of-corpus query test still abstains.
- **Schema/contract drift.** The `partial` status already exists for comparisons; broadening it required documenting in `docs/answer-policy.md`. ADR 0003 (answer contract) is not violated — `schema_version` unchanged, all fields unchanged.

## Tests
- `pytest -q`: **96 passed** locally (was 90, +6 new). No regressions.
- New file `tests/test_partial_topic_grounding.py` ships both the recovery and the preservation guards.

## Eval impact

Measured locally on the `full` ablation (matches what the CI delta workflow runs):

| metric | main | PR | Δ |
|---|---|---|---|
| accuracy | 0.857 | 0.862 | +0.005 ✅ |
| groundedness | 0.857 | 0.861 | +0.004 ✅ |
| citation_precision | 0.857 | 0.847 | -0.010 ⚠️ |
| claim_citation_alignment | 0.966 | 0.967 | +0.001 ✅ |
| answer_format_compliance | 0.857 | 0.861 | +0.004 ✅ |
| **abstention (intended)** | **0.857** | **0.857** | **·** (preserved) |
| retry_rate | 0.314 | 0.333 | +0.019 (expected — recovery case takes a retry) |

`citation_precision -0.010` is the explicit design cost: partial answers can cite chunks that ground only some of the requested topics. The `partial` status itself is the contract telling callers the answer is not fully grounded. **Real-data impact is expected on the C6 backlog (9 cases)** and will be measured separately on the private surface (ADR 0005).

## Backward compatibility
- `verify_evidence`'s default behavior unchanged (`allow_partial_topic=False`).
- Answer schema `schema_version` unchanged. `partial` status already existed; semantics broadened per `docs/answer-policy.md`.
- No CLI flag changes.

## Out of scope (explicit)
- Tuning `PARTIAL_TOPIC_GROUNDING_MIN_FRACTION` from real-data results — picks a defensible default (0.5) now; tune later if real-data measurement justifies it.
- Hard CI gate on metric thresholds — still soft check per the original CI design.
- Citation grounding alignment improvements (#70) — separate PR; explicitly orthogonal to this trade-off.

## Test plan
- [ ] `Pytest` CI green (96 tests, +6 new).
- [ ] `Eval delta vs base` shows accuracy / groundedness / answer_format_compliance trending up; abstention preserved; comment posted to the PR.
- [ ] Verify in the CI artifact's `eval_summary.json` that case `partial_topic_security_quantum` has `answer.status == "partial"` and `status_reason.code == "partial_topic_grounding"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)