### PR TITLE
test(governance): G6 — narrative ↔ ADR directory sync guard

### DIFF
--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -282,3 +282,152 @@ def test_rag_core_has_no_shadow_answer_models():
         "parallel class. If a structural model is genuinely needed, "
         "write an ADR superseding 0003 first."
     )
+
+
+# ---------------------------------------------------------------------------
+# G6 — docs/senior-positioning.md narrative must stay in sync with the
+# actual docs/adr/ directory (issue #317).
+#
+# The narrative mirrors three pieces of ADR-directory state:
+#   1. an "{N}개 ADR" count label (in the signal-overview table intro AND
+#      in an in-body interview talking-point quote),
+#   2. an "{N} accepted / {M} proposed" status breakdown alongside (1),
+#   3. an ADR table with one row per `docs/adr/NNNN-*.md` file, each row
+#      carrying a status cell that must match the file's
+#      `- **Status**: ...` header.
+#
+# Without these guards, merging a new ADR (or flipping a status from
+# proposed → accepted) silently drifts the reviewer-facing narrative.
+# ---------------------------------------------------------------------------
+
+
+_SENIOR_POS_PATH = ROOT_DIR / "docs" / "senior-positioning.md"
+
+_SENIOR_POS_ROW_RE = re.compile(
+    r"^\|\s*\[(\d{4})\]\(\./adr/(\d{4}-[^)]+\.md)\)\s*\|\s*(\w+)\s*\|",
+    re.MULTILINE,
+)
+
+_SENIOR_POS_COUNT_RE = re.compile(r"(\d+)\s*개\s+ADR")
+
+_SENIOR_POS_STATUS_LABEL_RE = re.compile(
+    r"(\d+)\s+accepted\s*/\s*(\d+)\s+proposed"
+)
+
+_ADR_STATUS_HEADER_RE = re.compile(
+    r"^-\s*\*\*Status\*\*\s*:\s*(\w+)\s*$",
+    re.MULTILINE,
+)
+
+
+def _adr_files() -> list[Path]:
+    return sorted(
+        (ROOT_DIR / "docs" / "adr").glob("[0-9][0-9][0-9][0-9]-*.md")
+    )
+
+
+def _adr_statuses() -> dict[str, str]:
+    """Map ADR number ('0001') -> declared status ('accepted'/'proposed')."""
+    result: dict[str, str] = {}
+    for path in _adr_files():
+        m = _ADR_STATUS_HEADER_RE.search(path.read_text())
+        assert m, (
+            f"ADR {path.name}: missing `- **Status**: ...` header line. "
+            f"Add it near the top of the file (see ADR 0001 for the pattern)."
+        )
+        result[path.name[:4]] = m.group(1)
+    return result
+
+
+def test_senior_positioning_count_label_matches_adr_files():
+    text = _SENIOR_POS_PATH.read_text()
+    label_values = {int(n) for n in _SENIOR_POS_COUNT_RE.findall(text)}
+    assert label_values, (
+        "docs/senior-positioning.md must contain a '{N}개 ADR' count label."
+    )
+    actual = len(_adr_files())
+    assert label_values == {actual}, (
+        f"senior-positioning.md '{{N}}개 ADR' labels = {sorted(label_values)}, "
+        f"docs/adr/ file count = {actual}. Issue #317: when a new ADR is "
+        f"merged, update every '{{N}}개 ADR' occurrence in "
+        f"docs/senior-positioning.md (signal-overview table intro + interview "
+        f"talking-point quote)."
+    )
+
+
+def test_senior_positioning_status_breakdown_matches_adr_files():
+    text = _SENIOR_POS_PATH.read_text()
+    m = _SENIOR_POS_STATUS_LABEL_RE.search(text)
+    assert m, (
+        "docs/senior-positioning.md must contain a "
+        "'{N} accepted / {M} proposed' status breakdown label "
+        "(near the '{N}개 ADR' count)."
+    )
+    declared = (int(m.group(1)), int(m.group(2)))
+
+    statuses = list(_adr_statuses().values())
+    actual = (statuses.count("accepted"), statuses.count("proposed"))
+
+    assert declared == actual, (
+        f"senior-positioning.md status breakdown = "
+        f"{declared[0]} accepted / {declared[1]} proposed, "
+        f"actual ADR file headers = "
+        f"{actual[0]} accepted / {actual[1]} proposed. "
+        f"Issue #317: update the breakdown label whenever an ADR's "
+        f"`- **Status**: ...` header changes or a new ADR is added."
+    )
+
+
+def test_senior_positioning_table_rows_match_adr_files():
+    text = _SENIOR_POS_PATH.read_text()
+    rows = _SENIOR_POS_ROW_RE.findall(text)
+    assert rows, (
+        "docs/senior-positioning.md must contain ADR table rows of the form "
+        "`| [NNNN](./adr/NNNN-slug.md) | <status> | ... |`."
+    )
+
+    narrative_numbers = {row[0] for row in rows}
+    narrative_filenames = {row[1] for row in rows}
+    narrative_status_by_num = {row[0]: row[2] for row in rows}
+
+    actual_files = _adr_files()
+    actual_numbers = {p.name[:4] for p in actual_files}
+    actual_filenames = {p.name for p in actual_files}
+    actual_statuses = _adr_statuses()
+
+    assert narrative_numbers == actual_numbers, (
+        f"ADR set drift between docs/senior-positioning.md table and "
+        f"docs/adr/ files.\n"
+        f"  missing from narrative: "
+        f"{sorted(actual_numbers - narrative_numbers)}\n"
+        f"  unknown in narrative:   "
+        f"{sorted(narrative_numbers - actual_numbers)}\n"
+        f"Issue #317: add/remove rows in docs/senior-positioning.md so the "
+        f"narrative table tracks the directory."
+    )
+
+    assert narrative_filenames == actual_filenames, (
+        f"ADR filename drift between narrative table link targets and "
+        f"docs/adr/. Check `./adr/...` link targets in "
+        f"senior-positioning.md.\n"
+        f"  narrative-only: "
+        f"{sorted(narrative_filenames - actual_filenames)}\n"
+        f"  disk-only:      "
+        f"{sorted(actual_filenames - narrative_filenames)}"
+    )
+
+    mismatches = [
+        (n, narrative_status_by_num[n], actual_statuses[n])
+        for n in sorted(narrative_numbers)
+        if narrative_status_by_num[n] != actual_statuses[n]
+    ]
+    assert not mismatches, (
+        "Status cell drift between senior-positioning.md table and ADR "
+        "file `- **Status**:` headers:\n"
+        + "\n".join(
+            f"  {n}: narrative={narr!r}, file={file!r}"
+            for n, narr, file in mismatches
+        )
+        + "\nIssue #317: update the status cell in the narrative row when "
+        "the ADR file's status changes (e.g., proposed -> accepted)."
+    )


### PR DESCRIPTION
## 1. What changed and why

Closes #317.

Add three governance regression tests to `tests/test_governance.py` (G6.1–G6.3) that fail when `docs/senior-positioning.md` drifts from the `docs/adr/` directory. The narrative mirrors three pieces of ADR-directory state — a `{N}개 ADR` count label, an `{N} accepted / {M} proposed` status breakdown, and a 19-row ADR table — and each was previously silent-drift-prone whenever a new ADR was merged or a status flipped from proposed → accepted. The guards reuse G4's regex + helper pattern (G4 already enforces the `docs/adr/README.md` ↔ files mapping), and run as part of the existing `bash scripts/test.sh` gate.

## 2. Files affected

- `tests/test_governance.py` — `+149` lines: new G6 section with `_SENIOR_POS_*` / `_ADR_STATUS_HEADER_RE` regexes, `_adr_files()` / `_adr_statuses()` helpers, and three test functions.

No load-bearing path (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py`) is touched. The guard *reads* `docs/adr/` and `docs/senior-positioning.md` but does not modify either.

## 3. Risks

Most likely failure: the regexes are too strict and break when a future ADR uses a slightly different status-header format. Rule-out:

- `_ADR_STATUS_HEADER_RE = ^-\s*\*\*Status\*\*\s*:\s*(\w+)\s*$` — verified against the actual headers of ADR 0001 (accepted), 0009 (proposed), 0019 (accepted). All 19 current ADRs share this exact format.
- `_SENIOR_POS_ROW_RE` mirrors G4's existing `_ADR_INDEX_ROW_RE` with one change: link target prefix `./adr/` instead of `./`. Cross-checked against rows on lines 32–50 of `docs/senior-positioning.md`.
- Fail-mode sanity: created a dummy `docs/adr/0020-DELETE-ME.md` (`- **Status**: accepted`) and re-ran the suite — all three G6 tests failed with actionable messages (`missing from narrative: ['0020']`, `breakdown = 15 accepted / 4 proposed, actual = 16 accepted / 4 proposed`, count label mismatch). Removed the dummy; tests trivially pass again.

## 4. Tests

The new tests *are* the change. Behavior verification covered by:

- `python3 -m pytest tests/test_governance.py -k senior_positioning -v` → 3 passed.
- `python3 -m pytest tests/test_governance.py` → 49 passed (G1–G5 + new G6).
- `python3 -m pytest -q` → 650 passed (full suite, no regressions).
- Fail-mode reproduction documented in §3.

## 5. Eval impact

All `·`. This is a docs-governance test addition; no retrieval / verifier / answer-contract code is touched, so the synthetic CI eval delta should be flat across all metrics.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. No load-bearing file modified (see §2).

## 6. Backward compatibility

No contract / schema / CLI / doc-link breakage. The guard is purely additive — it asserts an invariant that already holds (19-ADR state passes trivially). `schema_version` (ADR 0003) untouched.

## 7. Out of scope

- Sync guards for other narrative docs (`portfolio-case-study.md`, `engineering-governance.md`) — same pattern is reusable, but flagged for a separate issue per the #317 spec.
- ADR README table self-sync — already covered by G4 (`test_adr_index_rows_resolve_to_files` / `test_no_unlinked_adr_files_on_disk`).
- Semantic quality of the narrative's "시니어 관점" cells — not amenable to regex-level regression guarding.