### PR TITLE
ci(leaderboard): switch to daily cron + workflow_dispatch

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -1,21 +1,31 @@
-name: Leaderboard — append history + render on merge to main
+name: Leaderboard — append history + render (daily / on demand)
 
-# Issue #166: every merge to main produces one history snapshot under
-# reports/history/ and re-renders reports/leaderboard.md +
-# docs/leaderboard.md (Jekyll page consumed by GitHub Pages).
+# Issue #166: produce one history snapshot under reports/history/ and
+# re-render reports/leaderboard.md + docs/leaderboard.md (Jekyll page
+# consumed by GitHub Pages).
 #
 # Aggregate-only by construction — the writer reuses extract_aggregate
 # from scripts/run_real_eval_delta.py, so per-case fields cannot leak.
+#
+# Issue #471: trigger moved from `push to main` to a daily cron +
+# workflow_dispatch. The previous "every merge" cadence stamped a bot
+# commit per PR even when naive_baseline metrics were bit-identical
+# (ADR 0001 keeps that surface intentionally stable), so the main log
+# filled with `ci: append leaderboard for <sha>` rather than meaningful
+# changes. Run on-demand via `gh workflow run leaderboard.yml` when an
+# immediate stamp is needed (e.g. right after a load-bearing merge).
 
 on:
-  push:
-    branches: [main]
-    # Skip merge commits that are *themselves* the leaderboard bot,
-    # to prevent infinite trigger loops.
-    paths-ignore:
-      - "reports/history/**"
-      - "reports/leaderboard.md"
-      - "docs/leaderboard.md"
+  schedule:
+    # 22:00 KST / 13:00 UTC daily. GitHub Actions cron has up to 5m of
+    # drift; that's well within the leaderboard's daily granularity.
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Optional note logged alongside the dispatch event.'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -26,7 +36,6 @@ concurrency:
 
 jobs:
   append-and-render:
-    if: "!contains(github.event.head_commit.message, '[skip leaderboard]')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for git provenance)


### PR DESCRIPTION
## 1. What changed and why

Closes #471.

The leaderboard workflow fired on every push to `main` and appended a `ci: append leaderboard for <sha> [skip leaderboard]` bot commit each merge. `naive_baseline` metrics are bit-identical across recent merges by design (ADR 0001), so most of those bot commits were pure noise on the main log without adding new information.

> Stacked on [#470](https://github.com/hskim-solv/BidMate-DocAgent/pull/470) → [#464](https://github.com/hskim-solv/BidMate-DocAgent/pull/464). PR auto-rebase to main as upstream PRs merge.

Trigger replaced with:
- `schedule`: `0 13 * * *` (22:00 KST / 13:00 UTC, daily).
- `workflow_dispatch` with optional `reason` input for on-demand runs (`gh workflow run "Leaderboard …"`).

## 2. Files affected

- `.github/workflows/leaderboard.yml` — trigger swap, comment refresh, drop the now-redundant `[skip leaderboard]` guard.

Not load-bearing. No application code touched.

## 3. Risks

- **Immediate post-merge visibility gap** — a freshly merged PR's metrics are not stamped until the next cron. Mitigation: `naive_baseline` metrics rarely move across merges (ADR 0001 surface), and a manual `gh workflow run` is one command. Documented in the yml header comment.
- **Cron drift / miss** — GitHub Actions cron has up to ~5m drift, occasionally a missed firing. Daily cadence makes this low-impact; next cron or `workflow_dispatch` recovers.
- **`[skip leaderboard]` guard removal** — only made sense when the workflow chased its own push event. cron and dispatch don't have a head_commit. The `git diff --staged --quiet` short-circuit downstream still prevents empty commits.
- **Schedule disabling on inactive repos** — GitHub auto-disables `schedule` triggers after 60 days of repository inactivity. This repo is actively pushed to so the risk is theoretical; if the project goes dormant, manual dispatch covers gaps.

## 4. Tests

- YAML validation: `python3 -c 'import yaml; yaml.safe_load(open(...))'` passes.
- pytest unchanged (CI infra only): 866 passed, 1 skipped.
- End-to-end behavior validated by:
  1. Merge to main produces **no** new leaderboard run / bot commit (confirm via `gh run list --workflow=leaderboard.yml`).
  2. Next 22:00 KST cron fires and appends one snapshot.
  3. `gh workflow run "Leaderboard — …"` triggers on demand.

## 5. Eval impact

PR Eval Delta — no change.

Synthetic leaderboard time series — same metric values, lower temporal resolution (1/day instead of per-merge). Acceptable because metrics rarely change between merges on the naive_baseline surface.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** Pure CI infra; `eval/`, `rag_*.py`, `ingestion.py` untouched.

## 6. Backward compatibility

- Existing snapshots in `reports/history/` are untouched.
- `scripts/leaderboard.py --check` still verifies render is in sync with history.
- Downstream renderers (`docs/leaderboard.md` Jekyll page) see the same schema, just fewer rows over time.

## 7. Out of scope

- Adding a `full` ablation row to the leaderboard headline — separate issue (F3 of the post-#463 backlog).
- Backfill rendering of skipped merges — explicit non-goal; time series fidelity at 1/day granularity is the point.