### PR TITLE
fix(deploy): fly.toml primary_region 'sea' → 'seo' (Fly deprecated sea)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,12 +18,13 @@
 #   flyctl secrets set BIDMATE_TRACE_BACKEND=otel
 #   flyctl secrets set OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io/v1/traces
 #
-# Region: sea (Seattle) by default — adjust to one closer to your
-# expected reviewers. `seo` (Seoul) is a natural fit for a Korean RFP
-# demo when Fly.io has capacity there.
+# Region: seo (Seoul) for the Korean RFP reviewer audience — lowest
+# latency for the primary user base. Fly.io deprecated `sea` (Seattle)
+# in 2026, so the prior default would silently fail at machine creation
+# even though build/push succeeded (issue #371).
 
 app = "bidmate-docagent-demo"   # rename via `flyctl apps create` before first deploy
-primary_region = "sea"
+primary_region = "seo"
 
 [build]
   dockerfile = "Dockerfile"


### PR DESCRIPTION
## 1. What changed and why

Closes #371

`fly.toml` 의 `primary_region` 을 `sea` (deprecated by Fly.io) → `seo` (Seoul) 로 변경. 첫 deploy run([25712966826](https://github.com/hskim-solv/BidMate-DocAgent/actions/runs/25712966826)) 이 머신 생성 단계에서 `Region sea is deprecated and cannot have new resources provisioned` 로 실패. 빌드/푸시까지는 정상이었고 (2.9 GB 이미지 push 완료), 거부는 머신 placement 단계뿐. `seo` 는 fly.toml 헤더 주석이 이미 한국 RFP 데모용으로 권장하던 리전.

## 2. Files affected

- `fly.toml` — `primary_region` + 헤더 주석 (이력 노트로 #371 참조)

Load-bearing 경로 (rag_core / ingestion / visual_ingestion / eval / api / docs/adr / scripts/build_index) 변경 없음.

## 3. Risks

- **Risk**: `seo` 리전도 일시적 capacity 부족 시 동일 패턴(머신 생성 거부) 가능. 확인 방법은 다음 deploy run; 실패 시 `nrt` (Tokyo) 또는 Fly가 직접 권한 `sjc` 로 follow-up. 빌드/push 는 이미 검증된 경로이므로 실패 진단은 빠름.
- **Mitigation already in place**: 새 워크플로의 `flyctl status --json` 가 머신 상태를 명시적으로 assert 하므로 부분 실패가 silent 통과되지 않음.

## 4. Tests

운영 검증:
1. 머지 후 deploy-fly 워크플로 (`fly.toml` 가 path filter 에 포함) 자동 재트리거
2. `flyctl deploy --remote-only` 가 머신 생성을 통과
3. `Assert all machines healthy` step 통과
4. `curl https://bidmate-docagent-demo.fly.dev/health` 200
5. PR 코멘트 자동 게시

## 5. Eval impact

All `·` — 인프라/리전 설정 변경 단독. RAG 코드 경로 미수정.

### 5b. Real-data delta

**N/A** — load-bearing 경로 미수정.

## 6. Backward compatibility

기존 `sea` 리전에 배포된 머신이 없으므로 (#359 deploy 가 머신 생성 단계에서 실패했기 때문) 마이그레이션 없음. fly.toml 설정만 교체.

## 7. Out of scope

- HF Spaces auto-sync 워크플로 (#181 의 optional 항목) — 여전히 별도 follow-up PR.
- 멀티 리전 / blue-green 전략 — #181 본문에 명시적으로 out of scope.