### PR TITLE
refactor: introduce tests/conftest.py with shared index fixture (#258)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared pytest fixtures for the tests/ tree (issue #258)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rag_core import build_index_payload
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="session")
+def shared_raw_index() -> dict:
+    """Hashing-backend index built once per session from data/raw."""
+    return build_index_payload(ROOT_DIR / "data" / "raw", embedding_backend="hashing")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,18 +8,17 @@ matching the pattern used by other retrieval regression tests.
 from __future__ import annotations
 
 import unittest
-from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from api import main as api_main
-from rag_core import build_index_payload
 
 
 class ApiSmokeTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.index = build_index_payload(Path("data/raw"), embedding_backend="hashing")
+    @pytest.fixture(autouse=True)
+    def _inject_shared_index(self, shared_raw_index):
+        self.index = shared_raw_index
 
     def _client(self, *, with_index: bool = True) -> TestClient:
         client = TestClient(api_main.app)

--- a/tests/test_chunk_boundary_probes.py
+++ b/tests/test_chunk_boundary_probes.py
@@ -20,12 +20,12 @@ existing `data/raw` fixture, matching the pattern in
 """
 
 import unittest
-from pathlib import Path
+
+import pytest
 
 from rag_core import (
     DEFAULT_CHUNK_MAX_CHARS,
     build_chunk_records,
-    build_index_payload,
     run_rag_query,
 )
 
@@ -95,11 +95,9 @@ class ChunkBoundaryProbeRetrievalTest(unittest.TestCase):
     `supported`.
     """
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"), embedding_backend="hashing"
-        )
+    @pytest.fixture(autouse=True)
+    def _inject_shared_index(self, shared_raw_index):
+        self.index = shared_raw_index
 
     def _expect_supported_with_term(
         self, query: str, expected_term: str

--- a/tests/test_latency_instrumentation.py
+++ b/tests/test_latency_instrumentation.py
@@ -1,9 +1,10 @@
 import time
 import unittest
-from pathlib import Path
+
+import pytest
 
 import rag_core
-from rag_core import _StageTimer, build_index_payload, run_rag_query
+from rag_core import _StageTimer, run_rag_query
 from eval.run_eval import metric_block, summarize_run
 
 
@@ -26,9 +27,9 @@ class StageTimerTest(unittest.TestCase):
 
 
 class RunRagQueryTimingTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.index = build_index_payload(Path("data/raw"), embedding_backend="hashing")
+    @pytest.fixture(autouse=True)
+    def _inject_shared_index(self, shared_raw_index):
+        self.index = shared_raw_index
 
     def setUp(self) -> None:
         rag_core._PROCESS_WARM = False


### PR DESCRIPTION
## 1. What changed and why

Closes #258

Add `tests/conftest.py` with a session-scope `shared_raw_index`
fixture (hashing backend, `data/raw`) so regression tests that
previously rebuilt the same index in `setUpClass` share a single
build across the session. Three `unittest.TestCase` classes
(`ApiSmokeTest`, `RunRagQueryTimingTest`,
`ChunkBoundaryProbeRetrievalTest`) now consume the fixture via
`@pytest.fixture(autouse=True)` that assigns `self.index =
shared_raw_index`.

## 2. Files affected

- `tests/conftest.py` — **new**, session fixture.
- `tests/test_api.py` — `ApiSmokeTest` migrated; stale `Path` / `build_index_payload` imports removed.
- `tests/test_latency_instrumentation.py` — `RunRagQueryTimingTest` migrated; imports cleaned.
- `tests/test_chunk_boundary_probes.py` — `ChunkBoundaryProbeRetrievalTest` migrated; imports cleaned.

No load-bearing file changed (`rag_core.py` / `ingestion.py` / `visual_ingestion.py` / `eval/` / `api/` / `docs/adr/` untouched).

## 3. Risks

Most likely failure mode: pytest does not inject the autouse fixture into the `unittest.TestCase` subclass and `self.index` is unset, so tests crash with `AttributeError`. Ruled out by `pytest -q tests/test_api.py tests/test_latency_instrumentation.py tests/test_chunk_boundary_probes.py` (20 passed, 3 subtests) and the full suite `pytest -q` (469 passed, 121 subtests). The autouse-on-TestCase pattern is the supported path per the pytest "Mixing pytest fixtures into unittest.TestCase" guide.

## 4. Tests

No new tests added — pure refactor. Behavior is preserved (same index, same backend, same call sites). The existing 20 test methods + 3 subtests across the three migrated files act as the regression guard; any fixture-injection breakage would surface immediately.

## 5. Eval impact

All `·`. Test infrastructure only — no retrieval, ingestion, eval, or answer-contract code touched.

### 5b. Real-data delta

N/A — no behavior change in retrieval / verifier path. Only `tests/` changed (test infra refactor).

## 6. Backward compatibility

None broken. Other `TestCase` classes that still use the per-class `setUpClass` pattern continue to work as-is — adoption of the new fixture is opt-in and incremental.

## 7. Out of scope

- Bulk migration of the remaining ~13 `TestCase` classes that follow the same `setUpClass(cls): cls.index = build_index_payload(Path("data/raw"), ...)` pattern (`test_fuzzy_retrieval`, `test_hybrid_retrieval_regression`, `test_retrieval_loop_regression`, `test_partial_topic_grounding`, `test_llm_synthesis`, `test_single_turn_ambiguity`, `test_observability_tracing`, `test_followup_entity_injection`, `test_demo_helpers`, etc.). Follow-up iterations.
- `test_naive_baseline_ranking_invariance` uses a `chunking_strategy="fixed"` index variant — needs a sibling fixture (not added in this PR).
- function-scope `tmp_path` is already provided by pytest itself; no new fixture introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)