### PR TITLE
fix(hooks): remove dead merge_mode field from auto-ship armed schema (#547)

### DIFF
--- a/scripts/claude-hooks/_ship_arm.py
+++ b/scripts/claude-hooks/_ship_arm.py
@@ -93,7 +93,6 @@ def main() -> int:
         "issue": issue,
         "armed_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "expires_at": expires.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "merge_mode": "squash-admin",
         "real_eval_mode": args.real_eval,
         "draft": args.draft,
         "dry_run": int(args.dry_run) if args.dry_run.isdigit() else 0,

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -46,7 +46,7 @@ gate_0_parse_armed_file() {
 import json, sys
 try:
     d = json.load(open(sys.argv[1]))
-    for k in ("branch", "expires_at", "merge_mode", "real_eval_mode"):
+    for k in ("branch", "expires_at", "real_eval_mode"):
         if k not in d:
             print(f"missing:{k}"); sys.exit(1)
     print(d["branch"])


### PR DESCRIPTION
## Summary

- `_ship_arm.py` 가 `.claude/.ship-armed` 에 `"merge_mode": "squash-admin"` 을 상수 필드로 write
- `stop-ship.sh` 의 `gate_0_parse_armed_file` 이 `merge_mode` 를 required-keys 체크에 포함하지만 **value 를 읽지 않음** — merge 전략은 `stage_5_merge` 에서 `--squash --admin` 으로 직접 하드코딩
- writer (`_ship_arm.py`) + required-keys 목록 (`stop-ship.sh`) 양쪽에서 필드 제거 → dead schema 해소

## Changes

- `scripts/claude-hooks/_ship_arm.py`: `state` dict 에서 `"merge_mode": "squash-admin"` 제거
- `scripts/claude-hooks/stop-ship.sh`: `gate_0_parse_armed_file` required-keys tuple 에서 `"merge_mode"` 제거

## Test plan

- [ ] `make ship-arm --dry-run` → `.claude/.ship-armed` 에 `merge_mode` 키 없음
- [ ] `merge_mode` 없는 armed 파일이 `gate_0_parse_armed_file` 통과 (키 미요구)
- [ ] 변경 전 작성된 기존 armed 파일 (merge_mode 존재) 도 정상 parse (extra 키는 `d.get(...)` 호출에서 무시)

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

`scripts/claude-hooks/` 훅 인프라만 변경.

Closes #547

Generated with [Claude Code](https://claude.com/claude-code)
