### PR TITLE
feat: wire rag_metadata_extraction into ingestion (#180 wire-up)

### DIFF
--- a/docs/agentic-metadata-extraction.md
+++ b/docs/agentic-metadata-extraction.md
@@ -1,0 +1,125 @@
+# Agentic Metadata Extraction (issue #180 / ADR 0017)
+
+> **Status:** wired into `ingestion.py` as the additive
+> `metadata["extracted"]` sidecar. Default backend is `regex`
+> (ADR 0001 invariant). LLM backends require an API key and are opt-in
+> via `BIDMATE_METADATA_BACKEND`.
+
+The classic regex / CSV-column passthrough fills RFP metadata
+(`agency`, `project`, `budget`, deadlines) cheaply and deterministically
+— it is the default and ships unchanged. This module adds an **additive**
+LLM-driven extraction path that reads the same body text and returns a
+strict eight-field JSON payload via tool / function calling. The two
+paths coexist on the same chunk; downstream consumers can pick which
+one to trust per field.
+
+## Schema
+
+`rag_metadata_extraction.MetadataExtraction` (eight fields):
+
+| Field                 | Type           | Notes                                                |
+|-----------------------|----------------|------------------------------------------------------|
+| `agency`              | `str \| None`  | 발주 기관 short name (한글 가능).                    |
+| `project_name`        | `str \| None`  | 사업명.                                              |
+| `budget_amount`       | `float \| None`| Amount only — no `원` / `만원` / commas.              |
+| `budget_currency`     | `str \| None`  | ISO 4217 (KRW by default for Korean RFPs).           |
+| `deadline_iso`        | `str \| None`  | `YYYY-MM-DD`.                                        |
+| `submission_date_iso` | `str \| None`  | `YYYY-MM-DD`.                                        |
+| `contact_email`       | `str \| None`  | First email matched in body text.                    |
+| `contact_name`        | `str \| None`  | Conservative — regex baseline leaves this `None`.    |
+
+The tool schema (`TOOL_DEFINITION` in `rag_metadata_extraction.py`)
+uses `additionalProperties: false` so an LLM response cannot smuggle
+unexpected fields into the chunk metadata.
+
+## Backends
+
+Switched via `BIDMATE_METADATA_BACKEND`:
+
+| Backend                | Default | Deterministic | Network | Notes                                                                                       |
+|------------------------|---------|---------------|---------|---------------------------------------------------------------------------------------------|
+| `regex`                | ✅      | ✅            | —       | The ADR 0001 invariant. Reads CSV columns + an email regex from body text.                  |
+| `stub`                 | —       | ✅            | —       | Delegates to `regex`. Used by tests; guarantees `stub == regex` bit-for-bit.                |
+| `anthropic_tool_use`   | —       | —             | yes     | Claude API (`extract_rfp_metadata` tool). `ANTHROPIC_API_KEY` required.                     |
+| `openai_function_call` | —       | —             | yes     | OpenAI-compatible (`BIDMATE_METADATA_API_KEY` + `BIDMATE_METADATA_MODEL` + `_BASE_URL`).    |
+
+Failure handling: any backend exception (missing SDK, missing key,
+malformed response, network error) silently falls back to the regex
+baseline. The pipeline never loses metadata to a tool-use error.
+
+## Wire-up
+
+`ingestion.normalize_ingestion_row` is the seam — every successfully
+indexed row gets the extracted sidecar before the document leaves the
+ingestion path:
+
+```python
+document = {
+    "doc_id": validation.doc_id,
+    "title": clean_cell(row.get("사업명")) or Path(validation.file_name).stem,
+    "agency": clean_cell(row.get("발주 기관")),
+    "project": clean_cell(row.get("사업명")),
+    "metadata": metadata,
+    "sections": [{"heading": "본문", "text": text}],
+    "source_path": str(validation.source_path),
+}
+document["metadata"]["extracted"] = extract_rfp_metadata(document).as_dict()
+```
+
+The top-level `agency` / `project` fields are deliberately left
+untouched — they feed the answer/citation contract (ADR 0003) and
+metadata-first retrieval; rebinding them to an LLM value mid-pipeline
+would break determinism on the public synthetic surface. The LLM
+value lives in the sidecar so reviewers can A/B it per field.
+
+## Eval ablation
+
+`eval/config.yaml` row `full_llm_metadata` runs the standard
+`agentic_full` pipeline against an index built with the LLM backend
+enabled. Because the extraction happens at *ingest* time, this row is
+meaningful only when the index was built with
+`BIDMATE_METADATA_BACKEND=anthropic_tool_use` (or
+`openai_function_call`); under the default `regex` backend it is
+identical to `full`. The latency budget mirrors `full` — per-query
+latency is unchanged; the cost shifts to a one-time index build.
+
+## How to A/B locally
+
+```bash
+# 1. Build a regex-extracted index (the default).
+python scripts/build_index.py
+
+# 2. Build an LLM-extracted index into a separate directory.
+BIDMATE_METADATA_BACKEND=anthropic_tool_use \
+ANTHROPIC_API_KEY=$YOUR_KEY \
+BIDMATE_INDEX_DIR=data/index_llm_metadata \
+  python scripts/build_index.py
+
+# 3. Compare per-field extraction agreement on the two payloads
+#    (script lives operator-side per ADR 0005; see issue #180
+#    acceptance criteria for the per-field accuracy table).
+```
+
+The per-field accuracy table (regex vs. `anthropic_tool_use` on
+`data/raw` + the private 100-doc corpus) is captured operator-side
+per ADR 0005 and surfaced via `reports/eval_summary.json` deltas
+rather than committed here — the private corpus rows are the
+authoritative signal and never land in the public repo.
+
+## Failure modes & escalations
+
+| Symptom                                                       | Likely cause                                                                                      | Fix                                                                                  |
+|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `metadata["extracted"]` is identical to the regex baseline    | Backend env not set, SDK missing, or the API key is empty — `extract_rfp_metadata` fell back.     | Verify `BIDMATE_METADATA_BACKEND` + `ANTHROPIC_API_KEY` and re-run `build_index.py`. |
+| Index build is slow under `anthropic_tool_use`                | One Claude call per document — by design. The synthesis-prompt + tool schema are cached server-side. | Run ingest once and reuse `data/index`. Per-query latency is unchanged.              |
+| Per-field accuracy lower than regex on Korean RFPs            | Conservative-prompt drift — the LLM should *omit* fields, not invent them.                        | Sanity-check `SYSTEM_PROMPT` and add a contrastive example in the next ADR follow-up. |
+
+## Related
+
+- [ADR 0001 — preserve naive baseline](adr/0001-preserve-naive-baseline.md)
+- [ADR 0003 — structured answer / citation contract](adr/0003-structured-answer-citation-contract.md)
+- [ADR 0011 — LLM synthesis as additive ablation](adr/0011-llm-synthesis-as-additive-ablation.md)
+- [ADR 0017 — LLM metadata extraction as additive](adr/0017-llm-metadata-extraction-additive.md)
+- [`rag_metadata_extraction.py`](../rag_metadata_extraction.py) — backends + tool schema
+- [`ingestion.py`](../ingestion.py) — wire-up seam
+- [`tests/test_ingestion_metadata_wireup_regression.py`](../tests/test_ingestion_metadata_wireup_regression.py) — additive-contract test suite

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -18,6 +18,11 @@ latency_budgets:
     # Stub synthesis backend adds <1 ms; real `anthropic` backend is
     # measured separately (operator-side, ADR 0005 boundary).
     p95_ms: 300
+  full_llm_metadata:
+    # Metadata extraction happens at ingest time, not query time, so
+    # the per-query budget is identical to ``full``. The LLM-backed
+    # ingest path is measured separately (operator-side, ADR 0005).
+    p95_ms: 200
 answer_policy:
   answerable_status: supported
   unanswerable_status: insufficient
@@ -37,6 +42,22 @@ ablation_runs:
   # Real-data + live demo override `BIDMATE_SYNTHESIS_BACKEND=anthropic`.
   - name: full_llm
     pipeline: agentic_full_llm
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+  # Issue #180 / ADR 0017 — additive LLM-driven RFP metadata extraction
+  # via Claude tool use. Metadata extraction happens at ingest time
+  # (``ingestion.normalize_ingestion_row``), so this row is meaningful
+  # only when the index was rebuilt with
+  # ``BIDMATE_METADATA_BACKEND=anthropic_tool_use`` (or
+  # ``openai_function_call``). Default backend is ``regex`` (the
+  # ADR 0001 invariant); ``stub`` matches the regex output bit-for-bit
+  # so public CI / synthetic harness runs stay deterministic and free.
+  # The pipeline itself is identical to ``full`` — only the
+  # ``metadata["extracted"]`` sidecar in each chunk differs.
+  - name: full_llm_metadata
+    pipeline: agentic_full
     metadata_first: true
     rerank: true
     verifier_retry: true

--- a/ingestion.py
+++ b/ingestion.py
@@ -17,6 +17,8 @@ import re
 from typing import Any
 import unicodedata
 
+from rag_metadata_extraction import extract_rfp_metadata
+
 SUPPORTED_FILE_FORMATS = {"pdf", "hwp"}
 
 REQUIRED_COLUMNS = [
@@ -388,6 +390,15 @@ def normalize_ingestion_row(
         "sections": [{"heading": "본문", "text": text}],
         "source_path": str(validation.source_path),
     }
+    # Issue #180 wire-up: write the eight-field structured extraction
+    # into ``metadata["extracted"]`` as an *additive* sidecar. The
+    # regex backend is the default (ADR 0001 invariant), so this stays
+    # deterministic and offline unless ``BIDMATE_METADATA_BACKEND`` is
+    # flipped to ``anthropic_tool_use`` / ``openai_function_call``.
+    # Top-level ``agency`` / ``project`` are intentionally untouched —
+    # downstream chunk metadata propagation in rag_core.py and the
+    # answer/citation contract (ADR 0003) read those fields.
+    document["metadata"]["extracted"] = extract_rfp_metadata(document).as_dict()
     return document, make_record(
         row_number,
         "indexed",

--- a/tests/test_ingestion_metadata_wireup_regression.py
+++ b/tests/test_ingestion_metadata_wireup_regression.py
@@ -1,0 +1,192 @@
+"""Regression for the #180 metadata-extraction wire-up in ingestion.py.
+
+Issue #180 (ADR 0017) adds an *additive* metadata sidecar — every
+ingested document carries an eight-field structured extraction under
+``document["metadata"]["extracted"]``. The contract here:
+
+* The default backend is ``regex`` (the ADR 0001 invariant).
+* The ``stub`` backend matches ``regex`` bit-for-bit so deterministic
+  / offline runs (public CI, unit tests) stay stable.
+* The wire-up never overwrites the top-level ``agency`` /
+  ``project`` fields — those feed the answer/citation contract
+  (ADR 0003) and chunk-metadata propagation in rag_core.py.
+* An LLM-backend exception falls back to ``regex`` rather than
+  losing the metadata; the network path is not exercised here.
+
+The test runs the real ``normalize_ingestion_row`` against a tiny
+in-memory CSV row so it covers the integration seam, not just the
+``extract_rfp_metadata`` unit.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from ingestion import _DuplicateTracker, normalize_ingestion_row
+from rag_metadata_extraction import (
+    ENV_BACKEND,
+    FIELD_NAMES,
+    MetadataExtraction,
+    extract_rfp_metadata,
+)
+
+
+def _csv_row(
+    *,
+    notice_id: str = "202500001",
+    project: str = "기관 A 보안 사업",
+    agency: str = "기관 A",
+    budget: str = "100000000",
+    deadline: str = "2025-04-01 17:00:00",
+    start_at: str = "2025-03-01 09:00:00",
+    file_name: str = "sample.pdf",
+    text: str = "본문입니다. 문의: contact@example.com",
+) -> dict[str, str]:
+    return {
+        "공고 번호": notice_id,
+        "공고 차수": "0.0",
+        "사업명": project,
+        "사업 금액": budget,
+        "발주 기관": agency,
+        "공개 일자": "2025-01-01 09:00:00",
+        "입찰 참여 시작일": start_at,
+        "입찰 참여 마감일": deadline,
+        "사업 요약": "요약",
+        "파일형식": "pdf",
+        "파일명": file_name,
+        "텍스트": text,
+    }
+
+
+class IngestionMetadataWireupTest(unittest.TestCase):
+    """The wire-up populates ``metadata["extracted"]`` on every doc."""
+
+    def _normalize_one(
+        self, row: dict[str, str], files_dir: Path
+    ) -> dict:
+        tracker = _DuplicateTracker()
+        document, record = normalize_ingestion_row(
+            row, row_number=1, files_dir=files_dir, tracker=tracker
+        )
+        self.assertEqual(
+            record.status,
+            "indexed",
+            f"row should have been indexed; record={record}",
+        )
+        assert document is not None  # narrow for mypy / readers
+        return document
+
+    def test_extracted_sidecar_is_present_with_eight_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            (files_dir / "sample.pdf").write_bytes(b"%PDF-1.4\n")
+            document = self._normalize_one(_csv_row(), files_dir)
+        extracted = document["metadata"].get("extracted")
+        self.assertIsInstance(extracted, dict, "extracted sidecar missing")
+        # The dataclass-as-dict ships every field declared in
+        # ``MetadataExtraction`` — even if the value is ``None`` —
+        # so downstream consumers can rely on a stable shape.
+        for field in FIELD_NAMES:
+            self.assertIn(
+                field,
+                extracted,
+                f"extracted sidecar is missing field {field!r}",
+            )
+
+    def test_extracted_matches_regex_baseline_on_default_backend(self) -> None:
+        """Without env override, the wire-up must mirror ``extract_rfp_metadata``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            (files_dir / "sample.pdf").write_bytes(b"%PDF-1.4\n")
+            row = _csv_row()
+            document = self._normalize_one(row, files_dir)
+        # Re-run extract_rfp_metadata against the document the wire-up
+        # built and confirm the sidecar matches — this also catches
+        # silent drift if the regex backend logic ever changes.
+        expected = extract_rfp_metadata(document).as_dict()
+        self.assertEqual(document["metadata"]["extracted"], expected)
+
+    def test_wireup_preserves_top_level_agency_and_project(self) -> None:
+        """ADR 0003 / chunk-propagation guard: top-level fields are untouched."""
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            (files_dir / "sample.pdf").write_bytes(b"%PDF-1.4\n")
+            row = _csv_row(agency="기관 X", project="프로젝트 X")
+            document = self._normalize_one(row, files_dir)
+        self.assertEqual(document["agency"], "기관 X")
+        self.assertEqual(document["project"], "프로젝트 X")
+        # The legacy ``metadata["agency"]`` / ``metadata["project"]``
+        # CSV-passthrough mirrors must also stay intact — they feed
+        # the existing metadata-first retrieval path.
+        self.assertEqual(document["metadata"]["agency"], "기관 X")
+        self.assertEqual(document["metadata"]["project"], "프로젝트 X")
+
+    def test_stub_backend_matches_regex_on_wireup_path(self) -> None:
+        """ADR 0001 invariant: stub backend produces the regex output bit-for-bit."""
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            (files_dir / "sample.pdf").write_bytes(b"%PDF-1.4\n")
+            row = _csv_row()
+            with mock.patch.dict(os.environ, {ENV_BACKEND: "regex"}):
+                regex_doc = self._normalize_one(row, files_dir)
+            with mock.patch.dict(os.environ, {ENV_BACKEND: "stub"}):
+                stub_doc = self._normalize_one(row, files_dir)
+        self.assertEqual(
+            regex_doc["metadata"]["extracted"],
+            stub_doc["metadata"]["extracted"],
+            "stub backend must mirror regex baseline on the wire-up path",
+        )
+
+    def test_extracted_captures_email_from_body_text(self) -> None:
+        """The regex baseline grabs the first email out of section text."""
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            (files_dir / "sample.pdf").write_bytes(b"%PDF-1.4\n")
+            row = _csv_row(text="문의는 contact-A@example.co.kr 로 보내주세요.")
+            document = self._normalize_one(row, files_dir)
+        extracted = document["metadata"]["extracted"]
+        self.assertEqual(extracted["contact_email"], "contact-A@example.co.kr")
+
+    def test_extracted_carries_csv_budget_as_float(self) -> None:
+        """CSV `사업 금액` should surface as ``budget_amount`` with KRW currency."""
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            (files_dir / "sample.pdf").write_bytes(b"%PDF-1.4\n")
+            row = _csv_row(budget="250000000")
+            document = self._normalize_one(row, files_dir)
+        extracted = document["metadata"]["extracted"]
+        self.assertEqual(extracted["budget_amount"], 250000000.0)
+        self.assertEqual(extracted["budget_currency"], "KRW")
+
+    def test_llm_backend_exception_falls_back_to_regex_baseline(self) -> None:
+        """An LLM-backend error must NEVER strip metadata from the document.
+
+        Simulates a network/API failure by pointing the backend to the
+        Anthropic path with the SDK explicitly missing the API key —
+        ``extract_rfp_metadata`` catches the exception and returns the
+        regex baseline. The wire-up therefore never produces a
+        partially-populated document.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            files_dir = Path(tmp)
+            (files_dir / "sample.pdf").write_bytes(b"%PDF-1.4\n")
+            row = _csv_row()
+            # Force the Anthropic path; clearing the API key triggers
+            # the RuntimeError inside ``_anthropic_tool_use_backend``,
+            # which ``extract_rfp_metadata`` converts to a regex
+            # fallback (per its docstring contract).
+            env = {ENV_BACKEND: "anthropic_tool_use", "ANTHROPIC_API_KEY": ""}
+            with mock.patch.dict(os.environ, env, clear=False):
+                document = self._normalize_one(row, files_dir)
+        extracted = document["metadata"]["extracted"]
+        regex_expected = extract_rfp_metadata(
+            document, backend="regex"
+        ).as_dict()
+        self.assertEqual(extracted, regex_expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Inserts a single call to ``extract_rfp_metadata`` inside ``ingestion.normalize_ingestion_row`` so every indexed document now carries the eight-field structured extraction under ``metadata["extracted"]``.
- Adds the ``full_llm_metadata`` ablation row + latency budget to ``eval/config.yaml`` (per the original #180 acceptance criteria) and a dedicated regression suite covering the additive contract.
- Adds ``docs/agentic-metadata-extraction.md`` with the schema, backend matrix, wire-up location, A/B procedure, and failure-mode table.

## Motivation

PR #287 merged the ``rag_metadata_extraction.py`` module (backends + tool schema + ADR 0017) but the module had no call site — the LLM metadata path was inert. This PR closes that gap. The default backend stays ``regex`` (ADR 0001 invariant), so public CI / synthetic harness runs are unchanged.

## Changes

- ``ingestion.py``: import ``extract_rfp_metadata``; populate ``document["metadata"]["extracted"]`` after the document dict is assembled. Top-level ``agency`` / ``project`` are intentionally untouched — they feed ADR 0003 (answer/citation contract) and chunk-metadata propagation in ``rag_core.py``.
- ``eval/config.yaml``: new ``full_llm_metadata`` ablation row (pipeline=agentic_full, requires ``BIDMATE_METADATA_BACKEND=anthropic_tool_use`` at index-build time to be meaningful) + matching latency budget.
- ``docs/agentic-metadata-extraction.md``: schema, backend matrix, wire-up seam, A/B procedure, failure-mode table.
- ``tests/test_ingestion_metadata_wireup_regression.py``: 7 tests covering sidecar presence (8 fields), regex baseline parity, stub=regex bit-for-bit invariant, top-level field preservation, email regex capture, CSV budget coercion to float + KRW currency, and the LLM-backend-exception → regex fallback path.

## ADR alignment

- **ADR 0001** (preserve naive baseline) — Default backend is ``regex``, the deterministic baseline. Stub matches regex bit-for-bit (covered by the existing ``test_metadata_extraction_regression.py`` plus the new wire-up test). No regression on the naive_baseline row.
- **ADR 0003** (answer/citation contract) — Top-level ``document["agency"]`` / ``document["project"]`` are left untouched. Only the additive sidecar is added; chunk metadata propagation in ``rag_core.normalize_document_sections`` / ``make_chunk`` is unaffected.
- **ADR 0017** (LLM metadata extraction additive) — LLM backends remain opt-in via ``BIDMATE_METADATA_BACKEND``. Any backend exception silently falls back to the regex baseline (regression-tested).

## Out of scope (deferred follow-ups)

- Per-field accuracy table comparing regex vs. ``anthropic_tool_use`` on ``data/raw`` + the private 100-doc corpus → operator-side write-up per ADR 0005 (private rows are the authoritative signal and never land in the public repo).
- Refactoring ``build_index.py`` to *also* run extraction outside the loader path. Not needed — ``normalize_ingestion_row`` is the single seam every ingest path flows through.
- Adding ``metadata_backend`` as a first-class knob in ``eval/config.yaml``; the env-variable approach matches the precedent set by ``BIDMATE_SYNTHESIS_BACKEND`` (ADR 0011) and keeps the YAML reproducible without leaking secrets.

## Test plan

- [x] ``pytest tests/test_ingestion_metadata_wireup_regression.py -v`` → **7/7 pass**.
- [x] Full ``pytest -q`` → **632 passed, 5 warnings**, no new failures (naive_baseline + agentic_full unchanged on regex default).
- [x] ``python scripts/check_branch_and_issue.py --branch feat/issue-180-metadata-wireup`` → no errors (ADR 0007).
- [ ] Operator-side: re-run ``make real-eval && make real-eval-delta`` with ``BIDMATE_METADATA_BACKEND`` unset (default ``regex``) — see §5b below.

### 5a. Synthetic delta

Public synthetic surface (hashing embedding, stub synthesis, regex metadata): no change. The wire-up adds one extra dict key per indexed document; retrieval, ranking, and verifier paths read the same fields they did before, so ``reports/eval_summary.json`` is bit-stable on the existing rows. Latency budget for the new ``full_llm_metadata`` row mirrors ``full`` (200 ms p95) because extraction happens at ingest time, not query time.

### 5b. Real-data delta

**No behavior change in ingestion path under the default ``regex`` backend** — the wire-up adds a *new* key (``metadata["extracted"]``) under ``document["metadata"]`` but does not modify any existing key that downstream consumers (``rag_core.normalize_document_sections``, ``make_chunk``, ``apply_comparison_balance``, citation grounding) read today. Retrieval scoring, verifier behaviour, and the answer / citation contract are bit-identical on the default ``regex`` backend.

The 632-test green run on the synthetic surface includes the metadata-first retrieval path and the comparison ablation, both of which exercise the touched code with the new sidecar in place.

Operators who flip ``BIDMATE_METADATA_BACKEND=anthropic_tool_use`` to A/B the LLM path locally can compare ``reports/eval_summary.json`` deltas against the regex baseline — that comparison is the deferred follow-up captured in the issue (per-field accuracy table) and lives operator-side per ADR 0005 because it depends on the private 100-doc corpus.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)