### PR TITLE
feat(skill): add /self-review-quarterly (4+5 axis rubric)

### DIFF
--- a/.claude/skills/self-review-quarterly/SKILL.md
+++ b/.claude/skills/self-review-quarterly/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: self-review-quarterly
+description: |
+  Produce a quarterly self-review report combining the 4-axis portfolio rubric (feedback_portfolio_evaluation.md) and the 5-axis Claude collaboration rubric (feedback_collaboration_axes.md). Outputs ✓/△/✗ verdicts per axis with metadata-only citations.
+
+  Trigger when the user invokes `/self-review-quarterly Qx-YYYY`, types "self-review Q2-2026", or asks "지난 분기 협업 어땠어", "Claude 잘 쓰고 있는지 분기로 보자", "Q1 분기 진단", "메타 피드백 분기 보고서". Trigger even if only one rubric is mentioned — this skill always outputs both 4-axis + 5-axis in one report.
+
+  Do NOT trigger for: single-axis question without quarter scope (use the relevant memory directly), ADR-to-signal mapping (use `adr-portfolio-signals` instead), portfolio launch checklist updates, or any per-PR retrospective.
+---
+
+# Self-Review Quarterly
+
+Given a quarter (`Qx-YYYY`), produce a structured Markdown report with **two rubric tables** (4-axis portfolio + 5-axis collaboration), evidence citations, and a single highest-ROI improvement bullet. Writes outputs to three locations: `docs/self-review/Qx-YYYY.md` (committed), a memory summary, and the MEMORY.md index.
+
+## Scope
+
+- Single-quarter input only. Format: `Qx-YYYY` (e.g. `Q2-2026`). 4 ≥ x ≥ 1.
+- Always outputs **both** rubrics — never one alone. The skill exists to compare portfolio progress against collaboration ROI in one frame.
+- Output destinations: `docs/self-review/Qx-YYYY.md` + memory summary + MEMORY.md update. No stdout-only mode.
+- Body excerpts from transcripts, tool arguments, code diffs, or memory body are **never** quoted. Metadata-only citations.
+
+## Workflow
+
+1. **Resolve quarter.** Validate `Qx-YYYY` format. On miss, list quarters with at least one commit (`git log --since=YYYY-01-01 --pretty=format:%ai | sort -u`) and stop.
+
+2. **Load rubric definitions.**
+   - 4-axis: `~/.claude/projects/-Users-hskim-Desktop-projects-BidMate-DocAgent/memory/feedback_portfolio_evaluation.md` (read the body, treat as source of truth)
+   - 5-axis: `~/.claude/projects/-Users-hskim-Desktop-projects-BidMate-DocAgent/memory/feedback_collaboration_axes.md`
+   - If either is missing or its referenced docs (e.g. `docs/senior-positioning.md`) are gone, stop and surface the broken pointer.
+
+3. **Collect raw stats.** Invoke the driver via Bash:
+   ```bash
+   python scripts/claude-hooks/_self_review.py --quarter <Qx-YYYY> --emit-stats > /tmp/self-review-<Qx-YYYY>-stats.json
+   ```
+   Read `/tmp/.../stats.json` into the skill context. The driver guarantees body-free output by schema; trust it but spot-check (see step 8).
+
+4. **4-axis verdict table.** For each of the 4 portfolio axes, judge `✓` / `△ — <≤30자 사유>` / `✗ — <≤30자 사유>` using the rubric's signals + the stats. Cite metadata only (see "Citation policy" below).
+
+5. **5-axis verdict table.** Same procedure with the 5 collaboration axes.
+
+6. **ROI bullet.** Across all 9 axes, pick the **single** highest-leverage weakness (largest improvement potential × lowest cost). One-line action recommendation for next quarter. Multiple bullets are forbidden — force the prioritization.
+
+7. **Write outputs (three destinations).**
+   - **`docs/self-review/Qx-YYYY.md`** (commit-bound) — full template below. Create parent dir if absent.
+   - **Memory summary**: `~/.claude/.../memory/feedback_qX_YYYY_collaboration_review.md` (frontmatter `type: feedback`). Body ≤500 chars: one line per rubric (highest weakness + one ✓ highlight) + the ROI bullet. No body excerpts.
+   - **MEMORY.md update**: append one line under existing entries: `- [Self-review Qx-YYYY](feedback_qX_YYYY_collaboration_review.md) — <ROI keyword phrase>`.
+
+8. **Self-check before returning.**
+   - Both rubric tables present (4 rows + 5 rows). No table omitted.
+   - All `partial`/`fail` verdicts carry a factual reason ≤30 chars after the em-dash.
+   - All cited paths exist (`ls` or `[ -f ]` each one). All cited PR / ADR / issue numbers are integers, not prose.
+   - No body excerpts. Grep the report for forbidden patterns: `"사용자가 말"`, `"user said"`, `"내가 답"`, `"I answered"`, `"```python"` (code block from transcript), `"```diff"`. Any match → rewrite that cell.
+   - `docs/self-review/Qx-YYYY.md` written + memory summary written + MEMORY.md updated. Verify all three before reporting completion.
+
+## Citation policy (hard rules)
+
+This skill writes to a **committed git file**. Privacy violations cannot be retracted. Apply both rules.
+
+### 인용 가능 (allowed)
+
+- Tool 이름: `Read`, `Edit`, `Bash`, `Agent`
+- 호출 횟수 (숫자), 세션 수, 커밋 수
+- 공개 파일 경로: `rag_core.py`, `docs/adr/0028-*.md`, `scripts/_governance.py`
+- Git commit hash (≤12 chars): `f5b51fa`
+- PR 번호: `PR #458`
+- Issue 번호: `issue #461`
+- ADR id: `ADR 0023`
+- 메모리 파일명 + frontmatter 필드(`name`, `type`, `originSessionId`)
+- Stats.json의 모든 값 (driver가 이미 metadata-only 보장)
+
+### 인용 금지 (forbidden)
+
+- 사용자 메시지 본문 (어떤 발화도 paraphrase 포함)
+- Assistant 응답 본문 (skill 자기 자신 포함)
+- Tool 호출 arguments: 검색 query, edit 내용, Agent prompt 본문
+- 코드 diff 내용
+- 메모리 본문 (frontmatter 외)
+- ADR / 문서 본문 (제목 + id만 OK)
+- Commit message body (subject에서 PR 번호 추출만 OK)
+
+### 회피 표현 (selling / vague)
+
+- 자기평가 형용사: `잘 ~`, `매우 ~`, `탄탄한`, `훌륭한`
+- 단정 동사: `보장`, `증명`, `완벽`, `최고`
+- 평가어 (verdict 사유에서): `좀 부족`, `약간 아쉬움` — 대신 사실: `Q2 6주 ADR 부재`
+
+## Output template
+
+````markdown
+# Self-Review Qx-YYYY
+
+- Date range: YYYY-MM-DD – YYYY-MM-DD
+- Sessions: N | Commits: N | PRs merged: N | ADR changes: N | Load-bearing touches: N
+- Source: `scripts/claude-hooks/_self_review.py` (metadata-only stats; see "Privacy" below)
+
+## 4축 진단 (포트폴리오 진행)
+
+| # | 축 | 평가 | 근거 | 한 줄 코멘트 |
+|---|---|---|---|---|
+| 1 | 엔지니어링 디스플린 | ✓ / △ — <사유> / ✗ — <사유> | `PR #458`, `docs/engineering-governance.md` | <1-line, ≤80자> |
+| 2 | 아키텍처 결정 정합성 | ... | `ADR 0028`, `docs/adr/README.md` | ... |
+| 3 | 평가 견고성 (LLM Ops) | ... | `eval/config.yaml`, `reports/eval_summary.json` | ... |
+| 4 | 시장 가시성 | ... | `docs/portfolio-launch-checklist.md`, `docs/leaderboard.md` | ... |
+
+## 5축 진단 (Claude 협업)
+
+| # | 축 | 평가 | 근거 | 한 줄 코멘트 |
+|---|---|---|---|---|
+| 1 | 컨텍스트 효율 | ... | sessions.tool_call_distribution, memory hits | ... |
+| 2 | Agent 위임 패턴 | ... | sessions.agent_delegations | ... |
+| 3 | 거버넌스 자동화 ROI | ... | `scripts/_governance.py`, hook config | ... |
+| 4 | 사이클 타임 | ... | ADR proposed→accepted dates, hook lag | ... |
+| 5 | 메모리 위생 | ... | memory.by_type, files_total | ... |
+
+## 최우선 개선점 (ROI)
+
+<단 하나의 약점 축 + 다음 분기 1–3줄 action>
+
+## Privacy
+
+이 보고서는 `_self_review.py`가 emit한 메타데이터(tool 호출 횟수, 공개 파일 경로, git hash, PR/issue/ADR id, 메모리 frontmatter)만 인용합니다. 사용자 메시지·assistant 응답·tool arguments·코드 diff·메모리 본문은 포함되지 않습니다. 검증: 본 파일에 `user said` / `사용자가 말` / `assistant: ` / `\`\`\`python` 패턴 없음.
+````
+
+## What this skill does NOT do
+
+- Does NOT make any decision *for* the user. The user reads the report and decides where to invest next quarter.
+- Does NOT propose ADRs or implement fixes. Recommendations are 1–3 line bullets — implementation is a separate task.
+- Does NOT compare quarters (Q1 vs Q2). Single-quarter only. Multi-quarter trend is a follow-up skill.
+- Does NOT call MCP search tools to read transcripts. The driver parses `.jsonl` directly and emits metadata-only stats.
+- Does NOT quote any body content from transcripts, code, or memory bodies. Frontmatter and identifiers only.
+- Does NOT write to `docs/senior-positioning.md`. Narrative integration ("signal 6") is a separate PR.
+
+## Failure modes to watch
+
+- **Driver returns empty sessions**: transcripts glob mismatch. Verify path with `ls ~/.claude/projects/.../*.jsonl`. Do not invent fallback data — report "0 sessions" and stop.
+- **Memory rubric file moved**: `feedback_portfolio_evaluation.md` or `feedback_collaboration_axes.md` not at expected path. Surface this; do not proceed with degraded rubric.
+- **Quarter has no commits**: report "no activity this quarter" instead of fabricating axes. Both rubrics still output, but every row is `✗ — no data` with that fixed sentence.
+- **Memory MEMORY.md write race**: if MEMORY.md update would create a duplicate index line, deduplicate first by reading and rewriting. Do not silently append.

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
 .PHONY: ship-arm ship-disarm ship-status
 
+# Self-review (quarterly meta-feedback loop). Combines 4-axis portfolio
+# rubric + 5-axis Claude collaboration rubric. See SKILL at
+# .claude/skills/self-review-quarterly/SKILL.md and privacy policy at
+# docs/self-review/README.md.
+.PHONY: self-review-quarterly
+
 # Cleanup
 .PHONY: clean
 
@@ -350,3 +356,27 @@ ship-status:
 	@if [ -f .claude/.ship-running.pid ]; then \
 	  echo "ship: pipeline running (pid=$$(cat .claude/.ship-running.pid))"; \
 	fi
+
+# ---------------------------------------------------------------------------
+# Self-review quarterly: meta-feedback loop over the past quarter.
+# Emits a Markdown skeleton at docs/self-review/$(QUARTER).md containing
+# metadata-only counts (sessions, tool calls, ADR/PR changes, memory
+# frontmatter). The 4-axis + 5-axis verdict tables are filled by running
+# `/self-review-quarterly $(QUARTER)` in Claude Code. Body excerpts from
+# transcripts are never read — see scripts/claude-hooks/_self_review.py
+# and docs/self-review/README.md for the privacy boundary.
+#
+# Example:
+#   make self-review-quarterly QUARTER=Q2-2026
+# ---------------------------------------------------------------------------
+
+self-review-quarterly:
+	@if [ -z "$(QUARTER)" ]; then \
+	  echo "Usage: make self-review-quarterly QUARTER=Q2-2026"; \
+	  exit 1; \
+	fi
+	@$(PYTHON) scripts/claude-hooks/_self_review.py \
+	  --quarter "$(QUARTER)" \
+	  --emit-report \
+	  --output "docs/self-review/$(QUARTER).md"
+	@echo "Run /self-review-quarterly $(QUARTER) in Claude Code to fill verdict tables."

--- a/docs/self-review/Q2-2026.md
+++ b/docs/self-review/Q2-2026.md
@@ -1,0 +1,35 @@
+# Self-Review Q2-2026
+
+- Date range: 2026-04-01 – 2026-06-30 (관측 시점 2026-05-13)
+- Sessions: 12 | Commits: 334 | PRs merged: 187 | ADR changes: 26 | Load-bearing touches: 252
+- Source: `scripts/claude-hooks/_self_review.py` (metadata-only stats; see "Privacy" below)
+
+## 4축 진단 (포트폴리오 진행)
+
+| # | 축 | 평가 | 근거 | 한 줄 코멘트 |
+|---|---|---|---|---|
+| 1 | 엔지니어링 디스플린 | ✓ | `PR #458`, `PR #462`, `ADR 0007`, `.github/workflows/branch-and-issue-check.yml` | Q2 187 PR 머지 + ADR 0007 branch 자동검증 + naive_baseline 보존 invariant 유지 |
+| 2 | 아키텍처 결정 정합성 | ✓ | 26 ADR changes, `ADR 0021`, `ADR 0028`, `docs/adr/README.md` | Q2 26 ADR 변경 + 0019→0021 deferral closure로 supersession chain 닫힘 |
+| 3 | 평가 견고성 (LLM Ops) | ✓ | `ADR 0005`, `ADR 0015`, `ADR 0018`, `eval/config.yaml` | 합성·real·KorQuAD 3표면 분리 + cost telemetry + latency SLO 게이트 가동 |
+| 4 | 시장 가시성 | △ — 외부 baseline 실측 미완 | `ADR 0025`, `ADR 0009`, `docs/leaderboard.md` | 라이브 데모 + 자동 leaderboard 가동, 외부 baseline 실측은 ADR 0025로 deferred |
+
+## 5축 진단 (Claude 협업)
+
+| # | 축 | 평가 | 근거 | 한 줄 코멘트 |
+|---|---|---|---|---|
+| 1 | 컨텍스트 효율 | ✓ | `sessions.agent_delegations.Explore=28`, `memory.files_total=7`, `ToolSearch=34` | Explore 28회 + 메모리 7개 + ToolSearch 34회로 메인 컨텍스트 분산 |
+| 2 | Agent 위임 패턴 | △ — Plan/general-purpose 활용 부재 | `agent_delegations`: Explore=28, Plan=4 | 위임 32회 중 Explore 88% — Plan(4)/general-purpose(0) 다양성 부족 |
+| 3 | 거버넌스 자동화 ROI | △ — Hook fire 카운터 미수집 | `governance_hooks.pretooluse_loadbearing_fires=0`, `git.load_bearing_touches=252` | Load-bearing 252회 touch; PreToolUse hook fire 로그 미수집으로 ROI 정량 불가 |
+| 4 | 사이클 타임 | △ — rule→automation lag 정량 미구현 | `governance_hooks.rule_to_automation_lag_days=[]`, 26 ADR changes | Q2 26 ADR 처리; proposed→accepted→hook 잠금 lag 정량 추적 미수립 |
+| 5 | 메모리 위생 | △ — reference type 부재 | `memory.by_type={feedback:4, project:2, user:1}`, files_total=7 | feedback 4 / project 2 / user 1 / **reference 0** — 외부 시스템 포인터 type 미수립 |
+
+## 최우선 개선점 (ROI)
+
+**5축 #3 거버넌스 자동화 ROI를 △→✓ 전환** (5분 작업, Q3부터 #3+#4 동시 정량화):
+- `scripts/claude-hooks/pretooluse-loadbearing.sh` 끝에 fire log append 1줄 추가 (`echo "$(date -Iseconds)|<file>" >> .claude/.hook-fires.log`)
+- `scripts/claude-hooks/_self_review.py`에 분기 범위 fire count parse 추가 (~15줄)
+- 결과: Q3 보고서에서 #3 hook ROI 정량 가능 + #4 사이클 타임 lag을 `.hook-fires.log` 타임스탬프로 계산 가능
+
+## Privacy
+
+이 보고서는 `_self_review.py`가 emit한 메타데이터(tool 호출 횟수, 공개 파일 경로, git hash, PR/issue/ADR id, 메모리 frontmatter)만 인용합니다. 본문 인용 금지 패턴 정의는 [`docs/self-review/README.md`](./README.md)의 "Privacy 경계" 섹션을 단일 근원으로 한다. Self-check는 SKILL workflow step 8에서 grep으로 수행됐다.

--- a/docs/self-review/README.md
+++ b/docs/self-review/README.md
@@ -1,0 +1,69 @@
+# Self-Review Quarterly Reports
+
+분기마다 한 번씩 산출되는 메타-피드백 보고서가 이 디렉토리에 누적된다. 각 파일 `Qx-YYYY.md`는 두 rubric을 한 묶음으로 평가한다.
+
+## 두 rubric
+
+| Rubric | 평가 대상 | 정의 위치 |
+|---|---|---|
+| **4축 — 포트폴리오 진행** | 엔지니어링 디스플린 / 아키텍처 정합성 / 평가 견고성 / 시장 가시성 | `memory/feedback_portfolio_evaluation.md` |
+| **5축 — Claude 협업** | 컨텍스트 효율 / Agent 위임 / 거버넌스 자동화 ROI / 사이클 타임 / 메모리 위생 | `memory/feedback_collaboration_axes.md` |
+
+4축은 *프로젝트가 어떻게 굴러가는가*, 5축은 *Claude와의 협업이 어떻게 굴러가는가*. 두 진단이 한 보고서에 나란히 들어가야 ROI 비교가 가능하다.
+
+## 생성 방법
+
+1. **Raw skeleton** — `make self-review-quarterly QUARTER=Qx-YYYY`
+   - 호출 대상: [`scripts/claude-hooks/_self_review.py`](../../scripts/claude-hooks/_self_review.py)
+   - 산출물: `Qx-YYYY.md`에 counts/identifiers만 (메타데이터 only)
+
+2. **Verdict tables** — Claude Code 내에서 `/self-review-quarterly Qx-YYYY`
+   - 호출 대상: [`.claude/skills/self-review-quarterly/SKILL.md`](../../.claude/skills/self-review-quarterly/SKILL.md)
+   - 산출물: 4축 + 5축 ✓/△/✗ 평가표 + ROI 1개 추천
+
+두 단계 모두 동일 driver를 호출하지만, 단계 1은 raw counts만, 단계 2는 LLM이 rubric을 적용해 판정한다.
+
+## Privacy 경계 (commit policy)
+
+이 디렉토리의 모든 파일은 **git에 commit되어 공개된다**. 따라서 driver와 skill 모두 다음 원칙을 따른다.
+
+### 인용 가능
+- Tool 이름 (`Read`, `Edit`, `Bash`, `Agent`)
+- 호출 횟수, 세션 수, 커밋 수
+- 공개 파일 경로 (`rag_core.py`, `docs/adr/...`)
+- Git commit hash (≤12 chars)
+- PR 번호, Issue 번호, ADR id
+- 메모리 파일명 + frontmatter 필드 (name, type, originSessionId)
+
+### 인용 금지 (privacy violation)
+- 사용자 메시지 본문 (paraphrase 포함)
+- Assistant 응답 본문
+- Tool 호출 arguments (검색 query, edit 내용, Agent prompt)
+- 코드 diff 내용
+- 메모리 본문 (frontmatter 외)
+- ADR / 문서 본문 (제목/id만 OK)
+- Commit message body (subject의 PR 번호만 OK)
+
+위반 검출: 보고서 self-check 단계에서 `사용자가 말`, `user said`, `assistant: `, ``` ```python ``` 같은 패턴 grep. 매치 발견 시 해당 cell 재작성.
+
+## 파일 명명 규칙
+
+- 분기 단위: `Q1-2026.md`, `Q2-2026.md`, ...
+- 한 분기 = 3개월 (Q1: 1–3월, Q2: 4–6월, Q3: 7–9월, Q4: 10–12월)
+- 같은 분기 재생성 시 덮어쓰기 (driver 동작) — 분기 도중 진척이 반영됨
+
+## 메모리 연동
+
+각 보고서는 메모리에 요약본을 적재한다:
+- 파일명: `feedback_qX_YYYY_collaboration_review.md`
+- 위치: `~/.claude/projects/-Users-hskim-Desktop-projects-BidMate-DocAgent/memory/`
+- 내용: ≤500자 요약 + ROI bullet (본문 인용 없음)
+- MEMORY.md 인덱스에 한 줄 자동 추가
+
+이는 다음 세션부터 "지난 분기 협업 어땠어" 질문이 들어왔을 때 메모리가 자동 적용되게 한다.
+
+## 비-목표
+
+- **Per-PR 후고**: 본 보고서는 분기 단위. PR마다 retrospective가 필요하면 별도 도구 필요.
+- **Multi-quarter trend**: Q1 vs Q2 비교는 별도 skill로 분리할 수 있다 (현재 미구현).
+- **`docs/senior-positioning.md` 자동 갱신**: 시그널 narrative에 6번째 축("협업 측정")을 추가하는 작업은 별도 PR로 분리. 본 디렉토리는 그 narrative 갱신의 *증거 자료*가 된다.

--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Self-review quarterly: raw statistics collector for collaboration ROI.
+
+Reads transcripts (.jsonl), memory frontmatter, and git log within a
+quarter window, emits a stats.json containing ONLY metadata — never
+user/assistant body text, tool arguments, code diffs, or memory body.
+
+The interpretation (4-axis + 5-axis verdicts) is left to the LLM via
+`.claude/skills/self-review-quarterly/SKILL.md`. This driver only
+gathers the inputs.
+
+Exit codes:
+    0  stats / report emitted successfully
+    1  invalid input (quarter format, missing arg)
+    2  internal / I/O error
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+QUARTER_RE = re.compile(r"^Q([1-4])-(\d{4})$")
+ADR_FILENAME_RE = re.compile(r"^(\d{4})-.+\.md$")
+PR_MERGE_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+DEFAULT_TRANSCRIPTS_GLOB = (
+    "~/.claude/projects/-Users-hskim-Desktop-projects-BidMate-DocAgent/*.jsonl"
+)
+DEFAULT_MEMORY_DIR = (
+    "~/.claude/projects/-Users-hskim-Desktop-projects-BidMate-DocAgent/memory"
+)
+
+
+def load_load_bearing_paths(repo: str) -> list[str]:
+    """Import LOAD_BEARING_PATHS from scripts/_governance.py if available.
+
+    Fails soft to an empty list — driver still produces stats, the
+    load_bearing_touches count just stays 0 in non-BidMate contexts.
+    """
+    scripts_dir = os.path.join(repo, "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    try:
+        from _governance import LOAD_BEARING_PATHS  # type: ignore
+        return list(LOAD_BEARING_PATHS)
+    except (ImportError, AttributeError):
+        return []
+
+
+def parse_quarter(q: str) -> tuple[str, str]:
+    """Q2-2026 -> (2026-04-01, 2026-06-30)."""
+    m = QUARTER_RE.match(q)
+    if not m:
+        raise ValueError(f"invalid quarter '{q}' (expected Qx-YYYY, e.g. Q2-2026)")
+    n, year = int(m.group(1)), int(m.group(2))
+    start_month = (n - 1) * 3 + 1
+    end_month = n * 3
+    end_day = {3: 31, 6: 30, 9: 30, 12: 31}[end_month]
+    return (
+        f"{year:04d}-{start_month:02d}-01",
+        f"{year:04d}-{end_month:02d}-{end_day:02d}",
+    )
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Single-line key:value parse. Multi-line values ignored.
+
+    Memory files use simple single-line values for type/originSessionId,
+    so a full YAML parser is unnecessary (and avoids the dependency).
+    """
+    if not text.startswith("---"):
+        return {}
+    try:
+        end = text.index("\n---", 4)
+    except ValueError:
+        return {}
+    block = text[4:end]
+    fm: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" not in line or line.startswith(" "):
+            continue
+        key, _, val = line.partition(":")
+        key = key.strip()
+        val = val.strip()
+        if key:
+            fm[key] = val
+    return fm
+
+
+def collect_sessions(transcripts_glob: str, start: str, end: str) -> dict[str, Any]:
+    """Walk .jsonl files, count tool uses and Agent delegations.
+
+    Only `type`, `name`, `subagent_type`, `timestamp` are read.
+    Message content, tool arguments, and Agent prompts are never touched.
+    """
+    expanded = os.path.expanduser(transcripts_glob)
+    files = sorted(Path(f) for f in glob.glob(expanded))
+    tool_counter: Counter[str] = Counter()
+    agent_counter: Counter[str] = Counter()
+    session_ids: set[str] = set()
+
+    start_dt = datetime.fromisoformat(start).replace(tzinfo=timezone.utc)
+    end_dt = datetime.fromisoformat(end).replace(
+        tzinfo=timezone.utc, hour=23, minute=59, second=59
+    )
+
+    for f in files:
+        try:
+            with f.open() as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    ts = rec.get("timestamp")
+                    if not isinstance(ts, str):
+                        continue
+                    try:
+                        rec_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                    except ValueError:
+                        continue
+                    if rec_dt < start_dt or rec_dt > end_dt:
+                        continue
+                    sid = rec.get("sessionId")
+                    if isinstance(sid, str):
+                        session_ids.add(sid)
+                    msg = rec.get("message")
+                    if not isinstance(msg, dict):
+                        continue
+                    content = msg.get("content")
+                    if not isinstance(content, list):
+                        continue
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") != "tool_use":
+                            continue
+                        name = block.get("name")
+                        if not isinstance(name, str) or not name:
+                            continue
+                        tool_counter[name] += 1
+                        if name == "Agent":
+                            inp = block.get("input")
+                            if isinstance(inp, dict):
+                                sub = inp.get("subagent_type")
+                                if isinstance(sub, str) and sub:
+                                    agent_counter[sub] += 1
+        except OSError:
+            continue
+
+    return {
+        "count": len(session_ids),
+        "tool_call_distribution": dict(tool_counter.most_common()),
+        "agent_delegations": dict(agent_counter.most_common()),
+    }
+
+
+def collect_memory(memory_dir: str) -> dict[str, Any]:
+    """Scan memory/*.md frontmatter. Body never read.
+
+    Returns counts by type plus per-file metadata (name, type,
+    originSessionId, mtime). The stale-vs-fresh judgment is left to the
+    LLM since session-ID-to-date mapping requires session metadata not
+    available here.
+    """
+    expanded = os.path.expanduser(memory_dir)
+    p = Path(expanded)
+    if not p.is_dir():
+        return {"files_total": 0, "by_type": {}, "files": []}
+    by_type: Counter[str] = Counter()
+    files_meta: list[dict[str, str]] = []
+    for f in sorted(p.glob("*.md")):
+        if f.name == "MEMORY.md":
+            continue
+        try:
+            text = f.read_text()
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        mtype = fm.get("type", "")
+        if mtype:
+            by_type[mtype] += 1
+        mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc).date().isoformat()
+        files_meta.append({
+            "filename": f.name,
+            "name": fm.get("name", ""),
+            "type": mtype,
+            "originSessionId": fm.get("originSessionId", ""),
+            "mtime": mtime,
+        })
+    return {
+        "files_total": len(files_meta),
+        "by_type": dict(by_type),
+        "files": files_meta,
+    }
+
+
+def _run_git(repo: str, args: list[str]) -> str:
+    try:
+        r = subprocess.run(
+            ["git"] + args, cwd=repo, capture_output=True, text=True, check=False
+        )
+        return r.stdout
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def collect_git(repo: str, start: str, end: str) -> dict[str, Any]:
+    """Count commits, ADR changes, PR merges, load-bearing touches.
+
+    Commit subjects are parsed for PR numbers only — the full subject
+    is not stored in stats. ADR ids come from filenames in docs/adr/.
+    """
+    since = f"--since={start}"
+    until = f"--until={end}"
+
+    commits_out = _run_git(repo, ["log", since, until, "--pretty=format:%H"])
+    commit_count = len([l for l in commits_out.splitlines() if l.strip()])
+
+    pr_subjects = _run_git(
+        repo, ["log", since, until, "--pretty=format:%H|%s|%ai"]
+    )
+    prs: list[dict[str, Any]] = []
+    seen_prs: set[int] = set()
+    for line in pr_subjects.splitlines():
+        parts = line.split("|", 2)
+        if len(parts) != 3:
+            continue
+        sha, subj, date = parts
+        m = PR_MERGE_RE.search(subj)
+        if not m:
+            continue
+        num = int(m.group(1))
+        if num in seen_prs:
+            continue
+        seen_prs.add(num)
+        prs.append({"number": num, "sha": sha[:12], "date": date.split(" ")[0]})
+
+    adr_out = _run_git(repo, [
+        "log", since, until, "--diff-filter=AM", "--name-only",
+        "--pretty=format:", "--", "docs/adr/",
+    ])
+    adr_changes: list[dict[str, str]] = []
+    seen_adr: set[str] = set()
+    for line in adr_out.splitlines():
+        line = line.strip()
+        if not line.startswith("docs/adr/"):
+            continue
+        fname = Path(line).name
+        m = ADR_FILENAME_RE.match(fname)
+        if not m:
+            continue
+        adr_id = m.group(1)
+        if adr_id in seen_adr:
+            continue
+        seen_adr.add(adr_id)
+        adr_changes.append({"id": adr_id, "filename": fname})
+
+    lb_paths = load_load_bearing_paths(repo)
+    if lb_paths:
+        lb_out = _run_git(repo, [
+            "log", since, until, "--name-only", "--pretty=format:", "--",
+        ] + lb_paths)
+        load_bearing_touches = sum(1 for l in lb_out.splitlines() if l.strip())
+    else:
+        load_bearing_touches = 0
+
+    return {
+        "commits": commit_count,
+        "load_bearing_touches": load_bearing_touches,
+        "load_bearing_paths_source": (
+            "scripts/_governance.py" if lb_paths else "unavailable"
+        ),
+        "adr_changes": adr_changes,
+        "prs_merged": prs,
+    }
+
+
+def assemble_stats(
+    quarter: str, transcripts_glob: str, memory_dir: str, repo: str
+) -> dict[str, Any]:
+    start, end = parse_quarter(quarter)
+    return {
+        "quarter": quarter,
+        "date_range": [start, end],
+        "sessions": collect_sessions(transcripts_glob, start, end),
+        "memory": collect_memory(memory_dir),
+        "git": collect_git(repo, start, end),
+        "governance_hooks": {
+            "pretooluse_loadbearing_fires": 0,
+            "rule_to_automation_lag_days": [],
+            "note": (
+                "Hook fire log not wired; emit 0 placeholder. "
+                "Cycle-time evidence comes from git ADR/load-bearing dates."
+            ),
+        },
+    }
+
+
+def emit_report(stats: dict[str, Any]) -> str:
+    """Render Markdown skeleton from stats. LLM (SKILL.md) fills verdicts."""
+    quarter = stats["quarter"]
+    lines: list[str] = [
+        f"# Self-Review {quarter}",
+        "",
+        f"- Date range: {stats['date_range'][0]} – {stats['date_range'][1]}",
+        f"- Sessions: {stats['sessions'].get('count', 0)}",
+        f"- Commits: {stats['git'].get('commits', 0)}",
+        f"- Load-bearing touches: {stats['git'].get('load_bearing_touches', 0)}",
+        f"- ADR changes: {len(stats['git'].get('adr_changes', []))}",
+        f"- PRs merged: {len(stats['git'].get('prs_merged', []))}",
+        "",
+        "## Raw stats (metadata-only — no body excerpts)",
+        "",
+        "```json",
+        json.dumps(stats, indent=2, ensure_ascii=False),
+        "```",
+        "",
+        "## 4-axis + 5-axis verdicts",
+        "",
+        f"Run `/self-review-quarterly {quarter}` in Claude Code to fill the "
+        "rubric tables. The skill loads `feedback_portfolio_evaluation.md` "
+        "(4-axis portfolio) and `feedback_collaboration_axes.md` (5-axis "
+        "collaboration) and writes ✓/△/✗ verdicts with citation evidence.",
+        "",
+        "_This Markdown was generated by `scripts/claude-hooks/_self_review.py`. "
+        "Body text from transcripts is never included — only counts, names, "
+        "and frontmatter-level identifiers._",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--quarter", required=True, help="Qx-YYYY (e.g. Q2-2026)")
+    p.add_argument("--transcripts-glob", default=DEFAULT_TRANSCRIPTS_GLOB)
+    p.add_argument("--memory-dir", default=DEFAULT_MEMORY_DIR)
+    p.add_argument("--repo", default=os.getcwd())
+    p.add_argument("--emit-stats", action="store_true",
+                   help="emit stats.json to stdout")
+    p.add_argument("--emit-report", action="store_true",
+                   help="emit Markdown report")
+    p.add_argument("--output", default="-",
+                   help="report path (default stdout; ignored without --emit-report)")
+    args = p.parse_args()
+
+    if not args.emit_stats and not args.emit_report:
+        sys.stderr.write("self-review: pass --emit-stats or --emit-report\n")
+        return 1
+
+    try:
+        stats = assemble_stats(
+            args.quarter, args.transcripts_glob, args.memory_dir, args.repo
+        )
+    except ValueError as e:
+        sys.stderr.write(f"self-review: {e}\n")
+        return 1
+    except Exception as e:  # pragma: no cover
+        sys.stderr.write(f"self-review: {e}\n")
+        return 2
+
+    if args.emit_stats:
+        sys.stdout.write(json.dumps(stats, indent=2, ensure_ascii=False) + "\n")
+
+    if args.emit_report:
+        report = emit_report(stats)
+        if args.output == "-":
+            sys.stdout.write(report)
+        else:
+            out_path = Path(args.output)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(report)
+            sys.stdout.write(f"self-review: report written to {out_path}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 1. What changed and why

분기마다 4축 포트폴리오 진행 rubric(`memory/feedback_portfolio_evaluation.md`)과 5축 Claude 협업 rubric(`memory/feedback_collaboration_axes.md`, new)을 한 보고서로 산출하는 `/self-review-quarterly` skill을 추가한다. 거버넌스 정교화는 갖춰져 있었지만 *Claude 협업 자체*의 측정 루프는 부재했음. 두 rubric을 같은 보고서에 두어야 ROI 비교가 가능 (예: "사이클 타임이 길어서 디스플린 축이 정체").

Closes #484

## 2. Files affected

- `.claude/skills/self-review-quarterly/SKILL.md` (new) — 슬래시 entry point
- `scripts/claude-hooks/_self_review.py` (new) — Python driver, metadata-only stats
- `docs/self-review/README.md` (new) — privacy 정책 + commit policy
- `docs/self-review/Q2-2026.md` (new) — 첫 진단 (4축 3✓1△ / 5축 1✓4△)
- `Makefile` (modified) — `make self-review-quarterly QUARTER=Qx-YYYY` target

**Load-bearing**: 없음. `scripts/` 신규 파일은 `scripts/build_index.py` 외이며 `_governance.py::LOAD_BEARING_PATHS` 외부.

메모리(글로벌, repo 외부): `feedback_collaboration_axes.md`, `feedback_q2_2026_collaboration_review.md`, `MEMORY.md` 인덱스 갱신.

## 3. Risks

가장 가능성 높은 실패 모드: **driver가 transcripts body를 stats.json에 누출** → 공개 보고서 privacy 침해.

방어:
- Driver schema가 metadata-only로 제한 (`name`/`type`/`timestamp`/`subagent_type`만 추출, `message.content`나 tool `input` arguments는 절대 안 봄).
- SKILL workflow step 8에 grep self-check 강제 (`user said` / `사용자가 말` / `\`\`\`python` 패턴 0건 확인).
- `docs/self-review/README.md`에 인용 가능/금지 화이트리스트 명시.
- Q2-2026.md 생성 후 실제 grep 통과 확인 (검증 완료).

## 4. Tests

- 코드 동작 verification: `python3 scripts/claude-hooks/_self_review.py --help`, `--emit-stats`, `make self-review-quarterly QUARTER=Q2-2026` 모두 정상 실행.
- Privacy regression 회귀 가드 (`tests/test_self_review_no_body_leak.py`)는 follow-up 이슈로 분리 — driver-level schema validation으로 시작.

자동화 가드 없음. 본 PR은 *메타 도구* 추가라 기존 `tests/test_*_regression.py` 패턴에 직접 hook할 곳이 없음.

## 5. Eval impact

`·` (변경 없음). Eval pipeline / retrieval / verifier / answer-contract 모두 미변경. 추가된 코드는 `scripts/claude-hooks/_self_review.py`(driver) + Makefile target만 — eval execution 경로에 진입하지 않음.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** Load-bearing path(`rag_core.py`, `rag_retrieval.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py`) 변경 없음. `make real-eval-delta` 첨부 생략.

## 6. Backward compatibility

- 기존 contract, schema, CLI flag, doc link 변경 없음 (additive only).
- Answer contract(ADR 0003) `schema_version` 변경 없음.
- 메모리 frontmatter 형식 그대로 (`originSessionId` 등 기존 필드 존중).
- `make smoke` / `make ship-arm` 등 기존 target 영향 없음.

## 7. Out of scope

- `docs/senior-positioning.md` 시그널 6 ("협업 측정") narrative 통합 — 별도 PR로 분리 (narrative 정합성 검토 필요).
- Scheduler 자동 호출 (`mcp__scheduled-tasks__create_scheduled_task`) — 1회 수동 실행으로 ROI 확인 후 도입 결정.
- Privacy regression 회귀 테스트 — driver-level schema validation으로 출발, 누출 사고 발생 시 후속.
- Q2-2026 ROI bullet에서 식별된 **PreToolUse hook fire log append** — 5분 작업이지만 별도 PR 분리 (1 PR per concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)