### PR TITLE
refactor(eval-delta): collapse fmt/silence helpers into _eval_delta.py

### DIFF
--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -36,6 +36,29 @@ import sys
 from pathlib import Path
 from typing import Any
 
+# Issue #473: share the silence-band + formatting helpers with
+# scripts/_eval_delta.py rather than carrying parallel copies. The
+# sys.path insert mirrors scripts/compare_eval.py so the same module
+# resolves whether the script is invoked as `python3 scripts/run_real_eval_delta.py`
+# or imported as `scripts.run_real_eval_delta` (the test suite does both).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _eval_delta import (  # noqa: E402
+    fmt_delta as _fmt_delta,
+    fmt_value as _fmt_value,
+    get_path as _get_path,
+    min_num_predictions as _min_num_predictions_shared,
+    silence_threshold as _silence_threshold,
+)
+
+
+def _min_num_predictions(base: dict[str, Any], head: dict[str, Any]) -> int | None:
+    """Thin wrapper around :func:`_eval_delta.min_num_predictions`.
+
+    Kept as a module-private name so callers and tests can keep using
+    the underscore-prefixed identifier they already imported.
+    """
+    return _min_num_predictions_shared(base, head)
+
 # Top-level aggregate keys that are safe to commit. Anything else in
 # the input JSONs is ignored. Keep this list intentionally narrow —
 # adding a key requires a privacy review.
@@ -360,76 +383,6 @@ def _assert_no_forbidden(obj: Any, path: str = "") -> None:
 # -----------------------------------------------------------------------------
 # Rendering
 # -----------------------------------------------------------------------------
-
-
-def _get_path(data: Any, path: str) -> Any:
-    cur = data
-    for part in path.split("."):
-        if not isinstance(cur, dict):
-            return None
-        cur = cur.get(part)
-    return cur
-
-
-def _fmt_value(value: Any) -> str:
-    if value is None:
-        return "—"
-    if isinstance(value, float):
-        return f"{value:.3f}"
-    return str(value)
-
-
-_ABS_SILENCE_FLOOR = 5e-4
-
-
-def _silence_threshold(n_min: int | None) -> float:
-    """``|delta| < threshold`` band that renders as ``·``.
-
-    Issue #463: on N=21 a single case is ±4.76 pp, so the original
-    fixed ``5e-4`` band silences only sub-rounding noise and lets
-    sub-case wobble look like real movement. Sizing the band to
-    ``0.5 / n_min`` keeps it case-aware while floored by the original
-    rounding guard when N is unknown or large.
-    """
-    if isinstance(n_min, int) and n_min > 0:
-        return max(_ABS_SILENCE_FLOOR, 0.5 / n_min)
-    return _ABS_SILENCE_FLOOR
-
-
-def _fmt_delta(
-    base: Any,
-    head: Any,
-    higher_is_better: bool,
-    *,
-    n_min: int | None = None,
-) -> str:
-    if not isinstance(base, (int, float)) or not isinstance(head, (int, float)):
-        return "—"
-    delta = float(head) - float(base)
-    if abs(delta) < _silence_threshold(n_min):
-        return "·"
-    sign = "+" if delta > 0 else ""
-    improved = (delta > 0) if higher_is_better else (delta < 0)
-    flag = " ✅" if improved else " ⚠️"
-    return f"{sign}{delta:.3f}{flag}"
-
-
-def _min_num_predictions(base: dict[str, Any], head: dict[str, Any]) -> int | None:
-    """Smallest positive ``num_predictions`` across base and head.
-
-    Tied to :func:`_silence_threshold`. Real-eval delta uses the
-    minimum of the two so the silence band is the *less powered* side's
-    half-case width — a slice that shrinks shouldn't lower the noise
-    floor with it.
-    """
-    counts: list[int] = []
-    for summary in (base, head):
-        if not isinstance(summary, dict):
-            continue
-        value = summary.get("num_predictions")
-        if isinstance(value, int) and value > 0:
-            counts.append(value)
-    return min(counts) if counts else None
 
 
 def _fmt_ci(summary: dict[str, Any], metric_key: str) -> str:

--- a/tests/test_render_real_eval_history.py
+++ b/tests/test_render_real_eval_history.py
@@ -45,7 +45,16 @@ class RealEvalHistoryRendererTest(unittest.TestCase):
         (self.root / "reports" / "real100" / "history").mkdir(parents=True)
         # Copy the scripts module so subprocess can find it.
         repo_root = Path(__file__).resolve().parents[1]
-        for fname in ("_utils.py", "run_real_eval_delta.py", "render_real_eval_history.py"):
+        # `_eval_delta.py` is the single-source helper module that
+        # `run_real_eval_delta.py` imports for fmt_delta / silence_threshold
+        # (issue #473). Stage it alongside the other scripts so the
+        # subprocess can resolve the sibling import.
+        for fname in (
+            "_utils.py",
+            "_eval_delta.py",
+            "run_real_eval_delta.py",
+            "render_real_eval_history.py",
+        ):
             shutil.copy(repo_root / "scripts" / fname, self.root / "scripts" / fname)
         # __init__.py so `import scripts.run_real_eval_delta` works.
         (self.root / "scripts" / "__init__.py").write_text("")


### PR DESCRIPTION
## 1. What changed and why

Closes #473.

`scripts/run_real_eval_delta.py` carried parallel copies of `fmt_value`, `fmt_delta`, `get_path`, `silence_threshold`, `min_num_predictions`, and an `_ABS_SILENCE_FLOOR` constant alongside identical implementations in `scripts/_eval_delta.py`. After #464 introduced N-aware silence in both, the divergence risk grew — future tuning would have had to touch two files in lockstep.

Pull the shared logic from `_eval_delta.py` via a `sys.path` import (mirroring `scripts/compare_eval.py`'s pattern) and re-bind to the existing underscored names so call sites and tests stay unchanged. `_fmt_ci` remains module-local because it's tied to `SAFE_CI_METRIC_KEYS` (real-eval-specific). `_min_num_predictions` stays as a thin wrapper so test imports keep the underscored name.

> Stacked on [#472](https://github.com/hskim-solv/BidMate-DocAgent/pull/472) → [#470](https://github.com/hskim-solv/BidMate-DocAgent/pull/470) → [#464](https://github.com/hskim-solv/BidMate-DocAgent/pull/464).

## 2. Files affected

- `scripts/run_real_eval_delta.py` — remove parallel helpers, import from `_eval_delta` (load-bearing — answer-contract / aggregate-only commit boundary unchanged).
- `tests/test_render_real_eval_history.py` — fixture: stage `_eval_delta.py` next to the other scripts in the subprocess tempdir so the sibling import resolves.

Net: **-71 lines, +33 lines**.

## 3. Risks

- **Behavior change** — none. Helpers are renamed bindings to the same functions tested by `tests/test_compare_eval_regression_gate.py::SilenceBandTest` and `tests/test_run_real_eval_delta.py::NAwareSilenceTest`. Both pass before and after.
- **Import path** — `python3 scripts/run_real_eval_delta.py` (CLI) and `from scripts.run_real_eval_delta import …` (pytest) both exercised:
  - CLI: `python3 scripts/run_real_eval_delta.py --help` returns usage.
  - pytest: `FullScriptInvocationTest::test_end_to_end_renders_table` does a subprocess invocation; passes.
- **Subprocess tempdir** — `test_render_real_eval_history.py` runs `render_real_eval_history.py` from a copied tempdir; the fixture now also stages `_eval_delta.py` so the import chain stays intact.

## 4. Tests

- pytest: **866 passed, 1 skipped** (identical pre/post).
- `python3 scripts/run_real_eval_delta.py --help` smoke (CLI argument plumbing).

No new tests; the existing coverage (`SilenceBandTest`, `NAwareSilenceTest`, `BaseHeadCIRenderTest`, `AbstentionOutcomeBreakdownTest`, `FullScriptInvocationTest`, `RealEvalHistoryRendererTest`) collectively exercises every helper that moved.

## 5. Eval impact

Pure refactor — no metric change anywhere. PR comment delta table will render exactly as before.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** The `_assert_no_forbidden` guard, `SAFE_TOPLEVEL_KEYS`, `SAFE_SLICE_METRICS`, and `extract_aggregate` are untouched. ADR 0005 commit boundary preserved by construction.

## 6. Backward compatibility

- `extract_aggregate`, `render_markdown`, `FORBIDDEN_KEYS`, `SAFE_*` public API unchanged.
- Underscored helper names (`_fmt_value`, `_fmt_delta`, `_get_path`, `_silence_threshold`, `_min_num_predictions`) remain importable from `scripts.run_real_eval_delta` for tests.
- Answer-contract (ADR 0003) untouched; `schema_version` not bumped.

## 7. Out of scope

- Renaming the public functions in `_eval_delta.py` to drop the parallel underscored aliases in `run_real_eval_delta.py` — kept as aliases on purpose so existing tests don't churn.
- Inlining `_fmt_ci` into `_eval_delta.py` — only used by real-eval render path and depends on `SAFE_CI_METRIC_KEYS`; would tangle the synthetic-side module with real-eval whitelists.