### PR TITLE
feat(vlm): add PaddleOCR provider + ADR 0034 (ablation, defer) (#594)

### DIFF
--- a/docs/adr/0034-vlm-provider-ablation.md
+++ b/docs/adr/0034-vlm-provider-ablation.md
@@ -1,0 +1,101 @@
+# ADR 0034: VLM Provider Ablation — Donut defer + PaddleOCR 실측
+
+| Field | Value |
+|---|---|
+| **Status** | Accepted |
+| **Date** | 2026-05-13 |
+| **Issue** | #594 |
+| **Supersedes** | — |
+| **Superseded by** | — |
+
+## Context
+
+[docs/vision-spike.md](../vision-spike.md) (issue #168) 에서 Donut vision model 과 pytesseract baseline 을 1-page 합성 PDF 에서 비교했다. 결과: Donut 은 `torch≥2.6 + safetensors` 요건 미충족으로 실측 불가, baseline text_recall=0.914 가 상한선으로 남았다.
+
+이 ADR 은 세 가지를 확정한다:
+1. **Donut defer 결정 공식화** (vision-spike.md 의 결론을 ADR 로 격상).
+2. **PaddleOCR PP-OCRv4 실측** — GPU-free 대안으로 같은 합성 PDF 에서 측정.
+3. **향후 VLM 채택 기준 명시** — real Korean RFP corpus 에서 lift 확인까지 ocr baseline 유지.
+
+## Decision
+
+**tesseract baseline 유지. PaddleOCR 와 Donut 모두 현재 시점 defer.**
+
+추가로: `BIDMATE_VISUAL_OCR=paddleocr` 를 통해 PaddleOCR 를 opt-in 으로 사용할 수 있는 인프라 (`visual_ingestion.paddleocr_provider`) 를 추가해 향후 real-data 재검증 준비.
+
+## Measured Results
+
+Spike 실행: `python3 scripts/run_donut_spike.py --backend all` (2026-05-13, 합성 1-page PDF, CPU, macOS)
+
+| Backend | text_recall | heading_match | table_cell_match | field_P | field_R | latency/page |
+|---|---|---|---|---|---|---|
+| pymupdf+pytesseract (baseline) | 0.914 | 3/3 | 1.000 | 1.000 | 1.000 | 65ms |
+| PaddleOCR PP-OCRv4 | 0.914 | 3/3 | 1.000 | 1.000 | 1.000 | 142ms |
+| Donut (Korean-finetuned / base) | N/A | N/A | N/A | N/A | N/A | ~7s |
+
+**Donut 오류**: `donut_load_failed: torch≥2.6 required (CVE-2025-32434); models still ship .bin (not .safetensors)`
+
+**PaddleOCR 해석**: 합성 PDF 는 ASCII 텍스트 기반이라 tesseract 가 이미 ceiling 에 가깝게 처리. PaddleOCR 의 강점 (복잡한 다단 레이아웃, 한자 혼용, 기울어진 텍스트) 이 발현되지 않는 조건 — baseline 대비 **+0pp lift, latency 2.2× 증가**.
+
+## Rationale
+
+### 왜 채택하지 않는가 (현 시점)
+
+채택 기준 (vision-spike.md Decision 섹션):
+
+1. **private 100-doc RFP corpus 에서 ≥+5pp text_recall lift** — 측정 안 됨 (합성 0pp)
+2. **GPU available in production / CI** — macOS CI 에서 CPU 전용; latency 불가
+3. **Korean-finetuned .safetensors checkpoint** — Donut 에 한정; PaddleOCR 는 CPU OK 이나 (1) 미달
+4. **ADR 제안 및 수락** — 이 ADR 이 (4) 를 충족
+
+PaddleOCR 는 (1) 과 (2) 를 동시에 충족해야 baseline 교체 가능. 현재 실측은 (1) 미확인.
+
+### 왜 인프라는 추가하는가
+
+real-data 재검증 시 코드 변경 없이 환경 변수 하나로 provider 교체 가능:
+
+```bash
+BIDMATE_VISUAL_OCR=paddleocr python3 scripts/build_index.py --input_dir data/raw
+python3 eval/run_parser_eval.py --artifacts artifacts/visual_paddleocr/ --gold eval/parser_gold.yaml
+```
+
+`paddleocr_provider` 는 기존 `OcrProvider` 프로토콜을 구현하므로 `parse_visual_document` 의 모든 호출 경로가 동작함.
+
+## Alternatives Considered
+
+| 대안 | 기각 이유 |
+|---|---|
+| TrOCR (Microsoft) | `transformers` 의존이 Donut 과 동일; GPU 불리 |
+| EasyOCR | MIT 라이선스, CPU 지원이나 한국어 모델 정확도 불확실 — 추후 benchmark 후보 |
+| Qwen2.5-VL-3B-Instruct | VLM 통합 품질이 높으나 GPU 메모리 ~6GB 필요, CI 경로 불가 |
+| LayoutLMv3 (Microsoft) | document understanding 특화이나 OCR layer 미포함; ingestion pipeline 재설계 필요 |
+| 현 상태 유지 (Donut opt-in 제공) | ADR 0001 baseline invariant 준수. OCR provider 인프라만 확장 |
+
+## Consequences
+
+**Positive**:
+- `OCR_PROVIDERS` 에 `"paddleocr"` 추가 → 세 backend 병렬 비교 인프라 완성.
+- `scripts/run_donut_spike.py --backend paddleocr` 로 재현 가능한 spike 문서화.
+- 향후 real Korean RFP 에서 lift 확인 시 ADR 재평가 조건 명시.
+
+**Negative / Risk**:
+- `paddleocr paddlepaddle` 설치 (~300MB) 가 일부 환경에서 기존 패키지 (safetensors, PyYAML) 를 업그레이드할 수 있음. 설치 전 `pip check` 권장.
+- `paddleocr_provider` 는 optional dep — 미설치 시 `OcrUnavailable` 예외.
+
+## Re-evaluation Trigger
+
+다음 조건 중 하나가 충족되면 이 ADR 을 재열어 채택 검토:
+
+- private 100-doc RFP corpus (또는 50-doc 이상 한국어 도메인 실데이터) 에서 text_recall +5pp 이상 lift 확인
+- EasyOCR 또는 다른 CPU-feasible 한국어 OCR 가 위 조건 충족
+- GPU 가 CI / production path 에 추가되고 Donut safetensors checkpoint 사용 가능
+
+ADR 레이블: [`adr-reopen`](https://github.com/hskim-solv/BidMate-DocAgent/labels/adr-reopen)
+
+## Implementation Notes
+
+변경 파일:
+- `visual_ingestion.py`: `paddleocr_provider` 추가, `OCR_PROVIDERS` 업데이트, `get_ocr_provider` 에 `"paddleocr"` case 추가.
+- `scripts/run_donut_spike.py`: `run_paddleocr` 함수, `--backend paddleocr|all` 추가.
+
+회귀 보호: 기존 `tests/test_visual_donut_regression.py` 가 `OcrProvider` 인터페이스와 factory wiring 을 검증 (model load 불필요). 새 provider 는 같은 인터페이스를 구현하므로 추가 회귀 테스트 불필요.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,6 +90,7 @@ project record.
 | [0030](./0030-leaderboard-headline-includes-agentic-full.md) | accepted | Leaderboard headline expands to render `agentic_full` alongside `naive_baseline` as parallel time series; ADR 0001 baseline preserved, `ablation_full` aggregate key added to history snapshots (extends ADR 0001 / ADR 0024 visibility surface) |
 | [0031](./0031-bm25-korean-morphology-additive.md) | superseded by 0010 | BM25 Korean morphology tokenizer (`bm25_tokenizer: "regex" \| "kiwi"`) as additive ablation |
 | [0032](./0032-eval-saturation-routed-subset.md) | accepted | Eval-set saturation falsifier: 4-embedding × routed_subset (n=11, metadata_first=false) measurement complete; spread **0.0pp** < +3pp threshold → saturation_cross_validated. MiniLM default lock empirically justified on both `full` + `routed` surfaces. (Closes ADR 0019 deferral saturation axis.) |
+| [0034](./0034-vlm-provider-ablation.md) | accepted | VLM provider ablation — Donut defer (torch≥2.6 + GPU required) + PaddleOCR PP-OCRv4 実測 (synthetic: +0pp vs baseline, latency 2.2×); tesseract baseline kept; `paddleocr_provider` opt-in infra added (`BIDMATE_VISUAL_OCR=paddleocr`); re-open on real Korean RFP +5pp lift |
 
 ## Roadmap (proposed, not yet committed)
 

--- a/scripts/run_donut_spike.py
+++ b/scripts/run_donut_spike.py
@@ -231,6 +231,59 @@ def run_donut(pdf_path: Path) -> PipelineResult:
     )
 
 
+def run_paddleocr(pdf_path: Path) -> PipelineResult:
+    try:
+        import fitz  # type: ignore
+        from PIL import Image  # type: ignore
+    except Exception as exc:
+        return PipelineResult(
+            label="paddleocr (PP-OCRv4)",
+            full_text="", headings=[], table_cells=[], fields=[],
+            latency_seconds=0.0,
+            error=f"pymupdf or pillow missing: {exc}",
+        )
+    try:
+        from visual_ingestion import paddleocr_provider
+    except Exception as exc:
+        return PipelineResult(
+            label="paddleocr (PP-OCRv4)",
+            full_text="", headings=[], table_cells=[], fields=[],
+            latency_seconds=0.0,
+            error=f"paddleocr import failed: {exc}",
+        )
+
+    start = time.perf_counter()
+    error: str | None = None
+    artifact: dict[str, Any] = {}
+    try:
+        _, artifact = parse_visual_document(
+            pdf_path, doc_id="spike-paddleocr", title=pdf_path.stem, ocr_provider=paddleocr_provider
+        )
+    except Exception as exc:
+        error = f"paddleocr inference failed: {exc}"
+    elapsed = time.perf_counter() - start
+
+    if artifact and artifact.get("diagnostics", {}).get("status") == "failed":
+        error = str(artifact["diagnostics"].get("reasons"))
+
+    blocks = [block for page in artifact.get("pages", []) for block in page.get("blocks", [])]
+    full_text = "\n".join(str(b.get("text") or "") for b in blocks).strip()
+    if not full_text and not error:
+        error = "paddleocr produced empty text"
+    headings = [str(b.get("text") or "").strip() for b in blocks if b.get("type") == "heading"]
+    table_cells = [cell for table in (artifact.get("tables") or []) for row in table.get("rows", []) for cell in row]
+    fields = [(c["key"], c["value"]) for c in (artifact.get("field_candidates") or [])]
+    return PipelineResult(
+        label="paddleocr (PP-OCRv4)",
+        full_text=full_text,
+        headings=headings,
+        table_cells=table_cells,
+        fields=fields,
+        latency_seconds=elapsed,
+        error=error,
+    )
+
+
 def strip_donut_tags(text: str) -> str:
     return re.sub(r"</?s_[^>]+>", " ", re.sub(r"<[^>]+>", " ", text)).strip()
 
@@ -347,7 +400,7 @@ def write_doc_results(doc_path: Path, table_md: str, gt_available: bool, errors:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Donut vs OCR 1-page comparison spike (issue #168).")
     parser.add_argument("--input", type=Path, default=None, help="optional real PDF path; default = synthetic")
-    parser.add_argument("--backend", choices=["both", "baseline", "donut"], default="both")
+    parser.add_argument("--backend", choices=["both", "baseline", "donut", "paddleocr", "all"], default="both")
     parser.add_argument("--write-doc", action="store_true", help="update docs/vision-spike.md Results section")
     parser.add_argument("--doc-path", type=Path, default=REPO_ROOT / "docs" / "vision-spike.md")
     args = parser.parse_args(argv)
@@ -366,10 +419,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"generated synthetic PDF: {pdf_path}")
 
     results: list[PipelineResult] = []
-    if args.backend in ("both", "baseline"):
+    if args.backend in ("both", "baseline", "all"):
         results.append(run_baseline(pdf_path))
-    if args.backend in ("both", "donut"):
+    if args.backend in ("both", "donut", "all"):
         results.append(run_donut(pdf_path))
+    if args.backend in ("paddleocr", "all"):
+        results.append(run_paddleocr(pdf_path))
 
     rows = [compute_metrics(r, gt) for r in results]
     table_md = render_markdown_table(rows, gt_available=gt is not None)

--- a/visual_ingestion.py
+++ b/visual_ingestion.py
@@ -44,7 +44,7 @@ VISUAL_METADATA_FORMATS = { *SUPPORTED_VISUAL_FORMATS, "hwp" }
 
 DEFAULT_DONUT_MODEL = "daekeun-ml/donut-base-finetuned-korean"
 DONUT_FALLBACK_MODEL = "naver-clova-ix/donut-base"
-OCR_PROVIDERS = ("tesseract", "donut")
+OCR_PROVIDERS = ("tesseract", "donut", "paddleocr")
 
 OcrProvider = Callable[[Any], str | list[dict[str, Any]]]
 
@@ -637,6 +637,54 @@ def donut_ocr_provider(image: Any) -> str:
     return sequence.strip()
 
 
+_PADDLE_OCR_CACHE: dict[str, Any] = {}
+
+
+def paddleocr_provider(image: Any) -> list[dict[str, Any]]:
+    """PaddleOCR PP-OCRv4 provider: returns structured text blocks for one page image.
+
+    Requires ``paddleocr`` and ``paddlepaddle`` (CPU-only install sufficient).
+    Language is controlled by BIDMATE_PADDLE_LANG env var (default: 'korean').
+    """
+    try:
+        from paddleocr import PaddleOCR  # type: ignore
+    except ImportError as exc:
+        raise OcrUnavailable(
+            f"paddleocr_unavailable: pip install paddleocr paddlepaddle ({exc})"
+        ) from exc
+    try:
+        import numpy as np  # type: ignore
+    except ImportError as exc:
+        raise OcrUnavailable(f"paddleocr_unavailable: numpy required ({exc})") from exc
+
+    lang = os.environ.get("BIDMATE_PADDLE_LANG", "korean")
+    cache_key = f"paddle_{lang}"
+    if cache_key not in _PADDLE_OCR_CACHE:
+        _PADDLE_OCR_CACHE[cache_key] = PaddleOCR(
+            use_angle_cls=True, lang=lang, use_gpu=False, show_log=False
+        )
+    engine = _PADDLE_OCR_CACHE[cache_key]
+
+    img_array = np.array(image)
+    raw = engine.ocr(img_array, cls=True)
+
+    blocks: list[dict[str, Any]] = []
+    if not raw or raw[0] is None:
+        return blocks
+    for line in raw[0]:
+        if not line:
+            continue
+        pts, (text, conf) = line
+        xs = [float(p[0]) for p in pts]
+        ys = [float(p[1]) for p in pts]
+        blocks.append({
+            "text": text,
+            "bbox": [min(xs), min(ys), max(xs), max(ys)],
+            "confidence": float(conf),
+        })
+    return blocks
+
+
 def get_ocr_provider(name: str | None = None) -> OcrProvider:
     """Return the OCR provider matching ``name`` (or env var BIDMATE_VISUAL_OCR)."""
     resolved = (name or os.environ.get("BIDMATE_VISUAL_OCR") or "tesseract").lower()
@@ -644,6 +692,8 @@ def get_ocr_provider(name: str | None = None) -> OcrProvider:
         return tesseract_ocr_provider
     if resolved == "donut":
         return donut_ocr_provider
+    if resolved == "paddleocr":
+        return paddleocr_provider
     raise ValueError(
         f"unknown ocr provider: {resolved!r}. Valid options: {sorted(OCR_PROVIDERS)}"
     )


### PR DESCRIPTION
## 1. What changed and why

VLM 축 포트폴리오 자산 채우기: Donut spike defer 결정을 ADR 0034 로 격상하고, GPU-free 대안 PaddleOCR PP-OCRv4 를 실측 후 opt-in provider 로 wiring.

Closes #594

## 2. Files affected

- `visual_ingestion.py` — `paddleocr_provider` 추가, `OCR_PROVIDERS += "paddleocr"`, `get_ocr_provider` "paddleocr" case. **기본값 tesseract 불변.** ⚠️ load-bearing 파일 (5b 참조)
- `scripts/run_donut_spike.py` — `run_paddleocr()` + `--backend paddleocr|all` 추가.
- `docs/adr/0034-vlm-provider-ablation.md` (신규) — Accepted. 실측 결과 표, defer 조건, alternatives, re-open trigger. ⚠️ docs/adr/ load-bearing
- `docs/adr/README.md` — ADR 0034 index entry 추가.

## 3. Risks

새 provider 는 opt-in (`BIDMATE_VISUAL_OCR=paddleocr` 또는 명시적 `get_ocr_provider("paddleocr")` 호출 시에만 활성화). 기본 경로 (`BIDMATE_VISUAL_OCR` 미설정 = tesseract) 는 코드 경로 변화 없음.

위험 확인:
- `get_ocr_provider()` 기본값: `(name or os.environ.get("BIDMATE_VISUAL_OCR") or "tesseract").lower()` — 변경 없음.
- `paddleocr` 미설치 시: `OcrUnavailable` 예외 (기존 `donut_unavailable` 패턴과 동일).
- `pip install paddleocr paddlepaddle` 가 safetensors, PyYAML 버전을 업그레이드할 수 있음 — 로컬 환경에서 확인, 전체 테스트 933 passed.

## 4. Tests

기존 `tests/test_visual_donut_regression.py` 가 `OcrProvider` 인터페이스 + factory wiring 을 검증 (model load 불필요). 새 provider 는 동일 인터페이스 구현. 전체 suite: **933 passed, 0 failures**.

## 5. Eval impact

기본 tesseract path 무변경 → CI eval delta: All `·` 예상.

### 5b. Real-data delta

No behavior change in ingestion pipeline (default tesseract path is unchanged).

PaddleOCR provider 는 opt-in (`BIDMATE_VISUAL_OCR=paddleocr`). 실측 결과 (ADR 0034, synthetic 1-page PDF, 2026-05-13):

| Backend | text_recall | table_cell | field_P | field_R | latency/page |
|---|---|---|---|---|---|
| pymupdf+pytesseract (baseline) | 0.914 | 12/12 | 1.000 | 1.000 | 65ms |
| PaddleOCR PP-OCRv4 | 0.914 | 12/12 | 1.000 | 1.000 | 142ms |
| Donut (Korean-finetuned) | N/A | N/A | N/A | N/A | ~7s |

Δ vs baseline = 0pp lift, latency 2.2× → baseline 유지 (ADR 0001 invariant 준수).

## 6. Backward compatibility

기존 API 변경 없음. `OCR_PROVIDERS` tuple 확장 (기존 코드 `OCR_PROVIDERS` 를 enumerate 하는 곳 없음). `get_ocr_provider("unknown_name")` 동작 불변 (ValueError).

## 7. Out of scope

- `eval/config.yaml` 에 `ocr_paddleocr` ablation row 추가 — lift 0pp 이므로 현 시점 불필요. real Korean RFP +5pp 확인 시 ADR 0034 re-open 트리거로 추가.
- EasyOCR, TrOCR, Qwen2.5-VL 비교 — ADR 0034 re-evaluation trigger 조건에 포함.