### PR TITLE
ci: baseline.aggregate.json provenance reachability gate (#413)

### DIFF
--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -70,6 +70,45 @@ jobs:
       - name: Verify leaderboard artifacts are in sync with history
         run: python3 scripts/leaderboard.py --check
 
+  baseline-provenance:
+    # Gate (issue #413): verify reports/real100/baseline.aggregate.json's
+    # `provenance.git_commit` is still reachable from origin/<base ref>.
+    # Catches the silent-breakage tail of issue #160 — a baseline whose
+    # commit was force-pushed or rebased off main, leaving real-eval-delta
+    # diffing against a phantom code state. Fast (stdlib only, no deps).
+    name: Baseline provenance reachability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            scripts/check_baseline_provenance.py
+            reports/real100/baseline.aggregate.json
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Verify baseline commit is reachable from base ref
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # If this PR modifies the baseline, the new provenance.git_commit
+          # legitimately points at a commit that is not yet ancestor of
+          # the base ref. Accept ancestry of the PR head SHA as the escape
+          # hatch — the gate re-runs on every push and the merge commit,
+          # so a stale SHA is caught the moment the PR moves past it.
+          if git diff --name-only "$BASE_REF"...HEAD \
+               | grep -qx 'reports/real100/baseline.aggregate.json'; then
+            python scripts/check_baseline_provenance.py \
+              --ref "$BASE_REF" --allow-equal-to "$PR_HEAD_SHA"
+          else
+            python scripts/check_baseline_provenance.py --ref "$BASE_REF"
+          fi
+
   eval-delta:
     name: Eval delta vs base
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Governance gates (branch + issue, README metrics, latency SLO, leaderboard
 # freshness, real-eval history freshness, benchmark manifest check). Run
 # `make governance-check` to invoke the pre-PR subset in sequence.
-.PHONY: check-branch governance-check check check-latency leaderboard-check real-eval-history-check benchmark-check
+.PHONY: check-branch governance-check check check-latency leaderboard-check real-eval-history-check benchmark-check check-baseline-provenance
 
 # Index build + ad-hoc ask
 .PHONY: index ask
@@ -62,8 +62,17 @@ check-branch:
 # already wired into CI / hooks individually; this target just shortens
 # the local pre-PR checklist into a single invocation. Fails on the
 # first sub-target that exits non-zero.
-governance-check: check-branch leaderboard-check real-eval-history-check
-	@echo "governance-check: branch + leaderboard + real-eval-history OK."
+governance-check: check-branch leaderboard-check real-eval-history-check check-baseline-provenance
+	@echo "governance-check: branch + leaderboard + real-eval-history + baseline-provenance OK."
+
+# Verify reports/real100/baseline.aggregate.json's provenance.git_commit is
+# still reachable from origin/main (issue #413). Catches the silent-breakage
+# tail of issue #160: a baseline committed at a SHA that was later
+# force-pushed/rebased off main, leaving `make real-eval-delta` diffing
+# against a phantom code state. For non-default refs, invoke the script
+# directly: `python scripts/check_baseline_provenance.py --ref <ref>`.
+check-baseline-provenance:
+	$(PYTHON) scripts/check_baseline_provenance.py
 
 index:
 	$(PYTHON) scripts/build_index.py --input_dir data/raw --output_dir data/index

--- a/scripts/check_baseline_provenance.py
+++ b/scripts/check_baseline_provenance.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Verify reports/real100/baseline.aggregate.json's commit is reachable.
+
+The committed baseline pairs metrics with the ``provenance.git_commit``
+they were generated at. If that commit is later force-pushed, rebased,
+or otherwise made unreachable from ``origin/main``, then every
+subsequent ``make real-eval-delta`` silently diffs against a phantom
+code state. This script is the gate: CI verifies the baseline's SHA is
+still an ancestor of ``origin/main`` (or of an explicitly allowed ref,
+for PRs that are themselves bumping the baseline).
+
+Operational tail of issue #160; tracked as issue #413.
+
+Exit codes:
+  0 — provenance.git_commit is reachable from --ref (or --allow-equal-to).
+  1 — SHA is not reachable from any allowed ref (dangling / unmerged).
+  2 — config error: baseline missing/malformed, provenance/run_manifest
+      commit mismatch, or git unavailable.
+
+Usage:
+  python scripts/check_baseline_provenance.py
+  python scripts/check_baseline_provenance.py --ref origin/main
+  python scripts/check_baseline_provenance.py --allow-equal-to <pr-head-sha>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_BASELINE = "reports/real100/baseline.aggregate.json"
+DEFAULT_REF = "origin/main"
+
+
+def _run_git(args: list[str], cwd: Path) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        return (127, "", f"git executable not available: {exc}")
+    return (result.returncode, result.stdout.strip(), result.stderr.strip())
+
+
+def _extract_provenance_sha(baseline: dict[str, Any]) -> str:
+    prov = baseline.get("provenance")
+    if not isinstance(prov, dict):
+        raise ValueError("baseline has no `provenance` block")
+    sha = prov.get("git_commit")
+    if not isinstance(sha, str) or not sha.strip():
+        raise ValueError("baseline `provenance.git_commit` is empty or non-string")
+    return sha.strip()
+
+
+def _extract_run_manifest_sha(baseline: dict[str, Any]) -> str | None:
+    manifest = baseline.get("run_manifest")
+    if not isinstance(manifest, dict):
+        return None
+    sha = manifest.get("git_commit")
+    if not isinstance(sha, str) or not sha.strip():
+        return None
+    return sha.strip()
+
+
+def check(
+    baseline_path: Path,
+    ref: str,
+    allow_equal_to: str | None,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[int, str]:
+    """Return ``(exit_code, message)``.
+
+    See module docstring for exit-code semantics.
+    """
+    if not baseline_path.exists():
+        return (2, f"[ERROR] baseline not found: {baseline_path}")
+    try:
+        baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return (2, f"[ERROR] baseline JSON malformed at {baseline_path}: {exc}")
+    if not isinstance(baseline, dict):
+        return (2, f"[ERROR] baseline must be a JSON object: {baseline_path}")
+
+    try:
+        provenance_sha = _extract_provenance_sha(baseline)
+    except ValueError as exc:
+        return (2, f"[ERROR] {exc}")
+
+    manifest_sha = _extract_run_manifest_sha(baseline)
+    if manifest_sha is not None and manifest_sha != provenance_sha:
+        return (
+            2,
+            "[ERROR] provenance/run_manifest commit mismatch: "
+            f"provenance.git_commit={provenance_sha} "
+            f"run_manifest.git_commit={manifest_sha}",
+        )
+
+    rc, _, stderr = _run_git(["cat-file", "-e", provenance_sha], cwd=repo_root)
+    if rc != 0:
+        return (
+            1,
+            f"[ERROR] baseline `provenance.git_commit`={provenance_sha} does not "
+            "exist in the git object database. The commit was likely "
+            "force-pushed or rebased away. "
+            "Run `make real-eval` then `make real-eval-baseline-update` at a "
+            f"commit reachable from {ref}. ({stderr or 'no stderr'})",
+        )
+
+    rc, _, _ = _run_git(
+        ["merge-base", "--is-ancestor", provenance_sha, ref], cwd=repo_root
+    )
+    if rc == 0:
+        return (
+            0,
+            f"[OK] baseline.aggregate.json git_commit={provenance_sha} "
+            f"is reachable from {ref}.",
+        )
+
+    if allow_equal_to:
+        rc, _, _ = _run_git(
+            ["merge-base", "--is-ancestor", provenance_sha, allow_equal_to],
+            cwd=repo_root,
+        )
+        if rc == 0:
+            return (
+                0,
+                f"[OK] baseline.aggregate.json git_commit={provenance_sha} "
+                f"is reachable from {allow_equal_to} (--allow-equal-to escape "
+                f"hatch; will be ancestor of {ref} after merge).",
+            )
+
+    refs_msg = ref if not allow_equal_to else f"{ref} or {allow_equal_to}"
+    return (
+        1,
+        f"[ERROR] baseline `provenance.git_commit`={provenance_sha} is not "
+        f"reachable from {refs_msg}. This is the #160 / #413 failure mode: "
+        "the baseline points at a code state that no longer lives on the "
+        "target branch. Run `make real-eval` then "
+        "`make real-eval-baseline-update` on the current HEAD before merging.",
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--baseline",
+        default=DEFAULT_BASELINE,
+        help="Path to baseline aggregate JSON (default: %(default)s).",
+    )
+    ap.add_argument(
+        "--ref",
+        default=DEFAULT_REF,
+        help="Ref that must contain the baseline's commit (default: %(default)s).",
+    )
+    ap.add_argument(
+        "--allow-equal-to",
+        default=None,
+        metavar="SHA",
+        help=(
+            "Additional ref/SHA that the baseline commit may be an ancestor of. "
+            "Use for PRs that themselves bump the baseline: pass the PR head "
+            "SHA so the in-flight commit is accepted while the SHA is still "
+            "outside origin/main."
+        ),
+    )
+    ap.add_argument(
+        "--repo-root",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root) if args.repo_root else ROOT_DIR
+    baseline_path = Path(args.baseline)
+    if not baseline_path.is_absolute():
+        baseline_path = repo_root / baseline_path
+    exit_code, message = check(baseline_path, args.ref, args.allow_equal_to, repo_root)
+    stream = sys.stdout if exit_code == 0 else sys.stderr
+    print(message, file=stream)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_baseline_provenance.py
+++ b/tests/test_check_baseline_provenance.py
@@ -1,0 +1,247 @@
+"""Contract test for the baseline provenance reachability gate (issue #413).
+
+Locks the semantics so silent regressions (dangling SHAs, run_manifest
+mismatch, malformed baseline) cannot ship a green real-eval-delta gate.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_baseline_provenance import check  # noqa: E402
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def _init_repo(td: Path) -> dict[str, str]:
+    """Build a tempdir git repo with a known commit graph.
+
+    Layout::
+
+        main ── A ── B   (HEAD on `feature`)
+                 \\
+                  └── C  (on `feature`, NOT yet on main)
+
+        D                 (orphan commit, not on any ref)
+
+    Returns shas: ``{"a": A12, "b": B12, "c": C12, "d_orphan": D12}``.
+    """
+    _git(["init", "--initial-branch=main"], cwd=td)
+    _git(["config", "user.email", "test@example.com"], cwd=td)
+    _git(["config", "user.name", "Test"], cwd=td)
+    _git(["commit", "--allow-empty", "-m", "A"], cwd=td)
+    sha_a = _git(["rev-parse", "HEAD"], cwd=td)
+    _git(["commit", "--allow-empty", "-m", "B"], cwd=td)
+    sha_b = _git(["rev-parse", "HEAD"], cwd=td)
+    _git(["checkout", "-b", "feature", sha_a], cwd=td)
+    _git(["commit", "--allow-empty", "-m", "C"], cwd=td)
+    sha_c = _git(["rev-parse", "HEAD"], cwd=td)
+
+    empty_tree = subprocess.run(
+        ["git", "mktree"],
+        cwd=td,
+        input="",
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+    sha_d = subprocess.run(
+        ["git", "commit-tree", empty_tree, "-m", "D-orphan"],
+        cwd=td,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+    _git(["checkout", "main"], cwd=td)
+
+    return {
+        "a": sha_a[:12],
+        "b": sha_b[:12],
+        "c": sha_c[:12],
+        "d_orphan": sha_d[:12],
+    }
+
+
+def _write_baseline(
+    path: Path,
+    provenance_sha: str,
+    run_manifest_sha: str | None = "match",
+) -> None:
+    body: dict[str, object] = {
+        "provenance": {
+            "generated_at": "2026-05-12T00:00:00.000000Z",
+            "git_commit": provenance_sha,
+            "git_dirty": False,
+        }
+    }
+    if run_manifest_sha == "match":
+        body["run_manifest"] = {
+            "config_sha256": "deadbeefcafe",
+            "generated_at": "2026-05-12T00:00:00.000000Z",
+            "git_commit": provenance_sha,
+            "git_dirty": False,
+        }
+    elif run_manifest_sha is not None:
+        body["run_manifest"] = {
+            "config_sha256": "deadbeefcafe",
+            "generated_at": "2026-05-12T00:00:00.000000Z",
+            "git_commit": run_manifest_sha,
+            "git_dirty": False,
+        }
+    path.write_text(
+        json.dumps(body, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+class CheckBaselineProvenanceUnit(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = Path(tempfile.mkdtemp())
+        self._shas = _init_repo(self._td)
+        self._baseline = self._td / "baseline.aggregate.json"
+
+    def test_ancestor_of_main_passes(self) -> None:
+        _write_baseline(self._baseline, self._shas["a"])
+        code, msg = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 0, msg)
+        self.assertIn("[OK]", msg)
+        self.assertIn(self._shas["a"], msg)
+
+    def test_head_of_main_passes(self) -> None:
+        _write_baseline(self._baseline, self._shas["b"])
+        code, _ = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 0)
+
+    def test_unmerged_branch_commit_fails_against_main(self) -> None:
+        _write_baseline(self._baseline, self._shas["c"])
+        code, msg = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 1, msg)
+        self.assertIn("not reachable", msg)
+
+    def test_unmerged_commit_passes_with_allow_equal_to(self) -> None:
+        _write_baseline(self._baseline, self._shas["c"])
+        code, msg = check(
+            self._baseline, "main", self._shas["c"], repo_root=self._td
+        )
+        self.assertEqual(code, 0, msg)
+        self.assertIn("escape hatch", msg)
+
+    def test_dangling_orphan_sha_fails(self) -> None:
+        _write_baseline(self._baseline, self._shas["d_orphan"])
+        code, msg = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 1, msg)
+        self.assertIn("not reachable", msg)
+
+    def test_completely_missing_sha_fails_with_object_db_error(self) -> None:
+        _write_baseline(self._baseline, "deadbeefcafe")
+        code, msg = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 1, msg)
+        self.assertIn("does not exist in the git object database", msg)
+
+    def test_provenance_run_manifest_mismatch_fails(self) -> None:
+        _write_baseline(
+            self._baseline,
+            self._shas["a"],
+            run_manifest_sha=self._shas["b"],
+        )
+        code, msg = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 2, msg)
+        self.assertIn("mismatch", msg)
+
+    def test_missing_baseline_file_returns_config_error(self) -> None:
+        missing = self._td / "does-not-exist.json"
+        code, msg = check(missing, "main", None, repo_root=self._td)
+        self.assertEqual(code, 2, msg)
+        self.assertIn("baseline not found", msg)
+
+    def test_malformed_json_returns_config_error(self) -> None:
+        self._baseline.write_text("not json {", encoding="utf-8")
+        code, msg = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 2, msg)
+        self.assertIn("malformed", msg)
+
+    def test_missing_provenance_block_returns_config_error(self) -> None:
+        self._baseline.write_text(
+            json.dumps({"some_other_key": "value"}), encoding="utf-8"
+        )
+        code, msg = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 2, msg)
+        self.assertIn("provenance", msg)
+
+    def test_baseline_without_run_manifest_still_passes(self) -> None:
+        _write_baseline(
+            self._baseline, self._shas["a"], run_manifest_sha=None
+        )
+        code, _ = check(self._baseline, "main", None, repo_root=self._td)
+        self.assertEqual(code, 0)
+
+
+class CheckBaselineProvenanceCli(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = Path(tempfile.mkdtemp())
+        self._shas = _init_repo(self._td)
+        self._baseline = self._td / "baseline.aggregate.json"
+
+    def _invoke(self, *extra: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "check_baseline_provenance.py"),
+                "--baseline", str(self._baseline),
+                "--ref", "main",
+                "--repo-root", str(self._td),
+                *extra,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_cli_exits_zero_for_ancestor(self) -> None:
+        _write_baseline(self._baseline, self._shas["a"])
+        result = self._invoke()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[OK]", result.stdout)
+
+    def test_cli_exits_one_for_unreachable(self) -> None:
+        _write_baseline(self._baseline, self._shas["c"])
+        result = self._invoke()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("not reachable", result.stderr)
+
+    def test_cli_allow_equal_to_lets_pr_commit_pass(self) -> None:
+        _write_baseline(self._baseline, self._shas["c"])
+        result = self._invoke("--allow-equal-to", self._shas["c"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("escape hatch", result.stdout)
+
+    def test_cli_exits_two_for_mismatch(self) -> None:
+        _write_baseline(
+            self._baseline,
+            self._shas["a"],
+            run_manifest_sha=self._shas["b"],
+        )
+        result = self._invoke()
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("mismatch", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Adds a CI-enforced reachability gate for `reports/real100/baseline.aggregate.json`. The baseline pairs aggregate metrics with a `provenance.git_commit`; if that commit is later force-pushed or rebased off main, every subsequent `make real-eval-delta` silently diffs against a phantom code state — the operational tail of issue #160. The new `scripts/check_baseline_provenance.py` verifies `provenance.git_commit` is still an ancestor of `origin/<base ref>` on every PR, with a `--allow-equal-to <pr-head-sha>` escape hatch for PRs that themselves bump the baseline (the SHA is accepted on the in-flight branch and re-verified on the merge commit).

Closes #413

## 2. Files affected

- `scripts/check_baseline_provenance.py` — new gate script (stdlib only).
- `tests/test_check_baseline_provenance.py` — 15 cases (unit + CLI subprocess) including dangling-orphan via `git commit-tree`.
- `.github/workflows/pr-eval.yml` — new `baseline-provenance` job with sparse checkout + `fetch-depth: 0`.
- `Makefile` — new `check-baseline-provenance` target, folded into `governance-check`.

None of these are load-bearing paths (canonical list: `scripts/_governance.py:LOAD_BEARING_PATHS`).

## 3. Risks

Most likely break: a real PR that legitimately bumps the baseline gets blocked because the new `provenance.git_commit` is not yet ancestor of `origin/main`. Mitigated by the `--allow-equal-to "${{ github.event.pull_request.head.sha }}"` conditional branch in the workflow — when the PR diff contains `baseline.aggregate.json`, the SHA may instead be an ancestor of the PR head. Verified manually with a tempdir repo simulating the bump scenario (`test_unmerged_commit_passes_with_allow_equal_to`, `test_cli_allow_equal_to_lets_pr_commit_pass`).

Second risk: the workflow needs full git history (`fetch-depth: 0`) for `git merge-base --is-ancestor` to work against `origin/main`. Sparse checkout is preserved so the job still completes in seconds despite the full clone.

## 4. Tests

`tests/test_check_baseline_provenance.py` — 15 cases following the dual unit + CLI subprocess pattern from `tests/test_check_latency_slo.py`. Covers: ancestor-of-main, head-of-main, unmerged-branch-fails-against-main, unmerged-branch-passes-with-allow-equal-to, dangling orphan SHA (via `git commit-tree` against an empty tree), completely-missing SHA, provenance/run_manifest mismatch, missing baseline file, malformed JSON, missing provenance block, missing run_manifest (still passes). All 15 pass locally.

## 5. Eval impact

All \`·\`. CI is read-only against the baseline; no retrieval / answer / scoring path touched.

### 5b. Real-data delta

N/A — no load-bearing path changed (no entry from \`scripts/_governance.py:LOAD_BEARING_PATHS\` is modified). Verified: the changed files are \`scripts/check_baseline_provenance.py\` (new), \`tests/test_check_baseline_provenance.py\` (new), \`.github/workflows/pr-eval.yml\`, and \`Makefile\` — none in the SSoT.

## 6. Backward compatibility

No contract change. New script + new CI job + new Makefile target; \`governance-check\` gains one more sub-target but its existing semantics ("fails on the first non-zero sub-target") are preserved. The current baseline (\`git_commit=2ce37653b048\`) is already reachable from \`origin/main\`, so the gate passes on existing PRs out of the box.

## 7. Out of scope

- Hard-fail mode in \`scripts/write_real_eval_baseline.py\` (the writer-side strict toggle). Tracked separately as issue #414; the stacked follow-up PR layers on top of this one.
- Escalating \`provenance.git_dirty: true\` to a failure. Flagged during planning as a real gap but expands #414's scope; deferred for a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)