### PR TITLE
Add pre-commit hook to enforce ADR 0005 commit boundary

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Pre-commit hook for BidMate-DocAgent.
+#
+# Activate per-developer with:
+#   git config core.hooksPath .githooks
+#
+# Behavior: hard-blocks commits that include files from the private side of
+# the eval split (ADR 0005). These paths are `.gitignore`d, but `git add -f`
+# or other force-paths can bypass that. The hook is the second line of
+# defense, aligned with `.gitignore`.
+#
+# Bypass with `git commit --no-verify` only if you are intentionally
+# committing an aggregate artifact that the allowlist regex below failed to
+# match — and please fix the allowlist in that same change.
+
+set -u
+
+# Blocked path patterns (regex). Must mirror `.gitignore`'s ADR 0005 boundary.
+BLOCKED_PATTERNS=(
+  '^data/files/'
+  '^data/data_list\.csv$'
+  '^data/data_list\.xlsx$'
+  '^eval/.*\.local\.yaml$'
+  '^reports/real[^/]*/'
+)
+
+# Allowlist (regex). These aggregate artifacts ARE safe to commit; they
+# mirror the `!`-rules in `.gitignore`.
+ALLOWED_PATTERNS=(
+  '^reports/real100/baseline\.aggregate\.json$'
+  '^reports/real100/history/[^/]+\.aggregate\.json$'
+)
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+
+if [[ -z "$staged" ]]; then
+  exit 0
+fi
+
+violations=()
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  # Skip files that match the allowlist.
+  allowed=0
+  for allow_pat in "${ALLOWED_PATTERNS[@]}"; do
+    if [[ "$file" =~ $allow_pat ]]; then
+      allowed=1
+      break
+    fi
+  done
+  [[ "$allowed" -eq 1 ]] && continue
+
+  # Flag files that match a blocked pattern.
+  for block_pat in "${BLOCKED_PATTERNS[@]}"; do
+    if [[ "$file" =~ $block_pat ]]; then
+      violations+=("$file")
+      break
+    fi
+  done
+done <<< "$staged"
+
+if [[ ${#violations[@]} -gt 0 ]]; then
+  cat >&2 <<EOF
+
+❌ Pre-commit hook blocked: staged files violate the ADR 0005 commit boundary.
+
+   The following are on the private side of the eval split and must not
+   enter git:
+
+EOF
+  for f in "${violations[@]}"; do
+    echo "     - $f" >&2
+  done
+  cat >&2 <<EOF
+
+   These paths are .gitignored, so you typically don't see them. If you
+   used \`git add -f\` to force-add, undo with:
+
+       git restore --staged ${violations[*]}
+
+   See ADR 0005 (docs/adr/0005-eval-split-public-synthetic-private-local.md)
+   and docs/private-100-doc-experiments.md.
+
+   Bypass with \`git commit --no-verify\` only if you are intentionally
+   committing an aggregate artifact that the allowlist regex failed to
+   match — and please fix the allowlist in the same change.
+
+EOF
+  exit 1
+fi
+
+exit 0

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -130,12 +130,21 @@ without duplicating their content.
 
 ## Local hook setup (one-time, per developer)
 
-Activate the opt-in pre-push reminder hook:
+Activate the opt-in hooks:
 
     git config core.hooksPath .githooks
 
-The hook prints a warning when a push touches retrieval / verifier / eval / api
-paths, reminding you to attach `make real-eval-delta` to the PR (PR template
-item 5b). It is **non-fatal** — it exits 0 and never blocks a push. Skip with
-`git push --no-verify` only with a documented reason (e.g. doc-only follow-up
-of a measured PR).
+This enables two hooks under `.githooks/`:
+
+- **`pre-commit`** — **hard-blocks** commits that include files from the
+  private side of the eval split (ADR 0005). Aligned with `.gitignore`;
+  catches `git add -f` and other force-paths. Bypass with `git commit
+  --no-verify` only when intentionally committing an aggregate artifact
+  that the hook's allowlist missed — and fix the allowlist in the same
+  change.
+
+- **`pre-push`** — **soft-warns** when a push touches retrieval / verifier /
+  eval / api paths, reminding you to attach `make real-eval-delta` to the
+  PR (PR template item 5b). Exits 0 — never blocks. Skip with `git push
+  --no-verify` only with a documented reason (e.g. doc-only follow-up of
+  a measured PR).


### PR DESCRIPTION
## 1. What changed and why

\`.gitignore\` is the first line of defense for the private side of the eval split (ADR 0005) — \`data/files/\`, \`data/data_list.{csv,xlsx}\`, \`eval/*.local.yaml\`, \`reports/real*/\` — but `git add -f` and other force-paths can bypass it. There's no enforcement-by-construction for the most security-sensitive content in this repo: real RFP documents and private eval results.

This PR adds an opt-in **`.githooks/pre-commit`** hook as the second line of defense. It reads `git diff --cached`, matches against the same patterns as `.gitignore`, honors the allowlist for aggregate artifacts, and **hard-blocks** with a helpful error message if violations are found.

Defense-in-depth: a single tier of protection (`.gitignore`) for material this sensitive isn't enough — `git add -f` is a one-line bypass with no friction.

Closes #: N/A — defensive hardening, no issue filed.

## 2. Files affected

- \`.githooks/pre-commit\` — new (80 lines, executable).
- \`docs/engineering-governance.md\` — "Local hook setup" section rewritten to describe both hooks (pre-commit hard-block, pre-push soft-warn) under the unchanged \`git config core.hooksPath .githooks\` activation.

**No load-bearing files touched** (\`rag_core.py\`, \`ingestion.py\`, \`visual_ingestion.py\`, \`eval/\`, \`api/\`, \`docs/adr/\` all untouched).

## 3. Risks

**False positives** — hook blocks a commit that should pass:
- Allowlist mirrors `.gitignore`'s \`!\`-rules (\`reports/real100/baseline.aggregate.json\`, \`reports/real100/history/*.aggregate.json\`). Tested explicitly in cases 2 and 5.
- If `.gitignore` adds a new aggregate allowlist entry in the future, the hook regex must be updated too. This coupling is documented in the hook's header comment.

**False negatives** — hook misses a file pattern:
- BLOCKED_PATTERNS array mirrors `.gitignore` private-side patterns exactly (\`data/files/\`, \`data/data_list.{csv,xlsx}\`, \`eval/*.local.yaml\`, \`reports/real*/\`).
- Verified by inspection of \`.gitignore\` lines for \`data/\`, \`eval/\`, and \`reports/\`.

**Workflow disruption** — hook blocks a legitimate \`git add -f\` of an aggregate that the allowlist missed: bypass with \`git commit --no-verify\` (documented in hook output and in engineering-governance.md), then fix the allowlist in the same change.

**Opt-in only** — developers without \`git config core.hooksPath .githooks\` set are unaffected. Existing developers' workflow is unchanged until they opt in.

## 4. Tests

No Python regression test added. Rationale: \`tests/test_*_regression.py\` is the pattern for retrieval/verifier/answer-logic regressions; bash hook testing from pytest requires subprocess + git fixture setup that is disproportionate to a 80-line shell script doing regex matching. Precedent: the existing \`.githooks/pre-push\` has no Python test either.

**Manual verification — 6 end-to-end cases, all PASS:**

| # | Case | Path | Expected | Actual |
|---|---|---|---|---|
| 1 | BLOCK | \`data/files/test.pdf\` | exit 1 | exit 1 ✓ |
| 2 | ALLOW | \`reports/real100/baseline.aggregate.json\` | exit 0 | exit 0 ✓ |
| 3 | BLOCK | \`reports/real100/judge.local.json\` | exit 1 | exit 1 ✓ |
| 4 | BLOCK | \`eval/private.local.yaml\` | exit 1 | exit 1 ✓ |
| 5 | ALLOW | \`reports/real100/history/2026-05-11.aggregate.json\` | exit 0 | exit 0 ✓ |
| 6 | PASS | (empty staging) | exit 0 | exit 0 ✓ |

Each case staged the file via \`git add -f\` (to bypass \`.gitignore\` for the test), ran \`./.githooks/pre-commit\`, captured exit code, then \`git restore --staged\` + \`rm\` to clean up. Final \`git status\` was clean (only the new hook file untracked, as expected).

To reproduce locally: \`git config core.hooksPath .githooks\` then \`mkdir -p data/files && echo dummy > data/files/x && git add -f data/files/x && git commit -m test\` should fail; \`git restore --staged data/files/x && rm -rf data/files\` to clean.

## 5. Eval impact

Expected: all \`·\`. No code path affecting retrieval / answer / eval / api was touched.

### 5b. Real-data delta

N/A — no behavior change in retrieval / verifier path. None of the load-bearing files was modified.

## 6. Backward compatibility

- Hook is **opt-in** via \`git config core.hooksPath .githooks\` (already required for the existing \`pre-push\` hook). Developers who haven't opted in are unaffected.
- Existing \`pre-push\` hook behavior unchanged — added file at \`.githooks/pre-commit\`, not modified \`.githooks/pre-push\`.
- No CLI / schema / answer-contract changes.

## 7. Out of scope

Deferred (each gets its own follow-up PR if value is demonstrated):

- Automated hook test script (\`scripts/test_hooks.sh\`) — defer until hook complexity warrants it.
- \`.claude/settings.json\` PreToolUse hook for awareness when editing load-bearing files.
- Skills at \`.claude/skills/\`: \`write-adr\`, \`regression-test\`.
- \`pre-push\` policy hardening (stays soft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)