### PR TITLE
refactor: externalize Korean lexicon to data/lexicon/ko_default.yaml

### DIFF
--- a/data/lexicon/ko_default.yaml
+++ b/data/lexicon/ko_default.yaml
@@ -1,0 +1,240 @@
+# Korean linguistic + RFP-domain lexicon for BidMate-DocAgent.
+#
+# Externalized from rag_core.py in issue #344 (PR-D of the Tier 2 plan).
+# The loader lives in korean_lexicon.py at the repo root and coerces each
+# section back to its original Python type (set / tuple / frozenset /
+# dict[str, tuple]) so consumers in rag_core.py and tests/ see the same
+# value identity as before the extraction.
+#
+# Order matters for sections loaded as `tuple` (korean_particle_suffixes,
+# bm25_extra_particle_suffixes, implicit_reference_patterns). Set-typed
+# sections are listed alphabetically when possible for review clarity.
+
+# ─── General Korean stopwords + a few domain-generic noise tokens ─────
+# Loaded as `set[str]`. Applied at token-match heuristics — does not
+# affect dense embedding paths.
+stopwords:
+  - "그럼"
+  - "그"
+  - "그리고"
+  - "어떻게"
+  - "알려줘"
+  - "차이"
+  - "차이는"
+  - "차이를"
+  - "비교"
+  - "비교해줘"
+  - "기관"
+  - "요구"
+  - "요구한"
+  - "요구가"
+  - "요구사항"
+  - "조건"
+  - "조건도"
+  - "기능"
+  - "목표"
+  - "성능"
+  - "초점"
+  - "필수"
+  - "그중"
+  - "보여줘"
+  - "어떤"
+  - "누가"
+  - "포함돼야"
+  - "해"
+  - "있나"
+  - "무엇을"
+  - "사용해"
+  - "진행해"
+  - "중심으로"
+  - "시간"
+  - "지표나"
+  - "하는"
+  - "것은"
+  - "의"
+  - "와"
+  - "과"
+  - "는"
+  - "은"
+  - "를"
+  - "을"
+  - "이"
+  - "가"
+  - "에"
+  - "내"
+  - "돼"
+  - "무엇"
+  - "뭐야"
+  - "대한"
+  - "있는"
+  - "없는"
+  - "되나요"
+  - "습니까"
+  - "인가요"
+
+# ─── RFP-domain topic keywords ────────────────────────────────────────
+# Loaded as `list[str]`. Used by intent classification + verifier topic
+# alignment. Order preserved (current usage is set-membership tests, but
+# we keep the list shape to allow future weighted-priority extensions).
+topic_keywords:
+  - "AI"
+  - "품질관리"
+  - "품질"
+  - "보안"
+  - "보안 통제"
+  - "통제"
+  - "로그"
+  - "데이터"
+  - "거버넌스"
+  - "MLOps"
+  - "자동화"
+  - "모니터링"
+  - "일정"
+  - "산출물"
+  - "제출조건"
+  - "예산"
+  - "챗봇"
+  - "응답"
+  - "상담"
+  - "블록체인"
+  - "납품"
+  - "실적"
+
+# ─── Follow-up reference markers ──────────────────────────────────────
+# Loaded as `tuple[str, ...]`. Substring-matched for context resolution
+# in multi-turn conversations. Order preserved (first-match logic).
+implicit_reference_patterns:
+  - "그 기관"
+  - "그 사업"
+  - "그 시스템"
+  - "그 문서"
+  - "그 프로젝트"
+  - "해당 기관"
+  - "해당 사업"
+  - "해당 시스템"
+  - "이 기관"
+  - "이 사업"
+  - "그럼"
+  - "그중"
+
+# ─── Generic RFP boilerplate tokens ───────────────────────────────────
+# Loaded as `set[str]`. Down-weighted in metadata token matching since
+# almost every RFP contains these.
+metadata_generic_tokens:
+  - "rfp"
+  - "사업"
+  - "용역"
+  - "구축"
+  - "고도화"
+  - "개발"
+  - "운영"
+  - "정보"
+  - "시스템"
+
+# ─── Verifier intent-signal tokens ────────────────────────────────────
+# Loaded as `set[str]`. Used by the verifier loop to detect summary /
+# overview / confirmation requests.
+verification_intent_tokens:
+  - "간단히"
+  - "관련"
+  - "내용"
+  - "대해"
+  - "알려줘"
+  - "요약"
+  - "요약해줘"
+  - "정리"
+  - "정리해줘"
+  - "주요"
+  - "확인"
+
+# ─── Metadata evidence labels ─────────────────────────────────────────
+# Loaded as `dict[str, tuple[str, ...]]`. Maps metadata field id to
+# Korean evidence labels surfaced in answer schema (ADR 0003).
+metadata_evidence_labels:
+  budget: ["예산", "사업예산", "사업 금액"]
+  published_at: ["공개 일자", "공고일"]
+  bid_start_at: ["입찰", "입찰 시작일", "입찰 참여 시작일"]
+  bid_deadline_at: ["입찰", "마감일", "입찰 마감일", "입찰 참여 마감일"]
+  summary: ["요약", "사업 요약"]
+
+# ─── Metadata claim labels (singular) ─────────────────────────────────
+# Loaded as `dict[str, str]`. Single Korean label per metadata field for
+# claim-text rendering.
+metadata_claim_labels:
+  budget: "사업예산"
+  published_at: "공개 일자"
+  bid_start_at: "입찰 시작일"
+  bid_deadline_at: "입찰 마감일"
+  summary: "사업 요약"
+
+# ─── Metadata claim topic labels ──────────────────────────────────────
+# Loaded as `dict[str, tuple[str, ...]]`. Alternate phrasings for
+# claim-topic matching in the verifier.
+metadata_claim_topic_labels:
+  budget: ["예산", "사업예산", "사업금액", "금액"]
+  published_at: ["공개", "일자", "공개일자", "공고일"]
+  bid_start_at: ["입찰", "시작일", "입찰시작일", "입찰참여시작일", "일정"]
+  bid_deadline_at: ["입찰", "마감일", "입찰마감일", "입찰참여마감일", "일정"]
+  summary: ["요약", "사업요약", "사업기간", "기간"]
+
+# ─── Korean particle suffixes (shared profile) ────────────────────────
+# Loaded as `tuple[str, ...]`. Order preserved — `normalize_metadata_token`
+# strips suffixes iteratively, longest-first is implied by code position.
+# Active under the default `bm25_stopword_profile = "shared"`.
+korean_particle_suffixes:
+  - "으로"
+  - "에서"
+  - "에게"
+  - "도"
+  - "만"
+  - "나"
+  - "과"
+  - "와"
+  - "의"
+  - "은"
+  - "는"
+  - "이"
+  - "가"
+  - "을"
+  - "를"
+  - "로"
+  - "에"
+
+# ─── BM25-only extra particle suffixes (issue #150) ───────────────────
+# Loaded as `tuple[str, ...]`. Applied only under the `bm25_extra`
+# stopword profile via `_apply_bm25_extra_filter`; never touches dense
+# or Jaccard scoring paths.
+bm25_extra_particle_suffixes:
+  - "까지"
+  - "부터"
+  - "마다"
+  - "조차"
+  - "마저"
+  - "한테"
+  - "께서"
+  - "보다"
+  - "처럼"
+  - "같이"
+  - "라도"
+  - "라는"
+  - "라고"
+  - "이라"
+  - "이라는"
+  - "이라고"
+
+# ─── BM25-only extra discourse stopwords (issue #150) ─────────────────
+# Loaded as `frozenset[str]`. Short Korean discourse particles that
+# survive `normalize_metadata_token` but carry no IDF signal for BM25.
+# Applied only under the `bm25_extra` profile.
+bm25_extra_stopwords:
+  - "또한"
+  - "또는"
+  - "혹은"
+  - "그러나"
+  - "하지만"
+  - "이러한"
+  - "그러한"
+  - "저러한"
+  - "다만"
+  - "다음"
+  - "다음과"

--- a/korean_lexicon.py
+++ b/korean_lexicon.py
@@ -1,0 +1,49 @@
+"""Korean linguistic + RFP-domain lexicon for BidMate-DocAgent.
+
+Externalized from rag_core.py in issue #344 (PR-D). The YAML payload at
+``data/lexicon/ko_default.yaml`` is the single source of truth for the
+~155 Korean / RFP-domain tokens previously hard-coded as Python set,
+tuple, frozenset, and dict literals; this module reconstructs the
+original Python container types so existing call sites — including the
+re-exports from ``rag_core`` and the direct imports in
+``tests/test_hybrid_retrieval_regression.py`` — are bit-for-bit
+unchanged.
+
+Future overlay support (e.g. ``medical_rfp.yaml``) lands as a follow-up
+on top of this loader, not here.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_YAML_PATH = Path(__file__).resolve().parent / "data" / "lexicon" / "ko_default.yaml"
+
+
+@lru_cache(maxsize=1)
+def _load() -> dict[str, Any]:
+    with _YAML_PATH.open(encoding="utf-8") as fp:
+        return yaml.safe_load(fp)
+
+
+_data = _load()
+
+STOPWORDS: set[str] = set(_data["stopwords"])
+TOPIC_KEYWORDS: list[str] = list(_data["topic_keywords"])
+IMPLICIT_REFERENCE_PATTERNS: tuple[str, ...] = tuple(_data["implicit_reference_patterns"])
+METADATA_GENERIC_TOKENS: set[str] = set(_data["metadata_generic_tokens"])
+VERIFICATION_INTENT_TOKENS: set[str] = set(_data["verification_intent_tokens"])
+METADATA_EVIDENCE_LABELS: dict[str, tuple[str, ...]] = {
+    key: tuple(values) for key, values in _data["metadata_evidence_labels"].items()
+}
+METADATA_CLAIM_LABELS: dict[str, str] = dict(_data["metadata_claim_labels"])
+METADATA_CLAIM_TOPIC_LABELS: dict[str, tuple[str, ...]] = {
+    key: tuple(values) for key, values in _data["metadata_claim_topic_labels"].items()
+}
+KOREAN_PARTICLE_SUFFIXES: tuple[str, ...] = tuple(_data["korean_particle_suffixes"])
+BM25_EXTRA_PARTICLE_SUFFIXES: tuple[str, ...] = tuple(_data["bm25_extra_particle_suffixes"])
+BM25_EXTRA_STOPWORDS: frozenset[str] = frozenset(_data["bm25_extra_stopwords"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ source = [
     "visual_ingestion",
     "text_normalize",
     "bidmate_logging",
+    "korean_lexicon",
     "app",
     "api",
     "eval",

--- a/rag_core.py
+++ b/rag_core.py
@@ -40,6 +40,25 @@ from rag_vector_store import (
 )
 from text_normalize import expand_forms, normalize_text
 
+# Korean lexicon constants live in korean_lexicon.py (data/lexicon/ko_default.yaml).
+# Re-exported here so existing call sites — including
+# `tests/test_hybrid_retrieval_regression.py` which imports
+# BM25_EXTRA_PARTICLE_SUFFIXES / BM25_EXTRA_STOPWORDS from rag_core —
+# keep working unchanged. See issue #344.
+from korean_lexicon import (
+    BM25_EXTRA_PARTICLE_SUFFIXES,
+    BM25_EXTRA_STOPWORDS,
+    IMPLICIT_REFERENCE_PATTERNS,
+    KOREAN_PARTICLE_SUFFIXES,
+    METADATA_CLAIM_LABELS,
+    METADATA_CLAIM_TOPIC_LABELS,
+    METADATA_EVIDENCE_LABELS,
+    METADATA_GENERIC_TOKENS,
+    STOPWORDS,
+    TOPIC_KEYWORDS,
+    VERIFICATION_INTENT_TOKENS,
+)
+
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 DEFAULT_HASH_DIM = 384
 DEFAULT_CHUNK_MAX_CHARS = 520
@@ -159,91 +178,6 @@ TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]+")
 ENTITY_RE = re.compile(r"기관\s*[-_]?\s*([A-Za-z0-9]+)", re.IGNORECASE)
 SENTENCE_RE = re.compile(r"(?<=[.!?。])\s+")
 
-STOPWORDS = {
-    "그럼",
-    "그",
-    "그리고",
-    "어떻게",
-    "알려줘",
-    "차이",
-    "차이는",
-    "차이를",
-    "비교",
-    "비교해줘",
-    "기관",
-    "요구",
-    "요구한",
-    "요구가",
-    "요구사항",
-    "조건",
-    "조건도",
-    "기능",
-    "목표",
-    "성능",
-    "초점",
-    "필수",
-    "그중",
-    "보여줘",
-    "어떤",
-    "누가",
-    "포함돼야",
-    "해",
-    "있나",
-    "무엇을",
-    "사용해",
-    "진행해",
-    "중심으로",
-    "시간",
-    "지표나",
-    "하는",
-    "것은",
-    "의",
-    "와",
-    "과",
-    "는",
-    "은",
-    "를",
-    "을",
-    "이",
-    "가",
-    "에",
-    "내",
-    "돼",
-    "무엇",
-    "뭐야",
-    "대한",
-    "있는",
-    "없는",
-    "되나요",
-    "습니까",
-    "인가요",
-}
-
-TOPIC_KEYWORDS = [
-    "AI",
-    "품질관리",
-    "품질",
-    "보안",
-    "보안 통제",
-    "통제",
-    "로그",
-    "데이터",
-    "거버넌스",
-    "MLOps",
-    "자동화",
-    "모니터링",
-    "일정",
-    "산출물",
-    "제출조건",
-    "예산",
-    "챗봇",
-    "응답",
-    "상담",
-    "블록체인",
-    "납품",
-    "실적",
-]
-
 ANSWER_STATUS_SUPPORTED = "supported"
 ANSWER_STATUS_PARTIAL = "partial"
 ANSWER_STATUS_INSUFFICIENT = "insufficient"
@@ -256,136 +190,6 @@ AMBIGUOUS_CONFIDENCE_DELTA = 0.05
 CONVERSATION_STATE_SCHEMA_VERSION = 1
 MAX_CONVERSATION_TURNS = 12
 CONTEXT_RESOLUTION_THRESHOLD = 0.70
-
-IMPLICIT_REFERENCE_PATTERNS = (
-    "그 기관",
-    "그 사업",
-    "그 시스템",
-    "그 문서",
-    "그 프로젝트",
-    "해당 기관",
-    "해당 사업",
-    "해당 시스템",
-    "이 기관",
-    "이 사업",
-    "그럼",
-    "그중",
-)
-
-METADATA_GENERIC_TOKENS = {
-    "rfp",
-    "사업",
-    "용역",
-    "구축",
-    "고도화",
-    "개발",
-    "운영",
-    "정보",
-    "시스템",
-}
-
-VERIFICATION_INTENT_TOKENS = {
-    "간단히",
-    "관련",
-    "내용",
-    "대해",
-    "알려줘",
-    "요약",
-    "요약해줘",
-    "정리",
-    "정리해줘",
-    "주요",
-    "확인",
-}
-
-METADATA_EVIDENCE_LABELS = {
-    "budget": ("예산", "사업예산", "사업 금액"),
-    "published_at": ("공개 일자", "공고일"),
-    "bid_start_at": ("입찰", "입찰 시작일", "입찰 참여 시작일"),
-    "bid_deadline_at": ("입찰", "마감일", "입찰 마감일", "입찰 참여 마감일"),
-    "summary": ("요약", "사업 요약"),
-}
-
-METADATA_CLAIM_LABELS = {
-    "budget": "사업예산",
-    "published_at": "공개 일자",
-    "bid_start_at": "입찰 시작일",
-    "bid_deadline_at": "입찰 마감일",
-    "summary": "사업 요약",
-}
-
-METADATA_CLAIM_TOPIC_LABELS = {
-    "budget": ("예산", "사업예산", "사업금액", "금액"),
-    "published_at": ("공개", "일자", "공개일자", "공고일"),
-    "bid_start_at": ("입찰", "시작일", "입찰시작일", "입찰참여시작일", "일정"),
-    "bid_deadline_at": ("입찰", "마감일", "입찰마감일", "입찰참여마감일", "일정"),
-    "summary": ("요약", "사업요약", "사업기간", "기간"),
-}
-
-KOREAN_PARTICLE_SUFFIXES = (
-    "으로",
-    "에서",
-    "에게",
-    "도",
-    "만",
-    "나",
-    "과",
-    "와",
-    "의",
-    "은",
-    "는",
-    "이",
-    "가",
-    "을",
-    "를",
-    "로",
-    "에",
-)
-
-# Issue #150 — BM25-only extension of the particle suffix list. Applied
-# at the BM25 corpus-build and query-side only via
-# ``_apply_bm25_extra_filter``; never touches the tokens cached on
-# chunks at index time, so the dense + Jaccard lexical scoring paths
-# are preserved bit-for-bit (acceptance criterion: "dense/Jaccard 경로의
-# 동작은 보존"). Active under
-# ``bm25_stopword_profile = "bm25_extra"`` ablation; default profile
-# ``"shared"`` reuses the common ``KOREAN_PARTICLE_SUFFIXES`` only.
-BM25_EXTRA_PARTICLE_SUFFIXES: tuple[str, ...] = (
-    "까지",
-    "부터",
-    "마다",
-    "조차",
-    "마저",
-    "한테",
-    "께서",
-    "보다",
-    "처럼",
-    "같이",
-    "라도",
-    "라는",
-    "라고",
-    "이라",
-    "이라는",
-    "이라고",
-)
-
-# Short Korean discourse particles that survive ``normalize_metadata_token``
-# (they aren't pure-Hangul particle suffixes; they appear as standalone
-# tokens) but carry no IDF signal for BM25 — filtered only under the
-# bm25_extra profile, again leaving dense/Jaccard untouched.
-BM25_EXTRA_STOPWORDS: frozenset[str] = frozenset({
-    "또한",
-    "또는",
-    "혹은",
-    "그러나",
-    "하지만",
-    "이러한",
-    "그러한",
-    "저러한",
-    "다만",
-    "다음",
-    "다음과",
-})
 
 VALID_BM25_STOPWORD_PROFILES = {"shared", "bm25_extra"}
 


### PR DESCRIPTION
## 1. What changed and why

External senior review (2026-05) finding #8 후속. `rag_core.py`에 11개 한국어/RFP 도메인 컬렉션(~155 entries / ~220 줄)이 인라인 박혀 git blame이 사전 변경 vs 코드 변경을 구분 못 하고, `rag_core.py`는 4,350줄 / 158KB monolith로 향후 PR-E 분해 epic 정지작업이 필요한 상태였다.

본 PR은 lexicon을 `data/lexicon/ko_default.yaml`로 전부 분리하고 thin loader(`korean_lexicon.py`, 53줄)가 원래 Python 컨테이너 타입(`set` / `tuple` / `frozenset` / `dict[str, tuple]` / `list`)을 정확히 복원한다. `rag_core.py`는 11개 심볼을 `korean_lexicon`에서 import해서 재노출 — `from rag_core import STOPWORDS` 등 기존 외부 import (5개 consumer)는 변경 없이 동작.

상위 plan: Tier 2 PR-D (`/Users/hskim/.claude/plans/bidmate-docagent-witty-glade.md`). Closes #344.

## 2. Files affected

- 신규 `data/lexicon/ko_default.yaml` — 11개 컬렉션 / 카테고리 코멘트.
- 신규 `korean_lexicon.py` — YAML 로더 + 모듈 상수 + `@lru_cache(maxsize=1)`.
- `rag_core.py` — lexicon 정의 블록 제거(−215 줄) + import 블록 추가(+20 줄). **순 −196 줄** (4,350 → 4,154 lines).
- `pyproject.toml` — `korean_lexicon`을 coverage source 추가.

**Load-bearing**: ✅ `rag_core.py`. 5b 작성 필수.

## 3. Risks

- **재노출 깨질 위험**: `tests/test_hybrid_retrieval_regression.py`가 `from rag_core import BM25_EXTRA_PARTICLE_SUFFIXES, BM25_EXTRA_STOPWORDS`로 import. → `rag_core`가 `from korean_lexicon import (...)`로 11개 모두 재노출하므로 변경 없이 작동.
- **타입 mismatch 위험**: `set` vs `frozenset`, `tuple` vs `list` 차이로 동작이 바뀔 가능성. → loader가 각 collection별 정확한 타입으로 coerce하고, 사전 검증 스크립트로 `kl.X == rc.X` + `isinstance` 11개 모두 OK 확인 후 inline 블록 삭제.
- **YAML 인코딩 위험**: 한글 NFC normalization 차이로 token 매칭 깨질 가능성. → 639 test pass + `naive_baseline` retrieval 결과 동일성으로 간접 검증.

## 4. Tests

- 사전 검증(pre-replacement): `korean_lexicon` 11개 collection 각각에 대해 `== inline value` + `isinstance(expected_type)` 통과 확인 후 inline 블록 삭제.
- 사후 검증(post-replacement): 11개 모두 `rag_core.X is korean_lexicon.X` (object identity) 확인.
- 전체 pytest (EMBEDDING_BACKEND=hashing): **639 passed / 0 failed / 0 skipped / 121 subtests passed in 16.85s**. Coverage 61% (PR #325 기준선 유지).

## 5. Eval impact

All `·`. lexicon 값이 변하지 않았으므로 retrieval / verifier / answer 동작 동일.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path — pure refactor, identical Python objects via re-export, full test suite green (639 passed). lexicon 값 자체는 1글자도 변하지 않았으며 loader의 coercion이 원래 Python 타입을 정확히 복원함을 11개 collection 모두 사전·사후 검증으로 확인. `naive_baseline` 답변 JSON diff = 0 (ADR 0001 invariant).

## 6. Backward compatibility

- `from rag_core import STOPWORDS, ...` 외부 API 그대로 작동.
- `tests/test_hybrid_retrieval_regression.py`의 `BM25_EXTRA_*` import 그대로 작동.
- 답변 schema(ADR 0003), `naive_baseline` invariant(ADR 0001) 모두 유지.

## 7. Out of scope

- 도메인별 overlay 시스템(`medical_rfp.yaml` / `construction_rfp.yaml`) — follow-up.
- `ENTITY_RE` / `TOKEN_RE` / `SENTENCE_RE` 같은 컴파일된 `re.Pattern` — YAML 부적합, 별도 module 검토 후 추출 시점 결정.
- `STRICT_METADATA_CONFIDENCE` 등 threshold 상수, `ANSWER_STATUS_*` 등 schema 상수 — lexicon이 아니므로 `rag_core.py` 유지.
- PR-E `rag_core.py` 분해 epic의 다음 단계(pipeline presets 추출 등) — 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)