### PR TITLE
docs(adr): promote ADR 0022 to accepted (#453)

### DIFF
--- a/docs/adr/0022-langgraph-orchestration-stage-1.md
+++ b/docs/adr/0022-langgraph-orchestration-stage-1.md
@@ -1,9 +1,10 @@
 # 0022: LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough)
 
-- **Status**: proposed
+- **Status**: accepted
 - **Date**: 2026-05-12
 - **Deciders**: hskim
-- **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (naive_baseline reserved as direct-path ablation), [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (agentic_full_llm under same retrieval surface), [ADR 0013](./0013-observability-as-additive-pluggable-surface.md) (trace backend additivity pattern this ADR reuses), issue #401
+- **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (naive_baseline reserved as direct-path ablation), [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (agentic_full_llm under same retrieval surface), [ADR 0013](./0013-observability-as-additive-pluggable-surface.md) (trace backend additivity pattern this ADR reuses), issue #401, PR #404 (implementation), issue #453 (status flip)
+- **Update (status flip, 2026-05-12, issue #453)**: Status promoted `proposed` → `accepted`. The stage-1 implementation merged via PR [#404](https://github.com/hskim-solv/BidMate-DocAgent/pull/404) (commit `349dd08`) lands all four sub-items from the Decision section: `requirements-graph.txt`, [`rag_graph_agentic_full.py`](../../rag_graph_agentic_full.py) (`AgenticFullState` TypedDict + `run_via_langgraph` entry point + process-cached compiled graph), [`rag_core.py:3673-3690`](../../rag_core.py) (env-var dispatch + `_skip_graph` recursion guard + `naive_baseline` bypass), and [`tests/test_langgraph_orchestrator_regression.py`](../../tests/test_langgraph_orchestrator_regression.py) (JSON-identity over `(agentic_full, agentic_full_llm) × (single-doc, comparison)` modulo timing fields, ADR 0001 invariant gate, module import smoke). The "What stage 2 will do" section below remains the unchanged forward plan and is *not* part of this status flip.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,7 +83,7 @@ project record.
 | [0018](./0018-korean-public-rag-bench.md) | accepted | Korean public RAG bench as supplementary out-of-domain surface (extends 0005) |
 | [0019](./0019-embedding-default-stays-minilm.md) | accepted | Embedding default stays MiniLM-L12-v2 with explicit re-open conditions (extends 0002) |
 | [0021](./0021-bge-m3-completes-phase-1-3.md) | accepted | BGE-M3 closes ADR 0019 Phase 1.3 condition 2; default stays MiniLM (supplements 0019) |
-| [0022](./0022-langgraph-orchestration-stage-1.md) | proposed | LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough, opt-in via BIDMATE_ORCHESTRATOR=langgraph, preserves ADR 0001) |
+| [0022](./0022-langgraph-orchestration-stage-1.md) | accepted | LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough, opt-in via BIDMATE_ORCHESTRATOR=langgraph, preserves ADR 0001) |
 | [0023](./0023-hyde-query-expansion-ablation.md) | proposed | HyDE query expansion as additive ablation (extends 0001, preserves 0003, reuses 0011 / 0020 backend pattern) |
 | [0024](./0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) |
 | [0025](./0025-cost-frontier-defer-until-real-baselines.md) | accepted | Cost-accuracy frontier deferred until external baseline real runs land (defers #177; backs README §Limitations "비용 영점"; follows ADR 0019 → 0021 measurement-gated pattern) |

--- a/docs/senior-positioning.md
+++ b/docs/senior-positioning.md
@@ -15,7 +15,7 @@
 
 | 시그널 | 어디서 확인하나 |
 |---|---|
-| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 26개 ADR (19 accepted / 7 proposed), status-tracked, supersession chains 명시 |
+| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 26개 ADR (20 accepted / 6 proposed), status-tracked, supersession chains 명시 |
 | **측정 가능한 성공 기준**을 미리 잡고 그 기준으로 평가한다 | [`portfolio-case-study.md` §2](./portfolio-case-study.md), [`eval/config.yaml`](../eval/config.yaml), README headline 표 |
 | 합성 평가의 한계를 알고 **공개/비공개 평가 분리**로 보완한다 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) |
 | **실패를 분류·우선순위화**한 뒤 백로그로 만든다 | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), 메타 이슈 #49 |
@@ -49,7 +49,7 @@
 | [0018](./adr/0018-korean-public-rag-bench.md) | accepted | Korean public RAG bench (KorQuAD 2.1) as supplementary out-of-domain surface (extends 0005) | "한국어 일반 텍스트에서도 동작합니까?" 질문에 공개 재현 가능한 한 줄 명령(`make korean-public-eval`)으로 답변 — 합성 surface와 분리, CI 게이트가 *아님* |
 | [0019](./adr/0019-embedding-default-stays-minilm.md) | accepted | embedding 디폴트 = MiniLM-L12-v2 잠금 + 재오픈 조건 명시 (extends 0002) | 2차 사이클 측정이 env mismatch로 deferred됐을 때 *deferral 자체*를 ADR로 잠금 — 다음 contributor가 같은 실험을 다시 시도하지 않고, "디폴트 교체"의 empirical bar(`full` 파이프라인 ≥+5pp)도 명시 |
 | [0021](./adr/0021-bge-m3-completes-phase-1-3.md) | accepted | BGE-M3 Phase 1.3 측정 완료, ADR 0019 condition 2 closure (supplements 0019) | deferred 결정이 *실제로 닫히는 과정*까지 ADR로 박음. 4개 named candidate + 5개 임베딩(2019–2024) cross-architecture 측정으로 `0pp-on-full` 패턴이 empirical support 받는 단계까지 도달 |
-| [0022](./adr/0022-langgraph-orchestration-stage-1.md) | proposed | LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough + env-var dispatch, opt-in via `BIDMATE_ORCHESTRATOR=langgraph`) | "Agentic" 라벨에 코드 실체를 붙이는 epic의 stage 1 — JSON-identity 보장 가능한 단일 노드부터 land 후 stage 2에서 multi-node 분해. ADR 0001 `naive_baseline`은 직접 경로 유지. |
+| [0022](./adr/0022-langgraph-orchestration-stage-1.md) | accepted | LangGraph orchestrator path for agentic_full presets — stage 1 (single-node passthrough + env-var dispatch, opt-in via `BIDMATE_ORCHESTRATOR=langgraph`) | "Agentic" 라벨에 코드 실체를 붙이는 epic의 stage 1 — JSON-identity 보장 가능한 단일 노드부터 land 후 stage 2에서 multi-node 분해. ADR 0001 `naive_baseline`은 직접 경로 유지. |
 | [0023](./adr/0023-hyde-query-expansion-ablation.md) | proposed | HyDE query expansion as additive ablation (extends 0001, preserves 0003) | Reranker Protocol과 별도 Protocol seam — 쿼리↔문서 어휘 갭(공식체 RFP vs 일상 질의)을 LLM 가상답변 임베딩으로 메우는 ablation. `IdentityExpander` 디폴트로 ADR 0001 골든 비트동일 유지 |
 | [0024](./adr/0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) | "Agentic RAG" 라벨에 *기본 API surface*를 맞추는 절충안. preset만 flip하고 synthesis backend default(`stub`)는 유지 — CI 결정성 + cost 0 보존. CLI / function-level / backend 3개 default 경계를 회귀 테스트로 잠금. |
 | [0025](./adr/0025-cost-frontier-defer-until-real-baselines.md) | accepted | cost-accuracy frontier을 외부 baseline 실측이 land할 때까지 deferral (defers #177; backs README §Limitations "비용 영점"; follows 0019 → 0021 pattern) | "왜 비용 축 frontier plot이 없냐?"에 modeled-cost 가짜 그림 대신 measurement-gated deferral로 응답. self-hosted 전부 cost=0이라 in-repo ablation들은 x=0에 모임 → 외부 baseline(`backend != "stub"`) 실측이 들어와야 비로소 의미 — 그 조건을 ADR로 잠금. #124의 latency-quality Pareto frontier가 그동안 portfolio asset. |


### PR DESCRIPTION
## 1. What changed and why

ADR 0022 (LangGraph orchestrator stage 1) was labeled `proposed` while its stage-1 implementation has been in `main` since PR #404 (commit `349dd08`). Every sub-item from the Decision section is live: `requirements-graph.txt`, `rag_graph_agentic_full.py`, `rag_core.py:3673-3690` dispatch, `tests/test_langgraph_orchestrator_regression.py`. This PR flips the status to `accepted` and adds an Update note pointing to PR #404. Pure-docs.

Closes #453

## 2. Files affected

- `docs/adr/0022-langgraph-orchestration-stage-1.md` — status header + new Update note
- `docs/adr/README.md` — index row 0022 status column

`docs/adr/` is load-bearing per `scripts/_governance.py`.

## 3. Risks

Mis-statement of which sub-items shipped vs. didn't. Mitigated by checking each file referenced in the Update note exists on `main` and that the existing `test_langgraph_orchestrator_regression.py` matches the regression-test description in the ADR Decision section.

## 4. Tests

N/A — docs-only PR. The relevant regression test (`tests/test_langgraph_orchestrator_regression.py`) already exists in `main` (added by #404).

## 5. Eval impact

All `·`. No code changes — no retrieval, verifier, or answer-generation paths touched.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. The status flip touches only ADR text + the index row; no load-bearing code path is modified. The implementation has been live since #404.

## 6. Backward compatibility

None affected. ADR status flips do not change behavior, contracts, or schemas. The implementation has been live since #404.

## 7. Out of scope

- Adding "What stage 2 will do" implementation (multi-node decomposition into analyze / retrieve / build_answer with conditional retry edge). That section of ADR 0022 remains the forward plan and is *not* part of this status flip.

## Discovery

Surfaced during PR #452 (external review followup) implementation. The "Deferred decisions (measurement-gated re-open)" matrix added in that PR explicitly excluded ADR 0022 because it's an accepted action item — but the ADR body still read `proposed`. Closing the inconsistency.