### PR TITLE
eval: annotate gold_chunk_ids on 10 synthetic cases (#175)

### DIFF
--- a/docs/ablation-results.md
+++ b/docs/ablation-results.md
@@ -73,6 +73,25 @@
 
 현재 commit 된 aggregate 는 **stub backend** 기준 — verifier status 를 거울처럼 반사하므로 `agreement_with_verifier=1.0` 이고 RAGAS 점수는 status-derived fixture (supported→0.85, partial→0.5, insufficient→0.1) 이다. 진짜 신호가 아니다. 실제 LLM judge 수치를 보려면 live 백엔드로 다시 돌려 aggregate 를 갱신한다.
 
+## Chunk-level retrieval (PR #147 + human-annotated gold from #175)
+
+이슈 [#147](https://github.com/hskim-solv/BidMate-DocAgent/issues/147)에서 추가된 chunk-level retrieval 메트릭 (recall@k / MRR / nDCG@10) — gold chunk 는 `expected_doc_ids` + `expected_terms` 휴리스틱으로 자동 유도되며 case 단위로 `gold_chunk_ids` override 가능 ([`eval/run_eval.py` `derive_gold_chunk_ids`](../eval/run_eval.py)).
+
+`naive_baseline` 기준 (2026-05-11 re-run, `eval/config.yaml` n=42):
+
+| slice | cases_total | cases_with_gold | chunk_recall@5 | chunk_recall@10 | chunk_MRR | chunk_nDCG@10 |
+|---|---:|---:|---:|---:|---:|---:|
+| single_doc | 14 | 14 | 1.000 | 1.000 | 0.893 | 0.921 |
+| comparison | 10 | 10 | 0.950 | 0.950 | 1.000 | 0.953 |
+| follow_up | 9 | 8 | 0.750 | 0.750 | 0.750 | 0.750 |
+| abstention | 9 | 0 | N/A | N/A | N/A | N/A |
+
+`abstention` 슬라이스 및 `follow_up_state_ambiguous_clarification` 1건은 `answerable: false` 라 gold chunk 가 존재하지 않는다 (의도된 N/A — abstention 계약, ADR 0003).
+
+이슈 [#175](https://github.com/hskim-solv/BidMate-DocAgent/issues/175) 일환으로 답변 가능한 8 follow_up + 2 chunk-boundary single_doc 케이스에 `gold_chunk_ids` 를 사람이 직접 확인해 명시 (annotation log: [`docs/local-gold-authoring.md`](./local-gold-authoring.md#annotation-log--gold_chunk_ids)). 휴리스틱 결과와 사람 annotation 이 10/10 케이스에서 동일 — follow_up 의 0.750 은 multi-turn 컨텍스트 (`follow_up_state_a_security`, `follow_up_state_multi_step_a_deliverables`) 에서 retriever 가 chunk 를 가져오지 못하는 진짜 결함이며 (이슈 [#57](https://github.com/hskim-solv/BidMate-DocAgent/issues/57) C4), gold-labeling artifact 가 아니다.
+
+후속 PR 후보: `metric_block` 에 chunk metric aggregation roll-up 추가 (현재 case 단위로만 emit). 본 표 수치는 case_results 평균으로 계산.
+
 ## Pending rows
 
 - **Live synthetic judge aggregate** (ADR 0012, issue #164): stub-mode aggregate 만 commit 되어 있음. live 백엔드(openai_compatible) 로 갱신한 aggregate diff 를 별도 PR 로 commit 하면 RAGAS-style 실측 노출.

--- a/docs/embedding-ablation.md
+++ b/docs/embedding-ablation.md
@@ -51,6 +51,17 @@ Run date: 2026-05-11. Public synthetic corpus (n=42; single_doc 14 / comparison 
 
 All other agentic ablations (`hierarchical`, `no_metadata_first`, `no_rerank`, `no_verifier_retry`) show **0pp delta** in primary metrics.
 
+### Chunk-level retrieval (human-annotated gold subset, n=10)
+
+Issue [#175](https://github.com/hskim-solv/BidMate-DocAgent/issues/175) added explicit `gold_chunk_ids` to 8 `follow_up` + 2 `single_doc` chunk-boundary cases. Per-slice averages over the **annotated subset** (re-run 2026-05-11, `naive_baseline`, `hashing` backend):
+
+| slice | n_annotated | chunk_recall@5 | chunk_MRR | chunk_nDCG@10 |
+|---|---:|---:|---:|---:|
+| single_doc (chunk-boundary probes) | 2 | 1.000 | 0.750 | 0.815 |
+| follow_up | 8 | 0.750 | 0.750 | 0.750 |
+
+Annotation outcome: heuristic-derived gold and human-annotated gold **agree on all 10 cases** — the 0.750 follow_up score reflects two multi-turn cases (`follow_up_state_a_security`, `follow_up_state_multi_step_a_deliverables`) where the retriever returns no chunks at all (tracked under issue [#57](https://github.com/hskim-solv/BidMate-DocAgent/issues/57) C4), not a gold-labeling artifact. Embedding-model comparisons can now distinguish retrieval misses from heuristic blind spots on these cases.
+
 ### Reading the result
 
 1. **For the full agentic pipeline, the embedding choice is irrelevant on this corpus.** Metadata-first filtering (ADR 0002) bypasses dense retrieval for most queries, so a better embedding doesn't help. This is empirical validation of the metadata-first design — the pipeline is robust to a suboptimal embedding.

--- a/docs/local-gold-authoring.md
+++ b/docs/local-gold-authoring.md
@@ -59,6 +59,12 @@ cp eval/real_config.example.yaml eval/real_config.local.yaml
 - `context_entities`: 평가 시점에 강제로 주입할 발주기관/사업명. 보통은 비워둔다.
 - `hardcase_categories`: 카테고리별 슬라이스 메트릭에 포함시키고 싶을 때(예: `["C1", "C5"]`).
 - `expected_citation_pages`, `expected_citation_regions`: visual 인덱스에서 페이지·영역 단위 grounding을 검증할 때만.
+- `gold_chunk_ids`: chunk-level retrieval 메트릭(recall@k / MRR / nDCG@10)의 정답 chunk 목록. 비워두면 `expected_doc_ids` + `expected_terms` 휴리스틱으로 자동 유도된다([`eval/run_eval.py` `derive_gold_chunk_ids`](../eval/run_eval.py)). 휴리스틱이 잡지 못하는 경우나 동일 doc 내 여러 chunk 중 어느 것이 진짜 정답인지 명시하고 싶을 때만 손으로 적는다. chunk id는 `data/index/index.json`의 `chunks[].chunk_id`(보통 `<doc_id>::chunk-NNN`)에서 그대로 복사한다.
+  ```yaml
+  gold_chunk_ids:
+    - rfp-agency-d-spectrometer-probe::chunk-003
+  ```
+  대화형으로 후보 chunk를 확인하려면 [`scripts/dump_case_chunks.py`](../scripts/dump_case_chunks.py)를 쓴다.
 
 ## doc_id를 어떻게 알아내나
 
@@ -166,6 +172,19 @@ PDF/HWP 인덱스의 한 사업에 대해 사업기간과 사업예산을 묻는
 - **`expected_terms`에 너무 긴 문장을 넣어서 정답이 fail로 잡힘** — 답변 생성 형식과 어순이 달라서이다. 명사·숫자·일자 단위로 쪼갠다.
 - **abstention 케이스가 false negative로 잡힘** — 그 키워드가 다른 row의 `텍스트`에 우연히 등장하는 경우이다. 코퍼스에 정말 없는 키워드인지 `grep` 한 번 해본다.
 - **follow_up이 abstain으로 빠짐** — 현재 구현은 1단계 follow-up까지만 강하게 처리한다(C4-1, 이슈 [#57](https://github.com/hskim-solv/BidMate-DocAgent/issues/57)). 2단계 implicit chain은 보수적으로 케이스에서 빼두는 것을 권장한다.
+
+## Annotation log — `gold_chunk_ids`
+
+[이슈 #175](https://github.com/hskim-solv/BidMate-DocAgent/issues/175) 일환으로 `eval/config.yaml`의 답변 가능(answerable) 케이스 중 휴리스틱 blind-spot 위험이 가장 높은 10건에 대해 `gold_chunk_ids`를 사람이 직접 확인하고 명시했다.
+
+- **Annotator**: hskim (`times21c@gmail.com`)
+- **Date**: 2026-05-11
+- **Method**: [`scripts/dump_case_chunks.py`](../scripts/dump_case_chunks.py)로 `expected_doc_ids`에 속한 chunk를 모두 dump하고 본문을 읽어 정답 chunk를 1건 선택.
+- **Cases (10)**:
+  - `follow_up` (8건, all answerable): `follow_up_schedule`, `follow_up_b_deliverables`, `follow_up_c_response_target`, `follow_up_common_evaluation`, `follow_up_a_team`, `follow_up_c_operation_metrics`, `follow_up_state_a_security`, `follow_up_state_multi_step_a_deliverables`.
+  - `single_doc` chunk-boundary 프로브 (2건): `chunk_probe_external_audit_period` (chunk-002), `chunk_probe_report_storage` (chunk-003). agency-D 문서는 3-chunk로 분할되어 있어 단일 doc 내 chunk 선택이 자명하지 않은 유일한 케이스.
+- **Result**: 위 10건에서 휴리스틱이 선택한 gold와 사람 annotation이 완전히 일치(per-case `chunk_recall@5`/`MRR`/`nDCG@10` 변동 없음). `follow_up_state_a_security` / `follow_up_state_multi_step_a_deliverables`의 R@5=0은 retriever가 multi-turn 컨텍스트에서 chunk를 가져오지 못하는 **진짜 retrieval 결함**임을 사람 gold로 재확인 (이슈 [#57](https://github.com/hskim-solv/BidMate-DocAgent/issues/57) C4 대응 추적).
+- **Skipped**: `abstention` 슬라이스 (9건) 및 `follow_up_state_ambiguous_clarification` — `answerable: false`라 정답 chunk가 존재하지 않음. 강제 annotation은 ADR 0003 abstention 계약을 왜곡한다.
 
 ## 참고
 

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -502,6 +502,9 @@ cases:
     expected_terms:
       - "4개월"
       - "6개월"
+    # Manually verified (issue #175): single chunk covers agency-A schedule.
+    gold_chunk_ids:
+      - rfp-agency-a-ai-quality::chunk-001
     expected_citation_terms:
       - "4개월"
       - "6개월"
@@ -520,6 +523,9 @@ cases:
       - "데이터 표준 사전"
       - "MLOps 운영 가이드"
       - "모니터링 대시보드"
+    # Manually verified (issue #175).
+    gold_chunk_ids:
+      - rfp-agency-b-mlops-governance::chunk-001
     expected_citation_terms:
       - "데이터 표준 사전"
       - "MLOps 운영 가이드"
@@ -537,6 +543,9 @@ cases:
     expected_terms:
       - "2초"
       - "주요 문의"
+    # Manually verified (issue #175).
+    gold_chunk_ids:
+      - rfp-agency-c-chatbot::chunk-001
     expected_citation_terms:
       - "2초"
       - "주요 문의"
@@ -555,6 +564,9 @@ cases:
       - "요구사항 이해도"
       - "근거 기반 실행 계획"
       - "보안 및 운영 리스크"
+    # Manually verified (issue #175).
+    gold_chunk_ids:
+      - rfp-common-submission::chunk-001
     expected_citation_terms:
       - "요구사항 이해도"
       - "근거 기반 실행 계획"
@@ -573,6 +585,9 @@ cases:
       - "PM"
       - "ML 엔지니어"
       - "보안 담당자"
+    # Manually verified (issue #175).
+    gold_chunk_ids:
+      - rfp-agency-a-ai-quality::chunk-001
     expected_citation_terms:
       - "PM"
       - "ML 엔지니어"
@@ -591,6 +606,9 @@ cases:
       - "답변 정확도"
       - "상담 이관 적절성"
       - "사용자 만족도"
+    # Manually verified (issue #175).
+    gold_chunk_ids:
+      - rfp-agency-c-chatbot::chunk-001
     expected_citation_terms:
       - "답변 정확도"
       - "사용자 만족도"
@@ -608,6 +626,10 @@ cases:
     expected_terms:
       - "보안 통제"
       - "로그"
+    # Manually verified (issue #175). Baseline retriever currently returns
+    # empty retrieved_chunk_ids on this multi-turn case — see follow-up gap.
+    gold_chunk_ids:
+      - rfp-agency-a-ai-quality::chunk-001
     expected_citation_terms:
       - "보안 통제"
       - "로그"
@@ -637,6 +659,9 @@ cases:
       - "모델 점검 리포트"
       - "보안 통제 매뉴얼"
       - "운영자 교육 자료"
+    # Manually verified (issue #175). Multi-step follow-up — known retrieval gap.
+    gold_chunk_ids:
+      - rfp-agency-a-ai-quality::chunk-001
     expected_citation_terms:
       - "모델 점검 리포트"
       - "보안 통제 매뉴얼"
@@ -780,6 +805,9 @@ cases:
       - rfp-agency-d-spectrometer-probe
     expected_terms:
       - "분기별"
+    # Manually verified (issue #175). Audit-period text lives in chunk-002.
+    gold_chunk_ids:
+      - rfp-agency-d-spectrometer-probe::chunk-002
     expected_citation_terms:
       - "분기별"
     answerable: true
@@ -794,6 +822,9 @@ cases:
     expected_terms:
       - "5년"
       - "NAS"
+    # Manually verified (issue #175). Storage spec lives in chunk-003.
+    gold_chunk_ids:
+      - rfp-agency-d-spectrometer-probe::chunk-003
     expected_citation_terms:
       - "5년"
     answerable: true

--- a/scripts/dump_case_chunks.py
+++ b/scripts/dump_case_chunks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Annotation aid for issue #175.
+
+Dumps the chunks belonging to a case's ``expected_doc_ids`` so a human
+can pick the ``gold_chunk_ids`` to add to ``eval/config.yaml``. Marks
+chunks that the substring heuristic (``expected_terms``) would already
+catch with a ``*`` so the annotator can spot blind spots quickly.
+
+Usage:
+
+    python3 scripts/dump_case_chunks.py \
+        --config eval/config.yaml \
+        --index_dir data/index \
+        --case follow_up_schedule
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_case(config_path: Path, case_id: str) -> dict[str, Any]:
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    for case in config.get("cases") or []:
+        if case.get("id") == case_id:
+            return case
+    raise SystemExit(f"case id not found: {case_id}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="eval/config.yaml")
+    parser.add_argument("--index_dir", default="data/index")
+    parser.add_argument("--case", required=True, help="case id from eval config")
+    parser.add_argument(
+        "--text_chars", type=int, default=240, help="characters of chunk text to show"
+    )
+    args = parser.parse_args()
+
+    case = load_case(Path(args.config), args.case)
+    expected_doc_ids = set(case.get("expected_doc_ids") or [])
+    expected_terms = [str(t) for t in case.get("expected_terms") or [] if t]
+
+    index = json.loads((Path(args.index_dir) / "index.json").read_text(encoding="utf-8"))
+    chunks = index.get("chunks") or []
+
+    print(f"case: {args.case}")
+    print(f"query: {case.get('query')}")
+    print(f"expected_doc_ids: {sorted(expected_doc_ids)}")
+    print(f"expected_terms: {expected_terms}")
+    explicit = case.get("gold_chunk_ids") or []
+    print(f"current explicit gold_chunk_ids: {explicit}")
+    print("-" * 80)
+
+    if not expected_doc_ids:
+        print("(no expected_doc_ids — abstention / unanswerable case)")
+        return 0
+
+    for chunk in chunks:
+        if chunk.get("doc_id") not in expected_doc_ids:
+            continue
+        text = str(chunk.get("text") or "")
+        hits = [t for t in expected_terms if t in text]
+        marker = "*" if hits else " "
+        preview = text[: args.text_chars].replace("\n", " ")
+        print(f"{marker} {chunk.get('chunk_id')}  hits={hits}")
+        print(f"    {preview}")
+    print("-" * 80)
+    print("(*) = chunk would be picked up by the substring heuristic today")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 1. What changed and why

Closes #175

PR #147 shipped chunk-level retrieval metrics (recall@k / MRR / nDCG@10) using a heuristic that derives gold chunks from `expected_doc_ids` + `expected_terms`. Per the issue, reviewers need a `cases_with_gold` number that is close to `cases_total` and human-verified — not heuristic-derived — to trust the chunk-level signal on `follow_up`.

This PR adds explicit `gold_chunk_ids` to **10 cases**: all 8 answerable `follow_up` cases plus 2 `chunk_boundary` `single_doc` probes (`chunk_probe_external_audit_period` → agency-D chunk-002, `chunk_probe_report_storage` → agency-D chunk-003 — the only cases where intra-doc chunk selection is non-trivial since agency-D is the only multi-chunk doc).

Annotation outcome: heuristic-derived gold and human-annotated gold **agree on all 10 cases**. The `follow_up` slice's `chunk_recall@5 = 0.750` reflects two multi-turn cases (`follow_up_state_a_security`, `follow_up_state_multi_step_a_deliverables`) where the retriever returns no chunks at all (real failure tracked under #57 C4), **not** a gold-labeling artifact. The split is now reviewer-legible.

Skipped: all 9 `abstention` cases + `follow_up_state_ambiguous_clarification` — these are `answerable: false`, so no gold chunk exists by design (ADR 0003 abstention contract).

## 2. Files affected

- \`eval/config.yaml\` — added \`gold_chunk_ids\` block to 10 cases. **Load-bearing per CLAUDE.md.**
- \`scripts/dump_case_chunks.py\` (new) — one-shot annotation helper: prints candidate chunks restricted to \`expected_doc_ids\` with a heuristic-hit marker.
- \`docs/local-gold-authoring.md\` — documented optional \`gold_chunk_ids\` field + annotation log (annotator, date, method, scope, skipped cases).
- \`docs/ablation-results.md\` — added "Chunk-level retrieval" section with per-slice table.
- \`docs/embedding-ablation.md\` — chunk-level subsection on the annotated subset.

No load-bearing code path changes. \`derive_gold_chunk_ids\` already honored the explicit \`gold_chunk_ids\` override since #147.

## 3. Risks

- **An annotated chunk_id could go stale if chunking params change.** Chunk-ids are stable per \`scripts/build_index.py\` under the current params; \`tests/test_chunk_metrics_regression.py\` already covers the missing-chunk branch (returns empty list / surfaces a recall drop, not an exception). Re-annotation is a small follow-up if chunking params ever change.
- **Per-slice numbers in docs go stale on next ablation re-run.** Mitigated by tagging run date in the doc section (same convention as the rest of \`docs/ablation-results.md\`).

## 4. Tests

- \`python3 -m pytest -q\` → **416 passed, 5 warnings, 121 subtests passed**.
- \`tests/test_chunk_metrics_regression.py\` (12 tests, unchanged) covers the explicit \`gold_chunk_ids\` override path already shipped in #147.
- No new test added: this PR is data-annotation only; the code path it exercises was already test-covered.

## 5. Eval impact

Synthetic CI delta: **0pp on every answer-level metric** (accuracy, groundedness, citation_precision, abstention, format_compliance). Verified by re-running \`make eval\` before and after the YAML edit — chunk metrics for the 10 annotated cases are identical to the heuristic-derived values.

The only intentional eval-surface change: \`reports/eval_summary.json\` \`case_results[].gold_chunk_ids\` now contains human-verified IDs for the 10 cases (previously: heuristic-derived). \`cases_with_gold\` per slice is unchanged (heuristic and human agree).

### 5b. Real-data delta

**N/A — synthetic-only change, no rag_core / ingestion / eval-runner code change.** The only load-bearing file touched is \`eval/config.yaml\` (a data file under \`eval/\`), and only by adding optional \`gold_chunk_ids\` fields on the public synthetic config. \`eval/real_config.local.yaml\` is untouched. Per #175 out-of-scope: "Re-running real-data delta — this is synthetic-only".

## 6. Backward compatibility

- ADR 0001 \`naive_baseline\` preset preserved.
- ADR 0003 answer contract untouched (no \`schema_version\` bump).
- \`derive_gold_chunk_ids\` signature unchanged.
- New \`gold_chunk_ids\` field on case entries is **optional** — existing local/private configs without it continue to work via the heuristic.

## 7. Out of scope

- **Slice-level chunk-metric roll-up in \`metric_block\`.** Currently chunk metrics live per-case in \`case_results[]\` only; \`docs/ablation-results.md\` computes the per-slice table by averaging case results manually. A follow-up PR can add aggregation to \`metric_block\` if reviewers want a top-level \`chunk_retrieval\` block. Flagged in the docs.
- **Multi-annotator agreement / per-chunk relevance scoring** — explicitly out-of-scope per #175.
- **Fix for the multi-turn retrieval gap** (\`follow_up_state_a_security\`, \`follow_up_state_multi_step_a_deliverables\`) — tracked under #57 C4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)