### PR TITLE
Add real-data eval delta cycle (aggregate-only, ADR 0005 boundary)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Opt-in pre-push hook for BidMate-DocAgent.
+#
+# Activate per-developer with:
+#   git config core.hooksPath .githooks
+#
+# Behavior: if the commits about to be pushed touch retrieval /
+# verifier / eval / api paths, remind the contributor to attach a
+# real-data eval delta to the PR (see CLAUDE.md pre-PR checklist
+# item 5b). Non-fatal — prints a warning, exits 0.
+#
+# Skip with `git push --no-verify` only if you have a documented
+# reason (e.g. doc-only follow-up of a measured PR).
+
+set -u
+
+# Watch-list: files whose change implies a real-data delta is owed.
+WATCH_PATTERNS=(
+  "rag_core.py"
+  "ingestion.py"
+  "visual_ingestion.py"
+  "eval/"
+  "api/"
+  "scripts/build_index.py"
+)
+
+# Resolve upstream / base ref. Prefer @{upstream}; fall back to origin/main.
+if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null); then
+  base="$upstream"
+else
+  base="origin/main"
+fi
+
+# Files changed between the upstream and HEAD.
+if ! changed=$(git diff --name-only "$base"...HEAD 2>/dev/null); then
+  # No upstream / new branch — fall back to diff vs origin/main if it exists.
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    changed=$(git diff --name-only origin/main...HEAD 2>/dev/null || true)
+  else
+    changed=""
+  fi
+fi
+
+if [[ -z "$changed" ]]; then
+  exit 0
+fi
+
+# Match against the watch-list.
+hit=""
+while IFS= read -r file; do
+  for pat in "${WATCH_PATTERNS[@]}"; do
+    case "$file" in
+      "$pat"|"$pat"*)
+        hit="$file"
+        break 2
+        ;;
+    esac
+  done
+done <<< "$changed"
+
+if [[ -n "$hit" ]]; then
+  cat >&2 <<EOF
+
+⚠️  Retrieval / verifier / eval path changed in this push.
+    (first match: $hit)
+
+    Per CLAUDE.md pre-PR checklist item 5b, attach the aggregate
+    real-data eval delta to the PR body before requesting review:
+
+        make real-eval
+        make real-eval-delta
+
+    The delta script is aggregate-only (ADR 0005 commit boundary) so
+    its output is safe to paste into the PR.
+
+    Push proceeds. Skip this reminder with --no-verify only if you
+    have a documented reason.
+
+EOF
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,17 @@ data/index/*
 !data/index/index.json
 outputs/*
 !outputs/answer.json
-reports/
+reports/*
+# Aggregate-only artifacts under reports/real100/ are committable
+# (ADR 0005 commit boundary). The negation chain below allowlists
+# only the explicit aggregate filenames — eval_summary.json and any
+# per-case trace stay ignored.
+!reports/real100/
+reports/real100/*
+!reports/real100/baseline.aggregate.json
+!reports/real100/history/
+reports/real100/history/*
+!reports/real100/history/*.aggregate.json
 
 # Benchmark raw/local artifacts
 artifacts/benchmarks/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,13 @@ Every PR description must answer these, in order:
    that acceptable?
 5. **Eval impact.** What do you expect the CI eval delta to show?
    ("All `·`" is a valid answer for non-RAG changes — say so.)
+   - **5b. Real-data delta.** If `rag_core.py`, `ingestion.py`,
+     `visual_ingestion.py`, `eval/`, or `api/` changed, attach the
+     `make real-eval-delta` aggregate table (or explicitly state
+     "no behavior change in retrieval / verifier path"). The
+     synthetic CI delta alone missed #69's intended-abstention
+     regression — see ADR 0005 and
+     [`docs/private-100-doc-experiments.md`](docs/private-100-doc-experiments.md).
 6. **Backward compatibility.** Anything that breaks an existing
    contract, schema, CLI flag, or doc link? If yes, what's the
    migration?
@@ -85,6 +92,19 @@ Every PR description must answer these, in order:
 - Heavy-dep tests (visual ingestion, sentence-transformers) are fine
   but must use the hashing embedding backend wherever the test is
   about retrieval / verifier logic rather than the embedding itself.
+
+## Local hook setup (one-time, per developer)
+
+Activate the opt-in pre-push reminder hook:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook prints a warning if a push touches retrieval / verifier /
+eval / api paths without (currently a soft signal — see CLAUDE.md
+pre-PR checklist 5b). Skip with `git push --no-verify` only with a
+documented reason. The hook is non-fatal; it never blocks a push.
 
 ## Reproducibility & performance expectations
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker real-eval real-eval-delta real-eval-baseline-update clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -50,6 +50,42 @@ api:
 api-docker:
 	docker build -t bidmate-demo .
 	docker run --rm -p 8000:8000 bidmate-demo
+
+# ---------------------------------------------------------------------------
+# Real-data eval cycle (private; ADR 0005 commit boundary). Requires
+# eval/real_config.local.yaml + data/files/ + data/data_list.csv to
+# exist locally. None of these are committed.
+# ---------------------------------------------------------------------------
+
+# Run the private real-data eval end-to-end (build index, sample query,
+# eval). Writes reports/real100/eval_summary.json locally (gitignored).
+real-eval:
+	bash scripts/smoke_real.sh
+
+# Render an aggregate-only markdown delta between the current
+# real-data run and the committed baseline. Aggregate-only by
+# construction; no per-case data is read or printed.
+real-eval-delta:
+	$(PYTHON) scripts/run_real_eval_delta.py \
+	  --head reports/real100/eval_summary.json \
+	  --base reports/real100/baseline.aggregate.json
+
+# Deliberate baseline bump. Reads the current eval_summary.json and
+# overwrites reports/real100/baseline.aggregate.json with the
+# aggregate-only fields. Intended to run *after* a decision is made
+# (PR merged, threshold tightened, etc.), not on every eval. Diff the
+# result with `git diff` before committing.
+real-eval-baseline-update:
+	$(PYTHON) -c "import json, sys, datetime, subprocess; \
+	sys.path.insert(0, '.'); \
+	from scripts.run_real_eval_delta import extract_aggregate; \
+	raw = json.load(open('reports/real100/eval_summary.json')); \
+	agg = extract_aggregate(raw); \
+	sha = subprocess.run(['git','rev-parse','HEAD'], capture_output=True, text=True).stdout.strip()[:12]; \
+	dirty = subprocess.run(['git','status','--porcelain'], capture_output=True, text=True).stdout.strip() != ''; \
+	agg['provenance'] = {'git_commit': sha, 'git_dirty': bool(dirty), 'generated_at': datetime.datetime.utcnow().isoformat()+'Z'}; \
+	open('reports/real100/baseline.aggregate.json','w').write(json.dumps(agg, ensure_ascii=False, indent=2, sort_keys=True)+chr(10)); \
+	print('[OK] baseline.aggregate.json updated. git diff to review.')"
 
 clean:
 	rm -rf data/index outputs reports

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Aggregate-only delta between two real-data eval summaries.
+
+Designed for the **private real-data surface only**. The script:
+
+1. Reads the current run (`reports/real100/eval_summary.json` by
+   default) and a committed baseline snapshot
+   (`reports/real100/baseline.aggregate.json`).
+2. Extracts an explicit allow-list of **aggregate-only fields** — no
+   `case_results`, no `query` text, no per-case `evidence`, no
+   `doc_id`. The extractor refuses to even look at forbidden keys, so
+   schema drift cannot accidentally leak per-case content into the
+   committable diff.
+3. Renders a markdown delta table to stdout for the contributor to
+   paste into the PR body (or for the optional Decision Log stub
+   appender to use).
+
+This is the structural mechanism behind ADR 0005's commit boundary
+on the contributor side: aggregates are committable, anything
+case-level is not.
+
+CLI:
+
+    python3 scripts/run_real_eval_delta.py \
+        --head reports/real100/eval_summary.json \
+        --base reports/real100/baseline.aggregate.json \
+        [--title "Real-data delta — #NN"] \
+        [--write-decision-log-stub]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Top-level aggregate keys that are safe to commit. Anything else in
+# the input JSONs is ignored. Keep this list intentionally narrow —
+# adding a key requires a privacy review.
+SAFE_TOPLEVEL_KEYS = frozenset(
+    {
+        "num_predictions",
+        "accuracy",
+        "groundedness",
+        "citation_precision",
+        "citation_grounding",
+        "claim_citation_alignment",
+        "answer_format_compliance",
+        "abstention",
+        "retry",
+        "latency",  # only sub-keys "p50", "p95", "mean" extracted below
+        "stage_latency",  # aggregated p50/p95/mean per stage
+        "retry_reason_counts",  # reason strings are non-identifying
+        "pipeline",
+        "primary_run",
+        "prompt_profile",
+        "top_k",
+    }
+)
+
+# Per-slice subkeys extracted from `by_query_type`.
+SAFE_SLICE_METRICS = (
+    "num_predictions",
+    "accuracy",
+    "groundedness",
+    "abstention",
+    "answer_format_compliance",
+)
+
+# Keys that must never be read or written by this script. The
+# extractor asserts none of these are present in its output as a
+# defense against schema drift.
+FORBIDDEN_KEYS = frozenset(
+    {
+        "case_results",
+        "query",
+        "answer",
+        "answer_text",
+        "evidence",
+        "expected_doc_ids",
+        "expected_terms",
+        "expected_citation_terms",
+        "expected_citation_pages",
+        "expected_citation_regions",
+        "expected_claim_citations",
+        "evidence_doc_ids",
+        "metadata_selected_doc_ids",
+        "doc_id",
+        "chunk_id",
+        "resolved_query",
+    }
+)
+
+# Metric direction for the rendered delta arrow.
+# (path, label, higher_is_better)
+METRICS: list[tuple[str, str, bool]] = [
+    ("accuracy", "accuracy", True),
+    ("groundedness", "groundedness", True),
+    ("citation_precision", "citation_precision", True),
+    ("citation_grounding", "citation_grounding", True),
+    ("claim_citation_alignment", "claim_citation_alignment", True),
+    ("answer_format_compliance", "answer_format_compliance", True),
+    ("abstention", "abstention (intended)", True),
+    ("retry", "retry_rate", False),
+    ("latency.p50", "latency_p50_ms", False),
+    ("latency.p95", "latency_p95_ms", False),
+]
+
+
+# -----------------------------------------------------------------------------
+# Extraction
+# -----------------------------------------------------------------------------
+
+
+def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
+    """Return a dict containing only ADR-0005-safe aggregate fields.
+
+    Anything outside :data:`SAFE_TOPLEVEL_KEYS` is dropped. The output
+    is then re-validated against :data:`FORBIDDEN_KEYS` as a guard
+    against silent schema drift; an :class:`AssertionError` is raised
+    if a forbidden key somehow makes it through.
+    """
+    if not isinstance(summary, dict):
+        raise ValueError("Eval summary must be a JSON object.")
+
+    out: dict[str, Any] = {}
+    for key in SAFE_TOPLEVEL_KEYS:
+        if key not in summary:
+            continue
+        value = summary[key]
+        if key == "latency" and isinstance(value, dict):
+            out[key] = {
+                sub: value.get(sub)
+                for sub in ("p50", "p95", "mean")
+                if value.get(sub) is not None
+            }
+        elif key == "stage_latency" and isinstance(value, dict):
+            # value is {stage_name: {p50,p95,mean,count}}
+            out[key] = {
+                stage: {k: v.get(k) for k in ("p50", "p95", "mean") if v.get(k) is not None}
+                for stage, v in value.items()
+                if isinstance(v, dict)
+            }
+        elif key == "retry_reason_counts" and isinstance(value, dict):
+            # Reason strings are taxonomy codes ("topic_not_grounded"), not
+            # identifying. Counts are integers. Safe.
+            out[key] = {str(k): int(v) for k, v in value.items()}
+        else:
+            out[key] = value
+
+    by_query_type = summary.get("by_query_type")
+    if isinstance(by_query_type, dict):
+        slice_out: dict[str, dict[str, Any]] = {}
+        for slice_name, slice_summary in by_query_type.items():
+            if not isinstance(slice_summary, dict):
+                continue
+            slice_out[str(slice_name)] = {
+                m: slice_summary.get(m)
+                for m in SAFE_SLICE_METRICS
+                if slice_summary.get(m) is not None
+            }
+        out["by_query_type"] = slice_out
+
+    _assert_no_forbidden(out)
+    return out
+
+
+def _assert_no_forbidden(obj: Any, path: str = "") -> None:
+    """Recursively assert that no forbidden key appears in the aggregate."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if str(key) in FORBIDDEN_KEYS:
+                raise AssertionError(
+                    f"Aggregate output contains forbidden key '{key}' at '{path}'. "
+                    "This indicates a schema drift in the extractor and would "
+                    "violate ADR 0005's commit boundary. Refusing to emit."
+                )
+            _assert_no_forbidden(value, f"{path}.{key}" if path else str(key))
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            _assert_no_forbidden(item, f"{path}[{i}]")
+
+
+# -----------------------------------------------------------------------------
+# Rendering
+# -----------------------------------------------------------------------------
+
+
+def _get_path(data: Any, path: str) -> Any:
+    cur = data
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def _fmt_value(value: Any) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def _fmt_delta(base: Any, head: Any, higher_is_better: bool) -> str:
+    if not isinstance(base, (int, float)) or not isinstance(head, (int, float)):
+        return "—"
+    delta = float(head) - float(base)
+    if abs(delta) < 5e-4:
+        return "·"
+    sign = "+" if delta > 0 else ""
+    improved = (delta > 0) if higher_is_better else (delta < 0)
+    flag = " ✅" if improved else " ⚠️"
+    return f"{sign}{delta:.3f}{flag}"
+
+
+def render_markdown(
+    base: dict[str, Any],
+    head: dict[str, Any],
+    title: str,
+) -> str:
+    lines: list[str] = []
+    lines.append(f"### {title}")
+    lines.append("")
+    lines.append(
+        f"- pipeline: `{head.get('pipeline', '?')}` "
+        f"(primary run: `{head.get('primary_run', '?')}`)"
+    )
+    lines.append(
+        f"- cases: base={base.get('num_predictions', '?')} · "
+        f"head={head.get('num_predictions', '?')}"
+    )
+    lines.append("")
+    lines.append("| metric | base | head | Δ |")
+    lines.append("|---|---|---|---|")
+    for path, label, higher in METRICS:
+        b = _get_path(base, path)
+        h = _get_path(head, path)
+        lines.append(
+            f"| {label} | {_fmt_value(b)} | {_fmt_value(h)} | "
+            f"{_fmt_delta(b, h, higher)} |"
+        )
+
+    # Slice-level abstention is the most important signal we surfaced
+    # from #69 — render it explicitly so future regressions are obvious.
+    base_slices = base.get("by_query_type") or {}
+    head_slices = head.get("by_query_type") or {}
+    slice_names = sorted(set(base_slices) | set(head_slices))
+    if slice_names:
+        lines.append("")
+        lines.append("#### Slice abstention rate (intended-abstention preservation)")
+        lines.append("")
+        lines.append("| slice | base | head | Δ |")
+        lines.append("|---|---|---|---|")
+        for name in slice_names:
+            b = (base_slices.get(name) or {}).get("abstention")
+            h = (head_slices.get(name) or {}).get("abstention")
+            lines.append(
+                f"| {name} | {_fmt_value(b)} | {_fmt_value(h)} | "
+                f"{_fmt_delta(b, h, True)} |"
+            )
+
+    base_reasons = base.get("retry_reason_counts") or {}
+    head_reasons = head.get("retry_reason_counts") or {}
+    if base_reasons or head_reasons:
+        lines.append("")
+        lines.append("#### Retry reason counts")
+        lines.append("")
+        lines.append("| reason | base | head |")
+        lines.append("|---|---:|---:|")
+        for reason in sorted(set(base_reasons) | set(head_reasons)):
+            lines.append(
+                f"| `{reason}` | {base_reasons.get(reason, 0)} | "
+                f"{head_reasons.get(reason, 0)} |"
+            )
+
+    lines.append("")
+    lines.append(
+        "_Aggregate-only. Per-case data is never read or rendered by this "
+        "script (ADR 0005). ✅ direction-of-improvement; ⚠️ "
+        "direction-of-regression._"
+    )
+    return "\n".join(lines)
+
+
+# -----------------------------------------------------------------------------
+# Decision Log stub
+# -----------------------------------------------------------------------------
+
+
+_DECISION_LOG_TEMPLATE = """
+
+### Entry: {date} — TODO short title
+
+**Change.** TODO 1-2 sentences. Link the PR/issue.
+
+**Surface.** Local private real-data set (`eval/real_config.local.yaml`,
+N={cases} cases). Same index, same case set, same tooling for both
+sides.
+
+{table}
+
+**Interpretation.** TODO — what worked? what regressed? what to do
+next?
+
+**Decision.** TODO — ship / revert / tighten / follow-up issue.
+"""
+
+
+def append_decision_log_stub(
+    docs_path: Path,
+    table_md: str,
+    cases: int,
+) -> None:
+    import datetime
+
+    if not docs_path.exists():
+        raise FileNotFoundError(f"Decision log target not found: {docs_path}")
+    date = datetime.date.today().isoformat()
+    body = _DECISION_LOG_TEMPLATE.format(date=date, cases=cases, table=table_md)
+    with docs_path.open("a", encoding="utf-8") as fh:
+        fh.write(body)
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--head",
+        default="reports/real100/eval_summary.json",
+        help="Current real-data eval_summary.json path.",
+    )
+    ap.add_argument(
+        "--base",
+        default="reports/real100/baseline.aggregate.json",
+        help="Committed baseline aggregate snapshot path.",
+    )
+    ap.add_argument("--title", default="Real-data eval delta")
+    ap.add_argument(
+        "--write-decision-log-stub",
+        action="store_true",
+        help=(
+            "Append a Decision Log entry stub (with the rendered table) to "
+            "docs/private-100-doc-experiments.md so you only fill the "
+            "interpretation paragraph."
+        ),
+    )
+    ap.add_argument(
+        "--decision-log-path",
+        default="docs/private-100-doc-experiments.md",
+        help="Target file for the Decision Log stub (default is the public doc).",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    head_path = Path(args.head)
+    base_path = Path(args.base)
+    if not head_path.exists():
+        print(
+            f"[ERROR] Head eval summary not found: {head_path}\n"
+            "Run `make real-eval` first to generate it.",
+            file=sys.stderr,
+        )
+        return 2
+    if not base_path.exists():
+        print(
+            f"[ERROR] Baseline aggregate not found: {base_path}\n"
+            "Run `make real-eval-baseline-update` once to seed it.",
+            file=sys.stderr,
+        )
+        return 2
+
+    head_raw = json.loads(head_path.read_text(encoding="utf-8"))
+    base_raw = json.loads(base_path.read_text(encoding="utf-8"))
+
+    head = extract_aggregate(head_raw)
+    base = extract_aggregate(base_raw) if "case_results" in base_raw else base_raw
+    # If the baseline file was already in aggregate form (it should be),
+    # re-running the extractor is a no-op but also re-asserts the
+    # privacy invariant. Do it anyway:
+    base = extract_aggregate(base)
+
+    table = render_markdown(base, head, args.title)
+    print(table)
+
+    if args.write_decision_log_stub:
+        cases = head.get("num_predictions") or "?"
+        append_decision_log_stub(Path(args.decision_log_path), table, cases)
+        print(
+            f"\n[OK] Decision Log stub appended to {args.decision_log_path}",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -1,0 +1,186 @@
+"""Tests for the real-data eval delta script.
+
+The script's main job is to enforce the ADR 0005 commit boundary
+mechanically: aggregate-only output, no per-case data, no query/doc
+text. These tests pin that contract.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from scripts.run_real_eval_delta import (
+    FORBIDDEN_KEYS,
+    extract_aggregate,
+    render_markdown,
+)
+
+
+# A realistic-ish eval_summary.json with *case-level fields*. The
+# extractor must drop every one of them.
+FULL_SUMMARY = {
+    "primary_run": "full",
+    "pipeline": "agentic_full",
+    "num_predictions": 21,
+    "accuracy": 0.471,
+    "groundedness": 0.476,
+    "citation_precision": 0.286,
+    "abstention": 0.5,
+    "retry": 0.429,
+    "latency": {"p50": 100.0, "p95": 300.0, "mean": 150.0},
+    "stage_latency": {
+        "retrieve_ms": {"p50": 5.0, "p95": 20.0, "mean": 8.0, "count": 21}
+    },
+    "retry_reason_counts": {"topic_not_grounded": 12},
+    "by_query_type": {
+        "single_doc": {
+            "num_predictions": 12,
+            "accuracy": 0.5,
+            "abstention": None,
+        },
+        "abstention": {
+            "num_predictions": 4,
+            "abstention": 0.5,
+        },
+    },
+    # Forbidden territory below — must not appear in extracted output.
+    "case_results": [
+        {
+            "id": "real_secret_case",
+            "query": "이건 진짜 비공개 질의 텍스트",
+            "answer": "case-level answer leak",
+            "evidence": [{"doc_id": "private_doc_1", "text": "private text"}],
+            "expected_doc_ids": ["private_doc_1"],
+        }
+    ],
+    "trace_dir": "reports/real100/traces",
+}
+
+
+class ExtractAggregateTest(unittest.TestCase):
+    def test_extracts_top_level_aggregates(self) -> None:
+        agg = extract_aggregate(FULL_SUMMARY)
+        self.assertEqual(agg["accuracy"], 0.471)
+        self.assertEqual(agg["pipeline"], "agentic_full")
+        self.assertEqual(agg["num_predictions"], 21)
+        self.assertEqual(agg["latency"], {"p50": 100.0, "p95": 300.0, "mean": 150.0})
+        self.assertEqual(
+            agg["retry_reason_counts"], {"topic_not_grounded": 12}
+        )
+
+    def test_drops_case_results(self) -> None:
+        agg = extract_aggregate(FULL_SUMMARY)
+        self.assertNotIn("case_results", agg)
+
+    def test_drops_query_and_evidence_anywhere(self) -> None:
+        agg = extract_aggregate(FULL_SUMMARY)
+        flat = json.dumps(agg, ensure_ascii=False)
+        # None of the leaked strings from FULL_SUMMARY's case_results
+        # should appear in the serialized aggregate.
+        self.assertNotIn("real_secret_case", flat)
+        self.assertNotIn("진짜 비공개", flat)
+        self.assertNotIn("private_doc_1", flat)
+        self.assertNotIn("case-level answer leak", flat)
+
+    def test_slice_aggregates_preserved(self) -> None:
+        agg = extract_aggregate(FULL_SUMMARY)
+        slices = agg["by_query_type"]
+        self.assertIn("single_doc", slices)
+        self.assertIn("abstention", slices)
+        self.assertEqual(slices["single_doc"]["num_predictions"], 12)
+        self.assertEqual(slices["abstention"]["abstention"], 0.5)
+        # None of the case-level fields per slice should appear.
+        for slice_payload in slices.values():
+            for key in slice_payload:
+                self.assertNotIn(key, FORBIDDEN_KEYS)
+
+    def test_forbidden_key_assertion_fires_on_drift(self) -> None:
+        """If a future maintainer adds a forbidden key to SAFE list,
+        the assertion in extract_aggregate must crash rather than
+        silently emit case-level data."""
+        bad_input = {"case_results": [{"query": "leak"}]}
+        # The extractor itself never copies case_results into output,
+        # so this should still work — the assertion guards the OUTPUT.
+        # But we can validate the recursive scanner separately by
+        # feeding it a tainted dict.
+        from scripts.run_real_eval_delta import _assert_no_forbidden
+
+        with self.assertRaises(AssertionError):
+            _assert_no_forbidden({"latency": {"case_results": []}})
+
+    def test_extraction_is_idempotent(self) -> None:
+        agg1 = extract_aggregate(FULL_SUMMARY)
+        agg2 = extract_aggregate(agg1)
+        self.assertEqual(agg1, agg2)
+
+    def test_render_markdown_has_no_leaked_text(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate({**FULL_SUMMARY, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+        # Strings that would only exist in case-level fields:
+        for leak in [
+            "real_secret_case",
+            "진짜 비공개",
+            "private_doc_1",
+            "case-level answer leak",
+        ]:
+            self.assertNotIn(leak, md)
+        # Aggregate values should be visible:
+        self.assertIn("accuracy", md)
+        self.assertIn("0.471", md)
+        self.assertIn("0.600", md)
+
+    def test_render_includes_slice_abstention(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate({**FULL_SUMMARY, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+        # Slice section should be present.
+        self.assertIn("Slice abstention", md)
+        self.assertIn("abstention", md)
+
+
+class FullScriptInvocationTest(unittest.TestCase):
+    """Smoke-test the full script end-to-end via subprocess so the
+    CLI argument plumbing is exercised."""
+
+    def test_end_to_end_renders_table(self) -> None:
+        import subprocess
+        import sys
+
+        with TemporaryDirectory() as tmp:
+            base_path = Path(tmp) / "base.json"
+            head_path = Path(tmp) / "head.json"
+            base_path.write_text(json.dumps(FULL_SUMMARY))
+            # Mutate head accuracy upward.
+            head_path.write_text(json.dumps({**FULL_SUMMARY, "accuracy": 0.6}))
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/run_real_eval_delta.py",
+                    "--base",
+                    str(base_path),
+                    "--head",
+                    str(head_path),
+                    "--title",
+                    "smoke",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("smoke", result.stdout)
+            self.assertIn("accuracy", result.stdout)
+            self.assertIn("0.471", result.stdout)
+            self.assertIn("0.600", result.stdout)
+            self.assertIn("+0.129", result.stdout)
+            # Privacy assertion at the CLI boundary:
+            for leak in ["real_secret_case", "진짜 비공개", "private_doc_1"]:
+                self.assertNotIn(leak, result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
The CI eval delta runs on public synthetic only — by design (ADR 0005 keeps private data out of git). **#69's intended-abstention regression (real-data abstention 1.000 → 0.500) was invisible to synthetic CI** and was caught only because a contributor manually ran the local real-data eval and transcribed the numbers. This PR adds the structural mechanism so catching it next time is not optional.

Closes the "no drift detector + no PR-time prompt + manual transcription" gap diagnosed in the approved plan. Extensions A (history archive) and B (LLM-judge) follow as separate PRs.

## Files affected
- **`scripts/run_real_eval_delta.py`** — aggregate-only delta renderer with allowlist + recursive forbidden-key assertion. *(load-bearing privacy contract)*
- **`Makefile`** — `make real-eval`, `make real-eval-delta`, `make real-eval-baseline-update`.
- **`.githooks/pre-push`** — opt-in, non-fatal reminder hook.
- **`CLAUDE.md`** — pre-PR checklist item **5b. Real-data delta** + "Local hook setup" subsection.
- **`.gitignore`** — surgical allowlist so `baseline.aggregate.json` and `history/*.aggregate.json` are committable while `eval_summary.json` stays ignored. Verified with `git check-ignore -v`.
- **`tests/test_run_real_eval_delta.py`** — 9 tests pinning the privacy contract.

## Risks
- **Privacy leak through schema drift.** Mitigated: `extract_aggregate` reads an allowlist (not denylist); `_assert_no_forbidden` recursively scans the *output*; tests assert leaked strings from forbidden fields never appear in serialized aggregate or rendered markdown. If a future contributor adds `case_results` to `SAFE_TOPLEVEL_KEYS`, the assertion will fire when populated data passes through.
- **Hook noise.** The hook is opt-in (`git config core.hooksPath .githooks`) and non-fatal — never blocks a push, only prints a reminder.
- **Initial baseline not seeded.** Deliberate: first baseline is a user step per the plan's out-of-band note, so the user chooses what state to anchor (e.g. wait until #89 tightening lands).

## Tests
- `pytest -q`: **105 passed** locally (was 96, +9 new). No regressions.
- New file: `tests/test_run_real_eval_delta.py` — case_results dropped, leaked strings absent from aggregate AND rendered markdown, forbidden-key assertion fires on synthetic drift, end-to-end CLI via subprocess.

## Eval impact
- Expected: **all `·`**. RAG code untouched.
- No real-data delta attached — this PR is the *infrastructure*; the first real-data delta with values will appear on the next PR that touches retrieval/verifier (e.g. #89's tightening). The plan's out-of-band note explains the deliberate choice to not seed a baseline here.

## Backward compatibility
- No code/schema/CLI breakage. New files only on `Makefile` / `.gitignore` / `CLAUDE.md`.
- ADR 0005 unchanged. ADR 0004 unchanged. New mechanisms operate inside the existing commit boundary.

## Out of scope (separate PRs to follow)
- **Extension A**: `reports/real100/history/<run_id>.aggregate.json` committable archive + `scripts/render_real_eval_history.py` in-repo dashboard.
- **Extension B**: `scripts/llm_judge.py` + new **ADR 0006** "LLM-judge on real-data only" refining ADR 0004's deterministic-only stance.
- Tightening `PARTIAL_TOPIC_GROUNDING_MIN_FRACTION` — tracked in #89.

## Test plan
- [ ] `Pytest` CI green (105 tests).
- [ ] `Eval delta vs base` CI shows `·` across metrics.
- [ ] Manual: after merge, run `make real-eval-baseline-update && make real-eval-delta` on a fresh clone; confirm aggregate table renders without per-case data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
