### PR TITLE
eval: add cost-quality Pareto frontier extractor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker demo demo-docker real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke harness-smoke test test-regression api api-docker demo demo-docker pareto real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -28,6 +28,13 @@ ask:
 
 eval:
 	$(PYTHON) eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml
+
+# Cost-quality Pareto frontier table (and PNG if matplotlib installed)
+# from the latest reports/eval_summary.json. Read-only consumer — see
+# scripts/plot_pareto.py for cost/quality axis choice (latency p95 vs
+# citation_precision).
+pareto:
+	$(PYTHON) scripts/plot_pareto.py --summary reports/eval_summary.json --markdown-out reports/pareto.md --png-out reports/pareto.png
 
 benchmark:
 	$(PYTHON) scripts/run_benchmark.py --suite benchmarks/suites/public_synthetic_rfp.yaml --ablations benchmarks/ablations/rag_quality_axes.yaml

--- a/docs/ablation-results.md
+++ b/docs/ablation-results.md
@@ -79,6 +79,7 @@
 - **`hybrid_bm25`** (ADR 0010, issue #119): `eval/config.yaml` 에 추가됨. `make eval` 의 ablation 블록에는 이미 채워지지만 (`accuracy=0.906`, `groundedness=0.929` — `full` 과 동일 ceiling), 본 문서의 committed snapshot 은 `make benchmark` 의 manifest 기반이므로 다음 benchmark 실행 후 row 를 추가한다. 실측 차이는 private real-data eval (`make real-eval-delta`) 에서 드러날 가능성이 크다.
 - **KO RFP per-axis** (issue #126): `eval/ko_axes.py` 에 `detect_ko_axes()` 가 추가되어 dev 결과 CSV 를 `eval/evaluate_dev_results.py` 로 평가할 때 `summary["by_ko_axes"]` 블록으로 per-axis (`금액단위 / 날짜형식 / 한자 / 사업번호 / 약칭`) accuracy 가 emit 된다. 차기 dev-side run 결과를 본 표에 별도 row 로 누적한다. `eval/run_eval.py` (CI 표면) 으로의 승격은 후속 PR.
 - **Multi-turn decay** (issue #125): `eval/multiturn_eval.py` 에 `derive_turn_depth()` + `build_qid_parent_map()` 가 추가되어 `summary["by_turn_depth"]` 블록으로 per-turn (turn 1 / 2 / 3 / …) accuracy 가 emit 된다. ADR 0001 invariant 준수 — `naive_baseline` / `agentic_full` 위에 *측정 축* 만 추가, 어느 파이프라인도 대체하지 않음. 초기 시나리오 fixture: `eval/multiturn_scenarios_v1.jsonl` (2 시나리오 × 3 turns, entity carryover + graceful-degradation abstention 포함). 차기 dev-side run 결과로 decay 커브를 본 표에 누적.
+- **Cost-quality Pareto** (issue #124): `scripts/plot_pareto.py` 가 `reports/eval_summary.json` 을 읽어 `(latency_p95, citation_precision)` 평면 위 ablation runs 의 Pareto frontier 를 `reports/pareto.md` 로 emit 한다 (matplotlib 설치 시 `reports/pareto.png` 도 함께). 호출: `make pareto`. 본 utility 는 retrieval / verifier / answer-generation 경로를 수정하지 않으며 (`scripts/` + `tests/` 만 추가), `reports/eval_summary.json` 의 read-only consumer 다.
 
 ## Next Actions
 

--- a/eval/evaluate_dev_results.py
+++ b/eval/evaluate_dev_results.py
@@ -35,7 +35,6 @@ from typing import List, Set
 import pandas as pd
 
 from eval.ko_axes import KO_AXES, detect_ko_axes
-from eval.multiturn_eval import build_qid_parent_map, derive_turn_depth
 
 
 ABSTAIN_PATTERNS = [
@@ -228,15 +227,6 @@ def summarise(per_q: pd.DataFrame) -> dict:
         if mask.any():
             summary["by_ko_axes"][axis] = block(per_q[mask])
 
-    summary["by_turn_depth"] = {}
-    if "turn_depth" in per_q.columns:
-        for depth, sub in per_q.groupby("turn_depth"):
-            try:
-                depth_key = int(depth)
-            except (TypeError, ValueError):
-                continue
-            summary["by_turn_depth"][depth_key] = block(sub)
-
     return summary
 
 
@@ -261,13 +251,6 @@ def main():
         merged = row.to_dict()
         merged.update(evaluate_row(row))
         per_q_rows.append(merged)
-
-    qid_to_parent = build_qid_parent_map(per_q_rows)
-    for entry in per_q_rows:
-        qid = str(entry.get("qid") or "")
-        entry["turn_depth"] = derive_turn_depth(
-            qid, qid_to_parent.get(qid), qid_to_parent
-        )
 
     per_q = pd.DataFrame(per_q_rows)
     summary = summarise(per_q)
@@ -304,16 +287,6 @@ def main():
             lines.append(f"### {axis}")
             lines.append("")
             for key, value in block.items():
-                lines.append(f"- {key}: {value}")
-            lines.append("")
-
-    if summary.get("by_turn_depth"):
-        lines.append("## By turn depth")
-        lines.append("")
-        for depth in sorted(summary["by_turn_depth"]):
-            lines.append(f"### turn {depth}")
-            lines.append("")
-            for key, value in summary["by_turn_depth"][depth].items():
                 lines.append(f"- {key}: {value}")
             lines.append("")
 

--- a/eval/evaluate_dev_results.py
+++ b/eval/evaluate_dev_results.py
@@ -35,6 +35,7 @@ from typing import List, Set
 import pandas as pd
 
 from eval.ko_axes import KO_AXES, detect_ko_axes
+from eval.multiturn_eval import build_qid_parent_map, derive_turn_depth
 
 
 ABSTAIN_PATTERNS = [
@@ -227,6 +228,15 @@ def summarise(per_q: pd.DataFrame) -> dict:
         if mask.any():
             summary["by_ko_axes"][axis] = block(per_q[mask])
 
+    summary["by_turn_depth"] = {}
+    if "turn_depth" in per_q.columns:
+        for depth, sub in per_q.groupby("turn_depth"):
+            try:
+                depth_key = int(depth)
+            except (TypeError, ValueError):
+                continue
+            summary["by_turn_depth"][depth_key] = block(sub)
+
     return summary
 
 
@@ -251,6 +261,13 @@ def main():
         merged = row.to_dict()
         merged.update(evaluate_row(row))
         per_q_rows.append(merged)
+
+    qid_to_parent = build_qid_parent_map(per_q_rows)
+    for entry in per_q_rows:
+        qid = str(entry.get("qid") or "")
+        entry["turn_depth"] = derive_turn_depth(
+            qid, qid_to_parent.get(qid), qid_to_parent
+        )
 
     per_q = pd.DataFrame(per_q_rows)
     summary = summarise(per_q)
@@ -287,6 +304,16 @@ def main():
             lines.append(f"### {axis}")
             lines.append("")
             for key, value in block.items():
+                lines.append(f"- {key}: {value}")
+            lines.append("")
+
+    if summary.get("by_turn_depth"):
+        lines.append("## By turn depth")
+        lines.append("")
+        for depth in sorted(summary["by_turn_depth"]):
+            lines.append(f"### turn {depth}")
+            lines.append("")
+            for key, value in summary["by_turn_depth"][depth].items():
                 lines.append(f"- {key}: {value}")
             lines.append("")
 

--- a/scripts/plot_pareto.py
+++ b/scripts/plot_pareto.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Cost-quality Pareto frontier extractor for eval ablation results (issue #124).
+
+Reads ``reports/eval_summary.json`` (produced by ``make eval``) and emits a
+Markdown table at ``reports/pareto.md`` highlighting which ablation runs sit
+on the cost-quality Pareto frontier. Optionally renders ``reports/pareto.png``
+when matplotlib is available; the PNG render is skipped cleanly otherwise so
+the same script runs in CI containers that don't install matplotlib.
+
+Cost axis (lower-is-better): primary summary latency p95 in milliseconds.
+Quality axis (higher-is-better): citation_precision (the metric whose CI
+separation is most discriminating per docs/ablation-results.md).
+
+The script does not modify the eval pipeline or the answer contract; it is
+a read-only consumer of ``reports/eval_summary.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, NamedTuple, Sequence
+
+
+class ParetoPoint(NamedTuple):
+    name: str
+    cost: float
+    quality: float
+    extras: dict
+
+
+def compute_pareto_frontier(points: Sequence[ParetoPoint]) -> list[ParetoPoint]:
+    """Return the subset of points on the 2D Pareto frontier.
+
+    Frontier rule: a point ``P`` is on the frontier iff no other point ``Q``
+    has both strictly lower cost and strictly higher quality (``Q`` dominates
+    ``P``). Tied points are both kept — neither dominates the other.
+    """
+    frontier: list[ParetoPoint] = []
+    for candidate in points:
+        dominated = False
+        for other in points:
+            if other is candidate:
+                continue
+            if (
+                other.cost <= candidate.cost
+                and other.quality >= candidate.quality
+                and (other.cost < candidate.cost or other.quality > candidate.quality)
+            ):
+                dominated = True
+                break
+        if not dominated:
+            frontier.append(candidate)
+    return frontier
+
+
+def extract_points(summary: dict) -> list[ParetoPoint]:
+    """Pull ``(name, cost, quality, extras)`` tuples out of an eval_summary."""
+    points: list[ParetoPoint] = []
+    for run in summary.get("ablation", {}).get("runs", []) or []:
+        name = str(run.get("name") or "")
+        if not name:
+            continue
+        latency_p95 = (
+            run.get("latency", {}).get("p95")
+            if isinstance(run.get("latency"), dict)
+            else None
+        )
+        citation_precision = run.get("citation_precision")
+        if isinstance(citation_precision, dict):
+            citation_precision = citation_precision.get("mean")
+        if latency_p95 is None or citation_precision is None:
+            continue
+        try:
+            cost = float(latency_p95)
+            quality = float(citation_precision)
+        except (TypeError, ValueError):
+            continue
+        points.append(
+            ParetoPoint(
+                name=name,
+                cost=cost,
+                quality=quality,
+                extras={
+                    "accuracy": run.get("accuracy"),
+                    "groundedness": run.get("groundedness"),
+                    "retry_rate": run.get("retry"),
+                },
+            )
+        )
+    return points
+
+
+def render_markdown(
+    points: Sequence[ParetoPoint],
+    frontier: Iterable[ParetoPoint],
+) -> str:
+    frontier_names = {p.name for p in frontier}
+    lines = [
+        "# Cost-quality Pareto frontier",
+        "",
+        "Cost axis = primary-run latency p95 (ms, lower is better).",
+        "Quality axis = citation_precision (higher is better).",
+        "",
+        "| On frontier | Run | Latency p95 (ms) | Citation precision | Accuracy | Groundedness |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for point in sorted(points, key=lambda p: (p.cost, -p.quality)):
+        marker = "✓" if point.name in frontier_names else ""
+        accuracy = point.extras.get("accuracy")
+        groundedness = point.extras.get("groundedness")
+        lines.append(
+            f"| {marker} | {point.name} | {point.cost:.2f} | {point.quality:.3f} | "
+            f"{_fmt(accuracy)} | {_fmt(groundedness)} |"
+        )
+    lines.append("")
+    if frontier_names:
+        lines.append(
+            f"Frontier members ({len(frontier_names)}): "
+            + ", ".join(sorted(frontier_names))
+            + "."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, dict):
+        value = value.get("mean")
+    if value is None:
+        return "—"
+    try:
+        return f"{float(value):.3f}"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def try_render_png(
+    points: Sequence[ParetoPoint],
+    frontier: Iterable[ParetoPoint],
+    out_path: Path,
+) -> bool:
+    """Attempt PNG render; return True on success, False if matplotlib missing."""
+    try:
+        import matplotlib  # type: ignore  # noqa: F401
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt  # type: ignore
+    except ImportError:
+        return False
+
+    frontier_names = {p.name for p in frontier}
+    fig, ax = plt.subplots(figsize=(8, 6))
+    for point in points:
+        on_frontier = point.name in frontier_names
+        ax.scatter(
+            point.cost,
+            point.quality,
+            s=120 if on_frontier else 60,
+            facecolors="tab:orange" if on_frontier else "tab:gray",
+            edgecolors="black",
+            zorder=3 if on_frontier else 2,
+        )
+        ax.annotate(
+            point.name,
+            (point.cost, point.quality),
+            textcoords="offset points",
+            xytext=(6, 6),
+            fontsize=9,
+        )
+    frontier_sorted = sorted(frontier, key=lambda p: p.cost)
+    if len(frontier_sorted) >= 2:
+        ax.plot(
+            [p.cost for p in frontier_sorted],
+            [p.quality for p in frontier_sorted],
+            color="tab:orange",
+            linestyle="--",
+            linewidth=1,
+            zorder=1,
+        )
+    ax.set_xlabel("Cost — latency p95 (ms, lower is better)")
+    ax.set_ylabel("Quality — citation_precision (higher is better)")
+    ax.set_title("Ablation runs: cost-quality Pareto frontier")
+    ax.grid(True, linestyle=":", alpha=0.4)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=144)
+    plt.close(fig)
+    return True
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--summary",
+        default="reports/eval_summary.json",
+        help="Path to eval_summary.json (default: reports/eval_summary.json).",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        default="reports/pareto.md",
+        help="Where to write the Markdown frontier table (default: reports/pareto.md).",
+    )
+    parser.add_argument(
+        "--png-out",
+        default="reports/pareto.png",
+        help="Where to write the PNG render if matplotlib is installed (default: reports/pareto.png).",
+    )
+    args = parser.parse_args(argv)
+
+    summary_path = Path(args.summary)
+    if not summary_path.exists():
+        sys.stderr.write(
+            f"[plot_pareto] {summary_path} not found. Run `make eval` first.\n"
+        )
+        return 2
+
+    try:
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[plot_pareto] Failed to parse {summary_path}: {exc}\n")
+        return 2
+
+    points = extract_points(summary)
+    if not points:
+        sys.stderr.write(
+            "[plot_pareto] No ablation runs with both latency.p95 and "
+            "citation_precision found.\n"
+        )
+        return 1
+
+    frontier = compute_pareto_frontier(points)
+
+    markdown_out = Path(args.markdown_out)
+    markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    markdown_out.write_text(render_markdown(points, frontier), encoding="utf-8")
+    print(f"[plot_pareto] Wrote {markdown_out}")
+
+    png_out = Path(args.png_out)
+    png_out.parent.mkdir(parents=True, exist_ok=True)
+    if try_render_png(points, frontier, png_out):
+        print(f"[plot_pareto] Wrote {png_out}")
+    else:
+        print(
+            "[plot_pareto] matplotlib not installed; PNG render skipped. "
+            "Install with `pip install matplotlib` and re-run.",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pareto_frontier.py
+++ b/tests/test_pareto_frontier.py
@@ -1,0 +1,142 @@
+"""Tests for the cost-quality Pareto frontier helper (issue #124).
+
+PNG render goes through matplotlib which is not a CI dependency; only the
+pure-Python frontier logic and the eval_summary extraction are tested here.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts.plot_pareto import (
+    ParetoPoint,
+    compute_pareto_frontier,
+    extract_points,
+    render_markdown,
+)
+
+
+class TestComputeParetoFrontier(unittest.TestCase):
+    def _pt(self, name: str, cost: float, quality: float) -> ParetoPoint:
+        return ParetoPoint(name=name, cost=cost, quality=quality, extras={})
+
+    def test_dominated_point_removed(self) -> None:
+        # B dominates A (cheaper and higher quality) → A is dropped.
+        points = [
+            self._pt("A", cost=10, quality=0.5),
+            self._pt("B", cost=5, quality=0.6),
+        ]
+        frontier = compute_pareto_frontier(points)
+        self.assertEqual({p.name for p in frontier}, {"B"})
+
+    def test_undominated_points_kept(self) -> None:
+        # A is cheap-but-low-quality; B is expensive-but-high-quality.
+        # Neither dominates the other.
+        points = [
+            self._pt("cheap_low", cost=1, quality=0.4),
+            self._pt("medium", cost=5, quality=0.6),
+            self._pt("expensive_high", cost=10, quality=0.9),
+        ]
+        frontier = compute_pareto_frontier(points)
+        self.assertEqual(
+            {p.name for p in frontier},
+            {"cheap_low", "medium", "expensive_high"},
+        )
+
+    def test_strictly_dominated_in_middle(self) -> None:
+        # `middle` is dominated by `good` (cheaper AND higher quality).
+        points = [
+            self._pt("cheap", cost=1, quality=0.3),
+            self._pt("middle", cost=5, quality=0.5),
+            self._pt("good", cost=4, quality=0.6),
+            self._pt("expensive", cost=10, quality=0.9),
+        ]
+        frontier = compute_pareto_frontier(points)
+        self.assertEqual(
+            {p.name for p in frontier},
+            {"cheap", "good", "expensive"},
+        )
+
+    def test_ties_are_kept(self) -> None:
+        # Two points with identical cost and quality should both stay —
+        # neither strictly dominates the other.
+        points = [
+            self._pt("twin_a", cost=5, quality=0.7),
+            self._pt("twin_b", cost=5, quality=0.7),
+        ]
+        frontier = compute_pareto_frontier(points)
+        self.assertEqual({p.name for p in frontier}, {"twin_a", "twin_b"})
+
+    def test_empty_input_returns_empty(self) -> None:
+        self.assertEqual(compute_pareto_frontier([]), [])
+
+    def test_single_point_always_on_frontier(self) -> None:
+        only = self._pt("solo", cost=3, quality=0.5)
+        self.assertEqual(compute_pareto_frontier([only]), [only])
+
+
+class TestExtractPoints(unittest.TestCase):
+    def test_run_without_required_fields_dropped(self) -> None:
+        summary = {
+            "ablation": {
+                "runs": [
+                    {"name": "ok", "latency": {"p95": 2.0}, "citation_precision": 0.9},
+                    {"name": "missing_latency", "citation_precision": 0.9},
+                    {"name": "missing_citation", "latency": {"p95": 5.0}},
+                    {"name": "", "latency": {"p95": 1.0}, "citation_precision": 0.5},
+                ]
+            }
+        }
+        points = extract_points(summary)
+        self.assertEqual([p.name for p in points], ["ok"])
+        self.assertEqual(points[0].cost, 2.0)
+        self.assertEqual(points[0].quality, 0.9)
+
+    def test_citation_precision_as_dict(self) -> None:
+        # Some eval_summary entries surface metrics as {"mean": ..., "ci": ...}
+        # rather than a flat float. The extractor should accept both shapes.
+        summary = {
+            "ablation": {
+                "runs": [
+                    {
+                        "name": "ci_form",
+                        "latency": {"p95": 3.0},
+                        "citation_precision": {"mean": 0.905, "ci": [0.821, 0.976]},
+                        "accuracy": 0.906,
+                    }
+                ]
+            }
+        }
+        points = extract_points(summary)
+        self.assertEqual(len(points), 1)
+        self.assertAlmostEqual(points[0].quality, 0.905)
+
+    def test_missing_ablation_block(self) -> None:
+        self.assertEqual(extract_points({}), [])
+        self.assertEqual(extract_points({"ablation": {}}), [])
+        self.assertEqual(extract_points({"ablation": {"runs": []}}), [])
+
+
+class TestRenderMarkdown(unittest.TestCase):
+    def test_frontier_marker_and_sort(self) -> None:
+        points = [
+            ParetoPoint("expensive", cost=10, quality=0.9, extras={"accuracy": 0.95}),
+            ParetoPoint("cheap", cost=1, quality=0.4, extras={"accuracy": 0.8}),
+            ParetoPoint("dominated", cost=5, quality=0.3, extras={"accuracy": 0.7}),
+        ]
+        frontier = [points[0], points[1]]
+        out = render_markdown(points, frontier)
+        # Sorted by ascending cost: cheap → dominated → expensive.
+        cheap_idx = out.find("| ✓ | cheap |")
+        dominated_idx = out.find("|  | dominated |")
+        expensive_idx = out.find("| ✓ | expensive |")
+        self.assertNotEqual(cheap_idx, -1)
+        self.assertNotEqual(dominated_idx, -1)
+        self.assertNotEqual(expensive_idx, -1)
+        self.assertLess(cheap_idx, dominated_idx)
+        self.assertLess(dominated_idx, expensive_idx)
+        self.assertIn("Frontier members (2):", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #124

Add a **cost-quality Pareto frontier** utility that turns the existing ablation rows into a 2D plot a reviewer can scan in one glance. The script reads `reports/eval_summary.json` (already produced by `make eval`), extracts each ablation run's `(latency_p95, citation_precision)` point, computes the frontier, and emits a Markdown table marking which runs sit on it. An optional PNG render is produced when `matplotlib` is installed.

Cost axis: primary-run **latency p95** (ms, lower-is-better).
Quality axis: **citation_precision** (higher-is-better) — the metric whose bootstrap CI separation is most discriminating per `docs/ablation-results.md`.

The utility is a **read-only consumer** of `reports/eval_summary.json` and does not touch the eval pipeline, the answer contract, or any retrieval / verifier code.

Stacked on #219 (`feat/issue-125-multiturn-decay`).

## 2. Files affected

- `scripts/plot_pareto.py` (new, ~210 lines) — `ParetoPoint`, `compute_pareto_frontier`, `extract_points`, `render_markdown`, optional `try_render_png` with graceful matplotlib-missing handling.
- `tests/test_pareto_frontier.py` (new, ~125 lines) — 10 test methods.
- `Makefile` (+8 / -1) — new `pareto` target with default in/out paths.
- `docs/ablation-results.md` (+1) — Pending row entry pointing at the new utility.

**Not** touched: `rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/main.py`. The CLAUDE.md load-bearing trigger list is not hit. See section 5b.

## 3. Risks

Most likely way this breaks: the citation_precision field shape in `reports/eval_summary.json` changes (e.g. from `{"mean": ..., "ci": [...]}` to a different envelope). Mitigation: `extract_points` handles both flat-float and CI-dict shapes; a missing or unparseable field causes the run to be silently skipped (`extract_points` only emits runs with both metrics resolvable). The `test_run_without_required_fields_dropped` and `test_citation_precision_as_dict` tests lock in both shapes.

Second-likely break: matplotlib-installed-in-CI assumption. Mitigation: `try_render_png` returns `False` rather than raising when matplotlib is missing, and the script exits 0 with a stderr note. The Markdown table is always emitted.

Out-of-scope follow-ups:
- Adding `make pareto` to a CI gate. Today it's a manual `make` target the user runs after `make eval`.
- Adding `cost = retry_rate × token_cost` for the LLM synthesis path. Once the synthesis backend produces a real token-cost number, the cost axis can be extended; the frontier logic itself is metric-agnostic.
- Embedding the rendered PNG in README.md headline section. Same dependency — the PNG path needs to be reliably generated in CI first.

## 4. Tests

`tests/test_pareto_frontier.py`: 10 test methods, all green.

- `TestComputeParetoFrontier`: dominated removed; ties kept; middle-strict-dominated handled; empty input → empty; single point always on frontier; cheap-low / medium / expensive-high all kept when none dominates the others.
- `TestExtractPoints`: missing latency / citation / name → dropped; citation_precision accepted as both flat float and `{"mean": ..., "ci": [...]}` dict; missing `ablation` block returns `[]`.
- `TestRenderMarkdown`: frontier marker `✓` appears on frontier rows only; rows sorted by ascending cost; "Frontier members (N): …" footer correct.

Run: `python3 -m pytest tests/test_pareto_frontier.py -v`.

## 5. Eval impact

All `·` — no `eval/run_eval.py` / `rag_core.py` / retrieval / verifier paths touched. `make eval` output is unchanged.

### 5b. Real-data delta

**Borderline-N/A** — flagged here for transparency. The change touches `scripts/`, `tests/`, `Makefile`, and a doc pending-row entry. None of the CLAUDE.md trigger paths (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/main.py`) are modified. The script is a read-only consumer of `reports/eval_summary.json`.

Therefore `make real-eval-delta` would emit `·` for every regression-tracked metric. The Pareto utility is not part of the real-data delta surface.

## 6. Backward compatibility

None broken.
- `scripts/plot_pareto.py` is a new file — no existing import paths affected.
- `Makefile` adds a new `pareto` target; the `.PHONY` list is extended additively.
- `docs/ablation-results.md` Pending rows section gains one bullet; existing bullets unchanged.
- No `schema_version` bump needed.

## 7. Out of scope

- Adding `make pareto` to CI gating.
- Extending cost axis to include LLM token spend.
- Embedding rendered PNG into README headline section.
- Polishing the chart aesthetic (markers, colour palette, annotations) — that lands once the PNG path is reliable in CI.