### PR TITLE
docs(governance): codify communication + autonomy + ADR-number reservation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,16 @@ Supporting:
 - `data/raw/` → `data/index/` → `outputs/` → `reports/` (pipeline artifacts).
 - `docs/` — design notes, ADRs, failure analyses, reviewer artifacts.
 
+## Communication
+
+- **Respond in Korean when the user writes in Korean.** Reserve English for English-language prompts or an explicit "respond in English" request. Code, identifiers, commit messages, file/directory names stay in English.
+- **Lead summaries with a 2-3 line TL;DR; details below.** One decision per turn — do not dump multiple PRs / issues / branches in a single message.
+
+## Autonomy & Approvals
+
+- **State-changing actions require explicit approval.** `git push`, `gh pr merge`, `gh pr create`, `git branch -D`, `gh issue create` only after the user gives an explicit go-ahead (e.g. "진행", "go", "merge it", "ok"). Short interrogatives like `"머지?"`, `"PR?"`, `"?"` are **questions** — answer them, do not act on them.
+- **For chained side effects** (stacked-PR merge, ADR-then-PR, multi-issue triage), get a separate approval per step instead of bundling.
+
 ## Core principles
 
 - **Issue first; convention-matched branch.** Every PR must reference an issue (`Closes #N` in body) and its branch must match `<type>/issue-<N>[-<slug>]` (ADR 0007). The CI workflow `branch-and-issue-check.yml` enforces both at PR time.
@@ -62,6 +72,7 @@ Supporting:
 - **Behavior change ↔ test change.** Behavior change without a test is presumed accidental. Regression tests go in `tests/test_*_regression.py` (pattern: `tests/test_retrieval_loop_regression.py`).
 - **Backward compatibility.** Breaking changes need an explicit reason. Answer-contract break (ADR 0003) requires `schema_version` bump.
 - **ADR threshold.** Removing or replacing a load-bearing decision (baseline / pipeline / answer contract / eval surface) needs an ADR. Criteria: [`docs/adr/README.md`](docs/adr/README.md).
+- **Reserve ADR numbers up front.** Before drafting a new ADR, check both `ls docs/adr/` and `gh pr list --search "ADR" --state open` to find the next available number. Propose it and wait for user confirmation before creating the file — concurrent worktree work has produced repeat collisions (0022→0023, 0023→0025, 0029→0030).
 
 ## PR description
 
@@ -86,6 +97,7 @@ important — the synthetic CI delta alone missed #69's intended-abstention regr
 - Adding a parallel pydantic / TypedDict model that shadows `run_rag_query`'s answer dict — the dict is the contract (ADR 0003).
 - Removing the `naive_baseline` preset from `eval/config.yaml` (ADR 0001).
 - Adding unrelated commits mid-review — open a follow-up PR.
+- Running `gh pr merge --delete-branch` without first verifying `gh pr list --base <this-PR-head-branch> --state open --json number` is empty. Open results mean a stacked dependent exists — drop `--delete-branch` or rebase the children onto main first. (A follow-up PreToolUse Bash guard hook automates this; the rule is stated here so it survives even if the hook is disabled.)
 
 ## Non-goals (unless explicitly requested)
 


### PR DESCRIPTION
## 1. What changed and why

`/insights` 5-day report flagged the top-2 friction patterns:

1. Claude treats short Korean interrogatives (`"머지?"`) as commands → PR #437 auto-merged. Long English summaries to Korean prompts → repeated `"뭐라고?"` re-explains.
2. ADR number collisions 3× in 4 days (0022→0023, 0023→0025, 0029→0030). `--delete-branch` on a base branch with stacked dependents closed PR #423 → recovery PR #431.

Automation is split into two follow-up PRs (`/ship-pr` skill, PreToolUse Bash guard hook). This PR carries only the **policy text** so the rules survive across sessions even if automation is disabled.

Two new top-level sections + one bullet each in `Core principles` and `Prohibited`:

- `## Communication` — Korean-default response, TL;DR-first, one decision per turn.
- `## Autonomy & Approvals` — state-changing actions need explicit go-ahead; short interrogatives are questions.
- `Core principles` — reserve ADR numbers up front via `ls docs/adr/` + open ADR PR scan.
- `Prohibited` — `gh pr merge --delete-branch` requires `gh pr list --base ...` check first.

Closes #491

## 2. Files affected

- `CLAUDE.md` — +12 lines, 0 removed. Non-load-bearing per `scripts/_governance.py` `LOAD_BEARING_PATHS`.

## 3. Risks

Misalignment with reality: the rules describe behavior the system can't enforce yet (automation is in follow-up PRs). Specifically checked:

- All four rules also appear as policy in `## Prohibited (not enforced by automation)` style or explicitly mark the future automation hook ("A follow-up PreToolUse Bash guard hook automates this") — text remains self-consistent if PR-C never lands.
- No conflict with `## Core principles` "Issue first; convention-matched branch" or ADR 0007 — new ADR-number-reservation rule is an additive step before drafting, not a replacement.

## 4. Tests

N/A — pure policy text in a CLAUDE.md governance section. No code path changed; no regression test surface.

## 5. Eval impact

All `·` — pure documentation change, no retrieval / answer / eval surface touched.

### 5b. Real-data delta

N/A — `CLAUDE.md` is not in `scripts/_governance.py` `LOAD_BEARING_PATHS`. Confirmed via `python3 scripts/_governance.py --is-load-bearing CLAUDE.md` (exit code 1 = not load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)