### PR TITLE
feat(retrieval): LoRA-fine-tuned embedding adapter as additive ablation + ADR 0027 (#434)

### DIFF
--- a/docs/adr/0027-lora-finetuned-embedding-additive.md
+++ b/docs/adr/0027-lora-finetuned-embedding-additive.md
@@ -1,0 +1,149 @@
+# 0025: LoRA-fine-tuned embedding adapter as additive ablation
+
+- **Status**: proposed
+- **Date**: 2026-05-12
+- **Deciders**: hskim
+- **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (naive baseline invariant), [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (additive-opt-in pattern), [ADR 0019](./0019-embedding-default-stays-minilm.md) (re-open criteria for swapping the default), [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) (Phase 1.3 closure), issue #179
+
+## Context
+
+Phase 1.2 ([ADR 0019](./0019-embedding-default-stays-minilm.md)) and
+Phase 1.3 ([ADR 0021](./0021-bge-m3-completes-phase-1-3.md)) measured
+four off-the-shelf embedding candidates (MiniLM-L12-v2, e5-large-instruct,
+KoSimCSE-roberta-multitask, BGE-M3) on the public n=42 synthetic
+surface. All four produced bit-identical metrics on the `full`
+pipeline because metadata-first retrieval (ADR 0002) routes around
+the dense vector for most queries. On `naive_baseline` (dense-only,
+ADR 0001 invariant) BGE-M3 and e5-large-instruct lift accuracy
++18.8 pp (0.656 → 0.844), confirming the dense vector still matters
+when the pipeline cannot route around it.
+
+Issue #179 adds a *trained* embedding artifact — a LoRA-fine-tuned
+adapter over `nlpai-lab/KURE-v1` — covering the "pretrain →
+fine-tune → evaluate" cycle that Phases 1.2 and 1.3 deliberately
+left out (off-the-shelf only). The portfolio motivation is the
+"have you fine-tuned a model?" interview signal for senior AI
+engineer roles in the Korean market; the technical motivation is
+testing whether domain-specialized embeddings recover the dense-only
+lift the metadata-first pipeline currently masks.
+
+The trained adapter is a third-party artifact: a PEFT delta hosted
+on the public Hugging Face Hub, loaded at index-build time by
+`rag_core.embed_texts` via `peft.PeftModel.from_pretrained(...)
+.merge_and_unload()`. This introduces a new artifact class to the
+repo — pinned, optional, and reviewable — and the ADR codifies how
+it integrates with the additive-ablation pattern that ADRs 0011,
+0017, and 0023 established.
+
+## Decision
+
+The LoRA adapter is added as an **additive ablation**, gated by an
+environment variable, with the default (env unset) bit-identical to
+pre-#434 behavior.
+
+**Three load-bearing rules:**
+
+1. **`rag_core.embed_texts` extension is env-var gated.** The PEFT
+   branch executes only when `BIDMATE_EMBEDDING_LORA_ADAPTER` is set
+   to a path or HF Hub repo id. When unset (CI default), the function
+   is byte-identical to its pre-#434 implementation. PEFT is imported
+   lazily *inside* the conditional, so the hashing-only public CI
+   never needs the package installed.
+2. **Two new ablation rows are added to `eval/config.yaml`** —
+   `agentic_full_finetuned` (clones `full`) + `naive_baseline_finetuned`
+   (clones `naive_baseline`). The `embedding_model` and
+   `embedding_lora_adapter` keys on these rows are documentation read
+   by `scripts/run_embedding_ablation.py` at index-build time; they
+   are silently dropped by `eval/run_eval.normalize_run_config` so on
+   the default deterministic surface the **correctness metrics**
+   (`accuracy`, `groundedness`, `citation_precision`, `abstention`,
+   `answer_format_compliance` — the canonical `REPRODUCIBLE_METRICS`
+   set) are byte-equal to the parent rows'. Latency / `stage_latency`
+   drifts μs-scale run-to-run — universal across every ablation, not a
+   contract break (mirrors the same exclusion in
+   `tests/test_eval_reproducibility_regression.py`). A regression
+   test (`tests/test_finetuned_ablation_baseline_invariant.py`) pins
+   both the structural (normalize_run_config) and the end-to-end
+   (eval_summary correctness-metric) layers of the invariant.
+3. **The HF Hub-hosted adapter is pinned by commit SHA** in
+   `eval/config.yaml` (`<repo>@<sha>` form), not by tag or branch.
+   This closes the silent-republish supply-chain hole: a re-push to
+   the same tag would change eval results without changing the repo
+   SHA. Pinning by SHA means every adapter swap is a git diff.
+
+The CLI default stays `naive_baseline` (ADR 0001). The function-level
+default `model_name` in `embed_texts` stays
+`paraphrase-multilingual-MiniLM-L12-v2` ([ADR 0019](./0019-embedding-default-stays-minilm.md)).
+This ADR does *not* trigger the ADR 0019 re-open criteria — those
+require ≥ +5 pp lift on the `full` pipeline with non-overlapping 95%
+CIs; per Phase 1.2 the metadata-first design makes that nearly
+impossible to clear with embeddings alone.
+
+## Why "adapter only at index-build time, not query time"
+
+<!-- TODO(user): fill in the rationale for keeping the adapter merge
+     at index-build time (offline) rather than per-query inference.
+     Cover: (1) merge_and_unload() inference cost vs the load cost
+     amortized once per index, (2) why we don't need to support
+     query-time hot-swap, (3) how this composes with the existing
+     `data/embedding-ablation/<slug>/` per-model directory pattern
+     introduced in #174. Reference your own thinking here — this is
+     the kind of design rationale future-you needs to recall, and
+     ghost-written justification rots fast. -->
+
+## Consequences
+
+<!-- TODO(user): fill in the operator-facing consequences. Suggested
+     bullets to expand or replace with your own framing:
+
+     Easier:
+     - The "have you fine-tuned a model?" interview signal is now
+       grounded in a reproducible artifact (notebook + HF Hub repo
+       + invariance test).
+     - The additive-ablation pattern (ADR 0011/0017/0023) gains a
+       fourth example, reinforcing that "new capability = new env-
+       var + new ablation row, never a default swap."
+
+     Costs / honesty:
+     - New optional dep (PEFT) — install path is
+       `requirements-lora.txt`, not `requirements.txt`.
+     - New artifact class: HF Hub-hosted binary. Supply-chain rule
+       (SHA pinning) is the mitigation; reviewers must check the
+       SHA on every change.
+     - The `full` pipeline delta is expected to be ~0 pp on the
+       n=42 public synthetic surface (Phase 1.2 invariance). The
+       writeup (`docs/embedding-finetune.md`) must lead with the
+       `naive_baseline_finetuned` delta and publish the `full`
+       null as a deliberate result — not hide it. -->
+
+## Alternatives considered
+
+<!-- TODO(user): fill in each alternative with your reasoning for
+     rejecting it. Skeleton bullets:
+
+     - **Full fine-tune of the base encoder.** Rejected because …
+     - **Merge LoRA into the base and re-upload the merged checkpoint
+       to HF Hub.** Rejected because the ablation surface needs to
+       compare base vs adapted, which a merged checkpoint hides.
+     - **Pin adapter by HF tag or branch instead of commit SHA.**
+       Rejected because a silent re-push to the same tag changes
+       eval results without changing the repo SHA — supply-chain
+       hole the current pattern is designed to close.
+     - **Train both KURE-v1 and BGE-M3 adapters and compare.**
+       Deferred — BGE-M3's asymmetric dense/sparse/multi-vector
+       heads complicate the LoRA target decision; KURE-v1's
+       symmetric encoder needs only one LoRA head and is the
+       Korean-market signal. Future ADR if revisited. -->
+
+## See also
+
+- [`rag_core.py`](../../rag_core.py) — `embed_texts` LoRA branch + `MODEL_CACHE` 3-tuple key.
+- [`eval/config.yaml`](../../eval/config.yaml) — the two new
+  `ablation_runs` rows + `latency_budgets` entries.
+- [`requirements-lora.txt`](../../requirements-lora.txt) — optional PEFT install path.
+- [`scripts/generate_finetune_pairs.py`](../../scripts/generate_finetune_pairs.py) — synthetic pair generation (issue #433).
+- `notebooks/embedding_finetune.ipynb` *(issue #435, not yet landed)* — training notebook.
+- `docs/embedding-finetune.md` *(issue #435, not yet landed)* — model card + measured results.
+- [`tests/test_finetuned_ablation_baseline_invariant.py`](../../tests/test_finetuned_ablation_baseline_invariant.py) — pins the byte-equality invariant.
+- [ADR 0019](./0019-embedding-default-stays-minilm.md) — re-open criteria for swapping the embedding default (NOT triggered by this ADR).
+- [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) — Phase 1.3 closure (off-the-shelf measurement).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -88,6 +88,7 @@ project record.
 | [0024](./0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) |
 | [0025](./0025-cost-frontier-defer-until-real-baselines.md) | accepted | Cost-accuracy frontier deferred until external baseline real runs land (defers #177; backs README §Limitations "비용 영점"; follows ADR 0019 → 0021 measurement-gated pattern) |
 | [0026](./0026-cross-encoder-reranker-deferral.md) | proposed | Cross-encoder reranker default stays stub-identity; real-backend (bge / bge_ko / cohere) measurement deferred — `full_reranker ≡ full` under CI stub by construction, `full` vs `no_rerank` already 0pp on public synthetic (mirrors ADR 0019 / 0025 pattern) |
+| [0027](./0027-lora-finetuned-embedding-additive.md) | proposed | LoRA-fine-tuned embedding adapter as additive ablation, env-var gated (`BIDMATE_EMBEDDING_LORA_ADAPTER`), HF Hub adapter pinned by commit SHA (extends 0001 / 0011 / 0019; does NOT trigger 0019 re-open) |
 
 ## Decision evolution
 

--- a/docs/senior-positioning.md
+++ b/docs/senior-positioning.md
@@ -15,7 +15,7 @@
 
 | 시그널 | 어디서 확인하나 |
 |---|---|
-| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 25개 ADR (18 accepted / 7 proposed), status-tracked, supersession chains 명시 |
+| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 26개 ADR (18 accepted / 8 proposed), status-tracked, supersession chains 명시 |
 | **측정 가능한 성공 기준**을 미리 잡고 그 기준으로 평가한다 | [`portfolio-case-study.md` §2](./portfolio-case-study.md), [`eval/config.yaml`](../eval/config.yaml), README headline 표 |
 | 합성 평가의 한계를 알고 **공개/비공개 평가 분리**로 보완한다 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) |
 | **실패를 분류·우선순위화**한 뒤 백로그로 만든다 | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), 메타 이슈 #49 |
@@ -54,6 +54,7 @@
 | [0024](./adr/0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) | "Agentic RAG" 라벨에 *기본 API surface*를 맞추는 절충안. preset만 flip하고 synthesis backend default(`stub`)는 유지 — CI 결정성 + cost 0 보존. CLI / function-level / backend 3개 default 경계를 회귀 테스트로 잠금. |
 | [0025](./adr/0025-cost-frontier-defer-until-real-baselines.md) | accepted | cost-accuracy frontier을 외부 baseline 실측이 land할 때까지 deferral (defers #177; backs README §Limitations "비용 영점"; follows 0019 → 0021 pattern) | "왜 비용 축 frontier plot이 없냐?"에 modeled-cost 가짜 그림 대신 measurement-gated deferral로 응답. self-hosted 전부 cost=0이라 in-repo ablation들은 x=0에 모임 → 외부 baseline(`backend != "stub"`) 실측이 들어와야 비로소 의미 — 그 조건을 ADR로 잠금. #124의 latency-quality Pareto frontier가 그동안 portfolio asset. |
 | [0026](./adr/0026-cross-encoder-reranker-deferral.md) | proposed | cross-encoder reranker 기본값 = stub-identity 유지, 실 backend(bge / bge_ko / cohere) 측정 deferral (skeleton, mirrors 0019/0025 pattern) | `full` vs `no_rerank`가 공개 합성에서 이미 0pp (ADR 0002 metadata-first가 dense 위 reorder를 무의미하게 함). `full_reranker`는 CI stub 디폴트에서 `full`과 by-construction 비트동일. Protocol 표면은 향후 HyDE-reranker / LLM-as-reranker seam으로 보존 — 측정 효과 없으나 *측정이 안 됐다*는 점을 ADR로 잠금. |
+| [0027](./adr/0027-lora-finetuned-embedding-additive.md) | proposed | LoRA-fine-tuned embedding adapter as additive ablation, env-var gated (`BIDMATE_EMBEDDING_LORA_ADAPTER`), HF Hub adapter pinned by commit SHA (extends 0001 / 0011 / 0019; does NOT trigger 0019 re-open) | **TODO(user)**: 시니어 관점 한 줄 직접 작성 — pretrain → fine-tune → eval cycle 시연 / HF Hub 아티팩트 supply-chain SHA pin 패턴 / ADR 0019 re-open 조건(`full` ≥+5pp)을 의도적으로 *비*트리거하는 측정 설계 등을 골라 자기 framing으로. |
 
 **인터뷰 talking point 1 (real-data 회귀)**: "ADR 0005가 없었다면 공개본의 abstention 회귀(#69의 `1.000 → 0.500` 사건)는 아무도 보지 못했을 것이다. 공개 합성만 보던 시기에는 1-of-2 incidental overlap 패턴이 잡히지 않았다." — 근거: [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) 2026-05-11 entry.
 
@@ -181,7 +182,7 @@ make reproduce  # smoke + SHA-256 over the environment-invariant metric subset
 
 ### 30초 자기소개
 
-> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **25개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
+> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **26개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
 
 읽는 시간 ≈ 30초. 면접 첫 답으로 그대로 사용 가능. 상대가 "좀 더 자세히"를 물으면 §1, 측정 의문에는 §2, 운영 의문에는 [`production-readiness.md`](./production-readiness.md)로 넘어간다.
 

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -23,6 +23,16 @@ latency_budgets:
     # the per-query budget is identical to ``full``. The LLM-backed
     # ingest path is measured separately (operator-side, ADR 0005).
     p95_ms: 200
+  agentic_full_finetuned:
+    # Issue #179 / ADR 0027 — LoRA adapter merge happens at index-
+    # build time, so per-query latency mirrors ``full``. Real
+    # sentence-transformers encoding is the heavier path (operator-
+    # side, ADR 0005); CI default backend (hashing) is a no-op.
+    p95_ms: 200
+  naive_baseline_finetuned:
+    # Same as ``naive_baseline`` — the LoRA adapter does not change
+    # the per-query retrieval shape, only the vector content.
+    p95_ms: 100
 answer_policy:
   answerable_status: supported
   unanswerable_status: insufficient
@@ -184,6 +194,31 @@ ablation_runs:
     verifier_retry: true
     retrieval_mode: flat
     query_expansion: hyde
+  # Issue #179 / ADR 0027 — additive LoRA-fine-tuned embedding adapter.
+  # The ``embedding_model`` / ``embedding_lora_adapter`` keys are
+  # documentation read by ``scripts/run_embedding_ablation.py`` at
+  # index-build time; they are silently dropped by
+  # ``eval/run_eval.normalize_run_config`` so under the default
+  # hashing CI backend these rows are byte-equal to their parents
+  # (``full`` / ``naive_baseline``). The adapter only changes vector
+  # content when both ``BIDMATE_EMBEDDING_BACKEND=sentence-transformers``
+  # and ``BIDMATE_EMBEDDING_LORA_ADAPTER=<hf-repo>@<sha>`` are set —
+  # mirrors the ADR 0011 / 0017 / 0023 additive-opt-in pattern.
+  # The ``@<sha>`` placeholder is replaced with the pinned commit SHA
+  # in #179 once the adapter is trained and uploaded; ADR 0027
+  # mandates SHA pinning to close the supply-chain hole.
+  - name: agentic_full_finetuned
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    embedding_model: nlpai-lab/KURE-v1
+    embedding_lora_adapter: bidmate/embedding-lora-kure-rfp-ko-v1@<sha>
+  - name: naive_baseline_finetuned
+    pipeline: naive_baseline
+    embedding_model: nlpai-lab/KURE-v1
+    embedding_lora_adapter: bidmate/embedding-lora-kure-rfp-ko-v1@<sha>
 cases:
   - id: single_doc_security
     query_type: single_doc

--- a/rag_core.py
+++ b/rag_core.py
@@ -146,7 +146,7 @@ INDEX_FILENAME = "index.json"
 # without touching the chunk-metadata payload.
 EMBEDDINGS_FILENAME = "embeddings.npy"
 INDEX_SCHEMA_VERSION = 2
-MODEL_CACHE: dict[tuple[str, bool], Any] = {}
+MODEL_CACHE: dict[tuple[str, bool, str | None], Any] = {}
 
 TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]+")
 ENTITY_RE = re.compile(r"기관\s*[-_]?\s*([A-Za-z0-9]+)", re.IGNORECASE)
@@ -718,10 +718,26 @@ def embed_texts(
             with huggingface_offline(local_only or backend == "auto"):
                 from sentence_transformers import SentenceTransformer
 
-                cache_key = (model_name, local_only or backend == "auto")
+                # ADR 0027 — additive LoRA adapter, gated by env var so
+                # the default (env unset) path remains byte-identical
+                # to pre-#434 behavior. ``adapter_path`` is part of the
+                # cache key so adapted / unadapted variants of the same
+                # base model don't clobber each other.
+                adapter_path = os.environ.get("BIDMATE_EMBEDDING_LORA_ADAPTER") or None
+                cache_key = (model_name, local_only or backend == "auto", adapter_path)
                 model = MODEL_CACHE.get(cache_key)
                 if model is None:
                     model = SentenceTransformer(model_name)
+                    if adapter_path:
+                        # PEFT is lazy-imported (optional dep in
+                        # requirements-lora.txt) — the hashing-only CI
+                        # path never executes this branch and so never
+                        # needs the package installed.
+                        from peft import PeftModel  # type: ignore[import-not-found]
+
+                        underlying = model[0].auto_model
+                        adapted = PeftModel.from_pretrained(underlying, adapter_path)
+                        model[0].auto_model = adapted.merge_and_unload()
                     MODEL_CACHE[cache_key] = model
             vectors = model.encode(
                 texts,

--- a/requirements-lora.txt
+++ b/requirements-lora.txt
@@ -1,0 +1,17 @@
+# Optional LoRA fine-tuned embedding adapter backend (ADR 0027, issue #179).
+#
+# Install with:
+#   pip install -r requirements-lora.txt
+#
+# Activate at runtime by pointing the embedding loader at a Hugging Face
+# Hub repo (or a local adapter directory):
+#   export BIDMATE_EMBEDDING_BACKEND=sentence-transformers
+#   export BIDMATE_EMBEDDING_LORA_ADAPTER=bidmate/embedding-lora-kure-rfp-ko-v1
+#
+# Default (`BIDMATE_EMBEDDING_LORA_ADAPTER` unset) keeps `rag_core.embed_texts`
+# bit-identical to pre-#434 behavior — the lazy `from peft import PeftModel`
+# never executes, so the hashing-only public CI stays free of the dep.
+# This is the ADR 0001 invariant for the additive-ablation pattern (mirrors
+# requirements-graph.txt for LangGraph and requirements-observability.txt
+# for the tracing backend).
+peft>=0.13,<1.0

--- a/scripts/run_embedding_ablation.py
+++ b/scripts/run_embedding_ablation.py
@@ -37,10 +37,12 @@ Approximate disk + cost guide (opt-in models):
     nlpai-lab/KURE-v1                    ~1.1GB disk, 768-dim, free (Korean-specialized)
     text-embedding-3-large               OpenAI, 3072-dim, ~$0.004 for n=42
 """
+
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -74,6 +76,25 @@ def _slug(model_id: str) -> str:
     return model_id.replace("/", "_").replace("-", "_").replace(".", "_")
 
 
+def _adapter_suffix() -> str:
+    """Slug fragment that disambiguates base vs LoRA-adapted runs.
+
+    Issue #179 / ADR 0027: when ``BIDMATE_EMBEDDING_LORA_ADAPTER`` is set,
+    the index + report directory slugs get an ``__lora_<adapter>`` suffix
+    so running this script twice (baseline + adapted) on the same base
+    model writes to *separate* output paths instead of overwriting.
+    Without the env var (CI default), the suffix is empty — slug stays
+    identical to pre-#434 output.
+    """
+    adapter = os.environ.get("BIDMATE_EMBEDDING_LORA_ADAPTER")
+    if not adapter:
+        return ""
+    # Drop ``@<sha>`` pin for a stable on-disk slug; the SHA is captured
+    # in the eval_summary.json provenance block, not the path.
+    repo = adapter.split("@", 1)[0]
+    return "__lora_" + _slug(repo)
+
+
 def _derive_backend(model_id: str) -> str:
     if model_id.startswith("text-embedding-"):
         return "openai"
@@ -83,9 +104,7 @@ def _derive_backend(model_id: str) -> str:
 def _run(cmd: list[str]) -> None:
     proc = subprocess.run(cmd, cwd=REPO_ROOT, check=False)
     if proc.returncode != 0:
-        raise SystemExit(
-            f"Command failed (exit {proc.returncode}): {' '.join(cmd)}"
-        )
+        raise SystemExit(f"Command failed (exit {proc.returncode}): {' '.join(cmd)}")
 
 
 def build_index(model_id: str, index_dir: Path, backend: str | None = None) -> None:
@@ -94,10 +113,14 @@ def build_index(model_id: str, index_dir: Path, backend: str | None = None) -> N
         [
             sys.executable,
             "scripts/build_index.py",
-            "--input_dir", "data/raw",
-            "--output_dir", str(index_dir),
-            "--embedding_backend", backend,
-            "--model", model_id,
+            "--input_dir",
+            "data/raw",
+            "--output_dir",
+            str(index_dir),
+            "--embedding_backend",
+            backend,
+            "--model",
+            model_id,
         ]
     )
 
@@ -107,9 +130,12 @@ def run_eval(index_dir: Path, output_dir: Path) -> Path:
         [
             sys.executable,
             "eval/run_eval.py",
-            "--index_dir", str(index_dir),
-            "--output_dir", str(output_dir),
-            "--config", "eval/config.yaml",
+            "--index_dir",
+            str(index_dir),
+            "--output_dir",
+            str(output_dir),
+            "--config",
+            "eval/config.yaml",
         ]
     )
     return output_dir / "eval_summary.json"
@@ -181,8 +207,9 @@ def main() -> int:
     base_reports.mkdir(parents=True, exist_ok=True)
 
     per_model: dict[str, dict[str, dict]] = {}
+    adapter_suffix = _adapter_suffix()
     for model_id in args.models:
-        slug = _slug(model_id)
+        slug = _slug(model_id) + adapter_suffix
         index_dir = base_index / slug
         report_dir = base_reports / slug
         summary_path = report_dir / "eval_summary.json"

--- a/tests/test_finetuned_ablation_baseline_invariant.py
+++ b/tests/test_finetuned_ablation_baseline_invariant.py
@@ -1,0 +1,306 @@
+"""Baseline-invariance contract for the LoRA-fine-tuned embedding rows
+(issue #434 / ADR 0027).
+
+Both ``agentic_full_finetuned`` and ``naive_baseline_finetuned`` are
+additive ablations. Under the default deterministic CI surface
+(hashing embedding backend, ``BIDMATE_EMBEDDING_LORA_ADAPTER`` unset)
+the **correctness metrics** (``REPRODUCIBLE_METRICS`` — accuracy,
+groundedness, citation_precision, abstention, answer_format_compliance)
+MUST be byte-equal to their parents' (``full`` / ``naive_baseline``).
+Latency / stage-latency drifts run-to-run by μs-scale system noise —
+this is universal across every ablation row and is *not* a contract
+break (mirrors ``tests/test_eval_reproducibility_regression.py`` which
+also excludes latency from its reproducibility check).
+
+The proof has two layers:
+
+1. **Structural** (fast unit test) — the ``embedding_model`` and
+   ``embedding_lora_adapter`` keys are silently dropped by
+   ``eval/run_eval.normalize_run_config`` (they are not part of the
+   hardcoded returned-keys set), so once normalized the two configs
+   are identical to their parents. The single behavioral side-effect
+   — the LoRA branch in ``rag_core.embed_texts`` — is gated by an
+   env var that is unset in CI.
+
+2. **End-to-end** (slow subprocess test) — runs ``eval/run_eval.py``
+   once under CI defaults, then pins per-run correctness-metric
+   equality between each finetuned row and its parent. Same pattern
+   as ``full_reranker`` (ADR 0011) and ``full_hyde`` (ADR 0023).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _normalize_run_config(row: dict) -> dict:
+    sys.path.insert(0, str(ROOT / "eval"))
+    try:
+        from run_eval import normalize_run_config
+    finally:
+        sys.path.pop(0)
+    return normalize_run_config(row)
+
+
+def _load_config() -> dict:
+    return yaml.safe_load((ROOT / "eval" / "config.yaml").read_text(encoding="utf-8"))
+
+
+def _row_by_name(config: dict, name: str) -> dict:
+    for row in config["ablation_runs"]:
+        if row["name"] == name:
+            return row
+    raise KeyError(name)
+
+
+class YamlRowsLandedTest(unittest.TestCase):
+    def test_agentic_full_finetuned_row_present(self) -> None:
+        row = _row_by_name(_load_config(), "agentic_full_finetuned")
+        self.assertEqual(row["pipeline"], "agentic_full")
+        self.assertEqual(row["embedding_model"], "nlpai-lab/KURE-v1")
+        self.assertTrue(
+            row["embedding_lora_adapter"].startswith("bidmate/embedding-lora-kure-rfp-ko-v1")
+        )
+
+    def test_naive_baseline_finetuned_row_present(self) -> None:
+        row = _row_by_name(_load_config(), "naive_baseline_finetuned")
+        self.assertEqual(row["pipeline"], "naive_baseline")
+        self.assertEqual(row["embedding_model"], "nlpai-lab/KURE-v1")
+
+    def test_latency_budgets_have_entries_for_new_rows(self) -> None:
+        config = _load_config()
+        budgets = config["latency_budgets"]
+        self.assertIn("agentic_full_finetuned", budgets)
+        self.assertIn("naive_baseline_finetuned", budgets)
+        # The full pipeline path is the heavier surface; the
+        # finetuned variant inherits the same budget as its parent.
+        self.assertEqual(
+            budgets["agentic_full_finetuned"]["p95_ms"],
+            budgets["full"]["p95_ms"],
+        )
+        self.assertEqual(
+            budgets["naive_baseline_finetuned"]["p95_ms"],
+            budgets["naive_baseline"]["p95_ms"],
+        )
+
+
+class NormalizedConfigEqualityTest(unittest.TestCase):
+    """The core byte-equality invariant: normalize the finetuned row
+    and its parent — they must produce identical normalized dicts
+    (modulo ``name``). This is the additive-ablation contract."""
+
+    def test_agentic_full_finetuned_normalizes_equal_to_full(self) -> None:
+        config = _load_config()
+        finetuned = _row_by_name(config, "agentic_full_finetuned")
+        parent = _row_by_name(config, "full")
+        n_finetuned = _normalize_run_config(finetuned)
+        n_parent = _normalize_run_config(parent)
+        # Strip ``name`` — that's the only field that legitimately
+        # differs between an ablation row and its parent.
+        n_finetuned.pop("name", None)
+        n_parent.pop("name", None)
+        self.assertEqual(
+            n_finetuned,
+            n_parent,
+            "agentic_full_finetuned must be byte-equal to full after "
+            "normalization (modulo name) — additive ablation invariant",
+        )
+
+    def test_naive_baseline_finetuned_normalizes_equal_to_parent(self) -> None:
+        config = _load_config()
+        finetuned = _row_by_name(config, "naive_baseline_finetuned")
+        parent = _row_by_name(config, "naive_baseline")
+        n_finetuned = _normalize_run_config(finetuned)
+        n_parent = _normalize_run_config(parent)
+        n_finetuned.pop("name", None)
+        n_parent.pop("name", None)
+        self.assertEqual(n_finetuned, n_parent)
+
+    def test_embedding_keys_are_silently_dropped(self) -> None:
+        """``embedding_model`` and ``embedding_lora_adapter`` are
+        documentation read by ``scripts/run_embedding_ablation.py`` at
+        index-build time. They MUST NOT propagate into the runtime
+        ``run_config`` — that would break byte-equality with the
+        parent and pollute every trace record."""
+        config = _load_config()
+        finetuned = _row_by_name(config, "agentic_full_finetuned")
+        normalized = _normalize_run_config(finetuned)
+        self.assertNotIn("embedding_model", normalized)
+        self.assertNotIn("embedding_lora_adapter", normalized)
+
+
+class EmbedTextsAdapterGatingTest(unittest.TestCase):
+    """The single behavioral side-effect of ADR 0027 is the
+    ``BIDMATE_EMBEDDING_LORA_ADAPTER`` branch in ``embed_texts``.
+    With the env var unset (CI default) the branch never executes —
+    the function falls back to the hashing path bit-identically."""
+
+    def test_hashing_backend_unchanged_with_env_unset(self) -> None:
+        """Force the hashing backend (CI default) — with the LoRA env
+        var unset the result must be byte-identical to pre-#434
+        behavior. The PEFT branch never executes; no adapter cache
+        key gets created."""
+        prior = os.environ.pop("BIDMATE_EMBEDDING_LORA_ADAPTER", None)
+        try:
+            import rag_core
+
+            result = rag_core.embed_texts(["기관 A의 보안 통제 요구사항은?"], backend="hashing")
+            self.assertEqual(result.backend, "hashing")
+            self.assertEqual(result.model, "local-hashing-bow")
+            # No cache entry should have been created with a non-None
+            # adapter slot — the LoRA branch must not have fired.
+            for key in rag_core.MODEL_CACHE:
+                self.assertIsNone(
+                    key[2],
+                    f"MODEL_CACHE got an adapter-tagged key with env unset: {key}",
+                )
+        finally:
+            if prior is not None:
+                os.environ["BIDMATE_EMBEDDING_LORA_ADAPTER"] = prior
+
+    def test_model_cache_key_is_three_tuple(self) -> None:
+        """The cache-key shape change (#434) is observable here.
+        A 2-tuple key would crash on lookup the first time the env
+        var is set; the test pins the new shape."""
+        import rag_core
+
+        # The MODEL_CACHE type annotation declares the 3-tuple shape.
+        # An empty cache is the CI state; reach into the type hints
+        # to assert the contract without forcing an ST model load.
+        annotation = rag_core.MODEL_CACHE.__class__
+        self.assertIs(annotation, dict)
+        # Type annotation introspection on the module attribute:
+        type_hints = getattr(rag_core, "__annotations__", {})
+        cache_type_str = str(type_hints.get("MODEL_CACHE", ""))
+        self.assertIn("tuple", cache_type_str.lower())
+        self.assertIn("str", cache_type_str.lower())
+        # The third tuple slot is the adapter_path (Optional[str]).
+        self.assertTrue(
+            "None" in cache_type_str or "str | None" in cache_type_str,
+            f"MODEL_CACHE third tuple slot must be Optional[str]; got {cache_type_str}",
+        )
+
+
+class EvalSummaryMetricEqualityTest(unittest.TestCase):
+    """End-to-end invariance: run ``eval/run_eval.py`` once and assert
+    that the finetuned rows produce byte-equal correctness metrics to
+    their parents on the public synthetic surface.
+
+    Slow-ish (single eval invocation, ~10 s). Latency / stage_latency
+    keys are *not* compared — they vary μs-scale run-to-run regardless
+    of which row generated them. The canonical correctness set is the
+    ``REPRODUCIBLE_METRICS`` tuple from
+    ``tests/test_eval_reproducibility_regression.py``.
+    """
+
+    REPRODUCIBLE_METRICS = (
+        "accuracy",
+        "groundedness",
+        "citation_precision",
+        "abstention",
+        "answer_format_compliance",
+    )
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        import subprocess
+        import tempfile
+
+        cls._tmp = tempfile.TemporaryDirectory()
+        output_dir = Path(cls._tmp.name)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "eval/run_eval.py",
+                "--index_dir",
+                str(ROOT / "data" / "index"),
+                "--output_dir",
+                str(output_dir),
+                "--config",
+                str(ROOT / "eval" / "config.yaml"),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"eval/run_eval.py exited {result.returncode}\n"
+                f"stdout: {result.stdout[-2000:]}\n"
+                f"stderr: {result.stderr[-2000:]}"
+            )
+        summary_path = output_dir / "eval_summary.json"
+        cls.summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        cls.runs = {r["name"]: r for r in cls.summary["ablation"]["runs"]}
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def _assert_metrics_equal(self, finetuned_name: str, parent_name: str) -> None:
+        ft = self.runs.get(finetuned_name)
+        parent = self.runs.get(parent_name)
+        self.assertIsNotNone(ft, f"missing run {finetuned_name!r}")
+        self.assertIsNotNone(parent, f"missing run {parent_name!r}")
+        for metric in self.REPRODUCIBLE_METRICS:
+            a = ft.get(metric)
+            b = parent.get(metric)
+            if a is None and b is None:
+                continue
+            self.assertEqual(
+                a,
+                b,
+                f"{finetuned_name}.{metric}={a} != {parent_name}.{metric}={b} "
+                f"— additive-ablation contract broken",
+            )
+
+    def test_agentic_full_finetuned_metrics_equal_to_full(self) -> None:
+        self._assert_metrics_equal("agentic_full_finetuned", "full")
+
+    def test_naive_baseline_finetuned_metrics_equal_to_naive_baseline(self) -> None:
+        self._assert_metrics_equal("naive_baseline_finetuned", "naive_baseline")
+
+    def test_per_slice_correctness_metrics_equal(self) -> None:
+        """The per-slice (`by_query_type.*`) accuracy/abstention numbers
+        drive the `make real-eval-delta` rendering downstream. They
+        must also be invariant — otherwise the additive ablation would
+        masquerade as a slice-level regression."""
+        for ft_name, parent_name in (
+            ("agentic_full_finetuned", "full"),
+            ("naive_baseline_finetuned", "naive_baseline"),
+        ):
+            ft = self.runs[ft_name]
+            parent = self.runs[parent_name]
+            ft_slices = ft.get("by_query_type") or {}
+            parent_slices = parent.get("by_query_type") or {}
+            self.assertEqual(
+                set(ft_slices.keys()),
+                set(parent_slices.keys()),
+                f"slice key drift between {ft_name} and {parent_name}",
+            )
+            for slice_name in ft_slices:
+                for metric in ("accuracy", "abstention", "num_predictions"):
+                    a = (ft_slices[slice_name] or {}).get(metric)
+                    b = (parent_slices[slice_name] or {}).get(metric)
+                    if a is None and b is None:
+                        continue
+                    self.assertEqual(
+                        a,
+                        b,
+                        f"{ft_name}.by_query_type.{slice_name}.{metric}={a} != {parent_name}.…={b}",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Phase 3.4b — wires up the loader and ablation surface so the trained LoRA adapter (uploaded by the operator-run #179 follow-up) can drive retrieval, without disturbing the ADR 0001 invariant or the public CI hashing surface. Three load-bearing rules codified in ADR 0027:

1. `rag_core.embed_texts` extension is env-var gated. The `BIDMATE_EMBEDDING_LORA_ADAPTER` branch lazy-imports `peft` only when the env var is set, then merges the adapter into the base model via `PeftModel.from_pretrained(...).merge_and_unload()`. Default (env unset) is byte-identical to pre-#434 behavior.
2. Two new rows in `eval/config.yaml` — `agentic_full_finetuned` (clones `full`) + `naive_baseline_finetuned` (clones `naive_baseline`). The `embedding_model` / `embedding_lora_adapter` keys are documentation only — silently dropped by `normalize_run_config` so on the default CI surface the **correctness metrics** are byte-equal to parents (latency drifts μs-scale, universal across every ablation, not a contract break).
3. HF Hub adapter pinned by commit SHA (`<repo>@<sha>` form) in `eval/config.yaml` — closes the silent-republish supply-chain hole. SHA placeholder filled by the operator after the training run.

Stacked on top of #437 (#433 pair generation).

Closes #434

## 2. Files affected

**Load-bearing** (item 5b real-data delta required):

- `rag_core.py` — `MODEL_CACHE` key 3-tuple + `embed_texts` LoRA branch
- `eval/config.yaml` — 2 new `ablation_runs` rows + 2 new `latency_budgets` entries
- `docs/adr/0027-lora-finetuned-embedding-additive.md` (new)
- `docs/adr/README.md` — picks up ADR 0027 index row
- `docs/senior-positioning.md` — 25→26 ADR count + 18/8 status breakdown + ADR 0027 narrative row (with `TODO(user)` for the rationale column per cognitive-ownership boundary)

**Supporting**:

- `requirements-lora.txt` (new) — optional PEFT dep, mirrors `requirements-graph.txt` pattern
- `scripts/run_embedding_ablation.py` — adapter-aware output slug (`__lora_<repo>` suffix when env set) so base-vs-LoRA runs don't overwrite each other
- `tests/test_finetuned_ablation_baseline_invariant.py` (new) — 11 tests pinning structural + end-to-end invariance

## 3. Risks

**Most likely break:** the `embedding_model` / `embedding_lora_adapter` YAML keys silently propagate into `normalize_run_config`'s return dict — breaking byte-equality on the eval_summary.json and masquerading the additive row as a slice-level regression. Ruled out by:

- `test_embedding_keys_are_silently_dropped` asserts both keys are absent from normalized run config.
- `test_*_normalizes_equal_to_*` asserts each finetuned row's normalized config is byte-equal to its parent's modulo `name`.
- `EvalSummaryMetricEqualityTest` runs `eval/run_eval.py` end-to-end and pins per-row `REPRODUCIBLE_METRICS` equality + per-slice `accuracy`/`abstention`/`num_predictions` equality between finetuned rows and their parents.

**Second risk:** the lazy `from peft import PeftModel` inside the env-var branch fires even when env is unset (regression that breaks hashing-only CI). Ruled out by `test_hashing_backend_unchanged_with_env_unset` — asserts the hashing fallback runs cleanly with env unset, and `MODEL_CACHE` never gets an adapter-tagged key.

**Third risk:** the new `MODEL_CACHE` key shape `(model_name, local_only, adapter_path)` collides with code reading the old 2-tuple shape elsewhere. Grep confirmed `MODEL_CACHE` has no other call sites besides `embed_texts`. `test_model_cache_key_is_three_tuple` pins the contract.

## 4. Tests

`tests/test_finetuned_ablation_baseline_invariant.py` — 11 tests across 4 classes:

- `YamlRowsLandedTest` (3) — row presence + latency budget matches parent
- `NormalizedConfigEqualityTest` (3) — normalize_run_config byte-equal modulo `name`; embedding keys silently dropped
- `EmbedTextsAdapterGatingTest` (2) — env-unset hashing fallback; MODEL_CACHE 3-tuple shape
- `EvalSummaryMetricEqualityTest` (3) — subprocess `eval/run_eval.py` + per-row + per-slice correctness-metric equality

11/11 pass. Adjacent tests (`test_governance.py`, `test_cross_encoder_rerank.py`, `test_query_expansion_protocol.py`, `test_api_default_pipeline_regression.py`, `test_eval_metrics.py`, `test_eval_reproducibility_regression.py`) all green. Full suite 802 passed (1 pre-existing HWP failure unrelated to this PR).

## 5. Eval impact

All `·` on the public synthetic CI surface. The new rows are byte-equal to their parents under the default `hashing` embedding backend (proven by `EvalSummaryMetricEqualityTest`). Latency may drift μs-scale row-to-row but that's universal across every ablation, not a regression — same exclusion as `tests/test_eval_reproducibility_regression.py`.

### 5b. Real-data delta

**Deferred to the operator-run #179 follow-up.** Rationale: under CI defaults (hashing backend, `BIDMATE_EMBEDDING_LORA_ADAPTER` unset), the new rows are byte-equal to their parents on the correctness-metric surface. The real delta only materializes when both `BIDMATE_EMBEDDING_BACKEND=sentence-transformers` AND `BIDMATE_EMBEDDING_LORA_ADAPTER=bidmate/...@<sha>` are set, which requires the adapter to be trained first (#435 + the operator-run follow-up).

The operator-run follow-up will produce the real-data delta tables in `docs/embedding-finetune.md` (skeleton lands in #435).

## 6. Backward compatibility

Pure addition. `BIDMATE_EMBEDDING_LORA_ADAPTER` unset → byte-identical to pre-#434 behavior (codified by the invariance test suite). The `eval/config.yaml` schema gains two optional row fields that older readers silently ignore (`normalize_run_config` drops them).

ADR 0001 invariant (naive_baseline / agentic_full byte-identical) preserved. ADR 0003 answer-citation contract untouched (no `schema_version` bump needed). ADR 0019 re-open criteria (≥+5pp on `full` with non-overlapping CIs) explicitly NOT triggered — see ADR 0027 §Decision.

## 7. Out of scope

- Notebook (deferred to #435).
- Model-card writeup (skeleton in #435; results filled by the operator).
- Actual training run + measured eval-delta tables (operator-run, tracked under #179 follow-up).
- BGE-M3 LoRA variant — asymmetric encoder makes target-module decision its own ADR-worthy question (future work, flagged in ADR 0027).

🤖 Generated with [Claude Code](https://claude.com/claude-code)