### PR TITLE
chore(makefile): group .PHONY by domain + add governance-check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,36 @@
-.PHONY: setup index ask eval benchmark benchmark-check check check-latency korean-public-eval korean-public-fetch external-baselines-stub external-baselines-langchain external-baselines-llamaindex smoke smoke-with-judge reproduce harness-smoke harness-real harness-ablation harness-compare test test-regression api api-docker demo demo-docker pareto docker-publish real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-history-check real-eval-with-judge synthetic-judge leaderboard leaderboard-check clean
+# PHONY declarations are grouped by workflow domain to mirror the recipe
+# sections below. Composite gates (e.g. `governance-check`) live alongside
+# their member targets. Preserve target names verbatim when adding to a
+# group — downstream docs (CLAUDE.md, docs/engineering-governance.md) and
+# .githooks/ reference these names directly.
+
+# Setup / hooks
+.PHONY: setup install-hooks
+
+# Governance gates (branch + issue, README metrics, latency SLO, leaderboard
+# freshness, real-eval history freshness, benchmark manifest check). Run
+# `make governance-check` to invoke the pre-PR subset in sequence.
+.PHONY: check-branch governance-check check check-latency leaderboard-check real-eval-history-check benchmark-check
+
+# Index build + ad-hoc ask
+.PHONY: index ask
+
+# Synthetic eval surface (public corpus). Includes smoke, full eval, harness
+# matrix, judges, leaderboard render, pareto, korean public bench, external
+# baselines.
+.PHONY: eval smoke smoke-with-judge reproduce benchmark synthetic-judge leaderboard pareto korean-public-fetch korean-public-eval external-baselines-stub external-baselines-langchain external-baselines-llamaindex harness-smoke harness-ablation harness-compare
+
+# Real-data eval cycle (private; ADR 0005 commit boundary).
+.PHONY: real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
+
+# API / demo (FastAPI + Streamlit; local + docker variants)
+.PHONY: api api-docker demo demo-docker docker-publish
+
+# Tests
+.PHONY: test test-regression
+
+# Cleanup
+.PHONY: clean
 
 PYTHON ?= python3
 VENV ?= .venv
@@ -19,6 +51,15 @@ install-hooks:
 check-branch:
 	$(PYTHON) scripts/check_branch_and_issue.py \
 	  --branch "$$(git rev-parse --abbrev-ref HEAD)" --check-issue
+
+# Composite governance gate. Runs the three pre-PR freshness checks in
+# sequence: branch + issue convention (ADR 0007), leaderboard render
+# freshness, and real-data history-table freshness. Each sub-target is
+# already wired into CI / hooks individually; this target just shortens
+# the local pre-PR checklist into a single invocation. Fails on the
+# first sub-target that exits non-zero.
+governance-check: check-branch leaderboard-check real-eval-history-check
+	@echo "governance-check: branch + leaderboard + real-eval-history OK."
 
 index:
 	$(PYTHON) scripts/build_index.py --input_dir data/raw --output_dir data/index


### PR DESCRIPTION
## 1. What changed and why

The top-level `Makefile` previously declared every PHONY target on a single ~250-character line, making it hard to see which targets belong to which workflow surface (governance, synthetic eval, real eval, api/demo). Recipe sections were already grouped by domain comments (see line 169 "Real-data eval cycle" block), but the PHONY list at the top didn't reflect that organization.

This PR:
- Reorganizes the single `.PHONY:` line into seven domain-grouped blocks with a leading comment explaining the convention. Every existing target name is preserved verbatim — no renames, no removals, no recipe changes.
- Adds a new composite `governance-check` target that runs `check-branch`, `leaderboard-check`, and `real-eval-history-check` in sequence. These are the three freshness gates a contributor would otherwise invoke separately before opening a PR. Each sub-target remains independently invocable; `governance-check` is pure composition (Make dependency list + a single `@echo`).

Closes #331

Parent: #284 (R5 of the PR #281 audit backlog).

### Naming note

The issue body of #284 names the three sub-targets as `branch-check + leaderboard-check + history-check`. The actual target names in the current Makefile are `check-branch` (hyphenated the other way), `leaderboard-check` (matches), and `real-eval-history-check` (more specific). Per the scope rule "Preserve every existing target name verbatim — no renames", `governance-check` calls the existing names rather than introducing aliases.

## 2. Files affected

- `Makefile` — only file touched. **Not load-bearing** (`scripts/_governance.py LOAD_BEARING_PATHS` ⇒ `rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py`).

## 3. Risks

- **PHONY membership drift** — splitting into seven `.PHONY:` lines is functionally identical to one cumulative line in GNU Make (PHONY targets are additive across multiple declarations). Verified by running `make -n governance-check`, `make -n check-branch`, and re-running the full pytest suite — no behavior change.
- **Composite recipe failure surfacing** — `governance-check` uses prerequisite-style composition (`governance-check: check-branch leaderboard-check real-eval-history-check`), so Make stops on the first non-zero exit and prints which sub-target failed. The trailing `@echo` only fires on full success. Confirmed with `make -n` showing the four expected lines.
- **No CI workflow references the new target** — `governance-check` is purely a local convenience; CI keeps invoking each gate individually. Adding it to CI is out of scope and would be a separate PR.

## 4. Tests

```
make -n governance-check
# → prints the three sub-target invocations + the trailing @echo, as expected

make check-branch
# → exits 0 on chore/issue-331-makefile-phony-grouping

python3 -m pytest -q
# → 639 passed, 5 warnings, 121 subtests passed in 14.90s
```

No new pytest cases — Makefile target-grouping is a structural refactor with no executable Python contract. The PHONY split is verified by behavior parity (Make treats N additive `.PHONY:` lines identically to one concatenated line) and by the existing target invocations still working.

## 5. Eval impact

All `·`. No retrieval / verifier / eval code touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. `Makefile` is not in `LOAD_BEARING_PATHS`.

## 6. Backward compatibility

N/A — every existing target name is preserved. Any existing `make <target>`, CI workflow, `.githooks/`, or doc reference continues to work unchanged. The new `governance-check` target is purely additive.

## 7. Out of scope

- Wiring `governance-check` into CI / `.githooks/pre-push` — separate decision, separate PR.
- Renaming `check-branch` → `branch-check` or `real-eval-history-check` → `history-check` to literally match the names in #284's body text. Per "Preserve every existing target name verbatim", I composed over the actual names instead.
- Recipe consolidation (e.g. extracting common `$(PYTHON) scripts/...` patterns into a variable). Pure refactor, not in #284 R5.
- Other #284 audit-backlog items, each a separate PR per "One PR, one concern":
  - G2 + G4 + G5 governance invariants → merged as #316
  - G3 answer-contract snapshot → merged as #328
  - G8 + G9 ruff + dependabot
  - R2 `_provenance` / `_utils` consolidation
  - R3 composite action `run-eval`
  - R4 `.githooks/pre-push` split

Generated with [Claude Code](https://claude.com/claude-code)