### PR TITLE
fix(hooks): use mktemp for TEST_SUMMARY_PATH to prevent concurrent-worktree collision

### DIFF
--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -20,7 +20,7 @@ ARMED_FILE=".claude/.ship-armed"
 PID_FILE=".claude/.ship-running.pid"
 HISTORY_LOG=".claude/.ship-history.log"
 DRYRUN_LOG=".claude/.ship-dryrun.log"
-TEST_SUMMARY_PATH="/tmp/ship-test-summary.txt"
+TEST_SUMMARY_PATH="$(mktemp /tmp/ship-test-summary.XXXXXX)"
 
 DRY_RUN=0
 ARM_BRANCH=""
@@ -140,6 +140,7 @@ acquire_lock() {
 
 release_lock() {
   rm -f "$PID_FILE"
+  rm -f "$TEST_SUMMARY_PATH"
 }
 
 abort_disarm() {


### PR DESCRIPTION
## Summary

- `stop-ship.sh` 의 `TEST_SUMMARY_PATH="/tmp/ship-test-summary.txt"` 하드코딩 — auto-ship 파이프라인 동시 실행 두 worktree 가 서로의 테스트 출력 덮어씀
- 같은 스크립트의 `body_file` + `commit_body_file` 는 이미 `mktemp` 사용; 이것이 유일한 잔여 하드코딩 temp 경로
- `mktemp /tmp/ship-test-summary.XXXXXX` 로 전환 + `release_lock` (`trap ... EXIT` trigger) 에서 cleanup — 성공/abort 양쪽에서 파일 제거

Closes #548

## Change

`scripts/claude-hooks/stop-ship.sh` — 2 라인:
- Line 23: 하드코딩 경로 대신 `mktemp`
- Line 142: `release_lock` 에 `rm -f "$TEST_SUMMARY_PATH"`

## Test Plan

- [x] `bash scripts/test.sh` — 전부 pass (테스트 로직 동작 변경 없음)
- [x] `body_file`/`commit_body_file` 가 이미 `mktemp` 사용 확인 — 이 패치가 패턴 완성

## Load-bearing files

`scripts/claude-hooks/stop-ship.sh` 는 `LOAD_BEARING_PATHS` 미포함.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. Hook 인프라만.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
