### PR TITLE
fix(leaderboard): preserve top-level ci block through extract_aggregate

### DIFF
--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -79,8 +79,34 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         # commit boundary; per-case verdicts stay in
         # reports/eval_summary.judge.local.json and reports/judge_cache/.
         "judge_ragas",
+        # Bootstrap 95% CI per headline metric (issue #166 / #267 leaderboard).
+        # The block is {metric: {mean, ci_lo, ci_hi, n, num_resamples, alpha}};
+        # the extractor below whitelists both the metric and sub-key sets.
+        "ci",
     }
 )
+
+# Headline metrics whose bootstrap CI is allowed to round-trip the
+# extractor. Mirrors the scalar metrics already whitelisted at the top
+# level (run_eval.py:1213) so `aggregate.json` and `aggregate.json["ci"]`
+# can never carry different metric inventories.
+SAFE_CI_METRIC_KEYS = (
+    "accuracy",
+    "groundedness",
+    "citation_precision",
+    "citation_page_precision",
+    "citation_region_precision",
+    "citation_grounding",
+    "claim_citation_alignment",
+    "answer_format_compliance",
+    "abstention",
+    "retry",
+    # Comparison-aware retrieval metrics (run_eval.py:1273-1279) — only
+    # populated when the eval includes comparison cases.
+    "comparison_target_recall",
+    "comparison_pool_recall",
+)
+SAFE_CI_SUB_KEYS = ("mean", "ci_lo", "ci_hi", "n", "num_resamples", "alpha")
 
 # RAGAS metric sub-keys whitelisted from `judge_ragas`. Float scalars + CI dicts.
 SAFE_JUDGE_RAGAS_METRIC_KEYS = (
@@ -229,6 +255,21 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                     extracted["cross_ablation"] = cross_out
             if extracted:
                 out[key] = extracted
+        elif key == "ci" and isinstance(value, dict):
+            ci_out: dict[str, Any] = {}
+            for metric in SAFE_CI_METRIC_KEYS:
+                metric_ci = value.get(metric)
+                if not isinstance(metric_ci, dict):
+                    continue
+                trimmed = {
+                    sub: metric_ci.get(sub)
+                    for sub in SAFE_CI_SUB_KEYS
+                    if metric_ci.get(sub) is not None
+                }
+                if trimmed:
+                    ci_out[metric] = trimmed
+            if ci_out:
+                out[key] = ci_out
         elif key == "run_manifest" and isinstance(value, dict):
             # Drop config_path (filesystem layout, not committable).
             # Keep git_commit / git_dirty / config_sha256 / generated_at.

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -55,6 +55,18 @@ def _snapshot(
                 "ci_hi": min(1.0, accuracy + 0.07),
                 "n": 42,
             },
+            "citation_precision": {
+                "mean": accuracy - 0.01,
+                "ci_lo": max(0.0, accuracy - 0.06),
+                "ci_hi": min(1.0, accuracy + 0.04),
+                "n": 42,
+            },
+            "answer_format_compliance": {
+                "mean": accuracy,
+                "ci_lo": max(0.0, accuracy - 0.04),
+                "ci_hi": min(1.0, accuracy + 0.04),
+                "n": 42,
+            },
         },
         "provenance": {
             "git_commit": sha,
@@ -148,6 +160,21 @@ class LeaderboardRenderTest(unittest.TestCase):
             self.assertIn(key, data["metrics"])
             self.assertEqual(2, len(data["metrics"][key]["values"]))
             self.assertEqual(2, len(data["metrics"][key]["ci_lo"]))
+        # Issue #267 regression: CI bands must be numeric, not None,
+        # when the source snapshots include a ci block. A previous bug
+        # let extract_aggregate strip the ci block silently, leaving
+        # the chart bands as null arrays and a flat-line leaderboard.
+        for key, _ in HEADLINE_METRICS:
+            ci_lo = data["metrics"][key]["ci_lo"]
+            ci_hi = data["metrics"][key]["ci_hi"]
+            self.assertTrue(
+                all(isinstance(v, (int, float)) for v in ci_lo),
+                f"{key} ci_lo lost numeric values during round-trip: {ci_lo}",
+            )
+            self.assertTrue(
+                all(isinstance(v, (int, float)) for v in ci_hi),
+                f"{key} ci_hi lost numeric values during round-trip: {ci_hi}",
+            )
 
     def test_page_does_not_leak_per_case_fields_if_present_in_history(self) -> None:
         """Defense-in-depth: even if a history file contained case_results

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -341,6 +341,80 @@ class ExtractAggregateTest(unittest.TestCase):
         self.assertIn("0.950", md)
 
 
+class CIBlockExtractTest(unittest.TestCase):
+    """Bootstrap CI block (#166 leaderboard / #267 chart bands) must
+    round-trip the headline-metric subset and drop unknown sub-keys
+    or per-case payload smuggled in by a future maintainer."""
+
+    SUMMARY_WITH_CI = {
+        **FULL_SUMMARY,
+        "ci": {
+            "accuracy": {
+                "mean": 0.471,
+                "ci_lo": 0.286,
+                "ci_hi": 0.667,
+                "n": 21,
+                "num_resamples": 1000,
+                "alpha": 0.05,
+            },
+            "groundedness": {
+                "mean": 0.476,
+                "ci_lo": 0.286,
+                "ci_hi": 0.667,
+                "n": 21,
+            },
+            # Unknown metric — must be dropped.
+            "made_up_metric": {"mean": 0.99, "ci_lo": 0.98, "ci_hi": 1.0},
+            # Per-case smuggling attempt — extractor must drop the entire
+            # entry because the inner shape is wrong (list, not dict).
+            "case_results": [{"id": "leak", "query": "leak"}],
+        },
+    }
+
+    def test_ci_block_round_trips_for_whitelisted_metrics(self) -> None:
+        agg = extract_aggregate(self.SUMMARY_WITH_CI)
+        ci = agg["ci"]
+        self.assertIn("accuracy", ci)
+        self.assertIn("groundedness", ci)
+        self.assertAlmostEqual(0.286, ci["accuracy"]["ci_lo"])
+        self.assertAlmostEqual(0.667, ci["accuracy"]["ci_hi"])
+        self.assertEqual(21, ci["accuracy"]["n"])
+        self.assertEqual(1000, ci["accuracy"]["num_resamples"])
+
+    def test_ci_unknown_metrics_dropped(self) -> None:
+        agg = extract_aggregate(self.SUMMARY_WITH_CI)
+        self.assertNotIn("made_up_metric", agg["ci"])
+        self.assertNotIn("case_results", agg["ci"])
+
+    def test_ci_no_leak_strings(self) -> None:
+        agg = extract_aggregate(self.SUMMARY_WITH_CI)
+        self.assertNotIn("leak", json.dumps(agg))
+
+    def test_ci_unknown_sub_keys_dropped(self) -> None:
+        summary = {
+            **FULL_SUMMARY,
+            "ci": {
+                "accuracy": {
+                    "mean": 0.5,
+                    "ci_lo": 0.3,
+                    "ci_hi": 0.7,
+                    # Smuggling attempts — must be dropped.
+                    "raw_scores": [0.1, 0.2, 0.3],
+                    "case_ids": ["c1", "c2"],
+                }
+            },
+        }
+        agg = extract_aggregate(summary)
+        self.assertEqual(
+            set(agg["ci"]["accuracy"].keys()),
+            {"mean", "ci_lo", "ci_hi"},
+        )
+
+    def test_ci_omitted_when_summary_has_no_ci(self) -> None:
+        agg = extract_aggregate(FULL_SUMMARY)
+        self.assertNotIn("ci", agg)
+
+
 class FullScriptInvocationTest(unittest.TestCase):
     """Smoke-test the full script end-to-end via subprocess so the
     CLI argument plumbing is exercised."""


### PR DESCRIPTION
## 1. What changed and why

The synthetic eval leaderboard (#166) showed a flat line across all 11 history commits because `extract_aggregate()` in `scripts/run_real_eval_delta.py` stripped the top-level `ci` block emitted by `eval/run_eval.py:1213-1224`. `write_synthetic_history.py` therefore wrote snapshots without CI data, and `scripts/leaderboard.py` rendered chart bands as `null` arrays — defeating the leaderboard's purpose (readers cannot distinguish *no change* from *cannot detect change*).

This change adds `"ci"` to `SAFE_TOPLEVEL_KEYS` with an extractor that whitelists headline metrics + CI sub-keys (`mean`, `ci_lo`, `ci_hi`, `n`, `num_resamples`, `alpha`), reusing the defense-in-depth pattern already in place for `judge_ragas.ci` (ADR 0012) and `retry_effectiveness.ci` (#120).

Closes #289

## 2. Files affected

- `scripts/run_real_eval_delta.py` — added `"ci"` to `SAFE_TOPLEVEL_KEYS`, added `SAFE_CI_METRIC_KEYS` / `SAFE_CI_SUB_KEYS`, added extractor branch
- `tests/test_run_real_eval_delta.py` — new `CIBlockExtractTest` class (4 tests)
- `tests/test_leaderboard.py` — fixture expanded to include all 4 headline metrics' CI; existing test tightened to assert CI bands are *numeric*, not just present

None of the load-bearing files (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`) are touched.

## 3. Risks

The most likely failure mode: an upstream `eval_summary.json` carrying an unexpected sub-key inside `ci.<metric>` would silently get included in committed aggregates, violating ADR 0005. Ruled out by `SAFE_CI_SUB_KEYS` allowlist + new `test_ci_unknown_sub_keys_dropped` regression test (smuggles `raw_scores` and `case_ids` and asserts they are dropped).

Second risk: schema drift — a new metric added to `bootstrap_ci(...)` in `eval/run_eval.py` would not flow through unless added to `SAFE_CI_METRIC_KEYS`. This is intentional fail-closed behavior; the new metric simply won't appear on the leaderboard until explicitly whitelisted.

## 4. Tests

`tests/test_run_real_eval_delta.py::CIBlockExtractTest` — 4 new tests:
- `test_ci_block_round_trips_for_whitelisted_metrics`
- `test_ci_unknown_metrics_dropped` (smuggles `made_up_metric` and `case_results`)
- `test_ci_no_leak_strings`
- `test_ci_unknown_sub_keys_dropped` (smuggles per-case `raw_scores`)
- `test_ci_omitted_when_summary_has_no_ci`

`tests/test_leaderboard.py::test_render_page_embeds_valid_chart_data` — strengthened: now asserts `ci_lo` / `ci_hi` arrays are numeric, not just length-correct (the prior assertion let the bug pass).

`pytest -q` — 474 passed (full suite, no regressions).

## 5. Eval impact

All `·` for the synthetic CI delta — this PR does not change retrieval, verification, or answer generation. The only behavior change is in aggregate extraction for committed history snapshots.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path. The change is purely additive to the aggregate extractor (whitelist now includes the existing top-level `ci` block from `eval/run_eval.py`). Real-data metric values do not move.

## 6. Backward compatibility

No contract break. Existing 11 history snapshots without `ci` continue to render correctly (chart bands stay `null` for those rows). New CI runs after merge will produce snapshots with CI data and proper bands. No `schema_version` bump required (ADR 0003 contract untouched).

## 7. Out of scope

- Backfilling the 11 existing history snapshots with CI data — would require re-running eval at each historical commit; deferred to a separate run.
- Validating `_assert_no_forbidden` recursive scan on the new `ci` payload — already covered by the existing assertion (the recursive scanner runs against the full output of `extract_aggregate`).