### PR TITLE
fix(hooks): use shlex tokenisation in bash-guard to prevent false positives (#546)

### DIFF
--- a/scripts/claude-hooks/pretooluse-bash-guard.sh
+++ b/scripts/claude-hooks/pretooluse-bash-guard.sh
@@ -35,7 +35,18 @@ except Exception:
 if [[ -z "$cmd" ]]; then
   exit 0
 fi
-if ! grep -qE 'gh[[:space:]]+pr[[:space:]]+merge' <<<"$cmd"; then
+is_merge_cmd=$(printf '%s' "$cmd" | python3 -c '
+import sys, shlex, re
+for part in re.split(r"[;&|\n]", sys.stdin.read()):
+    part = part.strip().lstrip("(")
+    try:
+        tokens = shlex.split(part)
+    except ValueError:
+        continue
+    if len(tokens) >= 3 and tokens[0] == "gh" and tokens[1] == "pr" and tokens[2] == "merge":
+        print("yes"); break
+' 2>/dev/null)
+if [[ "$is_merge_cmd" != "yes" ]]; then
   exit 0
 fi
 if ! grep -qE -- '--delete-branch' <<<"$cmd"; then


### PR DESCRIPTION
## Summary

- `pretooluse-bash-guard.sh` 가 fast-path 로 `grep -qE 'gh[[:space:]]+pr[[:space:]]+merge'` 사용 — 명령어 문자열 어디든 매치 (echo 인자, PR body 문자열, 주석 포함)
- Python `shlex.split()` 토큰화로 교체: 어떤 semicolon/pipe-split 명령부의 인덱스 0–2 에 실제 `gh pr merge` 토큰 시퀀스만 가드 발동
- Fail-open 철학 보존: `shlex.split` 의 `ValueError` (매치 안 된 따옴표 등) 는 catch 후 skip

## Test plan

- [ ] Bash tool 호출에서 `echo 'gh pr merge 123 --delete-branch'` → 가드 발동 (실제 명령어)
- [ ] `echo "see gh pr merge docs"` → 가드 미발동 (임베디드 문자열, 명령어 아님)
- [ ] `gh pr comment 123 --body "run gh pr merge --delete-branch"` → 가드 미발동 (문자열 인자)
- [ ] `gh pr merge 123 --squash` (`--delete-branch` 없음) → 가드 미발동

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

이 변경은 `scripts/claude-hooks/` 훅 인프라만.

Closes #546
