### PR TITLE
refactor: extract ADR 0003 answer schema constants to rag_answer_schema.py (PR-E stage 4a)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ source = [
     "korean_lexicon",
     "rag_pipeline_presets",
     "rag_conversation_state",
+    "rag_answer_schema",
     "rag_graph_agentic_full",
     "app",
     "api",

--- a/rag_answer_schema.py
+++ b/rag_answer_schema.py
@@ -1,0 +1,42 @@
+"""Answer-contract schema constants for the BidMate RAG core.
+
+Extracted from ``rag_core.py`` in issue #417 (PR-E stage 4a of the
+``rag_core.py`` decomposition epic — external senior review 2026-05
+finding #3). This module owns the **canonical** definitions of the
+load-bearing symbols that
+[ADR 0003 — Structured answer / citation contract](docs/adr/0003-structured-answer-citation-contract.md)
+codifies:
+
+- :data:`ANSWER_STATUS_SUPPORTED` / :data:`ANSWER_STATUS_PARTIAL` /
+  :data:`ANSWER_STATUS_INSUFFICIENT` — the three values
+  ``answer["status"]`` may take. Every consumer that branches on the
+  status (verifier, LLM judge, eval scorers, demo UI) keys off these
+  exact strings; a typo here would invalidate the contract for every
+  downstream gate.
+- :data:`ANSWER_SCHEMA_VERSION` — bumps whenever the dict that
+  ``rag_core.run_rag_query`` returns adds, removes, or renames a
+  field in a way that breaks a downstream consumer. CLAUDE.md
+  ``Prohibited`` list flags this bump as load-bearing.
+
+The module is a **leaf**: it imports nothing from ``rag_core``.
+``rag_core`` imports the four symbols back and re-exports them, so
+external consumers — ``tests/test_demo_helpers.py``,
+``tests/test_governance.py``,
+``tests/test_answer_contract_snapshot.py`` — keep their existing
+``from rag_core import ANSWER_STATUS_SUPPORTED`` imports.
+
+Stage 4b will move the answer-builder *functions*
+(``generate_answer``, ``build_claims``, ``render_answer_text``,
+``answer_status``, ...) — those have a deeper dependency chain
+(``normalize_regions``, ``best_sentence``, ``PARTIAL_TOPIC_GROUNDING_REASON``)
+and need their own JSON-identity gate.
+"""
+
+from __future__ import annotations
+
+
+ANSWER_STATUS_SUPPORTED = "supported"
+ANSWER_STATUS_PARTIAL = "partial"
+ANSWER_STATUS_INSUFFICIENT = "insufficient"
+
+ANSWER_SCHEMA_VERSION = 2

--- a/rag_core.py
+++ b/rag_core.py
@@ -98,6 +98,19 @@ from rag_conversation_state import (
     normalize_conversation_state,
 )
 
+# ADR 0003 answer-contract schema constants live in rag_answer_schema.py
+# as of issue #417 (PR-E stage 4a). Re-exported here so external
+# consumers (tests/test_demo_helpers, tests/test_governance,
+# tests/test_answer_contract_snapshot) keep their existing
+# ``from rag_core import ANSWER_STATUS_SUPPORTED, ANSWER_SCHEMA_VERSION``
+# imports unchanged.
+from rag_answer_schema import (
+    ANSWER_SCHEMA_VERSION,
+    ANSWER_STATUS_INSUFFICIENT,
+    ANSWER_STATUS_PARTIAL,
+    ANSWER_STATUS_SUPPORTED,
+)
+
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 DEFAULT_HASH_DIM = 384
 DEFAULT_CHUNK_MAX_CHARS = 520
@@ -139,10 +152,6 @@ TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]+")
 ENTITY_RE = re.compile(r"기관\s*[-_]?\s*([A-Za-z0-9]+)", re.IGNORECASE)
 SENTENCE_RE = re.compile(r"(?<=[.!?。])\s+")
 
-ANSWER_STATUS_SUPPORTED = "supported"
-ANSWER_STATUS_PARTIAL = "partial"
-ANSWER_STATUS_INSUFFICIENT = "insufficient"
-ANSWER_SCHEMA_VERSION = 2
 TRACE_SCHEMA_VERSION = 1
 
 STRICT_METADATA_CONFIDENCE = 0.90


### PR DESCRIPTION
## 1. What changed and why

PR-E stage 4a of the `rag_core.py` 분해 epic (외부 senior review 2026-05 finding #3; follows #373/#380/#416). 원래 plan의 stage 4(answer/citation contract 본체, ~446 lines / 20+ functions)는 `normalize_regions`/`best_sentence`/`PARTIAL_TOPIC_GROUNDING_REASON` 등 깊은 dep tree로 JSON-identity 위험 크므로 **constants-only 4a + functions-only 4b** 로 split. 본 PR이 4a.

4개 schema 상수는 [ADR 0003 — Structured answer / citation contract](docs/adr/0003-structured-answer-citation-contract.md)의 *load-bearing 심볼*. 분리 후 \"answer contract = ADR 0003의 canonical 코드 표면\"이 grep-able. 다음 stage 4b가 함수 본체 옮길 때 import 경로 자리 잡혀 있어 risk 작아짐.

Closes #417.

## 2. Files affected

- 신규 `rag_answer_schema.py` (42 lines, **leaf module** — `rag_core` 미import):
  - `ANSWER_STATUS_SUPPORTED` / `_PARTIAL` / `_INSUFFICIENT` / `ANSWER_SCHEMA_VERSION`.
  - 모듈 docstring에 ADR 0003 cross-link.
- `rag_core.py` (+13 import / −5 inline): import + delete inline. 4 심볼 **re-export**로 외부 3개 test 호환 유지.
- `pyproject.toml` (+1): coverage source.

**Load-bearing**: `rag_core.py`. 5b 필수.

## 3. Risks

- **외부 test import 깨질 위험**: `tests/test_demo_helpers.py`, `tests/test_governance.py`, `tests/test_answer_contract_snapshot.py`가 `from rag_core import ANSWER_STATUS_*` 또는 `ANSWER_SCHEMA_VERSION` 사용. → `rag_core`에서 re-export로 그대로 작동. `rag_core.X is rag_answer_schema.X` identity 검증 통과.
- **Circular import 위험**: 없음. `rag_answer_schema`는 strict leaf — `rag_core` 미참조.
- **`TRACE_SCHEMA_VERSION` 미동반**: 의도. observability 영역이라 trace 모듈 추출 시 함께. 본 PR은 answer-contract만.

## 4. Tests

- Pre-extraction parity: 4 constants `==` + type 동일.
- Post-extraction identity: 4 심볼 모두 `rag_core.X is rag_answer_schema.X`.
- External-style import smoke: `from rag_core import ANSWER_STATUS_SUPPORTED, ...` 모두 호출 가능.
- **Full pytest**: **720 passed / 1 skipped / 0 failed / 121 subtests passed in 12.44s**.

## 5. Eval impact

All `·` — pure constant extraction, behavior 변화 0.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path — pure constant extraction with re-export, JSON diff = 0. ADR 0003 contract의 4개 load-bearing 심볼 값은 1글자도 변하지 않음. `naive_baseline` 답변 JSON diff = 0 (ADR 0001 invariant).

## 6. Backward compatibility

- 외부 test (`from rag_core import ANSWER_STATUS_*`, `ANSWER_SCHEMA_VERSION`): re-export로 그대로 작동.
- 답변 schema (ADR 0003), `naive_baseline` invariant (ADR 0001), ADR 0011 / 0024 모두 유지.

## 7. Out of scope (stage 4b+)

- `generate_answer` / `build_claims` / `build_extract_claims` / `build_comparison_claims` / `render_answer_text` / `build_insufficiency` / `answer_summary` — function body 추출, 별도 PR + JSON-identity 게이트.
- `answer_status` / `answer_status_reason` / `answer_query_type` — `PARTIAL_TOPIC_GROUNDING_REASON` (verifier-side) 의존, stage 4b 결정.
- `TRACE_SCHEMA_VERSION` — trace module 추출 시.
- `PARTIAL_TOPIC_GROUNDING_REASON` — verifier module 추출 시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)