### PR TITLE
docs: remove portfolio meta-doc cross-references from engineering docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,7 +50,7 @@ Required if any load-bearing path changed
 (rag_core.py, rag_retrieval.py, rag_verifier.py, rag_answer.py, rag_query.py, ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py).
 Attach the `make real-eval-delta` aggregate table, or state explicitly:
 "No behavior change in retrieval / verifier path."
-See ADR 0005 and docs/private-100-doc-experiments.md.
+See ADR 0005.
 The synthetic CI delta alone missed #69's intended-abstention regression;
 the §5b CI gate (scripts/check_branch_and_issue.py --check-5b) now enforces this.
 -->

--- a/docs/architecture-deep-dive.md
+++ b/docs/architecture-deep-dive.md
@@ -62,7 +62,7 @@ flowchart TD
 | Latency p95 (hashing) | 6.2ms | 2.9ms | metadata-first가 dense 호출 단축 |
 | Latency p95 (ST embedding) | 367ms | 32ms | 약 10–200× cold path 비용 차이 |
 
-real-data n=21 측정 결과는 [`docs/private-100-doc-experiments.md`](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/private-100-doc-experiments.md)의 aggregate-only Decision Log 참고.
+real-data 측정 결과는 aggregate-only commit boundary로 관리된다 (ADR 0005 참고).
 
 ## 한계와 다음 사이클
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -63,13 +63,13 @@ python3 scripts/summarize_benchmark.py \
   --docs /private/tmp/private100-summary.md
 ```
 
-이 예시는 흐름 검증용 fixture이며 실측 private 성과가 아니다. 실제 private 운영 기준과 금지 항목은 [`docs/private-100-doc-experiments.md`](private-100-doc-experiments.md)에 정리했다.
+이 예시는 흐름 검증용 fixture이며 실측 private 성과가 아니다. private 운영 원칙은 [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md)의 commit boundary 규칙을 따른다.
 
 ## Private Hard-case Slice
 
 이슈 #24의 private hard-case slice는 공개 benchmark를 대체하지 않고 현실적인 문서 조건에서 품질 하락을 분리하기 위한 보조 suite다. `eval/private_hardcase.example.yaml`은 익명 case list와 `hardcase_categories` 형식을 보여준다. 실제 실행 파일은 `eval/private_hardcase.local.yaml`처럼 `.gitignore` 대상 local YAML로 복사해 사용한다.
 
-`eval/run_eval.py`와 benchmark manifest는 `by_hardcase_category` 집계를 포함한다. 이 값만 registry/docs에 남기고 raw private prediction, trace, 원문 artifact는 `artifacts/benchmarks/` 아래 local-only 산출물로 유지한다. 운영 절차와 금지 항목은 [`docs/private-hardcase-benchmark.md`](private-hardcase-benchmark.md)에 정리했다.
+`eval/run_eval.py`와 benchmark manifest는 `by_hardcase_category` 집계를 포함한다. 이 값만 registry/docs에 남기고 raw private prediction, trace, 원문 artifact는 `artifacts/benchmarks/` 아래 local-only 산출물로 유지한다. 운영 원칙은 [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md)의 commit boundary 규칙을 따른다.
 
 ## Stage Latency & Retry Cost
 

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -171,17 +171,10 @@ Reading order for a new contributor:
 2. This file — how the rules connect.
 3. [`docs/adr/README.md`](./adr/README.md) and skim the 6 current
    ADRs — the load-bearing decisions.
-4. [`docs/portfolio-case-study.md`](./portfolio-case-study.md) — the
-   narrative.
-5. [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md)
+4. [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md)
    — what the backlog comes from.
 
-A reviewer who has 10 minutes should start at step 3. A reviewer
-evaluating senior-engineering signals (architectural reasoning,
-measurement rigor, governance, regression discipline) should read
-[`docs/senior-positioning.md`](./senior-positioning.md) first — it
-threads the artifacts above into one interview-ready narrative
-without duplicating their content.
+A reviewer who has 10 minutes should start at step 3.
 
 ## Hook setup
 

--- a/docs/model-upgrade-playbook.md
+++ b/docs/model-upgrade-playbook.md
@@ -348,4 +348,3 @@ quality 회귀가 모델 때문인지 평가 도구 때문인지 분리 불가.
 - [`docs/observability.md`](observability.md) — LangFuse / OTLP trace 백엔드, step 2 의 trace 검증에 사용.
 - [`docs/deployment.md`](deployment.md) — 데모 배포 시점에 본 playbook 의 단계 4 가 production 으로 승격.
 - [`docs/real-data-failure-taxonomy.md`](real-data-failure-taxonomy.md) — Step 2 의 6 카테고리 회귀 카운트 정의.
-- [`docs/portfolio-case-study.md`](portfolio-case-study.md) — 본 playbook 이 답하는 portfolio 질문 (LLM Ops 운영 시그널).

--- a/docs/real-data-failure-taxonomy.md
+++ b/docs/real-data-failure-taxonomy.md
@@ -176,8 +176,7 @@ Effort: **S**(≤1일), **M**(1-3일), **L**(1-2주). Impact: **H**(카테고리
 
 - 기존 실패 카테고리: [docs/failure-cases.md](failure-cases.md)
 - parser-stage 실패 분류: `eval/run_parser_eval.py`의 `FAILURE_TAXONOMY` ([failure-cases.md](failure-cases.md)에서 참조)
-- 회고와 향후 개선: [docs/retrospective.md](retrospective.md)
 - 실데이터 ingestion 흐름: [docs/real-data-ingestion.md](real-data-ingestion.md)
-- private hard-case benchmark 운영: [docs/private-hardcase-benchmark.md](private-hardcase-benchmark.md)
+- private hard-case benchmark 운영 기준: [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md)
 - 청크 진단: [docs/chunking-diagnostics.md](chunking-diagnostics.md)
 - 답변 정책: [docs/answer-policy.md](answer-policy.md)


### PR DESCRIPTION
## Summary

- public engineering docs에서 곧 private repo로 이동될 portfolio 메타문서 참조 제거
- 참조 제거만 — 실제 파일 이동은 private repo 생성 후 별도 PR

## What Changed

- `.github/pull_request_template.md`: `docs/private-100-doc-experiments.md` → ADR 0005 참조
- `docs/engineering-governance.md`: `portfolio-case-study.md`, `senior-positioning.md` 링크 제거
- `docs/model-upgrade-playbook.md`: `portfolio-case-study.md` 참조 제거
- `docs/real-data-failure-taxonomy.md`: `retrospective.md`, `private-hardcase-benchmark.md` → ADR 0005
- `docs/benchmarking.md`: `private-100-doc-experiments.md`, `private-hardcase-benchmark.md` → ADR 0005
- `docs/architecture-deep-dive.md`: `private-100-doc-experiments.md` 참조 제거

## Test Plan

- [x] `bash scripts/test.sh` — 930 passed, 0 failed

## Load-bearing files

N/A — docs only, no code change.

## Real-data delta

N/A — docs only.

Closes #553