### PR TITLE
Enforce issue-linked branch naming as required CI check (ADR 0007)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,16 +3,48 @@
 #
 # Activate per-developer with:
 #   git config core.hooksPath .githooks
+#   (or: make install-hooks)
 #
-# Behavior: if the commits about to be pushed touch retrieval /
-# verifier / eval / api paths, remind the contributor to attach a
-# real-data eval delta to the PR (see CLAUDE.md pre-PR checklist
-# item 5b). Non-fatal — prints a warning, exits 0.
+# Behavior (two checks, in order):
 #
-# Skip with `git push --no-verify` only if you have a documented
+# 1. Branch name + issue convention (ADR 0007) — HARD-FAILS the push
+#    if the current branch does not match <type>/issue-<N>[-<slug>].
+#    If `gh` is installed and authed, also verifies issue #N exists.
+#    Mirror of the CI check `.github/workflows/branch-and-issue-check.yml`.
+#
+# 2. Real-data eval delta reminder — SOFT-WARNS (exits 0) if the push
+#    touches retrieval / verifier / eval / api paths without a
+#    real-data delta, per CLAUDE.md pre-PR checklist item 5b.
+#
+# Skip both with `git push --no-verify` only if you have a documented
 # reason (e.g. doc-only follow-up of a measured PR).
 
 set -u
+
+# ---------------------------------------------------------------------------
+# 1. Branch name + issue convention (ADR 0007).
+# ---------------------------------------------------------------------------
+
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ -n "$current_branch" && "$current_branch" != "HEAD" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    if ! python3 scripts/check_branch_and_issue.py \
+           --branch "$current_branch" --check-issue; then
+      cat >&2 <<EOF
+
+   Bypass (only with a documented reason):
+       git push --no-verify
+
+EOF
+      exit 1
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Real-data eval delta reminder (existing behavior, unchanged).
+# ---------------------------------------------------------------------------
+
 
 # Watch-list: files whose change implies a real-data delta is owed.
 WATCH_PATTERNS=(

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Something in the pipeline produced the wrong answer, failed, or regressed.
+title: "[bug] "
+labels: bug
+---
+
+<!--
+Per ADR 0007, every PR must be linked to an issue. Open this first;
+your branch will be `fix/issue-<N>-<slug>` once this issue is filed.
+-->
+
+## What happened
+
+<!-- The shortest concrete reproduction. Include the query, the expected
+answer, and the observed answer (or stack trace). -->
+
+## Expected behavior
+
+<!-- What the answer / log / output should have been, and which doc /
+ADR / test makes that the expected baseline. -->
+
+## Suggested next step
+
+<!-- One sentence: where you'd start looking. Filename + line if you
+can. Useful even if you don't intend to take the fix yourself. -->
+
+## Surface
+
+<!-- Tick one. Most bugs live in exactly one. -->
+
+- [ ] Ingestion (`ingestion.py`, `visual_ingestion.py`)
+- [ ] Retrieval / verifier / answer (`rag_core.py`)
+- [ ] Eval / metrics (`eval/`)
+- [ ] API demo (`api/`)
+- [ ] Docs / governance
+- [ ] Other:

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,46 @@
+---
+name: Feature / enhancement
+about: A new capability or improvement to an existing one.
+title: "[feat] "
+labels: enhancement
+---
+
+<!--
+Per ADR 0007, every PR must be linked to an issue. Open this first;
+your branch will be `feat/issue-<N>-<slug>` once this issue is filed.
+-->
+
+## Motivation
+
+<!-- What user-visible / reviewer-visible problem does this solve?
+Link to a failure taxonomy entry, ADR, or prior PR if applicable. -->
+
+## Proposed scope
+
+<!-- Bulleted list of the smallest change that delivers the motivation.
+"One PR, one concern" — if this needs more than ~3 bullets,
+consider splitting into multiple issues. -->
+
+## Out of scope
+
+<!-- What this issue is deliberately NOT going to touch. Helps the
+implementer resist "while I'm here" scope creep (CLAUDE.md). -->
+
+## Acceptance signal
+
+<!-- How the reviewer will know it's done. A metric, a test name, a
+demo command, or an artifact. If it's RAG-related, name the eval
+metric you'd expect to move (or "No behavior change in retrieval /
+verifier path" for governance-only work). -->
+
+## Surface
+
+<!-- Tick all that apply, but the implementer's PR will declare a
+single PR concern. -->
+
+- [ ] Ingestion (`ingestion.py`, `visual_ingestion.py`)
+- [ ] Retrieval / verifier / answer (`rag_core.py`)
+- [ ] Eval / metrics (`eval/`)
+- [ ] API demo (`api/`)
+- [ ] Docs / governance
+- [ ] Other:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,12 @@ If a section truly doesn't apply, write "N/A" with a one-line reason — don't d
 
 ## 1. What changed and why
 
-<!-- One paragraph. Link the issue. -->
+<!--
+One paragraph. The `Closes #N` below is **required** (ADR 0007) and
+must match the issue number in your branch name (e.g. branch
+`feat/issue-79-foo` → `Closes #79`). The Branch & Issue Convention CI
+check will block merge if missing or mismatched.
+-->
 
 Closes #
 

--- a/.github/workflows/branch-and-issue-check.yml
+++ b/.github/workflows/branch-and-issue-check.yml
@@ -1,0 +1,41 @@
+name: Branch & Issue Convention
+
+# Enforces ADR 0007: every PR must come from a branch named
+# `<type>/issue-<N>[-<slug>]` AND have `Closes #N` in its body
+# matching the branch's issue number. The referenced issue must
+# exist in this repo.
+#
+# Fast (~15s, no checkout). Should be set as a required status
+# check on `main` after one green run.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  branch-and-issue:
+    name: Validate branch name + issue link
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/check_branch_and_issue.py
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python scripts/check_branch_and_issue.py --pr ${{ github.event.pull_request.number }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,14 @@ Pipeline: ingestion → metadata normalization → chunking → retrieval →
 reranking/planning → evidence aggregation → grounded answer → verification →
 evaluation → reviewer-facing docs.
 
-Automation surface: `.gitignore`, CI (`pr-eval.yml`), `.githooks/`,
+Automation surface: `.gitignore`,
+CI ([`pr-eval.yml`](.github/workflows/pr-eval.yml),
+[`branch-and-issue-check.yml`](.github/workflows/branch-and-issue-check.yml)),
+`.githooks/`,
+[`scripts/check_branch_and_issue.py`](scripts/check_branch_and_issue.py)
+(single-source regex for branch + issue convention, ADR 0007),
 [`.github/pull_request_template.md`](.github/pull_request_template.md),
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/),
 [`.claude/settings.json`](.claude/settings.json) (PreToolUse awareness hook
 for load-bearing edits). This file captures the principles and pointers
 that aren't auto-enforced.
@@ -40,6 +46,7 @@ Supporting:
 
 ## Core principles
 
+- **Issue first; convention-matched branch.** Every PR must reference an issue (`Closes #N` in body) and its branch must match `<type>/issue-<N>[-<slug>]` (ADR 0007). The CI workflow `branch-and-issue-check.yml` enforces both at PR time.
 - **Reuse over invent.** Inspect existing implementation before coding. Search for reusable utilities first.
 - **One PR, one concern.** Out-of-scope fixes → separate issue / follow-up PR.
 - **Behavior change ↔ test change.** Behavior change without a test is presumed accidental. Regression tests go in `tests/test_*_regression.py` (pattern: `tests/test_retrieval_loop_regression.py`).
@@ -55,8 +62,10 @@ important — the synthetic CI delta alone missed #69's intended-abstention regr
 
 ## Frequently used commands
 
+- `make install-hooks` — one-time per clone: activates `.githooks/` (pre-commit ADR 0005 boundary, pre-push branch/eval checks).
 - `make smoke` — quick sanity check (few minutes, `EMBEDDING_BACKEND=hashing`).
 - `bash scripts/test.sh` — `pytest -q`; same as the CI gate.
+- `make check-branch` — ad-hoc validation of the current branch against ADR 0007.
 - `make real-eval` + `make real-eval-delta` — private 100-doc eval; required when load-bearing files change.
 - Latency numbers come from `reports/eval_summary.json` `stage_latency` block — not ad-hoc measurement.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge clean
+.PHONY: setup install-hooks check-branch index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -7,6 +7,18 @@ ACTIVATE = . $(VENV)/bin/activate
 setup:
 	$(PYTHON) -m venv $(VENV)
 	$(ACTIVATE) && pip install -r requirements.txt
+
+# One-time per clone: activate the opt-in git hooks in .githooks/
+# (pre-commit ADR 0005 boundary, pre-push branch/eval checks).
+install-hooks:
+	git config core.hooksPath .githooks
+	@echo "Activated .githooks/ for this clone. See docs/engineering-governance.md §Hook setup."
+
+# Ad-hoc validation of the current branch against ADR 0007.
+# Useful before opening a PR; mirrors the CI check.
+check-branch:
+	$(PYTHON) scripts/check_branch_and_issue.py \
+	  --branch "$$(git rev-parse --abbrev-ref HEAD)" --check-issue
 
 index:
 	$(PYTHON) scripts/build_index.py --input_dir data/raw --output_dir data/index

--- a/docs/adr/0007-issue-linked-branch-naming.md
+++ b/docs/adr/0007-issue-linked-branch-naming.md
@@ -1,0 +1,142 @@
+# 0007: Issue-linked branch naming as a required check
+
+- **Status**: accepted
+- **Date**: 2026-05-11
+- **Related**: extends [`docs/engineering-governance.md`](../engineering-governance.md) §"Change lifecycle"; supersedes the informal `claude/<auto>` worktree naming pattern
+- **Deciders**: hskim
+
+## Context
+
+Until now the repo had no enforced linkage between work and a tracking issue:
+
+- The PR template carries a `Closes #` placeholder under §1, but nothing
+  validates it ([`.github/pull_request_template.md`](../../.github/pull_request_template.md)).
+- Branch names in `git branch -a` are a mix of `claude/issue-<N>-<slug>`,
+  `claude/<adj>-<name>-<hash>` (auto-named worktrees), and a few legacy
+  `feat/<N>-<slug>` shapes. The convention is observable from history but
+  not stated as a rule.
+- `engineering-governance.md` step 1 ("Open or pick an issue") is a soft
+  instruction. PRs can be merged without an issue number anywhere.
+
+Consequence: traceability gaps. A reviewer cannot grep `Closes #123` to
+find the PR that closed an issue if the link was never recorded. Worse,
+the `claude/<auto>` worktree pattern actively obscures whether an issue
+exists at all — the branch name encodes random words, not intent.
+
+The new rule below makes the link required and machine-checked at the
+PR boundary.
+
+## Decision
+
+Every PR merged to `main` must satisfy three conditions, enforced by a
+new CI workflow `.github/workflows/branch-and-issue-check.yml`:
+
+1. **Branch name matches the convention:**
+   ```
+   ^(?:feat|fix|docs|chore|refactor|test|ci|perf|build|style)/issue-(\d+)(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?$
+   ```
+   - Prefix is one of the conventional-commit types listed above.
+     **`claude/` is rejected** — Claude Code's auto-named worktree
+     branches must be renamed before opening a PR.
+   - `issue-<N>` is mandatory; the slug after it is optional but
+     recommended for human readability.
+   - Examples: `feat/issue-79-senior-positioning`, `fix/issue-104`.
+
+2. **The referenced issue exists** in this repo (state — open or closed
+   — is not checked; follow-up branches can legitimately reference a
+   closed issue).
+
+3. **The PR body contains `Closes #N` (or `Fixes` / `Resolves`)** and
+   at least one of those numbers equals the branch's `<N>`. This is
+   the same regex GitHub uses to auto-close issues on merge, so the
+   check piggybacks on existing UX.
+
+The regex, issue check, and `Closes`-matching all live in a single
+script — [`scripts/check_branch_and_issue.py`](../../scripts/check_branch_and_issue.py)
+— used by both the CI workflow (`--pr <N>`) and the local
+[`.githooks/pre-push`](../../.githooks/pre-push) hook (`--branch <name>`).
+No regex duplication, no drift.
+
+### Exemptions
+
+The following branch prefixes skip the check (they have no tracking
+issue by construction):
+
+- `revert-*` — GitHub auto-generated revert branches.
+- `dependabot/*` — Dependabot PRs.
+- `renovate/*` — Renovate PRs.
+- `pre-commit-ci/*` — pre-commit autoupdate PRs.
+
+### Enforcement layers
+
+| Layer | When | Bypassable? | What it checks |
+|---|---|---|---|
+| CI (`branch-and-issue-check.yml`) | every `pull_request` to `main` | **No** (required status check) | branch regex + issue exists + `Closes #N` matches |
+| Local `.githooks/pre-push` | `git push` (opt-in via `make install-hooks`) | `--no-verify` | branch regex + (if `gh` installed) issue exists |
+
+CI is the contract. The local hook is a fast-feedback mirror for
+developers who have run `make install-hooks`.
+
+## Consequences
+
+**Wins**
+
+- Every merged PR is issue-traceable. `git log --grep '#'` finds the
+  whole change set for an issue, and the GitHub UI auto-closes the
+  issue on merge.
+- Branch names encode intent (`feat/issue-79-…` says what kind of work
+  this is and what it tracks) rather than random words.
+- The PR template's `Closes #` placeholder becomes a contract instead
+  of a hint — reviewers know it will block merge if missing.
+- CI gate cannot be silently bypassed; the local hook gives instant
+  feedback for developers who opt in.
+
+**Costs**
+
+- **Claude Code's default worktree branch name (`claude/<adj>-<name>-<hash>`)
+  will be rejected.** Contributors must rename before opening a PR
+  (`git branch -m feat/issue-<N>-<slug>`). This is one rename per
+  branch, paid at branch creation rather than commit time.
+- One extra workflow run per PR. Fast (~15s, no checkout of code).
+- Bots (Dependabot, Renovate) are exempted by prefix; their PRs are
+  trusted.
+- Some legitimate work (small typo fixes, doc-only follow-ups) now
+  requires an issue first. We accept this friction in exchange for
+  uniform traceability.
+
+**Constraints introduced**
+
+- The script `scripts/check_branch_and_issue.py` is the single source
+  of truth for the regex. Future tweaks (allowed prefixes, exemptions,
+  slug shape) edit that file and the corresponding test
+  `tests/test_branch_convention.py` — never duplicate the regex in
+  the CI workflow or the hook.
+- Branch protection on `main` should mark *"Branch & Issue Convention"*
+  as a required status check **after** the workflow has run green on
+  one known-good PR and red on a deliberate probe.
+
+## Alternatives considered
+
+- **Keep `claude/issue-<N>-<slug>` allowed and just reject the
+  auto-name pattern.** Rejected: the user explicitly opted to drop the
+  `claude/` prefix in favor of conventional-commit types. This also
+  aligns branch names with commit-message conventions and makes the
+  branch list scan like a categorized changelog (`feat/`, `fix/`,
+  `docs/` are immediately legible).
+- **Allow `epic/<slug>` as an issue-less exception for multi-issue
+  work.** Rejected: an epic is itself a tracking issue. Forcing the
+  epic-issue number into the branch name (e.g.
+  `feat/issue-<epic-N>-multi-doc-retrieval`) is a small price for
+  uniformity.
+- **Enforce only in the local hook, not in CI.** Rejected: the existing
+  hooks are opt-in (`git config core.hooksPath .githooks`). Without CI,
+  any contributor who hasn't run `make install-hooks` silently bypasses
+  the rule. CI is the only universal surface.
+- **Validate the issue *body* (e.g. require a checklist).** Rejected as
+  scope creep. This ADR is about traceability, not about issue
+  hygiene. Issue templates ([`.github/ISSUE_TEMPLATE/`](../../.github/ISSUE_TEMPLATE/))
+  encourage hygiene without enforcing it.
+- **Cross-check `Closes #N` without matching the branch's `<N>`.**
+  Rejected: a PR that says `Closes #50` but lives on `feat/issue-49-…`
+  is almost certainly a mistake — either the branch was reused or the
+  body was copy-pasted from a sibling PR. The match catches this.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,3 +69,4 @@ project record.
 | [0004](./0004-verifier-retry-policy.md) | accepted | Verifier-driven retry with strict → relaxed staging |
 | [0005](./0005-eval-split-public-synthetic-private-local.md) | accepted | Eval split: public synthetic vs private local |
 | [0006](./0006-llm-judge-on-real-data-only.md) | accepted | LLM-judge on the real-data surface only (refines 0004) |
+| [0007](./0007-issue-linked-branch-naming.md) | accepted | Issue-linked branch naming as a required check |

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -25,17 +25,24 @@ If you are new to the repo or onboarding a reviewer, start here.
 The expected flow for any non-trivial change, written as a checklist
 a contributor (human or AI) can walk through:
 
-1. **Open or pick an issue.** Real-data failure taxonomy entries
-   (`docs/real-data-failure-taxonomy.md`) and the prioritized backlog
-   are the primary feed.
+1. **Open or pick an issue. (Required, ADR 0007.)** Real-data failure
+   taxonomy entries (`docs/real-data-failure-taxonomy.md`) and the
+   prioritized backlog are the primary feed. Use the templates in
+   [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/). The
+   branch + PR are required to reference this issue number; the
+   convention check (CI) will block merge otherwise.
 2. **Decide if it needs an ADR.** Use the criteria in
    [`docs/adr/README.md`](./adr/README.md). Most changes do **not**;
    when in doubt, ask in the issue.
 3. **Inspect what exists.** Per `CLAUDE.md` ("Before coding,
    inspect..."). Name the files you read, the functions you intend
    to reuse, and what you found that surprised you.
-4. **Branch + worktree if parallel.** Two independent tracks → two
-   worktrees, two PRs. Coupled tracks → one PR, one branch.
+4. **Branch + worktree if parallel.** Name the branch
+   `<type>/issue-<N>[-<slug>]` per ADR 0007 — e.g.
+   `feat/issue-79-senior-positioning`. Claude Code's default
+   worktree names (`claude/<auto>`) must be renamed before the PR
+   (`git branch -m feat/issue-<N>-<slug>`). Two independent tracks
+   → two worktrees, two PRs. Coupled tracks → one PR, one branch.
 5. **Make the change.** Reuse over invent. One concern per PR.
 6. **Add or update tests.** Behavior change without a test is
    presumed accidental. Regressions get a guard test in
@@ -46,9 +53,12 @@ a contributor (human or AI) can walk through:
 8. **Push, open PR.** PR body fills in
    [`.github/pull_request_template.md`](../.github/pull_request_template.md)
    (what / files / risks / tests / eval impact / back-compat / out-of-scope).
-9. **CI verifies.** `Pytest` job + `Eval delta vs base` job. The
-   delta job upserts a comment with the metrics table; expect `·`
-   across the board for non-RAG changes.
+9. **CI verifies.** Three checks run on every PR:
+   - `Pytest` (in `pr-eval.yml`).
+   - `Eval delta vs base` (in `pr-eval.yml`) — upserts a comment with
+     the metrics table; expect `·` across the board for non-RAG changes.
+   - `Validate branch name + issue link` (in `branch-and-issue-check.yml`,
+     ADR 0007) — enforces the convention. Required status check.
 10. **Address review.** No mid-review scope creep — open a follow-up
     issue instead.
 11. **Merge.** Squash-merge, delete the branch, remove the worktree
@@ -134,6 +144,8 @@ without duplicating their content.
 
 Activate:
 
+    make install-hooks
+    # or equivalently:
     git config core.hooksPath .githooks
 
 This enables two hooks under `.githooks/`:
@@ -145,11 +157,18 @@ This enables two hooks under `.githooks/`:
   that the hook's allowlist missed — and fix the allowlist in the same
   change.
 
-- **`pre-push`** — **soft-warns** when a push touches retrieval / verifier /
-  eval / api paths, reminding you to attach `make real-eval-delta` to the
-  PR (PR template item 5b). Exits 0 — never blocks. Skip with `git push
-  --no-verify` only with a documented reason (e.g. doc-only follow-up of
-  a measured PR).
+- **`pre-push`** — two checks:
+  1. **Branch + issue convention (ADR 0007)** — **hard-fails** if the
+     current branch doesn't match `<type>/issue-<N>[-<slug>]`. Mirror of
+     the CI check so violations surface before push round-trip. If `gh`
+     is installed and authed, also verifies issue #N exists.
+  2. **Real-data eval reminder** — **soft-warns** when a push touches
+     retrieval / verifier / eval / api paths, reminding you to attach
+     `make real-eval-delta` to the PR (PR template item 5b). Exits 0 —
+     never blocks.
+
+  Skip both with `git push --no-verify` only with a documented reason
+  (e.g. doc-only follow-up of a measured PR).
 
 ### Claude Code hook (auto-loaded, no setup)
 

--- a/scripts/check_branch_and_issue.py
+++ b/scripts/check_branch_and_issue.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Validate branch naming convention and PR-issue linkage (ADR 0007).
+
+Single source of truth for the regex. Called from two places:
+
+- `.githooks/pre-push` (local) → `--branch <name> --check-issue`
+- `.github/workflows/branch-and-issue-check.yml` (CI) → `--pr <number>`
+
+Exit codes:
+    0  ok (or exempt)
+    1  convention violation (printed to stderr)
+    2  internal error (e.g. `gh` unavailable in --pr mode)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Optional
+
+
+BRANCH_REGEX = re.compile(
+    r"^(?:feat|fix|docs|chore|refactor|test|ci|perf|build|style)"
+    r"/issue-(\d+)(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?$"
+)
+
+EXEMPT_REGEX = re.compile(r"^(?:revert-|dependabot/|renovate/|pre-commit-ci/)")
+
+CLOSES_REGEX = re.compile(r"(?i)\b(?:closes|fixes|resolves)\s+#(\d+)\b")
+
+ALLOWED_PREFIXES = "feat, fix, docs, chore, refactor, test, ci, perf, build, style"
+
+
+def _err(msg: str) -> None:
+    sys.stderr.write(msg)
+    if not msg.endswith("\n"):
+        sys.stderr.write("\n")
+
+
+def _branch_violation_msg(branch: str) -> str:
+    return (
+        f"\n❌ Branch name '{branch}' violates the convention (ADR 0007).\n"
+        f"   Required: <type>/issue-<N>[-<kebab-slug>]\n"
+        f"   Allowed types: {ALLOWED_PREFIXES}.\n"
+        f"   Examples: feat/issue-79-senior-positioning, fix/issue-104.\n"
+        f"   Rename: git branch -m <new-name>\n"
+        f"   See docs/adr/0007-issue-linked-branch-naming.md\n"
+    )
+
+
+def parse_branch(branch: str) -> Optional[int]:
+    """Return the issue number if the branch matches the convention.
+
+    Returns None if the branch is in the exempt list (bot / revert
+    branches that never have a corresponding issue).
+    Raises ValueError if the branch is non-exempt and non-matching;
+    the caller decides how to report this.
+    """
+    if EXEMPT_REGEX.match(branch):
+        return None
+    m = BRANCH_REGEX.match(branch)
+    if not m:
+        raise ValueError(branch)
+    return int(m.group(1))
+
+
+def gh_available() -> bool:
+    try:
+        subprocess.run(
+            ["gh", "--version"], capture_output=True, check=True
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def get_repo_slug() -> Optional[str]:
+    """Determine the GitHub repo slug (owner/name) from env or `gh`."""
+    if r := os.environ.get("GITHUB_REPOSITORY"):
+        return r
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner",
+             "-q", ".nameWithOwner"],
+            capture_output=True, text=True, check=True,
+        )
+        slug = result.stdout.strip()
+        return slug or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def issue_exists(repo: str, n: int) -> bool:
+    """Return True if issue (or PR — same numbering space) N exists in repo."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/issues/{n}"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def check_branch_mode(branch: str, check_issue: bool) -> int:
+    try:
+        issue_n = parse_branch(branch)
+    except ValueError:
+        _err(_branch_violation_msg(branch))
+        return 1
+    if issue_n is None:
+        return 0
+    if not check_issue:
+        return 0
+    if not gh_available():
+        _err(
+            "ℹ️  `gh` CLI not installed — skipping issue-existence check locally.\n"
+            "    CI will still verify the issue exists.\n"
+        )
+        return 0
+    repo = get_repo_slug()
+    if not repo:
+        _err("ℹ️  Could not determine repo slug — skipping issue-existence check.\n")
+        return 0
+    if not issue_exists(repo, issue_n):
+        _err(
+            f"\n❌ Branch references issue #{issue_n}, but that issue does not exist in {repo}.\n"
+            f"   Open one at https://github.com/{repo}/issues/new/choose\n"
+            f"   or rename the branch to reference an existing issue.\n"
+        )
+        return 1
+    return 0
+
+
+def check_pr_mode(pr_number: int) -> int:
+    if not gh_available():
+        _err("❌ `gh` CLI is required in --pr mode but is not available.\n")
+        return 2
+    repo = get_repo_slug()
+    if not repo:
+        _err("❌ Could not determine repo slug (set GITHUB_REPOSITORY).\n")
+        return 2
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--repo", repo,
+             "--json", "headRefName,body,number"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        _err(f"❌ Could not fetch PR #{pr_number}: {e.stderr}\n")
+        return 2
+    pr = json.loads(result.stdout)
+    branch = pr["headRefName"]
+    body = pr.get("body") or ""
+
+    try:
+        issue_n = parse_branch(branch)
+    except ValueError:
+        _err(_branch_violation_msg(branch))
+        return 1
+    if issue_n is None:
+        sys.stdout.write(
+            f"Branch '{branch}' is exempt from the convention check (bot / revert).\n"
+        )
+        return 0
+    if not issue_exists(repo, issue_n):
+        _err(
+            f"\n❌ Branch '{branch}' references issue #{issue_n}, "
+            f"but that issue does not exist in {repo}.\n"
+            f"   Open one at https://github.com/{repo}/issues/new/choose\n"
+            f"   or rename the branch to reference an existing issue.\n"
+        )
+        return 1
+    matches = CLOSES_REGEX.findall(body)
+    if not matches:
+        _err(
+            f"\n❌ PR body must contain `Closes #{issue_n}` (or `Fixes` / `Resolves`).\n"
+            f"   The branch references issue #{issue_n}; the PR body must record\n"
+            f"   the linkage too so GitHub auto-closes the issue on merge.\n"
+        )
+        return 1
+    if str(issue_n) not in matches:
+        joined = ", #".join(matches)
+        _err(
+            f"\n❌ PR body has Closes #{joined} but branch references issue #{issue_n}.\n"
+            f"   At least one Closes/Fixes/Resolves must match the branch's issue number.\n"
+        )
+        return 1
+    sys.stdout.write(
+        f"OK: branch '{branch}' references issue #{issue_n}; "
+        f"PR body has matching Closes link.\n"
+    )
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Validate branch + issue convention (ADR 0007).",
+    )
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--branch", help="Branch name to validate (local mode).")
+    g.add_argument("--pr", type=int, help="PR number to validate (CI mode).")
+    p.add_argument(
+        "--check-issue", action="store_true",
+        help="In --branch mode, also verify the referenced issue exists via gh.",
+    )
+    args = p.parse_args()
+
+    if args.branch is not None:
+        return check_branch_mode(args.branch, args.check_issue)
+    return check_pr_mode(args.pr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_branch_convention.py
+++ b/tests/test_branch_convention.py
@@ -1,0 +1,105 @@
+"""Regex tests for branch naming convention + Closes-#N parsing (ADR 0007).
+
+The regexes live in `scripts/check_branch_and_issue.py` (single source of
+truth used by both `.githooks/pre-push` and `.github/workflows/
+branch-and-issue-check.yml`). We import them here so any future change
+to the convention forces a corresponding test update.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR / "scripts"))
+
+import check_branch_and_issue as cbi  # noqa: E402
+
+
+@pytest.mark.parametrize("name", [
+    "feat/issue-79-senior-positioning",
+    "feat/issue-104-mermaid-diagram",
+    "fix/issue-87",
+    "fix/issue-87-trailing-slug",
+    "docs/issue-130-pre-commit-hook",
+    "chore/issue-150-update-deps",
+    "refactor/issue-12-extract-helper",
+    "test/issue-50-regression",
+    "ci/issue-100-add-workflow",
+    "perf/issue-66-cache-embeddings",
+    "build/issue-200",
+    "style/issue-1-format",
+])
+def test_branch_regex_accepts_conventional(name):
+    assert cbi.BRANCH_REGEX.match(name), f"expected accept: {name}"
+
+
+@pytest.mark.parametrize("name", [
+    "claude/issue-79-foo",
+    "claude/epic-saha-0d9d25",
+    "claude/agitated-shirley-dfa25e",
+    "feat/79-foo",
+    "feat/issue-abc-foo",
+    "feat/issue--foo",
+    "feature/issue-1-foo",
+    "main",
+    "develop",
+    "fix-something",
+    "feat/issue-1-WithUpperCase",
+    "feat/issue-1-with_underscore",
+    "feat/ISSUE-1-foo",
+    "feat/issue-1-trailing-",
+    "",
+])
+def test_branch_regex_rejects_off_pattern(name):
+    assert not cbi.BRANCH_REGEX.match(name), f"expected reject: {name!r}"
+
+
+@pytest.mark.parametrize("name", [
+    "revert-123-old-branch",
+    "dependabot/pip/requests-2.31.0",
+    "renovate/python-3.x",
+    "pre-commit-ci/update-config",
+])
+def test_exempt_regex_matches_bot_branches(name):
+    assert cbi.EXEMPT_REGEX.match(name), f"expected exempt: {name}"
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("feat/issue-79-foo", 79),
+    ("fix/issue-104", 104),
+    ("revert-123-old", None),
+    ("dependabot/pip/x", None),
+])
+def test_parse_branch_returns_issue_number(name, expected):
+    assert cbi.parse_branch(name) == expected
+
+
+@pytest.mark.parametrize("name", [
+    "claude/issue-1-foo",
+    "main",
+    "feat/no-issue",
+])
+def test_parse_branch_raises_on_violation(name):
+    with pytest.raises(ValueError):
+        cbi.parse_branch(name)
+
+
+@pytest.mark.parametrize("body,expected", [
+    ("Closes #42", ["42"]),
+    ("closes #1, fixes #2", ["1", "2"]),
+    ("Resolves #99\n\nMore text", ["99"]),
+    ("Closes #5.", ["5"]),
+    ("CLOSES #7", ["7"]),
+    ("No issue ref here", []),
+    ("Closes#5", []),
+    ("Will close #5", []),
+    ("discloses #5", []),
+    ("", []),
+])
+def test_closes_regex_finds_issue_refs(body, expected):
+    assert cbi.CLOSES_REGEX.findall(body) == expected


### PR DESCRIPTION
## 1. What changed and why

Introduce a layered enforcement of issue-linked branch naming + PR-body cross-check per ADR 0007. Every PR to `main` must now come from a `<type>/issue-<N>[-<slug>]` branch and have a matching `Closes #N` in the body. CI is the required gate; `.githooks/pre-push` is a fast-feedback local mirror.

Closes #132

## 2. Files affected

**Load-bearing (per CLAUDE.md):**
- `docs/adr/0007-issue-linked-branch-naming.md` (new)

**Other:**
- `scripts/check_branch_and_issue.py` (new) — single-source regex + verifier (used by both CI and the hook).
- `.github/workflows/branch-and-issue-check.yml` (new) — CI workflow.
- `.githooks/pre-push` — extended with branch check (hard-fail).
- `.github/ISSUE_TEMPLATE/{bug,feature}.md` (new).
- `.github/pull_request_template.md` — `Closes #` is now mandatory with cross-check note.
- `tests/test_branch_convention.py` (new) — 48 unit tests.
- `CLAUDE.md`, `docs/engineering-governance.md`, `docs/adr/README.md`, `Makefile`.

## 3. Risks

**Most likely break:** the regex rejects a legitimate-looking branch name. Mitigation: `tests/test_branch_convention.py` has an explicit accept/reject matrix including grandfathered patterns (`claude/`, `feat/<N>`, `claude/epic-*`), so any future widening is a deliberate test change.

**Secondary:** the CI check needs `gh api` to verify issue existence. Auth uses the auto-provided `GITHUB_TOKEN`; the workflow declares explicit `issues: read` permission.

**Self-check:** the introducing PR itself satisfies the new convention — branch `feat/issue-132-enforce-branch-convention` and `Closes #132` above. The new workflow should run green on its own PR.

## 4. Tests

- New `tests/test_branch_convention.py` covers 48 cases (12 accept, 15 reject, 4 exempt, 4 `parse_branch` returns, 3 `parse_branch` raises, 10 `Closes` regex). Imports the regex constants from the script directly so any future regex tweak forces a corresponding test update.
- Full suite: `python -m pytest -q` → **187 passed** locally.

## 5. Eval impact

All `·` — no RAG-code change.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

**Breaking for in-flight work:** existing branches that don't match the new regex (e.g. `claude/<auto>` worktree branches) must be renamed before opening a PR against `main`. Already-merged branches are not re-scanned (CI fires only on `pull_request`).

The required-status-check toggle in branch protection should be flipped **after** this PR merges (and after a known-bad probe PR confirms the red path), not by this PR. ADR 0007 §Migration documents the sequence.

## 7. Out of scope

- Validating issue body content / enforcing issue-template usage.
- Auto-installing `.githooks/` on `make setup` (kept opt-in via `make install-hooks`).
- A `commit-msg` hook to validate commit-message style.