### PR TITLE
chore(make): add external-baselines-{stub,langchain,llamaindex} shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup index ask eval benchmark benchmark-check check check-latency korean-public-eval korean-public-fetch smoke smoke-with-judge reproduce harness-smoke harness-real harness-ablation harness-compare test test-regression api api-docker demo demo-docker pareto docker-publish real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
+.PHONY: setup index ask eval benchmark benchmark-check check check-latency korean-public-eval korean-public-fetch external-baselines-stub external-baselines-langchain external-baselines-llamaindex smoke smoke-with-judge reproduce harness-smoke harness-real harness-ablation harness-compare test test-regression api api-docker demo demo-docker pareto docker-publish real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -70,6 +70,27 @@ korean-public-fetch:
 
 korean-public-eval: korean-public-fetch
 	$(PYTHON) eval/korean_public/run.py
+
+# External baseline comparison (ADR 0009 / issue #157).
+# Stub backend is deterministic and free — exercises the comparison
+# infrastructure without API cost. Live backends require ANTHROPIC_API_KEY
+# and a one-time install of the SDK extras (~$2 / 42 cases at Sonnet 4.6).
+external-baselines-stub:
+	BIDMATE_EXTERNAL_BACKEND=stub $(PYTHON) scripts/compare_external_baselines.py
+
+external-baselines-langchain:
+	@if [ -z "$$ANTHROPIC_API_KEY" ]; then \
+		echo "ANTHROPIC_API_KEY not set. Live LangChain run needs an Anthropic key (~\$$2 / 42 cases)."; \
+		exit 1; \
+	fi
+	BIDMATE_EXTERNAL_BACKEND=langchain $(PYTHON) scripts/compare_external_baselines.py
+
+external-baselines-llamaindex:
+	@if [ -z "$$ANTHROPIC_API_KEY" ]; then \
+		echo "ANTHROPIC_API_KEY not set. Live LlamaIndex run needs an Anthropic key (~\$$2 / 42 cases)."; \
+		exit 1; \
+	fi
+	BIDMATE_EXTERNAL_BACKEND=llamaindex $(PYTHON) scripts/compare_external_baselines.py
 
 smoke:
 	bash scripts/smoke.sh


### PR DESCRIPTION
## 1. What changed and why

`scripts/compare_external_baselines.py` (ADR 0009) already supports `stub` / `langchain` / `llamaindex` backends via `BIDMATE_EXTERNAL_BACKEND`, but each invocation required spelling out the env-var prefix. This adds three Makefile targets so live runs are one line.

The two live targets guard against missing `ANTHROPIC_API_KEY` with a friendly error including the cost estimate (`~$2 / 42 cases at Sonnet 4.6`). Stub stays free and deterministic — exercises the comparison infrastructure without API cost, suitable for tests / CI / contributors without keys.

Per ADR 0009 these are *not* invoked by `make smoke` or `pr-eval.yml`; public CI stays deterministic and free.

Closes #157

## 2. Files affected

- `Makefile` — added 3 targets + updated `.PHONY` line

None of the load-bearing files (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`) are touched.

## 3. Risks

The most likely failure mode: a contributor without `ANTHROPIC_API_KEY` runs `make external-baselines-langchain` and sees the guard error message. Verified: the guard runs *before* `python3` is invoked (via `@if [ -z "$$ANTHROPIC_API_KEY" ]`), so no Python import is attempted; the error message is the only output. The stub target has no guard and runs the full deterministic comparison.

Second risk: the `.PHONY` line drift if a target is renamed in the future. Mitigated by keeping the new targets adjacent to existing eval-related targets (after `check-latency`) so they get touched together.

## 4. Tests

N/A — Makefile target additions don't have test coverage in this repo. Manual verification:
- `make -n external-baselines-stub external-baselines-langchain external-baselines-llamaindex check-latency`: all 4 targets parse and resolve
- `BIDMATE_EXTERNAL_BACKEND=stub python3 scripts/compare_external_baselines.py` (the underlying invocation): exits 0 with deterministic accuracy=1.0 / retrieval_recall=1.0

## 5. Eval impact

All `·`. No retrieval / verification / answer behavior change. The targets invoke an existing script.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path. Pure Makefile shortcut.

## 6. Backward compatibility

No contract break. Existing targets (`check`, `check-latency`, `smoke`, etc.) unchanged. The 3 new targets are additive.

## 7. Out of scope

- Wiring `external-baselines-stub` into `make smoke` — explicitly rejected per ADR 0009 (CI should not depend on external SDKs even in stub mode, since the script imports `langchain` lazily but the backend selector path is exercised).
- README update with comparison results — separate work, requires actually running live and committing the resulting `reports/external_baselines.json` aggregate.