### PR TITLE
benchmark: add hybrid_bm25 row + retrieval_backend column to committed snapshot (#178)

### DIFF
--- a/benchmarks/ablations/rag_quality_axes.yaml
+++ b/benchmarks/ablations/rag_quality_axes.yaml
@@ -36,3 +36,10 @@ runs:
     rerank: true
     verifier_retry: false
     retrieval_mode: flat
+  - name: hybrid_bm25
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    retrieval_backend: hybrid

--- a/benchmarks/examples/private100_aggregate_manifest.example.json
+++ b/benchmarks/examples/private100_aggregate_manifest.example.json
@@ -28,6 +28,7 @@
       "rerank": true,
       "verifier_retry": true,
       "retrieval_mode": "flat",
+      "retrieval_backend": "dense",
       "prompt_profile": "private_text_v1"
     },
     "private100_visual_v2_full": {
@@ -37,6 +38,7 @@
       "rerank": true,
       "verifier_retry": true,
       "retrieval_mode": "hierarchical",
+      "retrieval_backend": "dense",
       "prompt_profile": "private_visual_v2"
     }
   },

--- a/benchmarks/registry.json
+++ b/benchmarks/registry.json
@@ -499,6 +499,11310 @@
           }
         }
       ]
+    },
+    {
+      "run_id": "public_synthetic_rfp_20260511T101606Z",
+      "generated_at": "2026-05-11T10:16:07.404473Z",
+      "git_commit": "3ee1796f2869cc8176fa99156d7e84316283cba1",
+      "git_dirty": true,
+      "suite_id": "public_synthetic_rfp",
+      "dataset_id": "public_synthetic_rfp_v1",
+      "ablation_suite_id": "rag_quality_axes",
+      "baseline_run": "naive_baseline",
+      "primary_run": "full",
+      "baseline_metrics": {
+        "num_predictions": 42,
+        "accuracy": 0.84375,
+        "groundedness": 0.7142857142857143,
+        "citation_precision": 0.5119047619047619,
+        "citation_page_precision": null,
+        "citation_region_precision": null,
+        "citation_grounding": null,
+        "answer_format_compliance": 0.6666666666666666,
+        "abstention": 0.3,
+        "retry": 0.0,
+        "latency": {
+          "p50": 1.4449999999999998,
+          "p95": 2.921499999999998,
+          "mean": 1.5716666666666668
+        },
+        "retry_cost": {
+          "total_retries": 0,
+          "mean_retry_count": 0.0,
+          "max_retry_count": 0,
+          "cases_with_retry": 0
+        },
+        "retry_reason_counts": {},
+        "citation_grounding_error_counts": {},
+        "by_hardcase_category": {
+          "alias_entity": {
+            "num_predictions": 2,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 0.5,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 0.5,
+                "ci_lo": 0.5,
+                "ci_hi": 0.5,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.5699999999999998,
+              "p95": 1.669,
+              "mean": 1.5699999999999998
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.635,
+                "p95": 0.6755,
+                "mean": 0.635,
+                "count": 2
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 2
+              },
+              "answer_generation_ms": {
+                "p50": 0.375,
+                "p95": 0.4065,
+                "mean": 0.375,
+                "count": 2
+              },
+              "retrieve_ms": {
+                "p50": 0.2,
+                "p95": 0.218,
+                "mean": 0.2,
+                "count": 2
+              },
+              "verify_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 2
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.5699999999999998,
+                "p95": 1.669,
+                "mean": 1.5699999999999998,
+                "count": 2
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "ambiguous_follow_up": {
+            "num_predictions": 3,
+            "accuracy": null,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": null,
+            "abstention": 1.0,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": null,
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": null,
+              "abstention": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 0.72,
+              "p95": 0.972,
+              "mean": 0.69
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.53,
+                "p95": 0.773,
+                "mean": 0.49333333333333335,
+                "count": 3
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.009,
+                "mean": 0.0033333333333333335,
+                "count": 3
+              },
+              "answer_generation_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              },
+              "retrieve_ms": {
+                "p50": null,
+                "p95": null,
+                "mean": null,
+                "count": 0
+              },
+              "verify_ms": {
+                "p50": null,
+                "p95": null,
+                "mean": null,
+                "count": 0
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 0.72,
+                "p95": 0.972,
+                "mean": 0.69,
+                "count": 3
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "answer_schema_v2": {
+            "num_predictions": 1,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 0.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.25,
+              "p95": 1.25,
+              "mean": 1.25
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.57,
+                "p95": 0.57,
+                "mean": 0.57,
+                "count": 1
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              },
+              "answer_generation_ms": {
+                "p50": 0.17,
+                "p95": 0.17,
+                "mean": 0.17,
+                "count": 1
+              },
+              "retrieve_ms": {
+                "p50": 0.18,
+                "p95": 0.18,
+                "mean": 0.18,
+                "count": 1
+              },
+              "verify_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.25,
+                "p95": 1.25,
+                "mean": 1.25,
+                "count": 1
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "chunk_boundary": {
+            "num_predictions": 3,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 2.35,
+              "p95": 2.8810000000000002,
+              "mean": 2.5233333333333334
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 1.39,
+                "p95": 1.8399999999999999,
+                "mean": 1.5,
+                "count": 3
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              },
+              "answer_generation_ms": {
+                "p50": 0.46,
+                "p95": 0.469,
+                "mean": 0.43,
+                "count": 3
+              },
+              "retrieve_ms": {
+                "p50": 0.19,
+                "p95": 0.217,
+                "mean": 0.20000000000000004,
+                "count": 3
+              },
+              "verify_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 2.35,
+                "p95": 2.8810000000000002,
+                "mean": 2.5233333333333334,
+                "count": 3
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "follow_up_context": {
+            "num_predictions": 1,
+            "accuracy": 0.0,
+            "groundedness": 0.0,
+            "citation_precision": 0.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": null,
+            "abstention": null,
+            "answer_format_compliance": 0.0,
+            "ci": {
+              "accuracy": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": null,
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 0.39,
+              "p95": 0.39,
+              "mean": 0.39
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.21,
+                "p95": 0.21,
+                "mean": 0.21,
+                "count": 1
+              },
+              "context_resolution_ms": {
+                "p50": 0.01,
+                "p95": 0.01,
+                "mean": 0.01,
+                "count": 1
+              },
+              "answer_generation_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              },
+              "retrieve_ms": {
+                "p50": null,
+                "p95": null,
+                "mean": null,
+                "count": 0
+              },
+              "verify_ms": {
+                "p50": null,
+                "p95": null,
+                "mean": null,
+                "count": 0
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 0.39,
+                "p95": 0.39,
+                "mean": 0.39,
+                "count": 1
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "noisy_entity": {
+            "num_predictions": 1,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 0.5,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 0.5,
+                "ci_lo": 0.5,
+                "ci_hi": 0.5,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.57,
+              "p95": 1.57,
+              "mean": 1.57
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.69,
+                "p95": 0.69,
+                "mean": 0.69,
+                "count": 1
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              },
+              "answer_generation_ms": {
+                "p50": 0.33,
+                "p95": 0.33,
+                "mean": 0.33,
+                "count": 1
+              },
+              "retrieve_ms": {
+                "p50": 0.19,
+                "p95": 0.19,
+                "mean": 0.19,
+                "count": 1
+              },
+              "verify_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.57,
+                "p95": 1.57,
+                "mean": 1.57,
+                "count": 1
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "one_sided_comparison": {
+            "num_predictions": 3,
+            "accuracy": 0.0,
+            "groundedness": 0.0,
+            "citation_precision": 0.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 0.0,
+            "ci": {
+              "accuracy": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "comparison_target_recall": {
+                "mean": 0.5,
+                "ci_lo": 0.5,
+                "ci_hi": 0.5,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "comparison_pool_recall": {
+                "mean": 0.8333333333333334,
+                "ci_lo": 0.5,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 2.11,
+              "p95": 2.875,
+              "mean": 2.2966666666666664
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 1.29,
+                "p95": 2.082,
+                "mean": 1.4833333333333334,
+                "count": 3
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              },
+              "answer_generation_ms": {
+                "p50": 0.17,
+                "p95": 0.179,
+                "mean": 0.15333333333333332,
+                "count": 3
+              },
+              "retrieve_ms": {
+                "p50": 0.21,
+                "p95": 0.219,
+                "mean": 0.21,
+                "count": 3
+              },
+              "verify_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 2.11,
+                "p95": 2.875,
+                "mean": 2.2966666666666664,
+                "count": 3
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {},
+            "comparison_target_recall": 0.5,
+            "comparison_target_full_coverage_rate": 0.0,
+            "comparison_pool_recall": 0.8333333333333334,
+            "comparison_pool_full_coverage_rate": 0.6666666666666666
+          },
+          "partial_comparison": {
+            "num_predictions": 1,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 0.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.25,
+              "p95": 1.25,
+              "mean": 1.25
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.57,
+                "p95": 0.57,
+                "mean": 0.57,
+                "count": 1
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              },
+              "answer_generation_ms": {
+                "p50": 0.17,
+                "p95": 0.17,
+                "mean": 0.17,
+                "count": 1
+              },
+              "retrieve_ms": {
+                "p50": 0.18,
+                "p95": 0.18,
+                "mean": 0.18,
+                "count": 1
+              },
+              "verify_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.25,
+                "p95": 1.25,
+                "mean": 1.25,
+                "count": 1
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "retrieval_hardening": {
+            "num_predictions": 5,
+            "accuracy": 0.75,
+            "groundedness": 0.8,
+            "citation_precision": 0.5,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": 1.0,
+            "answer_format_compliance": 0.8,
+            "ci": {
+              "accuracy": {
+                "mean": 0.75,
+                "ci_lo": 0.25,
+                "ci_hi": 1.0,
+                "n": 4,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 0.8,
+                "ci_lo": 0.4,
+                "ci_hi": 1.0,
+                "n": 5,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 0.5,
+                "ci_lo": 0.3,
+                "ci_hi": 0.8,
+                "n": 5,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "answer_format_compliance": {
+                "mean": 0.8,
+                "ci_lo": 0.4,
+                "ci_hi": 1.0,
+                "n": 5,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 5,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.46,
+              "p95": 1.658,
+              "mean": 1.0899999999999999
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.59,
+                "p95": 0.688,
+                "mean": 0.46399999999999997,
+                "count": 5
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.01,
+                "mean": 0.004,
+                "count": 5
+              },
+              "answer_generation_ms": {
+                "p50": 0.33,
+                "p95": 0.39599999999999996,
+                "mean": 0.21600000000000003,
+                "count": 5
+              },
+              "retrieve_ms": {
+                "p50": 0.19,
+                "p95": 0.217,
+                "mean": 0.19666666666666666,
+                "count": 3
+              },
+              "verify_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.46,
+                "p95": 1.658,
+                "mean": 1.0899999999999999,
+                "count": 5
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          }
+        }
+      },
+      "primary_metrics": {
+        "num_predictions": 42,
+        "accuracy": 0.90625,
+        "groundedness": 0.9285714285714286,
+        "citation_precision": 0.9047619047619048,
+        "citation_page_precision": null,
+        "citation_region_precision": null,
+        "citation_grounding": null,
+        "answer_format_compliance": 0.9047619047619048,
+        "abstention": 1.0,
+        "retry": 0.30952380952380953,
+        "latency": {
+          "p50": 1.375,
+          "p95": 2.984,
+          "mean": 1.5914285714285712
+        },
+        "retry_cost": {
+          "total_retries": 13,
+          "mean_retry_count": 0.30952380952380953,
+          "max_retry_count": 1,
+          "cases_with_retry": 13
+        },
+        "retry_reason_counts": {
+          "missing_comparison_topic:기관 A": 2,
+          "missing_comparison_topic:기관 B": 4,
+          "missing_comparison_topic:기관 D": 2,
+          "partial_topic_grounding": 3,
+          "topic_not_grounded": 19
+        },
+        "citation_grounding_error_counts": {},
+        "by_hardcase_category": {
+          "alias_entity": {
+            "num_predictions": 2,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 2,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.2,
+              "p95": 1.218,
+              "mean": 1.2
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.6,
+                "p95": 0.609,
+                "mean": 0.6,
+                "count": 2
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 2
+              },
+              "answer_generation_ms": {
+                "p50": 0.165,
+                "p95": 0.1695,
+                "mean": 0.165,
+                "count": 2
+              },
+              "retrieve_ms": {
+                "p50": 0.05,
+                "p95": 0.05,
+                "mean": 0.05,
+                "count": 2
+              },
+              "verify_ms": {
+                "p50": 0.095,
+                "p95": 0.0995,
+                "mean": 0.095,
+                "count": 2
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.2,
+                "p95": 1.218,
+                "mean": 1.2,
+                "count": 2
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "ambiguous_follow_up": {
+            "num_predictions": 3,
+            "accuracy": null,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": null,
+            "abstention": 1.0,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": null,
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": null,
+              "abstention": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 0.72,
+              "p95": 0.9359999999999999,
+              "mean": 0.6699999999999999
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.52,
+                "p95": 0.736,
+                "mean": 0.47333333333333333,
+                "count": 3
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.009,
+                "mean": 0.0033333333333333335,
+                "count": 3
+              },
+              "answer_generation_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              },
+              "retrieve_ms": {
+                "p50": null,
+                "p95": null,
+                "mean": null,
+                "count": 0
+              },
+              "verify_ms": {
+                "p50": null,
+                "p95": null,
+                "mean": null,
+                "count": 0
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 0.72,
+                "p95": 0.9359999999999999,
+                "mean": 0.6699999999999999,
+                "count": 3
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "answer_schema_v2": {
+            "num_predictions": 1,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.99,
+              "p95": 1.99,
+              "mean": 1.99
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.57,
+                "p95": 0.57,
+                "mean": 0.57,
+                "count": 1
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              },
+              "answer_generation_ms": {
+                "p50": 0.26,
+                "p95": 0.26,
+                "mean": 0.26,
+                "count": 1
+              },
+              "retrieve_ms": {
+                "p50": 0.145,
+                "p95": 0.1765,
+                "mean": 0.145,
+                "count": 2
+              },
+              "verify_ms": {
+                "p50": 0.235,
+                "p95": 0.2485,
+                "mean": 0.235,
+                "count": 2
+              }
+            },
+            "latency_by_retry_count": {
+              "1": {
+                "p50": 1.99,
+                "p95": 1.99,
+                "mean": 1.99,
+                "count": 1
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 1.0,
+            "retry_cost": {
+              "total_retries": 1,
+              "mean_retry_count": 1.0,
+              "max_retry_count": 1,
+              "cases_with_retry": 1
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 2.0,
+              "max_used": 2,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {
+              "missing_comparison_topic:기관 D": 2
+            },
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "chunk_boundary": {
+            "num_predictions": 3,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 2.44,
+              "p95": 2.827,
+              "mean": 2.49
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 1.46,
+                "p95": 1.775,
+                "mean": 1.46,
+                "count": 3
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              },
+              "answer_generation_ms": {
+                "p50": 0.46,
+                "p95": 0.469,
+                "mean": 0.43,
+                "count": 3
+              },
+              "retrieve_ms": {
+                "p50": 0.11,
+                "p95": 0.11,
+                "mean": 0.10333333333333333,
+                "count": 3
+              },
+              "verify_ms": {
+                "p50": 0.15,
+                "p95": 0.15,
+                "mean": 0.14666666666666667,
+                "count": 3
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 2.44,
+                "p95": 2.827,
+                "mean": 2.49,
+                "count": 3
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "follow_up_context": {
+            "num_predictions": 1,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.7,
+              "p95": 1.7,
+              "mean": 1.7
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 1.03,
+                "p95": 1.03,
+                "mean": 1.03,
+                "count": 1
+              },
+              "context_resolution_ms": {
+                "p50": 0.01,
+                "p95": 0.01,
+                "mean": 0.01,
+                "count": 1
+              },
+              "answer_generation_ms": {
+                "p50": 0.17,
+                "p95": 0.17,
+                "mean": 0.17,
+                "count": 1
+              },
+              "retrieve_ms": {
+                "p50": 0.07,
+                "p95": 0.07,
+                "mean": 0.07,
+                "count": 1
+              },
+              "verify_ms": {
+                "p50": 0.13,
+                "p95": 0.13,
+                "mean": 0.13,
+                "count": 1
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.7,
+                "p95": 1.7,
+                "mean": 1.7,
+                "count": 1
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "noisy_entity": {
+            "num_predictions": 1,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.19,
+              "p95": 1.19,
+              "mean": 1.19
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.61,
+                "p95": 0.61,
+                "mean": 0.61,
+                "count": 1
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              },
+              "answer_generation_ms": {
+                "p50": 0.17,
+                "p95": 0.17,
+                "mean": 0.17,
+                "count": 1
+              },
+              "retrieve_ms": {
+                "p50": 0.06,
+                "p95": 0.06,
+                "mean": 0.06,
+                "count": 1
+              },
+              "verify_ms": {
+                "p50": 0.09,
+                "p95": 0.09,
+                "mean": 0.09,
+                "count": 1
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.19,
+                "p95": 1.19,
+                "mean": 1.19,
+                "count": 1
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "one_sided_comparison": {
+            "num_predictions": 3,
+            "accuracy": 0.0,
+            "groundedness": 0.0,
+            "citation_precision": 0.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 0.0,
+            "ci": {
+              "accuracy": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "comparison_target_recall": {
+                "mean": 0.5,
+                "ci_lo": 0.5,
+                "ci_hi": 0.5,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "comparison_pool_recall": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 3,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 2.99,
+              "p95": 3.674,
+              "mean": 3.0700000000000003
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 1.29,
+                "p95": 2.055,
+                "mean": 1.4600000000000002,
+                "count": 3
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 3
+              },
+              "answer_generation_ms": {
+                "p50": 0.29,
+                "p95": 0.317,
+                "mean": 0.27666666666666667,
+                "count": 3
+              },
+              "retrieve_ms": {
+                "p50": 0.14500000000000002,
+                "p95": 0.20500000000000002,
+                "mean": 0.14333333333333334,
+                "count": 6
+              },
+              "verify_ms": {
+                "p50": 0.20500000000000002,
+                "p95": 0.2725,
+                "mean": 0.21166666666666667,
+                "count": 6
+              }
+            },
+            "latency_by_retry_count": {
+              "1": {
+                "p50": 2.99,
+                "p95": 3.674,
+                "mean": 3.0700000000000003,
+                "count": 3
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 1.0,
+            "retry_cost": {
+              "total_retries": 3,
+              "mean_retry_count": 1.0,
+              "max_retry_count": 1,
+              "cases_with_retry": 3
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 2.0,
+              "max_used": 2,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {
+              "missing_comparison_topic:기관 A": 2,
+              "missing_comparison_topic:기관 B": 4,
+              "partial_topic_grounding": 3,
+              "topic_not_grounded": 3
+            },
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {},
+            "comparison_target_recall": 0.5,
+            "comparison_target_full_coverage_rate": 0.0,
+            "comparison_pool_recall": 1.0,
+            "comparison_pool_full_coverage_rate": 1.0
+          },
+          "partial_comparison": {
+            "num_predictions": 1,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": null,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": null,
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.99,
+              "p95": 1.99,
+              "mean": 1.99
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.57,
+                "p95": 0.57,
+                "mean": 0.57,
+                "count": 1
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.0,
+                "mean": 0.0,
+                "count": 1
+              },
+              "answer_generation_ms": {
+                "p50": 0.26,
+                "p95": 0.26,
+                "mean": 0.26,
+                "count": 1
+              },
+              "retrieve_ms": {
+                "p50": 0.145,
+                "p95": 0.1765,
+                "mean": 0.145,
+                "count": 2
+              },
+              "verify_ms": {
+                "p50": 0.235,
+                "p95": 0.2485,
+                "mean": 0.235,
+                "count": 2
+              }
+            },
+            "latency_by_retry_count": {
+              "1": {
+                "p50": 1.99,
+                "p95": 1.99,
+                "mean": 1.99,
+                "count": 1
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 1.0,
+            "retry_cost": {
+              "total_retries": 1,
+              "mean_retry_count": 1.0,
+              "max_retry_count": 1,
+              "cases_with_retry": 1
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 2.0,
+              "max_used": 2,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {
+              "missing_comparison_topic:기관 D": 2
+            },
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          },
+          "retrieval_hardening": {
+            "num_predictions": 5,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "claim_citation_alignment": 1.0,
+            "abstention": 1.0,
+            "answer_format_compliance": 1.0,
+            "ci": {
+              "accuracy": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 4,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "groundedness": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 5,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_precision": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 5,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "citation_page_precision": null,
+              "citation_region_precision": null,
+              "citation_grounding": null,
+              "claim_citation_alignment": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 4,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "abstention": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 1,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "answer_format_compliance": {
+                "mean": 1.0,
+                "ci_lo": 1.0,
+                "ci_hi": 1.0,
+                "n": 5,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              },
+              "retry": {
+                "mean": 0.0,
+                "ci_lo": 0.0,
+                "ci_hi": 0.0,
+                "n": 5,
+                "num_resamples": 1000,
+                "alpha": 0.05
+              }
+            },
+            "latency": {
+              "p50": 1.19,
+              "p95": 1.6039999999999999,
+              "mean": 1.124
+            },
+            "stage_latency": {
+              "query_analysis_ms": {
+                "p50": 0.61,
+                "p95": 0.946,
+                "mean": 0.596,
+                "count": 5
+              },
+              "context_resolution_ms": {
+                "p50": 0.0,
+                "p95": 0.01,
+                "mean": 0.004,
+                "count": 5
+              },
+              "answer_generation_ms": {
+                "p50": 0.17,
+                "p95": 0.17,
+                "mean": 0.134,
+                "count": 5
+              },
+              "retrieve_ms": {
+                "p50": 0.055,
+                "p95": 0.0685,
+                "mean": 0.0575,
+                "count": 4
+              },
+              "verify_ms": {
+                "p50": 0.095,
+                "p95": 0.1255,
+                "mean": 0.10250000000000001,
+                "count": 4
+              }
+            },
+            "latency_by_retry_count": {
+              "0": {
+                "p50": 1.19,
+                "p95": 1.6039999999999999,
+                "mean": 1.124,
+                "count": 5
+              }
+            },
+            "cold_start_samples": {
+              "count": 0,
+              "latency_ms": null
+            },
+            "retry": 0.0,
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "iterations": {
+              "cap": 3,
+              "mean_used": 1.0,
+              "max_used": 1,
+              "cases_at_cap": 0,
+              "pct_at_cap": 0.0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "claim_citation_error_counts": {}
+          }
+        }
+      },
+      "delta": {
+        "accuracy": 0.0625,
+        "groundedness": 0.2142857142857143,
+        "citation_precision": 0.3928571428571429,
+        "citation_page_precision": null,
+        "citation_region_precision": null,
+        "citation_grounding": null,
+        "answer_format_compliance": 0.23809523809523814,
+        "abstention": 0.7,
+        "retry": 0.30952380952380953,
+        "latency_p95": 0.06250000000000178
+      },
+      "artifact_manifest": "artifacts/benchmarks/public_synthetic_rfp_20260511T101606Z/run_manifest.json",
+      "runs": [
+        {
+          "name": "full",
+          "flags": {
+            "pipeline": "agentic_full",
+            "top_k": null,
+            "metadata_first": true,
+            "rerank": true,
+            "verifier_retry": true,
+            "retrieval_mode": "flat",
+            "retrieval_backend": "dense",
+            "prompt_profile": "structured_grounded_claims"
+          },
+          "metrics": {
+            "num_predictions": 42,
+            "accuracy": 0.90625,
+            "groundedness": 0.9285714285714286,
+            "citation_precision": 0.9047619047619048,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "answer_format_compliance": 0.9047619047619048,
+            "abstention": 1.0,
+            "retry": 0.30952380952380953,
+            "latency": {
+              "p50": 1.375,
+              "p95": 2.984,
+              "mean": 1.5914285714285712
+            },
+            "retry_cost": {
+              "total_retries": 13,
+              "mean_retry_count": 0.30952380952380953,
+              "max_retry_count": 1,
+              "cases_with_retry": 13
+            },
+            "retry_reason_counts": {
+              "missing_comparison_topic:기관 A": 2,
+              "missing_comparison_topic:기관 B": 4,
+              "missing_comparison_topic:기관 D": 2,
+              "partial_topic_grounding": 3,
+              "topic_not_grounded": 19
+            },
+            "citation_grounding_error_counts": {},
+            "by_hardcase_category": {
+              "alias_entity": {
+                "num_predictions": 2,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.2,
+                  "p95": 1.218,
+                  "mean": 1.2
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.6,
+                    "p95": 0.609,
+                    "mean": 0.6,
+                    "count": 2
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.165,
+                    "p95": 0.1695,
+                    "mean": 0.165,
+                    "count": 2
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.05,
+                    "p95": 0.05,
+                    "mean": 0.05,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.095,
+                    "p95": 0.0995,
+                    "mean": 0.095,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.2,
+                    "p95": 1.218,
+                    "mean": 1.2,
+                    "count": 2
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "ambiguous_follow_up": {
+                "num_predictions": 3,
+                "accuracy": null,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": null,
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.72,
+                  "p95": 0.9359999999999999,
+                  "mean": 0.6699999999999999
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.52,
+                    "p95": 0.736,
+                    "mean": 0.47333333333333333,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.009,
+                    "mean": 0.0033333333333333335,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.72,
+                    "p95": 0.9359999999999999,
+                    "mean": 0.6699999999999999,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "answer_schema_v2": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.99,
+                  "p95": 1.99,
+                  "mean": 1.99
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.57,
+                    "p95": 0.57,
+                    "mean": 0.57,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.26,
+                    "p95": 0.26,
+                    "mean": 0.26,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.145,
+                    "p95": 0.1765,
+                    "mean": 0.145,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.235,
+                    "p95": 0.2485,
+                    "mean": 0.235,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 1.99,
+                    "p95": 1.99,
+                    "mean": 1.99,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 1,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 1
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 2
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "chunk_boundary": {
+                "num_predictions": 3,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.44,
+                  "p95": 2.827,
+                  "mean": 2.49
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.46,
+                    "p95": 1.775,
+                    "mean": 1.46,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.46,
+                    "p95": 0.469,
+                    "mean": 0.43,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.11,
+                    "p95": 0.11,
+                    "mean": 0.10333333333333333,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.15,
+                    "p95": 0.15,
+                    "mean": 0.14666666666666667,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.44,
+                    "p95": 2.827,
+                    "mean": 2.49,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "follow_up_context": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.7,
+                  "p95": 1.7,
+                  "mean": 1.7
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.03,
+                    "p95": 1.03,
+                    "mean": 1.03,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.01,
+                    "p95": 0.01,
+                    "mean": 0.01,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.07,
+                    "p95": 0.07,
+                    "mean": 0.07,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.13,
+                    "p95": 0.13,
+                    "mean": 0.13,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.7,
+                    "p95": 1.7,
+                    "mean": 1.7,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "noisy_entity": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.19,
+                  "p95": 1.19,
+                  "mean": 1.19
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.61,
+                    "p95": 0.61,
+                    "mean": 0.61,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.06,
+                    "p95": 0.06,
+                    "mean": 0.06,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.09,
+                    "p95": 0.09,
+                    "mean": 0.09,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.19,
+                    "p95": 1.19,
+                    "mean": 1.19,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "one_sided_comparison": {
+                "num_predictions": 3,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_target_recall": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_pool_recall": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.99,
+                  "p95": 3.674,
+                  "mean": 3.0700000000000003
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.29,
+                    "p95": 2.055,
+                    "mean": 1.4600000000000002,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.29,
+                    "p95": 0.317,
+                    "mean": 0.27666666666666667,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.14500000000000002,
+                    "p95": 0.20500000000000002,
+                    "mean": 0.14333333333333334,
+                    "count": 6
+                  },
+                  "verify_ms": {
+                    "p50": 0.20500000000000002,
+                    "p95": 0.2725,
+                    "mean": 0.21166666666666667,
+                    "count": 6
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 2.99,
+                    "p95": 3.674,
+                    "mean": 3.0700000000000003,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 3,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 3
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 A": 2,
+                  "missing_comparison_topic:기관 B": 4,
+                  "partial_topic_grounding": 3,
+                  "topic_not_grounded": 3
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {},
+                "comparison_target_recall": 0.5,
+                "comparison_target_full_coverage_rate": 0.0,
+                "comparison_pool_recall": 1.0,
+                "comparison_pool_full_coverage_rate": 1.0
+              },
+              "partial_comparison": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.99,
+                  "p95": 1.99,
+                  "mean": 1.99
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.57,
+                    "p95": 0.57,
+                    "mean": 0.57,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.26,
+                    "p95": 0.26,
+                    "mean": 0.26,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.145,
+                    "p95": 0.1765,
+                    "mean": 0.145,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.235,
+                    "p95": 0.2485,
+                    "mean": 0.235,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 1.99,
+                    "p95": 1.99,
+                    "mean": 1.99,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 1,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 1
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 2
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "retrieval_hardening": {
+                "num_predictions": 5,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.19,
+                  "p95": 1.6039999999999999,
+                  "mean": 1.124
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.61,
+                    "p95": 0.946,
+                    "mean": 0.596,
+                    "count": 5
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.01,
+                    "mean": 0.004,
+                    "count": 5
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.134,
+                    "count": 5
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.055,
+                    "p95": 0.0685,
+                    "mean": 0.0575,
+                    "count": 4
+                  },
+                  "verify_ms": {
+                    "p50": 0.095,
+                    "p95": 0.1255,
+                    "mean": 0.10250000000000001,
+                    "count": 4
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.19,
+                    "p95": 1.6039999999999999,
+                    "mean": 1.124,
+                    "count": 5
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              }
+            }
+          }
+        },
+        {
+          "name": "hierarchical",
+          "flags": {
+            "pipeline": "agentic_full",
+            "top_k": null,
+            "metadata_first": true,
+            "rerank": true,
+            "verifier_retry": true,
+            "retrieval_mode": "hierarchical",
+            "retrieval_backend": "dense",
+            "prompt_profile": "structured_grounded_claims"
+          },
+          "metrics": {
+            "num_predictions": 42,
+            "accuracy": 0.90625,
+            "groundedness": 0.9285714285714286,
+            "citation_precision": 0.9047619047619048,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "answer_format_compliance": 0.9047619047619048,
+            "abstention": 1.0,
+            "retry": 0.30952380952380953,
+            "latency": {
+              "p50": 1.3450000000000002,
+              "p95": 2.9395,
+              "mean": 1.5930952380952372
+            },
+            "retry_cost": {
+              "total_retries": 13,
+              "mean_retry_count": 0.30952380952380953,
+              "max_retry_count": 1,
+              "cases_with_retry": 13
+            },
+            "retry_reason_counts": {
+              "missing_comparison_topic:기관 A": 2,
+              "missing_comparison_topic:기관 B": 4,
+              "missing_comparison_topic:기관 D": 2,
+              "partial_topic_grounding": 3,
+              "topic_not_grounded": 19
+            },
+            "citation_grounding_error_counts": {},
+            "by_hardcase_category": {
+              "alias_entity": {
+                "num_predictions": 2,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.24,
+                  "p95": 1.249,
+                  "mean": 1.24
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.625,
+                    "p95": 0.6295,
+                    "mean": 0.625,
+                    "count": 2
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.175,
+                    "p95": 0.1795,
+                    "mean": 0.175,
+                    "count": 2
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.06,
+                    "p95": 0.06,
+                    "mean": 0.06,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.1,
+                    "p95": 0.1,
+                    "mean": 0.1,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.24,
+                    "p95": 1.249,
+                    "mean": 1.24,
+                    "count": 2
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "ambiguous_follow_up": {
+                "num_predictions": 3,
+                "accuracy": null,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": null,
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.71,
+                  "p95": 0.9169999999999999,
+                  "mean": 0.66
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.51,
+                    "p95": 0.708,
+                    "mean": 0.45999999999999996,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.009,
+                    "mean": 0.0033333333333333335,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.71,
+                    "p95": 0.9169999999999999,
+                    "mean": 0.66,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "answer_schema_v2": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.86,
+                  "p95": 1.86,
+                  "mean": 1.86
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.57,
+                    "p95": 0.57,
+                    "mean": 0.57,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.24,
+                    "p95": 0.24,
+                    "mean": 0.24,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.145,
+                    "p95": 0.1765,
+                    "mean": 0.145,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.19,
+                    "p95": 0.217,
+                    "mean": 0.19,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 1.86,
+                    "p95": 1.86,
+                    "mean": 1.86,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 1,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 1
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 2
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "chunk_boundary": {
+                "num_predictions": 3,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.47,
+                  "p95": 2.8930000000000002,
+                  "mean": 2.533333333333333
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.38,
+                    "p95": 1.776,
+                    "mean": 1.4433333333333334,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.54,
+                    "p95": 0.54,
+                    "mean": 0.5333333333333333,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.11,
+                    "p95": 0.119,
+                    "mean": 0.10999999999999999,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.13,
+                    "p95": 0.139,
+                    "mean": 0.13333333333333333,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.47,
+                    "p95": 2.8930000000000002,
+                    "mean": 2.533333333333333,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "follow_up_context": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.73,
+                  "p95": 1.73,
+                  "mean": 1.73
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.04,
+                    "p95": 1.04,
+                    "mean": 1.04,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.01,
+                    "p95": 0.01,
+                    "mean": 0.01,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.07,
+                    "p95": 0.07,
+                    "mean": 0.07,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.13,
+                    "p95": 0.13,
+                    "mean": 0.13,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.73,
+                    "p95": 1.73,
+                    "mean": 1.73,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "noisy_entity": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.19,
+                  "p95": 1.19,
+                  "mean": 1.19
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.6,
+                    "p95": 0.6,
+                    "mean": 0.6,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.06,
+                    "p95": 0.06,
+                    "mean": 0.06,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.09,
+                    "p95": 0.09,
+                    "mean": 0.09,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.19,
+                    "p95": 1.19,
+                    "mean": 1.19,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "one_sided_comparison": {
+                "num_predictions": 3,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_target_recall": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_pool_recall": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.93,
+                  "p95": 3.722,
+                  "mean": 3.09
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.26,
+                    "p95": 2.106,
+                    "mean": 1.4733333333333334,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.28,
+                    "p95": 0.289,
+                    "mean": 0.25666666666666665,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.16,
+                    "p95": 0.225,
+                    "mean": 0.15666666666666665,
+                    "count": 6
+                  },
+                  "verify_ms": {
+                    "p50": 0.21000000000000002,
+                    "p95": 0.27,
+                    "mean": 0.21666666666666667,
+                    "count": 6
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 2.93,
+                    "p95": 3.722,
+                    "mean": 3.09,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 3,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 3
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 A": 2,
+                  "missing_comparison_topic:기관 B": 4,
+                  "partial_topic_grounding": 3,
+                  "topic_not_grounded": 3
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {},
+                "comparison_target_recall": 0.5,
+                "comparison_target_full_coverage_rate": 0.0,
+                "comparison_pool_recall": 1.0,
+                "comparison_pool_full_coverage_rate": 1.0
+              },
+              "partial_comparison": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.86,
+                  "p95": 1.86,
+                  "mean": 1.86
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.57,
+                    "p95": 0.57,
+                    "mean": 0.57,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.24,
+                    "p95": 0.24,
+                    "mean": 0.24,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.145,
+                    "p95": 0.1765,
+                    "mean": 0.145,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.19,
+                    "p95": 0.217,
+                    "mean": 0.19,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 1.86,
+                    "p95": 1.86,
+                    "mean": 1.86,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 1,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 1
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 2
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "retrieval_hardening": {
+                "num_predictions": 5,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.23,
+                  "p95": 1.634,
+                  "mean": 1.1460000000000001
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.62,
+                    "p95": 0.958,
+                    "mean": 0.6060000000000001,
+                    "count": 5
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.01,
+                    "mean": 0.004,
+                    "count": 5
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.178,
+                    "mean": 0.138,
+                    "count": 5
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.06,
+                    "p95": 0.0685,
+                    "mean": 0.0625,
+                    "count": 4
+                  },
+                  "verify_ms": {
+                    "p50": 0.1,
+                    "p95": 0.1255,
+                    "mean": 0.10500000000000001,
+                    "count": 4
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.23,
+                    "p95": 1.634,
+                    "mean": 1.1460000000000001,
+                    "count": 5
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              }
+            }
+          }
+        },
+        {
+          "name": "hybrid_bm25",
+          "flags": {
+            "pipeline": "agentic_full",
+            "top_k": null,
+            "metadata_first": true,
+            "rerank": true,
+            "verifier_retry": true,
+            "retrieval_mode": "flat",
+            "retrieval_backend": "hybrid",
+            "prompt_profile": "structured_grounded_claims"
+          },
+          "metrics": {
+            "num_predictions": 42,
+            "accuracy": 0.90625,
+            "groundedness": 0.9285714285714286,
+            "citation_precision": 0.9047619047619048,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "answer_format_compliance": 0.9047619047619048,
+            "abstention": 1.0,
+            "retry": 0.30952380952380953,
+            "latency": {
+              "p50": 1.48,
+              "p95": 3.1124999999999994,
+              "mean": 1.695714285714285
+            },
+            "retry_cost": {
+              "total_retries": 13,
+              "mean_retry_count": 0.30952380952380953,
+              "max_retry_count": 1,
+              "cases_with_retry": 13
+            },
+            "retry_reason_counts": {
+              "missing_comparison_topic:기관 A": 2,
+              "missing_comparison_topic:기관 B": 4,
+              "missing_comparison_topic:기관 D": 2,
+              "partial_topic_grounding": 3,
+              "topic_not_grounded": 19
+            },
+            "citation_grounding_error_counts": {},
+            "by_hardcase_category": {
+              "alias_entity": {
+                "num_predictions": 2,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.355,
+                  "p95": 1.4585,
+                  "mean": 1.355
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.6599999999999999,
+                    "p95": 0.696,
+                    "mean": 0.6599999999999999,
+                    "count": 2
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.175,
+                    "p95": 0.1795,
+                    "mean": 0.175,
+                    "count": 2
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.11499999999999999,
+                    "p95": 0.1465,
+                    "mean": 0.11499999999999999,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.10500000000000001,
+                    "p95": 0.1095,
+                    "mean": 0.10500000000000001,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.355,
+                    "p95": 1.4585,
+                    "mean": 1.355,
+                    "count": 2
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "ambiguous_follow_up": {
+                "num_predictions": 3,
+                "accuracy": null,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": null,
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.71,
+                  "p95": 0.9169999999999999,
+                  "mean": 0.6633333333333333
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.52,
+                    "p95": 0.727,
+                    "mean": 0.47000000000000003,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.009,
+                    "mean": 0.0033333333333333335,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.71,
+                    "p95": 0.9169999999999999,
+                    "mean": 0.6633333333333333,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "answer_schema_v2": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.01,
+                  "p95": 2.01,
+                  "mean": 2.01
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.59,
+                    "mean": 0.59,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.24,
+                    "p95": 0.24,
+                    "mean": 0.24,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.175,
+                    "p95": 0.2065,
+                    "mean": 0.175,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.22,
+                    "p95": 0.238,
+                    "mean": 0.22,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 2.01,
+                    "p95": 2.01,
+                    "mean": 2.01,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 1,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 1
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 2
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "chunk_boundary": {
+                "num_predictions": 3,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.68,
+                  "p95": 2.9410000000000003,
+                  "mean": 2.6300000000000003
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.65,
+                    "p95": 1.83,
+                    "mean": 1.5433333333333332,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.45,
+                    "p95": 0.46799999999999997,
+                    "mean": 0.43,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.16,
+                    "p95": 0.169,
+                    "mean": 0.15333333333333335,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.15,
+                    "p95": 0.159,
+                    "mean": 0.15,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.68,
+                    "p95": 2.9410000000000003,
+                    "mean": 2.6300000000000003,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "follow_up_context": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.79,
+                  "p95": 1.79,
+                  "mean": 1.79
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.08,
+                    "p95": 1.08,
+                    "mean": 1.08,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.01,
+                    "p95": 0.01,
+                    "mean": 0.01,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.11,
+                    "p95": 0.11,
+                    "mean": 0.11,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.13,
+                    "p95": 0.13,
+                    "mean": 0.13,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.79,
+                    "p95": 1.79,
+                    "mean": 1.79,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "noisy_entity": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.2,
+                  "p95": 1.2,
+                  "mean": 1.2
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.59,
+                    "mean": 0.59,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.08,
+                    "p95": 0.08,
+                    "mean": 0.08,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.09,
+                    "p95": 0.09,
+                    "mean": 0.09,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.2,
+                    "p95": 1.2,
+                    "mean": 1.2,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "one_sided_comparison": {
+                "num_predictions": 3,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_target_recall": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_pool_recall": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 3.12,
+                  "p95": 4.02,
+                  "mean": 3.2733333333333334
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.32,
+                    "p95": 2.247,
+                    "mean": 1.54,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.29,
+                    "p95": 0.299,
+                    "mean": 0.26333333333333336,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.20500000000000002,
+                    "p95": 0.265,
+                    "mean": 0.19833333333333333,
+                    "count": 6
+                  },
+                  "verify_ms": {
+                    "p50": 0.21500000000000002,
+                    "p95": 0.265,
+                    "mean": 0.21333333333333335,
+                    "count": 6
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 3.12,
+                    "p95": 4.02,
+                    "mean": 3.2733333333333334,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 3,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 3
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 A": 2,
+                  "missing_comparison_topic:기관 B": 4,
+                  "partial_topic_grounding": 3,
+                  "topic_not_grounded": 3
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {},
+                "comparison_target_recall": 0.5,
+                "comparison_target_full_coverage_rate": 0.0,
+                "comparison_pool_recall": 1.0,
+                "comparison_pool_full_coverage_rate": 1.0
+              },
+              "partial_comparison": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.01,
+                  "p95": 2.01,
+                  "mean": 2.01
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.59,
+                    "mean": 0.59,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.24,
+                    "p95": 0.24,
+                    "mean": 0.24,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.175,
+                    "p95": 0.2065,
+                    "mean": 0.175,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.22,
+                    "p95": 0.238,
+                    "mean": 0.22,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 2.01,
+                    "p95": 2.01,
+                    "mean": 2.01,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 1,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 1
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 2
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "retrieval_hardening": {
+                "num_predictions": 5,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.24,
+                  "p95": 1.726,
+                  "mean": 1.208
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.62,
+                    "p95": 1.004,
+                    "mean": 0.6260000000000001,
+                    "count": 5
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.01,
+                    "mean": 0.004,
+                    "count": 5
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.178,
+                    "mean": 0.138,
+                    "count": 5
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.095,
+                    "p95": 0.144,
+                    "mean": 0.105,
+                    "count": 4
+                  },
+                  "verify_ms": {
+                    "p50": 0.10500000000000001,
+                    "p95": 0.127,
+                    "mean": 0.1075,
+                    "count": 4
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.24,
+                    "p95": 1.726,
+                    "mean": 1.208,
+                    "count": 5
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              }
+            }
+          }
+        },
+        {
+          "name": "naive_baseline",
+          "flags": {
+            "pipeline": "naive_baseline",
+            "top_k": 4,
+            "metadata_first": false,
+            "rerank": false,
+            "verifier_retry": false,
+            "retrieval_mode": "flat",
+            "retrieval_backend": "dense",
+            "prompt_profile": "minimal_grounded_extractive"
+          },
+          "metrics": {
+            "num_predictions": 42,
+            "accuracy": 0.84375,
+            "groundedness": 0.7142857142857143,
+            "citation_precision": 0.5119047619047619,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "answer_format_compliance": 0.6666666666666666,
+            "abstention": 0.3,
+            "retry": 0.0,
+            "latency": {
+              "p50": 1.4449999999999998,
+              "p95": 2.921499999999998,
+              "mean": 1.5716666666666668
+            },
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "by_hardcase_category": {
+              "alias_entity": {
+                "num_predictions": 2,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 0.5,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.5699999999999998,
+                  "p95": 1.669,
+                  "mean": 1.5699999999999998
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.635,
+                    "p95": 0.6755,
+                    "mean": 0.635,
+                    "count": 2
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.375,
+                    "p95": 0.4065,
+                    "mean": 0.375,
+                    "count": 2
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.2,
+                    "p95": 0.218,
+                    "mean": 0.2,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.5699999999999998,
+                    "p95": 1.669,
+                    "mean": 1.5699999999999998,
+                    "count": 2
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "ambiguous_follow_up": {
+                "num_predictions": 3,
+                "accuracy": null,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": null,
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.72,
+                  "p95": 0.972,
+                  "mean": 0.69
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.53,
+                    "p95": 0.773,
+                    "mean": 0.49333333333333335,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.009,
+                    "mean": 0.0033333333333333335,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.72,
+                    "p95": 0.972,
+                    "mean": 0.69,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "answer_schema_v2": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.25,
+                  "p95": 1.25,
+                  "mean": 1.25
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.57,
+                    "p95": 0.57,
+                    "mean": 0.57,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.18,
+                    "p95": 0.18,
+                    "mean": 0.18,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.25,
+                    "p95": 1.25,
+                    "mean": 1.25,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "chunk_boundary": {
+                "num_predictions": 3,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.35,
+                  "p95": 2.8810000000000002,
+                  "mean": 2.5233333333333334
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.39,
+                    "p95": 1.8399999999999999,
+                    "mean": 1.5,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.46,
+                    "p95": 0.469,
+                    "mean": 0.43,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.19,
+                    "p95": 0.217,
+                    "mean": 0.20000000000000004,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.35,
+                    "p95": 2.8810000000000002,
+                    "mean": 2.5233333333333334,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "follow_up_context": {
+                "num_predictions": 1,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.39,
+                  "p95": 0.39,
+                  "mean": 0.39
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.21,
+                    "p95": 0.21,
+                    "mean": 0.21,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.01,
+                    "p95": 0.01,
+                    "mean": 0.01,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.39,
+                    "p95": 0.39,
+                    "mean": 0.39,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "noisy_entity": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 0.5,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.57,
+                  "p95": 1.57,
+                  "mean": 1.57
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.69,
+                    "p95": 0.69,
+                    "mean": 0.69,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.33,
+                    "p95": 0.33,
+                    "mean": 0.33,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.19,
+                    "p95": 0.19,
+                    "mean": 0.19,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.57,
+                    "p95": 1.57,
+                    "mean": 1.57,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "one_sided_comparison": {
+                "num_predictions": 3,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_target_recall": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_pool_recall": {
+                    "mean": 0.8333333333333334,
+                    "ci_lo": 0.5,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.11,
+                  "p95": 2.875,
+                  "mean": 2.2966666666666664
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.29,
+                    "p95": 2.082,
+                    "mean": 1.4833333333333334,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.179,
+                    "mean": 0.15333333333333332,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.21,
+                    "p95": 0.219,
+                    "mean": 0.21,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.11,
+                    "p95": 2.875,
+                    "mean": 2.2966666666666664,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {},
+                "comparison_target_recall": 0.5,
+                "comparison_target_full_coverage_rate": 0.0,
+                "comparison_pool_recall": 0.8333333333333334,
+                "comparison_pool_full_coverage_rate": 0.6666666666666666
+              },
+              "partial_comparison": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.25,
+                  "p95": 1.25,
+                  "mean": 1.25
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.57,
+                    "p95": 0.57,
+                    "mean": 0.57,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.18,
+                    "p95": 0.18,
+                    "mean": 0.18,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.25,
+                    "p95": 1.25,
+                    "mean": 1.25,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "retrieval_hardening": {
+                "num_predictions": 5,
+                "accuracy": 0.75,
+                "groundedness": 0.8,
+                "citation_precision": 0.5,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": 1.0,
+                "answer_format_compliance": 0.8,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.75,
+                    "ci_lo": 0.25,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.8,
+                    "ci_lo": 0.4,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.5,
+                    "ci_lo": 0.3,
+                    "ci_hi": 0.8,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 0.8,
+                    "ci_lo": 0.4,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.46,
+                  "p95": 1.658,
+                  "mean": 1.0899999999999999
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.688,
+                    "mean": 0.46399999999999997,
+                    "count": 5
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.01,
+                    "mean": 0.004,
+                    "count": 5
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.33,
+                    "p95": 0.39599999999999996,
+                    "mean": 0.21600000000000003,
+                    "count": 5
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.19,
+                    "p95": 0.217,
+                    "mean": 0.19666666666666666,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.46,
+                    "p95": 1.658,
+                    "mean": 1.0899999999999999,
+                    "count": 5
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              }
+            }
+          }
+        },
+        {
+          "name": "no_metadata_first",
+          "flags": {
+            "pipeline": "agentic_full",
+            "top_k": null,
+            "metadata_first": false,
+            "rerank": true,
+            "verifier_retry": true,
+            "retrieval_mode": "flat",
+            "retrieval_backend": "dense",
+            "prompt_profile": "structured_grounded_claims"
+          },
+          "metrics": {
+            "num_predictions": 42,
+            "accuracy": 0.84375,
+            "groundedness": 0.8809523809523809,
+            "citation_precision": 0.6785714285714286,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "answer_format_compliance": 0.8571428571428571,
+            "abstention": 1.0,
+            "retry": 0.0,
+            "latency": {
+              "p50": 1.56,
+              "p95": 2.9974999999999987,
+              "mean": 1.6469047619047619
+            },
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {
+              "missing_comparison_topic:기관 A": 1,
+              "missing_comparison_topic:기관 B": 2,
+              "missing_comparison_topic:기관 D": 1,
+              "partial_topic_grounding": 3,
+              "topic_not_grounded": 7
+            },
+            "citation_grounding_error_counts": {},
+            "by_hardcase_category": {
+              "alias_entity": {
+                "num_predictions": 2,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 0.5,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.6349999999999998,
+                  "p95": 1.6395,
+                  "mean": 1.6349999999999998
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.62,
+                    "p95": 0.629,
+                    "mean": 0.62,
+                    "count": 2
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.35,
+                    "p95": 0.368,
+                    "mean": 0.35,
+                    "count": 2
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.18,
+                    "p95": 0.189,
+                    "mean": 0.18,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.14,
+                    "p95": 0.14,
+                    "mean": 0.14,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.6349999999999998,
+                    "p95": 1.6395,
+                    "mean": 1.6349999999999998,
+                    "count": 2
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "ambiguous_follow_up": {
+                "num_predictions": 3,
+                "accuracy": null,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": null,
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.72,
+                  "p95": 0.9269999999999999,
+                  "mean": 0.6666666666666666
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.52,
+                    "p95": 0.718,
+                    "mean": 0.4666666666666666,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.009,
+                    "mean": 0.0033333333333333335,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.72,
+                    "p95": 0.9269999999999999,
+                    "mean": 0.6666666666666666,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "answer_schema_v2": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.64,
+                  "p95": 1.64,
+                  "mean": 1.64
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.59,
+                    "mean": 0.59,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.25,
+                    "p95": 0.25,
+                    "mean": 0.25,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.19,
+                    "p95": 0.19,
+                    "mean": 0.19,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.24,
+                    "p95": 0.24,
+                    "mean": 0.24,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.64,
+                    "p95": 1.64,
+                    "mean": 1.64,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 1
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "chunk_boundary": {
+                "num_predictions": 3,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.61,
+                  "p95": 2.9699999999999998,
+                  "mean": 2.6566666666666663
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.51,
+                    "p95": 1.7530000000000001,
+                    "mean": 1.4866666666666666,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.45,
+                    "p95": 0.45,
+                    "mean": 0.4166666666666667,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.2,
+                    "p95": 0.218,
+                    "mean": 0.20333333333333337,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.16,
+                    "p95": 0.169,
+                    "mean": 0.16333333333333333,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.61,
+                    "p95": 2.9699999999999998,
+                    "mean": 2.6566666666666663,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "follow_up_context": {
+                "num_predictions": 1,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.39,
+                  "p95": 0.39,
+                  "mean": 0.39
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.21,
+                    "p95": 0.21,
+                    "mean": 0.21,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.01,
+                    "p95": 0.01,
+                    "mean": 0.01,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.39,
+                    "p95": 0.39,
+                    "mean": 0.39,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "noisy_entity": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 0.5,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.6,
+                  "p95": 1.6,
+                  "mean": 1.6
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.58,
+                    "p95": 0.58,
+                    "mean": 0.58,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.39,
+                    "p95": 0.39,
+                    "mean": 0.39,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.18,
+                    "p95": 0.18,
+                    "mean": 0.18,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.12,
+                    "p95": 0.12,
+                    "mean": 0.12,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.6,
+                    "p95": 1.6,
+                    "mean": 1.6,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "one_sided_comparison": {
+                "num_predictions": 3,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_target_recall": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_pool_recall": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.76,
+                  "p95": 3.444,
+                  "mean": 2.86
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.35,
+                    "p95": 2.079,
+                    "mean": 1.5,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.29,
+                    "p95": 0.308,
+                    "mean": 0.26999999999999996,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.21,
+                    "p95": 0.219,
+                    "mean": 0.21333333333333335,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.26,
+                    "p95": 0.269,
+                    "mean": 0.25333333333333335,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.76,
+                    "p95": 3.444,
+                    "mean": 2.86,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 A": 1,
+                  "missing_comparison_topic:기관 B": 2,
+                  "partial_topic_grounding": 3
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {},
+                "comparison_target_recall": 0.5,
+                "comparison_target_full_coverage_rate": 0.0,
+                "comparison_pool_recall": 1.0,
+                "comparison_pool_full_coverage_rate": 1.0
+              },
+              "partial_comparison": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.64,
+                  "p95": 1.64,
+                  "mean": 1.64
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.59,
+                    "mean": 0.59,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.25,
+                    "p95": 0.25,
+                    "mean": 0.25,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.19,
+                    "p95": 0.19,
+                    "mean": 0.19,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.24,
+                    "p95": 0.24,
+                    "mean": 0.24,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.64,
+                    "p95": 1.64,
+                    "mean": 1.64,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 1
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "retrieval_hardening": {
+                "num_predictions": 5,
+                "accuracy": 0.75,
+                "groundedness": 0.8,
+                "citation_precision": 0.5,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": 1.0,
+                "answer_format_compliance": 0.8,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.75,
+                    "ci_lo": 0.25,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.8,
+                    "ci_lo": 0.4,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.5,
+                    "ci_lo": 0.3,
+                    "ci_hi": 0.8,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 0.8,
+                    "ci_lo": 0.4,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.6,
+                  "p95": 1.638,
+                  "mean": 1.1179999999999999
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.58,
+                    "p95": 0.626,
+                    "mean": 0.434,
+                    "count": 5
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.01,
+                    "mean": 0.004,
+                    "count": 5
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.33,
+                    "p95": 0.386,
+                    "mean": 0.21799999999999997,
+                    "count": 5
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.18,
+                    "p95": 0.189,
+                    "mean": 0.18000000000000002,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.14,
+                    "p95": 0.14,
+                    "mean": 0.13333333333333333,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.6,
+                    "p95": 1.638,
+                    "mean": 1.1179999999999999,
+                    "count": 5
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              }
+            }
+          }
+        },
+        {
+          "name": "no_rerank",
+          "flags": {
+            "pipeline": "agentic_full",
+            "top_k": null,
+            "metadata_first": true,
+            "rerank": false,
+            "verifier_retry": true,
+            "retrieval_mode": "flat",
+            "retrieval_backend": "dense",
+            "prompt_profile": "structured_grounded_claims"
+          },
+          "metrics": {
+            "num_predictions": 42,
+            "accuracy": 0.90625,
+            "groundedness": 0.9285714285714286,
+            "citation_precision": 0.9047619047619048,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "answer_format_compliance": 0.9047619047619048,
+            "abstention": 1.0,
+            "retry": 0.30952380952380953,
+            "latency": {
+              "p50": 1.4,
+              "p95": 3.1649999999999996,
+              "mean": 1.6083333333333332
+            },
+            "retry_cost": {
+              "total_retries": 13,
+              "mean_retry_count": 0.30952380952380953,
+              "max_retry_count": 1,
+              "cases_with_retry": 13
+            },
+            "retry_reason_counts": {
+              "missing_comparison_topic:기관 A": 2,
+              "missing_comparison_topic:기관 B": 4,
+              "missing_comparison_topic:기관 D": 2,
+              "partial_topic_grounding": 3,
+              "topic_not_grounded": 19
+            },
+            "citation_grounding_error_counts": {},
+            "by_hardcase_category": {
+              "alias_entity": {
+                "num_predictions": 2,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.2149999999999999,
+                  "p95": 1.2465000000000002,
+                  "mean": 1.2149999999999999
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.61,
+                    "p95": 0.6279999999999999,
+                    "mean": 0.61,
+                    "count": 2
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 2
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.055,
+                    "p95": 0.0595,
+                    "mean": 0.055,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.095,
+                    "p95": 0.0995,
+                    "mean": 0.095,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.2149999999999999,
+                    "p95": 1.2465000000000002,
+                    "mean": 1.2149999999999999,
+                    "count": 2
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "ambiguous_follow_up": {
+                "num_predictions": 3,
+                "accuracy": null,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": null,
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.74,
+                  "p95": 0.902,
+                  "mean": 0.6666666666666666
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.55,
+                    "p95": 0.712,
+                    "mean": 0.47333333333333333,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.009,
+                    "mean": 0.0033333333333333335,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.74,
+                    "p95": 0.902,
+                    "mean": 0.6666666666666666,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "answer_schema_v2": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.97,
+                  "p95": 1.97,
+                  "mean": 1.97
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.61,
+                    "p95": 0.61,
+                    "mean": 0.61,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.26,
+                    "p95": 0.26,
+                    "mean": 0.26,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.14,
+                    "p95": 0.167,
+                    "mean": 0.14,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.215,
+                    "p95": 0.2375,
+                    "mean": 0.215,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 1.97,
+                    "p95": 1.97,
+                    "mean": 1.97,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 1,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 1
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 2
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "chunk_boundary": {
+                "num_predictions": 3,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.37,
+                  "p95": 2.9999999999999996,
+                  "mean": 2.526666666666667
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.41,
+                    "p95": 1.8780000000000001,
+                    "mean": 1.4866666666666666,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.44,
+                    "p95": 0.458,
+                    "mean": 0.42333333333333334,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.11,
+                    "p95": 0.128,
+                    "mean": 0.10999999999999999,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.15,
+                    "p95": 0.15,
+                    "mean": 0.14666666666666667,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.37,
+                    "p95": 2.9999999999999996,
+                    "mean": 2.526666666666667,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "follow_up_context": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.68,
+                  "p95": 1.68,
+                  "mean": 1.68
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.01,
+                    "p95": 1.01,
+                    "mean": 1.01,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.01,
+                    "p95": 0.01,
+                    "mean": 0.01,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.07,
+                    "p95": 0.07,
+                    "mean": 0.07,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.13,
+                    "p95": 0.13,
+                    "mean": 0.13,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.68,
+                    "p95": 1.68,
+                    "mean": 1.68,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "noisy_entity": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.18,
+                  "p95": 1.18,
+                  "mean": 1.18
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.59,
+                    "mean": 0.59,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.05,
+                    "p95": 0.05,
+                    "mean": 0.05,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.09,
+                    "p95": 0.09,
+                    "mean": 0.09,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.18,
+                    "p95": 1.18,
+                    "mean": 1.18,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "one_sided_comparison": {
+                "num_predictions": 3,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_target_recall": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_pool_recall": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 3.17,
+                  "p95": 3.7369999999999997,
+                  "mean": 3.1566666666666663
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.43,
+                    "p95": 2.105,
+                    "mean": 1.5233333333333334,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.29,
+                    "p95": 0.299,
+                    "mean": 0.26333333333333336,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.155,
+                    "p95": 0.21500000000000002,
+                    "mean": 0.15166666666666667,
+                    "count": 6
+                  },
+                  "verify_ms": {
+                    "p50": 0.22,
+                    "p95": 0.2725,
+                    "mean": 0.21833333333333335,
+                    "count": 6
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 3.17,
+                    "p95": 3.7369999999999997,
+                    "mean": 3.1566666666666663,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 3,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 3
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 A": 2,
+                  "missing_comparison_topic:기관 B": 4,
+                  "partial_topic_grounding": 3,
+                  "topic_not_grounded": 3
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {},
+                "comparison_target_recall": 0.5,
+                "comparison_target_full_coverage_rate": 0.0,
+                "comparison_pool_recall": 1.0,
+                "comparison_pool_full_coverage_rate": 1.0
+              },
+              "partial_comparison": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.97,
+                  "p95": 1.97,
+                  "mean": 1.97
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.61,
+                    "p95": 0.61,
+                    "mean": 0.61,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.26,
+                    "p95": 0.26,
+                    "mean": 0.26,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.14,
+                    "p95": 0.167,
+                    "mean": 0.14,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.215,
+                    "p95": 0.2375,
+                    "mean": 0.215,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "1": {
+                    "p50": 1.97,
+                    "p95": 1.97,
+                    "mean": 1.97,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 1.0,
+                "retry_cost": {
+                  "total_retries": 1,
+                  "mean_retry_count": 1.0,
+                  "max_retry_count": 1,
+                  "cases_with_retry": 1
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 2.0,
+                  "max_used": 2,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {
+                  "missing_comparison_topic:기관 D": 2
+                },
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "retrieval_hardening": {
+                "num_predictions": 5,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.18,
+                  "p95": 1.5939999999999999,
+                  "mean": 1.126
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.9339999999999999,
+                    "mean": 0.5920000000000001,
+                    "count": 5
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.01,
+                    "mean": 0.004,
+                    "count": 5
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.136,
+                    "count": 5
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.055,
+                    "p95": 0.0685,
+                    "mean": 0.0575,
+                    "count": 4
+                  },
+                  "verify_ms": {
+                    "p50": 0.095,
+                    "p95": 0.1255,
+                    "mean": 0.10250000000000001,
+                    "count": 4
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.18,
+                    "p95": 1.5939999999999999,
+                    "mean": 1.126,
+                    "count": 5
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              }
+            }
+          }
+        },
+        {
+          "name": "no_verifier_retry",
+          "flags": {
+            "pipeline": "agentic_full",
+            "top_k": null,
+            "metadata_first": true,
+            "rerank": true,
+            "verifier_retry": false,
+            "retrieval_mode": "flat",
+            "retrieval_backend": "dense",
+            "prompt_profile": "structured_grounded_claims"
+          },
+          "metrics": {
+            "num_predictions": 42,
+            "accuracy": 0.90625,
+            "groundedness": 0.7619047619047619,
+            "citation_precision": 0.7619047619047619,
+            "citation_page_precision": null,
+            "citation_region_precision": null,
+            "citation_grounding": null,
+            "answer_format_compliance": 0.7142857142857143,
+            "abstention": 0.3,
+            "retry": 0.0,
+            "latency": {
+              "p50": 1.165,
+              "p95": 2.8054999999999986,
+              "mean": 1.3916666666666666
+            },
+            "retry_cost": {
+              "total_retries": 0,
+              "mean_retry_count": 0.0,
+              "max_retry_count": 0,
+              "cases_with_retry": 0
+            },
+            "retry_reason_counts": {},
+            "citation_grounding_error_counts": {},
+            "by_hardcase_category": {
+              "alias_entity": {
+                "num_predictions": 2,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 2,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.13,
+                  "p95": 1.148,
+                  "mean": 1.13
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.615,
+                    "p95": 0.6285,
+                    "mean": 0.615,
+                    "count": 2
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.17,
+                    "count": 2
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.05,
+                    "p95": 0.05,
+                    "mean": 0.05,
+                    "count": 2
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 2
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.13,
+                    "p95": 1.148,
+                    "mean": 1.13,
+                    "count": 2
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "ambiguous_follow_up": {
+                "num_predictions": 3,
+                "accuracy": null,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": null,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": null,
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": null,
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 0.76,
+                  "p95": 0.958,
+                  "mean": 0.7433333333333333
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.55,
+                    "p95": 0.748,
+                    "mean": 0.51,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.009,
+                    "mean": 0.0033333333333333335,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  },
+                  "verify_ms": {
+                    "p50": null,
+                    "p95": null,
+                    "mean": null,
+                    "count": 0
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 0.76,
+                    "p95": 0.958,
+                    "mean": 0.7433333333333333,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "answer_schema_v2": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.22,
+                  "p95": 1.22,
+                  "mean": 1.22
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.57,
+                    "p95": 0.57,
+                    "mean": 0.57,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.19,
+                    "p95": 0.19,
+                    "mean": 0.19,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.11,
+                    "p95": 0.11,
+                    "mean": 0.11,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.22,
+                    "p95": 1.22,
+                    "mean": 1.22,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "chunk_boundary": {
+                "num_predictions": 3,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 2.53,
+                  "p95": 2.791,
+                  "mean": 2.5933333333333333
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.56,
+                    "p95": 1.794,
+                    "mean": 1.5999999999999999,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.47,
+                    "p95": 0.569,
+                    "mean": 0.48,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.12,
+                    "p95": 0.147,
+                    "mean": 0.12666666666666668,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 2.53,
+                    "p95": 2.791,
+                    "mean": 2.5933333333333333,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "follow_up_context": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.66,
+                  "p95": 1.66,
+                  "mean": 1.66
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.06,
+                    "p95": 1.06,
+                    "mean": 1.06,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.01,
+                    "p95": 0.01,
+                    "mean": 0.01,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.18,
+                    "p95": 0.18,
+                    "mean": 0.18,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.08,
+                    "p95": 0.08,
+                    "mean": 0.08,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.66,
+                    "p95": 1.66,
+                    "mean": 1.66,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "noisy_entity": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.09,
+                  "p95": 1.09,
+                  "mean": 1.09
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.59,
+                    "p95": 0.59,
+                    "mean": 0.59,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.16,
+                    "p95": 0.16,
+                    "mean": 0.16,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.05,
+                    "p95": 0.05,
+                    "mean": 0.05,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.09,
+                    "p95": 1.09,
+                    "mean": 1.09,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "one_sided_comparison": {
+                "num_predictions": 3,
+                "accuracy": 0.0,
+                "groundedness": 0.0,
+                "citation_precision": 0.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_target_recall": {
+                    "mean": 0.5,
+                    "ci_lo": 0.5,
+                    "ci_hi": 0.5,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "comparison_pool_recall": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 3,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.93,
+                  "p95": 2.839,
+                  "mean": 2.1566666666666667
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 1.29,
+                    "p95": 2.235,
+                    "mean": 1.53,
+                    "count": 3
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.17,
+                    "mean": 0.15,
+                    "count": 3
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.09,
+                    "p95": 0.108,
+                    "mean": 0.09666666666666666,
+                    "count": 3
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 3
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.93,
+                    "p95": 2.839,
+                    "mean": 2.1566666666666667,
+                    "count": 3
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {},
+                "comparison_target_recall": 0.5,
+                "comparison_target_full_coverage_rate": 0.0,
+                "comparison_pool_recall": 1.0,
+                "comparison_pool_full_coverage_rate": 1.0
+              },
+              "partial_comparison": {
+                "num_predictions": 1,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": null,
+                "answer_format_compliance": 0.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": null,
+                  "answer_format_compliance": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.22,
+                  "p95": 1.22,
+                  "mean": 1.22
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.57,
+                    "p95": 0.57,
+                    "mean": 0.57,
+                    "count": 1
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.19,
+                    "p95": 0.19,
+                    "mean": 0.19,
+                    "count": 1
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.11,
+                    "p95": 0.11,
+                    "mean": 0.11,
+                    "count": 1
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 1
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.22,
+                    "p95": 1.22,
+                    "mean": 1.22,
+                    "count": 1
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              },
+              "retrieval_hardening": {
+                "num_predictions": 5,
+                "accuracy": 1.0,
+                "groundedness": 1.0,
+                "citation_precision": 1.0,
+                "citation_page_precision": null,
+                "citation_region_precision": null,
+                "citation_grounding": null,
+                "claim_citation_alignment": 1.0,
+                "abstention": 1.0,
+                "answer_format_compliance": 1.0,
+                "ci": {
+                  "accuracy": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "groundedness": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_precision": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "citation_page_precision": null,
+                  "citation_region_precision": null,
+                  "citation_grounding": null,
+                  "claim_citation_alignment": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 4,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "abstention": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 1,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "answer_format_compliance": {
+                    "mean": 1.0,
+                    "ci_lo": 1.0,
+                    "ci_hi": 1.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  },
+                  "retry": {
+                    "mean": 0.0,
+                    "ci_lo": 0.0,
+                    "ci_hi": 0.0,
+                    "n": 5,
+                    "num_resamples": 1000,
+                    "alpha": 0.05
+                  }
+                },
+                "latency": {
+                  "p50": 1.11,
+                  "p95": 1.5579999999999998,
+                  "mean": 1.1
+                },
+                "stage_latency": {
+                  "query_analysis_ms": {
+                    "p50": 0.6,
+                    "p95": 0.974,
+                    "mean": 0.618,
+                    "count": 5
+                  },
+                  "context_resolution_ms": {
+                    "p50": 0.0,
+                    "p95": 0.01,
+                    "mean": 0.004,
+                    "count": 5
+                  },
+                  "answer_generation_ms": {
+                    "p50": 0.17,
+                    "p95": 0.178,
+                    "mean": 0.13599999999999998,
+                    "count": 5
+                  },
+                  "retrieve_ms": {
+                    "p50": 0.05,
+                    "p95": 0.0755,
+                    "mean": 0.05750000000000001,
+                    "count": 4
+                  },
+                  "verify_ms": {
+                    "p50": 0.0,
+                    "p95": 0.0,
+                    "mean": 0.0,
+                    "count": 4
+                  }
+                },
+                "latency_by_retry_count": {
+                  "0": {
+                    "p50": 1.11,
+                    "p95": 1.5579999999999998,
+                    "mean": 1.1,
+                    "count": 5
+                  }
+                },
+                "cold_start_samples": {
+                  "count": 0,
+                  "latency_ms": null
+                },
+                "retry": 0.0,
+                "retry_cost": {
+                  "total_retries": 0,
+                  "mean_retry_count": 0.0,
+                  "max_retry_count": 0,
+                  "cases_with_retry": 0
+                },
+                "iterations": {
+                  "cap": 3,
+                  "mean_used": 1.0,
+                  "max_used": 1,
+                  "cases_at_cap": 0,
+                  "pct_at_cap": 0.0
+                },
+                "retry_reason_counts": {},
+                "citation_grounding_error_counts": {},
+                "claim_citation_error_counts": {}
+              }
+            }
+          }
+        }
+      ],
+      "dataset": {
+        "type": "synthetic_rfp",
+        "privacy": "public_synthetic_only"
+      }
     }
   ]
 }

--- a/benchmarks/registry.schema.json
+++ b/benchmarks/registry.schema.json
@@ -79,6 +79,7 @@
         "rerank": { "type": "boolean" },
         "verifier_retry": { "type": "boolean" },
         "retrieval_mode": { "type": "string", "enum": ["flat", "hierarchical"] },
+        "retrieval_backend": { "type": "string", "enum": ["dense", "hybrid"] },
         "prompt_profile": { "type": "string" }
       },
       "additionalProperties": false

--- a/docs/ablation-results.md
+++ b/docs/ablation-results.md
@@ -1,54 +1,68 @@
 # Ablation Results
 
-이 문서는 커밋 가능한 집계 지표만 남긴다. Raw predictions, traces, logs, latency samples, error examples는 `artifacts/benchmarks/` 아래에 생성되며 Git에 커밋하지 않는다.
+이 문서는 커밋 가능한 집계 지표만 남긴다. 원시 예측, 진단 로그, 지연시간 샘플, 오류 예시는 `artifacts/benchmarks/` 아래에 생성되며 Git에 커밋하지 않는다.
 
 ## Latest Run
 
-- Run ID: `issue28_naive_baseline`
+- Run ID: `public_synthetic_rfp_20260511T101606Z`
 - Suite: `public_synthetic_rfp` / Dataset: `public_synthetic_rfp_v1`
-- Git commit: `9c85abd864352a630b144459617c22d862f8f5a7`
+- Git commit: `3ee1796f2869cc8176fa99156d7e84316283cba1`
 - Baseline: `naive_baseline`
 - Primary: `full`
-- Local manifest: `artifacts/benchmarks/issue28_naive_baseline/run_manifest.json`
+- Local manifest: `artifacts/benchmarks/public_synthetic_rfp_20260511T101606Z/run_manifest.json`
 
 ## Baseline To Primary
 
 | Metric | Baseline | Primary | Delta |
 |---|---:|---:|---:|
-| Accuracy | 0.947 | 1.000 | +0.053 |
-| Groundedness | 0.731 | 1.000 | +0.269 |
-| Citation Precision | 0.519 | 1.000 | +0.481 |
-| Format Compliance | 0.731 | 1.000 | +0.269 |
-| Abstention | 0.143 | 1.000 | +0.857 |
-| Retry Rate | 0.000 | 0.231 | +0.231 |
-| Latency p95 | 2.1ms | 1.7ms | -0.410 |
+| Accuracy | 0.844 | 0.906 | +0.062 |
+| Groundedness | 0.714 | 0.929 | +0.214 |
+| Citation Precision | 0.512 | 0.905 | +0.393 |
+| Citation Page Precision | N/A | N/A | N/A |
+| Citation Region Precision | N/A | N/A | N/A |
+| Citation Grounding | N/A | N/A | N/A |
+| Format Compliance | 0.667 | 0.905 | +0.238 |
+| Abstention | 0.300 | 1.000 | +0.700 |
+| Retry Rate | 0.000 | 0.310 | +0.310 |
+| Latency p95 | 2.9ms | 3.0ms | +0.063 |
 
 ## Ablation Table
 
-| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Retrieval | Prompt | Accuracy | Groundedness | Citation | Format | Abstention | Retry | Latency p95 |
-|---|---|---:|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---:|---:|
-| full | agentic_full | auto | on | on | on | flat | structured_grounded_claims | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 1.7ms |
-| hierarchical | agentic_full | auto | on | on | on | hierarchical | structured_grounded_claims | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 2.4ms |
-| naive_baseline | naive_baseline | 4 | off | off | off | flat | minimal_grounded_extractive | 0.947 | 0.731 | 0.519 | 0.731 | 0.143 | 0.000 | 2.1ms |
-| no_metadata_first | agentic_full | auto | off | on | on | flat | structured_grounded_claims | 0.947 | 0.962 | 0.750 | 0.962 | 1.000 | 0.000 | 18.1ms |
-| no_rerank | agentic_full | auto | on | off | on | flat | structured_grounded_claims | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 0.231 | 2.9ms |
-| no_verifier_retry | agentic_full | auto | on | on | off | flat | structured_grounded_claims | 1.000 | 0.769 | 0.769 | 0.769 | 0.143 | 0.000 | 3.2ms |
+| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Retrieval | Backend | Prompt | Accuracy | Groundedness | Citation | Citation Grounding | Format | Abstention | Retry | Latency p95 |
+|---|---|---:|---:|---:|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| full | agentic_full | auto | on | on | on | flat | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 | 0.310 | 3.0ms |
+| hierarchical | agentic_full | auto | on | on | on | hierarchical | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 | 0.310 | 2.9ms |
+| hybrid_bm25 | agentic_full | auto | on | on | on | flat | hybrid | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 | 0.310 | 3.1ms |
+| naive_baseline | naive_baseline | 4 | off | off | off | flat | dense | minimal_grounded_extractive | 0.844 | 0.714 | 0.512 | N/A | 0.667 | 0.300 | 0.000 | 2.9ms |
+| no_metadata_first | agentic_full | auto | off | on | on | flat | dense | structured_grounded_claims | 0.844 | 0.881 | 0.679 | N/A | 0.857 | 1.000 | 0.000 | 3.0ms |
+| no_rerank | agentic_full | auto | on | off | on | flat | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 | 0.310 | 3.2ms |
+| no_verifier_retry | agentic_full | auto | on | on | off | flat | dense | structured_grounded_claims | 0.906 | 0.762 | 0.762 | N/A | 0.714 | 0.300 | 0.000 | 2.8ms |
+
+## Hard-case Slices
+
+| Category | Cases | Accuracy | Groundedness | Citation | Citation Grounding | Format | Abstention | Retry |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| alias_entity | 2 | 1.000 | 1.000 | 1.000 | N/A | 1.000 | N/A | 0.000 |
+| ambiguous_follow_up | 3 | N/A | 1.000 | 1.000 | N/A | 1.000 | 1.000 | 0.000 |
+| answer_schema_v2 | 1 | 1.000 | 1.000 | 1.000 | N/A | 1.000 | N/A | 1.000 |
+| chunk_boundary | 3 | 1.000 | 1.000 | 1.000 | N/A | 1.000 | N/A | 0.000 |
+| follow_up_context | 1 | 1.000 | 1.000 | 1.000 | N/A | 1.000 | N/A | 0.000 |
+| noisy_entity | 1 | 1.000 | 1.000 | 1.000 | N/A | 1.000 | N/A | 0.000 |
+| one_sided_comparison | 3 | 0.000 | 0.000 | 0.000 | N/A | 0.000 | N/A | 1.000 |
+| partial_comparison | 1 | 1.000 | 1.000 | 1.000 | N/A | 1.000 | N/A | 1.000 |
+| retrieval_hardening | 5 | 1.000 | 1.000 | 1.000 | N/A | 1.000 | 1.000 | 0.000 |
 
 ## Interpretation
 
 - `naive_baseline`는 fixed chunk + dense top-k만 쓰는 naive control baseline이다.
 - `full`는 비교 대상 primary run이다.
-- "Retrieval" 컬럼은 `retrieval_mode` (flat / hierarchical) 를 의미한다. ADR 0010 에서 추가한 `retrieval_backend` (dense / hybrid) 는 직교 축이며, 다음 benchmark 스냅샷에서 별도 컬럼 또는 row 로 누적할 예정이다.
+- `Retrieval` 컬럼은 `retrieval_mode` (flat / hierarchical, ADR 0002), `Backend` 컬럼은 `retrieval_backend` (dense / hybrid, ADR 0010) 를 의미하며 두 축은 직교한다.
 - latency와 retry는 품질 지표와 함께 본다. retry가 늘어도 groundedness, citation, abstention 개선이 동반되는지 확인한다.
 - 현재 수치는 공개 synthetic RFP 평가셋 기준의 2차 가공 집계이며, 원본 RFP 문서나 raw example output은 포함하지 않는다.
-
-## Pending rows
-
-- **`hybrid_bm25`** (ADR 0010, issue #119): `eval/config.yaml` 에 추가됨. `make eval` 의 ablation 블록에는 이미 채워지지만 (`accuracy=0.906`, `groundedness=0.929` — `full` 과 동일 ceiling), 본 문서의 committed snapshot 은 `make benchmark` 의 manifest 기반이므로 다음 benchmark 실행 후 row 를 추가한다. 실측 차이는 private real-data eval (`make real-eval-delta`) 에서 드러날 가능성이 크다.
 
 ## Next Actions
 
 - 평가셋을 늘릴 때는 suite YAML을 추가하고 registry에는 집계 지표만 편입한다.
 - private RFP 기반 실험은 local artifact로만 보관하고 문서에는 익명화된 집계 결과만 남긴다.
-- citation 검증과 latency/retry 비용 분석은 별도 ablation axis로 분리해 누적한다.
-- 다음 benchmark 실행 시 `hybrid_bm25` row 를 위 표에 추가하고 `retrieval_backend` 컬럼을 도입한다.
+- citation 검증은 document/chunk precision과 page/region grounding을 분리해 누적한다.
+- latency/retry 비용 분석은 별도 ablation axis로 분리해 누적한다.

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -129,6 +129,7 @@ def normalize_run(run: dict[str, Any]) -> dict[str, Any]:
         "rerank": bool(config.get("rerank")),
         "verifier_retry": bool(config.get("verifier_retry")),
         "retrieval_mode": str(config.get("retrieval_mode", "flat")),
+        "retrieval_backend": str(config.get("retrieval_backend", "dense")),
         "prompt_profile": str(config.get("prompt_profile")),
     }
 
@@ -167,6 +168,7 @@ def run_flags(run: dict[str, Any]) -> dict[str, Any]:
         "rerank": bool(run.get("rerank", True)),
         "verifier_retry": bool(run.get("verifier_retry", True)),
         "retrieval_mode": str(run.get("retrieval_mode", "flat")),
+        "retrieval_backend": str(run.get("retrieval_backend", "dense")),
         "prompt_profile": str(run.get("prompt_profile") or ""),
     }
 
@@ -214,6 +216,7 @@ def evaluate_run_with_artifacts(
                 rerank=bool(run_config.get("rerank", True)),
                 verifier_retry=bool(run_config.get("verifier_retry", True)),
                 retrieval_mode=str(run_config.get("retrieval_mode", "flat")),
+                retrieval_backend=str(run_config.get("retrieval_backend", "dense")),
                 prompt_profile=str(run_config.get("prompt_profile") or ""),
                 conversation_state=conversation_state,
             )
@@ -229,6 +232,7 @@ def evaluate_run_with_artifacts(
             rerank=bool(run_config.get("rerank", True)),
             verifier_retry=bool(run_config.get("verifier_retry", True)),
             retrieval_mode=str(run_config.get("retrieval_mode", "flat")),
+            retrieval_backend=str(run_config.get("retrieval_backend", "dense")),
             prompt_profile=str(run_config.get("prompt_profile") or ""),
             conversation_state=conversation_state,
         )
@@ -452,6 +456,7 @@ def main() -> int:
         "retriever_config": {
             "index_dir": rel_path(index_dir),
             "retrieval_modes": sorted({run["retrieval_mode"] for run in normalized_runs}),
+            "retrieval_backends": sorted({run["retrieval_backend"] for run in normalized_runs}),
             "pipeline_by_run": {
                 run["name"]: str(run.get("pipeline") or "") for run in normalized_runs
             },

--- a/scripts/summarize_benchmark.py
+++ b/scripts/summarize_benchmark.py
@@ -226,14 +226,14 @@ def render_docs(registry: dict[str, Any]) -> str:
         "",
         "## Ablation Table",
         "",
-        "| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Retrieval | Prompt | Accuracy | Groundedness | Citation | Citation Grounding | Format | Abstention | Retry | Latency p95 |",
-        "|---|---|---:|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Retrieval | Backend | Prompt | Accuracy | Groundedness | Citation | Citation Grounding | Format | Abstention | Retry | Latency p95 |",
+        "|---|---|---:|---:|---:|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for run in latest.get("runs") or []:
         flags = run.get("flags") or {}
         metrics = run.get("metrics") or {}
         lines.append(
-            "| {name} | {pipeline} | {top_k} | {metadata_first} | {rerank} | {verifier_retry} | {retrieval_mode} | {prompt} | {accuracy} | {groundedness} | {citation} | {citation_grounding} | {format} | {abstention} | {retry} | {latency} |".format(
+            "| {name} | {pipeline} | {top_k} | {metadata_first} | {rerank} | {verifier_retry} | {retrieval_mode} | {retrieval_backend} | {prompt} | {accuracy} | {groundedness} | {citation} | {citation_grounding} | {format} | {abstention} | {retry} | {latency} |".format(
                 name=run.get("name"),
                 pipeline=flags.get("pipeline", ""),
                 top_k=fmt_top_k(flags.get("top_k")),
@@ -241,6 +241,7 @@ def render_docs(registry: dict[str, Any]) -> str:
                 rerank=flag(flags.get("rerank")),
                 verifier_retry=flag(flags.get("verifier_retry")),
                 retrieval_mode=flags.get("retrieval_mode", "flat"),
+                retrieval_backend=flags.get("retrieval_backend", "dense"),
                 prompt=flags.get("prompt_profile", ""),
                 accuracy=fmt_rate(metrics.get("accuracy")),
                 groundedness=fmt_rate(metrics.get("groundedness")),
@@ -302,6 +303,7 @@ def render_docs(registry: dict[str, Any]) -> str:
             "",
             f"- `{baseline_name}`는 fixed chunk + dense top-k만 쓰는 naive control baseline이다.",
             f"- `{primary_name}`는 비교 대상 primary run이다.",
+            "- `Retrieval` 컬럼은 `retrieval_mode` (flat / hierarchical, ADR 0002), `Backend` 컬럼은 `retrieval_backend` (dense / hybrid, ADR 0010) 를 의미하며 두 축은 직교한다.",
             "- latency와 retry는 품질 지표와 함께 본다. retry가 늘어도 groundedness, citation, abstention 개선이 동반되는지 확인한다.",
             "- 현재 수치는 공개 synthetic RFP 평가셋 기준의 2차 가공 집계이며, 원본 RFP 문서나 raw example output은 포함하지 않는다.",
             "",

--- a/tests/test_benchmark_summary.py
+++ b/tests/test_benchmark_summary.py
@@ -29,6 +29,7 @@ class BenchmarkSummaryTest(unittest.TestCase):
                     "rerank": True,
                     "verifier_retry": True,
                     "retrieval_mode": "hierarchical",
+                    "retrieval_backend": "dense",
                     "prompt_profile": "private_visual_v2",
                 }
             },
@@ -73,6 +74,8 @@ class BenchmarkSummaryTest(unittest.TestCase):
             "| table_heavy | 1 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | N/A | 1.000 |",
             docs,
         )
+        self.assertIn("| Retrieval | Backend | Prompt |", docs)
+        self.assertIn("| hierarchical | dense | private_visual_v2 |", docs)
 
     def test_private100_fixture_preserves_privacy_metadata_and_comparison(self) -> None:
         private_manifest = self.load_private100_fixture()
@@ -101,6 +104,7 @@ class BenchmarkSummaryTest(unittest.TestCase):
                         "rerank": True,
                         "verifier_retry": True,
                         "retrieval_mode": "flat",
+                        "retrieval_backend": "dense",
                         "prompt_profile": "structured_grounded_claims",
                     }
                 },


### PR DESCRIPTION
## 1. What changed and why

Closes #178

PR #159 introduced hybrid BM25+dense retrieval as the `hybrid_bm25` ablation in `eval/config.yaml`, and ADR 0010 (renumbered from 0009 by #190) declared `retrieval_backend ∈ {dense, hybrid}` as an axis orthogonal to the existing `retrieval_mode` (flat/hierarchical). The committed snapshot at [docs/ablation-results.md](docs/ablation-results.md) was still anchored to a pre-#159 manifest, so the hybrid row was absent and no column distinguished the two backends. This PR closes that gap end-to-end and re-runs `make benchmark` on current `main` (post-#190) to refresh the snapshot.

## 2. Files affected

- [benchmarks/ablations/rag_quality_axes.yaml](benchmarks/ablations/rag_quality_axes.yaml) — added 7th ablation row `hybrid_bm25` (`retrieval_backend: hybrid`)
- [scripts/run_benchmark.py](scripts/run_benchmark.py) — threaded `retrieval_backend` through `normalize_run`, `run_flags`, both `EVAL.run_rag_query` call sites, and the manifest's `retriever_config.retrieval_backends` aggregate
- [benchmarks/registry.schema.json](benchmarks/registry.schema.json) — extended `ablation_flags` properties with `retrieval_backend` (enum `["dense","hybrid"]`); not added to `required` for back-compat with older entries
- [scripts/summarize_benchmark.py](scripts/summarize_benchmark.py) — `Backend` column added between `Retrieval` and `Prompt`; Interpretation block now auto-describes the orthogonal `retrieval_mode` × `retrieval_backend` axes
- [tests/test_benchmark_summary.py](tests/test_benchmark_summary.py) — fixture flags + `Backend` column/cell assertions
- [benchmarks/examples/private100_aggregate_manifest.example.json](benchmarks/examples/private100_aggregate_manifest.example.json) — fixture fidelity update
- [docs/ablation-results.md](docs/ablation-results.md), [benchmarks/registry.json](benchmarks/registry.json) — auto-regenerated by `make benchmark` + `scripts/summarize_benchmark.py`

Load-bearing flag: none. `rag_core.py`, `ingestion.py`, `eval/`, `api/`, `docs/adr/` untouched.

## 3. Risks

Most likely failure mode: regenerated `docs/ablation-results.md` could shift `naive_baseline` metrics enough to look like an ADR 0001 violation. Verified to rule that out:
- The `naive_baseline` preset in `rag_core.py:71-83` is unchanged (`top_k=4`, all gates off, `retrieval_backend: "dense"`, `prompt_profile: "minimal_grounded_extractive"`).
- ADR 0010 (renumbered hybrid ADR) explicitly states "Default `dense` preserves `naive_baseline` bit-for-bit" — this PR honors that by leaving the preset's default unchanged.
- The metric drift relative to the prior snapshot (e.g. `accuracy 0.947 → 0.844`) reflects upstream pipeline evolution between commit `9c85abd864` (2026-05-03, prior snapshot) and HEAD `3ee1796` (post-#142/#144/#145/#147/#159/#190), not a regression introduced by this PR.

Schema risk: `additionalProperties: false` on `ablation_flags` would have rejected the new key. Mitigation: explicit property added in `registry.schema.json`. Validated via `make benchmark-check`.

## 4. Tests

- [tests/test_benchmark_summary.py](tests/test_benchmark_summary.py): added assertions `"| Retrieval | Backend | Prompt |"` (header) and `"| hierarchical | dense | private_visual_v2 |"` (row content). These would have failed before this PR.
- Full suite: `python3 -m pytest -q` → 256 passed, 27 subtests passed.

## 5. Eval impact

Public synthetic CI delta on the registry: the new `hybrid_bm25` row reports identical aggregate scores to `full` on this suite (`accuracy=0.906`, `groundedness=0.929`, `citation=0.905`) — expected because the public synthetic corpus is too small (n=42) for BM25 lexical recall to differentiate. Real lift (rare-term queries: 사업 코드, 약칭, 외래어/한자 표기) is expected only on private real-data eval, tracked by [#149](https://github.com/hskim-solv/BidMate-DocAgent/issues/149) / [#151](https://github.com/hskim-solv/BidMate-DocAgent/issues/151) / [#152](https://github.com/hskim-solv/BidMate-DocAgent/issues/152).

### 5b. Real-data delta

N/A — this change is documentation/snapshot only; the regenerated `docs/ablation-results.md` and `benchmarks/registry.json` reflect public synthetic suite output only. No behavior change in retrieval, verifier, or answer surfaces. `rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, and `api/` are untouched (issue #178 "Out of scope" explicitly says private 100-doc delta is covered by PR #159's #5b, not this issue).

## 6. Backward compatibility

- Schema: `retrieval_backend` added as optional property in `ablation_flags`. Older registry entries without the field continue to validate.
- Manifest: `retrieval_config.retrieval_backends` is new; consumers reading only `retrieval_modes` are unaffected.
- Doc structure: previously hand-edited "Pending rows" section is no longer emitted by the generator (its only entry was the now-landed `hybrid_bm25`). Auto-generation will now own this region — no migration needed since the section was a placeholder.

## 7. Out of scope

- RRF-k sweep ([#149](https://github.com/hskim-solv/BidMate-DocAgent/issues/149)), BGE-M3 multi-vector ([#151](https://github.com/hskim-solv/BidMate-DocAgent/issues/151)), SPLADE/ColBERT ([#152](https://github.com/hskim-solv/BidMate-DocAgent/issues/152)), Korean 조사 STOPWORDS audit ([#150](https://github.com/hskim-solv/BidMate-DocAgent/issues/150)) — separate follow-ups already tracked.
- `summarize-benchmark` convenience Makefile target — judged out-of-scope for "one PR, one concern" since the manual invocation works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)