### PR TITLE
refactor: introduce VectorStore Protocol (Stage 1 of #176)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Load-bearing — changes here require PR template **item 5b (real-data delta)** 
 Supporting:
 
 - `app.py` — CLI query entry point.
+- `rag_vector_store.py` — `VectorStore` Protocol behind the embeddings sidecar (issue #232, Stage 1 of #176). `BIDMATE_INDEX_BACKEND=memory` is the only supported value today; `qdrant` / `pgvector` are reserved for follow-up PRs.
 - `scripts/` — `build_index.py`, `update_readme_metrics.py`, `run_real_eval_delta.py`, etc.
 - `data/raw/` → `data/index/` → `outputs/` → `reports/` (pipeline artifacts).
 - `docs/` — design notes, ADRs, failure analyses, reviewer artifacts.

--- a/rag_core.py
+++ b/rag_core.py
@@ -29,6 +29,12 @@ except ImportError:  # pragma: no cover — defensive; declared in requirements.
 
 from rag_observability import resolve_trace_backend
 from rag_synthesis import synthesize_answer
+from rag_vector_store import (
+    InMemoryVectorStore,
+    VectorStore,
+    load_vector_store,
+    vector_store_from_matrix,
+)
 from text_normalize import expand_forms, normalize_text
 
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
@@ -1194,6 +1200,9 @@ def build_index_payload_from_documents(
     # M2 (#207): vectors live in a sidecar .npy. Chunks reference rows by
     # embedding_idx — inline lists were ~85% of the JSON file size and
     # forced a per-query Python-list → NumPy materialization.
+    # Stage 1 of #176 (#232): the matrix is wrapped in a VectorStore so
+    # future backends (Qdrant, pgvector) can slot in without touching
+    # chunk-metadata storage. InMemoryVectorStore is bit-identical.
     vectors_matrix = np.asarray(embedding_result.vectors, dtype=np.float32)
     for idx, chunk in enumerate(chunks):
         chunk["embedding_idx"] = idx
@@ -1231,7 +1240,7 @@ def build_index_payload_from_documents(
         "documents": public_docs,
         "parent_sections": parent_sections,
         "chunks": chunks,
-        "_vectors": vectors_matrix,
+        "_vector_store": vector_store_from_matrix(vectors_matrix),
     }
 
 
@@ -1245,42 +1254,38 @@ def load_index(index_dir: Path) -> dict[str, Any]:
     if not payload.get("chunks"):
         raise ValueError(f"Index has no chunks: {path}")
     schema = int(payload.get("schema_version", 1))
-    if schema >= INDEX_SCHEMA_VERSION:
-        embeddings_path = index_dir / EMBEDDINGS_FILENAME
-        if not embeddings_path.exists():
-            raise ValueError(
-                f"Index schema_version={schema} requires sidecar {embeddings_path}. "
-                f"Rebuild via scripts/build_index.py."
-            )
-        payload["_vectors"] = np.load(embeddings_path)
-    else:
-        # Legacy schema 1 — vectors inlined per chunk. Materialize the
-        # matrix once at load time so the retrieve() path can stay on
-        # the new index["_vectors"][embedding_idx] code path.
-        inline = [c.get("embedding") for c in payload["chunks"]]
-        if inline and all(v is not None for v in inline):
-            payload["_vectors"] = np.asarray(inline, dtype=np.float32)
+    # Stage 1 of #176 (#232): the vector matrix is now hidden behind a
+    # VectorStore. load_vector_store handles the schema-2 sidecar path
+    # and the legacy schema-1 inline-list materialization. The legacy
+    # chunk-mutation loop (embedding_idx / pop) stays here because it
+    # mutates payload["chunks"], not the store — and must run *after*
+    # load_vector_store has read the inline lists.
+    if schema < INDEX_SCHEMA_VERSION:
+        payload["_vector_store"] = load_vector_store(
+            index_dir, schema, chunks=payload["chunks"]
+        )
+        if payload["_vector_store"] is not None:
             for idx, chunk in enumerate(payload["chunks"]):
                 chunk["embedding_idx"] = idx
                 chunk.pop("embedding", None)
-        else:
-            payload["_vectors"] = None
+    else:
+        payload["_vector_store"] = load_vector_store(index_dir, schema)
     return payload
 
 
 def write_index(payload: dict[str, Any], output_dir: Path) -> Path:
     """Atomically persist an index payload + embeddings sidecar.
 
-    Pops the in-memory ``_vectors`` matrix from the payload, writes it to
-    ``embeddings.npy``, and serializes the remaining JSON-compatible
-    structure to ``index.json``. The caller's ``payload`` dict is mutated
-    (the private key is removed) — see scripts/build_index.py for the
-    canonical use site.
+    Pops the in-memory ``_vector_store`` from the payload, asks it to
+    persist its vectors (typically ``embeddings.npy``), and serializes
+    the remaining JSON-compatible structure to ``index.json``. The
+    caller's ``payload`` dict is mutated (the private key is removed) —
+    see scripts/build_index.py for the canonical use site.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    vectors = payload.pop("_vectors", None)
-    if vectors is not None:
-        np.save(output_dir / EMBEDDINGS_FILENAME, np.asarray(vectors, dtype=np.float32))
+    store = payload.pop("_vector_store", None)
+    if store is not None:
+        store.persist(output_dir)
     out_path = output_dir / INDEX_FILENAME
     out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     return out_path
@@ -2067,11 +2072,11 @@ def retrieve(
             stopword_profile=str(plan.get("bm25_stopword_profile", "shared")),
         )
 
-    vectors_matrix = index.get("_vectors")
+    vector_store = index.get("_vector_store")
     scored = []
     for chunk in candidates:
-        if vectors_matrix is not None and chunk.get("embedding_idx") is not None:
-            chunk_vec = vectors_matrix[int(chunk["embedding_idx"])]
+        if vector_store is not None and chunk.get("embedding_idx") is not None:
+            chunk_vec = vector_store.get(int(chunk["embedding_idx"]))
         else:
             # Defensive fallback: a chunk dict produced outside the normal
             # load_index path (e.g., a hand-crafted test fixture) may still

--- a/rag_vector_store.py
+++ b/rag_vector_store.py
@@ -1,0 +1,130 @@
+"""VectorStore abstraction for the RAG index (issue #232, Stage 1 of #176).
+
+Sits behind ``index["_vector_store"]`` so that future PRs can plug in
+Qdrant / pgvector adapters without touching the chunk-metadata payload
+or the retrieval loop's call site. Stage 1 introduces the seam only —
+``InMemoryVectorStore`` is a thin wrapper around the existing float32
+matrix, so the on-disk format (``embeddings.npy`` sidecar from #207) is
+unchanged and ranking is bit-identical.
+
+The Protocol is deliberately minimal: ``get(idx)`` is what the current
+retrieval loop in ``rag_core.py`` actually needs. A ``query(qvec, top_k)``
+method (filter-pushdown for Qdrant) is reserved for Stage 2 — adding it
+now would duplicate candidate-filter logic and break the no-behavior-
+change invariant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+
+INDEX_FILENAME = "index.json"
+EMBEDDINGS_FILENAME = "embeddings.npy"
+
+ENV_INDEX_BACKEND = "BIDMATE_INDEX_BACKEND"
+DEFAULT_INDEX_BACKEND = "memory"
+SUPPORTED_BACKENDS = frozenset({"memory"})
+
+
+@runtime_checkable
+class VectorStore(Protocol):
+    """Minimum surface used by the retrieval loop and the write/load paths.
+
+    Implementations are constructed by ``load_vector_store`` (read path)
+    or ``vector_store_from_matrix`` (build path), and are attached to the
+    in-memory index payload under the ``_vector_store`` key.
+    """
+
+    dimension: int
+
+    def __len__(self) -> int: ...
+
+    def get(self, idx: int) -> np.ndarray: ...
+
+    def persist(self, output_dir: Path) -> None: ...
+
+
+@dataclass
+class InMemoryVectorStore:
+    """numpy-backed VectorStore — the Stage 1 default.
+
+    Wraps a ``(N, D)`` float32 L2-normalized matrix. ``get`` returns a
+    view into the underlying array (not a copy), matching the prior
+    ``vectors_matrix[i]`` behavior in ``rag_core.retrieve``.
+    """
+
+    vectors: np.ndarray
+
+    @property
+    def dimension(self) -> int:
+        return int(self.vectors.shape[1])
+
+    def __len__(self) -> int:
+        return int(self.vectors.shape[0])
+
+    def get(self, idx: int) -> np.ndarray:
+        return self.vectors[idx]
+
+    def persist(self, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        np.save(
+            output_dir / EMBEDDINGS_FILENAME,
+            np.asarray(self.vectors, dtype=np.float32),
+        )
+
+
+def vector_store_from_matrix(vectors: np.ndarray) -> VectorStore:
+    """Wrap an in-memory float32 matrix as the default VectorStore."""
+    return InMemoryVectorStore(vectors=np.asarray(vectors, dtype=np.float32))
+
+
+def _resolve_backend() -> str:
+    return os.environ.get(ENV_INDEX_BACKEND, DEFAULT_INDEX_BACKEND).strip().lower()
+
+
+def load_vector_store(
+    index_dir: Path,
+    schema_version: int,
+    chunks: list[dict] | None = None,
+) -> VectorStore | None:
+    """Materialize a VectorStore from the on-disk index artifacts.
+
+    For ``schema_version >= 2`` (current), reads ``embeddings.npy``. For
+    legacy schema 1, materializes from inline per-chunk ``embedding``
+    lists if ``chunks`` is provided; returns ``None`` if no inline
+    vectors exist (matches the prior ``payload["_vectors"] = None``
+    fallback in ``rag_core.load_index``).
+
+    Selects the concrete implementation by ``$BIDMATE_INDEX_BACKEND``
+    (Stage 1 only accepts ``memory``).
+    """
+    backend = _resolve_backend()
+    if backend not in SUPPORTED_BACKENDS:
+        raise NotImplementedError(
+            f"Index backend {backend!r} is not yet implemented; "
+            f"Stage 1 only ships the in-memory backend. See issue #176 "
+            f"(Stage 2 = Qdrant, Stage 3 = pgvector)."
+        )
+
+    if schema_version >= 2:
+        embeddings_path = index_dir / EMBEDDINGS_FILENAME
+        if not embeddings_path.exists():
+            raise ValueError(
+                f"Index schema_version={schema_version} requires sidecar "
+                f"{embeddings_path}. Rebuild via scripts/build_index.py."
+            )
+        matrix = np.load(embeddings_path)
+        return InMemoryVectorStore(vectors=np.asarray(matrix, dtype=np.float32))
+
+    if chunks is None:
+        return None
+    inline = [c.get("embedding") for c in chunks]
+    if not inline or any(v is None for v in inline):
+        return None
+    return InMemoryVectorStore(vectors=np.asarray(inline, dtype=np.float32))

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -208,7 +208,7 @@ def main() -> int:
 
     output_dir.mkdir(parents=True, exist_ok=True)
     # M2 (#207): build counts come from the payload BEFORE write_index
-    # pops the in-memory _vectors matrix and serializes the sidecar.
+    # pops the in-memory _vector_store (#232) and serializes the sidecar.
     num_docs = payload["build"]["num_documents"]
     num_chunks = payload["build"]["num_chunks"]
     embedding_backend = payload["embedding"]["backend"]

--- a/tests/test_vector_store_protocol.py
+++ b/tests/test_vector_store_protocol.py
@@ -1,0 +1,69 @@
+"""Contract test for the VectorStore abstraction (#232, Stage 1 of #176).
+
+Single test file by design — the heavy lifting (bit-identical ranking
+across all dev queries) is done by
+``tests/test_naive_baseline_ranking_invariance.py``. This file only
+nails down the Protocol surface: shape, round-trip, and the unsupported-
+backend rejection path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rag_vector_store import (
+    ENV_INDEX_BACKEND,
+    InMemoryVectorStore,
+    VectorStore,
+    load_vector_store,
+    vector_store_from_matrix,
+)
+
+
+@pytest.fixture
+def matrix() -> np.ndarray:
+    rng = np.random.default_rng(seed=20260511)
+    m = rng.standard_normal((5, 8)).astype(np.float32)
+    m /= np.linalg.norm(m, axis=1, keepdims=True)
+    return m
+
+
+def test_in_memory_store_basic_shape(matrix: np.ndarray) -> None:
+    store = vector_store_from_matrix(matrix)
+    assert isinstance(store, VectorStore)
+    assert len(store) == 5
+    assert store.dimension == 8
+    np.testing.assert_array_equal(store.get(2), matrix[2])
+
+
+def test_in_memory_store_roundtrip(tmp_path: Path, matrix: np.ndarray) -> None:
+    original = vector_store_from_matrix(matrix)
+    original.persist(tmp_path)
+    assert (tmp_path / "embeddings.npy").exists()
+
+    restored = load_vector_store(tmp_path, schema_version=2)
+    assert restored is not None
+    assert len(restored) == len(original)
+    assert restored.dimension == original.dimension
+    for i in range(len(original)):
+        np.testing.assert_array_equal(restored.get(i), original.get(i))
+
+
+def test_legacy_schema1_materializes_from_inline_chunks(matrix: np.ndarray) -> None:
+    chunks = [{"embedding": matrix[i].tolist()} for i in range(matrix.shape[0])]
+    store = load_vector_store(Path("/nonexistent"), schema_version=1, chunks=chunks)
+    assert store is not None
+    assert len(store) == 5
+    np.testing.assert_allclose(store.get(0), matrix[0], rtol=0, atol=1e-6)
+
+
+def test_unsupported_backend_raises(
+    tmp_path: Path, matrix: np.ndarray, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vector_store_from_matrix(matrix).persist(tmp_path)
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    with pytest.raises(NotImplementedError, match="#176"):
+        load_vector_store(tmp_path, schema_version=2)


### PR DESCRIPTION
## 1. What changed and why

Closes #232

Stage 1 of [#176](https://github.com/hskim-solv/BidMate-DocAgent/issues/176) (Vector DB ablation). Hides the in-memory embedding matrix behind a `VectorStore` Protocol so future PRs can plug in Qdrant / pgvector adapters without touching the chunk-metadata payload or the retrieval loop's call site. **Abstraction only — zero behavior change.** Per stacked-PR discipline (one PR, one concern), the Qdrant / pgvector / benchmark / `docs/scale-experiment.md` work is left as explicit Stage 2/3/4 follow-ups under #176. Builds on #207 (which externalized embeddings into `embeddings.npy`).

## 2. Files affected

- `rag_vector_store.py` (NEW) — Protocol, `InMemoryVectorStore`, factories, env-var hook.
- `rag_core.py` (**load-bearing**) — 3 seam edits + 1 import: build-time `_vector_store` payload key, `load_index` delegates to `load_vector_store`, `write_index` calls `store.persist()`, retrieval loop calls `store.get(idx)`.
- `tests/test_vector_store_protocol.py` (NEW) — contract test (4 cases).
- `CLAUDE.md` — 1-line module-map update.
- `scripts/build_index.py` — 1-line stale comment update.

## 3. Risks

Most likely break: the load/query seams in `rag_core.py` accidentally drop the legacy schema-1 inline-embedding path or the hand-crafted-fixture fallback. Checked:
- Legacy schema-1 materialization is moved into `load_vector_store` and verified by `test_legacy_schema1_materializes_from_inline_chunks`. The chunk-mutation loop (`embedding_idx` / `pop`) stays in `load_index` and now runs *after* `load_vector_store` has read the inline lists (ordering bug fixed before commit).
- The defensive `chunk.get("embedding")` fallback for hand-crafted test fixtures (e.g., `tests/test_partial_topic_*.py`) is preserved verbatim in the query seam's `else` branch.
- Payload key rename `_vectors` → `_vector_store` is grep-safe: only `rag_core.py` referenced `_vectors`; no tests poke at it directly.

## 4. Tests

- New: `tests/test_vector_store_protocol.py` — 4 cases (basic shape, sidecar round-trip, legacy schema-1 materialization, unsupported-backend rejection). All pass.
- **Bit-identical regression gate**: `tests/test_naive_baseline_ranking_invariance.py` (the snapshot guard from #207) passes — top-K chunk_id ordering matches `tests/data/naive_baseline_top_k.json` across all dev queries. This is the real proof of no behavior change.
- Full suite: `431 passed, 121 subtests passed` via `pytest -q`.

## 5. Eval impact

All metric values from `make eval` on this branch are bit-identical to main — `accuracy=0.844`, `groundedness=0.714`, `citation_precision=0.512`, etc. Only stage_latency timings differ (machine-dependent run-to-run noise; not a behavior change). README metrics table is untouched in this PR — `make smoke` regenerated it locally with only latency drift, so I reverted that file to keep the diff scoped to the refactor.

### 5b. Real-data delta

The private real-100 corpus (`data/data_list.csv` + `data/files/`) is not present in this worktree. The bit-identical proof in the synthetic naive_baseline ranking guard (`tests/test_naive_baseline_ranking_invariance.py`) is the strongest signal we can produce here — identical rankings produce identical evidence and therefore identical metrics. The retrieval / verifier path itself is unchanged at the algorithmic level; only the in-memory carrier of the vector matrix changed.

If reviewer prefers, run locally before merge:
```
make real-eval
make real-eval-delta
```
Expected: every metric ±0 vs main; ranking bit-identical for naive_baseline.

## 6. Backward compatibility

No breaking change.
- On-disk format (`index.json` + `embeddings.npy`) is unchanged. `schema_version` stays at 2 — a bump would be cosmetic.
- Existing pre-built `data/index/` artifacts load cleanly through the abstraction (verified manually).
- Legacy schema-1 indexes (inline `embedding` per chunk) still materialize via the moved code path.
- `BIDMATE_INDEX_BACKEND` defaults to `memory` when unset.

## 7. Out of scope

Explicit follow-ups under #176:
- **Stage 2** — Qdrant adapter (`rag_vector_store_qdrant.py`, local-docker / in-memory mode, `SUPPORTED_BACKENDS` expansion).
- **Stage 3** — pgvector adapter.
- **Stage 4** — 100k synthetic-corpus generator (never-committed), p50/p95 latency benchmark across `{memory, qdrant, pgvector} × {10, 1k, 10k, 100k}`, `docs/scale-experiment.md` writeup, Korean-cloud (Naver / Kakao) compatibility note.
- Filter pushdown into a store-level `query(qvec, top_k)` — needs separate design issue when Stage 2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)