### PR TITLE
docs: add .env.example listing canonical BIDMATE_* env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,96 @@
+# BidMate-DocAgent — local environment configuration.
+#
+# Copy to `.env` and edit. Both `.env` and `.env.*` are .gitignore'd and
+# .dockerignore'd, so secrets pasted here never get committed or baked
+# into the Docker image. The image reads variables at `docker run` time
+# (e.g. `-e BIDMATE_SYNTHESIS_BACKEND=anthropic`).
+#
+# CI-source-of-truth defaults are also documented in CLAUDE.md and ADR
+# 0011 (synthesis), ADR 0019 (embedding), ADR 0013 (observability).
+# All variables are *optional* — the public extractive pipeline runs
+# with zero env vars set.
+
+# ─── Pipeline preset (API server default) ─────────────────────────────
+# Choose: naive_baseline | agentic_full | agentic_full_llm
+# CLI default is `naive_baseline` (ADR 0001 reproducibility invariant);
+# the FastAPI server default is `agentic_full`.
+# BIDMATE_DEFAULT_PIPELINE=agentic_full
+
+# ─── Index location + backend ─────────────────────────────────────────
+# Directory where `scripts/build_index.py` writes and `app.py` / the
+# FastAPI server read `index.json` + the `embeddings.npy` sidecar.
+# BIDMATE_INDEX_DIR=data/index
+# Vector store backend. Only `memory` is wired today; `qdrant` /
+# `pgvector` are reserved follow-ups (issue #176, #232).
+# BIDMATE_INDEX_BACKEND=memory
+
+# ─── Embedding backend ────────────────────────────────────────────────
+# Choose: hashing | sentence_transformers | openai
+# `hashing` is the reproducibility default (CI uses this — no model
+# download). `sentence_transformers` loads `paraphrase-multilingual-
+# MiniLM-L12-v2` (~120MB; see ADR 0019). `openai` requires
+# OPENAI_API_KEY and is intended for the embedding-ablation runner.
+# EMBEDDING_BACKEND=hashing
+
+# ─── HWP / HWPX ingestion (opt-in) ────────────────────────────────────
+# Choose: (unset, default) | native
+# Default reads the `텍스트` column from `data_list.csv`
+# (visual_fallback_hwp marker). `native` activates
+# `_extract_hwp_native()` in ingestion.py — experimental; the v3
+# default-path migration is tracked in the Tier 3 PR-F epic.
+# BIDMATE_HWP_LOADER=native
+
+# ─── Answer synthesis (ADR 0011 additive LLM path) ───────────────────
+# Choose: stub | anthropic | openai_compatible
+# CI default is `stub` (token-less, deterministic pass-through).
+# Real backends activate only when the `agentic_full_llm` preset is
+# selected AND this is set ≠ stub — extractive paths are unaffected.
+# BIDMATE_SYNTHESIS_BACKEND=stub
+# Anthropic Claude API key. Required when BACKEND=anthropic.
+# ANTHROPIC_API_KEY=
+# Default Anthropic model (rag_synthesis.py:48).
+# BIDMATE_SYNTHESIS_MODEL=claude-sonnet-4-6
+# OpenAI-compatible API key. Required when BACKEND=openai_compatible.
+# BIDMATE_SYNTHESIS_API_KEY=
+# Override base URL for Solar / HCX / vLLM / Ollama gateways
+# (BACKEND=openai_compatible).
+# BIDMATE_SYNTHESIS_BASE_URL=
+# Per-call response cap (default 1024).
+# BIDMATE_SYNTHESIS_MAX_TOKENS=1024
+
+# ─── Cross-encoder reranker (opt-in) ──────────────────────────────────
+# Choose: stub | flag_embedding | cohere
+# CI default is `stub` (identity rerank — see README ablation note).
+# Real cross-encoder activates only for the `full_reranker` ablation
+# row; the default `full` preset uses weighted-score rerank in
+# rag_core.py (0.60·dense + 0.25·lexical + 0.15·metadata).
+# BIDMATE_RERANK_BACKEND=stub
+# Override model id. Defaults: `BAAI/bge-reranker-v2-m3`
+# (flag_embedding) or `dragonkue/bge-reranker-v2-m3-ko` (Korean
+# variant) or `rerank-3.5-multilingual` (cohere).
+# BIDMATE_RERANK_MODEL=
+# Cohere API key (BACKEND=cohere). `COHERE_API_KEY` is also accepted.
+# BIDMATE_COHERE_API_KEY=
+# COHERE_API_KEY=
+
+# ─── Tracing / observability ──────────────────────────────────────────
+# Choose: none (default) | langfuse | otel
+# Default emits no external traces. `langfuse` posts spans to Langfuse
+# cloud (or self-hosted via LANGFUSE_HOST). `otel` exports OTLP to the
+# collector at OTEL_EXPORTER_OTLP_ENDPOINT.
+# BIDMATE_TRACE_BACKEND=none
+# Langfuse credentials.
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+# LANGFUSE_HOST=https://cloud.langfuse.com
+# OTel collector endpoint (e.g. http://localhost:4318/v1/traces).
+# OTEL_EXPORTER_OTLP_ENDPOINT=
+# OTEL_SERVICE_NAME=bidmate-docagent
+# Optional template for `outputs/answer.json` `diagnostics.trace_url`
+# (e.g. https://cloud.langfuse.com/trace/{trace_id}).
+# BIDMATE_TRACE_URL_TEMPLATE=
+
+# ─── Logging ──────────────────────────────────────────────────────────
+# BIDMATE_LOG_LEVEL=INFO         # DEBUG | INFO | WARNING | ERROR
+# BIDMATE_LOG_FORMAT=text        # text | json
+# BIDMATE_LOG_STREAM=stderr      # stderr | stdout

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ htmlcov/
 venv/
 .env
 .env.*
+!.env.example
 
 # OS/editor files
 .DS_Store


### PR DESCRIPTION
## 1. What changed and why

외부 시니어 리뷰(2026-05) finding #11, #15 후속: 본 레포는 `Dockerfile` + 엄격한 `.dockerignore`를 갖고 있지만 `.env.example`이 없어 처음 클론한 contributor/reviewer가 *"어떤 환경변수가 활성 토글인지"*를 코드 grep으로 찾아야 한다. ADR 0011 synthesis backend, ADR 0019 embedding default, `BIDMATE_RERANK_BACKEND`, `BIDMATE_HWP_LOADER` opt-in 등 토글이 늘면서 더 헷갈리는 상태.

본 PR은 루트에 `.env.example` 파일 하나만 추가해 8개 카테고리(pipeline / index / embedding / HWP / synthesis / reranker / observability / logging)로 그룹화하고 각 변수에 (a) 무엇을 제어하는지, (b) default, (c) ADR/파일 reference를 한 줄 주석으로 명시한다. 모든 값은 commented-out이라 `cp .env.example .env`만 해도 공개 extractive 파이프라인은 zero env var 상태로 동작한다.

`.gitignore`에 `!.env.example` 예외 추가 — 예시 파일은 추적되고 실제 `.env` / `.env.*` 시크릿은 계속 차단. `.dockerignore`는 의도적으로 그대로 두어 (`.env.*` 매칭) 예시 파일이 runtime 이미지에 들어가지 않게 함 — env 변수는 `docker run -e ...` 또는 `--env-file`로 전달.

상위 plan: Tier 1 PR-C (`/Users/hskim/.claude/plans/bidmate-docagent-witty-glade.md`). Closes #335.

## 2. Files affected

- `.env.example` (신규, 96줄). 카테고리 8개 + 약 27개 BIDMATE_* / 표준 vendor 변수.
- `.gitignore` — `!.env.example` 예외 1줄 추가.

**Load-bearing**: 없음. 코드 / eval / ADR / API 미터치.

## 3. Risks

- **`.env.example`이 누락 변수를 포함하지 않을 위험**: `grep -rhoE '\"(BIDMATE_[A-Z_]+|...)\"'` 결과(37개)와 비교했고, `BIDMATE_DONUT_MODEL`, `BIDMATE_VISUAL_OCR`, `BIDMATE_EXTERNAL_*`, `BIDMATE_METADATA_*`, `BIDMATE_JUDGE_*` 등 *극히 niche한 토글*은 의도적으로 생략(노이즈 차단). 누락 발견 시 follow-up 한 줄 PR로 보강.
- **`.dockerignore` 정합성**: 기존 `.env.*` 매칭이 `.env.example`도 차단(의도 — 이미지 안에서 안 씀). PR 머지 후 docker build 확인 권고.

## 4. Tests

신규 테스트 없음. `.env.example`은 documentation 파일이라 자동 검증 대상이 아님. 수동 검증:
- `git ls-files | grep '^.env'` → `.env.example`만 반환 ✓ (실제 `.env`는 차단).
- `git check-ignore -v .env.example` → `!.env.example` 예외 매칭 ✓.
- 기존 627 passed 테스트 스위트(PR #325에서 검증됨)는 무관.

## 5. Eval impact

All `·`. 코드 / eval config / pipeline 무관.

### 5b. Real-data delta

N/A — documentation-only, no behavior change in retrieval / verifier path.

## 6. Backward compatibility

- 신규 documentation 파일과 `.gitignore` exception 한 줄 추가뿐. 기존 contract 영향 없음.
- 답변 schema(ADR 0003), `naive_baseline` invariant(ADR 0001), 평가 게이트 모두 무관.

## 7. Out of scope

- 실제 secret 값 / `.env` 자체 — secret은 git/docker에 절대 들어가지 않음.
- Dockerfile 변경 (env 변수 forwarding 자동화 등) — 별도 PR.
- 누락된 niche 토글 보강(`BIDMATE_DONUT_MODEL` 등) — 필요 시 follow-up.
- Onboarding 문서 추가 (`docs/onboarding.md`에서 `.env.example` 참조하는 흐름) — 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)