### PR TITLE
fix: scripts/claude-hooks/*.py import path + dispatcher --required regression (#387)

### DIFF
--- a/scripts/claude-hooks/_ship_arm.py
+++ b/scripts/claude-hooks/_ship_arm.py
@@ -20,7 +20,9 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 
-from check_branch_and_issue import parse_branch
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from check_branch_and_issue import parse_branch  # noqa: E402
 
 
 ARMED_FILE = ".claude/.ship-armed"

--- a/scripts/claude-hooks/_ship_lock_check.py
+++ b/scripts/claude-hooks/_ship_lock_check.py
@@ -19,7 +19,9 @@ import argparse
 import os
 import sys
 
-from check_branch_and_issue import parse_branch
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from check_branch_and_issue import parse_branch  # noqa: E402
 
 
 # (path -> owner issue number). Directories end with "/".

--- a/scripts/claude-hooks/_ship_pr_body.py
+++ b/scripts/claude-hooks/_ship_pr_body.py
@@ -26,8 +26,10 @@ import sys
 import time
 from typing import Optional
 
-from _governance import is_load_bearing
-from check_branch_and_issue import (
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from _governance import is_load_bearing  # noqa: E402
+from check_branch_and_issue import (  # noqa: E402
     FIVE_B_ESCAPE_RE,
     FIVE_B_HEADER_RE,
     FIVE_B_TABLE_RE,

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -352,10 +352,10 @@ stage_3_pr() {
 stage_4_ci() {
   log "s4" "Stage 4: CI wait (timeout 30min)"
   if [[ "$DRY_RUN" == "1" ]]; then
-    log "s4" "[dry-run] gh pr checks $PR_NUMBER --watch --interval 30 --required"
+    log "s4" "[dry-run] gh pr checks $PR_NUMBER --watch --interval 30"
     return 0
   fi
-  if ! timeout 1800 gh pr checks "$PR_NUMBER" --watch --interval 30 --required; then
+  if ! timeout 1800 gh pr checks "$PR_NUMBER" --watch --interval 30; then
     local rc=$?
     if (( rc == 124 )); then
       gh pr comment "$PR_NUMBER" --body "Auto-ship: CI timeout after 30min; PR left open." || true


### PR DESCRIPTION
## 1. What changed and why

Two bugs found immediately after merging #382:

1. **Import path** — `_ship_arm.py`, `_ship_lock_check.py`, `_ship_pr_body.py` import `check_branch_and_issue` / `_governance` from `scripts/`, but they live one level deeper at `scripts/claude-hooks/`. CLI invocation died with `ModuleNotFoundError: No module named 'check_branch_and_issue'`. Tests passed only because `tests/conftest.py` and per-test `sys.path.insert` masked it.
2. **`--required` flag** — `stop-ship.sh` Stage 4 used `gh pr checks --watch --required`. With main's `required_status_checks` empty, `gh` returns "no required checks reported" and exits 0 immediately. Dispatcher would skip the actual CI wait (observed during #382 merge: `--required` returned green within seconds while Pytest + Eval delta were still pending).

Closes #387

## 2. Files affected

- `scripts/claude-hooks/_ship_arm.py` — sys.path.insert
- `scripts/claude-hooks/_ship_lock_check.py` — sys.path.insert
- `scripts/claude-hooks/_ship_pr_body.py` — sys.path.insert
- `scripts/claude-hooks/stop-ship.sh` — drop `--required` (2 occurrences)

None load-bearing.

## 3. Risks

The `sys.path.insert` is idempotent and only adds the script's own parent dir; no shadowing of stdlib or existing modules. Dropping `--required` makes all checks blocking — this is more conservative than before, not less.

## 4. Tests

- 52/52 existing tests pass
- Direct CLI smoke (no PYTHONPATH): `python3 scripts/claude-hooks/_ship_lock_check.py --branch feat/issue-238-foo --files-stdin <<< rag_core.py` → exit 0

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (No load-bearing files changed.)

## 6. Backward compatibility

No public-API change. No `schema_version` change.

## 7. Out of scope

- Adding `required_status_checks` to main protection (separate governance decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)