### PR TITLE
feat(governance): ADR lag parser + 4-field hook fire log format

### DIFF
--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -289,20 +289,80 @@ def collect_git(repo: str, start: str, end: str) -> dict[str, Any]:
     }
 
 
+def _compute_adr_lags(repo: str, start: str, end: str) -> list[dict[str, Any]]:
+    """Return ADR proposed→accepted lag for ADRs accepted within the quarter.
+
+    proposed_date: timestamp of the commit that first added the ADR file.
+    accepted_date: timestamp of the commit that introduced ``**Status**: accepted``.
+    Only emits ADRs whose accepted_date falls in [start, end].
+    lag_days = (accepted - proposed).days  (clamped to 0 if negative).
+    """
+    start_dt = datetime.fromisoformat(start).replace(tzinfo=timezone.utc)
+    end_dt = datetime.fromisoformat(end).replace(
+        tzinfo=timezone.utc, hour=23, minute=59, second=59
+    )
+    adr_dir = Path(repo) / "docs" / "adr"
+    if not adr_dir.is_dir():
+        return []
+    results: list[dict[str, Any]] = []
+    for adr_path in sorted(adr_dir.glob("*.md")):
+        m = ADR_FILENAME_RE.match(adr_path.name)
+        if not m:
+            continue
+        adr_id = m.group(1)
+        rel_path = str(adr_path.relative_to(repo))
+        try:
+            proposed_lines = subprocess.run(
+                ["git", "log", "--diff-filter=A", "--pretty=format:%aI", "--", rel_path],
+                cwd=repo, text=True, capture_output=True, timeout=15,
+            ).stdout.strip().splitlines()
+            if not proposed_lines:
+                continue
+            proposed_dt = datetime.fromisoformat(proposed_lines[-1])
+            if proposed_dt.tzinfo is None:
+                proposed_dt = proposed_dt.replace(tzinfo=timezone.utc)
+
+            accepted_lines = subprocess.run(
+                ["git", "log", "-S", "**Status**: accepted",
+                 "--pretty=format:%aI", "--", rel_path],
+                cwd=repo, text=True, capture_output=True, timeout=15,
+            ).stdout.strip().splitlines()
+            if not accepted_lines:
+                continue
+            accepted_dt = datetime.fromisoformat(accepted_lines[0])
+            if accepted_dt.tzinfo is None:
+                accepted_dt = accepted_dt.replace(tzinfo=timezone.utc)
+        except (subprocess.TimeoutExpired, ValueError, OSError):
+            continue
+
+        if accepted_dt < start_dt or accepted_dt > end_dt:
+            continue
+        lag_days = max((accepted_dt - proposed_dt).days, 0)
+        results.append({
+            "adr_id": adr_id,
+            "proposed_date": proposed_dt.date().isoformat(),
+            "accepted_date": accepted_dt.date().isoformat(),
+            "lag_days": lag_days,
+        })
+    return results
+
+
 def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
     """Parse `.claude/.hook-fires.log` for PreToolUse load-bearing fires.
 
-    Log line format: ``<ISO8601 UTC>|<file_path>`` appended by
-    ``scripts/claude-hooks/pretooluse-loadbearing.sh`` (issue #495).
-    Returns fires within the quarter window plus a top-10 by-path
-    distribution; never reads body of any other file.
+    Log line formats (both accepted):
+    - legacy 2-field: ``<ISO8601 UTC>|<file_path>``
+    - current 4-field: ``<ISO8601 UTC>|<action>|<context>|<detail>``
+      loadbearing fires use ``aware|load-bearing|<file_path>``
+      bash-guard blocks use ``blocked|gh-merge-delete-branch|<branch>``
     """
     log_path = Path(repo) / ".claude" / ".hook-fires.log"
     if not log_path.is_file():
         return {
             "pretooluse_loadbearing_fires": 0,
             "fires_by_path": {},
-            "rule_to_automation_lag_days": [],
+            "fires_by_action": {},
+            "rule_to_automation_lag_days": _compute_adr_lags(repo, start, end),
             "note": "Hook fire log absent at .claude/.hook-fires.log; emit 0.",
         }
     start_dt = datetime.fromisoformat(start).replace(tzinfo=timezone.utc)
@@ -311,30 +371,38 @@ def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
     )
     fires = 0
     by_path: Counter[str] = Counter()
+    by_action: Counter[str] = Counter()
     try:
         for line in log_path.read_text().splitlines():
             line = line.strip()
             if not line or "|" not in line:
                 continue
-            ts, _, path = line.partition("|")
+            parts = line.split("|", 3)
+            ts = parts[0]
             try:
                 fire_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
             except ValueError:
                 continue
             if fire_dt < start_dt or fire_dt > end_dt:
                 continue
+            if len(parts) >= 4:
+                action, path = parts[1], parts[3]
+            else:
+                action, path = "aware", parts[1] if len(parts) > 1 else ""
             fires += 1
-            by_path[path] += 1
+            if path:
+                by_path[path] += 1
+            if action:
+                by_action[action] += 1
     except OSError:
         pass
-    note = (
-        "Cycle-time lag uses ADR proposed→accepted dates (git history); "
-        "lag list intentionally empty until parsed."
-    )
+    lags = _compute_adr_lags(repo, start, end)
+    note = f"Lag: {len(lags)} ADR(s) with accepted date in window."
     return {
         "pretooluse_loadbearing_fires": fires,
         "fires_by_path": dict(by_path.most_common(10)),
-        "rule_to_automation_lag_days": [],
+        "fires_by_action": dict(by_action),
+        "rule_to_automation_lag_days": lags,
         "note": note,
     }
 

--- a/scripts/claude-hooks/pretooluse-loadbearing.sh
+++ b/scripts/claude-hooks/pretooluse-loadbearing.sh
@@ -35,7 +35,7 @@ fi
 if python3 "$REPO_ROOT/scripts/_governance.py" --is-load-bearing "$file_path" 2>/dev/null; then
   # Fire log for /self-review-quarterly governance ROI axis (issue #495).
   # Gitignored via `.claude/*` in repo root .gitignore.
-  printf '%s|%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$file_path" \
+  printf '%s|aware|load-bearing|%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$file_path" \
     >> "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
   cat >&2 <<EOF
 ⚠️  Load-bearing file: $file_path

--- a/tests/test_self_review_regression.py
+++ b/tests/test_self_review_regression.py
@@ -1,0 +1,130 @@
+"""Regression tests for governance hook fire log collector (issue #502).
+
+Pins backward-compatible log parsing, action distribution split,
+quarter-window filtering, ADR proposed→accepted lag calculation, and
+that unaccepted ADRs are not emitted.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "claude-hooks"))
+import _self_review as sr
+
+
+class TestHookFiresBackwardCompat(unittest.TestCase):
+    def test_legacy_2field_and_4field_both_counted(self):
+        lines = (
+            "2026-04-01T10:00:00Z|rag_core.py\n"
+            "2026-04-02T11:00:00Z|aware|load-bearing|rag_retrieval.py\n"
+            "2025-12-01T00:00:00Z|aware|load-bearing|old.py\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(lines)
+            result = sr.collect_governance_hooks(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(result["pretooluse_loadbearing_fires"], 2)
+        self.assertIn("aware", result["fires_by_action"])
+
+
+class TestHookFiresActionDistribution(unittest.TestCase):
+    def test_aware_and_blocked_counted_separately(self):
+        lines = (
+            "2026-04-01T10:00:00Z|aware|load-bearing|rag_core.py\n"
+            "2026-04-02T10:00:00Z|blocked|gh-merge-delete-branch|feat/issue-99\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(lines)
+            result = sr.collect_governance_hooks(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(result["fires_by_action"].get("aware"), 1)
+        self.assertEqual(result["fires_by_action"].get("blocked"), 1)
+        self.assertEqual(result["pretooluse_loadbearing_fires"], 2)
+
+
+class TestHookFiresQuarterWindowFilter(unittest.TestCase):
+    def test_outside_window_excluded(self):
+        lines = (
+            "2025-12-31T23:59:59Z|aware|load-bearing|old.py\n"
+            "2026-07-01T00:00:00Z|aware|load-bearing|future.py\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(lines)
+            result = sr.collect_governance_hooks(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(result["pretooluse_loadbearing_fires"], 0)
+
+
+def _git(*args, cwd, **kwargs):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, **kwargs)
+
+
+def _make_repo_with_adr(
+    td: str,
+    adr_filename: str,
+    content_at_add: str,
+    content_at_accept: str | None,
+    add_date: str,
+    accept_date: str | None,
+) -> Path:
+    repo = Path(td)
+    adr_dir = repo / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    adr_path = adr_dir / adr_filename
+    _git("init", cwd=str(repo))
+    _git("config", "user.email", "test@test.com", cwd=str(repo))
+    _git("config", "user.name", "Test", cwd=str(repo))
+    adr_path.write_text(content_at_add)
+    _git("add", ".", cwd=str(repo))
+    env = {**os.environ, "GIT_COMMITTER_DATE": add_date}
+    _git("commit", f"--date={add_date}", "-m", f"add {adr_filename}", cwd=str(repo), env=env)
+    if content_at_accept is not None and accept_date is not None:
+        adr_path.write_text(content_at_accept)
+        _git("add", ".", cwd=str(repo))
+        env2 = {**os.environ, "GIT_COMMITTER_DATE": accept_date}
+        _git("commit", f"--date={accept_date}", "-m", f"accept {adr_filename}", cwd=str(repo), env=env2)
+    return repo
+
+
+class TestRuleToAutomationLagBasic(unittest.TestCase):
+    def test_lag_days_computed_correctly(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = _make_repo_with_adr(
+                td,
+                "0001-test.md",
+                content_at_add="- **Status**: proposed\n",
+                content_at_accept="- **Status**: accepted\n",
+                add_date="2026-04-01T10:00:00+00:00",
+                accept_date="2026-04-11T10:00:00+00:00",
+            )
+            lags = sr._compute_adr_lags(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(len(lags), 1)
+        self.assertEqual(lags[0]["adr_id"], "0001")
+        self.assertEqual(lags[0]["lag_days"], 10)
+
+
+class TestRuleToAutomationLagSkipsUnaccepted(unittest.TestCase):
+    def test_proposed_only_not_emitted(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = _make_repo_with_adr(
+                td,
+                "0002-unaccepted.md",
+                content_at_add="- **Status**: proposed\n",
+                content_at_accept=None,
+                add_date="2026-04-01T10:00:00+00:00",
+                accept_date=None,
+            )
+            lags = sr._compute_adr_lags(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(lags, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #502

`collect_governance_hooks` in `_self_review.py`의 `rule_to_automation_lag_days`가 항상 빈 리스트였다 (issue #502). Q2-2026 self-review에서 5축 #4 사이클 타임이 △로 평가된 직접 원인. 본 PR은 (1) git history 기반 ADR proposed→accepted lag 계산을 구현하고 (2) hook fire log 포맷을 bash-guard와 grammar-통일된 4-필드로 교체해 `fires_by_action` 분포까지 정량화한다. 두 변경이 같이 land되면 Q3 self-review에서 #3(거버넌스 자동화 ROI) + #4(사이클 타임) 동시 △→✓ 전환이 가능하다.

## 2. Files affected

- `scripts/claude-hooks/pretooluse-loadbearing.sh` — fire log printf 포맷 2-field→4-field
- `scripts/claude-hooks/_self_review.py` — `_compute_adr_lags()` 신규 + `collect_governance_hooks()` 확장
- `tests/test_self_review_regression.py` — 신규 5-test regression suite

load-bearing 해당 없음 (`scripts/_governance.py::LOAD_BEARING_PATHS` 미포함).

## 3. Risks

가장 가능한 문제: `git log -S "**Status**: accepted"` 검색이 ADR 파일의 실제 표기와 불일치하는 경우. 확인: `docs/adr/0032-eval-saturation-routed-subset.md` line 3이 `- **Status**: accepted` 정확히 일치, git log -S 검색 성공.

2-field legacy 라인 파싱: `split("|", 3)` + `len(parts) >= 4` 분기로 backward compat 보장. legacy 라인이 2개 있을 경우 `parts[1]`이 path로 들어가 fires 카운트에 포함된다.

## 4. Tests

`tests/test_self_review_regression.py` 신규 5개:
1. `TestHookFiresBackwardCompat::test_legacy_2field_and_4field_both_counted` — 2-field + 4-field mixed fixture, fires=2
2. `TestHookFiresActionDistribution::test_aware_and_blocked_counted_separately` — action split 정확도
3. `TestHookFiresQuarterWindowFilter::test_outside_window_excluded` — 분기 밖 타임스탬프 제외
4. `TestRuleToAutomationLagBasic::test_lag_days_computed_correctly` — tmp git repo + 두 commit으로 lag=10 검증
5. `TestRuleToAutomationLagSkipsUnaccepted::test_proposed_only_not_emitted` — proposed 상태 ADR은 emit 안 됨

`python3 -m pytest tests/test_self_review_regression.py -v`: 5/5 passed. `bash scripts/test.sh -q`: 938 passed, 8 skipped.

## 5. Eval impact

All `·` — RAG 파이프라인 코드 미수정.

### 5b. Real-data delta

N/A — load-bearing 파일 변경 없음. `pretooluse-loadbearing.sh`와 `_self_review.py`는 `scripts/_governance.py::LOAD_BEARING_PATHS` 미포함.

## 6. Backward compatibility

hook fire log 포맷 변경 (2-field → 4-field)은 `.gitignore`된 로컬 파일(`.claude/.hook-fires.log`)에만 영향. 파서는 legacy 2-field 라인을 graceful하게 수용하도록 업데이트됨.

`fires_by_action`, `rule_to_automation_lag_days` 필드 추가는 `collect_governance_hooks` 반환 dict에 key 추가이고 기존 consumer(`assemble_stats`)가 해당 dict를 그대로 JSON에 포함하므로 breaking 없음.

## 7. Out of scope

- type 2 lag (accepted→hook landed): issue #502 본문 non-goal로 명시. 별도 follow-up.
- ADR Front-matter `enforced_by:` 필드: 별도 ADR/issue 필요.
- `/self-review-quarterly Q3-2026` 실제 실행은 Q3 분기 종료 후.