### PR TITLE
refactor: extract rag_text_processing.py from rag_core (removes late-import cycle)

### DIFF
--- a/rag_answer.py
+++ b/rag_answer.py
@@ -52,6 +52,12 @@ from korean_lexicon import (
     METADATA_CLAIM_TOPIC_LABELS,
     METADATA_EVIDENCE_LABELS,
 )
+from rag_text_processing import (
+    compact_metadata_text,
+    ordered_unique,
+    sentence_split,
+    tokenize,
+)
 from rag_answer_schema import (
     ANSWER_SCHEMA_VERSION,
     ANSWER_STATUS_INSUFFICIENT,
@@ -346,10 +352,6 @@ def render_answer_text(answer: dict[str, Any]) -> str:
 
 
 def best_sentence(text: str, topics: list[str], query_tokens: list[str]) -> str:
-    # Late-import — sentence_split and tokenize are multi-surface
-    # utilities in rag_core. See module docstring.
-    from rag_core import sentence_split, tokenize
-
     sentences = sentence_split(text) or [text]
     scored = []
     token_set = set(query_tokens)
@@ -364,9 +366,6 @@ def best_sentence(text: str, topics: list[str], query_tokens: list[str]) -> str:
 
 
 def metadata_claim_sentences(item: dict[str, Any], analysis: dict[str, Any]) -> list[str]:
-    # Late-import — see module docstring.
-    from rag_core import ordered_unique
-
     metadata = item.get("metadata")
     if not isinstance(metadata, dict):
         return []
@@ -383,9 +382,6 @@ def metadata_claim_sentences(item: dict[str, Any], analysis: dict[str, Any]) -> 
 
 
 def metadata_field_requested(key: str, value: Any, analysis: dict[str, Any]) -> bool:
-    # Late-import — compact_metadata_text is a multi-surface rag_core helper.
-    from rag_core import compact_metadata_text
-
     terms = [term for term in verification_topics(analysis) if term]
     if not terms:
         return False

--- a/rag_core.py
+++ b/rag_core.py
@@ -175,6 +175,26 @@ from rag_query import (
 # of issue #415 (PR-E stage 3 of the rag_core.py decomposition epic). The
 # symbols below are direct-imported (no re-export wrapper) — repo-wide
 # grep at PR filing confirmed zero external consumers.
+# Text-processing primitives extracted to rag_text_processing (issue #545).
+# Re-exported here so existing ``from rag_core import tokenize`` call sites
+# keep working unchanged.
+from rag_text_processing import (
+    ENTITY_RE,
+    QUERY_TYPE_TOP_K_DEFAULTS,
+    TOKEN_RE,
+    SENTENCE_RE,
+    coerce_alias_values,
+    coerce_string_list,
+    compact_metadata_text,
+    normalize_entity,
+    normalize_metadata_token,
+    normalize_section_path,
+    ordered_unique,
+    sentence_split,
+    split_long_text_unit,
+    tokenize,
+)
+
 from rag_conversation_state import (
     AMBIGUOUS_CONFIDENCE_DELTA,
     CONTEXT_RESOLUTION_THRESHOLD,
@@ -209,11 +229,6 @@ VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
 # past 3 must update this value and explain why in the PR description.
 MAX_AGENT_ITERATIONS = 3
 
-QUERY_TYPE_TOP_K_DEFAULTS: dict[str, int] = {
-    "single_doc": 4,
-    "follow_up": 6,
-    "comparison": 6,
-}
 WEAK_SECTION_HEADINGS = {
     "",
     "본문",
@@ -233,10 +248,6 @@ INDEX_FILENAME = "index.json"
 EMBEDDINGS_FILENAME = "embeddings.npy"
 INDEX_SCHEMA_VERSION = 2
 MODEL_CACHE: dict[tuple[str, bool, str | None], Any] = {}
-
-TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]+")
-ENTITY_RE = re.compile(r"기관\s*[-_]?\s*([A-Za-z0-9]+)", re.IGNORECASE)
-SENTENCE_RE = re.compile(r"(?<=[.!?。])\s+")
 
 TRACE_SCHEMA_VERSION = 1
 
@@ -279,29 +290,6 @@ class QueryParams:
     bm25_tokenizer: str | None = None
 
 
-def normalize_entity(value: str) -> str:
-    return re.sub(r"\s+", " ", value.strip())
-
-
-def compact_metadata_text(value: str) -> str:
-    normalized = unicodedata.normalize("NFC", value).lower()
-    return re.sub(r"[^0-9a-z가-힣]+", "", normalized)
-
-
-def normalize_metadata_token(token: str) -> str:
-    token = unicodedata.normalize("NFC", token).lower().strip()
-    if re.fullmatch(r"[가-힣]+", token):
-        changed = True
-        while changed:
-            changed = False
-            for suffix in KOREAN_PARTICLE_SUFFIXES:
-                if len(token) > len(suffix) + 1 and token.endswith(suffix):
-                    token = token[: -len(suffix)]
-                    changed = True
-                    break
-    return token
-
-
 def metadata_tokens(text: str) -> list[str]:
     tokens = []
     for match in TOKEN_RE.finditer(unicodedata.normalize("NFC", text)):
@@ -309,99 +297,6 @@ def metadata_tokens(text: str) -> list[str]:
         if token and token not in STOPWORDS:
             tokens.append(token)
     return tokens
-
-
-def ordered_unique(values: Iterable[str]) -> list[str]:
-    seen = set()
-    ordered = []
-    for value in values:
-        if value and value not in seen:
-            seen.add(value)
-            ordered.append(value)
-    return ordered
-
-
-def coerce_string_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return ordered_unique(str(item).strip() for item in value if str(item).strip())
-
-
-def coerce_alias_values(value: Any) -> list[str]:
-    if value is None:
-        return []
-    if isinstance(value, str):
-        raw_values = re.split(r"[,;/|]", value)
-        return ordered_unique(part.strip() for part in raw_values if part.strip())
-    if isinstance(value, list):
-        return ordered_unique(str(item).strip() for item in value if str(item).strip())
-    return []
-
-
-
-def tokenize(text: str) -> list[str]:
-    tokens = [normalize_metadata_token(m.group(0)) for m in TOKEN_RE.finditer(text)]
-    return [t for t in tokens if t and t not in STOPWORDS]
-
-
-def sentence_split(text: str) -> list[str]:
-    parts = SENTENCE_RE.split(text.strip())
-    return [p.strip() for p in parts if p.strip()]
-
-
-def split_long_text_unit(text: str, max_chars: int) -> list[str]:
-    if len(text) <= max_chars:
-        return [text]
-
-    lines = [line.strip() for line in text.splitlines() if line.strip()]
-    if len(lines) > 1:
-        chunks: list[str] = []
-        current: list[str] = []
-        current_len = 0
-        for line in lines:
-            if len(line) > max_chars:
-                if current:
-                    chunks.append(" ".join(current).strip())
-                    current = []
-                    current_len = 0
-                chunks.extend(split_long_text_unit(line, max_chars))
-                continue
-            next_len = current_len + len(line) + 1
-            if current and next_len > max_chars:
-                chunks.append(" ".join(current).strip())
-                current = []
-                current_len = 0
-            current.append(line)
-            current_len += len(line) + 1
-        if current:
-            chunks.append(" ".join(current).strip())
-        return chunks
-
-    words = text.split()
-    if len(words) <= 1:
-        return [text[idx : idx + max_chars].strip() for idx in range(0, len(text), max_chars)]
-
-    chunks = []
-    current = []
-    current_len = 0
-    for word in words:
-        if len(word) > max_chars:
-            if current:
-                chunks.append(" ".join(current).strip())
-                current = []
-                current_len = 0
-            chunks.extend(word[idx : idx + max_chars] for idx in range(0, len(word), max_chars))
-            continue
-        next_len = current_len + len(word) + 1
-        if current and next_len > max_chars:
-            chunks.append(" ".join(current).strip())
-            current = []
-            current_len = 0
-        current.append(word)
-        current_len += len(word) + 1
-    if current:
-        chunks.append(" ".join(current).strip())
-    return [chunk for chunk in chunks if chunk]
 
 
 def load_raw_documents(input_dir: Path) -> list[dict[str, Any]]:
@@ -493,18 +388,6 @@ def validate_chunking_options(
         raise ValueError("chunk_overlap_sentences must be zero or positive.")
 
 
-def normalize_section_path(section: dict[str, Any], heading: str) -> list[str]:
-    raw_path = section.get("section_path") or section.get("path") or []
-    if isinstance(raw_path, str):
-        parts = [part.strip() for part in raw_path.split(">")]
-    elif isinstance(raw_path, list):
-        parts = [str(part).strip() for part in raw_path]
-    else:
-        parts = []
-    path = [part for part in parts if part]
-    if not path:
-        path = [heading]
-    return path
 
 
 def normalize_regions(value: Any) -> list[dict[str, Any]]:

--- a/rag_query.py
+++ b/rag_query.py
@@ -75,6 +75,16 @@ from rag_pipeline_presets import (
     VALID_RETRIEVAL_MODES,
     VALID_RRF_K_RANGE,
 )
+from rag_text_processing import (
+    ENTITY_RE,
+    QUERY_TYPE_TOP_K_DEFAULTS,
+    coerce_string_list,
+    compact_metadata_text,
+    normalize_entity,
+    normalize_metadata_token,
+    ordered_unique,
+    tokenize,
+)
 from text_normalize import normalize_text
 
 
@@ -85,22 +95,16 @@ def is_metadata_ambiguous(matches: list[dict[str, Any]], query_type: str) -> boo
 
 
 def has_implicit_reference(query: str) -> bool:
-    from rag_core import normalize_entity
-
     normalized_query = normalize_entity(query)
     return any(pattern in normalized_query for pattern in IMPLICIT_REFERENCE_PATTERNS)
 
 
 def has_comparison_request(query: str) -> bool:
-    from rag_core import normalize_entity
-
     comparison_terms = ("차이", "비교", "각각", "대비")
     return any(term in normalize_entity(query) for term in comparison_terms)
 
 
 def extract_requested_agencies(query: str) -> list[str]:
-    from rag_core import ENTITY_RE, normalize_metadata_token, ordered_unique
-
     agencies = []
     for match in ENTITY_RE.finditer(unicodedata.normalize("NFC", query)):
         token = normalize_metadata_token(match.group(1))
@@ -113,8 +117,6 @@ def extract_requested_agencies(query: str) -> list[str]:
 
 
 def active_state_terms(state: dict[str, Any]) -> list[str]:
-    from rag_core import coerce_string_list, ordered_unique
-
     terms = [
         *coerce_string_list(state.get("active_agencies")),
         *coerce_string_list(state.get("active_projects")),
@@ -181,8 +183,6 @@ def resolve_conversation_context(
     conversation_state: dict[str, Any],
     context_entities: list[str] | None = None,
 ) -> tuple[str, list[str], dict[str, Any]]:
-    from rag_core import coerce_string_list
-
     explicit_context = coerce_string_list(context_entities or [])
     if explicit_context:
         # Issue #71: prepend entities into the retrieval query string
@@ -300,9 +300,6 @@ def analyze_query(
         metadata_ambiguity_details,
         metadata_filters_from_matches,
         metadata_matches_for_stage,
-        normalize_entity,
-        ordered_unique,
-        tokenize,
     )
 
     targets = coerce_metadata_targets(entities)
@@ -405,8 +402,6 @@ def comparison_targets_for_analysis(analysis: dict[str, Any]) -> tuple[list[str]
     Prefers matched doc_ids when ≥2 are present; otherwise falls back to matched
     agencies. Returns ([], "") when balancing is not applicable.
     """
-    from rag_core import ordered_unique
-
     matched_doc_ids = list(analysis.get("matched_doc_ids") or [])
     if len(matched_doc_ids) >= 2:
         return ordered_unique(matched_doc_ids), "doc_id"
@@ -438,14 +433,7 @@ def metadata_resolution_diagnostics(
     decision: str | None = None,
     reason: str = "",
 ) -> dict[str, Any]:
-    from rag_core import (
-        coerce_string_list,
-        compact_metadata_text,
-        metadata_matches_for_stage,
-        metadata_tokens,
-        normalize_entity,
-        ordered_unique,
-    )
+    from rag_core import metadata_matches_for_stage, metadata_tokens
 
     matches = list(analysis.get("metadata_matches") or [])
     selected_by_stage: dict[str, list[dict[str, Any]]] = {}
@@ -484,8 +472,6 @@ def metadata_resolution_diagnostics(
 
 
 def query_type_default_top_k(query_type: str) -> int:
-    from rag_core import QUERY_TYPE_TOP_K_DEFAULTS
-
     return QUERY_TYPE_TOP_K_DEFAULTS.get(query_type, QUERY_TYPE_TOP_K_DEFAULTS["single_doc"])
 
 
@@ -507,8 +493,6 @@ def make_plan(
     bm25_stopword_profile: str = "shared",
     bm25_tokenizer: str = "regex",
 ) -> dict[str, Any]:
-    from rag_core import QUERY_TYPE_TOP_K_DEFAULTS
-
     if retrieval_mode not in VALID_RETRIEVAL_MODES:
         choices = ", ".join(sorted(VALID_RETRIEVAL_MODES))
         raise ValueError(f"retrieval_mode must be one of: {choices}")

--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -64,6 +64,7 @@ import numpy as np
 from korean_lexicon import BM25_EXTRA_PARTICLE_SUFFIXES, BM25_EXTRA_STOPWORDS
 from rag_pipeline_presets import RRF_K, VALID_BM25_STOPWORD_PROFILES
 from rag_query_expansion import default_expander
+from rag_text_processing import tokenize
 
 try:  # noqa: SIM105 — import errors must keep _BM25Okapi defined
     from rank_bm25 import BM25Okapi as _BM25Okapi
@@ -576,13 +577,6 @@ def _chunk_tokens_for_bm25(
     stopword_profile: str = "shared",
     tokenizer: str = "regex",
 ) -> list[str]:
-    # Late-import the regex-based tokenizer from rag_core. ``tokenize``
-    # serves many non-retrieval surfaces (ingestion-time chunk token
-    # cache, query analyzer, partial-topic check, ...) so it stays in
-    # rag_core; this module's BM25 surface uses it only as a fallback
-    # when the chunk doesn't carry a pre-computed token list.
-    from rag_core import tokenize
-
     section_path = chunk.get("section_path") or [chunk.get("section", "")]
     text = " ".join(
         [
@@ -722,11 +716,6 @@ def bm25_scores_for_index(
 
 
 def lexical_similarity(query_tokens: set[str], topics: list[str], chunk: dict[str, Any]) -> float:
-    # Late-import tokenize (rag_core) — also used as a fallback when
-    # the chunk does not carry pre-computed tokens. Same rationale as
-    # ``_chunk_tokens_for_bm25``: tokenize is multi-surface in rag_core.
-    from rag_core import tokenize
-
     if not query_tokens and not topics:
         return 0.0
     section_path = chunk.get("section_path") or [chunk.get("section", "")]

--- a/rag_text_processing.py
+++ b/rag_text_processing.py
@@ -1,0 +1,158 @@
+"""Text-processing primitives shared across the rag_* module family.
+
+Extracted from ``rag_core.py`` (issue #545) as the first step of breaking
+the late-import cycle: rag_answer, rag_query, rag_verifier, and rag_retrieval
+all needed to late-import these utilities from rag_core to avoid a circular
+dependency.  Moving them here gives them a home that none of the rag_* modules
+depend on (this module imports only korean_lexicon and stdlib), so they can
+be imported at module level everywhere.
+
+``rag_core`` re-exports every public name for backward compatibility.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any, Iterable
+
+from korean_lexicon import KOREAN_PARTICLE_SUFFIXES, STOPWORDS
+
+QUERY_TYPE_TOP_K_DEFAULTS: dict[str, int] = {
+    "single_doc": 4,
+    "follow_up": 6,
+    "comparison": 6,
+}
+
+TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]+")
+ENTITY_RE = re.compile(r"기관\s*[-_]?\s*([A-Za-z0-9]+)", re.IGNORECASE)
+SENTENCE_RE = re.compile(r"(?<=[.!?。])\s+")
+
+
+def normalize_entity(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip())
+
+
+def compact_metadata_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFC", value).lower()
+    return re.sub(r"[^0-9a-z가-힣]+", "", normalized)
+
+
+def normalize_metadata_token(token: str) -> str:
+    token = unicodedata.normalize("NFC", token).lower().strip()
+    if re.fullmatch(r"[가-힣]+", token):
+        changed = True
+        while changed:
+            changed = False
+            for suffix in KOREAN_PARTICLE_SUFFIXES:
+                if len(token) > len(suffix) + 1 and token.endswith(suffix):
+                    token = token[: -len(suffix)]
+                    changed = True
+                    break
+    return token
+
+
+def ordered_unique(values: Iterable[str]) -> list[str]:
+    seen = set()
+    ordered = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            ordered.append(value)
+    return ordered
+
+
+def coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return ordered_unique(str(item).strip() for item in value if str(item).strip())
+
+
+def coerce_alias_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_values = re.split(r"[,;/|]", value)
+        return ordered_unique(part.strip() for part in raw_values if part.strip())
+    if isinstance(value, list):
+        return ordered_unique(str(item).strip() for item in value if str(item).strip())
+    return []
+
+
+def tokenize(text: str) -> list[str]:
+    tokens = [normalize_metadata_token(m.group(0)) for m in TOKEN_RE.finditer(text)]
+    return [t for t in tokens if t and t not in STOPWORDS]
+
+
+def sentence_split(text: str) -> list[str]:
+    parts = SENTENCE_RE.split(text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def split_long_text_unit(text: str, max_chars: int) -> list[str]:
+    if len(text) <= max_chars:
+        return [text]
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if len(lines) > 1:
+        chunks: list[str] = []
+        current: list[str] = []
+        current_len = 0
+        for line in lines:
+            if len(line) > max_chars:
+                if current:
+                    chunks.append(" ".join(current).strip())
+                    current = []
+                    current_len = 0
+                chunks.extend(split_long_text_unit(line, max_chars))
+                continue
+            next_len = current_len + len(line) + 1
+            if current and next_len > max_chars:
+                chunks.append(" ".join(current).strip())
+                current = []
+                current_len = 0
+            current.append(line)
+            current_len += len(line) + 1
+        if current:
+            chunks.append(" ".join(current).strip())
+        return chunks
+
+    words = text.split()
+    if len(words) <= 1:
+        return [text[idx : idx + max_chars].strip() for idx in range(0, len(text), max_chars)]
+
+    chunks = []
+    current = []
+    current_len = 0
+    for word in words:
+        if len(word) > max_chars:
+            if current:
+                chunks.append(" ".join(current).strip())
+                current = []
+                current_len = 0
+            chunks.extend(word[idx : idx + max_chars] for idx in range(0, len(word), max_chars))
+            continue
+        next_len = current_len + len(word) + 1
+        if current and next_len > max_chars:
+            chunks.append(" ".join(current).strip())
+            current = []
+            current_len = 0
+        current.append(word)
+        current_len += len(word) + 1
+    if current:
+        chunks.append(" ".join(current).strip())
+    return [chunk for chunk in chunks if chunk]
+
+
+def normalize_section_path(section: dict[str, Any], heading: str) -> list[str]:
+    raw_path = section.get("section_path") or section.get("path") or []
+    if isinstance(raw_path, str):
+        parts = [part.strip() for part in raw_path.split(">")]
+    elif isinstance(raw_path, list):
+        parts = [str(part).strip() for part in raw_path]
+    else:
+        parts = []
+    path = [part for part in parts if part]
+    if not path:
+        path = [heading]
+    return path

--- a/rag_verifier.py
+++ b/rag_verifier.py
@@ -52,6 +52,7 @@ from korean_lexicon import (
     TOPIC_KEYWORDS,
     VERIFICATION_INTENT_TOKENS,
 )
+from rag_text_processing import normalize_metadata_token, ordered_unique
 from text_normalize import expand_forms, normalize_text
 
 
@@ -166,11 +167,6 @@ def specific_topics(analysis: dict[str, Any]) -> list[str]:
 
 
 def verification_topics(analysis: dict[str, Any]) -> list[str]:
-    # Late-import the rag_core text/metadata utilities. They serve
-    # many non-verifier call sites (analysis path, metadata matching,
-    # claim builders) so the canonical home stays rag_core.
-    from rag_core import normalize_metadata_token, ordered_unique
-
     metadata_terms = metadata_terms_for_verification(analysis)
     keyword_terms = {
         normalize_metadata_token(keyword)
@@ -191,7 +187,6 @@ def verification_topics(analysis: dict[str, Any]) -> list[str]:
 
 
 def metadata_terms_for_verification(analysis: dict[str, Any]) -> set[str]:
-    # Late-import — see verification_topics.
     from rag_core import metadata_tokens
 
     values: list[str] = []


### PR DESCRIPTION
## Summary

- `rag_core.py`에서 텍스트 처리 primitives를 `rag_text_processing.py`로 추출
- rag_answer/verifier/retrieval/query의 late-import → module-level import 교체

## What Changed

**New file: `rag_text_processing.py`** (leaf module — stdlib + korean_lexicon만 의존)

이동된 심볼 (14개):
- `tokenize`, `sentence_split`, `split_long_text_unit`
- `normalize_entity`, `normalize_metadata_token`, `normalize_section_path`
- `ordered_unique`, `coerce_string_list`, `coerce_alias_values`
- `compact_metadata_text`
- `ENTITY_RE`, `TOKEN_RE`, `SENTENCE_RE`, `QUERY_TYPE_TOP_K_DEFAULTS`

**`rag_core.py`:** 함수 본문 제거 + `from rag_text_processing import ...` re-export 추가
**`rag_verifier.py`:** `normalize_metadata_token`, `ordered_unique` → module-level import
**`rag_answer.py`:** `sentence_split`, `tokenize`, `ordered_unique`, `compact_metadata_text` → module-level
**`rag_retrieval.py`:** `tokenize` → module-level
**`rag_query.py`:** 8개 심볼 → module-level

## Test Plan

- [x] `bash scripts/test.sh` — 930 passed, 0 failed
- [x] `make smoke` — passed
- [x] `python3 -c "import rag_text_processing; print('OK')"` — OK

## Load-bearing files

`rag_core.py` 변경 — backward-compat re-export 유지로 기존 테스트/스크립트 unbroken.

### 5b. Real-data delta


No behavior change in retrieval / verifier path. Pure structural refactor — JSON-identity guaranteed by 930 passing tests.

Closes #545