### PR TITLE
fix(query): import dedupe_metadata_matches in analyze_query (#509)

### DIFF
--- a/rag_query.py
+++ b/rag_query.py
@@ -295,6 +295,7 @@ def analyze_query(
     from rag_core import (
         best_metadata_doc_scores,
         coerce_metadata_targets,
+        dedupe_metadata_matches,
         match_metadata_targets,
         metadata_ambiguity_details,
         metadata_filters_from_matches,


### PR DESCRIPTION
## Summary

One-line fix: add `dedupe_metadata_matches` to the late-import tuple in `rag_query.analyze_query`. The symbol was used at [rag_query.py:319](rag_query.py:319) but never imported, so `ruff check .` fails across the whole repo with F821. Likely introduced by [#481](https://github.com/hskim-solv/api-DocAgent/pull/481) (PR-J3 query extraction) when the late-import block was constructed.

Closes #509.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. The added import wires a call that previously raised `NameError` only inside the context-fallback branch of `analyze_query`; existing tests cover the call site once the symbol resolves.

## Test plan

- [x] `ruff check .` passes
- [x] `bash scripts/test.sh` runs cleanly to pytest (910 passed, 5 skipped)
- [x] No `rag_core` change — `analyze_query` already late-imports nine other rag_core symbols; this just extends the tuple by one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)