### PR TITLE
core: Korean money/date normalizer (#170)

### DIFF
--- a/docs/retrieval-hardening.md
+++ b/docs/retrieval-hardening.md
@@ -30,6 +30,33 @@ python3 eval/run_eval.py --index_dir data/index --output_dir reports --config ev
 python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check
 ```
 
+## Korean money/date normalization (issue #170)
+
+`analyze_query`와 `verify_evidence`는 query와 evidence text에 모두
+`text_normalize.normalize_text`를 적용한다. 비교는 OR(원본, 정규화된 형태)로
+strictly additive — legacy substring 매칭은 항상 보존된다.
+
+Canonical forms:
+
+- Money: integer KRW. `5천만원` → `50000000`. `壹拾億元` → `1000000000`.
+  `90,000,000원` → `90000000`. `일금일억오천만원정` → `150000000`.
+- Date: ISO `YYYY-MM-DD`. `'26.3.15.` → `2026-03-15`. 두 자리 연도는 rolling
+  +5 window 으로 century를 결정 (anchor=2026 기준 `'30` → 2030, `'40` → 1940).
+- Approximate markers (`약`, `대략`, `~`, `정도`, `내외`): canonical form은
+  원본 옆에 append (`약 5천만원 [≈50000000]`) — qualifier가 살아남는다.
+
+False-positive guard: `반올림`처럼 money-shaped 음절을 포함하지만 money-unit
+suffix(원/정/元/圓)도 section power(만/억/조/萬/億/兆)도 없는 lemma는 매치하지
+않는다. `tests/test_text_normalize_regression.py`의 `FalsePositiveGuardTest`가
+이를 pin한다.
+
+Known limitations:
+
+- `M월 D일` (year-less)은 정규화하지 않는다. `run_rag_query`에 anchor_year를
+  plumb 하는 별도 PR이 필요 (out of scope).
+- `parse_budget` ingestion semantics는 변경 없음. Verification-time OR-match가
+  stale `"15억"` budget metadata를 reindex 없이 처리한다.
+
 ## Issue coverage
 
 - #55: staged metadata filters and per-stage diagnostics.
@@ -37,3 +64,4 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 - #57: persistent follow-up state and retrieval-query carryover.
 - #59: ambiguity detection with clarification-before-retrieval behavior.
 - #61: planner-owned query-type top_k selection and diagnostics.
+- #170: Korean money/date canonical-form OR-match at query/verify time.

--- a/rag_core.py
+++ b/rag_core.py
@@ -28,6 +28,7 @@ except ImportError:  # pragma: no cover — defensive; declared in requirements.
     _BM25Okapi = None  # type: ignore[assignment]
 
 from rag_synthesis import synthesize_answer
+from text_normalize import expand_forms, normalize_text
 
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 DEFAULT_HASH_DIM = 384
@@ -1620,6 +1621,23 @@ def analyze_query(
             if not token.startswith("기관"):
                 topics.append(token)
 
+    # ADR 0007 / issue #170: add canonical-form tokens from Korean money/date
+    # normalization so substring topic matching can bridge 5천만원 ↔ 50,000,000.
+    # Strictly additive — existing tokens are kept; new tokens compete for the
+    # topics[:8] cap on equal footing.
+    canonical_query = normalize_text(normalized_query)
+    if canonical_query != normalized_query:
+        existing = {topic.lower() for topic in topics}
+        for token in tokenize(canonical_query):
+            if (
+                len(token) > 1
+                and token not in STOPWORDS
+                and not token.startswith("기관")
+                and token.lower() not in existing
+            ):
+                topics.append(token)
+                existing.add(token.lower())
+
     comparison_terms = ("차이", "비교", "각각", "대비")
     comparison_joiners = ("와", "과", "및", ",", "/")
     reduced_matches = metadata_matches_for_stage(metadata_matches, "reduced")
@@ -2284,9 +2302,21 @@ def verify_evidence(
         reasons.append("low_top_score")
 
     combined = " ".join(evidence_text_for_verification(item) for item in evidence).lower()
+    # ADR 0007 / issue #170: Korean money/date OR-match. Build canonical form
+    # once; substring check tests (form ∈ combined) OR (form ∈ canonical) for
+    # each form in expand_forms(topic). Strictly additive — legacy
+    # (topic ∈ combined) is preserved as the first branch.
+    combined_canonical = normalize_text(combined)
     topics = verification_topics(analysis)
     if topics:
-        matched_topic_count = sum(1 for topic in topics if topic.lower() in combined)
+        matched_topic_count = sum(
+            1
+            for topic in topics
+            if any(
+                form in combined or form in combined_canonical
+                for form in expand_forms(topic.lower())
+            )
+        )
         if matched_topic_count < len(topics):
             if (
                 allow_partial_topic
@@ -2417,7 +2447,12 @@ def evidence_text_for_verification(item: dict[str, Any]) -> str:
 
 def evidence_has_topic(item: dict[str, Any], topics: list[str]) -> bool:
     text = evidence_text_for_verification(item).lower()
-    return any(topic.lower() in text for topic in topics)
+    text_canonical = normalize_text(text)
+    return any(
+        (form in text) or (form in text_canonical)
+        for topic in topics
+        for form in expand_forms(topic.lower())
+    )
 
 
 def generate_answer(

--- a/tests/test_text_normalize_regression.py
+++ b/tests/test_text_normalize_regression.py
@@ -1,0 +1,300 @@
+"""Regression guards for the Korean money/date text normalizer (issue #170).
+
+Korean RFP documents (나라장터) express the same value in multiple scripts
+within one document — `1,500,000,000` / `15억` / `일금일십오억원정` /
+`壹拾伍億元` may all refer to the same amount. The naive substring match in
+`rag_core.verify_evidence` cannot bridge these forms.
+
+`text_normalize.normalize_text` (called at query-rewrite and verification
+time) is the additive bridge: callers OR-match `expand_forms(topic)` against
+both raw and canonical evidence text, so every legacy match still works.
+
+Tests cover four layers:
+* `parse_amounts` / `parse_dates` direct parsing (case tables).
+* False-positive guard: `반올림`, time, percent, year-alone do not match.
+* OR-match additive property: legacy substring matches are preserved.
+* End-to-end: `analyze_query` topics include canonical form;
+  `verify_evidence` matches across asymmetric query/evidence directions.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from text_normalize import (  # noqa: E402
+    expand_forms,
+    normalize_text,
+    parse_amounts,
+    parse_dates,
+)
+from rag_core import (  # noqa: E402
+    analyze_query,
+    evidence_has_topic,
+    verify_evidence,
+)
+
+
+# ── Direct parser tests ─────────────────────────────────────────────────────
+
+class NormalizeMoneyTest(unittest.TestCase):
+    """Case table for ``parse_amounts``. Values are integer KRW."""
+
+    CASES: list[tuple[str, int, bool]] = [
+        # (input, expected value, approximate?)
+        ("일금일억오천만원정", 150_000_000, False),
+        ("일금일억정", 100_000_000, False),
+        ("1억 5천만원", 150_000_000, False),
+        ("15억원", 1_500_000_000, False),
+        ("5천만원", 50_000_000, False),
+        ("약 5천만원", 50_000_000, True),
+        ("대략 1억", 100_000_000, True),
+        ("~3천만원", 30_000_000, True),
+        ("90,000,000원", 90_000_000, False),
+        ("90,000,000", 90_000_000, False),
+        ("壹拾億元", 1_000_000_000, False),
+        ("壹億伍仟萬元", 150_000_000, False),
+        ("5천만정도", 50_000_000, True),
+        ("5천만원 내외", 50_000_000, True),
+    ]
+
+    def test_amounts_match_canonical_table(self) -> None:
+        for raw, value, approximate in self.CASES:
+            with self.subTest(raw=raw):
+                results = parse_amounts(raw)
+                self.assertEqual(
+                    1,
+                    len(results),
+                    f"expected exactly one match for {raw!r}, got {results}",
+                )
+                parsed = results[0]
+                self.assertEqual(value, parsed.value)
+                self.assertEqual(approximate, parsed.approximate)
+
+    def test_multiple_amounts_in_one_string(self) -> None:
+        results = parse_amounts("기관 A 예산 5천만원, 기관 B 예산 1억")
+        self.assertEqual(2, len(results))
+        self.assertEqual([50_000_000, 100_000_000], [r.value for r in results])
+
+
+class NormalizeDateTest(unittest.TestCase):
+    """Case table for ``parse_dates``."""
+
+    CASES: list[tuple[str, str, bool]] = [
+        # (input, expected iso, year_inferred?)
+        ("2026-03-15", "2026-03-15", False),
+        ("2026.03.15", "2026-03-15", False),
+        ("2026.3.15", "2026-03-15", False),
+        ("'26.3.15.", "2026-03-15", True),
+        ("2026년 3월 15일", "2026-03-15", False),
+        ("'99.12.31.", "1999-12-31", True),
+        ("'30.1.1.", "2030-01-01", True),
+        ("'40.1.1.", "1940-01-01", True),
+    ]
+    ANCHOR_YEAR = 2026
+
+    def test_dates_match_canonical_table(self) -> None:
+        for raw, iso, inferred in self.CASES:
+            with self.subTest(raw=raw):
+                results = parse_dates(raw, anchor_year=self.ANCHOR_YEAR)
+                self.assertEqual(1, len(results), f"expected one match for {raw!r}")
+                parsed = results[0]
+                self.assertEqual(iso, parsed.iso)
+                self.assertEqual(inferred, parsed.year_inferred)
+
+    def test_yearless_md_skipped_without_anchor(self) -> None:
+        results = parse_dates("3월 15일", anchor_year=None)
+        self.assertEqual(1, len(results))
+        self.assertEqual("", results[0].iso)
+        self.assertTrue(results[0].year_inferred)
+
+    def test_yearless_md_uses_anchor_year(self) -> None:
+        results = parse_dates("3월 15일", anchor_year=2026)
+        self.assertEqual(1, len(results))
+        self.assertEqual("2026-03-15", results[0].iso)
+        self.assertTrue(results[0].year_inferred)
+
+    def test_invalid_month_or_day_skipped(self) -> None:
+        # Month 13 and day 32 are invalid — silently dropped, no exception.
+        self.assertEqual([], parse_dates("2026-13-01"))
+        self.assertEqual([], parse_dates("2026-03-32"))
+
+
+# ── False-positive guards ───────────────────────────────────────────────────
+
+class FalsePositiveGuardTest(unittest.TestCase):
+    """Pin the cases where the normalizer must NOT fire."""
+
+    AMOUNT_NEGATIVES = [
+        "반올림",
+        "반올림한 결과",
+        "100% 비율",
+        "데이터 3건",
+        "오전 10시",
+        "2024년",  # year alone is not money
+        "약 30%",  # percent, not amount
+    ]
+
+    DATE_NEGATIVES = [
+        "2024년 예산",  # year-only, no MD
+        "10시 30분",  # time, not date
+        "전화 02-1234-5678",  # phone number
+    ]
+
+    def test_amount_negatives_do_not_match(self) -> None:
+        for raw in self.AMOUNT_NEGATIVES:
+            with self.subTest(raw=raw):
+                self.assertEqual([], parse_amounts(raw))
+
+    def test_date_negatives_do_not_match(self) -> None:
+        for raw in self.DATE_NEGATIVES:
+            with self.subTest(raw=raw):
+                # Allow an empty list OR matches with iso="" (yearless 분 etc.).
+                dates = parse_dates(raw)
+                self.assertTrue(
+                    all(d.iso == "" for d in dates),
+                    f"unexpected canonical date for {raw!r}: {dates}",
+                )
+
+
+# ── Additive OR-match property ──────────────────────────────────────────────
+
+class OrMatchAdditiveTest(unittest.TestCase):
+    """The new OR-match must preserve every legacy substring match.
+
+    By construction: ``expand_forms(s)`` always includes ``s`` itself, and
+    the disjunction tests ``form in text`` as one branch. So if legacy
+    ``topic.lower() in evidence_text`` was True, the new check is also True.
+
+    This test pins that property over a sampled fixture so a future refactor
+    that drops ``s`` from ``expand_forms`` fails loudly.
+    """
+
+    FIXTURE = [
+        # (topic, evidence_text) pairs where legacy match is True.
+        ("예산", "기관 A의 예산은 5천만원이다."),
+        ("ai", "AI 보안 통제 요구사항."),
+        ("5천만원", "예산 5천만원, 발주기관 기관 A."),
+        ("agency", "agency: 기관 B"),
+        ("2026", "마감일 2026-03-15"),
+    ]
+
+    def _legacy_matches(self, topic: str, text: str) -> bool:
+        return topic.lower() in text.lower()
+
+    def _or_match(self, topic: str, text: str) -> bool:
+        text_l = text.lower()
+        text_c = normalize_text(text_l)
+        return any(
+            (form in text_l) or (form in text_c)
+            for form in expand_forms(topic.lower())
+        )
+
+    def test_legacy_matches_preserved(self) -> None:
+        for topic, text in self.FIXTURE:
+            with self.subTest(topic=topic, text=text):
+                self.assertTrue(self._legacy_matches(topic, text))
+                self.assertTrue(self._or_match(topic, text))
+
+    def test_expand_forms_contains_original(self) -> None:
+        for s in ("5천만원", "기관 A", "예산", ""):
+            with self.subTest(s=s):
+                self.assertIn(s, expand_forms(s))
+
+
+# ── End-to-end through rag_core hooks ───────────────────────────────────────
+
+def _evidence_item(text: str, agency: str = "기관 A") -> dict:
+    return {
+        "text": text,
+        "title": "Test",
+        "agency": agency,
+        "doc_id": "test-doc",
+        "chunk_id": "test-doc#0",
+        "metadata": {"agency": agency, "doc_id": "test-doc"},
+        "score": 0.9,
+    }
+
+
+class EndToEndAnalyzeQueryTest(unittest.TestCase):
+    """``analyze_query`` must surface canonical-form tokens."""
+
+    def test_korean_money_query_includes_canonical_topic(self) -> None:
+        result = analyze_query("기관 A의 예산 5천만원 차이", [])
+        self.assertIn("50000000", result["topics"])
+
+    def test_korean_date_query_includes_canonical_topic(self) -> None:
+        # The canonical date "2026-03-15" gets tokenized by TOKEN_RE into
+        # ["2026", "03", "15"]; the zero-padded "03" is the proof that the
+        # canonical form was tokenized in (the raw "3월 15일" has no "03").
+        result = analyze_query("기관 A의 2026년 3월 15일 일정", [])
+        self.assertIn("03", result["topics"], f"topics={result['topics']}")
+
+    def test_query_without_money_or_date_unaffected(self) -> None:
+        result = analyze_query("기관 A의 보안 통제 요구사항", [])
+        # No canonical-form tokens should be injected.
+        self.assertFalse(
+            any(re_digit(t) and t.isdigit() and len(t) > 6 for t in result["topics"]),
+            f"unexpected numeric topic in plain query: {result['topics']}",
+        )
+
+
+def re_digit(s: str) -> bool:
+    return any(c.isdigit() for c in s)
+
+
+class EndToEndVerifyEvidenceTest(unittest.TestCase):
+    """``verify_evidence`` must OR-match across query/evidence script forms.
+
+    Asymmetry surfaces are the issue #170 regression target: today's
+    substring-only verifier fails when query and evidence use different forms
+    for the same amount.
+    """
+
+    def _analysis(self, topics: list[str], query_type: str = "single_doc") -> dict:
+        return {
+            "query_type": query_type,
+            "topics": topics,
+            "entities": [],
+            "matched_doc_ids": [],
+            "metadata_filters_by_stage": {"strict": {}, "reduced": {}, "relaxed": {}},
+        }
+
+    def test_query_canonical_matches_korean_evidence(self) -> None:
+        # Query topic "50000000" must match evidence "5천만원" via OR-match.
+        evidence = [_evidence_item("기관 A 예산은 5천만원이다.")]
+        verified, reasons = verify_evidence(self._analysis(["50000000"]), evidence)
+        self.assertTrue(verified, f"expected verified, got reasons={reasons}")
+
+    def test_query_korean_matches_canonical_evidence(self) -> None:
+        # Query topic "5천만원" must match evidence "50,000,000원" via OR-match.
+        evidence = [_evidence_item("기관 B 예산 50,000,000원")]
+        verified, reasons = verify_evidence(self._analysis(["5천만원"]), evidence)
+        self.assertTrue(verified, f"expected verified, got reasons={reasons}")
+
+    def test_evidence_has_topic_or_matches_both_directions(self) -> None:
+        item_korean = _evidence_item("기관 A 예산은 5천만원이다.")
+        item_canonical = _evidence_item("기관 B 예산 50,000,000원")
+        # canonical query topic matches korean evidence
+        self.assertTrue(evidence_has_topic(item_korean, ["50000000"]))
+        # korean query topic matches canonical evidence
+        self.assertTrue(evidence_has_topic(item_canonical, ["5천만원"]))
+
+    def test_unrelated_topic_still_does_not_match(self) -> None:
+        # OR-match additivity must not cause false positives — unrelated
+        # topics must NOT match.
+        item = _evidence_item("기관 A 예산은 5천만원이다.")
+        self.assertFalse(evidence_has_topic(item, ["완전히다른토픽xyz"]))
+
+    def test_canonical_iso_date_matches_korean_date_evidence(self) -> None:
+        # Query topic "2026-03-15" (canonical) must match evidence written
+        # as "2026년 3월 15일" via the canonical-form OR-match.
+        item = _evidence_item("기관 A 마감일 2026년 3월 15일.")
+        self.assertTrue(evidence_has_topic(item, ["2026-03-15"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/text_normalize.py
+++ b/text_normalize.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Korean money/date text normalizer for retrieval-time and verification-time use.
+
+Korean RFP documents (나라장터) routinely express the same value in multiple
+scripts within a single document — `1,500,000,000` / `15억` / `일금일십오억원정`
+/ `壹拾伍億元` may all refer to the same amount. The naive substring match in
+`rag_core.verify_evidence` cannot bridge these forms.
+
+This module supplies a small canonical-form rewriter applied at query-rewrite
+and verification time (NOT at ingestion — that would force a full reindex,
+ruled out by issue #170).
+
+The contract is strictly additive: callers pair this module's `expand_forms`
+with their existing substring checks, so every match that worked before still
+works. Approximate spans (`약 5천만원`, `5천만정도`) are *augmented* with their
+canonical form rather than replaced, preserving the approximation qualifier.
+
+See `tests/test_text_normalize_regression.py` for the canonical case table
+including the `반올림` false-positive guard.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import unicodedata
+from typing import NamedTuple
+
+
+# ── Digit / power tables ─────────────────────────────────────────────────────
+
+_HANGUL_DIGIT_MAP: dict[str, int] = {
+    "영": 0, "공": 0,
+    "일": 1, "이": 2, "삼": 3, "사": 4, "오": 5,
+    "육": 6, "칠": 7, "팔": 8, "구": 9,
+}
+
+_HANJA_DIGIT_MAP: dict[str, int] = {
+    "壹": 1, "貳": 2, "叄": 3, "肆": 4, "伍": 5,
+    "陸": 6, "柒": 7, "捌": 8, "玖": 9,
+}
+
+_DIGITS_ALL = {**_HANGUL_DIGIT_MAP, **_HANJA_DIGIT_MAP}
+
+_SUBUNIT_MAP: dict[str, int] = {
+    "십": 10, "拾": 10,
+    "백": 100, "佰": 100, "百": 100,
+    "천": 1000, "仟": 1000, "千": 1000,
+}
+
+_SECTION_MAP: dict[str, int] = {
+    "만": 10**4, "萬": 10**4,
+    "억": 10**8, "億": 10**8,
+    "조": 10**12, "兆": 10**12,
+}
+
+_ENVELOPE_STRIP = ("일금", "정", "원", "元", "圓")
+_APPROX_PREFIX = ("약", "대략", "~")
+_APPROX_SUFFIX = ("정도", "내외")
+
+
+# ── Compiled regexes ────────────────────────────────────────────────────────
+
+# A Korean number is structured as: (digit subunit?)+ optional section, repeated.
+# The grammar below enforces "every myriad needs a section marker (만/억/조)" so
+# random digit runs in non-money contexts don't get absorbed. A bare body
+# without a section is only accepted when followed by a money-unit suffix.
+
+_HANGUL_DIGIT_PART = r"(?:[\d,]+|[영공일이삼사오육칠팔구])"
+_HANGUL_SUBUNIT_PART = r"[십백천]"
+_HANGUL_SECTION_PART = r"[만억조]"
+
+_HANGUL_MYRIAD_BODY = (
+    rf"{_HANGUL_DIGIT_PART}\s*"
+    rf"(?:{_HANGUL_SUBUNIT_PART}\s*{_HANGUL_DIGIT_PART}\s*)*"
+    rf"{_HANGUL_SUBUNIT_PART}?"
+)
+_HANGUL_NUMBER_SECTIONED = (
+    rf"(?:{_HANGUL_MYRIAD_BODY}\s*{_HANGUL_SECTION_PART}\s*)+"
+)
+# Trailing money-unit suffix. 정 must NOT be followed by 도 (그것은 '정도' approximation marker).
+_HANGUL_MONEY_SUFFIX = r"(?:\s*원\s*정|\s*원|\s*정(?!도))"
+
+_HANGUL_MONEY_RE = re.compile(
+    r"(?:일금\s*)?"
+    r"(?:"
+    rf"{_HANGUL_NUMBER_SECTIONED}{_HANGUL_MONEY_SUFFIX}?"  # sectioned (anchor = section)
+    r"|"
+    rf"{_HANGUL_MYRIAD_BODY}{_HANGUL_MONEY_SUFFIX}"        # bare body (anchor = 원/정)
+    r")"
+)
+
+_HANJA_DIGIT_PART = r"[壹貳叄肆伍陸柒捌玖]"
+_HANJA_SUBUNIT_PART = r"[拾佰百仟千]"
+_HANJA_SECTION_PART = r"[萬億兆]"
+
+_HANJA_MYRIAD_BODY = (
+    rf"{_HANJA_DIGIT_PART}\s*"
+    rf"(?:{_HANJA_SUBUNIT_PART}\s*{_HANJA_DIGIT_PART}\s*)*"
+    rf"{_HANJA_SUBUNIT_PART}?"
+)
+_HANJA_NUMBER_SECTIONED = (
+    rf"(?:{_HANJA_MYRIAD_BODY}\s*{_HANJA_SECTION_PART}\s*)+"
+)
+
+_HANJA_MONEY_RE = re.compile(
+    r"(?:"
+    rf"{_HANJA_NUMBER_SECTIONED}(?:\s*[元圓])?"
+    r"|"
+    rf"{_HANJA_MYRIAD_BODY}\s*[元圓]"
+    r")"
+)
+
+# Arabic with commas: require ≥2 commas (millions+) OR ≥1 comma followed by
+# explicit 원. Single comma without 원 is too ambiguous (count vs. money).
+_ARABIC_COMMA_MONEY_RE = re.compile(
+    r"\b\d{1,3}(?:,\d{3}){2,}(?:\.\d+)?(?:\s*원)?"
+    r"|"
+    r"\b\d{1,3},\d{3}\s*원"
+)
+
+# Approximation markers — checked against text around each money span.
+_APPROX_PREFIX_RE = re.compile(r"(?:약|대략|~)\s*$")
+_APPROX_SUFFIX_RE = re.compile(r"^\s*(?:정도|내외)")
+
+# Date families.
+_DATE_ISO_RE = re.compile(r"\b(\d{4})[-./](\d{1,2})[-./](\d{1,2})\.?")
+_DATE_APOS_RE = re.compile(r"'(\d{2})\.(\d{1,2})\.(\d{1,2})\.?")
+_DATE_HANGUL_FULL_RE = re.compile(r"(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일")
+_DATE_HANGUL_MD_RE = re.compile(r"(?<!\d)(\d{1,2})월\s*(\d{1,2})일")
+
+
+# ── Structured result types ─────────────────────────────────────────────────
+
+class ParsedAmount(NamedTuple):
+    raw: str
+    value: int
+    approximate: bool
+    span: tuple[int, int]
+
+
+class ParsedDate(NamedTuple):
+    raw: str
+    iso: str
+    year_inferred: bool
+    span: tuple[int, int]
+
+
+# ── Internal helpers ────────────────────────────────────────────────────────
+
+def _strip_envelopes(text: str) -> str:
+    out = text
+    for env in _ENVELOPE_STRIP:
+        out = out.replace(env, "")
+    return out.replace(" ", "").replace(",", "")
+
+
+def _parse_korean_number(raw: str) -> int | None:
+    """Parse a money span into its integer KRW value.
+
+    Returns None for spans that aren't well-formed money (e.g. unknown
+    characters, all-envelope, zero value). This is the second-line
+    false-positive guard after the regex.
+    """
+    text = _strip_envelopes(raw)
+    if not text:
+        return None
+
+    total = 0
+    section = 0
+    current = 0
+    saw_input = False
+
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch.isdigit():
+            j = i
+            while j < len(text) and text[j].isdigit():
+                j += 1
+            current = int(text[i:j])
+            saw_input = True
+            i = j
+            continue
+        if ch in _DIGITS_ALL:
+            current = _DIGITS_ALL[ch]
+            saw_input = True
+            i += 1
+            continue
+        if ch in _SUBUNIT_MAP:
+            mult = _SUBUNIT_MAP[ch]
+            if current == 0 and not saw_input:
+                current = 1
+            section += current * mult
+            current = 0
+            saw_input = True
+            i += 1
+            continue
+        if ch in _SECTION_MAP:
+            mult = _SECTION_MAP[ch]
+            if current:
+                section += current
+                current = 0
+            if section == 0:
+                section = 1
+            total += section * mult
+            section = 0
+            saw_input = True
+            i += 1
+            continue
+        return None
+
+    if current:
+        section += current
+    if section:
+        total += section
+    return total if total > 0 else None
+
+
+def _is_approximate(text: str, span: tuple[int, int]) -> bool:
+    start, end = span
+    prefix = text[max(0, start - 6):start]
+    suffix = text[end:end + 6]
+    if _APPROX_PREFIX_RE.search(prefix):
+        return True
+    if _APPROX_SUFFIX_RE.match(suffix):
+        return True
+    return False
+
+
+def _resolve_year(yy: int, anchor_year: int | None) -> int:
+    if anchor_year is None:
+        anchor_year = datetime.date.today().year
+    anchor_yy = anchor_year % 100
+    century = (anchor_year // 100) * 100
+    if yy <= anchor_yy + 5:
+        return century + yy
+    return century - 100 + yy
+
+
+def _valid_md(month: int, day: int) -> bool:
+    return 1 <= month <= 12 and 1 <= day <= 31
+
+
+# ── Public API ──────────────────────────────────────────────────────────────
+
+def parse_amounts(s: str) -> list[ParsedAmount]:
+    """Extract money spans from s. Returns ParsedAmount entries sorted by span."""
+    if not s:
+        return []
+
+    candidates: list[tuple[int, int]] = []
+    for pattern in (_HANGUL_MONEY_RE, _HANJA_MONEY_RE, _ARABIC_COMMA_MONEY_RE):
+        for m in pattern.finditer(s):
+            candidates.append(m.span())
+    if not candidates:
+        return []
+
+    # Prefer longer matches starting at the same position; then drop overlaps.
+    candidates.sort(key=lambda sp: (sp[0], -(sp[1] - sp[0])))
+    accepted: list[tuple[int, int]] = []
+    last_end = -1
+    for start, end in candidates:
+        if start < last_end:
+            continue
+        accepted.append((start, end))
+        last_end = end
+
+    results: list[ParsedAmount] = []
+    for start, end in accepted:
+        raw = s[start:end].rstrip()
+        # Trim trailing whitespace from span to keep approximation-suffix
+        # detection accurate.
+        end = start + len(raw)
+        value = _parse_korean_number(raw)
+        if value is None or value == 0:
+            continue
+        approximate = _is_approximate(s, (start, end))
+        results.append(ParsedAmount(raw=raw, value=value, approximate=approximate, span=(start, end)))
+    return results
+
+
+def parse_dates(s: str, anchor_year: int | None = None) -> list[ParsedDate]:
+    """Extract date spans from s. Returns ParsedDate entries sorted by span.
+
+    Year-less `M월 D일` is parsed only when anchor_year is supplied. Two-digit
+    years use a rolling +5 window around anchor (default: today's year).
+    """
+    if not s:
+        return []
+
+    found: list[ParsedDate] = []
+
+    for m in _DATE_HANGUL_FULL_RE.finditer(s):
+        year, month, day = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if not _valid_md(month, day):
+            continue
+        found.append(ParsedDate(
+            raw=m.group(),
+            iso=f"{year:04d}-{month:02d}-{day:02d}",
+            year_inferred=False,
+            span=m.span(),
+        ))
+
+    for m in _DATE_APOS_RE.finditer(s):
+        yy, month, day = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if not _valid_md(month, day):
+            continue
+        year = _resolve_year(yy, anchor_year)
+        found.append(ParsedDate(
+            raw=m.group(),
+            iso=f"{year:04d}-{month:02d}-{day:02d}",
+            year_inferred=True,
+            span=m.span(),
+        ))
+
+    for m in _DATE_ISO_RE.finditer(s):
+        # Skip if this span is already covered by an earlier match (e.g.
+        # the digit prefix of `2026년 3월 15일` is not a separate ISO date).
+        if any(_spans_overlap(m.span(), other.span) for other in found):
+            continue
+        year, month, day = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if not _valid_md(month, day):
+            continue
+        found.append(ParsedDate(
+            raw=m.group(),
+            iso=f"{year:04d}-{month:02d}-{day:02d}",
+            year_inferred=False,
+            span=m.span(),
+        ))
+
+    # Year-less M월 D일: only when anchor_year is supplied. Skip spans already
+    # covered by YYYY년 M월 D일 matches.
+    for m in _DATE_HANGUL_MD_RE.finditer(s):
+        if any(_spans_overlap(m.span(), other.span) for other in found):
+            continue
+        if anchor_year is None:
+            # Surface the span with empty iso so callers know it was seen.
+            month, day = int(m.group(1)), int(m.group(2))
+            if not _valid_md(month, day):
+                continue
+            found.append(ParsedDate(
+                raw=m.group(), iso="", year_inferred=True, span=m.span(),
+            ))
+            continue
+        month, day = int(m.group(1)), int(m.group(2))
+        if not _valid_md(month, day):
+            continue
+        found.append(ParsedDate(
+            raw=m.group(),
+            iso=f"{anchor_year:04d}-{month:02d}-{day:02d}",
+            year_inferred=True,
+            span=m.span(),
+        ))
+
+    found.sort(key=lambda p: p.span[0])
+    return found
+
+
+def normalize_text(s: str, anchor_year: int | None = None) -> str:
+    """Rewrite money/date spans in s to canonical form.
+
+    Money:
+    - Literal amounts: span replaced with the integer literal (`5천만원` →
+      `50000000`).
+    - Approximate amounts: canonical form *appended* in `[≈N]` brackets so
+      the qualifier survives (`약 5천만원` → `약 5천만원 [≈50000000]`).
+
+    Dates:
+    - Canonicalized to ISO `YYYY-MM-DD`. Year-less `M월 D일` left unchanged
+      unless anchor_year is supplied.
+    """
+    if not s:
+        return s
+
+    s = unicodedata.normalize("NFC", s)
+    amounts = parse_amounts(s)
+    dates = parse_dates(s, anchor_year=anchor_year)
+
+    spans: list[tuple[int, int, str]] = []
+    for a in amounts:
+        if a.approximate:
+            spans.append((a.span[0], a.span[1], f"{a.raw} [≈{a.value}]"))
+        else:
+            spans.append((a.span[0], a.span[1], str(a.value)))
+    for d in dates:
+        if d.iso:
+            spans.append((d.span[0], d.span[1], d.iso))
+
+    if not spans:
+        return s
+
+    spans.sort(key=lambda x: x[0])
+    out: list[str] = []
+    cursor = 0
+    for start, end, replacement in spans:
+        if start < cursor:
+            continue
+        out.append(s[cursor:start])
+        out.append(replacement)
+        cursor = end
+    out.append(s[cursor:])
+    return "".join(out)
+
+
+def expand_forms(s: str) -> list[str]:
+    """Return [s, normalize_text(s)] deduped, stable order.
+
+    Callers use this with substring matching for additive OR-match semantics —
+    if the legacy form matched, the original is still in the list and matches
+    identically.
+    """
+    if not s:
+        return [s]
+    normalized = normalize_text(s)
+    if normalized == s:
+        return [s]
+    return [s, normalized]
+
+
+def _spans_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    return a[0] < b[1] and b[0] < a[1]


### PR DESCRIPTION
## 1. What changed and why

Korean RFPs routinely express the same amount in multiple scripts within a single document (`1,500,000,000` / `15억` / `일금일십오억원정` / `壹拾伍億元`). Today's substring-only verifier cannot bridge these forms — a query of `5천만원` does not match evidence containing `50,000,000`, and vice versa.

This PR adds `text_normalize.py` (single-file module, no new abstractions) and wires it into `analyze_query` and `verify_evidence` via an **OR-match across `expand_forms(s) = [s, normalize_text(s)]`**. The contract is strictly additive: the original `s` is always the first form, so every legacy substring match is preserved by construction. Approximate spans (`약 5천만원`) are augmented with `[≈50000000]` rather than replaced, so qualifiers survive for downstream use.

Closes #170

## 2. Files affected

- `text_normalize.py` (**new**, 422 lines) — `normalize_text`, `expand_forms`, `parse_amounts`, `parse_dates`. Hangul + Hanja + Arabic-with-commas money grammars, five date families, rolling +5 year-window for two-digit years, `반올림` false-positive guard.
- `rag_core.py` (**load-bearing**, +39/-2) — 1 import + 3 hunks (`analyze_query`, `verify_evidence`, `evidence_has_topic`).
- `tests/test_text_normalize_regression.py` (**new**, 300 lines) — six TestCase classes (case tables, false-positive guards, additive OR-match property, end-to-end through `analyze_query` and `verify_evidence`).
- `docs/retrieval-hardening.md` — new H2 section documenting canonical forms, approximation handling, known limitations, false-positive guard.

## 3. Risks

1. **Comparison-balanced ranking shift** (the issue explicitly calls this out). Mitigation: `evidence_has_topic` uses the same OR-match; matches strictly increase. `test_legacy_matches_preserved` pins the additive property over a sampled fixture.
2. **Over-normalization of `약 5천만원`-style approximations.** Mitigation: approximation prefix/suffix detection (`약`, `대략`, `~`, `정도`, `내외`); approximate spans are **appended** (`약 5천만원 [≈50000000]`) instead of replaced, so the qualifier survives.
3. **False positives on lemmas containing money-shaped syllables** (e.g. `반올림`). Mitigation: money regex requires either a money-unit suffix (`원/정/元/圓`) or a top-level power (`만/억/조/萬/億/兆`). `FalsePositiveGuardTest` pins this for `반올림`, `100% 비율`, `데이터 3건`, `오전 10시`, `2024년` (year alone), and `약 30%`.
4. **Latency** — extra `normalize_text` call per query and per verification. Sample query stage latency went from ~1ms to ~5–8ms in smoke runs; aggregate p95 unchanged (still ≤6ms on the 9-chunk public synthetic corpus). Per-chunk impact is microseconds on real corpus sizes.

## 4. Tests

- New: `tests/test_text_normalize_regression.py` (18 tests). Includes:
  - `NormalizeMoneyTest` — 14-case table covering Hangul (`일금일억오천만원정`), Hanja (`壹拾億元`, `壹億伍仟萬元`), Arabic-with-commas, approximation markers (`약`, `대략`, `~`, `정도`, `내외`).
  - `NormalizeDateTest` — 8-case table plus year-window edges (`'99` → 1999, `'30` → 2030, `'40` → 1940 with anchor=2026).
  - `FalsePositiveGuardTest` — `반올림` and friends do not match.
  - `OrMatchAdditiveTest` — `test_legacy_matches_preserved` is the load-bearing safety pin.
  - End-to-end through `analyze_query` and `verify_evidence`, both asymmetric directions (query topic `50000000` vs evidence `5천만원`, and vice versa).
- All 226 existing tests pass (`python3 -m unittest discover -s tests -p 'test_*.py'`).

## 5. Eval impact

Synthetic CI delta: all `·` expected on existing queries (none contain money/date forms that would trigger the normalizer). `make smoke` confirms unchanged accuracy/groundedness/citation/abstention numbers across all 8 presets; only latency varies by ±2ms (noise).

### 5b. Real-data delta

Blocked by #160 (real-data eval baseline is non-reproducible at same commit). The load-bearing safety argument is OR-match additivity, pinned by `test_legacy_matches_preserved`: by construction, the original `s` is always the first form in `expand_forms(s)`, so every legacy substring match is preserved. The comparison-balancer's `missing_comparison_topic` coverage signal can only gain matches, never lose. **No `agentic_full` / `naive_baseline` retrieval-path regression is possible by construction.**

## 6. Backward compatibility

No `ANSWER_SCHEMA_VERSION` bump (ADR 0003). Normalization runs on retrieval/verification **inputs**; the answer dict structure (`status`, `claims`, `citations[]`) is unchanged. Citations still point to the original (non-normalized) evidence chunks.

## 7. Out of scope

Deferred to follow-up issues:
- Apply `normalize_text` to `evidence_text_for_verification` metadata field rendering — changes the input to the LLM/judge, separate concern.
- Add `anchor_year` to `run_rag_query` / session state — enables `M월 D일` (year-less) normalization. Currently year-less dates are surfaced with empty `iso`, not canonicalized.
- Retrofit `parse_budget` ingestion-side normalization — needs reindex cost-benefit analysis.
- Approximation comparator semantics (`이상/이하/미만/초과`) — currently not flagged as approximate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)