### PR TITLE
Add Phase 4.1a blog + GitHub Pages bootstrap

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,36 @@
+title: BidMate Agent — Engineering Notes
+description: >-
+  RFP DocAgent의 baseline 유지, 평가 surface 분리, 실패 분류 등 엔지니어링 결정의 배경을 정리한 노트.
+  소스: https://github.com/hskim-solv/BidMate-DocAgent
+
+theme: minima
+
+# minima 2.5+의 hook — `_includes/custom-head.html`이 <head>에 주입된다.
+# 여기에 mermaid client-side 렌더러를 로드한다.
+
+# Pages는 docs/ 디렉토리를 source로 사용한다.
+# 기존 ADR/설계 문서는 frontmatter가 없어 markdown 변환만 되고 theme layout이 적용되지 않는다.
+# Pages 사이트의 콘텐츠는 frontmatter가 있는 페이지(index, blog/*, architecture-deep-dive)만 대상으로 한다.
+
+# Markdown 처리기. GitHub Pages는 kramdown만 지원.
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+  hard_wrap: false
+
+# 출력 경로에서 .html 접미 제거. 블로그 URL을 깔끔하게 만든다.
+permalink: pretty
+
+# Jekyll이 처리하지 않을 항목.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor
+  - node_modules
+  - "*.json"
+
+# 사이드바/탑바에 노출할 페이지 (minima header_pages 설정).
+header_pages:
+  - blog/index.md
+  - architecture-deep-dive.md

--- a/docs/_includes/custom-head.html
+++ b/docs/_includes/custom-head.html
@@ -1,0 +1,24 @@
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script>
+  // GitHub Pages의 kramdown은 ```mermaid 블록을 <pre><code class="language-mermaid">로 출력한다.
+  // mermaid.run()을 querySelector로 직접 호출해 <pre>/<code>를 mermaid가 인식하도록 정규화한다.
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll('pre > code.language-mermaid').forEach(function (block) {
+      var pre = block.parentNode;
+      var wrapper = document.createElement('div');
+      wrapper.className = 'mermaid';
+      wrapper.textContent = block.textContent;
+      pre.parentNode.replaceChild(wrapper, pre);
+    });
+    if (window.mermaid) {
+      window.mermaid.initialize({ startOnLoad: false, theme: 'default' });
+      window.mermaid.run();
+    }
+  });
+</script>
+<style>
+  /* 블로그 본문 가독성 보강 */
+  .post-content table, .page-content table { font-size: 0.9rem; }
+  .post-content blockquote, .page-content blockquote { border-left: 4px solid #d4a017; }
+  .mermaid { background: #fbfbfb; padding: 12px; border: 1px solid #eee; border-radius: 4px; }
+</style>

--- a/docs/blog/2026-05-extractive-baseline.md
+++ b/docs/blog/2026-05-extractive-baseline.md
@@ -1,0 +1,94 @@
+---
+layout: page
+title: Extractive를 1급 baseline로 유지하는 이유
+date: 2026-05-11
+permalink: /blog/2026-05-extractive-baseline/
+---
+
+> 결론: LLM 합성이 더 화려한 결과를 만들어도 extractive baseline은 *기본값으로* 살려둔다.
+> 새 기법은 baseline 옆에 *측정 가능한 ablation*으로만 추가한다. 통계가 효과를 확증하기 전까지 default를 바꾸지 않는다.
+
+## 왜 이 결정이 필요했는가
+
+BidMate-DocAgent는 RFP/제안요청서를 읽고 grounded answer를 생성하는 시스템이다. 초기 설계 시점부터 두 갈래가 있었다.
+
+- **Extractive**: retrieved evidence chunk에서 claim을 *그대로 발췌*해 citation과 함께 반환한다. 외부 LLM을 호출하지 않으므로 결정적이고, hallucination이 구조적으로 불가능하다.
+- **LLM 합성**: 같은 evidence를 LLM에 넘겨 자연스러운 산문 답변을 생성한다. 가독성과 추론 표현력이 좋다.
+
+LLM 합성이 *읽는 맛*에서 우위인 것은 일찍 분명해졌다. 그렇다면 기본 파이프라인을 LLM 합성으로 두는 것이 자연스러워 보인다. 하지만 그렇게 하지 않았고, 그 이유와 측정 근거를 정리한다.
+
+## 결정 — ADR 0001
+
+[ADR 0001](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/adr/0001-preserve-naive-baseline.md)이 그 정책을 단 한 문장으로 잠근다.
+
+> "Every advanced component adds latency, complexity, and a surface for regressions. Without a side-by-side comparison run on the same cases, it is impossible to tell whether the extra machinery actually improves quality on a given query slice — or just shifts the failure mode."
+
+핵심은 두 가지다. **(1)** advanced 구성요소는 비용을 *동반*한다. **(2)** baseline 옆에 두지 않으면 *질 개선*인지 *실패 모드 이동*인지 알 수 없다.
+
+## 코드 강제: 기본값이 곧 ADR
+
+ADR은 문서지만, 결정을 강제하는 것은 코드다. 본 프로젝트에서 그 강제점은 두 곳이다.
+
+```python
+# rag_core.py
+DEFAULT_PIPELINE = "naive_baseline"
+
+def pipeline_cli_choices() -> list[str]:
+    return ["naive_baseline", "agentic_full", "agentic_full_llm"]
+```
+
+```yaml
+# eval/config.yaml
+primary_run: naive_baseline
+```
+
+`pipeline_cli_choices()`에서 `naive_baseline`을 빼는 행위 자체가 ADR 0001을 revisit하겠다는 *명시적 신호*다. `eval/config.yaml`의 `primary_run`은 매 평가 호출마다 baseline 컬럼이 자동 생성되도록 한다 — "baseline은 코드에는 남아있는데 더 이상 측정하지 않는다"는 형태로 silently rot하는 길을 차단한다.
+
+## 측정 증거: 정량으로 ADR을 지탱한다
+
+n=42 공개 평가셋 + 1000-resample bootstrap 95% CI 측정 결과(README 성능표에서 발췌)는 두 가지 사실을 드러낸다.
+
+| 지표 | naive_baseline | agentic_full | 해석 |
+|---|---|---|---|
+| Answer Accuracy | 0.844 ± 0.12 | 0.906 ± 0.12 | **CI 겹침** — n=42에서는 통계적으로 약함 |
+| Citation Precision | 0.512 ± 0.12 | 0.905 ± 0.08 | **CI 분리** — metadata-first + verifier의 *진짜* 효용 |
+
+이 두 줄을 한 번에 보여주는 게 baseline 유지의 핵심 가치다. *Accuracy만 보면* "n=42에서 통계 효과 없음"으로 결론을 내릴 위험이 있고, *citation precision까지 보면* "agentic pipeline은 grounding 정확도에서 통계적으로 우월"이라는 정직한 결론에 도달한다. baseline 컬럼이 없었다면 우리는 둘 중 한 결론만 보고 있었을 것이다.
+
+같은 표에서 `no_verifier_retry` ablation은 accuracy는 동일(0.906)하지만 groundedness가 0.929 → 0.762 (-16.7pp)로 떨어진다. **무엇이 무엇 덕분에 작동하는지**는 baseline + ablation grid가 있어야 *비로소* 보인다.
+
+## Real-data 회귀를 잡은 사례 — 이슈 #69
+
+baseline의 가치는 통계 표에서만 드러나는 것이 아니다. 회귀를 *조기에* 잡는다.
+
+이슈 [#69](https://github.com/hskim-solv/BidMate-DocAgent/pull/88) 은 verifier의 relaxed 단계에서 partial-topic grounding을 허용해 false abstention을 줄이는 변경이었다. 공개 synthetic 평가(n=42)에서는 *회귀 없음*으로 보였다 — accuracy 그대로, citation precision 그대로. 그런데 private real-data 측정에서 intended-abstention 케이스 4건 중 2건이 `insufficient` → `partial`로 잘못 분류되는 것이 잡혔다([실데이터 기록](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/private-100-doc-experiments.md)).
+
+만약 synthetic 평가만 봤다면 이 회귀는 머지된 후 사용자가 production에서 발견했을 것이다. baseline + dual eval이 *같이* 작동했기 때문에 조기 검출이 가능했다. 이 사례는 다음 글([Public synthetic + Private real](./)) 에서 다룬다.
+
+## ADR 0011: 새 기법은 *교체*가 아니라 *additive ablation*으로
+
+2026년 LLM 합성 ablation을 추가하면서도 위 원칙은 깨지지 않았다. [ADR 0011](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/adr/0011-llm-synthesis-as-additive-ablation.md)은 이렇게 결정한다.
+
+- 새 preset `agentic_full_llm` 추가 — `prompt_profile=llm_synthesis`
+- 기본 CLI 값은 그대로 `naive_baseline`
+- LLM이 evidence에 없는 chunk_id를 인용하면 결과 *거부* + extractive 렌더러로 fallback
+- 공개 CI는 `stub` 백엔드(결정적, pass-through)로 zero-regression 계약 잠금
+
+이 패턴이 ADR 0001의 *모양 그 자체*다. 새 기능을 추가하되 baseline은 그대로, 측정 가능한 ablation 한 줄로만 들어간다. 이렇게 하면 "advanced 옵션이 켜져서 production에 들어갔는데 정작 측정해보니 약했다"는 시나리오가 발생하지 않는다.
+
+## 일반화 — 다른 프로젝트에 그대로 적용 가능한 4가지
+
+1. **Baseline을 *기본값으로* 둔다.** "선택하면 켜지는" 옵션이 아니라 "끄지 않으면 켜지는" 디폴트. 옵션 선택을 안 해본 사용자도 baseline의 결과를 보게 된다.
+2. **모든 advanced component는 ablation으로 들어간다.** 매 평가 호출에서 ablation 컬럼이 *자동 생성*되도록 평가 설정에 못 박는다.
+3. **CI는 bootstrap CI까지 같이 본다.** `mean` 값 비교는 n=42에서 noise일 수 있다. CI 겹침 여부가 *진짜 효과*의 임계점이다.
+4. **두 surface로 측정한다.** synthetic만으로는 못 잡는 회귀가 있다 — 다음 글의 주제.
+
+## 다음 글에서
+
+[Public synthetic + Private real, 두 평가 surface](./) — 두 surface를 어떻게 *코드 강제 경계*로 동시에 유지하는지, 그리고 이슈 #69 회귀가 *왜* 공개 평가에서 잡히지 않았는지의 메커니즘.
+
+---
+
+- 관련 ADR: [0001](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/adr/0001-preserve-naive-baseline.md), [0011](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/adr/0011-llm-synthesis-as-additive-ablation.md)
+- 측정 표: [README §핵심 성능표](https://github.com/hskim-solv/BidMate-DocAgent#%ED%95%B5%EC%8B%AC-%EC%84%B1%EB%8A%A5%ED%91%9C-%EC%8B%A4%EC%B8%A1)
+- 회귀 incident: [docs/private-100-doc-experiments.md](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/private-100-doc-experiments.md)

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: 엔지니어링 블로그
+permalink: /blog/
+---
+
+BidMate-DocAgent의 엔지니어링 결정과 그 *왜*를 정리한 시리즈입니다. 코드와 ADR이 *무엇*을 했는지 말한다면, 이 블로그는 *왜 그렇게 결정했는가*와 *어떻게 측정해 검증했는가*를 다룹니다.
+
+## Phase 4 시리즈
+
+### 1. [Extractive를 1급 baseline로 유지하는 이유](./2026-05-extractive-baseline/)
+
+LLM 합성이 화려해 보여도 **extractive baseline을 그대로 살려두고**, 새 기법은 baseline 옆에 *측정 가능한 ablation*으로만 추가한다는 원칙. citation precision `0.512 → 0.905`(95% CI 분리)이라는 정량 근거와, synthetic CI가 놓친 real-data 회귀(이슈 #69) 사례를 통해 이 원칙이 *비용을 정당화한 결정*임을 보입니다.
+
+### 2. Public synthetic + Private real, 두 평가 surface (준비 중)
+
+재현 가능성과 honest signal은 같은 평가 surface로 동시에 충족하기 어렵습니다. 두 surface를 *코드 강제 경계*로 유지해 둘 다 가지는 방법(.gitignore + pre-commit hook + script-level allowlist의 3중 방어).
+
+### 3. 실패 분류로 백로그 생성하기 (준비 중)
+
+발견한 실패를 ad-hoc하게 수정하는 대신 **분류 → 카테고리별 root cause → 코드 위치 → Impact/Effort grid → GitHub 이슈**로 매핑하는 방법론. C6 false abstention → 이슈 #69, C4 follow-up loss → 이슈 #71, C2 ambiguity → 이슈 #72 매핑 walk-through.
+
+## 관련 자료
+
+- 저장소 README: [github.com/hskim-solv/BidMate-DocAgent](https://github.com/hskim-solv/BidMate-DocAgent)
+- ADR 인덱스: [`docs/adr/README.md`](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/adr/README.md)
+- 실패 분류 본문: [`docs/real-data-failure-taxonomy.md`](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/real-data-failure-taxonomy.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+---
+layout: home
+title: BidMate Agent — Engineering Notes
+---
+
+RFP/제안요청서 문서 이해를 위한 Agentic RAG 시스템 [BidMate-DocAgent](https://github.com/hskim-solv/BidMate-DocAgent)의 엔지니어링 결정과 측정 결과를 정리한 노트입니다.
+
+핵심 메시지는 "고급 retrieval/생성 기법을 얹는 것보다, **extractive baseline · 이중 평가 surface · 실패 분류**라는 엔지니어링 규율을 일관되게 유지한 것"이 본 프로젝트의 차별점이라는 점입니다.
+
+## 진입점
+
+- **[엔지니어링 블로그](./blog/)** — Phase 4 시리즈 3편
+  - [Extractive를 1급 baseline로 유지하는 이유](./blog/2026-05-extractive-baseline/)
+  - Public synthetic + Private real, 두 평가 surface (준비 중)
+  - 실패 분류로 백로그 생성하기 (준비 중)
+- **[1-page Architecture deep-dive](./architecture-deep-dive/)** (준비 중)
+- **[저장소 문서 인덱스](./)** — ADR, 설계 노트, 벤치마크, 평가
+
+## 5분 리뷰 경로 (저장소 기준)
+
+1. README의 *TL;DR* + *핵심 성능표*: [github.com/hskim-solv/BidMate-DocAgent](https://github.com/hskim-solv/BidMate-DocAgent)
+2. ADR 0001 (baseline 유지), ADR 0005 (이중 평가): `docs/adr/`
+3. 실패 분류: [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy)
+
+저장소 README가 source of truth이며, 본 사이트는 narrative와 의사결정 배경을 보강합니다.


### PR DESCRIPTION
## 1. What changed and why

Phase 4의 첫 번째 PR. 두 가지 일을 한 번에 한다 — (a) `docs/`를 source로 하는 GitHub Pages 인프라 부트스트랩(Jekyll `_config.yml` + mermaid client-side include + site landing + blog index), (b) Phase 4.1a 블로그 1편 ("Extractive를 1급 baseline로 유지하는 이유"). Pages 인프라를 첫 머지에 묶어 4.1b·4.1c·4.2가 markdown만 추가하면 되도록 한다.

블로그는 ADR 0001의 결정을 (1) `pipeline_cli_choices()`의 코드 강제, (2) 측정 결과 (citation precision 0.512 → 0.905, CI 분리), (3) 이슈 #69 회귀 사례, (4) ADR 0011 additive ablation 패턴으로 정당화한다.

> **Action item (수동)**: 머지 후 repo Settings → Pages → Source: `main` branch / `/docs` folder로 설정해야 사이트가 빌드된다.

Closes #182

## 2. Files affected

- `docs/_config.yml` (new) — Jekyll minima theme + permalink: pretty + header_pages
- `docs/_includes/custom-head.html` (new) — mermaid.js v11 client-side 렌더러 + 기본 스타일
- `docs/index.md` (new) — Pages 사이트 랜딩
- `docs/blog/index.md` (new) — 블로그 인덱스 (Phase 4 시리즈 3편 소개)
- `docs/blog/2026-05-extractive-baseline.md` (new) — 본문, ~1500자 한국어

Load-bearing 파일 변경 없음.

## 3. Risks

가장 가능성 있는 회귀: GitHub Pages Jekyll 빌드 실패. 완화: `_config.yml`에 GitHub Pages가 기본 지원하는 minima + kramdown만 사용. 기존 `docs/*.md`는 모두 frontmatter가 없어 markdown 변환만 거치고 layout이 적용되지 않으므로 충돌 위험 없음(사전 검증: `head -3` 로 모든 핵심 docs 파일 확인). mermaid는 GitHub Pages allowlist 외부 플러그인을 쓰지 않고 client-side script로 렌더.

## 4. Tests

문서 추가만 있으므로 새 테스트 없음. 검증은 머지 후 Pages 빌드 워크플로(`pages-build-deployment`)와 사이트의 mermaid 렌더 육안 확인.

## 5. Eval impact

All ·. RAG/retrieval/eval 경로 변경 없음.

### 5b. Real-data delta

N/A — docs only, no behavior change in retrieval / verifier path.

## 6. Backward compatibility

기존 링크/스키마/CLI 플래그 변경 없음. `docs/README.md`도 그대로 유지(별도 PR에서 새 블로그 링크 추가 검토).

## 7. Out of scope

- 4.1b / 4.1c 블로그, 4.2 deep-dive, 4.3 README finalize → 후속 PR
- 라이브 데모 배포 / 데모 비디오 → 별도 issue (사용자 요청대로 placeholder 유지)
- `docs/README.md`에 블로그 링크 추가 → 4.3 PR에서 README 갱신과 함께 처리