### PR TITLE
test: Qdrant ↔ InMemory moderate-scale parity lockdown

### DIFF
--- a/tests/test_vector_store_qdrant.py
+++ b/tests/test_vector_store_qdrant.py
@@ -203,3 +203,58 @@ def test_qdrant_query_dim_mismatch_raises(
     store = vector_store_from_matrix(matrix)
     with pytest.raises(ValueError, match="dim"):
         store.query(np.zeros(99, dtype=np.float32), top_k=3)
+
+
+# ---------------------------------------------------------------------------
+# Issue #324: moderate-scale parity lockdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clustered_matrix() -> np.ndarray:
+    """200 x 64 L2-normalized matrix with 5 latent clusters; models real
+    RFP corpora where chunks naturally group around recurring topics."""
+    rng = np.random.default_rng(seed=20260512)
+    n_clusters = 5
+    n_per_cluster = 40
+    dim = 64
+    centroids = rng.standard_normal((n_clusters, dim)).astype(np.float32)
+    rows = []
+    for c in range(n_clusters):
+        noise = rng.standard_normal((n_per_cluster, dim)).astype(np.float32)
+        rows.append(centroids[c] + 0.3 * noise)
+    m = np.concatenate(rows, axis=0)
+    m /= np.linalg.norm(m, axis=1, keepdims=True)
+    return m
+
+
+@pytest.mark.parametrize("top_k", [5, 10])
+def test_qdrant_query_matches_in_memory_at_moderate_scale(
+    clustered_matrix: np.ndarray,
+    top_k: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #324: on a 200 x 64 clustered matrix, Qdrant ``:memory:``
+    top-k ranking and scores must still match ``InMemoryVectorStore``
+    exactly, locking the "in-memory Qdrant = exact cosine" assumption
+    against silent HNSW activation, distance-metric drift, or upsert /
+    point-id misalignment that the 6 x 4 Stage 2b parity test cannot
+    surface."""
+    monkeypatch.delenv(ENV_INDEX_BACKEND, raising=False)
+    memory_store = vector_store_from_matrix(clustered_matrix)
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    qdrant_store = vector_store_from_matrix(clustered_matrix)
+
+    for qi in range(0, clustered_matrix.shape[0], 10):
+        memory_result = memory_store.query(clustered_matrix[qi], top_k=top_k)
+        qdrant_result = qdrant_store.query(clustered_matrix[qi], top_k=top_k)
+        assert len(memory_result) == top_k
+        assert len(qdrant_result) == top_k
+        assert [idx for idx, _ in memory_result] == [
+            idx for idx, _ in qdrant_result
+        ], f"index ranking diverged for query row {qi}, top_k={top_k}"
+        for (m_idx, m_score), (q_idx, q_score) in zip(
+            memory_result, qdrant_result
+        ):
+            assert m_idx == q_idx
+            assert m_score == pytest.approx(q_score, abs=1e-5)


### PR DESCRIPTION
## 1. What changed and why

Closes #324

Stage 2b ([#296](https://github.com/hskim-solv/BidMate-DocAgent/pull/296)) added a Qdrant ↔ `InMemoryVectorStore` parity test, but it exercises only a 6 × 4 uniform-random matrix — too small to surface silent HNSW activation, `Distance` change, or upsert / point-id misalignment between the two backends.

This adds a single parameterized parity test (`top_k=5`, `top_k=10`) over a 200 × 64 L2-normalized matrix sampled from 5 latent clusters (modelling RFP corpora where chunks group by topic — more realistic than uniform random). The test locks the current "in-memory Qdrant runs exact cosine" assumption: if a future change flips collection config to HNSW or to a non-cosine-equivalent distance, the test fails loudly.

Flagged as the top vector-store risk by the Pre-Phase-3 audit.

## 2. Files affected

- `tests/test_vector_store_qdrant.py` (+55 lines, test-only)

No load-bearing file modified (canonical list: `scripts/_governance.py`).

## 3. Risks

The new test asserts exact index parity and 1e-5 score parity, so the realistic failure mode is floating-point ordering drift in the tail of `top_k=10` when intra-cluster scores tie. Mitigation: clustered embeddings with σ=0.3 noise produce well-separated scores within the requested top_k under seed `20260512`; verified deterministic across local runs.

## 4. Tests

- New: `test_qdrant_query_matches_in_memory_at_moderate_scale[5]` and `[10]` in `tests/test_vector_store_qdrant.py`.
- Future canary surface: HNSW activation, non-cosine-equivalent `Distance` change (e.g. L2 / Euclidean), or upsert / point-id misalignment will cause this test to fail.
- Full suite: `python3 -m pytest -q` → **641 passed, 121 subtests passed**, no regressions.

## 5. Eval impact

All `·` (no behavior change — test-only addition).

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion path.

## 6. Backward compatibility

No contract / schema / CLI change. Test-only addition. No `schema_version` bump needed.

## 7. Out of scope

- Full retrieval-pipeline regression through `rag_core.retrieve()` (Stage 2c integration — separate issue).
- Real-data 500-chunk benchmark with sentence-transformers embeddings (manual bench, not CI).
- Visual_ingestion v2 metadata-versioned parity (separate concern; tracked in pre-Phase-3 risk audit).
- Explicit HNSW config canary test — deferred until HNSW becomes opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)