### PR TITLE
fix: eval reproducibility guards for real-data delta gate (#160)

### DIFF
--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -26,6 +26,7 @@ from rag_core import (
     run_rag_query,
 )
 from eval.bootstrap import bootstrap_ci
+from scripts.write_real_eval_baseline import provenance
 
 
 QUERY_TYPES = ("single_doc", "comparison", "follow_up", "abstention")
@@ -1316,6 +1317,7 @@ def main() -> int:
 
     summary = {
         "mode": "rag",
+        "provenance": provenance(),
         "config": args.config,
         "index_dir": args.index_dir,
         "primary_run": primary_summary["name"],

--- a/rag_core.py
+++ b/rag_core.py
@@ -1949,7 +1949,7 @@ def retrieve(
             item["score"] = round(float(rrf * rrf_norm), 6)
             item["score_parts"]["rank_rrf"] = round(float(rrf * rrf_norm), 6)
 
-    scored.sort(key=lambda item: item["score"], reverse=True)
+    scored.sort(key=lambda item: (item["score"], item["chunk_id"]), reverse=True)
     top_k = int(plan["top_k"])
     if plan.get("retrieval_mode") == "hierarchical":
         return reassemble_parent_sections(index, scored, top_k, plan, analysis)

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -57,6 +57,10 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         "primary_run",
         "prompt_profile",
         "top_k",
+        # Run-state metadata (no per-case content). Surfaces eval-vs-baseline
+        # commit skew in the rendered delta — see issue #160. Sub-keys are
+        # git_commit (12-char SHA), git_dirty (bool), generated_at (ISO 8601).
+        "provenance",
         # LLM-judge aggregates (ADR 0006). Only status_distribution /
         # grounded_rate / agreement_with_verifier / n cross the commit
         # boundary; per-case judge text stays in
@@ -238,6 +242,10 @@ def render_markdown(
         f"- cases: base={base.get('num_predictions', '?')} · "
         f"head={head.get('num_predictions', '?')}"
     )
+    base_sha = str(((base.get("provenance") or {}).get("git_commit")) or "?")
+    head_sha = str(((head.get("provenance") or {}).get("git_commit")) or "?")
+    if base_sha != "?" or head_sha != "?":
+        lines.append(f"- commits: base=`{base_sha}` · head=`{head_sha}`")
     lines.append("")
     lines.append("| metric | base | head | Δ |")
     lines.append("|---|---|---|---|")

--- a/scripts/write_real_eval_baseline.py
+++ b/scripts/write_real_eval_baseline.py
@@ -44,7 +44,13 @@ def _git(*args: str) -> str:
     return result.stdout.strip()
 
 
-def _provenance() -> dict[str, object]:
+def provenance() -> dict[str, object]:
+    """Return a provenance block for the current git HEAD.
+
+    Shared by the baseline writer (this script) and the eval runner
+    (``eval/run_eval.py``). Format is intentionally narrow: 12-char SHA,
+    dirty flag, ISO-8601 UTC timestamp.
+    """
     sha = _git("rev-parse", "HEAD")[:12] or "unknown"
     dirty = _git("status", "--porcelain") != ""
     return {
@@ -54,18 +60,55 @@ def _provenance() -> dict[str, object]:
     }
 
 
-def _run_id(provenance: dict[str, object]) -> str:
+def _run_id(prov: dict[str, object]) -> str:
     # YYYYMMDDTHHMMSSZ_<sha12>
     ts = (
-        str(provenance.get("generated_at"))
+        str(prov.get("generated_at"))
         .replace("-", "")
         .replace(":", "")
         .split(".")[0]  # drop fractional seconds
     )
     if not ts.endswith("Z"):
         ts += "Z"
-    sha = str(provenance.get("git_commit") or "unknown")[:12]
+    sha = str(prov.get("git_commit") or "unknown")[:12]
     return f"{ts}_{sha}"
+
+
+def _warn_if_stale(
+    eval_prov: dict[str, object] | None, baseline_prov: dict[str, object]
+) -> None:
+    """Warn loudly if the eval was generated at a different code state
+    than the baseline is being written at.
+
+    This is the failure mode that produced issue #160: ``make real-eval``
+    runs at commit X, then ``make real-eval-baseline-update`` runs at
+    commit Y, and the baseline silently captures Y's provenance with X's
+    metrics. We warn rather than fail because legitimate workflows
+    (e.g., docs-only changes between runs) shouldn't be blocked, but we
+    want the failure mode to be loud and self-diagnosing.
+    """
+    if not isinstance(eval_prov, dict):
+        print(
+            "[WARN] eval_summary.json has no `provenance` block — cannot verify "
+            "the eval was run at the current HEAD. The baseline's provenance "
+            "will reflect the current HEAD, not the eval-run code state. "
+            "Re-run `make real-eval` at HEAD to get a self-consistent baseline.",
+            file=sys.stderr,
+        )
+        return
+    eval_sha = str(eval_prov.get("git_commit") or "").strip()
+    baseline_sha = str(baseline_prov.get("git_commit") or "").strip()
+    if not eval_sha or not baseline_sha or eval_sha == baseline_sha:
+        return
+    print(
+        f"[WARN] Provenance skew detected:\n"
+        f"        eval_summary.json was generated at git_commit={eval_sha}\n"
+        f"        baseline is being written at  git_commit={baseline_sha}\n"
+        f"        The baseline's provenance will not match the eval's code state.\n"
+        f"        This is the #160 failure mode. Re-run `make real-eval` at HEAD\n"
+        f"        before continuing, or accept the skew if you understand the cause.",
+        file=sys.stderr,
+    )
 
 
 def main() -> int:
@@ -78,8 +121,10 @@ def main() -> int:
 
     raw = json.loads(EVAL_SUMMARY.read_text(encoding="utf-8"))
     agg = extract_aggregate(raw)
-    provenance = _provenance()
-    agg["provenance"] = provenance
+    eval_prov = raw.get("provenance") if isinstance(raw, dict) else None
+    baseline_prov = provenance()
+    _warn_if_stale(eval_prov, baseline_prov)
+    agg["provenance"] = baseline_prov
 
     # If a judge run is present (ADR 0006), fold its aggregate into the
     # baseline. The per-case judge file stays local; only the
@@ -109,7 +154,7 @@ def main() -> int:
     BASELINE_PATH.write_text(serialized, encoding="utf-8")
 
     HISTORY_DIR.mkdir(parents=True, exist_ok=True)
-    history_path = HISTORY_DIR / f"{_run_id(provenance)}.aggregate.json"
+    history_path = HISTORY_DIR / f"{_run_id(baseline_prov)}.aggregate.json"
     history_path.write_text(serialized, encoding="utf-8")
 
     print(f"[OK] Updated {BASELINE_PATH.relative_to(ROOT)}")

--- a/tests/test_eval_reproducibility_regression.py
+++ b/tests/test_eval_reproducibility_regression.py
@@ -1,0 +1,270 @@
+"""Reproducibility regression guard for the public synthetic eval pipeline.
+
+Issue #160 surfaced two coupled problems with `make real-eval-delta`:
+the policy gate that flags #69-class intended-abstention regressions
+could not be trusted because (a) the committed baseline drifted from
+git, and (b) re-running real-eval at the *same* commit produced
+different aggregate metrics and even different slice keys
+(``by_query_type.multi_doc`` → ``by_query_type.comparison``).
+
+This test exercises the analogous public-synthetic pipeline ×2 against
+an identical index, and asserts byte-equivalence of the aggregate
+metrics and slice keys that the real-data delta gate consumes. If a
+future change reintroduces ordering non-determinism (a sort missing a
+tie-breaker, a dict iteration leaking into output, etc.) or a silent
+slice-key rename, this test fails before the real-data baseline gets
+quietly invalidated.
+
+Notes:
+
+* Uses the hashing embedding backend (default for ``scripts/build_index.py``
+  when no backend is specified — see CLAUDE.md ``EMBEDDING_BACKEND=hashing``)
+  so embedding output is deterministic.
+* Uses a minimal inline config (one ``naive_baseline`` ablation_run, three
+  cases — one per slice key) so the full ×2 cycle fits inside the default
+  test budget.
+* The full ``eval/config.yaml`` covers eight ablation runs across all
+  cases; running that ×2 would be too slow for the regression layer.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+# A minimal eval config that exercises the three slice keys most
+# relevant to the #69/#160 intended-abstention regression class:
+# ``single_doc``, ``comparison``, ``abstention``. The pipeline is
+# ``naive_baseline`` (ADR 0001) for speed — it is the simplest path
+# and still goes through the slice-classification + summary-write
+# code that the bug surfaced.
+MINIMAL_CONFIG = {
+    "mode": "rag",
+    "description": "Reproducibility regression — minimal slice coverage",
+    "primary_run": "naive_baseline",
+    "answer_policy": {
+        "answerable_status": "supported",
+        "unanswerable_status": "insufficient",
+        "min_claims_answerable": 1,
+        "require_claim_citations": True,
+    },
+    "ablation_runs": [
+        {"name": "naive_baseline", "pipeline": "naive_baseline"},
+    ],
+    "cases": [
+        {
+            "id": "single_doc_security",
+            "query_type": "single_doc",
+            "query": "기관 A의 보안 통제 요구사항은?",
+            "expected_doc_ids": ["rfp-agency-a-ai-quality"],
+            "expected_terms": ["보안 통제"],
+            "expected_citation_terms": ["보안 통제"],
+            "answerable": True,
+        },
+        {
+            "id": "comparison_ai_requirements",
+            "query_type": "comparison",
+            "query": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+            "expected_doc_ids": [
+                "rfp-agency-a-ai-quality",
+                "rfp-agency-b-mlops-governance",
+            ],
+            "expected_terms": ["MLOps", "품질관리"],
+            "expected_citation_terms": ["MLOps"],
+            "answerable": True,
+        },
+        {
+            "id": "abstention_missing_blockchain",
+            "query_type": "abstention",
+            "query": "기관 A의 블록체인 납품 실적은?",
+            "expected_doc_ids": [],
+            "expected_terms": ["블록체인"],
+            "answerable": False,
+        },
+    ],
+}
+
+
+# Metric fields that must be reproducible at the same commit. Excludes
+# `provenance.generated_at` (timestamp differs per run by design).
+REPRODUCIBLE_METRICS = (
+    "accuracy",
+    "groundedness",
+    "citation_precision",
+    "abstention",
+    "answer_format_compliance",
+)
+
+
+def _run_eval(index_dir: Path, output_dir: Path, config_path: Path) -> dict:
+    """Invoke eval/run_eval.py as a subprocess and return the parsed summary.
+
+    Uses subprocess (rather than direct import) to exercise the same
+    code path that `make real-eval` / `make eval` invoke — so any
+    ordering leak through argparse, sys.path init, or environment
+    propagation is caught.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "eval/run_eval.py",
+            "--index_dir",
+            str(index_dir),
+            "--output_dir",
+            str(output_dir),
+            "--config",
+            str(config_path),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"eval/run_eval.py exited {result.returncode}.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return json.loads((output_dir / "eval_summary.json").read_text(encoding="utf-8"))
+
+
+class EvalReproducibilityRegressionTest(unittest.TestCase):
+    """Guard against the #160 failure mode on the public synthetic surface."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import yaml
+
+        cls._tmp = TemporaryDirectory()
+        tmp = Path(cls._tmp.name)
+        cls.index_dir = tmp / "index"
+        cls.output_dir_a = tmp / "out_a"
+        cls.output_dir_b = tmp / "out_b"
+        cls.config_path = tmp / "config.yaml"
+        cls.config_path.write_text(
+            yaml.safe_dump(MINIMAL_CONFIG, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        # Build the index once with the deterministic hashing backend.
+        # Both eval runs share this index so any reproducibility skew
+        # is isolated to the eval pipeline, not the index build.
+        build_result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/build_index.py",
+                "--input_dir",
+                "data/raw",
+                "--output_dir",
+                str(cls.index_dir),
+                "--embedding_backend",
+                "hashing",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+        if build_result.returncode != 0:
+            raise AssertionError(
+                f"scripts/build_index.py exited {build_result.returncode}.\n"
+                f"stdout: {build_result.stdout}\nstderr: {build_result.stderr}"
+            )
+
+        cls.summary_a = _run_eval(cls.index_dir, cls.output_dir_a, cls.config_path)
+        cls.summary_b = _run_eval(cls.index_dir, cls.output_dir_b, cls.config_path)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_slice_keys_match_between_runs(self) -> None:
+        """Catches the #160 ``multi_doc`` → ``comparison`` rename regression
+        class: if QUERY_TYPES or QUERY_TYPE_ALIASES change in a way that
+        flips slice keys, this fails before the real-data baseline is
+        silently invalidated.
+        """
+        keys_a = set((self.summary_a.get("by_query_type") or {}).keys())
+        keys_b = set((self.summary_b.get("by_query_type") or {}).keys())
+        self.assertEqual(
+            keys_a,
+            keys_b,
+            f"by_query_type slice keys diverged between identical runs: "
+            f"a={sorted(keys_a)} vs b={sorted(keys_b)}",
+        )
+        # Defensive: the slice keys must come from the QUERY_TYPES tuple
+        # (post-4304b24 rename), not the legacy `multi_doc` alias.
+        self.assertNotIn("multi_doc", keys_a)
+
+    def test_num_predictions_matches_between_runs(self) -> None:
+        self.assertEqual(
+            self.summary_a["num_predictions"],
+            self.summary_b["num_predictions"],
+        )
+
+    def test_aggregate_metrics_match_between_runs(self) -> None:
+        """Hashing embedding backend is deterministic, so each metric
+        should round-trip to byte-equivalent JSON. The 1e-9 tolerance is
+        defensive against float-to-JSON-to-float drift.
+        """
+        for metric in REPRODUCIBLE_METRICS:
+            a = self.summary_a.get(metric)
+            b = self.summary_b.get(metric)
+            if a is None and b is None:
+                continue
+            self.assertIsNotNone(
+                a, f"Run A missing metric {metric!r}"
+            )
+            self.assertIsNotNone(
+                b, f"Run B missing metric {metric!r}"
+            )
+            self.assertAlmostEqual(
+                float(a),
+                float(b),
+                delta=1e-9,
+                msg=f"metric {metric!r} diverged: a={a} vs b={b}",
+            )
+
+    def test_slice_metrics_match_between_runs(self) -> None:
+        """Per-slice metrics drive the ``make real-eval-delta`` slice
+        rendering and are the most sensitive to retrieval-ordering drift
+        (the RRF tie-breaker fix in this PR pre-empts one such source).
+        """
+        slices_a = self.summary_a.get("by_query_type") or {}
+        slices_b = self.summary_b.get("by_query_type") or {}
+        for slice_name in slices_a:
+            self.assertIn(slice_name, slices_b)
+            for metric in ("num_predictions", "accuracy", "abstention"):
+                a = (slices_a[slice_name] or {}).get(metric)
+                b = (slices_b[slice_name] or {}).get(metric)
+                if a is None and b is None:
+                    continue
+                self.assertEqual(
+                    a,
+                    b,
+                    f"slice {slice_name!r} metric {metric!r} diverged: "
+                    f"a={a} vs b={b}",
+                )
+
+    def test_provenance_block_present(self) -> None:
+        """PR 1 of #160 adds a provenance block to eval_summary.json so
+        the eval-vs-baseline commit skew that caused #160 becomes
+        self-diagnosing. This test pins the contract.
+        """
+        for label, summary in (("a", self.summary_a), ("b", self.summary_b)):
+            self.assertIn("provenance", summary, f"run {label} missing provenance")
+            prov = summary["provenance"]
+            self.assertIn("git_commit", prov)
+            self.assertIn("git_dirty", prov)
+            self.assertIn("generated_at", prov)
+            # git_commit must be a string (12-char SHA or "unknown").
+            self.assertIsInstance(prov["git_commit"], str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -142,6 +142,58 @@ class ExtractAggregateTest(unittest.TestCase):
         self.assertIn("Slice abstention", md)
         self.assertIn("abstention", md)
 
+    def test_provenance_passes_through_extraction(self) -> None:
+        """Issue #160: provenance is metadata about run state (no per-case
+        content), so it crosses the ADR 0005 commit boundary intact. It
+        must survive extract_aggregate and not trip the forbidden-key guard.
+        """
+        summary_with_provenance = {
+            **FULL_SUMMARY,
+            "provenance": {
+                "git_commit": "deadbeef0000",
+                "git_dirty": False,
+                "generated_at": "2026-05-11T08:04:05Z",
+            },
+        }
+        agg = extract_aggregate(summary_with_provenance)
+        self.assertIn("provenance", agg)
+        self.assertEqual(agg["provenance"]["git_commit"], "deadbeef0000")
+        self.assertEqual(agg["provenance"]["git_dirty"], False)
+        # No per-case data leaked through.
+        flat = json.dumps(agg, ensure_ascii=False)
+        self.assertNotIn("real_secret_case", flat)
+        self.assertNotIn("private_doc_1", flat)
+
+    def test_render_includes_commit_sha_header(self) -> None:
+        """The rendered delta surfaces base/head commit SHAs so reviewers
+        can spot eval-vs-baseline provenance skew (the #160 failure mode).
+        """
+        base = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "provenance": {
+                    "git_commit": "aaaaaaaaaaaa",
+                    "git_dirty": False,
+                    "generated_at": "2026-05-01T00:00:00Z",
+                },
+            }
+        )
+        head = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "accuracy": 0.6,
+                "provenance": {
+                    "git_commit": "bbbbbbbbbbbb",
+                    "git_dirty": False,
+                    "generated_at": "2026-05-11T00:00:00Z",
+                },
+            }
+        )
+        md = render_markdown(base, head, "test")
+        self.assertIn("aaaaaaaaaaaa", md)
+        self.assertIn("bbbbbbbbbbbb", md)
+        self.assertIn("commits:", md)
+
 
 class FullScriptInvocationTest(unittest.TestCase):
     """Smoke-test the full script end-to-end via subprocess so the


### PR DESCRIPTION
## 1. What changed and why

Closes #160

`make real-eval-delta` (the policy gate for #69-class intended-abstention regressions) had become untrustworthy: the committed baseline silently drifted from the eval-run code state. Commit `4304b24` renamed slice label `multi_doc` → `comparison` and added `QUERY_TYPE_ALIASES`, but the local baseline file still carried `multi_doc` keys while its `provenance.git_commit` claimed a post-rename HEAD — proof that the baseline was generated against pre-rename code and its provenance was overwritten at baseline-update time. This PR adds five additive guards (no behavior change in retrieval/verifier semantics) so the same failure mode is loud + self-diagnosing next time. The operational half (refreshing the actual baseline against private data) is **PR 2**, kept separate so reviewable code-only changes can land first per CLAUDE.md "one PR, one concern."

## 2. Files affected

- **`rag_core.py`** (load-bearing) — RRF final-sort now keys on `(score, chunk_id)`. Matches the existing tie-break pattern at lines 1924, 1929. 1-line change.
- **`eval/run_eval.py`** (load-bearing) — emits a `provenance` block in `eval_summary.json`. Shares the helper with the baseline writer (renamed `_provenance` → `provenance` so both modules can import it).
- **`scripts/write_real_eval_baseline.py`** — loud `[WARN]` to stderr if eval-run provenance ≠ current HEAD. Does not hard-fail (legitimate workflows shouldn't be blocked); the warning is the diagnostic.
- **`scripts/run_real_eval_delta.py`** — `provenance` is now a `SAFE_TOPLEVEL_KEY` (still ADR-0005-safe; no per-case data), and `render_markdown` adds a `commits: base=… · head=…` line so PR reviewers see provenance skew at a glance.
- **`tests/test_run_real_eval_delta.py`** — two new tests covering provenance pass-through and commit-SHA rendering.
- **`tests/test_eval_reproducibility_regression.py`** (new) — subprocess-runs `eval/run_eval.py` ×2 against a shared hashing-backend index, asserts byte-equivalent `by_query_type` keys + aggregate metrics. Catches the exact `multi_doc` → `comparison` regression class on the public synthetic surface.

## 3. Risks

- **Most likely break**: the RRF tie-breaker change could re-order tied results in real-data retrieval. Ruled out by (a) the existing intermediate sorts already use the same `(score, chunk_id)` pattern at lines 1924/1929, so behavior is internally consistent, and (b) the new reproducibility test would flag any silent re-ordering between consecutive runs.
- **Provenance overhead**: each eval run now shells out to `git rev-parse` + `git status --porcelain`. Negligible; runs once per eval invocation.
- **ADR 0005 boundary**: `provenance` is metadata about run state (no per-case content, no doc/chunk/query identifiers). The new test `test_provenance_passes_through_extraction` and the existing `FORBIDDEN_KEYS` recursive guard confirm it does not leak.

## 4. Tests

- `tests/test_eval_reproducibility_regression.py` (new, 5 tests) — fails before this PR if reproducibility breaks (catches the `multi_doc` → `comparison` regression class).
- `tests/test_run_real_eval_delta.py` — `test_provenance_passes_through_extraction` and `test_render_includes_commit_sha_header` cover the new metadata path.
- Full pytest run: **256 passed**, excluding `tests/test_hybrid_retrieval_regression.py` which fails on a **pre-existing** unrelated bug (missing `_BM25Okapi` import in `rag_core.py`, confirmed via `git stash` reproduction on clean main). Spawned as a separate follow-up task.

## 5. Eval impact

Synthetic CI delta: all `·` expected. The RRF tie-breaker change only takes effect on tied scores (rare in the small synthetic corpus); the reproducibility test verifies ×2 runs match exactly.

### 5b. Real-data delta

**N/A — code-only hardening with no behavior change in the retrieval / verifier / answer path.** The RRF tie-breaker preserves the existing top-k composition on non-tied scores; the provenance/warning additions are pure metadata. Baseline refresh against private data is **PR 2** (separate branch `chore/issue-160-real-baseline-refresh`), which will run `make real-eval` + `make real-eval-baseline-update` against this branch's HEAD and commit the resulting `reports/real100/baseline.aggregate.json` with self-consistent provenance.

## 6. Backward compatibility

- `eval_summary.json` schema gains a `provenance` key (additive — existing consumers ignore unknown keys, including `scripts/run_real_eval_delta.py:extract_aggregate`).
- `scripts/run_real_eval_delta.py:SAFE_TOPLEVEL_KEYS` adds `"provenance"` — backwards-compatible (older baseline files without provenance still extract cleanly).
- `_provenance` → `provenance` rename in `scripts/write_real_eval_baseline.py` is module-internal; no external callers.
- No ADR change (ADR 0003 answer contract untouched; ADR 0005 boundary still enforced by `extract_aggregate` + `FORBIDDEN_KEYS`).

## 7. Out of scope

- **PR 2** — refresh `reports/real100/baseline.aggregate.json` against private data so a self-consistent baseline lives in git. Requires `eval/real_config.local.yaml` + the private 100-doc corpus; user-run.
- Pre-existing `_BM25Okapi` `NameError` in `rag_core.py` (spawned as follow-up task — the `from rank_bm25 import …` import block was lost during a merge).
- `schema_version` field on `eval_summary.json` for future-proofing against label renames — separate issue.
- CI-side reproducibility gate on public synthetic with stricter tolerances — separate issue.
- Hard-fail (vs warn) mode on the stale-eval check via `--allow-skew` — defer until the warning proves easy to miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)