### PR TITLE
Document Korean RFP domain adaptations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,46 @@ Final Response (grounded)
 
 ---
 
+## Korean RFP domain adaptations
+
+본 시스템은 한국 정부조달/B2B RFP 도메인 특성을 반영해 다음 5가지를 의도적으로 다르게 설계했습니다. 일반 multilingual RAG 템플릿에는 없는 결정들입니다.
+
+### 1) HWP 파일 처리 — CSV 텍스트 fallback
+
+원본 HWP를 native parse하는 대신 `data_list.csv`의 `텍스트` 컬럼을 본문 소스로 사용하고 `visual_fallback_hwp` 마커를 부여합니다. HWP native binary 포맷의 안정적 parsing 라이브러리 부재와 라이선스 제약을 회피하기 위한 의도된 trade-off입니다.
+
+- CSV 텍스트 로더: [`HwpCsvTextLoader` (ingestion.py:103)](ingestion.py)
+- Visual fallback document: [`make_hwp_fallback_document` (visual_ingestion.py:659)](visual_ingestion.py)
+
+### 2) Korean RFP 메타데이터 컬럼 컨벤션
+
+`공고 번호`, `사업명`, `발주 기관`, `파일형식`, `파일명`, `텍스트` 6개 컬럼을 `REQUIRED_COLUMNS`로 강제하고 metadata-first filter의 1차 필드로 사용합니다. 한국 조달 시스템의 표준 메타데이터 표기와 일치.
+
+- 컬럼 정의: [`REQUIRED_COLUMNS` (ingestion.py:21)](ingestion.py)
+
+### 3) Korean tokenization — 외부 형태소 분석기 미사용
+
+`[A-Za-z0-9]+|[가-힣]+` 정규식과 한국어 조사 제거 normalize만 사용합니다. **의도적으로** KoNLPy / soynlp / kiwipiepy 같은 형태소 분석 라이브러리를 도입하지 않았습니다. 이유: 한자/영문 기술 용어와 한글 사업명이 혼재된 RFP 텍스트에서 형태소 분석의 정확도 이득 대비, container 부피 / CI 재현성 / Java JVM 의존(KoNLPy) 비용이 큽니다.
+
+- 토큰 정규식: [`TOKEN_RE` (rag_core.py:93)](rag_core.py)
+- 조사 제거 정규화: [`normalize_metadata_token` (rag_core.py:297)](rag_core.py)
+
+### 4) 기관 약칭/alias 자동 추출
+
+`기관 A` ↔ `기관A` 같은 공백 압축형, 한글 1–4자 접두 토큰을 자동 추출해 metadata filter의 fuzzy match에 사용합니다. CSV 메타데이터의 `{field}_aliases` 컬럼도 병합.
+
+- 구현: [`metadata_aliases` (rag_core.py:1137)](rag_core.py)
+
+### 5) Embedding 모델 선택 — multilingual MiniLM
+
+`sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`를 기본으로 채택. 채택 이유: 한국어/영어 multilingual 지원, L12 경량(~120MB), API 의존 0, 로컬 재현성. **한계 명시**: 2019년 모델로 2025년 최신 multilingual 모델(BGE-M3, multilingual-e5-large, KURE 등) 대비 품질 ablation을 아직 실행하지 않았습니다. 다음 실험 사이클 항목.
+
+- 기본값: [`DEFAULT_EMBEDDING_MODEL` (rag_core.py:25)](rag_core.py)
+
+도메인-특화 retrieval hardening의 전체 카탈로그는 [`docs/retrieval-hardening.md`](docs/retrieval-hardening.md)를 참고하세요.
+
+---
+
 ## 실행 방법 (검증됨)
 
 두 가지 흐름을 제공합니다.


### PR DESCRIPTION
Closes #101

## 1. What changed and why

코드에는 한국 정부조달/B2B RFP 도메인에 특화된 처리가 다수 구현되어 있지만 README는 이를 노출하지 않아 portfolio 리뷰어가 \"한국 RFP 도메인 깊이\"를 가늠하기 어려웠음. 아키텍처 섹션 다음에 5가지 의도된 도메인 결정(HWP CSV fallback / 메타데이터 컬럼 컨벤션 / 형태소 분석기 미사용 / alias 자동 추출 / embedding 모델 선택)을 코드 경로와 함께 노출.

**핵심 메시지**: KoNLPy/soynlp/kiwipiepy를 *의도적으로 도입하지 않은* 결정과 그 이유(container 부피 / CI 재현성 / Java JVM 의존)를 명시. 부재가 oversight가 아닌 trade-off임을 reviewer에게 신호.

## 2. Files affected

- `README.md` — 40줄 insertion (아키텍처와 실행 방법 사이)

코드 파일 변경 없음.

## 3. Risks

- `docs/retrieval-hardening.md`와 부분 중복. README는 elevator 5가지, docs는 detail 전체 카탈로그로 cross-reference 처리.
- Embedding 모델 \"한계 명시\" 단락이 future work 약속으로 읽혀 후속 PR로 ablation 강제될 수 있음. 의도된 효과 — 실제 future cycle 항목.

## 4. Tests

신규 코드 없음. 코드 line number는 `grep -n`으로 사전 검증:
- HwpCsvTextLoader ingestion.py:103 ✓
- make_hwp_fallback_document visual_ingestion.py:659 ✓
- REQUIRED_COLUMNS ingestion.py:21 ✓
- TOKEN_RE rag_core.py:93 ✓
- normalize_metadata_token rag_core.py:297 ✓
- metadata_aliases rag_core.py:1137 ✓
- DEFAULT_EMBEDDING_MODEL rag_core.py:25 ✓

`python3 -m pytest -q` 로컬 실행: **115 passed**.

## 5. Eval impact

코드 경로 무변경이므로 CI eval delta는 \"all `·`\" 예상.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. CLAUDE.md 5b에 따라 real-data delta 첨부 면제.

## 6. Backward compatibility

문서 추가만 있고 schema/CLI/answer contract 무변경. 후방 호환성 영향 없음.

## 7. Out of scope

- 코드 변경 없음 (이미 존재하는 동작 문서화)
- KoNLPy 등 형태소 분석기 도입 없음 (오히려 \"의도적 비사용\"이 핵심 메시지)
- Embedding model ablation 실제 실행 없음 (future work 항목으로 명시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)