### PR TITLE
feat: harness profile expansion + matrix/compare mode (#235)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ reports/synthetic_judge.local.json
 # Benchmark raw/local artifacts
 artifacts/benchmarks/
 artifacts/runs/
+artifacts/matrices/
+
+# Harness private overlays (paired with eval/*.local.yaml). Only the
+# *.example.yaml templates are committed.
+harness/*.local.yaml
+harness/real.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check smoke smoke-with-judge harness-smoke test test-regression api api-docker demo demo-docker pareto docker-publish real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
+.PHONY: setup index ask eval benchmark benchmark-check check smoke smoke-with-judge harness-smoke harness-real harness-ablation harness-compare test test-regression api api-docker demo demo-docker pareto docker-publish real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -68,6 +68,26 @@ smoke-with-judge: smoke
 
 harness-smoke:
 	$(PYTHON) scripts/run_harness.py --config harness/smoke.yaml
+
+# Real-data harness profile. Requires harness/real.local.yaml (copied from
+# harness/real.example.yaml) and the eval/*.local.yaml it points to. None
+# of these resolved files are committed.
+harness-real:
+	$(PYTHON) scripts/run_harness.py --config harness/real.local.yaml
+
+# Run a matrix of harness cells on the committed public synthetic corpus.
+# Writes artifacts/matrices/<matrix_id>/{matrix_summary.json, compare.md}.
+# Pass MATRIX=harness/your.yaml to use a different matrix file.
+MATRIX ?= harness/ablation.example.yaml
+harness-ablation:
+	$(PYTHON) scripts/run_harness.py --matrix $(MATRIX) --force
+
+# Compare two harness runs (dirs under artifacts/runs/ or eval_summary.json).
+# Example: make harness-compare RUN_A=artifacts/runs/a RUN_B=artifacts/runs/b
+harness-compare:
+	$(PYTHON) scripts/run_harness.py --compare \
+	  --run-a $${RUN_A:?set RUN_A=<run-dir-or-eval_summary.json>} \
+	  --run-b $${RUN_B:?set RUN_B=<run-dir-or-eval_summary.json>}
 
 test:
 	bash scripts/test.sh

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -79,3 +79,77 @@ artifacts/runs/<run_id>/
 - 기관 A/B AI 요구사항 비교
 
 전체 품질 평가는 계속 `eval/run_eval.py --config eval/config.yaml`과 benchmark flow가 담당한다.
+
+## Real-data profile
+
+사설 RFP 데이터로 같은 manifest layout을 만들고 싶을 때는 `harness/real.example.yaml`을 `harness/real.local.yaml`로 복사하고 `eval.config` 경로를 자신의 `eval/real_config.local.yaml`로 맞춘 뒤 다음을 실행한다.
+
+```bash
+make harness-real
+```
+
+`harness/*.local.yaml`과 `eval/*.local.yaml`은 모두 `.gitignore`로 처리된다 (ADR 0005 commit boundary). real-data 산출물도 `artifacts/runs/`에 떨어지므로 자동으로 commit 대상에서 빠진다.
+
+## Ablation matrix
+
+`run_harness.py --matrix <yaml>`은 base config + cell override를 deep-merge해서 여러 cell을 직렬로 실행하고, 결과를 한 디렉터리에 묶는다.
+
+```bash
+make harness-ablation
+# 또는 다른 matrix 파일로
+make harness-ablation MATRIX=harness/my_ablation.yaml
+```
+
+생성물 layout:
+
+```text
+artifacts/matrices/<matrix_id>/
+  matrix_summary.json        # 집계 manifest
+  compare.md                 # compare.base가 설정된 경우만
+  errors.jsonl
+  cells/
+    <cell_name>/
+      cell_config.yaml       # 해당 cell의 merged config
+      run_manifest.json
+      config_snapshot.json
+      summary.json
+      predictions.jsonl
+      metrics/eval_summary.json
+      logs/{index,query,eval}.log
+      outputs/answer.json
+      index/
+```
+
+`harness/ablation.example.yaml`이 minimal 템플릿이다. 핵심 규칙:
+
+- `base.{dataset,index,query,eval}`만 deep-merge 대상. 그 외 키(`id`, `description`, `artifact_root`, `matrix`, `compare`, `base`)는 override 금지 — `ValueError` raise.
+- **ADR 0001 enforcement**: matrix 로드 시 `naive_baseline` 이름 cell이 없거나 `query.pipeline ≠ naive_baseline`이면 `SystemExit("ADR 0001 ...")`로 차단된다. naive baseline은 모든 matrix에 항상 존재해야 한다.
+- `on_cell_failure: continue`(기본) — 실패 cell은 `errors.jsonl`에 기록하고 다음 cell로. `abort`는 첫 실패에서 종료.
+- 매트릭스 exit code: 모든 cell pass 0, 하나라도 실패 2. (single-run과 동일 규약)
+- `compare.base: <cell_name>` 설정 시 해당 cell을 베이스로 다른 cell들의 metric delta가 `compare.md`로 렌더링된다.
+
+`matrix_summary.json` 주요 필드:
+
+- `schema_version`, `matrix_id`, `matrix_config_hash`, `generated_at`, `started_at`, `git_commit`, `git_dirty`
+- `matrix_config_path`, `matrix_dir`, `on_cell_failure`
+- `cells[]`: 각 cell의 `{name, run_id, status, config_hash, run_manifest_path, metrics_snapshot, failure}`
+- `compare`: `{base_cell, compare_md_path}` 또는 `null`
+- `status`, `cells_passed`, `cells_failed`
+
+## 두 run 비교 (compare 모드)
+
+임의의 두 run을 markdown delta로 비교할 수 있다.
+
+```bash
+make harness-compare \
+  RUN_A=artifacts/runs/public_synthetic_smoke_20260511T120000Z \
+  RUN_B=artifacts/runs/public_synthetic_smoke_20260511T140000Z
+
+# 또는 eval_summary.json 직접 지정
+python3 scripts/run_harness.py --compare \
+  --run-a reports/eval_summary.json \
+  --run-b reports/eval_summary.head.json \
+  --out compare.md
+```
+
+Metric 목록·formatting은 [`scripts/_eval_delta.py`](../scripts/_eval_delta.py)가 단일 source-of-truth이며, PR eval comment(`scripts/compare_eval.py`)와 matrix `compare.md`가 같은 정의를 공유한다.

--- a/harness/ablation.example.yaml
+++ b/harness/ablation.example.yaml
@@ -1,0 +1,35 @@
+id: ablation_example
+description: |
+  Example matrix — naive_baseline vs. a chunking variant on the committed
+  public synthetic corpus. Each cell inherits from base.* and is overridden
+  by matrix[i].override.*. Only dataset/index/query/eval may be overridden;
+  id/description/artifact_root/matrix/compare/base are reserved.
+artifact_root: artifacts/matrices
+base:
+  dataset:
+    id: public_synthetic_rfp_v1
+    input_dir: data/raw
+    privacy: public_synthetic_only
+  index:
+    embedding_backend: hashing
+    chunking_strategy: fixed
+  query:
+    text: "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
+    pipeline: naive_baseline
+  eval:
+    config: harness/smoke_eval.yaml
+matrix:
+  # ADR 0001 — a 'naive_baseline' cell running the naive pipeline must be
+  # present in every matrix. Validated at load time by run_harness.py.
+  - name: naive_baseline
+    override: {}
+  - name: hashing_section
+    override:
+      index:
+        chunking_strategy: section
+compare:
+  # Cell used as baseline for the delta table in compare.md.
+  base: naive_baseline
+# 'continue' (default): record failed cell, run the rest.
+# 'abort': stop at first failed cell.
+on_cell_failure: continue

--- a/harness/real.example.yaml
+++ b/harness/real.example.yaml
@@ -1,0 +1,15 @@
+id: real_local_full
+description: Local-only real RFP harness template. Copy to harness/real.local.yaml and point eval.config at your eval/real_config.local.yaml. None of these resolved files are committed (see .gitignore).
+artifact_root: artifacts/runs
+dataset:
+  id: real_rfp_local
+  input_dir: data/files
+  privacy: private_real_local
+index:
+  embedding_backend: hashing
+  chunking_strategy: fixed
+query:
+  text: "발주기관명 사업명의 사업기간과 사업예산 알려줘"
+  pipeline: agentic_full
+eval:
+  config: eval/real_config.local.yaml

--- a/scripts/_eval_delta.py
+++ b/scripts/_eval_delta.py
@@ -1,0 +1,53 @@
+"""Shared eval_summary.json delta helpers.
+
+Used by scripts/compare_eval.py (PR eval comment) and scripts/harness_compare.py
+(harness matrix compare). Keep the metric list aligned across both so synthetic
+matrix runs and PR delta tables surface the same surface.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+# (dotted_path, label, higher_is_better)
+METRICS: list[tuple[str, str, bool]] = [
+    ("accuracy", "accuracy", True),
+    ("groundedness", "groundedness", True),
+    ("citation_precision", "citation_precision", True),
+    ("citation_grounding", "citation_grounding", True),
+    ("claim_citation_alignment", "claim_citation_alignment", True),
+    ("answer_format_compliance", "answer_format_compliance", True),
+    ("abstention", "abstention (unanswerable cases)", True),
+    ("retry", "retry_rate", False),
+    ("latency.p50", "latency_p50_ms", False),
+    ("latency.p95", "latency_p95_ms", False),
+]
+
+
+def get_path(data: Any, path: str) -> Any:
+    cur = data
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def fmt_value(value: Any) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def fmt_delta(base: Any, head: Any, higher_is_better: bool) -> str:
+    if not isinstance(base, (int, float)) or not isinstance(head, (int, float)):
+        return "—"
+    delta = float(head) - float(base)
+    if abs(delta) < 5e-4:
+        return "·"
+    sign = "+" if delta > 0 else ""
+    improved = (delta > 0) if higher_is_better else (delta < 0)
+    flag = " ✅" if improved else " ⚠️"
+    return f"{sign}{delta:.3f}{flag}"

--- a/scripts/compare_eval.py
+++ b/scripts/compare_eval.py
@@ -2,56 +2,18 @@
 """Render a markdown delta table comparing two eval_summary.json files.
 
 Used by the PR eval workflow to post a base-vs-head comparison comment.
+Metric list and formatting helpers live in scripts/_eval_delta.py so the
+harness matrix compare reuses the same surface.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
-from typing import Any
 
-# (dotted_path, label, higher_is_better)
-METRICS: list[tuple[str, str, bool]] = [
-    ("accuracy", "accuracy", True),
-    ("groundedness", "groundedness", True),
-    ("citation_precision", "citation_precision", True),
-    ("citation_grounding", "citation_grounding", True),
-    ("claim_citation_alignment", "claim_citation_alignment", True),
-    ("answer_format_compliance", "answer_format_compliance", True),
-    ("abstention", "abstention (unanswerable cases)", True),
-    ("retry", "retry_rate", False),
-    ("latency.p50", "latency_p50_ms", False),
-    ("latency.p95", "latency_p95_ms", False),
-]
-
-
-def get_path(data: Any, path: str) -> Any:
-    cur = data
-    for part in path.split("."):
-        if not isinstance(cur, dict):
-            return None
-        cur = cur.get(part)
-    return cur
-
-
-def fmt_value(value: Any) -> str:
-    if value is None:
-        return "—"
-    if isinstance(value, float):
-        return f"{value:.3f}"
-    return str(value)
-
-
-def fmt_delta(base: Any, head: Any, higher_is_better: bool) -> str:
-    if not isinstance(base, (int, float)) or not isinstance(head, (int, float)):
-        return "—"
-    delta = float(head) - float(base)
-    if abs(delta) < 5e-4:
-        return "·"
-    sign = "+" if delta > 0 else ""
-    improved = (delta > 0) if higher_is_better else (delta < 0)
-    flag = " ✅" if improved else " ⚠️"
-    return f"{sign}{delta:.3f}{flag}"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _eval_delta import METRICS, fmt_delta, fmt_value, get_path  # noqa: E402
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/harness_compare.py
+++ b/scripts/harness_compare.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Compare two harness runs or render a matrix-cell delta table.
+
+Two entry points:
+
+  python3 scripts/harness_compare.py --run-a <dir> --run-b <dir> [--out FILE]
+    Standalone two-run compare. Either argument can point at a run directory
+    (resolves to <dir>/metrics/eval_summary.json) or directly at the JSON.
+
+  render_matrix_compare(cells, base_cell) -> str
+    Library helper used by scripts/run_harness.py --matrix to write
+    artifacts/matrices/<id>/compare.md.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _eval_delta import METRICS, fmt_delta, fmt_value, get_path  # noqa: E402
+
+
+def resolve_summary(path: Path) -> Path:
+    """Accept either a run directory or a direct eval_summary.json path."""
+    if path.is_dir():
+        candidate = path / "metrics" / "eval_summary.json"
+        if not candidate.exists():
+            raise SystemExit(f"[ERROR] No eval_summary.json under {path}")
+        return candidate
+    if not path.exists():
+        raise SystemExit(f"[ERROR] Path does not exist: {path}")
+    return path
+
+
+def render_pair(base: dict[str, Any], head: dict[str, Any], *, title: str,
+                base_label: str = "A", head_label: str = "B") -> str:
+    """Two-column delta table."""
+    lines: list[str] = []
+    lines.append(f"### {title}")
+    lines.append("")
+    lines.append(
+        f"- cases: {base_label}={base.get('num_predictions', '?')} · "
+        f"{head_label}={head.get('num_predictions', '?')}"
+    )
+    lines.append("")
+    lines.append(f"| metric | {base_label} | {head_label} | Δ |")
+    lines.append("|---|---|---|---|")
+    for path, label, higher in METRICS:
+        b = get_path(base, path)
+        h = get_path(head, path)
+        lines.append(
+            f"| {label} | {fmt_value(b)} | {fmt_value(h)} | {fmt_delta(b, h, higher)} |"
+        )
+    lines.append("")
+    lines.append(
+        "_✅ direction-of-improvement; ⚠️ direction-of-regression. "
+        "Synthetic-data delta — does not gate CI._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_matrix_compare(
+    cells: Sequence[dict[str, Any]],
+    base_cell_name: str,
+    *,
+    matrix_id: str,
+) -> str:
+    """N-column delta table: one base cell + N-1 cells with per-metric deltas.
+
+    Each cell dict must have:
+      - "name": str
+      - "status": "passed" | "failed"
+      - "eval_summary": dict (loaded eval_summary.json contents; may be {})
+    """
+    if not cells:
+        raise ValueError("matrix_compare requires at least one cell")
+    cell_names = [c["name"] for c in cells]
+    if base_cell_name not in cell_names:
+        raise ValueError(
+            f"base_cell '{base_cell_name}' not in cells {cell_names}"
+        )
+    base = next(c["eval_summary"] for c in cells if c["name"] == base_cell_name)
+    others = [c for c in cells if c["name"] != base_cell_name]
+
+    lines: list[str] = []
+    lines.append(f"### Matrix compare — {matrix_id}")
+    lines.append("")
+    lines.append(f"- base cell: `{base_cell_name}` · cases: {base.get('num_predictions', '?')}")
+    if any(c["status"] != "passed" for c in cells):
+        failed = [c["name"] for c in cells if c["status"] != "passed"]
+        lines.append(f"- failed cells: {', '.join(failed)} (rows show `—`)")
+    lines.append("")
+
+    header_cells = [base_cell_name] + [c["name"] for c in others]
+    delta_headers = [f"Δ {c['name']}" for c in others]
+    lines.append("| metric | " + " | ".join(header_cells) + " | " + " | ".join(delta_headers) + " |")
+    lines.append("|" + "---|" * (1 + len(header_cells) + len(delta_headers)))
+
+    for path, label, higher in METRICS:
+        base_val = get_path(base, path)
+        row = [label, fmt_value(base_val)]
+        for c in others:
+            if c["status"] != "passed":
+                row.append("—")
+            else:
+                row.append(fmt_value(get_path(c["eval_summary"], path)))
+        for c in others:
+            if c["status"] != "passed":
+                row.append("—")
+            else:
+                row.append(fmt_delta(base_val, get_path(c["eval_summary"], path), higher))
+        lines.append("| " + " | ".join(row) + " |")
+
+    lines.append("")
+    lines.append(
+        "_✅ direction-of-improvement; ⚠️ direction-of-regression. "
+        "Synthetic-data delta — does not gate CI._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--run-a", required=True, help="Run dir or eval_summary.json (baseline)")
+    ap.add_argument("--run-b", required=True, help="Run dir or eval_summary.json (head)")
+    ap.add_argument("--out", default=None, help="Write markdown to file in addition to stdout")
+    ap.add_argument("--title", default="Harness compare")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    a_path = resolve_summary(Path(args.run_a))
+    b_path = resolve_summary(Path(args.run_b))
+    a = json.loads(a_path.read_text(encoding="utf-8"))
+    b = json.loads(b_path.read_text(encoding="utf-8"))
+    markdown = render_pair(a, b, title=args.title)
+    print(markdown, end="")
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(markdown, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -1,7 +1,22 @@
 #!/usr/bin/env python3
+"""Reproducible local harness.
+
+Three modes:
+
+  python3 scripts/run_harness.py --config harness/smoke.yaml
+    Single-run: index → query → eval. Writes artifacts/runs/<run_id>/.
+
+  python3 scripts/run_harness.py --matrix harness/ablation.yaml
+    Matrix: deep-merge base + each cell override, run each cell, aggregate to
+    artifacts/matrices/<matrix_id>/matrix_summary.json + optional compare.md.
+
+  python3 scripts/run_harness.py --compare --run-a <dir> --run-b <dir>
+    Compare two run dirs (or eval_summary.json files) — markdown delta table.
+"""
 from __future__ import annotations
 
 import argparse
+import copy
 from datetime import datetime, timezone
 import hashlib
 import json
@@ -16,14 +31,22 @@ import yaml
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from harness_compare import render_matrix_compare, render_pair, resolve_summary  # noqa: E402
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a reproducible local harness.")
-    parser.add_argument("--config", required=True, help="Path to harness/*.yaml")
-    parser.add_argument("--run_id", default=None, help="Optional stable run id.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--config", help="Path to harness/*.yaml (single-run mode)")
+    mode.add_argument("--matrix", help="Path to matrix YAML (matrix mode)")
+    mode.add_argument("--compare", action="store_true", help="Compare two runs")
+    parser.add_argument("--run_id", default=None, help="Optional stable run id (single-run only).")
     parser.add_argument("--artifact_root", default=None, help="Override artifact root directory.")
     parser.add_argument("--force", action="store_true", help="Overwrite an existing run directory.")
+    parser.add_argument("--run-a", default=None, help="Run dir or eval_summary.json (compare mode)")
+    parser.add_argument("--run-b", default=None, help="Run dir or eval_summary.json (compare mode)")
+    parser.add_argument("--out", default=None, help="Write compare markdown to this file")
     return parser.parse_args()
 
 
@@ -213,22 +236,24 @@ def write_predictions(answer_path: Path, predictions_path: Path, query: str) -> 
     predictions_path.write_text(json.dumps(record, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
-def main() -> int:
-    args = parse_args()
+def _execute_pipeline(
+    config: dict[str, Any],
+    run_id: str,
+    run_dir: Path,
+    *,
+    source_paths: dict[str, str],
+    eval_config_path: Path,
+) -> dict[str, Any]:
+    """Run index → query → eval against a pre-resolved run_dir.
+
+    Writes config_snapshot.json, run_manifest.json, summary.json,
+    predictions.jsonl, errors.jsonl, metrics/, logs/, outputs/answer.json.
+    Returns the manifest dict.
+
+    The caller owns run_dir creation/wiping so matrix mode can write a
+    cell_config.yaml alongside before invoking.
+    """
     started_at = utc_now()
-    config_path = repo_path(args.config)
-    config = load_yaml(config_path)
-    config_id = str(config.get("id") or config_path.stem)
-    run_id = args.run_id or f"{config_id}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
-    artifact_root = repo_path(args.artifact_root or config.get("artifact_root") or "artifacts/runs")
-    run_dir = artifact_root / run_id
-
-    if run_dir.exists():
-        if not args.force:
-            raise SystemExit(f"[ERROR] Artifact directory already exists: {rel_path(run_dir)}")
-        shutil.rmtree(run_dir)
-    run_dir.mkdir(parents=True, exist_ok=True)
-
     logs_dir = run_dir / "logs"
     metrics_path = run_dir / "metrics" / "eval_summary.json"
     answer_path = run_dir / "outputs" / "answer.json"
@@ -238,15 +263,11 @@ def main() -> int:
     manifest_path = run_dir / "run_manifest.json"
     config_snapshot_path = run_dir / "config_snapshot.json"
 
-    eval_config_path = repo_path(require_mapping(config, "eval").get("config") or "harness/smoke_eval.yaml")
     eval_config = load_yaml(eval_config_path)
     config_snapshot = {
         "harness": config,
         "eval": eval_config,
-        "source_paths": {
-            "harness": rel_path(config_path),
-            "eval": rel_path(eval_config_path),
-        },
+        "source_paths": source_paths,
     }
     write_json(config_snapshot_path, config_snapshot)
     errors_path.touch()
@@ -321,7 +342,312 @@ def main() -> int:
 
     print(f"[OK] Harness run written: {rel_path(run_dir)}")
     print(f"[OK] Run manifest: {rel_path(manifest_path)}")
-    return 0 if status == "passed" else 2
+    return manifest
+
+
+def execute_single(
+    config_path: Path,
+    *,
+    run_id: str | None,
+    artifact_root: Path | None,
+    force: bool,
+) -> int:
+    config = load_yaml(config_path)
+    config_id = str(config.get("id") or config_path.stem)
+    effective_run_id = run_id or f"{config_id}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    effective_root = artifact_root or repo_path(config.get("artifact_root") or "artifacts/runs")
+    run_dir = effective_root / effective_run_id
+
+    if run_dir.exists():
+        if not force:
+            raise SystemExit(f"[ERROR] Artifact directory already exists: {rel_path(run_dir)}")
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    eval_config_path = repo_path(require_mapping(config, "eval").get("config") or "harness/smoke_eval.yaml")
+    source_paths = {
+        "harness": rel_path(config_path),
+        "eval": rel_path(eval_config_path),
+    }
+    manifest = _execute_pipeline(
+        config,
+        effective_run_id,
+        run_dir,
+        source_paths=source_paths,
+        eval_config_path=eval_config_path,
+    )
+    return 0 if manifest["status"] == "passed" else 2
+
+
+# ---------------------------------------------------------------------------
+# Matrix mode
+# ---------------------------------------------------------------------------
+
+_MERGE_KEYS = ("dataset", "index", "query", "eval")
+_FORBIDDEN_OVERRIDE_KEYS = ("id", "description", "artifact_root", "matrix", "compare", "base")
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Nested-merge override into a deep copy of base, restricted to _MERGE_KEYS.
+
+    Leaf values (scalars / lists) in override replace base wholesale — no list
+    concatenation, no auto-flattening. Keeps config_hash deterministic.
+    """
+    for forbidden in _FORBIDDEN_OVERRIDE_KEYS:
+        if forbidden in override:
+            raise ValueError(
+                f"override may not set top-level key '{forbidden}' "
+                f"(reserved for matrix metadata)"
+            )
+    merged = copy.deepcopy(base)
+    for section in _MERGE_KEYS:
+        if section not in override:
+            continue
+        section_override = override[section]
+        if not isinstance(section_override, dict):
+            merged[section] = section_override
+            continue
+        base_section = merged.get(section)
+        if not isinstance(base_section, dict):
+            merged[section] = copy.deepcopy(section_override)
+            continue
+        for key, value in section_override.items():
+            base_section[key] = copy.deepcopy(value)
+    return merged
+
+
+def _validate_matrix(matrix: dict[str, Any]) -> None:
+    for required in ("id", "base", "matrix"):
+        if required not in matrix:
+            raise SystemExit(f"[ERROR] Matrix YAML missing required key: {required}")
+    if not isinstance(matrix["base"], dict):
+        raise SystemExit("[ERROR] Matrix 'base' must be a mapping")
+    cells = matrix["matrix"]
+    if not isinstance(cells, list) or len(cells) == 0:
+        raise SystemExit("[ERROR] Matrix must declare ≥1 cell under 'matrix:'")
+    seen_names: set[str] = set()
+    for idx, cell in enumerate(cells):
+        if not isinstance(cell, dict) or "name" not in cell:
+            raise SystemExit(f"[ERROR] Matrix cell[{idx}] must be a mapping with 'name'")
+        name = cell["name"]
+        if name in seen_names:
+            raise SystemExit(f"[ERROR] Duplicate cell name: {name}")
+        seen_names.add(name)
+
+    # ADR 0001 — naive_baseline must remain runnable in every matrix.
+    base_pipeline = (matrix["base"].get("query") or {}).get("pipeline")
+    has_naive = False
+    for cell in cells:
+        override = cell.get("override") or {}
+        cell_pipeline = (override.get("query") or {}).get("pipeline", base_pipeline)
+        if cell["name"] == "naive_baseline" and cell_pipeline == "naive_baseline":
+            has_naive = True
+            break
+    if not has_naive:
+        raise SystemExit(
+            "[ERROR] Matrix must include a cell named 'naive_baseline' running the "
+            "naive_baseline pipeline (ADR 0001 — preserve naive baseline). "
+            "Add an empty-override cell or set query.pipeline=naive_baseline."
+        )
+
+    compare = matrix.get("compare")
+    if compare is not None:
+        if not isinstance(compare, dict) or "base" not in compare:
+            raise SystemExit("[ERROR] Matrix 'compare' must have a 'base' key")
+        if compare["base"] not in seen_names:
+            raise SystemExit(
+                f"[ERROR] compare.base '{compare['base']}' not in cell names: "
+                f"{sorted(seen_names)}"
+            )
+
+    on_failure = matrix.get("on_cell_failure", "continue")
+    if on_failure not in ("continue", "abort"):
+        raise SystemExit(
+            f"[ERROR] on_cell_failure must be 'continue' or 'abort', got: {on_failure}"
+        )
+
+
+def execute_matrix(matrix_path: Path, *, force: bool) -> int:
+    matrix = load_yaml(matrix_path)
+    _validate_matrix(matrix)
+
+    matrix_id = str(matrix["id"])
+    artifact_root = repo_path(matrix.get("artifact_root") or "artifacts/matrices")
+    matrix_dir = artifact_root / matrix_id
+
+    if matrix_dir.exists():
+        if not force:
+            raise SystemExit(f"[ERROR] Matrix directory already exists: {rel_path(matrix_dir)}")
+        shutil.rmtree(matrix_dir)
+    matrix_dir.mkdir(parents=True, exist_ok=True)
+
+    started_at = utc_now()
+    matrix_errors_path = matrix_dir / "errors.jsonl"
+    matrix_errors_path.touch()
+    on_failure = matrix.get("on_cell_failure", "continue")
+    base = matrix["base"]
+
+    cell_results: list[dict[str, Any]] = []
+    cells_passed = 0
+    cells_failed = 0
+
+    for cell in matrix["matrix"]:
+        cell_name = cell["name"]
+        override = cell.get("override") or {}
+        try:
+            merged = _deep_merge(base, override)
+        except ValueError as exc:
+            raise SystemExit(f"[ERROR] cell '{cell_name}': {exc}") from exc
+        merged["id"] = f"{matrix_id}__{cell_name}"
+        merged.setdefault(
+            "description",
+            f"Matrix cell {cell_name} of {matrix_id}",
+        )
+
+        cell_run_dir = matrix_dir / "cells" / cell_name
+        cell_run_dir.mkdir(parents=True, exist_ok=True)
+        cell_config_path = cell_run_dir / "cell_config.yaml"
+        cell_config_path.write_text(
+            yaml.safe_dump(merged, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        try:
+            eval_config_path = repo_path(
+                require_mapping(merged, "eval").get("config") or "harness/smoke_eval.yaml"
+            )
+        except ValueError as exc:
+            raise SystemExit(f"[ERROR] cell '{cell_name}': {exc}") from exc
+
+        source_paths = {
+            "harness": rel_path(cell_config_path),
+            "eval": rel_path(eval_config_path),
+        }
+        print(f"[matrix] running cell {cell_name} → {rel_path(cell_run_dir)}")
+        manifest = _execute_pipeline(
+            merged,
+            f"{matrix_id}__{cell_name}",
+            cell_run_dir,
+            source_paths=source_paths,
+            eval_config_path=eval_config_path,
+        )
+
+        cell_summary_path = cell_run_dir / "metrics" / "eval_summary.json"
+        eval_summary = (
+            json.loads(cell_summary_path.read_text(encoding="utf-8"))
+            if cell_summary_path.exists()
+            else {}
+        )
+        cell_result = {
+            "name": cell_name,
+            "run_id": manifest["run_id"],
+            "status": manifest["status"],
+            "config_hash": manifest["config_hash"],
+            "run_manifest_path": manifest["artifacts"]["run_manifest"],
+            "metrics_snapshot": manifest["metrics"],
+            "failure": manifest.get("failure"),
+            "eval_summary": eval_summary,
+        }
+        cell_results.append(cell_result)
+
+        if manifest["status"] == "passed":
+            cells_passed += 1
+        else:
+            cells_failed += 1
+            append_jsonl(
+                matrix_errors_path,
+                {"cell": cell_name, **(manifest.get("failure") or {})},
+            )
+            if on_failure == "abort":
+                print(f"[matrix] cell {cell_name} failed; on_cell_failure=abort → stopping")
+                break
+
+    compare_md_path: str | None = None
+    compare_cfg = matrix.get("compare")
+    if compare_cfg and cell_results:
+        try:
+            markdown = render_matrix_compare(
+                cell_results,
+                compare_cfg["base"],
+                matrix_id=matrix_id,
+            )
+        except ValueError as exc:
+            raise SystemExit(f"[ERROR] compare render: {exc}") from exc
+        compare_path = matrix_dir / "compare.md"
+        compare_path.write_text(markdown, encoding="utf-8")
+        compare_md_path = rel_path(compare_path)
+
+    ended_at = utc_now()
+    overall_status = "passed" if cells_failed == 0 else "failed"
+
+    matrix_summary = {
+        "schema_version": 1,
+        "matrix_id": matrix_id,
+        "matrix_config_hash": json_hash(matrix),
+        "generated_at": ended_at,
+        "started_at": started_at,
+        "git_commit": git_output(["rev-parse", "HEAD"]),
+        "git_dirty": git_dirty(),
+        "matrix_config_path": rel_path(matrix_path),
+        "matrix_dir": rel_path(matrix_dir),
+        "on_cell_failure": on_failure,
+        "cells": [
+            {k: v for k, v in c.items() if k != "eval_summary"} for c in cell_results
+        ],
+        "compare": (
+            {"base_cell": compare_cfg["base"], "compare_md_path": compare_md_path}
+            if compare_cfg
+            else None
+        ),
+        "status": overall_status,
+        "cells_passed": cells_passed,
+        "cells_failed": cells_failed,
+    }
+    write_json(matrix_dir / "matrix_summary.json", matrix_summary)
+    print(f"[OK] Matrix summary: {rel_path(matrix_dir / 'matrix_summary.json')}")
+    if compare_md_path:
+        print(f"[OK] Compare table: {compare_md_path}")
+    return 0 if overall_status == "passed" else 2
+
+
+# ---------------------------------------------------------------------------
+# Compare mode
+# ---------------------------------------------------------------------------
+
+
+def execute_compare(run_a: str, run_b: str, out: str | None) -> int:
+    a_path = resolve_summary(Path(run_a))
+    b_path = resolve_summary(Path(run_b))
+    a = json.loads(a_path.read_text(encoding="utf-8"))
+    b = json.loads(b_path.read_text(encoding="utf-8"))
+    markdown = render_pair(a, b, title="Harness compare")
+    print(markdown, end="")
+    if out:
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(markdown, encoding="utf-8")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    args = parse_args()
+    if args.compare:
+        if not args.run_a or not args.run_b:
+            raise SystemExit("[ERROR] --compare requires --run-a and --run-b")
+        return execute_compare(args.run_a, args.run_b, args.out)
+    if args.matrix:
+        return execute_matrix(repo_path(args.matrix), force=args.force)
+    return execute_single(
+        repo_path(args.config),
+        run_id=args.run_id,
+        artifact_root=repo_path(args.artifact_root) if args.artifact_root else None,
+        force=args.force,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_run_harness.py
+++ b/tests/test_run_harness.py
@@ -1,0 +1,453 @@
+"""Regression tests for scripts/run_harness.py.
+
+Covers issue #235 (Harness v2 — profile expansion + matrix/compare):
+
+* single-run roundtrip & config_hash determinism
+* matrix executor with deep-merge + ADR 0001 guard
+* compare mode rendering on synthetic eval_summary.json fixtures
+* errors.jsonl contract pinned (failure shape)
+* validation guards (zero cells, missing naive_baseline, missing compare.base)
+
+Pure-rendering and validation tests are fast. The end-to-end subprocess test
+uses the existing hashing-backend smoke surface (data/raw committed + the
+3-case harness/smoke_eval.yaml) and runs in well under a minute.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT_DIR / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import run_harness  # noqa: E402
+from harness_compare import render_matrix_compare, render_pair, resolve_summary  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — no subprocess
+# ---------------------------------------------------------------------------
+
+
+class DeepMergeTest(unittest.TestCase):
+    def test_overrides_nested_keys_only_in_whitelist(self) -> None:
+        base = {
+            "dataset": {"id": "x", "input_dir": "data/raw"},
+            "index": {"embedding_backend": "hashing"},
+        }
+        override = {"index": {"embedding_backend": "openai", "chunking_strategy": "paragraph"}}
+        merged = run_harness._deep_merge(base, override)
+        self.assertEqual(merged["dataset"], {"id": "x", "input_dir": "data/raw"})
+        self.assertEqual(
+            merged["index"],
+            {"embedding_backend": "openai", "chunking_strategy": "paragraph"},
+        )
+
+    def test_forbidden_top_level_override_raises(self) -> None:
+        for forbidden in ("id", "description", "artifact_root", "matrix", "compare", "base"):
+            with self.assertRaises(ValueError):
+                run_harness._deep_merge({"index": {}}, {forbidden: "x"})
+
+    def test_base_is_not_mutated(self) -> None:
+        base = {"index": {"embedding_backend": "hashing"}}
+        override = {"index": {"embedding_backend": "openai"}}
+        run_harness._deep_merge(base, override)
+        self.assertEqual(base["index"]["embedding_backend"], "hashing")
+
+
+class MatrixValidationTest(unittest.TestCase):
+    def _base_matrix(self) -> dict:
+        return {
+            "id": "test_matrix",
+            "base": {"query": {"pipeline": "naive_baseline"}},
+            "matrix": [{"name": "naive_baseline", "override": {}}],
+        }
+
+    def test_zero_cells_raises(self) -> None:
+        matrix = self._base_matrix()
+        matrix["matrix"] = []
+        with self.assertRaises(SystemExit):
+            run_harness._validate_matrix(matrix)
+
+    def test_missing_naive_baseline_raises_adr_0001(self) -> None:
+        matrix = self._base_matrix()
+        matrix["matrix"] = [
+            {"name": "other_cell", "override": {"query": {"pipeline": "agentic_full"}}}
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+            run_harness._validate_matrix(matrix)
+        self.assertIn("ADR 0001", str(ctx.exception))
+
+    def test_naive_baseline_with_wrong_pipeline_raises(self) -> None:
+        matrix = self._base_matrix()
+        matrix["matrix"] = [
+            {"name": "naive_baseline", "override": {"query": {"pipeline": "agentic_full"}}}
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+            run_harness._validate_matrix(matrix)
+        self.assertIn("ADR 0001", str(ctx.exception))
+
+    def test_compare_base_must_exist(self) -> None:
+        matrix = self._base_matrix()
+        matrix["compare"] = {"base": "missing_cell"}
+        with self.assertRaises(SystemExit) as ctx:
+            run_harness._validate_matrix(matrix)
+        self.assertIn("missing_cell", str(ctx.exception))
+
+    def test_duplicate_cell_names_raise(self) -> None:
+        matrix = self._base_matrix()
+        matrix["matrix"] = [
+            {"name": "naive_baseline", "override": {}},
+            {"name": "naive_baseline", "override": {}},
+        ]
+        with self.assertRaises(SystemExit):
+            run_harness._validate_matrix(matrix)
+
+    def test_invalid_on_cell_failure_raises(self) -> None:
+        matrix = self._base_matrix()
+        matrix["on_cell_failure"] = "panic"
+        with self.assertRaises(SystemExit):
+            run_harness._validate_matrix(matrix)
+
+    def test_minimal_valid_matrix_passes(self) -> None:
+        run_harness._validate_matrix(self._base_matrix())  # should not raise
+
+
+class CompareRenderingTest(unittest.TestCase):
+    def test_pair_renders_improvement_and_regression_flags(self) -> None:
+        base = {"num_predictions": 3, "accuracy": 0.5, "groundedness": 0.7, "retry": 0.0}
+        head = {"num_predictions": 3, "accuracy": 0.7, "groundedness": 0.7, "retry": 0.2}
+        markdown = render_pair(base, head, title="t")
+        self.assertIn("| accuracy |", markdown)
+        # accuracy up + higher-is-better → improvement
+        self.assertIn("✅", markdown)
+        # retry up + lower-is-better → regression
+        self.assertIn("⚠️", markdown)
+
+    def test_matrix_compare_renders_n_columns(self) -> None:
+        cells = [
+            {
+                "name": "naive_baseline",
+                "status": "passed",
+                "eval_summary": {"accuracy": 0.5, "groundedness": 0.6},
+            },
+            {
+                "name": "other",
+                "status": "passed",
+                "eval_summary": {"accuracy": 0.7, "groundedness": 0.6},
+            },
+        ]
+        markdown = render_matrix_compare(cells, "naive_baseline", matrix_id="m")
+        self.assertIn("naive_baseline", markdown)
+        self.assertIn("other", markdown)
+        self.assertIn("Δ other", markdown)
+        self.assertIn("| accuracy |", markdown)
+
+    def test_matrix_compare_marks_failed_cells_as_dash(self) -> None:
+        cells = [
+            {
+                "name": "naive_baseline",
+                "status": "passed",
+                "eval_summary": {"accuracy": 0.5},
+            },
+            {"name": "broken", "status": "failed", "eval_summary": {}},
+        ]
+        markdown = render_matrix_compare(cells, "naive_baseline", matrix_id="m")
+        self.assertIn("failed cells: broken", markdown)
+
+    def test_matrix_compare_missing_base_raises(self) -> None:
+        cells = [{"name": "a", "status": "passed", "eval_summary": {}}]
+        with self.assertRaises(ValueError):
+            render_matrix_compare(cells, "missing", matrix_id="m")
+
+
+class ResolveSummaryTest(unittest.TestCase):
+    def test_resolves_run_dir_to_eval_summary(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp) / "run"
+            (run_dir / "metrics").mkdir(parents=True)
+            summary = run_dir / "metrics" / "eval_summary.json"
+            summary.write_text("{}", encoding="utf-8")
+            resolved = resolve_summary(run_dir)
+            self.assertEqual(resolved, summary)
+
+    def test_resolves_direct_json(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            fh.write("{}")
+            tmp_path = Path(fh.name)
+        try:
+            self.assertEqual(resolve_summary(tmp_path), tmp_path)
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_path_raises(self) -> None:
+        with self.assertRaises(SystemExit):
+            resolve_summary(Path("/nonexistent/abc/xyz.json"))
+
+
+class CompareCliTest(unittest.TestCase):
+    def test_compare_cli_emits_delta_markdown(self) -> None:
+        import tempfile
+
+        a = {"num_predictions": 3, "accuracy": 0.5, "retry": 0.0}
+        b = {"num_predictions": 3, "accuracy": 0.7, "retry": 0.2}
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            a_path = tmp_path / "a.json"
+            b_path = tmp_path / "b.json"
+            out_path = tmp_path / "compare.md"
+            a_path.write_text(json.dumps(a), encoding="utf-8")
+            b_path.write_text(json.dumps(b), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT_DIR / "scripts" / "run_harness.py"),
+                    "--compare",
+                    "--run-a",
+                    str(a_path),
+                    "--run-b",
+                    str(b_path),
+                    "--out",
+                    str(out_path),
+                ],
+                cwd=ROOT_DIR,
+                text=True,
+                capture_output=True,
+                timeout=30,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("| accuracy |", result.stdout)
+            self.assertTrue(out_path.exists())
+            written = out_path.read_text(encoding="utf-8")
+            self.assertIn("✅", written)
+            self.assertIn("⚠️", written)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end subprocess tests (slower; share the committed smoke surface)
+# ---------------------------------------------------------------------------
+
+
+class HarnessE2ETest(unittest.TestCase):
+    """E2E: invoke run_harness.py as a subprocess against committed synthetic data.
+
+    Runs the harness with hashing backend on the 3-case harness/smoke_eval.yaml
+    fixture. Each run is ~10-15 s; total file run-time under a minute.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmp_root = Path(__file__).resolve().parent / "_tmp_harness_artifacts"
+        if cls.tmp_root.exists():
+            import shutil
+
+            shutil.rmtree(cls.tmp_root)
+        cls.tmp_root.mkdir(parents=True)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        import shutil
+
+        if cls.tmp_root.exists():
+            shutil.rmtree(cls.tmp_root)
+
+    def _run_smoke(self, run_id: str) -> dict:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT_DIR / "scripts" / "run_harness.py"),
+                "--config",
+                "harness/smoke.yaml",
+                "--run_id",
+                run_id,
+                "--artifact_root",
+                str(self.tmp_root),
+                "--force",
+            ],
+            cwd=ROOT_DIR,
+            text=True,
+            capture_output=True,
+            timeout=180,
+        )
+        self.assertEqual(result.returncode, 0, msg=f"stdout={result.stdout}\nstderr={result.stderr}")
+        manifest_path = self.tmp_root / run_id / "run_manifest.json"
+        self.assertTrue(manifest_path.exists())
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    def test_smoke_roundtrip_artifact_keys_pinned(self) -> None:
+        manifest = self._run_smoke("t1_keys")
+        self.assertEqual(manifest["schema_version"], 1)
+        self.assertEqual(manifest["status"], "passed")
+        expected_artifact_keys = {
+            "run_dir",
+            "run_manifest",
+            "config_snapshot",
+            "summary",
+            "predictions",
+            "metrics",
+            "errors",
+            "logs",
+            "index",
+            "answer",
+        }
+        self.assertEqual(set(manifest["artifacts"].keys()), expected_artifact_keys)
+
+    def test_config_hash_is_deterministic_across_run_ids(self) -> None:
+        m_a = self._run_smoke("t2_hash_a")
+        m_b = self._run_smoke("t2_hash_b")
+        self.assertEqual(
+            m_a["config_hash"],
+            m_b["config_hash"],
+            "config_hash should depend only on harness/eval YAML, not run_id",
+        )
+
+    def test_matrix_executor_writes_summary_and_compare(self) -> None:
+        matrix_id = "t3_matrix"
+        matrix_yaml = {
+            "id": matrix_id,
+            "description": "test matrix",
+            "artifact_root": str(self.tmp_root),
+            "base": {
+                "dataset": {
+                    "id": "public_synthetic_rfp_v1",
+                    "input_dir": "data/raw",
+                    "privacy": "public_synthetic_only",
+                },
+                "index": {"embedding_backend": "hashing", "chunking_strategy": "fixed"},
+                "query": {
+                    "text": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+                    "pipeline": "naive_baseline",
+                },
+                "eval": {"config": "harness/smoke_eval.yaml"},
+            },
+            "matrix": [
+                {"name": "naive_baseline", "override": {}},
+                {"name": "naive_baseline_v2", "override": {}},
+            ],
+            "compare": {"base": "naive_baseline"},
+            "on_cell_failure": "continue",
+        }
+        matrix_path = self.tmp_root / "matrix.yaml"
+        matrix_path.write_text(
+            yaml.safe_dump(matrix_yaml, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT_DIR / "scripts" / "run_harness.py"),
+                "--matrix",
+                str(matrix_path),
+                "--force",
+            ],
+            cwd=ROOT_DIR,
+            text=True,
+            capture_output=True,
+            timeout=300,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"stdout={result.stdout}\nstderr={result.stderr}",
+        )
+        matrix_dir = self.tmp_root / matrix_id
+        summary_path = matrix_dir / "matrix_summary.json"
+        compare_path = matrix_dir / "compare.md"
+        self.assertTrue(summary_path.exists())
+        self.assertTrue(compare_path.exists())
+
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        self.assertEqual(summary["status"], "passed")
+        self.assertEqual(summary["cells_passed"], 2)
+        self.assertEqual(summary["cells_failed"], 0)
+        cell_names = [c["name"] for c in summary["cells"]]
+        self.assertEqual(cell_names, ["naive_baseline", "naive_baseline_v2"])
+
+        compare_md = compare_path.read_text(encoding="utf-8")
+        self.assertIn("| accuracy |", compare_md)
+        self.assertIn("naive_baseline_v2", compare_md)
+
+    def test_errors_jsonl_contract_on_step_failure(self) -> None:
+        """Exercise the subprocess-step-failure path.
+
+        Use a pipeline name that fails argparse 'choices' validation in app.py,
+        which causes the 'query' step to exit non-zero. The harness records the
+        failure in errors.jsonl with {step, returncode, log, command}.
+        """
+        run_id = "t4_errors"
+        config = {
+            "id": "t4_errors",
+            "description": "failure case — invalid pipeline name",
+            "dataset": {
+                "id": "public_synthetic_rfp_v1",
+                "input_dir": "data/raw",
+                "privacy": "public_synthetic_only",
+            },
+            "index": {"embedding_backend": "hashing", "chunking_strategy": "fixed"},
+            "query": {
+                "text": "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+                "pipeline": "definitely_not_a_real_pipeline_xyz",
+            },
+            "eval": {"config": "harness/smoke_eval.yaml"},
+        }
+        config_path = self.tmp_root / "fail.yaml"
+        config_path.write_text(
+            yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT_DIR / "scripts" / "run_harness.py"),
+                "--config",
+                str(config_path),
+                "--run_id",
+                run_id,
+                "--artifact_root",
+                str(self.tmp_root),
+                "--force",
+            ],
+            cwd=ROOT_DIR,
+            text=True,
+            capture_output=True,
+            timeout=180,
+        )
+        self.assertEqual(
+            result.returncode,
+            2,
+            msg=f"expected step-failure exit=2, got {result.returncode}. "
+            f"stdout={result.stdout}\nstderr={result.stderr}",
+        )
+        run_dir = self.tmp_root / run_id
+        errors_path = run_dir / "errors.jsonl"
+        self.assertTrue(errors_path.exists())
+        lines = [
+            json.loads(line)
+            for line in errors_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        self.assertEqual(len(lines), 1, msg=f"expected 1 failure record, got {lines}")
+        record = lines[0]
+        for key in ("step", "returncode", "log", "command"):
+            self.assertIn(key, record)
+        self.assertEqual(record["step"], "query")
+        self.assertNotEqual(record["returncode"], 0)
+        self.assertIsInstance(record["command"], list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

\`scripts/run_harness.py\`는 smoke 한 가지만 지원하던 single-run runner였다. Phase 3로 진입하면서 ablation/real-eval iteration이 잦아지므로, 같은 manifest 계약(config_hash, run_manifest schema_version 1)을 그대로 보존하면서 (a) profile 확장(real, ablation) (b) matrix 모드(N-cell deep-merge + 집계) (c) compare 모드(두 run의 markdown delta)를 추가했다.

Closes #235

## 2. Files affected

- \`scripts/run_harness.py\` — \`execute_single\`/\`execute_matrix\`/\`execute_compare\` 분리, top-level CLI dispatcher(\`--config\`/\`--matrix\`/\`--compare\`). 단일 모드 동작은 비트-단위 보존.
- \`scripts/_eval_delta.py\` (신규) — METRICS / get_path / fmt_value / fmt_delta 공유 모듈
- \`scripts/compare_eval.py\` — 로컬 helper 정의 → \`_eval_delta\` import. CLI surface 무변경(\`pr-eval.yml\` 호환).
- \`scripts/harness_compare.py\` (신규) — pair / matrix-compare 렌더러 + standalone \`--compare\` CLI
- \`harness/real.example.yaml\` (신규) — private real-eval profile 템플릿
- \`harness/ablation.example.yaml\` (신규) — 2-cell matrix 템플릿
- \`Makefile\` — \`harness-real\`, \`harness-ablation\` (MATRIX=...), \`harness-compare\` (RUN_A=, RUN_B=)
- \`.gitignore\` — \`artifacts/matrices/\`, \`harness/*.local.yaml\`, \`harness/real.yaml\`
- \`docs/harness.md\` — real profile / matrix / compare 섹션 + ADR 0001 enforcement 명시
- \`tests/test_run_harness.py\` (신규) — 22 tests (18 pure unit + 4 e2e subprocess)

**Load-bearing 파일 미변경.** \`rag_core.py\`/\`ingestion.py\`/\`visual_ingestion.py\`/\`eval/\`/\`api/\`/\`docs/adr/\` 모두 손대지 않음.

## 3. Risks

가장 가능성 높은 회귀: 기존 \`make harness-smoke\`의 manifest 모양이 미세하게 달라지는 것. 방지책:

1. \`_execute_pipeline\`은 기존 \`main()\` (구 lines 232–323)의 본문을 그대로 들고 옴. 같은 순서 · 같은 필드 · 같은 stderr/stdout pattern.
2. \`tests/test_run_harness.py::test_smoke_roundtrip_artifact_keys_pinned\`이 manifest의 10-key artifact 집합을 핀.
3. \`test_config_hash_is_deterministic_across_run_ids\`이 \`config_hash\`가 \`run_id\`와 무관함을 보증.
4. \`scripts/compare_eval.py\`는 CLI surface 그대로 — \`.github/workflows/pr-eval.yml\`이 그대로 호출 가능. import 경로만 바뀜.

ADR 0001 invariant는 matrix loader가 직접 enforce — \`naive_baseline\` cell 부재 시 \`SystemExit("ADR 0001 ...")\`. 테스트 2개로 보증.

## 4. Tests

신규 \`tests/test_run_harness.py\` — 22 tests, 4 클래스:

| 클래스 | 테스트 | 비고 |
|---|---|---|
| DeepMergeTest | 3 | nested merge, forbidden keys, immutability |
| MatrixValidationTest | 7 | zero cells / missing naive_baseline / wrong pipeline / missing compare.base / duplicates / invalid on_cell_failure / minimal valid |
| CompareRenderingTest | 4 | pair flags, matrix N-column, failed cell dash, missing base raise |
| ResolveSummaryTest | 3 | run dir → eval_summary.json, direct file, missing path |
| CompareCliTest | 1 | end-to-end \`--compare\` subprocess |
| HarnessE2ETest | 4 | smoke roundtrip, hash determinism, matrix + compare.md, errors.jsonl 계약 |

전체 \`pytest -q\` → **438 passed**, 회귀 없음.

\`make harness-smoke\`, \`make harness-ablation MATRIX=harness/ablation.example.yaml\`, \`make harness-compare RUN_A=... RUN_B=...\` 모두 수동 검증.

## 5. Eval impact

All \`·\` — 이 PR은 \`scripts/\`/\`harness/\`/\`docs/\`/\`tests/\`만 건드린다. \`rag_core\` 응답 dict 미변경, retrieval/eval 파이프라인 미변경. 합성 CI delta는 noise 수준 외 변동 없을 것.

### 5b. Real-data delta

**N/A** — \`scripts/run_harness.py\`는 CLAUDE.md load-bearing 목록(\`rag_core\`/\`ingestion\`/\`visual_ingestion\`/\`eval/\`/\`api/\`/\`docs/adr/\`) 밖이며, 본 PR은 retrieval/verifier 경로를 건드리지 않는다.

## 6. Backward compatibility

- \`scripts/run_harness.py --config <yaml>\` 단일 모드 호출 contract 그대로. \`--run_id\`, \`--artifact_root\`, \`--force\` 인자 모두 유지.
- \`run_manifest.json\` schema_version 1 유지. 필드 add도 없음(기존 필드 동일).
- \`scripts/compare_eval.py\` CLI surface(\`--base\`, \`--head\`, \`--title\`) 그대로 — \`.github/workflows/pr-eval.yml\` 영향 없음.
- ADR 0003 answer-dict contract 무관.
- Make target \`harness-smoke\` 동일. 신규 target들은 add-only.

## 7. Out of scope

#235 meta가 추적하는 4개 방향 중 2개만 이 PR에서 닫는다.

- **Resume / index cache** — #236 (stacked PR)
- **Observability / leaderboard auto-append** — #237 (stacked PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)