### PR TITLE
docs: restore private-100-doc-experiments.md (broken link fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 | 설계 배경 (Korean RFP adaptations, 5가지) | [`docs/design-background.md`](docs/design-background.md) |
 | 답변 출력 정책 + Evidence boundary + Baseline policy | [`docs/answer-policy.md`](docs/answer-policy.md) |
 | 한계 + 회고 + 실패 사례 | [`docs/failure-cases.md`](docs/failure-cases.md) / [`docs/retrospective.md`](docs/retrospective.md) |
+| 공개 평가셋 상세 spec (n=42, 7-doc corpus, 방법론) | [`docs/eval-dataset-spec.md`](docs/eval-dataset-spec.md) |
+| 비공개 100-doc aggregate 정책 + placeholder | [`docs/private-100-doc-experiments.md`](docs/private-100-doc-experiments.md) |
 | 엔지니어링 블로그 (GitHub Pages) | [hskim-solv.github.io/BidMate-DocAgent](https://hskim-solv.github.io/BidMate-DocAgent/) |
 | 전체 문서 인덱스 | [`docs/README.md`](docs/README.md) |
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 - **문제**: 길고 복잡한 RFP 문서에서 실무 의사결정에 필요한 핵심 조건(예산/일정/요구사항/제출조건)을 빠르게 찾기 어렵습니다.
 - **해결**: 질문 유형 분석 + metadata-first 검색 + local dense retrieval/reranking + 근거 검증/retry를 결합한 Agentic RAG 파이프라인.
 - **시스템 설계**: 외부 LLM 호출 없이 evidence에서 claim을 추출하고 citation을 연결하는 **extractive grounded-answer 파이프라인** ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
-- **성과**: 공개 synthetic 평가셋 **n=42** (single_doc 14 / comparison 10 / follow_up 9 / abstention 9) 기준 근거 기반 응답 품질 검증. Abstention **+77.8pp** / Citation Precision **+39.3pp** (CI 분리, 통계적으로 유의).
+- **성과**: 공개 synthetic 평가셋 **n=42** (single_doc 14 / comparison 10 / follow_up 9 / abstention 9) 기준 근거 기반 응답 품질 검증. Abstention **+77.8pp** / Citation Precision **+39.3pp** (CI 분리, 통계적으로 유의). [평가셋 상세 spec](docs/eval-dataset-spec.md)
 - **Latency** (naive_baseline, hashing, macOS CPU, n=42): p50 1.9ms / p95 5.9ms.
 
 ---
@@ -99,7 +99,7 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 - **측정 범위**: `Latency p95` 컬럼은 query_analysis + context_resolution + answer_generation 합의 walltime. retrieve/verify stage는 `reports/eval_summary.json`의 `stage_latency` 블록.
 - **실행 환경**: macOS / CPU-only / Python 3.11 / 단일 워커.
 - **Cold start 분리**: hashing ≈ 2.1ms / sentence-transformers ≈ 5.7s.
-- **평가셋**: 공개 synthetic n=42 (single_doc 14 / comparison 10 / follow_up 9 / abstention 9). 비공개 RFP eval은 [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)에 따라 분리합니다.
+- **평가셋**: 공개 synthetic n=42 (single_doc 14 / comparison 10 / follow_up 9 / abstention 9). 비공개 RFP eval은 [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)에 따라 분리합니다. 평가셋 구성 상세: [docs/eval-dataset-spec.md](docs/eval-dataset-spec.md)
 - **헤드라인 latency 기준 preset**: naive_baseline Latency p95 (5.9ms)가 CI source of truth. `agentic_full_llm`은 LLM 레이턴시 포함해 환경 의존적이므로 CI 고정 대상 아님.
 - **`agentic_full_llm` 백엔드 구분**: ablation 표의 `full_llm` 행은 `BIDMATE_SYNTHESIS_BACKEND=stub`(token-less, deterministic; [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md)) 기준. stub은 pass-through 합성이라 `full`과 동일 metric이 *정상*.
 - **Rerank 종류 구분**: `Rerank on` 행 대부분은 weighted-score rerank. `full_reranker`만 cross-encoder rerank([rag_rerank.py](rag_rerank.py)) — CI default `stub`이라 `full`과 수치 일치.

--- a/docs/eval-dataset-spec.md
+++ b/docs/eval-dataset-spec.md
@@ -1,0 +1,179 @@
+# Eval Dataset Spec — Public Synthetic RFP Surface
+
+공개 합성 평가셋의 구성, 평가 방법론, 재현 절차를 담은 reviewer-facing 명세서입니다.
+
+- **평가셋 분리 정책**: [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md)
+- **비공개 100-doc 집계**: [`docs/private-100-doc-experiments.md`](private-100-doc-experiments.md) (별도 문서)
+
+---
+
+## 1. Corpus
+
+### 문서 구성 (7개 합성 RFP 문서)
+
+| Doc ID | 기관 | 도메인 | 용도 | sections |
+|---|---|---|---:|---:|
+| rfp-agency-a-ai-quality | 기관 A | AI 품질관리 | 표준 단일문서 / 비교 | 4 |
+| rfp-agency-b-mlops-governance | 기관 B | MLOps 자동화 | 표준 단일문서 / 비교 | 4 |
+| rfp-agency-c-chatbot | 기관 C | 고객지원 챗봇 | 표준 단일문서 / 비교 | 3 |
+| rfp-agency-d-spectrometer-probe | 기관 D | 분광기 시스템 | chunk-boundary probe | 3 |
+| rfp-agency-e-water-quality-main | 기관 E (본) | 수질 모니터링 | single-turn ambiguity probe | 2 |
+| rfp-agency-e-water-quality-supplement | 기관 E (부속) | 수질 모니터링 | multi-doc follow-up probe | 2 |
+| rfp-common-submission | 공통 | 제출조건·산출물 | 공통 참조 문서 | 2 |
+
+**합성 사유**: 한국 공공기관 발주 RFP의 실제 구조(추진목표 / 일정 / 예산 / 요구사항 / 제출조건)를 그대로 모방하되, 기관명·금액·일정을 익명 처리한 합성 문서. 원본 RFP 데이터는 저작권·계약 제약으로 저장소에 포함하지 않음 (ADR 0005).
+
+**도메인 특성**: 한국어 기관명 약칭(기관명 음운변화 포함) + alias-entity 패턴이 포함되어 있어, 형태소 분석 기반 lexical matcher와 metadata-first retrieval 모두 실전 조건에 노출됨.
+
+---
+
+## 2. Queries (n=42)
+
+> **`eval/config.yaml` 기준 n=42**. `eval/dev_queries_v1.jsonl` (44-line source)과 포맷이 다르며, jsonl은 human-readable 설계 문서 역할. 두 파일의 case 수 차이는 config의 `prior_turns` 방식 직렬화 때문.
+
+### 카테고리 분포
+
+| Category | n | 설명 |
+|---|---:|---|
+| `single_doc` | 14 | 단일 RFP 문서에서 항목(예산·일정·요구사항) 추출 |
+| `comparison` | 10 | 두 기관 RFP의 특정 항목을 직접 비교 |
+| `follow_up` | 9 | 선행 질의의 문맥을 이어받아 세부 범위를 재질의 |
+| `abstention` | 9 | 문서 내 관련 내용 없음 → `insufficient` 응답 기대 |
+| **합계** | **42** | |
+
+### Hardcase 태그 분포
+
+| Tag | count | 의미 |
+|---|---:|---|
+| `retrieval_hardening` | 5 | 표제어·키워드 없이 의미만으로 검색해야 하는 케이스 |
+| `one_sided_comparison` | 3 | 한쪽 기관에만 항목이 있어 비교 시 half-answer 위험 |
+| `ambiguous_follow_up` | 3 | 선행 문맥 없이 재질의만 보면 대상 기관이 불분명 |
+| `chunk_boundary` | 3 | 핵심 정보가 섹션 경계에 걸려있어 parent-reassembly 필요 |
+| `alias_entity` | 2 | 기관 약칭·alias로만 질의 — metadata normalization 필수 |
+| `noisy_entity` | 1 | 음운변화/오타 포함 질의 |
+| `partial_comparison` | 1 | 비교 항목 중 일부만 존재 — partial-grounding 판단 |
+| `answer_schema_v2` | 1 | ADR 0003 `schema_version: 2` 필드 준수 검증 케이스 |
+| `follow_up_context` | 1 | `prior_turns` 문맥 2-turn 이상 연쇄 |
+
+### 질의 예시 (anonymized)
+
+```
+# single_doc — 예산 추출
+Q: "기관 B의 MLOps 자동화 과제 총 예산은?"
+
+# comparison
+Q: "품질관리 관점에서 기관 A와 기관 B의 AI 요구사항 차이는?"
+
+# abstention
+Q: "기관 C의 데이터센터 운영 비용은?" → should_abstain: true
+```
+
+---
+
+## 3. Evaluation Methodology
+
+### 채점 기준
+
+| Metric | 계산 방식 | 해석 |
+|---|---|---|
+| Answer Accuracy | `gold_answer` vs model answer (LLM-judge) | 사실 일치 여부 |
+| Groundedness Rate | evidence coverage (verifier) | 근거 없는 claim 비율 |
+| Citation Precision | cited chunks ∩ target_chunks / cited chunks | 인용 정확도 |
+| Claim Citation Alignment | claim↔citation 매핑 일치 | ADR 0003 계약 이행 |
+| Answer Format Compliance | ADR 0003 schema 필드 체크 | 구조 준수 |
+| Abstention Accuracy | `should_abstain` 일치 (3-bin) | 부재판별 정확도 |
+
+**3-bin abstention outcomes**: `correct_refusal` (정상 abstention) / `incorrect_answer` (있다고 잘못 답변) / `boundary_partial` (부분 답변)
+
+### Bootstrap CI
+
+- **Resamples**: 1000
+- **Seed**: 17 (고정 — 재현성)
+- **Coverage**: 95% 양측
+- **구현**: [`eval/bootstrap.py`](../eval/bootstrap.py)
+- **비-CI 컬럼** (Format, Abstention, Retry): point estimate — CIs는 메인 성능표 별도 열에 보고
+
+### LLM-as-judge (ADR 0012)
+
+- `eval/synthetic_judge.py` — stub 기본값 (CI 비용 0)
+- live 점수: `BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible`로 개발자 수동 실행 후 commit
+- 공개 synthetic 표면 한정 (ADR 0006 real-data-only 원칙 준수)
+- aggregate 결과: [`reports/synthetic_judge.aggregate.json`](../reports/synthetic_judge.aggregate.json)
+
+---
+
+## 4. Reproducibility
+
+### 빠른 재현 (CI gate)
+
+```bash
+make smoke                          # hashing backend, ~수분
+bash scripts/test.sh                # pytest gate (동일 결과)
+```
+
+### 전체 ablation 재실행
+
+```bash
+python -m eval.run_eval \
+  --config eval/config.yaml \
+  --index_dir data/index \
+  --output_dir reports
+```
+
+### LLM-judge (선택)
+
+```bash
+BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible make synthetic-judge
+```
+
+### README 메트릭 갱신 검증
+
+```bash
+python3 scripts/update_readme_metrics.py --check   # reports/ ↔ README 일치 확인
+```
+
+### 카테고리 분포 재확인 (jsonl)
+
+```bash
+jq -r '.question_type' eval/dev_queries_v1.jsonl | sort | uniq -c
+```
+
+### Config 기준 n=42 재확인
+
+```bash
+python3 -c "
+import yaml
+cfg = yaml.safe_load(open('eval/config.yaml'))
+cases = cfg['cases']
+from collections import Counter
+print('n_cases:', len(cases))
+print(dict(Counter(c['query_type'] for c in cases)))
+"
+```
+
+---
+
+## 5. Boundary (ADR 0005)
+
+이 문서가 다루는 공개 합성 평가셋과, **공개하지 않는** 비공개 평가셋의 경계:
+
+| 항목 | 공개 synthetic (이 문서) | 비공개 100-doc |
+|---|---|---|
+| 문서 원본 | 저장소 내 `data/raw/` | **포함 금지** (계약·저작권) |
+| 평가 케이스 | `eval/config.yaml` (n=42) | 비공개 config |
+| 케이스별 예측 | `reports/` (gitignored, 로컬) | 동일 |
+| Aggregate 집계 | `reports/synthetic_judge.aggregate.json` | `docs/private-100-doc-experiments.md` 별도 공개 |
+| CI gate | `make smoke` / `bash scripts/test.sh` | 차단 (`tests/` 내 raw-data 의존 금지) |
+
+전체 정책 전문: [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md)
+
+---
+
+## 6. 관련 문서
+
+- [`eval/dev_queries_v1_summary.md`](../eval/dev_queries_v1_summary.md) — jsonl 기반 질의 목록 요약
+- [`eval/eval_scoring_guide.md`](../eval/eval_scoring_guide.md) — 채점 가이드
+- [`docs/private-100-doc-experiments.md`](private-100-doc-experiments.md) — 비공개 aggregate 정책 (PR-C)
+- [ADR 0003](adr/0003-structured-answer-citation-contract.md) — 답변/인용 계약
+- [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md) — eval split 정책
+- [ADR 0012](adr/0012-llm-judge-on-public-synthetic.md) — synthetic LLM-judge

--- a/docs/private-100-doc-experiments.md
+++ b/docs/private-100-doc-experiments.md
@@ -1,0 +1,242 @@
+# Private 100-doc Experiments
+
+이 문서는 private 100-doc RFP 평가 결과를 포트폴리오용 근거로 남기되, 원문이나 개별 예측이 커밋되지 않도록 하는 aggregate-only 운영 기준이다. 실제 private 원문과 per-example output은 로컬 `artifacts/benchmarks/` 아래에만 둔다.
+
+## Naming
+
+- Run ID: `private100_<profile>_<YYYYMMDDTHHMMSSZ>`
+- Dataset ID: `private100_rfp_anon_vN`
+- Document ID: `private100-doc-###`
+- Case ID: `private100-case-###`
+
+`profile`은 `text_v1`, `visual_v2`, `visual_v2_hierarchical`처럼 입력/파이프라인 차이를 설명하는 익명 이름만 사용한다. 원본 기관명, 사업명, 파일명, 도메인 특화 약어는 ID에 넣지 않는다.
+
+## Commit Boundary
+
+커밋 가능:
+
+- anonymized run/dataset/case/doc id
+- corpus size 같은 복원 불가능한 집계 metadata
+- overall aggregate metrics
+- hard-case slice aggregate metrics
+- local artifact manifest path reference
+- private/public aggregate delta table
+
+커밋 금지:
+
+- raw private documents
+- original filenames
+- organization or project identifiers
+- raw predictions, traces, per-example dumps
+- OCR snippets, citation snippets, query text, answer text
+- config snapshot 안의 private path 또는 source metadata
+
+## Summary Flow
+
+private run은 로컬 manifest를 먼저 만든 뒤, registry/docs에는 aggregate만 반영한다. 실측 private 수치를 공개 커밋에 남길 때도 아래 경계를 지킨다.
+
+```bash
+python3 scripts/summarize_benchmark.py \
+  --manifest artifacts/benchmarks/<private100_run_id>/run_manifest.json
+```
+
+이 저장소의 예시 fixture는 흐름 검증용이며 실측 성과가 아니다.
+
+```bash
+python3 scripts/summarize_benchmark.py \
+  --manifest benchmarks/examples/private100_aggregate_manifest.example.json \
+  --registry /private/tmp/private100-registry.json \
+  --docs /private/tmp/private100-summary.md
+```
+
+`docs/ablation-results.md`는 registry에 public aggregate와 private aggregate가 함께 있을 때 `Public vs Private Aggregate` 표를 생성한다. 이 표는 `primary_metrics`의 집계 값만 사용하며 raw query, prediction, trace는 사용하지 않는다.
+
+## Example Aggregate Comparison
+
+아래 값은 `benchmarks/examples/private100_aggregate_manifest.example.json`에 들어 있는 anonymized fixture 예시다. 실측 private 100-doc 결과로 해석하면 안 된다.
+
+| Metric | Public primary | Private fixture primary | Delta |
+|---|---:|---:|---:|
+| Cases | 26 | 100 | +74 |
+| Accuracy | 1.000 | 0.810 | -0.190 |
+| Groundedness | 1.000 | 0.790 | -0.210 |
+| Citation Precision | 1.000 | 0.730 | -0.270 |
+| Citation Grounding | 1.000 | 0.700 | -0.300 |
+| Abstention | 1.000 | 0.770 | -0.230 |
+
+실제 실험에서는 이 표보다 `by_hardcase_category`를 우선 확인한다. 전체 성능 하락이 `table_heavy`나 `noisy_ocr` 같은 slice에 집중되면 parser/layout 또는 citation grounding 쪽 병목으로 분류한다.
+## Real-data Decision Log
+
+이 섹션은 retrieval / verifier policy 변경의 **real-data aggregate-only** before/after를 기록한다. ADR 0005의 commit boundary를 준수해 case ID·query text·doc ID·파일명은 절대 포함하지 않는다. 목적은 "왜 이렇게 짰는가?" 그리고 "그 결정이 real-data에서 어떻게 작동했는가?" 두 질문에 답할 수 있는 자료를 남기는 것이다.
+
+### Entry: 2026-05-11 — Partial-topic grounding @ fraction=0.5 (#69)
+
+**Change.** `verify_evidence`에 `allow_partial_topic` 추가, 마지막 retrieval 시도에서 verification topics의 ≥50%가 evidence에 매칭되면 `partial_topic_grounding` reason으로 `verified=True`를 반환하고 status는 `partial`로 surface ([ADR 0004](./adr/0004-verifier-retry-policy.md) anticipated knob).
+
+**Surface.** Local private real-data set (`eval/real_config.local.yaml`, 21 cases, 17 answerable + 4 intended-abstention). 동일 index, 동일 case set, 동일 tooling으로 pre-commit (2f76671) vs post-commit (2249498) 비교.
+
+**Aggregate diff (case set N=21):**
+
+| Metric | Before | After | Δ |
+|---|---:|---:|---:|
+| accuracy | 0.353 | 0.471 | **+0.118** ✅ |
+| groundedness | 0.476 | 0.476 | · |
+| citation_precision | 0.381 | 0.286 | −0.095 ⚠️ |
+| claim_citation_alignment | 0.786 | 0.692 | −0.093 ⚠️ |
+| answer_format_compliance | 0.524 | 0.429 | −0.095 ⚠️ |
+| abstention (intended) | 1.000 | 0.500 | **−0.500** ⚠️ |
+| retry_reason: `topic_not_grounded` (count) | 18 | 12 | −6 ✅ |
+
+**Status distribution diff (anonymized case counts only):**
+
+| Slice | Status | Before | After |
+|---|---|---:|---:|
+| answerable (17) | supported | 7 | 7 |
+|  | partial | 0 | **4** ↑ |
+|  | insufficient | 10 | **6** ↓ |
+| intended-abstention (4) | insufficient | 4 | **2** ↓ |
+|  | partial | 0 | **2** ↑ ⚠️ |
+
+**Interpretation.**
+
+- **Recovery works.** 4 / 17 answerable cases recovered from `insufficient` → `partial`; net accuracy gain +0.118. `topic_not_grounded` retry signal dropped one-third (18 → 12), confirming the strict→relaxed staging is engaging as designed.
+- **False-positive on intended abstention.** 2 of 4 intended-abstention cases flipped from `insufficient` → `partial`. Issue #69's own acceptance criterion ("intended abstention cases remain abstentions") is **partially violated** at fraction=0.5. The public synthetic eval did not catch this because its out-of-corpus cases are crisply disjoint from the corpus; real-data abstention queries share incidental topic tokens with in-corpus content.
+- **Citation precision drop is mechanical.** Partial answers cite chunks that ground only some of the requested topics; the `partial` status itself is the contract telling callers the answer is weak. Same shape as the public synthetic delta in PR #88.
+
+**Decision.**
+
+Ship #69 as-is in main with this finding logged, then **tighten** in a follow-up: the false-positive rate on intended abstention is too high to accept long-term. Candidates for the tighten PR — pick by ablation:
+
+1. Raise `PARTIAL_TOPIC_GROUNDING_MIN_FRACTION` from 0.5 toward 0.66 or 0.75.
+2. Gate partial-topic acceptance on `len(topics) >= 2` so single-topic queries (more likely to be out-of-corpus phrasing) can't trigger it.
+3. Raise the `low_top_score` floor (currently 0.18) on the relaxed stage only.
+
+Follow-up issue tracked in the meta roadmap (#49).
+
+**How this entry was produced (reproducibility note).**
+
+```bash
+# Same index, same config, same tooling — run on pre-#69 commit
+# (2f76671) and current main, then diff aggregate-only fields. The
+# per-case results are NOT committed; only the numbers above.
+git worktree add /tmp/pre-69 2f76671
+python3 eval/run_eval.py --index_dir data/index/real100 \
+  --output_dir /tmp/real100-before --config eval/real_config.local.yaml
+python3 eval/run_eval.py --index_dir data/index/real100 \
+  --output_dir /tmp/real100-after  --config eval/real_config.local.yaml# (aggregate fields then transcribed into the table above)
+```
+
+### Entry: 2026-05-11 — Tighten partial-topic gate (#89)
+
+**Change.** [`rag_core.py:2058-2068`](../rag_core.py) adds
+`PARTIAL_TOPIC_GROUNDING_MIN_MATCHED = 2` and tightens the relaxed-stage
+gate at L2095-2099 so that `partial_topic_grounding` is accepted only
+when at least 2 verification topics match (in addition to the existing
+≥ 50% fraction floor). Direct follow-up to the 2026-05-11 #69 entry
+above, which logged a 1.000 → 0.500 regression on the intended-abstention
+slice. Issue [#89](https://github.com/hskim-solv/BidMate-DocAgent/issues/89);
+[ADR 0004](./adr/0004-verifier-retry-policy.md) staging policy unchanged.
+
+**Surface.** Same local private real-data set as the #69 entry above
+(`eval/real_config.local.yaml`, 21 cases, 17 answerable + 4 intended
+abstention). Same index, same case set, same tooling; only `rag_core.py`
+differs between runs.
+
+**Ablation comparison (case set N=21).** Each row is a candidate
+variant tested on the same data. The chosen variant is **V3**; rejected
+variants are kept in the table for traceability so future readers can
+see the search space. Numbers below are placeholders for the operator's
+ablation run — replace each `…` with the value from
+`reports/real100/eval_summary.json` after running `make real-eval` for
+that variant.
+
+| Variant | Description | accuracy | abstention (intended) | answer_format_compliance | retry_reason: topic_not_grounded |
+|---|---|---:|---:|---:|---:|
+| V0 | fraction=0.5, matched≥1 (post-#69 main, pre-#89) | 0.471 | 0.500 | 0.429 | 12 |
+| V1 | fraction=0.66, matched≥1 | … | … | … | … |
+| V2 | fraction=0.75, matched≥1 | … | … | … | … |
+| **V3** | **fraction=0.5, matched≥2 (chosen)** | **…** | **…** | **…** | **…** |
+| V4 | fraction=0.5, matched≥1, +relaxed_top_score≥0.25 | (not run) | (not run) | (not run) | (not run) |
+| V5 | combo V1+V3 | (not run) | (not run) | (not run) | (not run) |
+
+**Aggregate diff for V3 (case set N=21):**
+
+| Metric | Before (V0 / post-#69) | After (V3) | Δ |
+|---|---:|---:|---:|
+| accuracy | 0.471 | … | … |
+| groundedness | 0.476 | … | … |
+| citation_precision | 0.286 | … | … |
+| claim_citation_alignment | 0.692 | … | … |
+| answer_format_compliance | 0.429 | … | … |
+| abstention (intended) | 0.500 | … | … |
+| retry_reason: `topic_not_grounded` (count) | 12 | … | … |
+
+**Status distribution diff (anonymized case counts only):**
+
+| Slice | Status | Before | After |
+|---|---|---:|---:|
+| answerable (17) | supported | 7 | … |
+|  | partial | 4 | … |
+|  | insufficient | 6 | … |
+| intended-abstention (4) | insufficient | 2 | … |
+|  | partial | 2 | … |
+
+**Interpretation.**
+
+- **Abstention restored.** The matched≥2 floor cuts the 1-of-2
+  incidental-overlap pattern that flipped intended-abstention real-data
+  cases after #69. Genuine partial-recovery (2-of-3 etc.) keeps
+  passing — see the public synthetic guard
+  `partial_topic_security_quantum` updated to 2-of-3 in this same PR.
+- **Net answerable trade-off.** Some of #69's 4 recovered answerable
+  cases that depended on a 1-of-2 match flip back to `insufficient`.
+  Acceptance criterion (`accuracy ≥ 0.45`) ensures the recovery is not
+  fully undone. Fill in the actual delta after the ablation.
+- **Why V3 over V1/V2.** V3 is the structural cut (require multiple
+  topic agreement) rather than an incremental threshold tweak. V1/V2
+  numbers are kept in the table so it is empirically clear that V3 is
+  the cleanest cut for this failure pattern. V4/V5 were not needed
+  because V3 alone satisfied acceptance.
+
+**Decision.**
+
+Ship V3 as the new default. Issue #89 acceptance criteria
+(abstention ≥ 0.75 AND accuracy ≥ 0.45) verified on this dataset
+(transcribe the actual numbers from the V3 row above into this
+sentence after running the ablation). The discarded variants are
+kept in the ablation table for future-reader traceability. Re-open
+this decision if a future change to the analyzer's topic extraction
+shifts the typical `len(topics)` distribution downward (the matched≥2
+floor depends on queries usually having ≥ 2 topics).
+
+**How this entry was produced (reproducibility note).**
+
+```bash
+# Same index, same config, same tooling as the #69 entry. For each
+# variant, edit a single line in rag_core.py, run `make real-eval`,
+# capture aggregates from reports/real100/eval_summary.json, then
+# `git checkout -- rag_core.py` and move to the next variant. The
+# per-case results never leave the local machine — ADR 0005.
+#
+# V0 baseline: post-#69 main (commit 2249498) — already recorded above.
+# V1: rag_core.py:2058 PARTIAL_TOPIC_GROUNDING_MIN_FRACTION = 0.66
+# V2: rag_core.py:2058 PARTIAL_TOPIC_GROUNDING_MIN_FRACTION = 0.75
+# V3: rag_core.py:2059 PARTIAL_TOPIC_GROUNDING_MIN_MATCHED  = 2  (chosen)
+#
+# After capturing each variant's aggregates, transcribe only the
+# SAFE_TOPLEVEL_KEYS / SAFE_SLICE_METRICS values from
+# scripts/run_real_eval_delta.py into the tables above.
+make real-eval
+```
+
+## Real-data Eval History
+
+Chronological record of real-data aggregate snapshots committed under `reports/real100/history/`. The table is auto-generated; do not edit between the markers below. Each row corresponds to one deliberate `make real-eval-baseline-update` invocation, so the chain shows how real-data metrics moved as the repo changed.
+
+<!-- real-eval-history-start -->
+
+Auto-generated by `scripts/render_real_eval_history.py`. Each row is one committed aggregate snapshot under `reports/real100/history/`. Aggregate-only per ADR 0005 — per-case data is never read by this script.
+
+_No real-data history entries yet. Run `make real-eval-baseline-update` to seed the first snapshot._
+
+<!-- real-eval-history-end -->


### PR DESCRIPTION
## Summary

면접관 약점 (e) 해소: `docs/private-100-doc-experiments.md`가 여러 ADR, scripts에서 참조되지만 PR #566에서 삭제되어 broken 상태.

원본 파일을 git history (`1b9f8c6^`)에서 복구합니다.

## Changes

### `docs/private-100-doc-experiments.md` (복구)

PR #566에서 포트폴리오 repo로 이관하며 삭제되었던 파일 복구. 내용은 engineering-relevant 운영 기준:

| Section | 내용 |
|---|---|
| Naming | Run/Dataset/Doc/Case ID 컨벤션 |
| Commit Boundary | ADR 0005 커밋 가능/금지 항목 표 |
| Real-data Decision Log | PR #69 partial-topic grounding + PR #89 tighten 의 aggregate diff (N=21) |
| Real-data Eval History | `<!-- real-eval-history-start/end -->` markers (`scripts/render_real_eval_history.py` 자동 갱신) |

### `README.md`

주요 링크 표에 "비공개 100-doc aggregate 정책 + placeholder" 항목 추가 (2줄)

## Broken link 해소 목록

이 파일이 복구되어 다음 참조들이 모두 valid해짐:

- `docs/adr/0005-eval-split-public-synthetic-private-local.md`
- `docs/adr/0006-llm-judge-on-real-data-only.md`
- `docs/adr/0030-leaderboard-headline-includes-agentic-full.md`
- `docs/adr/0032-eval-saturation-routed-subset.md`
- `docs/investigations/152-splade-colbert-feasibility.md`
- `docs/eval-dataset-spec.md` (PR-B, stacked)
- `scripts/render_real_eval_history.py` (`DOC_PATH` 참조)
- `scripts/run_real_eval_delta.py` (default output path)

## Item 5b (real-data delta)

N/A — docs-only change, no load-bearing path touched.

## Verification

- [ ] `bash scripts/test.sh` 회귀 0
- [ ] `grep -rn "private-100-doc-experiments" docs/ scripts/ README.md` 모든 결과가 valid path
- [ ] `python3 scripts/render_real_eval_history.py` — markers found, no FileNotFoundError

## Portfolio rubric

- 4층 B층 보강 (5분 신뢰) — 면접관 약점 (e) 해소
- 4축 축 3 (평가 견고성)
- `scripts/render_real_eval_history.py` 정상 작동 복구

Closes #584