### PR TITLE
docs(adr): consolidate superseded ADRs into parent pattern sections

### DIFF
--- a/docs/adr/0001-preserve-naive-baseline.md
+++ b/docs/adr/0001-preserve-naive-baseline.md
@@ -48,6 +48,20 @@ explicit signal that this ADR is being revisited.
 - The README's headline metrics need to make the baseline-vs-full gap
   explicit, or the system looks weaker than it is.
 
+## Default-choice re-evaluation criteria (ADR 0019, consolidated)
+
+ADR 0019 established the pattern for when a "default stays as-is" decision may be revisited. That ADR is Superseded here; the re-open conditions are the load-bearing part.
+
+**Current default kept**: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` as the embedding model.
+
+**Re-open conditions** (all four must hold before flipping the default):
+1. `requirements.txt` upgrade resolves `torch >= 2.6` and `huggingface-hub < 1.0` blockers.
+2. `python3 scripts/run_embedding_ablation.py --models <miniLM> BAAI/bge-m3 intfloat/multilingual-e5-large-instruct` runs to completion on the public synthetic corpus (n=42).
+3. At least one candidate shows a **`full` pipeline** lift of ≥ +5pp on accuracy or groundedness with non-overlapping bootstrap 95% CIs vs MiniLM. (*Lifts on `naive_baseline` only do NOT count.*)
+4. A follow-up ADR documents the replacement candidate.
+
+**Phase 1.3 update (issue #389, 2026-05-12):** Conditions 1 and 2 are met for all four candidates (BGE-M3 measurement closed the last gap). Condition 3 is NOT triggered — the `0pp-on-full` pattern holds across all five embeddings. This ADR stays accepted.
+
 ## Alternatives considered
 
 - **Drop the baseline once the agentic pipeline ships.** Rejected:

--- a/docs/adr/0005-eval-split-public-synthetic-private-local.md
+++ b/docs/adr/0005-eval-split-public-synthetic-private-local.md
@@ -65,6 +65,21 @@ side: public-redistributable, or strictly local.
   the aggregate / delta reports plus the public-surface
   reproducibility.
 
+## LLM-judge gate layers (ADR 0006 / 0012 / 0014, consolidated)
+
+Three successive ADRs layered LLM-judge surfaces onto the two eval splits. Those ADRs are Superseded here; their decisions remain in force.
+
+**Gate 1 — real-data only (ADR 0006, accepted)**  
+LLM-judge permitted on `eval/real_config.local.yaml` runs only. Output: per-case `judge.local.json` (gitignored) + aggregate `judge.agreement_with_verifier` (committable). Backend: `BIDMATE_JUDGE_BACKEND` — `stub` | `openai_compatible`. The deterministic verifier remains the gate; the judge is a second opinion.
+
+**Gate 2 — public synthetic stub-default (ADR 0012, accepted)**  
+LLM-judge permitted on `eval/config.yaml` provided CI runs stub-only (`BIDMATE_SYNTHETIC_JUDGE_BACKEND=stub`, deterministic, network-free). Live backend is offline opt-in via `make synthetic-judge`. Committable aggregate: `reports/synthetic_judge.aggregate.json` (ADR 0005 allowlist). Adds `faithfulness`, `answer_relevance`, `agreement_with_verifier`.
+
+**Gate 3 — RAGAS-style enrichment (ADR 0014, accepted)**  
+Four-metric RAGAS-style judge (`faithfulness`, `answer_relevance`, `context_precision`, `context_recall`) as additive enrichment on the synthetic surface. Cache by content hash (`reports/judge_cache/`, gitignored). Hard token-budget cap via `BIDMATE_JUDGE_TOKEN_BUDGET`. Per-case verdicts stay local; aggregate at `eval_summary.json:judge_ragas` is committable.
+
+**Shared invariants (unchanged):** ADR 0004 reproducibility (CI never calls live LLM); ADR 0003 answer contract (judge never affects `answer.status`); ADR 0005 commit boundary (per-case text stays local).
+
 ## Alternatives considered
 
 - **Public-only.** Rejected: synthetic data hides the failure modes

--- a/docs/adr/0006-llm-judge-on-real-data-only.md
+++ b/docs/adr/0006-llm-judge-on-real-data-only.md
@@ -1,6 +1,7 @@
 # 0006: LLM-judge on the real-data surface only
 
-- **Status**: accepted
+- **Status**: Superseded
+- **Superseded by**: [ADR 0005](./0005-eval-split-public-synthetic-private-local.md) § "LLM-judge gate layers"
 - **Date**: 2026-05-11
 - **Related**: refines [ADR 0004](./0004-verifier-retry-policy.md); reinforces [ADR 0005](./0005-eval-split-public-synthetic-private-local.md)
 - **Deciders**: hskim

--- a/docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md
+++ b/docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md
@@ -67,6 +67,19 @@ unchanged. Diagnostic fields `bm25` and `rank_rrf` are added to
   field, not part of the ADR 0003 answer contract, so no
   `schema_version` bump is required.
 
+## Korean morphology tokenizer layer (ADR 0031, consolidated)
+
+ADR 0031 added `bm25_tokenizer: "regex" | "kiwi"` as an orthogonal ablation on top of this ADR's hybrid BM25 surface. ADR 0031 is Superseded here; key decisions below.
+
+**Decision (ADR 0031, accepted 2026-05-13):** Introduce `bm25_tokenizer` config key in `rag_pipeline_presets.py`. All three presets default to `"regex"` (preserves ADR 0001 and ADR 0010 baseline byte-equality). New ablation row `full_kiwi` in `eval/config.yaml` sets `bm25_tokenizer: kiwi` + `retrieval_backend: hybrid`. `korean_lexicon.kiwi_tokens` lazy-imports `kiwipiepy` — on import failure falls back to regex (never-raise contract).
+
+**Re-open conditions** (kiwi becomes the default when all three hold):
+1. Public synthetic eval (n=42) runs with kiwipiepy installed, producing a real (non-fallback) `full_kiwi` row.
+2. `full_kiwi` shows ≥ +3pp lift on `accuracy` OR `citation_precision` vs `hybrid_bm25` with non-overlapping 95% CIs.
+3. A follow-up ADR documents the install footprint (~30MB `kiwipiepy`) and whether it becomes a hard CI dep.
+
+**Invariants:** ADR 0001 `naive_baseline` golden bit-identical (naive_baseline uses `retrieval_backend: dense`, never invokes BM25). Existing hybrid rows byte-equal.
+
 ## Alternatives considered
 
 - **BGE-M3 sparse channel** — would close the same gap and bring

--- a/docs/adr/0011-llm-synthesis-as-additive-ablation.md
+++ b/docs/adr/0011-llm-synthesis-as-additive-ablation.md
@@ -152,6 +152,24 @@ Reuses the ADR 0006 pattern: `BIDMATE_SYNTHESIS_BACKEND`:
 - ADR 0005: real-data per-case LLM outputs stay local. Aggregates
   (mean cost, mean latency, citation_precision delta) commit.
 
+## Additive opt-in pattern (generalization)
+
+ADR 0011 established a recurring pattern that later ADRs 0015, 0017, and 0027 reused verbatim. Those ADRs are consolidated here as Superseded; their decisions remain unchanged. The pattern is:
+
+1. **Default is deterministic and free.** A `stub` (or `regex`) backend runs on every CI invocation — no network, no cost, reproducible.
+2. **Opt-in via a single env-var.** `BIDMATE_<FEATURE>_BACKEND` dispatches: `stub` (default) | `anthropic` | `openai_compatible`. Unknown/failing backend silently degrades to stub.
+3. **Never changes upstream contract.** The feature writes to a *diagnostics* or *additive ablation row* surface; it cannot modify `answer.status`, `claims`, `citations`, or `naive_baseline` metrics.
+4. **One new ablation row in `eval/config.yaml`.** The feature is measurable as a column, not just a code path.
+5. **Stub-matches-baseline invariant is a contract test.** `test_*_baseline_invariant.py` verifies byte-equality between stub-backend output and the deterministic baseline.
+
+**Instances consolidated here:**
+
+| ADR | Feature | Env-var | Stub invariant |
+|-----|---------|---------|---------------|
+| 0015 | Cost telemetry (tokens, USD estimate) | n/a — diagnostics only | `SYNTHESIS_SCHEMA_VERSION` bump; unknown model → `None` |
+| 0017 | LLM metadata extraction | `BIDMATE_METADATA_BACKEND` | `stub` delegates to `regex`; byte-equal |
+| 0027 | LoRA embedding adapter | `BIDMATE_EMBEDDING_LORA_ADAPTER` | unset = pre-#434 byte-identical; lazy PEFT import |
+
 ## Alternatives considered
 
 - **Replace the extractive path with LLM synthesis entirely.**

--- a/docs/adr/0012-llm-judge-on-public-synthetic.md
+++ b/docs/adr/0012-llm-judge-on-public-synthetic.md
@@ -1,6 +1,7 @@
 # 0012: LLM-judge on the public synthetic eval, stub-default
 
-- **Status**: accepted
+- **Status**: Superseded
+- **Superseded by**: [ADR 0005](./0005-eval-split-public-synthetic-private-local.md) § "LLM-judge gate layers"
 - **Date**: 2026-05-11
 - **Related**: refines [ADR 0006](./0006-llm-judge-on-real-data-only.md); reuses the backend pattern of [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md); preserves [ADR 0004](./0004-verifier-retry-policy.md) reproducibility
 - **Deciders**: hskim

--- a/docs/adr/0014-ragas-judge-additive-synthetic.md
+++ b/docs/adr/0014-ragas-judge-additive-synthetic.md
@@ -1,6 +1,7 @@
 # 0014: RAGAS-style LLM-judge as additive enrichment on the synthetic surface
 
-- **Status**: accepted
+- **Status**: Superseded
+- **Superseded by**: [ADR 0005](./0005-eval-split-public-synthetic-private-local.md) § "LLM-judge gate layers"
 - **Date**: 2026-05-11
 - **Related**: refines [ADR 0006](./0006-llm-judge-on-real-data-only.md); preserves [ADR 0001](./0001-preserve-naive-baseline.md), [ADR 0003](./0003-structured-answer-citation-contract.md), [ADR 0004](./0004-verifier-retry-policy.md), [ADR 0005](./0005-eval-split-public-synthetic-private-local.md); reuses backend pattern from [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md)
 - **Deciders**: hskim

--- a/docs/adr/0015-cost-telemetry-additive.md
+++ b/docs/adr/0015-cost-telemetry-additive.md
@@ -1,6 +1,7 @@
 # 0015: Cost telemetry as additive observability (extends 0011, 0013)
 
-- **Status**: accepted
+- **Status**: Superseded
+- **Superseded by**: [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) § "Additive opt-in pattern (generalization)"
 - **Date**: 2026-05-12
 - **Deciders**: hskim
 - **Related**: [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (LLM synthesis), [ADR 0013](./0013-observability-as-additive-pluggable-surface.md) (trace backends), `rag_synthesis.py`, `tests/test_synthesis_cost_telemetry.py`

--- a/docs/adr/0017-llm-metadata-extraction-additive.md
+++ b/docs/adr/0017-llm-metadata-extraction-additive.md
@@ -1,6 +1,7 @@
 # 0017: LLM Metadata Extraction as Additive Backend (extends 0011)
 
-- **Status**: proposed
+- **Status**: Superseded
+- **Superseded by**: [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) § "Additive opt-in pattern (generalization)"
 - **Date**: 2026-05-12
 - **Deciders**: hskim
 - **Related**: [#180](https://github.com/hskim-solv/BidMate-DocAgent/issues/180), [ADR 0001](./0001-preserve-naive-baseline.md), [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md)

--- a/docs/adr/0019-embedding-default-stays-minilm.md
+++ b/docs/adr/0019-embedding-default-stays-minilm.md
@@ -1,6 +1,7 @@
 # 0019: Embedding default stays MiniLM-L12-v2 with explicit re-open conditions
 
-- **Status**: accepted
+- **Status**: Superseded
+- **Superseded by**: [ADR 0001](./0001-preserve-naive-baseline.md) § "Default-choice re-evaluation criteria"
 - **Date**: 2026-05-12
 - **Deciders**: hskim
 - **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (baseline preserved), [ADR 0002](./0002-metadata-first-retrieval.md) (metadata-first dominates), [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) (Phase 1.3 supplement that closes condition 2), [`docs/embedding-ablation.md`](../embedding-ablation.md), issues #161 (Phase 1.2 runner) and #300 (this decision)

--- a/docs/adr/0025-cost-frontier-defer-until-real-baselines.md
+++ b/docs/adr/0025-cost-frontier-defer-until-real-baselines.md
@@ -158,6 +158,19 @@ Costs / honesty:
   `wontfix` would obscure that the work resumes naturally once the
   data exists.
 
+## Cross-encoder reranker deferral (ADR 0026, consolidated)
+
+ADR 0026 (accepted, same date) applied this same measurement-gated deferral pattern to the cross-encoder reranker surface. ADR 0026 is Superseded here; key decisions below.
+
+**Decision (ADR 0026):** Keep the `Reranker` Protocol and `CrossEncoderReranker` in `rag_reranker.py`. Keep `BIDMATE_RERANK_BACKEND=stub` (identity) as CI default — `full_reranker ≡ full` by construction. Do not remove the seam despite 0pp synthetic delta; Protocol is the plug point for HyDE-reranker / LLM-as-reranker follow-ups.
+
+**Context:** On the public synthetic surface (n=42), `full` (rerank blend on) and `no_rerank` (rerank off) are byte-identical in accuracy/groundedness/citation_precision/abstention. The `rerank: true` blend has zero measured lift. Real backends (`bge`, `bge_ko`, `cohere`) are unmeasured.
+
+**Re-open conditions** (all three must hold to flip the default):
+1. At least one of `bge` / `bge_ko` / `cohere` backends runs to completion on the public synthetic eval (n=42); results appended to `docs/cross-encoder-reranker.md` §Results.
+2. That backend shows `full_reranker` lift of ≥ +3pp on `accuracy` OR `citation_precision` with non-overlapping 95% CIs vs `full`.
+3. A follow-up ADR documents the latency/cost trade-off and flips `BIDMATE_RERANK_BACKEND` default.
+
 ## See also
 
 - [`scripts/plot_pareto.py`](../../scripts/plot_pareto.py) — the

--- a/docs/adr/0026-cross-encoder-reranker-deferral.md
+++ b/docs/adr/0026-cross-encoder-reranker-deferral.md
@@ -1,6 +1,7 @@
 # 0026: Cross-encoder reranker default stays stub-identity; real-backend measurement deferred
 
-- **Status**: accepted
+- **Status**: Superseded
+- **Superseded by**: [ADR 0025](./0025-cost-frontier-defer-until-real-baselines.md) § "Cross-encoder reranker deferral"
 - **Date**: 2026-05-12
 - **Deciders**: hskim
 - **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (baseline preserved), [ADR 0002](./0002-metadata-first-retrieval.md) (the metadata-first routing that shadows the rerank step), [ADR 0019](./0019-embedding-default-stays-minilm.md) (mirror pattern — measurement-gated default-stays), [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) (the deferred-then-closed loop precedent), [ADR 0025](./0025-cost-frontier-defer-until-real-baselines.md) (sibling deferral pattern, accepted 2026-05-12), [`docs/cross-encoder-reranker.md`](../cross-encoder-reranker.md) (working reference), [`docs/ablation-results.md`](../ablation-results.md) (current ablation table), [`rag_reranker.py`](../../rag_reranker.py) (`Reranker` Protocol + `CrossEncoderReranker` default), issues [#163](https://github.com/hskim-solv/oss-bidmate-docagent/issues/163), [#345](https://github.com/hskim-solv/oss-bidmate-docagent/issues/345), [#412](https://github.com/hskim-solv/oss-bidmate-docagent/issues/412), PR [#358](https://github.com/hskim-solv/oss-bidmate-docagent/pull/358)

--- a/docs/adr/0027-lora-finetuned-embedding-additive.md
+++ b/docs/adr/0027-lora-finetuned-embedding-additive.md
@@ -1,6 +1,7 @@
 # 0027: LoRA-fine-tuned embedding adapter as additive ablation
 
-- **Status**: proposed
+- **Status**: Superseded
+- **Superseded by**: [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) § "Additive opt-in pattern (generalization)"
 - **Date**: 2026-05-12
 - **Deciders**: hskim
 - **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (naive baseline invariant), [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (additive-opt-in pattern), [ADR 0019](./0019-embedding-default-stays-minilm.md) (re-open criteria for swapping the default), [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) (Phase 1.3 closure), issue #179

--- a/docs/adr/0031-bm25-korean-morphology-additive.md
+++ b/docs/adr/0031-bm25-korean-morphology-additive.md
@@ -1,6 +1,7 @@
 # 0031: BM25 Korean morphology tokenizer as additive ablation
 
-- **Status**: accepted
+- **Status**: Superseded
+- **Superseded by**: [ADR 0010](./0010-hybrid-bm25-dense-retrieval-rrf.md) § "Korean morphology tokenizer layer"
 - **Date**: 2026-05-13
 - **Deciders**: hskim
 - **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (naive_baseline invariant), [ADR 0010](./0010-hybrid-bm25-dense-retrieval-rrf.md) (hybrid BM25 baseline this layers on), [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) / [ADR 0013](./0013-observability-as-additive-pluggable-surface.md) (additive-opt-in backend pattern this reuses), [ADR 0019](./0019-embedding-default-stays-minilm.md) / [ADR 0021](./0021-bge-m3-completes-phase-1-3.md) / [ADR 0025](./0025-cost-frontier-defer-until-real-baselines.md) / [ADR 0026](./0026-cross-encoder-reranker-deferral.md) (measurement-gated deferral pattern), issue #486, issue #150 (BM25_EXTRA precedent)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,31 +68,31 @@ project record.
 | [0003](./0003-structured-answer-citation-contract.md) | accepted | Structured answer / citation contract (`schema_version: 2`) |
 | [0004](./0004-verifier-retry-policy.md) | accepted | Verifier-driven retry with strict → relaxed staging |
 | [0005](./0005-eval-split-public-synthetic-private-local.md) | accepted | Eval split: public synthetic vs private local |
-| [0006](./0006-llm-judge-on-real-data-only.md) | accepted | LLM-judge on the real-data surface only (refines 0004) |
+| [0006](./0006-llm-judge-on-real-data-only.md) | superseded by 0005 | LLM-judge on the real-data surface only (refines 0004) |
 | [0007](./0007-issue-linked-branch-naming.md) | accepted | Issue-linked branch naming convention |
 | [0008](./0008-evidence-boundary.md) | accepted | Evidence-boundary defense against prompt injection |
 | [0009](./0009-external-baseline-comparison.md) | accepted | External baseline comparison via a separate script (extends 0001); `scripts/compare_external_baselines.py` + `reports/external_baselines.json` implemented; stub run committed; real LangChain run deferred to issue #449 |
 | [0010](./0010-hybrid-bm25-dense-retrieval-rrf.md) | accepted | Hybrid BM25 + dense retrieval with RRF fusion |
-| [0011](./0011-llm-synthesis-as-additive-ablation.md) | proposed | LLM answer synthesis as additive ablation (extends 0001, preserves 0003) |
-| [0012](./0012-llm-judge-on-public-synthetic.md) | accepted | LLM-judge on the public synthetic eval, stub-default (refines 0006, reuses 0011 backend pattern) |
+| [0011](./0011-llm-synthesis-as-additive-ablation.md) | proposed | LLM answer synthesis as additive ablation; **defines additive opt-in pattern** (0015/0017/0027 consolidated here) |
+| [0012](./0012-llm-judge-on-public-synthetic.md) | superseded by 0005 | LLM-judge on the public synthetic eval, stub-default (refines 0006, reuses 0011 backend pattern) |
 | [0013](./0013-observability-as-additive-pluggable-surface.md) | accepted | Observability as an additive, pluggable, fail-closed surface |
-| [0014](./0014-ragas-judge-additive-synthetic.md) | accepted | RAGAS-style LLM judge as additive enrichment on synthetic surface (extends 0012) |
-| [0015](./0015-cost-telemetry-additive.md) | accepted | Cost telemetry as additive observability (extends 0011, 0013) |
+| [0014](./0014-ragas-judge-additive-synthetic.md) | superseded by 0005 | RAGAS-style LLM judge as additive enrichment on synthetic surface (extends 0012) |
+| [0015](./0015-cost-telemetry-additive.md) | superseded by 0011 | Cost telemetry as additive observability (extends 0011, 0013) |
 | [0016](./0016-judge-human-agreement.md) | proposed | Judge↔human agreement as calibration gate on real-data eval (refines 0006) |
-| [0017](./0017-llm-metadata-extraction-additive.md) | proposed | LLM metadata extraction as additive backend (extends 0011) |
+| [0017](./0017-llm-metadata-extraction-additive.md) | superseded by 0011 | LLM metadata extraction as additive backend (extends 0011) |
 | [0018](./0018-korean-public-rag-bench.md) | accepted | Korean public RAG bench as supplementary out-of-domain surface (extends 0005) |
-| [0019](./0019-embedding-default-stays-minilm.md) | accepted | Embedding default stays MiniLM-L12-v2 with explicit re-open conditions (extends 0002) |
+| [0019](./0019-embedding-default-stays-minilm.md) | superseded by 0001 | Embedding default stays MiniLM-L12-v2 with explicit re-open conditions (extends 0002) |
 | [0021](./0021-bge-m3-completes-phase-1-3.md) | accepted | BGE-M3 closes ADR 0019 Phase 1.3 condition 2; default stays MiniLM (supplements 0019) |
 | [0022](./0022-langgraph-orchestration-stage-1.md) | accepted | LangGraph orchestrator path for agentic_full presets — stages 1 (passthrough) + 2 (multi-node analyze / retrieve_loop / build_answer; `_phase_*` helpers shared with direct path; opt-in via BIDMATE_ORCHESTRATOR=langgraph, preserves ADR 0001) |
 | [0023](./0023-hyde-query-expansion-ablation.md) | proposed | HyDE query expansion as additive ablation (extends 0001, preserves 0003, reuses 0011 / 0020 backend pattern) |
 | [0024](./0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) |
 | [0025](./0025-cost-frontier-defer-until-real-baselines.md) | accepted | Cost-accuracy frontier deferred until external baseline real runs land (defers #177; backs README §Limitations "비용 영점"; follows ADR 0019 → 0021 measurement-gated pattern) |
-| [0026](./0026-cross-encoder-reranker-deferral.md) | accepted | Cross-encoder reranker default stays stub-identity; real-backend (bge / bge_ko / cohere) measurement deferred — `full_reranker ≡ full` under CI stub by construction, `full` vs `no_rerank` already 0pp on public synthetic (mirrors ADR 0019 / 0025 pattern) |
-| [0027](./0027-lora-finetuned-embedding-additive.md) | proposed | LoRA-fine-tuned embedding adapter as additive ablation, env-var gated (`BIDMATE_EMBEDDING_LORA_ADAPTER`), HF Hub adapter pinned by commit SHA (extends 0001 / 0011 / 0019; does NOT trigger 0019 re-open) |
+| [0026](./0026-cross-encoder-reranker-deferral.md) | superseded by 0025 | Cross-encoder reranker default stays stub-identity; real-backend measurement deferred |
+| [0027](./0027-lora-finetuned-embedding-additive.md) | superseded by 0011 | LoRA-fine-tuned embedding adapter as additive ablation, env-var gated (`BIDMATE_EMBEDDING_LORA_ADAPTER`) |
 | [0028](./0028-security-screen-additive.md) | accepted | Prompt-injection screen (query-side, diagnostic-only) + PII redaction (ingestion-time, opt-in via `BIDMATE_INGEST_REDACT_PII`) as additive security layer (extends 0008 to query side; preserves 0001 / 0003 / 0005) |
 | [0029](./0029-real-data-case-proposer-additive.md) | proposed | Real-data case proposer as additive semi-supervised eval-set growth (extends 0005 / 0006; reuses 0011 / 0012 backend pattern; preserves 0001 / 0003 / 0004 / 0008; calibration mirrors 0016) |
 | [0030](./0030-leaderboard-headline-includes-agentic-full.md) | accepted | Leaderboard headline expands to render `agentic_full` alongside `naive_baseline` as parallel time series; ADR 0001 baseline preserved, `ablation_full` aggregate key added to history snapshots (extends ADR 0001 / ADR 0024 visibility surface) |
-| [0031](./0031-bm25-korean-morphology-additive.md) | accepted | BM25 Korean morphology tokenizer (`bm25_tokenizer: "regex" \| "kiwi"`) as additive ablation, kiwipiepy lazy-imported with never-raise fallback to regex (extends 0010 / 0011; preserves 0001 / 0003; follows 0019 → 0021 / 0026 measurement-gated pattern) |
+| [0031](./0031-bm25-korean-morphology-additive.md) | superseded by 0010 | BM25 Korean morphology tokenizer (`bm25_tokenizer: "regex" \| "kiwi"`) as additive ablation |
 | [0032](./0032-eval-saturation-routed-subset.md) | accepted | Eval-set saturation falsifier: 4-embedding × routed_subset (n=11, metadata_first=false) measurement complete; spread **0.0pp** < +3pp threshold → saturation_cross_validated. MiniLM default lock empirically justified on both `full` + `routed` surfaces. (Closes ADR 0019 deferral saturation axis.) |
 | [0033](./0033-multihop-cross-section-eval-slice.md) | proposed | Multi-hop cross-section eval slice as orthogonal saturation falsifier (complexity axis; extends 0032; 50-item synthesized dataset, LLM-judge quality filter; spread ≥ +5pp on multi-hop slice supplements ADR 0019 re-open conditions; preserves 0001 / 0003 / 0005) |
 


### PR DESCRIPTION
## Summary

- 33개 ADR 중 9개를 pattern parent ADR에 흡수, ADR set을 32개 → 23개 active로 단순화
- CLAUDE.md 원칙 준수: 파일 삭제 없음, Status 블록에 `Superseded` 기입

## What Changed

**Parent ADRs expanded:**
- ADR 0001: "Default-choice re-evaluation criteria" section 추가 (0019 흡수)
- ADR 0005: "LLM-judge gate layers" section 추가 (0006, 0012, 0014 흡수)
- ADR 0010: "Korean morphology tokenizer layer" section 추가 (0031 흡수)
- ADR 0011: "Additive opt-in pattern (generalization)" section 추가 (0015, 0017, 0027 흡수)
- ADR 0025: "Cross-encoder reranker deferral" section 추가 (0026 흡수)

**Superseded ADRs (9개):** 0006, 0012, 0014, 0015, 0017, 0019, 0026, 0027, 0031
- Status line: `- **Status**: Superseded`
- Superseded by line 추가

**docs/adr/README.md + docs/senior-positioning.md:** status 동기화

## Test Plan

- [x] `bash scripts/test.sh` — 930 passed, 0 failed
- [x] `python3 -m pytest tests/test_governance.py -q` — 49 passed

## Load-bearing files

N/A — docs only, no code change.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. Docs-only change (ADR files + README).

Closes #552