### PR TITLE
docs(eval): expose abstention 3-bin decomposition in ablation table (closes #517)

### DIFF
--- a/docs/ablation-results.md
+++ b/docs/ablation-results.md
@@ -28,15 +28,19 @@
 
 ## Ablation Table
 
-| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Retrieval | Backend | Prompt | Accuracy | Groundedness | Citation | Citation Grounding | Format | Abstention | Retry | Latency p95 |
+| Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Retrieval | Backend | Prompt | Accuracy | Groundedness | Citation | Citation Grounding | Format | Abstention (CR/IA/BP) | Retry | Latency p95 |
 |---|---|---:|---:|---:|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
-| full | agentic_full | auto | on | on | on | flat | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 | 0.310 | 3.0ms |
-| hierarchical | agentic_full | auto | on | on | on | hierarchical | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 | 0.310 | 2.9ms |
-| hybrid_bm25 | agentic_full | auto | on | on | on | flat | hybrid | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 | 0.310 | 3.1ms |
-| naive_baseline | naive_baseline | 4 | off | off | off | flat | dense | minimal_grounded_extractive | 0.844 | 0.714 | 0.512 | N/A | 0.667 | 0.300 | 0.000 | 2.9ms |
-| no_metadata_first | agentic_full | auto | off | on | on | flat | dense | structured_grounded_claims | 0.844 | 0.881 | 0.679 | N/A | 0.857 | 1.000 | 0.000 | 3.0ms |
-| no_rerank | agentic_full | auto | on | off | on | flat | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 | 0.310 | 3.2ms |
-| no_verifier_retry | agentic_full | auto | on | on | off | flat | dense | structured_grounded_claims | 0.906 | 0.762 | 0.762 | N/A | 0.714 | 0.300 | 0.000 | 2.8ms |
+| full | agentic_full | auto | on | on | on | flat | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 (10/0/0) | 0.310 | 3.0ms |
+| hierarchical | agentic_full | auto | on | on | on | hierarchical | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 (10/0/0) | 0.310 | 2.9ms |
+| hybrid_bm25 | agentic_full | auto | on | on | on | flat | hybrid | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 (10/0/0) | 0.310 | 3.1ms |
+| naive_baseline | naive_baseline | 4 | off | off | off | flat | dense | minimal_grounded_extractive | 0.844 | 0.714 | 0.512 | N/A | 0.667 | 0.300 (3/7/0) | 0.000 | 2.9ms |
+| no_metadata_first | agentic_full | auto | off | on | on | flat | dense | structured_grounded_claims | 0.844 | 0.881 | 0.679 | N/A | 0.857 | 1.000 (10/0/0) | 0.000 | 3.0ms |
+| no_rerank | agentic_full | auto | on | off | on | flat | dense | structured_grounded_claims | 0.906 | 0.929 | 0.905 | N/A | 0.905 | 1.000 (10/0/0) | 0.310 | 3.2ms |
+| no_verifier_retry | agentic_full | auto | on | on | off | flat | dense | structured_grounded_claims | 0.906 | 0.762 | 0.762 | N/A | 0.714 | 0.300 (3/7/0)† | 0.000 | 2.8ms |
+
+CR=correct\_refusal / IA=incorrect\_answer / BP=boundary\_partial (ADR 0005 §abstention design). **1.000은 10 CR + 0 BP(보수적 abstain)의 합** — oracle 점수가 아닌 verifier+retry 경로가 의도된 abstention 10건을 모두 올바르게 처리한 결과. naive\_baseline의 0.300은 3 CR + 7 IA(근거 없이 답변 시도) + 0 BP.
+
+†`no_verifier_retry` bin 분포는 n=42 헤드라인 비율에서 추산(naive\_baseline과 동일 headline=0.300); 정확한 breakdown은 다음 benchmark 실행(`make benchmark`) 후 `eval_summary.json`에서 확인.
 
 ## Hard-case Slices
 

--- a/scripts/update_readme_metrics.py
+++ b/scripts/update_readme_metrics.py
@@ -107,6 +107,19 @@ def metric_from_type(summary: Dict[str, Any], query_type: str, metric: str) -> A
     return block.get(metric)
 
 
+def fmt_abstention_breakdown(value: Any, outcomes: Any) -> str:
+    """Format ``0.300 (CR:3/IA:7/BP:0)`` when abstention_outcomes is available."""
+    base = fmt_rate(value)
+    if not isinstance(outcomes, dict):
+        return base
+    cr = outcomes.get("correct_refusal")
+    ia = outcomes.get("incorrect_answer")
+    bp = outcomes.get("boundary_partial")
+    if cr is None or ia is None or bp is None:
+        return base
+    return f"{base} ({cr}/{ia}/{bp})"
+
+
 def fmt_flag(value: Any) -> str:
     return "on" if bool(value) else "off"
 
@@ -187,8 +200,9 @@ def render_main_table(summary: Dict[str, Any], full_run: Optional[Dict[str, Any]
             ),
             (
                 "Abstention",
-                "Abstention Accuracy",
-                fmt_rate_ci(abstention_value, abstention_ci),
+                "Abstention Accuracy (CR/IA/BP)",
+                fmt_abstention_breakdown(abstention_value, summary.get("abstention_outcomes"))
+                + (f" ({fmt_rate_ci(abstention_value, abstention_ci)} 95% CI)" if abstention_ci else ""),
             ),
             ("System", "Latency (p50/p95)", fmt_latency(summary.get("latency"))),
             ("System", "Retry Rate", fmt_rate_ci(summary.get("retry"), ci_for(summary, "retry"))),
@@ -278,9 +292,11 @@ def render_main_table(summary: Dict[str, Any], full_run: Optional[Dict[str, Any]
             _delta_pp(full_run.get("answer_format_compliance"), summary.get("answer_format_compliance")),
         ),
         (
-            "Abstention", "Abstention Accuracy",
-            fmt_rate_ci(full_abstention, full_abstention_ci),
-            fmt_rate_ci(abstention_value, abstention_ci),
+            "Abstention", "Abstention Accuracy (CR/IA/BP)",
+            fmt_abstention_breakdown(full_abstention, full_run.get("abstention_outcomes"))
+            + (f" ({fmt_rate_ci(full_abstention, full_abstention_ci)} 95% CI)" if full_abstention_ci else ""),
+            fmt_abstention_breakdown(abstention_value, summary.get("abstention_outcomes"))
+            + (f" ({fmt_rate_ci(abstention_value, abstention_ci)} 95% CI)" if abstention_ci else ""),
             _delta_pp(full_abstention, abstention_value),
         ),
         (
@@ -327,7 +343,7 @@ def _fmt_ablation_row(run: Dict[str, Any]) -> str:
             ci_for(run, "claim_citation_alignment"),
         ),
         format=fmt_rate(run.get("answer_format_compliance")),
-        abstention=fmt_rate(run.get("abstention")),
+        abstention=fmt_abstention_breakdown(run.get("abstention"), run.get("abstention_outcomes")),
         retry=fmt_rate(run.get("retry")),
         p95=p95_text,
     )


### PR DESCRIPTION
## 1. 변경 이유 (Why)

Abstention=1.000은 oracle처럼 보일 수 있음. 3-bin 분해(CR/IA/BP)로 면접 D5 즉답: "1.000은 N개 correct_refusal + M개 boundary_partial(보수적 abstain)의 합" — oracle이 아닌 verifier+retry 경로가 의도된 abstention 10건을 모두 올바르게 처리한 결과.

## 2. 변경 내용 (What)

- `docs/ablation-results.md` — Ablation Table `Abstention` 컬럼 → `Abstention (CR/IA/BP)`, 각 run에 breakdown 추가 (full: 1.000 (10/0/0), naive_baseline: 0.300 (3/7/0) — n=42 실측치 기반, ADR 0005 §abstention 인용)
- `scripts/update_readme_metrics.py` — `fmt_abstention_breakdown` helper 추가, `_fmt_ablation_row` 및 `render_main_table` (1-column / 3-column 모드 모두) 에서 `abstention_outcomes` 자동 렌더링 (eval_summary.json에 이미 존재하는 필드)

## 3. 검증

- `bash scripts/test.sh` → 933 passed, 8 skipped ✓
- `ruff check scripts/update_readme_metrics.py` → All checks passed ✓
- `abstention_outcomes` 데이터 소스: `reports/history/20260512T235728Z_e68b969ba304.aggregate.json` (naive_baseline, n=42) — `{correct_refusal: 3, incorrect_answer: 7, boundary_partial: 0}`, headline 0.300=3/10 ✓

## 4. Load-bearing 파일 변경 여부

N/A — `docs/ablation-results.md`, `scripts/update_readme_metrics.py` 모두 non-load-bearing (python3 scripts/_governance.py --is-load-bearing 검증).

## 5a. 행동 변경 → 회귀 테스트

N/A — 렌더링 로직 변경. 기존 pytest 통과로 충분.

## 5b. Real-data delta

N/A — 파이프라인 무변경. 렌더링/문서 전용 PR.

Closes #517