### PR TITLE
refactor: extract conversation state to rag_conversation_state.py (PR-E stage 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ source = [
     "bidmate_logging",
     "korean_lexicon",
     "rag_pipeline_presets",
+    "rag_conversation_state",
     "rag_graph_agentic_full",
     "app",
     "api",

--- a/rag_conversation_state.py
+++ b/rag_conversation_state.py
@@ -1,0 +1,119 @@
+"""Multi-turn conversation state for the BidMate RAG core.
+
+Extracted from ``rag_core.py`` in issue #415 (PR-E stage 3 of the
+``rag_core.py`` decomposition epic — external senior review 2026-05
+finding #3). This module owns the **canonical** definition of the
+conversation-state schema that ``run_rag_query`` consumes and emits
+across turns:
+
+- ``CONVERSATION_STATE_SCHEMA_VERSION`` — bumps when a follow-up PR
+  alters the state shape in a way that breaks producers / consumers.
+- ``MAX_CONVERSATION_TURNS`` — bounded-history cap on ``turns``.
+- ``CONTEXT_RESOLUTION_THRESHOLD`` — confidence floor for
+  cross-turn reference resolution.
+- ``AMBIGUOUS_CONFIDENCE_DELTA`` — minimum gap between the top
+  metadata score and the next candidate before we declare a single
+  winner. Used by the planner's ambiguity surface (rag_core, line
+  ~1229) and re-exported here so the conversation-state schema and
+  the ambiguity threshold travel together.
+- :func:`empty_conversation_state` — schema-version-tagged blank.
+- :func:`normalize_conversation_state` — defensive coercion of an
+  arbitrary external payload into the schema.
+
+The module is a **leaf**: it imports nothing from ``rag_core``.
+``rag_core`` imports the six public symbols back and uses them
+directly — no re-export wrapper because no external module references
+these names (verified via repo-wide grep at issue #415 filing time).
+
+Helper duplication note
+-----------------------
+``_ordered_unique`` and ``_coerce_string_list`` are five-line copies
+of the same-named utilities in ``rag_core.py``. Inlining them here
+keeps the leaf-module invariant (no rag_core import) at the cost of
+two tiny duplicates; a future stage that extracts a shared
+``rag_text_utils`` module can collapse them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+CONVERSATION_STATE_SCHEMA_VERSION = 1
+MAX_CONVERSATION_TURNS = 12
+CONTEXT_RESOLUTION_THRESHOLD = 0.70
+AMBIGUOUS_CONFIDENCE_DELTA = 0.05
+
+
+def _ordered_unique(values: Iterable[str]) -> list[str]:
+    """Return *values* with duplicates and falsy entries removed, order preserved."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            ordered.append(value)
+    return ordered
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    """Coerce *value* to ``list[str]`` of trimmed, deduped, non-empty entries.
+
+    Returns ``[]`` for any non-list input. Matches the semantics of
+    ``rag_core.coerce_string_list`` exactly.
+    """
+    if not isinstance(value, list):
+        return []
+    return _ordered_unique(str(item).strip() for item in value if str(item).strip())
+
+
+def empty_conversation_state() -> dict[str, Any]:
+    """Return a schema-versioned, empty conversation state."""
+    return {
+        "schema_version": CONVERSATION_STATE_SCHEMA_VERSION,
+        "active_agencies": [],
+        "active_projects": [],
+        "active_topics": [],
+        "active_doc_ids": [],
+        "active_candidates": [],
+        "confidence": 0.0,
+        "ambiguous": False,
+        "turns": [],
+    }
+
+
+def normalize_conversation_state(state: dict[str, Any] | None) -> dict[str, Any]:
+    """Defensively coerce *state* into the schema.
+
+    Trusts nothing about the input — any field that fails its type
+    contract is replaced with the empty-schema default. ``turns`` is
+    capped at the most recent ``MAX_CONVERSATION_TURNS`` entries;
+    ``active_candidates`` is capped at the most recent 8.
+    """
+    normalized = empty_conversation_state()
+    if not isinstance(state, dict):
+        return normalized
+
+    normalized["schema_version"] = int(
+        state.get("schema_version") or CONVERSATION_STATE_SCHEMA_VERSION
+    )
+    normalized["active_agencies"] = _coerce_string_list(state.get("active_agencies"))
+    normalized["active_projects"] = _coerce_string_list(state.get("active_projects"))
+    normalized["active_topics"] = _coerce_string_list(state.get("active_topics"))
+    normalized["active_doc_ids"] = _coerce_string_list(state.get("active_doc_ids"))
+    active_candidates = state.get("active_candidates")
+    if isinstance(active_candidates, list):
+        normalized["active_candidates"] = [
+            candidate for candidate in active_candidates[-8:] if isinstance(candidate, dict)
+        ]
+    normalized["ambiguous"] = bool(state.get("ambiguous", False))
+    try:
+        normalized["confidence"] = round(float(state.get("confidence") or 0.0), 3)
+    except (TypeError, ValueError):
+        normalized["confidence"] = 0.0
+
+    turns = state.get("turns") if isinstance(state.get("turns"), list) else []
+    normalized["turns"] = [
+        turn for turn in turns[-MAX_CONVERSATION_TURNS:] if isinstance(turn, dict)
+    ]
+    return normalized

--- a/rag_core.py
+++ b/rag_core.py
@@ -85,6 +85,19 @@ from rag_pipeline_presets import (
     resolve_pipeline_config,
 )
 
+# Conversation state schema + helpers live in rag_conversation_state.py as
+# of issue #415 (PR-E stage 3 of the rag_core.py decomposition epic). The
+# symbols below are direct-imported (no re-export wrapper) — repo-wide
+# grep at PR filing confirmed zero external consumers.
+from rag_conversation_state import (
+    AMBIGUOUS_CONFIDENCE_DELTA,
+    CONTEXT_RESOLUTION_THRESHOLD,
+    CONVERSATION_STATE_SCHEMA_VERSION,
+    MAX_CONVERSATION_TURNS,
+    empty_conversation_state,
+    normalize_conversation_state,
+)
+
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 DEFAULT_HASH_DIM = 384
 DEFAULT_CHUNK_MAX_CHARS = 520
@@ -134,10 +147,6 @@ TRACE_SCHEMA_VERSION = 1
 
 STRICT_METADATA_CONFIDENCE = 0.90
 REDUCED_METADATA_CONFIDENCE = 0.70
-AMBIGUOUS_CONFIDENCE_DELTA = 0.05
-CONVERSATION_STATE_SCHEMA_VERSION = 1
-MAX_CONVERSATION_TURNS = 12
-CONTEXT_RESOLUTION_THRESHOLD = 0.70
 
 
 @dataclass(frozen=True)
@@ -232,49 +241,6 @@ def coerce_alias_values(value: Any) -> list[str]:
         return ordered_unique(str(item).strip() for item in value if str(item).strip())
     return []
 
-
-def empty_conversation_state() -> dict[str, Any]:
-    return {
-        "schema_version": CONVERSATION_STATE_SCHEMA_VERSION,
-        "active_agencies": [],
-        "active_projects": [],
-        "active_topics": [],
-        "active_doc_ids": [],
-        "active_candidates": [],
-        "confidence": 0.0,
-        "ambiguous": False,
-        "turns": [],
-    }
-
-
-def normalize_conversation_state(state: dict[str, Any] | None) -> dict[str, Any]:
-    normalized = empty_conversation_state()
-    if not isinstance(state, dict):
-        return normalized
-
-    normalized["schema_version"] = int(
-        state.get("schema_version") or CONVERSATION_STATE_SCHEMA_VERSION
-    )
-    normalized["active_agencies"] = coerce_string_list(state.get("active_agencies"))
-    normalized["active_projects"] = coerce_string_list(state.get("active_projects"))
-    normalized["active_topics"] = coerce_string_list(state.get("active_topics"))
-    normalized["active_doc_ids"] = coerce_string_list(state.get("active_doc_ids"))
-    active_candidates = state.get("active_candidates")
-    if isinstance(active_candidates, list):
-        normalized["active_candidates"] = [
-            candidate for candidate in active_candidates[-8:] if isinstance(candidate, dict)
-        ]
-    normalized["ambiguous"] = bool(state.get("ambiguous", False))
-    try:
-        normalized["confidence"] = round(float(state.get("confidence") or 0.0), 3)
-    except (TypeError, ValueError):
-        normalized["confidence"] = 0.0
-
-    turns = state.get("turns") if isinstance(state.get("turns"), list) else []
-    normalized["turns"] = [
-        turn for turn in turns[-MAX_CONVERSATION_TURNS:] if isinstance(turn, dict)
-    ]
-    return normalized
 
 
 def tokenize(text: str) -> list[str]:


### PR DESCRIPTION
## 1. What changed and why

PR-E stage 3 of the `rag_core.py` 분해 epic (외부 senior review 2026-05 finding #3, follows #373/#380). conversation-state schema + helpers를 leaf module `rag_conversation_state.py`로 분리.

**선택 근거**: 6개 심볼(4 constants + 2 functions) 모두 `rag_core.py` 외부에서 import 안 됨 (repo-wide grep 확인). zero external surface — 가장 위험 낮은 stage. 분리 후 conversation 관련 변경이 코드 변경과 git blame에서 분리되고, 다음 stage 4(retrieval/verifier/answer 추출)의 의존성 그래프가 깨끗해진다.

상위 plan: Tier 2 PR-E stage 3 (`/Users/hskim/.claude/plans/bidmate-docagent-witty-glade.md`). Closes #415.

## 2. Files affected

- 신규 `rag_conversation_state.py` (119 lines, **leaf module** — `rag_core`에서 아무것도 import 안 함):
  - 4 constants: `CONVERSATION_STATE_SCHEMA_VERSION`, `MAX_CONVERSATION_TURNS`, `CONTEXT_RESOLUTION_THRESHOLD`, `AMBIGUOUS_CONFIDENCE_DELTA`.
  - 2 functions: `empty_conversation_state()`, `normalize_conversation_state()`.
  - 2 private helpers: `_ordered_unique`, `_coerce_string_list` (5-line 복제, leaf invariant 위해 — docstring에 명시).
- `rag_core.py` (−47 net, +13 import / −60 inline): inline 블록 제거 + import 추가.
- `pyproject.toml` (+1): coverage source.

**Load-bearing**: `rag_core.py`. 5b 필수.

## 3. Risks

- **외부 import 깨질 위험**: zero. repo-wide grep 결과 6개 심볼 모두 `rag_core.py` 외부에서 참조 없음 (PR description의 acceptance signal 참고).
- **`coerce_string_list` 중복**: 5-line helper를 두 곳에 둠. drift 위험은 있으나 (a) 5줄 / 변경 빈도 0에 가까움, (b) 모듈 docstring에 명시, (c) future PR로 collapse 가능.
- **Circular import 위험**: 없음. `rag_conversation_state`는 strict leaf — `rag_core` 미참조.

## 4. Tests

- **Pre-extraction parity**: 4 constants `==` + type, `empty_conversation_state()` JSON-canonical 동일, `normalize_conversation_state()`를 7개 diverse input(None, {}, populated dict, oversized list, invalid-type confidence, non-list turns, non-dict)에 대해 JSON-equal 검증.
- **Post-extraction identity**: 6개 심볼 모두 `rag_core.X is rag_conversation_state.X`.
- **Full pytest**: **720 passed / 1 skipped / 0 failed / 121 subtests passed in 12.43s**.

## 5. Eval impact

All `·` — pure refactor, behavior 변화 0.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path — pure module-boundary refactor, identical Python objects via direct import (no re-export indirection because no external consumers exist). `naive_baseline` 답변 JSON diff = 0 (ADR 0001 invariant). conversation-state schema는 입력/출력 모두 ADR-0003-orthogonal하므로 answer contract 영향 0.

## 6. Backward compatibility

- conversation state 관련 import 호환: 6개 심볼 모두 rag_core 외부에서 사용 안 되어 호환성 검토 불필요.
- 답변 schema (ADR 0003), `naive_baseline` invariant (ADR 0001), conversation_state schema_version=1 모두 유지.

## 7. Out of scope (stage 4+)

- `coerce_string_list` / `ordered_unique` shared utility 추출: alias resolution 코드(line 1039-1045, 1291)도 쓰므로 leaf-friendly split 별도 PR.
- `STRICT_METADATA_CONFIDENCE` / `REDUCED_METADATA_CONFIDENCE`: retrieval-side, 다음 stage.
- `ANSWER_SCHEMA_VERSION` / `ANSWER_STATUS_*`: answer-contract, 다음 stage.
- `metadata_stage_sequence` / `plan_retrieval` / `retrieve`: retrieval staged extraction, stage 4 핵심.

🤖 Generated with [Claude Code](https://claude.com/claude-code)