### PR TITLE
test: governance invariants — naive_baseline preset + ADR files + answer-dict shadow scan

### DIFF
--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -8,14 +8,25 @@ SSoT instead of carrying their own copy. The §5b tests confirm the
 gating logic accepts the documented escape sentence and rejects an
 empty/comment-only template body (which would otherwise let PR #69-class
 regressions through).
+
+Additional invariants (issue #315, parent #284):
+- `naive_baseline` preset retained in `eval/config.yaml` (ADR 0001).
+- Every ADR row in `docs/adr/README.md` resolves to a file on disk
+  (CLAUDE.md "Prohibited: Deleting or renaming ADR files").
+- `rag_core.py` defines no `pydantic.BaseModel` / `TypedDict` subclass
+  (CLAUDE.md "Prohibited: parallel ... model that shadows
+  run_rag_query's answer dict"; ADR 0003).
 """
 
 from __future__ import annotations
 
+import ast
+import re
 import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -159,4 +170,115 @@ def test_five_b_escape_regex_accepts_documented_escape(sentence):
 def test_five_b_escape_regex_rejects_off_pattern(sentence):
     assert not cbi.FIVE_B_ESCAPE_RE.search(sentence), (
         f"Should not match escape: {sentence!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# G2 — `naive_baseline` preset retained in eval/config.yaml (ADR 0001).
+# ---------------------------------------------------------------------------
+
+
+def test_naive_baseline_preset_present_in_eval_config():
+    cfg = yaml.safe_load((ROOT_DIR / "eval" / "config.yaml").read_text())
+
+    ablation_names = {a.get("name") for a in cfg.get("ablation_runs") or []}
+    assert "naive_baseline" in ablation_names, (
+        "ADR 0001 — `naive_baseline` must remain in eval/config.yaml "
+        "`ablation_runs`. It is the side-by-side comparison floor every "
+        "other ablation is measured against; removing it silently "
+        "invalidates every ablation delta. If a legitimate change "
+        "demands its removal, write an ADR superseding 0001 first."
+    )
+
+    assert "naive_baseline" in (cfg.get("latency_budgets") or {}), (
+        "`latency_budgets.naive_baseline` is the absolute p95 ceiling "
+        "enforced by scripts/check_latency_slo.py. Removing it silently "
+        "disables the baseline ablation's latency regression gate."
+    )
+
+
+# ---------------------------------------------------------------------------
+# G4 — every ADR row in docs/adr/README.md resolves to a file on disk and
+# vice versa (CLAUDE.md "Prohibited: Deleting or renaming ADR files").
+# ---------------------------------------------------------------------------
+
+
+_ADR_INDEX_ROW_RE = re.compile(
+    r"\|\s*\[(\d{4})\]\(\./(\d{4}-[^)]+\.md)\)\s*\|"
+)
+
+
+def _parsed_adr_index() -> list[tuple[str, str]]:
+    readme = (ROOT_DIR / "docs" / "adr" / "README.md").read_text()
+    rows = _ADR_INDEX_ROW_RE.findall(readme)
+    assert rows, (
+        "Could not parse any ADR rows in docs/adr/README.md. "
+        "Expected rows of the form `| [NNNN](./NNNN-slug.md) | status | title |`."
+    )
+    return rows
+
+
+def test_adr_index_rows_resolve_to_files():
+    adr_dir = ROOT_DIR / "docs" / "adr"
+    for number, filename in _parsed_adr_index():
+        path = adr_dir / filename
+        assert path.exists(), (
+            f"ADR {number} is listed in docs/adr/README.md but the file "
+            f"{filename!r} does not exist. CLAUDE.md Prohibited: "
+            f"'Deleting or renaming ADR files. Mark Superseded in the "
+            f"Status block; keep the file.' Restore the file or remove "
+            f"the README row with an explicit ADR-renumber rationale."
+        )
+
+
+def test_no_unlinked_adr_files_on_disk():
+    adr_dir = ROOT_DIR / "docs" / "adr"
+    indexed = {filename for _, filename in _parsed_adr_index()}
+    for path in sorted(adr_dir.glob("[0-9][0-9][0-9][0-9]-*.md")):
+        assert path.name in indexed, (
+            f"ADR file {path.name!r} exists on disk but is not listed in "
+            f"docs/adr/README.md index table. Either add a row to the "
+            f"index (preferred) or delete the file with a rationale in "
+            f"the PR description."
+        )
+
+
+# ---------------------------------------------------------------------------
+# G5 — rag_core.py must not introduce a pydantic/TypedDict class that
+# shadows the answer dict (CLAUDE.md "Prohibited"; ADR 0003).
+# ---------------------------------------------------------------------------
+
+
+_SHADOW_BASES = {"BaseModel", "TypedDict"}
+
+
+def test_rag_core_has_no_shadow_answer_models():
+    tree = ast.parse((ROOT_DIR / "rag_core.py").read_text())
+
+    offenders: list[tuple[str, str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for base in node.bases:
+            base_name: str | None = None
+            if isinstance(base, ast.Name):
+                base_name = base.id
+            elif isinstance(base, ast.Attribute):
+                base_name = base.attr
+            if base_name in _SHADOW_BASES:
+                offenders.append((node.name, base_name, node.lineno))
+
+    assert not offenders, (
+        "rag_core.py defines class(es) that shadow the answer dict:\n"
+        + "\n".join(
+            f"  - line {ln}: class {name}({base})"
+            for name, base, ln in offenders
+        )
+        + "\n\nCLAUDE.md Prohibited: 'Adding a parallel pydantic / "
+        "TypedDict model that shadows run_rag_query's answer dict — "
+        "the dict is the contract (ADR 0003).' The answer dict is "
+        "constructed near rag_core.py:2778 with `ANSWER_SCHEMA_VERSION`; "
+        "bump that constant on contract change, but do not introduce a "
+        "parallel class. If a structural model is genuinely needed, "
+        "write an ADR superseding 0003 first."
     )


### PR DESCRIPTION
## 1. What changed and why

Locks three CLAUDE.md "Prohibited" items into CI via static checks in `tests/test_governance.py`. Until now the load-bearing SSoT (PR #281) was guarded, but **`naive_baseline` preset removal**, **ADR file deletion/rename**, and **answer-dict shadow class introduction** could all slip past with only a reviewer's catch. Each invariant now fails the build with a CLAUDE.md citation and the fix direction (write a superseding ADR, restore the file, bump `ANSWER_SCHEMA_VERSION`).

Closes #315

Parent tracker: #284 (G2 + G4 + G5 of the PR #281 audit backlog).

## 2. Files affected

- `tests/test_governance.py` — 4 new test functions, +122 lines. **Not load-bearing.**

## 3. Risks

- **G4 regex tightness** — parser keys on the exact `| [NNNN](./NNNN-slug.md) |` index row format. If the README format changes, the test fails explicitly with "Could not parse any ADR rows" rather than silently skipping. Verified by parsing the live `docs/adr/README.md` (19 rows found, matches indices 0001–0019).
- **G5 AST scope** — only catches direct `BaseModel` / `TypedDict` base names. A motivated bypass via `from pydantic import BaseModel as PModel` would slip through. Verified `rag_core.py` has no pydantic / `typing.TypedDict` imports today; an alias rename would be obviously evasive in code review and a follow-up could add an import-graph scan if needed.
- **G2 preset shape** — assumes `ablation_runs[*].name` and `latency_budgets` keys. Cross-checked against `eval/config.yaml:4,12-14,31-33`.

## 4. Tests

```
python3 -m pytest tests/test_governance.py -q
46 passed in 0.16s   # +4 new

python3 -m pytest -q
631 passed, 1 skipped, 5 warnings in 11.35s
```

Negative-path smoke (in this PR's worktree, not committed):
- Forged `docs/adr/9999-forged.md` → G4 `test_no_unlinked_adr_files_on_disk` flags it.
- Synthetic `class AnswerShadow(BaseModel)` AST → G5 `test_rag_core_has_no_shadow_answer_models` flags it at the correct line.

## 5. Eval impact

All `·`. No retrieval / verifier / eval code touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

N/A — tests-only addition, no contract touched.

## 7. Out of scope

Other #284 audit-backlog items, each a separate PR per "One PR, one concern":
- G3 answer-contract snapshot test (separate PR — different file, complementary scope)
- G8+G9 ruff + dependabot
- R2 `_provenance` / `_utils` consolidation
- R3 composite action `run-eval`
- R4 `.githooks/pre-push` split
- R5 Makefile PHONY grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)