### PR TITLE
docs(claude-md): document LOAD_BEARING_PATHS SSoT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,14 @@ that aren't auto-enforced.
 
 ## Repository map
 
-Load-bearing — changes here require PR template **item 5b (real-data delta)** filled in:
+Load-bearing — changes here require PR template **item 5b (real-data delta)** filled in. Canonical machine-readable list lives in [`scripts/_governance.py`](scripts/_governance.py) `LOAD_BEARING_PATHS` (single source of truth read by `.githooks/pre-push`, `scripts/claude-hooks/pretooluse-loadbearing.sh`, and the `--check-5b` CI gate); add or remove entries there first so the three consumers pick it up automatically. The bullets below are the human reading guide.
 
 - `rag_core.py` — core RAG pipeline (retrieval, verifier, answer generation).
 - `ingestion.py`, `visual_ingestion.py` — document loading + parsing.
 - `eval/` — eval scripts and configs (`eval/config.yaml` defines the `naive_baseline` ablation preset).
-- `api/main.py` — FastAPI demo server.
+- `api/main.py` — FastAPI demo server (the whole `api/` directory is in the SSoT).
 - `docs/adr/` — accepted decision records.
+- `scripts/build_index.py` — index builder; downstream of `ingestion` + `rag_core`, surfaces ablation regressions before they reach eval.
 
 Supporting:
 


### PR DESCRIPTION
## 1. What changed and why

Closes #367

[`scripts/_governance.py`](scripts/_governance.py) is the canonical machine-readable list of load-bearing paths; three consumers (`.githooks/pre-push`, the Claude PreToolUse hook at `scripts/claude-hooks/pretooluse-loadbearing.sh`, and the `--check-5b` CI gate via `scripts/check_branch_and_issue.py`) read it. Its own docstring already names CLAUDE.md as the counterpart — but CLAUDE.md did not say so. A contributor who adds a file to the descriptive bullets here without updating `_governance.py` would have their addition silently ignored by all three §5b enforcement points.

This PR:
- Adds a one-sentence note at the "Load-bearing" section header naming `scripts/_governance.py` `LOAD_BEARING_PATHS` as the SSoT, with the three consumers spelled out.
- Restores the missing `scripts/build_index.py` bullet (it IS in the SSoT but was missing from the human reading guide).
- Annotates `api/main.py` to note that the whole `api/` directory is in the SSoT (the §5b gate triggers on any `api/` change, not just `main.py`).

Pre-Phase-3 audit cleanup item #5 — smallest of the five action items, pure documentation, closing the SSoT cross-reference gap.

## 2. Files affected

- `CLAUDE.md` — +3 lines / −2 lines (header expansion + one new bullet + `api/main.py` annotation)

No load-bearing path modified. No code touched.

## 3. Risks

None functional. Documentation-only — the SSoT and the three consumers were already correctly wired; this PR just makes the wiring discoverable. Worst case: a contributor reads only the bullets and not the new header sentence, and the status quo (silent miss on `_governance.py`) persists for them — which is the bug we're partially mitigating, not introducing.

## 4. Tests

No new tests — there is no behavior to test. Sanity:
- `python3 -m pytest -q` → **650 passed, 121 subtests passed**, unchanged.
- `make check-branch` passes (branch convention).

## 5. Eval impact

All `·` (documentation only).

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion path.

## 6. Backward compatibility

Documentation only. No contract / schema / CLI change.

## 7. Out of scope

- Modifying `scripts/_governance.py` itself.
- Modifying the PR template (it already cites `scripts/_governance.py` as the canonical list).
- Adding a linter that fails when CLAUDE.md descriptive bullets drift from `LOAD_BEARING_PATHS` (interesting follow-up — could read both and warn if a path appears in one but not the other; not in scope here).
- Restructuring the Repository map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)