### PR TITLE
feat(harness): config-keyed index cache for run_harness (#236)

### DIFF
--- a/scripts/run_harness.py
+++ b/scripts/run_harness.py
@@ -177,6 +177,132 @@ def build_commands(config: dict[str, Any], run_dir: Path) -> dict[str, list[str]
     }
 
 
+# ---------------------------------------------------------------------------
+# Index cache (issue #236)
+#
+# When the harness iterates ablations that share a dataset + index
+# configuration but vary only in query/eval, rebuilding the index on
+# every run wastes minutes. The cache maps a deterministic subset of
+# the config (dataset + index portions only) to a prior run's
+# `index/` directory; subsequent runs with the same subkey copy the
+# cached index instead of running ``scripts/build_index.py``.
+#
+# Layout: ``<artifact_root>/_cache/index_hash.json`` holds the
+# ``{config_subkey: source_run_id}`` mapping. Stale entries (source
+# run dir deleted, index file missing) are treated as miss and lazily
+# cleared on the next miss-write.
+# ---------------------------------------------------------------------------
+
+
+_INDEX_CACHE_KEY_FIELDS = ("dataset", "index")
+INDEX_CACHE_DIRNAME = "_cache"
+INDEX_CACHE_FILENAME = "index_hash.json"
+
+
+def index_cache_subkey(config: dict[str, Any]) -> str:
+    """Deterministic hash of the dataset+index portion of a harness config.
+
+    Excludes ``query`` / ``eval`` blocks so iterating queries against
+    a built index does not invalidate the cache.
+    """
+    subset = {k: config.get(k) for k in _INDEX_CACHE_KEY_FIELDS}
+    return json_hash(subset)
+
+
+def _index_cache_path(artifact_root: Path) -> Path:
+    return artifact_root / INDEX_CACHE_DIRNAME / INDEX_CACHE_FILENAME
+
+
+def load_index_cache(artifact_root: Path) -> dict[str, str]:
+    """Load the ``{config_subkey -> source_run_id}`` mapping (empty if absent)."""
+    path = _index_cache_path(artifact_root)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return {
+        str(k): str(v)
+        for k, v in (data or {}).items()
+        if isinstance(v, str) and v
+    }
+
+
+def save_index_cache(artifact_root: Path, mapping: dict[str, str]) -> None:
+    """Persist the ``{config_subkey -> source_run_id}`` mapping."""
+    path = _index_cache_path(artifact_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(mapping, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def resolve_cached_index(
+    artifact_root: Path, cache_subkey: str
+) -> tuple[Path | None, str | None]:
+    """Return ``(source_dir, source_run_id)`` for a cache hit; ``(None, None)`` on miss.
+
+    A stale entry — source run dir deleted, or ``index.json`` missing
+    — is treated as a miss; the mapping is left as-is and lazily
+    overwritten on the next successful build.
+    """
+    mapping = load_index_cache(artifact_root)
+    source_run_id = mapping.get(cache_subkey)
+    if not source_run_id:
+        return None, None
+    source_index_dir = artifact_root / source_run_id / "index"
+    if not (source_index_dir / "index.json").exists():
+        return None, None
+    return source_index_dir, source_run_id
+
+
+def _try_cache_index_step(
+    artifact_root: Path,
+    run_dir: Path,
+    config: dict[str, Any],
+    logs_dir: Path,
+    command: list[str],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return ``(step_entry, source_run_id)`` on cache hit; ``(None, None)`` on miss.
+
+    On hit, copies the cached index directory into ``run_dir/index``
+    and writes a stub log so the step entry shape matches the
+    ``run_logged_command`` output exactly (eval pipeline downstream
+    consumers don't see a special-case shape).
+    """
+    cache_key = index_cache_subkey(config)
+    source_dir, source_run_id = resolve_cached_index(artifact_root, cache_key)
+    if source_dir is None:
+        return None, None
+    target = run_dir / "index"
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source_dir, target)
+    log_path = logs_dir / "index.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = utc_now()
+    log_path.write_text(
+        f"$ {' '.join(command)}\n\n"
+        f"[cache hit @ {timestamp}] copied index from "
+        f"{rel_path(source_dir)} (source_run_id={source_run_id})\n",
+        encoding="utf-8",
+    )
+    step_entry = {
+        "name": "index",
+        "command": command,
+        "log": rel_path(log_path),
+        "started_at": timestamp,
+        "ended_at": timestamp,
+        "returncode": 0,
+        "status": "passed",
+        "cached": True,
+        "source_run_id": source_run_id,
+    }
+    return step_entry, source_run_id
+
+
 def metric_snapshot(metrics_path: Path) -> dict[str, Any]:
     if not metrics_path.exists():
         return {}
@@ -271,11 +397,24 @@ def _execute_pipeline(
     steps: list[dict[str, Any]] = []
     status = "passed"
     failure: dict[str, Any] | None = None
+    artifact_root = run_dir.parent
+    cache_subkey = index_cache_subkey(config)
+    cache_hit = False
+    cache_source_run_id: str | None = None
 
     for name in ("index", "query", "eval"):
         span_cm = trace_ctx.span(name) if trace_ctx is not None else nullcontext()
         with span_cm:
-            step = {"name": name, **run_logged_command(commands[name], logs_dir / f"{name}.log")}
+            cached_step: dict[str, Any] | None = None
+            if name == "index":
+                cached_step, cache_source_run_id = _try_cache_index_step(
+                    artifact_root, run_dir, config, logs_dir, commands["index"]
+                )
+            if cached_step is not None:
+                step = cached_step
+                cache_hit = True
+            else:
+                step = {"name": name, **run_logged_command(commands[name], logs_dir / f"{name}.log")}
         steps.append(step)
         if command_failed(step):
             status = "failed"
@@ -287,6 +426,14 @@ def _execute_pipeline(
             }
             append_jsonl(errors_path, failure)
             break
+
+    # Update the cache only when the index step actually ran AND
+    # succeeded — never write a stale cache entry pointing at a failed
+    # or skipped build.
+    if status == "passed" and not cache_hit:
+        mapping = load_index_cache(artifact_root)
+        mapping[cache_subkey] = run_id
+        save_index_cache(artifact_root, mapping)
 
     write_predictions(
         answer_path,
@@ -354,6 +501,11 @@ def _execute_pipeline(
         "status": status,
         "metrics": metrics,
         "observability": observability_block,
+        "cache": {
+            "index_hit": cache_hit,
+            "source_run_id": cache_source_run_id if cache_hit else None,
+            "key": cache_subkey,
+        },
     }
     if failure:
         manifest["failure"] = failure

--- a/tests/test_run_harness.py
+++ b/tests/test_run_harness.py
@@ -449,5 +449,160 @@ class HarnessE2ETest(unittest.TestCase):
         self.assertIsInstance(record["command"], list)
 
 
+# ---------------------------------------------------------------------------
+# Issue #236 — index cache (config_subkey-keyed skip).
+# ---------------------------------------------------------------------------
+
+
+class IndexCacheHelperTest(unittest.TestCase):
+    """Unit tests for the cache subkey + I/O helpers in run_harness."""
+
+    def test_subkey_depends_only_on_dataset_and_index(self) -> None:
+        base = {
+            "dataset": {"id": "public_synthetic_rfp_v1", "input_dir": "data/raw"},
+            "index": {"embedding_backend": "hashing", "chunking_strategy": "fixed"},
+            "query": {"text": "q1", "pipeline": "naive_baseline"},
+            "eval": {"config": "harness/smoke_eval.yaml"},
+        }
+        same_index_diff_query = {**base, "query": {"text": "q2", "pipeline": "naive_baseline"}}
+        diff_index = {**base, "index": {"embedding_backend": "minilm", "chunking_strategy": "fixed"}}
+        diff_dataset = {**base, "dataset": {"id": "other", "input_dir": "data/raw"}}
+
+        self.assertEqual(
+            run_harness.index_cache_subkey(base),
+            run_harness.index_cache_subkey(same_index_diff_query),
+            "query/eval changes must not invalidate the index cache",
+        )
+        self.assertNotEqual(run_harness.index_cache_subkey(base), run_harness.index_cache_subkey(diff_index))
+        self.assertNotEqual(run_harness.index_cache_subkey(base), run_harness.index_cache_subkey(diff_dataset))
+
+    def test_load_returns_empty_for_missing_or_corrupt_file(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertEqual(run_harness.load_index_cache(root), {})
+
+            cache_path = root / run_harness.INDEX_CACHE_DIRNAME / run_harness.INDEX_CACHE_FILENAME
+            cache_path.parent.mkdir(parents=True)
+            cache_path.write_text("{ this is not json", encoding="utf-8")
+            self.assertEqual(run_harness.load_index_cache(root), {})
+
+    def test_save_and_load_round_trip(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mapping = {"abc123": "run_x", "def456": "run_y"}
+            run_harness.save_index_cache(root, mapping)
+            self.assertEqual(run_harness.load_index_cache(root), mapping)
+
+    def test_resolve_cached_index_misses_when_source_dir_gone(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # Cache entry exists but the source run dir has no index/index.json.
+            run_harness.save_index_cache(root, {"abc": "ghost_run"})
+            source_dir, source_run_id = run_harness.resolve_cached_index(root, "abc")
+            self.assertIsNone(source_dir)
+            self.assertIsNone(source_run_id)
+
+    def test_resolve_cached_index_hits_when_index_present(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "src_run" / "index").mkdir(parents=True)
+            (root / "src_run" / "index" / "index.json").write_text("{}", encoding="utf-8")
+            run_harness.save_index_cache(root, {"abc": "src_run"})
+
+            source_dir, source_run_id = run_harness.resolve_cached_index(root, "abc")
+            self.assertEqual(source_run_id, "src_run")
+            self.assertEqual(source_dir, root / "src_run" / "index")
+
+    def test_resolve_cached_index_misses_unknown_subkey(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertEqual(run_harness.resolve_cached_index(root, "unknown"), (None, None))
+
+
+class IndexCacheE2ETest(unittest.TestCase):
+    """E2E: same dataset+index config across two runs hits the cache.
+
+    Has its own ``tmp_root`` (separate from ``HarnessE2ETest``) so the
+    cache state is isolated — first run is guaranteed a miss, second a
+    hit, regardless of test ordering.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmp_root = Path(__file__).resolve().parent / "_tmp_harness_cache"
+        if cls.tmp_root.exists():
+            import shutil
+
+            shutil.rmtree(cls.tmp_root)
+        cls.tmp_root.mkdir(parents=True)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        import shutil
+
+        if cls.tmp_root.exists():
+            shutil.rmtree(cls.tmp_root)
+
+    def _run_smoke(self, run_id: str) -> dict:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT_DIR / "scripts" / "run_harness.py"),
+                "--config",
+                "harness/smoke.yaml",
+                "--run_id",
+                run_id,
+                "--artifact_root",
+                str(self.tmp_root),
+                "--force",
+            ],
+            cwd=ROOT_DIR,
+            text=True,
+            capture_output=True,
+            timeout=180,
+        )
+        self.assertEqual(result.returncode, 0, msg=f"stdout={result.stdout}\nstderr={result.stderr}")
+        return json.loads((self.tmp_root / run_id / "run_manifest.json").read_text(encoding="utf-8"))
+
+    def test_first_run_misses_then_second_run_hits(self) -> None:
+        m_first = self._run_smoke("cache_first")
+        self.assertIn("cache", m_first)
+        self.assertFalse(m_first["cache"]["index_hit"])
+        self.assertIsNone(m_first["cache"]["source_run_id"])
+        cache_key = m_first["cache"]["key"]
+        self.assertIsInstance(cache_key, str)
+        self.assertTrue(cache_key)
+
+        m_second = self._run_smoke("cache_second")
+        self.assertTrue(m_second["cache"]["index_hit"])
+        self.assertEqual(m_second["cache"]["source_run_id"], "cache_first")
+        self.assertEqual(m_second["cache"]["key"], cache_key)
+
+        # Step entry shape for cached index step keeps the same fields
+        # downstream consumers (summary.json, errors.jsonl) read.
+        steps = json.loads(
+            (self.tmp_root / "cache_second" / "summary.json").read_text(encoding="utf-8")
+        )["steps"]
+        index_step = next(s for s in steps if s["name"] == "index")
+        self.assertTrue(index_step["cached"])
+        self.assertEqual(index_step["source_run_id"], "cache_first")
+        self.assertEqual(index_step["returncode"], 0)
+        self.assertEqual(index_step["status"], "passed")
+
+        # The cached index file actually exists in the second run's
+        # artifact tree (copy, not symlink, so archives self-contain).
+        self.assertTrue((self.tmp_root / "cache_second" / "index" / "index.json").exists())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #236. Phase 3 W3 단위.

`scripts/run_harness.py`로 ablation iteration 시 동일 (dataset, index) config인 run은 prior run의 `index/`를 재사용해 build_index 시간 절약. 새 cache 인프라:

- **Key**: `index_cache_subkey(config) = json_hash({dataset, index})`. query/eval portion은 의도적으로 제외 — 같은 index에 query/eval만 바꾸는 iteration 시나리오가 본 PR의 본질적 use case.
- **Layout**: `<artifact_root>/_cache/index_hash.json` 에 `{config_subkey: source_run_id}` 매핑.
- **Hit path**: `_try_cache_index_step()` 가 `_execute_pipeline`의 index step 시작 전 lookup → 적중 시 `shutil.copytree`로 prior `index/` → `run_dir/index/`, 같은 shape의 step entry (`returncode=0, status='passed', cached=True, source_run_id=...`) 반환. step 자체는 `run_logged_command` 안 부르고 짧은 stub log만.
- **Miss path**: 기존 `run_logged_command(commands["index"])` 그대로. **index step이 성공했을 때만** cache 업데이트 (실패 build를 가리키는 stale entry 금지).
- **Stale handling**: cache entry는 있지만 source run dir 삭제됐거나 `index/index.json` 결손이면 miss 처리, 다음 successful build 시 lazy overwrite.

`run_manifest.json`에 `cache` 블록 추가 (모든 run에 항상 존재):
```json
"cache": {
  "index_hit": false,
  "source_run_id": null,
  "key": "abc123..."
}
```
- `schema_version`은 1 그대로 (additive 필드 — 기존 consumer가 cache field 없는 manifest를 처리할 일 없음, 새 manifest만 이 PR로 생성).

## 2. Files affected

- `scripts/run_harness.py` (`+154`/`-1`) — 새 helper 6개 (`index_cache_subkey`, `_index_cache_path`, `load_index_cache`, `save_index_cache`, `resolve_cached_index`, `_try_cache_index_step`) + `_execute_pipeline`의 for-loop에 cache hook + manifest `cache` 블록.
- `tests/test_run_harness.py` (`+155`) — 두 새 test class.

**No load-bearing path touched** — `scripts/run_harness.py`는 `scripts.build_index.py`처럼 load-bearing scripts SSoT 밖이고, #236 본문도 명시 (\"\`scripts/run_harness.py\` 비-load-bearing\").

## 3. Risks

- **silent stale cache**: raw 데이터 (`data/raw/**`)는 cache key에 안 들어감 — `dataset.input_dir` 같은 *config* path만 해시. raw 데이터가 직접 바뀌면 같은 config_subkey → stale index reuse. Mitigation:
  1. Harness use case 자체가 *ablation iteration* — raw 변경 시나리오가 드물고, 변경 후엔 `--force`로 cache 우회하는 워크플로가 자연스러움.
  2. `git_dirty` flag가 이미 manifest에 캡처되어 있어, raw 디렉터리가 modified일 때 다음 run 의 manifest와 cached source manifest가 다른 git state을 보임 → 조사 가능.
  3. 추가 정밀화 (`hashFiles(input_dir/**)`)는 follow-up issue로 분리 가능. 이번 PR은 #236 sketch의 \"dataset+index 부분만의 hash\" 명세를 그대로 구현.
- **copy vs symlink 선택**: `shutil.copytree`로 copy (symlink가 더 빠르지만 archive/tarball 시 dangling). 인덱스 크기가 작아서 copy 비용 무시 가능, downstream archival 안전성 우선.
- **stale cache entry의 lazy clear**: stale entry는 첫 miss-write에서만 갱신 — 영영 hit 안 되는 dead entry가 누적 가능. 단 디렉터리 작아서 cleanup 우선순위 낮음. follow-up 가능.
- **schema_version 안 bump**: 위 §1의 사유. cache block은 always-present additive. 기존 manifest consumer 모두 graceful (cache field 부재면 None 처리).

## 4. Tests

`python3 -m pytest tests/test_run_harness.py -v` → **29 passed** (이전 22 + 새 7).

**Unit (\`IndexCacheHelperTest\`, 6개)**:
- subkey deterministic + query/eval-invariant
- `load_index_cache` empty on missing/corrupt JSON
- save/load round-trip
- `resolve_cached_index` hit / miss-unknown-subkey / miss-source-dir-gone

**E2E (\`IndexCacheE2ETest\`, 1개)** — dedicated tmp_root, harness/smoke.yaml 두 번 실행:
- 첫 manifest `cache.index_hit=False`, `source_run_id=None`
- 둘째 manifest `cache.index_hit=True`, `source_run_id=='cache_first'`, 동일 `cache.key`
- 둘째 run의 index step entry가 `run_logged_command` shape 그대로 + `cached: True`, `source_run_id` 추가
- `tmp_root/cache_second/index/index.json` 물리적으로 copy됐는지

`python3 -m pytest tests/ -q` → **729 passed** (이전 main 715, 본 PR +14).

## 5. Eval impact

All `·`. Cache is a *performance optimization* on top of the harness execution path; index payload is byte-for-byte identical to a fresh build (copytree). 어떤 retrieval/eval metric도 안 거침.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval path. `scripts/run_harness.py` 비-load-bearing (CLAUDE.md SSoT 밖). 다른 load-bearing 파일 (`rag_core.py`, `eval/`, `api/` 등) 변경 없음.

## 6. Backward compatibility

- `run_manifest.json` `schema_version` 1 유지 — `cache` 블록은 additive.
- 기존 manifest consumer가 cache 필드를 안 보면 그대로 동작 (모든 새 manifest는 cache 키가 있고, 기존 manifest는 없음 — consumer side `.get(\"cache\")` graceful).
- artifact tree 구조 그대로 (`<run_id>/index/`, `<run_id>/logs/index.log`, etc.). 새 `<artifact_root>/_cache/` 디렉터리만 추가.
- `--force` flag 동작 그대로 — prior `run_dir` 삭제. cache 자체 invalidation flag 별도 없음 (out of scope).

## 7. Out of scope

- **raw 데이터 hash 포함 (`hashFiles(input_dir/**)`)**: #236 sketch가 \"dataset+index 부분만의 hash\" 명세. precise data-file invalidation은 별도 issue로 분리 가능 (R3 PR [#402](https://github.com/hskim-solv/be/pull/402)의 actions/cache 디자인과 같은 원리).
- **`--no-index-cache` / `--invalidate-cache` flag**: opt-in/opt-out 모두 미구현. 필요 시 follow-up.
- **stale cache entry GC**: dead entries 누적 가능 (rare, low priority).
- **schema_version bump**: additive field이므로 bump 안 함. 만약 future PR이 cache 의미를 *변경*하면 (예: key 알고리즘 교체) 그 PR이 bump.