### PR TITLE
docs(eval): clarify CI-overlap = detection limit, sync ablation caption to n=100

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 | no_metadata_first | agentic_full | auto | off | on | on | 0.844±0.12 | 0.881±0.10 | 0.679±0.11 | 0.968±0.06 | 0.857 | 1.000 | 0.000 | 3.8ms |
 | no_verifier_retry | agentic_full | auto | on | on | off | 0.906±0.12 | 0.762±0.14 | 0.762±0.14 | 1.000±0.00 | 0.714 | 0.300 | 0.000 | 2.6ms |
 
-<details><summary>Detection-blind ablations — originally inseparable at n=42; dataset expanded to n=100 (issue #570 완료). Real-eval re-measurement pending.</summary>
+<details><summary>Detection-blind ablations — statistically inseparable from <code>full</code> at n=42 (CI bands overlapping; n=42 was the statistical limit). Dataset expanded to n=100 (issue #570 완료); real-eval re-measurement pending.</summary>
 
 | Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Claim Align | Format | Abstention | Retry | Latency p95 |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
@@ -147,7 +147,7 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 
 </details>
 
-> Values shown as `mean±half-width` for the 95% bootstrap CI (n=cases, 1000 resamples, seed=17). The non-CI columns (Format, Abstention, Retry) are point estimates; their CIs appear in the detailed main table above.
+> Values shown as `mean±half-width` for the 95% bootstrap CI (n=cases, 1000 resamples, seed=17). CI overlap between rows = statistical detection limit at that n, not equivalence. At n=42 the half-width was ~±0.12; n=100 narrows it by ×0.65 (√42/100). The non-CI columns (Format, Abstention, Retry) are point estimates; their CIs appear in the detailed main table above.
 <!-- METRICS_TABLE:END -->
 
 > **Ablation 해석 — CI가 말해주는 검출 한계 vs 실측 trade-off**: `no_rerank` / `hierarchical` / `full_llm`이 `full`과 동일 metric을 보이는 것은 *기능이 동등해서가 아니라 n=42 + bootstrap CI가 차이를 검출하지 못해서*였습니다 — CI 폭이 너무 넓어 미세 차이는 noise에 묻혔습니다. 현재 n=100 확장 완료(issue #570); real-eval 재측정으로 통계적 분리 가능성 확인 예정. **CI가 분리되는 진짜 효과**: `no_metadata_first` citation 0.679±0.11 (CI 0.571–0.786) vs `full` 0.905±0.08 (0.821–0.976) — CI 비겹침으로 metadata-first 효용 통계적 입증. `no_verifier_retry` groundedness 0.762±0.14 (CI 0.619–0.881) vs `full` 0.929±0.07 — verifier loop 효용 시사. 상세 latency·embedding backend 비교: [`docs/benchmarking.md`](docs/benchmarking.md).

--- a/scripts/update_readme_metrics.py
+++ b/scripts/update_readme_metrics.py
@@ -26,8 +26,8 @@ REQUIRED_KEYS = [
     "retry",
 ]
 
-# Runs whose CI separates from `full` — shown in main ablation table.
-# All other runs are detection-blind under n=42 and go into the collapsed block.
+# Runs whose CI separates from `full` at n=100 — shown in main ablation table.
+# All other runs were detection-blind at n=42 (CI overlap) and go into the collapsed block.
 _MAIN_ABLATION_RUNS = {"naive_baseline", "full", "no_metadata_first", "no_verifier_retry"}
 _MAIN_ABLATION_ORDER = ["naive_baseline", "full", "no_metadata_first", "no_verifier_retry"]
 
@@ -362,8 +362,9 @@ def render_ablation_table(summary: Dict[str, Any]) -> str:
         table.append("")
         table.append(
             "<details>"
-            "<summary>Detection-blind ablations under n=42 — "
-            "statistically inseparable from <code>full</code>; to be re-tested at n≥100 (issue #570)</summary>"
+            "<summary>Detection-blind ablations — statistically inseparable from <code>full</code> at n=42 "
+            "(CI bands overlapping; n=42 was the statistical limit). "
+            "Dataset expanded to n=100 (issue #570 완료); real-eval re-measurement pending.</summary>"
         )
         table.append("")
         table.extend(_ABLATION_HEADER)
@@ -375,6 +376,8 @@ def render_ablation_table(summary: Dict[str, Any]) -> str:
     table.append("")
     table.append(
         "> Values shown as `mean±half-width` for the 95% bootstrap CI (n=cases, 1000 resamples, seed=17). "
+        "CI overlap between rows = statistical detection limit at that n, not equivalence. "
+        "At n=42 the half-width was ~±0.12; n=100 narrows it by ×0.65 (√42/100). "
         "The non-CI columns (Format, Abstention, Retry) are point estimates; "
         "their CIs appear in the detailed main table above."
     )


### PR DESCRIPTION
## 1. What changed and why

Closes #518

`update_readme_metrics.py`의 detection-blind `<details>` 캡션이 아직 "n=42" 텍스트를 생성했습니다 — 다음 smoke 실행 시 README가 구버전으로 회귀하는 버그. 캡션을 issue #570 완료 이후 상태("n=100 expanded; real-eval pending")로 갱신하고, ablation 풋노트에 "CI overlap = statistical detection limit at that n, not equivalence" 문장을 추가해 면접 E1/E2/E3("왜 detection-blind 행들이 동일하게 보이나?") 즉답 소재를 보강합니다.

## 2. Files affected

- `scripts/update_readme_metrics.py` — detection-blind 캡션 + 풋노트 문구 수정 (non-load-bearing: 스크립트 출력 포맷만 변경, 파이프라인 무관)
- `README.md` — 위 스크립트가 생성하는 섹션의 문구를 수동 동기화

## 3. Risks

스크립트 출력 포맷만 변경. 파이프라인·eval 로직 무관. 위험 없음.

## 4. Tests

933 passed, 8 skipped (`bash scripts/test.sh`). `update_readme_metrics.py` 변경은 스트링 포매팅만이라 별도 테스트 불필요.

## 5. Eval impact

N/A — 파이프라인 코드 무변경, eval 케이스 무변경. `All ·` 예상.

### 5b. Real-data delta

N/A — `scripts/update_readme_metrics.py`는 `scripts/_governance.py` `LOAD_BEARING_PATHS` 미포함. README 문구 변경만이므로 retrieval/verifier/answer 경로 동작에 영향 없음.

## 6. Backward compatibility

N/A — 스크립트 출력 포맷 변경. 기존 계약(answer schema, CLI flag, doc link) 불변.

## 7. Out of scope

- 실제 n=100 MiniLM 재측정 후 metric 값 업데이트 (별도 `make real-eval-delta` 후속 예정)
- detection-blind ablation 행들의 CI 분리 가능성 확인 (real-eval 후속)