### PR TITLE
docs: README hero positioning paragraph (Korean RFP differentiation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
      in the GitHub README and in the pinned-repo profile card. -->
 ![BidMate-DocAgent live demo (60-90 s walkthrough)](docs/assets/demo.gif)
 
+> 일반 영어 LLM 벤치(KMMLU/MMLU) 점수 경쟁이 아닌 **한국어 RFP 도메인-특화 RAG**입니다. 차별화는 세 축: 비교 질의에서 한쪽 문서 starvation을 막는 [comparison-aware balanced top-k](#key-technical-contribution--comparison-aware-balanced-top-k), 의미 유사도 단독의 함정을 회피하는 metadata-first retrieval([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), hallucination을 구조적으로 차단하는 extractive grounded-answer 답변 계약([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)). 측정은 공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋으로 분리([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0018](docs/adr/0018-korean-public-rag-bench.md)) — silent regression이 한 표면에서 다른 표면으로 새지 않도록 설계됐습니다.
+
 ## 🚀 Live demo
 
 | 경로 | 상태 | 비고 |


### PR DESCRIPTION
## Summary

Insert a 3-sentence positioning paragraph between the hero gif and the Live demo table. Names domain (Korean RFP), differentiation axes (comparison-balance, metadata-first, extractive contract), and the evaluation split (synthetic + private + KorQuAD 2.1) with links to canonical sources.

Why: a senior reviewer scanning the top of the README today has to read 5 minutes to assemble these three signals from elsewhere in the file. The paragraph collapses that to ~30 seconds.

## Changes

- `README.md` (+2 lines): one blockquote-style paragraph inserted at L11, between the hero gif and the `## 🚀 Live demo` section header.

That's the entire diff.

## Scope discipline

- Pure additive insertion. Zero restructuring, zero deletions.
- No new ADRs. References existing ADRs 0002, 0003, 0005, 0018 + the existing "Key technical contribution" section anchor.
- No new behavior. Documentation only.

## Test plan

- [ ] CI passes (docs-only)
- [ ] Anchor link to "Key technical contribution" section renders correctly on GitHub web
- [ ] Branch matches `docs/issue-308-readme-hero-positioning` (ADR 0007)

## PR template items

**1. Type**: Docs.
**2. Issue**: Closes #308.
**3. ADR impact**: None. References existing ADRs 0002/0003/0005/0018; introduces no decision.
**4. Tests**: N/A — pure documentation.
**5a. Synthetic delta**: N/A — no behavior change.
**5b. Real-data delta**: N/A — no behavior change in retrieval / verifier / synthesis paths.
**6. Backward compatibility**: N/A.
**7. Out-of-scope**: Restructuring README; translating; adding new ADRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)