### PR TITLE
feat: harness observability auto-append (#237)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,12 @@ reports/real100/history/*
 reports/history/*
 !reports/history/*.aggregate.json
 !reports/leaderboard.md
+# Issue #237 — harness aggregate snapshots. Generated per ``run_harness``
+# invocation; untracked by default to keep developer working trees
+# clean. The leaderboard time-series lives under reports/history/
+# (real-eval results) — harness runs are isolated here so the
+# leaderboard isn't polluted with smoke-test data.
+reports/harness_history/
 # LLM-judge per-case verdicts (ADR 0006) stay local — only their
 # aggregate is folded into baseline.aggregate.json. Explicit ignore
 # for clarity (already caught by reports/real100/* above).

--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -16,6 +16,7 @@ Three modes:
 from __future__ import annotations
 
 import argparse
+from contextlib import nullcontext
 import copy
 from datetime import datetime, timezone
 import json
@@ -31,6 +32,7 @@ import yaml
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(ROOT_DIR))
 from _utils import (  # noqa: E402
     append_jsonl,
     git_dirty,
@@ -43,6 +45,16 @@ from _utils import (  # noqa: E402
     write_json,
 )
 from harness_compare import render_matrix_compare, render_pair, resolve_summary  # noqa: E402
+from rag_observability import (  # noqa: E402
+    OBSERVABILITY_SCHEMA_VERSION,
+    resolve_trace_backend,
+)
+
+# Harness aggregate snapshots use a sibling directory of
+# ``reports/history/`` so they coexist with the real-eval leaderboard
+# time series (``scripts/write_synthetic_history.py``) without
+# polluting it. The on-disk shape mirrors that script.
+HARNESS_HISTORY_DIR = ROOT_DIR / "reports" / "harness_history"
 
 
 def parse_args() -> argparse.Namespace:
@@ -57,6 +69,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--run-a", default=None, help="Run dir or eval_summary.json (compare mode)")
     parser.add_argument("--run-b", default=None, help="Run dir or eval_summary.json (compare mode)")
     parser.add_argument("--out", default=None, help="Write compare markdown to this file")
+    parser.add_argument(
+        "--no-observability",
+        action="store_true",
+        help=(
+            "Disable LangFuse/OTel trace + reports/harness_history append. "
+            "Manifest still records observability={backend:'none', "
+            "unavailable_reason:'disabled'} so downstream consumers can tell "
+            "the difference between 'tracing turned off' and 'tracing failed'."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -193,6 +215,7 @@ def _execute_pipeline(
     *,
     source_paths: dict[str, str],
     eval_config_path: Path,
+    no_observability: bool = False,
 ) -> dict[str, Any]:
     """Run index → query → eval against a pre-resolved run_dir.
 
@@ -202,6 +225,11 @@ def _execute_pipeline(
 
     The caller owns run_dir creation/wiping so matrix mode can write a
     cell_config.yaml alongside before invoking.
+
+    ``no_observability=True`` short-circuits the LangFuse / OTel trace
+    and the ``reports/harness_history`` append. The manifest still
+    carries an ``observability`` block so downstream consumers can
+    distinguish "tracing turned off" from "tracing failed".
     """
     started_at = utc_now()
     logs_dir = run_dir / "logs"
@@ -222,13 +250,32 @@ def _execute_pipeline(
     write_json(config_snapshot_path, config_snapshot)
     errors_path.touch()
 
+    # Observability is fail-closed by construction (ADR 0013): even if
+    # ``BIDMATE_TRACE_BACKEND`` requests langfuse/otel, an SDK miss or
+    # auth failure falls back to a noop context and reports the reason.
+    trace_ctx = None
+    trace_backend_name = "none"
+    trace_unavailable_reason: str | None = "disabled" if no_observability else None
+    if not no_observability:
+        backend, trace_backend_name, trace_unavailable_reason = resolve_trace_backend()
+        trace_ctx = backend.start_trace(
+            query=str(require_mapping(config, "query").get("text") or ""),
+            tags={
+                "run_id": run_id,
+                "source": "run_harness",
+                "config_id": str(config.get("id") or ""),
+            },
+        )
+
     commands = build_commands(config, run_dir)
     steps: list[dict[str, Any]] = []
     status = "passed"
     failure: dict[str, Any] | None = None
 
     for name in ("index", "query", "eval"):
-        step = {"name": name, **run_logged_command(commands[name], logs_dir / f"{name}.log")}
+        span_cm = trace_ctx.span(name) if trace_ctx is not None else nullcontext()
+        with span_cm:
+            step = {"name": name, **run_logged_command(commands[name], logs_dir / f"{name}.log")}
         steps.append(step)
         if command_failed(step):
             status = "failed"
@@ -273,6 +320,27 @@ def _execute_pipeline(
     }
     write_json(summary_path, summary)
 
+    # Finish the trace before writing the manifest so the trace_url
+    # can be embedded. Any backend error is swallowed inside finish()
+    # and surfaces as a None trace_url.
+    trace_url: str | None = None
+    if trace_ctx is not None:
+        trace_url = trace_ctx.finish(
+            {
+                "answer_status": metrics.get("answer_status"),
+                "latency_ms": (metrics.get("latency") or {}).get("p50_ms"),
+                "abstained": (metrics.get("abstention") or {}).get("count"),
+                "status": status,
+            }
+        )
+
+    observability_block: dict[str, Any] = {
+        "schema_version": OBSERVABILITY_SCHEMA_VERSION,
+        "backend": trace_backend_name,
+        "trace_url": trace_url,
+        "unavailable_reason": trace_unavailable_reason,
+    }
+
     manifest = {
         "schema_version": 1,
         "run_id": run_id,
@@ -285,14 +353,93 @@ def _execute_pipeline(
         "commands": commands,
         "status": status,
         "metrics": metrics,
+        "observability": observability_block,
     }
     if failure:
         manifest["failure"] = failure
+
+    # Aggregate snapshot mirror of write_synthetic_history.py — only on
+    # successful runs and only when observability is enabled. Failures
+    # here must NEVER break the harness run, so any exception is
+    # recorded back into the observability block.
+    if not no_observability and status == "passed":
+        try:
+            history_path = _append_harness_history_snapshot(
+                run_id=run_id,
+                manifest=manifest,
+                eval_summary_path=metrics_path,
+            )
+            observability_block["history_path"] = rel_path(history_path)
+        except Exception as exc:  # pragma: no cover - defensive
+            observability_block["history_error"] = (
+                f"{type(exc).__name__}: {str(exc)[:200]}"
+            )
+
     write_json(manifest_path, manifest)
 
     print(f"[OK] Harness run written: {rel_path(run_dir)}")
     print(f"[OK] Run manifest: {rel_path(manifest_path)}")
+    if observability_block.get("trace_url"):
+        print(f"[OK] Trace URL: {observability_block['trace_url']}")
+    if observability_block.get("history_path"):
+        print(f"[OK] History snapshot: {observability_block['history_path']}")
     return manifest
+
+
+def _append_harness_history_snapshot(
+    *,
+    run_id: str,
+    manifest: dict[str, Any],
+    eval_summary_path: Path,
+) -> Path:
+    """Mirror ``write_synthetic_history.py`` for harness runs.
+
+    Lives under ``reports/harness_history/`` (sibling of
+    ``reports/history/``) so the leaderboard time-series stays
+    pure-real-eval. The on-disk filename + JSON shape match the
+    sibling script so ``scripts/leaderboard.py:load_history`` can be
+    pointed at this directory for harness-only views.
+    """
+    HARNESS_HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    sha = (manifest.get("git_commit") or "unknown")[:12]
+    ts = (
+        str(manifest["generated_at"]).replace("-", "").replace(":", "").split(".")[0]
+    )
+    if not ts.endswith("Z"):
+        ts += "Z"
+    out_path = HARNESS_HISTORY_DIR / f"{ts}_{sha}.aggregate.json"
+
+    eval_summary: dict[str, Any] = {}
+    if eval_summary_path.exists():
+        try:
+            eval_summary = json.loads(eval_summary_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            eval_summary = {}
+
+    aggregate = {
+        "schema_version": 1,
+        "source": "run_harness",
+        "run_id": run_id,
+        "provenance": {
+            "git_commit": manifest.get("git_commit"),
+            "git_dirty": manifest.get("git_dirty"),
+            "generated_at": manifest.get("generated_at"),
+        },
+        "config_hash": manifest.get("config_hash"),
+        "metrics": manifest.get("metrics") or {},
+        "answer_status": eval_summary.get("answer_status"),
+        "abstention": eval_summary.get("abstention"),
+        "observability": {
+            k: v
+            for k, v in (manifest.get("observability") or {}).items()
+            if k in ("backend", "trace_url", "schema_version")
+        },
+    }
+    out_path.write_text(
+        json.dumps(aggregate, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return out_path
 
 
 def execute_single(
@@ -301,6 +448,7 @@ def execute_single(
     run_id: str | None,
     artifact_root: Path | None,
     force: bool,
+    no_observability: bool = False,
 ) -> int:
     config = load_yaml(config_path)
     config_id = str(config.get("id") or config_path.stem)
@@ -325,6 +473,7 @@ def execute_single(
         run_dir,
         source_paths=source_paths,
         eval_config_path=eval_config_path,
+        no_observability=no_observability,
     )
     return 0 if manifest["status"] == "passed" else 2
 
@@ -417,7 +566,7 @@ def _validate_matrix(matrix: dict[str, Any]) -> None:
         )
 
 
-def execute_matrix(matrix_path: Path, *, force: bool) -> int:
+def execute_matrix(matrix_path: Path, *, force: bool, no_observability: bool = False) -> int:
     matrix = load_yaml(matrix_path)
     _validate_matrix(matrix)
 
@@ -480,6 +629,7 @@ def execute_matrix(matrix_path: Path, *, force: bool) -> int:
             cell_run_dir,
             source_paths=source_paths,
             eval_config_path=eval_config_path,
+            no_observability=no_observability,
         )
 
         cell_summary_path = cell_run_dir / "metrics" / "eval_summary.json"
@@ -591,12 +741,17 @@ def main() -> int:
             raise SystemExit("[ERROR] --compare requires --run-a and --run-b")
         return execute_compare(args.run_a, args.run_b, args.out)
     if args.matrix:
-        return execute_matrix(repo_path(args.matrix), force=args.force)
+        return execute_matrix(
+            repo_path(args.matrix),
+            force=args.force,
+            no_observability=args.no_observability,
+        )
     return execute_single(
         repo_path(args.config),
         run_id=args.run_id,
         artifact_root=repo_path(args.artifact_root) if args.artifact_root else None,
         force=args.force,
+        no_observability=args.no_observability,
     )
 
 

--- a/tests/test_harness_observability.py
+++ b/tests/test_harness_observability.py
@@ -1,0 +1,204 @@
+"""E2E regression for the #237 harness observability auto-append.
+
+Each successful ``scripts/run_harness.py`` run must:
+
+1. Write an ``observability`` block into ``run_manifest.json`` carrying
+   ``backend`` / ``trace_url`` / ``unavailable_reason`` / ``schema_version``.
+2. Append a chronological aggregate snapshot to
+   ``reports/harness_history/`` whose on-disk shape mirrors
+   ``scripts/write_synthetic_history.py`` (so
+   ``scripts/leaderboard.py:load_history`` can be retargeted to
+   harness runs without code changes).
+3. Honour ``--no-observability``: no trace setup, no history file,
+   manifest still carries an ``observability`` block with
+   ``unavailable_reason == "disabled"`` so downstream consumers can
+   distinguish "tracing turned off" from "tracing failed".
+
+The tests do **not** require a live LangFuse instance — the default
+backend (``none``) is exercised, which is the realistic CI path. The
+manifest contract is identical regardless of which backend resolves;
+backend selection itself is covered by ``test_observability_tracing.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+class HarnessObservabilityE2ETest(unittest.TestCase):
+    """E2E: invoke ``scripts/run_harness.py`` and inspect the manifest contract."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmp_root = Path(__file__).resolve().parent / "_tmp_observability_artifacts"
+        if cls.tmp_root.exists():
+            shutil.rmtree(cls.tmp_root)
+        cls.tmp_root.mkdir(parents=True)
+        # Quarantine reports/harness_history side effects so a CI box
+        # doesn't accumulate junk and a developer's working tree stays
+        # clean. The harness writes into ROOT_DIR/reports/harness_history,
+        # so we capture its pre-test snapshot and restore the diff later.
+        cls.harness_history_dir = ROOT_DIR / "reports" / "harness_history"
+        cls._pre_existing = (
+            {p.name for p in cls.harness_history_dir.iterdir()}
+            if cls.harness_history_dir.exists()
+            else set()
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.tmp_root.exists():
+            shutil.rmtree(cls.tmp_root)
+        if cls.harness_history_dir.exists():
+            for p in cls.harness_history_dir.iterdir():
+                if p.name not in cls._pre_existing:
+                    p.unlink(missing_ok=True)
+
+    def _run_harness(
+        self,
+        run_id: str,
+        *,
+        extra_args: tuple[str, ...] = (),
+        env_overrides: dict[str, str] | None = None,
+    ) -> dict:
+        env = os.environ.copy()
+        # The test must drive its own observability behavior; clear any
+        # outer-scope BIDMATE_TRACE_BACKEND so we know the default
+        # ``none`` resolves cleanly.
+        env.pop("BIDMATE_TRACE_BACKEND", None)
+        if env_overrides:
+            env.update(env_overrides)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT_DIR / "scripts" / "run_harness.py"),
+                "--config",
+                "harness/smoke.yaml",
+                "--run_id",
+                run_id,
+                "--artifact_root",
+                str(self.tmp_root),
+                "--force",
+                *extra_args,
+            ],
+            cwd=ROOT_DIR,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=180,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"stdout={result.stdout}\nstderr={result.stderr}",
+        )
+        manifest_path = self.tmp_root / run_id / "run_manifest.json"
+        self.assertTrue(manifest_path.exists(), "manifest not written")
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    # --- Default-on observability ------------------------------------
+
+    def test_default_run_has_observability_block_with_none_backend(self) -> None:
+        manifest = self._run_harness("obs_default")
+        self.assertIn("observability", manifest, "manifest missing observability block")
+        block = manifest["observability"]
+        self.assertEqual(block["backend"], "none")
+        # Without ``BIDMATE_TRACE_BACKEND`` set, the resolver returns
+        # the noop backend "cleanly" — ``unavailable_reason`` is None.
+        self.assertIsNone(block["unavailable_reason"])
+        self.assertIsNone(block["trace_url"])
+        self.assertIn("schema_version", block)
+
+    def test_default_run_writes_harness_history_aggregate(self) -> None:
+        manifest = self._run_harness("obs_history")
+        block = manifest["observability"]
+        self.assertIn("history_path", block, "history snapshot was not written")
+        history_path = ROOT_DIR / block["history_path"]
+        self.assertTrue(history_path.exists(), f"missing {history_path}")
+        snapshot = json.loads(history_path.read_text(encoding="utf-8"))
+        # Mirror the public synthetic-history schema so the
+        # leaderboard loader is reusable on this directory.
+        for key in (
+            "schema_version",
+            "source",
+            "run_id",
+            "provenance",
+            "metrics",
+            "observability",
+        ):
+            self.assertIn(key, snapshot, f"history snapshot missing key {key!r}")
+        self.assertEqual(snapshot["source"], "run_harness")
+        self.assertEqual(snapshot["run_id"], "obs_history")
+        # Provenance must carry git_commit / generated_at so the
+        # leaderboard can sort chronologically and link back to a sha.
+        for key in ("git_commit", "generated_at"):
+            self.assertIn(key, snapshot["provenance"])
+
+    def test_history_filename_uses_timestamp_and_sha_prefix(self) -> None:
+        manifest = self._run_harness("obs_filename")
+        history_path = ROOT_DIR / manifest["observability"]["history_path"]
+        name = history_path.name
+        # ``<YYYYMMDDTHHMMSSZ>_<sha12>.aggregate.json`` — mirrors
+        # write_synthetic_history.py so the loader's filename parser
+        # works on both directories.
+        self.assertTrue(name.endswith(".aggregate.json"))
+        stem = name.removesuffix(".aggregate.json")
+        self.assertIn("_", stem)
+        ts, sha = stem.split("_", 1)
+        self.assertEqual(len(ts), len("YYYYMMDDTHHMMSSZ"))
+        self.assertEqual(ts[-1], "Z")
+        self.assertTrue(sha, "sha portion of filename is empty")
+
+    # --- --no-observability ------------------------------------------
+
+    def test_no_observability_flag_disables_history_and_marks_reason(self) -> None:
+        manifest = self._run_harness(
+            "obs_disabled", extra_args=("--no-observability",)
+        )
+        block = manifest["observability"]
+        self.assertEqual(block["backend"], "none")
+        self.assertEqual(
+            block["unavailable_reason"],
+            "disabled",
+            "--no-observability must mark the reason so downstream consumers "
+            "can distinguish opt-out from a failed backend resolve",
+        )
+        self.assertIsNone(block["trace_url"])
+        self.assertNotIn(
+            "history_path",
+            block,
+            "--no-observability must NOT write a history snapshot",
+        )
+
+    # --- Backwards compatibility with existing manifest contract -----
+
+    def test_existing_manifest_fields_unchanged(self) -> None:
+        manifest = self._run_harness("obs_compat")
+        # Non-observability fields must keep the schema_version=1 shape
+        # so consumers reading the prior manifest layout continue to work.
+        for key in (
+            "schema_version",
+            "run_id",
+            "generated_at",
+            "git_commit",
+            "config_hash",
+            "artifacts",
+            "commands",
+            "status",
+            "metrics",
+        ):
+            self.assertIn(key, manifest, f"manifest missing legacy key {key!r}")
+        self.assertEqual(manifest["schema_version"], 1)
+        self.assertEqual(manifest["status"], "passed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Wires the ADR 0013 trace surface (``rag_observability.resolve_trace_backend``) into ``scripts/run_harness.py``: every single-run and matrix-cell run starts a trace, wraps the three subprocess steps (index / query / eval) in spans, and embeds ``backend`` / ``trace_url`` / ``unavailable_reason`` into ``run_manifest.json`` under a new ``observability`` block.
- Adds a chronological aggregate-snapshot side-write to ``reports/harness_history/<YYYYMMDDTHHMMSSZ>_<sha12>.aggregate.json`` whose filename + JSON shape mirror ``scripts/write_synthetic_history.py`` — ``scripts/leaderboard.py:load_history`` is reusable on this directory without code changes.
- ``--no-observability`` flag short-circuits both (manifest still records the opt-out with ``unavailable_reason='disabled'`` so downstream consumers can distinguish "off" from "failed").
- 5 new E2E regression tests cover the manifest contract, history filename pattern, ``--no-observability`` semantics, and backward-compat with the existing schema_version=1 manifest layout.

## Why this PR is small / safe

- ``rag_core.py`` untouched.
- ``rag_observability.py`` already shipped via PR #199; this PR is a pure consumer.
- ``run_manifest.json`` ``schema_version`` stays at 1 — the change is purely additive (one new top-level key).
- ADR 0001 (naive_baseline) preserved — the harness still drives the same three subprocess commands; observability is a passive wrapper.
- Failure surface is fail-closed at every layer:
  - No env → noop backend, no overhead, no surface change.
  - SDK / creds missing → ``resolve_trace_backend`` returns noop + populates ``unavailable_reason``.
  - History append exception → recorded as ``observability.history_error``, never propagates.

## Out of scope (deferred)

- LangFuse / OTel live-instance setup docs → captured in the env vars on ``rag_observability.py``; no new docs needed.
- ``scripts/leaderboard.py`` retarget toggle so it can render the harness time-series alongside real-eval. Filename + schema parity means this is a one-arg follow-up if it turns out useful.
- ``scripts/run_harness.py --resume`` + index cache — that's the sibling #236 work and is intentionally a separate PR (same file, sequential merge).

## Test plan

- [x] ``pytest tests/test_harness_observability.py -v`` → **5/5 pass**.
- [x] ``pytest tests/test_run_harness.py -q`` → **22/22 pass** (backward-compat for the existing manifest contract).
- [x] Full ``pytest -q`` → **637 passed, 5 warnings** (632 prior + 5 new).
- [x] ``python scripts/check_branch_and_issue.py --branch feat/issue-237-harness-observability`` → no errors (ADR 0007).
- [ ] Operator-side smoke (optional): ``BIDMATE_TRACE_BACKEND=langfuse LANGFUSE_PUBLIC_KEY=... LANGFUSE_SECRET_KEY=... python scripts/run_harness.py --config harness/smoke.yaml`` → verify the trace URL appears in the manifest.

### 5a. Synthetic delta

No retrieval / verifier / answer code touched. The harness still drives ``scripts/build_index.py`` + ``app.py`` + ``eval/run_eval.py`` as subprocesses; only ``run_manifest.json`` gains one new key. Public synthetic surface is bit-stable.

### 5b. Real-data delta

**No behavior change in api / verifier / retrieval / ingestion / eval paths.** Only ``scripts/run_harness.py`` (non-load-bearing per CLAUDE.md) and tests are modified; the new ``reports/harness_history/`` directory is gitignored.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)