### PR TITLE
refactor: extract pipeline preset registry to rag_pipeline_presets.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ source = [
     "text_normalize",
     "bidmate_logging",
     "korean_lexicon",
+    "rag_pipeline_presets",
     "app",
     "api",
     "eval",

--- a/rag_core.py
+++ b/rag_core.py
@@ -59,6 +59,26 @@ from korean_lexicon import (
     VERIFICATION_INTENT_TOKENS,
 )
 
+# Pipeline preset registry (PIPELINE_PRESETS, PIPELINE_ALIASES, helpers,
+# RRF_K, VALID_RRF_K_RANGE, etc.) lives in rag_pipeline_presets.py as
+# of issue #364 — stage 1 of the rag_core.py decomposition epic. The
+# symbols below are re-exported so the FastAPI server, CLI app,
+# benchmark / build_index / eval scripts, Streamlit demo and the test
+# suite keep importing them from ``rag_core`` unchanged.
+from rag_pipeline_presets import (
+    DEFAULT_CLI_PIPELINE_NAME,
+    DEFAULT_COMPARISON_BALANCE,
+    DEFAULT_RAG_PIPELINE_NAME,
+    PIPELINE_ALIASES,
+    PIPELINE_CONFIG_KEYS,
+    PIPELINE_PRESETS,
+    RRF_K,
+    VALID_RRF_K_RANGE,
+    canonical_pipeline_name,
+    is_pipeline_name,
+    pipeline_cli_choices,
+)
+
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 DEFAULT_HASH_DIM = 384
 DEFAULT_CHUNK_MAX_CHARS = 520
@@ -66,11 +86,6 @@ DEFAULT_CHUNK_OVERLAP_SENTENCES = 1
 VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
 VALID_RETRIEVAL_MODES = {"flat", "hierarchical"}
 VALID_RETRIEVAL_BACKENDS = {"dense", "hybrid"}
-RRF_K = 60
-# Inclusive bounds for the hybrid RRF k knob (issue #149). The lower
-# bound rules out k=0 (division-by-zero); the upper bound is a sanity
-# cap — beyond ~1000 the fusion is effectively a flat sum of ranks.
-VALID_RRF_K_RANGE = (1, 1000)
 
 # Hard cap on the per-query agent loop. ``metadata_stage_sequence`` today
 # returns at most ["strict", "reduced", "relaxed"] (3 stages). This constant
@@ -78,82 +93,11 @@ VALID_RRF_K_RANGE = (1, 1000)
 # past 3 must update this value and explain why in the PR description.
 MAX_AGENT_ITERATIONS = 3
 
-DEFAULT_CLI_PIPELINE_NAME = "naive_baseline"
-DEFAULT_RAG_PIPELINE_NAME = "agentic_full"
-PIPELINE_CONFIG_KEYS = (
-    "top_k",
-    "metadata_first",
-    "rerank",
-    "rerank_cross_encoder",
-    "verifier_retry",
-    "retrieval_mode",
-    "retrieval_backend",
-    "prompt_profile",
-    "rrf_k",
-    "bm25_stopword_profile",
-)
-DEFAULT_COMPARISON_BALANCE: dict[str, Any] = {
-    "enabled": True,
-    "min_per_target": 1,
-    "k_per_target": 3,
-    "headroom": 2,
-    "max_top_k": 12,
-}
 QUERY_TYPE_TOP_K_DEFAULTS: dict[str, int] = {
     "single_doc": 4,
     "follow_up": 6,
     "comparison": 6,
 }
-PIPELINE_PRESETS: dict[str, dict[str, Any]] = {
-    "naive_baseline": {
-        "top_k": 4,
-        "metadata_first": False,
-        "rerank": False,
-        "rerank_cross_encoder": False,
-        "verifier_retry": False,
-        "retrieval_mode": "flat",
-        "retrieval_backend": "dense",
-        "prompt_profile": "minimal_grounded_extractive",
-        "rrf_k": RRF_K,
-        "bm25_stopword_profile": "shared",
-        "description": (
-            "Fixed-size chunks with dense top-k retrieval only; no metadata-first "
-            "filtering, reranking, or verifier retry."
-        ),
-    },
-    "agentic_full": {
-        "top_k": None,
-        "metadata_first": True,
-        "rerank": True,
-        "rerank_cross_encoder": False,
-        "verifier_retry": True,
-        "retrieval_mode": "flat",
-        "retrieval_backend": "dense",
-        "prompt_profile": "structured_grounded_claims",
-        "rrf_k": RRF_K,
-        "bm25_stopword_profile": "shared",
-        "comparison_balance": dict(DEFAULT_COMPARISON_BALANCE),
-        "description": "Metadata-first retrieval with lexical/metadata rerank and verifier retry.",
-    },
-    # ADR 0011 — additive LLM synthesis path. Same retrieval/verifier as
-    # agentic_full; only the summary/answer_text rendering swaps to a
-    # backend-pluggable LLM under the "no new chunk_ids" guard. Claims
-    # and citations remain extractive (ADR 0003 preserved).
-    "agentic_full_llm": {
-        "top_k": None,
-        "metadata_first": True,
-        "rerank": True,
-        "rerank_cross_encoder": False,
-        "verifier_retry": True,
-        "retrieval_mode": "flat",
-        "prompt_profile": "llm_synthesis",
-        "rrf_k": RRF_K,
-        "bm25_stopword_profile": "shared",
-        "comparison_balance": dict(DEFAULT_COMPARISON_BALANCE),
-        "description": "agentic_full retrieval; LLM-synthesized summary under ADR 0011 guard.",
-    },
-}
-PIPELINE_ALIASES = {"full": "agentic_full", "full_llm": "agentic_full_llm"}
 WEAK_SECTION_HEADINGS = {
     "",
     "본문",
@@ -241,28 +185,6 @@ def ordered_unique(values: Iterable[str]) -> list[str]:
             seen.add(value)
             ordered.append(value)
     return ordered
-
-
-def is_pipeline_name(value: Any) -> bool:
-    name = str(value or "")
-    return name in PIPELINE_PRESETS or name in PIPELINE_ALIASES
-
-
-def pipeline_cli_choices() -> list[str]:
-    # ADR 0001 explicit signal: this list is the source of truth for
-    # which pipeline names are surfaced to the CLI. Adding/removing an
-    # entry is the explicit revisit of that ADR (or, for additive
-    # changes like ADR 0011, the explicit follow-on).
-    return [DEFAULT_CLI_PIPELINE_NAME, DEFAULT_RAG_PIPELINE_NAME, "agentic_full_llm"]
-
-
-def canonical_pipeline_name(value: str | None, default: str = DEFAULT_RAG_PIPELINE_NAME) -> str:
-    requested = str(value or default)
-    canonical = PIPELINE_ALIASES.get(requested, requested)
-    if canonical not in PIPELINE_PRESETS:
-        choices = ", ".join(sorted([*PIPELINE_PRESETS, *PIPELINE_ALIASES]))
-        raise ValueError(f"pipeline must be one of: {choices}")
-    return canonical
 
 
 def resolve_pipeline_config(

--- a/rag_pipeline_presets.py
+++ b/rag_pipeline_presets.py
@@ -1,0 +1,140 @@
+"""Pipeline preset registry for the BidMate RAG core.
+
+Extracted from ``rag_core.py`` in issue #364 (PR-E, stage 1 of the
+``rag_core.py`` decomposition epic — external senior review 2026-05
+finding #3). This module is the **canonical home** for:
+
+- The CLI / API default pipeline names (ADR 0001 reproducibility
+  invariant for ``naive_baseline``; ADR 0011 for ``agentic_full_llm``).
+- The static ``PIPELINE_PRESETS`` dict and its ``PIPELINE_ALIASES``.
+- ``RRF_K`` / ``VALID_RRF_K_RANGE`` — the canonical RRF fusion default
+  used both inside the preset dict and by hybrid retrieval functions in
+  ``rag_core`` (which import them back).
+- ``DEFAULT_COMPARISON_BALANCE`` — comparison-aware top-k defaults.
+- The lookup helpers ``is_pipeline_name`` / ``pipeline_cli_choices`` /
+  ``canonical_pipeline_name`` whose behavior is pure-data (no
+  retrieval-side dependencies).
+
+This module is a **leaf** — it imports nothing from ``rag_core``.
+``rag_core`` re-exports every public symbol so existing call sites
+(``app.py``, ``api/main.py``, ``scripts/run_benchmark.py``,
+``demo/streamlit_app.py``, ``eval/run_eval.py`` and the test suite)
+continue to use ``from rag_core import ...`` unchanged.
+
+Validation / coercion (``resolve_pipeline_config``) stays in
+``rag_core`` for stage 1 because it depends on ``VALID_RETRIEVAL_MODES``
+and ``VALID_BM25_STOPWORD_PROFILES``. Stage 2 of the decomposition epic
+revisits that split.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+DEFAULT_CLI_PIPELINE_NAME = "naive_baseline"
+DEFAULT_RAG_PIPELINE_NAME = "agentic_full"
+
+# Canonical RRF fusion parameter. Imported back into ``rag_core`` for
+# the hybrid retrieval helpers and ``resolve_pipeline_config``.
+RRF_K = 60
+
+# Inclusive bounds for the hybrid RRF k knob (issue #149). The lower
+# bound rules out k=0 (division-by-zero); the upper bound is a sanity
+# cap — beyond ~1000 the fusion is effectively a flat sum of ranks.
+VALID_RRF_K_RANGE: tuple[int, int] = (1, 1000)
+
+PIPELINE_CONFIG_KEYS = (
+    "top_k",
+    "metadata_first",
+    "rerank",
+    "rerank_cross_encoder",
+    "verifier_retry",
+    "retrieval_mode",
+    "retrieval_backend",
+    "prompt_profile",
+    "rrf_k",
+    "bm25_stopword_profile",
+)
+
+DEFAULT_COMPARISON_BALANCE: dict[str, Any] = {
+    "enabled": True,
+    "min_per_target": 1,
+    "k_per_target": 3,
+    "headroom": 2,
+    "max_top_k": 12,
+}
+
+PIPELINE_PRESETS: dict[str, dict[str, Any]] = {
+    "naive_baseline": {
+        "top_k": 4,
+        "metadata_first": False,
+        "rerank": False,
+        "rerank_cross_encoder": False,
+        "verifier_retry": False,
+        "retrieval_mode": "flat",
+        "retrieval_backend": "dense",
+        "prompt_profile": "minimal_grounded_extractive",
+        "rrf_k": RRF_K,
+        "bm25_stopword_profile": "shared",
+        "description": (
+            "Fixed-size chunks with dense top-k retrieval only; no metadata-first "
+            "filtering, reranking, or verifier retry."
+        ),
+    },
+    "agentic_full": {
+        "top_k": None,
+        "metadata_first": True,
+        "rerank": True,
+        "rerank_cross_encoder": False,
+        "verifier_retry": True,
+        "retrieval_mode": "flat",
+        "retrieval_backend": "dense",
+        "prompt_profile": "structured_grounded_claims",
+        "rrf_k": RRF_K,
+        "bm25_stopword_profile": "shared",
+        "comparison_balance": dict(DEFAULT_COMPARISON_BALANCE),
+        "description": "Metadata-first retrieval with lexical/metadata rerank and verifier retry.",
+    },
+    # ADR 0011 — additive LLM synthesis path. Same retrieval/verifier as
+    # agentic_full; only the summary/answer_text rendering swaps to a
+    # backend-pluggable LLM under the "no new chunk_ids" guard. Claims
+    # and citations remain extractive (ADR 0003 preserved).
+    "agentic_full_llm": {
+        "top_k": None,
+        "metadata_first": True,
+        "rerank": True,
+        "rerank_cross_encoder": False,
+        "verifier_retry": True,
+        "retrieval_mode": "flat",
+        "prompt_profile": "llm_synthesis",
+        "rrf_k": RRF_K,
+        "bm25_stopword_profile": "shared",
+        "comparison_balance": dict(DEFAULT_COMPARISON_BALANCE),
+        "description": "agentic_full retrieval; LLM-synthesized summary under ADR 0011 guard.",
+    },
+}
+
+PIPELINE_ALIASES = {"full": "agentic_full", "full_llm": "agentic_full_llm"}
+
+
+def is_pipeline_name(value: Any) -> bool:
+    name = str(value or "")
+    return name in PIPELINE_PRESETS or name in PIPELINE_ALIASES
+
+
+def pipeline_cli_choices() -> list[str]:
+    # ADR 0001 explicit signal: this list is the source of truth for
+    # which pipeline names are surfaced to the CLI. Adding/removing an
+    # entry is the explicit revisit of that ADR (or, for additive
+    # changes like ADR 0011, the explicit follow-on).
+    return [DEFAULT_CLI_PIPELINE_NAME, DEFAULT_RAG_PIPELINE_NAME, "agentic_full_llm"]
+
+
+def canonical_pipeline_name(value: str | None, default: str = DEFAULT_RAG_PIPELINE_NAME) -> str:
+    requested = str(value or default)
+    canonical = PIPELINE_ALIASES.get(requested, requested)
+    if canonical not in PIPELINE_PRESETS:
+        choices = ", ".join(sorted([*PIPELINE_PRESETS, *PIPELINE_ALIASES]))
+        raise ValueError(f"pipeline must be one of: {choices}")
+    return canonical


### PR DESCRIPTION
## 1. What changed and why

External senior review (2026-05) finding #3 후속, PR-D(#357) 한국어 lexicon 외부화에 이은 `rag_core.py` 분해 epic의 **stage 1**. PR-D 후 `rag_core.py`는 4,154 라인. 다음으로 의존성 가장 약한 부분은 **pipeline preset 정적 데이터 + 단순 lookup helper** — 다른 도메인 함수(retrieval, verifier, answer builder)에서 import만 받지 정의 자체를 건드리지 않는다.

본 PR은 stage 1로 **정적 데이터 + 단순 helper만** 분리해서 안전한 패턴을 확립한다. `resolve_pipeline_config` 같은 검증/coercion 로직은 `VALID_RETRIEVAL_MODES` 등 retrieval 측 상수에 의존하므로 stage 2에서 별도 분리.

상위 plan: Tier 2 PR-E (`/Users/hskim/.claude/plans/bidmate-docagent-witty-glade.md`). Closes #364.

## 2. Files affected

- 신규 `rag_pipeline_presets.py` (루트, **leaf module** — `rag_core` import 의존 0). 140 줄. 8개 module-level constant + 3개 helper 함수.
- `rag_core.py` — inline 정의 블록 제거(−118 줄 변경, **4,154 → 4,106 lines, 순 −48**). 11개 심볼 모두 `from rag_pipeline_presets import (...)`로 re-export.
- `pyproject.toml` — `rag_pipeline_presets`를 coverage source 추가.

**Load-bearing**: ✅ `rag_core.py`. 5b 작성 필수.

## 3. Risks

- **외부 import 깨질 위험**: `app.py`, `api/main.py`, `scripts/run_benchmark.py`, `demo/streamlit_app.py`, `eval/run_eval.py`, `tests/`가 `from rag_core import DEFAULT_CLI_PIPELINE_NAME, PIPELINE_PRESETS, resolve_pipeline_config, ...` 사용. → `rag_core`가 11개 모두 재노출하므로 변경 없이 동작 (post-extraction `rc.X is pp.X` identity 검증 통과).
- **`resolve_pipeline_config` 분리 안 함**: 의도된 stage 1 scope. `VALID_RETRIEVAL_MODES` / `VALID_RETRIEVAL_BACKENDS` / `VALID_BM25_STOPWORD_PROFILES`는 retrieval-side 상수라 stage 2에서 검토.
- **Circular import 위험 없음**: 새 모듈은 `rag_core`에서 아무것도 import 안 함. 순수 leaf.

## 4. Tests

- 사전 검증(pre-replacement): 8개 module-level 상수 + 3개 helper 함수 각각에 대해 `== rag_core 값` + `isinstance` 통과. `canonical_pipeline_name`은 7개 input(aliases + invalid raise ValueError)으로 behavior parity 검증. `is_pipeline_name`은 8개 input으로 검증.
- 사후 검증(post-replacement): 11개 심볼 모두 `rag_core.X is rag_pipeline_presets.X` (object identity).
- `resolve_pipeline_config('naive_baseline' / 'agentic_full' / 'agentic_full_llm' / 'full')` 모두 정상 resolve. invalid name 시 `ValueError`.
- 전체 pytest (EMBEDDING_BACKEND=hashing): **659 passed / 0 failed / 121 subtests passed**. PR #325 coverage 기준선 유지.

## 5. Eval impact

All `·`. preset 값이 변하지 않았으므로 retrieval / verifier / answer 동작 동일.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path — pure refactor, identical Python objects via re-export, full test suite green (659 passed). preset 값 자체는 1글자도 변하지 않았으며 `resolve_pipeline_config`의 호출 chain은 그대로 작동. `naive_baseline` 답변 JSON diff = 0 (ADR 0001 invariant).

## 6. Backward compatibility

- `from rag_core import DEFAULT_CLI_PIPELINE_NAME, PIPELINE_PRESETS, pipeline_cli_choices, resolve_pipeline_config, canonical_pipeline_name, is_pipeline_name, RRF_K, VALID_RRF_K_RANGE, ...` 외부 API 모두 그대로 작동.
- 답변 schema(ADR 0003), `naive_baseline` invariant(ADR 0001), ADR 0011 stub backend 정책 모두 유지.

## 7. Out of scope

- `resolve_pipeline_config()` 추출 — stage 2 (`VALID_RETRIEVAL_MODES` / `VALID_RETRIEVAL_BACKENDS` / `VALID_BM25_STOPWORD_PROFILES`도 함께 검토 필요).
- `QUERY_TYPE_TOP_K_DEFAULTS` 추출 — retrieval 함수 signature default. retrieval module 분해 epic에서 검토.
- `MAX_AGENT_ITERATIONS` — agent loop cap, agent module 분리 epic 후보.
- pipeline preset YAML 외부화 — `dict(DEFAULT_COMPARISON_BALANCE)` deep copy 패턴이 코드 레벨에서 명확. follow-up PR에서 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)