### PR TITLE
fix(ingestion): catch InvalidHwp5FileError in HwpNativeLoader fallback

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -135,7 +135,7 @@ class HwpNativeLoader(CsvTextDocumentLoader):
         self.last_fallback_reason = None
         try:
             native_text = _extract_hwp_native(source_path)
-        except (ImportError, OSError, RuntimeError) as exc:
+        except _hwp_native_fallback_exceptions() as exc:
             native_text = None
             reason = f"{type(exc).__name__}: {str(exc)[:120]}"
             self.last_fallback_reason = reason
@@ -153,12 +153,38 @@ class HwpNativeLoader(CsvTextDocumentLoader):
         return text
 
 
+def _hwp_native_fallback_exceptions() -> tuple[type[BaseException], ...]:
+    """Exception tuple ``HwpNativeLoader`` catches to fall back to CSV text.
+
+    Includes pyhwp's own parse-time errors (``InvalidHwp5FileError``,
+    ``InvalidOleStorageError``) when ``hwp5`` is installed. Built lazily so
+    the handler is still well-formed when ``hwp5`` is absent (CI case),
+    where ``_extract_hwp_native`` raises ``ImportError`` and falls back.
+    """
+    base: tuple[type[BaseException], ...] = (
+        ImportError,
+        OSError,
+        RuntimeError,
+        ValueError,
+    )
+    try:
+        from hwp5.errors import (  # type: ignore[import-not-found]
+            InvalidHwp5FileError,
+            InvalidOleStorageError,
+        )
+    except ImportError:
+        return base
+    return base + (InvalidHwp5FileError, InvalidOleStorageError)
+
+
 def _extract_hwp_native(source_path: Path) -> str | None:
     """Extract body text from an HWP file using pyhwp's Hwp5File API.
 
     Returns ``None`` if parsing succeeds but yields no normalized text.
-    Raises ``ImportError`` if pyhwp is unavailable; other exceptions
-    (``OSError``, ``RuntimeError``) propagate to the caller for fallback.
+    Raises ``ImportError`` if pyhwp is unavailable; pyhwp's parse-time
+    errors (``InvalidHwp5FileError``, ``InvalidOleStorageError``) along
+    with ``OSError``, ``RuntimeError``, ``ValueError`` propagate to the
+    caller for fallback (see ``_hwp_native_fallback_exceptions``).
     """
     from hwp5.xmlmodel import Hwp5File  # type: ignore[import-not-found]
 


### PR DESCRIPTION
## 1. What changed and why

`HwpNativeLoader.load_text` caught `(ImportError, OSError, RuntimeError)` but missed `hwp5.errors.InvalidHwp5FileError`, which inherits directly from `Exception` (mro: `[InvalidHwp5FileError, Exception, BaseException, object]`). On CI (where `hwp5` isn't installed), the `from hwp5.xmlmodel import Hwp5File` raises `ImportError` and is caught — but local envs with `hwp5==0.1b15` exercise the real parse path on mock bytes and the exception leaked past the silent-fallback handler.

Result: `tests/test_hwp_native_loader_regression.py::HwpNativeLoaderRegressionTest::test_metadata_text_source_when_opt_in_with_invalid_hwp_falls_back` (line 243) failed locally, blocking `bash scripts/test.sh` and therefore the auto-ship Stage 1 test gate from any env that has pyhwp installed.

Fix is the explicit-list option (#432 recommendation #1): a new `_hwp_native_fallback_exceptions()` helper lazily imports `hwp5.errors.{InvalidHwp5FileError, InvalidOleStorageError}` so the catch tuple is well-formed whether or not pyhwp is installed. The base tuple gains `ValueError` (issue recommendation). `_extract_hwp_native`'s docstring is updated to reflect the new propagation contract.

Closes #432

## 2. Files affected

- [ingestion.py](ingestion.py) — **load-bearing** (per `scripts/_governance.py` `LOAD_BEARING_PATHS`). Adds `_hwp_native_fallback_exceptions()` helper at module scope; swaps the literal tuple in `HwpNativeLoader.load_text` for the helper call; updates `_extract_hwp_native` docstring.

No test file changes — `tests/test_hwp_native_loader_regression.py:243` was already correct (the test was designed to assert the fallback regardless of whether pyhwp is installed; the production code just hadn't honored it).

## 3. Risks

Most likely break: the broader catch tuple swallows a legitimate programming error (e.g. a `ValueError` from a future refactor of `_extract_hwp_native`) into a silent CSV fallback.

Ruled out by:
- The catch only fires on the opt-in path (`BIDMATE_HWP_LOADER=native`, off by default — see `_resolve_loader` at [ingestion.py:181-192](ingestion.py:181)).
- Every fallback emits a `RuntimeWarning` + records `last_fallback_reason` (issue #366 observability) — silent path stays visible in real-data eval logs.
- Existing `tests/test_hwp_native_loader_regression.py` (12 cases) covers fallback semantics: dispatch (default vs opt-in), `last_fallback_reason` reset, OSError fallback, ImportError-when-pyhwp-missing fallback, success path, invalid-HWP fallback. All pass.
- Helper is built lazily and the `hwp5` import is wrapped — verified to work without pyhwp (CI case) and with pyhwp `0.1b15` (the local repro env).

Considered and rejected: option 2 (catch bare `Exception`) — broader but masks programming errors per the issue's own trade-off note.

## 4. Tests

- `tests/test_hwp_native_loader_regression.py::test_metadata_text_source_when_opt_in_with_invalid_hwp_falls_back` ([line 243](tests/test_hwp_native_loader_regression.py:243)) — failed before, passes after. Exercises the real `hwp5.xmlmodel.Hwp5File` parse path on mock bytes and asserts CSV fallback.
- All 12 cases in the regression file pass locally with `hwp5==0.1b15` installed; the `RuntimeWarning` fires as expected on the new fallback case, confirming the catch tuple matched `InvalidHwp5FileError`.
- Full suite: `bash scripts/test.sh` → **780 passed, 1 skipped, 121 subtests passed** in 111.94s (was 740 pass / 1 fail before).

No new test added: the failing test was already a regression test that anticipated this exact scenario (test comment at line 252-254 says "pyhwp may be installed locally and raise on the mock bytes ... either way the loader records the CSV fallback as the source"). The production-side fix is what was missing.

## 5. Eval impact

All `·` expected on the synthetic CI eval delta: this is a pure exception-handling fix on an opt-in code path. No retrieval / verifier / answer-contract behavior change.

`make smoke` confirms ADR 0001 baseline metrics are bit-identical to pre-change (accuracy / groundedness / citation / claim-alignment all unchanged in `reports/eval_summary.json` and the README ablation table). Only latency numbers fluctuated — expected timing churn from artifact regeneration.

### 5b. Real-data delta

**No behavior change in ingestion default config.** The fix only touches the opt-in `HwpNativeLoader.load_text` catch tuple, which is constructed by `_resolve_loader` exclusively when `BIDMATE_HWP_LOADER=native` is set ([ingestion.py:187-191](ingestion.py:187)). The env var is unset in `eval/config.yaml` (all presets) and in `make real-eval` / `make real-eval-delta` runners — the private 100-doc real-data path goes through `HwpCsvTextLoader` (the CSV `텍스트` column), not `HwpNativeLoader`.

Behavior on the opt-in path itself also strictly improves: where `InvalidHwp5FileError` previously propagated and crashed ingestion, it now silently falls back to the same CSV text path the default code uses — i.e. it converges *towards* the default behavior, not away from it. Diagnostic surface (`last_fallback_reason`, `RuntimeWarning`) keeps the silent path visible per issue #366.

Therefore no `make real-eval-delta` run is required for this PR — the real-data path is dead in the default config, and the opt-in path converges to it on failure.

## 6. Backward compatibility

No contract / schema / CLI change. `HwpNativeLoader.last_text_source`, `last_fallback_reason`, and the `RuntimeWarning` emission are unchanged. The fallback `last_fallback_reason` string now includes new prefixes (`InvalidHwp5FileError: ...`, `InvalidOleStorageError: ...`) when applicable, but the format (`"ExceptionName: truncated message"`) is preserved.

## 7. Out of scope

- Upgrading `hwp5` (last release 2021; tracked elsewhere if at all).
- Reworking HWP ingestion architecture or removing the opt-in spike (#167).
- Adding a parent-tree traversal to `scripts/claude-hooks/_ship_lock_check.py` so `fix/issue-432-...` resolves to `ingestion.py`'s owner #239 via the GitHub issue parent link. The lock script currently exact-matches branch issue → file owner; #432 → #239 needs `CROSS_OWNER=ack` at ship time. Worth a follow-up issue, but not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)