### PR TITLE
refactor: auto-derive pipeline_cli_choices() from PIPELINE_PRESETS

### DIFF
--- a/rag_pipeline_presets.py
+++ b/rag_pipeline_presets.py
@@ -138,11 +138,13 @@ def is_pipeline_name(value: Any) -> bool:
 
 
 def pipeline_cli_choices() -> list[str]:
-    # ADR 0001 explicit signal: this list is the source of truth for
-    # which pipeline names are surfaced to the CLI. Adding/removing an
-    # entry is the explicit revisit of that ADR (or, for additive
-    # changes like ADR 0011, the explicit follow-on).
-    return [DEFAULT_CLI_PIPELINE_NAME, DEFAULT_RAG_PIPELINE_NAME, "agentic_full_llm"]
+    # ADR 0001 explicit signal: ``PIPELINE_PRESETS`` is the single source
+    # of truth for which pipeline names are surfaced to the CLI. Adding
+    # a preset to that dict above auto-extends this list; removing one
+    # disappears it. The historical hardcoded triple
+    # ``[naive_baseline, agentic_full, agentic_full_llm]`` is preserved
+    # bit-equal under Python 3.7+ dict insertion order (issue #384).
+    return list(PIPELINE_PRESETS.keys())
 
 
 def canonical_pipeline_name(value: str | None, default: str = DEFAULT_RAG_PIPELINE_NAME) -> str:


### PR DESCRIPTION
## 1. What changed and why

Closes #384

`pipeline_cli_choices()` in [`rag_pipeline_presets.py:140`](rag_pipeline_presets.py) hardcoded the list of CLI-surfaced pipeline names:

```python
return [DEFAULT_CLI_PIPELINE_NAME, DEFAULT_RAG_PIPELINE_NAME, "agentic_full_llm"]
```

This list happened to equal `list(PIPELINE_PRESETS.keys())` but the two were not enforced to stay in sync. Pre-Phase-3 audit 6-month-pain item #5: adding a new preset (ADR 0011-style additive paths, or the in-flight ADR 0024 API-default work) required remembering to update **both** locations.

Replaces the hardcoded triple with `list(PIPELINE_PRESETS.keys())`. Under Python 3.7+ dict insertion order the two are bit-equal:

```
>>> list(PIPELINE_PRESETS.keys())
['naive_baseline', 'agentic_full', 'agentic_full_llm']
```

So this is a **behavior-preserving** simplification. The ADR 0001 explicit-signal comment is preserved and strengthened — the dict's contents become the explicit revisit point.

Unblocked by [#364](https://github.com/hskim-solv/BidMate-DocAgent/issues/364) (PIPELINE_PRESETS now lives in `rag_pipeline_presets.py`); stacked-PR discipline made #384 a one-liner in the new home.

## 2. Files affected

- `rag_pipeline_presets.py` (+7 / −5; one function body + comment update)

No load-bearing path touched. `rag_pipeline_presets.py` is **not** in [`scripts/_governance.py`](scripts/_governance.py) `LOAD_BEARING_PATHS` (verified via `python3 scripts/_governance.py --is-load-bearing rag_pipeline_presets.py` → exit 1).

## 3. Risks

The only realistic failure mode is dict order changing — e.g., a future refactor inserts `agentic_full_llm` before `agentic_full` in the literal source, which would shift the returned order. Mitigation: the comment now explicitly cites "Python 3.7+ dict insertion order" so a future reader sees the contract.

A second-order risk: if a downstream consumer (CLI argument parser, API enum) was implicitly relying on the hardcoded list being in a specific order independent of dict declaration, behavior would shift. Verified by full suite — see Tests.

## 4. Tests

- Direct verification: `python3 -c "from rag_pipeline_presets import pipeline_cli_choices; print(pipeline_cli_choices())"` returns `['naive_baseline', 'agentic_full', 'agentic_full_llm']` — bit-identical to pre-PR output.
- Full suite: `python3 -m pytest -q` → **730 passed, 121 subtests passed**; the 3 governance failures (`test_senior_positioning_count_label_matches_adr_files` and siblings) are **pre-existing on `origin/main`** (verified via `git stash` baseline) — they fail because `docs/senior-positioning.md` hasn't been re-synced after ADR 0021 / 0022 / 0024 merges, and are not caused by this PR. They will resolve when the senior-positioning sync PR lands (separate concern, separate owner).

## 5. Eval impact

All `·` (no behavior change — bit-identical CLI surface).

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion path.

## 6. Backward compatibility

- `pipeline_cli_choices()` return value unchanged at this point in time.
- Function signature unchanged.
- `DEFAULT_CLI_PIPELINE_NAME` / `DEFAULT_RAG_PIPELINE_NAME` constants untouched (still exported, still used by other call sites).
- ADR 0001's "explicit signal" intent preserved — the comment now ties the signal to the dict declaration.

## 7. Out of scope

- The pre-existing senior-positioning.md governance test drift (ADR 0021/0022/0024 narrative table sync) — separate concern, separate owner.
- Filtering presets for "private" / "experimental" status (no such concept exists yet).
- Changes to `PIPELINE_ALIASES` surfacing.
- Modifying how eval ablations (`eval/config.yaml`) layer overrides on top of base presets — different concept from CLI choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)