### PR TITLE
tests: LLM judge fault injection + graceful error handling (#171)

### DIFF
--- a/scripts/llm_judge.py
+++ b/scripts/llm_judge.py
@@ -136,7 +136,16 @@ def _openai_compatible_backend(prompt: str, *, verifier_status: str) -> dict[str
         response_format={"type": "json_object"},
     )
     content = response.choices[0].message.content or "{}"
-    parsed = json.loads(content)
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        # Malformed model output (#171) — fall back to insufficient with
+        # a marker reason rather than crashing the entire eval run.
+        return {
+            "judge_status": "insufficient",
+            "judge_grounded": False,
+            "judge_reason_short": "malformed_json: judge backend returned non-JSON content",
+        }
     return _normalize_judge_payload(parsed, fallback_status=verifier_status)
 
 
@@ -226,7 +235,21 @@ def judge_summary(
             continue
         prompt = _build_prompt(case)
         verifier_status = str(case.get("answer_status") or "insufficient")
-        verdict = backend_fn(prompt, verifier_status=verifier_status)
+        try:
+            raw_verdict = backend_fn(prompt, verifier_status=verifier_status)
+            verdict = _normalize_judge_payload(
+                raw_verdict, fallback_status=verifier_status
+            )
+        except Exception as exc:  # noqa: BLE001 — by design (#171)
+            # One bad case must not block the rest of the eval run.
+            # Convert any backend exception (rate limit, server error,
+            # timeout, network failure) into an insufficient verdict
+            # with a marker reason; the dispatcher keeps going.
+            verdict = {
+                "judge_status": "insufficient",
+                "judge_grounded": False,
+                "judge_reason_short": f"backend_error: {type(exc).__name__}",
+            }
         judged.append(
             {
                 "id": case.get("id"),

--- a/tests/test_llm_fault_injection.py
+++ b/tests/test_llm_fault_injection.py
@@ -1,0 +1,276 @@
+"""Fault-injection tests for the LLM-judge backend layer (issue #171).
+
+The deterministic retrieval / verifier paths are extractive (no LLM
+call), so the only LLM consumer that can fail is the judge in
+``scripts/llm_judge.py``. External code review flagged the lack of
+fault-injection coverage on this surface specifically:
+
+> agent가 (LLM 호출 1회 실패 → retry → 또 실패 → planner가 fallback
+> tool 선택)을 안전하게 처리하는지에 대한 fault-injection 테스트
+
+For an extractive system the scope is narrower than for a generative
+one — these tests cover the *judge*-call boundary only.
+
+Two layers are tested:
+
+* **Backend dispatcher layer** (``judge_summary``) — a backend can
+  raise any ``Exception``. The dispatcher must convert it into a
+  per-case ``insufficient`` verdict with a marker reason, so that one
+  bad case does not crash the whole eval run.
+* **OpenAI-compatible HTTP layer** (``_openai_compatible_backend``) —
+  malformed JSON, empty responses, rate limits, server errors, and
+  timeouts must all degrade to ``insufficient`` rather than bubbling
+  up.
+
+The five scenarios from #171 are spelled out as separate test
+methods so a future reader can map each to the issue's acceptance
+criteria.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from typing import Any
+from unittest import mock
+
+import openai
+
+import scripts.llm_judge as judge_module
+from scripts.llm_judge import _openai_compatible_backend, judge_summary
+
+
+def _fake_summary() -> dict[str, Any]:
+    """One case per verifier status — enough to exercise the dispatcher
+    without bloating the test fixture."""
+    return {
+        "primary_run": "full",
+        "pipeline": "agentic_full",
+        "num_predictions": 2,
+        "case_results": [
+            {
+                "id": "case_supported",
+                "query": "private query 1",
+                "answer_status": "supported",
+                "answer": {"summary": "answer summary 1"},
+                "evidence": [{"text": "evidence text 1"}],
+            },
+            {
+                "id": "case_abstain",
+                "query": "private query 2",
+                "answer_status": "insufficient",
+                "answer": {"summary": ""},
+                "evidence": [],
+            },
+        ],
+    }
+
+
+def _install_backend(name: str, fn) -> None:
+    """Register a transient backend in the dispatcher table.
+
+    Tests register their fault-injecting backend, exercise
+    ``judge_summary``, then tear down — leaving the production
+    table untouched.
+    """
+    judge_module._BACKENDS[name] = fn
+
+
+def _remove_backend(name: str) -> None:
+    judge_module._BACKENDS.pop(name, None)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher-layer faults (backend raises)
+# ---------------------------------------------------------------------------
+
+
+class BackendFaultDispatcherTest(unittest.TestCase):
+    """``judge_summary`` should convert any backend exception into a
+    per-case ``insufficient`` verdict, never raise."""
+
+    def setUp(self) -> None:  # noqa: D401
+        self._installed: list[str] = []
+
+    def tearDown(self) -> None:
+        for name in self._installed:
+            _remove_backend(name)
+
+    def _install(self, name: str, fn) -> None:
+        _install_backend(name, fn)
+        self._installed.append(name)
+
+    def test_429_rate_limit_raised_by_backend_is_caught(self) -> None:
+        def rate_limit_backend(_prompt: str, *, verifier_status: str) -> dict[str, Any]:
+            raise openai.RateLimitError(
+                message="429 Too Many Requests",
+                response=mock.MagicMock(status_code=429),
+                body=None,
+            )
+
+        self._install("fault_429", rate_limit_backend)
+        local, agg = judge_summary(_fake_summary(), backend="fault_429")
+        self.assertEqual(2, len(local["cases"]))
+        for case in local["cases"]:
+            self.assertEqual("insufficient", case["judge_status"])
+            self.assertIn("backend_error", case["judge_reason_short"].lower())
+        self.assertEqual(2, agg["n"])
+
+    def test_5xx_server_error_is_caught(self) -> None:
+        def server_error_backend(_prompt: str, *, verifier_status: str) -> dict[str, Any]:
+            raise openai.InternalServerError(
+                message="500 Internal Server Error",
+                response=mock.MagicMock(status_code=500),
+                body=None,
+            )
+
+        self._install("fault_5xx", server_error_backend)
+        local, _agg = judge_summary(_fake_summary(), backend="fault_5xx")
+        for case in local["cases"]:
+            self.assertEqual("insufficient", case["judge_status"])
+            self.assertFalse(case["judge_grounded"])
+
+    def test_connection_timeout_is_caught(self) -> None:
+        def timeout_backend(_prompt: str, *, verifier_status: str) -> dict[str, Any]:
+            raise openai.APITimeoutError(request=mock.MagicMock())
+
+        self._install("fault_timeout", timeout_backend)
+        local, _agg = judge_summary(_fake_summary(), backend="fault_timeout")
+        for case in local["cases"]:
+            self.assertEqual("insufficient", case["judge_status"])
+
+    def test_one_case_failure_does_not_block_others(self) -> None:
+        """A single transient failure must not cascade — the dispatcher
+        proceeds to subsequent cases. Verifies one-bad-apple isolation."""
+        call_count = {"n": 0}
+
+        def flaky_backend(_prompt: str, *, verifier_status: str) -> dict[str, Any]:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise openai.APIConnectionError(request=mock.MagicMock())
+            return {
+                "judge_status": "supported" if verifier_status == "supported" else "insufficient",
+                "judge_grounded": verifier_status == "supported",
+                "judge_reason_short": "ok",
+            }
+
+        self._install("fault_flaky", flaky_backend)
+        local, agg = judge_summary(_fake_summary(), backend="fault_flaky")
+        self.assertEqual(2, agg["n"])
+        # First case raised → insufficient marker; second case proceeded normally.
+        self.assertEqual("insufficient", local["cases"][0]["judge_status"])
+        self.assertEqual("insufficient", local["cases"][1]["judge_status"])
+
+    def test_malformed_json_at_dispatcher_level(self) -> None:
+        """If a custom backend returns a malformed shape (missing required
+        keys), the normalizer should still produce a valid verdict."""
+        def garbage_backend(_prompt: str, *, verifier_status: str) -> dict[str, Any]:
+            return {"junk_key": "not_a_valid_verdict"}
+
+        self._install("fault_garbage", garbage_backend)
+        local, _agg = judge_summary(_fake_summary(), backend="fault_garbage")
+        # Should not crash — but the verdict structure must be intact.
+        for case in local["cases"]:
+            self.assertIn(case["judge_status"], {"supported", "partial", "insufficient"})
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible backend HTTP-layer faults
+# ---------------------------------------------------------------------------
+
+
+class OpenAICompatibleBackendFaultTest(unittest.TestCase):
+    """Mock the openai SDK client at the call site of
+    ``_openai_compatible_backend`` to simulate HTTP-layer faults."""
+
+    def setUp(self) -> None:
+        # The backend reads three env vars before instantiating the
+        # client. Patch them so the function gets past its early
+        # validation gate.
+        self._env_patcher = mock.patch.dict(
+            "os.environ",
+            {
+                "BIDMATE_JUDGE_API_KEY": "fake-key",
+                "BIDMATE_JUDGE_MODEL": "fake-model",
+            },
+            clear=False,
+        )
+        self._env_patcher.start()
+
+    def tearDown(self) -> None:
+        self._env_patcher.stop()
+
+    @staticmethod
+    def _build_mock_response(content: str) -> mock.MagicMock:
+        response = mock.MagicMock()
+        message = mock.MagicMock()
+        message.content = content
+        response.choices = [mock.MagicMock(message=message)]
+        return response
+
+    def test_malformed_json_response_returns_insufficient(self) -> None:
+        with mock.patch("openai.OpenAI") as mock_openai:
+            client = mock.MagicMock()
+            client.chat.completions.create.return_value = self._build_mock_response(
+                "not a valid JSON {"
+            )
+            mock_openai.return_value = client
+            verdict = _openai_compatible_backend(
+                "prompt", verifier_status="supported"
+            )
+        self.assertEqual("insufficient", verdict["judge_status"])
+        self.assertFalse(verdict["judge_grounded"])
+        self.assertIn("malformed_json", verdict["judge_reason_short"].lower())
+
+    def test_empty_response_falls_back_to_verifier_status(self) -> None:
+        """An empty content string (None or '') must not raise. The
+        normalizer's existing fallback path applies — defensive but
+        already exercised by the upstream code."""
+        with mock.patch("openai.OpenAI") as mock_openai:
+            client = mock.MagicMock()
+            client.chat.completions.create.return_value = self._build_mock_response("")
+            mock_openai.return_value = client
+            verdict = _openai_compatible_backend(
+                "prompt", verifier_status="supported"
+            )
+        # Falls back to verifier_status (existing _normalize_judge_payload behavior).
+        self.assertEqual("supported", verdict["judge_status"])
+
+    def test_none_response_content_falls_back(self) -> None:
+        with mock.patch("openai.OpenAI") as mock_openai:
+            client = mock.MagicMock()
+            client.chat.completions.create.return_value = self._build_mock_response(None)
+            mock_openai.return_value = client
+            verdict = _openai_compatible_backend(
+                "prompt", verifier_status="partial"
+            )
+        self.assertEqual("partial", verdict["judge_status"])
+
+    def test_rate_limit_propagates_for_dispatcher_to_handle(self) -> None:
+        """The HTTP-level backend itself does not retry — it lets the
+        dispatcher convert the exception into an insufficient verdict.
+        Verified by ``BackendFaultDispatcherTest.test_429_*`` above; this
+        test just pins that the backend doesn't silently swallow."""
+        with mock.patch("openai.OpenAI") as mock_openai:
+            client = mock.MagicMock()
+            client.chat.completions.create.side_effect = openai.RateLimitError(
+                message="429",
+                response=mock.MagicMock(status_code=429),
+                body=None,
+            )
+            mock_openai.return_value = client
+            with self.assertRaises(openai.RateLimitError):
+                _openai_compatible_backend("prompt", verifier_status="supported")
+
+    def test_connection_error_propagates(self) -> None:
+        with mock.patch("openai.OpenAI") as mock_openai:
+            client = mock.MagicMock()
+            client.chat.completions.create.side_effect = openai.APIConnectionError(
+                request=mock.MagicMock()
+            )
+            mock_openai.return_value = client
+            with self.assertRaises(openai.APIConnectionError):
+                _openai_compatible_backend("prompt", verifier_status="insufficient")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

External code review (Wave 2) flagged the lack of fault-injection coverage on the LLM-judge surface. The deterministic retrieval / verifier paths are extractive (no LLM call), so this is the only place where network or model-output faults can propagate. New unit tests cover the five scenarios from issue #171 — and the writing of these tests exposed two genuine defects in `scripts/llm_judge.py` that are fixed in this same PR (per the issue's "fix in same PR if exposed" clause).

Closes #171

## 2. Files affected

- [scripts/llm_judge.py](scripts/llm_judge.py) — graceful error handling: wrap `json.loads()` in `_openai_compatible_backend` (returns insufficient on `JSONDecodeError`), wrap backend call in `judge_summary` (returns insufficient on any exception), route every verdict through `_normalize_judge_payload` so garbage backend output no longer KeyErrors at the dict-access site.
- [tests/test_llm_fault_injection.py](tests/test_llm_fault_injection.py) — new file. Two test classes: `BackendFaultDispatcherTest` (5 dispatcher-layer cases: 429, 5xx, timeout, one-bad-case isolation, garbage payload) and `OpenAICompatibleBackendFaultTest` (5 HTTP-layer cases: malformed JSON, empty content, None content, rate-limit propagation, connection-error propagation).

## 3. Risks

The most likely failure mode is a **silent degradation** when the judge fails — operators might miss that half the cases got insufficient verdicts because of backend errors rather than the model's actual judgment. Ruled out by: the marker reason `judge_reason_short` carries the exception type (`backend_error: RateLimitError`, `malformed_json: ...`), so a reviewer reading `reports/real100/judge.local.json` can grep for "backend_error" or "malformed_json" to see how many cases were degraded. The aggregate `agreement_with_verifier` will also drop on a run with many backend failures — that's an actionable signal already wired into ADR 0006's existing metric.

Secondary risk: a maintainer adds a *new* backend (e.g., `anthropic`) and assumes the dispatcher will handle its exceptions. Ruled out by the dispatcher catching `Exception` (not just `openai.*`) — any new backend's exceptions fall into the same insufficient-marker path.

## 4. Tests

10 new test cases in `tests/test_llm_fault_injection.py`:

- 5 dispatcher-layer tests verifying judge_summary doesn't raise on any backend exception
- 5 HTTP-layer tests verifying `_openai_compatible_backend` handles malformed JSON gracefully and lets unexpected exceptions propagate to the dispatcher (which catches them)

All 341 existing tests still pass (`python3 -m pytest -q`). The new tests exercise paths that previously crashed.

## 5. Eval impact

None. The judge runs on the real-data eval surface (ADR 0006) and is invoked manually via `make real-eval-with-judge` — not from public CI. The deterministic verifier path is untouched.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. The change is purely about how the *judge*'s exceptions are converted into verdicts. On a clean run with the stub backend, behavior is identical to before. On a run where the live backend fails, previously the entire `make real-eval-with-judge` would crash; now affected cases are recorded as `insufficient` with a `backend_error:` marker and the run completes.

## 6. Backward compatibility

No `schema_version` bump required. The judge's verdict schema is unchanged. The only difference is that `judge_reason_short` may now carry an error-type marker for degraded cases. Downstream consumers (`scripts/write_real_eval_baseline.py`) already strip per-case judge text from the committable aggregate per ADR 0005.

## 7. Out of scope

- Fault injection for `eval/synthetic_judge.py` (PR #196, ADR 0012 on the synthetic surface) — issue #171's text predates that surface and explicitly scopes to `scripts/llm_judge.py`. The synthetic judge has its own dispatcher with the same shape and would benefit from the same fix; follow-up issue can carry that work.
- Retry-with-backoff on transient backend errors — current behavior gives up after one attempt per case. A short retry loop with exponential backoff is reasonable for a future PR, but the issue explicitly framed this as "documenting current behavior" first, and the marker-reason verdict gives operators a clear signal to investigate.
- API server fault injection (`api/main.py`) — out of scope per issue #171; `/health` already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)