### PR TITLE
feat(synthesis): per-query token & cost telemetry + tool prompt caching

### DIFF
--- a/docs/adr/0015-cost-telemetry-additive.md
+++ b/docs/adr/0015-cost-telemetry-additive.md
@@ -1,0 +1,97 @@
+# 0015: Cost telemetry as additive observability (extends 0011, 0013)
+
+- **Status**: accepted
+- **Date**: 2026-05-12
+- **Deciders**: hskim
+- **Related**: [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (LLM synthesis), [ADR 0013](./0013-observability-as-additive-pluggable-surface.md) (trace backends), `rag_synthesis.py`, `tests/test_synthesis_cost_telemetry.py`
+
+## Context
+
+The LLM synthesis path (ADR 0011) already captures
+`tokens_in` / `tokens_out` in `diagnostics.synthesis`, but the public
+synthetic surface defaults to the stub backend so cost is always zero
+in CI. On the real-data flow (`BIDMATE_SYNTHESIS_BACKEND=anthropic`),
+the operator has no in-repo signal for *what an answer cost* or
+*whether prompt caching is actually helping* — both are first-tier
+questions in a senior LLM-Ops review.
+
+The trace backend (ADR 0013) ships span data to LangFuse/OTel, but
+those backends are optional and downstream of the query. The pipeline
+itself should carry a cost estimate so even the noop trace backend
+case ("operator runs locally, no LangFuse account") leaves an audit
+trail.
+
+A real billing source of truth is the Anthropic console — we are not
+trying to replace it. We need an *order-of-magnitude regression
+signal* ("this refactor 10x'd token spend") that lives next to the
+existing eval metrics.
+
+## Decision
+
+Treat per-query LLM cost the same way ADR 0013 treats traces: it is
+*additive*, *pluggable*, and *fail-closed*.
+
+Concretely:
+
+1. `rag_synthesis.SYNTHESIS_SCHEMA_VERSION` is bumped to **2**. The
+   `synthesis` meta dict gains three new keys, always present (may be
+   `None`):
+   - `cache_read_tokens`
+   - `cache_write_tokens`
+   - `cost_estimate_usd`
+2. `rag_synthesis.compute_cost_usd(model, tokens_in, tokens_out,
+   cache_read_tokens, cache_write_tokens)` is the single source of
+   truth for the per-Mtok price table. Unknown models return `None`
+   (we do not invent prices for stub / openai-compatible deployments).
+3. The Anthropic backend captures `cache_read_input_tokens` and
+   `cache_creation_input_tokens` from the SDK `usage` object. Tool
+   definitions get `cache_control: ephemeral` alongside the existing
+   system-prompt cache breakpoint, maximizing cache-hit surface on
+   repeat queries.
+4. The price card lives in `PRICING_PER_MTOK_USD` keyed by base model
+   id (longest-prefix match so dated SKUs resolve). Updates ship as
+   small PRs with a one-line provenance note in this ADR's history.
+
+The default backend remains `stub` — public CI never pays, never
+reports a cost, never depends on a price card.
+
+## Consequences
+
+Easier:
+
+- Real-data review can answer "what's our $/query?" by reading
+  `diagnostics.synthesis.cost_estimate_usd` directly. Aggregation in
+  `eval/run_eval.py` can be added in a follow-up PR.
+- "Prompt caching is enabled" stops being a wish — `cache_read_tokens
+  > 0` on the second call proves it. The contract test
+  (`test_meta_promotes_payload_cache_tokens`) locks the surface.
+- The ADR 0003 answer contract is untouched; cost lives in
+  `diagnostics`, which is explicitly a non-contract surface.
+
+Harder / costs:
+
+- `SYNTHESIS_SCHEMA_VERSION` bumped to 2. Any consumer that pinned to
+  v1 must update — this is the explicit "no silent drift" guard from
+  ADR 0003 applied to the synthesis meta block. We considered it
+  cheaper than introducing a parallel v2 dict.
+- The price card needs occasional updates when Anthropic publishes a
+  new tier. Owner: whoever opens the next ADR-noteworthy synthesis
+  change. The constants live in `rag_synthesis.py:PRICING_PER_MTOK_USD`.
+- We are not pricing OpenAI-compatible deployments. Local
+  vLLM/llama.cpp would be billed as zero, paid deployments would need
+  a per-deployment override — out of scope here.
+
+## Alternatives considered
+
+- **Track tokens only, skip USD**: easier to maintain (no price
+  card), but the senior signal of "$/query" is exactly what reviewers
+  ask for. Tokens alone require the reader to know the rate card.
+- **Source cost from Anthropic billing API**: gives ground truth but
+  introduces a paid-API dependency and breaks the offline CI promise.
+  Out of scope per CLAUDE.md non-goals.
+- **Embed cost in `answer` dict**: would violate ADR 0003 (answer is
+  the verifiable contract; cost is a side-effect of generation). The
+  `diagnostics` surface is the right home.
+- **Separate `rag_cost.py` module**: premature abstraction. The cost
+  table lives next to the only producer (synthesis) for now; extract
+  it when a second producer appears (e.g., a judge backend).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -77,6 +77,7 @@ project record.
 | [0012](./0012-llm-judge-on-public-synthetic.md) | accepted | LLM-judge on the public synthetic eval, stub-default (refines 0006, reuses 0011 backend pattern) |
 | [0013](./0013-observability-as-additive-pluggable-surface.md) | accepted | Observability as an additive, pluggable, fail-closed surface |
 | [0014](./0014-ragas-judge-additive-synthetic.md) | accepted | RAGAS-style LLM judge as additive enrichment on synthetic surface (extends 0012) |
+| [0015](./0015-cost-telemetry-additive.md) | accepted | Cost telemetry as additive observability (extends 0011, 0013) |
 
 ## Decision evolution
 

--- a/docs/senior-positioning.md
+++ b/docs/senior-positioning.md
@@ -15,7 +15,7 @@
 
 | 시그널 | 어디서 확인하나 |
 |---|---|
-| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 14개 ADR (12 accepted / 2 proposed), status-tracked, supersession chains 명시 |
+| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 15개 ADR (13 accepted / 2 proposed), status-tracked, supersession chains 명시 |
 | **측정 가능한 성공 기준**을 미리 잡고 그 기준으로 평가한다 | [`portfolio-case-study.md` §2](./portfolio-case-study.md), [`eval/config.yaml`](../eval/config.yaml), README headline 표 |
 | 합성 평가의 한계를 알고 **공개/비공개 평가 분리**로 보완한다 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) |
 | **실패를 분류·우선순위화**한 뒤 백로그로 만든다 | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), 메타 이슈 #49 |
@@ -25,7 +25,7 @@
 
 ## 시니어 시그널 1 — 아키텍처 결정의 추적성
 
-각 ADR은 **하나의 의사결정**을 다룬다. 14개를 빠르게 읽고 나면, 이 시스템에서 어떤 선택이 load-bearing인지와 supersession chain이 명확해진다.
+각 ADR은 **하나의 의사결정**을 다룬다. 15개를 빠르게 읽고 나면, 이 시스템에서 어떤 선택이 load-bearing인지와 supersession chain이 명확해진다.
 
 | ADR | 상태 | 결정 | 시니어 관점에서 왜 중요한가 |
 |---|---|---|---|
@@ -43,6 +43,7 @@
 | [0012](./adr/0012-llm-judge-on-public-synthetic.md) | accepted | LLM-judge on public synthetic, stub-default (refines 0006, reuses 0011) | judge backend는 결정적 stub으로 CI 통과; real backend는 운영자 옵트인 |
 | [0013](./adr/0013-observability-as-additive-pluggable-surface.md) | accepted | observability를 additive·pluggable·fail-closed로 | trace backend(LangFuse/OTel) 장애가 query를 깨뜨리지 않음; LLM Ops 의식의 코드화 |
 | [0014](./adr/0014-ragas-judge-additive-synthetic.md) | accepted | RAGAS judge as additive enrichment (extends 0012) | 외부 표준 메트릭으로 cross-validation; 결정적 stub-default 유지 |
+| [0015](./adr/0015-cost-telemetry-additive.md) | accepted | cost telemetry as additive observability (extends 0011, 0013) | per-query `cost_estimate_usd` + `cache_read_tokens` 캡처 — LLM Ops 핵심 시그널을 계약 위반 없이 추가 |
 
 **인터뷰 talking point 1 (real-data 회귀)**: "ADR 0005가 없었다면 공개본의 abstention 회귀(#69의 `1.000 → 0.500` 사건)는 아무도 보지 못했을 것이다. 공개 합성만 보던 시기에는 1-of-2 incidental overlap 패턴이 잡히지 않았다." — 근거: [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) 2026-05-11 entry.
 
@@ -132,6 +133,7 @@ make reproduce  # smoke + SHA-256 over the environment-invariant metric subset
 | "LangChain/LlamaIndex 안 쓰고 왜 자체 구축?" | [ADR 0009](./adr/0009-external-baseline-comparison.md) — 비대칭 metric(citation/abstention)을 외부 시스템이 producer 못하는 게 정량 답변 |
 | "LLM-as-judge bias는 어떻게 다루나요?" | [ADR 0012](./adr/0012-llm-judge-on-public-synthetic.md) + [ADR 0014](./adr/0014-ragas-judge-additive-synthetic.md) — stub-default + RAGAS cross-check |
 | "운영에서 latency/cost/trace는 어떻게 봅니까?" | [ADR 0013](./adr/0013-observability-as-additive-pluggable-surface.md) + [`docs/observability.md`](./observability.md) — LangFuse/OTel pluggable, fail-closed |
+| "토큰 비용은 어떻게 추적하나요? prompt caching hit rate는요?" | [ADR 0015](./adr/0015-cost-telemetry-additive.md) — `diagnostics.synthesis.cost_estimate_usd` + `cache_read_tokens` + `cache_write_tokens`; price card는 `rag_synthesis.PRICING_PER_MTOK_USD`, 회귀 가드는 `tests/test_synthesis_cost_telemetry.py` |
 | "확장한다면 다음 우선순위는?" | [`portfolio-case-study.md` §7](./portfolio-case-study.md) + 메타 이슈 #49 |
 
 ## 이 프로젝트가 입증하지 않는 것 (정직한 범위)

--- a/rag_synthesis.py
+++ b/rag_synthesis.py
@@ -36,7 +36,7 @@ import os
 import time
 from typing import Any
 
-SYNTHESIS_SCHEMA_VERSION = 1
+SYNTHESIS_SCHEMA_VERSION = 2
 ENV_BACKEND = "BIDMATE_SYNTHESIS_BACKEND"
 ENV_MODEL = "BIDMATE_SYNTHESIS_MODEL"
 ENV_API_KEY = "BIDMATE_SYNTHESIS_API_KEY"
@@ -49,6 +49,70 @@ DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS = 1024
 EVIDENCE_TEXT_LIMIT = 600
 EVIDENCE_FOR_PROMPT = 6
+
+# Public list-pricing per million tokens (USD) used for portfolio-side
+# cost estimation only — NOT an Anthropic billing source of truth. The
+# real invoice authority is the Anthropic console; these constants let
+# the eval surface flag order-of-magnitude regressions ("a refactor
+# 10x'd token spend") without a billing API dependency. Update when
+# Anthropic publishes new tiers.
+PRICING_PER_MTOK_USD: dict[str, dict[str, float]] = {
+    # Claude 4.x family (input/output, plus the standard 0.1x cache-read
+    # discount and 1.25x cache-write surcharge on input).
+    "claude-opus-4-7": {
+        "input": 15.0, "output": 75.0, "cache_read": 1.50, "cache_write": 18.75,
+    },
+    "claude-sonnet-4-6": {
+        "input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75,
+    },
+    "claude-haiku-4-5-20251001": {
+        "input": 1.0, "output": 5.0, "cache_read": 0.10, "cache_write": 1.25,
+    },
+}
+
+
+def _resolve_pricing(model: str | None) -> dict[str, float] | None:
+    if not model:
+        return None
+    # Allow versioned ids (e.g. ``claude-sonnet-4-6-20260301``) to match
+    # the base entry — we look up by longest known prefix.
+    candidates = [m for m in PRICING_PER_MTOK_USD if model.startswith(m)]
+    if not candidates:
+        return None
+    best = max(candidates, key=len)
+    return PRICING_PER_MTOK_USD[best]
+
+
+def compute_cost_usd(
+    *,
+    model: str | None,
+    tokens_in: int | None,
+    tokens_out: int | None,
+    cache_read_tokens: int | None = None,
+    cache_write_tokens: int | None = None,
+) -> float | None:
+    """Estimate USD cost from token counts and the model price card.
+
+    Returns ``None`` when the model is unknown (e.g. ``stub`` or any
+    openai-compatible endpoint where local pricing is not modeled).
+    ``tokens_in`` is the *uncached* input tokens — cache-read and
+    cache-write tokens are billed separately and must be passed
+    explicitly, not double-counted.
+    """
+    pricing = _resolve_pricing(model)
+    if pricing is None:
+        return None
+    cost = 0.0
+    if tokens_in:
+        cost += (tokens_in / 1_000_000.0) * pricing["input"]
+    if tokens_out:
+        cost += (tokens_out / 1_000_000.0) * pricing["output"]
+    if cache_read_tokens:
+        cost += (cache_read_tokens / 1_000_000.0) * pricing["cache_read"]
+    if cache_write_tokens:
+        cost += (cache_write_tokens / 1_000_000.0) * pricing["cache_write"]
+    # Six-decimal rounding: the typical per-query spend is fractions of a cent.
+    return round(cost, 6)
 
 SYSTEM_PROMPT = (
     "You rewrite the summary of an answer produced by a retrieval-augmented "
@@ -110,6 +174,9 @@ def synthesize_answer(
         "model": None,
         "tokens_in": None,
         "tokens_out": None,
+        "cache_read_tokens": None,
+        "cache_write_tokens": None,
+        "cost_estimate_usd": None,
         "latency_ms": None,
         "fell_back": False,
         "fallback_reason": None,
@@ -167,6 +234,15 @@ def synthesize_answer(
     meta["model"] = payload.get("model")
     meta["tokens_in"] = payload.get("tokens_in")
     meta["tokens_out"] = payload.get("tokens_out")
+    meta["cache_read_tokens"] = payload.get("cache_read_tokens")
+    meta["cache_write_tokens"] = payload.get("cache_write_tokens")
+    meta["cost_estimate_usd"] = compute_cost_usd(
+        model=meta["model"],
+        tokens_in=meta["tokens_in"],
+        tokens_out=meta["tokens_out"],
+        cache_read_tokens=meta["cache_read_tokens"],
+        cache_write_tokens=meta["cache_write_tokens"],
+    )
     meta["used_chunk_ids"] = used_chunk_ids
     return updated, meta
 
@@ -311,6 +387,12 @@ def _anthropic_backend(  # pragma: no cover - network
 
     client = anthropic.Anthropic(api_key=api_key)
     user_prompt = _build_user_prompt(query, analysis, answer, evidence)
+    # Tool definitions stay stable across queries, so we mark the LAST
+    # tool in the array with cache_control — that creates a cache
+    # breakpoint covering tools + system in one block, maximizing hit
+    # rate on subsequent calls.
+    cached_tool = dict(TOOL_DEFINITION)
+    cached_tool["cache_control"] = {"type": "ephemeral"}
     response = client.messages.create(
         model=model,
         max_tokens=max_tokens,
@@ -322,7 +404,7 @@ def _anthropic_backend(  # pragma: no cover - network
                 "cache_control": {"type": "ephemeral"},
             }
         ],
-        tools=[TOOL_DEFINITION],
+        tools=[cached_tool],
         tool_choice={"type": "tool", "name": TOOL_DEFINITION["name"]},
         messages=[{"role": "user", "content": user_prompt}],
     )
@@ -335,6 +417,8 @@ def _anthropic_backend(  # pragma: no cover - network
         "model": model,
         "tokens_in": getattr(usage, "input_tokens", None) if usage else None,
         "tokens_out": getattr(usage, "output_tokens", None) if usage else None,
+        "cache_read_tokens": getattr(usage, "cache_read_input_tokens", None) if usage else None,
+        "cache_write_tokens": getattr(usage, "cache_creation_input_tokens", None) if usage else None,
     }
 
 
@@ -411,5 +495,7 @@ __all__ = [
     "DEFAULT_BACKEND",
     "ENV_BACKEND",
     "ENV_MODEL",
+    "PRICING_PER_MTOK_USD",
+    "compute_cost_usd",
     "synthesize_answer",
 ]

--- a/tests/test_synthesis_cost_telemetry.py
+++ b/tests/test_synthesis_cost_telemetry.py
@@ -1,0 +1,185 @@
+"""Cost telemetry contract for the LLM synthesis path (ADR 0011 + ADR 0015).
+
+Locks the pricing-card semantics and the cache-token capture surface so
+the LLM Ops portfolio claim ("we track token spend and cache hit rate
+per query") is backed by a regression test, not just an env-time wish.
+
+Coverage:
+
+* ``compute_cost_usd`` reflects the per-Mtok price table for input,
+  output, and cache-read/write tokens with the standard 0.1x / 1.25x
+  modifiers.
+* Unknown models (``stub`` / arbitrary OpenAI-compatible deployments)
+  return ``None`` — we do not invent a price for them.
+* ``synthesize_answer`` surfaces ``cache_read_tokens`` /
+  ``cache_write_tokens`` / ``cost_estimate_usd`` in the meta dict for
+  any backend that returns them in its payload.
+* The synthesizer ``schema_version`` bumped to 2; downstream consumers
+  that pin to v1 must be updated explicitly (no silent drift).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import rag_synthesis
+
+
+def _make_answer():
+    return {
+        "schema_version": 2,
+        "status": "supported",
+        "status_reason": {"code": "verified", "verified": True, "verification_reasons": []},
+        "query_type": "single_doc",
+        "summary": "기관 A는 보안 통제와 로그 추적이 필요하다.",
+        "claims": [
+            {
+                "target": "기관 A",
+                "claim": "보안 통제 매뉴얼과 로그 추적 시스템을 구축한다",
+                "support": [],
+                "citations": [{"doc_id": "rfp-a", "chunk_id": "rfp-a::chunk-001"}],
+            }
+        ],
+        "insufficiency": None,
+    }
+
+
+def _make_evidence():
+    return [
+        {
+            "chunk_id": "rfp-a::chunk-001",
+            "doc_id": "rfp-a",
+            "agency": "기관 A",
+            "text": "제안사는 보안 통제 매뉴얼과 로그 추적 시스템을 구축해야 한다.",
+        }
+    ]
+
+
+class ComputeCostUsdTest(unittest.TestCase):
+    def test_unknown_model_returns_none(self) -> None:
+        self.assertIsNone(
+            rag_synthesis.compute_cost_usd(
+                model="not-a-real-model", tokens_in=1000, tokens_out=500
+            )
+        )
+
+    def test_none_model_returns_none(self) -> None:
+        self.assertIsNone(
+            rag_synthesis.compute_cost_usd(model=None, tokens_in=10, tokens_out=10)
+        )
+
+    def test_sonnet_input_output_only(self) -> None:
+        # Sonnet 4.6: $3 / Mtok input, $15 / Mtok output.
+        # 1_000_000 input + 1_000_000 output = $3 + $15 = $18.00.
+        cost = rag_synthesis.compute_cost_usd(
+            model="claude-sonnet-4-6", tokens_in=1_000_000, tokens_out=1_000_000
+        )
+        self.assertAlmostEqual(cost, 18.0, places=6)
+
+    def test_cache_read_uses_discount(self) -> None:
+        # Cache read = 0.1x input = $0.30 / Mtok on Sonnet 4.6.
+        cost = rag_synthesis.compute_cost_usd(
+            model="claude-sonnet-4-6",
+            tokens_in=0,
+            tokens_out=0,
+            cache_read_tokens=1_000_000,
+        )
+        self.assertAlmostEqual(cost, 0.30, places=6)
+
+    def test_cache_write_uses_surcharge(self) -> None:
+        # Cache write = 1.25x input = $3.75 / Mtok on Sonnet 4.6.
+        cost = rag_synthesis.compute_cost_usd(
+            model="claude-sonnet-4-6",
+            tokens_in=0,
+            tokens_out=0,
+            cache_write_tokens=1_000_000,
+        )
+        self.assertAlmostEqual(cost, 3.75, places=6)
+
+    def test_full_breakdown_sums(self) -> None:
+        # Hand-computed: Sonnet 4.6 on 1k input + 500 output + 800 cache_read
+        # + 200 cache_write
+        # = 1000*3/1e6 + 500*15/1e6 + 800*0.3/1e6 + 200*3.75/1e6
+        # = 0.003 + 0.0075 + 0.00024 + 0.00075 = 0.011490
+        cost = rag_synthesis.compute_cost_usd(
+            model="claude-sonnet-4-6",
+            tokens_in=1000,
+            tokens_out=500,
+            cache_read_tokens=800,
+            cache_write_tokens=200,
+        )
+        self.assertAlmostEqual(cost, 0.01149, places=6)
+
+    def test_versioned_model_id_matches_prefix(self) -> None:
+        # The lookup must accept dated SKUs like ``claude-sonnet-4-6-20260301``.
+        cost = rag_synthesis.compute_cost_usd(
+            model="claude-sonnet-4-6-20260301", tokens_in=1_000_000, tokens_out=0
+        )
+        self.assertAlmostEqual(cost, 3.0, places=6)
+
+    def test_zero_tokens_zero_cost(self) -> None:
+        cost = rag_synthesis.compute_cost_usd(
+            model="claude-sonnet-4-6", tokens_in=0, tokens_out=0
+        )
+        self.assertEqual(cost, 0.0)
+
+
+class SynthesisMetaSurfaceTest(unittest.TestCase):
+    def test_schema_version_is_2(self) -> None:
+        # v2 introduces the cost telemetry fields. Downstream consumers
+        # that pin to v1 must update explicitly — see ADR 0015.
+        self.assertEqual(rag_synthesis.SYNTHESIS_SCHEMA_VERSION, 2)
+
+    def test_meta_exposes_cache_and_cost_keys_even_for_stub(self) -> None:
+        _, meta = rag_synthesis.synthesize_answer(
+            query="기관 A의 보안 통제 요구사항은?",
+            analysis={"query_type": "single_doc", "entities": ["기관 A"]},
+            answer=_make_answer(),
+            evidence=_make_evidence(),
+            backend="stub",
+        )
+        # Keys must always be present so dashboards don't trip on missing fields.
+        for key in ("cache_read_tokens", "cache_write_tokens", "cost_estimate_usd"):
+            self.assertIn(key, meta, f"meta missing key: {key}")
+        # Stub backend does not invent prices.
+        self.assertIsNone(meta["cost_estimate_usd"])
+
+    def test_meta_promotes_payload_cache_tokens(self) -> None:
+        # A backend that returns cache token counts must surface them
+        # in meta and yield a non-None cost when the model is priced.
+        original = rag_synthesis._BACKENDS["stub"]
+
+        def priced_backend(*, query, analysis, answer, evidence):
+            return {
+                "summary": "기관 A는 보안 통제 매뉴얼과 로그 추적을 요구한다.",
+                "used_chunk_ids": ["rfp-a::chunk-001"],
+                "model": "claude-sonnet-4-6",
+                "tokens_in": 100,
+                "tokens_out": 50,
+                "cache_read_tokens": 2000,
+                "cache_write_tokens": 500,
+            }
+
+        rag_synthesis._BACKENDS["stub"] = priced_backend
+        try:
+            _, meta = rag_synthesis.synthesize_answer(
+                query="기관 A의 보안 통제 요구사항은?",
+                analysis={"query_type": "single_doc"},
+                answer=_make_answer(),
+                evidence=_make_evidence(),
+                backend="stub",
+            )
+        finally:
+            rag_synthesis._BACKENDS["stub"] = original
+
+        self.assertEqual(meta["tokens_in"], 100)
+        self.assertEqual(meta["tokens_out"], 50)
+        self.assertEqual(meta["cache_read_tokens"], 2000)
+        self.assertEqual(meta["cache_write_tokens"], 500)
+        # 100*3/1e6 + 50*15/1e6 + 2000*0.3/1e6 + 500*3.75/1e6
+        # = 0.0003 + 0.00075 + 0.0006 + 0.001875 = 0.003525
+        self.assertAlmostEqual(meta["cost_estimate_usd"], 0.003525, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacked on top of #273 (structured logging). Review/merge in order: #272 → #273 → this.

## Summary
- `PRICING_PER_MTOK_USD` price card (Claude 4.x family) + `compute_cost_usd()` pure helper; unknown models return `None` so stub/openai_compatible paths don't fabricate prices.
- Anthropic backend captures `cache_read_input_tokens` + `cache_creation_input_tokens`; `TOOL_DEFINITION` gets its own `cache_control` breakpoint.
- `SYNTHESIS_SCHEMA_VERSION` 1 → 2; meta dict gains `cache_read_tokens` / `cache_write_tokens` / `cost_estimate_usd` (always present, may be `None`).
- ADR 0015 documents the additive boundary, "not the billing source of truth" disclaimer, and the `extends 0011, 0013` chain.
- senior-positioning gets the ADR 0015 row and the cost/caching Q→A.

Closes #268. ADR 0003 answer contract untouched (cost lives in `diagnostics`).

## Test plan
- [x] `pytest tests/test_synthesis_cost_telemetry.py tests/test_llm_synthesis.py` — 21 cases pass.
- [x] Schema-version bump asserted by a dedicated test (`test_schema_version_is_2`).
- [x] Pricing math verified against hand-computed Sonnet 4.6 example (`test_full_breakdown_sums`).
- [x] No openai_compatible price card (intentional — heterogeneous deployments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)