### PR TITLE
fix(deploy): poll /health to wake machine + verify (drop status assert)

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -69,25 +69,34 @@ jobs:
             flyctl deploy --remote-only --app "$FLY_APP"
           fi
 
-      - name: Assert all machines healthy
+      - name: Poll /health until ready (also wakes the machine)
+        # `flyctl status` immediately after deploy reports `stopped` because
+        # fly.toml sets `auto_stop_machines=true` + `min_machines_running=0`
+        # for cost savings — Fly intentionally stops idle machines and only
+        # auto-starts them on the next request. So the only real validation
+        # is the actual user path: GET /health. The first request both wakes
+        # the machine (auto_start_machines=true) and verifies the response.
+        # Poll for ~3 minutes to cover cold start (index build + uvicorn
+        # boot + DNS propagation on first deploy).
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
           set -eu
-          flyctl status --json --app "$FLY_APP" \
-            | jq -e '[.Machines[] | select(.state != "started")] | length == 0'
-
-      - name: Smoke-test public route
-        if: ${{ github.event.inputs.dry_run != 'true' }}
-        run: |
-          set -eu
-          for i in 1 2 3 4 5; do
-            if curl --fail --max-time 10 "$FLY_URL/health"; then
-              echo "Health check passed on attempt $i"
+          deadline=$(( $(date +%s) + 180 ))
+          attempt=0
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            attempt=$((attempt + 1))
+            if curl --fail --max-time 15 "$FLY_URL/health"; then
+              echo ""
+              echo "::notice::Health check passed on attempt $attempt"
               exit 0
             fi
-            sleep 10
+            remaining=$(( deadline - $(date +%s) ))
+            echo "attempt $attempt — waiting for $FLY_URL/health (${remaining}s remaining)"
+            sleep 5
           done
-          echo "::error::Health check failed after 5 attempts"
+          echo "::error::Health check failed after 3 minutes"
+          echo "=== Final machine status ==="
+          flyctl status --app "$FLY_APP" || true
           exit 1
 
       - name: Upsert PR comment with live URL + SHA
@@ -107,7 +116,7 @@ jobs:
           fi
           marker="<!-- deploy-fly-bot -->"
           short_sha="${SHA:0:7}"
-          body="$(printf '%s\n\n🟢 **Live demo deployed**\n\n- URL: %s/\n- SHA: `%s`\n- Healthcheck: passed\n\nRollback: `flyctl releases revert <version>` (see [docs/deployment.md](../blob/main/docs/deployment.md#rollback))\n' \
+          body="$(printf '%s\n\n🟢 **Live demo deployed**\n\n- URL: %s/\n- SHA: `%s`\n- Healthcheck: passed\n\nFirst request after idle wakes the machine — expect ~5-10s cold start. Rollback: `flyctl releases revert <version>` (see [docs/deployment.md](../blob/main/docs/deployment.md#rollback)).\n' \
             "$marker" "$FLY_URL" "$short_sha")"
           for pr in $prs; do
             existing=$(gh api "repos/$REPO/issues/$pr/comments" \


### PR DESCRIPTION
## 1. What changed and why

Closes #398

#386 이후 컨테이너 부팅은 정상 (4초 만에 \`GET /health 200\`). 그런데 워크플로의 \"Assert all machines healthy\" 가 여전히 fail — fly.toml 의 cost-saving 정책 (\`auto_stop_machines=true\` + \`min_machines_running=0\`) 이 deploy 직후 머신을 즉시 정지시키기 때문. \`flyctl status\` 가 \`stopped\` 를 보고 \"unhealthy\" 로 판단하지만, 이건 의도된 비용 절약 동작이지 deploy 실패가 아님.

실제 사용자 경험과 동일하게 \`/health\` polling 단일 단계로 통합 — curl 요청 자체가 (a) auto_start 트리거, (b) 응답 검증 두 역할을 동시 수행. fly.toml 정책 변경 없음 → idle 시 비용 0 유지.

## 2. Files affected

- \`.github/workflows/deploy-fly.yml\` — \`Assert all machines healthy\` 제거, \`Smoke-test\` 를 180초 polling 으로 확장, PR 코멘트 본문에 cold-start 안내 한 줄 추가

Load-bearing 변경 없음.

## 3. Risks

- **Polling timeout 3분이 부족할 가능성**: 현재 데이터 (인덱스 7 docs, 9 chunks) 기준 cold start 가 4초, 마진 충분. 만일 미래에 \`data/raw/\` 가 크게 증가하면 timeout 조정 필요할 수 있음. 그때 가서 별도 PR.
- **DNS propagation 지연**: 첫 deploy 시 \`*.fly.dev\` 레코드 publish 가 약간 늦을 수 있는데, polling 이 그 동안 \"Could not resolve host\" 를 그냥 다음 attempt 로 흘려보내므로 견고.
- **\`status\` assert 제거로 multi-machine 시나리오에서 부분 실패를 못 잡을 가능성**: 현재 \`min_machines_running=0\` 이라 단일 머신만 운영. multi-machine 운영으로 전환 시 별도 검증 추가 필요.

## 4. Tests

운영 검증:
1. 머지 후 deploy-fly 워크플로 자동 트리거
2. \`Poll /health\` step 이 180초 내에 200 응답 확인
3. \`Upsert PR comment\` step 이 PR 에 cold-start 노트 포함된 코멘트 게시
4. \`curl https://bidmate-docagent-demo.fly.dev/health\` (idle 후 cold curl) → ~5-10s 대기 후 200

## 5. Eval impact

All \`·\` — 워크플로 단독, RAG 코드 미변경.

### 5b. Real-data delta

**N/A** — load-bearing 경로 미수정.

## 6. Backward compatibility

워크플로 외부 인터페이스 동일 (PR 코멘트 marker \`<!-- deploy-fly-bot -->\` 유지, dry_run input 유지, 트리거 동일).

## 7. Out of scope

- \`fly.toml\` 의 always-on 전환 (\`min_machines_running=1\`) — 비용 발생하므로 의도적으로 보류. 현재 cost-conscious 정책 유지.
- HF Spaces auto-sync — 원래 #181 의 별도 follow-up.
- \`data/raw/\` 가 커진 미래에 polling timeout 조정 — 그때 별도 issue.