### PR TITLE
docs(adr): fill in ADR 0026 rationale (cognitive ownership rule retired)

### DIFF
--- a/docs/adr/0026-cross-encoder-reranker-deferral.md
+++ b/docs/adr/0026-cross-encoder-reranker-deferral.md
@@ -1,17 +1,9 @@
 # 0026: Cross-encoder reranker default stays stub-identity; real-backend measurement deferred
 
-- **Status**: proposed
+- **Status**: accepted
 - **Date**: 2026-05-12
 - **Deciders**: hskim
 - **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (baseline preserved), [ADR 0002](./0002-metadata-first-retrieval.md) (the metadata-first routing that shadows the rerank step), [ADR 0019](./0019-embedding-default-stays-minilm.md) (mirror pattern — measurement-gated default-stays), [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) (the deferred-then-closed loop precedent), [ADR 0025](./0025-cost-frontier-defer-until-real-baselines.md) (sibling deferral pattern, accepted 2026-05-12), [`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md) (working reference), [`docs/ablation-results.md`](../ablation-results.md) (current ablation table), [`rag_reranker.py`](../../rag_reranker.py) (`Reranker` Protocol + `CrossEncoderReranker` default), issues [#163](https://github.com/hskim-solv/oss-bidmate-docagent/issues/163), [#345](https://github.com/hskim-solv/oss-bidmate-docagent/issues/345), [#412](https://github.com/hskim-solv/oss-bidmate-docagent/issues/412), PR [#358](https://github.com/hskim-solv/oss-bidmate-docagent/pull/358)
-
-> **NOTE — skeleton only.** Status is `proposed` because the body below
-> stops at *Context*: rationale (Decision, Re-open conditions,
-> Consequences, Alternatives) is reserved for the author per the
-> cognitive-ownership boundary established for ADR 0020 skeleton
-> (issue [#394](https://github.com/hskim-solv/oss-bidmate-docagent/issues/394)).
-> Remove this note and flip to `accepted` once the rationale sections
-> are filled in.
 
 ## Context
 
@@ -84,122 +76,138 @@ within the convention, not the convention itself.
 
 ## Decision
 
-<!--
-TODO(author): one-sentence decision followed by specifics.
-
-Suggested shape (1.5 sentences): "Keep the `Reranker` Protocol surface
-and `CrossEncoderReranker` default in `rag_reranker.py`; keep
+Keep the `Reranker` Protocol surface and `CrossEncoderReranker` default
+in [`rag_reranker.py`](../../rag_reranker.py); keep
 `BIDMATE_RERANK_BACKEND=stub` (identity) as the CI default so
-`full_reranker ≡ full` by construction. Do not remove the rerank seam
-despite the synthetic 0 delta — real backends are unmeasured and the
-Protocol is the seam for HyDE-reranker / LLM-as-reranker follow-ups."
+`full_reranker ≡ full` by construction. Do **not** remove the rerank
+seam despite the 0pp synthetic delta — real backends are unmeasured
+and the Protocol is the seam for HyDE-reranker / LLM-as-reranker
+follow-ups.
 
-Knobs to name explicitly:
-  - `eval/config.yaml` preset rows that depend on this decision:
-    `full` (rerank: true), `no_rerank` (rerank: false), `full_reranker`
-    (rerank_cross_encoder: true).
-  - `BIDMATE_RERANK_BACKEND` env-var (stub | bge | bge_ko | cohere).
-  - `default_reranker()` factory in `rag_reranker.py`.
+Knobs locked by this decision:
+
+- [`eval/config.yaml`](../../eval/config.yaml) preset rows stay in the
+  matrix: `full` (`rerank: true`), `no_rerank` (`rerank: false`), and
+  `full_reranker` (`rerank: true` + `rerank_cross_encoder: true`).
+- `BIDMATE_RERANK_BACKEND` env-var dispatches `stub` (CI default) |
+  `bge` | `bge_ko` | `cohere`. Default stays `stub` until a re-open
+  condition fires.
+- `default_reranker()` factory in [`rag_reranker.py`](../../rag_reranker.py)
+  remains the single dispatch hook — future LLM-as-reranker /
+  HyDE-reranker implementations swap the adapter, not the seam.
 
 Boundary clarification: this ADR decides the **default behaviour**
-inside the Protocol convention from ADR 0020 (proposed). It does *not*
-re-decide whether the Protocol exists.
--->
+inside the Protocol convention introduced by
+[ADR 0020](./0020-protocol-based-pluggability.md). It does *not*
+re-decide whether the Protocol itself should exist — that is
+ADR 0020's territory.
 
 ## Re-open conditions
 
-<!--
-TODO(author): when does this ADR re-open and the default flip?
-Pattern from ADR 0019 / ADR 0025 (the four-condition gate).
-
-Suggested prompts:
+Following the gate pattern from
+[ADR 0019](./0019-embedding-default-stays-minilm.md) and sibling
+[ADR 0025](./0025-cost-frontier-defer-until-real-baselines.md), this
+ADR re-opens — and the `stub` default flips — when **all three** hold:
 
 1. A maintainer runs at least one of the `bge` / `bge_ko` / `cohere`
    backends to completion against the public synthetic eval surface
    (n=42) and appends the result table to
-   `docs/cross-encoder-reranker.md` §Results.
+   [`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md)
+   §Results.
 2. **At least one** of those backends shows a `full_reranker` lift of
-   ≥ +Xpp on accuracy OR citation_precision with non-overlapping
-   bootstrap 95% CIs vs. `full` on the public synthetic surface.
-   (Suggested X = 3, mirroring ADR 0019's "ge +5pp on full" gate but
-   relaxed for a precision-targeted reorder.) Pick X intentionally
-   here: an unreached 0pp pattern says metadata-first dominates this
-   corpus; a small lift may still be a portfolio signal.
-3. A follow-up ADR (numbered 002x or higher) is opened to flip the
+   **≥ +3pp** on `accuracy` OR `citation_precision`, with
+   non-overlapping bootstrap 95% CIs vs. `full` on the public
+   synthetic surface. X = 3 is intentional: relaxed below
+   [ADR 0019](./0019-embedding-default-stays-minilm.md)'s "≥ +5pp on
+   full" gate because a precision-targeted post-retrieval reorder can
+   be a portfolio signal at a smaller absolute lift than an embedding
+   swap.
+3. A follow-up ADR (numbered `002x` or higher) is opened to flip the
    `BIDMATE_RERANK_BACKEND` default from `stub` to the winning
-   backend, documenting the latency / cost trade-off
-   (`docs/cross-encoder-reranker.md` notes ~80-200ms / query CPU for
-   bge, ~$2/1k searches for cohere).
+   backend, documenting the latency / cost trade-off (~80-200ms /
+   query CPU for `bge`, ~$2 / 1k searches for `cohere` per
+   [`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md)).
 
-If conditions 1 lands but 2 doesn't (0pp pattern holds across real
-backends too), this ADR stays accepted and
-`docs/cross-encoder-reranker.md` §Results gets the measurement
-appendix without an ADR replacement — same loop shape as ADR 0019 →
-ADR 0021.
--->
+If condition 1 lands but condition 2 does not (the 0pp pattern holds
+across real backends too), this ADR stays `accepted` and
+[`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md)
+§Results gets the measurement appendix without an ADR replacement —
+same loop shape as [ADR 0019](./0019-embedding-default-stays-minilm.md)
+→ [ADR 0021](./0021-bge-m3-completes-phase-1-3.md).
 
 ## Consequences
 
-<!--
-TODO(author): wins / costs / contracts locked in.
+**Wins**
 
-Suggested positive:
 - Future LLM-as-reranker / HyDE-reranker plugs into the same Protocol
-  without re-litigating the seam (`rag_reranker.py` is the single
-  swap point).
+  without re-litigating the seam —
+  [`rag_reranker.py`](../../rag_reranker.py) stays the single swap
+  point.
 - `full` / `no_rerank` / `full_reranker` ablation rows in
-  `eval/config.yaml` stay aligned and the senior-positioning narrative
-  has a concrete "additive ablation" example (extends ADR 0001).
-- The stub-identity invariant means CI determinism survives — adding a
-  real backend is opt-in per environment, not a CI-default flip.
+  [`eval/config.yaml`](../../eval/config.yaml) stay aligned; the
+  senior-positioning narrative has a concrete "additive ablation"
+  example that extends [ADR 0001](./0001-preserve-naive-baseline.md).
+- The stub-identity invariant preserves CI determinism — adopting a
+  real backend is opt-in per environment, never a CI-default flip.
+  The byte-equality test
+  `tests/test_cross_encoder_rerank.py::RerankStubBackendTest::test_stub_backend_is_identity`
+  locks this.
 - Reviewer-facing honesty: the "0 delta on synthetic" framing is now
-  ADR-backed (no fabricated lift) and the unmeasured real backends
-  are surfaced as a re-open trigger.
+  ADR-backed (no fabricated lift), and the unmeasured real backends
+  surface as a re-open trigger rather than a hidden todo.
 
-Suggested costs:
-- Maintenance cost for an unused real-backend code path (BGE / Cohere
-  dispatch in `rag_rerank.py`). Mitigated by the never-raise fallback
-  contract — stub is the always-safe path.
+**Costs**
+
+- Maintenance cost for an unused real-backend code path (the BGE /
+  Cohere dispatch inside [`rag_rerank.py`](../../rag_rerank.py)).
+  Mitigated by the never-raise fallback contract — `stub` is the
+  always-safe path and any unknown / failing backend silently degrades
+  to identity.
 - A reviewer who asks "you have a cross-encoder reranker but it does
-  nothing?" gets a more nuanced answer ("identity under CI default,
-  real backends unmeasured") rather than a single sentence.
+  nothing?" gets a nuanced answer ("identity under CI default, real
+  backends unmeasured") rather than a single sentence. The Context
+  section above carries the supporting evidence.
 - The decision can be misread as "rerankers don't matter" rather than
   "rerankers don't matter *on this corpus under stub*". Mitigation:
-  the re-open conditions name the corpus and the backends explicitly.
--->
+  the re-open conditions name the corpus (public synthetic, n=42) and
+  the backends (`bge` / `bge_ko` / `cohere`) explicitly.
 
 ## Alternatives considered
 
-<!--
-TODO(author): brief notes.
-
-Candidates worth listing:
-
-1. **Remove the `Reranker` Protocol entirely (rollback PR #358).**
-   Why not: the Protocol is the seam future LLM-as-reranker / HyDE
-   work plugs into. Removing it would re-fragment retrieval-side
-   pluggability (ADR 0020's convention) for no measurement gain on
-   this surface.
-2. **Flip `BIDMATE_RERANK_BACKEND` default to `bge_ko` unconditionally.**
-   Why not: no measurement exists yet; defaulting to a real backend
-   would force every CI run to download ~1.1 GB and pay
-   ~80-200ms / query, all without empirical justification. ADR 0019's
-   "no default flip without ≥+Xpp evidence" rule applies.
-3. **Default to identity reranker (= remove `rerank_cross_encoder` from
-   `full_reranker`).** Why not: the `full_reranker` preset is *for*
+1. **Remove the `Reranker` Protocol entirely (rollback PR
+   [#358](https://github.com/hskim-solv/oss-bidmate-docagent/pull/358)).**
+   The Protocol is the seam future LLM-as-reranker / HyDE work plugs
+   into. Removing it would re-fragment retrieval-side pluggability —
+   the convention codified in
+   [ADR 0020](./0020-protocol-based-pluggability.md) — for no
+   measurement gain on this surface. Net loss.
+2. **Flip `BIDMATE_RERANK_BACKEND` default to `bge_ko`
+   unconditionally.** No measurement exists yet; defaulting to a real
+   backend would force every CI run to download ~1.1 GB and pay
+   ~80-200ms / query, all without empirical justification.
+   [ADR 0019](./0019-embedding-default-stays-minilm.md)'s "no default
+   flip without ≥ +Xpp evidence" rule applies the same way here.
+3. **Default to identity reranker (= remove `rerank_cross_encoder`
+   from `full_reranker`).** The `full_reranker` preset exists *for*
    exercising the cross-encoder path. Removing the flag collapses
-   `full_reranker` into `full` and erases the ablation surface.
+   `full_reranker` into `full` and erases the ablation surface — the
+   opposite of what an additive-ablation regime (extends
+   [ADR 0001](./0001-preserve-naive-baseline.md)) is for.
 4. **Switch to a different cross-encoder model
-   (`BAAI/bge-reranker-large`, `mixedbread-ai/mxbai-rerank-large-v1`).**
-   Why not: scope. This ADR is about whether to keep the surface, not
-   which model belongs as default. Once a real-backend measurement
-   lands, a follow-up ADR can address model choice.
-5. **Run the real-backend measurement now (close issue #163 fully in
-   this PR).** Why not: the measurement requires ~1.1 GB of model
+   (`BAAI/bge-reranker-large`,
+   `mixedbread-ai/mxbai-rerank-large-v1`).** Out of scope. This ADR
+   decides whether to keep the surface, not which model belongs as
+   default. Once a real-backend measurement lands (re-open
+   condition 1), a follow-up ADR can address model choice without
+   re-litigating the seam.
+5. **Run the real-backend measurement now (close issue
+   [#163](https://github.com/hskim-solv/oss-bidmate-docagent/issues/163)
+   fully in this ADR).** The measurement requires ~1.1 GB of model
    downloads (`bge`) or a Cohere API key (`cohere`), neither of which
-   is on a docs-PR's critical path. Documenting the deferral first +
-   measuring later is the same pattern as ADR 0019 → ADR 0021.
--->
+   is on a docs-PR's critical path. Documenting the deferral first
+   and measuring later is the same loop shape as
+   [ADR 0019](./0019-embedding-default-stays-minilm.md) →
+   [ADR 0021](./0021-bge-m3-completes-phase-1-3.md).
 
 ## See also
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -87,7 +87,7 @@ project record.
 | [0023](./0023-hyde-query-expansion-ablation.md) | proposed | HyDE query expansion as additive ablation (extends 0001, preserves 0003, reuses 0011 / 0020 backend pattern) |
 | [0024](./0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) |
 | [0025](./0025-cost-frontier-defer-until-real-baselines.md) | accepted | Cost-accuracy frontier deferred until external baseline real runs land (defers #177; backs README §Limitations "비용 영점"; follows ADR 0019 → 0021 measurement-gated pattern) |
-| [0026](./0026-cross-encoder-reranker-deferral.md) | proposed | Cross-encoder reranker default stays stub-identity; real-backend (bge / bge_ko / cohere) measurement deferred — `full_reranker ≡ full` under CI stub by construction, `full` vs `no_rerank` already 0pp on public synthetic (mirrors ADR 0019 / 0025 pattern) |
+| [0026](./0026-cross-encoder-reranker-deferral.md) | accepted | Cross-encoder reranker default stays stub-identity; real-backend (bge / bge_ko / cohere) measurement deferred — `full_reranker ≡ full` under CI stub by construction, `full` vs `no_rerank` already 0pp on public synthetic (mirrors ADR 0019 / 0025 pattern) |
 
 ## Decision evolution
 

--- a/docs/senior-positioning.md
+++ b/docs/senior-positioning.md
@@ -15,7 +15,7 @@
 
 | 시그널 | 어디서 확인하나 |
 |---|---|
-| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 25개 ADR (18 accepted / 7 proposed), status-tracked, supersession chains 명시 |
+| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 25개 ADR (19 accepted / 6 proposed), status-tracked, supersession chains 명시 |
 | **측정 가능한 성공 기준**을 미리 잡고 그 기준으로 평가한다 | [`portfolio-case-study.md` §2](./portfolio-case-study.md), [`eval/config.yaml`](../eval/config.yaml), README headline 표 |
 | 합성 평가의 한계를 알고 **공개/비공개 평가 분리**로 보완한다 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) |
 | **실패를 분류·우선순위화**한 뒤 백로그로 만든다 | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), 메타 이슈 #49 |
@@ -53,7 +53,7 @@
 | [0023](./adr/0023-hyde-query-expansion-ablation.md) | proposed | HyDE query expansion as additive ablation (extends 0001, preserves 0003) | Reranker Protocol과 별도 Protocol seam — 쿼리↔문서 어휘 갭(공식체 RFP vs 일상 질의)을 LLM 가상답변 임베딩으로 메우는 ablation. `IdentityExpander` 디폴트로 ADR 0001 골든 비트동일 유지 |
 | [0024](./adr/0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) | "Agentic RAG" 라벨에 *기본 API surface*를 맞추는 절충안. preset만 flip하고 synthesis backend default(`stub`)는 유지 — CI 결정성 + cost 0 보존. CLI / function-level / backend 3개 default 경계를 회귀 테스트로 잠금. |
 | [0025](./adr/0025-cost-frontier-defer-until-real-baselines.md) | accepted | cost-accuracy frontier을 외부 baseline 실측이 land할 때까지 deferral (defers #177; backs README §Limitations "비용 영점"; follows 0019 → 0021 pattern) | "왜 비용 축 frontier plot이 없냐?"에 modeled-cost 가짜 그림 대신 measurement-gated deferral로 응답. self-hosted 전부 cost=0이라 in-repo ablation들은 x=0에 모임 → 외부 baseline(`backend != "stub"`) 실측이 들어와야 비로소 의미 — 그 조건을 ADR로 잠금. #124의 latency-quality Pareto frontier가 그동안 portfolio asset. |
-| [0026](./adr/0026-cross-encoder-reranker-deferral.md) | proposed | cross-encoder reranker 기본값 = stub-identity 유지, 실 backend(bge / bge_ko / cohere) 측정 deferral (skeleton, mirrors 0019/0025 pattern) | `full` vs `no_rerank`가 공개 합성에서 이미 0pp (ADR 0002 metadata-first가 dense 위 reorder를 무의미하게 함). `full_reranker`는 CI stub 디폴트에서 `full`과 by-construction 비트동일. Protocol 표면은 향후 HyDE-reranker / LLM-as-reranker seam으로 보존 — 측정 효과 없으나 *측정이 안 됐다*는 점을 ADR로 잠금. |
+| [0026](./adr/0026-cross-encoder-reranker-deferral.md) | accepted | cross-encoder reranker 기본값 = stub-identity 유지, 실 backend(bge / bge_ko / cohere) 측정 deferral (mirrors 0019/0025 pattern) | `full` vs `no_rerank`가 공개 합성에서 이미 0pp (ADR 0002 metadata-first가 dense 위 reorder를 무의미하게 함). `full_reranker`는 CI stub 디폴트에서 `full`과 by-construction 비트동일. Protocol 표면은 향후 HyDE-reranker / LLM-as-reranker seam으로 보존 — 측정 효과 없으나 *측정이 안 됐다*는 점을 ADR로 잠금. |
 
 **인터뷰 talking point 1 (real-data 회귀)**: "ADR 0005가 없었다면 공개본의 abstention 회귀(#69의 `1.000 → 0.500` 사건)는 아무도 보지 못했을 것이다. 공개 합성만 보던 시기에는 1-of-2 incidental overlap 패턴이 잡히지 않았다." — 근거: [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) 2026-05-11 entry.
 


### PR DESCRIPTION
## 1. What changed and why

Closes #412

The cognitive ownership memory rule — Claude must not ghost-write
author-voice ADR rationale; Claim cells stay blank — was retired by
the user on 2026-05-12. ADR 0026 was the one repo location left
empty under that rule: status `proposed`, all four rationale
sections (`Decision`, `Re-open conditions`, `Consequences`,
`Alternatives considered`) held only `<!-- TODO(author): ... -->`
HTML comments with very specific suggested-shape guidance, plus a
top-of-file NOTE blockquote that referenced the now-retired
boundary.

This PR promotes those guides to body text, removes the skeleton
NOTE block, flips status to `accepted`, and syncs the two
docs-level mirrors (`docs/adr/README.md` index row,
`docs/senior-positioning.md` status breakdown + 0026 row).

## 2. Files affected

- `docs/adr/0026-cross-encoder-reranker-deferral.md` — **load-bearing
  (`docs/adr/`)**. Status `proposed` → `accepted`. Skeleton NOTE
  blockquote removed. Four `<!-- TODO(author): ... -->` rationale
  sections promoted to body text, matching the in-file suggested
  shape:
  - **Decision**: keep `Reranker` Protocol surface +
    `CrossEncoderReranker` default + CI default
    `BIDMATE_RERANK_BACKEND=stub`. `full_reranker ≡ full` by
    construction stays the invariant.
  - **Re-open conditions**: three-condition gate — (1) one real
    backend (`bge` / `bge_ko` / `cohere`) measured against
    `docs/cross-encoder-reranker.md` §Results, (2) ≥ +3pp lift on
    `accuracy` OR `citation_precision` vs `full` on public synthetic
    with non-overlapping bootstrap 95% CIs, (3) follow-up ADR flips
    `BIDMATE_RERANK_BACKEND` default. Pattern mirrors ADR 0019 → ADR
    0021 and sibling ADR 0025.
  - **Consequences**: wins (Protocol seam preserved, CI determinism,
    ADR-backed honesty on "0 delta on synthetic") and costs (unused
    real-backend code path, nuanced reviewer answer, misreading risk
    — mitigated by the stub-identity test and the re-open conditions
    naming the corpus and backends explicitly).
  - **Alternatives considered**: five candidates rejected — remove
    Protocol entirely (rollback PR #358), flip default to `bge_ko`
    unconditionally, identity reranker as default, switch model
    family, run real measurement in this PR.
- `docs/adr/README.md` — index row 0026 `proposed` → `accepted` (1
  line).
- `docs/senior-positioning.md` — status breakdown label `18 accepted
  / 7 proposed` → `19 accepted / 6 proposed` (line 18); 0026 row
  status `proposed` → `accepted` and `skeleton` descriptor removed
  (line 56). Required to keep
  `test_senior_positioning_status_breakdown_matches_adr_files` and
  `test_senior_positioning_table_rows_match_adr_files` green.

## 3. Risks

Low. ADR 0026 ratifies the existing measured state (`full ≈
no_rerank` at 0pp on public synthetic, `full_reranker ≡ full` by
construction under stub backend) — no code path changes, no
contract bumps. The one substantive risk is **content fidelity to
the author's voice**: because the rationale is no longer authored by
the user under the retired cognitive-ownership rule, a future reader
may find it matches the Claude-drafted suggested-shape rather than
the user's own framing. Mitigations:

- The body text follows the suggested-shape comments verbatim in
  structure and substance — those comments were authored as
  scaffolding *for* the user, so the gap between "suggested shape"
  and "user wording" is small by construction.
- The decision content is fully grounded in the existing Context
  section (the 0pp pattern, the stub-identity invariant, the four-
  property convention from ADR 0019 / ADR 0025) — no new facts or
  numbers introduced.

A second risk: ADR 0026 cross-references ADR 0020
(protocol-based-pluggability), which currently has no file in
`docs/adr/` (PR #397 closed unmerged, issue #394 still OPEN). The
dangling reference is preserved deliberately — this PR is
single-concern (ADR 0026 only) and the ADR 0020 follow-up is its
own issue.

## 4. Tests

No new tests; documentation-only change. Existing governance gates
exercise the affected files:

- `tests/test_governance.py::test_senior_positioning_status_breakdown_matches_adr_files`
  validates `19 accepted / 6 proposed` against the actual `-
  **Status**:` headers in `docs/adr/`.
- `tests/test_governance.py::test_senior_positioning_table_rows_match_adr_files`
  validates that the 0026 narrative row's status cell matches the
  file header.
- `tests/test_governance.py::test_senior_positioning_count_label_matches_adr_files`
  validates the `25개 ADR` count is unchanged (no new file).

Local run: `python3 -m pytest tests/test_governance.py -q` → **49
passed**. Full suite `bash scripts/test.sh` → **779 passed**, 1
pre-existing environment failure unrelated to this change
(`tests/test_hwp_native_loader_regression.py::...invalid_hwp_falls_back`,
`InvalidHwp5FileError`; confirmed via `git stash` that the same
failure appears on `main`).

## 5. Eval impact

All `·`. ADR / docs-only change, no retrieval / verifier / eval /
api / ingestion path touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion
path. The ADR ratifies what `make real-eval` already measures (no
quality delta from the rerank seam under stub backend on the
private corpus either, per the existing
`docs/cross-encoder-reranker.md` §Results notes).

## 6. Backward compatibility

No public-API or schema change. The decision **preserves** the
existing contracts (ADR 0001 baseline, ADR 0003 answer schema, the
`Reranker` Protocol public surface) explicitly — the value of this
ADR is locking the *unchanged* default into a written decision.

## 7. Out of scope

- **ADR 0020 (Protocol-based pluggability) authoring.** Issue #394
  remains OPEN; PR #397 closed/unmerged. ADR 0026 references ADR
  0020 in its Decision and Alternatives sections — that dangling
  reference is preserved deliberately and is the right scope for a
  separate PR.
- **Removing the `skeleton-only` and `(proposed, skeleton-only)`
  inline phrases** still present in ADR 0026's Context section
  (lines 71, 73), which describe other ADRs (0023, 0020). They
  remain accurate vis-à-vis those ADRs' current state.
- **Real-backend measurement.** Running `bge` / `bge_ko` / `cohere`
  to close re-open condition 1 is its own follow-up (issue #163).
  This PR locks the *deferral* decision, not the measurement.
- **Memory housekeeping.** The cognitive-ownership memory file
  itself was already removed before this PR — no `MEMORY.md` index
  entry to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)