### PR TITLE
refactor: extract shared row-validation helper in ingestion.py (#257)

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -239,14 +239,38 @@ def validate_fieldnames(fieldnames: list[str], metadata_csv: Path) -> None:
         )
 
 
-def normalize_ingestion_row(
+@dataclass
+class _RowValidation:
+    """Row-level resolution result shared by ingestion + audit paths."""
+
+    file_name: str
+    file_format: str
+    source_path: Path
+    doc_id: str
+    base_doc_id: str
+    failure_reason: str | None
+    duplicate_resolution: dict[str, Any] | None
+    # True when this row reserved a fresh slot in the tracker (no
+    # duplicate collision and validation passed up to that point).
+    # Callers use this to gate post-resolution checks like ``empty_text``.
+    tracker_registered: bool
+
+
+def _resolve_row_validation(
     row: dict[str, str],
     row_number: int,
     files_dir: Path,
     tracker: _DuplicateTracker,
     *,
     on_duplicate_doc_id: str = "fail",
-) -> tuple[dict[str, Any] | None, IngestionRecord]:
+) -> _RowValidation:
+    """Run the shared row-identity + duplicate-resolution validation chain.
+
+    Used by ``normalize_ingestion_row`` (which then loads the body text)
+    and ``audit_metadata_row`` (which then checks for blank body text).
+    Mutates ``tracker`` in place: a fresh row is recorded; a suffix
+    collision reserves the next unique id.
+    """
     notice_id = clean_cell(row.get("공고 번호"))
     notice_round = clean_cell(row.get("공고 차수"))
     file_name = clean_cell(row.get("파일명"))
@@ -257,6 +281,7 @@ def normalize_ingestion_row(
     duplicate_resolution: dict[str, Any] | None = None
     failure_reason: str | None = None
     doc_id = base_doc_id
+    tracker_registered = False
 
     if not file_name:
         failure_reason = "missing_file_name"
@@ -279,9 +304,9 @@ def normalize_ingestion_row(
                     "assigned_doc_id": suggested,
                 }
             else:
-                # Read-only peek: do not reserve the suggested id, otherwise a
-                # later row whose canonical doc_id is legitimately <base>-N
-                # would be falsely flagged as a duplicate.
+                # Read-only peek: do not reserve the suggested id, otherwise
+                # a later row whose canonical doc_id is legitimately
+                # <base>-N would be falsely flagged as a duplicate.
                 suggested = peek_next_unique_doc_id(base_doc_id, tracker)
                 failure_reason = "duplicate_doc_id"
                 duplicate_resolution = {
@@ -293,59 +318,84 @@ def normalize_ingestion_row(
         else:
             tracker.seen[base_doc_id] = row_number
             tracker.counts[base_doc_id] = 1
+            tracker_registered = True
 
-    if failure_reason:
+    return _RowValidation(
+        file_name=file_name,
+        file_format=file_format,
+        source_path=source_path,
+        doc_id=doc_id,
+        base_doc_id=base_doc_id,
+        failure_reason=failure_reason,
+        duplicate_resolution=duplicate_resolution,
+        tracker_registered=tracker_registered,
+    )
+
+
+def normalize_ingestion_row(
+    row: dict[str, str],
+    row_number: int,
+    files_dir: Path,
+    tracker: _DuplicateTracker,
+    *,
+    on_duplicate_doc_id: str = "fail",
+) -> tuple[dict[str, Any] | None, IngestionRecord]:
+    validation = _resolve_row_validation(
+        row, row_number, files_dir, tracker, on_duplicate_doc_id=on_duplicate_doc_id
+    )
+
+    if validation.failure_reason:
         return None, make_record(
             row_number,
             "failed",
-            doc_id,
-            file_name,
-            file_format,
-            source_path,
-            failure_reason,
-            duplicate_resolution=duplicate_resolution,
+            validation.doc_id,
+            validation.file_name,
+            validation.file_format,
+            validation.source_path,
+            validation.failure_reason,
+            duplicate_resolution=validation.duplicate_resolution,
         )
 
-    loader = _resolve_loader(file_format)
+    loader = _resolve_loader(validation.file_format)
     try:
-        text = loader.load_text(row, source_path)
+        text = loader.load_text(row, validation.source_path)
     except ValueError as exc:
         return None, make_record(
             row_number,
             "failed",
-            doc_id,
-            file_name,
-            file_format,
-            source_path,
+            validation.doc_id,
+            validation.file_name,
+            validation.file_format,
+            validation.source_path,
             str(exc),
-            duplicate_resolution=duplicate_resolution,
+            duplicate_resolution=validation.duplicate_resolution,
         )
 
     text_source = getattr(loader, "last_text_source", "data_list_csv_text")
     metadata = normalize_metadata(
-        row, file_format, file_name, text_source=text_source
+        row, validation.file_format, validation.file_name, text_source=text_source
     )
-    metadata["doc_id"] = doc_id
-    if duplicate_resolution and on_duplicate_doc_id == "suffix":
-        metadata["doc_id_resolution"] = duplicate_resolution["policy"]
-        metadata["doc_id_base"] = duplicate_resolution["base_doc_id"]
+    metadata["doc_id"] = validation.doc_id
+    if validation.duplicate_resolution and on_duplicate_doc_id == "suffix":
+        metadata["doc_id_resolution"] = validation.duplicate_resolution["policy"]
+        metadata["doc_id_base"] = validation.duplicate_resolution["base_doc_id"]
     document = {
-        "doc_id": doc_id,
-        "title": clean_cell(row.get("사업명")) or Path(file_name).stem,
+        "doc_id": validation.doc_id,
+        "title": clean_cell(row.get("사업명")) or Path(validation.file_name).stem,
         "agency": clean_cell(row.get("발주 기관")),
         "project": clean_cell(row.get("사업명")),
         "metadata": metadata,
         "sections": [{"heading": "본문", "text": text}],
-        "source_path": str(source_path),
+        "source_path": str(validation.source_path),
     }
     return document, make_record(
         row_number,
         "indexed",
-        doc_id,
-        file_name,
-        file_format,
-        source_path,
-        duplicate_resolution=duplicate_resolution,
+        validation.doc_id,
+        validation.file_name,
+        validation.file_format,
+        validation.source_path,
+        duplicate_resolution=validation.duplicate_resolution,
     )
 
 
@@ -683,13 +733,6 @@ def audit_metadata_row(
     *,
     on_duplicate_doc_id: str = "fail",
 ) -> IngestionRecord:
-    notice_id = clean_cell(row.get("공고 번호"))
-    notice_round = clean_cell(row.get("공고 차수"))
-    file_name = clean_cell(row.get("파일명"))
-    file_format = normalize_file_format(row.get("파일형식"), file_name)
-    source_path = find_source_file(files_dir, file_name) if file_name else files_dir
-    base_doc_id = canonical_doc_id(notice_id, notice_round, file_name)
-
     # Track non-fatal warnings on fields ingestion accepts but downstream
     # eval often relies on. Blank body text is NOT a warning: the ingestion
     # path raises ``empty_text`` for that row, and the validator must
@@ -700,54 +743,29 @@ def audit_metadata_row(
     if not clean_cell(row.get("사업명")):
         messages.append("blank_project")
 
-    duplicate_resolution: dict[str, Any] | None = None
-    failure_reason: str | None = None
-    doc_id = base_doc_id
+    validation = _resolve_row_validation(
+        row, row_number, files_dir, tracker, on_duplicate_doc_id=on_duplicate_doc_id
+    )
 
-    if not file_name:
-        failure_reason = "missing_file_name"
-    elif not doc_id:
-        failure_reason = "missing_doc_id"
-    elif file_format not in SUPPORTED_FILE_FORMATS:
-        failure_reason = "unsupported_file_format"
-    elif not source_path.exists() or not source_path.is_file():
-        failure_reason = "missing_file"
-    else:
-        existing_row = tracker.seen.get(base_doc_id)
-        if existing_row is not None:
-            if on_duplicate_doc_id == "suffix":
-                suggested = reserve_next_unique_doc_id(base_doc_id, tracker)
-                doc_id = suggested
-                duplicate_resolution = {
-                    "policy": "suffix",
-                    "base_doc_id": base_doc_id,
-                    "first_seen_row": existing_row,
-                    "assigned_doc_id": suggested,
-                }
-            else:
-                suggested = peek_next_unique_doc_id(base_doc_id, tracker)
-                failure_reason = "duplicate_doc_id"
-                duplicate_resolution = {
-                    "policy": "fail",
-                    "base_doc_id": base_doc_id,
-                    "first_seen_row": existing_row,
-                    "suggested_doc_id": suggested,
-                }
-        else:
-            tracker.seen[base_doc_id] = row_number
-            tracker.counts[base_doc_id] = 1
-            if not clean_cell(row.get("텍스트")):
-                failure_reason = "empty_text"
+    # audit-only: after a clean tracker registration, a blank body text
+    # surfaces as ``empty_text`` so a clean validator exit code mirrors
+    # the ingestion path's runtime failure for the same row.
+    if (
+        validation.tracker_registered
+        and validation.failure_reason is None
+        and not clean_cell(row.get("텍스트"))
+    ):
+        validation.failure_reason = "empty_text"
 
     return make_record(
         row_number,
-        "failed" if failure_reason else "ok",
-        doc_id,
-        file_name,
-        file_format,
-        source_path,
-        failure_reason,
-        duplicate_resolution=duplicate_resolution,
+        "failed" if validation.failure_reason else "ok",
+        validation.doc_id,
+        validation.file_name,
+        validation.file_format,
+        validation.source_path,
+        validation.failure_reason,
+        duplicate_resolution=validation.duplicate_resolution,
         messages=tuple(messages),
     )
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -115,5 +115,100 @@ class MetadataCsvIngestionTest(unittest.TestCase):
             self.assertEqual("202400001", payload["chunks"][0]["metadata"]["notice_id"])
 
 
+class RowValidationParityRegression(unittest.TestCase):
+    """Both ingestion and audit paths must surface the same failure_reason
+    on shared validation-chain failures (issue #257). Guards against drift
+    after the shared `_resolve_row_validation` helper was introduced."""
+
+    def _row(self, **overrides: str) -> dict[str, str]:
+        row = {col: "" for col in FIELDNAMES}
+        row.update(
+            {
+                "공고 번호": "202400001",
+                "공고 차수": "0",
+                "사업명": "샘플 사업",
+                "발주 기관": "기관 X",
+                "파일형식": "pdf",
+                "텍스트": "본문 텍스트입니다.",
+            }
+        )
+        row.update(overrides)
+        return row
+
+    def _reasons(
+        self, files_dir: Path, row: dict[str, str]
+    ) -> tuple[str | None, str | None]:
+        from ingestion import (
+            _DuplicateTracker,
+            audit_metadata_row,
+            normalize_ingestion_row,
+        )
+
+        _, record_n = normalize_ingestion_row(
+            row, row_number=2, files_dir=files_dir, tracker=_DuplicateTracker()
+        )
+        record_a = audit_metadata_row(
+            row, row_number=2, files_dir=files_dir, tracker=_DuplicateTracker()
+        )
+        return record_n.reason, record_a.reason
+
+    def test_missing_file_name_reason_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            normalize_reason, audit_reason = self._reasons(
+                Path(tmp), self._row(파일명="")
+            )
+            self.assertEqual("missing_file_name", normalize_reason)
+            self.assertEqual("missing_file_name", audit_reason)
+
+    def test_unsupported_file_format_reason_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp) / "files"
+            files_dir.mkdir()
+            (files_dir / "report.docx").write_bytes(b"")
+            normalize_reason, audit_reason = self._reasons(
+                files_dir, self._row(파일명="report.docx", 파일형식="docx")
+            )
+            self.assertEqual("unsupported_file_format", normalize_reason)
+            self.assertEqual("unsupported_file_format", audit_reason)
+
+    def test_missing_file_reason_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp) / "files"
+            files_dir.mkdir()
+            normalize_reason, audit_reason = self._reasons(
+                files_dir, self._row(파일명="absent.pdf")
+            )
+            self.assertEqual("missing_file", normalize_reason)
+            self.assertEqual("missing_file", audit_reason)
+
+    def test_duplicate_doc_id_reason_matches(self) -> None:
+        # First row reserves the doc_id; second row collides on the same
+        # canonical key. Both paths must report duplicate_doc_id on the
+        # collider row when on_duplicate_doc_id defaults to "fail".
+        from ingestion import (
+            _DuplicateTracker,
+            audit_metadata_row,
+            normalize_ingestion_row,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp) / "files"
+            files_dir.mkdir()
+            (files_dir / "sample.pdf").write_bytes(b"%PDF-1.4\n")
+            row1 = self._row(파일명="sample.pdf")
+            row2 = self._row(파일명="sample.pdf")
+
+            tracker_n = _DuplicateTracker()
+            normalize_ingestion_row(row1, 2, files_dir, tracker_n)
+            _, record_n = normalize_ingestion_row(row2, 3, files_dir, tracker_n)
+
+            tracker_a = _DuplicateTracker()
+            audit_metadata_row(row1, 2, files_dir, tracker_a)
+            record_a = audit_metadata_row(row2, 3, files_dir, tracker_a)
+
+            self.assertEqual("duplicate_doc_id", record_n.reason)
+            self.assertEqual("duplicate_doc_id", record_a.reason)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #257

`normalize_ingestion_row` and `audit_metadata_row` in `ingestion.py` shared a ~35-line row-identity + duplicate-resolution validation block before diverging into their distinct work (text load + document assembly vs. blank-field audit). The duplication created drift risk: any new `FAILURE_TAXONOMY` key or doc_id rule had to be applied to both functions.

This PR extracts the shared chain into `_resolve_row_validation` (returns a new `_RowValidation` dataclass); the two public functions reduce to a fixed pre-amble + their distinct tail. No behavior change.

## 2. Files affected

- `ingestion.py` — **load-bearing**. Added `_RowValidation` dataclass + `_resolve_row_validation` helper. `normalize_ingestion_row` and `audit_metadata_row` now delegate to the helper.
- `tests/test_ingestion.py` — added `RowValidationParityRegression` (4 tests).

No other load-bearing file (`rag_core.py` / `visual_ingestion.py` / `eval/` / `api/` / `docs/adr/`) touched.

## 3. Risks

Most likely failure mode: the audit-only `empty_text` check used to live inside the `else` branch of the duplicate chain and would only fire on a fresh tracker registration. The refactor moves that check into the audit caller, gated by the new `tracker_registered` flag, which must be true exactly when the original `else` branch executed. Ruled out by:

1. Reading the original branch (`tests/test_ingestion.py:23+`, `tests/test_data_list_validation.py`) and tracing every flag value.
2. `pytest -q` full suite green (469 → 473; no existing test flipped).
3. New parity tests assert the two paths converge on identical `record.reason` for the four shared failure types.

A second risk — that `_RowValidation`'s mutation in `audit_metadata_row` (setting `failure_reason = "empty_text"` after the helper returns) leaks state — is contained because the dataclass is constructed fresh per row inside the helper.

## 4. Tests

`tests/test_ingestion.py::RowValidationParityRegression` (new):
- `test_missing_file_name_reason_matches` — both paths surface `missing_file_name` on blank `파일명` (gives this branch its first explicit test).
- `test_unsupported_file_format_reason_matches`
- `test_missing_file_reason_matches`
- `test_duplicate_doc_id_reason_matches`

`pytest -q` full suite: **469 → 473 passed, 121 subtests passed in 6.69s**. Touched files exercised by:
- `tests/test_ingestion.py`
- `tests/test_data_list_validation.py`
- `tests/test_mixed_format_ingestion_regression.py`
- `tests/test_hwp_native_loader_regression.py`

## 5. Eval impact

All `·` expected. Refactor is pure — same inputs produce same `IngestionRecord` outputs; downstream chunking / embedding / retrieval / answer paths see byte-identical documents.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** This is a load-bearing-file refactor with strict input→output equivalence:

1. `FAILURE_TAXONOMY` keys unchanged.
2. `IngestionRecord` fields and types unchanged.
3. `on_duplicate_doc_id` semantics ("fail" peeks, "suffix" reserves) preserved verbatim.
4. The `else: tracker.seen[...] = row_number; tracker.counts[...] = 1` body lives in the helper now but executes under the same condition (no duplicate collision).
5. Parity tests assert two-path equivalence on four representative failure paths.

`make real-eval-delta` not run in this PR — recommend the maintainer trigger it locally before merge if extra confidence is desired (no production data dependency in this refactor).

## 6. Backward compatibility

All public signatures unchanged: `normalize_ingestion_row`, `audit_metadata_row`, `make_record`, `IngestionRecord`. New names (`_RowValidation`, `_resolve_row_validation`) are underscore-prefixed and internal.

## 7. Out of scope

- `build_ingestion_report` / `_build_validation_report` consolidation (called out as separate concern in the issue).
- An explicit `missing_doc_id` parity test: triggering that branch requires a row with valid `파일명` but empty `공고 번호`/`공고 차수` such that `canonical_doc_id` returns empty — needs a closer look at `canonical_doc_id`'s fallback chain. Follow-up.
- Wider rename of `_DuplicateTracker.counts` (only `reserve_next_unique_doc_id` reads it today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)