### PR TITLE
docs: README live demo 표 클린업 (hero asset 주석 + 비디오 행 중복 제거)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![PR Eval Delta](https://github.com/hskim-solv/BidMate-DocAgent/actions/workflows/pr-eval.yml/badge.svg?branch=main)](https://github.com/hskim-solv/BidMate-DocAgent/actions/workflows/pr-eval.yml) [![Python 3.11](https://img.shields.io/badge/Python-3.11-blue.svg)](pyproject.toml) [![Engineering notes](https://img.shields.io/badge/engineering--notes-GitHub%20Pages-blue)](https://hskim-solv.github.io/BidMate-DocAgent/) [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/hskim-solv/BidMate-DocAgent/blob/main/demo/bidmate_quickstart.ipynb) [![Open in HF Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-sm.svg)](https://huggingface.co/spaces/hskim-solv/bidmate-docagent)
 
-<!-- Hero demo asset slot. Recording guide: docs/deployment.md#recording-the-demo-video.
-     Replace docs/assets/demo.gif with the actual asset once captured; renders inline
-     in the GitHub README and in the pinned-repo profile card. -->
-![BidMate-DocAgent live demo (60-90 s walkthrough)](docs/assets/demo.gif)
+<!-- Hero demo asset slot. Asset (docs/assets/demo.gif) not yet captured;
+     image line is commented out to avoid broken-image rendering on GitHub.
+     Recording guide: docs/deployment.md#recording-the-demo-video.
+     To re-enable: uncomment the line below once docs/assets/demo.gif exists. -->
+<!-- ![BidMate-DocAgent live demo (60-90 s walkthrough)](docs/assets/demo.gif) -->
 
 > 일반 영어 LLM 벤치(KMMLU/MMLU) 점수 경쟁이 아닌 **한국어 RFP 도메인-특화 RAG**입니다. 차별화는 세 축: 비교 질의에서 한쪽 문서 starvation을 막는 [comparison-aware balanced top-k](#key-technical-contribution--comparison-aware-balanced-top-k), 의미 유사도 단독의 함정을 회피하는 metadata-first retrieval([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), hallucination을 구조적으로 차단하는 extractive grounded-answer 답변 계약([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)). 측정은 공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋으로 분리([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0018](docs/adr/0018-korean-public-rag-bench.md)) — silent regression이 한 표면에서 다른 표면으로 새지 않도록 설계됐습니다.
 
@@ -20,7 +21,6 @@
 | **One-line docker run** | `docker run -p 8501:8501 -p 8000:8000 -e BIDMATE_DEMO_MODE=both ghcr.io/hskim-solv/bidmate-demo:latest` | 클론 없이 published image 로 Streamlit + FastAPI 동시 실행 ([`docs/deployment.md`](docs/deployment.md#one-line-docker-run-no-clone-fastest-reviewer-path) 참고) |
 | **FastAPI Swagger** | `make api` 후 [/docs](http://localhost:8000/docs) | 프로그래매틱 사용·통합 테스트용 |
 | **로컬 1분 시작** | `make index && make demo` | `http://localhost:8501` |
-| **데모 비디오 (2~3분)** | 녹화 가이드: [docs/deployment.md#recording-the-demo-video](docs/deployment.md#recording-the-demo-video) | 라이브 배포 후 README 상단에 embed 예정 |
 | **📈 Live leaderboard** | [https://hskim-solv.github.io/BidMate-DocAgent/leaderboard/](https://hskim-solv.github.io/BidMate-DocAgent/leaderboard/) | 메인 브랜치 머지마다 자동 누적되는 headline metric time-series + bootstrap CI 밴드 (ADR 0005 aggregate-only) |
 | **데모 비디오 (2~3분)** | 후속 작업 — 가이드: [docs/deployment.md#recording-the-demo-video](docs/deployment.md#recording-the-demo-video) | 배포·녹화 완료 후 본 표 상단에 embed |
 | **엔지니어링 노트** | [hskim-solv.github.io/BidMate-DocAgent](https://hskim-solv.github.io/BidMate-DocAgent/) | 결정의 *왜*와 측정 결과를 정리한 GitHub Pages 사이트 (블로그 3편 + 1-page deep-dive) |


### PR DESCRIPTION
## 1. What changed and why

`README.md` Live demo 표의 두 가지 sync mismatch 해소:
- `docs/assets/demo.gif` 미존재 상태에서 broken-image 렌더링을 차단하기 위해 hero asset 라인을 HTML 주석으로 감쌌다. asset commit 후 주석 해제 가이드를 inline 안내로 명시.
- 동일한 "데모 비디오 (2~3분)" 행이 라인 21과 23에 중복으로 등장하던 부분에서 라인 21을 삭제. "후속 작업" 표기가 더 정확한 라인 23을 유지.

Closes #318

## 2. Files affected

- `README.md` (Live demo 표 + hero asset slot)

비-load-bearing.

## 3. Risks

- README 렌더링 외 영향 없음. GitHub 마크다운 파서가 HTML 주석을 안전하게 처리하는 것은 표준 동작.
- 라인 21 삭제로 표 행 순서가 바뀌므로 "Live leaderboard" 행과 "데모 비디오" 행 사이 시각적 순서 정도가 변경. 의도된 정렬.

## 4. Tests

- 신규 회귀 가드 없음. 동일 갭 재발 차단을 위한 `tests/test_governance.py` ADR↔narrative sync 가드는 별도 이슈 #317에서 다룸 (이 PR 범위 밖).
- 기존 테스트(`tests/test_governance.py`의 `is_load_bearing` 등)는 README path string만 사용 — 본 변경에 영향 없음.

## 5. Eval impact

All `·` — README 표/주석만 변경, RAG 파이프라인 무영향.

### 5b. Real-data delta

N/A — No behavior change in retrieval / verifier path. 변경 표면이 `README.md` 단일 파일 (비-load-bearing).

## 6. Backward compatibility

호환성 영향 없음. 답변 contract(ADR 0003) / 평가 contract(ADR 0005) 무관. 외부 링크/배지 URL 유지.

## 7. Out of scope

- 실제 `docs/assets/demo.gif` 녹화/commit — `docs/portfolio-launch-checklist.md` author-only action으로 별도 트랙.
- 다른 README 섹션(business context / TL;DR / 성능표) 수정.
- repo rename / live demo URL 갱신 (#172 별도).

🤖 Generated with [Claude Code](https://claude.com/claude-code)