### PR TITLE
chore: wire demo asset slots + portfolio launch checklist (#172 partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![PR Eval Delta](https://github.com/hskim-solv/BidMate-DocAgent/actions/workflows/pr-eval.yml/badge.svg?branch=main)](https://github.com/hskim-solv/BidMate-DocAgent/actions/workflows/pr-eval.yml) [![Python 3.11](https://img.shields.io/badge/Python-3.11-blue.svg)](pyproject.toml) [![Engineering notes](https://img.shields.io/badge/engineering--notes-GitHub%20Pages-blue)](https://hskim-solv.github.io/BidMate-DocAgent/) [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/hskim-solv/BidMate-DocAgent/blob/main/demo/bidmate_quickstart.ipynb)
 
+<!-- Hero demo asset slot. Recording guide: docs/deployment.md#recording-the-demo-video.
+     Replace docs/assets/demo.gif with the actual asset once captured; renders inline
+     in the GitHub README and in the pinned-repo profile card. -->
+![BidMate-DocAgent live demo (60-90 s walkthrough)](docs/assets/demo.gif)
+
 ## 🚀 Live demo
 
 | 경로 | 상태 | 비고 |

--- a/demo/README.md
+++ b/demo/README.md
@@ -12,6 +12,11 @@ license: mit
 
 # BidMate-DocAgent live demo
 
+<!-- Hero asset slot — recorded walkthrough (60-90 s). See
+     docs/deployment.md#recording-the-demo-video for capture instructions.
+     The same asset is referenced from the repo-root README. -->
+![Live demo walkthrough](../docs/assets/demo.gif)
+
 This directory holds the **reviewer-facing** demo UI. The Streamlit
 front-page lets anyone exercise the RAG pipeline (extractive +
 LLM-synthesis ablation) against the public synthetic RFP corpus

--- a/docs/portfolio-launch-checklist.md
+++ b/docs/portfolio-launch-checklist.md
@@ -1,0 +1,115 @@
+# Portfolio launch checklist
+
+This is the **author-only** punch list for promoting BidMate-DocAgent
+into a "click-and-try" portfolio piece. Issue [#172](https://github.com/hskim-solv/BidMate-DocAgent/issues/172)
+groups the steps; some are wired in code (badges, asset slots,
+Makefile targets), others are admin actions the author runs once
+on GitHub or with their own recording tool.
+
+## Code / asset wiring (already in place after PR #172)
+
+- [x] Hero asset slot in `README.md` (top of file, above the badge row) — points at `docs/assets/demo.gif`.
+- [x] Hero asset slot in `demo/README.md` — points at `docs/assets/demo.gif`.
+- [x] `docs/assets/` directory exists (`.gitkeep`) so the asset has a stable home.
+- [x] One-line `docker run` recipe + GHCR target (`make docker-publish`) — see [`docs/deployment.md`](deployment.md#one-line-docker-run-no-clone-fastest-reviewer-path).
+- [x] Colab quickstart notebook + Open-in-Colab badge — see [`demo/bidmate_quickstart.ipynb`](../demo/bidmate_quickstart.ipynb).
+- [x] Recording guide section in `docs/deployment.md#recording-the-demo-video`.
+
+## Author actions (run once, not codable)
+
+These cannot be done by a code change; they require the author's
+GitHub account, local machine, and a few minutes per item.
+
+### 1. Repo rename
+
+The current name `BidMate-DocAgent` collides with the parked
+`bidmate.co.kr` brand. Pick a final name and rename **once**:
+
+```bash
+# On GitHub: Settings → General → Repository name → Rename
+# Then locally:
+git remote set-url origin git@github.com:<user>/<new-name>.git
+```
+
+After rename, search-replace the old name in:
+
+- `README.md` (badge URLs, repo references, hero asset path comments)
+- `demo/README.md` (HF Spaces YAML — `title:` field)
+- `demo/bidmate_quickstart.ipynb` (the `!git clone` URL)
+- `docs/deployment.md` (Fly.io / HF Spaces / Railway recipes)
+- `Makefile` (`IMAGE_TAG ?= ghcr.io/<user>/bidmate-demo:latest`)
+- `.github/workflows/*.yml` (any hardcoded repo references)
+
+A single follow-up PR per rename is the safest path — the search-replace
+diff is large but mechanical.
+
+### 2. GitHub profile pin
+
+Pin the repo to the author's profile so it shows on the public profile
+page:
+
+- GitHub → click the profile picture → **Your profile** → **Customize
+  your pins** → tick the renamed repo → **Save pins**.
+
+Pinned repos render the first README section as a card preview, so the
+hero asset (below) is what reviewers see in the profile grid.
+
+### 3. Record the demo asset
+
+A 60–90 second walkthrough is enough. Two recommended formats:
+
+**A. asciinema cast (terminal demo)**
+
+```bash
+asciinema rec docs/assets/demo.cast
+# inside the recording session:
+make index
+make demo
+# open http://localhost:8501 in another tab, run a query
+# Ctrl-D to stop recording
+```
+
+Convert to GIF if desired:
+
+```bash
+# npm install -g asciicast2gif
+asciicast2gif docs/assets/demo.cast docs/assets/demo.gif
+```
+
+**B. screen recording (UI demo)**
+
+Record at 1280×720 with QuickTime / OBS, trim to 60–90 s, export as
+MP4 or GIF, save to `docs/assets/demo.gif` (or `.mp4`). Keep file size
+under 5 MB for the README to render quickly.
+
+### 4. Publish the GHCR image (one-time)
+
+The `docker run ghcr.io/<user>/bidmate-demo:latest` recipe in the
+README only works if the image is pushed:
+
+```bash
+docker login ghcr.io        # use a PAT with write:packages scope
+make docker-publish         # builds + pushes ghcr.io/hskim-solv/bidmate-demo:latest
+```
+
+After the first push, the image is **public** by default for new
+GHCR pushes; if the author had set it private, flip it via
+**GitHub → Packages → bidmate-demo → Package settings → Change visibility**.
+
+### 5. Update live demo URL in README
+
+Once the Fly.io / HF Spaces deploy is up, replace the placeholder
+"배포 가이드: [`docs/deployment.md`](deployment.md)" cell in the
+"🚀 Live demo" table with the actual URL:
+
+```markdown
+| **Streamlit UI** | [bidmate-docagent-demo.fly.dev](https://bidmate-docagent-demo.fly.dev) | ... |
+```
+
+## Verification (after all actions)
+
+- [ ] README hero asset renders on GitHub (the .gif or .mp4 plays inline).
+- [ ] Open-in-Colab badge opens the notebook in colab.research.google.com and the 5 cells run green.
+- [ ] `docker run ghcr.io/<user>/bidmate-demo:latest` boots the demo on a clean machine.
+- [ ] Live demo URL responds 200 and the radio buttons (`naive_baseline` / `agentic_full` / `agentic_full_llm`) all return grounded answers.
+- [ ] Repo is pinned on the author's GitHub profile.

--- a/eval/evaluate_dev_results.py
+++ b/eval/evaluate_dev_results.py
@@ -35,7 +35,6 @@ from typing import List, Set
 import pandas as pd
 
 from eval.ko_axes import KO_AXES, detect_ko_axes
-from eval.multiturn_eval import build_qid_parent_map, derive_turn_depth
 
 
 ABSTAIN_PATTERNS = [
@@ -228,15 +227,6 @@ def summarise(per_q: pd.DataFrame) -> dict:
         if mask.any():
             summary["by_ko_axes"][axis] = block(per_q[mask])
 
-    summary["by_turn_depth"] = {}
-    if "turn_depth" in per_q.columns:
-        for depth, sub in per_q.groupby("turn_depth"):
-            try:
-                depth_key = int(depth)
-            except (TypeError, ValueError):
-                continue
-            summary["by_turn_depth"][depth_key] = block(sub)
-
     return summary
 
 
@@ -261,13 +251,6 @@ def main():
         merged = row.to_dict()
         merged.update(evaluate_row(row))
         per_q_rows.append(merged)
-
-    qid_to_parent = build_qid_parent_map(per_q_rows)
-    for entry in per_q_rows:
-        qid = str(entry.get("qid") or "")
-        entry["turn_depth"] = derive_turn_depth(
-            qid, qid_to_parent.get(qid), qid_to_parent
-        )
 
     per_q = pd.DataFrame(per_q_rows)
     summary = summarise(per_q)
@@ -304,16 +287,6 @@ def main():
             lines.append(f"### {axis}")
             lines.append("")
             for key, value in block.items():
-                lines.append(f"- {key}: {value}")
-            lines.append("")
-
-    if summary.get("by_turn_depth"):
-        lines.append("## By turn depth")
-        lines.append("")
-        for depth in sorted(summary["by_turn_depth"]):
-            lines.append(f"### turn {depth}")
-            lines.append("")
-            for key, value in summary["by_turn_depth"][depth].items():
                 lines.append(f"- {key}: {value}")
             lines.append("")
 

--- a/eval/evaluate_dev_results.py
+++ b/eval/evaluate_dev_results.py
@@ -35,6 +35,7 @@ from typing import List, Set
 import pandas as pd
 
 from eval.ko_axes import KO_AXES, detect_ko_axes
+from eval.multiturn_eval import build_qid_parent_map, derive_turn_depth
 
 
 ABSTAIN_PATTERNS = [
@@ -227,6 +228,15 @@ def summarise(per_q: pd.DataFrame) -> dict:
         if mask.any():
             summary["by_ko_axes"][axis] = block(per_q[mask])
 
+    summary["by_turn_depth"] = {}
+    if "turn_depth" in per_q.columns:
+        for depth, sub in per_q.groupby("turn_depth"):
+            try:
+                depth_key = int(depth)
+            except (TypeError, ValueError):
+                continue
+            summary["by_turn_depth"][depth_key] = block(sub)
+
     return summary
 
 
@@ -251,6 +261,13 @@ def main():
         merged = row.to_dict()
         merged.update(evaluate_row(row))
         per_q_rows.append(merged)
+
+    qid_to_parent = build_qid_parent_map(per_q_rows)
+    for entry in per_q_rows:
+        qid = str(entry.get("qid") or "")
+        entry["turn_depth"] = derive_turn_depth(
+            qid, qid_to_parent.get(qid), qid_to_parent
+        )
 
     per_q = pd.DataFrame(per_q_rows)
     summary = summarise(per_q)
@@ -287,6 +304,16 @@ def main():
             lines.append(f"### {axis}")
             lines.append("")
             for key, value in block.items():
+                lines.append(f"- {key}: {value}")
+            lines.append("")
+
+    if summary.get("by_turn_depth"):
+        lines.append("## By turn depth")
+        lines.append("")
+        for depth in sorted(summary["by_turn_depth"]):
+            lines.append(f"### turn {depth}")
+            lines.append("")
+            for key, value in summary["by_turn_depth"][depth].items():
                 lines.append(f"- {key}: {value}")
             lines.append("")
 


### PR DESCRIPTION
## 1. What changed and why

Refs #172 (closes the Claude-doable subset; user-only actions deferred)

Three of the items in #172 are admin / recording actions the author runs on GitHub or with their own tools (repo rename, profile pin, asset recording, GHCR push, live-demo URL update). This PR wires the **code-side scaffolding** so those user actions are mechanical drop-ins:

- `README.md` — hero asset reference between the badge row and the "🚀 Live demo" table. Renders inline on GitHub and in the pinned-repo profile card; degrades gracefully (broken-image placeholder) until the recorded asset is dropped at the slot path.
- `demo/README.md` — same hero asset reference (relative path to `../docs/assets/demo.gif`) so the HF Spaces page also surfaces the walkthrough.
- `docs/assets/.gitkeep` — establishes the directory as a stable home for the recorded asset.
- `docs/portfolio-launch-checklist.md` (new) — author-only punch list with the user actions (repo rename, profile pin, asset recording, GHCR publish, live-demo URL update) and a verification block at the end. Each action has the exact commands or click-paths inline.

**Closes Refs #172 (not Closes)** — the user-only actions remain open. Once the author completes them, the issue can be closed manually.

Stacked on #222 (`docs/issue-123-five-min-reviewer-path`).

## 2. Files affected

- `README.md` (+5) — hero asset slot, comment with capture pointer.
- `demo/README.md` (+5) — same hero asset slot for HF Spaces.
- `docs/assets/.gitkeep` (new, 0 bytes) — directory placeholder.
- `docs/portfolio-launch-checklist.md` (new, ~115 lines) — user-action punch list.

**Not** touched: `rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/main.py`. CLAUDE.md load-bearing trigger list not hit.

## 3. Risks

Most likely way this breaks: the hero asset slot renders a broken-image icon until the author drops `docs/assets/demo.gif`. Mitigation: this is an expected transient state — the checklist explicitly calls out the asset capture as step 3 of the author actions. GitHub's broken-image fallback is harmless; the page below renders normally. The HTML comment above the `![...]` tag points the next reader at the recording guide.

Second-likely break: after the repo rename (one of the user actions), the README badge URLs and the Colab notebook's `!git clone` URL still point at `hskim-solv/BidMate-DocAgent`. Mitigation: the checklist's "Repo rename" section explicitly lists every file that needs the search-replace.

Out-of-scope follow-ups (in the checklist):
- Recording and committing the actual demo asset.
- Repo rename and the consequent search-replace PR.
- GitHub profile pin (one click on the profile page).
- `docker login ghcr.io && make docker-publish` to publish the image referenced from #222's README addition.
- Replacing the "배포 가이드: docs/deployment.md" placeholder in the Live demo table with the actual live URL.

## 4. Tests

N/A — doc + wiring change, no behavior or contract affected. Verification is manual once the user actions complete (the checklist's "Verification" block lists what to confirm).

## 5. Eval impact

All `·` — no code paths touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

None broken.
- `README.md` and `demo/README.md` gain an `![...]` reference; existing content is unchanged.
- `docs/assets/.gitkeep` is a 0-byte directory marker.
- `docs/portfolio-launch-checklist.md` is a new file.
- No `schema_version` bump needed.

## 7. Out of scope (deferred to author actions, tracked in checklist)

- **Repo rename** — admin action on GitHub Settings.
- **GitHub profile pin** — one click on the profile page.
- **Recording the demo asset** — asciinema or screen recording → `docs/assets/demo.gif`.
- **Publishing the ghcr.io image** — `docker login ghcr.io && make docker-publish` (target landed in #222).
- **Updating live demo URL** in the README table — one cell replace once Fly.io / HF Spaces deploy is up.

Each is documented with exact commands in `docs/portfolio-launch-checklist.md`.