### PR TITLE
feat(self-review): wire PreToolUse hook fire log + driver parse

### DIFF
--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -289,6 +289,56 @@ def collect_git(repo: str, start: str, end: str) -> dict[str, Any]:
     }
 
 
+def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
+    """Parse `.claude/.hook-fires.log` for PreToolUse load-bearing fires.
+
+    Log line format: ``<ISO8601 UTC>|<file_path>`` appended by
+    ``scripts/claude-hooks/pretooluse-loadbearing.sh`` (issue #495).
+    Returns fires within the quarter window plus a top-10 by-path
+    distribution; never reads body of any other file.
+    """
+    log_path = Path(repo) / ".claude" / ".hook-fires.log"
+    if not log_path.is_file():
+        return {
+            "pretooluse_loadbearing_fires": 0,
+            "fires_by_path": {},
+            "rule_to_automation_lag_days": [],
+            "note": "Hook fire log absent at .claude/.hook-fires.log; emit 0.",
+        }
+    start_dt = datetime.fromisoformat(start).replace(tzinfo=timezone.utc)
+    end_dt = datetime.fromisoformat(end).replace(
+        tzinfo=timezone.utc, hour=23, minute=59, second=59
+    )
+    fires = 0
+    by_path: Counter[str] = Counter()
+    try:
+        for line in log_path.read_text().splitlines():
+            line = line.strip()
+            if not line or "|" not in line:
+                continue
+            ts, _, path = line.partition("|")
+            try:
+                fire_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if fire_dt < start_dt or fire_dt > end_dt:
+                continue
+            fires += 1
+            by_path[path] += 1
+    except OSError:
+        pass
+    note = (
+        "Cycle-time lag uses ADR proposed→accepted dates (git history); "
+        "lag list intentionally empty until parsed."
+    )
+    return {
+        "pretooluse_loadbearing_fires": fires,
+        "fires_by_path": dict(by_path.most_common(10)),
+        "rule_to_automation_lag_days": [],
+        "note": note,
+    }
+
+
 def assemble_stats(
     quarter: str, transcripts_glob: str, memory_dir: str, repo: str
 ) -> dict[str, Any]:
@@ -299,14 +349,7 @@ def assemble_stats(
         "sessions": collect_sessions(transcripts_glob, start, end),
         "memory": collect_memory(memory_dir),
         "git": collect_git(repo, start, end),
-        "governance_hooks": {
-            "pretooluse_loadbearing_fires": 0,
-            "rule_to_automation_lag_days": [],
-            "note": (
-                "Hook fire log not wired; emit 0 placeholder. "
-                "Cycle-time evidence comes from git ADR/load-bearing dates."
-            ),
-        },
+        "governance_hooks": collect_governance_hooks(repo, start, end),
     }
 
 

--- a/scripts/claude-hooks/pretooluse-loadbearing.sh
+++ b/scripts/claude-hooks/pretooluse-loadbearing.sh
@@ -31,6 +31,10 @@ fi
 # Load-bearing list lives in scripts/_governance.py (single source of
 # truth, also consumed by .githooks/pre-push and the §5b CI gate).
 if python3 scripts/_governance.py --is-load-bearing "$file_path" 2>/dev/null; then
+  # Fire log for /self-review-quarterly governance ROI axis (issue #495).
+  # Gitignored via `.claude/*` in repo root .gitignore.
+  printf '%s|%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$file_path" \
+    >> .claude/.hook-fires.log 2>/dev/null || true
   cat >&2 <<EOF
 ⚠️  Load-bearing file: $file_path
 


### PR DESCRIPTION
## 1. What changed and why

Q2-2026 self-review([docs/self-review/Q2-2026.md](../blob/main/docs/self-review/Q2-2026.md))에서 식별된 ROI #1을 land — **5축 #3 거버넌스 자동화 ROI △→✓ 전환**. 이전엔 `governance_hooks.pretooluse_loadbearing_fires=0`이 측정값이 아니라 placeholder였음. 이제 hook이 fire될 때마다 `.claude/.hook-fires.log`에 `<ISO8601 UTC>|<file>` 1줄 append하고, driver가 분기 범위로 parse해서 실제 카운트 + by-path 분포를 emit한다.

Closes #495

## 2. Files affected

- `scripts/claude-hooks/pretooluse-loadbearing.sh` (modified) — load-bearing 매칭 분기 안에 fire log append 5줄(주석 포함). awareness 동작은 그대로 (always exit 0).
- `scripts/claude-hooks/_self_review.py` (modified) — `collect_governance_hooks()` 추가, `assemble_stats`에서 호출. placeholder 0 제거.

**Load-bearing**: 없음. `scripts/`는 `_governance.py::LOAD_BEARING_PATHS` 외부.

## 3. Risks

가장 가능성 높은 실패 모드: **hook script가 fire log append에서 오류 → Claude 작업 차단**. 

방어:
- Append를 `|| true`로 wrap — log 쓰기 실패해도 hook은 exit 0 유지.
- Stderr redirect (`2>/dev/null`)로 어떤 에러도 사용자 응답에 끼지 않음.
- `.claude/` 디렉토리는 이미 존재 (`.claude/settings.json`이 그 안에 있어 보장됨).
- Hook은 본문/argument 파싱 안 함 — 기존 동작 100% 보존.

부수 모드: **fires_by_path가 본문 누출**. 방어: path는 hook input의 `tool_input.file_path` (이미 metadata로 hook이 받음). user 메시지/응답 본문 아님. SKILL의 인용 가능 화이트리스트에 포함된 category.

## 4. Tests

자동 회귀 없음. Verified manually:
- `bash -n scripts/claude-hooks/pretooluse-loadbearing.sh` — syntax OK
- `python3 scripts/claude-hooks/_self_review.py --help` — syntax OK
- Hook fire simulation:
  - Load-bearing path (`rag_core.py`) → stderr 경고 출력 + log append 발생
  - Non-load-bearing path (`README.md`) → stderr 출력 없음 + log 변경 없음
- Driver parse output: `pretooluse_loadbearing_fires: 1`, `fires_by_path: {"rag_core.py": 1}` — schema 일치

Privacy regression 회귀 가드(`tests/test_self_review_no_body_leak.py`)는 별도 follow-up issue로 분리.

## 5. Eval impact

`·` (변경 없음). Hook script는 awareness layer (always exit 0). Driver는 eval path 외부. Eval pipeline / retrieval / verifier / answer-contract 미접촉.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.** Load-bearing path 변경 없음. `make real-eval-delta` 첨부 생략.

## 6. Backward compatibility

- Driver `stats.json` schema: `governance_hooks` 블록에 `fires_by_path` 키 추가 (기존 키 보존, additive only).
- Hook의 stderr 메시지 그대로.
- 기존 self-review 보고서(Q2-2026.md) 영향 없음 — placeholder note만 다음 호출에서 갱신.
- Answer contract(ADR 0003) `schema_version` 변경 없음.

## 7. Out of scope

- `rule_to_automation_lag_days` 정밀 계산 (ADR proposed→accepted+hook landed) — git history parse 필요, 별도 issue.
- Stop hook / 다른 hook fire 집계.
- Privacy regression 회귀 테스트.
- `docs/senior-positioning.md` 시그널 6 narrative 통합.

🤖 Generated with [Claude Code](https://claude.com/claude-code)