### PR TITLE
feat(eval): add routed_subset measurement surface (ADR 0032 Step 1)

### DIFF
--- a/eval/dev_queries_v1_summary.md
+++ b/eval/dev_queries_v1_summary.md
@@ -54,3 +54,25 @@
 - 1차 평가는 `gold_answer`와 `must_include` 기반의 규칙 평가로 시작
 - 2차 평가는 실제 답변에 포함된 근거 chunk와 `target_doc_ids` 일치 여부를 함께 확인
 - 비교형은 두 문서를 모두 커버했는지, 부재판별형은 모른다고 답했는지를 별도 지표로 분리
+
+## Routed surface (ADR 0032 Step 1)
+
+`eval/routed_config.yaml` is an additive surface for the saturation falsifier
+defined in [ADR 0032](../docs/adr/0032-eval-saturation-routed-subset.md). It
+ships 11 cases — picked so metadata-first routing cannot fully resolve the
+query — and two ablation rows (`agentic_full` baseline vs
+`agentic_full_routed` with `metadata_first: false`). The case set spans three
+categories from ADR 0032 §Decision:
+
+- Multi-turn follow-up where the follow-up question omits the entity (3 cases)
+- Multi-doc comparison where the same metadata candidate is distributed across ≥ 2 docs (4 cases)
+- Inference queries without an explicit metadata column hook (4 cases, incl. 1 abstention)
+
+Run with:
+
+```
+python -m eval.run_eval --config eval/routed_config.yaml --index_dir data/index --output_dir reports
+```
+
+The 5-embedding × routed-subset matrix and the resulting ADR 0019/0021/0032
+prose update land in a separate follow-up PR (Step 2 of ADR 0032).

--- a/eval/routed_config.yaml
+++ b/eval/routed_config.yaml
@@ -1,0 +1,327 @@
+mode: rag
+description: >
+  Routed-subset measurement surface for ADR 0032 (saturation falsifier).
+  Cases here are picked specifically so metadata-first routing does NOT
+  fully resolve the query — dense retrieval is exercised and embedding-
+  level spreads become measurable. Compare `agentic_full` (baseline,
+  metadata_first=true) vs `agentic_full_routed` (metadata_first=false)
+  on the same case set; in PR-2 the matrix is extended to 5 embeddings.
+  Surface is additive — `eval/config.yaml` and the `naive_baseline`
+  golden bytes are untouched (ADR 0001 invariant).
+index_dir: data/index
+primary_run: agentic_full
+latency_budgets:
+  agentic_full:
+    p95_ms: 200
+  agentic_full_routed:
+    # Same ceiling as `agentic_full` — disabling metadata-first only
+    # changes which retrieval path runs, not the per-query budget on
+    # the deterministic hashing backend (real-data measurement is
+    # separate, ADR 0005).
+    p95_ms: 200
+answer_policy:
+  answerable_status: supported
+  unanswerable_status: insufficient
+  min_claims_answerable: 1
+  require_claim_citations: true
+ablation_runs:
+  - name: agentic_full
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+  - name: agentic_full_routed
+    pipeline: agentic_full
+    metadata_first: false
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+cases:
+  # ============================================================
+  # Category 1 — Multi-turn follow-up where metadata matching is
+  # non-deterministic. The follow-up question omits the agency
+  # entity that was set up by `prior_turns`; metadata-first cannot
+  # uniquely route, so dense retrieval has to disambiguate via
+  # context entity injection.
+  # ============================================================
+  - id: routed_followup_entity_switch_a_to_b
+    query_type: follow_up
+    hardcase_categories:
+      - retrieval_hardening
+      - follow_up_context
+    prior_turns:
+      - query: "기관 A의 보안 통제 요구사항은?"
+    query: "그럼 같은 항목을 기관 B에서는 어떻게 요구하고 있어?"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "개인정보 비식별화"
+      - "접근 권한 분리"
+    expected_citation_terms:
+      - "개인정보 비식별화"
+      - "접근 권한 분리"
+    expected_claim_targets:
+      - "기관 B"
+    expected_claim_citations:
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "개인정보 비식별화"
+          - "접근 권한 분리"
+    answerable: true
+
+  - id: routed_followup_implicit_metric_c
+    query_type: follow_up
+    hardcase_categories:
+      - retrieval_hardening
+      - follow_up_context
+    prior_turns:
+      - query: "기관 C의 챗봇 응답 시간 목표는?"
+    query: "그 외에 어떤 성능 지표가 함께 요구돼?"
+    expected_doc_ids:
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "상담 이관"
+    expected_citation_terms:
+      - "상담 이관"
+    expected_claim_targets:
+      - "기관 C"
+    expected_claim_citations:
+      - target: "기관 C"
+        expected_doc_ids:
+          - rfp-agency-c-chatbot
+        expected_terms:
+          - "상담 이관"
+    answerable: true
+
+  - id: routed_followup_2step_implicit_a
+    query_type: follow_up
+    hardcase_categories:
+      - retrieval_hardening
+      - follow_up_context
+    prior_turns:
+      - query: "기관 A의 AI 요구사항은?"
+      - query: "그 기관이 요구한 보안 조건도 알려줘"
+    query: "그 사업의 산출물 검수 항목은 뭐야?"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "모델 점검 리포트"
+      - "보안 통제 매뉴얼"
+    expected_citation_terms:
+      - "모델 점검 리포트"
+      - "보안 통제 매뉴얼"
+    expected_claim_targets:
+      - "기관 A"
+    answerable: true
+
+  # ============================================================
+  # Category 2 — Multi-doc comparison ambiguity. The same metadata
+  # candidate (e.g. "보안", "산출물") is distributed across ≥ 2
+  # docs, so metadata-first cannot pick a single agency — dense
+  # retrieval has to rank semantically across all candidates.
+  # ============================================================
+  - id: routed_compare_strongest_security
+    query_type: comparison
+    hardcase_categories:
+      - retrieval_hardening
+    query: "보안 통제 요구사항이 가장 구체적으로 명시된 기관 두 곳을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "보안 통제"
+      - "개인정보 비식별화"
+    expected_citation_terms:
+      - "보안 통제"
+      - "개인정보 비식별화"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 B"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "보안 통제"
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "개인정보 비식별화"
+    answerable: true
+
+  - id: routed_compare_deliverables_breadth
+    query_type: comparison
+    hardcase_categories:
+      - retrieval_hardening
+    query: "산출물 요구 항목이 가장 많이 명시된 두 기관을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "모델 점검 리포트"
+      - "MLOps"
+    expected_citation_terms:
+      - "모델 점검 리포트"
+      - "MLOps"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 B"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "모델 점검 리포트"
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "MLOps"
+    answerable: true
+
+  - id: routed_compare_common_vs_agency_a
+    query_type: comparison
+    hardcase_categories:
+      - retrieval_hardening
+    query: "공통 제출조건과 기관 A의 산출물 요구를 비교해줘"
+    expected_doc_ids:
+      - rfp-common-submission
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "일정 준수 계획"
+      - "모델 점검 리포트"
+    expected_citation_terms:
+      - "일정 준수 계획"
+      - "모델 점검 리포트"
+    expected_claim_targets:
+      - "공통"
+      - "기관 A"
+    expected_claim_citations:
+      - target: "공통"
+        expected_doc_ids:
+          - rfp-common-submission
+        expected_terms:
+          - "일정 준수 계획"
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "모델 점검 리포트"
+    answerable: true
+
+  - id: routed_compare_mlops_kinship_a_b
+    query_type: comparison
+    hardcase_categories:
+      - retrieval_hardening
+    query: "MLOps 거버넌스 요구와 가장 유사한 품질 통제 요구를 가진 두 기관을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "품질관리"
+      - "MLOps"
+    expected_citation_terms:
+      - "품질관리"
+      - "MLOps"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 B"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "품질관리"
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "MLOps"
+    answerable: true
+
+  # ============================================================
+  # Category 3 — Inference queries without an explicit metadata
+  # column hook. There is no agency / project / column name in the
+  # query, so metadata-first has nothing to filter on; the answer
+  # has to come from semantic similarity across the corpus.
+  # ============================================================
+  - id: routed_inference_privacy_required_agency
+    query_type: single_doc
+    hardcase_categories:
+      - retrieval_hardening
+    query: "개인정보 비식별화가 핵심 요구로 명시된 사업은 어디야?"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "개인정보 비식별화"
+      - "접근 권한 분리"
+    expected_citation_terms:
+      - "개인정보 비식별화"
+      - "접근 권한 분리"
+    expected_claim_targets:
+      - "기관 B"
+    expected_claim_citations:
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "개인정보 비식별화"
+    answerable: true
+
+  - id: routed_inference_response_time_owner
+    query_type: single_doc
+    hardcase_categories:
+      - retrieval_hardening
+    query: "응답 시간 목표가 명시적으로 정해진 사업은?"
+    expected_doc_ids:
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "2초"
+      - "상담 이관"
+    expected_citation_terms:
+      - "2초"
+      - "상담 이관"
+    expected_claim_targets:
+      - "기관 C"
+    expected_claim_citations:
+      - target: "기관 C"
+        expected_doc_ids:
+          - rfp-agency-c-chatbot
+        expected_terms:
+          - "2초"
+    answerable: true
+
+  - id: routed_inference_common_submission_item
+    query_type: single_doc
+    hardcase_categories:
+      - retrieval_hardening
+    query: "모든 제안사가 공통적으로 제출해야 하는 산출물 검수 항목은?"
+    expected_doc_ids:
+      - rfp-common-submission
+    expected_terms:
+      - "산출물 품질 검수 절차"
+    expected_citation_terms:
+      - "산출물 품질 검수 절차"
+    expected_claim_targets:
+      - "공통"
+    expected_claim_citations:
+      - target: "공통"
+        expected_doc_ids:
+          - rfp-common-submission
+        expected_terms:
+          - "산출물 품질 검수 절차"
+    answerable: true
+
+  - id: routed_inference_unanswerable_blockchain_focus
+    query_type: abstention
+    hardcase_categories:
+      - retrieval_hardening
+    query: "블록체인 기반 거래 검증이 핵심 요구인 사업은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "블록체인"
+    answerable: false


### PR DESCRIPTION
## 1. 변경 내용 및 이유

ADR 0032 (`proposed`) 가 pin 한 saturation 가설을 falsify 하는 additive 측정 surface (`eval/routed_config.yaml`) 추가. ADR 0019 의 embedding default lock 이 의존하는 full-set "0pp on `full`" 패턴은 metadata-first routing 이 dense retrieval 을 흡수한 부수효과일 가능성 — embedding 강건성 아님. 이 PR 은 **surface 만** ship; Step 2 (5-embedding × routed-subset matrix 와 ADR 0019/0021/0032 prose 갱신) 는 별도 stacked PR.

Config 는 11 케이스 × 2 분석 변형 row (`agentic_full` baseline vs `agentic_full_routed` with `metadata_first: false`) 보유, 한 config run 이 routed-vs-routing-bypassed spread 직접 산출. 케이스는 ADR 0032 §Decision 카테고리: follow-up 이 entity 생략한 multi-turn follow-up (3), ≥ 2 doc 에서 같은 메타데이터 candidate 인 multi-doc 비교 (4), 명시적 메타데이터 column hook 없는 inference 쿼리 (4, 보류 1 포함).

구현 노트: ADR 0032 본문은 경로를 `eval/synthetic/routed_subset.jsonl` 로 명명. 이 PR 은 케이스 inline 의 `eval/routed_config.yaml` 사용 (기존 `eval/config.yaml` 패턴 일치 — `eval/run_eval.py` 는 config YAML 에서 직접 `cases` 읽음, jsonl loader 없음). Step 2 의 ADR prose 갱신이 ADR 0032 경로 참조 정정.

Closes #529

## 2. 영향 파일

- `eval/routed_config.yaml` (신규) — **load-bearing** (`eval/` 가 `LOAD_BEARING_PATHS`)
- `eval/dev_queries_v1_summary.md` — 신규 config 가리키는 additive "Routed surface" 섹션

## 3. 리스크

가장 가능성 높은 break: 향후 PR 이 `eval/config.yaml` 대량 편집하며 `routed_config.yaml` 의 parallel surface 존재 잊어 schema drift. 완화: `dev_queries_v1_summary.md` 가 routed surface 를 `config.yaml` 의 first-class peer 로 문서화, ADR 0032 prose (Step 2 에서) 가 경로 pin.

부차: 케이스 설계는 synthetic — 실제 long-tail RFP 케이스 대비 representativeness 는 제한 (ADR 0032 §Consequences 가 이미 명시). Step 2 의 측정 출력이 saturation falsifiability 결정, Step 1 의 케이스 curation 아님.

## 4. 테스트

신규 테스트 없음 — 이 PR 은 데이터 + config ship, 동작 아님. 기존 invariant 검증:

- `tests/data/naive_baseline_top_k.json` byte-identical (`make smoke` 후 `git diff` 비어있음)
- `pytest -q tests/test_eval_metrics.py tests/test_eval_reproducibility_regression.py tests/test_naive_baseline_ranking_invariance.py` → 25 passed
- `make smoke` end-to-end pass
- `python -m eval.run_eval --config eval/routed_config.yaml --index_dir data/index --output_dir reports` 가 11 케이스 전부 두 분석 변형 row 에서 실행 (saturation surface 예상대로 `supported` / `partial` / `insufficient` 혼합)

## 5. Eval 영향

Public CI (`eval/config.yaml`): **전부 `·`** — `eval/config.yaml` 미터치. 신규 surface 는 별도 `--config eval/routed_config.yaml` 명령으로 invoke, default CI run 에 없음.

### 5b. Real-data delta

N/A — no behavior change in retrieval / verifier path. `eval/routed_config.yaml` 는 데이터 + 분석 변형 config 만; `rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, `rag_query.py`, `ingestion.py`, `visual_ingestion.py`, `api/`, `scripts/build_index.py` 코드 미수정.

## 6. 하위 호환성

Breaking 변경 없음. `eval/config.yaml` schema 미변경. `eval/run_eval.py` 미수정. Answer 계약 (ADR 0003) 미터치. ADR 0001 (`naive_baseline` golden) invariant 보존.

## 7. Out of scope

- 5-embedding × routed-subset 측정 matrix (Step 2 / 별도 stacked PR 로 유예)
- ADR 0032 status flip `proposed → accepted` (Step 2 측정 결과 의존)
- saturation cross-link 위한 ADR 0019 / 0021 prose 갱신 (Step 2)
- ADR 0032 본문 파일명 정정 `routed_subset.jsonl → routed_config.yaml` (Step 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
