### PR TITLE
agent: make MAX_AGENT_ITERATIONS cap explicit + iterations aggregate

### DIFF
--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -16,6 +16,7 @@ if str(ROOT_DIR) not in sys.path:
 
 from rag_core import (
     DEFAULT_CLI_PIPELINE_NAME,
+    MAX_AGENT_ITERATIONS,
     load_index,
     percentile,
     rate,
@@ -968,6 +969,17 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
             "mean_retry_count": rate([float(count) for count in retry_counts]),
             "max_retry_count": max(retry_counts) if retry_counts else 0,
             "cases_with_retry": sum(1 for count in retry_counts if count > 0),
+        },
+        "iterations": {
+            "cap": MAX_AGENT_ITERATIONS,
+            "mean_used": rate([float(count + 1) for count in retry_counts]),
+            "max_used": (max(retry_counts) + 1) if retry_counts else 0,
+            "cases_at_cap": sum(
+                1 for count in retry_counts if count + 1 >= MAX_AGENT_ITERATIONS
+            ),
+            "pct_at_cap": rate(
+                [float(count + 1 >= MAX_AGENT_ITERATIONS) for count in retry_counts]
+            ),
         },
         "retry_reason_counts": dict(sorted(retry_reason_counts.items())),
         "citation_grounding_error_counts": dict(sorted(citation_grounding_error_counts.items())),

--- a/rag_core.py
+++ b/rag_core.py
@@ -28,6 +28,13 @@ DEFAULT_CHUNK_MAX_CHARS = 520
 DEFAULT_CHUNK_OVERLAP_SENTENCES = 1
 VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
 VALID_RETRIEVAL_MODES = {"flat", "hierarchical"}
+
+# Hard cap on the per-query agent loop. ``metadata_stage_sequence`` today
+# returns at most ["strict", "reduced", "relaxed"] (3 stages). This constant
+# pins the contract — any future addition to the stage list that pushes
+# past 3 must update this value and explain why in the PR description.
+MAX_AGENT_ITERATIONS = 3
+
 DEFAULT_CLI_PIPELINE_NAME = "naive_baseline"
 DEFAULT_RAG_PIPELINE_NAME = "agentic_full"
 PIPELINE_CONFIG_KEYS = (
@@ -3381,6 +3388,12 @@ def run_rag_query(
         metadata_first=metadata_first,
         verifier_retry=verifier_retry,
     )
+    if len(stage_sequence) > MAX_AGENT_ITERATIONS:
+        raise RuntimeError(
+            f"stage_sequence length {len(stage_sequence)} exceeds "
+            f"MAX_AGENT_ITERATIONS={MAX_AGENT_ITERATIONS}; "
+            "update MAX_AGENT_ITERATIONS and revisit the loop contract."
+        )
     stage_attempts = []
     retry_count = 0
     plan: dict[str, Any] = {}

--- a/tests/test_retrieval_loop_regression.py
+++ b/tests/test_retrieval_loop_regression.py
@@ -17,7 +17,12 @@ slowing down the dev loop. See ``make test-regression``.
 import unittest
 from pathlib import Path
 
-from rag_core import build_index_payload, run_rag_query
+from rag_core import (
+    MAX_AGENT_ITERATIONS,
+    build_index_payload,
+    metadata_stage_sequence,
+    run_rag_query,
+)
 
 
 ANSWERABLE_QUERY = "기관 A의 보안 통제 요구사항은?"
@@ -74,6 +79,57 @@ class RetrievalLoopRegressionTest(unittest.TestCase):
         self.assertEqual(0, diagnostics["retry_count"])
         self.assertIsInstance(diagnostics["final_relaxation_reason"], list)
         self.assertEqual([], diagnostics["final_relaxation_reason"])
+
+    def test_stage_sequence_never_exceeds_cap(self) -> None:
+        """Explicit-cap invariant (PR-02).
+
+        ``metadata_stage_sequence`` is the only producer of ``stage_sequence``.
+        Across all relevant analysis shapes it must stay within
+        ``MAX_AGENT_ITERATIONS``; otherwise the loop guard in
+        ``run_rag_query`` would raise.
+        """
+        analyses = [
+            {},
+            {"metadata_filters_by_stage": {"strict": {"agency": "기관 A"}}},
+            {
+                "metadata_filters_by_stage": {
+                    "strict": {"agency": "기관 A"},
+                    "reduced": {"agency": "기관"},
+                }
+            },
+        ]
+        for analysis in analyses:
+            for metadata_first in (True, False):
+                for verifier_retry in (True, False):
+                    with self.subTest(
+                        analysis=analysis,
+                        metadata_first=metadata_first,
+                        verifier_retry=verifier_retry,
+                    ):
+                        seq = metadata_stage_sequence(
+                            analysis,
+                            metadata_first=metadata_first,
+                            verifier_retry=verifier_retry,
+                        )
+                        self.assertGreaterEqual(len(seq), 1)
+                        self.assertLessEqual(len(seq), MAX_AGENT_ITERATIONS)
+
+    def test_iteration_cap_constant_matches_observed_max(self) -> None:
+        """Sanity: the published cap is at least the observed worst case."""
+        # Comparison + strict + reduced + verifier_retry exercises the longest
+        # sequence today (strict, reduced, relaxed = 3 stages).
+        seq = metadata_stage_sequence(
+            {
+                "metadata_filters_by_stage": {
+                    "strict": {"agency": "기관 A"},
+                    "reduced": {"agency": "기관"},
+                }
+            },
+            metadata_first=True,
+            verifier_retry=True,
+        )
+        self.assertLessEqual(len(seq), MAX_AGENT_ITERATIONS)
+        self.assertGreaterEqual(MAX_AGENT_ITERATIONS, len(seq))
 
     def test_out_of_corpus_query_exits_loop_without_indexerror(self) -> None:
         """R1 guard for the retry/abstention path.


### PR DESCRIPTION
## Summary
- Introduces \`MAX_AGENT_ITERATIONS = 3\` constant in \`rag_core.py\` to pin the per-query loop cap that was previously only implicit (via \`metadata_stage_sequence\` length)
- Fail-fast guard: \`RuntimeError\` if \`len(stage_sequence) > MAX_AGENT_ITERATIONS\` (no-op today; protects against future growth)
- New \`iterations\` aggregate per slice in \`reports/eval_summary.json\` — \`cap\` / \`mean_used\` / \`max_used\` / \`cases_at_cap\` / \`pct_at_cap\`
- Two new tests in \`test_retrieval_loop_regression.py\`: matrix coverage + worst-case anchor

Closes #137

## 1. What changed and why
A reviewer asking "what is the cap on this agent's iterations?" should not have to read \`metadata_stage_sequence\` to figure out the answer. Naming the cap makes the contract explicit and the failure mode (raising rather than looping) catches regressions.

The \`iterations\` aggregate also surfaces a metric reviewers want: how often does the agent actually retry vs. converge on the first stage? Currently 0% in the \`naive_baseline\` and \`full\` runs on the public synthetic corpus, but useful telemetry for harder corpora.

## 2. Files affected
**Load-bearing (per CLAUDE.md):** \`rag_core.py\`, \`eval/run_eval.py\`. Real-data delta not required because the guard is no-op for any currently-producible stage_sequence (max length is 3 today).
**Other:** \`tests/test_retrieval_loop_regression.py\` (+2 tests / 12 subtests).

## 3. Risks
None — the guard raises only on a contract violation that can't happen today (max stage_sequence length is 3, cap is 3). Aggregate is additive.

## 4. Tests
\`python -m pytest -q\` → 189 passed locally, including the new matrix walk.

## 5. Eval impact
No primary metric change. \`reports/eval_summary.json\` gains a new \`iterations\` block per slice / per ablation.

### 5b. Real-data delta
N/A — no-op equivalence on every currently producible stage_sequence (verified by the matrix test).

## 6. Backward compatibility
- ADR 0003 contract unchanged.
- \`schema_version\` not bumped.
- Downstream eval consumers see a new \`iterations\` block (additive, ignorable).

## 7. Out of scope
- Lowering the cap (would be a behavior change; needs separate proposal).
- Adding the same explicit cap inside \`metadata_stage_sequence\` (the guard at the loop entry is sufficient single-point enforcement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)