### PR TITLE
feat(eval-delta): N=21 real eval — signal recovery (N-aware silence + base/head CI + abstention 3-bin)

### DIFF
--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -364,6 +364,43 @@ def cross_ablation_retry_precision(
     }
 
 
+def _abstention_outcomes(case_results: list[dict[str, Any]]) -> dict[str, int]:
+    """Bucket intended-abstention cases into 3 outcome bins.
+
+    Issue #463: the headline ``abstention`` rate is bimodal — correct
+    refusals and "wrong answer plus hallucinated evidence" both collapse
+    into the same scalar, so a regression that flips a confident
+    abstention into a hallucinated answer can land at the same delta as
+    a regression that flips one into a partial refusal. The bins:
+
+    * ``correct_refusal`` — model abstained AND returned no evidence.
+    * ``incorrect_answer`` — model answered AND attached evidence
+      (a hallucination on a topic the corpus does not cover).
+    * ``boundary_partial`` — everything else: an abstention with
+      stray evidence, or an answer without evidence. These are the
+      ambiguous boundary cases worth manual triage.
+
+    Counts only; no per-case payload, no document IDs, no query text.
+    """
+    correct = incorrect = boundary = 0
+    for result in case_results:
+        if result.get("answerable") is not False:
+            continue
+        abstained = bool(result.get("abstained"))
+        has_evidence = bool(result.get("evidence_doc_ids"))
+        if abstained and not has_evidence:
+            correct += 1
+        elif not abstained and has_evidence:
+            incorrect += 1
+        else:
+            boundary += 1
+    return {
+        "correct_refusal": correct,
+        "incorrect_answer": incorrect,
+        "boundary_partial": boundary,
+    }
+
+
 def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
     accuracy_scores = [r["accuracy"] for r in case_results if r["accuracy"] is not None]
     groundedness_scores = [
@@ -391,6 +428,11 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         if r.get("claim_citation_alignment") is not None
     ]
     abstention_scores = [r["abstention"] for r in case_results if r["abstention"] is not None]
+    # Issue #463: decompose intended-abstention cases into 3 bins so the
+    # bimodal abstention score (0.0 / 1.0) stops collapsing distinct
+    # failure modes. Counts only — no per-case text — so the aggregate
+    # crosses the ADR 0005 commit boundary intact.
+    abstention_outcomes = _abstention_outcomes(case_results)
     comparison_recall_scores = [
         r["comparison_target_recall"]
         for r in case_results
@@ -487,6 +529,7 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         "citation_grounding": rate(citation_grounding_scores),
         "claim_citation_alignment": rate(claim_alignment_scores),
         "abstention": rate(abstention_scores),
+        "abstention_outcomes": abstention_outcomes,
         "answer_format_compliance": rate(format_scores),
         "ci": ci_block,
         "latency": {
@@ -801,6 +844,7 @@ def main() -> int:
         "citation_grounding": primary_summary["citation_grounding"],
         "claim_citation_alignment": primary_summary["claim_citation_alignment"],
         "abstention": primary_summary["abstention"],
+        "abstention_outcomes": primary_summary.get("abstention_outcomes"),
         "answer_format_compliance": primary_summary["answer_format_compliance"],
         "ci": primary_summary.get("ci", {}),
         "latency": primary_summary["latency"],

--- a/scripts/_eval_delta.py
+++ b/scripts/_eval_delta.py
@@ -82,11 +82,52 @@ def fmt_value(value: Any) -> str:
     return str(value)
 
 
-def fmt_delta(base: Any, head: Any, higher_is_better: bool) -> str:
+_ABS_SILENCE_FLOOR = 5e-4
+
+
+def min_num_predictions(*summaries: Any) -> int | None:
+    """Return the smallest positive ``num_predictions`` across summaries.
+
+    Used to size the N-aware silence threshold. Non-int / missing /
+    non-positive values are ignored; if no summary has a usable count
+    the caller falls back to the absolute floor.
+    """
+    counts: list[int] = []
+    for summary in summaries:
+        if not isinstance(summary, dict):
+            continue
+        value = summary.get("num_predictions")
+        if isinstance(value, int) and value > 0:
+            counts.append(value)
+    return min(counts) if counts else None
+
+
+def silence_threshold(n_min: int | None) -> float:
+    """Return the ``|delta| < threshold`` band that renders as ``·``.
+
+    Issue #463: a fixed ``5e-4`` floor silences only sub-rounding noise,
+    which is too tight for small N — on a real eval of N=21, a single
+    case is ±4.76 pp, so any move under half a case (~0.024) is
+    statistically indistinguishable from a tied state. Tying the band
+    to ``0.5 / n_min`` makes the silence rule N-aware while still
+    floored by the original rounding guard for large or unknown N.
+    """
+    if isinstance(n_min, int) and n_min > 0:
+        return max(_ABS_SILENCE_FLOOR, 0.5 / n_min)
+    return _ABS_SILENCE_FLOOR
+
+
+def fmt_delta(
+    base: Any,
+    head: Any,
+    higher_is_better: bool,
+    *,
+    n_min: int | None = None,
+) -> str:
     if not isinstance(base, (int, float)) or not isinstance(head, (int, float)):
         return "—"
     delta = float(head) - float(base)
-    if abs(delta) < 5e-4:
+    if abs(delta) < silence_threshold(n_min):
         return "·"
     sign = "+" if delta > 0 else ""
     improved = (delta > 0) if higher_is_better else (delta < 0)

--- a/scripts/compare_eval.py
+++ b/scripts/compare_eval.py
@@ -27,7 +27,14 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _eval_delta import METRICS, detect_regressions, fmt_delta, fmt_value, get_path  # noqa: E402
+from _eval_delta import (  # noqa: E402
+    METRICS,
+    detect_regressions,
+    fmt_delta,
+    fmt_value,
+    get_path,
+    min_num_predictions,
+)
 
 DEFAULT_REGRESSION_THRESHOLD = 0.05
 ENV_ALLOW_REGRESSION = "ALLOW_REGRESSION"
@@ -106,12 +113,16 @@ def main() -> int:
         f"head={head.get('num_predictions', '?')}"
     )
     lines.append("")
+    n_min = min_num_predictions(base, head)
     lines.append("| metric | main | PR | Δ |")
     lines.append("|---|---|---|---|")
     for path, label, higher, _gated in METRICS:
         b = get_path(base, path)
         h = get_path(head, path)
-        lines.append(f"| {label} | {fmt_value(b)} | {fmt_value(h)} | {fmt_delta(b, h, higher)} |")
+        lines.append(
+            f"| {label} | {fmt_value(b)} | {fmt_value(h)} | "
+            f"{fmt_delta(b, h, higher, n_min=n_min)} |"
+        )
     lines.append("")
 
     regressions: list[dict] = []

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -83,8 +83,15 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         # The block is {metric: {mean, ci_lo, ci_hi, n, num_resamples, alpha}};
         # the extractor below whitelists both the metric and sub-key sets.
         "ci",
+        # Issue #463: integer counts decomposing intended-abstention cases
+        # into 3 outcome bins. The extractor whitelists the bin names below
+        # and casts to int — no per-case text crosses the boundary.
+        "abstention_outcomes",
     }
 )
+
+# Whitelisted bin names for ``abstention_outcomes``. Integer counts only.
+SAFE_ABSTENTION_OUTCOME_KEYS = ("correct_refusal", "incorrect_answer", "boundary_partial")
 
 # Headline metrics whose bootstrap CI is allowed to round-trip the
 # extractor. Mirrors the scalar metrics already whitelisted at the top
@@ -148,6 +155,7 @@ SAFE_SLICE_METRICS = (
     "accuracy",
     "groundedness",
     "abstention",
+    "abstention_outcomes",
     "answer_format_compliance",
 )
 
@@ -255,6 +263,14 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                     extracted["cross_ablation"] = cross_out
             if extracted:
                 out[key] = extracted
+        elif key == "abstention_outcomes" and isinstance(value, dict):
+            bin_out = {
+                sub: int(value[sub])
+                for sub in SAFE_ABSTENTION_OUTCOME_KEYS
+                if isinstance(value.get(sub), (int, float))
+            }
+            if bin_out:
+                out[key] = bin_out
         elif key == "ci" and isinstance(value, dict):
             ci_out: dict[str, Any] = {}
             for metric in SAFE_CI_METRIC_KEYS:
@@ -303,11 +319,22 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
         for slice_name, slice_summary in by_query_type.items():
             if not isinstance(slice_summary, dict):
                 continue
-            slice_out[str(slice_name)] = {
-                m: slice_summary.get(m)
-                for m in SAFE_SLICE_METRICS
-                if slice_summary.get(m) is not None
-            }
+            extracted_slice: dict[str, Any] = {}
+            for m in SAFE_SLICE_METRICS:
+                raw = slice_summary.get(m)
+                if raw is None:
+                    continue
+                if m == "abstention_outcomes" and isinstance(raw, dict):
+                    bin_out = {
+                        sub: int(raw[sub])
+                        for sub in SAFE_ABSTENTION_OUTCOME_KEYS
+                        if isinstance(raw.get(sub), (int, float))
+                    }
+                    if bin_out:
+                        extracted_slice[m] = bin_out
+                else:
+                    extracted_slice[m] = raw
+            slice_out[str(slice_name)] = extracted_slice
         out["by_query_type"] = slice_out
 
     _assert_no_forbidden(out)
@@ -352,16 +379,82 @@ def _fmt_value(value: Any) -> str:
     return str(value)
 
 
-def _fmt_delta(base: Any, head: Any, higher_is_better: bool) -> str:
+_ABS_SILENCE_FLOOR = 5e-4
+
+
+def _silence_threshold(n_min: int | None) -> float:
+    """``|delta| < threshold`` band that renders as ``·``.
+
+    Issue #463: on N=21 a single case is ±4.76 pp, so the original
+    fixed ``5e-4`` band silences only sub-rounding noise and lets
+    sub-case wobble look like real movement. Sizing the band to
+    ``0.5 / n_min`` keeps it case-aware while floored by the original
+    rounding guard when N is unknown or large.
+    """
+    if isinstance(n_min, int) and n_min > 0:
+        return max(_ABS_SILENCE_FLOOR, 0.5 / n_min)
+    return _ABS_SILENCE_FLOOR
+
+
+def _fmt_delta(
+    base: Any,
+    head: Any,
+    higher_is_better: bool,
+    *,
+    n_min: int | None = None,
+) -> str:
     if not isinstance(base, (int, float)) or not isinstance(head, (int, float)):
         return "—"
     delta = float(head) - float(base)
-    if abs(delta) < 5e-4:
+    if abs(delta) < _silence_threshold(n_min):
         return "·"
     sign = "+" if delta > 0 else ""
     improved = (delta > 0) if higher_is_better else (delta < 0)
     flag = " ✅" if improved else " ⚠️"
     return f"{sign}{delta:.3f}{flag}"
+
+
+def _min_num_predictions(base: dict[str, Any], head: dict[str, Any]) -> int | None:
+    """Smallest positive ``num_predictions`` across base and head.
+
+    Tied to :func:`_silence_threshold`. Real-eval delta uses the
+    minimum of the two so the silence band is the *less powered* side's
+    half-case width — a slice that shrinks shouldn't lower the noise
+    floor with it.
+    """
+    counts: list[int] = []
+    for summary in (base, head):
+        if not isinstance(summary, dict):
+            continue
+        value = summary.get("num_predictions")
+        if isinstance(value, int) and value > 0:
+            counts.append(value)
+    return min(counts) if counts else None
+
+
+def _fmt_ci(summary: dict[str, Any], metric_key: str) -> str:
+    """Return `` [ci_lo, ci_hi]`` for the metric or empty string.
+
+    Issue #463: surface the single-run bootstrap CI (already aggregate-
+    safe via ADR 0005 whitelist, see ``SAFE_CI_METRIC_KEYS``) next to
+    each base/head value so reviewers can eyeball whether a delta sits
+    inside the noise band. Dotted paths (``latency.p50``) and metrics
+    without a CI block render as empty string and the table falls back
+    to bare values.
+    """
+    if not isinstance(summary, dict) or "." in metric_key:
+        return ""
+    ci_block = summary.get("ci")
+    if not isinstance(ci_block, dict):
+        return ""
+    metric_ci = ci_block.get(metric_key)
+    if not isinstance(metric_ci, dict):
+        return ""
+    lo = metric_ci.get("ci_lo")
+    hi = metric_ci.get("ci_hi")
+    if not isinstance(lo, (int, float)) or not isinstance(hi, (int, float)):
+        return ""
+    return f" [{lo:.3f}, {hi:.3f}]"
 
 
 def render_markdown(
@@ -384,15 +477,21 @@ def render_markdown(
     head_sha = str(((head.get("provenance") or {}).get("git_commit")) or "?")
     if base_sha != "?" or head_sha != "?":
         lines.append(f"- commits: base=`{base_sha}` · head=`{head_sha}`")
+    n_min = _min_num_predictions(base, head)
+    if n_min:
+        lines.append(
+            f"- silence band: ±{_silence_threshold(n_min):.3f} (N={n_min})"
+        )
     lines.append("")
-    lines.append("| metric | base | head | Δ |")
+    lines.append("| metric | base (95% CI) | head (95% CI) | Δ |")
     lines.append("|---|---|---|---|")
     for path, label, higher in METRICS:
         b = _get_path(base, path)
         h = _get_path(head, path)
         lines.append(
-            f"| {label} | {_fmt_value(b)} | {_fmt_value(h)} | "
-            f"{_fmt_delta(b, h, higher)} |"
+            f"| {label} | {_fmt_value(b)}{_fmt_ci(base, path)} "
+            f"| {_fmt_value(h)}{_fmt_ci(head, path)} "
+            f"| {_fmt_delta(b, h, higher, n_min=n_min)} |"
         )
 
     # Slice-level abstention is the most important signal we surfaced
@@ -411,8 +510,24 @@ def render_markdown(
             h = (head_slices.get(name) or {}).get("abstention")
             lines.append(
                 f"| {name} | {_fmt_value(b)} | {_fmt_value(h)} | "
-                f"{_fmt_delta(b, h, True)} |"
+                f"{_fmt_delta(b, h, True, n_min=n_min)} |"
             )
+
+    # Issue #463: 3-bin breakdown so a confident-refusal → hallucination
+    # regression and a confident-refusal → boundary-partial regression
+    # don't collapse onto the same scalar abstention delta.
+    base_outcomes = (base_slices.get("abstention") or {}).get("abstention_outcomes")
+    head_outcomes = (head_slices.get("abstention") or {}).get("abstention_outcomes")
+    if isinstance(base_outcomes, dict) or isinstance(head_outcomes, dict):
+        lines.append("")
+        lines.append("#### Abstention outcome breakdown (intended-abstention slice)")
+        lines.append("")
+        lines.append("| outcome | base | head |")
+        lines.append("|---|---:|---:|")
+        for outcome_key in SAFE_ABSTENTION_OUTCOME_KEYS:
+            b_count = (base_outcomes or {}).get(outcome_key, 0)
+            h_count = (head_outcomes or {}).get(outcome_key, 0)
+            lines.append(f"| {outcome_key} | {b_count} | {h_count} |")
 
     base_reasons = base.get("retry_reason_counts") or {}
     head_reasons = head.get("retry_reason_counts") or {}
@@ -446,7 +561,7 @@ def render_markdown(
             h = head_retry_eff.get(key)
             lines.append(
                 f"| {label} | {_fmt_value(b)} | {_fmt_value(h)} | "
-                f"{_fmt_delta(b, h, higher)} |"
+                f"{_fmt_delta(b, h, higher, n_min=n_min)} |"
             )
         base_cross = base_retry_eff.get("cross_ablation") or {}
         head_cross = head_retry_eff.get("cross_ablation") or {}
@@ -472,7 +587,7 @@ def render_markdown(
             h = head_ragas.get(metric)
             lines.append(
                 f"| {metric} | {_fmt_value(b)} | {_fmt_value(h)} | "
-                f"{_fmt_delta(b, h, True)} |"
+                f"{_fmt_delta(b, h, True, n_min=n_min)} |"
             )
 
     base_judge = base.get("judge") or {}
@@ -491,7 +606,7 @@ def render_markdown(
             h = head_judge.get(key)
             lines.append(
                 f"| {label} | {_fmt_value(b)} | {_fmt_value(h)} | "
-                f"{_fmt_delta(b, h, higher)} |"
+                f"{_fmt_delta(b, h, higher, n_min=n_min)} |"
             )
         base_dist = base_judge.get("status_distribution") or {}
         head_dist = head_judge.get("status_distribution") or {}

--- a/tests/test_compare_eval_regression_gate.py
+++ b/tests/test_compare_eval_regression_gate.py
@@ -27,7 +27,12 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from _eval_delta import detect_regressions  # noqa: E402
+from _eval_delta import (  # noqa: E402
+    detect_regressions,
+    fmt_delta,
+    min_num_predictions,
+    silence_threshold,
+)
 
 
 def _base_summary() -> dict:
@@ -107,6 +112,45 @@ class DetectRegressionsTest(unittest.TestCase):
         for r in regressions:
             self.assertIn("delta", r)
             self.assertIn("threshold", r)
+
+
+class SilenceBandTest(unittest.TestCase):
+    """Issue #463: ``fmt_delta`` silences sub-rounding noise on large N
+    but widens the band to half a case width when N is small, so 1-case
+    wobble on a tiny eval doesn't look like real signal."""
+
+    def test_silence_threshold_floor_when_n_omitted(self) -> None:
+        self.assertAlmostEqual(silence_threshold(None), 5e-4)
+
+    def test_silence_threshold_floor_for_large_n(self) -> None:
+        self.assertAlmostEqual(silence_threshold(10000), 5e-4)
+
+    def test_silence_threshold_scales_for_small_n(self) -> None:
+        self.assertAlmostEqual(silence_threshold(42), 0.5 / 42)
+        self.assertAlmostEqual(silence_threshold(21), 0.5 / 21)
+
+    def test_fmt_delta_silences_below_band_with_n_min(self) -> None:
+        # 0.5 / 21 ~= 0.024; a 0.010 delta sits below it.
+        self.assertEqual(fmt_delta(0.50, 0.51, True, n_min=21), "·")
+
+    def test_fmt_delta_surfaces_above_band_with_n_min(self) -> None:
+        rendered = fmt_delta(0.50, 0.55, True, n_min=21)
+        self.assertIn("+0.050", rendered)
+        self.assertIn("✅", rendered)
+
+    def test_fmt_delta_back_compat_without_n_min(self) -> None:
+        # Existing callers without n_min keep the original 5e-4 floor.
+        self.assertEqual(fmt_delta(0.500, 0.5002, True), "·")
+        self.assertIn("+0.001", fmt_delta(0.500, 0.5010, True))
+
+    def test_min_num_predictions_picks_smaller_side(self) -> None:
+        self.assertEqual(
+            min_num_predictions(
+                {"num_predictions": 42}, {"num_predictions": 21}
+            ),
+            21,
+        )
+        self.assertIsNone(min_num_predictions({}, None))
 
 
 class CompareEvalCliGateTest(unittest.TestCase):

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -15,6 +15,10 @@ import pytest
 
 from scripts.run_real_eval_delta import (
     FORBIDDEN_KEYS,
+    SAFE_ABSTENTION_OUTCOME_KEYS,
+    _fmt_delta,
+    _min_num_predictions,
+    _silence_threshold,
     extract_aggregate,
     render_markdown,
 )
@@ -413,6 +417,208 @@ class CIBlockExtractTest(unittest.TestCase):
     def test_ci_omitted_when_summary_has_no_ci(self) -> None:
         agg = extract_aggregate(FULL_SUMMARY)
         self.assertNotIn("ci", agg)
+
+
+class NAwareSilenceTest(unittest.TestCase):
+    """Issue #463: silence band must grow as ``num_predictions`` shrinks.
+
+    On a real eval of N=21 a single case is ±4.76 pp, so the original
+    fixed 5e-4 floor silenced only rounding noise and let sub-case
+    wobble look like real movement. The N-aware rule sizes the band to
+    half a case.
+    """
+
+    def test_silence_threshold_falls_back_to_floor_for_unknown_n(self) -> None:
+        self.assertAlmostEqual(_silence_threshold(None), 5e-4)
+
+    def test_silence_threshold_floor_for_large_n(self) -> None:
+        # 0.5 / 10000 = 5e-5 < 5e-4 floor, so the floor wins.
+        self.assertAlmostEqual(_silence_threshold(10000), 5e-4)
+
+    def test_silence_threshold_scales_for_small_n(self) -> None:
+        # 0.5 / 21 ~= 0.02381
+        self.assertAlmostEqual(_silence_threshold(21), 0.5 / 21)
+
+    def test_fmt_delta_silences_sub_half_case_on_small_n(self) -> None:
+        # delta = 0.010 is well under 0.5/21 ~ 0.024 → ·
+        self.assertEqual(_fmt_delta(0.50, 0.51, True, n_min=21), "·")
+
+    def test_fmt_delta_surfaces_above_half_case_on_small_n(self) -> None:
+        # delta = 0.050 > 0.024 → renders with direction arrow
+        rendered = _fmt_delta(0.50, 0.55, True, n_min=21)
+        self.assertIn("+0.050", rendered)
+        self.assertIn("✅", rendered)
+
+    def test_fmt_delta_silences_below_floor_when_n_omitted(self) -> None:
+        # Back-compat: callers without n_min still observe the 5e-4 floor.
+        self.assertEqual(_fmt_delta(0.500, 0.5003, True), "·")
+        rendered = _fmt_delta(0.500, 0.5010, True)
+        self.assertIn("+0.001", rendered)
+
+    def test_min_num_predictions_handles_missing_and_invalid(self) -> None:
+        self.assertIsNone(_min_num_predictions({}, {}))
+        self.assertIsNone(
+            _min_num_predictions({"num_predictions": -1}, {"num_predictions": 0})
+        )
+        self.assertEqual(
+            _min_num_predictions({"num_predictions": 42}, {"num_predictions": 21}),
+            21,
+        )
+
+
+class BaseHeadCIRenderTest(unittest.TestCase):
+    """Issue #463: surface single-run bootstrap CI next to base/head
+    values so reviewers can eyeball whether a delta sits inside the
+    noise band. The CI block is already aggregate-safe per ADR 0005."""
+
+    SUMMARY_WITH_CI = {
+        **FULL_SUMMARY,
+        "ci": {
+            "accuracy": {
+                "mean": 0.471,
+                "ci_lo": 0.235,
+                "ci_hi": 0.706,
+                "n": 21,
+                "num_resamples": 1000,
+            }
+        },
+    }
+
+    def test_render_includes_ci_bracket_for_metric_with_ci(self) -> None:
+        base = extract_aggregate(self.SUMMARY_WITH_CI)
+        head = extract_aggregate({**self.SUMMARY_WITH_CI, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+        # Bracketed CI appears next to the value.
+        self.assertIn("[0.235, 0.706]", md)
+
+    def test_render_skips_ci_bracket_for_dotted_path(self) -> None:
+        # latency.p50 has no `ci` block under its dotted path; render
+        # must not invent one.
+        base = extract_aggregate(self.SUMMARY_WITH_CI)
+        head = extract_aggregate({**self.SUMMARY_WITH_CI, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+        # latency_p50_ms row should not have a [lo, hi] bracket on it.
+        # We assert the value 100.000 (base latency p50) is not followed
+        # by a bracket.
+        self.assertNotIn("100.000 [", md)
+
+    def test_render_omits_bracket_when_ci_absent(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate({**FULL_SUMMARY, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+        # No CI block in FULL_SUMMARY → no brackets.
+        self.assertNotIn("[0.", md)
+
+    def test_render_shows_silence_band_header_when_n_known(self) -> None:
+        base = extract_aggregate(self.SUMMARY_WITH_CI)
+        head = extract_aggregate({**self.SUMMARY_WITH_CI, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+        self.assertIn("silence band", md)
+        self.assertIn("N=21", md)
+
+
+class AbstentionOutcomeBreakdownTest(unittest.TestCase):
+    """Issue #463: intended-abstention bimodality (0/1) collapsed two
+    distinct failure modes (hallucination vs ambiguous boundary).
+    The 3-bin breakdown surfaces them separately while staying within
+    the ADR 0005 aggregate-only commit boundary."""
+
+    SUMMARY_WITH_OUTCOMES = {
+        **FULL_SUMMARY,
+        "abstention_outcomes": {
+            "correct_refusal": 2,
+            "incorrect_answer": 1,
+            "boundary_partial": 1,
+        },
+        "by_query_type": {
+            **FULL_SUMMARY["by_query_type"],
+            "abstention": {
+                "num_predictions": 4,
+                "abstention": 0.5,
+                "abstention_outcomes": {
+                    "correct_refusal": 2,
+                    "incorrect_answer": 1,
+                    "boundary_partial": 1,
+                },
+            },
+        },
+    }
+
+    def test_outcomes_round_trip_at_top_level(self) -> None:
+        agg = extract_aggregate(self.SUMMARY_WITH_OUTCOMES)
+        self.assertIn("abstention_outcomes", agg)
+        outcomes = agg["abstention_outcomes"]
+        self.assertEqual(outcomes["correct_refusal"], 2)
+        self.assertEqual(outcomes["incorrect_answer"], 1)
+        self.assertEqual(outcomes["boundary_partial"], 1)
+        for value in outcomes.values():
+            self.assertIsInstance(value, int)
+
+    def test_outcomes_round_trip_in_slice(self) -> None:
+        agg = extract_aggregate(self.SUMMARY_WITH_OUTCOMES)
+        slice_payload = agg["by_query_type"]["abstention"]
+        self.assertIn("abstention_outcomes", slice_payload)
+        self.assertEqual(slice_payload["abstention_outcomes"]["correct_refusal"], 2)
+
+    def test_outcomes_extractor_drops_unknown_bin_keys(self) -> None:
+        summary = {
+            **FULL_SUMMARY,
+            "abstention_outcomes": {
+                "correct_refusal": 2,
+                "incorrect_answer": 1,
+                "boundary_partial": 1,
+                # Smuggling attempt — must be dropped.
+                "case_results": [{"id": "leak", "query": "leak"}],
+                "made_up_bin": 99,
+            },
+        }
+        agg = extract_aggregate(summary)
+        outcomes = agg["abstention_outcomes"]
+        self.assertEqual(set(outcomes.keys()), set(SAFE_ABSTENTION_OUTCOME_KEYS))
+        self.assertNotIn("made_up_bin", outcomes)
+        self.assertNotIn("leak", json.dumps(agg))
+
+    def test_outcomes_in_slice_drops_unknown_keys(self) -> None:
+        summary = {
+            **FULL_SUMMARY,
+            "by_query_type": {
+                "abstention": {
+                    "num_predictions": 4,
+                    "abstention_outcomes": {
+                        "correct_refusal": 1,
+                        "case_results": [{"id": "leak"}],
+                    },
+                }
+            },
+        }
+        agg = extract_aggregate(summary)
+        slice_outcomes = agg["by_query_type"]["abstention"]["abstention_outcomes"]
+        self.assertEqual(set(slice_outcomes.keys()), {"correct_refusal"})
+        self.assertNotIn("leak", json.dumps(agg))
+
+    def test_render_includes_outcome_breakdown_table(self) -> None:
+        base = extract_aggregate(self.SUMMARY_WITH_OUTCOMES)
+        head = extract_aggregate(
+            {
+                **self.SUMMARY_WITH_OUTCOMES,
+                "by_query_type": {
+                    **self.SUMMARY_WITH_OUTCOMES["by_query_type"],
+                    "abstention": {
+                        "num_predictions": 4,
+                        "abstention": 0.75,
+                        "abstention_outcomes": {
+                            "correct_refusal": 3,
+                            "incorrect_answer": 0,
+                            "boundary_partial": 1,
+                        },
+                    },
+                },
+            }
+        )
+        md = render_markdown(base, head, "test")
+        self.assertIn("Abstention outcome breakdown", md)
+        for key in SAFE_ABSTENTION_OUTCOME_KEYS:
+            self.assertIn(key, md)
 
 
 class FullScriptInvocationTest(unittest.TestCase):


### PR DESCRIPTION
## 1. What changed and why

Closes #463.

`reports/real100/baseline.aggregate.json` 실측 N=21. 그 위에서 `scripts/run_real_eval_delta._fmt_delta` 의 침묵 임계값(`5e-4`)은 *rounding noise* 수준이라, 시스템 변경이 1 케이스(±4.76 pp) 미만의 효과만 만들 때 거의 ✅/⚠️로 잡혀 "뭘 바꿔도 안 움직인다"는 체감을 만들고 있었다. 또한 abstention scalar(0/1 bimodal)와 base/head 값 옆에 CI가 없는 점이 변별력을 더 떨어뜨렸다.

이 PR은 *aggregate-only* 경계 안에서 셋을 함께 보완해 변별력을 회복한다:

1. **N-aware silence band** — `fmt_delta`/`_fmt_delta` 에 `n_min` 추가. 침묵 규칙을 `max(5e-4, 0.5 / n_min)` 로 N에 비례. real(N=21)=0.024, synthetic(N=42)=0.012, N 미지 시 기존 5e-4 유지.
2. **Base/head 단일-run bootstrap CI 동반 표시** — `scripts/run_real_eval_delta.render_markdown` 메트릭 표가 base/head 옆에 `[ci_lo, ci_hi]`를 함께 출력. CI 블록은 이미 `SAFE_CI_METRIC_KEYS` 화이트리스트로 ADR 0005 안전.
3. **Abstention 3-bin 분해** — `eval/run_eval.metric_block` 결과에 `abstention_outcomes = {correct_refusal, incorrect_answer, boundary_partial}` (정수 카운트). `SAFE_TOPLEVEL_KEYS` + `SAFE_SLICE_METRICS` 에 키 추가, 전용 extractor 분기로 unknown sub-key는 모두 drop.

## 2. Files affected

- `eval/run_eval.py` *(load-bearing)* — `_abstention_outcomes` 헬퍼 + `metric_block` / 최종 summary 매핑
- `scripts/run_real_eval_delta.py` *(load-bearing)* — N-aware silence, `_fmt_ci`, `SAFE_ABSTENTION_OUTCOME_KEYS` 화이트리스트, 3-bin 렌더 + slice 추출 보강
- `scripts/_eval_delta.py` — `fmt_delta(n_min=)`, `silence_threshold`, `min_num_predictions`
- `scripts/compare_eval.py` — 표 렌더에 `n_min` 전달
- `tests/test_run_real_eval_delta.py` — `NAwareSilenceTest`, `BaseHeadCIRenderTest`, `AbstentionOutcomeBreakdownTest`
- `tests/test_compare_eval_regression_gate.py` — `SilenceBandTest`

## 3. Risks

- **검증 항목 1**: `naive_baseline` 메트릭 결정성. *확인*: `make smoke` 후 `accuracy=0.84375 / groundedness=0.7143 / citation_precision=0.5119 / answer_format_compliance=0.6667 / abstention=0.30 / retry=0.0` 비트 동일 (이전 main의 5개 leaderboard 행과 일치). ADR 0001 위반 없음.
- **검증 항목 2**: ADR 0005 commit boundary. *확인*: 신규 키(`abstention_outcomes`)는 정수 카운트만; `_assert_no_forbidden` 재귀 가드가 그대로 작동; `test_outcomes_extractor_drops_unknown_bin_keys` / `test_outcomes_in_slice_drops_unknown_keys` 가 smuggling-attempt 입력을 drop 처리하는지 명시적으로 검증.
- **검증 항목 3**: 회귀 게이트(`detect_regressions`)는 `fmt_delta` 의 침묵 임계값을 사용하지 않으므로 N-aware silence가 그 동작을 바꾸지 않음. 기존 `test_compare_eval_regression_gate` 전부 통과.

## 4. Tests

- 추가 회귀 테스트 4개 클래스 (총 16개 신규 케이스):
  - `tests/test_run_real_eval_delta.py::NAwareSilenceTest` (×7) — `_silence_threshold` 분기 + `_fmt_delta` silence/표시/하위호환.
  - `tests/test_run_real_eval_delta.py::BaseHeadCIRenderTest` (×4) — CI 블록 있을 때 `[lo, hi]` 표시, dotted path는 건너뜀, silence band 헤더 노출.
  - `tests/test_run_real_eval_delta.py::AbstentionOutcomeBreakdownTest` (×5) — top-level/slice round-trip, unknown bin drop, smuggling drop, 렌더 표 노출.
  - `tests/test_compare_eval_regression_gate.py::SilenceBandTest` (×6) — `_eval_delta` 공유 헬퍼의 동일 거동.
- `pytest -q` 전체 결과: **866 passed, 1 skipped**. 새 테스트가 변경 전 코드에서는 실패(silence 5e-4 / CI 표시 없음 / abstention_outcomes 누락)함을 검토 단계에서 확인.

## 5. Eval impact

PR Eval Delta (`full` ablation, N=42) — 메트릭 값은 모두 비변경이므로 **전 항목 `·`** 가 예상됨. 새 silence band(0.012)에서도 sub-rounding 변화는 침묵 처리. CI 표시는 코멘트 표에 함께 노출되어 reviewer가 noise band를 한 눈에 볼 수 있음.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** 변경은 (a) delta 렌더링과 (b) ADR-0005-안전한 *aggregate 키 추가* 에 한정. `make real-eval` 산출물의 6개 헤드라인 메트릭은 본 PR로 비변경 — `make smoke` 가 동일 input에 대해 `naive_baseline` 비트 동일(이상치 절대값 동일)을 확인. 본 worktree에 `eval/real_config.local.yaml` 이 없어 `make real-eval-delta` 의 실 출력은 첨부하지 못함 — 머지 후 baseline 재생성 시 `abstention_outcomes` 키가 비파괴적으로 추가됨 (기존 메트릭은 그대로). 

후속 작업으로 `make real-eval` → `make real-eval-baseline-update` 한 번 돌려 baseline 스냅샷에 3-bin 카운트를 채워주는 follow-up issue 권장.

## 6. Backward compatibility

- `fmt_delta` / `_fmt_delta` 모두 `n_min` 을 *keyword-only* 로 추가. 기존 호출자는 모두 그대로 동작 (5e-4 floor 유지). 답변 contract(ADR 0003), `schema_version` 미변경.
- `eval_summary.json` 에 키만 *추가* (`abstention_outcomes`). 기존 컨슈머(leaderboard, compare_eval, write_synthetic_history)는 미해석 키를 무시.

## 7. Out of scope

다음은 본 PR과 별개 follow-up 이슈로 진행 예정:
- Leaderboard append 빈도 변경 (main 푸시 → 일 1회 스케줄). main 히스토리 봇 커밋 노이즈 감소.
- `run-eval` composite action 에 `eval_summary.json` 캐시 추가.
- Leaderboard headline 에 `naive_baseline` 외 `full` 한 줄 추가 (ADR 보강 필요).
- `_eval_delta.py` 와 `run_real_eval_delta.py` 의 중복된 fmt 헬퍼 통합.