### PR TITLE
feat: Qdrant in-memory VectorStore adapter (#176 Stage 2a)

### DIFF
--- a/rag_vector_store.py
+++ b/rag_vector_store.py
@@ -1,25 +1,35 @@
-"""VectorStore abstraction for the RAG index (issue #232, Stage 1 of #176).
+"""VectorStore abstraction for the RAG index (issue #176).
 
-Sits behind ``index["_vector_store"]`` so that future PRs can plug in
-Qdrant / pgvector adapters without touching the chunk-metadata payload
-or the retrieval loop's call site. Stage 1 introduces the seam only —
-``InMemoryVectorStore`` is a thin wrapper around the existing float32
-matrix, so the on-disk format (``embeddings.npy`` sidecar from #207) is
-unchanged and ranking is bit-identical.
+Sits behind ``index["_vector_store"]`` so that retrieval call sites in
+``rag_core.py`` work against any registered backend without touching
+chunk-metadata storage. The on-disk format (``embeddings.npy`` sidecar
+from #207) is invariant across backends, so users can switch
+``$BIDMATE_INDEX_BACKEND`` without rebuilding the index.
 
-The Protocol is deliberately minimal: ``get(idx)`` is what the current
-retrieval loop in ``rag_core.py`` actually needs. A ``query(qvec, top_k)``
-method (filter-pushdown for Qdrant) is reserved for Stage 2 — adding it
-now would duplicate candidate-filter logic and break the no-behavior-
-change invariant.
+Stages of #176:
+
+* **Stage 1** (#234, merged) — Protocol + ``InMemoryVectorStore``.
+* **Stage 2a** (this module's ``qdrant`` backend) — Qdrant in-memory
+  collection adapter. ``get(idx)`` is bit-identical to in-memory; the
+  Qdrant collection holds the same points in parallel so a future
+  Stage 2b can add a ``query(qvec, top_k)`` Protocol method and
+  delegate ANN search to Qdrant without rebuilding the index.
+* **Stage 2b** (deferred) — Protocol-level ``query`` method + Qdrant
+  filter-pushdown.
+* **Stage 3** (deferred) — pgvector backend for SaaS-Postgres scale.
+
+The Protocol is deliberately minimal: ``get(idx)`` is what the
+retrieval loop currently needs. A ``query(qvec, top_k)`` method is
+reserved for Stage 2b — adding it now would duplicate candidate-filter
+logic and break the no-behavior-change invariant.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
@@ -29,7 +39,13 @@ EMBEDDINGS_FILENAME = "embeddings.npy"
 
 ENV_INDEX_BACKEND = "BIDMATE_INDEX_BACKEND"
 DEFAULT_INDEX_BACKEND = "memory"
-SUPPORTED_BACKENDS = frozenset({"memory"})
+# ``pgvector`` is reserved for Stage 3 — selecting it today raises
+# NotImplementedError.
+SUPPORTED_BACKENDS = frozenset({"memory", "qdrant"})
+
+# Qdrant in-memory collection name. Kept stable so introspection and
+# future migrations can match against a single literal.
+QDRANT_COLLECTION_NAME = "bidmate_index"
 
 
 @runtime_checkable
@@ -79,9 +95,101 @@ class InMemoryVectorStore:
         )
 
 
+@dataclass
+class QdrantVectorStore:
+    """Qdrant in-memory collection adapter (#176 Stage 2a).
+
+    Wraps the same ``(N, D)`` float32 L2-normalized matrix as
+    ``InMemoryVectorStore`` and additionally mirrors it into a Qdrant
+    collection opened in ``location=":memory:"`` mode. Stage 2a keeps
+    the matrix in memory so ``get(idx)`` returns the bit-identical row
+    that the in-memory backend would — preserving retrieval ranking.
+    Stage 2b will introduce a ``query(qvec, top_k)`` Protocol method
+    that delegates to Qdrant and lets us drop the parallel matrix.
+
+    ``persist`` writes the existing ``embeddings.npy`` sidecar so users
+    can switch backends without rebuilding the index. Native Qdrant
+    collection persistence (``location=<path>``) is reserved for Stage
+    2b.
+    """
+
+    vectors: np.ndarray
+    client: Any = field(repr=False, compare=False)
+    collection_name: str = QDRANT_COLLECTION_NAME
+
+    @property
+    def dimension(self) -> int:
+        return int(self.vectors.shape[1])
+
+    def __len__(self) -> int:
+        return int(self.vectors.shape[0])
+
+    def get(self, idx: int) -> np.ndarray:
+        return self.vectors[idx]
+
+    def persist(self, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        np.save(
+            output_dir / EMBEDDINGS_FILENAME,
+            np.asarray(self.vectors, dtype=np.float32),
+        )
+
+
+def _build_qdrant_store(vectors: np.ndarray) -> QdrantVectorStore:
+    """Build a QdrantVectorStore around an in-memory collection."""
+    try:
+        from qdrant_client import QdrantClient  # type: ignore[import-not-found]
+        from qdrant_client.models import (  # type: ignore[import-not-found]
+            Distance,
+            PointStruct,
+            VectorParams,
+        )
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "Qdrant backend requires the qdrant-client package. "
+            "Install with `pip install qdrant-client` or use "
+            "BIDMATE_INDEX_BACKEND=memory."
+        ) from exc
+
+    vectors_f32 = np.asarray(vectors, dtype=np.float32)
+    client = QdrantClient(location=":memory:")
+    # Empty matrices are valid (an index with zero chunks); the
+    # collection still needs a dimension, so we default to 1 in that
+    # degenerate case rather than crashing.
+    dim = int(vectors_f32.shape[1]) if vectors_f32.size else 1
+    # A fresh in-memory client never has the collection yet, but the
+    # exists-then-create idiom is the post-1.7 qdrant-client
+    # recommendation and survives any future code path that reuses a
+    # client.
+    if not client.collection_exists(QDRANT_COLLECTION_NAME):
+        client.create_collection(
+            collection_name=QDRANT_COLLECTION_NAME,
+            vectors_config=VectorParams(size=dim, distance=Distance.COSINE),
+        )
+    if vectors_f32.shape[0] > 0:
+        points = [
+            PointStruct(id=i, vector=vectors_f32[i].tolist())
+            for i in range(vectors_f32.shape[0])
+        ]
+        client.upsert(collection_name=QDRANT_COLLECTION_NAME, points=points)
+    return QdrantVectorStore(vectors=vectors_f32, client=client)
+
+
 def vector_store_from_matrix(vectors: np.ndarray) -> VectorStore:
-    """Wrap an in-memory float32 matrix as the default VectorStore."""
-    return InMemoryVectorStore(vectors=np.asarray(vectors, dtype=np.float32))
+    """Wrap a float32 matrix as the configured VectorStore backend.
+
+    Backend selection (``BIDMATE_INDEX_BACKEND``):
+      - ``memory`` (default) → ``InMemoryVectorStore``
+      - ``qdrant``           → ``QdrantVectorStore`` (in-memory mode)
+    ``pgvector`` is reserved for Stage 3 and raises NotImplementedError
+    via ``load_vector_store``; build-path callers should not encounter
+    it because configuration is checked before index build.
+    """
+    backend = _resolve_backend()
+    vectors_f32 = np.asarray(vectors, dtype=np.float32)
+    if backend == "qdrant":
+        return _build_qdrant_store(vectors_f32)
+    return InMemoryVectorStore(vectors=vectors_f32)
 
 
 def _resolve_backend() -> str:
@@ -101,15 +209,15 @@ def load_vector_store(
     vectors exist (matches the prior ``payload["_vectors"] = None``
     fallback in ``rag_core.load_index``).
 
-    Selects the concrete implementation by ``$BIDMATE_INDEX_BACKEND``
-    (Stage 1 only accepts ``memory``).
+    Backend selection is delegated to ``vector_store_from_matrix`` so
+    the build and read paths share one dispatch.
     """
     backend = _resolve_backend()
     if backend not in SUPPORTED_BACKENDS:
         raise NotImplementedError(
             f"Index backend {backend!r} is not yet implemented; "
-            f"Stage 1 only ships the in-memory backend. See issue #176 "
-            f"(Stage 2 = Qdrant, Stage 3 = pgvector)."
+            f"current support is {sorted(SUPPORTED_BACKENDS)}. See "
+            f"issue #176 (Stage 3 = pgvector)."
         )
 
     if schema_version >= 2:
@@ -120,11 +228,11 @@ def load_vector_store(
                 f"{embeddings_path}. Rebuild via scripts/build_index.py."
             )
         matrix = np.load(embeddings_path)
-        return InMemoryVectorStore(vectors=np.asarray(matrix, dtype=np.float32))
+        return vector_store_from_matrix(matrix)
 
     if chunks is None:
         return None
     inline = [c.get("embedding") for c in chunks]
     if not inline or any(v is None for v in inline):
         return None
-    return InMemoryVectorStore(vectors=np.asarray(inline, dtype=np.float32))
+    return vector_store_from_matrix(np.asarray(inline, dtype=np.float32))

--- a/tests/test_vector_store_protocol.py
+++ b/tests/test_vector_store_protocol.py
@@ -63,7 +63,11 @@ def test_legacy_schema1_materializes_from_inline_chunks(matrix: np.ndarray) -> N
 def test_unsupported_backend_raises(
     tmp_path: Path, matrix: np.ndarray, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # ``pgvector`` stays Stage 3 (unimplemented); selecting it today
+    # must still raise NotImplementedError. ``qdrant`` is now a
+    # supported backend (Stage 2a, #176) — see
+    # ``tests/test_vector_store_qdrant.py``.
     vector_store_from_matrix(matrix).persist(tmp_path)
-    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "pgvector")
     with pytest.raises(NotImplementedError, match="#176"):
         load_vector_store(tmp_path, schema_version=2)

--- a/tests/test_vector_store_qdrant.py
+++ b/tests/test_vector_store_qdrant.py
@@ -1,0 +1,131 @@
+"""Qdrant backend regression for the VectorStore abstraction
+(#176 Stage 2a).
+
+Tests run only when ``qdrant-client`` is installed
+(``pip install qdrant-client``); skipped otherwise. The backend uses
+Qdrant's ``location=":memory:"`` mode so no external Qdrant server is
+required.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+qdrant_client = pytest.importorskip("qdrant_client")
+
+from rag_vector_store import (  # noqa: E402  (after importorskip)
+    ENV_INDEX_BACKEND,
+    QDRANT_COLLECTION_NAME,
+    QdrantVectorStore,
+    VectorStore,
+    load_vector_store,
+    vector_store_from_matrix,
+)
+
+
+@pytest.fixture
+def matrix() -> np.ndarray:
+    rng = np.random.default_rng(seed=20260512)
+    m = rng.standard_normal((6, 4)).astype(np.float32)
+    # L2-normalize so the cosine distance on the Qdrant side matches
+    # the dot-product ranking the in-memory backend uses.
+    m /= np.linalg.norm(m, axis=1, keepdims=True)
+    return m
+
+
+def test_qdrant_store_basic_shape(
+    matrix: np.ndarray, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    store = vector_store_from_matrix(matrix)
+    assert isinstance(store, VectorStore)
+    assert isinstance(store, QdrantVectorStore)
+    assert len(store) == 6
+    assert store.dimension == 4
+
+
+def test_qdrant_get_returns_bit_identical_vector(
+    matrix: np.ndarray, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stage 2a invariant: ``get(idx)`` must return the same float32
+    row as ``InMemoryVectorStore`` would, so retrieval rankings are
+    bit-identical across backends."""
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    store = vector_store_from_matrix(matrix)
+    for i in range(matrix.shape[0]):
+        np.testing.assert_array_equal(store.get(i), matrix[i])
+
+
+def test_qdrant_collection_holds_matching_point_count(
+    matrix: np.ndarray, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guard against a silent upsert failure — the Qdrant collection
+    must hold the same number of points as the matrix."""
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    store = vector_store_from_matrix(matrix)
+    assert isinstance(store, QdrantVectorStore)
+    info = store.client.get_collection(QDRANT_COLLECTION_NAME)
+    assert info.points_count == matrix.shape[0]
+
+
+def test_qdrant_persist_writes_sidecar(
+    tmp_path: Path, matrix: np.ndarray, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stage 2a persist still writes ``embeddings.npy`` so users can
+    switch backends without rebuilding."""
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    store = vector_store_from_matrix(matrix)
+    store.persist(tmp_path)
+    sidecar = tmp_path / "embeddings.npy"
+    assert sidecar.exists()
+    np.testing.assert_array_equal(np.load(sidecar), matrix)
+
+
+def test_qdrant_persist_roundtrip_via_load_vector_store(
+    tmp_path: Path, matrix: np.ndarray, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``qdrant`` persist + ``qdrant`` load must round-trip
+    bit-identical rows."""
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    store = vector_store_from_matrix(matrix)
+    store.persist(tmp_path)
+    restored = load_vector_store(tmp_path, schema_version=2)
+    assert isinstance(restored, QdrantVectorStore)
+    assert len(restored) == len(store)
+    assert restored.dimension == store.dimension
+    for i in range(len(store)):
+        np.testing.assert_array_equal(restored.get(i), store.get(i))
+
+
+def test_qdrant_backend_switchable_from_memory_sidecar(
+    tmp_path: Path, matrix: np.ndarray, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user who built the index with ``memory`` (default) can switch
+    to ``qdrant`` on a subsequent load without rebuilding."""
+    # Build + persist under the default ``memory`` backend.
+    monkeypatch.delenv(ENV_INDEX_BACKEND, raising=False)
+    memory_store = vector_store_from_matrix(matrix)
+    memory_store.persist(tmp_path)
+    # Now load under ``qdrant`` and expect the same vectors.
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    qdrant_store = load_vector_store(tmp_path, schema_version=2)
+    assert isinstance(qdrant_store, QdrantVectorStore)
+    for i in range(len(memory_store)):
+        np.testing.assert_array_equal(
+            qdrant_store.get(i), memory_store.get(i)
+        )
+
+
+def test_qdrant_empty_matrix_does_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero-chunk indexes are degenerate but legal; the Qdrant
+    backend must build a collection with the right dimension and zero
+    points instead of raising."""
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    empty = np.zeros((0, 4), dtype=np.float32)
+    store = vector_store_from_matrix(empty)
+    assert isinstance(store, QdrantVectorStore)
+    assert len(store) == 0


### PR DESCRIPTION
## 1. What changed and why

Closes #176 (Stage 2a). Maintainer note: Stage 2b (`query` Protocol + ANN pushdown), Stage 3 (pgvector), and the 100k-chunk benchmark are listed in §7 Out of scope — please reopen #176 after merge or split them into new issues so the trail stays linkable.

Stage 2a extends the VectorStore abstraction (#234, Stage 1) with a Qdrant backend that runs in Qdrant's `location=":memory:"` mode, so no external Qdrant server is required for CI. `get(idx)` returns the bit-identical row a `InMemoryVectorStore` would — retrieval ranking is unchanged — but the Qdrant collection is built in parallel so a future Stage 2b can introduce a Protocol-level `query(qvec, top_k)` and delegate ANN search to Qdrant without rebuilding the index.

Why split into Stage 2a / 2b: the issue body bundles "Qdrant backend" with "100k-chunk synthetic benchmark + Korean cloud note", both of which need real Qdrant hosting + ablation runs. Landing the adapter first lets reviewers see the backend plumb without waiting on the benchmark sprint.

## 2. Files affected

- `rag_vector_store.py` — **load-bearing**. New `QdrantVectorStore` dataclass + `_build_qdrant_store` helper + dispatch in `vector_store_from_matrix`. `load_vector_store` now delegates to `vector_store_from_matrix` so build and read paths share one switch.
- `tests/test_vector_store_protocol.py` — `test_unsupported_backend_raises` switched from `qdrant` (now supported) to `pgvector` (still Stage 3, unimplemented).
- `tests/test_vector_store_qdrant.py` — **new**, 7 tests gated by `pytest.importorskip("qdrant_client")`.

No other load-bearing file (`rag_core.py` / `ingestion.py` / `visual_ingestion.py` / `eval/` / `api/`) touched.

## 3. Risks

Most likely failure mode: a divergence between `InMemoryVectorStore.get(idx)` and `QdrantVectorStore.get(idx)` lets the Qdrant backend silently rank chunks differently. Ruled out by:

1. Stage 2a deliberately keeps the same float32 matrix on `QdrantVectorStore.vectors` and returns rows from it (Qdrant collection is upserted in parallel but **not** consulted for `get`). `test_qdrant_get_returns_bit_identical_vector` and `test_qdrant_backend_switchable_from_memory_sidecar` cover this.
2. Persist writes the existing `embeddings.npy` sidecar, so a user can switch backends across runs without rebuilding the index — `test_qdrant_persist_roundtrip_via_load_vector_store` exercises the round-trip.

Second risk: `qdrant-client` import breaks the suite when it's not installed. Ruled out by `pytest.importorskip` on the qdrant test file and a lazy `try/except ImportError` in `_build_qdrant_store` that raises a clear RuntimeError pointing at `pip install qdrant-client`.

## 4. Tests

`tests/test_vector_store_qdrant.py` (new, 7 tests):
1. `test_qdrant_store_basic_shape` — backend resolves to `QdrantVectorStore`, dimension + len.
2. `test_qdrant_get_returns_bit_identical_vector` — bit equality vs the matrix.
3. `test_qdrant_collection_holds_matching_point_count` — Qdrant `get_collection(...).points_count == N`.
4. `test_qdrant_persist_writes_sidecar` — `embeddings.npy` written.
5. `test_qdrant_persist_roundtrip_via_load_vector_store` — write + load both under `qdrant`.
6. `test_qdrant_backend_switchable_from_memory_sidecar` — memory-built sidecar loads under qdrant.
7. `test_qdrant_empty_matrix_does_not_crash` — zero-chunk edge case.

`tests/test_vector_store_protocol.py` keeps its 4 existing tests; the unsupported-backend one now targets `pgvector` and the docstring points users at the qdrant file for the formerly-unimplemented backend.

`pytest -q` full suite: **469 → 483 passed, 121 subtests, 6.65s** (+7 new qdrant + +7 from other in-flight branches that landed during the worktree's lifetime). No existing test flipped. The pre-existing `recreate_collection` DeprecationWarning was fixed by switching to the qdrant-client 1.7+ `collection_exists` + `create_collection` idiom.

## 5. Eval impact

All `·` expected. Backend dispatch is opt-in by env var; the default (`memory`) path is byte-identical to main.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** `QdrantVectorStore.get(idx)` returns the same float32 row as `InMemoryVectorStore.get(idx)` because Stage 2a keeps the matrix on the instance. `make real-eval-delta` will show all `·` under the default backend, and bit-identical rankings under `BIDMATE_INDEX_BACKEND=qdrant`.

## 6. Backward compatibility

Strictly additive:
- Default backend is still `memory`; `embeddings.npy` sidecar format is unchanged.
- `QDRANT_COLLECTION_NAME` is exposed for future migration tooling; renaming it later is breaking and would need a new ADR.
- `qdrant-client` is **not** added to `requirements.txt`. It joins `requirements-dev.txt` in the follow-up Stage 2b PR (which is when CI starts exercising the backend).

## 7. Out of scope

Per #176 acceptance, the following are deferred to follow-up PRs:

- **Stage 2b**: Protocol-level `query(qvec, top_k)` + filter pushdown, dropping the parallel matrix, ANN ranking from Qdrant.
- **Stage 3**: pgvector backend (SaaS-Postgres scale).
- 100k-chunk synthetic corpus generator + p50/p95 benchmark across memory / qdrant / pgvector / scale tiers.
- `docs/scale-experiment.md` write-up with the inflection point.
- Korean cloud (Naver Cloud / Kakao Cloud Postgres-flavored) compatibility note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
