### PR TITLE
ci(workflows): composite run-eval action + pr-eval concurrency + index cache (#284 R3)

### DIFF
--- a/.github/actions/run-eval/action.yml
+++ b/.github/actions/run-eval/action.yml
@@ -1,0 +1,72 @@
+name: 'Run BidMate eval'
+description: >-
+  Build the index and run eval/run_eval.py, with `actions/cache` keyed
+  on data/raw + builder code so unchanged-data PRs skip the build step.
+  Shared by .github/workflows/pr-eval.yml (PR + base checkouts) and
+  .github/workflows/leaderboard.yml (main merge). See issue #400.
+
+inputs:
+  working-directory:
+    description: >-
+      Subdirectory holding the checked-out repo (e.g. `pr` or `base`
+      when pr-eval.yml uses dual checkouts). Use `.` for a default
+      single-checkout layout (leaderboard.yml).
+    required: false
+    default: '.'
+  config:
+    description: >-
+      Eval config path relative to `working-directory`. PR/base
+      pipelines pass `eval/config.ci.yaml` (full-pipeline-only
+      variant built earlier in the job); leaderboard uses the
+      default committed config.
+    required: false
+    default: 'eval/config.yaml'
+  embedding-backend:
+    description: >-
+      Value forwarded to `scripts/build_index.py --embedding_backend`.
+      Also a cache-key dimension — `hashing` (deterministic CI default)
+      gets a different cache scope than e.g. `minilm`.
+    required: false
+    default: 'hashing'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore cached index
+      id: cache-index
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.working-directory }}/data/index
+        # Invalidate when raw data changes (the inputs the index is
+        # built from) OR when the builder code changes (build_index +
+        # ingestion). Backend is part of the key because different
+        # embedding backends produce different index payloads even
+        # for the same raw inputs.
+        key: >-
+          bidmate-index-${{ inputs.embedding-backend }}-${{
+          hashFiles(format('{0}/data/raw/**', inputs.working-directory))
+          }}-${{
+          hashFiles(
+            format('{0}/scripts/build_index.py', inputs.working-directory),
+            format('{0}/ingestion.py', inputs.working-directory),
+            format('{0}/visual_ingestion.py', inputs.working-directory)
+          ) }}
+
+    - name: Build index (cache miss only)
+      if: steps.cache-index.outputs.cache-hit != 'true'
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: >-
+        python scripts/build_index.py
+        --input_dir data/raw
+        --output_dir data/index
+        --embedding_backend ${{ inputs.embedding-backend }}
+
+    - name: Run eval
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: >-
+        python eval/run_eval.py
+        --index_dir data/index
+        --output_dir reports
+        --config ${{ inputs.config }}

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -46,11 +46,11 @@ jobs:
           pip install -r requirements.txt
 
       - name: Build index + run eval (hashing backend, deterministic)
-        env:
-          EMBEDDING_BACKEND: hashing
-        run: |
-          make index
-          make eval
+        uses: ./.github/actions/run-eval
+        with:
+          working-directory: '.'
+          config: eval/config.yaml
+          embedding-backend: hashing
 
       - name: Append history snapshot
         run: python3 scripts/write_synthetic_history.py

--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -8,6 +8,13 @@ permissions:
   contents: read
   pull-requests: write
 
+# Cancel in-progress runs on the same PR when a new push arrives —
+# the new push triggers a fresh run anyway, so finishing the stale
+# one is wasted minutes (and risks stale PR comments).
+concurrency:
+  group: pr-eval-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   EMBEDDING_BACKEND: hashing
   PYTHONDONTWRITEBYTECODE: "1"
@@ -99,21 +106,24 @@ jobs:
         run: |
           python -c "import yaml; c=yaml.safe_load(open('eval/config.yaml')); c['primary_run']='full'; c['ablation_runs']=[r for r in c['ablation_runs'] if r['name']=='full']; open('eval/config.ci.yaml','w').write(yaml.safe_dump(c, allow_unicode=True, sort_keys=False))"
 
-      - name: Build index — PR
-        working-directory: pr
-        run: python scripts/build_index.py --input_dir data/raw --output_dir data/index --embedding_backend hashing
+      # Both PR and base sides use the *PR side's* composite action
+      # so this workflow keeps working in the transition PR (when main
+      # / base hasn't received the action yet) and after merge (when
+      # the two copies are identical). The composite's
+      # `working-directory` input handles the divergence cleanly.
+      - name: Build index + run eval — PR
+        uses: ./pr/.github/actions/run-eval
+        with:
+          working-directory: pr
+          config: eval/config.ci.yaml
+          embedding-backend: hashing
 
-      - name: Run eval — PR
-        working-directory: pr
-        run: python eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.ci.yaml
-
-      - name: Build index — base
-        working-directory: base
-        run: python scripts/build_index.py --input_dir data/raw --output_dir data/index --embedding_backend hashing
-
-      - name: Run eval — base
-        working-directory: base
-        run: python eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.ci.yaml
+      - name: Build index + run eval — base
+        uses: ./pr/.github/actions/run-eval
+        with:
+          working-directory: base
+          config: eval/config.ci.yaml
+          embedding-backend: hashing
 
       - name: Render delta table
         run: |


### PR DESCRIPTION
## 1. What changed and why

Closes #400. (#284 R3 — the last open item in the audit follow-ups; R2 was [#391](https://github.com/hskim-solv/BidMate-DocAgent/pull/391) + [#395](https://github.com/hskim-solv/BidMate-DocAgent/pull/395).)

세 가지 CI 인프라 변경을 하나의 PR에 묶습니다:

1. **Composite action `.github/actions/run-eval/`** — `pr-eval.yml`에 4번 / `leaderboard.yml`에 1번 등장하는 build_index → run_eval 쌍을 하나로. `actions/cache@v4`가 `data/raw/**` + builder 코드 hash로 키 잡혀 raw 데이터 + builder 미변경 PR은 인덱스 빌드 스킵.
2. **`pr-eval.yml` workflow-level concurrency** — 같은 PR에 새 push 시 진행 중 run 취소 (`cancel-in-progress: true`). 새 push가 어차피 fresh run을 띄우므로 진행 중 run은 자원 낭비 + PR comment race.
3. **`leaderboard.yml`도 composite 사용** — main merge의 `make index && make eval`이 같은 캐시 + step 디자인을 받음.

## 2. Files affected

- `.github/actions/run-eval/action.yml` (new, `+72`) — composite action. 3 inputs (`working-directory`, `config`, `embedding-backend`), 3 steps (cache → conditional build → eval).
- `.github/workflows/pr-eval.yml` (`+24`/`-15`) — workflow-level `concurrency` 블록 신설; `eval-delta` job의 4 step (build/eval × PR/base) → 2 composite step. **양쪽 모두 `./pr/.github/actions/run-eval`을 호출** — 자기-참조 transition PR을 위한 의도된 디자인 (§3 참조).
- `.github/workflows/leaderboard.yml` (`+5`/`-6`) — \"Build index + run eval\" step이 composite 호출로 교체. job-level `leaderboard-append` concurrency (`cancel-in-progress: false`)는 그대로 (main merge cancel 금지).

**No load-bearing path touched** (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py` 모두 무관).

## 3. Risks

- **자기-참조 PR (transition PR 문제)**: 이번 PR이 머지되기 전 main에는 `.github/actions/run-eval/`이 없음. `pr-eval.yml`이 base side에서 `./base/.github/actions/run-eval`을 호출하면 본 PR의 CI 자체가 fail. 해결: 양쪽 모두 `./pr/.github/actions/run-eval` 호출 (PR 코드의 action을 base side에도 사용). `working-directory` input이 pr/base 차이를 흡수. 머지 후에도 main에 action 들어오니 PR=main 같은 동작 그대로.
- **cache key collision / staleness**: builder 코드 (`build_index.py`, `ingestion.py`, `visual_ingestion.py`)도 hash에 포함 — builder 바뀌면 강제 rebuild. backend도 key dim이라 hashing/minilm 다른 캐시. `data/raw/**`의 임의 변경도 invalidate. 잘못된 hit 시나리오 없음.
- **GitHub Actions YAML syntax**: actionlint 미설치 환경. PyYAML `yaml.safe_load`로 3개 파일 parse 통과 + composite action의 inputs/steps + workflow의 concurrency/composite use 구조를 inline assert로 검증.
- **concurrency cancel 시 부작용**: pr-eval은 PR push 시 cancel 의도. test job + eval-delta job 모두 cancel되지만 새 push가 둘 다 다시 실행하므로 net OK. leaderboard.yml은 별도 workflow + `cancel-in-progress: false`라 main merge에 영향 없음.

## 4. Tests

- `python3 -m pytest tests/test_governance.py -q` → 49 passed (CI 변경이 governance SSoT에 영향 없음 — `.github/`는 LOAD_BEARING_PATHS 밖).
- YAML 검증 (`§3` inline):
  ```python
  yaml.safe_load(action.yml) → 3 inputs, 3 steps
  yaml.safe_load(pr-eval.yml) → workflow-level concurrency block + 2 composite uses
  yaml.safe_load(leaderboard.yml) → 1 composite use
  ```
- 실제 cache hit/miss 효과는 머지 후 다음 PR run에서 GitHub Actions UI로 관찰 가능 (cache action의 `cache-hit` output이 Job summary에 노출됨).

## 5. Eval impact

All `·`. CI infra 변경 — 실행되는 명령은 동일 (`scripts/build_index.py ... --embedding_backend hashing` + `eval/run_eval.py ... --config eval/config.yaml` / `eval/config.ci.yaml`). 어떤 metric path도 안 거침.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval path. No load-bearing file modified (see §2). Composite action 내부 명령이 inline command와 byte-identical — `--input_dir`, `--output_dir`, `--embedding_backend`, `--index_dir`, `--config` 인자 그대로.

## 6. Backward compatibility

- API 변경 없음.
- 기존 environment variable (`EMBEDDING_BACKEND`)은 그대로 — composite action은 `embedding-backend` input을 explicit 인자로 받음. workflow의 `env:` 블록도 유지.
- `make index` / `make eval` Makefile target 변경 없음. composite은 GitHub Actions runner 안에서만 동작, 로컬 dev path 무관.
- 머지된 직후 main에 action 들어오면, 이후 PR의 base side도 정상 동작.

## 7. Out of scope

- **Test job의 `bash scripts/test.sh`**: build_index/run_eval 안 함, 캐시 대상 아님.
- **\"Build CI eval config\" step 통합** (`pr-eval.yml`의 `python -c \"import yaml; ...\"` 한 줄): PR/base에서 working-directory만 다른 동일 명령이지만 composite 1 step에 묶기엔 부수효과 (config file write)가 build/eval과 분리되어 있고, dedupe 가치 < composite invocation 추가 비용. inline 유지.
- **base side composite을 `./base/.github/actions/run-eval`로 전환**: 이 PR이 머지된 *후속* PR에서 cleanup 가능 (작은 별도 변경). 이번에는 transition PR 안전 위해 `./pr/...` 통일.
- `actionlint` 도입: 별도 CI step 가치 있지만 #400 scope 밖.