### PR TITLE
build: .dockerignore for Docker build context hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,71 @@
+# BidMate-DocAgent Docker build context allowlist.
+#
+# The Dockerfile uses explicit COPY of named files (rag_core.py, api/,
+# demo/, scripts/build_index.py, data/raw/, docker-entrypoint.sh —
+# see Dockerfile lines 35-40), so the image content is already
+# tightly scoped. This file shrinks the *build context* the daemon
+# receives, which speeds up local and remote builds and avoids
+# uploading transient eval / scratch state.
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+.githooks/
+
+# CI / workflow / GitHub state (not needed in the runtime image)
+.github/
+
+# Claude Code worktree-side state and hooks scratch
+.claude/
+
+# Python caches and build artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+build/
+dist/
+
+# Local environments and secrets
+.venv/
+venv/
+.env
+.env.*
+
+# OS / editor noise
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*~
+
+# Tests, benchmarks, eval — the demo image is a runtime surface,
+# not a CI surface. Keeping these out of the context also keeps
+# fixtures out of cache invalidation for image rebuilds.
+tests/
+benchmarks/
+eval/
+artifacts/
+
+# Reviewer-facing docs are not needed inside the image
+docs/
+
+# Reports / outputs are generated artifacts; the entrypoint
+# regenerates data/index on first start (Dockerfile lines 8-9).
+reports/
+outputs/
+data/index/
+data/files/
+data/data_list.csv
+data/data_list.xlsx
+원본 데이터/
+
+# IDE / scratch dirs that sometimes appear locally
+.tmp/
+.cache/


### PR DESCRIPTION
## 1. What changed and why

Add `.dockerignore` at repo root so the Docker daemon stops uploading transient worktree state (`.git/`, `tests/`, `eval/`, `reports/`, `.claude/`, `data/index/`, private CSVs, IDE caches) into the build context. The [Dockerfile](Dockerfile) uses explicit `COPY` of named files (lines 35–40), so image content is unchanged — this only shrinks the daemon-side context transfer and prevents cache invalidation from unrelated file changes. Pre-flight micro M1 of the Phase 3 12-PR stack (portfolio backlog #187).

Closes #204

## 2. Files affected

- [.dockerignore](.dockerignore) — new file.

No load-bearing files touched.

## 3. Risks

**Most likely break**: excluding a path the Dockerfile actually needs. Ruled out by re-reading the [Dockerfile](Dockerfile) line by line: every `COPY` source (`rag_core.py`, `rag_synthesis.py`, `ingestion.py`, `visual_ingestion.py`, `app.py`, `api/`, `demo/`, `scripts/build_index.py`, `data/raw/`, `docker-entrypoint.sh`, `requirements.txt`) is NOT excluded by the new `.dockerignore`. The exclusions are limited to scratch (`.git/`, caches), tests/eval surface (`tests/`, `eval/`, `benchmarks/`), reviewer docs (`docs/`), regenerated artifacts (`data/index/` — entrypoint rebuilds), and private data (`data/files/`, `data/data_list.*`, `원본 데이터/`).

## 4. Tests

No new test added. `.dockerignore` has no Python execution path. `bash scripts/test.sh` (full pytest) passes unchanged on this branch.

## 5. Eval impact

All `·` — non-RAG change.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** No Python file modified.

## 6. Backward compatibility

None. New file; no existing contract / schema / CLI flag touched.

## 7. Out of scope

- Multi-stage Dockerfile refactor.
- Image base swap (still `python:3.11-slim`).
- The Fly.io deploy workflow itself — that's #181 (P10 of the Phase 3 stack).
- Local docker build verification — Docker is not installed in the implementation environment; reviewer can verify via `docker build -t bm-test .` or wait for the #181 Fly.io workflow to exercise the same context.