### PR TITLE
chore(hooks): split pre-push into branch-check + real-eval-reminder sub-scripts

### DIFF
--- a/.githooks/_pre-push-branch-check.sh
+++ b/.githooks/_pre-push-branch-check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Branch name + issue convention check (ADR 0007). HARD-FAILS the push.
+#
+# Sourced by `.githooks/pre-push`, but also runnable standalone for manual
+# debugging:
+#
+#     bash .githooks/_pre-push-branch-check.sh
+#
+# Behavior: exits non-zero if the current branch does not match
+# <type>/issue-<N>[-<slug>]. If `gh` is installed and authed, also verifies
+# issue #N exists. Mirror of the CI check `.github/workflows/branch-and-issue-check.yml`.
+#
+# Skip the parent `pre-push` (including this check) with `git push --no-verify`
+# only if you have a documented reason (e.g. doc-only follow-up of a measured PR).
+
+set -euo pipefail
+
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ -z "$current_branch" || "$current_branch" == "HEAD" ]]; then
+  # Detached HEAD or unresolvable — nothing to validate.
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  # No python3 available; conservatively skip rather than block.
+  exit 0
+fi
+
+# `scripts/check_branch_and_issue.py` is the single-source regex for the
+# ADR 0007 branch convention (also consumed by the CI workflow).
+if ! python3 scripts/check_branch_and_issue.py \
+       --branch "$current_branch" --check-issue; then
+  cat >&2 <<EOF
+
+   Bypass (only with a documented reason):
+       git push --no-verify
+
+EOF
+  exit 1
+fi
+
+exit 0

--- a/.githooks/_pre-push-real-eval-reminder.sh
+++ b/.githooks/_pre-push-real-eval-reminder.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Pre-push SOFT-WARN reminders. NEVER blocks the push (explicit `exit 0`).
+#
+# Sourced by `.githooks/pre-push`, but also runnable standalone:
+#
+#     bash .githooks/_pre-push-real-eval-reminder.sh
+#
+# Two reminders, both soft-warn only:
+#
+# 1. Real-data eval delta reminder — if the push touches retrieval / verifier /
+#    eval / api paths (per `scripts/_governance.py` SSoT, also consumed by the
+#    Claude PreToolUse hook and the §5b CI gate), echo a reminder to attach
+#    `make real-eval-delta` output to the PR body per CLAUDE.md item 5b.
+#
+# 2. README metrics freshness reminder — if `reports/eval_summary.json` exists
+#    locally and the committed README's metrics block diverges from what
+#    `update_readme_metrics.py` would render, remind the developer to refresh
+#    it. `eval_summary.json` is gitignored, so this is the only feasible
+#    enforcement point — CI cannot compare against it.
+#
+# By design no `set -e`: a missing optional dep (gh, python3 module) should
+# emit a warning at worst, never block the push.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# 1. Real-data eval delta reminder.
+# ---------------------------------------------------------------------------
+
+# Resolve upstream / base ref. Prefer @{upstream}; fall back to origin/main.
+if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null); then
+  base="$upstream"
+else
+  base="origin/main"
+fi
+
+# Files changed between the upstream and HEAD.
+if ! changed=$(git diff --name-only "$base"...HEAD 2>/dev/null); then
+  # No upstream / new branch — fall back to diff vs origin/main if it exists.
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    changed=$(git diff --name-only origin/main...HEAD 2>/dev/null || true)
+  else
+    changed=""
+  fi
+fi
+
+if [[ -n "$changed" ]]; then
+  # Match against the load-bearing SSoT (scripts/_governance.py).
+  hit=""
+  if command -v python3 >/dev/null 2>&1; then
+    hit=$(printf '%s\n' "$changed" | python3 scripts/_governance.py --any-match 2>/dev/null | head -n1)
+  fi
+
+  if [[ -n "$hit" ]]; then
+    cat >&2 <<EOF
+
+⚠️  Retrieval / verifier / eval path changed in this push.
+    (first match: $hit)
+
+    Per CLAUDE.md pre-PR checklist item 5b, attach the aggregate
+    real-data eval delta to the PR body before requesting review:
+
+        make real-eval
+        make real-eval-delta
+
+    The delta script is aggregate-only (ADR 0005 commit boundary) so
+    its output is safe to paste into the PR.
+
+    Push proceeds. Skip this reminder with --no-verify only if you
+    have a documented reason.
+
+EOF
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. README metrics freshness reminder.
+# ---------------------------------------------------------------------------
+
+if [[ -f "reports/eval_summary.json" ]] && command -v python3 >/dev/null 2>&1; then
+  if ! python3 scripts/update_readme_metrics.py \
+         --report reports/eval_summary.json --readme README.md --check \
+         >/dev/null 2>&1; then
+    cat >&2 <<EOF
+
+⚠️  README metrics block looks stale vs reports/eval_summary.json.
+
+    Refresh before reviewers see outdated numbers:
+
+        make check     # confirm staleness
+        python3 scripts/update_readme_metrics.py \\
+            --report reports/eval_summary.json --readme README.md
+        git add README.md && git commit --amend --no-edit  # or new commit
+
+    Push proceeds. Skip this reminder with --no-verify if README
+    intentionally lags eval_summary in this PR.
+
+EOF
+  fi
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,136 +1,38 @@
 #!/usr/bin/env bash
-# Opt-in pre-push hook for BidMate-DocAgent.
+# Opt-in pre-push hook for BidMate-DocAgent. Thin dispatcher.
 #
 # Activate per-developer with:
 #   git config core.hooksPath .githooks
 #   (or: make install-hooks)
 #
-# Behavior (three checks, in order):
+# Behavior (two phases, in order):
 #
-# 1. Branch name + issue convention (ADR 0007) — HARD-FAILS the push
-#    if the current branch does not match <type>/issue-<N>[-<slug>].
-#    If `gh` is installed and authed, also verifies issue #N exists.
-#    Mirror of the CI check `.github/workflows/branch-and-issue-check.yml`.
+# 1. `_pre-push-branch-check.sh` — HARD-FAILS if the current branch does not
+#    match the ADR 0007 convention `<type>/issue-<N>[-<slug>]`. Exit code
+#    propagates and blocks the push.
 #
-# 2. Real-data eval delta reminder — SOFT-WARNS (exits 0) if the push
-#    touches retrieval / verifier / eval / api paths without a
-#    real-data delta, per CLAUDE.md pre-PR checklist item 5b.
+# 2. `_pre-push-real-eval-reminder.sh` — SOFT-WARNS (always exits 0) for:
+#    - real-data eval delta reminder when retrieval / verifier / eval / api
+#      paths changed (load-bearing SSoT: `scripts/_governance.py`),
+#    - README metrics freshness reminder when `reports/eval_summary.json`
+#      diverges from the committed README block.
 #
-# 3. README metrics freshness reminder — SOFT-WARNS (exits 0) if
-#    reports/eval_summary.json exists locally and the committed
-#    README's metrics block diverges. eval_summary.json is gitignored,
-#    so this is the only feasible enforcement point.
+# Both sub-scripts are independently runnable for manual debugging:
 #
-# Skip all with `git push --no-verify` only if you have a documented
-# reason (e.g. doc-only follow-up of a measured PR).
+#     bash .githooks/_pre-push-branch-check.sh
+#     bash .githooks/_pre-push-real-eval-reminder.sh
+#
+# Skip the whole hook with `git push --no-verify` only if you have a
+# documented reason (e.g. doc-only follow-up of a measured PR).
 
 set -u
 
-# ---------------------------------------------------------------------------
-# 1. Branch name + issue convention (ADR 0007).
-# ---------------------------------------------------------------------------
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-if [[ -n "$current_branch" && "$current_branch" != "HEAD" ]]; then
-  if command -v python3 >/dev/null 2>&1; then
-    if ! python3 scripts/check_branch_and_issue.py \
-           --branch "$current_branch" --check-issue; then
-      cat >&2 <<EOF
+# Phase 1: hard-fail branch convention check.
+bash "$HOOK_DIR/_pre-push-branch-check.sh" || exit $?
 
-   Bypass (only with a documented reason):
-       git push --no-verify
-
-EOF
-      exit 1
-    fi
-  fi
-fi
-
-# ---------------------------------------------------------------------------
-# 2. Real-data eval delta reminder (existing behavior, unchanged).
-# ---------------------------------------------------------------------------
-
-
-# Watch-list lives in scripts/_governance.py (single source of truth,
-# also consumed by the Claude PreToolUse hook and the §5b CI gate).
-
-# Resolve upstream / base ref. Prefer @{upstream}; fall back to origin/main.
-if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null); then
-  base="$upstream"
-else
-  base="origin/main"
-fi
-
-# Files changed between the upstream and HEAD.
-if ! changed=$(git diff --name-only "$base"...HEAD 2>/dev/null); then
-  # No upstream / new branch — fall back to diff vs origin/main if it exists.
-  if git rev-parse --verify origin/main >/dev/null 2>&1; then
-    changed=$(git diff --name-only origin/main...HEAD 2>/dev/null || true)
-  else
-    changed=""
-  fi
-fi
-
-if [[ -z "$changed" ]]; then
-  exit 0
-fi
-
-# Match against the load-bearing SSoT.
-hit=""
-if command -v python3 >/dev/null 2>&1; then
-  hit=$(printf '%s\n' "$changed" | python3 scripts/_governance.py --any-match 2>/dev/null | head -n1)
-fi
-
-if [[ -n "$hit" ]]; then
-  cat >&2 <<EOF
-
-⚠️  Retrieval / verifier / eval path changed in this push.
-    (first match: $hit)
-
-    Per CLAUDE.md pre-PR checklist item 5b, attach the aggregate
-    real-data eval delta to the PR body before requesting review:
-
-        make real-eval
-        make real-eval-delta
-
-    The delta script is aggregate-only (ADR 0005 commit boundary) so
-    its output is safe to paste into the PR.
-
-    Push proceeds. Skip this reminder with --no-verify only if you
-    have a documented reason.
-
-EOF
-fi
-
-# ---------------------------------------------------------------------------
-# 3. README metrics freshness reminder (SOFT-WARN).
-# ---------------------------------------------------------------------------
-# If reports/eval_summary.json exists locally and the committed README's
-# metrics block diverges from what `update_readme_metrics.py` would render,
-# remind the developer to refresh it before reviewers see stale numbers.
-# eval_summary.json is gitignored, so this is the only feasible enforcement
-# point — CI cannot compare against it.
-
-if [[ -f "reports/eval_summary.json" ]] && command -v python3 >/dev/null 2>&1; then
-  if ! python3 scripts/update_readme_metrics.py \
-         --report reports/eval_summary.json --readme README.md --check \
-         >/dev/null 2>&1; then
-    cat >&2 <<EOF
-
-⚠️  README metrics block looks stale vs reports/eval_summary.json.
-
-    Refresh before reviewers see outdated numbers:
-
-        make check     # confirm staleness
-        python3 scripts/update_readme_metrics.py \\
-            --report reports/eval_summary.json --readme README.md
-        git add README.md && git commit --amend --no-edit  # or new commit
-
-    Push proceeds. Skip this reminder with --no-verify if README
-    intentionally lags eval_summary in this PR.
-
-EOF
-  fi
-fi
+# Phase 2: soft-warn reminders (real-eval §5b + README freshness).
+bash "$HOOK_DIR/_pre-push-real-eval-reminder.sh" || true
 
 exit 0


### PR DESCRIPTION
## 1. What changed and why

Splits `.githooks/pre-push` (~130 lines, three responsibilities) into a thin dispatcher + two single-responsibility sub-scripts so the **hard-fail** contract (ADR 0007 branch convention) and the **soft-warn** contract (real-eval §5b reminder + README freshness reminder) cannot accidentally interfere with each other.

Previously a bug in the soft-warn path — e.g. a propagated `set -e` from an earlier section or a `python3` missing dep — could in principle block a push even though the branch convention check itself succeeded. The split makes each contract explicit at the file level: branch-check runs under `set -euo pipefail` and propagates failure; real-eval-reminder deliberately does not `set -e` and always ends with `exit 0`.

Both sub-scripts are also independently runnable for manual debugging (e.g. `bash .githooks/_pre-push-branch-check.sh`) — useful when iterating on either contract without re-pushing.

Closes #333

Parent tracker: #284 (R4 of the PR #281 audit backlog).

## 2. Files affected

- `.githooks/_pre-push-branch-check.sh` (new, 39 lines) — hard-fail wrapper around `scripts/check_branch_and_issue.py`.
- `.githooks/_pre-push-real-eval-reminder.sh` (new, 102 lines) — soft-warn for §5b real-eval delta + README metrics freshness, reaching back to `scripts/_governance.py` SSoT.
- `.githooks/pre-push` (rewritten, 28 lines) — thin dispatcher: `bash .../_pre-push-branch-check.sh || exit $?` then `bash .../_pre-push-real-eval-reminder.sh || true`. Retains a `_governance.py` reference in its phase-2 docstring so the existing `tests/test_governance.py::test_pre_push_hook_uses_governance_module` drift guard passes without modification.

**Not load-bearing.** No `rag_core.py` / `ingestion.py` / `eval/` / `api/` / `docs/adr/` / `scripts/build_index.py` touched.

## 3. Risks

- **Hook dispatch correctness** — verified the dispatcher propagates the branch-check exit code by inspecting `|| exit $?`, and that the reminder errors are swallowed via `|| true`. Confirmed the standalone behavior of both sub-scripts (see Tests).
- **Drift guard breakage** — `tests/test_governance.py::test_pre_push_hook_uses_governance_module` requires the literal string `_governance.py` to appear in `.githooks/pre-push`. The dispatcher's phase-2 docstring keeps that reference, so no test edit was needed.
- **README metrics check placement** — the original script had three sections; R4's spec only names two sub-scripts. I co-located the README freshness check with the real-eval reminder because both share the "soft-warn, never block" contract and the same `git diff … origin/main` context shape. A future R-prefixed PR could split it into a third sub-script if a contract divergence appears.
- **No `make install-hooks` change needed** — the Makefile target is `git config core.hooksPath .githooks` only; it does not glob file names. Git dispatches by hook name, so the new sub-scripts (underscore-prefixed) are correctly ignored by git's own hook lookup and only invoked via the dispatcher.

## 4. Tests

```
bash .githooks/_pre-push-branch-check.sh        # EXIT=0 (conformant branch)
bash .githooks/_pre-push-real-eval-reminder.sh  # EXIT=0
bash .githooks/pre-push                          # EXIT=0 (dispatcher end-to-end)

python3 scripts/check_branch_and_issue.py --branch "bad-branch-name" --check-issue
# EXIT=1, prints ADR 0007 violation message — confirms hard-fail path still rejects.

python3 -m pytest tests/test_governance.py -v
# 42 passed in 0.04s
# (includes test_pre_push_hook_uses_governance_module — unchanged.)

python3 -m pytest -q
# 639 passed, 5 warnings, 121 subtests passed in 12.14s

make check-branch
# python3 scripts/check_branch_and_issue.py --branch chore/issue-333-pre-push-split --check-issue
# (exits 0)
```

No new tests added; the existing `test_pre_push_hook_uses_governance_module` and `test_pretooluse_hook_uses_governance_module` continue to guard the SSoT linkage, and the file structure is a behavior-preserving refactor that the manual smoke tests above cover.

## 5. Eval impact

All `·`. No retrieval / verifier / eval / api code touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

N/A — no contract / schema / CLI flag change. Same activation step (`make install-hooks` → `git config core.hooksPath .githooks`), same `git push --no-verify` bypass, same SSoT pointers. Developers who already activated the hooks need no action.

## 7. Out of scope

- Splitting the README metrics freshness check into its own third sub-script (`_pre-push-readme-metrics.sh`). Co-located here with the real-eval reminder since both share the soft-warn contract; a follow-up could split it if a contract divergence emerges.
- Other items from #284 (G2/G4/G5 → PR #316; G3 → PR #328; R2, R3, R5, G8/G9 remain open).
- Touching `.githooks/pre-commit` or the Makefile `install-hooks` target — both out of scope per R4.