### PR TITLE
refactor: split retrieve() into retrieve_candidates + apply_fusion_and_reranking

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -2043,6 +2043,21 @@ def retrieve(
     analysis: dict[str, Any],
     plan: dict[str, Any],
 ) -> list[dict[str, Any]]:
+    scored = retrieve_candidates(index, query, analysis, plan)
+    return apply_fusion_and_reranking(scored, index, query, analysis, plan)
+
+
+def retrieve_candidates(
+    index: dict[str, Any],
+    query: str,
+    analysis: dict[str, Any],
+    plan: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Filter + per-chunk dense / lexical / metadata / BM25 scoring; the
+    pre-fusion phase of ``retrieve``. Split out so future Phase 3
+    multi-query / HyDE work can fan out this phase without piling onto
+    the fusion+rerank tail. Mutates ``plan`` with ``candidate_count``,
+    ``total_chunks``, ``filter_fallback_used`` (unchanged order)."""
     chunks = index["chunks"]
     filters = plan.get("metadata_filters") or {}
     doc_ids = set(filters.get("doc_ids") or [])
@@ -2157,7 +2172,22 @@ def retrieve(
         if page_span:
             item["page_span"] = page_span
         scored.append(item)
+    return scored
 
+
+def apply_fusion_and_reranking(
+    scored: list[dict[str, Any]],
+    index: dict[str, Any],
+    query: str,
+    analysis: dict[str, Any],
+    plan: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Fuse, sort, optionally cross-encoder rerank, then apply top-k.
+    Takes the pre-fusion list from ``retrieve_candidates`` and returns
+    the final ranked evidence. Mutates ``plan`` with
+    ``rerank_cross_encoder_meta`` only when the cross-encoder stage
+    runs (unchanged behavior)."""
+    retrieval_backend = str(plan.get("retrieval_backend", "dense"))
     if retrieval_backend == "hybrid" and scored:
         by_dense = sorted(
             scored,


### PR DESCRIPTION
## 1. What changed and why

Closes #332

[`rag_core.py:2040-2197`](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/rag_core.py#L2040) `retrieve()` was a 158-line function combining filtering, per-chunk dense/lexical/metadata/BM25 scoring, RRF fusion, cross-encoder rerank, top-K, and hierarchical reassembly. The Pre-Phase-3 risk audit flagged this as a structural blocker: adding multi-query / HyDE / additional rerankers under the current shape would push it toward 400+ lines.

This PR is a **pure behavior-preserving refactor**: the body is split along the natural phase boundary into two helpers, with `retrieve()` itself becoming a 2-line orchestrator. Signature and return value are unchanged.

- `retrieve_candidates(index, query, analysis, plan)` — filtering + per-chunk scoring loop
- `apply_fusion_and_reranking(scored, index, query, analysis, plan)` — RRF (hybrid), sort, optional cross-encoder rerank, top-K, hierarchical reassembly / comparison balance
- `retrieve()` — preserves the original signature so the existing test import in `tests/test_hybrid_retrieval_regression.py:44` and the sole caller inside `run_rag_query` (`rag_core.py:4093`) keep working as-is

Reranker Protocol abstraction is a **separate follow-up issue** (out of scope here).

## 2. Files affected

- `rag_core.py` (load-bearing) — +30 lines net (helper docstrings + orchestrator)

No other file changed. `retrieve()` still defined at line 2040.

## 3. Risks

The realistic break mode is silent ranking drift: a typo during the extraction could shuffle a `dense/lexical/metadata` weighted-sum branch or reorder `plan` mutations, producing top-K scores that drift by <0.01 (invisible in unit tests, visible to downstream eval).

Mitigation:
- `tests/test_naive_baseline_ranking_invariance.py` (ADR 0001 golden — bit-identical top-K + scores) — **PASS**
- `tests/test_hybrid_retrieval_regression.py` (25 tests covering dense / hybrid / RRF / cross-encoder paths) — **PASS**
- `tests/test_retrieval_loop_regression.py` (agentic loop integration) — **PASS**
- `make smoke`: every quality metric in `reports/eval_summary.json` identical to pre-refactor (Accuracy 0.906, Groundedness 0.929, Citation 0.905, Claim Align 1.000, Format 0.905, Abstention 1.000, Retry 0.310 — same across all ablation rows). Only latency numbers vary, which is wall-clock noise.

## 4. Tests

- No new test added — this is an extraction refactor, the existing invariance + regression suite is the contract.
- Full suite: `python3 -m pytest -q` → **639 passed, 121 subtests passed**, no regressions.

## 5. Eval impact

All `·` (no behavior change — pure extraction refactor; smoke eval shows identical quality metrics).

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

(`make real-eval-delta` is not runnable in this worktree: `data/private` is unavailable locally. The naive_baseline ADR 0001 golden file is the bit-identical proxy and it passes.)

## 6. Backward compatibility

`retrieve()` signature and return value unchanged. No `schema_version` bump needed. `plan` mutation keys (`candidate_count`, `total_chunks`, `filter_fallback_used`, `rerank_cross_encoder_meta`) and order preserved.

## 7. Out of scope

- Reranker Protocol abstraction (`CrossEncoderReranker` as first impl) — separate PR, to be filed once this lands.
- Multi-query / HyDE — Phase 3 feature work that this refactor unblocks.
- async/await unification.
- Any change to scoring weights, RRF formula, or ranking output.
- README metrics-table refresh — the local smoke regenerated a `full_llm_metadata` row + latency drift, but those changes are unrelated to this refactor's concern (memory: one PR per concern). Belongs in a follow-up "metrics-table refresh" PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)