### PR TITLE
chore: refresh real-eval baseline with self-consistent provenance (closes #160 PR 2)

### DIFF
--- a/reports/real100/baseline.aggregate.json
+++ b/reports/real100/baseline.aggregate.json
@@ -1,0 +1,187 @@
+{
+  "abstention": 0.5,
+  "accuracy": 0.47058823529411764,
+  "answer_format_compliance": 0.42857142857142855,
+  "by_query_type": {
+    "abstention": {
+      "abstention": 0.5,
+      "answer_format_compliance": 0.5,
+      "groundedness": 0.5,
+      "num_predictions": 4
+    },
+    "comparison": {
+      "accuracy": 1.0,
+      "answer_format_compliance": 1.0,
+      "groundedness": 1.0,
+      "num_predictions": 1
+    },
+    "follow_up": {
+      "accuracy": 0.25,
+      "answer_format_compliance": 0.5,
+      "groundedness": 0.25,
+      "num_predictions": 4
+    },
+    "single_doc": {
+      "accuracy": 0.5,
+      "answer_format_compliance": 0.3333333333333333,
+      "groundedness": 0.5,
+      "num_predictions": 12
+    }
+  },
+  "ci": {
+    "abstention": {
+      "alpha": 0.05,
+      "ci_hi": 1.0,
+      "ci_lo": 0.0,
+      "mean": 0.5,
+      "n": 4,
+      "num_resamples": 1000
+    },
+    "accuracy": {
+      "alpha": 0.05,
+      "ci_hi": 0.7058823529411765,
+      "ci_lo": 0.23529411764705882,
+      "mean": 0.47058823529411764,
+      "n": 17,
+      "num_resamples": 1000
+    },
+    "answer_format_compliance": {
+      "alpha": 0.05,
+      "ci_hi": 0.6190476190476191,
+      "ci_lo": 0.23809523809523808,
+      "mean": 0.42857142857142855,
+      "n": 21,
+      "num_resamples": 1000
+    },
+    "citation_precision": {
+      "alpha": 0.05,
+      "ci_hi": 0.47619047619047616,
+      "ci_lo": 0.09523809523809523,
+      "mean": 0.2857142857142857,
+      "n": 21,
+      "num_resamples": 1000
+    },
+    "claim_citation_alignment": {
+      "alpha": 0.05,
+      "ci_hi": 0.875,
+      "ci_lo": 0.4583333333333333,
+      "mean": 0.6666666666666666,
+      "n": 12,
+      "num_resamples": 1000
+    },
+    "comparison_pool_recall": {
+      "alpha": 0.05,
+      "ci_hi": 1.0,
+      "ci_lo": 1.0,
+      "mean": 1.0,
+      "n": 1,
+      "num_resamples": 1000
+    },
+    "comparison_target_recall": {
+      "alpha": 0.05,
+      "ci_hi": 1.0,
+      "ci_lo": 1.0,
+      "mean": 1.0,
+      "n": 1,
+      "num_resamples": 1000
+    },
+    "groundedness": {
+      "alpha": 0.05,
+      "ci_hi": 0.6666666666666666,
+      "ci_lo": 0.23809523809523808,
+      "mean": 0.47619047619047616,
+      "n": 21,
+      "num_resamples": 1000
+    },
+    "retry": {
+      "alpha": 0.05,
+      "ci_hi": 0.6190476190476191,
+      "ci_lo": 0.23809523809523808,
+      "mean": 0.42857142857142855,
+      "n": 21,
+      "num_resamples": 1000
+    }
+  },
+  "citation_grounding": null,
+  "citation_precision": 0.2857142857142857,
+  "claim_citation_alignment": 0.6666666666666666,
+  "groundedness": 0.47619047619047616,
+  "latency": {
+    "mean": 136.87190476190474,
+    "p50": 139.5,
+    "p95": 234.33
+  },
+  "num_predictions": 21,
+  "pipeline": "agentic_full",
+  "primary_run": "full",
+  "prompt_profile": "structured_grounded_claims",
+  "provenance": {
+    "generated_at": "2026-05-12T02:55:49.434862Z",
+    "git_commit": "2ce37653b048",
+    "git_dirty": true
+  },
+  "retry": 0.42857142857142855,
+  "retry_effectiveness": {
+    "cases_with_retry": 6,
+    "cases_without_retry": 11,
+    "ci": {
+      "recovery_rate": {
+        "alpha": 0.05,
+        "ci_hi": 0.6666666666666666,
+        "ci_lo": 0.0,
+        "mean": 0.3333333333333333,
+        "n": 6,
+        "num_resamples": 1000
+      },
+      "residual_failure_rate": {
+        "alpha": 0.05,
+        "ci_hi": 1.0,
+        "ci_lo": 0.3333333333333333,
+        "mean": 0.6666666666666666,
+        "n": 6,
+        "num_resamples": 1000
+      }
+    },
+    "recovery_rate": 0.3333333333333333,
+    "residual_failure_rate": 0.6666666666666666,
+    "retry_lift_vs_no_retry": -0.2121212121212121,
+    "retry_resolution_rate": 0.5
+  },
+  "retry_reason_counts": {
+    "topic_not_grounded": 13
+  },
+  "run_manifest": {
+    "config_sha256": "11a4125af938bfad",
+    "generated_at": "2026-05-12T02:55:49.285826Z",
+    "git_commit": "2ce37653b048",
+    "git_dirty": true
+  },
+  "stage_latency": {
+    "answer_generation_ms": {
+      "mean": 1.006,
+      "p50": 0.7250000000000001,
+      "p95": 2.851500000000002
+    },
+    "context_resolution_ms": {
+      "mean": 0.004999999999999999,
+      "p50": 0.0,
+      "p95": 0.010500000000000008
+    },
+    "query_analysis_ms": {
+      "mean": 78.425,
+      "p50": 77.495,
+      "p95": 125.6855
+    },
+    "retrieve_ms": {
+      "mean": 28.40291666666667,
+      "p50": 23.22,
+      "p95": 89.49099999999991
+    },
+    "verify_ms": {
+      "mean": 7.974166666666668,
+      "p50": 5.220000000000001,
+      "p95": 32.22949999999996
+    }
+  },
+  "top_k": null
+}


### PR DESCRIPTION
## 1. What changed and why

Closes #160 (PR 2 of 2). PR #189가 코드 hardening(provenance block + RRF deterministic tie-break + reproducibility regression guard)을 처리했고, 이 PR은 그 operational follow-up: `reports/real100/baseline.aggregate.json`을 본 브랜치 HEAD 기준으로 private 100-doc 코퍼스에 대해 재생성. `provenance.git_commit`이 실제 eval-run commit과 일치 → `make real-eval-delta`가 비로소 self-consistent baseline을 diff 대상으로 갖게 됨 → 후속 load-bearing PR의 §5b gate 복구.

## 2. Files affected

- `reports/real100/baseline.aggregate.json` — `make real-eval-baseline-update`로 전면 재생성. ADR-0005-safe (aggregate-only, per-case content 없음). `.gitignore` whitelist는 이미 수용. 코드 파일 변경 없음.

## 3. Risks

- 새 baseline 수치는 현재 main HEAD eval 동작을 반영. 이전 (un-committed, 로컬 drift된) baseline과 다르면 첫 `make real-eval-delta`가 한 번 큰 jump로 보일 수 있음 — 이는 #160 §B가 기록한 drift의 surfacing이고 의도된 동작.
- 코드 경로 변경 없음. retrieval / verifier / answer 동작 변경 없음.

## 4. Tests

- `tests/test_eval_reproducibility_regression.py` (PR #189에서 추가)가 향후 byte-equivalent re-run 불변성을 enforce.
- Manual: `make real-eval && make real-eval-baseline-update`이 본 브랜치 HEAD와 일치하는 `provenance.git_commit`을 가진 baseline 파일을 산출 — #160 §B가 missing이라고 지적한 바로 그 invariant.

## 5. Eval impact

### 5a. Synthetic CI delta
All `·` expected — code 변경 없음.

### 5b. Real-data delta
**N/A — 이 PR *자체*가 baseline refresh.** 자기 자신을 측정하지 않고, 후속 load-bearing PR들이 diff할 anchor를 세움. 이전 (un-committed) baseline 대비 수치 변동은 #160 §B가 문서화한 drift의 표면화.

## 6. Backward compatibility

- `reports/real100/baseline.aggregate.json` 스키마 변경 없음 (ADR-0005-safe aggregate-only).
- `scripts/run_real_eval_delta.py`가 이미 PR #189 시점 스키마를 소비.
- ADR 변경 없음.

## 7. Out of scope

- CI-side 검증: committed baseline의 `provenance.git_commit`이 `main`에서 reachable한지 자동 체크 — 별도 이슈 후보.
- `write_real_eval_baseline.py`의 hard-fail (vs warn) 모드 — PR #189 §7에서 명시적으로 deferred.
