### PR TITLE
refactor: extract duplicated I/O and metric helpers in scripts/ into _utils.py

### DIFF
--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -1,0 +1,127 @@
+"""Shared helpers for scripts/ — I/O, git introspection, and metric snapshots.
+
+Internal to scripts/; not part of any public API.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+from typing import Any
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def repo_path(value: str | Path) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def rel_path(path: str | Path) -> str:
+    resolved = Path(path).resolve()
+    try:
+        return str(resolved.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(resolved)
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML must be a mapping: {path}")
+    return data
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def stable_json(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+
+def append_jsonl(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def json_hash(payload: Any) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def git_output(args: list[str], default: str = "unknown") -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=ROOT_DIR,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception:
+        return default
+    return result.stdout.strip() or default
+
+
+def git_dirty() -> bool:
+    status = git_output(["status", "--porcelain", "--untracked-files=no"], default="")
+    return bool(status.strip())
+
+
+def fmt_rate(value: Any) -> str:
+    return f"{value:.3f}" if isinstance(value, (int, float)) else "N/A"
+
+
+_METRIC_SNAPSHOT_KEYS_PRE = (
+    "num_predictions",
+    "accuracy",
+    "groundedness",
+    "citation_precision",
+    "citation_page_precision",
+    "citation_region_precision",
+    "citation_grounding",
+    "answer_format_compliance",
+    "abstention",
+    "retry",
+    "latency",
+    "retry_cost",
+    "retry_reason_counts",
+    "citation_grounding_error_counts",
+)
+
+
+def metric_snapshot(
+    summary: dict[str, Any] | None,
+    *,
+    include_query_type: bool = True,
+) -> dict[str, Any]:
+    """Slice the canonical aggregate metric keys out of an eval summary.
+
+    With ``include_query_type=True`` matches the ``run_benchmark`` shape
+    (used for per-run snapshots inside the run manifest).
+    With ``include_query_type=False`` matches the ``summarize_benchmark`` shape
+    (used for the committed registry entries that drop the per-query-type slice).
+    """
+    summary = summary or {}
+    keys: list[str] = list(_METRIC_SNAPSHOT_KEYS_PRE)
+    if include_query_type:
+        keys.append("by_query_type")
+    keys.append("by_hardcase_category")
+    return {key: summary.get(key) for key in keys if key in summary}

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime, timezone
-import hashlib
 import importlib.util
 import json
 import os
@@ -14,13 +13,21 @@ import subprocess
 import sys
 from typing import Any
 
-import yaml
-
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from rag_core import DEFAULT_CLI_PIPELINE_NAME, load_index, resolve_pipeline_config
+from rag_core import DEFAULT_CLI_PIPELINE_NAME, load_index, resolve_pipeline_config  # noqa: E402
+from scripts._utils import (  # noqa: E402
+    git_dirty,
+    git_output,
+    json_hash,
+    load_yaml,
+    metric_snapshot,
+    rel_path,
+    repo_path,
+    write_json,
+)
 
 
 def load_eval_module() -> Any:
@@ -44,56 +51,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--artifact_root", default=None, help="Override artifact root directory.")
     parser.add_argument("--force", action="store_true", help="Overwrite an existing run artifact directory.")
     return parser.parse_args()
-
-
-def repo_path(value: str | Path) -> Path:
-    path = Path(value)
-    return path if path.is_absolute() else ROOT_DIR / path
-
-
-def rel_path(path: str | Path) -> str:
-    resolved = Path(path).resolve()
-    try:
-        return str(resolved.relative_to(ROOT_DIR))
-    except ValueError:
-        return str(resolved)
-
-
-def load_yaml(path: Path) -> dict[str, Any]:
-    data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError(f"YAML must be a mapping: {path}")
-    return data
-
-
-def write_json(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-
-
-def json_hash(payload: Any) -> str:
-    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def git_output(args: list[str], default: str = "unknown") -> str:
-    try:
-        result = subprocess.run(
-            ["git", *args],
-            cwd=ROOT_DIR,
-            check=True,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except Exception:
-        return default
-    return result.stdout.strip() or default
-
-
-def git_dirty() -> bool:
-    status = git_output(["status", "--porcelain", "--untracked-files=no"], default="")
-    return bool(status.strip())
 
 
 def run_logged_command(command: list[str], log_path: Path) -> None:
@@ -136,28 +93,6 @@ def normalize_run(run: dict[str, Any]) -> dict[str, Any]:
 
 def safe_name(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_") or "case"
-
-
-def metric_snapshot(summary: dict[str, Any]) -> dict[str, Any]:
-    keys = [
-        "num_predictions",
-        "accuracy",
-        "groundedness",
-        "citation_precision",
-        "citation_page_precision",
-        "citation_region_precision",
-        "citation_grounding",
-        "answer_format_compliance",
-        "abstention",
-        "retry",
-        "latency",
-        "retry_cost",
-        "retry_reason_counts",
-        "citation_grounding_error_counts",
-        "by_query_type",
-        "by_hardcase_category",
-    ]
-    return {key: summary.get(key) for key in keys if key in summary}
 
 
 def run_flags(run: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime, timezone
-import hashlib
 import json
 import os
 from pathlib import Path
@@ -12,10 +11,22 @@ import subprocess
 import sys
 from typing import Any
 
-import yaml
-
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts._utils import (  # noqa: E402
+    append_jsonl,
+    git_dirty,
+    git_output,
+    json_hash,
+    load_yaml,
+    rel_path,
+    repo_path,
+    utc_now,
+    write_json,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,66 +36,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--artifact_root", default=None, help="Override artifact root directory.")
     parser.add_argument("--force", action="store_true", help="Overwrite an existing run directory.")
     return parser.parse_args()
-
-
-def repo_path(value: str | Path) -> Path:
-    path = Path(value)
-    return path if path.is_absolute() else ROOT_DIR / path
-
-
-def rel_path(path: str | Path) -> str:
-    resolved = Path(path).resolve()
-    try:
-        return str(resolved.relative_to(ROOT_DIR))
-    except ValueError:
-        return str(resolved)
-
-
-def load_yaml(path: Path) -> dict[str, Any]:
-    data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError(f"YAML must be a mapping: {path}")
-    return data
-
-
-def write_json(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-
-
-def append_jsonl(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as file:
-        file.write(json.dumps(payload, ensure_ascii=False) + "\n")
-
-
-def json_hash(payload: Any) -> str:
-    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def git_output(args: list[str], default: str = "unknown") -> str:
-    try:
-        result = subprocess.run(
-            ["git", *args],
-            cwd=ROOT_DIR,
-            check=True,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except Exception:
-        return default
-    return result.stdout.strip() or default
-
-
-def git_dirty() -> bool:
-    status = git_output(["status", "--porcelain", "--untracked-files=no"], default="")
-    return bool(status.strip())
 
 
 def run_logged_command(command: list[str], log_path: Path) -> dict[str, Any]:

--- a/scripts/summarize_benchmark.py
+++ b/scripts/summarize_benchmark.py
@@ -3,12 +3,22 @@ from __future__ import annotations
 
 import argparse
 import copy
-import json
 from pathlib import Path
 import sys
 from typing import Any
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts._utils import (  # noqa: E402
+    fmt_rate,
+    load_json,
+    metric_snapshot,
+    repo_path,
+    stable_json,
+)
+
 DATASET_PRIVACY_KEYS = (
     "type",
     "privacy",
@@ -29,28 +39,11 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def repo_path(value: str | Path) -> Path:
-    path = Path(value)
-    return path if path.is_absolute() else ROOT_DIR / path
-
-
 def display_path(path: Path) -> str:
     try:
         return str(path.relative_to(ROOT_DIR))
     except ValueError:
         return str(path)
-
-
-def load_json(path: Path) -> Any:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def stable_json(payload: Any) -> str:
-    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
-
-
-def fmt_rate(value: Any) -> str:
-    return f"{value:.3f}" if isinstance(value, (int, float)) else "N/A"
 
 
 def fmt_latency(value: Any) -> str:
@@ -67,28 +60,6 @@ def fmt_delta(primary: Any, baseline: Any) -> str:
     return f"{sign}{delta:.3f}"
 
 
-def metric_block(summary: dict[str, Any] | None) -> dict[str, Any]:
-    summary = summary or {}
-    keys = [
-        "num_predictions",
-        "accuracy",
-        "groundedness",
-        "citation_precision",
-        "citation_page_precision",
-        "citation_region_precision",
-        "citation_grounding",
-        "answer_format_compliance",
-        "abstention",
-        "retry",
-        "latency",
-        "retry_cost",
-        "retry_reason_counts",
-        "citation_grounding_error_counts",
-        "by_hardcase_category",
-    ]
-    return {key: summary.get(key) for key in keys if key in summary}
-
-
 def dataset_privacy_metadata(dataset: dict[str, Any] | None) -> dict[str, Any]:
     dataset = dataset or {}
     return {key: dataset.get(key) for key in DATASET_PRIVACY_KEYS if key in dataset}
@@ -99,15 +70,15 @@ def registry_entry(manifest: dict[str, Any]) -> dict[str, Any]:
     flags_by_run = manifest.get("ablation_flags") or {}
     baseline_run = str(manifest.get("ablation_suite", {}).get("baseline_run") or "")
     primary_run = str(manifest.get("ablation_suite", {}).get("primary_run") or "")
-    baseline = metric_block(metrics_by_run.get(baseline_run))
-    primary = metric_block(metrics_by_run.get(primary_run))
+    baseline = metric_snapshot(metrics_by_run.get(baseline_run), include_query_type=False)
+    primary = metric_snapshot(metrics_by_run.get(primary_run), include_query_type=False)
     runs = []
     for name in sorted(metrics_by_run):
         runs.append(
             {
                 "name": name,
                 "flags": flags_by_run.get(name) or {},
-                "metrics": metric_block(metrics_by_run.get(name)),
+                "metrics": metric_snapshot(metrics_by_run.get(name), include_query_type=False),
             }
         )
     dataset = manifest.get("suite", {}).get("dataset", {}) or {}

--- a/scripts/update_readme_metrics.py
+++ b/scripts/update_readme_metrics.py
@@ -10,6 +10,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from eval.bootstrap import format_ci_band  # noqa: E402
+from scripts._utils import fmt_rate  # noqa: E402
 
 START_MARKER = "<!-- METRICS_TABLE:START -->"
 END_MARKER = "<!-- METRICS_TABLE:END -->"
@@ -38,10 +39,6 @@ def load_summary(path: Path) -> Dict[str, Any]:
     for key in REQUIRED_KEYS:
         data.setdefault(key, None)
     return data
-
-
-def fmt_rate(value: Any) -> str:
-    return f"{value:.3f}" if isinstance(value, (int, float)) else "N/A"
 
 
 def fmt_rate_ci(value: Any, ci: Any) -> str:


### PR DESCRIPTION
## 1. What changed and why

`scripts/` 디렉토리의 20개 파일 중 4개가 동일한 I/O·git·메트릭 유틸을 거의 똑같이 재정의하고 있어 한 카피에 픽스를 넣어도 다른 카피로 전파되지 않는 문제가 있었다. 이를 `scripts/_utils.py`로 통합한다. CLAUDE.md의 "Reuse over invent" 원칙을 만족시키고 향후 스크립트 추가 비용을 줄이는 게 목표.

Closes #254

## 2. Files affected

- 신규: `scripts/_utils.py`, `scripts/__init__.py` (빈 파일, explicit package)
- 수정: `scripts/run_benchmark.py`, `scripts/run_harness.py`, `scripts/summarize_benchmark.py`, `scripts/update_readme_metrics.py`

Load-bearing 파일 (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`) 미접촉.

## 3. Risks

가장 가능성 높은 회귀 경로는 `metric_block` → `metric_snapshot(include_query_type=False)` 통합. 16개 키 중 15개 동일이고 `by_query_type` 키 제외 여부만 차이여서 행위가 보존되는지가 핵심. → `tests/test_benchmark_summary.py`의 3개 테스트가 `registry_entry`/`render_docs` 경로를 모두 커버하며 그린.

두 번째는 import 경로. `python3 scripts/foo.py`로 실행되는 스크립트가 `from scripts._utils import ...`를 찾으려면 repo root가 sys.path에 있어야 함. → 마이그레이션된 4개 스크립트 모두 `sys.path.insert(0, str(ROOT_DIR))` 적용 후 `--help` 정상 동작 확인.

## 4. Tests

- 행위 변경 없음 → 신규 테스트 미추가
- 기존 `tests/test_benchmark_summary.py` 3개가 `metric_block` → `metric_snapshot(include_query_type=False)` 통합을 import + 실행 시점에 자동 검증
- `tests/test_run_real_eval_delta.py`, `tests/test_leaderboard.py`, `tests/test_render_real_eval_history.py`도 영향 받는 스크립트들의 import를 커버
- 전체: `pytest -q` → **427 passed**

## 5. Eval impact

All `·` — RAG 파이프라인/eval 로직 변경 없음. 변경된 건 `scripts/` 내부 헬퍼 위치뿐.

### 5b. Real-data delta

N/A: scripts-only refactor, no pipeline/baseline behavior change.

## 6. Backward compatibility

호환성 유지. 변경된 함수들은 모두 `scripts/` 내부에서만 호출되며, 외부 import는 `tests/test_benchmark_summary.py`가 `registry_entry, render_docs`만 import (둘 다 시그니처/동작 유지). 답변 계약(ADR 0003) 미접촉, `schema_version` 변경 없음.

## 7. Out of scope

다음은 의도적으로 통합하지 않음:
- `parse_args` — 스크립트마다 플래그/기본값이 달라 추상화 가치 없음
- `fmt_latency` — `update_readme_metrics.py`(p50/p95)와 `summarize_benchmark.py`(p95만) 포맷 다름
- `fmt_delta` — `compare_eval.py`, `summarize_benchmark.py`, `run_real_eval_delta.py` 세 곳 모두 다른 반환 계약
- `display_path` — `rel_path`와 `.resolve()` 호출 여부에서 미묘하게 다른 동작
- `run_harness.py:metric_snapshot(Path)` — 이름 충돌이지만 파일 읽어오는 별개 함수
- `ci_for`, `metric_from_type`, `ci_from_type` — `update_readme_metrics.py` 단일 파일 내부에서만 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)