### PR TITLE
feat(scripts): --strict / BIDMATE_BASELINE_STRICT for baseline writer (#414)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,8 +244,13 @@ real-eval-delta:
 # entry. Aggregate-only (extractor enforces ADR 0005). Intended to run
 # *after* a decision is made (PR merged, threshold tightened, etc.),
 # not on every eval. Diff the result with `git diff` before committing.
+#
+# Pass STRICT=1 (or set BIDMATE_BASELINE_STRICT=1, issue #414) to escalate
+# the two existing provenance warnings (no eval-side provenance; eval/
+# baseline SHA skew per issue #160) to hard failures — for CI/pre-push
+# or any gate that requires a self-consistent baseline.
 real-eval-baseline-update:
-	$(PYTHON) scripts/write_real_eval_baseline.py
+	$(PYTHON) scripts/write_real_eval_baseline.py $(if $(STRICT),--strict,)
 
 # Render the chronological real-data history table into
 # docs/private-100-doc-experiments.md (between the

--- a/scripts/write_real_eval_baseline.py
+++ b/scripts/write_real_eval_baseline.py
@@ -16,10 +16,18 @@ makes them visible to git).
 
 Intended cadence: deliberate, after a decision lands (PR merged,
 threshold tightened). Not every run.
+
+Strict mode (issue #414): pass ``--strict`` or set
+``BIDMATE_BASELINE_STRICT=1`` to escalate the two existing provenance
+warnings (no eval-side provenance block; eval/baseline SHA skew per
+issue #160) from stderr-only to hard failures (exit 2, no baseline
+written). Default behavior is unchanged.
 """
 from __future__ import annotations
 
+import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -30,40 +38,63 @@ if str(ROOT) not in sys.path:
 from scripts._utils import build_provenance, make_run_id
 from scripts.run_real_eval_delta import extract_aggregate
 
+STRICT_ENV_VAR = "BIDMATE_BASELINE_STRICT"
+_TRUTHY = {"1", "true", "yes"}
+
 EVAL_SUMMARY = ROOT / "reports" / "real100" / "eval_summary.json"
 BASELINE_PATH = ROOT / "reports" / "real100" / "baseline.aggregate.json"
 HISTORY_DIR = ROOT / "reports" / "real100" / "history"
 JUDGE_LOCAL = ROOT / "reports" / "real100" / "judge.local.json"
 
 
+def _resolve_strict(flag: bool) -> bool:
+    """Effective strict mode = CLI flag OR ``BIDMATE_BASELINE_STRICT`` truthy.
+
+    Truthy values (case-insensitive): ``1``, ``true``, ``yes``. Any other
+    value of the env var is treated as falsy, including ``0``, ``false``,
+    ``no``, the empty string, or anything unrecognized.
+    """
+    if flag:
+        return True
+    raw = os.environ.get(STRICT_ENV_VAR, "").strip().lower()
+    return raw in _TRUTHY
+
+
 def _warn_if_stale(
-    eval_prov: dict[str, object] | None, baseline_prov: dict[str, object]
+    eval_prov: dict[str, object] | None,
+    baseline_prov: dict[str, object],
+    strict: bool = False,
 ) -> None:
-    """Warn loudly if the eval was generated at a different code state
-    than the baseline is being written at.
+    """Warn — or, in strict mode, hard-fail — when the eval was generated
+    at a different code state than the baseline is being written at.
 
     This is the failure mode that produced issue #160: ``make real-eval``
     runs at commit X, then ``make real-eval-baseline-update`` runs at
     commit Y, and the baseline silently captures Y's provenance with X's
-    metrics. We warn rather than fail because legitimate workflows
-    (e.g., docs-only changes between runs) shouldn't be blocked, but we
-    want the failure mode to be loud and self-diagnosing.
+    metrics. Default is warn (legitimate workflows like docs-only changes
+    between runs shouldn't be blocked). Strict mode (``--strict`` or
+    ``BIDMATE_BASELINE_STRICT=1``, issue #414) escalates both branches
+    to ``SystemExit(2)`` — for CI/pre-push and other gates that require
+    a self-consistent baseline.
     """
+    level = "ERROR" if strict else "WARN"
     if not isinstance(eval_prov, dict):
         print(
-            "[WARN] eval_summary.json has no `provenance` block — cannot verify "
+            f"[{level}] eval_summary.json has no `provenance` block — cannot verify "
             "the eval was run at the current HEAD. The baseline's provenance "
             "will reflect the current HEAD, not the eval-run code state. "
             "Re-run `make real-eval` at HEAD to get a self-consistent baseline.",
             file=sys.stderr,
         )
+        if strict:
+            raise SystemExit(2)
         return
     eval_sha = str(eval_prov.get("git_commit") or "").strip()
     baseline_sha = str(baseline_prov.get("git_commit") or "").strip()
     if not eval_sha or not baseline_sha or eval_sha == baseline_sha:
         return
     print(
-        f"[WARN] Provenance skew detected:\n"
+        f"[{level}] Provenance skew detected:\n"
         f"        eval_summary.json was generated at git_commit={eval_sha}\n"
         f"        baseline is being written at  git_commit={baseline_sha}\n"
         f"        The baseline's provenance will not match the eval's code state.\n"
@@ -71,9 +102,28 @@ def _warn_if_stale(
         f"        before continuing, or accept the skew if you understand the cause.",
         file=sys.stderr,
     )
+    if strict:
+        raise SystemExit(2)
 
 
-def main() -> int:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Escalate provenance warnings (missing eval provenance; eval/"
+            "baseline SHA skew per issue #160) to hard failures: exit 2, "
+            f"baseline NOT written. Equivalent to {STRICT_ENV_VAR}=1."
+        ),
+    )
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    strict = _resolve_strict(args.strict)
+
     if not EVAL_SUMMARY.exists():
         print(
             f"[ERROR] {EVAL_SUMMARY} not found. Run `make real-eval` first.",
@@ -85,7 +135,7 @@ def main() -> int:
     agg = extract_aggregate(raw)
     eval_prov = raw.get("provenance") if isinstance(raw, dict) else None
     baseline_prov = build_provenance()
-    _warn_if_stale(eval_prov, baseline_prov)
+    _warn_if_stale(eval_prov, baseline_prov, strict=strict)
     agg["provenance"] = baseline_prov
 
     # If a judge run is present (ADR 0006), fold its aggregate into the

--- a/tests/test_write_real_eval_baseline.py
+++ b/tests/test_write_real_eval_baseline.py
@@ -1,0 +1,222 @@
+"""Contract test for strict mode in scripts/write_real_eval_baseline.py (#414).
+
+Locks (a) the default warn-only behavior preserved for back-compat and
+(b) the strict-mode escalation: ``--strict`` and
+``BIDMATE_BASELINE_STRICT=1`` must both flip the two existing
+provenance warnings to hard failures (exit 2, no baseline written).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import write_real_eval_baseline as writer  # noqa: E402
+
+
+# ---- _resolve_strict unit -------------------------------------------------
+
+
+class ResolveStrictUnit(unittest.TestCase):
+    def test_flag_true_returns_true(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(writer.STRICT_ENV_VAR, None)
+            self.assertTrue(writer._resolve_strict(True))
+
+    def test_flag_false_env_unset_returns_false(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(writer.STRICT_ENV_VAR, None)
+            self.assertFalse(writer._resolve_strict(False))
+
+    def test_env_truthy_values(self) -> None:
+        for value in ("1", "true", "TRUE", "yes", "Yes"):
+            with mock.patch.dict(os.environ, {writer.STRICT_ENV_VAR: value}):
+                self.assertTrue(
+                    writer._resolve_strict(False),
+                    f"expected {value!r} to be truthy",
+                )
+
+    def test_env_falsy_values(self) -> None:
+        for value in ("0", "false", "no", "", "off", "garbage"):
+            with mock.patch.dict(os.environ, {writer.STRICT_ENV_VAR: value}):
+                self.assertFalse(
+                    writer._resolve_strict(False),
+                    f"expected {value!r} to be falsy",
+                )
+
+    def test_flag_overrides_falsy_env(self) -> None:
+        with mock.patch.dict(os.environ, {writer.STRICT_ENV_VAR: "0"}):
+            self.assertTrue(writer._resolve_strict(True))
+
+
+# ---- _warn_if_stale unit --------------------------------------------------
+
+
+class WarnIfStaleUnit(unittest.TestCase):
+    def test_default_warns_on_skew_and_returns(self) -> None:
+        eval_prov = {"git_commit": "abc123"}
+        baseline_prov = {"git_commit": "def456"}
+        try:
+            writer._warn_if_stale(eval_prov, baseline_prov)
+        except SystemExit:
+            self.fail("default mode must not raise on skew")
+
+    def test_strict_raises_on_skew(self) -> None:
+        eval_prov = {"git_commit": "abc123"}
+        baseline_prov = {"git_commit": "def456"}
+        with self.assertRaises(SystemExit) as cm:
+            writer._warn_if_stale(eval_prov, baseline_prov, strict=True)
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_default_warns_on_missing_eval_provenance_and_returns(self) -> None:
+        baseline_prov = {"git_commit": "def456"}
+        try:
+            writer._warn_if_stale(None, baseline_prov)
+        except SystemExit:
+            self.fail("default mode must not raise on missing eval provenance")
+
+    def test_strict_raises_on_missing_eval_provenance(self) -> None:
+        baseline_prov = {"git_commit": "def456"}
+        with self.assertRaises(SystemExit) as cm:
+            writer._warn_if_stale(None, baseline_prov, strict=True)
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_no_skew_returns_silently_in_both_modes(self) -> None:
+        eval_prov = {"git_commit": "abc123"}
+        baseline_prov = {"git_commit": "abc123"}
+        try:
+            writer._warn_if_stale(eval_prov, baseline_prov)
+            writer._warn_if_stale(eval_prov, baseline_prov, strict=True)
+        except SystemExit:
+            self.fail("matching SHAs must not raise in either mode")
+
+
+# ---- CLI integration ------------------------------------------------------
+
+
+class WriterCli(unittest.TestCase):
+    """End-to-end: run the writer in a tempdir layout with a synthesized
+    eval_summary.json. We avoid invoking it in REPO_ROOT to keep the test
+    isolated from the real reports/real100/ state."""
+
+    def setUp(self) -> None:
+        self._td = Path(tempfile.mkdtemp())
+        self._reports = self._td / "reports" / "real100"
+        self._reports.mkdir(parents=True)
+        self._eval_summary = self._reports / "eval_summary.json"
+        self._baseline = self._reports / "baseline.aggregate.json"
+        self._history = self._reports / "history"
+
+    def _write_eval_summary(self, eval_sha: str | None) -> None:
+        body: dict[str, object] = {
+            "num_predictions": 21,
+            "accuracy": 0.47,
+            "pipeline": "agentic_full",
+            "latency": {"mean": 100, "p50": 90, "p95": 200},
+        }
+        if eval_sha is not None:
+            body["provenance"] = {
+                "generated_at": "2026-05-12T00:00:00.000000Z",
+                "git_commit": eval_sha,
+                "git_dirty": False,
+            }
+        self._eval_summary.write_text(
+            json.dumps(body, ensure_ascii=False), encoding="utf-8"
+        )
+
+    def _invoke(
+        self,
+        *extra_args: str,
+        env_strict: str | None = None,
+    ) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env.pop(writer.STRICT_ENV_VAR, None)
+        if env_strict is not None:
+            env[writer.STRICT_ENV_VAR] = env_strict
+        # Run a small driver that points the writer at the tempdir.
+        # ROOT is also rebound so the success-path `relative_to(ROOT)`
+        # call (used only for the [OK] print) resolves cleanly.
+        driver = (
+            "import sys, os\n"
+            f"sys.path.insert(0, {str(REPO_ROOT)!r})\n"
+            "from scripts import write_real_eval_baseline as w\n"
+            "from pathlib import Path\n"
+            f"w.ROOT = Path({str(self._td)!r})\n"
+            f"w.EVAL_SUMMARY = Path({str(self._eval_summary)!r})\n"
+            f"w.BASELINE_PATH = Path({str(self._baseline)!r})\n"
+            f"w.HISTORY_DIR = Path({str(self._history)!r})\n"
+            f"w.JUDGE_LOCAL = Path({str(self._td / 'no-such-judge.json')!r})\n"
+            "raise SystemExit(w.main())\n"
+        )
+        return subprocess.run(
+            [sys.executable, "-c", driver, *extra_args],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_warn_mode_no_skew_writes_baseline(self) -> None:
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()[:12]
+        self._write_eval_summary(eval_sha=head_sha)
+        result = self._invoke()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(self._baseline.exists(), "baseline must be written")
+
+    def test_warn_mode_with_skew_still_writes_baseline(self) -> None:
+        # Default behavior: warn but proceed. Regression guard for back-compat.
+        self._write_eval_summary(eval_sha="deadbeefcafe")
+        result = self._invoke()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[WARN] Provenance skew detected", result.stderr)
+        self.assertTrue(self._baseline.exists(), "baseline must be written in warn mode")
+
+    def test_strict_flag_with_skew_blocks_write(self) -> None:
+        self._write_eval_summary(eval_sha="deadbeefcafe")
+        result = self._invoke("--strict")
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("[ERROR] Provenance skew detected", result.stderr)
+        self.assertFalse(
+            self._baseline.exists(), "baseline must NOT be written in strict-skew"
+        )
+
+    def test_strict_env_with_skew_blocks_write(self) -> None:
+        self._write_eval_summary(eval_sha="deadbeefcafe")
+        result = self._invoke(env_strict="1")
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("[ERROR] Provenance skew detected", result.stderr)
+        self.assertFalse(self._baseline.exists())
+
+    def test_strict_env_falsy_keeps_warn_mode(self) -> None:
+        self._write_eval_summary(eval_sha="deadbeefcafe")
+        result = self._invoke(env_strict="0")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[WARN]", result.stderr)
+        self.assertTrue(self._baseline.exists())
+
+    def test_strict_blocks_when_eval_provenance_missing(self) -> None:
+        self._write_eval_summary(eval_sha=None)
+        result = self._invoke("--strict")
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn(
+            "[ERROR] eval_summary.json has no `provenance` block", result.stderr
+        )
+        self.assertFalse(self._baseline.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Recreated after #423 was auto-closed when its base branch was deleted on #420 merge. Same content, rebased onto current main.

## 1. What changed and why

PR #189 §7 deferred a hard-fail mode for \`scripts/write_real_eval_baseline.py\` but no follow-up issue was filed at the time. Today, two validation paths (no \`provenance\` block in \`eval_summary.json\`; eval/baseline SHA skew per issue #160) print \`[WARN]\` to stderr and proceed — ergonomic for local dev but unsafe for CI/pre-push gates that need a self-consistent baseline. This PR adds an opt-in strict toggle.

- \`--strict\` CLI flag.
- \`BIDMATE_BASELINE_STRICT=1\` env var (truthy: \`1\`, \`true\`, \`yes\`, case-insensitive).
- Effective strict = flag OR env. Either escalates both warnings to \`[ERROR]\` + \`SystemExit(2)\` **before** the write, so no baseline file is created on failure.

Default behavior is unchanged for back-compat.

Closes #414

## 2. Files affected

- \`scripts/write_real_eval_baseline.py\` — argparse, env-var resolution, \`strict\` parameter threaded into \`_warn_if_stale\`.
- \`tests/test_write_real_eval_baseline.py\` — 16 cases: \`_resolve_strict\` truthy/falsy matrix, \`_warn_if_stale\` raise semantics, end-to-end CLI verifying warn-mode writes / strict-mode blocks-and-doesn't-write, env-var equivalence, env-var explicit-falsy keeps warn mode.
- \`Makefile\` — \`real-eval-baseline-update\` gains \`STRICT=1\` passthrough via \`\$(if \$(STRICT),--strict,)\`.

None of these are load-bearing paths (canonical list: \`scripts/_governance.py:LOAD_BEARING_PATHS\`).

## 3. Risks

Most likely break: local dev workflow that today silently tolerates SHA skew (e.g. \`make real-eval\` at commit X followed by \`make real-eval-baseline-update\` at commit Y for a docs-only delta) now hard-fails if the user starts setting \`BIDMATE_BASELINE_STRICT=1\` in their shell. Mitigation: the env var is opt-in and the default behavior is identical to today; regression-locked by \`test_warn_mode_with_skew_still_writes_baseline\`.

Second risk: strict mode raises \`SystemExit(2)\` mid-function inside \`_warn_if_stale\`, so callers must be prepared. \`main()\` is the only caller and propagates the exception via \`raise SystemExit(main())\`. Unit-tested.

## 4. Tests

\`tests/test_write_real_eval_baseline.py\` — 16 cases in three classes:
- \`ResolveStrictUnit\` (5) — flag/env precedence + truthy/falsy strings.
- \`WarnIfStaleUnit\` (5) — warn returns vs strict raises on each branch (skew, missing eval provenance, matching SHAs).
- \`WriterCli\` (6) — end-to-end with synthesized \`eval_summary.json\` in a tempdir: warn writes / strict blocks / env equivalence / env-falsy keeps warn mode / strict on missing eval provenance.

Regression guard: \`test_warn_mode_with_skew_still_writes_baseline\` locks today's default behavior; if it ever turns red, we've broken back-compat.

## 5. Eval impact

All \`·\`. The writer doesn't run any eval; it only transcribes existing aggregate metrics into the committable baseline shape.

### 5b. Real-data delta

N/A — no load-bearing path changed (canonical list in \`scripts/_governance.py:LOAD_BEARING_PATHS\` is \`rag_core.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py\`; this PR touches none of them). The writer script and its tests are governance tooling, not the pipeline.

## 6. Backward compatibility

No contract change. The writer's default behavior is identical to today (warn + proceed). Strict mode is opt-in via flag or env; absent both, every existing invocation behaves exactly as before. \`make real-eval-baseline-update\` without \`STRICT=1\` produces the same command line it always did.

## 7. Out of scope

- Escalating \`provenance.git_dirty: true\` to a strict-mode failure. Plan-agent review flagged it as a real gap but expanded the issue's stated scope ("warn → error 격상" of *existing* warnings). Worth a follow-up issue.
- Wiring \`BIDMATE_BASELINE_STRICT=1\` into any CI workflow. The writer is a deliberate local action (per its docstring); no CI currently invokes it. If we later add a CI step that bumps the baseline, that PR can flip the env var on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)