### PR TITLE
feat(ingestion): HwpNativeLoader silent-fallback observability

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import csv
 import os
+import warnings
 from collections import OrderedDict
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -114,21 +115,35 @@ class HwpNativeLoader(CsvTextDocumentLoader):
     parse failure, falls back to the CSV ``텍스트`` column so the baseline
     ingestion contract (ADR 0001) keeps working without pyhwp installed.
 
-    The selected source is exposed via ``last_text_source`` so the caller can
-    propagate it into the document metadata.
+    Diagnostics (issue #363): ``last_text_source`` records which source the
+    final text came from; ``last_fallback_reason`` records ``"ExceptionName:
+    truncated message"`` when fallback fires (``None`` otherwise). Because
+    this loader is only constructed when the user opts in via
+    ``BIDMATE_HWP_LOADER=native`` (see ``_resolve_loader``), every fallback
+    here also emits a ``RuntimeWarning`` so the silent path is visible in
+    real-data eval logs.
     """
 
     file_format = "hwp"
 
     def __init__(self) -> None:
         self.last_text_source = "data_list_csv_text"
+        self.last_fallback_reason: str | None = None
 
     def load_text(self, row: dict[str, str], source_path: Path) -> str:
         self.last_text_source = "data_list_csv_text"
+        self.last_fallback_reason = None
         try:
             native_text = _extract_hwp_native(source_path)
-        except (ImportError, OSError, RuntimeError):
+        except (ImportError, OSError, RuntimeError) as exc:
             native_text = None
+            reason = f"{type(exc).__name__}: {str(exc)[:120]}"
+            self.last_fallback_reason = reason
+            warnings.warn(
+                f"HwpNativeLoader fallback to CSV text: {reason}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         if native_text:
             self.last_text_source = "hwp_native"
             return native_text

--- a/tests/test_hwp_native_loader_regression.py
+++ b/tests/test_hwp_native_loader_regression.py
@@ -8,6 +8,10 @@ Covers:
     pyhwp installed in CI)
   * ``text_source`` metadata propagates from the loader (no longer hardcoded)
   * cross-format isolation: PDF dispatch ignores the HWP-specific env var
+  * fallback observability (issue #363): ``last_fallback_reason`` field is
+    populated and a ``RuntimeWarning`` is emitted on every silent CSV
+    fallback; clean native success leaves the field ``None`` and emits
+    nothing
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ import csv
 import os
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
 from unittest import mock
 
@@ -136,41 +141,84 @@ class HwpNativeLoaderRegressionTest(unittest.TestCase):
         loader = HwpNativeLoader()
         # Force the import inside _extract_hwp_native to fail by injecting a
         # patched importer. This mirrors the no-pyhwp CI environment.
-        with mock.patch(
-            "ingestion._extract_hwp_native",
-            side_effect=ImportError("pyhwp not installed"),
-        ):
-            text = loader.load_text(
-                {"텍스트": "fallback body"}, Path("/nonexistent.hwp")
-            )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with mock.patch(
+                "ingestion._extract_hwp_native",
+                side_effect=ImportError("pyhwp not installed"),
+            ):
+                text = loader.load_text(
+                    {"텍스트": "fallback body"}, Path("/nonexistent.hwp")
+                )
         self.assertEqual("fallback body", text)
         self.assertEqual("data_list_csv_text", loader.last_text_source)
+        # Issue #363: silent fallback is now observable.
+        self.assertIsNotNone(loader.last_fallback_reason)
+        self.assertIn("ImportError", loader.last_fallback_reason)
+        self.assertIn("pyhwp not installed", loader.last_fallback_reason)
+        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        self.assertEqual(1, len(runtime_warnings))
+        self.assertIn("HwpNativeLoader fallback", str(runtime_warnings[0].message))
 
     def test_native_loader_falls_back_when_parser_raises_oserror(self) -> None:
         loader = HwpNativeLoader()
-        with mock.patch(
-            "ingestion._extract_hwp_native",
-            side_effect=OSError("not a valid OLE file"),
-        ):
-            text = loader.load_text(
-                {"텍스트": "csv text after parse failure"},
-                Path("/nonexistent.hwp"),
-            )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with mock.patch(
+                "ingestion._extract_hwp_native",
+                side_effect=OSError("not a valid OLE file"),
+            ):
+                text = loader.load_text(
+                    {"텍스트": "csv text after parse failure"},
+                    Path("/nonexistent.hwp"),
+                )
         self.assertEqual("csv text after parse failure", text)
         self.assertEqual("data_list_csv_text", loader.last_text_source)
+        # Issue #363: silent fallback is now observable.
+        self.assertIsNotNone(loader.last_fallback_reason)
+        self.assertIn("OSError", loader.last_fallback_reason)
+        self.assertIn("not a valid OLE file", loader.last_fallback_reason)
+        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        self.assertEqual(1, len(runtime_warnings))
 
     def test_native_loader_records_hwp_native_source_on_success(self) -> None:
         loader = HwpNativeLoader()
-        with mock.patch(
-            "ingestion._extract_hwp_native",
-            return_value="native extracted body",
-        ):
-            text = loader.load_text(
-                {"텍스트": "csv text (should be ignored)"},
-                Path("/nonexistent.hwp"),
-            )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with mock.patch(
+                "ingestion._extract_hwp_native",
+                return_value="native extracted body",
+            ):
+                text = loader.load_text(
+                    {"텍스트": "csv text (should be ignored)"},
+                    Path("/nonexistent.hwp"),
+                )
         self.assertEqual("native extracted body", text)
         self.assertEqual("hwp_native", loader.last_text_source)
+        # Issue #363: clean native success leaves no fallback trace.
+        self.assertIsNone(loader.last_fallback_reason)
+        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        self.assertEqual(0, len(runtime_warnings))
+
+    def test_native_loader_fallback_reason_resets_between_calls(self) -> None:
+        """Issue #363: a clean call after a failed one must clear the reason
+        so diagnostics never bleed across documents in a multi-doc ingest."""
+        loader = HwpNativeLoader()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            with mock.patch(
+                "ingestion._extract_hwp_native",
+                side_effect=RuntimeError("corrupted body section"),
+            ):
+                loader.load_text({"텍스트": "first csv"}, Path("/a.hwp"))
+            self.assertIsNotNone(loader.last_fallback_reason)
+            with mock.patch(
+                "ingestion._extract_hwp_native",
+                return_value="second native body",
+            ):
+                loader.load_text({"텍스트": "second csv"}, Path("/b.hwp"))
+            self.assertIsNone(loader.last_fallback_reason)
+            self.assertEqual("hwp_native", loader.last_text_source)
 
     def test_native_loader_empty_native_and_empty_csv_raises(self) -> None:
         loader = HwpNativeLoader()


### PR DESCRIPTION
## 1. What changed and why

Closes #363

`HwpNativeLoader` ([`ingestion.py`](ingestion.py)) is opt-in via `BIDMATE_HWP_LOADER=native` (spike, [#167](https://github.com/hskim-solv/BidMate-DocAgent/issues/167)). When the native pyhwp parse fails it silently catches `ImportError` / `OSError` / `RuntimeError` and falls back to the CSV `텍스트` column. The Pre-Phase-3 risk audit flagged this as Risk #2: a user explicitly setting `BIDMATE_HWP_LOADER=native` could not tell from logs alone whether native parsing actually fired.

This PR makes the silent path observable **without changing behavior**:
- New `last_fallback_reason` field on the loader records `"ExceptionClassName: truncated message"` when fallback fires (`None` on success).
- Each fallback emits exactly one `RuntimeWarning`. Because `HwpNativeLoader` is only ever constructed when the user opts in (see `_resolve_loader`), every warning is actionable.
- Test suite extended: existing 2 fallback tests now assert reason + warning; new test asserts no warning on native success; new test asserts reason resets between calls.

The larger architectural question — **deprecate `HwpNativeLoader` vs integrate into `visual_ingestion` v2** — is deferred to a follow-up issue ([#365](https://github.com/hskim-solv/BidMate-DocAgent/issues/365)) so this PR keeps to one concern.

## 2. Files affected

- `ingestion.py` (load-bearing) — +21 lines: `import warnings`, new field init/reset, fallback `as exc` capture, `warnings.warn` call, docstring update
- `tests/test_hwp_native_loader_regression.py` — +94 / -26: existing 3 fallback / success tests extended with reason + warning assertions; 1 new reset-between-calls test; module docstring updated

## 3. Risks

The realistic break mode is over-warning (e.g. emitting on benign cases that aren't user-opted-in). Mitigation: `HwpNativeLoader` is only instantiated via `_resolve_loader` when `BIDMATE_HWP_LOADER=native` is set, so the no-opt-in path emits no warnings — confirmed by the unchanged `test_default_dispatch_returns_csv_loader` and `test_metadata_text_source_default_preserves_baseline_string` tests, which exercise the default-CSV path and continue to pass with zero warnings.

Secondary risk: the new RuntimeWarning showing up under `-W error` in downstream CI. The repo's `pyproject.toml` does not promote RuntimeWarning to error in `pytest` config, and `python3 -m pytest -q` runs clean (651 passed, 6 warnings — 5 pre-existing + 1 expected new one from the opt-in invalid-HWP fallback test, which is the intended observability surface).

## 4. Tests

- `tests/test_hwp_native_loader_regression.py`: 12 tests, all passing.
  - Existing fallback / success tests now assert `last_fallback_reason` correctness and warning emission (or absence).
  - New `test_native_loader_fallback_reason_resets_between_calls` locks the cross-document reset behavior so diagnostics don't bleed across a multi-doc ingest.
- Full suite: `python3 -m pytest -q` → **651 passed, 121 subtests passed**, no regressions.
- `make smoke`: PASS — the new RuntimeWarning is the only expected delta in the warning summary (originates from the opt-in-with-invalid-HWP regression case that already existed).

## 5. Eval impact

All `·` (no behavior change — diagnostics only).

### 5b. Real-data delta

No behavior change in ingestion path.

(`make real-eval-delta` is not runnable in this worktree: `data/private` is unavailable locally. Behavior preservation is asserted via the unchanged `_resolve_loader` dispatch logic + the unchanged `text_source` propagation tests.)

## 6. Backward compatibility

- `_resolve_loader` dispatch logic unchanged — default still `HwpCsvTextLoader`.
- `BIDMATE_HWP_LOADER` env-var semantics unchanged.
- `last_text_source` values unchanged (`"hwp_native"` / `"data_list_csv_text"`).
- New `last_fallback_reason` field is additive (`None` by default) — no consumer reads it yet, so adding it cannot break anything.
- ADR 0001 baseline invariant preserved (test_metadata_text_source_default_preserves_baseline_string passes).

## 7. Out of scope

- **Deprecate vs integrate decision** for `HwpNativeLoader` → tracked in [#365](https://github.com/hskim-solv/BidMate-DocAgent/issues/365). One eval cycle of fallback-reason data should inform that choice.
- Promoting the env var beyond opt-in spike.
- Restructuring CSV / native dispatch in `_resolve_loader`.
- Changes to `visual_ingestion.make_hwp_fallback_document` (separate HWP path, separate concern).
- Surfacing `last_fallback_reason` into the document `metadata` or `ingestion_report.json` — additive next step once we have eval data on warning frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)