### PR TITLE
docs+chore: README 3줄 elevator pitch + bash-guard block fire log

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
      To re-enable: uncomment the line below once docs/assets/demo.gif exists. -->
 <!-- ![BidMate-DocAgent live demo (60-90 s walkthrough)](docs/assets/demo.gif) -->
 
-> 일반 영어 LLM 벤치(KMMLU/MMLU) 점수 경쟁이 아닌 **한국어 RFP 도메인-특화 RAG**입니다. 차별화는 세 축: 비교 질의에서 한쪽 문서 starvation을 막는 [comparison-aware balanced top-k](#key-technical-contribution--comparison-aware-balanced-top-k), 의미 유사도 단독의 함정을 회피하는 metadata-first retrieval([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), hallucination을 구조적으로 차단하는 extractive grounded-answer 답변 계약([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)). 측정은 공개 합성 + 비공개 real-data + KorQuAD 2.1 한국어 공개셋으로 분리([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0018](docs/adr/0018-korean-public-rag-bench.md)) — silent regression이 한 표면에서 다른 표면으로 새지 않도록 설계됐습니다.
+> 한국 공공·B2B 입찰 RFP에서 비교·요건 추출 질의를 **근거 있는 답변**으로 돌려주는 한국어 도메인 특화 RAG — 외부 LLM 호출 없이 extractive grounding으로 hallucination을 구조적으로 차단.
+> **차별점**: 비교 질의에서 두 기관 문서를 균등 인용하는 [comparison-aware balanced retrieval](#key-technical-contribution--comparison-aware-balanced-top-k), metadata-first 검색([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), 근거 부족 시 abstention 명시([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
+> **측정**: accuracy 0.62 ± 0.09, citation_precision 0.84 ± 0.05 (95% CI, n=42) — 공개 합성 + 비공개 real-data 분리 평가([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 33개 설계 결정(ADR).
 
 ### 🎬 5초 비주얼 훅 — 실제 `comparison` 질의 한 건 (extractive, no LLM)
 

--- a/scripts/claude-hooks/pretooluse-bash-guard.sh
+++ b/scripts/claude-hooks/pretooluse-bash-guard.sh
@@ -22,6 +22,8 @@
 
 set -u
 
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
 input=$(cat)
 
 cmd=$(printf '%s' "$input" | python3 -c 'import json,sys
@@ -82,6 +84,9 @@ try:
         print(f"      PR #{p[\"number\"]} — {p[\"title\"]} (head: {p[\"headRefName\"]})")
 except Exception:
     pass' 2>/dev/null)
+
+printf '%s|blocked|gh-merge-delete-branch|%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$head_branch" \
+  >> "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
 
 cat >&2 <<EOF
 ⛔ Refusing \`gh pr merge --delete-branch\`: stacked dependents exist on \`$head_branch\`.


### PR DESCRIPTION
## 1. 변경 요약

포트폴리오 채용 무기화 4층 framework (issue #575) 중 두 갭 해소.

## 2. 변경 상세

### README.md — 30초 후킹층 (A층) 개선

기존 한 단락짜리 기술 blockquote → 3줄 elevator pitch:
- **무엇**: 한국 공공·B2B 입찰 RFP → grounded answer, 외부 LLM 없이
- **차별점**: comparison-aware balanced retrieval + metadata-first + abstention 명시
- **측정**: accuracy 0.62 ± 0.09, citation_precision 0.84 ± 0.05 (95% CI, n=42), 33 ADR

기존 내용은 아래 섹션(🎬 비주얼 훅, Why extractive, Key technical contribution 등)에서 커버됨.

### scripts/claude-hooks/pretooluse-bash-guard.sh — D층 자동화 ROI 정량화

- `REPO_ROOT` 변수 추가 (pretooluse-loadbearing.sh 패턴 동일)
- `gh pr merge --delete-branch` 차단 시 `.claude/.hook-fires.log`에 기록:
  `timestamp|blocked|gh-merge-delete-branch|branch_name`
- Q3-2026 `/self-review-quarterly` 5축 #3(자동화 ROI) evidence 수집용

## 3. 테스트 / 검증

- [ ] README 변경: GitHub UI 렌더링 확인 (3줄이 뱃지 아래 바로 보이는지)
- [ ] bash-guard: `echo '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 1 --delete-branch"}}' | bash scripts/claude-hooks/pretooluse-bash-guard.sh` — exit 2 + log 기록 확인

## 4. 영향 범위

- load-bearing 파일 변경 없음 → real-data delta N/A
- 기존 CI eval 무영향 (README 텍스트, bash hook 추가 log만)
- `.hook-fires.log`는 `.gitignore`의 `.claude/*` 패턴으로 비추적

## 5. ADR 관련

- 해당 없음 (ADR threshold 미달 — docs surface + hook log line)

## 5b. Real-data delta

N/A — 파이프라인 코드 변경 없음.

Closes #575