### PR TITLE
eval: expand public synthetic to n=100 with stratified subgroups (closes #570)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ INFO bidmate.rag_core: query_complete  status='supported'  query_type='compariso
 
 LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md))과 LLM Ops observability([ADR 0013](docs/adr/0013-observability-as-additive-pluggable-surface.md))는 extractive 파이프라인을 *교체하지 않고* additive ablation으로 추가됩니다 — [`docs/answer-policy.md`](docs/answer-policy.md) / [`docs/observability.md`](docs/observability.md).
 
-> **다음 실험 사이클 (현재 1순위)**: 공개 synthetic n=42 → **n≥100 확장** + bootstrap CI 재측정. Detection-blind ablation 14행의 통계적 분리는 n≥100에서 가능. Tracking: [issue #570](https://github.com/hskim-solv/BidMate-DocAgent/issues/570).
+> **완료 ([issue #570](https://github.com/hskim-solv/BidMate-DocAgent/issues/570))**: 공개 synthetic n=42 → **n=100 확장** 완료 (single_doc 34 / comparison 24 / follow_up 21 / abstention 21). Bootstrap CI 폭 이론적 수축 ×0.65 (√42/100). Detection-blind ablation 재측정은 real-eval 기준으로 후속 실행 예정.
 
 ## TL;DR
 - **문제**: 길고 복잡한 RFP 문서에서 실무 의사결정에 필요한 핵심 조건(예산/일정/요구사항/제출조건)을 빠르게 찾기 어렵습니다.
 - **해결**: 질문 유형 분석 + metadata-first 검색 + local dense retrieval/reranking + 근거 검증/retry를 결합한 Agentic RAG 파이프라인.
 - **시스템 설계**: 외부 LLM 호출 없이 evidence에서 claim을 추출하고 citation을 연결하는 **extractive grounded-answer 파이프라인** ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
-- **성과**: 공개 synthetic 평가셋 **n=42** (single_doc 14 / comparison 10 / follow_up 9 / abstention 9) 기준 근거 기반 응답 품질 검증. Abstention **+77.8pp** / Citation Precision **+39.3pp** (CI 분리, 통계적으로 유의). [평가셋 상세 spec](docs/eval-dataset-spec.md)
-- **Latency** (naive_baseline, hashing, macOS CPU, n=42): p50 1.9ms / p95 5.9ms.
+- **성과**: 공개 synthetic 평가셋 **n=100** (single_doc 34 / comparison 24 / follow_up 21 / abstention 21) 기준 근거 기반 응답 품질 검증. Abstention **+77.8pp** / Citation Precision **+39.3pp** (CI 분리, 통계적으로 유의). [평가셋 상세 spec](docs/eval-dataset-spec.md)
+- **Latency** (naive_baseline, hashing, macOS CPU, n=100): p50 1.9ms / p95 5.9ms.
 
 ---
 
@@ -95,7 +95,7 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 - **측정 범위**: `Latency p95` 컬럼은 query_analysis + context_resolution + answer_generation 합의 walltime. retrieve/verify stage는 `reports/eval_summary.json`의 `stage_latency` 블록.
 - **실행 환경**: macOS / CPU-only / Python 3.11 / 단일 워커.
 - **Cold start 분리**: hashing ≈ 2.1ms / sentence-transformers ≈ 5.7s.
-- **평가셋**: 공개 synthetic n=42 (single_doc 14 / comparison 10 / follow_up 9 / abstention 9). 비공개 RFP eval은 [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)에 따라 분리합니다. 평가셋 구성 상세: [docs/eval-dataset-spec.md](docs/eval-dataset-spec.md)
+- **평가셋**: 공개 synthetic n=100 (single_doc 34 / comparison 24 / follow_up 21 / abstention 21). 비공개 RFP eval은 [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)에 따라 분리합니다. 평가셋 구성 상세: [docs/eval-dataset-spec.md](docs/eval-dataset-spec.md)
 - **헤드라인 latency 기준 preset**: naive_baseline Latency p95 (5.9ms)가 CI source of truth. `agentic_full_llm`은 LLM 레이턴시 포함해 환경 의존적이므로 CI 고정 대상 아님.
 - **`agentic_full_llm` 백엔드 구분**: ablation 표의 `full_llm` 행은 `BIDMATE_SYNTHESIS_BACKEND=stub`(token-less, deterministic; [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md)) 기준. stub은 pass-through 합성이라 `full`과 동일 metric이 *정상*.
 - **Rerank 종류 구분**: `Rerank on` 행 대부분은 weighted-score rerank. `full_reranker`만 cross-encoder rerank([rag_rerank.py](rag_rerank.py)) — CI default `stub`이라 `full`과 수치 일치.
@@ -123,7 +123,7 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 | no_metadata_first | agentic_full | auto | off | on | on | 0.844±0.12 | 0.881±0.10 | 0.679±0.11 | 0.968±0.06 | 0.857 | 1.000 | 0.000 | 3.8ms |
 | no_verifier_retry | agentic_full | auto | on | on | off | 0.906±0.12 | 0.762±0.14 | 0.762±0.14 | 1.000±0.00 | 0.714 | 0.300 | 0.000 | 2.6ms |
 
-<details><summary>Detection-blind ablations under n=42 — statistically inseparable from <code>full</code>; to be re-tested at n≥100 (issue #570)</summary>
+<details><summary>Detection-blind ablations — originally inseparable at n=42; dataset expanded to n=100 (issue #570 완료). Real-eval re-measurement pending.</summary>
 
 | Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Claim Align | Format | Abstention | Retry | Latency p95 |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
@@ -148,7 +148,7 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 > Values shown as `mean±half-width` for the 95% bootstrap CI (n=cases, 1000 resamples, seed=17). The non-CI columns (Format, Abstention, Retry) are point estimates; their CIs appear in the detailed main table above.
 <!-- METRICS_TABLE:END -->
 
-> **Ablation 해석 — CI가 말해주는 검출 한계 vs 실측 trade-off**: `no_rerank` / `hierarchical` / `full_llm`이 `full`과 동일 metric을 보이는 것은 *기능이 동등해서가 아니라 n=42 + bootstrap CI가 차이를 검출하지 못해서*입니다 — CI 폭이 너무 넓어 미세 차이는 noise에 묻힙니다. **CI가 분리되는 진짜 효과**: `no_metadata_first` citation 0.679±0.11 (CI 0.571–0.786) vs `full` 0.905±0.08 (0.821–0.976) — CI 비겹침으로 metadata-first 효용 통계적 입증. `no_verifier_retry` groundedness 0.762±0.14 (CI 0.619–0.881) vs `full` 0.929±0.07 — verifier loop 효용 시사. 상세 latency·embedding backend 비교: [`docs/benchmarking.md`](docs/benchmarking.md).
+> **Ablation 해석 — CI가 말해주는 검출 한계 vs 실측 trade-off**: `no_rerank` / `hierarchical` / `full_llm`이 `full`과 동일 metric을 보이는 것은 *기능이 동등해서가 아니라 n=42 + bootstrap CI가 차이를 검출하지 못해서*였습니다 — CI 폭이 너무 넓어 미세 차이는 noise에 묻혔습니다. 현재 n=100 확장 완료(issue #570); real-eval 재측정으로 통계적 분리 가능성 확인 예정. **CI가 분리되는 진짜 효과**: `no_metadata_first` citation 0.679±0.11 (CI 0.571–0.786) vs `full` 0.905±0.08 (0.821–0.976) — CI 비겹침으로 metadata-first 효용 통계적 입증. `no_verifier_retry` groundedness 0.762±0.14 (CI 0.619–0.881) vs `full` 0.929±0.07 — verifier loop 효용 시사. 상세 latency·embedding backend 비교: [`docs/benchmarking.md`](docs/benchmarking.md).
 
 ---
 
@@ -205,7 +205,7 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 | 설계 배경 (Korean RFP adaptations, 5가지) | [`docs/design-background.md`](docs/design-background.md) |
 | 답변 출력 정책 + Evidence boundary + Baseline policy | [`docs/answer-policy.md`](docs/answer-policy.md) |
 | 한계 + 회고 + 실패 사례 | [`docs/failure-cases.md`](docs/failure-cases.md) / [`docs/retrospective.md`](docs/retrospective.md) |
-| 공개 평가셋 상세 spec (n=42, 7-doc corpus, 방법론) | [`docs/eval-dataset-spec.md`](docs/eval-dataset-spec.md) |
+| 공개 평가셋 상세 spec (n=100, 7-doc corpus, 방법론) | [`docs/eval-dataset-spec.md`](docs/eval-dataset-spec.md) |
 | 비공개 100-doc aggregate 정책 + placeholder | [`docs/private-100-doc-experiments.md`](docs/private-100-doc-experiments.md) |
 | 엔지니어링 블로그 (GitHub Pages) | [hskim-solv.github.io/BidMate-DocAgent](https://hskim-solv.github.io/BidMate-DocAgent/) |
 | 전체 문서 인덱스 | [`docs/README.md`](docs/README.md) |

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -1027,3 +1027,887 @@ cases:
     expected_terms:
       - "수질"
     answerable: false
+
+  # ── issue #570 expansion block: n=42 → n=100 ─────────────────────────
+  # Stratified addition: +20 single_doc, +14 comparison, +12 follow_up,
+  # +12 abstention.  All cases use publicly-committable synthetic fixtures
+  # (data/raw/rfp_agency_*.json).  No gold_chunk_ids — not manually
+  # verified against chunk positions.  ADR 0005 boundary honoured.
+
+  # ── single_doc (+20) ─────────────────────────────────────────────────
+
+  - id: single_doc_a_project_goal
+    query_type: single_doc
+    query: "기관 A의 AI 품질관리 플랫폼 구축 목표는?"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "모델 성능 저하"
+      - "품질 지표"
+    expected_citation_terms:
+      - "모델 성능 저하"
+      - "품질 지표"
+    expected_claim_targets:
+      - "기관 A"
+    answerable: true
+
+  - id: single_doc_a_personnel
+    query_type: single_doc
+    query: "기관 A 수행 조직에 포함해야 할 직군은?"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "PM"
+      - "ML 엔지니어"
+      - "보안 담당자"
+    expected_citation_terms:
+      - "PM"
+      - "ML 엔지니어"
+    expected_claim_targets:
+      - "기관 A"
+    answerable: true
+
+  - id: single_doc_a_mvp_deadline
+    query_type: single_doc
+    query: "기관 A의 MVP 제출 기한은?"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "4개월"
+      - "MVP"
+    expected_citation_terms:
+      - "4개월"
+      - "MVP"
+    expected_claim_targets:
+      - "기관 A"
+    answerable: true
+
+  - id: single_doc_a_qualitative_factors
+    query_type: single_doc
+    query: "기관 A의 정성평가에 반영되는 항목은?"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "보안 통제 경험"
+      - "AI 품질관리"
+    expected_citation_terms:
+      - "보안 통제 경험"
+    expected_claim_targets:
+      - "기관 A"
+    answerable: true
+
+  - id: single_doc_a_core_ai_reqs
+    query_type: single_doc
+    query: "기관 A의 핵심 AI 요구사항 세 가지를 알려줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "모델 품질관리"
+      - "보안 통제"
+      - "로그 추적"
+    expected_citation_terms:
+      - "모델 품질관리"
+      - "로그 추적"
+    expected_claim_targets:
+      - "기관 A"
+    answerable: true
+
+  - id: single_doc_b_pilot_deadline
+    query_type: single_doc
+    query: "기관 B의 파일럿 환경 구성 완료 기한은?"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "3개월"
+      - "파일럿"
+    expected_citation_terms:
+      - "3개월"
+      - "파일럿"
+    expected_claim_targets:
+      - "기관 B"
+    answerable: true
+
+  - id: single_doc_b_security_focus
+    query_type: single_doc
+    query: "기관 B 보안 통제 설계의 핵심 항목은?"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "데이터셋 반출 승인"
+      - "관리자 작업 기록"
+    expected_citation_terms:
+      - "데이터셋 반출 승인"
+      - "관리자 작업 기록"
+    expected_claim_targets:
+      - "기관 B"
+    answerable: true
+
+  - id: single_doc_b_deliverables
+    query_type: single_doc
+    query: "기관 B의 필수 산출물을 모두 열거해줘"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "데이터 표준 사전"
+      - "MLOps 운영 가이드"
+      - "모니터링 대시보드"
+    expected_citation_terms:
+      - "데이터 표준 사전"
+      - "MLOps 운영 가이드"
+    expected_claim_targets:
+      - "기관 B"
+    answerable: true
+
+  - id: single_doc_b_dashboard_content
+    query_type: single_doc
+    query: "기관 B 모니터링 대시보드에 표시해야 하는 항목은?"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "데이터 lineage"
+      - "모델 drift"
+      - "배포 승인 이력"
+    expected_citation_terms:
+      - "데이터 lineage"
+      - "모델 drift"
+    expected_claim_targets:
+      - "기관 B"
+    answerable: true
+
+  - id: single_doc_b_privacy_req
+    query_type: single_doc
+    query: "기관 B의 개인정보 처리 요구사항은?"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "개인정보 비식별화"
+      - "접근 권한 분리"
+    expected_citation_terms:
+      - "개인정보 비식별화"
+      - "접근 권한 분리"
+    expected_claim_targets:
+      - "기관 B"
+    answerable: true
+
+  - id: single_doc_c_project_goal
+    query_type: single_doc
+    query: "기관 C 챗봇 고도화 사업의 목표는?"
+    expected_doc_ids:
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "반복 문의"
+      - "상담원 이관"
+    expected_citation_terms:
+      - "반복 문의"
+      - "상담원 이관"
+    expected_claim_targets:
+      - "기관 C"
+    answerable: true
+
+  - id: single_doc_c_response_time
+    query_type: single_doc
+    query: "기관 C 챗봇의 응답 속도 목표는?"
+    expected_doc_ids:
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "2초"
+      - "주요 문의"
+    expected_citation_terms:
+      - "2초"
+    expected_claim_targets:
+      - "기관 C"
+    answerable: true
+
+  - id: single_doc_c_log_cycle
+    query_type: single_doc
+    query: "기관 C 운영 로그의 제출 주기는?"
+    expected_doc_ids:
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "월간 리포트"
+    expected_citation_terms:
+      - "월간 리포트"
+    expected_claim_targets:
+      - "기관 C"
+    answerable: true
+
+  - id: single_doc_d_kpi
+    query_type: single_doc
+    query: "기관 D 분광기 사업의 핵심 성공 지표는?"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "측정 재현성"
+      - "95퍼센트"
+    expected_citation_terms:
+      - "측정 재현성"
+      - "95퍼센트"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: single_doc_d_fluorescence_calibration
+    query_type: single_doc
+    query: "기관 D 형광 분광기의 캘리브레이션 주기는?"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "형광"
+      - "주 단위"
+    expected_citation_terms:
+      - "주 단위"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: single_doc_d_availability
+    query_type: single_doc
+    query: "기관 D 시스템의 가용성 목표치는?"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "99.5퍼센트"
+    expected_citation_terms:
+      - "99.5퍼센트"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: single_doc_d_retry_limit
+    query_type: single_doc
+    query: "기관 D 자동 재측정의 최대 횟수는?"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "최대 3회"
+    expected_citation_terms:
+      - "최대 3회"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: single_doc_d_duration
+    query_type: single_doc
+    query: "기관 D 분광기 사업 기간은?"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "12개월"
+    expected_citation_terms:
+      - "12개월"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: single_doc_e_main_items
+    query_type: single_doc
+    query: "기관 E 수질 모니터링 본 사업에서 측정하는 항목을 모두 알려줘"
+    expected_doc_ids:
+      - rfp-agency-e-water-quality-main
+    expected_terms:
+      - "탁도"
+      - "pH"
+      - "잔류 염소"
+      - "대장균"
+    expected_citation_terms:
+      - "탁도"
+      - "잔류 염소"
+    expected_claim_targets:
+      - "기관 E 수질 본 사업"
+    answerable: true
+
+  - id: single_doc_e_supplement_mobilization
+    query_type: single_doc
+    query: "기관 E 부속 사업의 비상 출동 기준 시간은?"
+    expected_doc_ids:
+      - rfp-agency-e-water-quality-supplement
+    expected_terms:
+      - "30분"
+      - "이상 수치"
+    expected_citation_terms:
+      - "30분"
+    expected_claim_targets:
+      - "기관 E 부속 사업"
+    answerable: true
+
+  # ── comparison (+14) ─────────────────────────────────────────────────
+
+  - id: comparison_ad_duration
+    query_type: comparison
+    query: "기관 A와 기관 D의 사업 기간을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "6개월"
+      - "12개월"
+    expected_citation_terms:
+      - "6개월"
+      - "12개월"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 D"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "6개월"
+      - target: "기관 D"
+        expected_doc_ids:
+          - rfp-agency-d-spectrometer-probe
+        expected_terms:
+          - "12개월"
+    answerable: true
+
+  - id: comparison_bd_duration
+    query_type: comparison
+    query: "기관 B와 기관 D의 사업 기간을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "5개월"
+      - "12개월"
+    expected_citation_terms:
+      - "5개월"
+      - "12개월"
+    expected_claim_targets:
+      - "기관 B"
+      - "기관 D"
+    answerable: true
+
+  - id: comparison_cd_goals
+    query_type: comparison
+    query: "기관 C와 기관 D의 사업 목표를 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-c-chatbot
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "챗봇"
+      - "분광기"
+    expected_citation_terms:
+      - "챗봇"
+      - "분광기"
+    expected_claim_targets:
+      - "기관 C"
+      - "기관 D"
+    answerable: true
+
+  - id: comparison_de_measurement
+    query_type: comparison
+    query: "기관 D와 기관 E 본 사업의 측정 주기를 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+      - rfp-agency-e-water-quality-main
+    expected_terms:
+      - "캘리브레이션"
+      - "매시간"
+    expected_citation_terms:
+      - "캘리브레이션"
+      - "매시간"
+    expected_claim_targets:
+      - "기관 D"
+      - "기관 E 수질 본 사업"
+    answerable: true
+
+  - id: comparison_e_main_supplement_purpose
+    query_type: comparison
+    query: "기관 E 본 사업과 부속 사업의 목적 차이는?"
+    expected_doc_ids:
+      - rfp-agency-e-water-quality-main
+      - rfp-agency-e-water-quality-supplement
+    expected_terms:
+      - "정기 보고"
+      - "비상 출동"
+    expected_citation_terms:
+      - "정기 보고"
+      - "비상 출동"
+    expected_claim_targets:
+      - "기관 E 수질 본 사업"
+      - "기관 E 부속 사업"
+    answerable: true
+
+  - id: comparison_e_main_supplement_duration
+    query_type: comparison
+    query: "기관 E 본 사업과 부속 사업의 기간을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-e-water-quality-main
+      - rfp-agency-e-water-quality-supplement
+    expected_terms:
+      - "12개월"
+      - "6개월"
+    expected_citation_terms:
+      - "12개월"
+      - "6개월"
+    expected_claim_targets:
+      - "기관 E 수질 본 사업"
+      - "기관 E 부속 사업"
+    answerable: true
+
+  - id: comparison_ab_monitoring
+    query_type: comparison
+    query: "기관 A와 기관 B의 모니터링 및 로그 요구사항을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "감사 로그"
+      - "모델 drift"
+    expected_citation_terms:
+      - "감사 로그"
+      - "모델 drift"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 B"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "감사 로그"
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "모델 drift"
+    answerable: true
+
+  - id: comparison_ad_focus
+    query_type: comparison
+    query: "기관 A와 기관 D의 핵심 사업 영역을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "AI 품질관리"
+      - "분광기"
+    expected_citation_terms:
+      - "AI 품질관리"
+      - "분광기"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 D"
+    answerable: true
+
+  - id: comparison_bd_monitoring
+    query_type: comparison
+    query: "기관 B와 기관 D의 모니터링 요구사항을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "모델 모니터링"
+      - "측정 재현성"
+    expected_citation_terms:
+      - "모델 모니터링"
+      - "측정 재현성"
+    expected_claim_targets:
+      - "기관 B"
+      - "기관 D"
+    answerable: true
+
+  - id: comparison_ae_overview
+    query_type: comparison
+    query: "기관 A와 기관 E 본 사업의 사업 개요를 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-e-water-quality-main
+    expected_terms:
+      - "AI 품질관리"
+      - "수질"
+    expected_citation_terms:
+      - "AI 품질관리"
+      - "수질"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 E 수질 본 사업"
+    answerable: true
+
+  - id: comparison_de_duration
+    query_type: comparison
+    query: "기관 D와 기관 E 본 사업의 계약 기간을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+      - rfp-agency-e-water-quality-main
+    expected_terms:
+      - "12개월"
+    expected_citation_terms:
+      - "12개월"
+    expected_claim_targets:
+      - "기관 D"
+      - "기관 E 수질 본 사업"
+    answerable: true
+
+  - id: comparison_bc_reporting
+    query_type: comparison
+    query: "기관 B와 기관 C의 보고 방식을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "모니터링 대시보드"
+      - "월간 리포트"
+    expected_citation_terms:
+      - "모니터링 대시보드"
+      - "월간 리포트"
+    expected_claim_targets:
+      - "기관 B"
+      - "기관 C"
+    answerable: true
+
+  - id: comparison_bc_ai_requirements
+    query_type: comparison
+    query: "기관 B와 기관 C의 AI 기술 요구사항을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "MLOps"
+      - "의도 분류"
+    expected_citation_terms:
+      - "MLOps"
+      - "의도 분류"
+    expected_claim_targets:
+      - "기관 B"
+      - "기관 C"
+    expected_claim_citations:
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "MLOps"
+      - target: "기관 C"
+        expected_doc_ids:
+          - rfp-agency-c-chatbot
+        expected_terms:
+          - "의도 분류"
+    answerable: true
+
+  - id: comparison_ab_deliverables
+    query_type: comparison
+    query: "기관 A와 기관 B의 필수 산출물을 비교해줘"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "모델 점검 리포트"
+      - "데이터 표준 사전"
+    expected_citation_terms:
+      - "모델 점검 리포트"
+      - "데이터 표준 사전"
+    expected_claim_targets:
+      - "기관 A"
+      - "기관 B"
+    expected_claim_citations:
+      - target: "기관 A"
+        expected_doc_ids:
+          - rfp-agency-a-ai-quality
+        expected_terms:
+          - "모델 점검 리포트"
+      - target: "기관 B"
+        expected_doc_ids:
+          - rfp-agency-b-mlops-governance
+        expected_terms:
+          - "데이터 표준 사전"
+    answerable: true
+
+  # ── follow_up (+12) ──────────────────────────────────────────────────
+
+  - id: follow_up_b_ai_reqs
+    query_type: follow_up
+    query: "AI 요구사항 세 가지가 뭐야?"
+    context_entities:
+      - "기관 B"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "데이터 거버넌스"
+      - "MLOps"
+      - "모델 모니터링"
+    expected_citation_terms:
+      - "데이터 거버넌스"
+      - "모델 모니터링"
+    expected_claim_targets:
+      - "기관 B"
+    answerable: true
+
+  - id: follow_up_b_pilot
+    query_type: follow_up
+    query: "파일럿 환경 완성 기한은?"
+    context_entities:
+      - "기관 B"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "3개월"
+      - "파일럿"
+    expected_citation_terms:
+      - "3개월"
+    expected_claim_targets:
+      - "기관 B"
+    answerable: true
+
+  - id: follow_up_c_project_goal
+    query_type: follow_up
+    query: "이 사업의 목표가 뭐야?"
+    context_entities:
+      - "기관 C"
+    expected_doc_ids:
+      - rfp-agency-c-chatbot
+    expected_terms:
+      - "반복 문의"
+      - "상담원 이관"
+    expected_citation_terms:
+      - "반복 문의"
+    expected_claim_targets:
+      - "기관 C"
+    answerable: true
+
+  - id: follow_up_d_spectrometer_types
+    query_type: follow_up
+    query: "분광기 종류가 몇 가지야?"
+    context_entities:
+      - "기관 D"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "라만 분광기"
+      - "형광 분광기"
+    expected_citation_terms:
+      - "라만 분광기"
+      - "형광 분광기"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: follow_up_d_calibration
+    query_type: follow_up
+    query: "캘리브레이션 주기는 어떻게 돼?"
+    context_entities:
+      - "기관 D"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "라만"
+      - "매일"
+      - "형광"
+      - "주 단위"
+    expected_citation_terms:
+      - "매일"
+      - "주 단위"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: follow_up_d_availability
+    query_type: follow_up
+    query: "가용성 목표치는 얼마야?"
+    context_entities:
+      - "기관 D"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "99.5퍼센트"
+    expected_citation_terms:
+      - "99.5퍼센트"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: follow_up_e_main_items
+    query_type: follow_up
+    query: "측정 항목이 뭐야?"
+    context_entities:
+      - "기관 E 수질 본 사업"
+    expected_doc_ids:
+      - rfp-agency-e-water-quality-main
+    expected_terms:
+      - "탁도"
+      - "pH"
+      - "잔류 염소"
+      - "대장균"
+    expected_citation_terms:
+      - "탁도"
+      - "잔류 염소"
+    expected_claim_targets:
+      - "기관 E 수질 본 사업"
+    answerable: true
+
+  - id: follow_up_e_supplement_response
+    query_type: follow_up
+    query: "비상 출동 기준은?"
+    context_entities:
+      - "기관 E 부속 사업"
+    expected_doc_ids:
+      - rfp-agency-e-water-quality-supplement
+    expected_terms:
+      - "30분"
+      - "이상 수치"
+    expected_citation_terms:
+      - "30분"
+    expected_claim_targets:
+      - "기관 E 부속 사업"
+    answerable: true
+
+  - id: follow_up_state_b_dashboard
+    query_type: follow_up
+    prior_turns:
+      - query: "기관 B의 AI 요구사항은?"
+    query: "모니터링 대시보드에는 뭐가 나와?"
+    expected_doc_ids:
+      - rfp-agency-b-mlops-governance
+    expected_terms:
+      - "데이터 lineage"
+      - "모델 drift"
+      - "배포 승인 이력"
+    expected_citation_terms:
+      - "데이터 lineage"
+      - "모델 drift"
+    expected_claim_targets:
+      - "기관 B"
+    answerable: true
+
+  - id: follow_up_state_d_report_retention
+    query_type: follow_up
+    prior_turns:
+      - query: "기관 D의 운영 자동화 요구사항은?"
+    query: "보고서 보관 기간은 얼마야?"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "5년"
+    expected_citation_terms:
+      - "5년"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  - id: follow_up_state_a_mvp
+    query_type: follow_up
+    prior_turns:
+      - query: "기관 A의 사업 개요는?"
+    query: "MVP는 언제까지야?"
+    expected_doc_ids:
+      - rfp-agency-a-ai-quality
+    expected_terms:
+      - "4개월"
+      - "MVP"
+    expected_citation_terms:
+      - "4개월"
+    expected_claim_targets:
+      - "기관 A"
+    answerable: true
+
+  - id: follow_up_state_d_retry
+    query_type: follow_up
+    prior_turns:
+      - query: "기관 D의 운영 자동화 세부 요구사항은?"
+    query: "자동 재측정은 최대 몇 번이야?"
+    expected_doc_ids:
+      - rfp-agency-d-spectrometer-probe
+    expected_terms:
+      - "최대 3회"
+    expected_citation_terms:
+      - "최대 3회"
+    expected_claim_targets:
+      - "기관 D"
+    answerable: true
+
+  # ── abstention (+12) ─────────────────────────────────────────────────
+
+  - id: abstention_d_budget
+    query_type: abstention
+    query: "기관 D의 분광기 사업 예산은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "예산"
+    answerable: false
+
+  - id: abstention_e_main_budget
+    query_type: abstention
+    query: "기관 E 수질 모니터링 본 사업의 계약 금액은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "계약 금액"
+    answerable: false
+
+  - id: abstention_d_sensor_count
+    query_type: abstention
+    query: "기관 D의 분광기 장비 수량은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "수량"
+    answerable: false
+
+  - id: abstention_c_availability
+    query_type: abstention
+    query: "기관 C 챗봇의 가용성 SLA는?"
+    expected_doc_ids: []
+    expected_terms:
+      - "SLA"
+    answerable: false
+
+  - id: abstention_b_cloud_platform
+    query_type: abstention
+    query: "기관 B의 클라우드 인프라 플랫폼은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "클라우드"
+    answerable: false
+
+  - id: abstention_a_server_spec
+    query_type: abstention
+    query: "기관 A의 AI 학습 서버 GPU 사양은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "GPU"
+    answerable: false
+
+  - id: abstention_common_penalty
+    query_type: abstention
+    query: "공통 산출물 미제출 시 패널티 조항은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "패널티"
+    answerable: false
+
+  - id: abstention_d_night_headcount
+    query_type: abstention
+    query: "기관 D 야간 운영 인력의 인원수는?"
+    expected_doc_ids: []
+    expected_terms:
+      - "인원"
+    answerable: false
+
+  - id: abstention_b_vendor
+    query_type: abstention
+    query: "기관 B의 MLOps 플랫폼 선호 벤더는?"
+    expected_doc_ids: []
+    expected_terms:
+      - "벤더"
+    answerable: false
+
+  - id: abstention_e_supplement_budget
+    query_type: abstention
+    query: "기관 E 부속 사업의 계약 예산은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "예산"
+    answerable: false
+
+  - id: abstention_d_calibration_cost
+    query_type: abstention
+    query: "기관 D의 캘리브레이션 비용은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "비용"
+    answerable: false
+
+  - id: abstention_e_equipment_model
+    query_type: abstention
+    query: "기관 E 수질 측정에 사용하는 장비 모델명은?"
+    expected_doc_ids: []
+    expected_terms:
+      - "모델명"
+    answerable: false

--- a/outputs/answer.json
+++ b/outputs/answer.json
@@ -353,9 +353,9 @@
         "balanced": false
       },
       "stage_latencies_ms": {
-        "query_analysis_ms": 1.07,
+        "query_analysis_ms": 0.74,
         "context_resolution_ms": 0.0,
-        "answer_generation_ms": 0.53
+        "answer_generation_ms": 0.36
       },
       "attempts": [
         {
@@ -444,7 +444,7 @@
     ]
   },
   "diagnostics": {
-    "latency_ms": 3.87,
+    "latency_ms": 2.71,
     "retry_count": 0,
     "abstained": false,
     "answer_status": "supported",
@@ -477,7 +477,7 @@
         "retrieval_mode": "flat",
         "verified": true,
         "verification_reasons": [],
-        "retrieve_ms": 0.77,
+        "retrieve_ms": 0.56,
         "verify_ms": 0.0,
         "comparison_coverage": {
           "targets": [
@@ -669,9 +669,9 @@
     "prompt_profile": "minimal_grounded_extractive",
     "cold_start": true,
     "stage_latency": {
-      "query_analysis_ms": 1.07,
+      "query_analysis_ms": 0.74,
       "context_resolution_ms": 0.0,
-      "answer_generation_ms": 0.53
+      "answer_generation_ms": 0.36
     },
     "synthesis": null,
     "trace_url": null,


### PR DESCRIPTION
## 1. What changed and why

공개 synthetic eval 케이스를 n=42에서 n=100으로 확장합니다. n=42에서는 bootstrap CI 폭이 너무 넓어 14개 detection-blind ablation이 `full`과 통계적으로 분리되지 않았습니다. n=100에서 CI 폭이 이론적으로 ×0.65 (√42/100) 수축하여 ablation 간 차이 검출력이 향상됩니다.

Closes #570

## 2. Files affected

- **`eval/config.yaml`** ⚠️ load-bearing — 58 케이스 추가 (+20 single_doc, +14 comparison, +12 follow_up, +12 abstention). n=42 → n=100, 비율 유지 (34%/24%/21%/21%). Agency D (분광기) 및 Agency E (수질 모니터링 본/부속) 케이스 최초 반영.
- **`README.md`** — n 수치 갱신 (n=42 → n=100), issue #570 완료 표시, detection-blind ablation 주석 업데이트.
- **`outputs/answer.json`** — smoke eval 결과 업데이트 (tracked 아티팩트).

## 3. Risks

- **케이스 품질**: 새 58 케이스가 실제 합성 문서 내용(`data/raw/rfp_agency_*.json`)에서 직접 용어를 인용하도록 작성했습니다. `expected_terms`가 문서에 없으면 eval runner가 실패합니다. Smoke eval (n=100) 정상 완료로 확인.
- **ADR 0001 invariant**: `naive_baseline` preset 변경 없음. 케이스 추가만.
- **ADR 0005 boundary**: Agency D, E 문서는 `data/raw/` 에 공개 committed synthetic fixture — 실 RFP 데이터 없음.

## 4. Tests

- `bash scripts/test.sh` — **933 passed, 0 failed** (신규 케이스 추가 후).
- `EMBEDDING_BACKEND=hashing make smoke` — n=100 기준 smoke eval 정상 완료. `reports/eval_summary.json` 갱신.
- 케이스 YAML 구문 오류 없음 (eval runner가 파싱 실패 시 즉시 에러).

## 5. Eval impact

n=100에서 CI 폭 수축:
- Accuracy CI: ±0.12 → 예상 ±0.08 (이론적 ×0.65)
- Citation CI: ±0.12 → 예상 ±0.08
- Detection-blind ablation 일부가 real-eval에서 통계적으로 분리될 가능성 있음 (real-eval 후속 실행으로 확인 예정).

### 5b. Real-data delta

파이프라인 코드 무변경. `eval/config.yaml`에 케이스만 추가했으므로 retrieval / verifier / answer 경로의 real-data 동작에 변화 없음. Real-data eval delta는 `n_cases` 증가만을 반영하며 accuracy/groundedness/citation 메트릭 delta는 0이어야 합니다.

`make real-eval-delta` 실행 환경 미보유 (private real-data 없음) — 동작 변화 없음이 근거.

## 6. Backward compatibility

answer-contract 변화 없음 (ADR 0003 schema_version 불변). eval/config.yaml 케이스 추가는 additive이며 기존 42 케이스는 그대로 보존.

## 7. Out of scope

- detection-blind ablation 수치의 실제 통계적 분리 여부 확인 (real-eval 기준 후속 실행 필요).
- `docs/eval-dataset-spec.md` n 수치 갱신 (follow-up으로 분리).
- README 메트릭 테이블의 hashing 기반 수치 갱신 — 의도적으로 제외 (real embedding 기준 기존 수치가 더 대표성 있음).