### PR TITLE
refactor: Reranker Protocol with CrossEncoderReranker default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Supporting:
 
 - `app.py` — CLI query entry point.
 - `rag_vector_store.py` — `VectorStore` Protocol behind the embeddings sidecar (issue #232, Stage 1 of #176). `BIDMATE_INDEX_BACKEND=memory` is the only supported value today; `qdrant` / `pgvector` are reserved for follow-up PRs.
+- `rag_reranker.py` — `Reranker` Protocol + default `CrossEncoderReranker` adapter (issue #345, follow-up to #332). Wraps `rag_rerank.rerank` so future HyDE / LLM-as-reranker impls plug in without touching `rag_core.apply_fusion_and_reranking`.
 - `scripts/` — `build_index.py`, `update_readme_metrics.py`, `run_real_eval_delta.py`, etc.
 - `data/raw/` → `data/index/` → `outputs/` → `reports/` (pipeline artifacts).
 - `docs/` — design notes, ADRs, failure analyses, reviewer artifacts.

--- a/rag_core.py
+++ b/rag_core.py
@@ -2020,10 +2020,10 @@ def apply_fusion_and_reranking(
 
     scored.sort(key=lambda item: item["score"], reverse=True)
     if plan.get("rerank_cross_encoder"):
-        from rag_rerank import rerank as cross_rerank
+        from rag_reranker import default_reranker
 
         top_n = min(30, max(int(plan["top_k"] or 10) * 3, int(plan["top_k"] or 10)))
-        scored, rerank_meta = cross_rerank(query, scored, top_n=top_n)
+        scored, rerank_meta = default_reranker().rerank(query, scored, top_n=top_n)
         plan["rerank_cross_encoder_meta"] = rerank_meta
     top_k = int(plan["top_k"])
     if plan.get("retrieval_mode") == "hierarchical":

--- a/rag_reranker.py
+++ b/rag_reranker.py
@@ -1,0 +1,66 @@
+"""Reranker Protocol — pluggable post-retrieval reordering stage (#345).
+
+The Protocol decouples ``rag_core.apply_fusion_and_reranking`` from the
+specific cross-encoder backend dispatch in ``rag_rerank``, so future
+reranking strategies (HyDE, LLM-as-judge, custom domain models) can
+plug in without modifying retrieval orchestration code. Mirrors the
+``VectorStore`` Protocol pattern (``rag_vector_store.py``) introduced
+for #176.
+
+``CrossEncoderReranker`` is the default implementation; it delegates
+to ``rag_rerank.rerank`` so the existing ``BIDMATE_RERANK_BACKEND``
+env-var dispatch (stub / bge / cohere / bge_ko) and the never-raise
+fallback contract are preserved unchanged.
+
+``default_reranker()`` returns ``CrossEncoderReranker()`` today; when
+a second concrete reranker (e.g. ``HydeReranker``) lands, the plan-
+based dispatch becomes a one-file change here — ``rag_core.py`` stays
+untouched.
+"""
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Reranker(Protocol):
+    """Pluggable post-retrieval scoring + reordering stage.
+
+    Implementations must NEVER raise; on backend failure they must
+    return the input candidates unchanged with ``meta["fell_back"]``
+    set, preserving retrieval recall as the fallback contract
+    (matches ``rag_rerank.rerank``'s existing guarantee).
+    """
+
+    def rerank(
+        self,
+        query: str,
+        candidates: list[dict[str, Any]],
+        *,
+        top_n: int,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        ...
+
+
+class CrossEncoderReranker:
+    """Default ``Reranker`` — delegates to ``rag_rerank.rerank`` so the
+    existing ``BIDMATE_RERANK_BACKEND`` env-var dispatch and the
+    never-raise fallback path stay unchanged."""
+
+    def rerank(
+        self,
+        query: str,
+        candidates: list[dict[str, Any]],
+        *,
+        top_n: int,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        from rag_rerank import rerank as _cross_rerank
+
+        return _cross_rerank(query, candidates, top_n=top_n)
+
+
+def default_reranker() -> Reranker:
+    """The reranker ``apply_fusion_and_reranking`` uses unless a future
+    plan-level override is wired in. Returns a fresh instance so callers
+    can swap implementations in tests without module-level state."""
+    return CrossEncoderReranker()

--- a/tests/test_reranker_protocol.py
+++ b/tests/test_reranker_protocol.py
@@ -1,0 +1,54 @@
+"""Contract test for the Reranker Protocol (#345, follow-up to #332).
+
+Single test file by design — heavier behavior assertions
+(stub-backend identity pass-through, bge / cohere shape, postcondition
+guards) already live in ``tests/test_cross_encoder_rerank.py`` against
+``rag_rerank.rerank`` itself. This file only nails down the Protocol
+surface: ``default_reranker()`` returns a ``Reranker`` whose ``rerank``
+delegation produces the same shape as the underlying
+``rag_rerank.rerank`` contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rag_reranker import CrossEncoderReranker, Reranker, default_reranker
+
+
+def test_default_reranker_is_cross_encoder() -> None:
+    reranker = default_reranker()
+    assert isinstance(reranker, Reranker)
+    assert isinstance(reranker, CrossEncoderReranker)
+
+
+def test_cross_encoder_reranker_delegates_under_stub_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stub backend is identity pass-through (see rag_rerank.py
+    docstring on the full_reranker / full byte-equivalence contract);
+    the Protocol must preserve that semantics so a hashing-CI eval
+    swap from direct ``rag_rerank.rerank`` to ``default_reranker()``
+    leaves ``eval_summary.json`` byte-identical."""
+    monkeypatch.setenv("BIDMATE_RERANK_BACKEND", "stub")
+    candidates = [
+        {"chunk_id": "a", "text": "alpha", "score": 0.5},
+        {"chunk_id": "b", "text": "beta", "score": 0.3},
+        {"chunk_id": "c", "text": "gamma", "score": 0.1},
+    ]
+    reordered, meta = default_reranker().rerank(
+        "irrelevant query", candidates, top_n=3
+    )
+    assert reordered == candidates
+    assert meta["backend"] == "stub"
+    assert meta["fell_back"] is False
+    assert meta["candidates_scored"] == 3
+
+
+def test_cross_encoder_reranker_empty_candidates_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BIDMATE_RERANK_BACKEND", "stub")
+    reordered, meta = default_reranker().rerank("q", [], top_n=5)
+    assert reordered == []
+    assert meta["fell_back"] is False


### PR DESCRIPTION
## 1. What changed and why

Closes #345

Re-opens [#356](https://github.com/hskim-solv/BidMate-DocAgent/pull/356) after [#342](https://github.com/hskim-solv/BidMate-DocAgent/pull/342) (split `retrieve()`) landed on main and the original stacked PR was auto-closed by GitHub when its base branch was deleted. This PR is rebased onto current main; the c0f792e commit was dropped automatically by git (patch-id match against #342's squash).

After #342 `apply_fusion_and_reranking` still imports `rag_rerank.rerank` directly inside its body — every future reranker (HyDE, LLM-as-reranker, domain-specific) would have to add its dispatch there. This PR introduces a Protocol-level seam so the dispatch lives in one place outside retrieval orchestration.

- **New module** `rag_reranker.py`:
  - `@runtime_checkable Reranker` Protocol with `rerank(query, candidates, *, top_n) -> (reordered, meta)`.
  - `CrossEncoderReranker` — adapter that delegates to `rag_rerank.rerank`. The existing `BIDMATE_RERANK_BACKEND` env-var dispatch (stub / bge / cohere / bge_ko) and the never-raise fallback contract are preserved unchanged.
  - `default_reranker()` factory — returns `CrossEncoderReranker()`; the one-line dispatch hook for future plan-based routing.
- **Updated `rag_core.apply_fusion_and_reranking`** (load-bearing): replaced the inline `from rag_rerank import rerank as cross_rerank` + direct call with `default_reranker().rerank(...)`. Plan mutation order (`rerank_cross_encoder_meta`) unchanged.
- **New** `tests/test_reranker_protocol.py` — 3 contract tests (`runtime_checkable` instance check, stub-backend identity pass-through, empty-candidates guard).
- **CLAUDE.md** — one-line entry under "Supporting" pointing reviewers at the new Protocol module (mirrors the `rag_vector_store.py` entry added by #232).

Mirrors the `VectorStore` Protocol pattern (#176 Stage 1 / #232).

## 2. Files affected

- `rag_reranker.py` (new, 65 lines)
- `rag_core.py` (load-bearing) — 4-line diff (import + call-site swap)
- `tests/test_reranker_protocol.py` (new)
- `CLAUDE.md` — +1 line in the Supporting list

## 3. Risks

The realistic break mode is silent ranking drift if the adapter changes the `top_n` argument or the candidate ordering before delegating to `rag_rerank.rerank`. Mitigation:
- `tests/test_naive_baseline_ranking_invariance.py` (ADR 0001 golden, bit-identical) — **PASS**
- `tests/test_cross_encoder_rerank.py` (15 tests covering stub / bge / postcondition guards) — **PASS**
- `tests/test_hybrid_retrieval_regression.py` (25 tests) — **PASS**
- `make smoke`: identical quality metrics across all ablation rows (Accuracy / Groundedness / Citation / Format / Abstention / Retry all match pre-Protocol).

## 4. Tests

- New `tests/test_reranker_protocol.py` — 3 contract tests:
  - `test_default_reranker_is_cross_encoder` — Protocol surface + adapter identity.
  - `test_cross_encoder_reranker_delegates_under_stub_backend` — locks the byte-equivalence with the underlying `rag_rerank.rerank` stub path.
  - `test_cross_encoder_reranker_empty_candidates_returns_empty` — empty-list guard.
- Full suite: `python3 -m pytest -q` → **642 passed, 121 subtests passed**, no regressions.

## 5. Eval impact

All `·` (no behavior change — pure structural seam; smoke confirms identical quality metrics).

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

(`make real-eval-delta` is not runnable in this worktree: `data/private` is unavailable locally. The naive_baseline ADR 0001 golden file is the bit-identical proxy and it passes.)

## 6. Backward compatibility

- `rag_rerank.rerank()` public surface unchanged — still importable, still callable directly (used by `tests/test_cross_encoder_rerank.py`).
- `run_rag_query` / `retrieve` / `apply_fusion_and_reranking` signatures unchanged.
- `plan["rerank_cross_encoder_meta"]` schema unchanged.
- No `schema_version` bump needed.

## 7. Out of scope

- HyDE / multi-query / LLM-as-reranker implementations — separate Phase 3 issues.
- `resolve_reranker(plan)` plan-based dispatcher — not needed until ≥2 concrete impls exist. `default_reranker()` is the one-line evolution path.
- Changing `rag_rerank.py` backend code (stub / bge / cohere / bge_ko adapters unchanged).
- README metrics-table refresh (local smoke diff is wall-clock noise + the `full_llm_metadata` row already on main; tracked in #342's §7).

Supersedes #356 (auto-closed when base branch `refactor/issue-332-split-retrieve` was deleted on #342 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)