### PR TITLE
refactor(scripts): consolidate history table-render kernel in _utils.py (#284 R2 B)

### DIFF
--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -131,6 +131,75 @@ def fmt_rate(value: Any) -> str:
     return f"{value:.3f}" if isinstance(value, (int, float)) else "N/A"
 
 
+def fmt_cell(value: Any) -> str:
+    """Format a cell value for a markdown history table.
+
+    Conventions shared by the real-data history renderer
+    (``scripts/render_real_eval_history.py``) and the synthetic
+    leaderboard (``scripts/leaderboard.py``):
+
+    - ``None`` renders as ``"—"`` (em dash), not ``"None"`` — missing
+      metrics on older snapshots should look intentional, not broken.
+    - ``float`` renders with 3 decimals — the precision both eval
+      surfaces are calibrated to.
+    - Other values fall through to ``str(value)``.
+
+    Note: ``fmt_rate`` (also in this module) uses a different
+    convention (``"N/A"`` instead of ``"—"``) and is consumed by the
+    README ablation table renderer. Keep both — they target different
+    audiences (in-repo history tables vs README headline metrics).
+    """
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def render_history_table(
+    rows: list[dict[str, Any]],
+    columns: list[tuple[str, str]],
+    *,
+    empty_message: str = "",
+    trailing_newline: bool = False,
+) -> str:
+    """Render aggregate-history rows as a GitHub markdown table.
+
+    Shared kernel for ``render_real_eval_history.render_table()`` and
+    ``leaderboard._render_table_only()``. Conventions:
+
+    - ``columns`` is a list of ``(row_key, header_label)`` tuples.
+    - The ``"commit"`` column gets backtick-wrapped (``" `abc123`"``);
+      empty commit renders as ``"—"``.
+    - Every other column flows through :func:`fmt_cell`.
+    - ``empty_message`` is returned verbatim when ``rows`` is empty —
+      callers want different "no data" prose.
+    - ``trailing_newline=True`` appends ``"\\n"`` after the last row;
+      matches ``leaderboard._render_table_only`` (which embeds the
+      table under a ``## Tabular view`` section that expects a final
+      newline). Default ``False`` matches ``render_real_eval_history``
+      (which feeds the table into a marker-spliced block).
+    """
+    if not rows:
+        return empty_message
+    header = "| " + " | ".join(label for _, label in columns) + " |"
+    sep = "|" + "|".join(["---"] * len(columns)) + "|"
+    lines = [header, sep]
+    for row in rows:
+        cells = []
+        for key, _ in columns:
+            value = row.get(key)
+            if key == "commit":
+                cells.append(f"`{value}`" if value else "—")
+            else:
+                cells.append(fmt_cell(value))
+        lines.append("| " + " | ".join(cells) + " |")
+    result = "\n".join(lines)
+    if trailing_newline:
+        result += "\n"
+    return result
+
+
 _METRIC_SNAPSHOT_KEYS_PRE = (
     "num_predictions",
     "accuracy",

--- a/scripts/leaderboard.py
+++ b/scripts/leaderboard.py
@@ -37,6 +37,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts._utils import render_history_table  # noqa: E402
 from scripts.run_real_eval_delta import extract_aggregate  # noqa: E402
 
 HISTORY_DIR = ROOT / "reports" / "history"
@@ -61,14 +62,6 @@ TABLE_COLUMNS: list[tuple[str, str]] = [
     ("abstention", "Abstention"),
     ("retry", "Retry"),
 ]
-
-
-def _fmt(value: Any) -> str:
-    if value is None:
-        return "—"
-    if isinstance(value, float):
-        return f"{value:.3f}"
-    return str(value)
 
 
 def load_history(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]]:
@@ -113,21 +106,12 @@ def _render_table_only(rows: list[dict[str, Any]]) -> str:
     ``render_page`` (which embeds it under its own ``## Tabular view``
     section, where a duplicate title would be a bug).
     """
-    if not rows:
-        return ""
-    header = "| " + " | ".join(label for _, label in TABLE_COLUMNS) + " |"
-    sep = "|" + "|".join(["---"] * len(TABLE_COLUMNS)) + "|"
-    lines = [header, sep]
-    for row in rows:
-        cells = []
-        for key, _ in TABLE_COLUMNS:
-            value = row.get(key)
-            if key == "commit":
-                cells.append(f"`{value}`" if value else "—")
-            else:
-                cells.append(_fmt(value))
-        lines.append("| " + " | ".join(cells) + " |")
-    return "\n".join(lines) + "\n"
+    return render_history_table(
+        rows,
+        TABLE_COLUMNS,
+        empty_message="",
+        trailing_newline=True,
+    )
 
 
 def render_markdown_table(rows: list[dict[str, Any]]) -> str:

--- a/scripts/render_real_eval_history.py
+++ b/scripts/render_real_eval_history.py
@@ -35,6 +35,7 @@ from typing import Any
 # Reuse the extractor + privacy guards from the delta script. Adding a
 # new entry point should not weaken the boundary.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts._utils import render_history_table  # noqa: E402
 from scripts.run_real_eval_delta import extract_aggregate  # noqa: E402
 
 HISTORY_DIR = Path("reports/real100/history")
@@ -54,17 +55,9 @@ COLUMNS: list[tuple[str, str]] = [
     ("answer_format_compliance", "Format"),
     ("retry", "Retry"),
     # ADR 0006: LLM-judge agreement. Shown only when present; absent
-    # entries render as "—" via the _fmt fallback.
+    # entries render as "—" via render_history_table's fmt_cell fallback.
     ("agreement_with_verifier", "Judge⇄Verifier"),
 ]
-
-
-def _fmt(value: Any) -> str:
-    if value is None:
-        return "—"
-    if isinstance(value, float):
-        return f"{value:.3f}"
-    return str(value)
 
 
 def load_history() -> list[dict[str, Any]]:
@@ -100,26 +93,15 @@ def load_history() -> list[dict[str, Any]]:
 
 
 def render_table(rows: list[dict[str, Any]]) -> str:
-    if not rows:
-        return (
+    return render_history_table(
+        rows,
+        COLUMNS,
+        empty_message=(
             "_No real-data history entries yet. Run "
             "`make real-eval-baseline-update` to seed the first "
             "snapshot._"
-        )
-    header = "| " + " | ".join(label for _, label in COLUMNS) + " |"
-    sep = "|" + "|".join(["---"] * len(COLUMNS)) + "|"
-    lines = [header, sep]
-    for row in rows:
-        cells = []
-        for key, _ in COLUMNS:
-            value = row.get(key)
-            if key == "commit":
-                value = f"`{value}`" if value else "—"
-            else:
-                value = _fmt(value)
-            cells.append(value)
-        lines.append("| " + " | ".join(cells) + " |")
-    return "\n".join(lines)
+        ),
+    )
 
 
 def render_section(rows: list[dict[str, Any]]) -> str:

--- a/tests/test_render_real_eval_history.py
+++ b/tests/test_render_real_eval_history.py
@@ -45,7 +45,7 @@ class RealEvalHistoryRendererTest(unittest.TestCase):
         (self.root / "reports" / "real100" / "history").mkdir(parents=True)
         # Copy the scripts module so subprocess can find it.
         repo_root = Path(__file__).resolve().parents[1]
-        for fname in ("run_real_eval_delta.py", "render_real_eval_history.py"):
+        for fname in ("_utils.py", "run_real_eval_delta.py", "render_real_eval_history.py"):
             shutil.copy(repo_root / "scripts" / fname, self.root / "scripts" / fname)
         # __init__.py so `import scripts.run_real_eval_delta` works.
         (self.root / "scripts" / "__init__.py").write_text("")


### PR DESCRIPTION
## 1. What changed and why

Closes #393. Stacked on [#391](https://github.com/hskim-solv/BidMate-DocAgent/pull/391) (R2 Group A — provenance helpers). #284 R2의 후반부.

`scripts/render_real_eval_history.py` 와 `scripts/leaderboard.py` 사이의 두 byte-identical surface를 `scripts/_utils.py`로 통합:

- `fmt_cell(value)` — `None → '—'`, `float → 3 decimals`, 그 외 `str()`. (기존 `fmt_rate(value)`는 README ablation 표용으로 `"N/A"` convention을 유지, 둘은 audience가 다름.)
- `render_history_table(rows, columns, *, empty_message, trailing_newline)` — 두 caller가 wrap하는 markdown table kernel. `'commit'` 컬럼만 backtick 래핑, 나머지는 `fmt_cell`. `trailing_newline=True`는 leaderboard 의 `## Tabular view` embed가 `\n`을 요구하기 때문.

각 caller의 `load_history()`는 **그대로 유지** — schema 차이가 의미 있음:
- `render_real_eval_history.load_history()`: `agg.get('judge')` block + `agreement_with_verifier` (ADR 0006)
- `leaderboard.load_history()`: `agg.get('ci')` block + `agg.get('run_manifest')` provenance fallback

이 둘을 generic loader로 묶으면 caller-specific dict 구성이 callback으로 빠지면서 가독성 손해. 분기 자체가 design intent.

## 2. Files affected

- `scripts/_utils.py` (`+69`) — `fmt_cell` + `render_history_table`. 둘 다 docstring으로 audience/trailing-newline 선택 이유 명시.
- `scripts/render_real_eval_history.py` (`-26`/`+8`) — 로컬 `_fmt` 제거, `render_table()` body는 `render_history_table` 호출 한 줄. import 한 줄 추가.
- `scripts/leaderboard.py` (`-22`/`+7`) — 동일 패턴. `render_markdown_table()` (title+intro wrapper)와 `_chart_data()` (Chart.js JSON)는 leaderboard-only라 그대로.
- `tests/test_render_real_eval_history.py` (`+1`/`-1`) — subprocess가 renderer를 temp dir에서 실행하므로 `_utils.py`도 copy list에 추가. `tests/test_leaderboard.py`는 module을 직접 import하므로 코드 변경 불요.

**No load-bearing path touched** (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py` 모두 무관).

## 3. Risks

- **render output byte drift**: kernel 추출 시 trailing newline 처리 차이로 출력이 1바이트 달라질 수 있음. Mitigation — pre-refactor 로직을 inline에서 재구현 후 새 helper와 byte-for-byte 비교 검증:
  ```python
  # variants tested: real-eval style (no trailing \\n), leaderboard style (trailing \\n), empty rows
  # fmt_cell input types: None, float, int, str, bool
  # 모두 old_render_table(...) == render_history_table(...) 통과
  ```
  추가로 `tests/test_render_real_eval_history` (5 tests) + `tests/test_leaderboard` (6 tests) 모두 green — 이 테스트들은 출력을 byte-for-byte 또는 substring으로 검증.
- **subprocess test copy 누락**: `tests/test_render_real_eval_history.py`가 temp 디렉터리에 scripts 파일을 복사해 subprocess로 renderer를 실행. `_utils.py`를 copy list에 추가 안 하면 `ModuleNotFoundError`. 본 PR에서 처리. `tests/test_leaderboard.py`는 다른 패턴 (직접 import)이라 영향 없음 — 검증됨.
- **`fmt_rate` vs `fmt_cell` 혼란**: 둘 다 `_utils.py`에 공존. docstring으로 split 명시.

## 4. Tests

- `python3 -m pytest tests/test_render_real_eval_history.py tests/test_leaderboard.py -v` → 11 passed (5 + 6).
- `python3 -m pytest tests/ -q` → 715 passed.
- Byte-equality smoke (위 §3 inline) → OK.
- `python3 -m py_compile scripts/_utils.py scripts/render_real_eval_history.py scripts/leaderboard.py` → clean.

새 unit test for `fmt_cell` / `render_history_table` 별도 추가 안 함 — 위 11개 end-to-end test가 byte 비교로 cover. CLAUDE.md "Don't add error handling, fallbacks, or validation for scenarios that can't happen".

## 5. Eval impact

All `·`. Pure refactor — render output byte-identical (`§3` byte-equality 검증). No metric path touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval path. No load-bearing file modified (see §2). Renderer 출력이 byte-identical임이 검증됐으므로 `reports/leaderboard.md`, `docs/leaderboard.md`, `docs/private-100-doc-experiments.md`의 committed 내용은 `--check` 모드에서 통과 (재실행해도 diff 없음).

## 6. Backward compatibility

- API 변경 없음 — 외부 import surface 그대로.
- Renderer 출력 byte-identical — `make leaderboard-check` + `make real-eval-history-check` (governance-check target에 포함) diff 없음.
- `fmt_rate` 등 기존 `_utils.py` 함수 모두 그대로.

## 7. Out of scope

- **`load_history()` dedupe**: schema 분기가 의미 있어 의도적 비-dedupe (`§1` 참조).
- **`splice()` / `render_section()` (real-eval only)** + **`render_page()` / `_chart_data()` (leaderboard only)**: 대응물 없음.
- **`fmt_rate` 통합**: audience 다른 convention (`"N/A"` vs `"—"`), README 표에 영향 → 별도 결정.
- 새 unit test (위 §4).