### PR TITLE
feat(demo): surface synthesis backend + compare-mode guardrails in Streamlit UI

### DIFF
--- a/demo/streamlit_app.py
+++ b/demo/streamlit_app.py
@@ -16,6 +16,7 @@ the FastAPI surface for single-image deploys.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -155,6 +156,26 @@ def _run(query: str, *, pipeline: str, top_k: int | None, retrieval_mode: str, c
     )
 
 
+def _synthesis_backend() -> str:
+    return (os.environ.get("BIDMATE_SYNTHESIS_BACKEND") or "stub").strip().lower()
+
+
+def _retrieved_chunk_ids(result: dict) -> list[str]:
+    return [
+        str(item.get("chunk_id") or "")
+        for item in (result.get("evidence") or [])
+        if item.get("chunk_id")
+    ]
+
+
+def render_retrieved_caption(result: dict) -> None:
+    ids = _retrieved_chunk_ids(result)
+    if ids:
+        st.caption(f"📚 Retrieved ({len(ids)}): " + ", ".join(f"`{cid}`" for cid in ids))
+    else:
+        st.caption("📚 Retrieved: — (no evidence)")
+
+
 # -----------------------------------------------------------------------------
 # Layout
 # -----------------------------------------------------------------------------
@@ -181,12 +202,44 @@ st.caption(
 
 with st.sidebar:
     st.header("⚙️ Configuration")
+
+    backend = _synthesis_backend()
+    if backend == "anthropic":
+        st.success(f"🟢 LLM synthesis: `{backend}` (live Claude)")
+    elif backend == "stub":
+        st.warning("🟡 LLM synthesis: `stub` (pass-through)")
+        with st.expander("왜 `agentic_full_llm` 결과가 extractive와 같아 보이나요?"):
+            st.markdown(
+                "ADR 0011 계약상 `stub` 백엔드는 extractive summary를 그대로 통과시킵니다 — "
+                "compare 모드에서 좌·우가 byte-identical인 건 정상 동작입니다.\n\n"
+                "실제 Claude 합성을 보려면:\n"
+                "```bash\n"
+                "export ANTHROPIC_API_KEY=sk-ant-...\n"
+                "export BIDMATE_SYNTHESIS_BACKEND=anthropic\n"
+                "streamlit run demo/streamlit_app.py\n"
+                "```"
+            )
+    else:
+        st.info(f"🔵 LLM synthesis: `{backend}`")
+
     pipelines = pipeline_cli_choices()
     default_idx = pipelines.index("agentic_full") if "agentic_full" in pipelines else 0
-    pipeline = st.radio("Pipeline preset", pipelines, index=default_idx, help="naive_baseline = control · agentic_full = extractive · agentic_full_llm = LLM synthesis (ADR 0011, stub by default)")
+    compare_mode = st.checkbox(
+        "Compare extractive vs LLM side-by-side",
+        value=False,
+        help="체크 시 preset 라디오는 무시되고 agentic_full + agentic_full_llm이 동시에 실행됩니다.",
+    )
+    pipeline = st.radio(
+        "Pipeline preset",
+        pipelines,
+        index=default_idx,
+        disabled=compare_mode,
+        help="naive_baseline = control · agentic_full = extractive · agentic_full_llm = LLM synthesis (ADR 0011, stub by default)",
+    )
+    if compare_mode:
+        st.caption("⚠️ Compare 모드에서는 위 라디오 선택이 무시됩니다 (agentic_full + agentic_full_llm 동시 실행).")
     top_k = st.slider("Top-k retrieval", 1, 12, 4)
     retrieval_mode = st.selectbox("Retrieval mode", ["flat", "hierarchical"])
-    compare_mode = st.checkbox("Compare extractive vs LLM side-by-side", value=False)
 
     st.divider()
     st.header("📝 Sample queries")
@@ -228,12 +281,24 @@ run_btn = st.button("🔍 Run query", type="primary", use_container_width=True)
 
 if run_btn and query.strip():
     if compare_mode:
-        st.subheader("Extractive vs LLM Synthesis (stub backend)")
+        backend = _synthesis_backend()
+        if backend == "stub":
+            st.subheader("Extractive vs LLM Synthesis")
+            st.warning(
+                "🟡 `stub` backend — 좌·우 summary는 의도적으로 동일합니다 (ADR 0011 pass-through 계약). "
+                "실제 Claude 합성을 보려면 `BIDMATE_SYNTHESIS_BACKEND=anthropic`로 전환하세요."
+            )
+        elif backend == "anthropic":
+            st.subheader("Extractive vs LLM Synthesis")
+            st.success("🟢 `anthropic` backend — 우측은 라이브 Claude 합성 결과입니다.")
+        else:
+            st.subheader(f"Extractive vs LLM Synthesis ({backend} backend)")
         col_l, col_r = st.columns(2)
         with col_l:
             st.markdown("#### 📐 `agentic_full` (extractive)")
             try:
                 ext = _run(query, pipeline="agentic_full", top_k=top_k, retrieval_mode=retrieval_mode, context_entities=context_entities)
+                render_retrieved_caption(ext)
                 render_answer(ext["answer"])
                 render_trace_link(ext.get("diagnostics") or {})
                 st.caption(f"Wall: {ext['_wall_ms']:.1f} ms")
@@ -243,6 +308,7 @@ if run_btn and query.strip():
             st.markdown("#### 🤖 `agentic_full_llm` (LLM synthesis)")
             try:
                 llm = _run(query, pipeline="agentic_full_llm", top_k=top_k, retrieval_mode=retrieval_mode, context_entities=context_entities)
+                render_retrieved_caption(llm)
                 render_answer(llm["answer"])
                 render_trace_link(llm.get("diagnostics") or {})
                 synth = (llm.get("diagnostics") or {}).get("synthesis") or {}
@@ -252,11 +318,6 @@ if run_btn and query.strip():
                 )
             except Exception as exc:
                 st.error(f"LLM run failed: {exc}")
-        st.info(
-            "ADR 0011: stub backend is a pass-through, so the answers are byte-identical. "
-            "Set `BIDMATE_SYNTHESIS_BACKEND=anthropic` (with `ANTHROPIC_API_KEY`) "
-            "to see the live Claude synthesis."
-        )
     else:
         try:
             result = _run(
@@ -274,6 +335,7 @@ if run_btn and query.strip():
             ["📝 Answer", "📚 Evidence", "🔍 Diagnostics", "🐞 Raw JSON"]
         )
         with tab_answer:
+            render_retrieved_caption(result)
             render_answer(result["answer"])
             render_trace_link(result.get("diagnostics") or {})
         with tab_evidence:


### PR DESCRIPTION
## 1. What changed and why

Streamlit 데모([`demo/streamlit_app.py`](demo/streamlit_app.py))에서 사용자가 사이드바 설정(Pipeline preset / Top-k / Retrieval mode)을 바꿔도 답변이 동일해 보이는 UX 문제를 해결. 코드 버그가 아니라 **세 가지 의도된 동작이 가드레일 없이 겹치면서** "어떤 설정도 무력화됐다"는 인상을 줌:

| 사용자가 본 증상 | 실제 원인 |
| --- | --- |
| Compare 좌·우 패널 byte-identical | `BIDMATE_SYNTHESIS_BACKEND=stub` 기본값 (ADR 0011 pass-through 계약) |
| Pipeline preset 라디오 변경 무반응 | Compare 모드에서 라디오 무시, `agentic_full` + `agentic_full_llm` 강제 실행 |
| Top-k / retrieval mode 변경이 final summary에 잘 안 드러남 | retrieval delta가 결정적 요약 1~2문장에 묻힘 |

코드 동작은 그대로 유지하고 UI에 가드레일 4종만 추가:

1. 사이드바 상단에 `BIDMATE_SYNTHESIS_BACKEND` 배지 + stub일 때 "왜 동일한가 + 어떻게 켜는가" expander.
2. Compare 모드 체크 시 preset 라디오 `disabled=True` + ⚠️ 캡션.
3. 답변 헤더 아래 `📚 Retrieved (N): chunk_id ...` 캡션 (compare 좌·우 + 단일 모드) — top_k/mode 변경이 실제로 retrieval에 영향을 주고 있음을 시각화.
4. Compare sub-header를 backend-aware로 격상 (stub=`st.warning`, anthropic=`st.success`). 결과 하단의 중복 `st.info` 안내는 제거.

Closes #341

## 2. Files affected

- [`demo/streamlit_app.py`](demo/streamlit_app.py) — UI 표시 레이어만 (+70/−8)

Load-bearing 파일 미변경.

## 3. Risks

가장 가능성 있는 회귀: `os.environ.get(...)` 호출과 새 헬퍼(`_synthesis_backend`, `_retrieved_chunk_ids`, `render_retrieved_caption`)가 import-time 에러를 일으킬 가능성. 확인:
- `python -c \"import ast; ast.parse(open('demo/streamlit_app.py').read())\"` 통과.
- `pytest tests/test_demo_helpers.py` 8/8 통과 (helpers.py 미변경).
- `evidence` 페이로드 키(`chunk_id`)는 ADR 0003 answer-contract의 일부라 안정. `result.get("evidence")` fallback도 빈 리스트 처리.

## 4. Tests

Streamlit UI 변경이라 unit test 추가 불가. 수동 시나리오로 검증:
1. `streamlit run demo/streamlit_app.py` (stub 기본) → 사이드바 🟡 stub 배지 즉시 표시, expander 안내 확인.
2. Compare 체크 → preset 라디오 회색 처리, ⚠️ 캡션 출력.
3. Top-k 4 → 10 변경 후 재실행 → `📚 Retrieved` 캡션 chunk_id 개수/구성 변화.
4. Retrieval mode `flat` → `hierarchical` 변경 → 동일 방식으로 chunk_id 변화 확인.
5. `BIDMATE_SYNTHESIS_BACKEND=anthropic` + API 키 후 재기동 → 배지 🟢, stub expander 사라짐, compare 좌·우 summary가 실제로 달라야 함.

## 5. Eval impact

All `·` 예상. retrieval / verifier / answer 경로 미변경 — UI 표시 레이어만.

### 5b. Real-data delta

N/A — `run_rag_query` 시그니처·동작·load-bearing 파일 모두 미변경. No behavior change in retrieval / verifier / eval / api / ingestion.

## 6. Backward compatibility

깨지는 계약 없음. `BIDMATE_SYNTHESIS_BACKEND` 미설정 시 `stub`으로 기본값 처리 (rag_synthesis.py 동작과 일치). Answer contract / schema_version 미변경.

## 7. Out of scope

- "코퍼스가 작아서 top_k 효과가 final summary에 잘 안 보이는" 본질적 한계 — 더 풍부한 stub 또는 큰 데이터셋은 별도 이슈.
- API 키 발급 / Anthropic 백엔드 비용 가드는 [docs/deployment.md](docs/deployment.md) / [docs/model-upgrade-playbook.md](docs/model-upgrade-playbook.md)에 이미 있으므로 추가 안 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)