### PR TITLE
docs: add decision-evolution view to ADR index (#261)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -77,3 +77,135 @@ project record.
 | [0012](./0012-llm-judge-on-public-synthetic.md) | accepted | LLM-judge on the public synthetic eval, stub-default (refines 0006, reuses 0011 backend pattern) |
 | [0013](./0013-observability-as-additive-pluggable-surface.md) | accepted | Observability as an additive, pluggable, fail-closed surface |
 | [0014](./0014-ragas-judge-additive-synthetic.md) | accepted | RAGAS-style LLM judge as additive enrichment on synthetic surface (extends 0012) |
+
+## Decision evolution
+
+Every ADR file carries `Date: 2026-05-11` because that's when the ADR
+governance itself was introduced (PR #87 back-filled the five
+foundational ADRs in a single batch). The decisions themselves
+*evolved* through two weeks of build — see [`docs/portfolio-case-study.md`](../portfolio-case-study.md)
+and the [`docs/blog/`](../blog) series for the experiment-narrative — but
+on the time axis they look bunched.
+The more honest evolution axis is **logical dependency**: what extends,
+refines, defends, or reuses the backend of what. See
+[`docs/engineering-governance.md`](../engineering-governance.md) for the
+broader process context.
+
+### Clusters
+
+#### Foundation — what to preserve, what to measure (0001–0005)
+
+[ADR 0001](./0001-preserve-naive-baseline.md) freezes the extractive
+baseline as an invariant. [ADR 0002](./0002-metadata-first-retrieval.md)
+names the retrieval strategy that beats naive lexical/dense on Korean
+RFPs. [ADR 0003](./0003-structured-answer-citation-contract.md) is the
+answer-and-citation contract every downstream metric reads.
+[ADR 0004](./0004-verifier-retry-policy.md) makes verifier-driven retry
+the failure-handling default. [ADR 0005](./0005-eval-split-public-synthetic-private-local.md)
+splits public-synthetic from private-local eval so reviewers can
+reproduce something without the private corpus.
+
+#### Real-data hardening — when synthetic CI isn't enough (0006, 0008)
+
+The deterministic verifier in 0004 hit a ceiling on real procurement
+documents (issue #69 abstention regression). [ADR 0006](./0006-llm-judge-on-real-data-only.md)
+refines 0004 with an LLM judge restricted to the private surface,
+reinforcing 0005's public reproducibility. [ADR 0008](./0008-evidence-boundary.md)
+defends the answer contract (0003) and the LLM judge (0006) against
+prompt-injection patterns embedded in retrieved evidence.
+
+#### Governance — process codified as a decision (0007)
+
+[ADR 0007](./0007-issue-linked-branch-naming.md) lifts the issue↔branch
+convention from informal practice to a CI-enforced rule. Without 0007
+the rest of this index could not be maintained at scale.
+
+#### Additive ablation surface — extend, don't replace (0009, 0010, 0011)
+
+0001's "preserve the baseline" invariant materializes in three
+alongside-ablations: [ADR 0009](./0009-external-baseline-comparison.md)
+(external frameworks), [ADR 0010](./0010-hybrid-bm25-dense-retrieval-rrf.md)
+(hybrid BM25+RRF retrieval), and [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md)
+(LLM answer synthesis). Each adds a preset; none removes one. 0011 also
+reuses the 0006 backend pattern so cost/trace plumbing stays consistent.
+
+#### Eval depth — same answer, more lenses (0012, 0014)
+
+[ADR 0012](./0012-llm-judge-on-public-synthetic.md) extends LLM-as-judge
+to the synthetic surface as a stub-default enrichment, refining 0006's
+"real-data only" restriction without breaking 0005's reproducibility.
+[ADR 0014](./0014-ragas-judge-additive-synthetic.md) layers RAGAS-style
+multi-axis judgment on top — both strictly additive (not gating).
+
+#### Ops — observability as a fail-closed surface (0013)
+
+[ADR 0013](./0013-observability-as-additive-pluggable-surface.md) makes
+LangFuse / OpenTelemetry trace emission optional, pluggable, and
+fail-closed. It extends 0001, preserves 0003, reuses the 0006 and 0011
+backend pattern, and respects 0005's eval split.
+
+### Dependency graph
+
+```mermaid
+graph LR
+  subgraph Foundation
+    A1[0001 Naive baseline]
+    A2[0002 Metadata-first]
+    A3[0003 Answer contract]
+    A4[0004 Verifier retry]
+    A5[0005 Eval split]
+  end
+
+  A7[0007 Branch naming]
+
+  subgraph Real-data hardening
+    A6[0006 LLM judge real-data]
+    A8[0008 Evidence boundary]
+  end
+
+  subgraph Additive ablation surface
+    A9[0009 External baseline]
+    A10[0010 Hybrid BM25+RRF]
+    A11[0011 LLM synthesis]
+  end
+
+  subgraph Eval depth
+    A12[0012 LLM judge synthetic]
+    A14[0014 RAGAS additive]
+  end
+
+  A13[0013 Observability]
+
+  A4 -- refines --> A6
+  A5 -- reinforces --> A6
+  A3 -. defends .-> A8
+  A6 -. defends .-> A8
+
+  A1 -- extends --> A9
+  A1 -- extends --> A10
+  A2 -- extends --> A10
+  A1 -- extends --> A11
+  A1 -- extends --> A13
+
+  A6 -- refines --> A12
+  A6 -- refines --> A14
+
+  A6 -. backend .-> A9
+  A6 -. backend .-> A11
+  A6 -. backend .-> A13
+  A11 -. backend .-> A12
+  A11 -. backend .-> A13
+  A11 -. backend .-> A14
+```
+
+Legend:
+
+- **`-- extends -->`** — new ADR builds on an earlier invariant (0001's "preserve baseline" is the most extended).
+- **`-- refines -->`** / **`-- reinforces -->`** — tightens or specializes an earlier decision.
+- **`-. defends .->`** — protects an earlier contract against a specific attack or regression.
+- **`-. backend .->`** — reuses the LLM-call backend pattern (env-keyed providers, fail-closed, cost/latency in diagnostics).
+
+Edges intentionally omitted from the diagram (kept in each ADR's
+`Related` field for accuracy): the chain of "preserves" courtesies that
+0011, 0012, 0013, and 0014 extend toward 0003/0004/0005 — they reinforce
+the cluster narratives but would clutter the visual.


### PR DESCRIPTION
## 1. What changed and why

Augments [`docs/adr/README.md`](docs/adr/README.md) with a new `## Decision evolution` section after the existing Index. Three pieces:

- **Theme clusters** (Foundation / Real-data hardening / Governance / Additive ablation surface / Eval depth / Ops), each one paragraph explaining what the cluster proves about the project.
- **Mermaid dependency graph** showing `extends / refines / defends / backend-reuses` arrows between the 14 ADRs, with subgraph grouping by cluster.
- **Short note on dates** explaining why every ADR carries `Date: 2026-05-11` — governance was introduced as a single batch in PR #87, but the underlying decisions evolved across the two-week build. Avoids the misread "14 decisions in one day."

The index table itself is untouched (other docs link to it).

Closes #261

## 2. Files affected

- `docs/adr/README.md` — **load-bearing** per CLAUDE.md (anything under `docs/adr/`). The change is additive: new section after the existing Index table; existing content unmodified.

## 3. Risks

- **Mermaid render failure on GitHub UI** — most likely break: subgraph syntax or label characters not parsing. Mitigation: kept node labels simple (`A1[0001 Naive baseline]`), used Mermaid's documented `-- label -->` and `-. label .->` edge forms, and verified the block extracts cleanly via `awk '/^\`\`\`mermaid/,/^\`\`\`$/'`.
- **Stale link to `docs/case-study/`** — caught and fixed in a follow-up edit; the actual path is `docs/portfolio-case-study.md` + `docs/blog/`. All 32 markdown links in the file verified to resolve.
- **Misrepresentation of ADR relationships** — graph edges are sourced verbatim from each ADR's `Related` field (extends / refines / reinforces / preserves / reuses backend pattern from), not invented. "preserves" courtesy edges intentionally omitted from the diagram to keep it readable; called out explicitly under the legend.

## 4. Tests

No code tests apply — docs-only addition. Manual verification:

- All 14 `[ADR NNNN](./NNNN-...md)` cross-links resolve to existing files.
- All `../` relative links resolve (`docs/engineering-governance.md`, `docs/portfolio-case-study.md`, `docs/blog/`).
- Mermaid block extracted cleanly with no broken edges.

## 5. Eval impact

All `·` (no behavior change). This PR adds prose + a Mermaid block to one markdown file.

### 5b. Real-data delta

N/A — no behavior change in retrieval / verifier / answer / ingestion / eval path. The PR touches `docs/adr/README.md` only. `rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, and `api/` are unmodified. `make real-eval-delta` would produce identical numbers.

## 6. Backward compatibility

No contract change. Existing index table preserved verbatim — anything that already links to `docs/adr/README.md#index` (or any ADR file by number/slug) continues to work. New section is purely additive content below the index.

## 7. Out of scope

- Touching the `Date` field on individual ADR files. They legitimately reflect when governance was introduced; rewriting them would be historical revisionism.
- Creating a separate `docs/adr/evolution.md` — single source of truth principle.
- Automation (auto-update of the graph when a new ADR lands). At 14 ADRs manual is cleaner. Reconsider above ~30.
- Mirroring the evolution view into `docs/portfolio-case-study.md` or the blog series — separate concern, follow-up PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)