### PR TITLE
ci: opt-in ruff lint in scripts/test.sh + dependabot weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Issue #334 (G9 of #284): weekly dependency updates.
+# Preferred over a `pip-audit` CI step because dependabot ships native to
+# GitHub, needs no extra workflow, and surfaces issues as PRs that go through
+# the same review path as any other change.
+#
+# Ecosystems:
+#   - pip: picks up requirements.txt, requirements-dev.txt,
+#     requirements-observability.txt, and pyproject.toml dependencies.
+#   - github-actions: picks up pinned action versions in
+#     .github/workflows/*.yml.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,19 @@
 pythonpath = ["."]
 testpaths = ["tests"]
 
+# Issue #334 (G8 of #284): opt-in ruff lint gate from scripts/test.sh.
+# Rule selection is narrowed to the fatal pyflakes subset (syntax errors,
+# undefined names). Pre-existing E402 / F401 / F841 findings across the
+# codebase are real but out of scope for this PR — see "One PR, one concern"
+# in CLAUDE.md. Broaden after a focused clean-up sweep lands.
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+extend-exclude = ["data/", "reports/", "artifacts/", "outputs/"]
+
+[tool.ruff.lint]
+select = ["E9", "F63", "F7", "F82"]
+
 [tool.coverage.run]
 branch = true
 source = [

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Issue #334 (G8 of #284): opt-in ruff lint gate.
+# Ruff is treated as an optional dev dependency — if it is not on PATH we
+# print a one-line install hint and continue, so minimal envs (smoke runs,
+# fresh worktrees) keep working. When ruff IS installed, `ruff check` is a
+# hard gate (rule selection is narrowed in pyproject.toml to fatal pyflakes
+# only — see the [tool.ruff.lint] block). `ruff format --check` runs in
+# warn-only mode until the codebase is `ruff format`-clean (separate PR).
+if command -v ruff >/dev/null 2>&1; then
+  ruff check .
+  if ! ruff format --check . >/dev/null 2>&1; then
+    echo "ruff format --check: formatting drift detected (warn-only; see issue #334)." >&2
+  fi
+else
+  echo "ruff not installed -- skipping lint; install via 'pip install ruff'." >&2
+fi
+
 # Coverage flags emit coverage.xml for CI artifact + Codecov upload (issue #323).
 # pytest-cov is an opt-in dev dependency: gracefully fall back to plain pytest
 # if it is not installed (e.g. minimal envs that only run a smoke subset).


### PR DESCRIPTION
## 1. What changed and why

Lands two operational hygiene additions to CI (G8 + G9 of the #284 audit
backlog):

- **G8 (lint)** — `scripts/test.sh` now runs `ruff check` (hard gate) and
  `ruff format --check` (warn-only) when ruff is on `PATH`. If ruff is not
  installed (minimal envs, fresh worktrees), prints a one-line install hint
  and continues. The hard-gate rule selection in `[tool.ruff.lint]` is
  narrowed to the fatal pyflakes subset (`E9` / `F63` / `F7` / `F82`) so the
  gate turns ON without forcing a separate cleanup PR for pre-existing
  `E402` / `F401` / `F841` findings (34 across `rag_core.py`, `eval/`,
  `scripts/`, `tests/`).
- **G9 (deps)** — `.github/dependabot.yml` registers weekly updates for `pip`
  (picks up `requirements*.txt` + `pyproject.toml` deps) and
  `github-actions` (picks up pinned action versions in `.github/workflows/*.yml`).
  Preferred over `pip-audit` because dependabot ships native to GitHub, needs
  no extra workflow, and surfaces issues as reviewable PRs.

Closes #334

Parent tracker: #284 (G8 + G9 of the PR #281 audit backlog).

## 2. Files affected

- `pyproject.toml` — adds `[tool.ruff]` + `[tool.ruff.lint]` blocks (no
  existing tooling sections touched). **Not load-bearing.**
- `scripts/test.sh` — prepends an opt-in ruff lint section before the
  existing pytest invocation. **Not load-bearing.**
- `.github/dependabot.yml` — new file, weekly `pip` + `github-actions`.
  **Not load-bearing.**

No `rag_core.py` / `ingestion.py` / `eval/` / `api/` / `docs/adr/` /
`scripts/build_index.py` touched.

## 3. Risks

- **Ruff narrows rule selection.** The `select = ["E9", "F63", "F7", "F82"]`
  block intentionally drops `E4` (import-organization), `E7` (statement-level),
  the rest of `E5` (line-length), and most of `F` (unused imports / variables).
  This is the minimum useful set that catches actual breaks
  (syntax errors / undefined names) without flagging the 34 pre-existing
  findings. A motivated follow-up could broaden after a focused
  cleanup PR. Verified `ruff check .` is green with this selection.
- **`ruff format --check` is warn-only.** 103 files would be reformatted today
  (the repo isn't `ruff format`-clean). Making this a hard gate would break
  CI; warn-only surfaces drift without blocking. Flip to hard gate in a
  one-line follow-up once the format-sweep PR lands.
- **Dependabot may open many PRs.** Capped at 5 open per ecosystem
  (`open-pull-requests-limit: 5`). Initial week may produce several updates;
  expected and reviewable.
- **`scripts/test.sh` behavioral surface.** Verified the change is
  purely additive: existing pytest / coverage path is byte-identical
  to before. Ran the suite locally — `639 passed, 5 warnings, 121 subtests
  passed in 14.55s` — same total as before.

## 4. Tests

```
$ ruff check .
All checks passed!

$ bash scripts/test.sh
All checks passed!
ruff format --check: formatting drift detected (warn-only; see issue #334).
[...] 639 passed [...]
```

Negative-path smoke (not committed):
- Removed ruff from PATH → script prints
  `ruff not installed -- skipping lint; install via 'pip install ruff'.`
  and continues to pytest.
- Introduced a syntax error in a temp `.py` → `ruff check` fails with
  exit 1, blocking the run.

No new test files — this PR's surface (a build script + a config file) is
not the kind tested by `pytest`. The hard gate is the `ruff check` exit code
itself.

## 5. Eval impact

All `·`. No retrieval / verifier / eval code touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

N/A — additive CI tooling. No contract, schema, CLI flag, or doc link
changes. `ANSWER_SCHEMA_VERSION` stays at 2.

## 7. Out of scope

Deliberate deferrals per "One PR, one concern":
- Broadening ruff rules to `E,F` default (requires a separate cleanup PR
  for the 34 pre-existing `E402` / `F401` / `F841` findings).
- Flipping `ruff format --check` from warn-only to hard gate (requires a
  separate `ruff format` cleanup PR across ~103 files).
- A dedicated `.github/workflows/lint.yml` workflow (G8 is intentionally
  collapsed into the existing test entrypoint; no extra YAML surface).

Other #284 sibling items, each a separate PR:
- G2 + G4 + G5 governance invariants — PR #316 (merged)
- G3 answer-contract snapshot — PR #328 (merged)
- R2 `_provenance` / `_utils` consolidation
- R3 composite action `run-eval`
- R4 `.githooks/pre-push` split
- R5 Makefile PHONY grouping