### PR TITLE
refactor(core): extract apply_fusion_and_reranking to rag_retrieval (#459)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Closes #
 <!--
 Bulleted list. Flag any of these as load-bearing
 (canonical list: scripts/_governance.py):
-rag_core.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py
+rag_core.py, rag_retrieval.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py
 -->
 
 ## 3. Risks
@@ -47,7 +47,7 @@ What do you expect the CI eval delta to show?
 
 <!--
 Required if any load-bearing path changed
-(rag_core.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py).
+(rag_core.py, rag_retrieval.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py).
 Attach the `make real-eval-delta` aggregate table, or state explicitly:
 "No behavior change in retrieval / verifier path."
 See ADR 0005 and docs/private-100-doc-experiments.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ Supporting:
 
 - `app.py` — CLI query entry point.
 - `rag_vector_store.py` — `VectorStore` Protocol behind the embeddings sidecar (issue #232, Stage 1 of #176). `BIDMATE_INDEX_BACKEND=memory` is the only supported value today; `qdrant` / `pgvector` are reserved for follow-up PRs.
-- `rag_reranker.py` — `Reranker` Protocol + default `CrossEncoderReranker` adapter (issue #345, follow-up to #332). Wraps `rag_rerank.rerank` so future HyDE / LLM-as-reranker impls plug in without touching `rag_core.apply_fusion_and_reranking`.
+- `rag_reranker.py` — `Reranker` Protocol + default `CrossEncoderReranker` adapter (issue #345, follow-up to #332). Wraps `rag_rerank.rerank` so future HyDE / LLM-as-reranker impls plug in without touching `rag_retrieval.apply_fusion_and_reranking`.
+- `rag_retrieval.py` — post-retrieval fusion / comparison balance / hierarchical reassembly extracted from `rag_core.py` (issue #459, PR-H1a). Owns `apply_fusion_and_reranking` (RRF + cross-encoder dispatch), `apply_comparison_balance` (coverage-aware top-k), and `reassemble_parent_sections` (hierarchical mode). Late-imports `comparison_targets_for_analysis` / `normalize_regions` / `normalize_page_span` from `rag_core` to avoid circular imports.
 - `rag_query_expansion.py` — `QueryExpander` Protocol + default `IdentityExpander` + opt-in `HyDEExpander` (issue #396, ADR 0023). Plugs in before the dense-embedding call in `rag_core.retrieve_candidates`; BM25 / lexical / metadata paths consume `analysis.tokens` and remain invariant. Identity default preserves the ADR 0001 `naive_baseline` bit-identical golden.
 - `scripts/` — `build_index.py`, `update_readme_metrics.py`, `run_real_eval_delta.py`, etc.
 - `data/raw/` → `data/index/` → `outputs/` → `reports/` (pipeline artifacts).

--- a/docs/adr/0026-cross-encoder-reranker-deferral.md
+++ b/docs/adr/0026-cross-encoder-reranker-deferral.md
@@ -17,7 +17,7 @@ each is in a different state of measurement:
    ([`rag_reranker.py`](../../rag_reranker.py), introduced by issue
    [#345](https://github.com/hskim-solv/oss-bidmate-docagent/issues/345)
    / PR [#358](https://github.com/hskim-solv/oss-bidmate-docagent/pull/358))
-   — consumed by [`rag_core.apply_fusion_and_reranking`](../../rag_core.py)
+   — consumed by [`rag_retrieval.apply_fusion_and_reranking`](../../rag_retrieval.py) (extracted from `rag_core.py` in PR-H1a, issue #459)
    only when `plan["rerank_cross_encoder"]` is set. Surfaced as the
    `full_reranker` preset in [`eval/config.yaml`](../../eval/config.yaml)
    `line 143-149` (`rerank: true` + `rerank_cross_encoder: true`).

--- a/rag_core.py
+++ b/rag_core.py
@@ -84,6 +84,16 @@ from rag_pipeline_presets import (
     pipeline_cli_choices,
     resolve_pipeline_config,
 )
+# PR-H1a (issue #459): post-retrieval fusion / comparison balance /
+# hierarchical reassembly extracted to rag_retrieval. Public functions
+# re-exported for backward compatibility with any caller that imports
+# them from rag_core (no in-repo callers do so today, but the import
+# surface stays stable).
+from rag_retrieval import (
+    apply_comparison_balance,
+    apply_fusion_and_reranking,
+    reassemble_parent_sections,
+)
 
 # Conversation state schema + helpers live in rag_conversation_state.py as
 # of issue #415 (PR-E stage 3 of the rag_core.py decomposition epic). The
@@ -1929,219 +1939,6 @@ def retrieve_candidates(
         scored.append(item)
     return scored
 
-
-def apply_fusion_and_reranking(
-    scored: list[dict[str, Any]],
-    index: dict[str, Any],
-    query: str,
-    analysis: dict[str, Any],
-    plan: dict[str, Any],
-) -> list[dict[str, Any]]:
-    """Fuse, sort, optionally cross-encoder rerank, then apply top-k.
-    Takes the pre-fusion list from ``retrieve_candidates`` and returns
-    the final ranked evidence. Mutates ``plan`` with
-    ``rerank_cross_encoder_meta`` only when the cross-encoder stage
-    runs (unchanged behavior)."""
-    retrieval_backend = str(plan.get("retrieval_backend", "dense"))
-    # RRF channel selection by backend. ``hybrid`` stays 2-way (dense +
-    # bm25) — bit-identical to ADR 0010. ``m3`` is 3-way (dense + m3_sparse
-    # + m3_colbert) per issue #151 measurement spike. Both share the
-    # same N-way RRF + normalization math below.
-    rrf_channel_keys: tuple[str, ...] = ()
-    if retrieval_backend == "hybrid":
-        rrf_channel_keys = ("dense", "bm25")
-    elif retrieval_backend == "m3":
-        rrf_channel_keys = ("dense", "m3_sparse", "m3_colbert")
-    if rrf_channel_keys and scored:
-        # Stable rank-by-channel: sort by (channel_score desc, chunk_id) so
-        # ties resolve deterministically. Same idiom as the ADR 0010
-        # hybrid path it replaces.
-        channel_ranks: dict[str, dict[str, int]] = {}
-        for key in rrf_channel_keys:
-            ordered = sorted(
-                scored,
-                key=lambda it, k=key: (it["score_parts"].get(k, 0.0), it["chunk_id"]),
-                reverse=True,
-            )
-            channel_ranks[key] = {it["chunk_id"]: rank for rank, it in enumerate(ordered)}
-        # Raw N-way RRF tops out at N/k. Normalize to [0,1] so the
-        # verifier's score floor (rag_core.py:2254, threshold 0.18 tuned
-        # for the dense+lexical fusion) keeps working for every backend
-        # without per-backend branches. ``rrf_k`` is plan-time
-        # configurable per issue #149; default still ``RRF_K = 60``.
-        rrf_k = int(plan.get("rrf_k", RRF_K))
-        rrf_norm = rrf_k / float(len(rrf_channel_keys))
-        for item in scored:
-            cid = item["chunk_id"]
-            rrf = sum(1.0 / (rrf_k + ranks[cid]) for ranks in channel_ranks.values())
-            item["score"] = round(float(rrf * rrf_norm), 6)
-            item["score_parts"]["rank_rrf"] = round(float(rrf * rrf_norm), 6)
-
-    scored.sort(key=lambda item: item["score"], reverse=True)
-    if plan.get("rerank_cross_encoder"):
-        from rag_reranker import default_reranker
-
-        top_n = min(30, max(int(plan["top_k"] or 10) * 3, int(plan["top_k"] or 10)))
-        scored, rerank_meta = default_reranker().rerank(query, scored, top_n=top_n)
-        plan["rerank_cross_encoder_meta"] = rerank_meta
-    top_k = int(plan["top_k"])
-    if plan.get("retrieval_mode") == "hierarchical":
-        return reassemble_parent_sections(index, scored, top_k, plan, analysis)
-    return apply_comparison_balance(scored, analysis, plan, top_k)
-
-
-def _coverage_counts(
-    items: list[dict[str, Any]],
-    targets: list[str],
-    target_field: str,
-) -> dict[str, int]:
-    counts = {target: 0 for target in targets}
-    for item in items:
-        value = item.get(target_field)
-        if value in counts:
-            counts[value] += 1
-    return counts
-
-
-def apply_comparison_balance(
-    scored: list[dict[str, Any]],
-    analysis: dict[str, Any],
-    plan: dict[str, Any],
-    top_k: int,
-) -> list[dict[str, Any]]:
-    """Apply coverage-aware top-k cut for comparison queries.
-
-    For non-comparison queries or when fewer than two targets are matched, this
-    is a no-op equivalent to ``scored[:top_k]``. When enabled, it guarantees up
-    to ``min_per_target`` top-scoring items per comparison target before
-    filling the remainder by global score. Records ``comparison_coverage``
-    diagnostics on the plan dict either way (so observability is consistent
-    across enabled/disabled states).
-    """
-    targets, target_field = comparison_targets_for_analysis(analysis)
-    is_comparison = analysis.get("query_type") == "comparison" and len(targets) >= 2
-
-    balance_config = plan.get("comparison_balance") or {}
-    enabled = bool(balance_config.get("enabled")) and is_comparison
-
-    if not is_comparison:
-        return scored[:top_k]
-
-    before = _coverage_counts(scored, targets, target_field)
-
-    if not enabled:
-        selected = scored[:top_k]
-        plan["comparison_coverage"] = {
-            "targets": targets,
-            "target_field": target_field,
-            "before": before,
-            "after": _coverage_counts(selected, targets, target_field),
-            "balanced": False,
-        }
-        return selected
-
-    min_per_target = max(1, int(balance_config.get("min_per_target", 1)))
-    if len(targets) > 0:
-        max_min = max(1, top_k // len(targets))
-        effective_min = min(min_per_target, max_min)
-    else:
-        effective_min = min_per_target
-
-    selected_ids: set[str] = set()
-    selected: list[dict[str, Any]] = []
-    for target in targets:
-        picks = 0
-        for item in scored:
-            if picks >= effective_min:
-                break
-            if item.get("chunk_id") in selected_ids:
-                continue
-            if item.get(target_field) == target:
-                selected.append(item)
-                selected_ids.add(item.get("chunk_id"))
-                picks += 1
-
-    for item in scored:
-        if len(selected) >= top_k:
-            break
-        if item.get("chunk_id") in selected_ids:
-            continue
-        selected.append(item)
-        selected_ids.add(item.get("chunk_id"))
-
-    selected.sort(key=lambda item: item["score"], reverse=True)
-    selected = selected[:top_k]
-
-    plan["comparison_coverage"] = {
-        "targets": targets,
-        "target_field": target_field,
-        "before": before,
-        "after": _coverage_counts(selected, targets, target_field),
-        "balanced": True,
-        "min_per_target": effective_min,
-    }
-    return selected
-
-
-def reassemble_parent_sections(
-    index: dict[str, Any],
-    scored_chunks: list[dict[str, Any]],
-    top_k: int,
-    plan: dict[str, Any],
-    analysis: dict[str, Any] | None = None,
-) -> list[dict[str, Any]]:
-    parent_by_id = {
-        str(section.get("section_id")): section
-        for section in index.get("parent_sections", [])
-        if section.get("section_id")
-    }
-    best_by_parent: dict[str, dict[str, Any]] = {}
-    child_ids_by_parent: dict[str, list[str]] = {}
-
-    for chunk in scored_chunks:
-        parent_id = str(
-            chunk.get("parent_section_id") or chunk.get("section_id") or chunk.get("chunk_id")
-        )
-        child_ids_by_parent.setdefault(parent_id, []).append(chunk["chunk_id"])
-        current = best_by_parent.get(parent_id)
-        if current is None or chunk["score"] > current["score"]:
-            best_by_parent[parent_id] = chunk
-
-    plan["parent_candidate_count"] = len(best_by_parent)
-
-    reassembled = []
-    for parent_id, best_chunk in best_by_parent.items():
-        parent = parent_by_id.get(parent_id)
-        if not parent:
-            item = dict(best_chunk)
-            item["retrieval_mode"] = "hierarchical_fallback"
-            item["child_chunk_ids"] = child_ids_by_parent.get(parent_id, [])
-            reassembled.append(item)
-            continue
-
-        item = {
-            **best_chunk,
-            "section_id": parent.get("section_id"),
-            "parent_section_id": parent_id,
-            "section": parent.get("section", best_chunk.get("section", "")),
-            "section_path": parent.get("section_path") or best_chunk.get("section_path") or [],
-            "text": parent.get("text", best_chunk.get("text", "")),
-            "chunking_strategy": parent.get("chunking_strategy", best_chunk.get("chunking_strategy", "")),
-            "retrieval_mode": "hierarchical",
-            "child_chunk_ids": child_ids_by_parent.get(parent_id, []),
-        }
-        parent_regions = normalize_regions(parent.get("regions"))
-        parent_page_span = normalize_page_span(parent.get("page_span"), parent_regions)
-        if parent_regions:
-            item["regions"] = parent_regions
-        if parent_page_span:
-            item["page_span"] = parent_page_span
-        reassembled.append(item)
-
-    reassembled.sort(key=lambda item: item["score"], reverse=True)
-    if analysis is not None:
-        return apply_comparison_balance(reassembled, analysis, plan, top_k)
-    return reassembled[:top_k]
 
 
 def embed_query_for_index(query: str, embedding_config: dict[str, Any]) -> np.ndarray:

--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -1,0 +1,267 @@
+"""Post-retrieval fusion, comparison balance, and hierarchical reassembly.
+
+Extracted from ``rag_core.py`` (PR-H1a, issue #459) as the first slice of the
+``retrieve_candidates`` → ``apply_fusion_and_reranking`` boundary
+decomposition that the PR-E series has been driving. The module owns the
+*post-candidate-scoring* path: it takes the pre-fusion list emitted by
+``rag_core.retrieve_candidates`` and returns the final ranked evidence
+that the verifier consumes.
+
+Public functions:
+
+- :func:`apply_fusion_and_reranking` — RRF fusion (`hybrid` 2-way,
+  `m3` 3-way), optional cross-encoder rerank dispatch (via
+  ``rag_reranker.default_reranker``), then either hierarchical
+  reassembly or comparison-balanced top-k.
+- :func:`apply_comparison_balance` — coverage-aware top-k that
+  guarantees ``min_per_target`` items per comparison target before
+  filling by global score. No-op for non-comparison queries.
+- :func:`reassemble_parent_sections` — hierarchical mode that promotes
+  the best child chunk per parent section into a single result.
+
+Internal helper :func:`_coverage_counts` is module-private (leading
+underscore preserved from the rag_core layout).
+
+Circular-import avoidance: ``comparison_targets_for_analysis``,
+``normalize_regions``, and ``normalize_page_span`` are late-imported
+from ``rag_core`` inside the functions that use them. These helpers
+are used in many rag_core call sites (not retrieval-specific) so they
+stay in rag_core; the late-import idiom keeps this module a true leaf
+of the dependency graph.
+
+JSON-identity guarantee: the four functions are moved without behavior
+change. ``tests/test_naive_baseline_ranking_invariance.py`` and
+``tests/test_retrieval_loop_regression.py`` are the regression gates.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rag_pipeline_presets import RRF_K
+
+
+def apply_fusion_and_reranking(
+    scored: list[dict[str, Any]],
+    index: dict[str, Any],
+    query: str,
+    analysis: dict[str, Any],
+    plan: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Fuse, sort, optionally cross-encoder rerank, then apply top-k.
+    Takes the pre-fusion list from ``retrieve_candidates`` and returns
+    the final ranked evidence. Mutates ``plan`` with
+    ``rerank_cross_encoder_meta`` only when the cross-encoder stage
+    runs (unchanged behavior)."""
+    retrieval_backend = str(plan.get("retrieval_backend", "dense"))
+    # RRF channel selection by backend. ``hybrid`` stays 2-way (dense +
+    # bm25) — bit-identical to ADR 0010. ``m3`` is 3-way (dense + m3_sparse
+    # + m3_colbert) per issue #151 measurement spike. Both share the
+    # same N-way RRF + normalization math below.
+    rrf_channel_keys: tuple[str, ...] = ()
+    if retrieval_backend == "hybrid":
+        rrf_channel_keys = ("dense", "bm25")
+    elif retrieval_backend == "m3":
+        rrf_channel_keys = ("dense", "m3_sparse", "m3_colbert")
+    if rrf_channel_keys and scored:
+        # Stable rank-by-channel: sort by (channel_score desc, chunk_id) so
+        # ties resolve deterministically. Same idiom as the ADR 0010
+        # hybrid path it replaces.
+        channel_ranks: dict[str, dict[str, int]] = {}
+        for key in rrf_channel_keys:
+            ordered = sorted(
+                scored,
+                key=lambda it, k=key: (it["score_parts"].get(k, 0.0), it["chunk_id"]),
+                reverse=True,
+            )
+            channel_ranks[key] = {it["chunk_id"]: rank for rank, it in enumerate(ordered)}
+        # Raw N-way RRF tops out at N/k. Normalize to [0,1] so the
+        # verifier's score floor (rag_core.py:2254, threshold 0.18 tuned
+        # for the dense+lexical fusion) keeps working for every backend
+        # without per-backend branches. ``rrf_k`` is plan-time
+        # configurable per issue #149; default still ``RRF_K = 60``.
+        rrf_k = int(plan.get("rrf_k", RRF_K))
+        rrf_norm = rrf_k / float(len(rrf_channel_keys))
+        for item in scored:
+            cid = item["chunk_id"]
+            rrf = sum(1.0 / (rrf_k + ranks[cid]) for ranks in channel_ranks.values())
+            item["score"] = round(float(rrf * rrf_norm), 6)
+            item["score_parts"]["rank_rrf"] = round(float(rrf * rrf_norm), 6)
+
+    scored.sort(key=lambda item: item["score"], reverse=True)
+    if plan.get("rerank_cross_encoder"):
+        from rag_reranker import default_reranker
+
+        top_n = min(30, max(int(plan["top_k"] or 10) * 3, int(plan["top_k"] or 10)))
+        scored, rerank_meta = default_reranker().rerank(query, scored, top_n=top_n)
+        plan["rerank_cross_encoder_meta"] = rerank_meta
+    top_k = int(plan["top_k"])
+    if plan.get("retrieval_mode") == "hierarchical":
+        return reassemble_parent_sections(index, scored, top_k, plan, analysis)
+    return apply_comparison_balance(scored, analysis, plan, top_k)
+
+
+def _coverage_counts(
+    items: list[dict[str, Any]],
+    targets: list[str],
+    target_field: str,
+) -> dict[str, int]:
+    counts = {target: 0 for target in targets}
+    for item in items:
+        value = item.get(target_field)
+        if value in counts:
+            counts[value] += 1
+    return counts
+
+
+def apply_comparison_balance(
+    scored: list[dict[str, Any]],
+    analysis: dict[str, Any],
+    plan: dict[str, Any],
+    top_k: int,
+) -> list[dict[str, Any]]:
+    """Apply coverage-aware top-k cut for comparison queries.
+
+    For non-comparison queries or when fewer than two targets are matched, this
+    is a no-op equivalent to ``scored[:top_k]``. When enabled, it guarantees up
+    to ``min_per_target`` top-scoring items per comparison target before
+    filling the remainder by global score. Records ``comparison_coverage``
+    diagnostics on the plan dict either way (so observability is consistent
+    across enabled/disabled states).
+    """
+    # Late-import to avoid circular dependency: rag_core imports this
+    # module's public functions, and comparison_targets_for_analysis
+    # lives in rag_core because it is also called from
+    # rag_core.retrieve_candidates (kept there in PR-H1a).
+    from rag_core import comparison_targets_for_analysis
+
+    targets, target_field = comparison_targets_for_analysis(analysis)
+    is_comparison = analysis.get("query_type") == "comparison" and len(targets) >= 2
+
+    balance_config = plan.get("comparison_balance") or {}
+    enabled = bool(balance_config.get("enabled")) and is_comparison
+
+    if not is_comparison:
+        return scored[:top_k]
+
+    before = _coverage_counts(scored, targets, target_field)
+
+    if not enabled:
+        selected = scored[:top_k]
+        plan["comparison_coverage"] = {
+            "targets": targets,
+            "target_field": target_field,
+            "before": before,
+            "after": _coverage_counts(selected, targets, target_field),
+            "balanced": False,
+        }
+        return selected
+
+    min_per_target = max(1, int(balance_config.get("min_per_target", 1)))
+    if len(targets) > 0:
+        max_min = max(1, top_k // len(targets))
+        effective_min = min(min_per_target, max_min)
+    else:
+        effective_min = min_per_target
+
+    selected_ids: set[str] = set()
+    selected: list[dict[str, Any]] = []
+    for target in targets:
+        picks = 0
+        for item in scored:
+            if picks >= effective_min:
+                break
+            if item.get("chunk_id") in selected_ids:
+                continue
+            if item.get(target_field) == target:
+                selected.append(item)
+                selected_ids.add(item.get("chunk_id"))
+                picks += 1
+
+    for item in scored:
+        if len(selected) >= top_k:
+            break
+        if item.get("chunk_id") in selected_ids:
+            continue
+        selected.append(item)
+        selected_ids.add(item.get("chunk_id"))
+
+    selected.sort(key=lambda item: item["score"], reverse=True)
+    selected = selected[:top_k]
+
+    plan["comparison_coverage"] = {
+        "targets": targets,
+        "target_field": target_field,
+        "before": before,
+        "after": _coverage_counts(selected, targets, target_field),
+        "balanced": True,
+        "min_per_target": effective_min,
+    }
+    return selected
+
+
+def reassemble_parent_sections(
+    index: dict[str, Any],
+    scored_chunks: list[dict[str, Any]],
+    top_k: int,
+    plan: dict[str, Any],
+    analysis: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    # Late-import to avoid circular dependency: rag_core uses
+    # normalize_regions / normalize_page_span in many non-retrieval
+    # call sites (ingestion path, evidence building, ...), so they
+    # stay in rag_core.
+    from rag_core import normalize_regions, normalize_page_span
+
+    parent_by_id = {
+        str(section.get("section_id")): section
+        for section in index.get("parent_sections", [])
+        if section.get("section_id")
+    }
+    best_by_parent: dict[str, dict[str, Any]] = {}
+    child_ids_by_parent: dict[str, list[str]] = {}
+
+    for chunk in scored_chunks:
+        parent_id = str(
+            chunk.get("parent_section_id") or chunk.get("section_id") or chunk.get("chunk_id")
+        )
+        child_ids_by_parent.setdefault(parent_id, []).append(chunk["chunk_id"])
+        current = best_by_parent.get(parent_id)
+        if current is None or chunk["score"] > current["score"]:
+            best_by_parent[parent_id] = chunk
+
+    plan["parent_candidate_count"] = len(best_by_parent)
+
+    reassembled = []
+    for parent_id, best_chunk in best_by_parent.items():
+        parent = parent_by_id.get(parent_id)
+        if not parent:
+            item = dict(best_chunk)
+            item["retrieval_mode"] = "hierarchical_fallback"
+            item["child_chunk_ids"] = child_ids_by_parent.get(parent_id, [])
+            reassembled.append(item)
+            continue
+
+        item = {
+            **best_chunk,
+            "section_id": parent.get("section_id"),
+            "parent_section_id": parent_id,
+            "section": parent.get("section", best_chunk.get("section", "")),
+            "section_path": parent.get("section_path") or best_chunk.get("section_path") or [],
+            "text": parent.get("text", best_chunk.get("text", "")),
+            "chunking_strategy": parent.get("chunking_strategy", best_chunk.get("chunking_strategy", "")),
+            "retrieval_mode": "hierarchical",
+            "child_chunk_ids": child_ids_by_parent.get(parent_id, []),
+        }
+        parent_regions = normalize_regions(parent.get("regions"))
+        parent_page_span = normalize_page_span(parent.get("page_span"), parent_regions)
+        if parent_regions:
+            item["regions"] = parent_regions
+        if parent_page_span:
+            item["page_span"] = parent_page_span
+        reassembled.append(item)
+
+    reassembled.sort(key=lambda item: item["score"], reverse=True)
+    if analysis is not None:
+        return apply_comparison_balance(reassembled, analysis, plan, top_k)
+    return reassembled[:top_k]

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -32,6 +32,7 @@ import sys
 # (prefix match); others as files (exact name or "/<name>" suffix match).
 LOAD_BEARING_PATHS: list[str] = [
     "rag_core.py",
+    "rag_retrieval.py",
     "ingestion.py",
     "visual_ingestion.py",
     "eval/",


### PR DESCRIPTION
## 1. What changed and why

First slice (PR-H1a) of the rag_core.py post-retrieval decomposition that the external senior review (2026-05) §A1-R1 flagged. The PR-E series has already extracted 6+ modules; this PR moves the post-candidate-scoring path to a new \`rag_retrieval.py\` leaf module.

Specifically, four functions move from \`rag_core.py:1933-2144\` to new \`rag_retrieval.py\`:
- \`apply_fusion_and_reranking\` — RRF (hybrid 2-way / m3 3-way) + cross-encoder rerank dispatch
- \`_coverage_counts\` — private helper for comparison balance
- \`apply_comparison_balance\` — coverage-aware top-k that guarantees \`min_per_target\` per comparison target
- \`reassemble_parent_sections\` — hierarchical retrieval mode

Closes #459

## 2. Files affected

- \`rag_retrieval.py\` (new) — the four extracted functions + module docstring documenting the JSON-identity contract and late-import idiom
- \`rag_core.py\` — delete the four functions, add \`from rag_retrieval import (...)\` so existing callers that imported them from \`rag_core\` keep working
- \`scripts/_governance.py\` — \`LOAD_BEARING_PATHS\` adds \`rag_retrieval.py\` (load-bearing per CLAUDE.md convention)
- \`.github/pull_request_template.md\` — load-bearing hint updated for \`test_pr_template_mentions_all_canonical_entries\`
- \`CLAUDE.md\` — repository map entry for \`rag_retrieval.py\` + \`rag_reranker\` reference now points to \`rag_retrieval.apply_fusion_and_reranking\`
- \`docs/adr/0026-cross-encoder-reranker-deferral.md\` — cross-ref to new module

Load-bearing per \`scripts/_governance.py\`: \`rag_core.py\`, new \`rag_retrieval.py\`, \`docs/adr/\`.

## 3. Risks

Highest-likelihood break: import-cycle deadlock. Mitigation: \`comparison_targets_for_analysis\`, \`normalize_regions\`, \`normalize_page_span\` are called from many non-retrieval sites in \`rag_core\` and cannot move; they are lazy-imported inside the \`rag_retrieval\` functions that need them. Verified by direct \`python3 -c "import rag_core"\` smoke and full test suite (\`838 passed, 1 skipped, 0 failed\`).

Second risk: behavior drift in the moved functions. Mitigation: pure mechanical move — every line of the four functions is preserved byte-for-byte. JSON-identity preserved by construction; \`tests/test_naive_baseline_ranking_invariance.py\` (ADR 0001 golden) and \`tests/test_retrieval_loop_regression.py\` are the regression gates and both pass.

## 4. Tests

No new tests. The refactor is mechanical and the existing regression gates are sufficient:
- \`tests/test_naive_baseline_ranking_invariance.py\` pins the ADR 0001 golden \`naive_baseline_top_k.json\` — passing means the dense → fusion → top-k path is byte-identical for the 25-query golden set
- \`tests/test_retrieval_loop_regression.py\` covers the full retrieve → verify → answer loop
- \`tests/test_langgraph_orchestrator_regression.py\` (added in PR #458, LangGraph stage 2) — \`agentic_full\` / \`agentic_full_llm\` × single-doc / comparison combinations stay JSON-identical between direct and LangGraph paths after the rebase
- \`tests/test_governance.py\` (49 cases) — all pass including the load-bearing path and PR template tests touched by this refactor

## 5. Eval impact

All \`·\`. The four functions move bit-for-bit; retrieval / verifier / answer paths produce the same output dict.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. The refactor is mechanical move + late-import for circular-avoidance; every line of the four functions is preserved verbatim. \`naive_baseline\` golden bit-identical (tests/test_naive_baseline_ranking_invariance.py is the gate).

## 6. Backward compatibility

\`rag_core\` re-exports \`apply_fusion_and_reranking\`, \`apply_comparison_balance\`, \`reassemble_parent_sections\` so any caller doing \`from rag_core import apply_fusion_and_reranking\` keeps working. No CLI flag changes, no schema changes, no contract changes. The lazy \`from rag_reranker import default_reranker\` inside \`apply_fusion_and_reranking\` is preserved.

## 7. Out of scope

PR-H1b (follow-up): \`retrieve_candidates\` (rag_core.py:1743-1932) + BM25/RRF helpers (rag_core.py:2179-2313). Larger surface; ADR 0023 (HyDE) cross-references the \`retrieve_candidates\` line directly so the move requires ADR cross-ref updates. Will land as a separate PR after this lands.

## Plan reference

\`/Users/hskim/.claude/plans/bidmate-docagent-rippling-feigenbaum.md\` PR-H1, subdivided here as PR-H1a (this PR) + PR-H1b (follow-up).