### PR TITLE
docs: cross-link multi-agent ownership model from CLAUDE.md and engineering-governance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ that aren't auto-enforced.
 
 - [`docs/engineering-governance.md`](docs/engineering-governance.md) — workflow map.
 - [`docs/adr/README.md`](docs/adr/README.md) — decision index.
+- [`docs/multi-agent-ownership.md`](docs/multi-agent-ownership.md) — coordination model when multiple agents work in parallel.
 - If touching retrieval / answer / eval, also read:
   [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) (naive baseline),
   [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) (answer contract),

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -13,6 +13,7 @@ If you are new to the repo or onboarding a reviewer, start here.
 | Concern | Source of truth | Notes |
 |---|---|---|
 | Coding & review rules | [`CLAUDE.md`](../CLAUDE.md) | Pre-PR checklist, prohibited shortcuts, performance expectations. |
+| Multi-agent coordination | [`docs/multi-agent-ownership.md`](./multi-agent-ownership.md) | 7-way ownership split, `rag_core.py` lock holder, conflict-resolution rules when several agents work in parallel. |
 | Load-bearing decisions | [`docs/adr/`](./adr/README.md) | One short file per decision; status-tracked. |
 | Behavior contracts | [ADR 0003](./adr/0003-structured-answer-citation-contract.md), [`docs/answer-policy.md`](./answer-policy.md) | Answer JSON shape, `schema_version`, status values. |
 | Eval surfaces | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`eval/config.yaml`](../eval/config.yaml), `eval/*.example.yaml` | Public synthetic is committed; private local is `.gitignore`d. |


### PR DESCRIPTION
## 1. What changed and why

Surfaces [`docs/multi-agent-ownership.md`](../blob/docs/issue-248-crosslink-ownership-doc/docs/multi-agent-ownership.md) (added in #247) from the two canonical entry points so a reader does not need to know the meta-issue to find it:

- [`CLAUDE.md`](../blob/docs/issue-248-crosslink-ownership-doc/CLAUDE.md) "Start here" — adds one bullet next to the workflow map and ADR index.
- [`docs/engineering-governance.md`](../blob/docs/issue-248-crosslink-ownership-doc/docs/engineering-governance.md) "Where each thing lives" — adds a row pointing at the coordination model.

Kept as a separate PR per the stacked-PR discipline (one PR, one concern). **Stacks on #247** — this PR's base is `docs/issue-245-multi-agent-ownership`; will be retargeted to `main` automatically once #247 merges.

Closes #248.

## 2. Files affected

- `CLAUDE.md` — one new bullet in the "Start here" list.
- `docs/engineering-governance.md` — one new row in the "Where each thing lives" table.

No load-bearing files touched.

## 3. Risks

Lowest-risk class — two-line additions in two markdown files. Most likely defect: the path resolves wrong if the ownership doc's filename changes. Same path is referenced in three other places (PR #247 body, owner issues #238–#244, this PR body) so any rename would be a deliberate sweep.

## 4. Tests

N/A — docs-only change with no behavior surface.

## 5. Eval impact

All `·` — non-RAG change.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. No load-bearing files modified.

## 6. Backward compatibility

None broken. Both edits are additive — no removed bullets, no reordered rows, no link rewrites.

## 7. Out of scope

- Adding the ownership doc to the reading order in `docs/engineering-governance.md`'s "Onboarding shortcuts" section — defer until the model has been used at least once and we know whether it belongs in the new-contributor path.
- Linking from any ADR — the model is convention, not a contract, so it does not belong in `docs/adr/`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)