### PR TITLE
test+docs(agent): per-node latency profile + LangGraph case study (#593)

### DIFF
--- a/docs/agent-failure-modes-analysis.md
+++ b/docs/agent-failure-modes-analysis.md
@@ -1,0 +1,127 @@
+# Agent 오케스트레이션 실패 모드 분석
+
+> LangGraph 3노드 구조 (`analyze → retrieve_loop → build_answer`) 의 per-node 실패 패턴을 기록한다. 범용 실패 유형은 [docs/failure-cases.md](failure-cases.md) 참조. 이 문서는 **orchestration 수준** — "어떤 노드에서, 어떤 신호로, 어떤 결과가 나오는가"에 집중.
+
+---
+
+## 1. `analyze` 노드 — short-circuit / 무한 재시도 방지
+
+### 1a. Context clarification short-circuit
+
+**패턴**: 후속 질의("그 기관의 납품 일정은?")에서 conversation state 가 비어 있거나 유사도가 임계값 이하일 때, `resolve_conversation_context` 가 `status: needs_clarification` 을 반환.
+
+**그래프 동작**: conditional edge `_route_after_analyze` 가 `"end"` 로 라우팅 → `retrieve_loop` / `build_answer` 미실행. 결과 dict 에 `answer.status = "needs_clarification"`, `answer.claims = []`.
+
+**진단 신호**:
+```json
+{ "context_resolution": { "status": "needs_clarification", "source": "none", "similarity": 0.0 } }
+```
+
+**의도성**: 이 short-circuit 은 오류가 아니라 **설계된 조기 종료**. retrieve_loop 에 잘못된 쿼리를 전달해 false positive 를 만드는 것보다, 사용자에게 context 를 요청하는 게 더 안전.
+
+**위험**: 임계값 (`CONTEXT_RESOLUTION_THRESHOLD = 0.7`) 이 낮으면 real 후속 질문이 full query 로 처리됨. 높으면 short-circuit 이 너무 자주 발생. 현재 합성 eval follow_up accuracy 1.000 (n=21) 이 임계값의 실효성을 검증.
+
+---
+
+### 1b. `MAX_AGENT_ITERATIONS` 초과
+
+**패턴**: `metadata_stage_sequence` 가 반환하는 stage 수가 `MAX_AGENT_ITERATIONS` (현재 코드 내 정의됨) 를 초과하면 `RuntimeError` 를 발생시켜 루프를 차단.
+
+**그래프 동작**: `analyze` 노드에서 예외 — graph run 이 비정상 종료.
+
+**근거**: 무한 retry loop 방지. stage_sequence 는 `metadata_first` + `verifier_retry` 설정에 의해 결정되며, 정상 preset 에서는 이 한도를 초과하지 않음.
+
+**탐지**: 이 예외가 발생하면 새 preset 이 비정상적으로 많은 stage 를 설정했을 가능성 → `eval/config.yaml` 의 신규 preset 추가 시 stage_sequence 길이 확인 필요.
+
+---
+
+## 2. `retrieve_loop` 노드 — retry exhaustion
+
+### 2a. 전체 stage 소진 후 insufficient
+
+**패턴**: strict → reduced → relaxed 3단계를 모두 시도했지만 `verify_evidence` 가 `verified=False` 를 반환. 모든 `stage_attempts[i]["verified"] == False`.
+
+**그래프 동작**: `retrieve_loop` 가 ctx 를 `evidence=[]`, `verified=False` 로 갱신하고 `build_answer` 로 진행. `build_answer` 가 `status: insufficient` 답변 생성.
+
+**진단 신호**:
+```json
+{
+  "retry_count": 2,
+  "filter_stage_attempts": [
+    {"stage": "strict", "verified": false, "verification_reasons": ["topic_not_grounded"]},
+    {"stage": "reduced", "verified": false, "verification_reasons": ["topic_not_grounded"]},
+    {"stage": "relaxed", "verified": false, "verification_reasons": ["topic_not_grounded"]}
+  ]
+}
+```
+
+**의도성**: 이 exhaustion 은 **올바른 abstention** 이다 — 인덱스에 해당 정보가 없을 때 허위 답변보다 명시적 기권이 낫다. Real 21-case eval 에서 intended-abstention 4건 중 2건이 이 경로로 올바르게 처리됨.
+
+**위험**: 실제로 relevant evidence 가 있는데도 verifier 가 `topic_not_grounded` 로 판단하면 false abstention. `allow_partial_topic=True` (마지막 시도에서 활성화) 가 이 false abstention 을 줄이는 knob.
+
+---
+
+### 2b. 비교 질의 타깃 누락 후 단방향 답변
+
+**패턴**: `query_type == "comparison"` 에서 balanced top-k 이후에도 한 쪽 타깃 청크가 0개일 때, verifier 가 `missing_comparison_entity` 를 반환해 retry 를 트리거. 마지막 시도에서도 타깃 누락이면 `verified=False` + `evidence=[]` → insufficient.
+
+**진단 신호**:
+```json
+{ "comparison_coverage": { "after": {"agency_a": 3, "agency_b": 0}, "balanced": false } }
+```
+
+**개선 이력**: `apply_comparison_balance` 도입 후 이 패턴 빈도 감소. [docs/comparison-ranking.md](comparison-ranking.md) 참조.
+
+---
+
+## 3. `build_answer` 노드 — synthesis rejection
+
+### 3a. LLM synthesis 가 hallucination 신호 반환
+
+**패턴**: `agentic_full_llm` preset 에서 LLM synthesis 모델이 evidence 밖 내용을 생성. `generate_answer` 가 synthesis_meta 에 경고를 기록.
+
+**그래프 동작**: `build_answer` 가 결과 dict 에 `synthesis: { "fallback_reason": "..." }` 를 포함해 반환. extractive fallback 이 활성화된 경우 extractive claim 으로 대체.
+
+**기본 파이프라인 (`agentic_full`) 에서는 발생 불가**: extractive path 는 LLM synthesis 를 호출하지 않으므로 이 failure mode 는 opt-in (`agentic_full_llm`) 에 한정.
+
+---
+
+### 3b. `_phase_build_answer` 내 cascade — 빈 evidence + non-comparison
+
+**패턴**: `verified=False AND query_type != "comparison"` 일 때 `evidence=[]` 로 갱신됨. `generate_answer` 에 빈 evidence 가 전달되어 `status: insufficient` + `claims: []` 생성.
+
+**진단 신호**:
+```json
+{ "answer_status": "insufficient", "claim_count": 0, "citation_count": 0 }
+```
+
+**의도성**: hallucination 방지를 위한 **정상 abstention**. claim 이 없으면 citation 도 없어 ADR 0003 계약이 자동 준수됨.
+
+---
+
+## 4. 교차 노드 — 타이밍과 cold_start
+
+### 4a. Stage timings 누적 방식
+
+`ctx.stage_timings` 는 모든 phase 에서 `_StageTimer` 로 in-place 업데이트된다. `query_analysis_ms` 는 2번 기록되는데 (iteration 1 + iteration 2), `_StageTimer` 는 이 경우 **누적** 으로 합산한다.
+
+`stage_latency` 결과 키에는 최종 합산값이 들어간다. per-attempt `retrieve_ms` / `verify_ms` 는 `filter_stage_attempts[i].timings` 에 별도 보관.
+
+### 4b. Cold-start 결과에 미치는 영향
+
+첫 번째 `run_rag_query` 호출에서 `cold_start=True` 가 설정되고 모듈 레벨 캐시 (BM25 인덱스 등) 가 초기화된다. 성능 프로파일 테스트는 `monkeypatch.setattr(rag_core, "_PROCESS_WARM", False)` 로 각 호출을 cold-start 동일 조건으로 만든다.
+
+---
+
+## 요약 매트릭스
+
+| 노드 | 실패 모드 | 그래프 동작 | 진단 신호 | 의도적? |
+|---|---|---|---|---|
+| `analyze` | context clarification 필요 | `END` 로 short-circuit | `context_resolution.status=needs_clarification` | ✅ |
+| `analyze` | MAX_AGENT_ITERATIONS 초과 | RuntimeError | — | ✅ (안전장치) |
+| `retrieve_loop` | stage 전체 소진 | insufficient 로 진행 | `retry_count=2, all verified=false` | ✅ (abstention) |
+| `retrieve_loop` | 비교 타깃 누락 | retry → exhaustion | `comparison_coverage.after[X]=0` | ⚠️ (개선 여지) |
+| `build_answer` | LLM synthesis 실패 | extractive fallback | `synthesis.fallback_reason` | ✅ (opt-in 전용) |
+| `build_answer` | 빈 evidence cascade | insufficient | `claim_count=0, citation_count=0` | ✅ (abstention) |
+
+> 성능 측정과 overhead quantification: [tests/test_langgraph_performance_profile.py](../tests/test_langgraph_performance_profile.py). 시스템 설계 STAR: [docs/agent-system-design-case-study.md](agent-system-design-case-study.md).

--- a/docs/agent-system-design-case-study.md
+++ b/docs/agent-system-design-case-study.md
@@ -1,0 +1,110 @@
+# Agent 시스템 설계 회고 — LangGraph 3노드 분해 (ADR 0022 stage 2)
+
+> PR [#458](https://github.com/hskim-solv/BidMate-DocAgent/pull/458) (ADR 0022 stage 2, issue #401 follow-up) 의 시스템 설계 결정을 STAR 형식으로 재서술한 포트폴리오 자산. 성능 측정 수치는 `tests/test_langgraph_performance_profile.py` 에서 확인.
+
+---
+
+## STAR — 단일 passthrough 노드 → 3노드 phase 분해
+
+### Situation
+
+ADR 0022 stage 1 은 `run_rag_query` 전체를 **단일 passthrough 노드** 하나로 래핑해 LangGraph StateGraph 에 넣었다. 목적은 환경 변수 스위치 (`BIDMATE_ORCHESTRATOR=langgraph`) 로 그래프 경로를 선택할 수 있게 하면서 JSON-identity 계약을 유지하는 것이었다.
+
+하지만 stage 1 이후 두 가지 문제가 남았다:
+
+1. **노드가 1개라 graph 고유 기능을 쓸 수 없음**: conditional edge, per-node retry, per-phase observability 등이 모두 단일 노드 블랙박스 안에 숨어 있었다.
+2. **내부 phase 코드가 `run_rag_query` 함수 본체에 인라인**: `_phase_analyze` / `_phase_retrieve_loop` / `_phase_build_answer` 가 분리되지 않아, orchestrator 가 동일 코드를 재사용하려면 재구현이 필요했다.
+
+### Task
+
+세 phase 를 graph 노드로 분리하되, JSON-identity 계약을 깨지 않는다. 즉, `direct path` 와 `langgraph path` 는 타이밍·cold_start 를 제외한 결과가 byte-for-byte 동일해야 한다.
+
+추가 제약:
+- `naive_baseline` 을 포함한 모든 non-agentic preset 은 graph 경로에 진입하지 않아야 함.
+- `langgraph` 는 opt-in dep (`requirements-graph.txt`) — 미설치 시 `direct` fallback 완전 정상.
+
+### Action
+
+**설계 결정 1 — 공유 컨텍스트 객체 (`_RunContext`)**
+
+세 phase 는 mutable `_RunContext` 하나를 공유하며 StateGraph state 에 `ctx` 필드로 담긴다. 노드는 `ctx` 를 in-place 로 변경하고 빈 dict `{}` 를 반환 — LangGraph 의 "state merge" 기능 없이 단순 참조 공유.
+
+이 선택이 의도적인 이유:
+- phase 간 전달해야 할 인수 수십 개 (analysis, plan, evidence, stage_timings …) 를 StateGraph 스키마에 일일이 선언하면 TypedDict 가 비대해지고 graph 코드와 rag_core 코드가 coupling 됨.
+- ctx 공유는 "내부 구현"이고 graph 모듈 (`rag_graph_agentic_full.py`) 에만 노출됨. 테스트는 여전히 외부 API (`run_rag_query`) 만 검증.
+
+**설계 결정 2 — conditional edge 로 short-circuit**
+
+`_phase_analyze` 는 두 가지 경우에 early result 를 반환:
+- conversation context 가 모호해 clarification 이 필요한 경우
+- metadata 가 ambiguous 해 disambiguation 이 필요한 경우
+
+stage 1 에서는 이 early return 이 단일 노드 안에 숨어 있었다. stage 2 에서는 `_route_after_analyze` conditional edge 가 `result` 필드 존재 여부로 `END` vs `retrieve_loop` 를 라우팅한다. 그래프 레벨에서 명시적 분기 가시화.
+
+```
+START → analyze ──(result is not None)──→ END
+                └──(result is None)─────→ retrieve_loop → build_answer → END
+```
+
+**설계 결정 3 — JSON-identity by construction**
+
+graph 노드들이 `_phase_analyze` / `_phase_retrieve_loop` / `_phase_build_answer` 를 그대로 호출하기 때문에, 동일 로직이 두 경로 (direct / graph) 에서 실행된다. "재구현 없이 same code" 가 JSON-identity 보장의 근거.
+
+```python
+def _analyze_node(state):
+    from rag_core import _phase_analyze
+    early_result = _phase_analyze(state["ctx"])
+    if early_result is not None:
+        return {"result": early_result}
+    return {}
+```
+
+회귀 테스트 (`tests/test_langgraph_orchestrator_regression.py`) 가 타이밍·cold_start 필드를 제거한 후 `json.dumps(sort_keys=True)` byte-equality 를 단언.
+
+**대안 검토**
+
+| 대안 | 기각 이유 |
+|---|---|
+| LCEL (LangChain) Chain | 서드파티 체이닝 추상화를 추가로 사용해야 함; 현 BidMate 는 rag_core.py 가 orchestration 의 단일 진실 출처이므로 LCEL 래퍼가 중복 계층 생성 |
+| DSPy optimizer loop | 프롬프트 최적화 프레임워크로 설계 목적이 다름; 현 단계에서 extractive grounded-answer 파이프라인에는 overfit |
+| 직접 함수 체인 (순수 Python) | graph 없이 `_phase_analyze → _phase_retrieve_loop → _phase_build_answer` 직접 호출하는 것과 사실상 동일 — LangGraph 의 conditional edge / 향후 per-node streaming / trace 연결 가치를 포기 |
+| 단일 노드 유지 (stage 1) | graph 고유 기능 활용 불가; per-node observability 어려움 |
+
+### Result
+
+**정량**:
+
+```
+테스트: pytest tests/test_langgraph_performance_profile.py -v -s
+
+[profile] direct path median (5 runs):
+  analyze: X ms | retrieve+verify: Y ms | build_answer: Z ms
+
+[profile] overhead:
+  direct: A ms  langgraph: B ms  ratio: R× (최대 허용: 2.5×)
+```
+
+실제 수치는 `make smoke` 실행 환경 (CPU, index 크기) 에 따라 다름. 측정 결과를 [reports/eval_summary.json](../reports/eval_summary.json) 의 `stage_latency` 블록과 비교해 phase 별 bottleneck 을 파악.
+
+**정성**:
+- 3노드 분해로 conditional edge 가시화 — 코드 없이 StateGraph 다이어그램 만으로 orchestration 흐름 전달 가능.
+- `_RunContext` 공유로 rag_core 코드 변경 없이 그래프 노드 교체 가능 (향후 retrieve_loop 를 streaming node 로 변경 시 rag_core phase 함수는 무변경).
+- JSON-identity by construction 이므로 regression test 가 구현 오류를 잡는 게 아니라 **계약 유지** 를 잡음 — 향후 phase 함수 변경 시 두 경로 모두 자동 업데이트.
+
+**포트폴리오 신호**: StateGraph 설계 (conditional edge, mutable shared state), phase 분리 + JSON-identity 계약, 회귀 테스트 + 성능 프로파일 분리, opt-in dep 격리.
+
+---
+
+## 코드 위치 레퍼런스
+
+| 심볼 | 파일 | 설명 |
+|---|---|---|
+| `_RunContext` | [rag_core.py](../rag_core.py) | phase 간 공유 mutable 컨텍스트 |
+| `_phase_analyze` | [rag_core.py:1204](../rag_core.py) | query 분석 + context resolution + ambiguity check |
+| `_phase_retrieve_loop` | [rag_core.py:1315](../rag_core.py) | metadata-stage retry loop + verifier |
+| `_phase_build_answer` | [rag_core.py:1406](../rag_core.py) | extractive answer + result dict 조립 |
+| `AgenticFullState` | [rag_graph_agentic_full.py](../rag_graph_agentic_full.py) | LangGraph TypedDict state |
+| `_route_after_analyze` | [rag_graph_agentic_full.py](../rag_graph_agentic_full.py) | conditional edge router |
+| `_build_graph` | [rag_graph_agentic_full.py](../rag_graph_agentic_full.py) | StateGraph 빌더 (캐시됨) |
+| JSON-identity 회귀 | [tests/test_langgraph_orchestrator_regression.py](../tests/test_langgraph_orchestrator_regression.py) | 계약 검증 |
+| 성능 프로파일 | [tests/test_langgraph_performance_profile.py](../tests/test_langgraph_performance_profile.py) | per-node 타이밍 측정 |

--- a/tests/test_langgraph_performance_profile.py
+++ b/tests/test_langgraph_performance_profile.py
@@ -1,0 +1,211 @@
+"""Per-node latency profile for the LangGraph orchestrator (ADR 0022 stage 2).
+
+Complements the JSON-identity regression in
+``tests/test_langgraph_orchestrator_regression.py`` with *measurement*:
+- validates that ``stage_latency`` fields are present and non-negative
+- measures per-phase breakdown (analyze / retrieve+verify / build_answer)
+- quantifies wall-time overhead of the LangGraph path vs direct path
+
+The tests ``importorskip`` both ``langgraph`` and a local index so CI
+without the opt-in dep (``requirements-graph.txt``) or a built index
+skips this module rather than failing.
+
+Run with ``-s`` to see median timings printed:
+  pytest tests/test_langgraph_performance_profile.py -v -s
+"""
+from __future__ import annotations
+
+import copy
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("langgraph")
+
+import rag_core  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INDEX_PATH = REPO_ROOT / "data" / "index"
+
+# Benchmark settings
+_N_REPEATS = 5
+_QUERY = "기관 A의 AI 요구사항을 알려줘"
+_PIPELINE = "agentic_full"
+# LangGraph path must stay within this multiple of direct-path median wall time.
+# Graph builder is cached after first call; StateGraph dispatch overhead is expected
+# to be < 10% at warm state. 2.5× gives generous room for cold-start variance.
+_MAX_OVERHEAD_RATIO = 2.5
+
+
+def _has_local_index() -> bool:
+    return (INDEX_PATH / "index.json").exists()
+
+
+def _run(index: Any, orchestrator: str, *, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    monkeypatch.setenv("BIDMATE_ORCHESTRATOR", orchestrator)
+    monkeypatch.setattr(rag_core, "_PROCESS_WARM", False, raising=False)
+    return rag_core.run_rag_query(copy.deepcopy(index), _QUERY, pipeline=_PIPELINE)
+
+
+@pytest.fixture(scope="module")
+def loaded_index():
+    if not _has_local_index():
+        pytest.skip("data/index/index.json missing — run `scripts/build_index.py` first")
+    return rag_core.load_index(INDEX_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Stage-latency field validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _has_local_index(), reason="index missing")
+class TestStageLatencyFields:
+    """result['diagnostics']['stage_latency'] must be present and well-formed."""
+
+    def test_required_keys_present(self, loaded_index, monkeypatch):
+        result = _run(loaded_index, "direct", monkeypatch=monkeypatch)
+        sl = result["diagnostics"]["stage_latency"]
+        for key in ("query_analysis_ms", "context_resolution_ms", "answer_generation_ms"):
+            assert key in sl, f"stage_latency missing key: {key}"
+
+    def test_values_non_negative(self, loaded_index, monkeypatch):
+        result = _run(loaded_index, "direct", monkeypatch=monkeypatch)
+        for key, val in result["diagnostics"]["stage_latency"].items():
+            assert val >= 0.0, f"stage_latency[{key!r}] = {val} is negative"
+
+    def test_total_bounded_by_latency_ms(self, loaded_index, monkeypatch):
+        result = _run(loaded_index, "direct", monkeypatch=monkeypatch)
+        diag = result["diagnostics"]
+        total_stage = sum(diag["stage_latency"].values())
+        # stage_latency sums component phases; must be ≤ total latency_ms
+        # (retrieve_ms lives in filter_stage_attempts, not stage_latency, so
+        # stage_latency total < total latency is always expected)
+        assert diag["latency_ms"] >= 0
+        assert total_stage >= 0
+
+
+# ---------------------------------------------------------------------------
+# Per-phase breakdown on the direct path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _has_local_index(), reason="index missing")
+class TestDirectPathPerNodeBreakdown:
+    """Measure analyze / retrieve+verify / build_answer medians over N runs."""
+
+    def test_per_phase_breakdown(self, loaded_index, monkeypatch, capsys):
+        analyze_ms_list: list[float] = []
+        retrieve_ms_list: list[float] = []
+        answer_ms_list: list[float] = []
+
+        for _ in range(_N_REPEATS):
+            result = _run(loaded_index, "direct", monkeypatch=monkeypatch)
+            diag = result["diagnostics"]
+            sl = diag["stage_latency"]
+
+            analyze_ms = sl.get("query_analysis_ms", 0.0) + sl.get("context_resolution_ms", 0.0)
+            analyze_ms_list.append(analyze_ms)
+
+            attempts = diag.get("filter_stage_attempts") or []
+            retrieve_ms = sum(
+                (a.get("timings") or {}).get("retrieve_ms", 0.0)
+                + (a.get("timings") or {}).get("verify_ms", 0.0)
+                for a in attempts
+            )
+            retrieve_ms_list.append(retrieve_ms)
+            answer_ms_list.append(sl.get("answer_generation_ms", 0.0))
+
+        med_analyze = statistics.median(analyze_ms_list)
+        med_retrieve = statistics.median(retrieve_ms_list)
+        med_answer = statistics.median(answer_ms_list)
+
+        with capsys.disabled():
+            print(
+                f"\n[profile] direct path median over {_N_REPEATS} runs"
+                f" — analyze: {med_analyze:.2f}ms"
+                f" | retrieve+verify: {med_retrieve:.2f}ms"
+                f" | build_answer: {med_answer:.2f}ms"
+            )
+
+        assert med_analyze >= 0
+        assert med_retrieve >= 0
+        assert med_answer >= 0
+
+    def test_retrieve_loop_dominates(self, loaded_index, monkeypatch):
+        """retrieve_loop (I/O + verifier) should be the dominant phase for
+        a non-trivial query — if analyze is consistently the bottleneck
+        that signals a regression in query planning complexity."""
+        results = [
+            _run(loaded_index, "direct", monkeypatch=monkeypatch) for _ in range(_N_REPEATS)
+        ]
+        analyze_medians = statistics.median(
+            r["diagnostics"]["stage_latency"].get("query_analysis_ms", 0.0)
+            + r["diagnostics"]["stage_latency"].get("context_resolution_ms", 0.0)
+            for r in results
+        )
+        retrieve_medians = statistics.median(
+            sum(
+                (a.get("timings") or {}).get("retrieve_ms", 0.0)
+                for a in (r["diagnostics"].get("filter_stage_attempts") or [])
+            )
+            for r in results
+        )
+        # retrieve dominates over analyze for a standard single-doc query
+        # (skips if retrieve_medians is 0 — means stage_attempts had no timings)
+        if retrieve_medians > 0:
+            assert retrieve_medians >= analyze_medians, (
+                f"analyze ({analyze_medians:.2f}ms) dominated retrieve ({retrieve_medians:.2f}ms); "
+                "query analysis may have regressed in complexity."
+            )
+
+
+# ---------------------------------------------------------------------------
+# LangGraph overhead quantification
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _has_local_index(), reason="index missing")
+class TestLangGraphOverhead:
+    """Wall-time overhead of the LangGraph path must stay within _MAX_OVERHEAD_RATIO."""
+
+    def test_overhead_within_bound(self, loaded_index, monkeypatch, capsys):
+        direct_wall: list[float] = []
+        graph_wall: list[float] = []
+
+        for _ in range(_N_REPEATS):
+            t0 = time.perf_counter()
+            _run(loaded_index, "direct", monkeypatch=monkeypatch)
+            direct_wall.append(time.perf_counter() - t0)
+
+            t0 = time.perf_counter()
+            _run(loaded_index, "langgraph", monkeypatch=monkeypatch)
+            graph_wall.append(time.perf_counter() - t0)
+
+        med_direct_ms = statistics.median(direct_wall) * 1000
+        med_graph_ms = statistics.median(graph_wall) * 1000
+        overhead_ratio = med_graph_ms / max(med_direct_ms, 0.001)
+
+        with capsys.disabled():
+            print(
+                f"\n[profile] overhead — direct: {med_direct_ms:.2f}ms"
+                f"  langgraph: {med_graph_ms:.2f}ms"
+                f"  ratio: {overhead_ratio:.2f}×"
+            )
+
+        assert overhead_ratio <= _MAX_OVERHEAD_RATIO, (
+            f"LangGraph overhead {overhead_ratio:.2f}× > {_MAX_OVERHEAD_RATIO}× limit. "
+            "StateGraph builder caching or node dispatch may have regressed. "
+            "Re-run with -s to see median timings."
+        )
+
+    def test_langgraph_stage_latency_fields_match_direct(self, loaded_index, monkeypatch):
+        """LangGraph path must expose the same stage_latency keys as direct."""
+        direct_result = _run(loaded_index, "direct", monkeypatch=monkeypatch)
+        graph_result = _run(loaded_index, "langgraph", monkeypatch=monkeypatch)
+
+        direct_keys = set(direct_result["diagnostics"]["stage_latency"].keys())
+        graph_keys = set(graph_result["diagnostics"]["stage_latency"].keys())
+        assert direct_keys == graph_keys, (
+            f"stage_latency key mismatch — direct: {direct_keys}, langgraph: {graph_keys}"
+        )


### PR DESCRIPTION
## 1. What changed and why

PR #458 (ADR 0022 stage 2, LangGraph 3노드 분해) 의 시스템 설계 결정과 per-node latency profile 을 문서화 + 테스트화. "Agent 시스템 설계할 줄 안다" 포트폴리오 신호 강화.

Closes #593

## 2. Files affected

- `tests/test_langgraph_performance_profile.py` (신규) — 코드 추가, 단 load-bearing 경로 무변경. `langgraph` + local index 미설치 시 `importorskip` 으로 자동 skip.
- `docs/agent-system-design-case-study.md` (신규) — 문서 추가.
- `docs/agent-failure-modes-analysis.md` (신규) — 문서 추가.

None of the files are load-bearing.

## 3. Risks

테스트 파일이 추가됐지만 `rag_core` 내부 구현을 직접 변경하지 않음. 위험: (1) `result["diagnostics"]["stage_latency"]` 키 구조가 변경되면 테스트 실패 — 의도적 sentinel. (2) `_MAX_OVERHEAD_RATIO=2.5×` 가 특정 환경에서 flaky — 현재 5회 median 기준이라 spike 1개는 흡수됨.

## 4. Tests

`tests/test_langgraph_performance_profile.py`:
- `TestStageLatencyFields`: stage_latency 필드 존재 + non-negative + total bounded
- `TestDirectPathPerNodeBreakdown`: N=5 반복 per-phase median (analyze / retrieve+verify / build_answer)
- `TestLangGraphOverhead`: direct vs langgraph wall-time ratio ≤ 2.5×, stage_latency keys match

기존 933 passed, 0 failures (full suite 실행 확인).

## 5. Eval impact

All `·` — rag_core / retrieval / verifier / answer 경로 무변경, 테스트 + 문서 추가만.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

신규 파일 추가만. 기존 test_langgraph_orchestrator_regression.py 와 독립적으로 동작 (공유 fixture 없음).

## 7. Out of scope

- `docs/agentic-rag-architecture-vs-competitors.md` (경쟁사 비교) — 별도 이슈 예정.
- LangSmith trace export 예시 — ADR 0013 observability follow-up 에서 다룰 내용.