### PR TITLE
feat(eval): case proposer skeleton (ADR 0029)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,13 @@ reports/external_baselines.local.json
 !reports/synthetic_judge.aggregate.json
 reports/synthetic_judge.local.json
 
+# ADR 0029 — real-data case proposer aggregate is committable;
+# per-case proposed/reviewed yaml stays local. Mirrors the
+# ADR 0005 / 0006 / 0012 split.
+!reports/proposed/
+reports/proposed/*
+!reports/proposed/proposer.aggregate.json
+
 # Benchmark raw/local artifacts
 artifacts/benchmarks/
 artifacts/runs/

--- a/docs/adr/0029-real-data-case-proposer-additive.md
+++ b/docs/adr/0029-real-data-case-proposer-additive.md
@@ -1,0 +1,207 @@
+# 0029: Real-data case proposer as additive semi-supervised eval-set growth
+
+- **Status**: proposed
+- **Date**: 2026-05-13
+- **Related**: extends [ADR 0005](./0005-eval-split-public-synthetic-private-local.md) / [ADR 0006](./0006-llm-judge-on-real-data-only.md); reuses backend pattern of [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) / [ADR 0012](./0012-llm-judge-on-public-synthetic.md); preserves [ADR 0001](./0001-preserve-naive-baseline.md) / [ADR 0003](./0003-structured-answer-citation-contract.md) / [ADR 0004](./0004-verifier-retry-policy.md) / [ADR 0008](./0008-evidence-boundary.md); calibration mirrors [ADR 0016](./0016-judge-human-agreement.md)
+- **Deciders**: hskim
+
+## Context
+
+The private real-data eval surface
+([`eval/real_config.example.yaml`](../../eval/real_config.example.yaml))
+caps at whatever the human labels — currently N=100. Each case is an
+8-field dict (`query`, `query_type`, `expected_doc_ids`,
+`expected_terms`, `expected_citation_terms`, `expected_claim_targets`,
+`answerable`, `id`) that costs 5–15 minutes to author. Scaling to
+N=200+ is a labeling-throughput problem, not an infrastructure
+problem.
+
+[ADR 0005](./0005-eval-split-public-synthetic-private-local.md) locks
+case bodies out of the commit boundary (aggregate-only). [ADR 0006](./0006-llm-judge-on-real-data-only.md)
+allows LLMs on the real-data surface but only as a *judge* — a
+second-opinion read of an existing answer. "LLM proposes a case
+candidate, human reviews" is not in either ADR's scope; doing it
+without an explicit decision would silently mix machine-generated
+labels into a surface that ADR 0005 treats as ground truth.
+
+The pattern that fits is ADR 0011's *additive ablation*: introduce a
+new surface (stub-default backend, opt-in live backend) alongside the
+existing one without touching its contract. ADR 0012 already applied
+this to the synthetic judge. The same shape applies to a real-data
+case proposer, with two extra constraints: case bodies still cannot
+cross the commit boundary (ADR 0005), and the human reviewer is the
+gate that decides what enters `eval/real_config.local.yaml`.
+
+## Decision
+
+Add a **case proposer** as an additive, semi-supervised input surface
+to the real-data eval. The proposer generates candidate case dicts
+that match `eval/real_config.example.yaml`'s 8-field schema; a human
+reviews each candidate (accept / edit / reject) before any case is
+appended to `eval/real_config.local.yaml`.
+
+### Contract
+
+- **Input**: `data/data_list.csv` metadata + the top-3 chunks of each
+  seed document from `data/index/real100/index.json`. The `live`
+  backend may consume chunk bodies; the deterministic fields
+  (`expected_doc_ids`, `answerable`) are *always* derived from the
+  source row and `query_type`, never from a model response.
+- **Output (per case)**: superset of the 8-field schema with two
+  meta fields:
+  ```yaml
+  - id: proposed_<YYYYMMDD>_<NNN>
+    source: "proposed-then-reviewed"          # vs. "human"
+    proposer_meta:
+      backend: "stub" | "openai_compatible"
+      model: "<model-id or 'stub'>"
+      seed_doc_id: "<doc-id from index>"
+      generated_at: "<ISO8601Z>"
+      proposer_version: 1
+    # ... 8 schema fields ...
+  ```
+  Both `source` and `proposer_meta` are stripped on append to
+  `eval/real_config.local.yaml`, so the active config stays a
+  byte-equal subset of the existing schema.
+- **Committable aggregate** (`reports/proposed/proposer.aggregate.json`,
+  ADR 0005 allowlist):
+  ```json
+  {
+    "schema_version": 1,
+    "backend": "stub" | "openai_compatible",
+    "n_proposed": 30, "n_reviewed": 25, "n_accepted": 18,
+    "proposer_accept_rate": 0.72,
+    "field_edit_rate": {"query": 0.40, "expected_terms": 0.65, ...},
+    "by_query_type": {"single_doc": {...}, "abstention": {...}}
+  }
+  ```
+  Per-case proposed / reviewed yaml stays under
+  `reports/proposed/*.local.yaml` (gitignored).
+
+### Backend pluggability
+
+`eval/case_proposer.py` mirrors `eval/synthetic_judge.py`'s backend
+dispatch:
+
+- `stub` (default) — deterministic; emits metadata-driven template
+  queries (`사업기간` / `사업예산` / abstention) from `data_list.csv`
+  rows. Byte-equal across runs. Used by tests and CI plumbing.
+- `openai_compatible` — generic OpenAI-compatible endpoint. Reuses
+  the existing `BIDMATE_JUDGE_API_KEY` / `BIDMATE_JUDGE_MODEL` /
+  `BIDMATE_JUDGE_BASE_URL` env vars (a single model can serve both
+  the judge and the proposer); backend selection is a separate var
+  (`BIDMATE_CASE_PROPOSER_BACKEND`) so the two surfaces toggle
+  independently. Chunk bodies pass through
+  `neutralize_instruction_patterns` + `EVIDENCE_BOUNDARY`
+  (ADR 0008) before reaching the prompt.
+
+### Two-stage human gate
+
+- `make case-propose` writes
+  `reports/proposed/proposed_cases.local.yaml`.
+- `make case-review` is an interactive CLI that walks each candidate,
+  shows a yaml diff, and records `approved: true|false` plus any
+  edits to `reports/proposed/reviewed_cases.local.yaml`.
+- `make case-promote` performs an *idempotent* append of approved
+  cases to `eval/real_config.local.yaml`, skipping any `id` already
+  present. The promote step is explicit (not auto-triggered by
+  review) so the human confirms one more time.
+- `make case-proposer-aggregate` computes
+  `proposer.aggregate.json` from the reviewed yaml.
+
+### Statistical hygiene
+
+- The active `run_eval.py` aggregate **does not** expose the `source`
+  field (`human` vs `proposed-then-reviewed`). All cases in
+  `eval/real_config.local.yaml` are treated as equally authoritative
+  by the downstream pipeline. The mix ratio is only visible in
+  `proposer.aggregate.json` and in the README's two-column
+  "100 hand + N proposed-reviewed" rendering. This keeps the headline
+  eval surface honest while making the labeling provenance auditable.
+- `proposer_accept_rate` is the calibration knob, parallel to
+  ADR 0016's `judge_human_agreement`: < 0.5 means the proposer is
+  systematically producing rejected cases — backend / prompt
+  rethink, not a numeric gate.
+
+### Cadence
+
+Manual, like the rest of the real-data cycle. The user runs
+`make case-propose && make case-review && make case-promote`
+when they want to grow the case set, then `make real-eval` re-runs
+the pipeline over the (now larger) `eval/real_config.local.yaml`.
+
+## Consequences
+
+**Wins**
+
+- Real-data N can grow past 100 without breaking ADR 0005 — case
+  bodies still never cross the commit boundary.
+- Per-case labeling time drops from 5–15 min (full hand-label) to
+  1–3 min (review + edit) once the proposer is competent, with
+  `proposer_accept_rate` measuring how competent.
+- One more application of ADR 0011's "stub-default + opt-in live"
+  pattern (now: 0011 synthesis, 0012 synthetic judge, 0013
+  observability, 0017 metadata extraction, 0023 HyDE, 0027 LoRA,
+  0028 security screen, 0029 case proposer). Reviewers see the same
+  shape eight times — the additive-pluggable idiom is the project's
+  default.
+- `proposer.aggregate.json` is committable, so the growth from N=100
+  to N=130, N=150, ... is chronological in git log (mirrors ADR 0005
+  history pattern via `make real-eval-history-render`).
+
+**Costs**
+
+- One more file under the ADR 0005 allowlist
+  (`reports/proposed/proposer.aggregate.json`). Mirrors the existing
+  exceptions for `synthetic_judge.aggregate.json` (ADR 0012) and
+  `external_baselines.json` (ADR 0009).
+- Two-stage human gate is more steps than "edit the yaml directly".
+  Mitigated by `make case-propose` skipping any seed doc that
+  already has 2+ proposed cases in the past 30 days, so the user
+  doesn't re-review identical templates.
+- Prompt-injection surface expands once the live backend lands
+  (PR3); the chunk-body sanitizer reuse from ADR 0008 is the
+  mitigation but adds one more callsite to keep in sync.
+
+**Constraints (unchanged)**
+
+- ADR 0001 byte-identity of the naive baseline golden
+  (`tests/data/naive_baseline_top_k.json`). The proposer touches
+  only `eval/real_config.local.yaml` (private) and never
+  `eval/config.yaml` (public synthetic).
+- ADR 0003 answer contract. The proposer is upstream of
+  `run_rag_query`; it produces eval *inputs*, not answer outputs.
+- ADR 0004 deterministic verifier. Public CI never invokes the
+  proposer (no `make case-propose` in `pr-eval.yml` or `make smoke`).
+- ADR 0005 aggregate-only commit boundary. Case bodies stay
+  gitignored under `reports/proposed/*.local.yaml`; only the
+  metric aggregate crosses.
+- ADR 0008 evidence boundary. PR3's live backend passes chunks
+  through the same sanitizer as `scripts/llm_judge.py`.
+
+## Alternatives considered
+
+- **Skip the proposer; just hand-label more cases.** Rejected:
+  labeling at 5–15 min/case caps the practical N around 100 — even
+  one work-day of effort only adds ~30 cases, and the marginal
+  case has the lowest value (most novel failure modes already
+  caught). The proposer's 1–3 min/case review economics make N=200+
+  realistic.
+- **Auto-generate cases and skip the human gate.** Rejected: ADR 0006
+  pinned the LLM-as-second-opinion principle for the real-data
+  surface. Allowing an LLM to produce *both* the question and the
+  expected labels would mean the eval set is grading itself —
+  exactly the failure mode ADR 0006 was written to prevent.
+- **Use the proposer on the public synthetic surface instead.**
+  Rejected: synthetic cases are crisply discriminable by
+  construction (ADR 0006 §Alternatives); the marginal case there
+  has near-zero value. The labeling bottleneck is real-data only.
+- **Reuse `eval/synthetic_judge.py` to also propose cases.**
+  Rejected: doubles the blast radius of any change to either
+  surface. The two scripts share ~50 lines of backend dispatch; the
+  duplication is the cheaper option until a third LLM surface
+  appears (then extract `eval/llm_backend.py`).
+- **Train a deterministic proposer from past hand-labeled cases.**
+  Premature; revisit if `proposer_accept_rate` on the
+  `openai_compatible` backend plateaus below 0.5 across multiple
+  prompt iterations.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,6 +90,7 @@ project record.
 | [0026](./0026-cross-encoder-reranker-deferral.md) | accepted | Cross-encoder reranker default stays stub-identity; real-backend (bge / bge_ko / cohere) measurement deferred — `full_reranker ≡ full` under CI stub by construction, `full` vs `no_rerank` already 0pp on public synthetic (mirrors ADR 0019 / 0025 pattern) |
 | [0027](./0027-lora-finetuned-embedding-additive.md) | proposed | LoRA-fine-tuned embedding adapter as additive ablation, env-var gated (`BIDMATE_EMBEDDING_LORA_ADAPTER`), HF Hub adapter pinned by commit SHA (extends 0001 / 0011 / 0019; does NOT trigger 0019 re-open) |
 | [0028](./0028-security-screen-additive.md) | accepted | Prompt-injection screen (query-side, diagnostic-only) + PII redaction (ingestion-time, opt-in via `BIDMATE_INGEST_REDACT_PII`) as additive security layer (extends 0008 to query side; preserves 0001 / 0003 / 0005) |
+| [0029](./0029-real-data-case-proposer-additive.md) | proposed | Real-data case proposer as additive semi-supervised eval-set growth (extends 0005 / 0006; reuses 0011 / 0012 backend pattern; preserves 0001 / 0003 / 0004 / 0008; calibration mirrors 0016) |
 
 ## Deferred decisions (measurement-gated re-open)
 

--- a/docs/senior-positioning.md
+++ b/docs/senior-positioning.md
@@ -15,7 +15,7 @@
 
 | 시그널 | 어디서 확인하나 |
 |---|---|
-| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 27개 ADR (21 accepted / 6 proposed), status-tracked, supersession chains 명시 |
+| 아키텍처 결정이 **사후 합리화가 아닌 기록된 결정**으로 남아있다 | [`docs/adr/`](./adr/README.md) — 28개 ADR (21 accepted / 7 proposed), status-tracked, supersession chains 명시 |
 | **측정 가능한 성공 기준**을 미리 잡고 그 기준으로 평가한다 | [`portfolio-case-study.md` §2](./portfolio-case-study.md), [`eval/config.yaml`](../eval/config.yaml), README headline 표 |
 | 합성 평가의 한계를 알고 **공개/비공개 평가 분리**로 보완한다 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) |
 | **실패를 분류·우선순위화**한 뒤 백로그로 만든다 | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), 메타 이슈 #49 |
@@ -56,6 +56,7 @@
 | [0026](./adr/0026-cross-encoder-reranker-deferral.md) | accepted | cross-encoder reranker 기본값 = stub-identity 유지, 실 backend(bge / bge_ko / cohere) 측정 deferral (mirrors 0019/0025 pattern) | `full` vs `no_rerank`가 공개 합성에서 이미 0pp (ADR 0002 metadata-first가 dense 위 reorder를 무의미하게 함). `full_reranker`는 CI stub 디폴트에서 `full`과 by-construction 비트동일. Protocol 표면은 향후 HyDE-reranker / LLM-as-reranker seam으로 보존 — 측정 효과 없으나 *측정이 안 됐다*는 점을 ADR로 잠금. |
 | [0027](./adr/0027-lora-finetuned-embedding-additive.md) | proposed | LoRA-fine-tuned embedding adapter as additive ablation, env-var gated (`BIDMATE_EMBEDDING_LORA_ADAPTER`), HF Hub adapter pinned by commit SHA (extends 0001 / 0011 / 0019; does NOT trigger 0019 re-open) | "have you fine-tuned a model?" 인터뷰 질문에 reproducible artifact(Colab 노트북 + HF Hub adapter)로 답. Phase 1.2/ADR 0019에서 metadata-first가 embedding variance를 흡수한다는 것이 확인됐으므로 `full` 행은 ~0pp가 honest 결과 — 그래서 dense-only `naive_baseline_finetuned` 행을 같이 land해서 측정 가능한 표면을 분리. HF Hub adapter는 `<repo>@<sha>` SHA pin으로 silent re-push supply-chain 차단. |
 | [0028](./adr/0028-security-screen-additive.md) | accepted | Prompt-injection screen (query-side, diagnostic-only) + PII redaction (ingestion-time, opt-in via `BIDMATE_INGEST_REDACT_PII`) as additive security layer (extends 0008 to query side; preserves 0001 / 0003 / 0005) | ADR 0008이 evidence 측 injection 방어라면 0028은 query 측 보완. 5개 한국 RFP 도메인 + 3개 영문 일반 패턴의 regex floor — Llama Guard 같은 ML 분류기는 측정-게이트로 미루고 결정적 floor부터. PII는 default off + 단일 env-var 토글로 ADR 0001 byte-identical 유지. "production 보안 어떻게?" 질문에 측정 가능한 답 + ADR 0008과 짝을 이루는 surface 설계. |
+| [0029](./adr/0029-real-data-case-proposer-additive.md) | proposed | Real-data case proposer as additive semi-supervised eval-set growth (extends 0005 / 0006; reuses 0011 / 0012 backend pattern; preserves 0001 / 0003 / 0004 / 0008; calibration mirrors 0016) | ADR 0005가 case 본문 commit을 막아 N=100에 묶인 private real-data eval을 사람-검수 게이트로 확장. proposer 자체를 ADR 0011 additive-ablation 패턴(stub-default + opt-in live, 0012 미러)으로 만들고, `proposer_accept_rate` / `field_edit_rate`만 commit boundary 위로 올림 — case 본문은 안 보이지만 "proposer가 얼마나 믿을 만한지"는 git log에 남는다. 자동 라벨링 시스템 자체를 정량 평가한다는 ADR 0016 패턴 재사용. "private eval을 어떻게 확장하셨나요?" 질문에 측정-게이트 답 + commit boundary 유지 설계. |
 
 **인터뷰 talking point 1 (real-data 회귀)**: "ADR 0005가 없었다면 공개본의 abstention 회귀(#69의 `1.000 → 0.500` 사건)는 아무도 보지 못했을 것이다. 공개 합성만 보던 시기에는 1-of-2 incidental overlap 패턴이 잡히지 않았다." — 근거: [`docs/private-100-doc-experiments.md`](./private-100-doc-experiments.md) 2026-05-11 entry.
 
@@ -183,7 +184,7 @@ make reproduce  # smoke + SHA-256 over the environment-invariant metric subset
 
 ### 30초 자기소개
 
-> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **27개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
+> "BidMate-DocAgent는 **한국어 RFP 도메인-특화 RAG**입니다. 일반 영어 벤치(KMMLU/MMLU) 점수 경쟁이 아니라, 한국 B2B/공공 입찰 시장의 비교 질의에서 발생하는 한쪽 문서 starvation 패턴을 발견하고 막은 게 차별점입니다. **comparison-aware balanced top-k** + **metadata-first retrieval** + **extractive grounded-answer 계약**으로 hallucination을 구조적으로 차단하고, **공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋** 세 표면으로 silent regression을 분리 탐지합니다. 운영 시그널 측에서는 **28개 ADR**, prompt-caching 적용 **cost telemetry**, fail-closed **observability(LangFuse/OTel)**, **CI 회귀 게이트**까지 완성했습니다."
 
 읽는 시간 ≈ 30초. 면접 첫 답으로 그대로 사용 가능. 상대가 "좀 더 자세히"를 물으면 §1, 측정 의문에는 §2, 운영 의문에는 [`production-readiness.md`](./production-readiness.md)로 넘어간다.
 

--- a/eval/case_proposer.example.yaml
+++ b/eval/case_proposer.example.yaml
@@ -1,0 +1,44 @@
+# Case proposer config template (ADR 0029).
+# Copy to eval/case_proposer.local.yaml before use; this template is
+# committed, the .local.yaml stays gitignored alongside
+# eval/real_config.local.yaml.
+#
+# PR1 ships only the skeleton — the runner CLI (`make case-propose`)
+# and the actual stub generation logic land in PR2. Fields below are
+# the planned shape so reviewers can sanity-check the contract.
+
+# Backend selection. CI must run "stub". Live calls are opt-in via
+# the BIDMATE_CASE_PROPOSER_BACKEND env var, which overrides this key.
+backend: stub  # stub | openai_compatible
+
+# Optional model identifier passed through to the backend. For stub,
+# this is recorded verbatim in proposer_meta.model (default "stub").
+# For openai_compatible (PR3), this is the live model id, e.g.
+# "claude-sonnet-4-6" or a self-hosted equivalent.
+model: stub
+
+# How many seed documents from data/data_list.csv to consider per run.
+# PR2 will cap and sample deterministically. N=10 with 2 templates
+# per doc yields ~20 candidate cases per cycle, which matches the
+# review throughput a single reviewer can handle in a sitting.
+n_seed_docs: 10
+templates_per_doc: 2
+
+# Inputs the proposer reads. Both are gitignored.
+metadata_csv: data/data_list.csv
+index_dir: data/index/real100
+
+# Outputs (gitignored except for the aggregate; ADR 0005 boundary).
+proposed_out: reports/proposed/proposed_cases.local.yaml
+reviewed_out: reports/proposed/reviewed_cases.local.yaml
+aggregate_out: reports/proposed/proposer.aggregate.json
+
+# Query type mix. PR4's by_query_type χ²-test will flag if the
+# proposed distribution skews vs. the existing 100 hand-labeled
+# cases. The default below mirrors the expected mix in
+# real_config.local.yaml.
+query_type_mix:
+  single_doc: 0.6
+  abstention: 0.2
+  comparison: 0.15
+  follow_up: 0.05

--- a/eval/case_proposer.py
+++ b/eval/case_proposer.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Real-data case proposer (ADR 0029).
+
+Generates candidate case dicts that match
+``eval/real_config.example.yaml``'s 8-field schema, for the private
+real-data eval surface (ADR 0005 commit boundary). A human reviews
+each candidate before it can be appended to
+``eval/real_config.local.yaml`` — the proposer is upstream of, and
+strictly separate from, the active eval input.
+
+This is the case-input sibling of ``scripts/llm_judge.py`` (ADR 0006
+real-data judge) and ``eval/synthetic_judge.py`` (ADR 0012 synthetic
+judge). All three reuse the stub-default + opt-in live backend
+pattern from ADR 0011.
+
+PR1 scope (this file): skeleton + Protocol + backend dispatch. The
+``stub`` backend returns an empty list; the ``openai_compatible``
+backend raises NotImplementedError. PR2 fills the stub with
+metadata-driven template queries; PR3 wires the live backend.
+
+Backends:
+
+* ``stub`` (default, PR1: empty) — deterministic; PR2 will emit
+  metadata-driven template queries from ``data/data_list.csv``.
+  Byte-equal across runs. Used by tests and CI plumbing. Never
+  invokes a network call or LLM SDK.
+* ``openai_compatible`` (PR3) — generic OpenAI-compatible endpoint.
+  Will reuse ``BIDMATE_JUDGE_API_KEY`` / ``BIDMATE_JUDGE_MODEL`` /
+  ``BIDMATE_JUDGE_BASE_URL`` (shared with the real-data judge).
+  Backend selection is independent
+  (``BIDMATE_CASE_PROPOSER_BACKEND``).
+
+Per-case proposed schema (never committed; ADR 0005):
+
+    {
+      "id": "proposed_<YYYYMMDD>_<NNN>",
+      "source": "proposed-then-reviewed",
+      "proposer_meta": {
+        "backend": "stub" | "openai_compatible",
+        "model": "<model-id or 'stub'>",
+        "seed_doc_id": "<doc-id from index>",
+        "generated_at": "<ISO8601Z>",
+        "proposer_version": 1,
+      },
+      "query_type": "single_doc" | "comparison" | "follow_up" | "abstention",
+      "query": "...",
+      "expected_doc_ids": [...],
+      "expected_terms": [...],
+      "expected_citation_terms": [...],
+      "expected_claim_targets": [...],
+      "answerable": bool,
+    }
+
+Importantly, this module does NOT import ``rag_core`` or any
+retrieval / verifier code path. The proposer is upstream of
+``run_rag_query`` — it produces eval *inputs* that downstream
+pipelines consume. Keeping the import surface narrow is the
+mechanical guarantee that ADR 0001's ``naive_baseline`` golden
+cannot drift as a side-effect of loading this module (covered by
+``tests/test_case_proposer_stub.py``).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DEFAULT_METADATA_PATH = ROOT / "data" / "data_list.csv"
+DEFAULT_INDEX_PATH = ROOT / "data" / "index" / "real100" / "index.json"
+DEFAULT_PROPOSED_PATH = ROOT / "reports" / "proposed" / "proposed_cases.local.yaml"
+DEFAULT_REVIEWED_PATH = ROOT / "reports" / "proposed" / "reviewed_cases.local.yaml"
+DEFAULT_AGGREGATE_PATH = ROOT / "reports" / "proposed" / "proposer.aggregate.json"
+
+PROPOSER_VERSION = 1
+BACKEND_ENV_VAR = "BIDMATE_CASE_PROPOSER_BACKEND"
+
+QUERY_TYPES = ("single_doc", "comparison", "follow_up", "abstention")
+
+
+class CaseProposerBackend(Protocol):
+    """Backend contract for case proposers.
+
+    A backend takes a sequence of metadata rows (each describing one
+    seed document plus the top-3 chunks from the index) and returns a
+    list of proposed case dicts conforming to the schema in this
+    module's docstring. Implementations must be deterministic when
+    given the same inputs *and* the same model snapshot — the
+    ``openai_compatible`` backend uses ``temperature=0`` to satisfy
+    this in practice.
+    """
+
+    def __call__(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        model: str,
+    ) -> list[dict[str, Any]]:
+        ...
+
+
+def _stub_backend(
+    rows: list[dict[str, Any]],
+    *,
+    model: str,
+) -> list[dict[str, Any]]:
+    """Deterministic stub backend.
+
+    PR1: returns an empty list — the skeleton is plumbing-only.
+    PR2 will emit metadata-driven template queries (e.g.
+    ``"{발주기관} {사업명}의 사업기간은?"``) from each row, with
+    ``expected_doc_ids`` derived directly from ``row["doc_id"]`` and
+    ``answerable`` derived from ``query_type``.
+
+    Byte-equal across runs by construction. Used by CI plumbing.
+    """
+    _ = rows  # PR2 will consume
+    _ = model  # always "stub" for this backend; kept for symmetry
+    return []
+
+
+def _openai_compatible_backend(  # pragma: no cover - PR3
+    rows: list[dict[str, Any]],
+    *,
+    model: str,
+) -> list[dict[str, Any]]:
+    """Generic OpenAI-compatible endpoint (PR3).
+
+    Will lazily import the openai SDK so the stub-only path has no
+    network / SDK dependency, mirroring ``eval/synthetic_judge.py``
+    and ``scripts/llm_judge.py``.
+    """
+    _ = rows
+    _ = model
+    raise NotImplementedError(
+        "openai_compatible backend lands in PR3 (ADR 0029). "
+        "Use BIDMATE_CASE_PROPOSER_BACKEND=stub for now."
+    )
+
+
+_BACKENDS: dict[str, CaseProposerBackend] = {
+    "stub": _stub_backend,
+    "openai_compatible": _openai_compatible_backend,
+}
+
+
+def resolve_backend(name: str | None = None) -> tuple[str, CaseProposerBackend]:
+    """Resolve a backend name to its (name, callable) pair.
+
+    Precedence: explicit ``name`` argument > ``$BIDMATE_CASE_PROPOSER_BACKEND``
+    env var > ``"stub"`` default. Raises ``ValueError`` for unknown
+    backends so callers fail loudly rather than silently falling back.
+    """
+    resolved = name or os.environ.get(BACKEND_ENV_VAR) or "stub"
+    backend = _BACKENDS.get(resolved)
+    if backend is None:
+        raise ValueError(
+            f"Unknown case proposer backend: {resolved!r}. "
+            f"Available: {sorted(_BACKENDS)}"
+        )
+    return resolved, backend
+
+
+def propose_cases(
+    rows: list[dict[str, Any]] | None = None,
+    *,
+    backend: str | None = None,
+    model: str | None = None,
+) -> list[dict[str, Any]]:
+    """Public entry point.
+
+    PR1 scope: dispatch to the resolved backend and return its raw
+    output. PR2 will add CSV reading, index loading, and YAML writing
+    (currently the caller is responsible for both ends — the proposer
+    only owns the generation step).
+
+    Args:
+        rows: List of metadata rows. Each row should contain at
+            minimum ``doc_id`` + the standard ``data_list.csv``
+            columns. PR2 will define the precise schema as it wires
+            the CSV reader.
+        backend: Backend name; see ``resolve_backend`` for precedence.
+        model: Model identifier to pass through to the backend. For
+            ``stub`` this is recorded as ``"stub"`` in
+            ``proposer_meta.model``; for ``openai_compatible`` it is
+            the live model id.
+
+    Returns:
+        A list of proposed case dicts. PR1's stub returns ``[]``.
+    """
+    rows = rows or []
+    resolved_name, backend_fn = resolve_backend(backend)
+    resolved_model = model or ("stub" if resolved_name == "stub" else "")
+    return backend_fn(rows, model=resolved_model)
+
+
+__all__ = [
+    "BACKEND_ENV_VAR",
+    "DEFAULT_AGGREGATE_PATH",
+    "DEFAULT_INDEX_PATH",
+    "DEFAULT_METADATA_PATH",
+    "DEFAULT_PROPOSED_PATH",
+    "DEFAULT_REVIEWED_PATH",
+    "PROPOSER_VERSION",
+    "QUERY_TYPES",
+    "CaseProposerBackend",
+    "propose_cases",
+    "resolve_backend",
+]

--- a/tests/test_case_proposer_stub.py
+++ b/tests/test_case_proposer_stub.py
@@ -1,0 +1,141 @@
+"""Tests for the real-data case proposer skeleton (ADR 0029, PR1).
+
+The stub backend ships empty in PR1 — these tests pin the skeleton's
+shape (Protocol, backend dispatch, error surface) and the
+ADR 0001 byte-identity guard: loading ``eval.case_proposer`` must not
+pull in ``rag_core``, because the proposer is upstream of
+``run_rag_query`` and any accidental dependency would risk a
+side-effect on the naive baseline golden.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+from eval.case_proposer import (
+    BACKEND_ENV_VAR,
+    DEFAULT_AGGREGATE_PATH,
+    DEFAULT_PROPOSED_PATH,
+    PROPOSER_VERSION,
+    propose_cases,
+    resolve_backend,
+)
+
+
+class CaseProposerStubTest(unittest.TestCase):
+    def test_stub_returns_empty_list_in_pr1(self) -> None:
+        """PR1 invariant: skeleton stub emits no candidates."""
+        out = propose_cases([{"doc_id": "doc-001"}], backend="stub")
+        self.assertEqual(out, [])
+
+    def test_stub_deterministic_across_calls(self) -> None:
+        """Stub must be byte-equal across runs (ADR 0011 stub-default contract)."""
+        rows = [
+            {"doc_id": "doc-001", "사업명": "사업A"},
+            {"doc_id": "doc-002", "사업명": "사업B"},
+        ]
+        calls = [propose_cases(rows, backend="stub") for _ in range(5)]
+        for result in calls[1:]:
+            self.assertEqual(result, calls[0])
+
+    def test_resolve_backend_default_is_stub(self) -> None:
+        name, fn = resolve_backend()
+        self.assertEqual(name, "stub")
+        self.assertEqual(fn([], model="stub"), [])
+
+    def test_resolve_backend_explicit_arg_wins_over_env(self) -> None:
+        """Explicit ``name`` argument overrides $BIDMATE_CASE_PROPOSER_BACKEND."""
+        import os
+
+        prior = os.environ.get(BACKEND_ENV_VAR)
+        os.environ[BACKEND_ENV_VAR] = "openai_compatible"
+        try:
+            name, _ = resolve_backend("stub")
+            self.assertEqual(name, "stub")
+        finally:
+            if prior is None:
+                os.environ.pop(BACKEND_ENV_VAR, None)
+            else:
+                os.environ[BACKEND_ENV_VAR] = prior
+
+    def test_resolve_backend_env_var_overrides_default(self) -> None:
+        import os
+
+        prior = os.environ.get(BACKEND_ENV_VAR)
+        os.environ[BACKEND_ENV_VAR] = "openai_compatible"
+        try:
+            name, _ = resolve_backend()
+            self.assertEqual(name, "openai_compatible")
+        finally:
+            if prior is None:
+                os.environ.pop(BACKEND_ENV_VAR, None)
+            else:
+                os.environ[BACKEND_ENV_VAR] = prior
+
+    def test_resolve_backend_unknown_raises_value_error(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            resolve_backend("does-not-exist")
+        self.assertIn("does-not-exist", str(ctx.exception))
+
+    def test_openai_compatible_backend_raises_not_implemented_in_pr1(self) -> None:
+        """Live backend lands in PR3 — callers must fail loudly, not silently fall back."""
+        with self.assertRaises(NotImplementedError):
+            propose_cases(
+                [{"doc_id": "doc-001"}],
+                backend="openai_compatible",
+                model="claude-sonnet-4-6",
+            )
+
+    def test_default_paths_under_reports_proposed(self) -> None:
+        """ADR 0005 commit-boundary intent: proposed/reviewed yaml stays under reports/proposed/."""
+        for path in (DEFAULT_PROPOSED_PATH, DEFAULT_AGGREGATE_PATH):
+            parts = path.parts
+            self.assertIn("reports", parts)
+            self.assertIn("proposed", parts)
+
+    def test_proposer_version_is_int(self) -> None:
+        self.assertIsInstance(PROPOSER_VERSION, int)
+        self.assertGreaterEqual(PROPOSER_VERSION, 1)
+
+
+class CaseProposerImportSurfaceTest(unittest.TestCase):
+    """ADR 0001 byte-identity guard.
+
+    The naive-baseline golden (``tests/data/naive_baseline_top_k.json``)
+    is produced by ``rag_core``'s retrieval path. ``eval.case_proposer``
+    is strictly upstream of ``run_rag_query`` — it produces eval
+    inputs, not answer outputs — so importing it must NOT trigger any
+    ``rag_core`` import. A subprocess check is used so the parent
+    pytest process (which has already imported ``rag_core`` via other
+    test modules) cannot mask a regression here.
+    """
+
+    def test_importing_case_proposer_does_not_import_rag_core(self) -> None:
+        script = textwrap.dedent(
+            """
+            import sys
+            import eval.case_proposer  # noqa: F401
+            forbidden = [m for m in sys.modules if m == "rag_core" or m.startswith("rag_core.")]
+            if forbidden:
+                print(f"FAIL: {forbidden}", file=sys.stderr)
+                sys.exit(1)
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"eval.case_proposer pulled in rag_core (regression). "
+            f"stderr: {result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #467

PR1 of a 4-PR stack that introduces a **real-data case proposer** as an additive, semi-supervised surface for growing the private eval set beyond N=100 without breaking ADR 0005's case-body commit boundary. This PR lands the **decision (ADR 0029, proposed) + skeleton**: the stub backend returns an empty list and the live backend raises NotImplementedError, so reviewers can audit the contract shape and ADR 0001 invariant before any actual generation logic ships in PR2/PR3. ADR 0029 explicitly reuses ADR 0011 / 0012's stub-default + opt-in live pattern (now applied 8 times in the repo), with `proposer_accept_rate` / `field_edit_rate` mirroring ADR 0016's judge↔human calibration — the proposer itself is quantitatively evaluated.

## 2. Files affected

- **load-bearing** [`docs/adr/0029-real-data-case-proposer-additive.md`](docs/adr/0029-real-data-case-proposer-additive.md) — new ADR (proposed)
- **load-bearing** [`eval/case_proposer.py`](eval/case_proposer.py) — Protocol + backend dispatch skeleton
- **load-bearing** [`eval/case_proposer.example.yaml`](eval/case_proposer.example.yaml) — planned config shape
- [`tests/test_case_proposer_stub.py`](tests/test_case_proposer_stub.py) — 10 tests
- [`docs/adr/README.md`](docs/adr/README.md) — index row added
- [`docs/senior-positioning.md`](docs/senior-positioning.md) — narrative table + count labels synced (test_governance gate)
- [`.gitignore`](.gitignore) — allowlist `reports/proposed/proposer.aggregate.json`; per-case proposed/reviewed yaml stays gitignored

## 3. Risks

Most likely break: the skeleton accidentally pulls `rag_core` into its import path, which would let the proposer side-effect the `naive_baseline` golden (ADR 0001).

Checked via `tests/test_case_proposer_stub.py::CaseProposerImportSurfaceTest::test_importing_case_proposer_does_not_import_rag_core` — a subprocess script imports `eval.case_proposer` and asserts no `rag_core*` module appears in `sys.modules`. `md5 tests/data/naive_baseline_top_k.json` is unchanged at `daa808e412f76e44ed979b77c33f70b3` end-to-end.

Secondary risk: the live backend raises NotImplementedError instead of falling back to stub. Intentional — fail-loud over silent fallback so PR3's wiring is auditable. Tested in `test_openai_compatible_backend_raises_not_implemented_in_pr1`.

## 4. Tests

`tests/test_case_proposer_stub.py` — 10 tests, all new:

- `test_stub_returns_empty_list_in_pr1` — PR1 invariant (skeleton emits nothing)
- `test_stub_deterministic_across_calls` — ADR 0011 stub-default contract
- `test_resolve_backend_default_is_stub` / `…_explicit_arg_wins_over_env` / `…_env_var_overrides_default` / `…_unknown_raises_value_error` — backend resolution precedence
- `test_openai_compatible_backend_raises_not_implemented_in_pr1` — fail-loud guard until PR3
- `test_default_paths_under_reports_proposed` — ADR 0005 commit-boundary intent
- `test_proposer_version_is_int` — schema version surface
- `test_importing_case_proposer_does_not_import_rag_core` — ADR 0001 import-surface guard via subprocess

Behavior-change-without-test invariant satisfied. No regression tests required since no existing behavior changed.

## 5. Eval impact

Public synthetic eval delta: **all `·`** (no retrieval / verifier / answer-path change). The skeleton is import-only — never invoked from `pr-eval.yml`, `make smoke`, or `make eval`.

### 5b. Real-data delta

**No behavior change in eval.** The skeleton adds no entry points, no Makefile targets (those land in PR2), and is not imported by `run_rag_query` or any retrieval module. `make smoke` passed locally with no change to the deterministic verifier or naive_baseline golden.

## 6. Backward compatibility

None broken. New file surface only; no existing module signature, env var, CLI flag, or schema is touched. Answer contract (ADR 0003 `schema_version: 2`) unchanged — the proposer is upstream of `run_rag_query` and only produces eval *inputs*.

## 7. Out of scope

- **PR2**: stub backend metadata-driven generation + interactive `case_proposer_review.py` CLI + Makefile targets (`case-propose` / `case-review` / `case-promote`). Separate issue.
- **PR3**: `openai_compatible` backend + ADR 0008 `EVIDENCE_BOUNDARY` + `neutralize_instruction_patterns` sanitization. Separate issue.
- **PR4**: `proposer.aggregate.json` writer + `case-proposer-aggregate` target + README two-column reporting + ADR 0029 promotion to `accepted`. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)