### PR TITLE
refactor(scripts): consolidate provenance / run_id helpers in _utils.py (#284 R2 A)

### DIFF
--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -37,7 +37,7 @@ from eval.scorers._shared import (
     retry_trigger_reasons,
 )
 from eval.scorers.citation import is_bbox
-from scripts.write_real_eval_baseline import provenance
+from scripts._utils import build_provenance
 
 
 QUERY_TYPES = ("single_doc", "comparison", "follow_up", "abstention")
@@ -68,9 +68,9 @@ def compute_run_manifest(config_path: Path) -> dict[str, Any]:
 
     Needed for leaderboard time-series (#166) and judge calibration
     reproducibility (#169). Field naming mirrors
-    ``scripts.write_real_eval_baseline._provenance`` (``git_commit``,
-    ``git_dirty``, ``generated_at``) so the real-eval baseline pipeline
-    and the synthetic eval pipeline share one schema.
+    ``scripts._utils.build_provenance`` (``git_commit``, ``git_dirty``,
+    ``generated_at``) so the real-eval baseline pipeline and the
+    synthetic eval pipeline share one schema.
     """
     commit = _git("rev-parse", "HEAD")[:12] or "unknown"
     dirty = _git("status", "--porcelain") != ""
@@ -761,7 +761,7 @@ def main() -> int:
 
     summary = {
         "mode": "rag",
-        "provenance": provenance(),
+        "provenance": build_provenance(),
         "run_manifest": compute_run_manifest(config_path),
         "config": args.config,
         "index_dir": args.index_dir,

--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -89,6 +89,44 @@ def git_dirty() -> bool:
     return bool(status.strip())
 
 
+def build_provenance() -> dict[str, object]:
+    """Provenance block for the current git HEAD.
+
+    Shared by the synthetic history writer
+    (``scripts/write_synthetic_history.py``) and the real-data baseline
+    writer (``scripts/write_real_eval_baseline.py``). Format is
+    intentionally narrow: 12-char SHA, dirty flag, ISO-8601 UTC
+    timestamp.
+
+    The dirty flag intentionally includes untracked files
+    (``git status --porcelain`` without ``--untracked-files=no``) so a
+    snapshot taken from a workspace with stray files is flagged as
+    not-clean — stricter than the ``git_dirty()`` helper used by the
+    leaderboard/render side.
+    """
+    sha = git_output(["rev-parse", "HEAD"], default="")[:12] or "unknown"
+    dirty = git_output(["status", "--porcelain"], default="") != ""
+    return {
+        "git_commit": sha,
+        "git_dirty": bool(dirty),
+        "generated_at": utc_now(),
+    }
+
+
+def make_run_id(provenance: dict[str, object]) -> str:
+    """Build ``YYYYMMDDTHHMMSSZ_<sha12>`` run id from a provenance block."""
+    ts = (
+        str(provenance.get("generated_at"))
+        .replace("-", "")
+        .replace(":", "")
+        .split(".")[0]  # drop fractional seconds
+    )
+    if not ts.endswith("Z"):
+        ts += "Z"
+    sha = str(provenance.get("git_commit") or "unknown")[:12]
+    return f"{ts}_{sha}"
+
+
 def fmt_rate(value: Any) -> str:
     return f"{value:.3f}" if isinstance(value, (int, float)) else "N/A"
 

--- a/scripts/write_real_eval_baseline.py
+++ b/scripts/write_real_eval_baseline.py
@@ -19,9 +19,7 @@ threshold tightened). Not every run.
 """
 from __future__ import annotations
 
-import datetime
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -29,49 +27,13 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts._utils import build_provenance, make_run_id
 from scripts.run_real_eval_delta import extract_aggregate
 
 EVAL_SUMMARY = ROOT / "reports" / "real100" / "eval_summary.json"
 BASELINE_PATH = ROOT / "reports" / "real100" / "baseline.aggregate.json"
 HISTORY_DIR = ROOT / "reports" / "real100" / "history"
 JUDGE_LOCAL = ROOT / "reports" / "real100" / "judge.local.json"
-
-
-def _git(*args: str) -> str:
-    result = subprocess.run(
-        ["git", *args], capture_output=True, text=True, cwd=ROOT
-    )
-    return result.stdout.strip()
-
-
-def provenance() -> dict[str, object]:
-    """Return a provenance block for the current git HEAD.
-
-    Shared by the baseline writer (this script) and the eval runner
-    (``eval/run_eval.py``). Format is intentionally narrow: 12-char SHA,
-    dirty flag, ISO-8601 UTC timestamp.
-    """
-    sha = _git("rev-parse", "HEAD")[:12] or "unknown"
-    dirty = _git("status", "--porcelain") != ""
-    return {
-        "git_commit": sha,
-        "git_dirty": bool(dirty),
-        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
-    }
-
-
-def _run_id(prov: dict[str, object]) -> str:
-    # YYYYMMDDTHHMMSSZ_<sha12>
-    ts = (
-        str(prov.get("generated_at"))
-        .replace("-", "")
-        .replace(":", "")
-        .split(".")[0]  # drop fractional seconds
-    )
-    if not ts.endswith("Z"):
-        ts += "Z"
-    sha = str(prov.get("git_commit") or "unknown")[:12]
-    return f"{ts}_{sha}"
 
 
 def _warn_if_stale(
@@ -122,7 +84,7 @@ def main() -> int:
     raw = json.loads(EVAL_SUMMARY.read_text(encoding="utf-8"))
     agg = extract_aggregate(raw)
     eval_prov = raw.get("provenance") if isinstance(raw, dict) else None
-    baseline_prov = provenance()
+    baseline_prov = build_provenance()
     _warn_if_stale(eval_prov, baseline_prov)
     agg["provenance"] = baseline_prov
 
@@ -154,7 +116,7 @@ def main() -> int:
     BASELINE_PATH.write_text(serialized, encoding="utf-8")
 
     HISTORY_DIR.mkdir(parents=True, exist_ok=True)
-    history_path = HISTORY_DIR / f"{_run_id(baseline_prov)}.aggregate.json"
+    history_path = HISTORY_DIR / f"{make_run_id(baseline_prov)}.aggregate.json"
     history_path.write_text(serialized, encoding="utf-8")
 
     print(f"[OK] Updated {BASELINE_PATH.relative_to(ROOT)}")

--- a/scripts/write_synthetic_history.py
+++ b/scripts/write_synthetic_history.py
@@ -16,9 +16,7 @@ them before writing. Same privacy boundary as
 """
 from __future__ import annotations
 
-import datetime
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -26,43 +24,11 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts._utils import build_provenance, make_run_id  # noqa: E402
 from scripts.run_real_eval_delta import extract_aggregate  # noqa: E402
 
 EVAL_SUMMARY = ROOT / "reports" / "eval_summary.json"
 HISTORY_DIR = ROOT / "reports" / "history"
-
-
-def _git(*args: str) -> str:
-    try:
-        result = subprocess.run(
-            ["git", *args], capture_output=True, text=True, cwd=ROOT, check=False
-        )
-        return result.stdout.strip()
-    except (OSError, subprocess.SubprocessError):
-        return ""
-
-
-def _provenance() -> dict[str, object]:
-    sha = _git("rev-parse", "HEAD")[:12] or "unknown"
-    dirty = _git("status", "--porcelain") != ""
-    return {
-        "git_commit": sha,
-        "git_dirty": bool(dirty),
-        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
-    }
-
-
-def _run_id(provenance: dict[str, object]) -> str:
-    ts = (
-        str(provenance.get("generated_at"))
-        .replace("-", "")
-        .replace(":", "")
-        .split(".")[0]
-    )
-    if not ts.endswith("Z"):
-        ts += "Z"
-    sha = str(provenance.get("git_commit") or "unknown")[:12]
-    return f"{ts}_{sha}"
 
 
 def main() -> int:
@@ -74,10 +40,10 @@ def main() -> int:
         return 2
     raw = json.loads(EVAL_SUMMARY.read_text(encoding="utf-8"))
     agg = extract_aggregate(raw)
-    provenance = _provenance()
+    provenance = build_provenance()
     agg["provenance"] = provenance
     HISTORY_DIR.mkdir(parents=True, exist_ok=True)
-    out_path = HISTORY_DIR / f"{_run_id(provenance)}.aggregate.json"
+    out_path = HISTORY_DIR / f"{make_run_id(provenance)}.aggregate.json"
     out_path.write_text(
         json.dumps(agg, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",


### PR DESCRIPTION
## 1. What changed and why

Closes #388. (#284 R2 split into Group A — this PR — and Group B [별도 후속].)

`scripts/write_synthetic_history.py` 와 `scripts/write_real_eval_baseline.py`가 갖던 세 가지 거의-동일 helper (`_git`, `provenance`/`_provenance`, `_run_id`)를 `scripts/_utils.py`로 통합합니다. `_utils.py`는 이미 `git_output` / `git_dirty` / `utc_now` 같은 git/시간 helper를 공유하는 SSoT이므로 자연스러운 자리.

새 helper:
- `build_provenance() -> dict` — 두 파일의 `_provenance()` / `provenance()`를 대체. 같은 shape (`git_commit` / `git_dirty` / `generated_at`), untracked-files-포함 dirty 의미 보존 (기존 `_utils.git_dirty()`는 `--untracked-files=no`를 쓰는 다른 의미, 그대로 유지).
- `make_run_id(provenance) -> str` — `YYYYMMDDTHHMMSSZ_<sha12>` 포맷. 두 파일의 `_run_id()`와 동일.

두 스크립트의 로컬 `_git()` 두 변형(`try/except` 차이)은 모두 제거 — `git_output(check=True, except → default)`이 둘 다의 union behavior (git 실패 시 빈 문자열).

## 2. Files affected

- `scripts/_utils.py` (`+38`) — 새 `build_provenance()` + `make_run_id()`.
- `scripts/write_synthetic_history.py` (`-34`/`+6`) — local helper 제거 + import. 더 이상 사용 안 하는 `datetime`/`subprocess` import 제거.
- `scripts/write_real_eval_baseline.py` (`-39`/`+5`) — 같은 처리, `_warn_if_stale()`는 real-only라 그대로 유지.
- `eval/run_eval.py` (`+5`/`-5`) — **load-bearing path**: `from scripts.write_real_eval_baseline import provenance`를 `from scripts._utils import build_provenance`로 변경 + docstring reference + 한 call site (`provenance()` → `build_provenance()`). 자체 `_git()` + `compute_run_manifest()`는 이번 scope 밖 (`config_sha256` 캡처가 manifest seam — `tests/test_run_real_eval_delta`가 의존).

## 3. Risks

- **`eval/run_eval.py` cross-import** (load-bearing): R2 dedupe 대상이지만 import path 깨짐 우려. Mitigation — pytest 715 passed (이전 main 650; cross-import 의존 테스트 `tests/test_run_real_eval_delta`, `tests/test_eval_metrics`, `tests/test_latency_instrumentation` 모두 green).
- **`build_provenance()` 출력 동일성**: `datetime.utcnow().isoformat() + \"Z\"` (old) vs `utc_now()` (new = `datetime.now(timezone.utc).isoformat().replace(\"+00:00\",\"Z\")`)는 microseconds 포함 동일 문자열 반환 — Python 3.12에서 `utcnow()`가 deprecated이므로 미래 호환성 ↑. Smoke 검증:
  ```python
  >>> from scripts._utils import build_provenance, make_run_id
  >>> p = build_provenance(); p
  {'git_commit': '8b80fcc09a91', 'git_dirty': True, 'generated_at': '2026-05-12T05:34:00.611520Z'}
  >>> make_run_id(p)
  '20260512T053400Z_8b80fcc09a91'
  ```
- **외부 호출자 누락**: `grep -rn \"from scripts.write_real_eval_baseline\" --include='*.py'` 으로 전체 리포 스캔 → `eval/run_eval.py:40` 단 한 곳. 위에서 처리.

## 4. Tests

- `python3 -m pytest tests/ -q` → 715 passed (이전 main 기준). Cross-import 의존 테스트 포함.
- `python3 -m py_compile scripts/_utils.py scripts/write_synthetic_history.py scripts/write_real_eval_baseline.py eval/run_eval.py` → clean.
- Helper output smoke test (위 §3 inline). 새 helper output shape이 두 history 디렉터리의 기존 `*.aggregate.json` 파일명/내용과 호환.
- 새 unit test for provenance/run_id: 추가 안 함 (over-engineering — 두 helper는 end-to-end로 `tests/test_render_real_eval_history` + `tests/test_leaderboard`가 indirectly cover, 4개 통합 테스트 통과).

## 5. Eval impact

All `·`. Pure refactor — `build_provenance()` returns the same dict shape and values as the removed `provenance()`, and `make_run_id()` produces byte-identical run ids. No metric path touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval path. `eval/run_eval.py` import only swaps the helper source (same return type, same values). The new `build_provenance()` is byte-equivalent to the removed `provenance()` — confirmed via Python 3.11 verification (microseconds preserved, untracked-files-included dirty semantics preserved). `compute_run_manifest()`의 git/timestamp 캡처 로직은 이번 PR에서 손대지 않음 (out of scope per §2).

## 6. Backward compatibility

- 외부 import 깨짐: `eval/run_eval.py:40` 단 한 곳, 이 PR에서 함께 업데이트.
- 새 helper API는 `_utils.py`에 추가. 기존 `git_output` / `git_dirty` / `utc_now` 모두 그대로.
- 출력 호환: 두 history 디렉터리의 기존 파일명 (`<timestamp>_<sha>.aggregate.json`), 파일 내 `provenance` block — 동일 schema.
- `schema_version` 영향 없음 (ADR 0003 답변 contract 무관).

## 7. Out of scope

- **R2 Group B**: `render_real_eval_history.py` + `leaderboard.py`의 history-render dedupe. `load_history()` schema 차이 (`judge` vs `ci` block, manifest fallback)와 render scope 차이 (Jekyll + Chart.js)로 strategy pattern 결정이 필요 — 별도 issue로 분리해야 review가 가벼움.
- **`eval/run_eval.py` 자체 `_git()` + `compute_run_manifest()` dedupe**: manifest는 `config_sha256`까지 캡처하는 superset이고 `tests/test_run_real_eval_delta`가 seam로 의존. 별도 후속 작업.
- 새 unit test for provenance/run_id (위 §4).