### PR TITLE
chore(deps): pin torch>=2.6 to unblock BGE-M3 (ADR 0019 condition 1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,14 @@ PyYAML>=6.0.3
 rank-bm25>=0.2.2,<1.0
 sentence-transformers>=2.7,<3.0
 transformers>=4.41,<5.0
+# ADR 0019 condition 1 — torch>=2.6 is the CVE-2025-32434 mitigation
+# enforced inside sentence_transformers' load path for BAAI/bge-m3 and
+# other models that ship custom code. Pinning here unblocks Phase 1.3
+# (BGE-M3 embedding ablation) and locks the floor against silent
+# downgrades in fresh installs. Older 2.2.x is still functional for
+# MiniLM / e5 / KoSimCSE — see docs/embedding-ablation.md Phase 1.2
+# "Env state" table.
+torch>=2.6
 pymupdf>=1.24,<2.0
 pdfplumber>=0.11.9,<1.0
 pytesseract>=0.3,<1.0


### PR DESCRIPTION
## 1. What changed and why

Closes #368

ADR 0019 ([docs/adr/0019-embedding-default-stays-minilm.md](docs/adr/0019-embedding-default-stays-minilm.md)) **re-open condition 1** requires a `requirements.txt` upgrade that resolves the BGE-M3 env blocker. PR #361 (Phase 1.2 measurement) confirmed that of the two env blockers ADR 0019 named, only the `torch` half remains:

| dependency | observed in #361 env | required | status |
|---|---|---|---|
| `huggingface-hub` | `0.36.2` | `< 1.0` | ✅ already cleared (e5-large-instruct loaded cleanly in Phase 1.2) |
| `torch` | `2.2.2` | `>= 2.6` | ❌ trips `sentence_transformers`' CVE-2025-32434 mitigation when loading `BAAI/bge-m3` |

This PR adds the missing `torch>=2.6` floor to `requirements.txt`. Older 2.2.x is still functional for MiniLM / e5 / KoSimCSE per `docs/embedding-ablation.md` Phase 1.2, so this is a forward-compatible floor rather than a raise that breaks existing surface.

## 2. Files affected

- `requirements.txt` — added `torch>=2.6` floor with an inline comment pointing to ADR 0019 condition 1 and Phase 1.2 env-state table.

No load-bearing files touched (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py` all unchanged).

## 3. Risks

- **Most likely break**: a downstream dependency conflicts with `torch>=2.6` in CI's fresh install. Ruled out by: `pip` resolver in CI is unconstrained on `torch` today (no other pin references it), `sentence-transformers >=2.7,<3.0` is `torch`-agnostic, and the Phase 1.2 probe (#361) loaded sentence-transformers 2.7.0 cleanly under torch 2.2.2 — newer torch is the directional fix, not a regression direction.
- **Secondary**: local maintainers on an old env that pip-installs from `requirements.txt` get the torch upgrade. Fine; that's the point.
- Verified locally that `make smoke` ✅ and `python3 -m pytest -q` ✅ (650 passed) under the **pre-bump** env (torch 2.2.2) — confirms my change is grammatically correct and does not break the existing test surface. CI will install the **post-bump** env (torch ≥ 2.6) and is the real signal for the upgrade itself.

## 4. Tests

해당 사항 없음 (`requirements.txt` 한 줄 추가 — behavior change 아님). 기존 650 pytest가 회귀 가드 역할.

## 5. Eval impact

All `·`. RAG 코드 경로 무변경. 합성 CI eval delta는 0pp.

### 5b. Real-data delta

N/A — No behavior change in retrieval / verifier path. `requirements.txt` 한 줄 추가만 있고 load-bearing 파일 (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py`) 어디도 안 건드림.

## 6. Backward compatibility

영향 없음. `torch>=2.6` 은 floor 추가이지 상한 변경 아님. 기존 사용자가 2.2.x로 고정한 환경은 `pip install -U`를 명시적으로 실행해야만 영향받음.

## 7. Out of scope

- **Phase 1.3 BGE-M3 measurement** — 본 chore가 land 한 후 별도 follow-up issue/PR로 stack. 측정 자체는 `scripts/run_embedding_ablation.py --models BAAI/bge-m3 ...` 한 줄로 idempotent하게 재현 가능 (PR #361에서 검증된 runner).
- **`sentence-transformers` / `transformers` / `huggingface-hub` 재pin** — pip resolver가 이 torch floor만으로 요구하지 않음. dependabot이 이미 정기 추적 중 (예: #355 numpy 자동 업데이트).
- **KURE-v1 / OpenAI text-embedding-3-large** — Phase 1.3 후보, 별도 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)