### PR TITLE
fix(demo): single-mode run_pipeline() call missing index argument

### DIFF
--- a/demo/streamlit_app.py
+++ b/demo/streamlit_app.py
@@ -259,7 +259,7 @@ if run_btn and query.strip():
         )
     else:
         try:
-            result = run_pipeline(
+            result = _run(
                 query,
                 pipeline=pipeline,
                 top_k=top_k,

--- a/tests/test_demo_helpers.py
+++ b/tests/test_demo_helpers.py
@@ -81,6 +81,30 @@ class StreamlitModuleSyntaxTest(unittest.TestCase):
         self.assertIn("from demo.helpers import", source)
         self.assertIn("SAMPLE_QUERIES", source)
 
+    def test_run_pipeline_calls_pass_index_first(self) -> None:
+        # Regression for issue #303: a single-mode call site invoked
+        # ``run_pipeline(query, ...)`` directly, mapping ``query`` to the
+        # ``index`` parameter and producing a TypeError at request time.
+        # Every call to ``run_pipeline`` in the Streamlit module must pass
+        # at least 2 positional args (index, query) — caller code should
+        # use the ``_run`` helper which auto-injects ``get_index()``.
+        path = ROOT_DIR / "demo" / "streamlit_app.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        bad_calls: list[tuple[int, int]] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "run_pipeline":
+                if len(node.args) < 2:
+                    bad_calls.append((node.lineno, len(node.args)))
+        self.assertEqual(
+            bad_calls, [],
+            f"streamlit_app.py has run_pipeline() calls with <2 positional args "
+            f"at {bad_calls}. Use _run(query, ...) instead — _run injects "
+            f"get_index() as the first positional arg. See issue #303.",
+        )
+
 
 class RunPipelineIntegrationTest(unittest.TestCase):
     """End-to-end exercise of ``run_pipeline`` against the real index.


### PR DESCRIPTION
## 1. What changed and why

The live HF Spaces demo was raising `TypeError: run_pipeline() missing 1 required positional argument: 'query'` on every **Run query** click in single-mode (default). Compare-mode (extractive vs LLM side-by-side) worked because that path correctly routes through the `_run` helper which auto-injects `get_index()` as the first positional argument.

The single-mode call site at [demo/streamlit_app.py:262](demo/streamlit_app.py#L262) bypassed `_run` and called `run_pipeline(query, ...)` directly — mapping `query` to the `index` parameter and leaving no `query` argument.

This PR replaces the direct `run_pipeline()` call with `_run(query, ...)` to match the compare-mode pattern. One-line behavior fix + an AST-based regression guard.

The hot-fix has already been applied directly to the HF Space repo (`hskim-solv/bidmate-docagent`) to unblock the live demo. This PR brings the source repo back in sync.

Closes #303

## 2. Files affected

- `demo/streamlit_app.py` — line 262: `run_pipeline(...)` → `_run(...)` (1 line)
- `tests/test_demo_helpers.py` — added `test_run_pipeline_calls_pass_index_first` to existing `StreamlitModuleSyntaxTest` class (~17 lines)

None of the load-bearing files (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`) are touched.

## 3. Risks

The most likely failure mode: the new regression test is too strict and rejects a legitimate `run_pipeline()` call that *intentionally* has explicit index passed positionally. Verified by grep: the only other `run_pipeline(...)` invocation in `streamlit_app.py` is inside the `_run` helper definition (line 148), which passes `get_index(), query` — 2 positional args. The test's `len(node.args) >= 2` threshold accepts this and rejects only the bug pattern.

Second risk: future callers might want a different signature for `run_pipeline`. If someone changes `run_pipeline` to take a different number of positional args, this AST test would need updating. Acceptable cost for a regression that broke the live demo for every reviewer.

## 4. Tests

- `tests/test_demo_helpers.py::StreamlitModuleSyntaxTest::test_run_pipeline_calls_pass_index_first` — new static AST test. Walks `streamlit_app.py` and asserts every `run_pipeline(...)` call has ≥2 positional arguments. Same style as the existing `test_streamlit_app_parses` and `test_streamlit_app_imports_from_helpers` in the same class — no Streamlit runtime needed.
- Verified bug-catching: with the buggy line `run_pipeline(query, ...)` (1 positional arg), the new test fails with the descriptive error message pointing at the line number and pointing the developer to use `_run` instead.
- Full demo test suite: 8 passed (including the existing `RunPipelineIntegrationTest` end-to-end coverage that uses `run_pipeline` directly with explicit index — unaffected by this change).

## 5. Eval impact

All `·`. Pure UI bug fix; no retrieval / verifier / answer-generation behavior change.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path. The fix only restores the correct argument-passing for the Streamlit single-mode invocation.

## 6. Backward compatibility

No contract break. `run_pipeline` signature unchanged. The `_run` helper signature unchanged. Only the single internal call site changes from one helper to another. ADR 0003 answer contract untouched.

## 7. Out of scope

- Renaming `run_pipeline` to make the index/query order self-documenting (e.g., separate `_run_with_index` and `_run_with_default_index`) — debatable refactor; the current `_run` helper convention is sufficient now that the regression test enforces correct usage.
- Adding a Streamlit headless integration test (e.g., via `streamlit.testing.v1.AppTest`) — the AST static test catches this exact bug pattern at lower cost; a full Streamlit runtime test could come in a separate hardening PR.