### PR TITLE
refactor: extract rag_metadata_processing.py from rag_core (C-2)

### DIFF
--- a/rag_answer.py
+++ b/rag_answer.py
@@ -52,6 +52,7 @@ from korean_lexicon import (
     METADATA_CLAIM_TOPIC_LABELS,
     METADATA_EVIDENCE_LABELS,
 )
+from rag_metadata_processing import normalize_page_span, normalize_regions
 from rag_text_processing import (
     compact_metadata_text,
     ordered_unique,
@@ -227,12 +228,6 @@ def claim_target(item: dict[str, Any]) -> str:
 
 
 def make_citation(item: dict[str, Any]) -> dict[str, Any]:
-    # Late-import region helpers — they serve many non-answer call
-    # sites in rag_core (ingestion, evidence builder, parent-section
-    # reassembly). Late-import avoids the circular rag_answer ← rag_core
-    # ← rag_answer chain via re-export.
-    from rag_core import normalize_page_span, normalize_regions
-
     citation = {
         "doc_id": item.get("doc_id", ""),
         "chunk_id": item.get("chunk_id", ""),

--- a/rag_core.py
+++ b/rag_core.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
-import difflib
 import hashlib
 import json
 import math
@@ -54,8 +53,6 @@ from korean_lexicon import (
     METADATA_CLAIM_LABELS,
     METADATA_CLAIM_TOPIC_LABELS,
     METADATA_EVIDENCE_LABELS,
-    METADATA_GENERIC_TOKENS,
-    STOPWORDS,
     TOPIC_KEYWORDS,
     VERIFICATION_INTENT_TOKENS,
 )
@@ -194,6 +191,34 @@ from rag_text_processing import (
     split_long_text_unit,
     tokenize,
 )
+# Metadata processing extracted to rag_metadata_processing (issue #557).
+# Re-exported here so existing ``from rag_core import normalize_regions``
+# call sites keep working unchanged.
+from rag_metadata_processing import (
+    WEAK_SECTION_HEADINGS,
+    STRICT_METADATA_CONFIDENCE,
+    REDUCED_METADATA_CONFIDENCE,
+    best_metadata_doc_scores,
+    best_metadata_phrase_similarity,
+    coerce_metadata_targets,
+    dedupe_metadata_matches,
+    document_has_section_structure,
+    fixed_parent_section,
+    make_metadata_match,
+    make_metadata_target,
+    match_metadata_target,
+    match_metadata_targets,
+    metadata_aliases,
+    metadata_ambiguity_details,
+    metadata_explicit_aliases,
+    metadata_filters_from_matches,
+    metadata_matches_for_stage,
+    metadata_tokens,
+    normalize_document_sections,
+    normalize_page_span,
+    normalize_regions,
+    split_section_text,
+)
 
 from rag_conversation_state import (
     AMBIGUOUS_CONFIDENCE_DELTA,
@@ -229,18 +254,6 @@ VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
 # past 3 must update this value and explain why in the PR description.
 MAX_AGENT_ITERATIONS = 3
 
-WEAK_SECTION_HEADINGS = {
-    "",
-    "본문",
-    "body",
-    "text",
-    "document",
-    "문서",
-    "문서 전체",
-    "section",
-    "section-1",
-    "section-001",
-}
 INDEX_FILENAME = "index.json"
 # M2 (#207): vectors live in a sidecar .npy so the JSON stays small and a
 # future VectorStore abstraction (#176) can swap in alternate backends
@@ -250,9 +263,6 @@ INDEX_SCHEMA_VERSION = 2
 MODEL_CACHE: dict[tuple[str, bool, str | None], Any] = {}
 
 TRACE_SCHEMA_VERSION = 1
-
-STRICT_METADATA_CONFIDENCE = 0.90
-REDUCED_METADATA_CONFIDENCE = 0.70
 
 
 @dataclass(frozen=True)
@@ -288,15 +298,6 @@ class QueryParams:
     rrf_k: int | None = None
     bm25_stopword_profile: str | None = None
     bm25_tokenizer: str | None = None
-
-
-def metadata_tokens(text: str) -> list[str]:
-    tokens = []
-    for match in TOKEN_RE.finditer(unicodedata.normalize("NFC", text)):
-        token = normalize_metadata_token(match.group(0))
-        if token and token not in STOPWORDS:
-            tokens.append(token)
-    return tokens
 
 
 def load_raw_documents(input_dir: Path) -> list[dict[str, Any]]:
@@ -390,156 +391,10 @@ def validate_chunking_options(
 
 
 
-def normalize_regions(value: Any) -> list[dict[str, Any]]:
-    if not isinstance(value, list):
-        return []
-    regions = []
-    for item in value:
-        if not isinstance(item, dict):
-            continue
-        region: dict[str, Any] = {}
-        page_number = item.get("page_number")
-        if isinstance(page_number, int):
-            region["page_number"] = page_number
-        elif page_number is None:
-            region["page_number"] = None
-        bbox = item.get("bbox")
-        if isinstance(bbox, list) and len(bbox) == 4:
-            region["bbox"] = bbox
-        elif bbox is None:
-            region["bbox"] = None
-        for key in ("source", "type", "block_id"):
-            if item.get(key) is not None:
-                region[key] = str(item.get(key))
-        if region:
-            regions.append(region)
-    return regions
-
-
-def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] | None:
-    if isinstance(value, list) and len(value) == 2:
-        try:
-            return [int(value[0]), int(value[1])]
-        except (TypeError, ValueError):
-            pass
-    page_numbers = [
-        int(region["page_number"])
-        for region in regions
-        if isinstance(region.get("page_number"), int)
-    ]
-    if not page_numbers:
-        return None
-    return [min(page_numbers), max(page_numbers)]
-
-
-def normalize_document_sections(doc: dict[str, Any]) -> list[dict[str, Any]]:
-    normalized = []
-    for idx, section in enumerate(doc.get("sections") or [], start=1):
-        heading = str(section.get("heading") or f"section-{idx}").strip()
-        text = str(section.get("text") or "").strip()
-        if not text:
-            continue
-        section_path = normalize_section_path(section, heading)
-        regions = normalize_regions(section.get("regions"))
-        page_span = normalize_page_span(section.get("page_span"), regions)
-        normalized_section = {
-            "section_id": f"{doc['doc_id']}::section-{idx:03d}",
-            "doc_id": doc["doc_id"],
-            "title": doc["title"],
-            "agency": doc.get("agency", ""),
-            "project": doc.get("project", ""),
-            "metadata": doc.get("metadata", {}),
-            "section": section_path[-1],
-            "heading": heading,
-            "section_path": section_path,
-            "text": text,
-        }
-        if regions:
-            normalized_section["regions"] = regions
-        if page_span:
-            normalized_section["page_span"] = page_span
-        normalized.append(normalized_section)
-    return normalized
-
-
-def document_has_section_structure(doc: dict[str, Any]) -> bool:
-    sections = normalize_document_sections(doc)
-    if len(sections) > 1:
-        return True
-    if not sections:
-        return False
-    section = sections[0]
-    heading = str(section.get("heading") or "").strip().lower()
-    section_path = section.get("section_path") or []
-    return len(section_path) > 1 or heading not in WEAK_SECTION_HEADINGS
-
-
 def resolve_chunking_strategy(doc: dict[str, Any], requested_strategy: str) -> str:
     if requested_strategy == "auto":
         return "section" if document_has_section_structure(doc) else "fixed"
     return requested_strategy
-
-
-def fixed_parent_section(doc: dict[str, Any], sections: list[dict[str, Any]]) -> dict[str, Any]:
-    parts = []
-    regions = []
-    for section in sections:
-        heading = str(section.get("section") or "").strip()
-        text = str(section.get("text") or "").strip()
-        regions.extend(normalize_regions(section.get("regions")))
-        if heading and heading not in WEAK_SECTION_HEADINGS:
-            parts.append(f"{heading}\n{text}")
-        else:
-            parts.append(text)
-    parent = {
-        "section_id": f"{doc['doc_id']}::section-001",
-        "doc_id": doc["doc_id"],
-        "title": doc["title"],
-        "agency": doc.get("agency", ""),
-        "project": doc.get("project", ""),
-        "metadata": doc.get("metadata", {}),
-        "section": "문서 전체",
-        "heading": "문서 전체",
-        "section_path": ["문서 전체"],
-        "text": "\n\n".join(part for part in parts if part).strip(),
-    }
-    page_span = normalize_page_span(None, regions)
-    if regions:
-        parent["regions"] = regions
-    if page_span:
-        parent["page_span"] = page_span
-    return parent
-
-
-def split_section_text(
-    text: str,
-    max_chars: int,
-    overlap_sentences: int,
-) -> list[list[str]]:
-    sentences = []
-    for sentence in sentence_split(text) or [text]:
-        sentences.extend(split_long_text_unit(sentence, max_chars))
-
-    chunks: list[list[str]] = []
-    current: list[str] = []
-    current_len = 0
-    for sentence in sentences:
-        next_len = current_len + len(sentence) + 1
-        if current and next_len > max_chars:
-            chunks.append(current)
-            overlap = current[-overlap_sentences:] if overlap_sentences else []
-            overlap_len = sum(len(s) + 1 for s in overlap)
-            if overlap and overlap_len + len(sentence) + 1 <= max_chars:
-                current = overlap
-                current_len = overlap_len
-            else:
-                current = []
-                current_len = 0
-        current.append(sentence)
-        current_len += len(sentence) + 1
-    if current:
-        chunks.append(current)
-    return chunks
 
 
 def build_chunk_records(
@@ -974,251 +829,6 @@ def metadata_targets(index: dict[str, Any]) -> list[dict[str, Any]]:
             if value:
                 targets.append(make_metadata_target(doc, field, value))
     return targets
-
-
-def make_metadata_target(doc: dict[str, Any], field: str, value: str) -> dict[str, Any]:
-    tokens = metadata_tokens(value)
-    core_tokens = [token for token in tokens if token not in METADATA_GENERIC_TOKENS]
-    explicit_aliases = metadata_explicit_aliases(doc, field)
-    return {
-        "doc_id": str(doc.get("doc_id") or ""),
-        "agency": str(doc.get("agency") or ""),
-        "project": str(doc.get("project") or ""),
-        "field": field,
-        "value": value,
-        "compact": compact_metadata_text(value),
-        "tokens": tokens,
-        "core_tokens": core_tokens,
-        "aliases": metadata_aliases(field, value, tokens, explicit_aliases),
-        "explicit_aliases": explicit_aliases,
-    }
-
-
-def metadata_explicit_aliases(doc: dict[str, Any], field: str) -> list[str]:
-    metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
-    aliases: list[str] = []
-    aliases.extend(coerce_alias_values(metadata.get(f"{field}_aliases")))
-
-    generic_aliases = metadata.get("aliases")
-    if isinstance(generic_aliases, dict):
-        aliases.extend(coerce_alias_values(generic_aliases.get(field)))
-    else:
-        aliases.extend(coerce_alias_values(generic_aliases))
-
-    return ordered_unique(aliases)
-
-
-def metadata_aliases(
-    field: str,
-    value: str,
-    tokens: list[str],
-    explicit_aliases: list[str] | None = None,
-) -> list[str]:
-    aliases = []
-    aliases.extend(explicit_aliases or [])
-    if field == "agency":
-        for token in tokens:
-            if 1 <= len(token) <= 4 and re.search(r"[a-z0-9]", token):
-                aliases.append(token)
-        compact = compact_metadata_text(value)
-        if compact.startswith("기관") and len(compact) > 2:
-            aliases.append(compact[2:])
-    return ordered_unique(aliases)
-
-
-def coerce_metadata_targets(values: list[Any]) -> list[dict[str, Any]]:
-    if not values:
-        return []
-    if isinstance(values[0], dict):
-        return values
-    return [
-        make_metadata_target(
-            {"doc_id": f"agency::{value}", "agency": str(value), "project": ""},
-            "agency",
-            str(value),
-        )
-        for value in values
-    ]
-
-
-def match_metadata_targets(query: str, targets: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    query_compact = compact_metadata_text(query)
-    query_tokens = metadata_tokens(query)
-    query_token_set = set(query_tokens)
-    matches = []
-    for target in targets:
-        match = match_metadata_target(query_compact, query_tokens, query_token_set, target)
-        if match:
-            matches.append(match)
-    return dedupe_metadata_matches(matches)
-
-
-def match_metadata_target(
-    query_compact: str,
-    query_tokens: list[str],
-    query_token_set: set[str],
-    target: dict[str, Any],
-) -> dict[str, Any] | None:
-    target_compact = target.get("compact", "")
-    target_tokens = target.get("core_tokens") or target.get("tokens") or []
-
-    if target_compact and len(target_compact) >= 2 and target_compact in query_compact:
-        return make_metadata_match(target, 1.0, "compact_contains", target_tokens)
-
-    explicit_alias_hits = []
-    for alias in target.get("explicit_aliases", []):
-        alias_compact = compact_metadata_text(str(alias))
-        alias_tokens = set(metadata_tokens(str(alias)))
-        if (
-            (alias_compact and alias_compact in query_compact)
-            or bool(alias_tokens and alias_tokens.issubset(query_token_set))
-        ):
-            explicit_alias_hits.append(str(alias))
-    if explicit_alias_hits:
-        return make_metadata_match(target, 0.92, "explicit_alias", explicit_alias_hits)
-
-    alias_hits = []
-    for alias in target.get("aliases", []):
-        alias_compact = compact_metadata_text(str(alias))
-        if alias in query_token_set or (
-            alias_compact and len(alias_compact) >= 2 and alias_compact in query_compact
-        ):
-            alias_hits.append(str(alias))
-    if alias_hits:
-        return make_metadata_match(target, 0.78, "abbreviation", alias_hits)
-
-    overlap = [token for token in target_tokens if token in query_token_set]
-    if len(overlap) >= 2:
-        overlap_ratio = len(overlap) / max(1, len(target_tokens))
-        confidence = min(0.89, 0.70 + (0.19 * overlap_ratio))
-        return make_metadata_match(target, confidence, "partial_tokens", overlap)
-    if len(overlap) == 1 and target["field"] in {"project", "title"} and len(target_tokens) <= 2:
-        if len(overlap[0]) >= 3:
-            return make_metadata_match(target, 0.72, "partial_tokens", overlap)
-
-    fuzzy_score = best_metadata_phrase_similarity(target_tokens, query_tokens)
-    if fuzzy_score >= REDUCED_METADATA_CONFIDENCE:
-        confidence = min(0.84, fuzzy_score)
-        return make_metadata_match(target, confidence, "fuzzy_similarity", target_tokens)
-
-    return None
-
-
-def best_metadata_phrase_similarity(target_tokens: list[str], query_tokens: list[str]) -> float:
-    if not target_tokens or not query_tokens:
-        return 0.0
-    target_text = "".join(target_tokens)
-    min_size = max(1, len(target_tokens) - 1)
-    max_size = min(len(query_tokens), len(target_tokens) + 1)
-    best = 0.0
-    for size in range(min_size, max_size + 1):
-        for start in range(0, len(query_tokens) - size + 1):
-            phrase = "".join(query_tokens[start : start + size])
-            best = max(best, difflib.SequenceMatcher(None, target_text, phrase).ratio())
-    return best
-
-
-def make_metadata_match(
-    target: dict[str, Any],
-    confidence: float,
-    match_type: str,
-    matched_terms: list[str],
-) -> dict[str, Any]:
-    stage = "strict" if confidence >= STRICT_METADATA_CONFIDENCE else "reduced"
-    return {
-        "doc_id": target["doc_id"],
-        "agency": target.get("agency", ""),
-        "project": target.get("project", ""),
-        "field": target["field"],
-        "value": target["value"],
-        "confidence": round(float(confidence), 3),
-        "stage": stage,
-        "match_type": match_type,
-        "matched_terms": ordered_unique(matched_terms),
-    }
-
-
-def dedupe_metadata_matches(matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    best_by_target: dict[tuple[str, str, str], dict[str, Any]] = {}
-    for match in matches:
-        key = (match["doc_id"], match["field"], match["value"])
-        current = best_by_target.get(key)
-        if current is None or match["confidence"] > current["confidence"]:
-            best_by_target[key] = match
-    return sorted(
-        best_by_target.values(),
-        key=lambda item: (item["confidence"], item["field"] == "agency"),
-        reverse=True,
-    )
-
-
-def metadata_matches_for_stage(matches: list[dict[str, Any]], stage: str) -> list[dict[str, Any]]:
-    if stage == "strict":
-        return [match for match in matches if match["confidence"] >= STRICT_METADATA_CONFIDENCE]
-    if stage == "reduced":
-        return [match for match in matches if match["confidence"] >= REDUCED_METADATA_CONFIDENCE]
-    return []
-
-
-def metadata_filters_from_matches(matches: list[dict[str, Any]]) -> dict[str, Any]:
-    if not matches:
-        return {}
-    return {
-        "doc_ids": ordered_unique(match["doc_id"] for match in matches),
-        "agencies": ordered_unique(match["agency"] for match in matches),
-        "projects": ordered_unique(match["project"] for match in matches),
-        "confidence": round(max(match["confidence"] for match in matches), 3),
-    }
-
-
-def best_metadata_doc_scores(matches: list[dict[str, Any]]) -> dict[str, float]:
-    scores: dict[str, float] = {}
-    for match in matches:
-        doc_id = match.get("doc_id", "")
-        if doc_id:
-            scores[doc_id] = max(scores.get(doc_id, 0.0), float(match["confidence"]))
-    return scores
-
-
-def metadata_ambiguity_details(matches: list[dict[str, Any]], query_type: str) -> dict[str, Any]:
-    if query_type == "comparison":
-        return {
-            "ambiguous": False,
-            "reason": "comparison_allows_multiple_targets",
-            "candidate_doc_ids": [],
-            "top_score": 0.0,
-            "confidence_delta": AMBIGUOUS_CONFIDENCE_DELTA,
-        }
-    reduced_matches = metadata_matches_for_stage(matches, "reduced")
-    if not reduced_matches:
-        return {
-            "ambiguous": False,
-            "reason": "no_reduced_candidates",
-            "candidate_doc_ids": [],
-            "top_score": 0.0,
-            "confidence_delta": AMBIGUOUS_CONFIDENCE_DELTA,
-        }
-    scores = best_metadata_doc_scores(reduced_matches)
-    if len(scores) <= 1:
-        return {
-            "ambiguous": False,
-            "reason": "single_candidate",
-            "candidate_doc_ids": list(scores.keys()),
-            "top_score": round(max(scores.values(), default=0.0), 3),
-            "confidence_delta": AMBIGUOUS_CONFIDENCE_DELTA,
-        }
-    top_score = max(scores.values())
-    close_doc_ids = [
-        doc_id for doc_id, score in scores.items() if score >= top_score - AMBIGUOUS_CONFIDENCE_DELTA
-    ]
-    ambiguous = len(close_doc_ids) > 1
-    return {
-        "ambiguous": ambiguous,
-        "reason": "close_candidate_scores" if ambiguous else "clear_top_candidate",
-        "candidate_doc_ids": close_doc_ids,
-        "top_score": round(top_score, 3),
-        "confidence_delta": AMBIGUOUS_CONFIDENCE_DELTA,
-    }
 
 
 def retrieve(

--- a/rag_metadata_processing.py
+++ b/rag_metadata_processing.py
@@ -1,0 +1,474 @@
+"""Metadata processing: targets, matching, regions, sections, and scoring.
+
+Extracted from ``rag_core.py`` (issue #557) as the second step of the
+rag_core decomposition. Owns the metadata surface that sits between the
+text-processing primitives (rag_text_processing) and the retrieval /
+answer / query layers:
+
+Public functions and constants:
+
+- :data:`WEAK_SECTION_HEADINGS` / :data:`STRICT_METADATA_CONFIDENCE` /
+  :data:`REDUCED_METADATA_CONFIDENCE` — policy constants consumed by the
+  matching and section-structure helpers.
+- :func:`metadata_tokens` — tokenise + normalise a metadata value string.
+- :func:`normalize_regions` / :func:`normalize_page_span` — citation
+  geometry normalisation (used by ingestion, rag_answer, rag_retrieval).
+- :func:`normalize_document_sections` / :func:`document_has_section_structure` /
+  :func:`fixed_parent_section` / :func:`split_section_text` — section-level
+  document structure helpers (ingestion + chunking path).
+- :func:`make_metadata_target` / :func:`metadata_explicit_aliases` /
+  :func:`metadata_aliases` — target-object constructors consumed by the
+  matching pipeline.
+- :func:`coerce_metadata_targets` / :func:`match_metadata_targets` /
+  :func:`match_metadata_target` / :func:`best_metadata_phrase_similarity` —
+  metadata entity matching.
+- :func:`make_metadata_match` / :func:`dedupe_metadata_matches` /
+  :func:`metadata_matches_for_stage` / :func:`metadata_filters_from_matches` /
+  :func:`best_metadata_doc_scores` / :func:`metadata_ambiguity_details` —
+  match result post-processing.
+
+Circular-import avoidance: all dependencies are leaves —
+``rag_text_processing`` (stdlib + korean_lexicon) and
+``rag_conversation_state`` (stdlib only). ``rag_core`` re-exports every
+public name so existing callers keep their ``from rag_core import ...``
+imports unchanged.
+
+JSON-identity guarantee: every function moves byte-for-byte from
+``rag_core``. The metadata-touching regression gates remain green.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+import unicodedata
+from typing import Any
+
+from korean_lexicon import METADATA_GENERIC_TOKENS, STOPWORDS
+from rag_conversation_state import AMBIGUOUS_CONFIDENCE_DELTA
+from rag_text_processing import (
+    TOKEN_RE,
+    coerce_alias_values,
+    compact_metadata_text,
+    normalize_metadata_token,
+    normalize_section_path,
+    ordered_unique,
+    sentence_split,
+    split_long_text_unit,
+)
+
+WEAK_SECTION_HEADINGS = {
+    "",
+    "본문",
+    "body",
+    "text",
+    "document",
+    "문서",
+    "문서 전체",
+    "section",
+    "section-1",
+    "section-001",
+}
+
+STRICT_METADATA_CONFIDENCE = 0.90
+REDUCED_METADATA_CONFIDENCE = 0.70
+
+
+def metadata_tokens(text: str) -> list[str]:
+    tokens = []
+    for match in TOKEN_RE.finditer(unicodedata.normalize("NFC", text)):
+        token = normalize_metadata_token(match.group(0))
+        if token and token not in STOPWORDS:
+            tokens.append(token)
+    return tokens
+
+
+def normalize_regions(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    regions = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        region: dict[str, Any] = {}
+        page_number = item.get("page_number")
+        if isinstance(page_number, int):
+            region["page_number"] = page_number
+        elif page_number is None:
+            region["page_number"] = None
+        bbox = item.get("bbox")
+        if isinstance(bbox, list) and len(bbox) == 4:
+            region["bbox"] = bbox
+        elif bbox is None:
+            region["bbox"] = None
+        for key in ("source", "type", "block_id"):
+            if item.get(key) is not None:
+                region[key] = str(item.get(key))
+        if region:
+            regions.append(region)
+    return regions
+
+
+def normalize_page_span(value: Any, regions: list[dict[str, Any]]) -> list[int] | None:
+    if isinstance(value, list) and len(value) == 2:
+        try:
+            return [int(value[0]), int(value[1])]
+        except (TypeError, ValueError):
+            pass
+    page_numbers = [
+        int(region["page_number"])
+        for region in regions
+        if isinstance(region.get("page_number"), int)
+    ]
+    if not page_numbers:
+        return None
+    return [min(page_numbers), max(page_numbers)]
+
+
+def normalize_document_sections(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    normalized = []
+    for idx, section in enumerate(doc.get("sections") or [], start=1):
+        heading = str(section.get("heading") or f"section-{idx}").strip()
+        text = str(section.get("text") or "").strip()
+        if not text:
+            continue
+        section_path = normalize_section_path(section, heading)
+        regions = normalize_regions(section.get("regions"))
+        page_span = normalize_page_span(section.get("page_span"), regions)
+        normalized_section = {
+            "section_id": f"{doc['doc_id']}::section-{idx:03d}",
+            "doc_id": doc["doc_id"],
+            "title": doc["title"],
+            "agency": doc.get("agency", ""),
+            "project": doc.get("project", ""),
+            "metadata": doc.get("metadata", {}),
+            "section": section_path[-1],
+            "heading": heading,
+            "section_path": section_path,
+            "text": text,
+        }
+        if regions:
+            normalized_section["regions"] = regions
+        if page_span:
+            normalized_section["page_span"] = page_span
+        normalized.append(normalized_section)
+    return normalized
+
+
+def document_has_section_structure(doc: dict[str, Any]) -> bool:
+    sections = normalize_document_sections(doc)
+    if len(sections) > 1:
+        return True
+    if not sections:
+        return False
+    section = sections[0]
+    heading = str(section.get("heading") or "").strip().lower()
+    section_path = section.get("section_path") or []
+    return len(section_path) > 1 or heading not in WEAK_SECTION_HEADINGS
+
+
+def fixed_parent_section(doc: dict[str, Any], sections: list[dict[str, Any]]) -> dict[str, Any]:
+    parts = []
+    regions = []
+    for section in sections:
+        heading = str(section.get("section") or "").strip()
+        text = str(section.get("text") or "").strip()
+        regions.extend(normalize_regions(section.get("regions")))
+        if heading and heading not in WEAK_SECTION_HEADINGS:
+            parts.append(f"{heading}\n{text}")
+        else:
+            parts.append(text)
+    parent = {
+        "section_id": f"{doc['doc_id']}::section-001",
+        "doc_id": doc["doc_id"],
+        "title": doc["title"],
+        "agency": doc.get("agency", ""),
+        "project": doc.get("project", ""),
+        "metadata": doc.get("metadata", {}),
+        "section": "문서 전체",
+        "heading": "문서 전체",
+        "section_path": ["문서 전체"],
+        "text": "\n\n".join(part for part in parts if part).strip(),
+    }
+    page_span = normalize_page_span(None, regions)
+    if regions:
+        parent["regions"] = regions
+    if page_span:
+        parent["page_span"] = page_span
+    return parent
+
+
+def split_section_text(
+    text: str,
+    max_chars: int,
+    overlap_sentences: int,
+) -> list[list[str]]:
+    sentences = []
+    for sentence in sentence_split(text) or [text]:
+        sentences.extend(split_long_text_unit(sentence, max_chars))
+
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    current_len = 0
+    for sentence in sentences:
+        next_len = current_len + len(sentence) + 1
+        if current and next_len > max_chars:
+            chunks.append(current)
+            overlap = current[-overlap_sentences:] if overlap_sentences else []
+            overlap_len = sum(len(s) + 1 for s in overlap)
+            if overlap and overlap_len + len(sentence) + 1 <= max_chars:
+                current = overlap
+                current_len = overlap_len
+            else:
+                current = []
+                current_len = 0
+        current.append(sentence)
+        current_len += len(sentence) + 1
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def make_metadata_target(doc: dict[str, Any], field: str, value: str) -> dict[str, Any]:
+    tokens = metadata_tokens(value)
+    core_tokens = [token for token in tokens if token not in METADATA_GENERIC_TOKENS]
+    explicit_aliases = metadata_explicit_aliases(doc, field)
+    return {
+        "doc_id": str(doc.get("doc_id") or ""),
+        "agency": str(doc.get("agency") or ""),
+        "project": str(doc.get("project") or ""),
+        "field": field,
+        "value": value,
+        "compact": compact_metadata_text(value),
+        "tokens": tokens,
+        "core_tokens": core_tokens,
+        "aliases": metadata_aliases(field, value, tokens, explicit_aliases),
+        "explicit_aliases": explicit_aliases,
+    }
+
+
+def metadata_explicit_aliases(doc: dict[str, Any], field: str) -> list[str]:
+    metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
+    aliases: list[str] = []
+    aliases.extend(coerce_alias_values(metadata.get(f"{field}_aliases")))
+
+    generic_aliases = metadata.get("aliases")
+    if isinstance(generic_aliases, dict):
+        aliases.extend(coerce_alias_values(generic_aliases.get(field)))
+    else:
+        aliases.extend(coerce_alias_values(generic_aliases))
+
+    return ordered_unique(aliases)
+
+
+def metadata_aliases(
+    field: str,
+    value: str,
+    tokens: list[str],
+    explicit_aliases: list[str] | None = None,
+) -> list[str]:
+    aliases = []
+    aliases.extend(explicit_aliases or [])
+    if field == "agency":
+        for token in tokens:
+            if 1 <= len(token) <= 4 and re.search(r"[a-z0-9]", token):
+                aliases.append(token)
+        compact = compact_metadata_text(value)
+        if compact.startswith("기관") and len(compact) > 2:
+            aliases.append(compact[2:])
+    return ordered_unique(aliases)
+
+
+def coerce_metadata_targets(values: list[Any]) -> list[dict[str, Any]]:
+    if not values:
+        return []
+    if isinstance(values[0], dict):
+        return values
+    return [
+        make_metadata_target(
+            {"doc_id": f"agency::{value}", "agency": str(value), "project": ""},
+            "agency",
+            str(value),
+        )
+        for value in values
+    ]
+
+
+def match_metadata_targets(query: str, targets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    query_compact = compact_metadata_text(query)
+    query_tokens = metadata_tokens(query)
+    query_token_set = set(query_tokens)
+    matches = []
+    for target in targets:
+        match = match_metadata_target(query_compact, query_tokens, query_token_set, target)
+        if match:
+            matches.append(match)
+    return dedupe_metadata_matches(matches)
+
+
+def match_metadata_target(
+    query_compact: str,
+    query_tokens: list[str],
+    query_token_set: set[str],
+    target: dict[str, Any],
+) -> dict[str, Any] | None:
+    target_compact = target.get("compact", "")
+    target_tokens = target.get("core_tokens") or target.get("tokens") or []
+
+    if target_compact and len(target_compact) >= 2 and target_compact in query_compact:
+        return make_metadata_match(target, 1.0, "compact_contains", target_tokens)
+
+    explicit_alias_hits = []
+    for alias in target.get("explicit_aliases", []):
+        alias_compact = compact_metadata_text(str(alias))
+        alias_tokens = set(metadata_tokens(str(alias)))
+        if (
+            (alias_compact and alias_compact in query_compact)
+            or bool(alias_tokens and alias_tokens.issubset(query_token_set))
+        ):
+            explicit_alias_hits.append(str(alias))
+    if explicit_alias_hits:
+        return make_metadata_match(target, 0.92, "explicit_alias", explicit_alias_hits)
+
+    alias_hits = []
+    for alias in target.get("aliases", []):
+        alias_compact = compact_metadata_text(str(alias))
+        if alias in query_token_set or (
+            alias_compact and len(alias_compact) >= 2 and alias_compact in query_compact
+        ):
+            alias_hits.append(str(alias))
+    if alias_hits:
+        return make_metadata_match(target, 0.78, "abbreviation", alias_hits)
+
+    overlap = [token for token in target_tokens if token in query_token_set]
+    if len(overlap) >= 2:
+        overlap_ratio = len(overlap) / max(1, len(target_tokens))
+        confidence = min(0.89, 0.70 + (0.19 * overlap_ratio))
+        return make_metadata_match(target, confidence, "partial_tokens", overlap)
+    if len(overlap) == 1 and target["field"] in {"project", "title"} and len(target_tokens) <= 2:
+        if len(overlap[0]) >= 3:
+            return make_metadata_match(target, 0.72, "partial_tokens", overlap)
+
+    fuzzy_score = best_metadata_phrase_similarity(target_tokens, query_tokens)
+    if fuzzy_score >= REDUCED_METADATA_CONFIDENCE:
+        confidence = min(0.84, fuzzy_score)
+        return make_metadata_match(target, confidence, "fuzzy_similarity", target_tokens)
+
+    return None
+
+
+def best_metadata_phrase_similarity(target_tokens: list[str], query_tokens: list[str]) -> float:
+    if not target_tokens or not query_tokens:
+        return 0.0
+    target_text = "".join(target_tokens)
+    min_size = max(1, len(target_tokens) - 1)
+    max_size = min(len(query_tokens), len(target_tokens) + 1)
+    best = 0.0
+    for size in range(min_size, max_size + 1):
+        for start in range(0, len(query_tokens) - size + 1):
+            phrase = "".join(query_tokens[start : start + size])
+            best = max(best, difflib.SequenceMatcher(None, target_text, phrase).ratio())
+    return best
+
+
+def make_metadata_match(
+    target: dict[str, Any],
+    confidence: float,
+    match_type: str,
+    matched_terms: list[str],
+) -> dict[str, Any]:
+    stage = "strict" if confidence >= STRICT_METADATA_CONFIDENCE else "reduced"
+    return {
+        "doc_id": target["doc_id"],
+        "agency": target.get("agency", ""),
+        "project": target.get("project", ""),
+        "field": target["field"],
+        "value": target["value"],
+        "confidence": round(float(confidence), 3),
+        "stage": stage,
+        "match_type": match_type,
+        "matched_terms": ordered_unique(matched_terms),
+    }
+
+
+def dedupe_metadata_matches(matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    best_by_target: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for match in matches:
+        key = (match["doc_id"], match["field"], match["value"])
+        current = best_by_target.get(key)
+        if current is None or match["confidence"] > current["confidence"]:
+            best_by_target[key] = match
+    return sorted(
+        best_by_target.values(),
+        key=lambda item: (item["confidence"], item["field"] == "agency"),
+        reverse=True,
+    )
+
+
+def metadata_matches_for_stage(matches: list[dict[str, Any]], stage: str) -> list[dict[str, Any]]:
+    if stage == "strict":
+        return [match for match in matches if match["confidence"] >= STRICT_METADATA_CONFIDENCE]
+    if stage == "reduced":
+        return [match for match in matches if match["confidence"] >= REDUCED_METADATA_CONFIDENCE]
+    return []
+
+
+def metadata_filters_from_matches(matches: list[dict[str, Any]]) -> dict[str, Any]:
+    if not matches:
+        return {}
+    return {
+        "doc_ids": ordered_unique(match["doc_id"] for match in matches),
+        "agencies": ordered_unique(match["agency"] for match in matches),
+        "projects": ordered_unique(match["project"] for match in matches),
+        "confidence": round(max(match["confidence"] for match in matches), 3),
+    }
+
+
+def best_metadata_doc_scores(matches: list[dict[str, Any]]) -> dict[str, float]:
+    scores: dict[str, float] = {}
+    for match in matches:
+        doc_id = match.get("doc_id", "")
+        if doc_id:
+            scores[doc_id] = max(scores.get(doc_id, 0.0), float(match["confidence"]))
+    return scores
+
+
+def metadata_ambiguity_details(matches: list[dict[str, Any]], query_type: str) -> dict[str, Any]:
+    if query_type == "comparison":
+        return {
+            "ambiguous": False,
+            "reason": "comparison_allows_multiple_targets",
+            "candidate_doc_ids": [],
+            "top_score": 0.0,
+            "confidence_delta": AMBIGUOUS_CONFIDENCE_DELTA,
+        }
+    reduced_matches = metadata_matches_for_stage(matches, "reduced")
+    if not reduced_matches:
+        return {
+            "ambiguous": False,
+            "reason": "no_reduced_candidates",
+            "candidate_doc_ids": [],
+            "top_score": 0.0,
+            "confidence_delta": AMBIGUOUS_CONFIDENCE_DELTA,
+        }
+    scores = best_metadata_doc_scores(reduced_matches)
+    if len(scores) <= 1:
+        return {
+            "ambiguous": False,
+            "reason": "single_candidate",
+            "candidate_doc_ids": list(scores.keys()),
+            "top_score": round(max(scores.values(), default=0.0), 3),
+            "confidence_delta": AMBIGUOUS_CONFIDENCE_DELTA,
+        }
+    top_score = max(scores.values())
+    close_doc_ids = [
+        doc_id for doc_id, score in scores.items() if score >= top_score - AMBIGUOUS_CONFIDENCE_DELTA
+    ]
+    ambiguous = len(close_doc_ids) > 1
+    return {
+        "ambiguous": ambiguous,
+        "reason": "close_candidate_scores" if ambiguous else "clear_top_candidate",
+        "candidate_doc_ids": close_doc_ids,
+        "top_score": round(top_score, 3),
+        "confidence_delta": AMBIGUOUS_CONFIDENCE_DELTA,
+    }

--- a/rag_query.py
+++ b/rag_query.py
@@ -75,6 +75,16 @@ from rag_pipeline_presets import (
     VALID_RETRIEVAL_MODES,
     VALID_RRF_K_RANGE,
 )
+from rag_metadata_processing import (
+    best_metadata_doc_scores,
+    coerce_metadata_targets,
+    dedupe_metadata_matches,
+    match_metadata_targets,
+    metadata_ambiguity_details,
+    metadata_filters_from_matches,
+    metadata_matches_for_stage,
+    metadata_tokens,
+)
 from rag_text_processing import (
     ENTITY_RE,
     QUERY_TYPE_TOP_K_DEFAULTS,
@@ -89,8 +99,6 @@ from text_normalize import normalize_text
 
 
 def is_metadata_ambiguous(matches: list[dict[str, Any]], query_type: str) -> bool:
-    from rag_core import metadata_ambiguity_details
-
     return bool(metadata_ambiguity_details(matches, query_type).get("ambiguous"))
 
 
@@ -292,16 +300,6 @@ def analyze_query(
     entities: list[Any],
     context_entities: list[str] | None = None,
 ) -> dict[str, Any]:
-    from rag_core import (
-        best_metadata_doc_scores,
-        coerce_metadata_targets,
-        dedupe_metadata_matches,
-        match_metadata_targets,
-        metadata_ambiguity_details,
-        metadata_filters_from_matches,
-        metadata_matches_for_stage,
-    )
-
     targets = coerce_metadata_targets(entities)
     normalized_query = normalize_entity(query)
     requested_agencies = extract_requested_agencies(normalized_query)
@@ -433,8 +431,6 @@ def metadata_resolution_diagnostics(
     decision: str | None = None,
     reason: str = "",
 ) -> dict[str, Any]:
-    from rag_core import metadata_matches_for_stage, metadata_tokens
-
     matches = list(analysis.get("metadata_matches") or [])
     selected_by_stage: dict[str, list[dict[str, Any]]] = {}
     for stage in ("strict", "reduced"):

--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -62,6 +62,7 @@ from typing import Any, Iterable
 import numpy as np
 
 from korean_lexicon import BM25_EXTRA_PARTICLE_SUFFIXES, BM25_EXTRA_STOPWORDS
+from rag_metadata_processing import normalize_page_span, normalize_regions
 from rag_pipeline_presets import RRF_K, VALID_BM25_STOPWORD_PROFILES
 from rag_query_expansion import default_expander
 from rag_text_processing import tokenize
@@ -238,12 +239,6 @@ def reassemble_parent_sections(
     plan: dict[str, Any],
     analysis: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    # Late-import to avoid circular dependency: rag_core uses
-    # normalize_regions / normalize_page_span in many non-retrieval
-    # call sites (ingestion path, evidence building, ...), so they
-    # stay in rag_core.
-    from rag_core import normalize_regions, normalize_page_span
-
     parent_by_id = {
         str(section.get("section_id")): section
         for section in index.get("parent_sections", [])
@@ -307,12 +302,6 @@ def retrieve_candidates(
     multi-query / HyDE work can fan out this phase without piling onto
     the fusion+rerank tail. Mutates ``plan`` with ``candidate_count``,
     ``total_chunks``, ``filter_fallback_used`` (unchanged order)."""
-    # Late-import region helpers — they serve many non-retrieval call
-    # sites in rag_core (ingestion, evidence builder, partial-topic
-    # grounding) so they stay there. Late-import avoids the circular
-    # ``rag_retrieval ← rag_core ← rag_retrieval`` chain.
-    from rag_core import normalize_page_span, normalize_regions
-
     chunks = index["chunks"]
     filters = plan.get("metadata_filters") or {}
     doc_ids = set(filters.get("doc_ids") or [])

--- a/rag_verifier.py
+++ b/rag_verifier.py
@@ -52,6 +52,7 @@ from korean_lexicon import (
     TOPIC_KEYWORDS,
     VERIFICATION_INTENT_TOKENS,
 )
+from rag_metadata_processing import metadata_tokens
 from rag_text_processing import normalize_metadata_token, ordered_unique
 from text_normalize import expand_forms, normalize_text
 
@@ -187,8 +188,6 @@ def verification_topics(analysis: dict[str, Any]) -> list[str]:
 
 
 def metadata_terms_for_verification(analysis: dict[str, Any]) -> set[str]:
-    from rag_core import metadata_tokens
-
     values: list[str] = []
     for key in ("entities", "matched_agencies", "matched_projects", "context_entities"):
         values.extend(str(value) for value in analysis.get(key) or [])


### PR DESCRIPTION
## Summary

rag_core 분해 plan 의 Track C-2. `rag_core.py` 에서 23 metadata-processing symbol 을 신규 leaf 모듈 `rag_metadata_processing.py` 로 추출.

Closes #557

## Changes

- **신규**: `rag_metadata_processing.py` — `rag_core.py` 에서 추출한 23 symbol
  - Constants: `WEAK_SECTION_HEADINGS`, `STRICT_METADATA_CONFIDENCE`, `REDUCED_METADATA_CONFIDENCE`
  - Functions: `metadata_tokens`, `normalize_regions`, `normalize_page_span`, `normalize_document_sections`, `document_has_section_structure`, `fixed_parent_section`, `split_section_text`, `make_metadata_target`, `metadata_explicit_aliases`, `metadata_aliases`, `coerce_metadata_targets`, `match_metadata_targets`, `match_metadata_target`, `best_metadata_phrase_similarity`, `make_metadata_match`, `dedupe_metadata_matches`, `metadata_matches_for_stage`, `metadata_filters_from_matches`, `best_metadata_doc_scores`, `metadata_ambiguity_details`
- **수정**: `rag_core.py` — 함수 본문 제거; re-export 블록 추가; 미사용 `difflib`, `STOPWORDS`, `METADATA_GENERIC_TOKENS` import 제거
- **수정**: `rag_verifier.py` — late-import `metadata_tokens` → module-level `from rag_metadata_processing import metadata_tokens`
- **수정**: `rag_retrieval.py` — late-import `normalize_regions, normalize_page_span` → module-level
- **수정**: `rag_answer.py` — late-import `normalize_regions, normalize_page_span` → module-level
- **수정**: `rag_query.py` — 8-symbol late-import 블록 → module-level `from rag_metadata_processing import (...)`

## 동기

`rag_metadata_processing` 은 순수 leaf: `rag_text_processing` (leaf), `rag_conversation_state` (leaf), stdlib 에서만 import. 4 downstream 모듈의 late-import 를 module-level import 로 전환하여 이 영역의 주요 구조적 부채인 순환-import 회피책 제거.

## Test plan

- [x] `bash scripts/test.sh` — 930 passed
- [x] `make smoke` — passed

## PR template items

1. **Issue**: Closes #557
2. **ADR**: N/A — 순수 code motion, 동작 변경 없음
3. **Backward compat**: `rag_core` 가 23 이름 전부 re-export; 기존 `from rag_core import X` 호출자 미변경
4. **Load-bearing files changed**: `rag_core.py` 수정 — 함수 본문 제거, 동작 identical
5. **Real-data delta**: N/A — re-export 로 JSON-identity 보장; 930 테스트 pass
5b. **Item 5b**: N/A — retrieval/answer/eval 동작 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
