### PR TITLE
feat(eval): case proposer stub generation + review/promote (ADR 0029)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@
 # Real-data eval cycle (private; ADR 0005 commit boundary).
 .PHONY: real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
 
+# Real-data case proposer cycle (ADR 0029; gitignored I/O).
+.PHONY: case-propose case-review case-promote
+
 # API / demo (FastAPI + Streamlit; local + docker variants)
 .PHONY: api api-docker demo demo-docker docker-publish
 
@@ -271,6 +274,30 @@ real-eval-history-check:
 real-eval-with-judge: real-eval
 	$(PYTHON) scripts/llm_judge.py
 	@echo "Run \`make real-eval-baseline-update\` to fold the judge aggregate into the committable baseline."
+
+# Case proposer cycle (ADR 0029). Two-stage human gate:
+#   case-propose -> reports/proposed/proposed_cases.local.yaml (gitignored)
+#   case-review  -> interactive walk; writes reviewed_cases.local.yaml
+#   case-promote -> idempotent append of approved cases into
+#                   eval/real_config.local.yaml.
+# Default backend is `stub` (deterministic, no network). Set
+# BIDMATE_CASE_PROPOSER_BACKEND=openai_compatible + BIDMATE_JUDGE_*
+# vars for the live proposer (PR3 / not in PR2 scope).
+case-propose:
+	$(PYTHON) -m eval.case_proposer \
+	  --metadata-csv data/data_list.csv \
+	  --index-dir data/index/real100 \
+	  --out reports/proposed/proposed_cases.local.yaml
+
+case-review:
+	$(PYTHON) scripts/case_proposer_review.py \
+	  --proposed reports/proposed/proposed_cases.local.yaml \
+	  --reviewed reports/proposed/reviewed_cases.local.yaml
+
+case-promote:
+	$(PYTHON) scripts/case_proposer_promote.py \
+	  --reviewed reports/proposed/reviewed_cases.local.yaml \
+	  --real-config eval/real_config.local.yaml
 
 # Run the LLM judge over the public synthetic eval summary (ADR 0012).
 # Default backend `stub` is deterministic and runs in CI; set

--- a/eval/case_proposer.py
+++ b/eval/case_proposer.py
@@ -13,17 +13,25 @@ real-data judge) and ``eval/synthetic_judge.py`` (ADR 0012 synthetic
 judge). All three reuse the stub-default + opt-in live backend
 pattern from ADR 0011.
 
-PR1 scope (this file): skeleton + Protocol + backend dispatch. The
-``stub`` backend returns an empty list; the ``openai_compatible``
-backend raises NotImplementedError. PR2 fills the stub with
-metadata-driven template queries; PR3 wires the live backend.
+Scope status:
+
+* PR1 — skeleton + Protocol + backend dispatch (landed).
+* PR2 (this PR) — stub backend emits metadata-driven template
+  queries from ``data/data_list.csv`` + index; CSV reader, index
+  reader, deterministic YAML writer, ``main()`` CLI.
+* PR3 — ``openai_compatible`` live backend with ADR 0008
+  ``EVIDENCE_BOUNDARY`` sanitization.
+* PR4 — ``proposer.aggregate.json`` writer and ADR 0029 promotion
+  to ``accepted``.
 
 Backends:
 
-* ``stub`` (default, PR1: empty) — deterministic; PR2 will emit
-  metadata-driven template queries from ``data/data_list.csv``.
-  Byte-equal across runs. Used by tests and CI plumbing. Never
-  invokes a network call or LLM SDK.
+* ``stub`` (default) — deterministic. Emits one ``single_doc`` +
+  one ``abstention`` template per seed doc; ``expected_doc_ids``
+  derived from the source row, ``answerable`` derived from
+  ``query_type``. Byte-equal across runs given the same inputs and
+  ``now_iso``. Used by tests and CI plumbing. Never invokes a
+  network call or LLM SDK.
 * ``openai_compatible`` (PR3) — generic OpenAI-compatible endpoint.
   Will reuse ``BIDMATE_JUDGE_API_KEY`` / ``BIDMATE_JUDGE_MODEL`` /
   ``BIDMATE_JUDGE_BASE_URL`` (shared with the real-data judge).
@@ -61,9 +69,14 @@ cannot drift as a side-effect of loading this module (covered by
 """
 from __future__ import annotations
 
+import argparse
+import csv
+import datetime as _dt
+import json
 import os
+import sys
 from pathlib import Path
-from typing import Any, Callable, Protocol
+from typing import Any, Iterable, Protocol
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -77,6 +90,27 @@ PROPOSER_VERSION = 1
 BACKEND_ENV_VAR = "BIDMATE_CASE_PROPOSER_BACKEND"
 
 QUERY_TYPES = ("single_doc", "comparison", "follow_up", "abstention")
+
+# Single-source-of-truth column names from ``ingestion.REQUIRED_COLUMNS``.
+# Hard-coded here (not imported) so this module stays free of
+# ``rag_core``-transitive imports (ADR 0001 byte-identity guard).
+# A drift guard test in tests/test_case_proposer_pipeline.py asserts
+# these match ingestion.REQUIRED_COLUMNS at runtime.
+CSV_COLUMN_NOTICE_ID = "공고 번호"
+CSV_COLUMN_PROJECT = "사업명"
+CSV_COLUMN_AGENCY = "발주 기관"
+CSV_COLUMN_FILE_FORMAT = "파일형식"
+CSV_COLUMN_FILE_NAME = "파일명"
+CSV_COLUMN_TEXT = "텍스트"
+
+REQUIRED_CSV_COLUMNS = (
+    CSV_COLUMN_NOTICE_ID,
+    CSV_COLUMN_PROJECT,
+    CSV_COLUMN_AGENCY,
+    CSV_COLUMN_FILE_FORMAT,
+    CSV_COLUMN_FILE_NAME,
+    CSV_COLUMN_TEXT,
+)
 
 
 class CaseProposerBackend(Protocol):
@@ -96,34 +130,125 @@ class CaseProposerBackend(Protocol):
         rows: list[dict[str, Any]],
         *,
         model: str,
+        now_iso: str,
     ) -> list[dict[str, Any]]:
         ...
+
+
+def _template_single_doc(row: dict[str, Any]) -> str:
+    agency = (row.get(CSV_COLUMN_AGENCY) or "").strip()
+    project = (row.get(CSV_COLUMN_PROJECT) or "").strip()
+    return f"{agency} {project}의 사업기간과 사업예산을 알려줘".strip()
+
+
+def _template_abstention(row: dict[str, Any]) -> str:
+    agency = (row.get(CSV_COLUMN_AGENCY) or "").strip()
+    project = (row.get(CSV_COLUMN_PROJECT) or "").strip()
+    return f"{agency} {project} 문서에 명시되지 않은 조건을 알려줘".strip()
+
+
+def _make_proposed_id(now_iso: str, idx: int) -> str:
+    # now_iso looks like "2026-05-13T08:45:50Z"; we want YYYYMMDD prefix.
+    day = now_iso[:10].replace("-", "")
+    return f"proposed_{day}_{idx:03d}"
+
+
+def _make_proposer_meta(
+    *,
+    backend: str,
+    model: str,
+    seed_doc_id: str,
+    now_iso: str,
+) -> dict[str, Any]:
+    return {
+        "backend": backend,
+        "model": model,
+        "seed_doc_id": seed_doc_id,
+        "generated_at": now_iso,
+        "proposer_version": PROPOSER_VERSION,
+    }
 
 
 def _stub_backend(
     rows: list[dict[str, Any]],
     *,
     model: str,
+    now_iso: str,
 ) -> list[dict[str, Any]]:
-    """Deterministic stub backend.
+    """Deterministic stub backend (PR2).
 
-    PR1: returns an empty list — the skeleton is plumbing-only.
-    PR2 will emit metadata-driven template queries (e.g.
-    ``"{발주기관} {사업명}의 사업기간은?"``) from each row, with
-    ``expected_doc_ids`` derived directly from ``row["doc_id"]`` and
-    ``answerable`` derived from ``query_type``.
+    For each seed-doc row, emit two cases:
+    - ``single_doc``: asks for the project period + budget.
+    - ``abstention``: asks for a fact deliberately not in the doc.
 
-    Byte-equal across runs by construction. Used by CI plumbing.
+    The 1:1 ratio is the cheapest defense against ADR 0029 §Risks #1
+    (systematic bias toward easy single_doc queries inflating the
+    `agentic_full_llm` vs `naive_baseline` delta) — the PR4
+    ``by_query_type`` χ²-test still has a balanced base to compare
+    against. ``expected_doc_ids`` is derived from the row, never
+    from a model response. ``expected_terms`` /
+    ``expected_citation_terms`` are intentionally left empty for the
+    stub — they are the high-edit-rate fields the live backend (PR3)
+    will fill and the human reviewer trims.
+
+    Byte-equal across runs by construction, given the same ``rows``
+    + ``now_iso``.
     """
-    _ = rows  # PR2 will consume
-    _ = model  # always "stub" for this backend; kept for symmetry
-    return []
+    _ = model  # always "stub"; kept for symmetry with live backend
+    cases: list[dict[str, Any]] = []
+    counter = 1
+    for row in rows:
+        doc_id = str(row.get("doc_id") or "").strip()
+        if not doc_id:
+            # Without a doc_id we cannot produce a useful case; skip
+            # rather than fabricate one. The CSV→doc_id mapping is the
+            # caller's responsibility (see ``_attach_doc_ids``).
+            continue
+        agency = (row.get(CSV_COLUMN_AGENCY) or "").strip()
+
+        cases.append(
+            {
+                "id": _make_proposed_id(now_iso, counter),
+                "source": "proposed-then-reviewed",
+                "proposer_meta": _make_proposer_meta(
+                    backend="stub", model="stub", seed_doc_id=doc_id, now_iso=now_iso
+                ),
+                "query_type": "single_doc",
+                "query": _template_single_doc(row),
+                "expected_doc_ids": [doc_id],
+                "expected_terms": [],
+                "expected_citation_terms": [],
+                "expected_claim_targets": [agency] if agency else [],
+                "answerable": True,
+            }
+        )
+        counter += 1
+
+        cases.append(
+            {
+                "id": _make_proposed_id(now_iso, counter),
+                "source": "proposed-then-reviewed",
+                "proposer_meta": _make_proposer_meta(
+                    backend="stub", model="stub", seed_doc_id=doc_id, now_iso=now_iso
+                ),
+                "query_type": "abstention",
+                "query": _template_abstention(row),
+                "expected_doc_ids": [],
+                "expected_terms": [],
+                "expected_citation_terms": [],
+                "expected_claim_targets": [],
+                "answerable": False,
+            }
+        )
+        counter += 1
+    return cases
 
 
 def _openai_compatible_backend(  # pragma: no cover - PR3
     rows: list[dict[str, Any]],
     *,
     model: str,
+    now_iso: str,
 ) -> list[dict[str, Any]]:
     """Generic OpenAI-compatible endpoint (PR3).
 
@@ -133,6 +258,7 @@ def _openai_compatible_backend(  # pragma: no cover - PR3
     """
     _ = rows
     _ = model
+    _ = now_iso
     raise NotImplementedError(
         "openai_compatible backend lands in PR3 (ADR 0029). "
         "Use BIDMATE_CASE_PROPOSER_BACKEND=stub for now."
@@ -162,41 +288,329 @@ def resolve_backend(name: str | None = None) -> tuple[str, CaseProposerBackend]:
     return resolved, backend
 
 
+def _utcnow_iso_z() -> str:
+    """ISO-8601 UTC timestamp with trailing ``Z`` (seconds precision)."""
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def propose_cases(
     rows: list[dict[str, Any]] | None = None,
     *,
     backend: str | None = None,
     model: str | None = None,
+    now_iso: str | None = None,
 ) -> list[dict[str, Any]]:
     """Public entry point.
 
-    PR1 scope: dispatch to the resolved backend and return its raw
-    output. PR2 will add CSV reading, index loading, and YAML writing
-    (currently the caller is responsible for both ends — the proposer
-    only owns the generation step).
-
     Args:
-        rows: List of metadata rows. Each row should contain at
-            minimum ``doc_id`` + the standard ``data_list.csv``
-            columns. PR2 will define the precise schema as it wires
-            the CSV reader.
+        rows: List of metadata rows. Each row must have ``doc_id`` set
+            (already filtered against the active index — see
+            ``propose_cases_from_files`` for the CSV→index pipeline).
+            ``CSV_COLUMN_AGENCY`` / ``CSV_COLUMN_PROJECT`` are read
+            for template substitution; missing values degrade
+            gracefully (the template just renders without them).
         backend: Backend name; see ``resolve_backend`` for precedence.
         model: Model identifier to pass through to the backend. For
             ``stub`` this is recorded as ``"stub"`` in
             ``proposer_meta.model``; for ``openai_compatible`` it is
             the live model id.
+        now_iso: Override timestamp for tests / reproducibility. When
+            ``None``, ``datetime.now(UTC)`` is used.
 
     Returns:
-        A list of proposed case dicts. PR1's stub returns ``[]``.
+        A list of proposed case dicts. The order is deterministic
+        given the same ``rows`` ordering.
     """
     rows = rows or []
     resolved_name, backend_fn = resolve_backend(backend)
     resolved_model = model or ("stub" if resolved_name == "stub" else "")
-    return backend_fn(rows, model=resolved_model)
+    resolved_now = now_iso or _utcnow_iso_z()
+    return backend_fn(rows, model=resolved_model, now_iso=resolved_now)
+
+
+# -----------------------------------------------------------------------------
+# CSV + index readers
+# -----------------------------------------------------------------------------
+
+
+class CaseProposerInputError(Exception):
+    """Raised when CSV/index inputs are malformed or missing."""
+
+
+def _read_data_list_csv(path: Path) -> list[dict[str, Any]]:
+    """Read ``data_list.csv`` rows, validating required columns.
+
+    Returns the raw dict per row (column → cell value). Caller is
+    responsible for the CSV→doc_id mapping (see ``_attach_doc_ids``).
+    """
+    if not path.exists():
+        raise CaseProposerInputError(f"data_list.csv not found at {path}")
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        if not reader.fieldnames:
+            raise CaseProposerInputError(f"data_list.csv at {path} has no header")
+        missing = [c for c in REQUIRED_CSV_COLUMNS if c not in reader.fieldnames]
+        if missing:
+            raise CaseProposerInputError(
+                f"data_list.csv at {path} missing required columns: {missing}"
+            )
+        return list(reader)
+
+
+def _read_index_doc_ids(index_dir: Path) -> set[str]:
+    """Extract the set of doc_ids present in ``index.json``.
+
+    Reads ``index.json["build"]["documents"][*]["doc_id"]`` if the
+    block is present (full build summary), else falls back to the
+    chunk-level ``index["chunks"][*]["doc_id"]`` set. Either path
+    yields the same set in a well-formed index.
+    """
+    index_path = index_dir / "index.json"
+    if not index_path.exists():
+        raise CaseProposerInputError(f"index.json not found at {index_path}")
+    with index_path.open("r", encoding="utf-8") as fh:
+        index = json.load(fh)
+    documents = (index.get("build") or {}).get("documents") or []
+    if documents:
+        return {str(d["doc_id"]) for d in documents if d.get("doc_id")}
+    chunks = index.get("chunks") or []
+    return {str(c["doc_id"]) for c in chunks if c.get("doc_id")}
+
+
+def _attach_doc_ids(
+    rows: list[dict[str, Any]],
+    valid_doc_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Derive ``doc_id`` per row via ``ingestion.canonical_doc_id`` and
+    drop rows whose derived id is not present in the active index.
+
+    The lazy import keeps ``rag_core`` out of this module's import
+    graph (ADR 0001 byte-identity guard) — ``ingestion.py`` does not
+    import ``rag_core`` directly, but the lazy form is the cheapest
+    defense against future drift.
+    """
+    from ingestion import canonical_doc_id  # noqa: WPS433 (intentional lazy import)
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        doc_id = canonical_doc_id(
+            row.get(CSV_COLUMN_NOTICE_ID),
+            row.get("회차"),  # optional; absent in many CSVs
+            row.get(CSV_COLUMN_FILE_NAME),
+        )
+        if not doc_id or doc_id not in valid_doc_ids:
+            continue
+        out.append({**row, "doc_id": doc_id})
+    return out
+
+
+# -----------------------------------------------------------------------------
+# YAML writer (deterministic, no PyYAML default-dict reordering)
+# -----------------------------------------------------------------------------
+
+
+def _yaml_escape_scalar(value: Any) -> str:
+    """Conservative quoting for YAML scalar values.
+
+    The writer is intentionally hand-rolled (rather than ``yaml.dump``)
+    so the output ordering is exactly the ADR 0029 schema order:
+    ``id`` → ``source`` → ``proposer_meta`` (5 keys) → 8 schema
+    fields. PyYAML's default order is alphabetical for dicts on Python
+    pre-3.7 semantics and ``sort_keys=False`` only gets us part way —
+    the dict iteration order is our promise here. Strings always
+    double-quoted (with `"`-escape) so Korean text + colons survive
+    round-trip; booleans and integers emit as-is.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{text}"'
+
+
+def _write_case_yaml_block(case: dict[str, Any], lines: list[str]) -> None:
+    """Emit one case as a YAML list element preserving schema order."""
+    lines.append(f"  - id: {_yaml_escape_scalar(case['id'])}")
+    lines.append(f"    source: {_yaml_escape_scalar(case['source'])}")
+    lines.append("    proposer_meta:")
+    meta = case["proposer_meta"]
+    for key in ("backend", "model", "seed_doc_id", "generated_at", "proposer_version"):
+        lines.append(f"      {key}: {_yaml_escape_scalar(meta[key])}")
+    lines.append(f"    query_type: {_yaml_escape_scalar(case['query_type'])}")
+    lines.append(f"    query: {_yaml_escape_scalar(case['query'])}")
+    for key in (
+        "expected_doc_ids",
+        "expected_terms",
+        "expected_citation_terms",
+        "expected_claim_targets",
+    ):
+        values = case[key]
+        if not values:
+            lines.append(f"    {key}: []")
+        else:
+            lines.append(f"    {key}:")
+            for item in values:
+                lines.append(f"      - {_yaml_escape_scalar(item)}")
+    lines.append(f"    answerable: {_yaml_escape_scalar(case['answerable'])}")
+
+
+def write_proposed_yaml(cases: list[dict[str, Any]], path: Path) -> None:
+    """Write proposed cases to ``path`` in deterministic block style.
+
+    Output shape:
+
+        proposed_cases:
+          - id: "..."
+            source: "..."
+            proposer_meta: { ... }
+            query_type: "..."
+            ...
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = ["proposed_cases:"]
+    if not cases:
+        lines = ["proposed_cases: []"]
+    else:
+        for case in cases:
+            _write_case_yaml_block(case, lines)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def propose_cases_from_files(
+    *,
+    metadata_csv: Path = DEFAULT_METADATA_PATH,
+    index_dir: Path = DEFAULT_INDEX_PATH.parent,
+    n_seed_docs: int = 10,
+    backend: str | None = None,
+    model: str | None = None,
+    now_iso: str | None = None,
+) -> list[dict[str, Any]]:
+    """End-to-end: read CSV + index, filter, propose, return cases.
+
+    Selects the first ``n_seed_docs`` rows whose ``canonical_doc_id``
+    is present in the active index. Deterministic sample order (first
+    N by CSV row order) — the proposer is not the place to randomize;
+    that would make ``proposer.aggregate.json`` non-comparable across
+    runs.
+    """
+    raw_rows = _read_data_list_csv(metadata_csv)
+    valid_doc_ids = _read_index_doc_ids(index_dir)
+    rows_with_ids = _attach_doc_ids(raw_rows, valid_doc_ids)
+    if not rows_with_ids:
+        raise CaseProposerInputError(
+            f"No CSV rows from {metadata_csv} resolve to a doc_id present in "
+            f"{index_dir / 'index.json'}. Run `make build-index` first."
+        )
+    selected = rows_with_ids[: max(n_seed_docs, 0)]
+    return propose_cases(
+        selected, backend=backend, model=model, now_iso=now_iso
+    )
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="case_proposer",
+        description=(
+            "Propose candidate cases for the real-data eval set (ADR 0029). "
+            "Output is deterministic; review with `make case-review`."
+        ),
+    )
+    p.add_argument(
+        "--metadata-csv",
+        type=Path,
+        default=DEFAULT_METADATA_PATH,
+        help=f"Path to data_list.csv (default: {DEFAULT_METADATA_PATH}).",
+    )
+    p.add_argument(
+        "--index-dir",
+        type=Path,
+        default=DEFAULT_INDEX_PATH.parent,
+        help=(
+            f"Directory containing index.json (default: "
+            f"{DEFAULT_INDEX_PATH.parent})."
+        ),
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_PROPOSED_PATH,
+        help=(
+            f"Output yaml path (default: {DEFAULT_PROPOSED_PATH}, "
+            f"gitignored under reports/proposed/)."
+        ),
+    )
+    p.add_argument(
+        "--n-seed-docs",
+        type=int,
+        default=10,
+        help=(
+            "Number of seed docs to use (default: 10). With 2 templates "
+            "per doc, this yields ~20 candidate cases."
+        ),
+    )
+    p.add_argument(
+        "--backend",
+        type=str,
+        default=None,
+        help=(
+            "Backend override. Precedence: arg > "
+            f"${BACKEND_ENV_VAR} > 'stub'. Allowed: "
+            + ", ".join(sorted(_BACKENDS))
+        ),
+    )
+    p.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help=(
+            "Model id passed to the backend. Ignored for stub "
+            "(always recorded as 'stub')."
+        ),
+    )
+    return p
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(list(argv) if argv is not None else None)
+    try:
+        cases = propose_cases_from_files(
+            metadata_csv=args.metadata_csv,
+            index_dir=args.index_dir,
+            n_seed_docs=args.n_seed_docs,
+            backend=args.backend,
+            model=args.model,
+        )
+    except CaseProposerInputError as exc:
+        print(f"case_proposer: {exc}", file=sys.stderr)
+        return 2
+    write_proposed_yaml(cases, args.out)
+    print(
+        f"case_proposer: wrote {len(cases)} candidate(s) to {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())
 
 
 __all__ = [
     "BACKEND_ENV_VAR",
+    "CSV_COLUMN_AGENCY",
+    "CSV_COLUMN_FILE_FORMAT",
+    "CSV_COLUMN_FILE_NAME",
+    "CSV_COLUMN_NOTICE_ID",
+    "CSV_COLUMN_PROJECT",
+    "CSV_COLUMN_TEXT",
     "DEFAULT_AGGREGATE_PATH",
     "DEFAULT_INDEX_PATH",
     "DEFAULT_METADATA_PATH",
@@ -204,7 +618,12 @@ __all__ = [
     "DEFAULT_REVIEWED_PATH",
     "PROPOSER_VERSION",
     "QUERY_TYPES",
+    "REQUIRED_CSV_COLUMNS",
     "CaseProposerBackend",
+    "CaseProposerInputError",
+    "main",
     "propose_cases",
+    "propose_cases_from_files",
     "resolve_backend",
+    "write_proposed_yaml",
 ]

--- a/scripts/case_proposer_promote.py
+++ b/scripts/case_proposer_promote.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Idempotent promote of reviewed cases into the active eval config
+(ADR 0029).
+
+Reads ``reports/proposed/reviewed_cases.local.yaml`` (gitignored,
+written by ``scripts/case_proposer_review.py``), filters down to
+``approved: true``, strips proposer/review metadata, and appends each
+new case to ``eval/real_config.local.yaml``'s ``cases:`` list. Cases
+whose ``id`` already exists in the active config are skipped — so
+running ``make case-promote`` twice in a row is a no-op for the
+second invocation. This is the "two-stage human gate" in ADR 0029:
+``case-review`` is the first explicit gate, ``case-promote`` is the
+second.
+
+PyYAML is used for round-trip on the active config. Comments in
+``real_config.local.yaml`` are NOT preserved — that is an intentional
+trade-off avoiding a ruamel.yaml dependency. Reviewers who keep
+heavy comments in the active config should review the diff after
+``make case-promote`` and re-add as needed.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eval.case_proposer import DEFAULT_REVIEWED_PATH  # noqa: E402
+
+DEFAULT_REAL_CONFIG_PATH = ROOT / "eval" / "real_config.local.yaml"
+
+# Fields produced by the proposer / review step that must NOT appear
+# in the active eval config (ADR 0029 §Decision: "active config stays
+# a byte-equal subset of the existing 8-field schema").
+PROPOSER_META_FIELDS = ("source", "proposer_meta", "approved", "review_meta")
+
+
+def _strip_meta(case: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in case.items() if k not in PROPOSER_META_FIELDS}
+
+
+def read_reviewed_yaml(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return list(data.get("reviewed_cases") or [])
+
+
+def read_real_config(path: Path) -> dict[str, Any]:
+    """Load active eval config. Empty if file missing."""
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def write_real_config(config: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def promote_cases(
+    reviewed: list[dict[str, Any]],
+    config: dict[str, Any],
+) -> tuple[dict[str, Any], int, int]:
+    """Append approved-and-new reviewed cases to the config in-place.
+
+    Returns (new_config, n_appended, n_skipped). ``n_skipped`` covers
+    both "id already in config.cases" (idempotency) and
+    "approved=false" (rejected) — the caller logs the distinction.
+    """
+    if "cases" not in config or not isinstance(config["cases"], list):
+        config = {**config, "cases": []}
+    existing_ids = {str(c.get("id") or "") for c in config["cases"]}
+    appended: list[dict[str, Any]] = []
+    n_skipped = 0
+    for case in reviewed:
+        if not case.get("approved"):
+            n_skipped += 1
+            continue
+        case_id = str(case.get("id") or "")
+        if not case_id or case_id in existing_ids:
+            n_skipped += 1
+            continue
+        appended.append(_strip_meta(case))
+        existing_ids.add(case_id)
+    config["cases"].extend(appended)
+    return config, len(appended), n_skipped
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="case_proposer_promote",
+        description=(
+            "Idempotently append approved reviewed cases to the active "
+            "real-eval config (ADR 0029 second-stage human gate)."
+        ),
+    )
+    p.add_argument(
+        "--reviewed",
+        type=Path,
+        default=DEFAULT_REVIEWED_PATH,
+        help=f"Reviewed yaml input (default: {DEFAULT_REVIEWED_PATH}).",
+    )
+    p.add_argument(
+        "--real-config",
+        type=Path,
+        default=DEFAULT_REAL_CONFIG_PATH,
+        help=(
+            f"Active real-eval config to update "
+            f"(default: {DEFAULT_REAL_CONFIG_PATH}). Must exist; "
+            "copy eval/real_config.example.yaml first if not."
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print counts without writing to --real-config.",
+    )
+    return p
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(list(argv) if argv is not None else None)
+    reviewed = read_reviewed_yaml(args.reviewed)
+    if not reviewed:
+        print(
+            f"case_proposer_promote: no reviewed cases at {args.reviewed}",
+            file=sys.stderr,
+        )
+        return 0
+    if not args.real_config.exists():
+        print(
+            f"case_proposer_promote: {args.real_config} not found. Copy "
+            "eval/real_config.example.yaml first.",
+            file=sys.stderr,
+        )
+        return 2
+    config = read_real_config(args.real_config)
+    new_config, n_appended, n_skipped = promote_cases(reviewed, config)
+    if args.dry_run:
+        print(
+            f"case_proposer_promote (dry-run): would append {n_appended} "
+            f"case(s), skip {n_skipped}",
+            file=sys.stderr,
+        )
+        return 0
+    write_real_config(new_config, args.real_config)
+    print(
+        f"case_proposer_promote: appended {n_appended} case(s), "
+        f"skipped {n_skipped} (rejected or already-present id) "
+        f"-> {args.real_config}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+__all__ = [
+    "DEFAULT_REAL_CONFIG_PATH",
+    "PROPOSER_META_FIELDS",
+    "main",
+    "promote_cases",
+    "read_real_config",
+    "read_reviewed_yaml",
+    "write_real_config",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/scripts/case_proposer_review.py
+++ b/scripts/case_proposer_review.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Interactive review CLI for case proposer candidates (ADR 0029).
+
+Reads ``reports/proposed/proposed_cases.local.yaml`` (gitignored,
+written by ``eval/case_proposer.py``), walks each candidate, and
+records the human reviewer's decision into
+``reports/proposed/reviewed_cases.local.yaml`` (also gitignored).
+
+Decision input:
+
+    a / accept   — keep as-is, ``approved: true``
+    e / edit     — open ``$EDITOR`` on the case yaml; result becomes
+                   the new case body. ``approved: true``,
+                   ``review_meta.edited: true``.
+    r / reject   — keep yaml but ``approved: false``. Useful audit
+                   trail; aggregate metrics in PR4 use this.
+    s / skip     — leave undecided; reviewer revisits later.
+    q / quit     — stop walking, write whatever was decided.
+    ? / help     — show this list again.
+
+The reviewed yaml schema mirrors the proposed schema with two
+additions:
+
+    - <8-field case body + source + proposer_meta>
+      approved: true | false
+      review_meta:
+        reviewed_at: "<ISO8601Z>"
+        edited: true | false
+
+Per ADR 0005, neither the proposed nor the reviewed yaml ever
+crosses the commit boundary — both are written to
+``reports/proposed/*.local.yaml`` which is gitignored. Only the
+``proposer.aggregate.json`` summary (PR4) is committable.
+
+The review walk is testable: the ``walk_review_session`` function
+takes injected ``prompt_fn`` and ``edit_fn`` callables so a unit
+test can simulate keystrokes and edits without a TTY or editor.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eval.case_proposer import (  # noqa: E402
+    DEFAULT_PROPOSED_PATH,
+    DEFAULT_REVIEWED_PATH,
+    write_proposed_yaml,
+)
+
+REVIEW_PROMPT = (
+    "  [a]ccept  [e]dit  [r]eject  [s]kip  [q]uit  [?]help > "
+)
+REVIEW_HELP = (
+    "    a / accept  — approve as-is\n"
+    "    e / edit    — open $EDITOR; result replaces the case body\n"
+    "    r / reject  — record approved=false\n"
+    "    s / skip    — defer (no decision recorded)\n"
+    "    q / quit    — write current results and exit\n"
+    "    ? / help    — show this help\n"
+)
+
+
+def _utcnow_iso_z() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _format_case_preview(case: dict[str, Any]) -> str:
+    """One-screen preview of a case for the reviewer."""
+    meta = case.get("proposer_meta", {})
+    return (
+        f"  id:                {case.get('id')}\n"
+        f"  query_type:        {case.get('query_type')}\n"
+        f"  seed_doc_id:       {meta.get('seed_doc_id')}\n"
+        f"  backend / model:   {meta.get('backend')} / {meta.get('model')}\n"
+        f"  query:             {case.get('query')}\n"
+        f"  expected_doc_ids:  {case.get('expected_doc_ids')}\n"
+        f"  expected_terms:    {case.get('expected_terms')}\n"
+        f"  claim_targets:     {case.get('expected_claim_targets')}\n"
+        f"  answerable:        {case.get('answerable')}"
+    )
+
+
+def _open_editor_on_case(case: dict[str, Any]) -> dict[str, Any]:
+    """Spawn $EDITOR on a temp yaml file containing the case; return the
+    edited dict back. Falls back to ``vi`` if ``$EDITOR`` is unset.
+    """
+    editor = os.environ.get("EDITOR") or "vi"
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", encoding="utf-8", delete=False
+    ) as fh:
+        yaml.safe_dump(case, fh, allow_unicode=True, sort_keys=False)
+        tmp_path = Path(fh.name)
+    try:
+        subprocess.run([editor, str(tmp_path)], check=True)
+        edited = yaml.safe_load(tmp_path.read_text(encoding="utf-8"))
+        if not isinstance(edited, dict):
+            raise ValueError("edited file did not parse to a dict")
+        return edited
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _annotate_reviewed(
+    case: dict[str, Any], *, approved: bool, edited: bool, now_iso: str
+) -> dict[str, Any]:
+    return {
+        **case,
+        "approved": approved,
+        "review_meta": {"reviewed_at": now_iso, "edited": edited},
+    }
+
+
+def walk_review_session(
+    proposed: list[dict[str, Any]],
+    *,
+    prompt_fn: Callable[[str], str],
+    edit_fn: Callable[[dict[str, Any]], dict[str, Any]] = _open_editor_on_case,
+    now_iso_fn: Callable[[], str] = _utcnow_iso_z,
+    write_fn: Callable[[str], None] = lambda msg: print(msg, file=sys.stderr),
+) -> list[dict[str, Any]]:
+    """Walk a list of proposed cases interactively, return reviewed list.
+
+    Pure-ish: side effects (stdout, editor) are injected so tests can
+    simulate the entire flow with deterministic callables. Returns the
+    in-order list of reviewed cases (``approved`` field set on each).
+    """
+    reviewed: list[dict[str, Any]] = []
+    for i, case in enumerate(proposed, start=1):
+        write_fn(f"\n=== Case {i}/{len(proposed)} ===")
+        write_fn(_format_case_preview(case))
+        while True:
+            choice = prompt_fn(REVIEW_PROMPT).strip().lower()
+            if choice in ("a", "accept"):
+                reviewed.append(
+                    _annotate_reviewed(
+                        case, approved=True, edited=False, now_iso=now_iso_fn()
+                    )
+                )
+                break
+            if choice in ("e", "edit"):
+                try:
+                    edited_case = edit_fn(case)
+                except Exception as exc:  # noqa: BLE001 - user-facing surface
+                    write_fn(f"  edit failed: {exc}; please try again")
+                    continue
+                reviewed.append(
+                    _annotate_reviewed(
+                        edited_case,
+                        approved=True,
+                        edited=True,
+                        now_iso=now_iso_fn(),
+                    )
+                )
+                break
+            if choice in ("r", "reject"):
+                reviewed.append(
+                    _annotate_reviewed(
+                        case, approved=False, edited=False, now_iso=now_iso_fn()
+                    )
+                )
+                break
+            if choice in ("s", "skip"):
+                break
+            if choice in ("q", "quit"):
+                return reviewed
+            if choice in ("?", "help"):
+                write_fn(REVIEW_HELP)
+                continue
+            write_fn(f"  unknown choice: {choice!r}; press ? for help")
+    return reviewed
+
+
+# -----------------------------------------------------------------------------
+# YAML I/O
+# -----------------------------------------------------------------------------
+
+
+def read_proposed_yaml(path: Path) -> list[dict[str, Any]]:
+    """Load proposed-cases yaml. Tolerant of empty / missing files."""
+    if not path.exists():
+        return []
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    cases = data.get("proposed_cases")
+    if not cases:
+        return []
+    return list(cases)
+
+
+def write_reviewed_yaml(reviewed: list[dict[str, Any]], path: Path) -> None:
+    """Write reviewed cases. Uses the proposer's deterministic writer
+    so reviewer-edited cases keep schema-stable ordering, then
+    appends the ``approved`` + ``review_meta`` fields per case.
+
+    The writer below intentionally uses ``yaml.safe_dump`` rather than
+    the proposer's hand-rolled emitter — reviewed yaml is consumed
+    only by ``case_proposer_promote.py`` (which uses PyYAML) and
+    never crosses the commit boundary, so block-style + alphabetic
+    ordering is fine here.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"reviewed_cases": reviewed}
+    path.write_text(
+        yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="case_proposer_review",
+        description=(
+            "Interactive review of proposed cases (ADR 0029). Reads "
+            "proposed yaml, writes reviewed yaml with `approved` per case."
+        ),
+    )
+    p.add_argument(
+        "--proposed",
+        type=Path,
+        default=DEFAULT_PROPOSED_PATH,
+        help=f"Input proposed yaml (default: {DEFAULT_PROPOSED_PATH}).",
+    )
+    p.add_argument(
+        "--reviewed",
+        type=Path,
+        default=DEFAULT_REVIEWED_PATH,
+        help=f"Output reviewed yaml (default: {DEFAULT_REVIEWED_PATH}).",
+    )
+    return p
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(list(argv) if argv is not None else None)
+    proposed = read_proposed_yaml(args.proposed)
+    if not proposed:
+        print(
+            f"case_proposer_review: no proposed cases found at {args.proposed}",
+            file=sys.stderr,
+        )
+        return 0
+    print(
+        f"case_proposer_review: walking {len(proposed)} proposed case(s)\n"
+        f"  proposed:  {args.proposed}\n"
+        f"  reviewed:  {args.reviewed}",
+        file=sys.stderr,
+    )
+    reviewed = walk_review_session(proposed, prompt_fn=input)
+    write_reviewed_yaml(reviewed, args.reviewed)
+    n_approved = sum(1 for c in reviewed if c.get("approved"))
+    print(
+        f"case_proposer_review: wrote {len(reviewed)} reviewed case(s) "
+        f"({n_approved} approved) to {args.reviewed}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+# Re-export for the promote step (PR2's case_proposer_promote.py).
+__all__ = [
+    "REVIEW_HELP",
+    "REVIEW_PROMPT",
+    "main",
+    "read_proposed_yaml",
+    "walk_review_session",
+    "write_reviewed_yaml",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/test_case_proposer_pipeline.py
+++ b/tests/test_case_proposer_pipeline.py
@@ -1,0 +1,400 @@
+"""Pipeline-level regression tests for the case proposer (ADR 0029, PR2).
+
+Covers the end-to-end shape of ``propose_cases_from_files`` (CSV
+reader + index reader + stub generation), the deterministic YAML
+writer, the review walk's branching logic, and the promote step's
+idempotency + meta-stripping. PR1 invariants (Protocol, backend
+dispatch, ADR 0001 import surface guard) stay in
+``tests/test_case_proposer_stub.py``.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import patch
+
+import yaml
+
+from eval.case_proposer import (
+    CSV_COLUMN_AGENCY,
+    CSV_COLUMN_FILE_FORMAT,
+    CSV_COLUMN_FILE_NAME,
+    CSV_COLUMN_NOTICE_ID,
+    CSV_COLUMN_PROJECT,
+    CSV_COLUMN_TEXT,
+    CaseProposerInputError,
+    REQUIRED_CSV_COLUMNS,
+    propose_cases,
+    propose_cases_from_files,
+    write_proposed_yaml,
+)
+from scripts.case_proposer_promote import (
+    PROPOSER_META_FIELDS,
+    promote_cases,
+)
+from scripts.case_proposer_review import (
+    read_proposed_yaml,
+    walk_review_session,
+    write_reviewed_yaml,
+)
+
+NOW_FIXED = "2026-05-13T08:00:00Z"
+
+
+def _make_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(REQUIRED_CSV_COLUMNS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _make_index(path: Path, doc_ids: list[str]) -> None:
+    payload = {
+        "schema_version": 2,
+        "build": {
+            "documents": [{"doc_id": d} for d in doc_ids],
+        },
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _sample_row(
+    notice_id: str = "K2026-001",
+    agency: str = "A기관",
+    project: str = "사업A",
+) -> dict[str, str]:
+    return {
+        CSV_COLUMN_NOTICE_ID: notice_id,
+        CSV_COLUMN_PROJECT: project,
+        CSV_COLUMN_AGENCY: agency,
+        CSV_COLUMN_FILE_FORMAT: "pdf",
+        CSV_COLUMN_FILE_NAME: f"{notice_id}.pdf",
+        CSV_COLUMN_TEXT: "본문 텍스트",
+    }
+
+
+class StubBackendGenerationTest(unittest.TestCase):
+    def test_two_templates_per_row_with_doc_id(self) -> None:
+        rows = [{"doc_id": "doc-001", CSV_COLUMN_AGENCY: "기관A", CSV_COLUMN_PROJECT: "사업A"}]
+        cases = propose_cases(rows, backend="stub", now_iso=NOW_FIXED)
+        self.assertEqual(len(cases), 2)
+        single_doc, abstention = cases
+        self.assertEqual(single_doc["query_type"], "single_doc")
+        self.assertEqual(single_doc["expected_doc_ids"], ["doc-001"])
+        self.assertTrue(single_doc["answerable"])
+        self.assertEqual(abstention["query_type"], "abstention")
+        self.assertEqual(abstention["expected_doc_ids"], [])
+        self.assertFalse(abstention["answerable"])
+
+    def test_skip_rows_without_doc_id(self) -> None:
+        rows = [
+            {"doc_id": "", CSV_COLUMN_AGENCY: "기관A", CSV_COLUMN_PROJECT: "사업A"},
+            {"doc_id": "doc-001", CSV_COLUMN_AGENCY: "기관B", CSV_COLUMN_PROJECT: "사업B"},
+        ]
+        cases = propose_cases(rows, backend="stub", now_iso=NOW_FIXED)
+        # Only the row with a doc_id produces cases (2 templates).
+        self.assertEqual(len(cases), 2)
+        for case in cases:
+            self.assertEqual(case["proposer_meta"]["seed_doc_id"], "doc-001")
+
+    def test_proposed_id_uses_iso_date_prefix(self) -> None:
+        rows = [{"doc_id": "doc-001"}]
+        cases = propose_cases(rows, backend="stub", now_iso="2026-05-13T12:34:56Z")
+        self.assertEqual(cases[0]["id"], "proposed_20260513_001")
+        self.assertEqual(cases[1]["id"], "proposed_20260513_002")
+
+    def test_required_csv_columns_match_ingestion_module(self) -> None:
+        """Drift guard: case_proposer hard-codes the column names to
+        stay free of rag_core-transitive imports. This test confirms
+        the duplicated list still matches ``ingestion.REQUIRED_COLUMNS``.
+        """
+        from ingestion import REQUIRED_COLUMNS as INGESTION_REQUIRED
+
+        self.assertEqual(set(REQUIRED_CSV_COLUMNS), set(INGESTION_REQUIRED))
+
+
+class ProposeCasesFromFilesTest(unittest.TestCase):
+    def test_end_to_end_yields_deterministic_cases(self) -> None:
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path = td_path / "data_list.csv"
+            index_dir = td_path / "index"
+            index_dir.mkdir()
+            _make_csv(csv_path, [
+                _sample_row("K2026-001", "기관A", "사업A"),
+                _sample_row("K2026-002", "기관B", "사업B"),
+            ])
+            _make_index(index_dir / "index.json", ["K2026-001", "K2026-002"])
+
+            cases = propose_cases_from_files(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=10,
+                backend="stub",
+                now_iso=NOW_FIXED,
+            )
+            self.assertEqual(len(cases), 4)
+            # Re-run produces byte-equal cases.
+            cases2 = propose_cases_from_files(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=10,
+                backend="stub",
+                now_iso=NOW_FIXED,
+            )
+            self.assertEqual(cases, cases2)
+
+    def test_raises_when_no_csv_row_matches_index(self) -> None:
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path = td_path / "data_list.csv"
+            index_dir = td_path / "index"
+            index_dir.mkdir()
+            _make_csv(csv_path, [_sample_row("K2026-001")])
+            _make_index(index_dir / "index.json", ["does-not-match"])
+
+            with self.assertRaises(CaseProposerInputError):
+                propose_cases_from_files(
+                    metadata_csv=csv_path,
+                    index_dir=index_dir,
+                    n_seed_docs=10,
+                    backend="stub",
+                    now_iso=NOW_FIXED,
+                )
+
+    def test_n_seed_docs_caps_selection(self) -> None:
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path = td_path / "data_list.csv"
+            index_dir = td_path / "index"
+            index_dir.mkdir()
+            _make_csv(csv_path, [
+                _sample_row(f"K2026-{i:03d}", f"기관{i}", f"사업{i}")
+                for i in range(1, 6)
+            ])
+            _make_index(
+                index_dir / "index.json",
+                [f"K2026-{i:03d}" for i in range(1, 6)],
+            )
+            cases = propose_cases_from_files(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=2,
+                backend="stub",
+                now_iso=NOW_FIXED,
+            )
+            self.assertEqual(len(cases), 4)  # 2 docs * 2 templates
+
+
+class YamlWriterTest(unittest.TestCase):
+    def test_write_proposed_yaml_is_byte_equal_across_runs(self) -> None:
+        rows = [{"doc_id": "doc-001", CSV_COLUMN_AGENCY: "기관A", CSV_COLUMN_PROJECT: "사업A"}]
+        cases = propose_cases(rows, backend="stub", now_iso=NOW_FIXED)
+        with TemporaryDirectory() as td:
+            path_a = Path(td) / "a.yaml"
+            path_b = Path(td) / "b.yaml"
+            write_proposed_yaml(cases, path_a)
+            write_proposed_yaml(cases, path_b)
+            self.assertEqual(
+                path_a.read_text(encoding="utf-8"),
+                path_b.read_text(encoding="utf-8"),
+            )
+
+    def test_write_proposed_yaml_round_trips_via_pyyaml(self) -> None:
+        rows = [{"doc_id": "doc-001", CSV_COLUMN_AGENCY: "기관A", CSV_COLUMN_PROJECT: "사업A"}]
+        cases = propose_cases(rows, backend="stub", now_iso=NOW_FIXED)
+        with TemporaryDirectory() as td:
+            path = Path(td) / "proposed.yaml"
+            write_proposed_yaml(cases, path)
+            read_back = read_proposed_yaml(path)
+            self.assertEqual(len(read_back), len(cases))
+            self.assertEqual(read_back[0]["id"], cases[0]["id"])
+            self.assertEqual(read_back[0]["query_type"], "single_doc")
+            self.assertEqual(read_back[0]["expected_doc_ids"], ["doc-001"])
+
+    def test_write_proposed_yaml_empty_list(self) -> None:
+        with TemporaryDirectory() as td:
+            path = Path(td) / "empty.yaml"
+            write_proposed_yaml([], path)
+            content = path.read_text(encoding="utf-8")
+            self.assertIn("proposed_cases: []", content)
+            self.assertEqual(read_proposed_yaml(path), [])
+
+
+class ReviewWalkSessionTest(unittest.TestCase):
+    def _sample_proposed(self) -> list[dict[str, Any]]:
+        rows = [{"doc_id": "doc-001", CSV_COLUMN_AGENCY: "기관A", CSV_COLUMN_PROJECT: "사업A"}]
+        return propose_cases(rows, backend="stub", now_iso=NOW_FIXED)
+
+    def test_accept_path_records_approved_true(self) -> None:
+        proposed = self._sample_proposed()
+        choices = iter(["a", "a"])  # accept both
+        reviewed = walk_review_session(
+            proposed,
+            prompt_fn=lambda _p: next(choices),
+            edit_fn=lambda c: c,
+            now_iso_fn=lambda: NOW_FIXED,
+            write_fn=lambda _m: None,
+        )
+        self.assertEqual(len(reviewed), 2)
+        for case in reviewed:
+            self.assertTrue(case["approved"])
+            self.assertFalse(case["review_meta"]["edited"])
+
+    def test_reject_path_records_approved_false(self) -> None:
+        proposed = self._sample_proposed()
+        choices = iter(["r", "r"])
+        reviewed = walk_review_session(
+            proposed,
+            prompt_fn=lambda _p: next(choices),
+            edit_fn=lambda c: c,
+            now_iso_fn=lambda: NOW_FIXED,
+            write_fn=lambda _m: None,
+        )
+        self.assertEqual(len(reviewed), 2)
+        for case in reviewed:
+            self.assertFalse(case["approved"])
+
+    def test_edit_path_replaces_case_body_and_flags_edited(self) -> None:
+        proposed = self._sample_proposed()
+        choices = iter(["e", "a"])
+
+        def fake_edit(case: dict[str, Any]) -> dict[str, Any]:
+            return {**case, "query": "edited query"}
+
+        reviewed = walk_review_session(
+            proposed,
+            prompt_fn=lambda _p: next(choices),
+            edit_fn=fake_edit,
+            now_iso_fn=lambda: NOW_FIXED,
+            write_fn=lambda _m: None,
+        )
+        self.assertEqual(len(reviewed), 2)
+        self.assertTrue(reviewed[0]["approved"])
+        self.assertTrue(reviewed[0]["review_meta"]["edited"])
+        self.assertEqual(reviewed[0]["query"], "edited query")
+
+    def test_skip_path_omits_case_from_output(self) -> None:
+        proposed = self._sample_proposed()
+        choices = iter(["s", "a"])
+        reviewed = walk_review_session(
+            proposed,
+            prompt_fn=lambda _p: next(choices),
+            edit_fn=lambda c: c,
+            now_iso_fn=lambda: NOW_FIXED,
+            write_fn=lambda _m: None,
+        )
+        # First case skipped → only second case in output.
+        self.assertEqual(len(reviewed), 1)
+        self.assertEqual(reviewed[0]["id"], proposed[1]["id"])
+
+    def test_quit_path_stops_walk(self) -> None:
+        proposed = self._sample_proposed()
+        choices = iter(["a", "q"])
+        reviewed = walk_review_session(
+            proposed,
+            prompt_fn=lambda _p: next(choices),
+            edit_fn=lambda c: c,
+            now_iso_fn=lambda: NOW_FIXED,
+            write_fn=lambda _m: None,
+        )
+        self.assertEqual(len(reviewed), 1)
+        self.assertTrue(reviewed[0]["approved"])
+
+    def test_help_path_re_prompts(self) -> None:
+        proposed = self._sample_proposed()[:1]
+        choices = iter(["?", "a"])
+        messages: list[str] = []
+        reviewed = walk_review_session(
+            proposed,
+            prompt_fn=lambda _p: next(choices),
+            edit_fn=lambda c: c,
+            now_iso_fn=lambda: NOW_FIXED,
+            write_fn=messages.append,
+        )
+        self.assertEqual(len(reviewed), 1)
+        self.assertTrue(any("help" in m.lower() or "accept" in m.lower() for m in messages))
+
+
+class PromoteIdempotencyTest(unittest.TestCase):
+    def _approved_reviewed(self, ids: list[str]) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": case_id,
+                "source": "proposed-then-reviewed",
+                "proposer_meta": {
+                    "backend": "stub",
+                    "model": "stub",
+                    "seed_doc_id": case_id,
+                    "generated_at": NOW_FIXED,
+                    "proposer_version": 1,
+                },
+                "query_type": "single_doc",
+                "query": f"query for {case_id}",
+                "expected_doc_ids": [case_id],
+                "expected_terms": [],
+                "expected_citation_terms": [],
+                "expected_claim_targets": [],
+                "answerable": True,
+                "approved": True,
+                "review_meta": {"reviewed_at": NOW_FIXED, "edited": False},
+            }
+            for case_id in ids
+        ]
+
+    def _empty_real_config(self) -> dict[str, Any]:
+        return {"mode": "rag", "cases": []}
+
+    def test_appends_only_approved_cases(self) -> None:
+        reviewed = self._approved_reviewed(["a", "b"])
+        reviewed[1]["approved"] = False  # b is rejected
+        config, n_appended, n_skipped = promote_cases(
+            reviewed, self._empty_real_config()
+        )
+        self.assertEqual(n_appended, 1)
+        self.assertEqual(n_skipped, 1)
+        self.assertEqual([c["id"] for c in config["cases"]], ["a"])
+
+    def test_strips_proposer_and_review_meta(self) -> None:
+        reviewed = self._approved_reviewed(["a"])
+        config, _, _ = promote_cases(reviewed, self._empty_real_config())
+        promoted = config["cases"][0]
+        for forbidden in PROPOSER_META_FIELDS:
+            self.assertNotIn(forbidden, promoted)
+        # Schema-fields preserved.
+        self.assertEqual(promoted["id"], "a")
+        self.assertEqual(promoted["query_type"], "single_doc")
+        self.assertEqual(promoted["expected_doc_ids"], ["a"])
+
+    def test_second_promote_is_idempotent(self) -> None:
+        reviewed = self._approved_reviewed(["a", "b"])
+        config, n1, _ = promote_cases(reviewed, self._empty_real_config())
+        self.assertEqual(n1, 2)
+        config_after, n2, n_skipped2 = promote_cases(reviewed, config)
+        self.assertEqual(n2, 0)
+        self.assertEqual(n_skipped2, 2)
+        self.assertEqual(
+            [c["id"] for c in config_after["cases"]],
+            ["a", "b"],
+        )
+
+    def test_preexisting_cases_block_appended_duplicate(self) -> None:
+        reviewed = self._approved_reviewed(["a"])
+        config = {
+            "mode": "rag",
+            "cases": [{"id": "a", "query": "preexisting"}],
+        }
+        new_config, n_appended, n_skipped = promote_cases(reviewed, config)
+        self.assertEqual(n_appended, 0)
+        self.assertEqual(n_skipped, 1)
+        # Original case preserved untouched.
+        self.assertEqual(new_config["cases"][0]["query"], "preexisting")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_case_proposer_stub.py
+++ b/tests/test_case_proposer_stub.py
@@ -1,11 +1,17 @@
-"""Tests for the real-data case proposer skeleton (ADR 0029, PR1).
+"""Tests for the real-data case proposer skeleton + backend dispatch
+(ADR 0029).
 
-The stub backend ships empty in PR1 — these tests pin the skeleton's
-shape (Protocol, backend dispatch, error surface) and the
-ADR 0001 byte-identity guard: loading ``eval.case_proposer`` must not
-pull in ``rag_core``, because the proposer is upstream of
-``run_rag_query`` and any accidental dependency would risk a
-side-effect on the naive baseline golden.
+These tests pin the always-on invariants: backend resolution
+precedence, fail-loud unknown / NotImplemented backends, default
+paths under ``reports/proposed/``, and the ADR 0001 byte-identity
+guard — loading ``eval.case_proposer`` must not pull in ``rag_core``,
+because the proposer is upstream of ``run_rag_query`` and any
+accidental dependency would risk a side-effect on the naive baseline
+golden.
+
+PR2 pipeline-level tests (CSV reader, yaml writer, end-to-end
+``propose_cases_from_files``, review walk, promote idempotency) live
+in ``tests/test_case_proposer_pipeline.py``.
 """
 from __future__ import annotations
 
@@ -25,25 +31,29 @@ from eval.case_proposer import (
 
 
 class CaseProposerStubTest(unittest.TestCase):
-    def test_stub_returns_empty_list_in_pr1(self) -> None:
-        """PR1 invariant: skeleton stub emits no candidates."""
-        out = propose_cases([{"doc_id": "doc-001"}], backend="stub")
+    def test_stub_returns_empty_when_no_rows(self) -> None:
+        """Stub emits no candidates without seed rows."""
+        out = propose_cases([], backend="stub", now_iso="2026-05-13T00:00:00Z")
         self.assertEqual(out, [])
 
     def test_stub_deterministic_across_calls(self) -> None:
         """Stub must be byte-equal across runs (ADR 0011 stub-default contract)."""
         rows = [
-            {"doc_id": "doc-001", "사업명": "사업A"},
-            {"doc_id": "doc-002", "사업명": "사업B"},
+            {"doc_id": "doc-001", "발주 기관": "A기관", "사업명": "사업A"},
+            {"doc_id": "doc-002", "발주 기관": "B기관", "사업명": "사업B"},
         ]
-        calls = [propose_cases(rows, backend="stub") for _ in range(5)]
+        calls = [
+            propose_cases(rows, backend="stub", now_iso="2026-05-13T00:00:00Z")
+            for _ in range(5)
+        ]
         for result in calls[1:]:
             self.assertEqual(result, calls[0])
+        self.assertEqual(len(calls[0]), 4)  # 2 rows * 2 templates
 
     def test_resolve_backend_default_is_stub(self) -> None:
         name, fn = resolve_backend()
         self.assertEqual(name, "stub")
-        self.assertEqual(fn([], model="stub"), [])
+        self.assertEqual(fn([], model="stub", now_iso="2026-05-13T00:00:00Z"), [])
 
     def test_resolve_backend_explicit_arg_wins_over_env(self) -> None:
         """Explicit ``name`` argument overrides $BIDMATE_CASE_PROPOSER_BACKEND."""
@@ -79,13 +89,14 @@ class CaseProposerStubTest(unittest.TestCase):
             resolve_backend("does-not-exist")
         self.assertIn("does-not-exist", str(ctx.exception))
 
-    def test_openai_compatible_backend_raises_not_implemented_in_pr1(self) -> None:
+    def test_openai_compatible_backend_raises_not_implemented(self) -> None:
         """Live backend lands in PR3 — callers must fail loudly, not silently fall back."""
         with self.assertRaises(NotImplementedError):
             propose_cases(
                 [{"doc_id": "doc-001"}],
                 backend="openai_compatible",
                 model="claude-sonnet-4-6",
+                now_iso="2026-05-13T00:00:00Z",
             )
 
     def test_default_paths_under_reports_proposed(self) -> None:


### PR DESCRIPTION
## 1. What changed and why

Closes #482

PR2 of ADR 0029. Fills in the case proposer behavior promised by PR1's skeleton ([#479](https://github.com/hskim-solv/BidMate-DocAgent/pull/479)): the stub backend now emits metadata-driven template queries from \`data_list.csv\`, and a **two-stage human gate** (interactive review CLI + idempotent promote step) feeds approved cases into \`eval/real_config.local.yaml\` — N can grow past 100 without breaking ADR 0005's case-body commit boundary.

Stub generation pattern: one \`single_doc\` + one \`abstention\` template per seed doc, 1:1 ratio. This is the cheapest defense against ADR 0029 §Risks #1 (systematic bias toward easy single-doc queries inflating \`agentic_full_llm\` vs \`naive_baseline\` delta) — PR4's \`by_query_type\` χ²-test still has a balanced base to compare against.

## 2. Files affected

- **load-bearing** [\`eval/case_proposer.py\`](eval/case_proposer.py) — stub body + CSV/index/yaml I/O + argparse CLI (+388 LOC over PR1)
- **load-bearing** [\`Makefile\`](Makefile) — \`case-propose\` / \`case-review\` / \`case-promote\` targets in a new .PHONY group next to real-eval
- [\`scripts/case_proposer_review.py\`](scripts/case_proposer_review.py) — interactive review walk (a/e/r/s/q/?) with \`\$EDITOR\` edit path; \`walk_review_session\` is pure-with-injected-IO for full branch coverage
- [\`scripts/case_proposer_promote.py\`](scripts/case_proposer_promote.py) — idempotent append + meta-stripping + dry-run
- [\`tests/test_case_proposer_pipeline.py\`](tests/test_case_proposer_pipeline.py) — 20 new tests covering generation, CSV pipeline, yaml writer, review walk branches, promote idempotency
- [\`tests/test_case_proposer_stub.py\`](tests/test_case_proposer_stub.py) — PR1 invariant tests updated (empty-rows variant replaces \"returns empty in PR1\"; backend dispatch + ADR 0001 import-surface guard preserved)

## 3. Risks

**Most likely break**: \`canonical_doc_id\` from \`ingestion.py\` returns a doc_id that no longer matches the active index, so \`propose_cases_from_files\` raises \`CaseProposerInputError\` even though the index is well-formed. Mitigated by:
- Lazy import (\`from ingestion import canonical_doc_id\` inside \`_attach_doc_ids\`) so a future ingestion refactor produces a localized error rather than corrupting case generation upstream.
- Explicit error message points the user at \`make build-index\` (covered in \`test_raises_when_no_csv_row_matches_index\`).

**Secondary risk**: PyYAML's round-trip in \`case-promote\` doesn't preserve comments in \`eval/real_config.local.yaml\`. Trade-off vs. a ruamel.yaml dependency. Documented in \`scripts/case_proposer_promote.py\` module docstring; reviewers who keep heavy comments check the diff and re-add as needed.

**Tertiary risk**: the hand-rolled yaml writer in \`eval/case_proposer.py\` (\`write_proposed_yaml\`) diverges from PyYAML's read shape. Pinned by \`test_write_proposed_yaml_round_trips_via_pyyaml\` — PyYAML must be able to read what we write back into a structurally equivalent dict.

## 4. Tests

**30 case-proposer tests** pass (10 PR1 invariants in \`test_case_proposer_stub.py\` + 20 new pipeline tests in \`test_case_proposer_pipeline.py\`). Highlights:

- \`test_two_templates_per_row_with_doc_id\` — stub 1:1 ratio invariant
- \`test_end_to_end_yields_deterministic_cases\` — full CSV → index → yaml byte-equal across runs
- \`test_required_csv_columns_match_ingestion_module\` — drift guard between \`eval.case_proposer.REQUIRED_CSV_COLUMNS\` and \`ingestion.REQUIRED_COLUMNS\` (the duplicated list stays in sync mechanically)
- \`test_write_proposed_yaml_is_byte_equal_across_runs\` + \`test_write_proposed_yaml_round_trips_via_pyyaml\` — hand-rolled writer correctness
- All 5 review-walk branches (\`accept\` / \`edit\` / \`reject\` / \`skip\` / \`quit\` + \`help\`)
- \`test_second_promote_is_idempotent\` — running \`make case-promote\` twice is a no-op for the second invocation
- \`test_strips_proposer_and_review_meta\` — active config stays a byte-equal subset of the 8-field schema
- \`test_preexisting_cases_block_appended_duplicate\` — pre-existing case ids in \`real_config.local.yaml\` are not overwritten

Full pytest: **883 passed, 1 skipped**. \`make smoke\` green. \`md5 tests/data/naive_baseline_top_k.json\` = \`daa808e412f76e44ed979b77c33f70b3\` (ADR 0001 byte-identity preserved).

## 5. Eval impact

Public synthetic eval delta: **all \`·\`**. The proposer is never invoked from \`pr-eval.yml\`, \`make smoke\`, or \`make eval\`. Stub backend has zero side effects on retrieval / verifier / answer paths.

### 5b. Real-data delta

**No behavior change in eval.** The proposer writes to \`reports/proposed/*.local.yaml\` (gitignored) and \`eval/real_config.local.yaml\` (gitignored). It is upstream of \`run_rag_query\` — produces eval inputs, not answer outputs. \`make real-eval\` after \`make case-promote\` would naturally show \`n_predictions\` go from 100 → 100 + N_accepted, but that's the user's deliberate growth step, not a behavior delta of the retrieval path.

## 6. Backward compatibility

None broken. New file surface only (\`scripts/case_proposer_*.py\`, new Makefile targets). \`eval/case_proposer.py\`'s public API additions (\`propose_cases_from_files\`, \`write_proposed_yaml\`, \`CaseProposerInputError\`, \`REQUIRED_CSV_COLUMNS\` + column constants) are additive; \`propose_cases\` gains an optional \`now_iso\` kwarg with \`None\` default (defaults to \`datetime.now(UTC)\` so existing callers are unaffected). Answer contract (ADR 0003 \`schema_version: 2\`) unchanged.

## 7. Out of scope

- **PR3**: \`openai_compatible\` backend wiring + ADR 0008 \`EVIDENCE_BOUNDARY\` + \`neutralize_instruction_patterns\` sanitization. The stub backend in this PR is the only execution path; the live path still raises \`NotImplementedError\` (covered by \`test_openai_compatible_backend_raises_not_implemented\`).
- **PR4**: \`proposer.aggregate.json\` writer + \`case-proposer-aggregate\` target + README two-column reporting (\"100 hand + N proposed-reviewed\") + ADR 0029 \`proposed\` → \`accepted\` promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)