### PR TITLE
docs: fix ADR 0014 header number typo (0012 → 0014)

### DIFF
--- a/docs/adr/0014-ragas-judge-additive-synthetic.md
+++ b/docs/adr/0014-ragas-judge-additive-synthetic.md
@@ -1,4 +1,4 @@
-# 0012: RAGAS-style LLM-judge as additive enrichment on the synthetic surface
+# 0014: RAGAS-style LLM-judge as additive enrichment on the synthetic surface
 
 - **Status**: accepted
 - **Date**: 2026-05-11


### PR DESCRIPTION
## 1. What changed and why

Fix a one-character typo on line 1 of `docs/adr/0014-ragas-judge-additive-synthetic.md`. The header read `# 0012: …` even though the filename, the `docs/adr/README.md` index entry, and the body's "refines ADR 0006" relation all confirm this file is ADR **0014**. Aligns the header with the filename and the index so the file is no longer self-contradicting.

Closes #250

## 2. Files affected

- `docs/adr/0014-ragas-judge-additive-synthetic.md` — 1 line (header only). **Load-bearing path (`docs/adr/`)**, but content unchanged except for the leading digit of the header number; no decision or contract is altered.
- `docs/adr/README.md` — **not** modified. Its index entry (line 79) already correctly links to `[0014](./0014-ragas-judge-additive-synthetic.md)`; the "(extends 0012)" phrase there refers to the genuine ADR 0012 relationship and is intentional.

## 3. Risks

Effectively none. The change is a single ASCII-digit substitution in a Markdown H1. The most likely failure mode would be unintentional whitespace or trailing-character changes, ruled out by inspecting `git diff` — only the `2 → 4` digit changes.

## 4. Tests

N/A. No executable code path is exercised. Verification is the diff itself plus `head -1 docs/adr/0014-ragas-judge-additive-synthetic.md` showing `# 0014: …`.

## 5. Eval impact

All `·`. This is a documentation-only typo fix with no retrieval / verifier / answer / eval code touched.

### 5b. Real-data delta

N/A. None of `rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, or `api/` changed. No behavior change in retrieval / verifier path.

## 6. Backward compatibility

N/A. No contract, schema, CLI flag, or doc link is affected. ADR 0001 (naive baseline) and ADR 0003 (answer contract) are unchanged. The `schema_version` does not need a bump.

## 7. Out of scope

- The `docs/adr/README.md` index entry — already correct.
- The "(extends 0012)" phrase in the README's 0014 row — a legitimate reference to the real ADR 0012, not a typo.
- The body of ADR 0014 — no other `0012` occurrences exist in the file (verified with `grep`).