### PR TITLE
feat: LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough, opt-in)

### DIFF
--- a/docs/adr/0022-langgraph-orchestration-stage-1.md
+++ b/docs/adr/0022-langgraph-orchestration-stage-1.md
@@ -1,0 +1,167 @@
+# 0022: LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough)
+
+- **Status**: proposed
+- **Date**: 2026-05-12
+- **Deciders**: hskim
+- **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (naive_baseline reserved as direct-path ablation), [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (agentic_full_llm under same retrieval surface), [ADR 0013](./0013-observability-as-additive-pluggable-surface.md) (trace backend additivity pattern this ADR reuses), issue #401
+
+## Context
+
+External senior review (2026-05) finding #2 argued the "Agentic RAG"
+label is overstated because the pipeline is a procedural Python call —
+no tool-call graph, no per-stage observability surface. The fair
+critique: the agentic loop (`metadata_stage_sequence` strict → reduced
+→ relaxed + verifier retry + answer build) is real but it is
+*structurally* an inner for-loop inside one 426-line function in
+`rag_core.py`, not a graph that an external reviewer can inspect.
+
+Plan PR-H (Tier 3 of the project review response) calls for a
+LangGraph migration that:
+
+1. Adds `langgraph` as an opt-in dependency (CI default stays direct).
+2. Wraps the `agentic_full` / `agentic_full_llm` flow in a StateGraph
+   whose edges make the retry policy and the prompt-profile branch
+   explicit.
+3. Leaves `naive_baseline` on the direct path — ADR 0001's
+   reproducibility invariant should not pay a langgraph-import cost
+   for the minimal ablation surface.
+4. Enables LangSmith / Langfuse multi-node traces (ADR 0013 backends)
+   once the nodes are actually distinct.
+
+The hard part is the JSON-identity guarantee. `run_rag_query` carries
+dozens of cross-stage fields — `query_hash`, attempt index, timings,
+stage transitions, conversation state, trace blocks, retrieved
+`chunk_ids`, claims, citations, synthesis metadata — and reproducing
+them through a multi-node graph risks subtle drift. A single regression
+that flips a `latency_ms` ordering or a `pipeline_alias` field can
+break every existing eval delta comparison and a slew of regression
+tests.
+
+## Decision (stage 1)
+
+Land the **dispatch infrastructure and a single passthrough node**
+*now*, defer the multi-node decomposition to stage 2 under its own ADR.
+
+Concretely:
+
+- New opt-in dependency file `requirements-graph.txt` with
+  `langgraph>=0.6,<2.0`. **Not** added to `requirements.txt` — public
+  CI never imports langgraph.
+- New module `rag_graph_agentic_full.py` (root, flat-layout
+  convention) exposing:
+  - `AgenticFullState` `TypedDict` carrying inputs + the final
+    `result` dict. Stage-1 schema is deliberately minimal; stage 2
+    expands it as nodes split.
+  - `run_via_langgraph(index, query, **kwargs) -> dict[str, Any]` —
+    the entry point. Builds a one-node `StateGraph` whose single node
+    calls back into `run_rag_query` with the **recursion-guard kwarg**
+    `_skip_graph=True`. The graph is process-cached so successive calls
+    skip the builder.
+- `rag_core.run_rag_query` gains an env-var dispatch at the top:
+  - `BIDMATE_ORCHESTRATOR=direct` (default) — existing call path,
+    unchanged behavior.
+  - `BIDMATE_ORCHESTRATOR=langgraph` + pipeline ≠ `naive_baseline` →
+    delegate to `rag_graph_agentic_full.run_via_langgraph`. The
+    recursion guard is the `_skip_graph` kwarg, kept private
+    (underscore-prefixed) and absent from any external caller.
+  - `naive_baseline` always stays on the direct path regardless of the
+    env var (ADR 0001 invariant). The dispatch check inspects both
+    `pipeline=` and `params.pipeline` to honor both kwarg shapes.
+- New regression test `tests/test_langgraph_orchestrator_regression.py`:
+  - `pytest.importorskip("langgraph")` so CI skips when the opt-in
+    extra is absent.
+  - Parametrized over `(pipeline, query)` for `agentic_full` and
+    `agentic_full_llm` × two queries (single-doc + comparison) → asserts
+    `json.dumps(..., sort_keys=True)` equality between direct and
+    LangGraph paths.
+  - A separate `test_naive_baseline_skips_langgraph_dispatch` pins the
+    ADR 0001 policy: even with `BIDMATE_ORCHESTRATOR=langgraph` set,
+    `naive_baseline` returns the direct-path result.
+  - A `GraphModuleImportTest` smoke-tests the module's public symbols
+    and the graph cache.
+
+Single-node passthrough is the **JSON-identity-by-construction**
+guarantee: the node literally calls the same `run_rag_query` body that
+the direct path executes. Any future multi-node decomposition must
+preserve that identity through explicit eval gates — this ADR is
+stage 1 and intentionally postpones that work.
+
+## What stage 2 will do (out of scope here)
+
+Stage 2 (a separate ADR + issue) splits the single node into at least
+three nodes:
+
+- `analyze_query_node` — calls the existing `analyze_query` helper.
+- `retrieve_loop_node` — wraps `metadata_stage_sequence` +
+  `plan_retrieval` + `retrieve` with a conditional edge for verifier
+  retry (the policy currently lives inside an inner `for stage in
+  stage_sequence` loop).
+- `build_answer_node` — calls `generate_answer` and, under the
+  `agentic_full_llm` preset, also `synthesize_answer`.
+
+The state schema in `AgenticFullState` is deliberately small in stage
+1 so that stage 2 can expand it without breaking any field the
+JSON-identity test currently checks (because stage 1 only checks the
+final `result` dict, the intermediate fields are unobserved here).
+
+## Consequences
+
+Easier:
+
+- The "Agentic RAG" label gets a concrete operational meaning —
+  `BIDMATE_ORCHESTRATOR=langgraph` produces a StateGraph that a
+  reviewer can inspect, even if stage 1's graph has one node.
+- Stage 2's multi-node decomposition lands on top of an already-wired
+  dispatch path. The risky JSON-identity work is bounded to the per-node
+  output assembly; the dispatch + dependency + test harness are paid
+  for in this ADR.
+- Test coverage: ADR 0001 invariant for `naive_baseline` is now
+  pinned by an explicit test, not just doc convention.
+
+Costs / honesty:
+
+- A single-node graph adds zero per-stage observability vs the direct
+  path. Stage 1 explicitly does NOT claim a "now we can see
+  per-stage latencies in LangSmith" benefit — that ships in stage 2.
+- LangGraph version range (`>=0.6,<2.0`) is broad. If LangGraph 2.x
+  introduces a breaking API the stage-2 ADR re-pins it.
+- The `_skip_graph` kwarg is a private API contract — external
+  callers must never pass it. Underscore prefix + ADR mention is the
+  signal; the type signature is otherwise unchanged.
+
+## Alternatives considered
+
+- **Skip stage 1, ship the full multi-node decomposition.** Rejected:
+  JSON-identity regression risk against `run_rag_query`'s
+  ~426-line output assembly is real, and a stage-2 PR that breaks
+  any of the existing 650+ regression tests would block on debugging
+  rather than design. Splitting the work bounds the risk.
+- **Add `langgraph` to `requirements.txt` (always-on).** Rejected:
+  langgraph + its dependency tree (`langchain-core`, `pydantic`, ...)
+  inflates every CI install and Docker image for what is, in stage 1,
+  a pure passthrough. ADR 0011 / ADR 0013's "additive opt-in"
+  pattern says opt-in extras live in their own requirements file.
+- **Use a thread-local recursion guard instead of `_skip_graph`
+  kwarg.** Rejected: thread-locals are invisible at the call site
+  (callers can't see the contract). A private kwarg is explicit and
+  testable.
+- **Migrate `naive_baseline` to LangGraph too.** Rejected by ADR
+  0001 — the minimal ablation surface should not depend on an opt-in
+  extra. If the LangGraph dependency is missing, `naive_baseline`
+  must still run.
+
+## See also
+
+- [`rag_graph_agentic_full.py`](../../rag_graph_agentic_full.py) — the
+  stage-1 graph module.
+- [`requirements-graph.txt`](../../requirements-graph.txt) — the
+  opt-in dependency.
+- [`tests/test_langgraph_orchestrator_regression.py`](../../tests/test_langgraph_orchestrator_regression.py)
+  — the JSON-identity + ADR-0001 dispatch tests.
+- [ADR 0001](./0001-preserve-naive-baseline.md) — naive_baseline policy
+  this ADR explicitly preserves.
+- [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) — the
+  additive opt-in pattern this ADR reuses.
+- [ADR 0013](./0013-observability-as-additive-pluggable-surface.md) —
+  the trace-backend additivity pattern that stage 2 will reuse for
+  LangSmith / Langfuse integration.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,6 +83,7 @@ project record.
 | [0018](./0018-korean-public-rag-bench.md) | accepted | Korean public RAG bench as supplementary out-of-domain surface (extends 0005) |
 | [0019](./0019-embedding-default-stays-minilm.md) | accepted | Embedding default stays MiniLM-L12-v2 with explicit re-open conditions (extends 0002) |
 | [0021](./0021-bge-m3-completes-phase-1-3.md) | accepted | BGE-M3 closes ADR 0019 Phase 1.3 condition 2; default stays MiniLM (supplements 0019) |
+| [0022](./0022-langgraph-orchestration-stage-1.md) | proposed | LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough, opt-in via BIDMATE_ORCHESTRATOR=langgraph, preserves ADR 0001) |
 
 ## Decision evolution
 

--- a/docs/senior-positioning.md
+++ b/docs/senior-positioning.md
@@ -15,7 +15,7 @@
 
 | 시그널 | 어디서 확인하나 |
 |---|---|
-| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 20개 ADR (16 accepted / 4 proposed), status-tracked, supersession chains 명시 |
+| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 21개 ADR (16 accepted / 5 proposed), status-tracked, supersession chains 명시 |
 | **측정 가능한 성공 기준**을 미리 잡고 그 기준으로 평가한다 | [`portfolio-case-study.md` §2](./portfolio-case-study.md), [`eval/config.yaml`](../eval/config.yaml), README headline 표 |
 | 합성 평가의 한계를 알고 **공개/비공개 평가 분리**로 보완한다 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) |
 | **실패를 분류·우선순위화**한 뒤 백로그로 만든다 | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), 메타 이슈 #49 |
@@ -49,6 +49,7 @@
 | [0018](./adr/0018-korean-public-rag-bench.md) | accepted | Korean public RAG bench (KorQuAD 2.1) as supplementary out-of-domain surface (extends 0005) | "한국어 일반 텍스트에서도 동작합니까?" 질문에 공개 재현 가능한 한 줄 명령(`make korean-public-eval`)으로 답변 — 합성 surface와 분리, CI 게이트가 *아님* |
 | [0019](./adr/0019-embedding-default-stays-minilm.md) | accepted | embedding 디폴트 = MiniLM-L12-v2 잠금 + 재오픈 조건 명시 (extends 0002) | 2차 사이클 측정이 env mismatch로 deferred됐을 때 *deferral 자체*를 ADR로 잠금 — 다음 contributor가 같은 실험을 다시 시도하지 않고, "디폴트 교체"의 empirical bar(`full` 파이프라인 ≥+5pp)도 명시 |
 | [0021](./adr/0021-bge-m3-completes-phase-1-3.md) | accepted | BGE-M3 Phase 1.3 측정 완료, ADR 0019 condition 2 closure (supplements 0019) | deferred 결정이 *실제로 닫히는 과정*까지 ADR로 박음. 4개 named candidate + 5개 임베딩(2019–2024) cross-architecture 측정으로 `0pp-on-full` 패턴이 empirical support 받는 단계까지 도달 |
+| [0022](./adr/0022-langgraph-orchestration-stage-1.md) | proposed | LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough + env-var dispatch, opt-in via `BIDMATE_ORCHESTRATOR=langgraph`) | "Agentic" 라벨에 코드 실체를 붙이는 epic의 stage 1 — JSON-identity 보장 가능한 단일 노드부터 land 후 stage 2에서 multi-node 분해. ADR 0001 `naive_baseline`은 직접 경로 유지. |
 
 **인터뷰 talking point 1 (real-data 회귀)**: "ADR 0005가 없었다면 공개본의 abstention 회귀(#69의 `1.000 → 0.500` 사건)는 아무도 보지 못했을 것이다. 공개 합성만 보던 시기에는 1-of-2 incidental overlap 패턴이 잡히지 않았다." — 근거: [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) 2026-05-11 entry.
 
@@ -176,7 +177,7 @@ make reproduce  # smoke + SHA-256 over the environment-invariant metric subset
 
 ### 30초 자기소개
 
-> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **20개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
+> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **21개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
 
 읽는 시간 ≈ 30초. 면접 첫 답으로 그대로 사용 가능. 상대가 "좀 더 자세히"를 물으면 §1, 측정 의문에는 §2, 운영 의문에는 [`production-readiness.md`](./production-readiness.md)로 넘어간다.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ source = [
     "bidmate_logging",
     "korean_lexicon",
     "rag_pipeline_presets",
+    "rag_graph_agentic_full",
     "app",
     "api",
     "eval",

--- a/rag_core.py
+++ b/rag_core.py
@@ -3602,7 +3602,42 @@ def run_rag_query(
     bm25_stopword_profile: str | None = None,
     *,
     params: QueryParams | None = None,
+    _skip_graph: bool = False,
 ) -> dict[str, Any]:
+    # ADR 0022 / issue #401 — opt-in LangGraph orchestrator path.
+    # ``BIDMATE_ORCHESTRATOR=langgraph`` (default ``direct``) routes
+    # through ``rag_graph_agentic_full.run_via_langgraph`` which builds
+    # a passthrough StateGraph and calls back here with
+    # ``_skip_graph=True`` to bypass this dispatch (recursion guard).
+    # The ``naive_baseline`` preset is preserved as ablation per
+    # ADR 0001 and is intentionally NOT routed through LangGraph.
+    if (
+        not _skip_graph
+        and os.environ.get("BIDMATE_ORCHESTRATOR", "direct").strip().lower() == "langgraph"
+        and (pipeline is None or pipeline != "naive_baseline")
+        and (params is None or params.pipeline != "naive_baseline")
+    ):
+        from rag_graph_agentic_full import run_via_langgraph
+
+        return run_via_langgraph(
+            index,
+            query,
+            top_k=top_k,
+            context_entities=context_entities,
+            metadata_first=metadata_first,
+            rerank=rerank,
+            verifier_retry=verifier_retry,
+            retrieval_mode=retrieval_mode,
+            retrieval_backend=retrieval_backend,
+            pipeline=pipeline,
+            prompt_profile=prompt_profile,
+            conversation_state=conversation_state,
+            comparison_balance=comparison_balance,
+            rrf_k=rrf_k,
+            bm25_stopword_profile=bm25_stopword_profile,
+            params=params,
+        )
+
     if params is not None:
         # Pre-bundle path (issue #260). `params=` is an additive opt-in:
         # individual pipeline kwargs are still accepted for compatibility,

--- a/rag_graph_agentic_full.py
+++ b/rag_graph_agentic_full.py
@@ -1,0 +1,114 @@
+"""LangGraph orchestrator path for the agentic_full / agentic_full_llm presets.
+
+Stage 1 of the PR-H epic (issue #401, ADR 0022). This module exposes
+:func:`run_via_langgraph` as an alternative entry point to
+:func:`rag_core.run_rag_query` that builds a one-node
+:class:`langgraph.graph.StateGraph` and runs the existing query body
+under it. The graph node delegates back to ``run_rag_query`` with a
+recursion guard kwarg (`_skip_graph=True`) so the dispatch in
+``rag_core.run_rag_query`` does not recurse.
+
+Why a single passthrough node in stage 1
+----------------------------------------
+The full plan in ADR 0022 calls for multi-node decomposition
+(``analyze`` → ``retrieve`` → ``build_answer`` with a conditional retry
+edge), but the JSON-identity guarantee for ``agentic_full`` and
+``agentic_full_llm`` is non-trivial: ``run_rag_query`` carries dozens
+of cross-stage fields (timings, attempt index, query hash, conversation
+state, trace blocks) and reproducing them through a multi-node graph
+risks drift. Stage 1 lands the *dispatch infrastructure* — env var,
+LangGraph dependency, regression-test harness — under a passthrough
+node where JSON identity is structurally guaranteed. Multi-node
+decomposition is a follow-up PR with its own regression budget.
+
+LangGraph is an opt-in dependency (`requirements-graph.txt`); when not
+installed, ``BIDMATE_ORCHESTRATOR=direct`` (the default) keeps the
+existing call path and this module is never imported.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+# Lazy import inside ``run_via_langgraph`` so a missing langgraph
+# dependency only surfaces when the env var actually requests it. The
+# module-level import would block ``import rag_core`` on plain installs.
+
+
+class AgenticFullState(TypedDict, total=False):
+    """LangGraph state shape for the agentic_full orchestrator path.
+
+    Stage 1 only carries the call-time inputs and the final result —
+    every intermediate field (analysis, evidence, plan, ...) is kept
+    inside the passthrough node call so the JSON-identity guarantee is
+    a tautology. Stage 2 expands this schema as nodes are split.
+    """
+
+    # Inputs (forwarded verbatim to run_rag_query under _skip_graph=True).
+    index: dict[str, Any]
+    query: str
+    pipeline_kwargs: dict[str, Any]
+    # Output of run_rag_query.
+    result: dict[str, Any]
+
+
+def _agentic_full_node(state: AgenticFullState) -> AgenticFullState:
+    """Single passthrough node — delegates to run_rag_query with recursion guard."""
+    # Imported lazily so ``rag_core`` never sees this module at import
+    # time unless ``BIDMATE_ORCHESTRATOR=langgraph`` is set.
+    from rag_core import run_rag_query
+
+    result = run_rag_query(
+        state["index"],
+        state["query"],
+        _skip_graph=True,
+        **state["pipeline_kwargs"],
+    )
+    return {"result": result}
+
+
+def _build_graph() -> Any:
+    """Construct the (cached) StateGraph instance."""
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(AgenticFullState)
+    builder.add_node("agentic_full", _agentic_full_node)
+    builder.add_edge(START, "agentic_full")
+    builder.add_edge("agentic_full", END)
+    return builder.compile()
+
+
+_GRAPH_CACHE: Any = None
+
+
+def _graph() -> Any:
+    """Return a process-cached compiled graph."""
+    global _GRAPH_CACHE
+    if _GRAPH_CACHE is None:
+        _GRAPH_CACHE = _build_graph()
+    return _GRAPH_CACHE
+
+
+def run_via_langgraph(
+    index: dict[str, Any],
+    query: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """LangGraph entry point with the same return shape as :func:`run_rag_query`.
+
+    All kwargs are forwarded to the passthrough node, which calls
+    ``run_rag_query`` with ``_skip_graph=True`` to bypass the env-var
+    dispatch. The compiled graph is process-cached so successive calls
+    avoid the LangGraph builder overhead.
+
+    Raises:
+        ModuleNotFoundError: if ``langgraph`` is not installed. Install
+            with ``pip install -r requirements-graph.txt``.
+    """
+    state: AgenticFullState = {
+        "index": index,
+        "query": query,
+        "pipeline_kwargs": dict(kwargs),
+    }
+    result_state = _graph().invoke(state)
+    return result_state["result"]

--- a/requirements-graph.txt
+++ b/requirements-graph.txt
@@ -1,0 +1,20 @@
+# Optional LangGraph orchestration backend (ADR 0022, issue #401).
+#
+# Install with:
+#   pip install -r requirements-graph.txt
+#
+# Activate at runtime:
+#   export BIDMATE_ORCHESTRATOR=langgraph
+#
+# Default (`BIDMATE_ORCHESTRATOR=direct`) uses the in-process Python call
+# path in `rag_core.run_rag_query` — no LangGraph dependency, no graph
+# construction overhead, CI-reproducible. Setting the env var to
+# `langgraph` routes through `rag_graph_agentic_full.run_via_langgraph`,
+# which builds a single-node StateGraph that calls the same query body
+# (recursion-guarded). Stage 1 of the PR-H epic — output is
+# JSON-identical to the direct path by construction.
+#
+# Multi-node decomposition (analyze / retrieve / build_answer as
+# separate graph nodes) is a follow-up stage; the dependency is the
+# same.
+langgraph>=0.6,<2.0

--- a/tests/test_langgraph_orchestrator_regression.py
+++ b/tests/test_langgraph_orchestrator_regression.py
@@ -1,0 +1,175 @@
+"""Regression guard for the LangGraph orchestrator dispatch (ADR 0022, issue #401).
+
+Stage 1 of the PR-H epic wraps ``run_rag_query`` in a single-node
+StateGraph behind ``BIDMATE_ORCHESTRATOR=langgraph``. This test asserts
+the JSON-identity contract: for the two LangGraph-eligible presets
+(``agentic_full`` and ``agentic_full_llm``), the env-var path must
+produce byte-for-byte identical output to the default ``direct`` path.
+
+The test ``importorskip``s ``langgraph`` so CI without the opt-in
+extra (``requirements-graph.txt``) just skips this module rather than
+failing. When the dep is present (e.g. a contributor running the full
+local install), the regression runs.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import unittest
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module if langgraph isn't installed. The graph module
+# imports langgraph lazily, but the dispatch test pretends to use it,
+# and a missing dep would fail the dispatch path.
+pytest.importorskip("langgraph")
+
+import rag_core
+import rag_graph_agentic_full  # noqa: F401 — exercises the import path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INDEX_PATH = REPO_ROOT / "data" / "index"
+
+
+def _has_local_index() -> bool:
+    return (INDEX_PATH / "index.json").exists()
+
+
+# Fields that legitimately vary between any two sequential
+# ``run_rag_query`` calls in the same Python process — independent of
+# orchestrator. The first call flips ``_PROCESS_WARM`` (so ``cold_start``
+# is ``True`` once and ``False`` thereafter); every call samples its own
+# walltime for any per-stage ``*_ms`` field (``retrieve_ms``,
+# ``verify_ms``, ``answer_generation_ms``, ``query_analysis_ms``,
+# ``context_resolution_ms``, ...). ADR 0022 makes the JSON-identity
+# claim *modulo* these non-deterministic fields.
+_NON_DETERMINISTIC_KEY_NAMES = {
+    "cold_start",
+    "stage_latency",  # parent dict — its children are all *_ms
+}
+
+
+def _is_timing_key(key: str) -> bool:
+    return key in _NON_DETERMINISTIC_KEY_NAMES or key.endswith("_ms")
+
+
+def _strip_nondeterministic(value: object) -> object:
+    """Recursively drop timing + cold_start fields for fair comparison."""
+    if isinstance(value, dict):
+        return {
+            k: _strip_nondeterministic(v)
+            for k, v in value.items()
+            if not _is_timing_key(k)
+        }
+    if isinstance(value, list):
+        return [_strip_nondeterministic(item) for item in value]
+    return value
+
+
+@pytest.mark.skipif(
+    not _has_local_index(),
+    reason="data/index/index.json missing — run `scripts/build_index.py` first",
+)
+@pytest.mark.parametrize(
+    "pipeline",
+    ["agentic_full", "agentic_full_llm"],
+)
+@pytest.mark.parametrize(
+    "query",
+    [
+        "기관 A의 AI 요구사항을 알려줘",
+        "기관 A와 기관 B의 AI 요구사항 차이 알려줘",
+    ],
+)
+def test_langgraph_orchestrator_json_identical_to_direct(
+    pipeline: str, query: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``BIDMATE_ORCHESTRATOR=langgraph`` must produce JSON-identical output.
+
+    ``json.dumps(..., sort_keys=True)`` byte-equality after stripping
+    the inherently non-deterministic fields (timing + cold_start flag —
+    see ``_NON_DETERMINISTIC_KEYS``) is the ADR-0022 contract for
+    stage 1 (single-node passthrough). Two sequential calls of
+    ``run_rag_query`` in the same process always disagree on those
+    fields regardless of orchestrator; the test asserts the graph
+    introduces *no other* drift.
+    """
+    index = rag_core.load_index(INDEX_PATH)
+
+    # Reset the module-level warm flag so both runs start from the same
+    # cold-start state. Equivalent to running each in a fresh process,
+    # without paying the process-spawn cost in the test loop.
+    monkeypatch.setattr(rag_core, "_PROCESS_WARM", False, raising=False)
+
+    monkeypatch.setenv("BIDMATE_ORCHESTRATOR", "direct")
+    direct_result = rag_core.run_rag_query(
+        copy.deepcopy(index),
+        query,
+        pipeline=pipeline,
+    )
+
+    # Reset again so the langgraph call also starts cold.
+    monkeypatch.setattr(rag_core, "_PROCESS_WARM", False, raising=False)
+
+    monkeypatch.setenv("BIDMATE_ORCHESTRATOR", "langgraph")
+    graph_result = rag_core.run_rag_query(
+        copy.deepcopy(index),
+        query,
+        pipeline=pipeline,
+    )
+
+    direct_json = json.dumps(
+        _strip_nondeterministic(direct_result), sort_keys=True, ensure_ascii=False
+    )
+    graph_json = json.dumps(
+        _strip_nondeterministic(graph_result), sort_keys=True, ensure_ascii=False
+    )
+    assert graph_json == direct_json, (
+        f"LangGraph orchestrator produced JSON drift vs direct path for "
+        f"pipeline={pipeline!r}, query={query!r}. "
+        f"direct[:200]={direct_json[:200]!r}, graph[:200]={graph_json[:200]!r}"
+    )
+
+
+def test_naive_baseline_skips_langgraph_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``naive_baseline`` preset bypasses LangGraph even with the env var set.
+
+    ADR 0001 reserves ``naive_baseline`` as the minimal reproducible
+    ablation surface. PR-H stage 1 leaves it on the direct path; this
+    test pins that policy so a future LangGraph-everywhere refactor
+    cannot silently sweep it in.
+    """
+    if not _has_local_index():
+        pytest.skip("data/index/index.json missing")
+    index = rag_core.load_index(INDEX_PATH)
+
+    monkeypatch.setenv("BIDMATE_ORCHESTRATOR", "langgraph")
+    result = rag_core.run_rag_query(
+        copy.deepcopy(index),
+        "기관 A의 AI 요구사항을 알려줘",
+        pipeline="naive_baseline",
+    )
+    # Must still return a real answer dict (i.e., we did NOT bail at
+    # dispatch with a ModuleNotFoundError or a graph state).
+    assert isinstance(result, dict)
+    assert result.get("diagnostics", {}).get("pipeline") == "naive_baseline"
+
+
+class GraphModuleImportTest(unittest.TestCase):
+    """Smoke-test the graph module independent of run_rag_query state."""
+
+    def test_module_imports_state_and_graph_builder(self) -> None:
+        # State TypedDict and builder helpers are public symbols.
+        self.assertTrue(hasattr(rag_graph_agentic_full, "AgenticFullState"))
+        self.assertTrue(hasattr(rag_graph_agentic_full, "run_via_langgraph"))
+        self.assertTrue(callable(rag_graph_agentic_full.run_via_langgraph))
+
+    def test_graph_compiles_once_and_is_cached(self) -> None:
+        graph_a = rag_graph_agentic_full._graph()
+        graph_b = rag_graph_agentic_full._graph()
+        # Same compiled graph object — the cache works.
+        self.assertIs(graph_a, graph_b)


### PR DESCRIPTION
## 1. What changed and why

외부 senior review (2026-05) finding #2 응답. Plan Tier 3 PR-H epic의 **stage 1**. \"Agentic RAG\" 라벨이 코드 실체와 일치하도록 `agentic_full`/`agentic_full_llm` preset의 흐름을 LangGraph StateGraph로 표현하는 epic의 첫 단계. Stage 1은 dispatch infrastructure + 단일 노드 passthrough + JSON-identity 보장만 land. 다중 노드 분해는 stage 2 follow-up.

핵심 결정: **single-node passthrough** for stage 1 — JSON-identity-by-construction 보장. `run_rag_query`가 426 lines + 수많은 cross-stage 필드를 가져서 multi-node migration이 subtle drift 위험. 위험은 stage 2에서 격리하여 land.

ADR 0001 `naive_baseline`은 LangGraph로 **migration 하지 않음** — 최소 ablation surface는 opt-in 의존성에 묶이면 안 됨. dispatch가 명시적으로 carve-out.

상위 plan: Tier 3 PR-H (`/Users/hskim/.claude/plans/bidmate-docagent-witty-glade.md`). Closes #401.

## 2. Files affected

- 신규 `requirements-graph.txt` (20 lines) — `langgraph>=0.6,<2.0` opt-in. `requirements.txt` 미터치.
- 신규 `rag_graph_agentic_full.py` (114 lines, 루트, flat-layout) — `AgenticFullState` TypedDict + `run_via_langgraph()` 진입점 + cached compiled graph.
- `rag_core.run_rag_query` (+35 lines) — env-var dispatch + `_skip_graph` recursion-guard kwarg (kwarg-only, underscore private).
- 신규 `tests/test_langgraph_orchestrator_regression.py` (175 lines) — JSON-identity + naive_baseline policy 테스트.
- 신규 `docs/adr/0022-langgraph-orchestration-stage-1.md` (167 lines, status `proposed`).
- `docs/adr/README.md` (+1): index에 0022 row.
- `docs/senior-positioning.md` (±5): 20→21 / 16+4→17+5 / table row.
- `pyproject.toml` (+1): coverage source `rag_graph_agentic_full`.

**Load-bearing**: ✅ `rag_core.py`. 5b 필수.

## 3. Risks

- **외부 import 깨질 위험**: `_skip_graph` kwarg-only 신규 추가는 default `False`로 기존 호출 사이트 영향 0. `app.py` / `api/main.py` / `eval/run_eval.py` / `scripts/run_benchmark.py` / `demo/streamlit_app.py` 모두 변경 없이 작동.
- **Recursion**: `BIDMATE_ORCHESTRATOR=langgraph` → `run_via_langgraph` → graph node → `run_rag_query` 재진입 시 무한 루프 가능성. `_skip_graph=True`로 차단. 테스트에서 검증.
- **JSON identity**: stage 1 단일 노드 passthrough라 by-construction 보장. timing 필드(`*_ms`, `cold_start`, `stage_latency`)만 strip 후 비교 — direct 경로 두 번 호출해도 같은 strip 필요(어차피 non-deterministic).
- **ADR 0001 invariant**: `naive_baseline`은 env var 무시. `test_naive_baseline_skips_langgraph_dispatch`로 회귀 가드.
- **LangGraph 1.x → 2.x breaking**: `>=0.6,<2.0` 범위. 2.x 나오면 stage 2 ADR이 re-pin.

## 4. Tests

- 신규 `tests/test_langgraph_orchestrator_regression.py` 7개 케이스:
  - 4× `test_langgraph_orchestrator_json_identical_to_direct[pipeline × query]`: agentic_full / agentic_full_llm × 단일 doc / 비교 쿼리 → `json.dumps(sort_keys=True)` equality after stripping `cold_start`/`*_ms`/`stage_latency` 필드.
  - `test_naive_baseline_skips_langgraph_dispatch`: env var 설정해도 naive_baseline은 direct 경로.
  - `GraphModuleImportTest.test_module_imports_state_and_graph_builder` + `test_graph_compiles_once_and_is_cached`.
- **Public CI (langgraph 미설치)**: 701 passed / **2 skipped** (langgraph 테스트) / 0 failed. Default direct 경로 회귀 없음.
- **Langgraph installed** (`pip install -r requirements-graph.txt`): **708 passed** / 1 skipped / 0 failed. 4개 JSON-identity 테스트 + naive_baseline 정책 테스트 + 모듈 smoke 모두 통과.

## 5. Eval impact

All `·` (default direct 경로). `BIDMATE_ORCHESTRATOR=langgraph`로 활성화돼도 stage 1은 passthrough라 동일 출력. 이후 stage 2 multi-node 분해에서 별도 eval gate.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path under the default `BIDMATE_ORCHESTRATOR=direct` (CI default). LangGraph orchestrator path produces JSON-identical output by construction (single-node passthrough) — verified by 4 parametrized regression tests after stripping inherently non-deterministic fields (timing + cold_start). `naive_baseline` invariant (ADR 0001) explicitly preserved by carve-out in dispatch + pinned by `test_naive_baseline_skips_langgraph_dispatch` regression test.

## 6. Backward compatibility

- `from rag_core import run_rag_query` 모든 외부 호출자: `_skip_graph` kwarg-only 신규 추가는 default `False`로 기존 시그니처 호환. 모든 기존 kwargs 그대로.
- 답변 schema (ADR 0003), `naive_baseline` invariant (ADR 0001), ADR 0011 stub backend 정책 모두 유지.
- `BIDMATE_ORCHESTRATOR` 환경변수 미설정 시 동작 변화 0.

## 7. Out of scope (stage 2 follow-up)

- **Multi-node decomposition**: `analyze` → `retrieve_loop` → `build_answer` 별도 LangGraph nodes. 의미 있는 per-stage trace의 핵심. JSON-identity 위험 격리 위해 별도 PR.
- **LangSmith / Langfuse trace export**: 단일 노드라 의미 없음. Multi-node 후.
- **`naive_baseline` LangGraph migration**: ADR 0001 invariant 위반. 미고려.
- **`requirements.txt`에 langgraph 추가**: CI 비용 증가, opt-in 유지가 ADR 0011/0013 패턴.
- **`AgenticFullState` schema 확장**: stage 2에서 nodes split 시 expand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)