### PR TITLE
Add Claude Code PreToolUse hook for load-bearing edits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/claude-hooks/pretooluse-loadbearing.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,10 @@ venv/
 .vscode/
 *.swp
 
-# Claude Code local settings
-.claude/
+# Claude Code: local state (worktrees, transcripts, per-user permissions)
+# is ignored; the shared `.claude/settings.json` (hooks etc.) IS committed.
+.claude/*
+!.claude/settings.json
 
 # Local/private source data
 data/files/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,11 @@ Pipeline: ingestion → metadata normalization → chunking → retrieval →
 reranking/planning → evidence aggregation → grounded answer → verification →
 evaluation → reviewer-facing docs.
 
-Deterministic rules live in `.gitignore` / CI (`pr-eval.yml`) / `.githooks/` /
-[`.github/pull_request_template.md`](.github/pull_request_template.md). This
-file captures the principles and pointers that aren't auto-enforced.
+Automation surface: `.gitignore`, CI (`pr-eval.yml`), `.githooks/`,
+[`.github/pull_request_template.md`](.github/pull_request_template.md),
+[`.claude/settings.json`](.claude/settings.json) (PreToolUse awareness hook
+for load-bearing edits). This file captures the principles and pointers
+that aren't auto-enforced.
 
 ## Start here
 

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -128,9 +128,11 @@ measurement rigor, governance, regression discipline) should read
 threads the artifacts above into one interview-ready narrative
 without duplicating their content.
 
-## Local hook setup (one-time, per developer)
+## Hook setup
 
-Activate the opt-in hooks:
+### Git hooks (opt-in, one-time per developer)
+
+Activate:
 
     git config core.hooksPath .githooks
 
@@ -148,3 +150,15 @@ This enables two hooks under `.githooks/`:
   PR (PR template item 5b). Exits 0 — never blocks. Skip with `git push
   --no-verify` only with a documented reason (e.g. doc-only follow-up of
   a measured PR).
+
+### Claude Code hook (auto-loaded, no setup)
+
+`.claude/settings.json` is committed in this repo and auto-loaded by Claude
+Code. It registers a **`PreToolUse`** hook on `Edit` / `MultiEdit` / `Write`
+that prints a stderr awareness reminder when Claude is about to modify a
+load-bearing file (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`,
+`eval/`, `api/`, `docs/adr/`). The reminder lists ADRs to consider and
+notes the PR template item 5b requirement.
+
+Hook script: [`scripts/claude-hooks/pretooluse-loadbearing.sh`](../scripts/claude-hooks/pretooluse-loadbearing.sh).
+Never blocks — pure awareness layer.

--- a/scripts/claude-hooks/pretooluse-loadbearing.sh
+++ b/scripts/claude-hooks/pretooluse-loadbearing.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook for BidMate-DocAgent.
+#
+# Registered in `.claude/settings.json` with matcher `Edit|MultiEdit|Write`.
+# Fires before Claude modifies a file; prints a stderr awareness warning
+# when the target is a load-bearing path (per CLAUDE.md), reminding Claude
+# to consider ADR impact and the PR template's real-data delta requirement.
+#
+# Behavior: NEVER blocks. Always exits 0. Pure awareness layer.
+#
+# Hook input (stdin, JSON):
+#   { "tool_name": "...", "tool_input": { "file_path": "...", ... }, ... }
+
+set -u
+
+# Read JSON from stdin.
+input=$(cat)
+
+# Extract tool_input.file_path. Use python3 — guaranteed in this repo.
+file_path=$(printf '%s' "$input" | python3 -c 'import json,sys
+try:
+    d = json.loads(sys.stdin.read())
+    print(d.get("tool_input", {}).get("file_path", ""))
+except Exception:
+    pass' 2>/dev/null)
+
+if [[ -z "$file_path" ]]; then
+  exit 0
+fi
+
+# Load-bearing patterns (extended regex). Mirror CLAUDE.md "Load-bearing
+# files" section. Anchored to "/" to avoid matching inside arbitrary
+# substrings.
+LOAD_BEARING_PATTERNS=(
+  '/rag_core\.py$'
+  '/ingestion\.py$'
+  '/visual_ingestion\.py$'
+  '/eval/'
+  '/api/'
+  '/docs/adr/'
+)
+
+for pat in "${LOAD_BEARING_PATTERNS[@]}"; do
+  if [[ "$file_path" =~ $pat ]]; then
+    cat >&2 <<EOF
+⚠️  Load-bearing file: $file_path
+
+    ADRs to consider (CLAUDE.md):
+      - ADR 0001 (preserve naive baseline)
+      - ADR 0003 (answer contract — bump schema_version if breaking)
+      - ADR 0005 (eval split — public synthetic / private local)
+
+    PR template item 5b (real-eval-delta aggregate table) will be required
+    when this change ships.
+EOF
+    break
+  fi
+done
+
+exit 0


### PR DESCRIPTION
## 1. What changed and why

CLAUDE.md has a "Load-bearing files" section reminding Claude (and humans) that edits to \`rag_core.py\`, \`ingestion.py\`, \`visual_ingestion.py\`, \`eval/\`, \`api/\`, \`docs/adr/\` need extra care (ADR review + PR template item 5b). But this only helps when CLAUDE.md is loaded *and read* before the edit happens.

PR #129 (slim CLAUDE.md) exposed a concrete failure mode: I dropped the "ADR threshold" rule during slimming and only caught it during cross-reference audit. The reminder existed; it just wasn't fired at the right moment.

This PR registers a Claude Code **\`PreToolUse\`** hook (matcher: \`Edit|MultiEdit|Write\`) that prints a stderr awareness reminder when Claude is about to modify a load-bearing file. The reminder lists the ADRs to consider and notes the PR template item 5b requirement. **Never blocks** — pure awareness layer.

Mechanism — \`.claude/settings.json\` is auto-loaded by Claude Code, so this is zero-config per developer once merged. To make the file shareable (while keeping the rest of \`.claude/\` ignored), \`.gitignore\` was updated from \`.claude/\` to \`.claude/*\` with an explicit \`!.claude/settings.json\` allowlist.

Closes #: N/A — defensive automation, no issue filed.

## 2. Files affected

- \`.claude/settings.json\` — new. Registers the PreToolUse hook.
- \`scripts/claude-hooks/pretooluse-loadbearing.sh\` — new (executable). Hook implementation.
- \`.gitignore\` — modified. \`.claude/\` → \`.claude/*\` + \`!.claude/settings.json\` so the shared config can be committed while \`settings.local.json\` / worktrees / transcripts stay ignored.
- \`CLAUDE.md\` — modified. "Automation surface" line updated to include \`.claude/settings.json\`.
- \`docs/engineering-governance.md\` — modified. "Local hook setup" section restructured into git-hooks (opt-in) + Claude Code hook (auto-loaded) subsections.

**No load-bearing files touched** (\`rag_core.py\`, \`ingestion.py\`, \`visual_ingestion.py\`, \`eval/\`, \`api/\`, \`docs/adr/\` all untouched). Hook only adds awareness; doesn't modify the pipeline.

## 3. Risks

**False positives** — hook warns on edits that don't actually need ADR review (e.g., a typo fix in \`eval/config.yaml\` comment). Mitigation: warning is informational; Claude can read and ignore if irrelevant. Cost is a few extra stderr lines per qualifying edit, not a workflow block.

**False negatives** — hook misses a load-bearing edit. Mitigation: regex array \`LOAD_BEARING_PATTERNS\` mirrors CLAUDE.md "Load-bearing files" list exactly. If CLAUDE.md adds another load-bearing path in the future, the hook regex needs the same update. Coupling is documented in the hook's header comment.

**JSON-parsing fragility** — hook parses tool input via Python (\`json.loads\`). Python3 is guaranteed in this repo (project requirement). Malformed JSON or missing \`tool_input.file_path\` → hook silently exits 0 (tested: edge cases 13-16).

**\`.gitignore\` change semantics** — switching \`.claude/\` to \`.claude/*\` was the only way to re-include a child file (git: "can't re-include a file if a parent directory is excluded"). Verified with \`git check-ignore -v\`:
- \`.claude/settings.json\` → matches \`!.claude/settings.json\` (NOT ignored ✓)
- \`.claude/settings.local.json\` → matches \`.claude/*\` (ignored ✓)
- \`.claude/worktrees/foo\` → matches \`.claude/*\` (ignored ✓)

## 4. Tests

No Python regression test added (same rationale as the pre-commit hook PR: bash hook testing from pytest is disproportionate to a ~60-line shell script).

**Manual verification — 16 cases, all PASS:**

| Group | Test | Expected |
|---|---|---|
| Load-bearing | \`rag_core.py\` | warn |
| Load-bearing | \`ingestion.py\` | warn |
| Load-bearing | \`visual_ingestion.py\` | warn |
| Load-bearing | \`eval/config.yaml\` | warn |
| Load-bearing | \`eval/run_eval.py\` (Write tool) | warn |
| Load-bearing | \`api/main.py\` (MultiEdit tool) | warn |
| Load-bearing | \`docs/adr/0001-foo.md\` | warn |
| Non-load-bearing | \`README.md\` | silent |
| Non-load-bearing | \`CLAUDE.md\` | silent |
| Non-load-bearing | \`scripts/build_index.py\` | silent |
| Non-load-bearing | \`docs/api-demo.md\` | silent |
| Non-load-bearing | \`tests/test_foo.py\` | silent |
| Edge | missing \`tool_input\` | silent + exit 0 |
| Edge | missing \`file_path\` | silent + exit 0 |
| Edge | empty stdin | silent + exit 0 |
| Edge | malformed JSON | silent + exit 0 |

Each case piped simulated tool-call JSON to the hook and asserted on exit code + stderr presence. Reproduce with:

\`\`\`bash
printf '{"tool_name":"Edit","tool_input":{"file_path":"/abs/rag_core.py"}}' \\
  | bash scripts/claude-hooks/pretooluse-loadbearing.sh
\`\`\`

## 5. Eval impact

Expected: all \`·\`. No code path affecting retrieval / answer / eval / api was touched.

### 5b. Real-data delta

N/A — no behavior change in retrieval / verifier path. None of the load-bearing files was modified. (Meta note: this PR ironically adds the hook that would have reminded me of this section.)

## 6. Backward compatibility

- \`.claude/settings.json\` is auto-loaded by Claude Code — no per-developer activation step. Developers not using Claude Code are unaffected.
- \`.gitignore\` change is semantically equivalent for everything except \`settings.json\`: previously ignored, now tracked. No existing files moved from "tracked" to "ignored" or vice versa (verified with \`git check-ignore\`).
- No CLI / schema / answer-contract changes.

## 7. Out of scope

Deferred:

- Skills at \`.claude/skills/\`: \`write-adr\` (referencing \`docs/adr/_template.md\`), \`regression-test\` (referencing \`tests/test_retrieval_loop_regression.py\` pattern). Now possible to commit since \`.claude/skills/\` could be allowlisted similarly — but adding the allowlist + writing two skills is its own concern.
- pre-push hook policy hardening (stays soft per earlier decision).
- Automated hook test script (\`scripts/test_hooks.sh\`) covering all three hooks together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)