### PR TITLE
eval: RAGAS-style LLM judge as additive enrichment on synthetic (#164)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker demo demo-docker pareto docker-publish real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke smoke-with-judge harness-smoke test test-regression api api-docker demo demo-docker pareto docker-publish real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -55,6 +55,16 @@ check:
 
 smoke:
 	bash scripts/smoke.sh
+
+# Run the synthetic smoke eval, then ask a RAGAS-style LLM judge for
+# enrichment metrics (ADR 0012). Opt-in additive only — never replaces
+# the deterministic verifier. Default backend is `stub` (zero-cost,
+# deterministic); set BIDMATE_JUDGE_BACKEND=openai_compatible plus
+# BIDMATE_JUDGE_* env vars for a paid judge call. Pass --fold-aggregate
+# to merge the judge_ragas block into reports/eval_summary.json.
+smoke-with-judge: smoke
+	$(PYTHON) eval/llm_judge.py --fold-aggregate
+	@echo "RAGAS scores written. Per-case verdicts in reports/eval_summary.judge.local.json (gitignored)."
 
 harness-smoke:
 	$(PYTHON) scripts/run_harness.py --config harness/smoke.yaml

--- a/docs/adr/0014-ragas-judge-additive-synthetic.md
+++ b/docs/adr/0014-ragas-judge-additive-synthetic.md
@@ -1,0 +1,98 @@
+# 0012: RAGAS-style LLM-judge as additive enrichment on the synthetic surface
+
+- **Status**: accepted
+- **Date**: 2026-05-11
+- **Related**: refines [ADR 0006](./0006-llm-judge-on-real-data-only.md); preserves [ADR 0001](./0001-preserve-naive-baseline.md), [ADR 0003](./0003-structured-answer-citation-contract.md), [ADR 0004](./0004-verifier-retry-policy.md), [ADR 0005](./0005-eval-split-public-synthetic-private-local.md); reuses backend pattern from [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md)
+- **Deciders**: hskim
+
+## Context
+
+[ADR 0006](./0006-llm-judge-on-real-data-only.md) restricted LLM-as-judge to the real-data eval surface for three valid reasons: external dependency, per-query token cost, and harder reproducibility on the public CI path. The decision held — and still holds — for *gating* metrics. But it left a gap visible to senior reviewers:
+
+> "The public-synthetic accuracy=0.906 number is retrieval-grounded but not LLM-graded. A reviewer's first instinct is *judged by what?*"
+
+The deterministic verifier answers that for **grounding rigor** (claims-citation alignment, evidence coverage, format compliance), but not for the multi-dimensional quality questions a RAGAS-style read surfaces:
+
+1. **Faithfulness** — do answer claims actually appear in the cited evidence?
+2. **Answer relevance** — does the answer address the query, or does it drift?
+3. **Context precision** — what fraction of the retrieved evidence is on-topic?
+4. **Context recall** — does the evidence cover what the answer needs?
+
+These are *enrichment* signals, not gates. A senior review wants to see them alongside the deterministic numbers; they do not replace anything.
+
+The same engineering shape that worked for [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (LLM synthesis as additive ablation, never replacing the extractive baseline) applies here: **add the RAGAS judge alongside the existing surface, never replace any existing metric, keep the CI deterministic and free by default.**
+
+## Decision
+
+A RAGAS-style LLM-judge is permitted as an **opt-in additive enrichment** on the **public synthetic eval surface**:
+
+- **Default off.** `BIDMATE_JUDGE_BACKEND=stub` is the CI default. Stub is deterministic, network-free, zero-cost, and the public CI workflows (`pr-eval.yml`) do not invoke the judge at all. ADR 0004's reproducibility argument holds.
+- **Opt-in paid mode.** `BIDMATE_JUDGE_BACKEND=openai_compatible` (or `anthropic`) calls the configured model with a per-case prompt that asks for all four RAGAS scores in a single JSON response. Invoked manually via `make smoke-with-judge` or `python3 eval/llm_judge.py`. Never invoked by automated CI.
+- **Cache by content hash.** Each `(query, summary, evidence[:3])` SHA256 hash maps to a cache file under `reports/judge_cache/` (gitignored). A re-run with unchanged inputs has zero token cost. Cache invalidation is by re-hashing; the existing input/output discipline is enough.
+- **Token budget cap.** `BIDMATE_JUDGE_TOKEN_BUDGET` (default 200,000 input-token estimate per full eval run). If reached, the script refuses to continue rather than racking up unbounded cost. Users override the env var deliberately.
+
+### Output schema
+
+Per-case verdict (local-only, gitignored):
+
+```json
+{
+  "id": "case_id",
+  "faithfulness": 0.0–1.0,
+  "answer_relevance": 0.0–1.0,
+  "context_precision": 0.0–1.0,
+  "context_recall": 0.0–1.0,
+  "reason_short": "string, ≤ 200 chars"
+}
+```
+
+Committable aggregate (lives at top-level of `reports/eval_summary.json` under `judge_ragas`):
+
+```json
+{
+  "faithfulness": float,
+  "answer_relevance": float,
+  "context_precision": float,
+  "context_recall": float,
+  "n": int,
+  "ci": { "<metric>": { "mean": ..., "ci_lo": ..., "ci_hi": ... } }
+}
+```
+
+The aggregate is mean ± 95% bootstrap CI per metric, reusing [`eval/bootstrap.py`](../../eval/bootstrap.py). No per-case payload crosses the commit boundary; `scripts/run_real_eval_delta.py:SAFE_TOPLEVEL_KEYS` whitelists `judge_ragas` with explicit sub-key allowlisting.
+
+### Refines ADR 0006, doesn't supersede it
+
+ADR 0006's gate-only restriction stays: the deterministic verifier remains the source of truth for `answer.status` (supported / partial / insufficient). The RAGAS judge contributes *enrichment metrics*, not status decisions. The two surfaces serve different epistemic purposes:
+
+- **ADR 0006 judge** (real-data, status-style): "does the model's read of the evidence agree with the verifier's call?" — `agreement_with_verifier` is the headline.
+- **ADR 0014 judge** (synthetic, RAGAS-style): "how does the answer score on four quality dimensions?" — four numeric scores, each with a CI.
+
+They coexist in the same `scripts/llm_judge.py` backend infrastructure (stub / openai_compatible / anthropic) but write to different top-level keys (`judge` for ADR 0006, `judge_ragas` for ADR 0014).
+
+## Consequences
+
+**Wins**
+
+- Public-synthetic numbers gain a second-opinion signal that's *not* trained on the same eval set. Reviewer's "judged by what?" question has a concrete answer.
+- Same backend idiom as ADR 0006 — no new auth flow, no new env vars (`BIDMATE_JUDGE_API_KEY`, `BIDMATE_JUDGE_MODEL`, optional `BIDMATE_JUDGE_BASE_URL` already exist).
+- Caching means re-runs across PRs against the same case set are free, so opt-in cost is bounded to first-time runs and prompt changes.
+- ADR 0001 / 0003 / 0004 / 0005 invariants unchanged.
+
+**Costs**
+
+- Per-run token cost when opt-in mode is used. Bounded by the budget cap (~$3-5 per full eval run with Sonnet 4.6 + prompt cache, per #164 estimate). Budget enforcement is a hard refusal, not a warning.
+- One more env var combination for users to know about. Mitigated by stub being the default and `make smoke-with-judge` orchestrating the workflow.
+- A judge outage on opt-in runs means RAGAS metrics aren't computed for that PR. The deterministic eval still completes; the `judge_ragas` block is simply absent.
+
+**Constraints (unchanged from prior ADRs)**
+
+- Public CI must not call out to any external LLM. Enforced by convention: `pr-eval.yml` does not invoke the judge, and stub is the default everywhere else.
+- Aggregate-only commit boundary stays intact. Per-case judge text under `reports/judge_cache/` is gitignored. Aggregate sub-keys are explicit-allowlist extracted by `scripts/run_real_eval_delta.py`.
+
+## Alternatives considered
+
+- **Use RAGAS directly (the upstream library).** Rejected: adds a paid framework dependency and its own opinion on which model to call. The four metrics are well-defined; a 50-line backend-agnostic implementation gives us the same signal with full control over prompt, caching, and budget enforcement.
+- **Compute the four metrics deterministically (token overlap / cosine).** Rejected: that's just a fancier version of the existing groundedness / citation_precision metrics. The point is *another model's read* — the same Goodhart concern (#169) applies if we generate metrics from the same retrieval scaffolding being evaluated.
+- **Gate CI on RAGAS thresholds.** Rejected for the same reasons as ADR 0006: reproducibility, cost, and external dependency on the *public* path. Future tightening would need a Judge↔Human agreement floor (#169 / ADR 0013-pending), not a raw RAGAS gate.
+- **Merge under existing `judge` top-level key.** Rejected: the schemas differ (status-style vs four-numeric-metrics), and the surfaces differ (real-data vs synthetic). Coexistence via separate top-level keys keeps the privacy boundary easier to audit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -76,3 +76,4 @@ project record.
 | [0011](./0011-llm-synthesis-as-additive-ablation.md) | proposed | LLM answer synthesis as additive ablation (extends 0001, preserves 0003) |
 | [0012](./0012-llm-judge-on-public-synthetic.md) | accepted | LLM-judge on the public synthetic eval, stub-default (refines 0006, reuses 0011 backend pattern) |
 | [0013](./0013-observability-as-additive-pluggable-surface.md) | accepted | Observability as an additive, pluggable, fail-closed surface |
+| [0014](./0014-ragas-judge-additive-synthetic.md) | accepted | RAGAS-style LLM judge as additive enrichment on synthetic surface (extends 0012) |

--- a/eval/llm_judge.py
+++ b/eval/llm_judge.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""RAGAS-style LLM-judge as additive enrichment on the synthetic surface.
+
+Refines [ADR 0006](../docs/adr/0006-llm-judge-on-real-data-only.md)'s
+real-data-only restriction by adding an opt-in additive judge on the
+public synthetic eval (see [ADR 0014](../docs/adr/0014-ragas-judge-
+additive-synthetic.md)). Same backend pluggability as
+``scripts/llm_judge.py`` — ``stub`` (deterministic, default) /
+``openai_compatible`` — and the same environment variable contract.
+
+Four metrics per case, each a float in [0.0, 1.0]:
+
+* ``faithfulness`` — fraction of answer claims supported by evidence
+* ``answer_relevance`` — how directly the answer addresses the query
+* ``context_precision`` — fraction of evidence chunks that are on-topic
+* ``context_recall`` — how well evidence covers what the answer needs
+
+CI default is ``BIDMATE_JUDGE_BACKEND=stub`` (zero-cost deterministic
+echo). Opt-in paid runs use ``openai_compatible``. Token budget is
+enforced — the script refuses to continue past
+``BIDMATE_JUDGE_TOKEN_BUDGET`` (default 200_000) input tokens
+estimated.
+
+Per-case verdicts are cached by SHA256(query, summary, evidence[:3])
+under ``reports/judge_cache/`` (gitignored); a re-run with unchanged
+inputs is free. The committable aggregate is mean + 95% bootstrap CI
+per metric, written to ``reports/eval_summary.json`` under the
+top-level ``judge_ragas`` key.
+
+CLI:
+
+    python3 eval/llm_judge.py \\
+        --eval-summary reports/eval_summary.json \\
+        --output reports/eval_summary.judge.local.json \\
+        --backend stub
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from eval.bootstrap import bootstrap_ci  # noqa: E402
+from rag_core import EVIDENCE_BOUNDARY, neutralize_instruction_patterns  # noqa: E402
+
+RAGAS_METRICS: tuple[str, ...] = (
+    "faithfulness",
+    "answer_relevance",
+    "context_precision",
+    "context_recall",
+)
+DEFAULT_CACHE_DIR = ROOT_DIR / "reports" / "judge_cache"
+DEFAULT_EVAL_SUMMARY = ROOT_DIR / "reports" / "eval_summary.json"
+DEFAULT_OUTPUT_PATH = ROOT_DIR / "reports" / "eval_summary.judge.local.json"
+DEFAULT_TOKEN_BUDGET = 200_000
+
+PROMPT_TEMPLATE = """You are scoring a retrieval-augmented QA system on a procurement (RFP) document.
+Rate four facets of the answer on a 0.0-1.0 scale.
+
+Query:
+{query}
+
+Answer summary:
+{summary}
+
+Top retrieved evidence chunks:
+{evidence}
+
+Definitions:
+- faithfulness: fraction of answer claims supported by the evidence
+- answer_relevance: how directly the answer addresses the query
+- context_precision: fraction of evidence chunks that are actually on-topic
+- context_recall: how well the evidence covers what the answer needs
+
+Reply ONLY with valid JSON of the form:
+{{"faithfulness": float,
+  "answer_relevance": float,
+  "context_precision": float,
+  "context_recall": float,
+  "reason_short": "short reason, <= 200 chars"}}
+"""
+
+
+# -----------------------------------------------------------------------------
+# Backends
+# -----------------------------------------------------------------------------
+
+
+def _stub_backend(_prompt: str) -> dict[str, Any]:
+    """Deterministic stub.
+
+    Returns a fixed score vector so plumbing tests do not depend on
+    network or API keys. The values are crafted to be distinguishable
+    from a real-world distribution: faithfulness=1.0 (perfect),
+    others=0.95 — useful as a smoke fixture.
+    """
+    return {
+        "faithfulness": 1.0,
+        "answer_relevance": 0.95,
+        "context_precision": 0.95,
+        "context_recall": 0.95,
+        "reason_short": "stub backend: synthetic constant scores",
+    }
+
+
+def _openai_compatible_backend(prompt: str) -> dict[str, Any]:  # pragma: no cover - network
+    """Generic OpenAI-compatible endpoint (Anthropic-Compat, OpenAI, vLLM, etc.).
+
+    Reads ``BIDMATE_JUDGE_API_KEY``, ``BIDMATE_JUDGE_MODEL``, optional
+    ``BIDMATE_JUDGE_BASE_URL``. Imported lazily so stub-mode tests have
+    no SDK dependency.
+    """
+    try:
+        from openai import OpenAI  # type: ignore[import-not-found]
+    except Exception as exc:
+        raise RuntimeError(
+            "openai_compatible backend requires the openai SDK. "
+            "Install with `pip install openai` or use BIDMATE_JUDGE_BACKEND=stub."
+        ) from exc
+
+    api_key = os.environ.get("BIDMATE_JUDGE_API_KEY")
+    if not api_key:
+        raise RuntimeError("BIDMATE_JUDGE_API_KEY is not set.")
+    base_url = os.environ.get("BIDMATE_JUDGE_BASE_URL") or None
+    model = os.environ.get("BIDMATE_JUDGE_MODEL")
+    if not model:
+        raise RuntimeError("BIDMATE_JUDGE_MODEL is not set.")
+
+    client = OpenAI(api_key=api_key, base_url=base_url)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.0,
+        response_format={"type": "json_object"},
+    )
+    content = response.choices[0].message.content or "{}"
+    return _normalize_verdict(json.loads(content))
+
+
+_BACKENDS: dict[str, Callable[[str], dict[str, Any]]] = {
+    "stub": _stub_backend,
+    "openai_compatible": _openai_compatible_backend,
+}
+
+
+def _normalize_verdict(payload: dict[str, Any]) -> dict[str, Any]:
+    """Clamp and coerce a raw backend payload to the RAGAS schema."""
+    out = {metric: _clamp01(payload.get(metric, 0.0)) for metric in RAGAS_METRICS}
+    out["reason_short"] = str(payload.get("reason_short") or "")[:200]
+    return out
+
+
+def _clamp01(value: Any) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, score))
+
+
+# -----------------------------------------------------------------------------
+# Prompt + cache helpers
+# -----------------------------------------------------------------------------
+
+
+def _extract_summary(case: dict[str, Any]) -> str:
+    answer = case.get("answer")
+    if isinstance(answer, dict):
+        return str(answer.get("summary") or "")
+    return str(answer or case.get("answer_text") or "")
+
+
+def _build_prompt(case: dict[str, Any]) -> str:
+    query = case.get("query") or ""
+    summary = _extract_summary(case)
+    evidence_items = case.get("evidence") or []
+    evidence_lines = []
+    for i, item in enumerate(evidence_items[:3], start=1):
+        text = (item.get("text") if isinstance(item, dict) else "") or ""
+        evidence_lines.append(
+            f"[{i}] {neutralize_instruction_patterns(text[:600])}"
+        )
+    evidence_block = EVIDENCE_BOUNDARY.join(evidence_lines) or "(no evidence)"
+    return PROMPT_TEMPLATE.format(
+        query=neutralize_instruction_patterns(query),
+        summary=neutralize_instruction_patterns(summary),
+        evidence=evidence_block,
+    )
+
+
+def _cache_key(case: dict[str, Any], backend: str, model: str) -> str:
+    """SHA256 over the inputs that determine the verdict.
+
+    Includes backend + model so switching the backend invalidates the
+    cache (we want fresh judgments when changing the underlying judge).
+    """
+    query = str(case.get("query") or "")
+    summary = _extract_summary(case)
+    evidence_items = case.get("evidence") or []
+    ev_repr = json.dumps(
+        [
+            {
+                "doc_id": (item.get("doc_id") if isinstance(item, dict) else ""),
+                "text": (item.get("text") if isinstance(item, dict) else "")[:300],
+            }
+            for item in evidence_items[:3]
+        ],
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    payload = "|".join([backend, model, query, summary, ev_repr])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _estimate_tokens(prompt: str) -> int:
+    return max(1, len(prompt) // 3)
+
+
+# -----------------------------------------------------------------------------
+# Pipeline
+# -----------------------------------------------------------------------------
+
+
+def _aggregate(cases: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-case verdicts into mean + 95% bootstrap CI per metric."""
+    if not cases:
+        out: dict[str, Any] = {metric: None for metric in RAGAS_METRICS}
+        out["n"] = 0
+        out["ci"] = {}
+        return out
+    out = {"n": len(cases), "ci": {}}
+    for metric in RAGAS_METRICS:
+        scores = [float(c.get(metric) or 0.0) for c in cases]
+        out[metric] = sum(scores) / len(scores)
+        ci = bootstrap_ci(scores)
+        if ci is not None:
+            out["ci"][metric] = ci
+    return out
+
+
+def judge_ragas(
+    summary: dict[str, Any],
+    *,
+    backend: str = "stub",
+    cache_dir: Path | None = None,
+    token_budget: int = DEFAULT_TOKEN_BUDGET,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run the RAGAS judge over an eval_summary dict.
+
+    Returns ``(local_payload, aggregate)``. The caller is responsible
+    for writing each — local payload contains per-case judge text and
+    stays gitignored; aggregate is committable.
+    """
+    if backend not in _BACKENDS:
+        raise ValueError(
+            f"Unknown judge backend {backend!r}; "
+            f"choose one of {sorted(_BACKENDS)}."
+        )
+    backend_fn = _BACKENDS[backend]
+    if cache_dir is None:
+        cache_dir = DEFAULT_CACHE_DIR
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    model = os.environ.get("BIDMATE_JUDGE_MODEL", "stub")
+
+    case_results = summary.get("case_results") or []
+    judged: list[dict[str, Any]] = []
+    cache_hits = 0
+    new_calls = 0
+    tokens_estimated = 0
+
+    for case in case_results:
+        if not isinstance(case, dict):
+            continue
+        key = _cache_key(case, backend, model)
+        cache_path = cache_dir / f"{key}.json"
+        if cache_path.exists():
+            try:
+                verdict = json.loads(cache_path.read_text(encoding="utf-8"))
+                cache_hits += 1
+            except json.JSONDecodeError:
+                cache_path.unlink(missing_ok=True)
+                verdict = None
+        else:
+            verdict = None
+        if verdict is None:
+            prompt = _build_prompt(case)
+            est = _estimate_tokens(prompt)
+            if tokens_estimated + est > token_budget:
+                raise RuntimeError(
+                    f"Judge token budget {token_budget} would be exceeded "
+                    f"(estimated +{est} on top of {tokens_estimated}). "
+                    "Raise BIDMATE_JUDGE_TOKEN_BUDGET deliberately or reduce "
+                    "the case set."
+                )
+            tokens_estimated += est
+            verdict = _normalize_verdict(backend_fn(prompt))
+            cache_path.write_text(
+                json.dumps(verdict, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            new_calls += 1
+        judged.append({"id": case.get("id"), **verdict})
+
+    aggregate = _aggregate(judged)
+    local_payload = {
+        "schema_version": 1,
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "backend": backend,
+        "model": model,
+        "cases": judged,
+        "cache_hits": cache_hits,
+        "new_calls": new_calls,
+        "tokens_estimated": tokens_estimated,
+    }
+    return local_payload, aggregate
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--eval-summary",
+        default=str(DEFAULT_EVAL_SUMMARY),
+        help="Path to reports/eval_summary.json (default: public synthetic).",
+    )
+    ap.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_PATH),
+        help=(
+            "Where to write the per-case judge payload (gitignored). "
+            "Aggregate is also folded into the eval_summary.json under "
+            "top-level 'judge_ragas'."
+        ),
+    )
+    ap.add_argument(
+        "--backend",
+        default=os.environ.get("BIDMATE_JUDGE_BACKEND", "stub"),
+        choices=sorted(_BACKENDS),
+        help="Judge backend (defaults to BIDMATE_JUDGE_BACKEND or 'stub').",
+    )
+    ap.add_argument(
+        "--token-budget",
+        type=int,
+        default=int(
+            os.environ.get("BIDMATE_JUDGE_TOKEN_BUDGET", DEFAULT_TOKEN_BUDGET)
+        ),
+        help=f"Input-token estimate budget per run (default {DEFAULT_TOKEN_BUDGET}).",
+    )
+    ap.add_argument(
+        "--cache-dir",
+        default=str(DEFAULT_CACHE_DIR),
+        help="Per-case verdict cache directory (gitignored).",
+    )
+    ap.add_argument(
+        "--fold-aggregate",
+        action="store_true",
+        help=(
+            "After scoring, also write the aggregate under the top-level "
+            "'judge_ragas' key in the eval_summary.json so 'make smoke' "
+            "and downstream readers see the metrics. Off by default to "
+            "avoid surprising users running stub mode for sanity."
+        ),
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    eval_path = Path(args.eval_summary)
+    if not eval_path.exists():
+        print(
+            f"[ERROR] Eval summary not found: {eval_path}\n"
+            "Run `make smoke` or `make eval` first.",
+            file=sys.stderr,
+        )
+        return 2
+    summary = json.loads(eval_path.read_text(encoding="utf-8"))
+    try:
+        local_payload, aggregate = judge_ragas(
+            summary,
+            backend=args.backend,
+            cache_dir=Path(args.cache_dir),
+            token_budget=args.token_budget,
+        )
+    except RuntimeError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(local_payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"[OK] Per-case verdicts written: {output_path}")
+    print(json.dumps(aggregate, ensure_ascii=False, indent=2))
+
+    if args.fold_aggregate:
+        summary["judge_ragas"] = aggregate
+        eval_path.write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"[OK] Aggregate folded into {eval_path} under 'judge_ragas'.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -74,8 +74,22 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         # boundary; per-case judge text stays in
         # reports/real100/judge.local.json.
         "judge",
+        # ADR 0012 RAGAS-style judge aggregates on the synthetic surface.
+        # Only the four metric means + their 95% bootstrap CIs cross the
+        # commit boundary; per-case verdicts stay in
+        # reports/eval_summary.judge.local.json and reports/judge_cache/.
+        "judge_ragas",
     }
 )
+
+# RAGAS metric sub-keys whitelisted from `judge_ragas`. Float scalars + CI dicts.
+SAFE_JUDGE_RAGAS_METRIC_KEYS = (
+    "faithfulness",
+    "answer_relevance",
+    "context_precision",
+    "context_recall",
+)
+SAFE_JUDGE_RAGAS_META_KEYS = ("n", "ci")
 
 # Sub-keys whitelisted from `retry_effectiveness` — all numeric or count
 # aggregates over the case set, no per-case payload.
@@ -223,6 +237,22 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                 for sub in SAFE_RUN_MANIFEST_KEYS
                 if value.get(sub) is not None
             }
+        elif key == "judge_ragas" and isinstance(value, dict):
+            ragas: dict[str, Any] = {}
+            for metric in SAFE_JUDGE_RAGAS_METRIC_KEYS:
+                if value.get(metric) is not None:
+                    ragas[metric] = value[metric]
+            for meta in SAFE_JUDGE_RAGAS_META_KEYS:
+                if meta == "ci" and isinstance(value.get(meta), dict):
+                    ragas[meta] = {
+                        m: value[meta].get(m)
+                        for m in SAFE_JUDGE_RAGAS_METRIC_KEYS
+                        if isinstance(value[meta].get(m), dict)
+                    }
+                elif value.get(meta) is not None:
+                    ragas[meta] = value[meta]
+            if ragas:
+                out[key] = ragas
         else:
             out[key] = value
 
@@ -386,6 +416,22 @@ def render_markdown(
                 f"base={_fmt_value(base_cross.get('retry_precision'))} · "
                 f"head={_fmt_value(head_cross.get('retry_precision'))} · "
                 f"method=`{head_cross.get('method') or base_cross.get('method', '—')}`_"
+            )
+
+    base_ragas = base.get("judge_ragas") or {}
+    head_ragas = head.get("judge_ragas") or {}
+    if base_ragas or head_ragas:
+        lines.append("")
+        lines.append("#### RAGAS judge (ADR 0012, opt-in)")
+        lines.append("")
+        lines.append("| metric | base | head | Δ |")
+        lines.append("|---|---|---|---|")
+        for metric in SAFE_JUDGE_RAGAS_METRIC_KEYS:
+            b = base_ragas.get(metric)
+            h = head_ragas.get(metric)
+            lines.append(
+                f"| {metric} | {_fmt_value(b)} | {_fmt_value(h)} | "
+                f"{_fmt_delta(b, h, True)} |"
             )
 
     base_judge = base.get("judge") or {}

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -1,13 +1,14 @@
-"""Tests for the LLM-judge plumbing on the real-data surface (ADR 0006).
+"""Tests for the LLM-judge plumbing on the real-data surface (ADR 0006)
+and the additive RAGAS-style judge on the synthetic surface (ADR 0014).
 
-The stub backend mirrors the verifier's status, which makes the
-plumbing testable without a network / API key. The tests pin:
+The stub backends are deterministic, so plumbing is testable without
+a network / API key. Tests pin:
 
-* the per-case verdict shape and the agreement-with-verifier
-  bookkeeping
-* the aggregate shape stays inside the ADR 0005 / ADR 0006 commit
-  boundary (no per-case judge text)
-* the CLI writes the local file but stdout shows only aggregates
+* per-case verdict shape (ADR 0006: status; ADR 0014: four RAGAS scores)
+* aggregate shape stays inside the ADR 0005 commit boundary
+* per-case content caching makes re-runs cost-free
+* token budget enforcement refuses past the cap
+* CLI writes local file but stdout shows only aggregates
 """
 from __future__ import annotations
 
@@ -18,6 +19,11 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from eval.llm_judge import (
+    DEFAULT_TOKEN_BUDGET,
+    RAGAS_METRICS,
+    judge_ragas,
+)
 from scripts.llm_judge import judge_summary
 
 
@@ -117,6 +123,167 @@ class JudgeCLIInvocationTest(unittest.TestCase):
             local = json.loads(out_path.read_text(encoding="utf-8"))
             self.assertEqual(len(local["cases"]), 3)
             self.assertIn("case_supported", json.dumps(local, ensure_ascii=False))
+
+
+class JudgeRagasStubTest(unittest.TestCase):
+    """ADR 0014: RAGAS-style judge on the synthetic surface (additive)."""
+
+    def test_stub_returns_four_metrics_with_fixed_scores(self) -> None:
+        with TemporaryDirectory() as tmp:
+            local, agg = judge_ragas(
+                _fake_summary(), backend="stub", cache_dir=Path(tmp)
+            )
+        self.assertEqual(3, len(local["cases"]))
+        for case in local["cases"]:
+            for metric in RAGAS_METRICS:
+                self.assertIn(metric, case)
+                self.assertTrue(0.0 <= case[metric] <= 1.0)
+        # Aggregate has the four metric means + n + ci.
+        self.assertEqual(3, agg["n"])
+        # Stub fixture: faithfulness=1.0, others=0.95.
+        self.assertAlmostEqual(1.0, agg["faithfulness"])
+        self.assertAlmostEqual(0.95, agg["answer_relevance"])
+        self.assertAlmostEqual(0.95, agg["context_precision"])
+        self.assertAlmostEqual(0.95, agg["context_recall"])
+        # CI block exists and is well-formed per metric.
+        for metric in RAGAS_METRICS:
+            ci = agg["ci"].get(metric)
+            self.assertIsNotNone(ci, metric)
+            self.assertIn("ci_lo", ci)
+            self.assertIn("ci_hi", ci)
+
+    def test_aggregate_does_not_leak_per_case_text(self) -> None:
+        with TemporaryDirectory() as tmp:
+            _local, agg = judge_ragas(
+                _fake_summary(), backend="stub", cache_dir=Path(tmp)
+            )
+        flat = json.dumps(agg, ensure_ascii=False)
+        for leak in [
+            "case_supported", "case_partial", "case_abstain",
+            "private query", "private answer summary", "private evidence text",
+        ]:
+            self.assertNotIn(leak, flat)
+
+    def test_cache_hit_skips_backend_call(self) -> None:
+        """A second invocation against the same cache dir + inputs should
+        be served entirely from cache (cache_hits == n, new_calls == 0)."""
+        with TemporaryDirectory() as tmp:
+            cache = Path(tmp)
+            _first, _ = judge_ragas(
+                _fake_summary(), backend="stub", cache_dir=cache
+            )
+            second, _ = judge_ragas(
+                _fake_summary(), backend="stub", cache_dir=cache
+            )
+        self.assertEqual(3, second["cache_hits"])
+        self.assertEqual(0, second["new_calls"])
+        self.assertEqual(0, second["tokens_estimated"])
+
+    def test_cache_invalidates_on_backend_switch(self) -> None:
+        """Different backend identity should bust the cache."""
+        with TemporaryDirectory() as tmp:
+            cache = Path(tmp)
+            _first, _ = judge_ragas(
+                _fake_summary(), backend="stub", cache_dir=cache
+            )
+            # Manually creating cache entries with a fake backend identity
+            # would be invasive; instead, verify the cache key includes
+            # backend: switching backends (if openai_compatible were
+            # available) would refresh. Here we just confirm consistency.
+            second, _ = judge_ragas(
+                _fake_summary(), backend="stub", cache_dir=cache
+            )
+        self.assertEqual(3, second["cache_hits"])
+
+    def test_token_budget_refusal(self) -> None:
+        """A zero-budget run must refuse rather than incur cost."""
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(RuntimeError):
+                judge_ragas(
+                    _fake_summary(),
+                    backend="stub",
+                    cache_dir=Path(tmp),
+                    token_budget=0,
+                )
+
+    def test_unknown_backend_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            judge_ragas(_fake_summary(), backend="does_not_exist")
+
+    def test_empty_case_set_yields_null_aggregate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            _local, agg = judge_ragas(
+                {"case_results": []}, backend="stub", cache_dir=Path(tmp)
+            )
+        self.assertEqual(0, agg["n"])
+        for metric in RAGAS_METRICS:
+            self.assertIsNone(agg[metric])
+
+
+class JudgeRagasCLITest(unittest.TestCase):
+    def test_cli_stub_writes_local_payload_and_aggregate_to_stdout(self) -> None:
+        with TemporaryDirectory() as tmp:
+            eval_path = Path(tmp) / "eval_summary.json"
+            out_path = Path(tmp) / "judge.local.json"
+            cache_dir = Path(tmp) / "cache"
+            eval_path.write_text(
+                json.dumps(_fake_summary(), ensure_ascii=False),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "eval/llm_judge.py",
+                    "--eval-summary", str(eval_path),
+                    "--output", str(out_path),
+                    "--cache-dir", str(cache_dir),
+                    "--backend", "stub",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=Path(__file__).resolve().parents[1],
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            # Aggregate JSON appears on stdout; per-case text does not.
+            self.assertIn("faithfulness", result.stdout)
+            self.assertIn("context_recall", result.stdout)
+            for leak in [
+                "case_supported", "private query", "private answer summary",
+            ]:
+                self.assertNotIn(leak, result.stdout)
+            # Local payload has per-case data + caching counters.
+            local = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertEqual(3, len(local["cases"]))
+            self.assertIn("cache_hits", local)
+            self.assertIn("tokens_estimated", local)
+
+    def test_cli_fold_aggregate_writes_into_summary(self) -> None:
+        with TemporaryDirectory() as tmp:
+            eval_path = Path(tmp) / "eval_summary.json"
+            out_path = Path(tmp) / "judge.local.json"
+            cache_dir = Path(tmp) / "cache"
+            eval_path.write_text(
+                json.dumps(_fake_summary(), ensure_ascii=False),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "eval/llm_judge.py",
+                    "--eval-summary", str(eval_path),
+                    "--output", str(out_path),
+                    "--cache-dir", str(cache_dir),
+                    "--backend", "stub",
+                    "--fold-aggregate",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=Path(__file__).resolve().parents[1],
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            folded = json.loads(eval_path.read_text(encoding="utf-8"))
+            self.assertIn("judge_ragas", folded)
+            self.assertAlmostEqual(1.0, folded["judge_ragas"]["faithfulness"])
 
 
 if __name__ == "__main__":

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -285,6 +285,61 @@ class ExtractAggregateTest(unittest.TestCase):
         self.assertIn("0.500", md)
         self.assertIn("0.800", md)
 
+    def test_judge_ragas_sub_keys_whitelisted(self) -> None:
+        """ADR 0012: judge_ragas aggregate must round-trip the four metric
+        means + CI sub-block, and drop any unexpected sub-keys (e.g.,
+        per-case payload smuggled in by a future maintainer)."""
+        summary = {
+            **FULL_SUMMARY,
+            "judge_ragas": {
+                "faithfulness": 0.92,
+                "answer_relevance": 0.85,
+                "context_precision": 0.78,
+                "context_recall": 0.81,
+                "n": 42,
+                "ci": {
+                    "faithfulness": {"mean": 0.92, "ci_lo": 0.85, "ci_hi": 0.97, "n": 42},
+                    "answer_relevance": {"mean": 0.85, "ci_lo": 0.78, "ci_hi": 0.92, "n": 42},
+                },
+                # Unexpected sub-keys must be dropped.
+                "cases": [{"id": "leak", "query": "leak"}],
+                "raw_prompts": "leak prompt content",
+            },
+        }
+        agg = extract_aggregate(summary)
+        ragas = agg["judge_ragas"]
+        self.assertAlmostEqual(0.92, ragas["faithfulness"])
+        self.assertAlmostEqual(0.78, ragas["context_precision"])
+        self.assertEqual(42, ragas["n"])
+        self.assertIn("faithfulness", ragas["ci"])
+        # Unexpected sub-keys dropped.
+        self.assertNotIn("cases", ragas)
+        self.assertNotIn("raw_prompts", ragas)
+        # Privacy: leaked strings should not appear anywhere in the aggregate.
+        self.assertNotIn("leak", json.dumps(agg))
+
+    def test_render_includes_judge_ragas_section(self) -> None:
+        summary_with_ragas = {
+            **FULL_SUMMARY,
+            "judge_ragas": {
+                "faithfulness": 0.92,
+                "answer_relevance": 0.85,
+                "context_precision": 0.78,
+                "context_recall": 0.81,
+                "n": 42,
+            },
+        }
+        base = extract_aggregate(summary_with_ragas)
+        head = extract_aggregate({**summary_with_ragas, "judge_ragas": {
+            **summary_with_ragas["judge_ragas"],
+            "faithfulness": 0.95,
+        }})
+        md = render_markdown(base, head, "test")
+        self.assertIn("RAGAS judge", md)
+        self.assertIn("faithfulness", md)
+        self.assertIn("0.920", md)
+        self.assertIn("0.950", md)
+
 
 class FullScriptInvocationTest(unittest.TestCase):
     """Smoke-test the full script end-to-end via subprocess so the


### PR DESCRIPTION
## 1. What changed and why

Today's public-synthetic accuracy=0.906 is retrieval-grounded but not LLM-graded — a senior reviewer's natural first question is "judged by what?", and we don't have a good answer. ADR 0006 deliberately restricted LLM-as-judge to the real-data surface to preserve ADR 0004's reproducibility / cost / determinism on the public CI path. This PR adds a RAGAS-style judge as **opt-in additive enrichment** on the synthetic surface (ADR 0012), refining (not superseding) ADR 0006: gating stays deterministic; the LLM judge contributes four numeric quality scores alongside the existing metrics.

Stacked on [#213 (issue #120)](https://github.com/hskim-solv/BidMate-DocAgent/pull/213) — that PR adds the `run_manifest` top-level block which this PR's downstream consumers (#166 leaderboard, #169 judge calibration) depend on.

Closes #164

## 2. Files affected

- [docs/adr/0012-ragas-judge-additive-synthetic.md](docs/adr/0012-ragas-judge-additive-synthetic.md) — new ADR refining ADR 0006.
- [eval/llm_judge.py](eval/llm_judge.py) — **load-bearing** (eval/). New module: stub + openai_compatible backends, content-hash cache, token budget refusal, four-metric aggregator + bootstrap CI, CLI with --fold-aggregate option.
- [scripts/run_real_eval_delta.py](scripts/run_real_eval_delta.py) — **load-bearing** (eval delta). Whitelists `judge_ragas` in `SAFE_TOPLEVEL_KEYS` with explicit four-metric + `n` + `ci` sub-key allowlist; renders new section in delta markdown.
- [Makefile](Makefile) — new target `make smoke-with-judge` (smoke + judge + fold).
- [README.md](README.md) — new "Judge metrics — opt-in, paid (ADR 0012)" section explaining metrics, env-var setup, cost expectations.
- [tests/test_llm_judge.py](tests/test_llm_judge.py) — adds `JudgeRagasStubTest` (7 cases including cache-hit verification, token budget refusal, privacy boundary) and `JudgeRagasCLITest` (2 end-to-end CLI invocations).
- [tests/test_run_real_eval_delta.py](tests/test_run_real_eval_delta.py) — adds 2 cases for `judge_ragas` sub-key allowlist + render section.
- [outputs/answer.json](outputs/answer.json) — incidental latency drift from smoke; no semantic change.

## 3. Risks

The most likely failure mode is **silent cost overrun on a paid run** if a maintainer raises the token budget without thinking through the case set size. Ruled out by: (a) `BIDMATE_JUDGE_TOKEN_BUDGET` is a hard refusal, not a soft warning — the script raises `RuntimeError` before incurring further cost; (b) the cache means re-runs against unchanged inputs are free, so the budget only matters on first-time runs and prompt changes; (c) a regression test (`test_token_budget_refusal`) feeds budget=0 and verifies the refusal fires.

Secondary risk: schema drift on `judge_ragas` aggregate (a future maintainer adds a per-case payload as a sub-key and it leaks into the committable aggregate). Ruled out by the explicit `SAFE_JUDGE_RAGAS_METRIC_KEYS` / `SAFE_JUDGE_RAGAS_META_KEYS` allowlist + recursive `_assert_no_forbidden` scan, with a regression test (`test_judge_ragas_sub_keys_whitelisted`) feeding `case_results` and `raw_prompts` smuggled sub-keys and verifying they're dropped.

Tertiary risk: CI starts calling the paid backend by accident. Ruled out by: stub being the default everywhere (`BIDMATE_JUDGE_BACKEND` env defaults to `stub`), `pr-eval.yml` not invoking the judge, and `make smoke-with-judge` being a deliberate manual target.

## 4. Tests

- `tests/test_llm_judge.py::JudgeRagasStubTest` — 7 cases: stub fixed-score schema, aggregate privacy boundary, cache hit zero-cost, cache stability across re-invocations, token budget refusal, unknown backend, empty case set null aggregate.
- `tests/test_llm_judge.py::JudgeRagasCLITest` — 2 end-to-end CLI invocations (basic + --fold-aggregate).
- `tests/test_run_real_eval_delta.py` — `judge_ragas` sub-key allowlist with smuggled-key drop + render section.

All 279 tests pass locally (`python3 -m pytest -q`). `make smoke-with-judge` end-to-end completes with stub backend, writes per-case verdicts to gitignored local file, folds aggregate into `reports/eval_summary.json` under `judge_ragas`.

## 5. Eval impact

Synthetic CI smoke with stub backend yields fixed scores (faithfulness=1.0, others=0.95 by design — easy to distinguish from real-world distributions in fixtures). The headline retrieval / verifier metrics are unchanged. Paid backend invocation is opt-in and never runs from CI.

### 5b. Real-data delta

No behavior change in retrieval / verifier path (ADR 0001 / ADR 0004 preserved). The judge is an enrichment surface, not a gate. `make real-eval-delta` is unaffected — the existing real-data judge (scripts/llm_judge.py, ADR 0006) continues to write to the `judge` top-level key; the new synthetic judge writes to `judge_ragas`. Both can coexist on the same eval_summary.json.

## 6. Backward compatibility

No `schema_version` bump required: ADR 0003's answer-contract dict is untouched. `eval_summary.json` adds one new top-level key (`judge_ragas`) — downstream consumers that ignore unknown keys are unaffected. The existing `judge` key (ADR 0006) is untouched.

## 7. Out of scope

- Anthropic-native backend (separate `anthropic` choice in `_BACKENDS`) — issue #164 mentions it as an option. Current implementation routes Anthropic via openai_compatible (Anthropic-Compat mode) since the env-var contract already supports it via `BIDMATE_JUDGE_BASE_URL`. Native `anthropic` SDK backend can be added in a follow-up if needed.
- Judge↔Human calibration (#169) requires this judge + manual human labels. The framework is here; the calibration ADR (0013) + label collection is a separate track.
- Token budget granularity (per-case vs per-run): current implementation is per-run input-token estimate. Per-case enforcement would require recording actual token usage from the backend response, which adds dependency on the backend's usage reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)