### PR TITLE
refactor: extract resolve_pipeline_config + VALID_* validation sets (PR-E stage 2)

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -73,10 +73,14 @@ from rag_pipeline_presets import (
     PIPELINE_CONFIG_KEYS,
     PIPELINE_PRESETS,
     RRF_K,
+    VALID_BM25_STOPWORD_PROFILES,
+    VALID_RETRIEVAL_BACKENDS,
+    VALID_RETRIEVAL_MODES,
     VALID_RRF_K_RANGE,
     canonical_pipeline_name,
     is_pipeline_name,
     pipeline_cli_choices,
+    resolve_pipeline_config,
 )
 
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
@@ -84,8 +88,6 @@ DEFAULT_HASH_DIM = 384
 DEFAULT_CHUNK_MAX_CHARS = 520
 DEFAULT_CHUNK_OVERLAP_SENTENCES = 1
 VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
-VALID_RETRIEVAL_MODES = {"flat", "hierarchical"}
-VALID_RETRIEVAL_BACKENDS = {"dense", "hybrid"}
 
 # Hard cap on the per-query agent loop. ``metadata_stage_sequence`` today
 # returns at most ["strict", "reduced", "relaxed"] (3 stages). This constant
@@ -135,8 +137,6 @@ CONVERSATION_STATE_SCHEMA_VERSION = 1
 MAX_CONVERSATION_TURNS = 12
 CONTEXT_RESOLUTION_THRESHOLD = 0.70
 
-VALID_BM25_STOPWORD_PROFILES = {"shared", "bm25_extra"}
-
 
 @dataclass(frozen=True)
 class EmbeddingResult:
@@ -185,64 +185,6 @@ def ordered_unique(values: Iterable[str]) -> list[str]:
             seen.add(value)
             ordered.append(value)
     return ordered
-
-
-def resolve_pipeline_config(
-    value: str | dict[str, Any] | None = None,
-    default_pipeline: str = DEFAULT_RAG_PIPELINE_NAME,
-) -> dict[str, Any]:
-    source = value if isinstance(value, dict) else {}
-    requested = str(value) if isinstance(value, str) else str(source.get("pipeline") or "")
-    if not requested and is_pipeline_name(source.get("name")):
-        requested = str(source.get("name"))
-    canonical = canonical_pipeline_name(requested or default_pipeline, default_pipeline)
-    config = dict(PIPELINE_PRESETS[canonical])
-    config["pipeline"] = canonical
-    if requested and requested != canonical:
-        config["pipeline_alias"] = requested
-
-    for key in PIPELINE_CONFIG_KEYS:
-        if key not in source or source.get(key) is None:
-            continue
-        config[key] = source[key]
-
-    if "comparison_balance" in source and source.get("comparison_balance") is not None:
-        config["comparison_balance"] = source["comparison_balance"]
-
-    top_k = config.get("top_k")
-    if top_k is not None:
-        top_k = int(top_k)
-        if top_k < 1:
-            raise ValueError("top_k must be positive.")
-    retrieval_mode = str(config.get("retrieval_mode") or "flat")
-    if retrieval_mode not in VALID_RETRIEVAL_MODES:
-        choices = ", ".join(sorted(VALID_RETRIEVAL_MODES))
-        raise ValueError(f"retrieval_mode must be one of: {choices}")
-    retrieval_backend = str(config.get("retrieval_backend") or "dense")
-    if retrieval_backend not in VALID_RETRIEVAL_BACKENDS:
-        choices = ", ".join(sorted(VALID_RETRIEVAL_BACKENDS))
-        raise ValueError(f"retrieval_backend must be one of: {choices}")
-    rrf_k_raw = config.get("rrf_k")
-    rrf_k = RRF_K if rrf_k_raw is None else int(rrf_k_raw)
-    rrf_lo, rrf_hi = VALID_RRF_K_RANGE
-    if rrf_k < rrf_lo or rrf_k > rrf_hi:
-        raise ValueError(f"rrf_k must be in [{rrf_lo}, {rrf_hi}].")
-    bm25_stopword_profile = str(config.get("bm25_stopword_profile") or "shared")
-    if bm25_stopword_profile not in VALID_BM25_STOPWORD_PROFILES:
-        choices = ", ".join(sorted(VALID_BM25_STOPWORD_PROFILES))
-        raise ValueError(f"bm25_stopword_profile must be one of: {choices}")
-
-    config["top_k"] = top_k
-    config["metadata_first"] = bool(config.get("metadata_first"))
-    config["rerank"] = bool(config.get("rerank"))
-    config["rerank_cross_encoder"] = bool(config.get("rerank_cross_encoder"))
-    config["verifier_retry"] = bool(config.get("verifier_retry"))
-    config["retrieval_mode"] = retrieval_mode
-    config["retrieval_backend"] = retrieval_backend
-    config["prompt_profile"] = str(config.get("prompt_profile") or "structured_grounded_claims")
-    config["rrf_k"] = rrf_k
-    config["bm25_stopword_profile"] = bm25_stopword_profile
-    return config
 
 
 def coerce_string_list(value: Any) -> list[str]:

--- a/rag_pipeline_presets.py
+++ b/rag_pipeline_presets.py
@@ -138,3 +138,73 @@ def canonical_pipeline_name(value: str | None, default: str = DEFAULT_RAG_PIPELI
         choices = ", ".join(sorted([*PIPELINE_PRESETS, *PIPELINE_ALIASES]))
         raise ValueError(f"pipeline must be one of: {choices}")
     return canonical
+
+
+# ─── Pipeline config validation (PR-E stage 2, issue #375) ────────────
+# Three retrieval-side validation sets used by ``resolve_pipeline_config``
+# AND by per-query override helpers in ``rag_core`` (e.g. the
+# ``rrf_k``/``retrieval_mode`` checks inside ``plan_retrieval`` and the
+# hybrid retriever entry points). Owning them here keeps the leaf module
+# self-contained — ``resolve_pipeline_config`` does not have to reach
+# back into ``rag_core`` to validate.
+VALID_RETRIEVAL_MODES = {"flat", "hierarchical"}
+VALID_RETRIEVAL_BACKENDS = {"dense", "hybrid"}
+VALID_BM25_STOPWORD_PROFILES = {"shared", "bm25_extra"}
+
+
+def resolve_pipeline_config(
+    value: str | dict[str, Any] | None = None,
+    default_pipeline: str = DEFAULT_RAG_PIPELINE_NAME,
+) -> dict[str, Any]:
+    source = value if isinstance(value, dict) else {}
+    requested = str(value) if isinstance(value, str) else str(source.get("pipeline") or "")
+    if not requested and is_pipeline_name(source.get("name")):
+        requested = str(source.get("name"))
+    canonical = canonical_pipeline_name(requested or default_pipeline, default_pipeline)
+    config = dict(PIPELINE_PRESETS[canonical])
+    config["pipeline"] = canonical
+    if requested and requested != canonical:
+        config["pipeline_alias"] = requested
+
+    for key in PIPELINE_CONFIG_KEYS:
+        if key not in source or source.get(key) is None:
+            continue
+        config[key] = source[key]
+
+    if "comparison_balance" in source and source.get("comparison_balance") is not None:
+        config["comparison_balance"] = source["comparison_balance"]
+
+    top_k = config.get("top_k")
+    if top_k is not None:
+        top_k = int(top_k)
+        if top_k < 1:
+            raise ValueError("top_k must be positive.")
+    retrieval_mode = str(config.get("retrieval_mode") or "flat")
+    if retrieval_mode not in VALID_RETRIEVAL_MODES:
+        choices = ", ".join(sorted(VALID_RETRIEVAL_MODES))
+        raise ValueError(f"retrieval_mode must be one of: {choices}")
+    retrieval_backend = str(config.get("retrieval_backend") or "dense")
+    if retrieval_backend not in VALID_RETRIEVAL_BACKENDS:
+        choices = ", ".join(sorted(VALID_RETRIEVAL_BACKENDS))
+        raise ValueError(f"retrieval_backend must be one of: {choices}")
+    rrf_k_raw = config.get("rrf_k")
+    rrf_k = RRF_K if rrf_k_raw is None else int(rrf_k_raw)
+    rrf_lo, rrf_hi = VALID_RRF_K_RANGE
+    if rrf_k < rrf_lo or rrf_k > rrf_hi:
+        raise ValueError(f"rrf_k must be in [{rrf_lo}, {rrf_hi}].")
+    bm25_stopword_profile = str(config.get("bm25_stopword_profile") or "shared")
+    if bm25_stopword_profile not in VALID_BM25_STOPWORD_PROFILES:
+        choices = ", ".join(sorted(VALID_BM25_STOPWORD_PROFILES))
+        raise ValueError(f"bm25_stopword_profile must be one of: {choices}")
+
+    config["top_k"] = top_k
+    config["metadata_first"] = bool(config.get("metadata_first"))
+    config["rerank"] = bool(config.get("rerank"))
+    config["rerank_cross_encoder"] = bool(config.get("rerank_cross_encoder"))
+    config["verifier_retry"] = bool(config.get("verifier_retry"))
+    config["retrieval_mode"] = retrieval_mode
+    config["retrieval_backend"] = retrieval_backend
+    config["prompt_profile"] = str(config.get("prompt_profile") or "structured_grounded_claims")
+    config["rrf_k"] = rrf_k
+    config["bm25_stopword_profile"] = bm25_stopword_profile
+    return config


### PR DESCRIPTION
## 1. What changed and why

PR-E stage 2, follow-up to #373. Stage 1은 정적 데이터 + 단순 helper만 옮겼고 `resolve_pipeline_config` + 3개 validation set은 의도적으로 `rag_core.py`에 남겼었다 — 다른 retrieval 함수에서도 쓰여서 한 PR로 묶으면 위험 컸음.

본 PR이 그 남은 분할을 마무리한다. `rag_pipeline_presets.py`가 이제 **pipeline config surface 전체**(registry + defaults + helpers + validator)의 canonical home이 된다. `rag_core`는 retrieval / verifier / answer 로직 + chunking-side `VALID_CHUNKING_STRATEGIES`만 보유.

상위 plan: Tier 2 PR-E stage 2 (`/Users/hskim/.claude/plans/bidmate-docagent-witty-glade.md`). Closes #375.

## 2. Files affected

- `rag_pipeline_presets.py` — 4 신규 symbol 추가 (+70 lines): `VALID_RETRIEVAL_MODES`, `VALID_RETRIEVAL_BACKENDS`, `VALID_BM25_STOPWORD_PROFILES`, `resolve_pipeline_config()`. **여전히 leaf module** — `rag_core` import 의존 0.
- `rag_core.py` — inline 정의 제거(−62 lines), import 블록에 4개 추가. **4,106 → 4,048 lines (순 −58)**.

**Load-bearing**: ✅ `rag_core.py`. 5b 작성 필수.

## 3. Risks

- **외부 import 깨질 위험**: `tests/test_cross_encoder_rerank.py`, `tests/test_hybrid_retrieval_regression.py`, `scripts/run_benchmark.py`, `eval/run_eval.py`가 `from rag_core import resolve_pipeline_config` 또는 `VALID_RETRIEVAL_BACKENDS` / `VALID_BM25_STOPWORD_PROFILES` 사용. → `rag_core`가 4개 모두 re-export하므로 `rc.X is pp.X` identity 검증 통과(15개 심볼 전체).
- **`rag_core` 내부 두 번째 validation block**: `plan_retrieval` / hybrid retriever helpers에 동일 패턴이 또 있다 (line 1670+). 같은 이름이 import 블록을 통해 resolve되므로 변경 없이 작동.
- **Circular import 위험 없음**: `rag_pipeline_presets`는 여전히 leaf — `rag_core`에서 아무것도 import 안 함.

## 4. Tests

- 사전 검증(pre-extraction parity): 3 validation set `== isinstance` + `resolve_pipeline_config` JSON output 7개 valid input(presets + aliases + override dicts) + 7개 invalid input(unknown name, unknown retrieval_mode/backend, unknown bm25 profile, rrf_k=0, rrf_k=9999, etc.) 모두 ValueError 메시지까지 동일.
- 사후 검증(post-extraction): 15개 심볼 모두 `rag_core.X is rag_pipeline_presets.X` (PR-E stage 1의 11개 + 본 PR의 4개).
- 전체 pytest (EMBEDDING_BACKEND=hashing): **650 passed / 0 failed / 121 subtests passed in 13.59s**. PR #325 coverage 기준선 유지.

## 5. Eval impact

All `·`. validation 로직이 변하지 않았으므로 retrieval / verifier / answer 동작 동일.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path — pure refactor, identical function semantics via re-export, full test suite green (650 passed). `naive_baseline` 답변 JSON diff = 0 (ADR 0001 invariant). 7개 invalid input의 ValueError 메시지까지 사전 검증으로 동일성 확인.

## 6. Backward compatibility

- `from rag_core import resolve_pipeline_config, VALID_RETRIEVAL_MODES, VALID_RETRIEVAL_BACKENDS, VALID_BM25_STOPWORD_PROFILES, ...` 외부 API 그대로 작동.
- 답변 schema(ADR 0003), `naive_baseline` invariant(ADR 0001), ADR 0011 stub backend 정책 모두 유지.

## 7. Out of scope

- `VALID_CHUNKING_STRATEGIES` — chunking-side validation, `resolve_pipeline_config`와 무관. 별도 chunking module 분해 epic에서.
- `MAX_AGENT_ITERATIONS` — agent loop cap, 별도 module 후보.
- `QUERY_TYPE_TOP_K_DEFAULTS` — retrieval default, 별도.
- `rag_pipeline_presets.py` 모듈명 변경 (예: `rag_pipeline_config.py`) — git blame 보존을 위해 stage 3 이상에서 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)