### PR TITLE
docs(adr): ADR 0020 skeleton — Protocol-based pluggability convention

### DIFF
--- a/docs/adr/0020-protocol-based-pluggability.md
+++ b/docs/adr/0020-protocol-based-pluggability.md
@@ -1,0 +1,111 @@
+# 0020: Protocol-based pluggability for retrieval-side extensions
+
+- **Status**: proposed
+- **Date**: 2026-05-12
+- **Deciders**: hskim
+- **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (baseline preserved), [ADR 0010](./0010-hybrid-bm25-dense-retrieval-rrf.md) (RRF fusion, retrieval-side), [ADR 0013](./0013-observability-as-additive-pluggable-surface.md) (pluggable surface — sibling pattern, observability domain), issues [#176](https://github.com/hskim-solv/BidMate-DocAgent/issues/176) / [#232](https://github.com/hskim-solv/BidMate-DocAgent/issues/232) / [#345](https://github.com/hskim-solv/BidMate-DocAgent/issues/345) / [#394](https://github.com/hskim-solv/BidMate-DocAgent/issues/394), PRs [#234](https://github.com/hskim-solv/BidMate-DocAgent/pull/234) / [#288](https://github.com/hskim-solv/BidMate-DocAgent/pull/288) / [#296](https://github.com/hskim-solv/BidMate-DocAgent/pull/296) / [#342](https://github.com/hskim-solv/BidMate-DocAgent/pull/342) / [#358](https://github.com/hskim-solv/BidMate-DocAgent/pull/358)
+
+> **NOTE — skeleton only.** Status is `proposed` because the body below
+> stops at *Context*: rationale (Decision, Consequences, Alternatives) is
+> reserved for the author per the cognitive-ownership boundary noted in
+> [#394](https://github.com/hskim-solv/BidMate-DocAgent/issues/394). Remove this note and
+> flip to `accepted` once the rationale sections are filled in.
+
+## Context
+
+Two retrieval-side refactors landed in Phase-3 prep with the same
+structural shape but without a formal convention:
+
+1. **`VectorStore` Protocol** ([#176](https://github.com/hskim-solv/BidMate-DocAgent/issues/176) Stage 1).
+   Leaf module [`rag_vector_store.py`](../../rag_vector_store.py)
+   defines a `@runtime_checkable typing.Protocol` (`dimension`, `__len__`,
+   `get`, `query`, `persist`). The default `InMemoryVectorStore` wraps
+   the original numpy matrix; `QdrantVectorStore` (#288/#296) is the
+   second adapter. Dispatch is env-var (`BIDMATE_INDEX_BACKEND={memory,qdrant}`).
+   The retrieval orchestrator (`rag_core.retrieve_candidates` after
+   [#342](https://github.com/hskim-solv/BidMate-DocAgent/pull/342)) consumes the Protocol via
+   `store.query(...)` without knowing the concrete backend.
+2. **`Reranker` Protocol** ([#345](https://github.com/hskim-solv/BidMate-DocAgent/issues/345)).
+   Leaf module [`rag_reranker.py`](../../rag_reranker.py) defines a
+   `@runtime_checkable Reranker` Protocol (`rerank(query, candidates,
+   *, top_n) -> (reordered, meta)`). The default `CrossEncoderReranker`
+   wraps the existing `rag_rerank.rerank` (preserving its env-var
+   backend dispatch — stub / bge / cohere / bge_ko). The retrieval
+   orchestrator (`rag_core.apply_fusion_and_reranking` after [#342](https://github.com/hskim-solv/BidMate-DocAgent/pull/342))
+   consumes it via `default_reranker().rerank(...)`.
+
+Both PRs justify the pattern in their own bodies, but no ADR codifies
+**the pattern itself**. Phase 3 will recur to it (HyDE-style query
+rewriting, multi-query retrieval, possibly an embedding-backend
+Protocol per [ADR 0019](./0019-embedding-default-stays-minilm.md) condition
+4) — without a written convention, each future PR re-litigates the
+shape (ABC vs Protocol, factory vs direct import, env-var vs plan-dict
+dispatch).
+
+[ADR 0013](./0013-observability-as-additive-pluggable-surface.md) already
+established "pluggable surface" semantics in the observability domain
+(tracer backends, fail-closed defaults). This ADR codifies the
+retrieval-side counterpart so the two pluggability surfaces share a
+documented shape.
+
+The observed convention (informal, four properties — to be made
+canonical in the *Decision* section below):
+
+- `@runtime_checkable typing.Protocol` (not `abc.ABC`).
+- Leaf module (`rag_*.py` at repo root) — imports nothing from
+  `rag_core.py`; `rag_core.py` consumes it.
+- Default adapter wraps the existing implementation so behavior is
+  preserved without flag flips.
+- Single `default_*()` factory or env-var dispatch — the **one** hook
+  future implementations swap.
+
+## Decision
+
+<!--
+TODO (author): one-sentence decision followed by the specifics needed
+to act on it. Name the knob/toggle (e.g. "any new retrieval-side
+extension point uses the four-property shape above; the dispatch hook
+is named `default_<surface>()` or routed via `BIDMATE_<SURFACE>_BACKEND`").
+Specify the boundaries — does this apply ONLY to retrieval-side, or
+also to ingestion / eval / answer surfaces? Cite the precedent ADRs
+(0013 for observability; 0019 condition 4 for the embedding-backend
+case if/when it arrives).
+-->
+
+## Consequences
+
+<!--
+TODO (author): wins and costs. Suggested prompts —
+- Positive: forward-compatible extension; testable via `isinstance`
+  checks on the runtime_checkable Protocol; behavior preserved by
+  wrapping existing implementations (zero-day ranking drift in eval).
+- Negative: ceremony cost per extension (Protocol + default adapter +
+  factory = three sites instead of one function); a small Python-only
+  decision (Protocol vs ABC is a language-version-sensitive call).
+- Reversal cost: low (each Protocol is a leaf module, no cross-cutting
+  changes; reverting one Protocol does not touch the others).
+- Contracts locked: the four-property shape becomes the review checklist
+  for future Phase 3 retrieval PRs.
+-->
+
+## Alternatives considered
+
+<!--
+TODO (author): one or two bullets each, suggested options to address —
+- ABC (`abc.ABC` + `@abstractmethod`) vs `typing.Protocol`. The repo
+  uses Protocol; ABC requires explicit subclassing, Protocol allows
+  structural typing for third-party adapters (e.g., a future user-
+  authored Reranker that doesn't import our base class).
+- Factory function (`default_reranker()`) vs direct constructor import.
+  Factory centralizes the dispatch hook for future plan-based routing
+  (without touching `rag_core.py`); direct import would force a
+  retrieval-orchestrator edit each time a new impl is added.
+- Env-var dispatch vs plan-dict dispatch. VectorStore uses env-var;
+  Reranker uses factory-with-future-plan-dispatch. Note whether this
+  ADR locks one of the two, or allows both based on the lifecycle of
+  the surface (env-var = build-time; plan = per-query).
+- Single shared Protocol module vs per-surface modules. Current
+  pattern: per-surface (`rag_vector_store.py`, `rag_reranker.py`).
+  Alternative: a `rag_protocols.py` collection — note why per-surface
+  was preferred (or revisit if the count grows past 3-4 Protocols).
+-->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,6 +82,7 @@ project record.
 | [0017](./0017-llm-metadata-extraction-additive.md) | proposed | LLM metadata extraction as additive backend (extends 0011) |
 | [0018](./0018-korean-public-rag-bench.md) | accepted | Korean public RAG bench as supplementary out-of-domain surface (extends 0005) |
 | [0019](./0019-embedding-default-stays-minilm.md) | accepted | Embedding default stays MiniLM-L12-v2 with explicit re-open conditions (extends 0002) |
+| [0020](./0020-protocol-based-pluggability.md) | proposed | Protocol-based pluggability for retrieval-side extensions (sibling to 0013; skeleton — rationale pending author) |
 
 ## Decision evolution
 

--- a/docs/senior-positioning.md
+++ b/docs/senior-positioning.md
@@ -15,7 +15,7 @@
 
 | 시그널 | 어디서 확인하나 |
 |---|---|
-| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 19개 ADR (15 accepted / 4 proposed), status-tracked, supersession chains 명시 |
+| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 20개 ADR (15 accepted / 5 proposed), status-tracked, supersession chains 명시 |
 | **측정 가능한 성공 기준**을 미리 잡고 그 기준으로 평가한다 | [`portfolio-case-study.md` §2](./portfolio-case-study.md), [`eval/config.yaml`](../eval/config.yaml), README headline 표 |
 | 합성 평가의 한계를 알고 **공개/비공개 평가 분리**로 보완한다 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) |
 | **실패를 분류·우선순위화**한 뒤 백로그로 만든다 | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), 메타 이슈 #49 |
@@ -48,6 +48,7 @@
 | [0017](./adr/0017-llm-metadata-extraction-additive.md) | proposed | LLM metadata extraction as additive backend (extends 0011) | metadata 추출도 LLM additive ablation으로 — 0011 backend 패턴 재사용, 결정적 추출기 baseline은 ADR 0002 metadata-first 경로에 그대로 보존 |
 | [0018](./adr/0018-korean-public-rag-bench.md) | accepted | Korean public RAG bench (KorQuAD 2.1) as supplementary out-of-domain surface (extends 0005) | "한국어 일반 텍스트에서도 동작합니까?" 질문에 공개 재현 가능한 한 줄 명령(`make korean-public-eval`)으로 답변 — 합성 surface와 분리, CI 게이트가 *아님* |
 | [0019](./adr/0019-embedding-default-stays-minilm.md) | accepted | embedding 디폴트 = MiniLM-L12-v2 잠금 + 재오픈 조건 명시 (extends 0002) | 2차 사이클 측정이 env mismatch로 deferred됐을 때 *deferral 자체*를 ADR로 잠금 — 다음 contributor가 같은 실험을 다시 시도하지 않고, "디폴트 교체"의 empirical bar(`full` 파이프라인 ≥+5pp)도 명시 |
+| [0020](./adr/0020-protocol-based-pluggability.md) | proposed | Protocol-based pluggability convention (sibling to 0013 observability) — VectorStore (#176) + Reranker (#345) 두 retrieval-side Protocol이 공유하는 4-요소 패턴 (`@runtime_checkable` Protocol + leaf module + default adapter + factory) 명시 — skeleton, rationale은 작성자 영역 |
 
 **인터뷰 talking point 1 (real-data 회귀)**: "ADR 0005가 없었다면 공개본의 abstention 회귀(#69의 `1.000 → 0.500` 사건)는 아무도 보지 못했을 것이다. 공개 합성만 보던 시기에는 1-of-2 incidental overlap 패턴이 잡히지 않았다." — 근거: [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) 2026-05-11 entry.
 
@@ -175,7 +176,7 @@ make reproduce  # smoke + SHA-256 over the environment-invariant metric subset
 
 ### 30초 자기소개
 
-> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **19개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
+> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **20개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
 
 읽는 시간 ≈ 30초. 면접 첫 답으로 그대로 사용 가능. 상대가 "좀 더 자세히"를 물으면 §1, 측정 의문에는 §2, 운영 의문에는 [`production-readiness.md`](./production-readiness.md)로 넘어간다.
 


### PR DESCRIPTION
## 1. What changed and why

Closes #394

Files ADR 0020 (the existing number-gap slot) as a **skeleton** that codifies the convention shared by the two Protocols that landed in Phase-3 prep:

- `VectorStore` Protocol — [#176](https://github.com/hskim-solv/BidMate-DocAgent/issues/176) Stage 1 + follow-ups ([#234](https://github.com/hskim-solv/BidMate-DocAgent/pull/234), [#288](https://github.com/hskim-solv/BidMate-DocAgent/pull/288), [#296](https://github.com/hskim-solv/BidMate-DocAgent/pull/296))
- `Reranker` Protocol — [#345](https://github.com/hskim-solv/BidMate-DocAgent/issues/345) ([#358](https://github.com/hskim-solv/BidMate-DocAgent/pull/358))

Both introduce the same four-property shape (`@runtime_checkable typing.Protocol` + leaf module + default adapter wrapping existing impl + `default_*()` factory). Without a written convention, future Phase-3 Protocols (HyDE / multi-query / embedding-backend per [ADR 0019](docs/adr/0019-embedding-default-stays-minilm.md) condition 4) would re-litigate the shape from scratch.

**Skeleton scope (cognitive-ownership boundary):**

The ADR file's **Context** section is filled with factual citations only — concrete files, PR numbers, the observed convention listed structurally. The three rationale sections (**Decision**, **Consequences**, **Alternatives considered**) carry TODO prompts and are reserved for the author per [#394](https://github.com/hskim-solv/BidMate-DocAgent/issues/394)'s explicit framing (Claude as reading aid + skeleton, never ghost-writer for ADR rationale). A visible note at the top of the file flags this and instructs flipping the status from `proposed` to `accepted` once the rationale lands.

## 2. Files affected

- `docs/adr/0020-protocol-based-pluggability.md` (new, 111 lines — Context filled + Decision/Consequences/Alternatives TODO)
- `docs/adr/README.md` (+1 line — index row for 0020)
- `docs/senior-positioning.md` (+1 line / −1 line edit + 1 new table row):
  - Count label sync: `19개 ADR (15 accepted / 4 proposed)` → `20개 ADR (15 accepted / 5 proposed)` — required to keep `test_senior_positioning_count_label_matches_adr_files` green.
  - Interview-quote count sync: `**19개 ADR**` → `**20개 ADR**` (same factual sync, same test).
  - New table row for ADR 0020 with a one-line factual description (no interview-rationale content — the `인터뷰 talking point` paragraphs are untouched and remain author territory).

No code touched. No load-bearing path touched.

## 3. Risks

None functional. Documentation only. The one substantive risk is **scope creep on the cognitive-ownership boundary**: by filing the skeleton I am providing structure that an author normally writes themselves. Mitigation: the Context section is purely factual (file paths, PR numbers, observed pattern); the three rationale sections are explicit TODOs with prompt bullets, not pre-written content; the skeleton note at the top makes the boundary visible; status is `proposed` until the author flips it.

## 4. Tests

- `python3 -m pytest -q` → **715 passed, 121 subtests passed** (governance tests now see 20 ADRs and the synced count labels; previously failing 3 tests now pass).

## 5. Eval impact

All `·` (documentation only).

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion path.

## 6. Backward compatibility

Documentation only. No contract / schema / CLI change.

## 7. Out of scope

- **Authoring the rationale sections** (Decision / Consequences / Alternatives) — owned by @hskim per #394's framing.
- Filing similar skeletons for other ADRs (this PR addresses #394 specifically).
- Updating prose/talking-points elsewhere in `docs/senior-positioning.md` — the interview "talking point" paragraphs (`인터뷰 talking point 1/2/3`) are author-voice content and stay untouched.
- Changes to either Protocol's API or its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)