### PR TITLE
fix(docker): COPY all top-level .py + data/lexicon/ (Fly crash loop)

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -12,17 +12,13 @@ on:
   push:
     branches: [main]
     paths:
-      # Dockerfile-copied runtime code
-      - 'rag_core.py'
-      - 'rag_synthesis.py'
-      - 'rag_observability.py'
-      - 'ingestion.py'
-      - 'visual_ingestion.py'
-      - 'app.py'
+      # Dockerfile-copied runtime code — keep in sync with Dockerfile COPY set.
+      - '*.py'                       # every top-level module (rag_core, ingestion, …)
       - 'api/**'
       - 'demo/**'
       - 'scripts/build_index.py'
       - 'data/raw/**'
+      - 'data/lexicon/**'
       # Container + deploy primitives
       - 'Dockerfile'
       - 'docker-entrypoint.sh'

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,20 @@ RUN pip install --upgrade pip \
 # Copy only the code/data needed at runtime. tests/, benchmarks/, eval/
 # are intentionally left out of the image to keep it small — they are
 # part of the CLI evaluation flow, not the demo surface.
-COPY rag_core.py rag_synthesis.py rag_observability.py ingestion.py visual_ingestion.py app.py ./
+#
+# `COPY *.py ./` deliberately picks up every top-level module — the
+# rag_core decomposition (#344/#364/#373/…) keeps extracting new ones
+# (rag_metadata_extraction, rag_pipeline_presets, korean_lexicon, …)
+# and an explicit list silently rotted past those refactors, causing a
+# ModuleNotFoundError crash loop on Fly (issue #383). Keep the COPY
+# generic so future extractions stay deployable without Dockerfile
+# edits, and mirror the same set in deploy-fly.yml's path filter.
+COPY *.py ./
 COPY api/ ./api/
 COPY demo/ ./demo/
 COPY scripts/build_index.py ./scripts/build_index.py
 COPY data/raw/ ./data/raw/
+COPY data/lexicon/ ./data/lexicon/
 COPY docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x docker-entrypoint.sh
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,10 +74,10 @@ to stay under the free-tier budget.
 Every push to `main` that touches a runtime path runs
 [`.github/workflows/deploy-fly.yml`](../.github/workflows/deploy-fly.yml)
 and re-deploys the live demo. The path filter mirrors the Dockerfile
-COPY set (`rag_core.py`, `rag_synthesis.py`, `rag_observability.py`,
-`ingestion.py`, `visual_ingestion.py`, `app.py`, `api/**`, `demo/**`,
-`scripts/build_index.py`, `data/raw/**`, `Dockerfile`,
-`docker-entrypoint.sh`, `requirements.txt`, `fly.toml`) — doc-only
+COPY set: every top-level `*.py`, `api/**`, `demo/**`,
+`scripts/build_index.py`, `data/raw/**`, `data/lexicon/**`, the
+container primitives (`Dockerfile`, `docker-entrypoint.sh`,
+`requirements.txt`, `fly.toml`), and the workflow itself. Doc-only
 changes do *not* trigger a deploy. The workflow asserts every machine
 is in `started` state via `flyctl status --json` and smoke-tests
 `https://<app>.fly.dev/health` before posting a comment on the merged


### PR DESCRIPTION
## 1. What changed and why

Closes #383

Fly deploy 컨테이너가 부팅 시 \`ModuleNotFoundError: No module named 'rag_metadata_extraction'\` 으로 즉시 죽고 \`max restart count of 10\` 도달 → 머신이 \`stopped\` 로 머무름 → 워크플로 healthcheck timeout. 원인은 Dockerfile L36 의 명시적 6개 \`.py\` COPY 리스트가 최근 rag_core 분해 PR들(#344/#364/#373)로 추출된 9개 추가 모듈 + \`data/lexicon/\` 디렉토리를 따라가지 못한 것.

Fix:
- \`Dockerfile\`: 명시적 리스트 → \`COPY *.py ./\`. 미래 모듈 추출도 자동 포함.
- \`Dockerfile\`: \`COPY data/lexicon/\` 추가 (#344 의 externalized lexicon).
- \`deploy-fly.yml\` path filter: 6개 \`.py\` 명시 → \`'*.py'\` glob + \`'data/lexicon/**'\`. Dockerfile COPY set 과 동기화 유지.
- \`docs/deployment.md\`: path filter 설명 prose 같이 갱신.

## 2. Files affected

- \`Dockerfile\` — COPY 일반화 + lexicon 디렉토리
- \`.github/workflows/deploy-fly.yml\` — path filter 동기화
- \`docs/deployment.md\` — path filter 설명 prose

Load-bearing 변경 없음.

## 3. Risks

- **이미지 크기**: 추가되는 top-level .py 약 9개 + \`data/lexicon/ko_default.yaml\` (~7 KB). 이미지 size 영향 무시 수준 (현재 2.9 GB 중 sentence-transformers/opencv 가 절대 비중).
- **광역 path filter**: \`*.py\` 가 새 top-level 모듈을 다 포함하므로 의도치 않은 deploy 가 더 자주 트리거될 수 있음. 다만 모든 top-level .py 가 사실상 \`rag_core\` 직간접 의존 (워크플로 자체 코멘트에 ground truth 명시) 이므로 의도와 일치.
- **다른 컨테이너 소비자**: \`make docker-publish\`, \`make demo-docker\`, GHCR image 모두 같은 Dockerfile. 추가 COPY 는 기존 빌드를 깨뜨리지 않음 (deletion 없음).

## 4. Tests

운영 검증 (#181 이후 첫 성공적인 머신 부팅이 목표):
1. 머지 후 deploy-fly 워크플로 자동 트리거
2. 컨테이너 부팅에서 ModuleNotFoundError 미발생
3. \`docker-entrypoint.sh\` 가 index build 완료 후 uvicorn(:8000) + streamlit(:8501) 기동
4. \`flyctl status --json\` 머신 \`started\` 상태
5. \`curl https://bidmate-docagent-demo.fly.dev/health\` 200
6. PR 코멘트 자동 게시

로컬 사전 검증 (사용자가 가능):
\`\`\`bash
docker build -t bidmate-demo:test . && docker run --rm -p 8000:8000 -e BIDMATE_DEMO_MODE=api bidmate-demo:test
curl http://localhost:8000/health
\`\`\`

## 5. Eval impact

All \`·\` — 빌드/컨테이너 설정 단독, RAG 코드 경로 미수정.

### 5b. Real-data delta

**N/A** — load-bearing 경로 미수정. ingestion / rag_core / eval / api 변경 없음.

## 6. Backward compatibility

\`make docker-publish\` 가 만드는 GHCR 이미지도 같은 변경 영향. 기존 image consumer 중 \`COPY\` 리스트에 의존하는 곳 없음 (모두 entrypoint 호출만). schema_version 영향 없음.

## 7. Out of scope

- HF Spaces auto-sync 워크플로 (#181 의 원래 optional 항목) — 별도 follow-up.
- \`nrt\` 등 Asia region capacity 시도 (#378 follow-up) — sjc 에서 일단 안정화 후 별도 PR.