### PR TITLE
ci(eval): cache eval_summary.json so base-side checkouts skip run_eval

### DIFF
--- a/.github/actions/run-eval/action.yml
+++ b/.github/actions/run-eval/action.yml
@@ -1,9 +1,13 @@
 name: 'Run BidMate eval'
 description: >-
-  Build the index and run eval/run_eval.py, with `actions/cache` keyed
-  on data/raw + builder code so unchanged-data PRs skip the build step.
+  Build the index and run eval/run_eval.py, with two `actions/cache`
+  layers: the index cache (#400) lets unchanged-data PRs skip the build
+  step, and the eval-summary cache (#469) lets unchanged-code base
+  checkouts skip run_eval entirely. PR-side is keyed on the head commit
+  so it remains a cache miss almost always; base-side is keyed on main
+  state and hits on every repeat PR against the same merge.
   Shared by .github/workflows/pr-eval.yml (PR + base checkouts) and
-  .github/workflows/leaderboard.yml (main merge). See issue #400.
+  .github/workflows/leaderboard.yml (main merge).
 
 inputs:
   working-directory:
@@ -62,7 +66,30 @@ runs:
         --output_dir data/index
         --embedding_backend ${{ inputs.embedding-backend }}
 
-    - name: Run eval
+    - name: Restore cached eval summary
+      id: cache-eval
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.working-directory }}/reports/eval_summary.json
+        # Invalidate when raw data changes, when the eval config / cases
+        # / scorers change, or when any RAG / ingestion code that
+        # run_eval actually executes changes. `inputs.config` is part of
+        # the key so PR-side `eval/config.ci.yaml` keeps a cache scope
+        # separate from leaderboard's `eval/config.yaml`.
+        key: >-
+          bidmate-eval-${{ inputs.embedding-backend }}-${{ inputs.config }}-${{
+          hashFiles(format('{0}/data/raw/**', inputs.working-directory))
+          }}-${{
+          hashFiles(
+            format('{0}/eval/**', inputs.working-directory),
+            format('{0}/rag_*.py', inputs.working-directory),
+            format('{0}/scripts/build_index.py', inputs.working-directory),
+            format('{0}/ingestion.py', inputs.working-directory),
+            format('{0}/visual_ingestion.py', inputs.working-directory)
+          ) }}
+
+    - name: Run eval (cache miss only)
+      if: steps.cache-eval.outputs.cache-hit != 'true'
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: >-
@@ -70,3 +97,12 @@ runs:
         --index_dir data/index
         --output_dir reports
         --config ${{ inputs.config }}
+
+    - name: Report eval cache outcome
+      shell: bash
+      run: |
+        if [ "${{ steps.cache-eval.outputs.cache-hit }}" = "true" ]; then
+          echo "::notice title=Eval cache::eval_summary.json restored from cache; run_eval was skipped."
+        else
+          echo "::notice title=Eval cache::eval_summary.json freshly computed (cache miss)."
+        fi


### PR DESCRIPTION
Re-opens previously-closed [#470](https://github.com/hskim-solv/BidMate-DocAgent/pull/470) (auto-closed when stacked base branch `feat/issue-463-real-eval-signal` was deleted on merge of #464). Same change, new base = main.

---

## 1. What changed and why

Closes #469.

PR Eval Delta calls the `run-eval` composite twice — once for the PR head, once for the merge-base. The base side runs against the same main SHA across many PRs and was burning ~5 minutes of CI per PR without producing new information. This PR adds a second `actions/cache` layer keyed on data + RAG/eval code so the base side hits whenever main hasn't moved.

> Stacked on [#464](https://github.com/hskim-solv/BidMate-DocAgent/pull/464). Rebase on main automatically once #464 merges.

## 2. Files affected

- `.github/actions/run-eval/action.yml` — second cache layer + gate the `Run eval` step on cache-miss + job-summary notice.

Not load-bearing (CI infra). No application code touched.

## 3. Risks

- **Stale cache** — key includes `data/raw/**` + every file `run_eval` traverses (`eval/**`, `rag_*.py`, `scripts/build_index.py`, `ingestion.py`, `visual_ingestion.py`). Any meaningful change invalidates. The only thing **not** in the key is dynamically generated `eval/config.ci.yaml` content, but the script that generates it is in `eval/run_eval.py` indirectly — and `inputs.config` (path) is in the key, so the two distinct configs (`config.yaml` vs `config.ci.yaml`) keep separate cache scopes. Verified: cache key is a string-concat of stable inputs, no race.
- **ADR 0001 (naive_baseline determinism)** — hashing backend is bit-deterministic. cache restored content equals a fresh run by construction. Confirmed locally that smoke metrics are unchanged.
- **Composite action used by both PR Eval Delta and Leaderboard** — same change applies to both. Leaderboard runs against fresh main commits so cache mostly misses there (expected).

## 4. Tests

- pytest: 866 passed, 1 skipped (no application code changed).
- YAML validation: `python3 -c 'import yaml; yaml.safe_load(open(...))'` passes.
- End-to-end cache behavior validated only in CI — `cache-hit` outcome surfaces as a `::notice` in the job summary so reviewers can verify on first PR after merge.

## 5. Eval impact

PR Eval Delta — no metric change. Comment continues to render the same delta table; only the wall-clock time for base-side `Run eval` drops to ~0s on cache hit.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** Pure CI infra; `eval/`, `rag_*.py`, `ingestion.py` untouched.

## 6. Backward compatibility

- `action.yml` inputs unchanged.
- Cache miss falls back to current behavior exactly.
- Leaderboard workflow + pr-eval workflow consume the action transparently.

## 7. Out of scope

- Folding the dynamically generated `eval/config.ci.yaml` content into the cache key (currently covered transitively by hashing `eval/**`). Follow-up if a cache-key edge case surfaces.
- 18-ablation leaderboard run caching — main pushes are sparse and the fresh recompute is the point. Not worth caching.