### PR TITLE
fix(test): skip senior-positioning governance tests when file absent

### DIFF
--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -339,6 +339,7 @@ def _adr_statuses() -> dict[str, str]:
     return result
 
 
+@pytest.mark.skipif(not _SENIOR_POS_PATH.exists(), reason="senior-positioning.md moved to portfolio repo")
 def test_senior_positioning_count_label_matches_adr_files():
     text = _SENIOR_POS_PATH.read_text()
     label_values = {int(n) for n in _SENIOR_POS_COUNT_RE.findall(text)}
@@ -355,6 +356,7 @@ def test_senior_positioning_count_label_matches_adr_files():
     )
 
 
+@pytest.mark.skipif(not _SENIOR_POS_PATH.exists(), reason="senior-positioning.md moved to portfolio repo")
 def test_senior_positioning_status_breakdown_matches_adr_files():
     text = _SENIOR_POS_PATH.read_text()
     m = _SENIOR_POS_STATUS_LABEL_RE.search(text)
@@ -378,6 +380,7 @@ def test_senior_positioning_status_breakdown_matches_adr_files():
     )
 
 
+@pytest.mark.skipif(not _SENIOR_POS_PATH.exists(), reason="senior-positioning.md moved to portfolio repo")
 def test_senior_positioning_table_rows_match_adr_files():
     text = _SENIOR_POS_PATH.read_text()
     rows = _SENIOR_POS_ROW_RE.findall(text)


### PR DESCRIPTION
## Summary

`docs/senior-positioning.md` 가 #565 에서 `BidMate-DocAgent-portfolio` 비공개 repo 로 이동. 이를 가드하던 G6 거버넌스 테스트 3개가 `FileNotFoundError` 로 실패.

Closes #567

## Change

`tests/test_governance.py` 의 `test_senior_positioning_*` 함수 3개에 `@pytest.mark.skipif(not _SENIOR_POS_PATH.exists(), ...)` 추가.

## Test plan

- [x] `pytest -k test_senior_positioning` — 3 테스트 skip (이전: 3 FAILED)
- [x] Full suite: 933 passed, 8 skipped

Generated with [Claude Code](https://claude.com/claude-code)
