### PR TITLE
feat: arun_rag_query async wrapper + FastAPI await (#173 Stage 1)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -28,9 +28,9 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 
 from rag_core import (
     DEFAULT_CLI_PIPELINE_NAME,
+    arun_rag_query,
     load_index,
     pipeline_cli_choices,
-    run_rag_query,
 )
 
 from .schemas import QueryRequest
@@ -145,7 +145,7 @@ def pipelines(request: Request) -> dict[str, Any]:
 
 
 @app.post("/query")
-def query(
+async def query(
     body: QueryRequest,
     request: Request,
     index: dict[str, Any] = Depends(get_index),
@@ -153,12 +153,16 @@ def query(
     """Run one RAG query and return the raw answer dict.
 
     The response shape is intentionally **not** wrapped in a pydantic
-    model — it passes through whatever ``run_rag_query`` returns so the
-    API never drifts from the canonical answer / citation contract.
+    model — it passes through whatever ``arun_rag_query`` returns so
+    the API never drifts from the canonical answer / citation contract.
+    ``arun_rag_query`` runs the sync RAG pipeline on a worker thread
+    (``asyncio.to_thread``) so the event loop stays free for the next
+    request (#173 Stage 1). Fan-out parallelism of comparison-query
+    branches is Stage 2.
     """
     pipeline = body.pipeline or request.app.state.default_pipeline
     try:
-        return run_rag_query(
+        return await arun_rag_query(
             index,
             body.query,
             pipeline=pipeline,

--- a/rag_core.py
+++ b/rag_core.py
@@ -4223,6 +4223,58 @@ def run_rag_query(
     return result
 
 
+async def arun_rag_query(
+    index: dict[str, Any],
+    query: str,
+    top_k: int | None = None,
+    context_entities: list[str] | None = None,
+    metadata_first: bool | None = None,
+    rerank: bool | None = None,
+    verifier_retry: bool | None = None,
+    retrieval_mode: str | None = None,
+    retrieval_backend: str | None = None,
+    pipeline: str | None = None,
+    prompt_profile: str | None = None,
+    conversation_state: dict[str, Any] | None = None,
+    comparison_balance: dict[str, Any] | None = None,
+    rrf_k: int | None = None,
+    bm25_stopword_profile: str | None = None,
+) -> dict[str, Any]:
+    """Async-aware entry point for the RAG pipeline (#173 Stage 1).
+
+    Stage 1 (this PR): thin async wrapper that runs
+    :func:`run_rag_query` on a worker thread via
+    :func:`asyncio.to_thread` so async callers (FastAPI, future
+    Streamlit-async hooks) do not block the event loop. The sync
+    body and its output are byte-identical to ``run_rag_query`` —
+    no behavior change.
+
+    Stage 2 (deferred): fan-out the comparison-query per-target
+    retrieval branches with :func:`asyncio.gather`. The async
+    surface introduced here is the seam Stage 2 needs.
+    """
+    import asyncio
+
+    return await asyncio.to_thread(
+        run_rag_query,
+        index,
+        query,
+        top_k=top_k,
+        context_entities=context_entities,
+        metadata_first=metadata_first,
+        rerank=rerank,
+        verifier_retry=verifier_retry,
+        retrieval_mode=retrieval_mode,
+        retrieval_backend=retrieval_backend,
+        pipeline=pipeline,
+        prompt_profile=prompt_profile,
+        conversation_state=conversation_state,
+        comparison_balance=comparison_balance,
+        rrf_k=rrf_k,
+        bm25_stopword_profile=bm25_stopword_profile,
+    )
+
+
 def strip_internal_scores(evidence: list[dict[str, Any]]) -> list[dict[str, Any]]:
     stripped = []
     for item in evidence:

--- a/tests/test_async_rag_query_regression.py
+++ b/tests/test_async_rag_query_regression.py
@@ -1,0 +1,92 @@
+"""Parity regression for ``arun_rag_query`` (#173 Stage 1).
+
+``arun_rag_query`` is a thin ``asyncio.to_thread`` wrapper around
+``run_rag_query`` — Stage 1 introduces the async seam without
+fan-out parallelism, so the two entry points MUST produce
+byte-equivalent results on the same input.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from pathlib import Path
+
+import pytest
+
+from rag_core import arun_rag_query, build_index_payload, run_rag_query
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+class AsyncRagQueryParityTest(unittest.TestCase):
+    """Stage 1 contract: sync and async entry points return identical dicts."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_shared_index(self, shared_raw_index):
+        self.index = shared_raw_index
+
+    def _run_async(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+    def test_arun_returns_dict_with_expected_keys(self) -> None:
+        result = self._run_async(
+            arun_rag_query(self.index, "기관 A의 보안 통제 요구사항은?")
+        )
+        self.assertIsInstance(result, dict)
+        for key in ("answer", "evidence", "diagnostics", "plan"):
+            self.assertIn(key, result, f"missing {key!r} in arun result")
+
+    def test_arun_matches_run_on_single_doc_query(self) -> None:
+        query = "기관 A의 보안 통제 요구사항은?"
+        sync_result = run_rag_query(self.index, query)
+        async_result = self._run_async(arun_rag_query(self.index, query))
+        # diagnostics.latency_ms and stage_latency are wall-clock —
+        # they will differ between two runs. Strip them before
+        # comparing the structural payload.
+        self._assert_structural_equal(sync_result, async_result)
+
+    def test_arun_propagates_keyword_args(self) -> None:
+        query = "기관 A의 보안 통제 요구사항은?"
+        sync_result = run_rag_query(
+            self.index, query, pipeline="naive_baseline", top_k=4
+        )
+        async_result = self._run_async(
+            arun_rag_query(
+                self.index, query, pipeline="naive_baseline", top_k=4
+            )
+        )
+        self._assert_structural_equal(sync_result, async_result)
+        # naive_baseline pipeline must surface in the diagnostics too.
+        self.assertEqual(
+            sync_result["diagnostics"].get("pipeline"),
+            async_result["diagnostics"].get("pipeline"),
+        )
+
+    # ------------------------------------------------------------------
+
+    def _assert_structural_equal(
+        self, sync_result: dict, async_result: dict
+    ) -> None:
+        """Compare the answer / evidence / plan branches, ignoring
+        wall-clock fields that legitimately differ between runs."""
+        self.assertEqual(sync_result["answer"], async_result["answer"])
+        self.assertEqual(sync_result["evidence"], async_result["evidence"])
+        # ``plan`` is deterministic apart from any latency tracking —
+        # compare the keys we care about explicitly.
+        for key in (
+            "pipeline",
+            "top_k",
+            "metadata_first",
+            "rerank",
+            "filter_stage",
+        ):
+            self.assertEqual(
+                sync_result["plan"].get(key),
+                async_result["plan"].get(key),
+                f"plan[{key!r}] diverged between sync and async paths",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #173 (Stage 1 — reopen on merge for Stage 2 fan-out work).

Introduces the async seam without behavior change. `arun_rag_query` runs the existing sync `run_rag_query` body on a worker thread via `asyncio.to_thread` so async callers (FastAPI, future async hooks) do not block the event loop. Stage 2 will fan-out the comparison-query per-target retrieval branches with `asyncio.gather`; the async surface introduced here is the seam Stage 2 needs.

**`#173` batched-embedding line item is already in `main`** — `embed_texts(texts)` calls `model.encode(texts, ...)` with the full list (`rag_core.py:1054`) and `build_index_payload` calls `embed_texts` once with every chunk (`rag_core.py:1207`). Verified, no change needed.

## 2. Files affected

- `rag_core.py` — **load-bearing**. New `arun_rag_query` mirrors `run_rag_query`'s keyword surface 1:1 and forwards through `asyncio.to_thread`. Sync entry point untouched — Streamlit / CLI / eval keep working unchanged.
- `api/main.py` — `/query` switches to `async def` + `await arun_rag_query(...)`. Throughput under concurrent load improves even before Stage 2 because requests no longer serialize on FastAPI's bounded sync-handler thread pool.
- `tests/test_async_rag_query_regression.py` — **new**, 3 parity tests.

No other load-bearing file (`ingestion.py` / `visual_ingestion.py` / `eval/` / `docs/adr/`) touched.

## 3. Risks

**Behavior drift between sync and async paths** — `asyncio.to_thread` runs the sync body on a default executor worker; thread-local state in `run_rag_query` could behave differently. Ruled out by:

1. The structural parity test compares `answer` + `evidence` payloads between `run` and `arun` on two pipelines (`agentic_full` default and `naive_baseline`).
2. `run_rag_query`'s only mutable global is `_PROCESS_WARM`, which is process-level (not thread-local) — `cold_start` flag still flips correctly.
3. `_StageTimer` is a per-instance context manager that writes into a dict passed in from `run_rag_query`. The async wrapper does not share the dict across calls; each `arun_rag_query` call gets its own `stage_timings`.

**FastAPI handler signature change** — `def query(...)` → `async def query(...)` is a contract change for any external code that imports the handler directly. There is no such caller in this repo (verified by `grep -rn "from api.main import query"` → 0 hits); FastAPI itself dispatches by route, not by handler symbol.

**`_StageTimer` thread-safety under Stage 2 fan-out** — out of scope here. Stage 2 will need a per-branch timing wrapper because multiple branches will write into the same `stage_timings` dict concurrently. Called out as a deferred concern in the issue body.

## 4. Tests

`tests/test_async_rag_query_regression.py` (3 new):
- `test_arun_returns_dict_with_expected_keys` — answer / evidence / diagnostics / plan keys present.
- `test_arun_matches_run_on_single_doc_query` — structural parity on default pipeline.
- `test_arun_propagates_keyword_args` — `pipeline="naive_baseline"` + `top_k=4` flow through correctly.

Plus the entire existing `tests/test_api.py` (FastAPI TestClient over the new async handler) and ranking-invariance suite stay green.

`pytest -q` full suite: **611 → 614 passed, 121 subtests, 7.01s**. No existing test flipped.

## 5. Eval impact

All `·` expected. The sync `run_rag_query` body is byte-identical; the async wrapper only changes the threading model around it.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** The sync body and its outputs are unchanged; `arun_rag_query` is a `asyncio.to_thread` wrapper. `make real-eval-delta` will show all `·`.

The latency target (p95 −30% on comparison queries) is a **Stage 2** outcome — Stage 1 only moves the work off the event loop, which does not change wall-clock for a single request. Stage 2's `asyncio.gather` over per-target retrieval is where the p95 win comes from.

## 6. Backward compatibility

`run_rag_query` is fully preserved — same signature, same behavior, same imports. New `arun_rag_query` is opt-in. FastAPI handler symbol is private (`api.main:query`) and not imported anywhere.

## 7. Out of scope (Stage 2)

- **Fan-out parallelism**: rewrite the comparison-query per-target retrieval inside `run_rag_query` so the targets dispatch concurrently via `asyncio.gather`. This is where the p95 −30% target lives.
- **`_StageTimer` async-safe rewrite**: per-branch timing collection without dict races once fan-out lands.
- **`docs/perf-improvements.md`**: before/after p50/p95 measurement on the same eval set. Needs Stage 2 + user-env benchmarking.
- **Streamlit async hook**: currently Streamlit uses the sync wrapper; an async hook would let multiple queries run concurrently in the demo. Low priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)