### PR TITLE
refactor(scripts): consolidate history table-render kernel in _utils.py (#393)

### DIFF
--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -131,6 +131,75 @@ def fmt_rate(value: Any) -> str:
     return f"{value:.3f}" if isinstance(value, (int, float)) else "N/A"
 
 
+def fmt_cell(value: Any) -> str:
+    """Format a cell value for a markdown history table.
+
+    Conventions shared by the real-data history renderer
+    (``scripts/render_real_eval_history.py``) and the synthetic
+    leaderboard (``scripts/leaderboard.py``):
+
+    - ``None`` renders as ``"—"`` (em dash), not ``"None"`` — missing
+      metrics on older snapshots should look intentional, not broken.
+    - ``float`` renders with 3 decimals — the precision both eval
+      surfaces are calibrated to.
+    - Other values fall through to ``str(value)``.
+
+    Note: ``fmt_rate`` (also in this module) uses a different
+    convention (``"N/A"`` instead of ``"—"``) and is consumed by the
+    README ablation table renderer. Keep both — they target different
+    audiences (in-repo history tables vs README headline metrics).
+    """
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def render_history_table(
+    rows: list[dict[str, Any]],
+    columns: list[tuple[str, str]],
+    *,
+    empty_message: str = "",
+    trailing_newline: bool = False,
+) -> str:
+    """Render aggregate-history rows as a GitHub markdown table.
+
+    Shared kernel for ``render_real_eval_history.render_table()`` and
+    ``leaderboard._render_table_only()``. Conventions:
+
+    - ``columns`` is a list of ``(row_key, header_label)`` tuples.
+    - The ``"commit"`` column gets backtick-wrapped (``" `abc123`"``);
+      empty commit renders as ``"—"``.
+    - Every other column flows through :func:`fmt_cell`.
+    - ``empty_message`` is returned verbatim when ``rows`` is empty —
+      callers want different "no data" prose.
+    - ``trailing_newline=True`` appends ``"\\n"`` after the last row;
+      matches ``leaderboard._render_table_only`` (which embeds the
+      table under a ``## Tabular view`` section that expects a final
+      newline). Default ``False`` matches ``render_real_eval_history``
+      (which feeds the table into a marker-spliced block).
+    """
+    if not rows:
+        return empty_message
+    header = "| " + " | ".join(label for _, label in columns) + " |"
+    sep = "|" + "|".join(["---"] * len(columns)) + "|"
+    lines = [header, sep]
+    for row in rows:
+        cells = []
+        for key, _ in columns:
+            value = row.get(key)
+            if key == "commit":
+                cells.append(f"`{value}`" if value else "—")
+            else:
+                cells.append(fmt_cell(value))
+        lines.append("| " + " | ".join(cells) + " |")
+    result = "\n".join(lines)
+    if trailing_newline:
+        result += "\n"
+    return result
+
+
 _METRIC_SNAPSHOT_KEYS_PRE = (
     "num_predictions",
     "accuracy",

--- a/scripts/leaderboard.py
+++ b/scripts/leaderboard.py
@@ -37,6 +37,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts._utils import render_history_table  # noqa: E402
 from scripts.run_real_eval_delta import extract_aggregate  # noqa: E402
 
 HISTORY_DIR = ROOT / "reports" / "history"
@@ -61,14 +62,6 @@ TABLE_COLUMNS: list[tuple[str, str]] = [
     ("abstention", "Abstention"),
     ("retry", "Retry"),
 ]
-
-
-def _fmt(value: Any) -> str:
-    if value is None:
-        return "—"
-    if isinstance(value, float):
-        return f"{value:.3f}"
-    return str(value)
 
 
 def load_history(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]]:
@@ -113,21 +106,12 @@ def _render_table_only(rows: list[dict[str, Any]]) -> str:
     ``render_page`` (which embeds it under its own ``## Tabular view``
     section, where a duplicate title would be a bug).
     """
-    if not rows:
-        return ""
-    header = "| " + " | ".join(label for _, label in TABLE_COLUMNS) + " |"
-    sep = "|" + "|".join(["---"] * len(TABLE_COLUMNS)) + "|"
-    lines = [header, sep]
-    for row in rows:
-        cells = []
-        for key, _ in TABLE_COLUMNS:
-            value = row.get(key)
-            if key == "commit":
-                cells.append(f"`{value}`" if value else "—")
-            else:
-                cells.append(_fmt(value))
-        lines.append("| " + " | ".join(cells) + " |")
-    return "\n".join(lines) + "\n"
+    return render_history_table(
+        rows,
+        TABLE_COLUMNS,
+        empty_message="",
+        trailing_newline=True,
+    )
 
 
 def render_markdown_table(rows: list[dict[str, Any]]) -> str:

--- a/scripts/render_real_eval_history.py
+++ b/scripts/render_real_eval_history.py
@@ -35,6 +35,7 @@ from typing import Any
 # Reuse the extractor + privacy guards from the delta script. Adding a
 # new entry point should not weaken the boundary.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts._utils import render_history_table  # noqa: E402
 from scripts.run_real_eval_delta import extract_aggregate  # noqa: E402
 
 HISTORY_DIR = Path("reports/real100/history")
@@ -54,17 +55,9 @@ COLUMNS: list[tuple[str, str]] = [
     ("answer_format_compliance", "Format"),
     ("retry", "Retry"),
     # ADR 0006: LLM-judge agreement. Shown only when present; absent
-    # entries render as "—" via the _fmt fallback.
+    # entries render as "—" via render_history_table's fmt_cell fallback.
     ("agreement_with_verifier", "Judge⇄Verifier"),
 ]
-
-
-def _fmt(value: Any) -> str:
-    if value is None:
-        return "—"
-    if isinstance(value, float):
-        return f"{value:.3f}"
-    return str(value)
 
 
 def load_history() -> list[dict[str, Any]]:
@@ -100,26 +93,15 @@ def load_history() -> list[dict[str, Any]]:
 
 
 def render_table(rows: list[dict[str, Any]]) -> str:
-    if not rows:
-        return (
+    return render_history_table(
+        rows,
+        COLUMNS,
+        empty_message=(
             "_No real-data history entries yet. Run "
             "`make real-eval-baseline-update` to seed the first "
             "snapshot._"
-        )
-    header = "| " + " | ".join(label for _, label in COLUMNS) + " |"
-    sep = "|" + "|".join(["---"] * len(COLUMNS)) + "|"
-    lines = [header, sep]
-    for row in rows:
-        cells = []
-        for key, _ in COLUMNS:
-            value = row.get(key)
-            if key == "commit":
-                value = f"`{value}`" if value else "—"
-            else:
-                value = _fmt(value)
-            cells.append(value)
-        lines.append("| " + " | ".join(cells) + " |")
-    return "\n".join(lines)
+        ),
+    )
 
 
 def render_section(rows: list[dict[str, Any]]) -> str:

--- a/tests/test_render_real_eval_history.py
+++ b/tests/test_render_real_eval_history.py
@@ -45,7 +45,7 @@ class RealEvalHistoryRendererTest(unittest.TestCase):
         (self.root / "reports" / "real100" / "history").mkdir(parents=True)
         # Copy the scripts module so subprocess can find it.
         repo_root = Path(__file__).resolve().parents[1]
-        for fname in ("run_real_eval_delta.py", "render_real_eval_history.py"):
+        for fname in ("_utils.py", "run_real_eval_delta.py", "render_real_eval_history.py"):
             shutil.copy(repo_root / "scripts" / fname, self.root / "scripts" / fname)
         # __init__.py so `import scripts.run_real_eval_delta` works.
         (self.root / "scripts" / "__init__.py").write_text("")


### PR DESCRIPTION
## 1. What changed and why

Closes #393

Extract the byte-identical `_fmt` function and the near-identical markdown table-render block shared by `scripts/render_real_eval_history.py` (real-data eval history) and `scripts/leaderboard.py` (synthetic public eval, Chart.js page) into `scripts/_utils.py`.

Two new helpers:

- `fmt_cell(value)` — `None → "—"`, `float → 3-dp`, else `str()`. Kept distinct from the existing `fmt_rate()` (which uses `"N/A"`); they target different audiences (history tables vs README ablation table). Module docstring explains the split.
- `render_history_table(rows, columns, *, empty_message="", trailing_newline=False)` — kernel both callers now wrap. The `empty_message` parameter folds each caller's no-data branch into the kernel; the `trailing_newline` flag preserves the leaderboard's `+ "\n"` on the last row (its caller embeds the table under `## Tabular view`, which expects a final newline) without forcing the same on the real-eval renderer (which feeds into a marker-spliced block).

`render_history_table` is named to avoid colliding with the existing `leaderboard.render_markdown_table` (the leaderboard-specific wrapper that adds title + intro at [scripts/leaderboard.py:133](scripts/leaderboard.py:133)).

`load_history()` stays per-script — real-eval extracts the judge block + `agreement_with_verifier` (ADR 0006); leaderboard extracts the `ci` block + falls back to `run_manifest` if `provenance` is missing. A generic loader would shove caller-specific dict construction into a callback for no reuse benefit; the schema divergence is real and was deliberately kept out of scope per #393.

## 2. Files affected

- `scripts/_utils.py` — added `fmt_cell` + `render_history_table`. **Not load-bearing** (canonical list in `scripts/_governance.py::LOAD_BEARING_PATHS`).
- `scripts/render_real_eval_history.py` — removed local `_fmt`, replaced inline table-render with `render_history_table` call.
- `scripts/leaderboard.py` — removed local `_fmt`, replaced inline table-render in `_render_table_only` with `render_history_table(..., empty_message="", trailing_newline=True)`.
- `tests/test_render_real_eval_history.py` — added `_utils.py` to the subprocess copy tuple at line 48.

No load-bearing path touched.

## 3. Risks

Most likely break: byte drift in the rendered tables (`docs/private-100-doc-experiments.md`, `reports/leaderboard.md`, `docs/leaderboard.md`).

Specifically checked:
- `make leaderboard-check` and `make real-eval-history-check` both green on this branch — proves both rendered files byte-match what's currently committed.
- `trailing_newline=True` is explicit at the leaderboard call site to preserve its final `"\n"`; default `False` keeps real-eval's no-trailing-newline behavior.
- Kernel uses `row.get(key)` (not `row[key]`) so older snapshots missing newer fields (e.g., real-eval rows missing `agreement_with_verifier`) still render `"—"` instead of crashing.
- `commit`-column backtick wrap is keyed on the literal string `"commit"` — preserved exactly; one-line docstring note flags the convention.
- Spacing pad (`"| " + " | ".join(cells) + " |"`) preserved verbatim — no f-string rebuild.

## 4. Tests

`pytest tests/test_render_real_eval_history.py tests/test_leaderboard.py -v` → 11 passed locally. The existing test suites already cover byte-equality for both renderers; no new tests added because the refactor is output-preserving (covered by the same suites).

The subprocess-based real-eval test required `_utils.py` to be added to the per-test copy list (line 48); without that, the renderer subprocess would `ModuleNotFoundError` on `from scripts._utils import …`. Caught and fixed.

## 5. Eval impact

All \`·\` — refactor of docs-generation kernels; no retrieval / verifier / answer-generation path touched.

### 5b. Real-data delta

N/A — \`scripts/_utils.py\` is not in \`LOAD_BEARING_PATHS\` (per \`scripts/_governance.py:1-7\`, that list is reserved for paths whose change could affect the retrieval/verifier eval surface). The byte-equality \`--check\` gates above are the relevant proof of no behavior change.

## 6. Backward compatibility

No contract / schema / CLI change. Pure internal refactor of two scripts. No \`schema_version\` bump (ADR 0003 unchanged). No public API change.

## 7. Out of scope

- Promotion of \`scripts/_utils.py\` to \`LOAD_BEARING_PATHS\` — deferred. The byte-equality \`--check\` gates already block silent drift at PR time; promoting would force every future \`_utils.py\` touch (e.g., adding a YAML helper) to attach a real-data delta for no extra signal. Revisit only if a future change shows the byte-equality gate insufficient.
- Inlining \`leaderboard._render_table_only\` (now a thin wrapper) — separate concern, keep this PR to one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)