### PR TITLE
docs: cross-link multi-agent ownership model — re-land on main (#248)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ that aren't auto-enforced.
 
 - [`docs/engineering-governance.md`](docs/engineering-governance.md) — workflow map.
 - [`docs/adr/README.md`](docs/adr/README.md) — decision index.
+- [`docs/multi-agent-ownership.md`](docs/multi-agent-ownership.md) — coordination model when multiple agents work in parallel.
 - If touching retrieval / answer / eval, also read:
   [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) (naive baseline),
   [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) (answer contract),

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -13,6 +13,7 @@ If you are new to the repo or onboarding a reviewer, start here.
 | Concern | Source of truth | Notes |
 |---|---|---|
 | Coding & review rules | [`CLAUDE.md`](../CLAUDE.md) | Pre-PR checklist, prohibited shortcuts, performance expectations. |
+| Multi-agent coordination | [`docs/multi-agent-ownership.md`](./multi-agent-ownership.md) | 7-way ownership split, `rag_core.py` lock holder, conflict-resolution rules when several agents work in parallel. |
 | Load-bearing decisions | [`docs/adr/`](./adr/README.md) | One short file per decision; status-tracked. |
 | Behavior contracts | [ADR 0003](./adr/0003-structured-answer-citation-contract.md), [`docs/answer-policy.md`](./answer-policy.md) | Answer JSON shape, `schema_version`, status values. |
 | Eval surfaces | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`eval/config.yaml`](../eval/config.yaml), `eval/*.example.yaml` | Public synthetic is committed; private local is `.gitignore`d. |


### PR DESCRIPTION
## 1. What changed and why

Closes #248

Re-applies the two cross-links from #249 onto **main**. PR #249 was
merged into the stacked base `docs/issue-245-multi-agent-ownership`
(not main); when that base squashed up to main as part of #247, the
two cross-link edits were dropped from the squash, so today's main
still does not surface `docs/multi-agent-ownership.md` from either
entry point.

Verified before re-applying — neither line is present on `main`:
```
$ git show main:CLAUDE.md | grep multi-agent-ownership
$ git show main:docs/engineering-governance.md | grep multi-agent-ownership
(both empty)
```

This PR cherry-picks the original commit `cbbfdee` so the change
finally lands.

## 2. Files affected

- `CLAUDE.md` — "Start here" gains a pointer next to the workflow map / ADR index.
- `docs/engineering-governance.md` — "Where each thing lives" table gains a row for multi-agent coordination.

No load-bearing file changed.

## 3. Risks

Most likely failure: stale base — `docs/multi-agent-ownership.md` no longer exists on main, so the links would 404. Ruled out by `ls docs/multi-agent-ownership.md` on this worktree (HEAD = main); the file is present.

## 4. Tests

N/A — docs only.

## 5. Eval impact

All `·`. Docs only.

### 5b. Real-data delta

N/A — docs only.

## 6. Backward compatibility

Additive only. No link in either file was removed or renamed.

## 7. Out of scope

- Auditing other stacked PRs from the same era for similarly dropped edits.
- Cleaning up the now-stale local branch `docs/issue-248-crosslink-ownership-doc` (will be deleted after this PR merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)