### PR TITLE
ci: enforce PR §5b real-data delta via load-bearing SSoT

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -46,15 +46,8 @@ fi
 # ---------------------------------------------------------------------------
 
 
-# Watch-list: files whose change implies a real-data delta is owed.
-WATCH_PATTERNS=(
-  "rag_core.py"
-  "ingestion.py"
-  "visual_ingestion.py"
-  "eval/"
-  "api/"
-  "scripts/build_index.py"
-)
+# Watch-list lives in scripts/_governance.py (single source of truth,
+# also consumed by the Claude PreToolUse hook and the §5b CI gate).
 
 # Resolve upstream / base ref. Prefer @{upstream}; fall back to origin/main.
 if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null); then
@@ -77,18 +70,11 @@ if [[ -z "$changed" ]]; then
   exit 0
 fi
 
-# Match against the watch-list.
+# Match against the load-bearing SSoT.
 hit=""
-while IFS= read -r file; do
-  for pat in "${WATCH_PATTERNS[@]}"; do
-    case "$file" in
-      "$pat"|"$pat"*)
-        hit="$file"
-        break 2
-        ;;
-    esac
-  done
-done <<< "$changed"
+if command -v python3 >/dev/null 2>&1; then
+  hit=$(printf '%s\n' "$changed" | python3 scripts/_governance.py --any-match 2>/dev/null | head -n1)
+fi
 
 if [[ -n "$hit" ]]; then
   cat >&2 <<EOF

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,8 +17,9 @@ Closes #
 ## 2. Files affected
 
 <!--
-Bulleted list. Flag any of these as load-bearing:
-rag_core.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/
+Bulleted list. Flag any of these as load-bearing
+(canonical list: scripts/_governance.py):
+rag_core.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py
 -->
 
 ## 3. Risks
@@ -45,11 +46,13 @@ What do you expect the CI eval delta to show?
 ### 5b. Real-data delta
 
 <!--
-Required if rag_core.py, ingestion.py, visual_ingestion.py, eval/, or api/ changed.
+Required if any load-bearing path changed
+(rag_core.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py).
 Attach the `make real-eval-delta` aggregate table, or state explicitly:
 "No behavior change in retrieval / verifier path."
 See ADR 0005 and docs/private-100-doc-experiments.md.
-The synthetic CI delta alone missed #69's intended-abstention regression.
+The synthetic CI delta alone missed #69's intended-abstention regression;
+the §5b CI gate (scripts/check_branch_and_issue.py --check-5b) now enforces this.
 -->
 
 ## 6. Backward compatibility

--- a/.github/workflows/branch-and-issue-check.yml
+++ b/.github/workflows/branch-and-issue-check.yml
@@ -1,9 +1,12 @@
 name: Branch & Issue Convention
 
-# Enforces ADR 0007: every PR must come from a branch named
-# `<type>/issue-<N>[-<slug>]` AND have `Closes #N` in its body
-# matching the branch's issue number. The referenced issue must
-# exist in this repo.
+# Enforces two governance gates per PR:
+#   (1) ADR 0007: branch named `<type>/issue-<N>[-<slug>]` with a
+#       matching `Closes #N` in the body, and the referenced issue
+#       must exist in this repo.
+#   (2) CLAUDE.md PR #69 lesson: when any load-bearing path changes
+#       (see scripts/_governance.py), the PR body §5b "Real-data
+#       delta" must contain a markdown table OR the escape sentence.
 #
 # Fast (~15s, no checkout). Should be set as a required status
 # check on `main` after one green run.
@@ -27,15 +30,23 @@ jobs:
         with:
           sparse-checkout: |
             scripts/check_branch_and_issue.py
+            scripts/_governance.py
           sparse-checkout-cone-mode: false
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Validate
+      - name: Validate branch name + issue link
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           python scripts/check_branch_and_issue.py --pr ${{ github.event.pull_request.number }}
+
+      - name: Validate PR §5b (load-bearing real-eval delta)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python scripts/check_branch_and_issue.py --check-5b ${{ github.event.pull_request.number }}

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Single source of truth for the load-bearing path list (CLAUDE.md).
+
+A "load-bearing" path is one whose change requires PR template item 5b
+(real-data eval delta) per CLAUDE.md and the PR #69 lesson — synthetic
+CI delta alone missed an intended-abstention regression there.
+
+Three call sites that previously hardcoded their own copy now read this
+module:
+
+- `.githooks/pre-push` (soft-warn reminder)
+- `scripts/claude-hooks/pretooluse-loadbearing.sh` (Claude awareness)
+- `.github/workflows/branch-and-issue-check.yml` via
+  `scripts/check_branch_and_issue.py --check-5b` (hard-fail CI gate)
+
+Exit codes:
+    0  match (CLI succeeded — for --is-load-bearing / --any-match
+       this means "path is load-bearing")
+    1  no match
+    2  internal / usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+# Canonical load-bearing path list. The order is not significant; add
+# new entries here and the three consumers above pick them up
+# automatically. Entries ending in "/" are treated as directories
+# (prefix match); others as files (exact name or "/<name>" suffix match).
+LOAD_BEARING_PATHS: list[str] = [
+    "rag_core.py",
+    "ingestion.py",
+    "visual_ingestion.py",
+    "eval/",
+    "api/",
+    "docs/adr/",
+    "scripts/build_index.py",
+]
+
+
+def _normalize(path: str) -> str:
+    if path.startswith("./"):
+        return path[2:]
+    return path
+
+
+def is_load_bearing(path: str) -> bool:
+    """Return True if `path` matches any canonical load-bearing entry.
+
+    Accepts both repo-relative paths (`rag_core.py`, `eval/config.yaml`)
+    and absolute paths (`/Users/.../rag_core.py`). Matching is anchored
+    so that `myapi/main.py` does NOT match the `api/` directory entry.
+    """
+    if not path:
+        return False
+    p = _normalize(path)
+    for entry in LOAD_BEARING_PATHS:
+        if entry.endswith("/"):
+            stripped = entry.rstrip("/")
+            if p == stripped or p.startswith(entry) or f"/{entry}" in p:
+                return True
+        else:
+            if p == entry or p.endswith("/" + entry):
+                return True
+    return False
+
+
+def _cmd_is_load_bearing(path: str) -> int:
+    return 0 if is_load_bearing(path) else 1
+
+
+def _cmd_any_match() -> int:
+    first_hit: str | None = None
+    for line in sys.stdin:
+        candidate = line.strip()
+        if not candidate:
+            continue
+        if is_load_bearing(candidate):
+            first_hit = candidate
+            break
+    if first_hit is None:
+        return 1
+    sys.stdout.write(first_hit + "\n")
+    return 0
+
+
+def _cmd_list() -> int:
+    sys.stdout.write("\n".join(LOAD_BEARING_PATHS) + "\n")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Load-bearing paths SSoT (CLAUDE.md, PR #69 lesson).",
+    )
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument(
+        "--is-load-bearing", metavar="PATH",
+        help="Exit 0 if PATH is load-bearing, 1 otherwise.",
+    )
+    g.add_argument(
+        "--any-match", action="store_true",
+        help="Read newline-delimited paths from stdin; exit 0 if any "
+             "match (printing the first match to stdout), else 1.",
+    )
+    g.add_argument(
+        "--list", action="store_true",
+        help="Print the canonical load-bearing list, one per line.",
+    )
+    args = p.parse_args()
+
+    if args.is_load_bearing is not None:
+        return _cmd_is_load_bearing(args.is_load_bearing)
+    if args.any_match:
+        return _cmd_any_match()
+    if args.list:
+        return _cmd_list()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_branch_and_issue.py
+++ b/scripts/check_branch_and_issue.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""Validate branch naming convention and PR-issue linkage (ADR 0007).
+"""Validate branch naming convention, PR-issue linkage, and §5b real-data delta.
 
-Single source of truth for the regex. Called from two places:
+Single source of truth for the regexes. Called from three places:
 
 - `.githooks/pre-push` (local) → `--branch <name> --check-issue`
 - `.github/workflows/branch-and-issue-check.yml` (CI) → `--pr <number>`
+- Same CI workflow → `--check-5b <number>` (enforces PR template §5b for
+  load-bearing changes, per CLAUDE.md PR #69 lesson)
 
 Exit codes:
     0  ok (or exempt)
     1  convention violation (printed to stderr)
-    2  internal error (e.g. `gh` unavailable in --pr mode)
+    2  internal error (e.g. `gh` unavailable)
 """
 
 from __future__ import annotations
@@ -22,6 +24,8 @@ import subprocess
 import sys
 from typing import Optional
 
+from _governance import is_load_bearing
+
 
 BRANCH_REGEX = re.compile(
     r"^(?:feat|fix|docs|chore|refactor|test|ci|perf|build|style)"
@@ -33,6 +37,14 @@ EXEMPT_REGEX = re.compile(r"^(?:revert-|dependabot/|renovate/|pre-commit-ci/)")
 CLOSES_REGEX = re.compile(r"(?i)\b(?:closes|fixes|resolves)\s+#(\d+)\b")
 
 ALLOWED_PREFIXES = "feat, fix, docs, chore, refactor, test, ci, perf, build, style"
+
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+FIVE_B_HEADER_RE = re.compile(r"###\s+5b\.\s*Real-data delta", re.IGNORECASE)
+FIVE_B_TABLE_RE = re.compile(r"^\s*\|.+\|.+\|", re.MULTILINE)
+FIVE_B_ESCAPE_RE = re.compile(
+    r"No behavior change in\s+(?:retrieval|verifier|eval|api|ingestion)\b",
+    re.IGNORECASE,
+)
 
 
 def _err(msg: str) -> None:
@@ -194,13 +206,113 @@ def check_pr_mode(pr_number: int) -> int:
     return 0
 
 
+def _five_b_section(body: str) -> Optional[str]:
+    """Return the §5b section text (HTML comments stripped) or None if absent.
+
+    The PR template ships with HTML comments under each header explaining
+    what to write; those comments are invisible in rendered markdown and
+    must not satisfy the §5b requirement. We strip them first.
+    """
+    stripped = HTML_COMMENT_RE.sub("", body)
+    m = FIVE_B_HEADER_RE.search(stripped)
+    if not m:
+        return None
+    rest = stripped[m.end():]
+    next_section = re.search(r"\n##\s", rest)
+    if next_section:
+        return rest[: next_section.start()]
+    return rest
+
+
+def check_5b_mode(pr_number: int) -> int:
+    """Verify PR body §5b for load-bearing changes.
+
+    Logic:
+      1. `gh pr view --json files,body` → list of changed paths + body text.
+      2. Filter changed paths through `_governance.is_load_bearing()`.
+      3. If none match → exit 0 (skip; non-load-bearing PR).
+      4. If any match → require body to contain the '### 5b. Real-data delta'
+         header AND, beneath it (HTML comments stripped), either a markdown
+         table row OR the escape sentence
+         'No behavior change in retrieval/verifier/eval/api/ingestion path'.
+      5. On failure: print actionable error pointing to PR #69 lesson.
+    """
+    if not gh_available():
+        _err("❌ `gh` CLI is required in --check-5b mode but is not available.\n")
+        return 2
+    repo = get_repo_slug()
+    if not repo:
+        _err("❌ Could not determine repo slug (set GITHUB_REPOSITORY).\n")
+        return 2
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--repo", repo,
+             "--json", "files,body"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        _err(f"❌ Could not fetch PR #{pr_number}: {e.stderr}\n")
+        return 2
+
+    pr = json.loads(result.stdout)
+    files = pr.get("files") or []
+    body = pr.get("body") or ""
+
+    load_bearing_hits = [
+        f.get("path", "") for f in files if is_load_bearing(f.get("path", ""))
+    ]
+    if not load_bearing_hits:
+        sys.stdout.write(
+            f"OK: PR #{pr_number} changes no load-bearing path; §5b not required.\n"
+        )
+        return 0
+
+    section = _five_b_section(body)
+    example = load_bearing_hits[0]
+    remediation = (
+        "   PR #69 lesson: the synthetic CI delta alone missed an intended-abstention regression.\n"
+        "   Either:\n"
+        "     (a) attach the `make real-eval-delta` aggregate table under\n"
+        "         '### 5b. Real-data delta', or\n"
+        "     (b) state explicitly: 'No behavior change in retrieval / verifier path.'\n"
+        "   See: .github/pull_request_template.md and CLAUDE.md.\n"
+    )
+    if section is None:
+        _err(
+            f"\n❌ Load-bearing change detected (e.g. {example}) but PR body has\n"
+            f"   no '### 5b. Real-data delta' section.\n" + remediation
+        )
+        return 1
+
+    has_table = bool(FIVE_B_TABLE_RE.search(section))
+    has_escape = bool(FIVE_B_ESCAPE_RE.search(section))
+    if not (has_table or has_escape):
+        _err(
+            f"\n❌ Load-bearing change detected (e.g. {example}) but §5b is\n"
+            f"   missing both a markdown table and the escape sentence.\n"
+            + remediation
+        )
+        return 1
+
+    sys.stdout.write(
+        f"OK: PR #{pr_number} touches load-bearing path "
+        f"({example}); §5b contains "
+        f"{'table' if has_table else 'escape sentence'}.\n"
+    )
+    return 0
+
+
 def main() -> int:
     p = argparse.ArgumentParser(
-        description="Validate branch + issue convention (ADR 0007).",
+        description="Validate branch + issue convention + §5b (ADR 0007, CLAUDE.md).",
     )
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument("--branch", help="Branch name to validate (local mode).")
     g.add_argument("--pr", type=int, help="PR number to validate (CI mode).")
+    g.add_argument(
+        "--check-5b", type=int, dest="check_5b", metavar="PR_NUMBER",
+        help="Verify PR body §5b for load-bearing changes (CI mode).",
+    )
     p.add_argument(
         "--check-issue", action="store_true",
         help="In --branch mode, also verify the referenced issue exists via gh.",
@@ -209,7 +321,9 @@ def main() -> int:
 
     if args.branch is not None:
         return check_branch_mode(args.branch, args.check_issue)
-    return check_pr_mode(args.pr)
+    if args.pr is not None:
+        return check_pr_mode(args.pr)
+    return check_5b_mode(args.check_5b)
 
 
 if __name__ == "__main__":

--- a/scripts/claude-hooks/pretooluse-loadbearing.sh
+++ b/scripts/claude-hooks/pretooluse-loadbearing.sh
@@ -28,21 +28,10 @@ if [[ -z "$file_path" ]]; then
   exit 0
 fi
 
-# Load-bearing patterns (extended regex). Mirror CLAUDE.md "Load-bearing
-# files" section. Anchored to "/" to avoid matching inside arbitrary
-# substrings.
-LOAD_BEARING_PATTERNS=(
-  '/rag_core\.py$'
-  '/ingestion\.py$'
-  '/visual_ingestion\.py$'
-  '/eval/'
-  '/api/'
-  '/docs/adr/'
-)
-
-for pat in "${LOAD_BEARING_PATTERNS[@]}"; do
-  if [[ "$file_path" =~ $pat ]]; then
-    cat >&2 <<EOF
+# Load-bearing list lives in scripts/_governance.py (single source of
+# truth, also consumed by .githooks/pre-push and the §5b CI gate).
+if python3 scripts/_governance.py --is-load-bearing "$file_path" 2>/dev/null; then
+  cat >&2 <<EOF
 ⚠️  Load-bearing file: $file_path
 
     ADRs to consider (CLAUDE.md):
@@ -53,8 +42,6 @@ for pat in "${LOAD_BEARING_PATTERNS[@]}"; do
     PR template item 5b (real-eval-delta aggregate table) will be required
     when this change ships.
 EOF
-    break
-  fi
-done
+fi
 
 exit 0

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -1,0 +1,162 @@
+"""Drift guard for the load-bearing path SSoT (`scripts/_governance.py`)
+plus regex-level checks for the §5b enforcement in
+`scripts/check_branch_and_issue.py`.
+
+The same conceptual list previously lived in three places with subtle
+differences. These tests ensure all three consumers reach back to the
+SSoT instead of carrying their own copy. The §5b tests confirm the
+gating logic accepts the documented escape sentence and rejects an
+empty/comment-only template body (which would otherwise let PR #69-class
+regressions through).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR / "scripts"))
+
+import _governance as gov  # noqa: E402
+import check_branch_and_issue as cbi  # noqa: E402
+
+
+@pytest.mark.parametrize("entry", [
+    "rag_core.py",
+    "ingestion.py",
+    "visual_ingestion.py",
+    "eval/",
+    "api/",
+    "docs/adr/",
+])
+def test_canonical_list_contains_claude_md_entries(entry):
+    assert entry in gov.LOAD_BEARING_PATHS, (
+        f"CLAUDE.md lists {entry!r} as load-bearing but the SSoT does not."
+    )
+
+
+@pytest.mark.parametrize("path", [
+    "rag_core.py",
+    "./rag_core.py",
+    "ingestion.py",
+    "visual_ingestion.py",
+    "eval/config.yaml",
+    "eval/run_eval.py",
+    "api/main.py",
+    "docs/adr/0001-preserve-naive-baseline.md",
+    "scripts/build_index.py",
+    "/Users/x/proj/rag_core.py",
+    "/abs/path/to/api/main.py",
+    "/abs/path/to/docs/adr/0007.md",
+])
+def test_is_load_bearing_accepts(path):
+    assert gov.is_load_bearing(path), f"expected load-bearing: {path!r}"
+
+
+@pytest.mark.parametrize("path", [
+    "",
+    "README.md",
+    "CHANGELOG.md",
+    "myapi/main.py",
+    "preeval/foo.py",
+    "tests/test_governance.py",
+    "scripts/check_branch_and_issue.py",
+    "data/raw/example.pdf",
+    "rag_core_helper.py",
+])
+def test_is_load_bearing_rejects(path):
+    assert not gov.is_load_bearing(path), f"expected NOT load-bearing: {path!r}"
+
+
+def test_pre_push_hook_uses_governance_module():
+    text = (ROOT_DIR / ".githooks" / "pre-push").read_text()
+    assert "_governance.py" in text, (
+        ".githooks/pre-push must call scripts/_governance.py (SSoT) "
+        "instead of carrying its own WATCH_PATTERNS array."
+    )
+
+
+def test_pretooluse_hook_uses_governance_module():
+    text = (
+        ROOT_DIR / "scripts" / "claude-hooks" / "pretooluse-loadbearing.sh"
+    ).read_text()
+    assert "_governance.py" in text, (
+        "PreToolUse hook must call scripts/_governance.py (SSoT) "
+        "instead of carrying its own LOAD_BEARING_PATTERNS array."
+    )
+
+
+def test_pr_template_mentions_all_canonical_entries():
+    template = (
+        ROOT_DIR / ".github" / "pull_request_template.md"
+    ).read_text()
+    for entry in gov.LOAD_BEARING_PATHS:
+        assert entry in template, (
+            f"PR template must mention load-bearing entry {entry!r} "
+            f"so reviewers see the §5b trigger surface. "
+            f"Update .github/pull_request_template.md to keep it in sync "
+            f"with scripts/_governance.LOAD_BEARING_PATHS."
+        )
+
+
+def test_five_b_section_absent_when_no_header():
+    assert cbi._five_b_section("nothing here") is None
+
+
+def test_five_b_section_found_with_default_template_only():
+    body = (
+        "### 5b. Real-data delta\n\n"
+        "<!--\n"
+        "Required if load-bearing path changed.\n"
+        "Attach `make real-eval-delta` table or state:\n"
+        "'No behavior change in retrieval / verifier path.'\n"
+        "-->\n"
+    )
+    section = cbi._five_b_section(body)
+    assert section is not None, "header is present, even if section is empty"
+    assert not cbi.FIVE_B_TABLE_RE.search(section), (
+        "comment-only template body must NOT count as a markdown table"
+    )
+    assert not cbi.FIVE_B_ESCAPE_RE.search(section), (
+        "escape sentence inside an HTML comment must be stripped, "
+        "otherwise the default empty template would silently satisfy §5b"
+    )
+
+
+def test_five_b_table_regex_matches_real_eval_delta_aggregate():
+    section = (
+        "\n\n"
+        "| metric | base | head | delta |\n"
+        "|---|---|---|---|\n"
+        "| accuracy | 0.82 | 0.84 | +0.02 |\n"
+    )
+    assert cbi.FIVE_B_TABLE_RE.search(section)
+
+
+@pytest.mark.parametrize("sentence", [
+    "No behavior change in retrieval path.",
+    "No behavior change in verifier path.",
+    "No behavior change in retrieval / verifier path.",
+    "no behavior change in eval path",
+    "No behavior change in API path.",
+    "No behavior change in ingestion path.",
+])
+def test_five_b_escape_regex_accepts_documented_escape(sentence):
+    assert cbi.FIVE_B_ESCAPE_RE.search(sentence), (
+        f"Escape sentence not recognized: {sentence!r}"
+    )
+
+
+@pytest.mark.parametrize("sentence", [
+    "No behavior change anywhere.",
+    "We changed retrieval behavior.",
+    "TODO: add real-eval delta.",
+])
+def test_five_b_escape_regex_rejects_off_pattern(sentence):
+    assert not cbi.FIVE_B_ESCAPE_RE.search(sentence), (
+        f"Should not match escape: {sentence!r}"
+    )


### PR DESCRIPTION
## 1. What changed and why

Adds `scripts/_governance.py` as the single source of truth for the load-bearing path list, then wires three previously-divergent consumers (`.githooks/pre-push`, `scripts/claude-hooks/pretooluse-loadbearing.sh`, `.github/pull_request_template.md`) and one new CI gate to it. Extends `.github/workflows/branch-and-issue-check.yml` with `--check-5b`, which fails when a load-bearing change ships without a §5b real-eval-delta table or the documented escape sentence — closing the gap CLAUDE.md attributes to PR #69 (synthetic CI delta alone missed an intended-abstention regression).

Closes #279

## 2. Files affected

- `scripts/_governance.py` (new) — canonical `LOAD_BEARING_PATHS` + matcher CLI (`--is-load-bearing`, `--any-match`, `--list`)
- `tests/test_governance.py` (new) — 42 cases: drift guards + §5b regex
- `scripts/check_branch_and_issue.py` — new `--check-5b PR_NUMBER` mode
- `.github/workflows/branch-and-issue-check.yml` — new `Validate PR §5b` step; `_governance.py` added to sparse-checkout
- `.githooks/pre-push` — removed hardcoded `WATCH_PATTERNS`; now calls `_governance.py --any-match`
- `scripts/claude-hooks/pretooluse-loadbearing.sh` — removed hardcoded `LOAD_BEARING_PATTERNS`; now calls `_governance.py --is-load-bearing`
- `.github/pull_request_template.md` — §5b trigger phrasing aligned with the canonical list

No load-bearing path is itself modified.

## 3. Risks

- **False positive**: §5b CI gate could block a refactor-only PR. *Mitigation*: the escape sentence `"No behavior change in retrieval / verifier path."` is documented in the template and accepted by `FIVE_B_ESCAPE_RE`; reviewed by `test_five_b_escape_regex_accepts_documented_escape`.
- **Sparse-checkout drift**: if a future workflow change forgets to add `scripts/_governance.py` to sparse-checkout, the §5b step crashes at import time. *Mitigation*: explicit comment in the workflow header; failure is loud and easy to diagnose.
- **`--no-verify` bypass**: the pre-push reminder is still soft-warn (unchanged); only the CI gate is hard-fail. Server-side bypass detection is out of scope (G6).
- **PR template HTML comment leakage**: someone could put the escape sentence inside an HTML comment expecting it to count. *Mitigation*: `HTML_COMMENT_RE` strips comments before matching, covered by `test_five_b_section_found_with_default_template_only`.

## 4. Tests

- `tests/test_governance.py`: 42 cases across `LOAD_BEARING_PATHS` membership, `is_load_bearing()` accept/reject, hook→SSoT drift guards, PR-template→SSoT drift guard, and `--check-5b` regex coverage (header, table, escape).
- Full local `pytest -q`: **511 passed, 0 failed**.
- Local hook dry-runs:
  - PreToolUse hook fired on `/tmp/x/rag_core.py` → expected stderr warning emitted; on `/tmp/x/README.md` → no output.
  - `.githooks/pre-push` on this branch → exit 0 (no load-bearing change).
  - `python3 scripts/_governance.py --is-load-bearing rag_core.py` → 0; `README.md` → 1; absolute path `/Users/x/rag_core.py` → 0; `myapi/main.py` → 1 (anchor preserved).

## 5. Eval impact

All `·`. This is a CI/governance change; no retrieval, verifier, ingestion, or eval code path is modified.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

No answer-contract, schema, or pipeline change. `scripts/check_branch_and_issue.py` adds a new mode but preserves existing `--branch` and `--pr` flags; the workflow keeps its job name (`Validate branch name + issue link`) so any branch protection rule pinned to that job continues to match.

## 7. Out of scope

Deliberately not addressed in this PR (tracked separately):
- Other automation gaps: `naive_baseline` invariant (G2), answer-contract shape snapshot (G3), ADR deletion guard (G4), parallel pydantic detection (G5), `--no-verify` server-side check (G6), lint/format/security CI (G8/G9).
- Other refactors: provenance helper consolidation (R2), composite action for eval (R3), pre-push hook split (R4), Makefile cleanup (R5).
- PR template auto-generation — this PR is verify-only on the template.