### PR TITLE
ci: auto-publish demo image to GHCR on main merge (#252)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: Publish Demo Image to GHCR
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and push to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/bidmate-demo
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docs/portfolio-launch-checklist.md
+++ b/docs/portfolio-launch-checklist.md
@@ -82,17 +82,26 @@ Record at 1280×720 with QuickTime / OBS, trim to 60–90 s, export as
 MP4 or GIF, save to `docs/assets/demo.gif` (or `.mp4`). Keep file size
 under 5 MB for the README to render quickly.
 
-### 4. Publish the GHCR image (one-time)
+### 4. Publish the GHCR image — automated by CI (issue #252)
 
-The `docker run ghcr.io/<user>/bidmate-demo:latest` recipe in the
-README only works if the image is pushed:
+Every push to `main` triggers
+[`.github/workflows/docker-publish.yml`](../.github/workflows/docker-publish.yml),
+which builds and pushes the demo image to
+`ghcr.io/<user>/bidmate-demo:latest` (plus a short-sha tag). No PAT
+is needed — the workflow's `GITHUB_TOKEN` carries `packages: write`.
+
+Manual triggers remain available for previewing a non-main branch
+image:
 
 ```bash
 docker login ghcr.io        # use a PAT with write:packages scope
 make docker-publish         # builds + pushes ghcr.io/hskim-solv/bidmate-demo:latest
 ```
 
-After the first push, the image is **public** by default for new
+…or click **Run workflow** on the Actions tab to re-run against a
+chosen branch.
+
+After the first CI push, the image is **public** by default for new
 GHCR pushes; if the author had set it private, flip it via
 **GitHub → Packages → bidmate-demo → Package settings → Change visibility**.
 


### PR DESCRIPTION
## 1. What changed and why

Adds a GitHub Actions workflow that publishes the demo Docker image to GHCR on every push to `main`. Previously, `make docker-publish` was a manual author action (item 4 in [`docs/portfolio-launch-checklist.md`](docs/portfolio-launch-checklist.md)), so the `docker run ghcr.io/<user>/bidmate-demo:latest` reviewer recipe stagnated between merges. Automating it removes the recurring context switch and keeps the 5-minute reviewer path (issue #123) reliably current.

Closes #252

## 2. Files affected

- `.github/workflows/docker-publish.yml` (new)
- `docs/portfolio-launch-checklist.md` (item 4 updated to reference the CI flow)

**Not load-bearing** per CLAUDE.md (no changes to `rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, or `docs/adr/`).

## 3. Risks

- **GHCR auth**: the workflow uses `GITHUB_TOKEN` with `packages: write` declared in the `permissions:` block — no PAT needed. Verified against GitHub's automatic-token-authentication docs.
- **First-push visibility**: if the package defaults to private, the first run creates a private package. The existing checklist instructions cover flipping it via Packages → Package settings.
- **Build time / image size**: the workflow uses `buildx` with `type=gha` cache, so steady-state runs are incremental. First run after merge will be a cold build (one-time cost).
- **Tag collisions**: `latest` is only applied on the default branch (`enable={{is_default_branch}}`), preventing accidental `latest` overwrite from a `workflow_dispatch` run on a non-main branch.

## 4. Tests

No application test change. YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker-publish.yml'))"`). End-to-end verification happens on the first post-merge run (workflow logs + `docker pull ghcr.io/hskim-solv/bidmate-demo:latest` on a clean host).

## 5. Eval impact

All `·` — no retrieval, verifier, answer, or eval code changes. No CI eval delta expected.

### 5b. Real-data delta

N/A — no behavior change in retrieval / verifier path; this is a CI-only addition.

## 6. Backward compatibility

Non-breaking.
- `make docker-publish` Makefile target is retained for local previews and feature-branch image inspection.
- No contract, schema, or CLI flag changes.
- No ADR 0001/0003 impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)