### PR TITLE
Add LLM-judge on real-data surface + ADR 0006 (Extension B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ reports/real100/*
 !reports/real100/history/
 reports/real100/history/*
 !reports/real100/history/*.aggregate.json
+# LLM-judge per-case verdicts (ADR 0006) stay local — only their
+# aggregate is folded into baseline.aggregate.json. Explicit ignore
+# for clarity (already caught by reports/real100/* above).
+reports/real100/judge.local.json
 
 # Benchmark raw/local artifacts
 artifacts/benchmarks/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -88,6 +88,15 @@ real-eval-history-render:
 # aggregate snapshots. Suitable for pre-PR gating.
 real-eval-history-check:
 	$(PYTHON) scripts/render_real_eval_history.py --check
+
+# Run the local real-data eval, then ask an LLM judge for a second
+# opinion (ADR 0006). The judge is real-data only; never invoked from
+# public CI. Default backend is `stub` (deterministic, no network);
+# set BIDMATE_JUDGE_BACKEND=openai_compatible plus BIDMATE_JUDGE_*
+# env vars for a real judge call.
+real-eval-with-judge: real-eval
+	$(PYTHON) scripts/llm_judge.py
+	@echo "Run \`make real-eval-baseline-update\` to fold the judge aggregate into the committable baseline."
 
 clean:
 	rm -rf data/index outputs reports

--- a/docs/adr/0006-llm-judge-on-real-data-only.md
+++ b/docs/adr/0006-llm-judge-on-real-data-only.md
@@ -1,0 +1,140 @@
+# 0006: LLM-judge on the real-data surface only
+
+- **Status**: accepted
+- **Date**: 2026-05-11
+- **Related**: refines [ADR 0004](./0004-verifier-retry-policy.md); reinforces [ADR 0005](./0005-eval-split-public-synthetic-private-local.md)
+- **Deciders**: hskim
+
+## Context
+
+[ADR 0004](./0004-verifier-retry-policy.md) rejected LLM-as-judge on the
+**public** path with three concrete reasons: external dependency, per-
+query token cost, and harder reproducibility. It also hedged: *"May be
+reconsidered if the deterministic verifier hits a ceiling."*
+
+#69 made the ceiling visible. The deterministic verifier's
+`PARTIAL_TOPIC_GROUNDING_MIN_FRACTION` knob recovered 4 false-abstain
+cases on real-data **and** flipped 2 intended abstentions
+(`docs/private-100-doc-experiments.md` Real-data Decision Log entry).
+The Decision Log records the trade-off honestly, but **the threshold
+itself is arbitrary** — no amount of synthetic eval tuning will
+distinguish a "real partial answer" from a "weak hallucination" if
+both pass a fraction-of-topics rule. The signal that would actually
+discriminate them is *another model's read of whether the answer is
+supported by the evidence*.
+
+That signal is too expensive (tokens) and too non-reproducible to
+gate the public CI on. But the **real-data cycle** is already manual,
+already aggregate-only, and already lives behind the ADR 0005 commit
+boundary. Adding a second-opinion judge there is in-scope; adding it
+to public CI is not.
+
+## Decision
+
+LLM-as-judge is permitted on the **local real-data eval surface
+only**:
+
+- **Allowed**: `eval/real_config.local.yaml` runs, with judge output
+  written under `reports/real100/judge.local.json` (per-case,
+  git-ignored) and aggregate / agreement metrics rolled into
+  `reports/real100/baseline.aggregate.json` (committable under the
+  ADR 0005 allowlist).
+- **Not allowed**: `eval/config.yaml` (public synthetic),
+  `.github/workflows/pr-eval.yml`, `make smoke`, `make eval`. These
+  paths stay deterministic, free, offline, and reproducible per
+  ADR 0004.
+
+### Contract
+
+- The judge consumes `(query, answer.summary, evidence[:3].text)` and
+  returns a structured JSON object:
+  ```json
+  {
+    "judge_status": "supported" | "partial" | "insufficient",
+    "judge_grounded": true | false,
+    "judge_reason_short": "string, ≤ 200 chars"
+  }
+  ```
+- The deterministic verifier remains the **gate**. The judge is a
+  **second opinion**, never a substitute. Status emitted to callers
+  is always the verifier's; the judge only contributes to evaluation
+  aggregates.
+- Aggregate metrics derived from the judge:
+  - `judge.status_distribution` — counts of `supported` / `partial` /
+    `insufficient`.
+  - `judge.grounded_rate` — fraction of cases where
+    `judge_grounded == true`.
+  - **`judge.agreement_with_verifier`** — fraction of cases where
+    `judge_status == answer.status`. **This is the key new metric.**
+    A drop here is an actionable signal: the verifier and the judge
+    disagree, go look at the case.
+- Per-case judge text (the `judge_reason_short` field, raw prompts,
+  raw model responses) **stay local**. Only the three aggregates
+  above cross the commit boundary.
+
+### Cadence
+
+Manual, like the rest of the real-data cycle. The user invokes
+`make real-eval-with-judge` after a retrieval / verifier change and
+attaches the resulting aggregate delta to the PR alongside the
+deterministic-verifier delta from ADR 0005's flow.
+
+### Backend pluggability
+
+`scripts/llm_judge.py` is backend-agnostic via
+`BIDMATE_JUDGE_BACKEND`:
+
+- `stub` (default) — deterministic fixture, no network. Used by
+  tests; lets the plumbing be exercised without API keys.
+- `openai_compatible` — generic OpenAI-compatible API endpoint
+  (works for Anthropic-Compatible mode, OpenAI, vLLM, llama.cpp
+  server, etc.). Requires `BIDMATE_JUDGE_API_KEY`,
+  `BIDMATE_JUDGE_MODEL`, optional `BIDMATE_JUDGE_BASE_URL`.
+- Future backends can be added without touching the upstream
+  pipeline.
+
+## Consequences
+
+**Wins**
+
+- Independent signal on real-data quality, gated against
+  deterministic verifier output via `agreement_with_verifier`.
+- ADR 0005 commit boundary stays intact: judge per-case text is
+  never committed.
+- ADR 0004 stays intact for the public path: synthetic CI is still
+  deterministic, free, offline, reproducible.
+- Future threshold tuning (e.g. #89) gains a second-opinion check
+  that's harder to overfit than the synthetic eval set.
+
+**Costs**
+
+- Token spend per real-data run (currently ~21 cases × judge calls).
+  Bounded by manual cadence and small N.
+- An external dependency exists on the real-data surface. A judge
+  outage doesn't break the deterministic eval; `agreement_with_verifier`
+  simply isn't computed for that run.
+- One more thing for the user to remember. Mitigated by
+  `make real-eval-with-judge` orchestrating the steps.
+
+**Constraints (unchanged from ADR 0004 + ADR 0005)**
+
+- Public CI must not call out to any external LLM. Enforced by
+  convention; no public-surface script imports `scripts/llm_judge.py`.
+- Aggregate-only commit boundary is enforced by reuse of
+  `extract_aggregate` and its `_assert_no_forbidden` recursive guard.
+
+## Alternatives considered
+
+- **Skip the judge entirely; just tune the deterministic threshold
+  more carefully.** Rejected: the threshold is arbitrary by
+  construction. Without an independent signal we cannot tell whether
+  a tightening pushed false-positives down or just shifted them into
+  a different failure mode.
+- **Put the judge in public CI behind a feature flag.** Rejected:
+  ADR 0004's reproducibility argument still holds for the public
+  path. Per-PR token spend on synthetic cases is also unjustified
+  — those cases are crisply discriminable without a model in the
+  loop.
+- **Train a deterministic judge from the LLM-judge labels.**
+  Premature; revisit if `agreement_with_verifier` drops below a
+  threshold that suggests systematic verifier drift.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,3 +68,4 @@ project record.
 | [0003](./0003-structured-answer-citation-contract.md) | accepted | Structured answer / citation contract (`schema_version: 2`) |
 | [0004](./0004-verifier-retry-policy.md) | accepted | Verifier-driven retry with strict → relaxed staging |
 | [0005](./0005-eval-split-public-synthetic-private-local.md) | accepted | Eval split: public synthetic vs private local |
+| [0006](./0006-llm-judge-on-real-data-only.md) | accepted | LLM-judge on the real-data surface only (refines 0004) |

--- a/docs/private-100-doc-experiments.md
+++ b/docs/private-100-doc-experiments.md
@@ -123,8 +123,7 @@ git worktree add /tmp/pre-69 2f76671
 python3 eval/run_eval.py --index_dir data/index/real100 \
   --output_dir /tmp/real100-before --config eval/real_config.local.yaml
 python3 eval/run_eval.py --index_dir data/index/real100 \
-  --output_dir /tmp/real100-after  --config eval/real_config.local.yaml
-# (aggregate fields then transcribed into the table above)
+  --output_dir /tmp/real100-after  --config eval/real_config.local.yaml# (aggregate fields then transcribed into the table above)
 ```
 
 ## Real-data Eval History

--- a/scripts/llm_judge.py
+++ b/scripts/llm_judge.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""LLM-judge for the local real-data eval surface (ADR 0006).
+
+Reads ``reports/real100/eval_summary.json``, asks a configured LLM
+backend whether each case's answer is supported by its evidence, and
+writes the per-case verdicts to ``reports/real100/judge.local.json``
+(git-ignored) plus an aggregate-only summary to stdout.
+
+**Scope discipline.** This script runs on the real-data surface only.
+The public CI path must not call it (ADR 0004 + ADR 0006).
+
+Backends:
+
+* ``stub`` (default) — deterministic synthetic verdict. No network.
+  Used by tests and by users without an API key. Produces verdicts
+  that exactly mirror the deterministic verifier's status so
+  ``agreement_with_verifier`` is 1.0 on a clean stub run.
+* ``openai_compatible`` — generic OpenAI-compatible endpoint
+  (Anthropic-Compat, OpenAI, vLLM, llama.cpp server, etc.). Reads
+  ``BIDMATE_JUDGE_API_KEY``, ``BIDMATE_JUDGE_MODEL``,
+  ``BIDMATE_JUDGE_BASE_URL``.
+
+Output schema for the local file (per-case, never committed):
+
+    {
+      "schema_version": 1,
+      "generated_at": "ISO8601Z",
+      "backend": "stub" | "openai_compatible" | ...,
+      "model": "string",
+      "cases": [
+        {
+          "id": "...",
+          "judge_status": "supported" | "partial" | "insufficient",
+          "judge_grounded": bool,
+          "judge_reason_short": "≤ 200 chars",
+          "verifier_status": "...",
+          "agrees": bool
+        }
+      ]
+    }
+
+The committable aggregate (merged into baseline.aggregate.json by
+``scripts/write_real_eval_baseline.py``) contains only
+``judge.status_distribution``, ``judge.grounded_rate``, and
+``judge.agreement_with_verifier``.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EVAL_PATH = ROOT / "reports" / "real100" / "eval_summary.json"
+DEFAULT_OUTPUT_PATH = ROOT / "reports" / "real100" / "judge.local.json"
+
+JUDGE_STATUSES = ("supported", "partial", "insufficient")
+
+PROMPT_TEMPLATE = """You are reviewing one answer from a retrieval-augmented QA
+system on a procurement (RFP) document. Judge whether the answer is
+supported by the evidence chunks.
+
+Query:
+{query}
+
+Answer summary:
+{summary}
+
+Top evidence chunks:
+{evidence}
+
+Reply ONLY with valid JSON of the form:
+{{"judge_status": "supported" | "partial" | "insufficient",
+  "judge_grounded": true | false,
+  "judge_reason_short": "short reason, <= 200 chars"}}
+"""
+
+
+# -----------------------------------------------------------------------------
+# Backends
+# -----------------------------------------------------------------------------
+
+
+def _stub_backend(_prompt: str, *, verifier_status: str) -> dict[str, Any]:
+    """Deterministic stub.
+
+    Echoes the verifier's status so a stub-mode run produces
+    ``agreement_with_verifier == 1.0`` — useful for plumbing tests
+    and for users without an API key who still want to exercise the
+    flow.
+    """
+    return {
+        "judge_status": verifier_status if verifier_status in JUDGE_STATUSES else "insufficient",
+        "judge_grounded": verifier_status == "supported",
+        "judge_reason_short": "stub backend: verifier status echoed",
+    }
+
+
+def _openai_compatible_backend(prompt: str, *, verifier_status: str) -> dict[str, Any]:  # pragma: no cover - network
+    """Generic OpenAI-compatible endpoint backend.
+
+    Imported lazily so the stub-only test path has no network / SDK
+    dependency.
+    """
+    try:
+        from openai import OpenAI  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        raise RuntimeError(
+            "openai_compatible backend requires the openai SDK. "
+            "Install with `pip install openai` or use BIDMATE_JUDGE_BACKEND=stub."
+        ) from exc
+
+    api_key = os.environ.get("BIDMATE_JUDGE_API_KEY")
+    if not api_key:
+        raise RuntimeError("BIDMATE_JUDGE_API_KEY is not set.")
+    base_url = os.environ.get("BIDMATE_JUDGE_BASE_URL") or None
+    model = os.environ.get("BIDMATE_JUDGE_MODEL")
+    if not model:
+        raise RuntimeError("BIDMATE_JUDGE_MODEL is not set.")
+
+    client = OpenAI(api_key=api_key, base_url=base_url)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.0,
+        response_format={"type": "json_object"},
+    )
+    content = response.choices[0].message.content or "{}"
+    parsed = json.loads(content)
+    return _normalize_judge_payload(parsed, fallback_status=verifier_status)
+
+
+def _normalize_judge_payload(
+    payload: dict[str, Any], fallback_status: str
+) -> dict[str, Any]:
+    status = str(payload.get("judge_status") or "").strip().lower()
+    if status not in JUDGE_STATUSES:
+        status = fallback_status if fallback_status in JUDGE_STATUSES else "insufficient"
+    grounded = bool(payload.get("judge_grounded", False))
+    reason = str(payload.get("judge_reason_short") or "")[:200]
+    return {
+        "judge_status": status,
+        "judge_grounded": grounded,
+        "judge_reason_short": reason,
+    }
+
+
+_BACKENDS = {
+    "stub": _stub_backend,
+    "openai_compatible": _openai_compatible_backend,
+}
+
+
+# -----------------------------------------------------------------------------
+# Pipeline
+# -----------------------------------------------------------------------------
+
+
+def _build_prompt(case: dict[str, Any]) -> str:
+    query = case.get("query") or ""
+    answer = case.get("answer") or ""
+    if isinstance(answer, dict):
+        summary = str(answer.get("summary") or "")
+    else:
+        summary = str(answer)
+    evidence_items = case.get("evidence") or []
+    evidence_lines = []
+    for i, item in enumerate(evidence_items[:3], start=1):
+        text = (item.get("text") if isinstance(item, dict) else "") or ""
+        evidence_lines.append(f"[{i}] {text[:600]}")
+    evidence_block = "\n".join(evidence_lines) or "(no evidence)"
+    return PROMPT_TEMPLATE.format(
+        query=query, summary=summary, evidence=evidence_block
+    )
+
+
+def _aggregate(cases: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute the *committable* aggregate from per-case verdicts."""
+    statuses = [c["judge_status"] for c in cases if c.get("judge_status")]
+    grounded = [bool(c.get("judge_grounded")) for c in cases]
+    agreements = [bool(c.get("agrees")) for c in cases if c.get("agrees") is not None]
+    return {
+        "status_distribution": dict(Counter(statuses)),
+        "grounded_rate": (sum(grounded) / len(grounded)) if grounded else None,
+        "agreement_with_verifier": (
+            sum(agreements) / len(agreements) if agreements else None
+        ),
+        "n": len(cases),
+    }
+
+
+def judge_summary(
+    summary: dict[str, Any],
+    backend: str = "stub",
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run the judge over an eval_summary dict.
+
+    Returns ``(local_payload, aggregate)`` — the caller decides where
+    to write each. The aggregate is safe to commit; the local payload
+    contains per-case judge text and stays under the ADR 0005 boundary.
+    """
+    if backend not in _BACKENDS:
+        raise ValueError(
+            f"Unknown judge backend {backend!r}; "
+            f"choose one of {sorted(_BACKENDS)}."
+        )
+    backend_fn = _BACKENDS[backend]
+
+    case_results = summary.get("case_results") or []
+    judged: list[dict[str, Any]] = []
+    for case in case_results:
+        if not isinstance(case, dict):
+            continue
+        prompt = _build_prompt(case)
+        verifier_status = str(case.get("answer_status") or "insufficient")
+        verdict = backend_fn(prompt, verifier_status=verifier_status)
+        judged.append(
+            {
+                "id": case.get("id"),
+                "judge_status": verdict["judge_status"],
+                "judge_grounded": verdict["judge_grounded"],
+                "judge_reason_short": verdict["judge_reason_short"],
+                "verifier_status": verifier_status,
+                "agrees": verdict["judge_status"] == verifier_status,
+            }
+        )
+
+    local_payload = {
+        "schema_version": 1,
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "backend": backend,
+        "model": os.environ.get("BIDMATE_JUDGE_MODEL", "stub"),
+        "cases": judged,
+    }
+    return local_payload, _aggregate(judged)
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--eval-summary",
+        default=str(DEFAULT_EVAL_PATH),
+        help="Path to reports/real100/eval_summary.json",
+    )
+    ap.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_PATH),
+        help="Where to write the per-case judge verdicts (git-ignored).",
+    )
+    ap.add_argument(
+        "--backend",
+        default=os.environ.get("BIDMATE_JUDGE_BACKEND", "stub"),
+        choices=sorted(_BACKENDS),
+        help="Judge backend (defaults to BIDMATE_JUDGE_BACKEND or 'stub').",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary_path = Path(args.eval_summary)
+    if not summary_path.exists():
+        print(
+            f"[ERROR] Eval summary not found: {summary_path}\n"
+            "Run `make real-eval` first.",
+            file=sys.stderr,
+        )
+        return 2
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    local_payload, aggregate = judge_summary(summary, backend=args.backend)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(local_payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"[OK] Per-case verdicts written: {output_path}")
+    print(json.dumps(aggregate, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_real_eval_history.py
+++ b/scripts/render_real_eval_history.py
@@ -53,6 +53,9 @@ COLUMNS: list[tuple[str, str]] = [
     ("abstention", "Abst."),
     ("answer_format_compliance", "Format"),
     ("retry", "Retry"),
+    # ADR 0006: LLM-judge agreement. Shown only when present; absent
+    # entries render as "—" via the _fmt fallback.
+    ("agreement_with_verifier", "Judge⇄Verifier"),
 ]
 
 
@@ -77,6 +80,7 @@ def load_history() -> list[dict[str, Any]]:
         raw = json.loads(path.read_text(encoding="utf-8"))
         agg = extract_aggregate(raw)
         provenance = raw.get("provenance") or {}
+        judge_block = agg.get("judge") or {}
         rows.append(
             {
                 "file": path.name,
@@ -88,6 +92,7 @@ def load_history() -> list[dict[str, Any]]:
                 "abstention": agg.get("abstention"),
                 "answer_format_compliance": agg.get("answer_format_compliance"),
                 "retry": agg.get("retry"),
+                "agreement_with_verifier": judge_block.get("agreement_with_verifier"),
             }
         )
     rows.sort(key=lambda row: (row["date"], row["file"]))

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -57,6 +57,11 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         "primary_run",
         "prompt_profile",
         "top_k",
+        # LLM-judge aggregates (ADR 0006). Only status_distribution /
+        # grounded_rate / agreement_with_verifier / n cross the commit
+        # boundary; per-case judge text stays in
+        # reports/real100/judge.local.json.
+        "judge",
     }
 )
 
@@ -277,6 +282,37 @@ def render_markdown(
                 f"{head_reasons.get(reason, 0)} |"
             )
 
+    base_judge = base.get("judge") or {}
+    head_judge = head.get("judge") or {}
+    if base_judge or head_judge:
+        lines.append("")
+        lines.append("#### LLM-judge aggregate (ADR 0006)")
+        lines.append("")
+        lines.append("| metric | base | head | Δ |")
+        lines.append("|---|---|---|---|")
+        for key, label, higher in (
+            ("grounded_rate", "judge_grounded_rate", True),
+            ("agreement_with_verifier", "agreement_with_verifier", True),
+        ):
+            b = base_judge.get(key)
+            h = head_judge.get(key)
+            lines.append(
+                f"| {label} | {_fmt_value(b)} | {_fmt_value(h)} | "
+                f"{_fmt_delta(b, h, higher)} |"
+            )
+        base_dist = base_judge.get("status_distribution") or {}
+        head_dist = head_judge.get("status_distribution") or {}
+        statuses = sorted(set(base_dist) | set(head_dist))
+        if statuses:
+            lines.append("")
+            lines.append("| judge_status | base count | head count |")
+            lines.append("|---|---:|---:|")
+            for status in statuses:
+                lines.append(
+                    f"| {status} | {base_dist.get(status, 0)} | "
+                    f"{head_dist.get(status, 0)} |"
+                )
+
     lines.append("")
     lines.append(
         "_Aggregate-only. Per-case data is never read or rendered by this "
@@ -383,6 +419,32 @@ def main() -> int:
     base_raw = json.loads(base_path.read_text(encoding="utf-8"))
 
     head = extract_aggregate(head_raw)
+
+    # ADR 0006: if a judge.local.json sits beside the head eval
+    # summary, fold its aggregate into the head view so the delta
+    # surfaces judge_grounded_rate / agreement_with_verifier when the
+    # user just ran `make real-eval-with-judge`. The per-case judge
+    # text is never copied into the head aggregate.
+    judge_local = head_path.parent / "judge.local.json"
+    if judge_local.exists():
+        from collections import Counter
+
+        judge_payload = json.loads(judge_local.read_text(encoding="utf-8"))
+        cases = judge_payload.get("cases") or []
+        statuses = [c.get("judge_status") for c in cases if c.get("judge_status")]
+        grounded = [bool(c.get("judge_grounded")) for c in cases]
+        agreements = [bool(c.get("agrees")) for c in cases if c.get("agrees") is not None]
+        head["judge"] = {
+            "status_distribution": dict(Counter(statuses)),
+            "grounded_rate": (sum(grounded) / len(grounded)) if grounded else None,
+            "agreement_with_verifier": (
+                sum(agreements) / len(agreements) if agreements else None
+            ),
+            "n": len(cases),
+        }
+        # Privacy guard: assert nothing leaked.
+        _assert_no_forbidden(head["judge"], "judge")
+
     base = extract_aggregate(base_raw) if "case_results" in base_raw else base_raw
     # If the baseline file was already in aggregate form (it should be),
     # re-running the extractor is a no-op but also re-asserts the

--- a/scripts/write_real_eval_baseline.py
+++ b/scripts/write_real_eval_baseline.py
@@ -34,6 +34,7 @@ from scripts.run_real_eval_delta import extract_aggregate
 EVAL_SUMMARY = ROOT / "reports" / "real100" / "eval_summary.json"
 BASELINE_PATH = ROOT / "reports" / "real100" / "baseline.aggregate.json"
 HISTORY_DIR = ROOT / "reports" / "real100" / "history"
+JUDGE_LOCAL = ROOT / "reports" / "real100" / "judge.local.json"
 
 
 def _git(*args: str) -> str:
@@ -79,6 +80,28 @@ def main() -> int:
     agg = extract_aggregate(raw)
     provenance = _provenance()
     agg["provenance"] = provenance
+
+    # If a judge run is present (ADR 0006), fold its aggregate into the
+    # baseline. The per-case judge file stays local; only the
+    # committable aggregate keys are copied here.
+    if JUDGE_LOCAL.exists():
+        from collections import Counter
+
+        judge_payload = json.loads(JUDGE_LOCAL.read_text(encoding="utf-8"))
+        cases = judge_payload.get("cases") or []
+        statuses = [c.get("judge_status") for c in cases if c.get("judge_status")]
+        grounded = [bool(c.get("judge_grounded")) for c in cases]
+        agreements = [bool(c.get("agrees")) for c in cases if c.get("agrees") is not None]
+        agg["judge"] = {
+            "status_distribution": dict(Counter(statuses)),
+            "grounded_rate": (sum(grounded) / len(grounded)) if grounded else None,
+            "agreement_with_verifier": (
+                sum(agreements) / len(agreements) if agreements else None
+            ),
+            "n": len(cases),
+            "backend": str(judge_payload.get("backend") or "unknown"),
+            "model": str(judge_payload.get("model") or "unknown"),
+        }
 
     serialized = json.dumps(agg, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
 

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -1,0 +1,123 @@
+"""Tests for the LLM-judge plumbing on the real-data surface (ADR 0006).
+
+The stub backend mirrors the verifier's status, which makes the
+plumbing testable without a network / API key. The tests pin:
+
+* the per-case verdict shape and the agreement-with-verifier
+  bookkeeping
+* the aggregate shape stays inside the ADR 0005 / ADR 0006 commit
+  boundary (no per-case judge text)
+* the CLI writes the local file but stdout shows only aggregates
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.llm_judge import judge_summary
+
+
+def _fake_summary() -> dict:
+    return {
+        "primary_run": "full",
+        "pipeline": "agentic_full",
+        "num_predictions": 3,
+        "case_results": [
+            {
+                "id": "case_supported",
+                "query": "private query 1",
+                "answer_status": "supported",
+                "answer": {"summary": "private answer summary 1"},
+                "evidence": [{"text": "private evidence text 1"}],
+            },
+            {
+                "id": "case_partial",
+                "query": "private query 2",
+                "answer_status": "partial",
+                "answer": {"summary": "private answer summary 2"},
+                "evidence": [{"text": "private evidence text 2"}],
+            },
+            {
+                "id": "case_abstain",
+                "query": "private query 3",
+                "answer_status": "insufficient",
+                "answer": {"summary": ""},
+                "evidence": [],
+            },
+        ],
+    }
+
+
+class JudgeSummaryStubTest(unittest.TestCase):
+    def test_stub_backend_agrees_with_verifier_perfectly(self) -> None:
+        local, agg = judge_summary(_fake_summary(), backend="stub")
+        # Per-case payload shape.
+        self.assertEqual(len(local["cases"]), 3)
+        for case in local["cases"]:
+            self.assertIn(case["judge_status"], {"supported", "partial", "insufficient"})
+            self.assertTrue(case["agrees"], case)
+        # Aggregate shape — only the four committable keys + n.
+        self.assertEqual(set(agg), {"status_distribution", "grounded_rate", "agreement_with_verifier", "n"})
+        self.assertEqual(agg["n"], 3)
+        self.assertEqual(agg["agreement_with_verifier"], 1.0)
+        # Only the supported case should count as grounded.
+        self.assertAlmostEqual(agg["grounded_rate"], 1 / 3)
+        self.assertEqual(
+            agg["status_distribution"],
+            {"supported": 1, "partial": 1, "insufficient": 1},
+        )
+
+    def test_aggregate_does_not_leak_per_case_text(self) -> None:
+        _local, agg = judge_summary(_fake_summary(), backend="stub")
+        flat = json.dumps(agg, ensure_ascii=False)
+        for leak in [
+            "case_supported", "case_partial", "case_abstain",
+            "private query", "private answer summary", "private evidence text",
+        ]:
+            self.assertNotIn(leak, flat)
+
+    def test_unknown_backend_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            judge_summary(_fake_summary(), backend="does_not_exist")
+
+
+class JudgeCLIInvocationTest(unittest.TestCase):
+    """Smoke the CLI end-to-end with the stub backend."""
+
+    def test_cli_writes_local_file_and_prints_aggregate_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            eval_path = Path(tmp) / "eval_summary.json"
+            out_path = Path(tmp) / "judge.local.json"
+            eval_path.write_text(
+                json.dumps(_fake_summary(), ensure_ascii=False), encoding="utf-8"
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/llm_judge.py",
+                    "--eval-summary", str(eval_path),
+                    "--output", str(out_path),
+                    "--backend", "stub",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=Path(__file__).resolve().parents[1],
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            # Aggregate JSON appears on stdout; per-case data does NOT.
+            self.assertIn("status_distribution", result.stdout)
+            self.assertIn("agreement_with_verifier", result.stdout)
+            for leak in ["case_supported", "private query", "private answer summary"]:
+                self.assertNotIn(leak, result.stdout)
+            # Local file has per-case data (this is OK — local-only).
+            local = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertEqual(len(local["cases"]), 3)
+            self.assertIn("case_supported", json.dumps(local, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Refreshed after #94 squash-merged.** Now targets `main` directly. Originally PR #93, which GitHub auto-closed when its parent branch was deleted post-merge.

## Summary
ADR 0004 rejected LLM-as-judge on the **public** path. It also hedged: *"May be reconsidered if the deterministic verifier hits a ceiling."* #69 made the ceiling visible.

This PR adds an **LLM-judge on the real-data surface only**, gated behind a new ADR 0006 that refines (does not supersede) ADR 0004. Public CI stays deterministic / free / offline. Real-data cycle gains an independent second opinion. The new metric **`agreement_with_verifier`** is the actionable signal — a drop means the verifier and the judge disagree, go look at the case.

## Files affected
- **`docs/adr/0006-llm-judge-on-real-data-only.md`** *(new ADR — load-bearing)*. Refines ADR 0004.
- **`scripts/llm_judge.py`** — pluggable judge (`stub` default; `openai_compatible` lazy-imported).
- **`scripts/run_real_eval_delta.py`** — `judge` added to SAFE_TOPLEVEL_KEYS; auto-loads `judge.local.json` from beside head eval summary; new "LLM-judge aggregate" section in rendered table.
- **`scripts/write_real_eval_baseline.py`** — folds judge aggregate into baseline + history entries.
- **`scripts/render_real_eval_history.py`** — adds `Judge⇄Verifier` column.
- **`Makefile`** — `make real-eval-with-judge` target.
- **`.gitignore`** — explicit deny on `reports/real100/judge.local.json` (clarity).
- **`docs/adr/README.md`** — ADR index updated.
- **`tests/test_llm_judge.py`** — 4 stub-backend tests.

## How it preserves the boundary
- Per-case judge text → `reports/real100/judge.local.json` → git-ignored.
- Aggregates only (`status_distribution`, `grounded_rate`, `agreement_with_verifier`, `n`, `backend`, `model`) → committable via `baseline.aggregate.json`.
- `extract_aggregate` + `_assert_no_forbidden` from #91 reused.

## Risks
- **External dependency on real-data path.** Bounded by manual cadence and aggregate-only commit. Judge outage doesn't break deterministic eval.
- **Per-case leak via judge.local.json.** Mitigated: explicit gitignore + tests assert stdout never contains per-case text.
- **Stub backend may hide real disagreement.** Stub mirrors verifier so `agreement = 1.0` is a "plumbing works" signal, not a quality signal. ADR 0006 documents this.

## Tests
- `pytest -q`: **114 passed** locally (was 110 with #94; +4 new). No regressions.

## Eval impact
- Expected: **all `·`**. **Public CI eval delta workflow is unaffected** — it does not call the judge.

## Backward compatibility
- ADR 0004's public-path policy unchanged. ADR 0005's commit boundary unchanged.
- New ADR 0006 is purely additive.

## Out of scope
- Switching public CI to LLM-judge — explicitly rejected by ADR 0006.
- Training a custom judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
