### PR TITLE
docs(adr): ADR 0026 cross-encoder reranker deferral skeleton (#412)

### DIFF
--- a/docs/adr/0026-cross-encoder-reranker-deferral.md
+++ b/docs/adr/0026-cross-encoder-reranker-deferral.md
@@ -1,0 +1,211 @@
+# 0026: Cross-encoder reranker default stays stub-identity; real-backend measurement deferred
+
+- **Status**: proposed
+- **Date**: 2026-05-12
+- **Deciders**: hskim
+- **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (baseline preserved), [ADR 0002](./0002-metadata-first-retrieval.md) (the metadata-first routing that shadows the rerank step), [ADR 0019](./0019-embedding-default-stays-minilm.md) (mirror pattern — measurement-gated default-stays), [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) (the deferred-then-closed loop precedent), [ADR 0025](./0025-cost-frontier-defer-until-real-baselines.md) (sibling deferral pattern, accepted 2026-05-12), [`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md) (working reference), [`docs/ablation-results.md`](../ablation-results.md) (current ablation table), [`rag_reranker.py`](../../rag_reranker.py) (`Reranker` Protocol + `CrossEncoderReranker` default), issues [#163](https://github.com/hskim-solv/oss-bidmate-docagent/issues/163), [#345](https://github.com/hskim-solv/oss-bidmate-docagent/issues/345), [#412](https://github.com/hskim-solv/oss-bidmate-docagent/issues/412), PR [#358](https://github.com/hskim-solv/oss-bidmate-docagent/pull/358)
+
+> **NOTE — skeleton only.** Status is `proposed` because the body below
+> stops at *Context*: rationale (Decision, Re-open conditions,
+> Consequences, Alternatives) is reserved for the author per the
+> cognitive-ownership boundary established for ADR 0020 skeleton
+> (issue [#394](https://github.com/hskim-solv/oss-bidmate-docagent/issues/394)).
+> Remove this note and flip to `accepted` once the rationale sections
+> are filled in.
+
+## Context
+
+Three retrieval-side surfaces interact with the reranking question and
+each is in a different state of measurement:
+
+1. **`rerank: true` blend** (the 60/25/15 dense + lexical + metadata
+   blend in [`rag_core.retrieve`](../../rag_core.py)) — present on the
+   `full` ablation preset.
+2. **`Reranker` Protocol + `CrossEncoderReranker` default**
+   ([`rag_reranker.py`](../../rag_reranker.py), introduced by issue
+   [#345](https://github.com/hskim-solv/oss-bidmate-docagent/issues/345)
+   / PR [#358](https://github.com/hskim-solv/oss-bidmate-docagent/pull/358))
+   — consumed by [`rag_core.apply_fusion_and_reranking`](../../rag_core.py)
+   only when `plan["rerank_cross_encoder"]` is set. Surfaced as the
+   `full_reranker` preset in [`eval/config.yaml`](../../eval/config.yaml)
+   `line 143-149` (`rerank: true` + `rerank_cross_encoder: true`).
+3. **Cross-encoder backends** (`bge`, `bge_ko`, `cohere`) selected via
+   `BIDMATE_RERANK_BACKEND`. CI default is `stub` —
+   [`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md)
+   describes the dispatch and explicitly states: *"`full_reranker` row
+   byte-equals `full` under stub"* (line 25). Stub is a pure-identity
+   pass-through; the test
+   `tests/test_cross_encoder_rerank.py::RerankStubBackendTest::test_stub_backend_is_identity`
+   locks this invariant.
+
+The current ablation table ([`docs/ablation-results.md`](../ablation-results.md))
+shows that on the public synthetic surface (n=42), the **first** surface
+already moves 0pp:
+
+| Run | Accuracy | Groundedness | Citation precision | Abstention |
+|---|---:|---:|---:|---:|
+| `full` (rerank on, blend only) | 0.906 | 0.929 | 0.905 | 1.000 |
+| `no_rerank` (rerank off entirely) | 0.906 | 0.929 | 0.905 | 1.000 |
+
+Three observations follow:
+
+- **The `rerank: true` blend has zero measured quality lift over
+  `no_rerank` on this surface.** Hypothesis (consistent with
+  [ADR 0002](./0002-metadata-first-retrieval.md) and the `0pp-on-full`
+  pattern documented in [ADR 0019](./0019-embedding-default-stays-minilm.md)):
+  metadata-first filtering routes around dense retrieval for most
+  queries, leaving very little for a post-retrieval reorder to
+  improve.
+- **`full_reranker` under stub is byte-identical to `full` by
+  construction**, not by empirical accident. The 0 delta there is an
+  architectural invariant, not a measurement finding.
+- **No real cross-encoder backend has been measured on this repo's eval
+  surface.** [`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md)
+  §Results closes with *"Measurement pending — append below after
+  running the reproduction commands."* The `bge` / `bge_ko` / `cohere`
+  commands ship but the runs require user-environment setup (model
+  download or API key) that has not been performed.
+
+So the question this ADR closes is: *given (a) the blend already shows
+0 lift, (b) cross-encoder under stub is identity by design, and (c)
+real backends are unmeasured, should the `Reranker` Protocol surface
+and `CrossEncoderReranker` default stay in the codebase?* The
+measurement-gated deferral pattern from [ADR 0019](./0019-embedding-default-stays-minilm.md)
+→ [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) and sibling
+[ADR 0025](./0025-cost-frontier-defer-until-real-baselines.md) applies
+naturally here: lock the decision now, document the re-open conditions
+that would flip the default to a real backend.
+
+[ADR 0023](./0023-hyde-query-expansion-ablation.md) (proposed)
+already cross-references [ADR 0020](./0020-protocol-based-pluggability.md)
+(proposed, skeleton-only) for the convention these Protocols follow;
+this ADR is downstream of both — it decides the **default behaviour**
+within the convention, not the convention itself.
+
+## Decision
+
+<!--
+TODO(author): one-sentence decision followed by specifics.
+
+Suggested shape (1.5 sentences): "Keep the `Reranker` Protocol surface
+and `CrossEncoderReranker` default in `rag_reranker.py`; keep
+`BIDMATE_RERANK_BACKEND=stub` (identity) as the CI default so
+`full_reranker ≡ full` by construction. Do not remove the rerank seam
+despite the synthetic 0 delta — real backends are unmeasured and the
+Protocol is the seam for HyDE-reranker / LLM-as-reranker follow-ups."
+
+Knobs to name explicitly:
+  - `eval/config.yaml` preset rows that depend on this decision:
+    `full` (rerank: true), `no_rerank` (rerank: false), `full_reranker`
+    (rerank_cross_encoder: true).
+  - `BIDMATE_RERANK_BACKEND` env-var (stub | bge | bge_ko | cohere).
+  - `default_reranker()` factory in `rag_reranker.py`.
+
+Boundary clarification: this ADR decides the **default behaviour**
+inside the Protocol convention from ADR 0020 (proposed). It does *not*
+re-decide whether the Protocol exists.
+-->
+
+## Re-open conditions
+
+<!--
+TODO(author): when does this ADR re-open and the default flip?
+Pattern from ADR 0019 / ADR 0025 (the four-condition gate).
+
+Suggested prompts:
+
+1. A maintainer runs at least one of the `bge` / `bge_ko` / `cohere`
+   backends to completion against the public synthetic eval surface
+   (n=42) and appends the result table to
+   `docs/cross-encoder-reranker.md` §Results.
+2. **At least one** of those backends shows a `full_reranker` lift of
+   ≥ +Xpp on accuracy OR citation_precision with non-overlapping
+   bootstrap 95% CIs vs. `full` on the public synthetic surface.
+   (Suggested X = 3, mirroring ADR 0019's "ge +5pp on full" gate but
+   relaxed for a precision-targeted reorder.) Pick X intentionally
+   here: an unreached 0pp pattern says metadata-first dominates this
+   corpus; a small lift may still be a portfolio signal.
+3. A follow-up ADR (numbered 002x or higher) is opened to flip the
+   `BIDMATE_RERANK_BACKEND` default from `stub` to the winning
+   backend, documenting the latency / cost trade-off
+   (`docs/cross-encoder-reranker.md` notes ~80-200ms / query CPU for
+   bge, ~$2/1k searches for cohere).
+
+If conditions 1 lands but 2 doesn't (0pp pattern holds across real
+backends too), this ADR stays accepted and
+`docs/cross-encoder-reranker.md` §Results gets the measurement
+appendix without an ADR replacement — same loop shape as ADR 0019 →
+ADR 0021.
+-->
+
+## Consequences
+
+<!--
+TODO(author): wins / costs / contracts locked in.
+
+Suggested positive:
+- Future LLM-as-reranker / HyDE-reranker plugs into the same Protocol
+  without re-litigating the seam (`rag_reranker.py` is the single
+  swap point).
+- `full` / `no_rerank` / `full_reranker` ablation rows in
+  `eval/config.yaml` stay aligned and the senior-positioning narrative
+  has a concrete "additive ablation" example (extends ADR 0001).
+- The stub-identity invariant means CI determinism survives — adding a
+  real backend is opt-in per environment, not a CI-default flip.
+- Reviewer-facing honesty: the "0 delta on synthetic" framing is now
+  ADR-backed (no fabricated lift) and the unmeasured real backends
+  are surfaced as a re-open trigger.
+
+Suggested costs:
+- Maintenance cost for an unused real-backend code path (BGE / Cohere
+  dispatch in `rag_rerank.py`). Mitigated by the never-raise fallback
+  contract — stub is the always-safe path.
+- A reviewer who asks "you have a cross-encoder reranker but it does
+  nothing?" gets a more nuanced answer ("identity under CI default,
+  real backends unmeasured") rather than a single sentence.
+- The decision can be misread as "rerankers don't matter" rather than
+  "rerankers don't matter *on this corpus under stub*". Mitigation:
+  the re-open conditions name the corpus and the backends explicitly.
+-->
+
+## Alternatives considered
+
+<!--
+TODO(author): brief notes.
+
+Candidates worth listing:
+
+1. **Remove the `Reranker` Protocol entirely (rollback PR #358).**
+   Why not: the Protocol is the seam future LLM-as-reranker / HyDE
+   work plugs into. Removing it would re-fragment retrieval-side
+   pluggability (ADR 0020's convention) for no measurement gain on
+   this surface.
+2. **Flip `BIDMATE_RERANK_BACKEND` default to `bge_ko` unconditionally.**
+   Why not: no measurement exists yet; defaulting to a real backend
+   would force every CI run to download ~1.1 GB and pay
+   ~80-200ms / query, all without empirical justification. ADR 0019's
+   "no default flip without ≥+Xpp evidence" rule applies.
+3. **Default to identity reranker (= remove `rerank_cross_encoder` from
+   `full_reranker`).** Why not: the `full_reranker` preset is *for*
+   exercising the cross-encoder path. Removing the flag collapses
+   `full_reranker` into `full` and erases the ablation surface.
+4. **Switch to a different cross-encoder model
+   (`BAAI/bge-reranker-large`, `mixedbread-ai/mxbai-rerank-large-v1`).**
+   Why not: scope. This ADR is about whether to keep the surface, not
+   which model belongs as default. Once a real-backend measurement
+   lands, a follow-up ADR can address model choice.
+5. **Run the real-backend measurement now (close issue #163 fully in
+   this PR).** Why not: the measurement requires ~1.1 GB of model
+   downloads (`bge`) or a Cohere API key (`cohere`), neither of which
+   is on a docs-PR's critical path. Documenting the deferral first +
+   measuring later is the same pattern as ADR 0019 → ADR 0021.
+-->
+
+## See also
+
+- [`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md) — design + reproduction commands; the doc this ADR locks the *decision* behind.
+- [`docs/ablation-results.md`](../ablation-results.md) — `full` vs `no_rerank` numbers cited above.
+- [`rag_reranker.py`](../../rag_reranker.py) — `Reranker` Protocol surface and `CrossEncoderReranker` default.
+- [`tests/test_cross_encoder_rerank.py`](../../tests/test_cross_encoder_rerank.py) — the stub-identity invariant tests.
+- [ADR 0019](./0019-embedding-default-stays-minilm.md) → [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) — the measurement-gated deferral pattern this ADR follows.
+- [ADR 0025](./0025-cost-frontier-defer-until-real-baselines.md) — sibling deferral ADR (same date, same pattern).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -87,6 +87,7 @@ project record.
 | [0023](./0023-hyde-query-expansion-ablation.md) | proposed | HyDE query expansion as additive ablation (extends 0001, preserves 0003, reuses 0011 / 0020 backend pattern) |
 | [0024](./0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) |
 | [0025](./0025-cost-frontier-defer-until-real-baselines.md) | accepted | Cost-accuracy frontier deferred until external baseline real runs land (defers #177; backs README §Limitations "비용 영점"; follows ADR 0019 → 0021 measurement-gated pattern) |
+| [0026](./0026-cross-encoder-reranker-deferral.md) | proposed | Cross-encoder reranker default stays stub-identity; real-backend (bge / bge_ko / cohere) measurement deferred — `full_reranker ≡ full` under CI stub by construction, `full` vs `no_rerank` already 0pp on public synthetic (mirrors ADR 0019 / 0025 pattern) |
 
 ## Decision evolution
 

--- a/docs/senior-positioning.md
+++ b/docs/senior-positioning.md
@@ -15,7 +15,7 @@
 
 | 시그널 | 어디서 확인하나 |
 |---|---|
-| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 24개 ADR (18 accepted / 6 proposed), status-tracked, supersession chains 명시 |
+| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 25개 ADR (18 accepted / 7 proposed), status-tracked, supersession chains 명시 |
 | **측정 가능한 성공 기준**을 미리 잡고 그 기준으로 평가한다 | [`portfolio-case-study.md` §2](./portfolio-case-study.md), [`eval/config.yaml`](../eval/config.yaml), README headline 표 |
 | 합성 평가의 한계를 알고 **공개/비공개 평가 분리**로 보완한다 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) |
 | **실패를 분류·우선순위화**한 뒤 백로그로 만든다 | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), 메타 이슈 #49 |
@@ -53,6 +53,7 @@
 | [0023](./adr/0023-hyde-query-expansion-ablation.md) | proposed | HyDE query expansion as additive ablation (extends 0001, preserves 0003) | Reranker Protocol과 별도 Protocol seam — 쿼리↔문서 어휘 갭(공식체 RFP vs 일상 질의)을 LLM 가상답변 임베딩으로 메우는 ablation. `IdentityExpander` 디폴트로 ADR 0001 골든 비트동일 유지 |
 | [0024](./adr/0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) | "Agentic RAG" 라벨에 *기본 API surface*를 맞추는 절충안. preset만 flip하고 synthesis backend default(`stub`)는 유지 — CI 결정성 + cost 0 보존. CLI / function-level / backend 3개 default 경계를 회귀 테스트로 잠금. |
 | [0025](./adr/0025-cost-frontier-defer-until-real-baselines.md) | accepted | cost-accuracy frontier을 외부 baseline 실측이 land할 때까지 deferral (defers #177; backs README §Limitations "비용 영점"; follows 0019 → 0021 pattern) | "왜 비용 축 frontier plot이 없냐?"에 modeled-cost 가짜 그림 대신 measurement-gated deferral로 응답. self-hosted 전부 cost=0이라 in-repo ablation들은 x=0에 모임 → 외부 baseline(`backend != "stub"`) 실측이 들어와야 비로소 의미 — 그 조건을 ADR로 잠금. #124의 latency-quality Pareto frontier가 그동안 portfolio asset. |
+| [0026](./adr/0026-cross-encoder-reranker-deferral.md) | proposed | cross-encoder reranker 기본값 = stub-identity 유지, 실 backend(bge / bge_ko / cohere) 측정 deferral (skeleton, mirrors 0019/0025 pattern) | `full` vs `no_rerank`가 공개 합성에서 이미 0pp (ADR 0002 metadata-first가 dense 위 reorder를 무의미하게 함). `full_reranker`는 CI stub 디폴트에서 `full`과 by-construction 비트동일. Protocol 표면은 향후 HyDE-reranker / LLM-as-reranker seam으로 보존 — 측정 효과 없으나 *측정이 안 됐다*는 점을 ADR로 잠금. |
 
 **인터뷰 talking point 1 (real-data 회귀)**: "ADR 0005가 없었다면 공개본의 abstention 회귀(#69의 `1.000 → 0.500` 사건)는 아무도 보지 못했을 것이다. 공개 합성만 보던 시기에는 1-of-2 incidental overlap 패턴이 잡히지 않았다." — 근거: [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) 2026-05-11 entry.
 
@@ -180,7 +181,7 @@ make reproduce  # smoke + SHA-256 over the environment-invariant metric subset
 
 ### 30초 자기소개
 
-> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **24개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
+> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **25개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
 
 읽는 시간 ≈ 30초. 면접 첫 답으로 그대로 사용 가능. 상대가 "좀 더 자세히"를 물으면 §1, 측정 의문에는 §2, 운영 의문에는 [`production-readiness.md`](./production-readiness.md)로 넘어간다.
 


### PR DESCRIPTION
## 1. What changed and why

Adds [`docs/adr/0026-cross-encoder-reranker-deferral.md`](docs/adr/0026-cross-encoder-reranker-deferral.md) — a **skeleton-only** ADR locking the decision to keep the [`Reranker` Protocol](rag_reranker.py) surface and `CrossEncoderReranker` default in `stub-identity` mode despite the synthetic-eval 0pp delta. Mirrors the [ADR 0019](docs/adr/0019-embedding-default-stays-minilm.md) → [ADR 0021](docs/adr/0021-bge-m3-completes-phase-1-3.md) and sibling [ADR 0025](docs/adr/0025-cost-frontier-defer-until-real-baselines.md) measurement-gated deferral pattern.

### Context section (filled)

Three facts motivate the decision:

1. **`full` vs `no_rerank` already 0pp on synthetic** ([`docs/ablation-results.md`](docs/ablation-results.md)). Hypothesis: [ADR 0002](docs/adr/0002-metadata-first-retrieval.md)'s metadata-first routing shadows the post-retrieval reorder for most queries.
2. **`full_reranker` under stub is byte-equal to `full` by construction** — not by measurement. [`docs/cross-encoder-reranker.md`](docs/cross-encoder-reranker.md) §Backends row \`stub\` explicitly states this, and \`RerankStubBackendTest::test_stub_backend_is_identity\` locks it.
3. **Real backends (`bge` / `bge_ko` / `cohere`) are unmeasured** on this repo — [`docs/cross-encoder-reranker.md`](docs/cross-encoder-reranker.md) §Results says *\"Measurement pending — append below after running the reproduction commands.\"*

### Skeleton sections (TODO markers for author)

\`Decision\` / \`Re-open conditions\` / \`Consequences\` / \`Alternatives considered\` are HTML-comment TODO markers per the cognitive-ownership boundary established by the ADR 0020 skeleton (commit \`9221498\`, [#394](https://github.com/hskim-solv/BidMate-DocAgent/issues/394)). The author fills the rationale; Claude provides Context + structure. Status starts at \`proposed\`; flip to \`accepted\` after the rationale lands.

### Slot selection (0026, not 0020/0025)

- **0020** — reserved by [#394](https://github.com/hskim-solv/BidMate-DocAgent/issues/394) (Protocol-based pluggability skeleton, commit \`9221498\`); [ADR 0023](docs/adr/0023-hyde-query-expansion-ablation.md) cross-references it in five places.
- **0025** — already filed today as [cost-frontier deferral](docs/adr/0025-cost-frontier-defer-until-real-baselines.md) ([#177](https://github.com/hskim-solv/BidMate-DocAgent/issues/177)).
- **0026** is the next sequential slot. Cross-linked in the ADR's \`Related\` field as the sibling deferral pattern to 0025.

The original [#412](https://github.com/hskim-solv/BidMate-DocAgent/issues/412) body suggested slot 0020; that was based on incomplete context (the #394 reservation wasn't merged to main at the time the issue was written). Slot 0026 preserves both the #394 reservation and ADR 0023's cross-references.

### Sync guard updates ([#317](https://github.com/hskim-solv/BidMate-DocAgent/issues/317))

- [`docs/adr/README.md`](docs/adr/README.md) Index — adds 0026 row.
- [`docs/senior-positioning.md`](docs/senior-positioning.md):
  - Line 18 (signal-overview): \`24개 ADR (18 accepted / 6 proposed)\` → \`25개 ADR (18 accepted / 7 proposed)\`.
  - Line 183 (30-second intro quote): \`24개 ADR\` → \`25개 ADR\`.
  - Add 0026 row to the ADR table.

Local sanity check confirmed all three #317 invariants:
- \`개 ADR\` count labels: \`['25', '25']\` matches \`len(adr files) == 25\`.
- Status breakdown: \`(18 accepted, 7 proposed)\` matches actual header counts.
- Table row numbers == file numbers: \`True\`.

Closes #412

## 2. Files affected

- \`docs/adr/0026-cross-encoder-reranker-deferral.md\` (new, 211 lines, load-bearing)
- \`docs/adr/README.md\` (+1 row)
- \`docs/senior-positioning.md\` (+1 row, 2 count-label updates)

## 3. Risks

Docs-only. No code change. Reviewer should focus on:
- **Context accuracy** — the three facts in §Context (0pp on \`full\` vs \`no_rerank\`, stub-identity invariant, real backends unmeasured) must be correct because the author's rationale will build on them.
- **Slot selection** — confirm 0026 is the intended slot, not 0020 (as #412 body suggested). Plan file: [`410-411-refactored-wozniak.md`](/Users/hskim/.claude/plans/410-411-refactored-wozniak.md).
- **Cognitive-ownership marker** — confirm the skeleton/TODO scope matches the author's intent (Decision / Re-open / Consequences / Alternatives are reserved).

## 4. Tests

\`bash scripts/test.sh\` — \"All checks passed!\" (governance / markdown link checks). Pytest unavailable in this worktree; the #317 sync invariants were checked with a standalone regex script that mirrors \`tests/test_governance.py::test_senior_positioning_*\` logic. CI pytest will be the authoritative gate.

## 5. Eval impact

All \`·\` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

No public-API change. No \`schema_version\` impact. The ADR is \`proposed\` — flipping to \`accepted\` later does not require a schema bump.

## 7. Out of scope

- Running the real cross-encoder backends (\`bge\` / \`bge_ko\` / \`cohere\`) to fill [`docs/cross-encoder-reranker.md`](docs/cross-encoder-reranker.md) §Results. The ADR's \`Re-open conditions\` TODO names this as the trigger; the run itself is a separate concern.
- Filling the Decision / Consequences / Alternatives sections — reserved for the author.
- ADR 0020 (Protocol-based pluggability) full rationale — [#394](https://github.com/hskim-solv/BidMate-DocAgent/issues/394)'s scope.
- Cleaning up the stale \`L1843\` / \`L2053\` line numbers in [ADR 0004](docs/adr/0004-verifier-retry-policy.md)'s Related field — noticed during research, deferred to a separate cleanup PR.

---

🤖 Plan: [`/Users/hskim/.claude/plans/410-411-refactored-wozniak.md`](https://github.com/hskim-solv/BidMate-DocAgent/issues/412) (ROI 3, completes the #410 → #411 → #412 sequence)