### PR TITLE
chore(bench): BM25 cold-start micro-bench + close #153 (gate FAIL)

### DIFF
--- a/scripts/bench_bm25_cold_start.py
+++ b/scripts/bench_bm25_cold_start.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Micro-bench: BM25 lazy-build cost on a prebuilt index (issue #153).
+
+ADR 0007 hybrid retrieval lazy-builds ``BM25Okapi`` over the full chunk
+corpus on the first hybrid query (see ``rag_core.get_or_build_bm25``).
+This script isolates that build cost so the issue-#153 decision gate
+can be applied with real numbers:
+
+  cond 1: bm25 build_ms.p50 ≥ 50 ms (vs dense cold-start)
+  cond 2: (dense retrieve_ms.p95 + bm25 build_ms.p50) / total_p95 ≥ 20%
+
+If both pass on a real-data 100-doc corpus, the issue proceeds to a
+disk-cached BM25 IDF state. Otherwise it closes.
+
+The script loads ``index.json`` once, then for each rep pops the
+BM25 caches (``_bm25_by_profile`` / ``_bm25`` / ``_bm25_chunk_ids``)
+and times one fresh ``get_or_build_bm25`` call. A subsequent
+``bm25_scores_for_index`` call is timed separately to capture any
+``BM25Okapi.get_scores`` one-time overhead beyond construction.
+
+Output JSON is written to the path provided by ``--output`` and a
+short human summary is printed to stdout. Output paths under
+``reports/real100/`` stay private per ADR 0005.
+
+Usage:
+  python scripts/bench_bm25_cold_start.py \
+      --index-dir data/index/real100 \
+      --reps 10 \
+      --output reports/real100/bm25_cold_start_bench.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from rag_core import (  # noqa: E402
+    bm25_scores_for_index,
+    get_or_build_bm25,
+    load_index,
+    tokenize,
+)
+
+
+DEFAULT_QUERY = "사업 공고 기관 코드"
+BM25_CACHE_KEYS = ("_bm25_by_profile", "_bm25", "_bm25_chunk_ids")
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return float(values[0])
+    ordered = sorted(values)
+    rank = q * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return float(ordered[lo] + (ordered[hi] - ordered[lo]) * frac)
+
+
+def _summary(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"min": 0.0, "p50": 0.0, "p95": 0.0, "mean": 0.0, "max": 0.0}
+    return {
+        "min": round(min(values), 3),
+        "p50": round(_percentile(values, 0.50), 3),
+        "p95": round(_percentile(values, 0.95), 3),
+        "mean": round(statistics.fmean(values), 3),
+        "max": round(max(values), 3),
+    }
+
+
+def _git_sha() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(REPO_ROOT),
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode("utf-8").strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _clear_bm25_cache(index: dict[str, Any]) -> None:
+    for key in BM25_CACHE_KEYS:
+        index.pop(key, None)
+
+
+def run_bench(
+    index: dict[str, Any],
+    query_tokens: list[str],
+    stopword_profile: str,
+    reps: int,
+) -> tuple[list[float], list[float]]:
+    build_ms: list[float] = []
+    score_ms: list[float] = []
+    for _ in range(reps):
+        _clear_bm25_cache(index)
+        t0 = time.perf_counter()
+        get_or_build_bm25(index, stopword_profile=stopword_profile)
+        build_ms.append((time.perf_counter() - t0) * 1000.0)
+        t1 = time.perf_counter()
+        bm25_scores_for_index(index, query_tokens, stopword_profile=stopword_profile)
+        score_ms.append((time.perf_counter() - t1) * 1000.0)
+    return build_ms, score_ms
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--index-dir",
+        required=True,
+        type=Path,
+        help="Directory containing index.json + sidecar.",
+    )
+    ap.add_argument(
+        "--reps",
+        type=int,
+        default=10,
+        help="Number of build/score reps (default: 10).",
+    )
+    ap.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path to write the JSON summary.",
+    )
+    ap.add_argument(
+        "--stopword-profile",
+        default="shared",
+        help="BM25 stopword profile (shared | bm25_extra). Default: shared.",
+    )
+    ap.add_argument(
+        "--query",
+        default=DEFAULT_QUERY,
+        help=f"Probe query string for first-score timing (default: {DEFAULT_QUERY!r}).",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.reps < 1:
+        print("ERROR: --reps must be >= 1", file=sys.stderr)
+        return 2
+    try:
+        index = load_index(args.index_dir)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    query_tokens = tokenize(args.query)
+    if not query_tokens:
+        print(
+            f"ERROR: query {args.query!r} tokenized to empty list",
+            file=sys.stderr,
+        )
+        return 2
+
+    build_ms, score_ms = run_bench(
+        index, query_tokens, args.stopword_profile, args.reps
+    )
+
+    payload = {
+        "index_dir": str(args.index_dir),
+        "num_chunks": len(index.get("chunks") or []),
+        "num_documents": int((index.get("build") or {}).get("num_documents") or 0),
+        "embedding_backend": (index.get("embedding") or {}).get("backend"),
+        "stopword_profile": args.stopword_profile,
+        "reps": args.reps,
+        "query": args.query,
+        "query_tokens": query_tokens,
+        "build_ms": _summary(build_ms),
+        "first_query_score_ms": _summary(score_ms),
+        "git_sha": _git_sha(),
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    print(
+        f"BM25 cold-start bench ({payload['num_chunks']} chunks, "
+        f"{payload['num_documents']} docs, reps={args.reps})"
+    )
+    print(
+        f"  build_ms:            min={payload['build_ms']['min']:.2f} "
+        f"p50={payload['build_ms']['p50']:.2f} "
+        f"p95={payload['build_ms']['p95']:.2f} "
+        f"mean={payload['build_ms']['mean']:.2f}"
+    )
+    print(
+        f"  first_query_score:   min={payload['first_query_score_ms']['min']:.2f} "
+        f"p50={payload['first_query_score_ms']['p50']:.2f} "
+        f"p95={payload['first_query_score_ms']['p95']:.2f} "
+        f"mean={payload['first_query_score_ms']['mean']:.2f}"
+    )
+    print(f"  wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 1. What changed and why

이슈 #153 은 "cold-start hybrid p95 가 dense 대비 +50ms 이상이고 retrieval 이 stage_latency 의 ≥20% 를 차지할 때만" BM25 IDF 디스크 캐시를 구현하는 investigation-gated 이슈였음. 그 게이트를 판정할 수 있는 작은 측정 도구를 추가하고, real100 (898 chunks / 100 docs) 에서 측정한 결과 게이트 FAIL → #153 close.

스크립트는 production 경로를 일절 건드리지 않고 `rag_core.get_or_build_bm25` 를 그대로 호출해 빌드 시간만 격리 측정한다. 코퍼스가 더 커질 때 동일 게이트를 재적용할 수 있도록 도구는 남겨둠.

Closes #153

## 2. Files affected

- `scripts/bench_bm25_cold_start.py` — 신규. **load-bearing 아님** (production code path 미접촉, `scripts/_governance.py::LOAD_BEARING_PATHS` 미해당).

## 3. Risks

- **거의 없음**: 스크립트 1개 추가, 기존 모듈은 read-only 로 import 만 함 (`load_index`, `tokenize`, `get_or_build_bm25`, `bm25_scores_for_index`).
- 확인: 740 pytest 통과, ruff clean. 1건 실패 (`test_hwp_native_loader_regression.py`) 는 본 변경 이전부터 존재하는 환경 이슈 (`hwp5` OLE2 파서) — 본 PR 과 무관.

## 4. Tests

- 신규 테스트 없음: 측정 스크립트는 behavior change 아님. 호출하는 함수 (`get_or_build_bm25`, `bm25_scores_for_index`) 는 [`tests/test_hybrid_retrieval_regression.py`](tests/test_hybrid_retrieval_regression.py) 에서 이미 커버됨.
- Smoke: 공개 9-chunk 인덱스에서 `build_ms.p50 ≈ 0.69 ms` — 배선 확인.

## 5. Eval impact

All `·` — 본 PR 은 production retrieval path 미수정. 합성 CI eval 델타 없음.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion path. 본 PR 의 real-data 시그널은 측정 결과 표 자체:

**real100 코퍼스 (898 chunks / 100 docs, reps=10):**

| Quantity | Value |
|---|---|
| `bm25 build_ms.min` | 18.62 ms |
| `bm25 build_ms.p50` | **20.53 ms** |
| `bm25 build_ms.p95` | 23.04 ms |
| `bm25 build_ms.mean` | 20.82 ms |
| `first_query_score_ms.p50` | 0.45 ms |
| 게이트 조건1 (`build_ms.p50 ≥ 50ms`) | **FAIL** (20.53 < 50) |
| 게이트 조건2 (retrieval ≥ 20% stage_latency) | N/A — 조건1 미달로 무의미 |
| **결정** | **close #153, no regression** |

원시 JSON 은 `reports/real100/bm25_cold_start_bench.json` 에 로컬 보관 (ADR 0005 — private).

## 6. Backward compatibility

해당 없음. `index.json` 스키마, 답변 계약 (ADR 0003), CLI flag 모두 미변경.

## 7. Out of scope

- BM25 디스크 캐시 구현: 게이트 FAIL 로 ROI 없음, 향후 코퍼스 성장 시 같은 스크립트로 재측정.
- `eval/run_eval.py` 의 cold-start stage-level disaggregation: 본 게이트 한 번에는 micro-bench 가 더 깔끔. 미래 cold-start 게이트가 더 늘어나면 별도 이슈로 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)