### PR TITLE
refactor: bundle run_rag_query pipeline kwargs into QueryParams dataclass

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -145,6 +145,33 @@ class EmbeddingResult:
     model: str
 
 
+@dataclass(frozen=True)
+class QueryParams:
+    """Bundle of pipeline configuration kwargs for ``run_rag_query`` (issue #260).
+
+    Additive, non-breaking signature extension. Existing callers using
+    individual kwargs (``top_k=...``, ``rerank=...``, etc.) keep working
+    unchanged. New callers can pass a single ``params=QueryParams(...)``
+    bundle instead.
+
+    Per-call inputs (``context_entities``, ``conversation_state``) stay
+    separate kwargs on ``run_rag_query`` — they vary per turn, not per
+    pipeline configuration. The return contract (ADR 0003) is unchanged.
+    """
+
+    top_k: int | None = None
+    metadata_first: bool | None = None
+    rerank: bool | None = None
+    verifier_retry: bool | None = None
+    retrieval_mode: str | None = None
+    retrieval_backend: str | None = None
+    pipeline: str | None = None
+    prompt_profile: str | None = None
+    comparison_balance: dict[str, Any] | None = None
+    rrf_k: int | None = None
+    bm25_stopword_profile: str | None = None
+
+
 def normalize_entity(value: str) -> str:
     return re.sub(r"\s+", " ", value.strip())
 
@@ -3573,7 +3600,46 @@ def run_rag_query(
     comparison_balance: dict[str, Any] | None = None,
     rrf_k: int | None = None,
     bm25_stopword_profile: str | None = None,
+    *,
+    params: QueryParams | None = None,
 ) -> dict[str, Any]:
+    if params is not None:
+        # Pre-bundle path (issue #260). `params=` is an additive opt-in:
+        # individual pipeline kwargs are still accepted for compatibility,
+        # but mixing both is almost always a caller bug, so surface it loudly.
+        # Per-call inputs (`context_entities`, `conversation_state`) stay
+        # separate kwargs because they vary per turn, not per pipeline config.
+        legacy_pipeline_kwargs = {
+            "top_k": top_k,
+            "metadata_first": metadata_first,
+            "rerank": rerank,
+            "verifier_retry": verifier_retry,
+            "retrieval_mode": retrieval_mode,
+            "retrieval_backend": retrieval_backend,
+            "pipeline": pipeline,
+            "prompt_profile": prompt_profile,
+            "comparison_balance": comparison_balance,
+            "rrf_k": rrf_k,
+            "bm25_stopword_profile": bm25_stopword_profile,
+        }
+        conflicting = sorted(k for k, v in legacy_pipeline_kwargs.items() if v is not None)
+        if conflicting:
+            raise ValueError(
+                "run_rag_query: cannot mix params= with explicit pipeline kwargs; "
+                f"set them on the QueryParams instance instead. Conflicting kwargs: {conflicting}"
+            )
+        top_k = params.top_k
+        metadata_first = params.metadata_first
+        rerank = params.rerank
+        verifier_retry = params.verifier_retry
+        retrieval_mode = params.retrieval_mode
+        retrieval_backend = params.retrieval_backend
+        pipeline = params.pipeline
+        prompt_profile = params.prompt_profile
+        comparison_balance = params.comparison_balance
+        rrf_k = params.rrf_k
+        bm25_stopword_profile = params.bm25_stopword_profile
+
     pipeline_source: dict[str, Any] = {"pipeline": pipeline or DEFAULT_RAG_PIPELINE_NAME}
     for key, value in (
         ("top_k", top_k),

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -1,0 +1,200 @@
+"""Regression guards for the ``QueryParams`` dataclass surface (issue #260).
+
+``run_rag_query`` keeps its pre-#260 positional/keyword signature, with
+``params: QueryParams | None`` added as a keyword-only opt-in. These
+tests pin three contracts:
+
+1. ``params=QueryParams()`` is byte-identical to the bare positional/keyword
+   call — no behavior drift when the bundle path is taken with defaults.
+2. ``params=QueryParams(top_k=..., rerank=..., ...)`` yields the same
+   stable answer-side fields as the equivalent legacy-kwarg call.
+3. Mixing ``params=`` with explicit pipeline kwargs raises ``ValueError``
+   so callers can't silently end up with surprising precedence.
+
+Per-call inputs (``context_entities`` / ``conversation_state``) stay
+separate kwargs and must still flow through when ``params=`` is set.
+
+The answer dict contract (ADR 0003) is untouched: this PR only bundles
+the input pipeline kwargs.
+"""
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import pytest
+
+import rag_core
+from rag_core import QueryParams, run_rag_query
+
+
+_QUERY = "기관A의 보안 통제 요구사항은?"
+
+
+def _stable_subset(result: dict[str, Any]) -> dict[str, Any]:
+    """Drop wall-clock + cold-start fields so two warm/cold runs can compare.
+
+    Pins answer, resolved query, evidence identity, and the plan keys that
+    are deterministic across runs. Latency, ``cold_start``, and trace
+    timestamps are excluded — they vary by wall clock, not by signature.
+    """
+
+    plan = result.get("plan") or {}
+    return {
+        "mode": result.get("mode"),
+        "query": result.get("query"),
+        "resolved_query": result.get("resolved_query"),
+        "answer": result.get("answer"),
+        "answer_text": result.get("answer_text"),
+        "evidence_ids": [
+            (item.get("doc_id"), item.get("chunk_id"))
+            for item in result.get("evidence") or []
+        ],
+        "plan_stable": {
+            key: plan.get(key)
+            for key in (
+                "top_k",
+                "rerank",
+                "metadata_first",
+                "verifier_retry",
+                "retrieval_mode",
+                "retrieval_backend",
+                "candidate_count",
+                "total_chunks",
+                "filter_fallback_used",
+                "rrf_k",
+                "bm25_stopword_profile",
+            )
+        },
+    }
+
+
+class QueryParamsEquivalenceTest(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_shared_index(self, shared_raw_index: dict[str, Any]) -> None:
+        self.index = shared_raw_index
+
+    def setUp(self) -> None:
+        # Force cold-start path identical for every test run.
+        rag_core._PROCESS_WARM = False
+
+    def test_empty_params_matches_bare_call(self) -> None:
+        """``QueryParams()`` must be a no-op equivalent to the bare positional call."""
+        rag_core._PROCESS_WARM = False
+        legacy = run_rag_query(self.index, _QUERY)
+        rag_core._PROCESS_WARM = False
+        bundled = run_rag_query(self.index, _QUERY, params=QueryParams())
+        self.assertEqual(_stable_subset(legacy), _stable_subset(bundled))
+
+    def test_custom_params_matches_equivalent_legacy_kwargs(self) -> None:
+        """Same field values via QueryParams vs explicit kwargs → same result."""
+        rag_core._PROCESS_WARM = False
+        legacy = run_rag_query(
+            self.index,
+            _QUERY,
+            top_k=3,
+            rerank=False,
+            retrieval_backend="dense",
+        )
+        rag_core._PROCESS_WARM = False
+        bundled = run_rag_query(
+            self.index,
+            _QUERY,
+            params=QueryParams(top_k=3, rerank=False, retrieval_backend="dense"),
+        )
+        self.assertEqual(_stable_subset(legacy), _stable_subset(bundled))
+
+    def test_hybrid_retrieval_backend_via_params(self) -> None:
+        """Hybrid backend (RRF fusion) honored via params= just like via kwarg."""
+        rag_core._PROCESS_WARM = False
+        legacy = run_rag_query(
+            self.index,
+            _QUERY,
+            retrieval_backend="hybrid",
+            rrf_k=60,
+        )
+        rag_core._PROCESS_WARM = False
+        bundled = run_rag_query(
+            self.index,
+            _QUERY,
+            params=QueryParams(retrieval_backend="hybrid", rrf_k=60),
+        )
+        self.assertEqual(_stable_subset(legacy), _stable_subset(bundled))
+
+    def test_mixing_params_with_explicit_pipeline_kwarg_raises(self) -> None:
+        """Surface the bug: caller can't pass both at once."""
+        with self.assertRaises(ValueError) as ctx:
+            run_rag_query(
+                self.index,
+                _QUERY,
+                top_k=5,
+                params=QueryParams(rerank=False),
+            )
+        message = str(ctx.exception)
+        self.assertIn("params=", message)
+        self.assertIn("top_k", message)
+
+    def test_mixing_params_with_explicit_comparison_balance_raises(self) -> None:
+        """Same conflict guard for dict-valued kwargs."""
+        with self.assertRaises(ValueError) as ctx:
+            run_rag_query(
+                self.index,
+                _QUERY,
+                comparison_balance={"enabled": True},
+                params=QueryParams(),
+            )
+        self.assertIn("comparison_balance", str(ctx.exception))
+
+    def test_per_call_kwargs_remain_separate_from_params(self) -> None:
+        """``context_entities`` / ``conversation_state`` are per-turn data,
+        not pipeline config — they must keep flowing when ``params=`` is set."""
+        rag_core._PROCESS_WARM = False
+        result = run_rag_query(
+            self.index,
+            _QUERY,
+            context_entities=["기관A"],
+            conversation_state=None,
+            params=QueryParams(top_k=3),
+        )
+        self.assertEqual(result["mode"], "rag")
+        # conversation_state always echoed back in the return dict.
+        self.assertIn("conversation_state", result)
+
+
+class QueryParamsShapeTest(unittest.TestCase):
+    def test_query_params_is_frozen(self) -> None:
+        params = QueryParams(top_k=5)
+        with self.assertRaises(Exception):
+            params.top_k = 10  # type: ignore[misc]
+
+    def test_query_params_defaults_are_none(self) -> None:
+        params = QueryParams()
+        for field_name in (
+            "top_k",
+            "metadata_first",
+            "rerank",
+            "verifier_retry",
+            "retrieval_mode",
+            "retrieval_backend",
+            "pipeline",
+            "prompt_profile",
+            "comparison_balance",
+            "rrf_k",
+            "bm25_stopword_profile",
+        ):
+            self.assertIsNone(
+                getattr(params, field_name),
+                f"QueryParams.{field_name} default must be None so the empty "
+                "bundle is a no-op equivalent to a bare call",
+            )
+
+    def test_query_params_is_hashable(self) -> None:
+        """frozen + default-only fields → suitable as a dict key / set member."""
+        a = QueryParams(top_k=5)
+        b = QueryParams(top_k=5)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual({a, b}, {a})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #260

[`run_rag_query`](rag_core.py) takes 14 parameters; 11 are pipeline-configuration defaults that the function body immediately re-bundles into a `pipeline_source` dict for `resolve_pipeline_config()`. The bundle was already implicit — this PR makes it a first-class `QueryParams` frozen dataclass so callers have a single typed object to pass.

This is a **pure additive signature extension** — every existing caller (positional or keyword) keeps working byte-identically.

- **New** [`rag_core.QueryParams`](rag_core.py) frozen dataclass bundling: `top_k`, `metadata_first`, `rerank`, `verifier_retry`, `retrieval_mode`, `retrieval_backend`, `pipeline`, `prompt_profile`, `comparison_balance`, `rrf_k`, `bm25_stopword_profile`.
  - `context_entities` and `conversation_state` stay separate kwargs — they're per-turn data, not pipeline config.
- **Updated** `run_rag_query` signature: adds a **keyword-only** `params: QueryParams | None = None` at the tail.
  - When `params is None` (default): byte-identical to pre-#260 behavior — the new code block is skipped entirely.
  - When `params is not None`: field values replace the corresponding legacy kwargs before the existing `pipeline_source` assembly runs.
  - Mixing `params=` with explicit pipeline kwargs raises `ValueError` listing the conflicting kwargs — surfaces caller bugs immediately instead of silently picking one.
- **New** `tests/test_query_params.py` (9 tests).

## 2. Files affected

- `rag_core.py` (load-bearing) — +66 lines (dataclass definition + signature/dispatch block; no deletions)
- `tests/test_query_params.py` (new, 200 lines)

## 3. Risks

The realistic break mode is the `params=` path silently diverging from the legacy-kwarg path on some retrieval backend, producing different scoring/answer for the same input.

Mitigation:
- The dispatch block assigns directly from `params.<field>` into the existing local variables, then control flow rejoins the original `pipeline_source` builder — no parallel code path.
- `tests/test_query_params.py::test_custom_params_matches_equivalent_legacy_kwargs` and `test_hybrid_retrieval_backend_via_params` pin `params=` vs legacy kwargs to the same answer + evidence_ids + plan fields, on both `dense` and `hybrid` backends.
- `tests/test_query_params.py::test_empty_params_matches_bare_call` pins `QueryParams()` (all defaults) as a no-op equivalent to the bare positional call.
- Mixing both → loud `ValueError` (regression-guarded by `test_mixing_params_with_explicit_pipeline_kwarg_raises` and `test_mixing_params_with_explicit_comparison_balance_raises`).

## 4. Tests

- New `tests/test_query_params.py` — **9 tests**:
  - `test_empty_params_matches_bare_call` — `QueryParams()` ≡ bare call.
  - `test_custom_params_matches_equivalent_legacy_kwargs` — same field values via params vs explicit kwargs.
  - `test_hybrid_retrieval_backend_via_params` — RRF/hybrid path honored via params=.
  - `test_mixing_params_with_explicit_pipeline_kwarg_raises` / `test_mixing_params_with_explicit_comparison_balance_raises` — conflict guard.
  - `test_per_call_kwargs_remain_separate_from_params` — `context_entities` / `conversation_state` flow through.
  - `test_query_params_is_frozen` / `test_query_params_defaults_are_none` / `test_query_params_is_hashable` — dataclass shape contract.
- Full suite: `python3 -m pytest -q` → **659 passed, 121 subtests** (no regressions vs. main).

## 5. Eval impact

All `·` (no behavior change — `params=None` default path is byte-identical, smoke confirms).

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

(`make smoke` BEFORE on main and AFTER on this branch produce a **byte-identical** env-invariant subset of `reports/eval_summary.json`. `make real-eval-delta` is not runnable in this worktree: `data/private` is unavailable locally. The byte-identical env-invariant comparison on the public synthetic smoke corpus is the strong proxy.)

## 6. Backward compatibility

- `run_rag_query` signature is **additive only** — positional + keyword args for the 14 existing kwargs are preserved unchanged. `params=` is keyword-only and after a `*,` separator, so no positional collision.
- ADR 0003 answer dict (return value) untouched — no `schema_version` bump needed.
- ADR 0001 `naive_baseline` invariance: the `params=None` path is byte-identical, so the baseline preset (which doesn't pass `params`) runs through the exact same code as before.
- All 7 known internal callers (`app.py`, `api/main.py`, `demo/helpers.py`, `eval/run_eval.py`, `eval/korean_public/run.py`, `scripts/run_chunking_ablation.py`, `scripts/run_benchmark.py`) keep working without changes. Migrating them to `params=` is a separate, optional follow-up.

## 7. Out of scope

- Migrating the 7 known callers to `params=QueryParams(...)` — separate follow-up issue. The current PR is the *introduction* of the type; migration is a distinct concern.
- Refactoring the 14-kwarg legacy signature into a leaner shape — would break callers and isn't necessary for the bundling benefit.
- Bundling `context_entities` / `conversation_state` into `QueryParams` — those are per-turn data, not per-pipeline config, and don't belong here.
- Async variant of `run_rag_query` — orthogonal to the signature shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)