### PR TITLE
docs: README AI collaboration transparency section + Q2-2026 self-review (closes #519)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,26 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 
 ---
 
+## Claude Code와의 협업 (AI Collaboration Transparency)
+
+이 프로젝트는 [Claude Code](https://claude.ai/code)(Opus 4.x)를 개발 파트너로 사용합니다. 과잉 주장(over-claim) 방지를 위해 역할 분담을 명시합니다.
+
+**본인 영역 (사람)**
+- ADR 설계 및 의사결정 게이트 — 어떤 문제를, 언제, 왜 해결할지
+- 포트폴리오 플랜 + 우선순위 (채용 funnel 4층 프레임워크)
+- 5축 협업 self-review 기준 정의 및 분기별 진단
+- 평가 설계 (공개/비공개 분리 경계, ADR 0005) 및 회귀 기준
+
+**Claude Code 영역 (AI)**
+- 코드 구현, 리팩터링, 문서 초안, 테스트 작성
+- 브랜치/PR/이슈 생성 및 CI gate 운영 보조
+- 탐색(Explore subagent), 설계 검토(Plan subagent), 반복 작업 자동화
+
+**분기별 협업 자가진단** — [`/self-review-quarterly`](docs/adr-self-interview-checklist.md) skill로 4축(포트폴리오 진행도) + 5축(Claude 협업 효율)을 한 보고서로 생성.
+최신 보고서: [`docs/self-review/Q2-2026.md`](docs/self-review/Q2-2026.md)
+
+---
+
 ## Notice
 - 원본 RFP 문서는 외부 공유 제한으로 저장소에 포함하지 않았습니다.
 - `data/raw` 문서는 공개 재현을 위해 작성한 synthetic RFP 샘플입니다.

--- a/docs/self-review/Q2-2026.md
+++ b/docs/self-review/Q2-2026.md
@@ -1,0 +1,47 @@
+# Self-Review Q2-2026
+
+**기간:** 2026-04-01 ~ 2026-06-30 (관측 시점: 2026-05-13)
+**도구:** `/self-review-quarterly` skill (4축 포트폴리오 + 5축 Claude 협업 동시 진단)
+
+---
+
+## 포트폴리오 4축 진단
+
+| 축 | 결과 | 근거 |
+|---|---|---|
+| 엔지니어링 디스플린 | ✓ | 251 PRs, issue-linked branch naming(ADR 0007) CI gate 100%, load-bearing path 330회 변경 모두 PR template 5b 기재 |
+| 아키텍처 정합성 | ✓ | 34개 ADR(22 accepted, 7 proposed, 결번 0020), rag_core → C-2~C-4(retrieval/verifier/answer/query) 모듈 분리, baseline invariant(ADR 0001) 유지 |
+| 평가 견고성 | ✓ | 공개 synthetic n=100 확장(issue #570), ADR 0032 saturation falsifier(4 embeddings × routed_subset, CI spread 0.0pp), 3-bin abstention 분해(issue #463) |
+| 시장 가시성 | △ | ADR 0025 cost frontier defer, demo.gif 미생성, live demo URL 미확보. 다음 마일스톤: hero asset + live demo |
+
+**종합:** 3✓1△ — 엔지니어링·아키텍처·평가 기반 완성, 시장 가시성이 남은 갭.
+
+---
+
+## Claude Code 협업 5축 진단
+
+| 축 | 결과 | 근거 |
+|---|---|---|
+| 컨텍스트 효율 | ✓ | 메모리 17개 파일 운영, ToolSearch 37회, CLAUDE.md 매 세션 컨텍스트 활용 |
+| Agent 위임 패턴 | △ | Explore 30회 + Plan 4회; general-purpose 위임 0회. 비-trivial 변경 전 Plan subagent 위임 부족 |
+| 거버넌스 자동화 ROI | △ | `.hook-fires.log` 미생성 — hook fire 횟수 정량화 불가. `make install-hooks` 재실행 필요 |
+| 사이클 타임 | △ | proposed → accepted ADR lag, accepted → hook landed lag 데이터 없음 |
+| 메모리 위생 | △ | reference type 2개(부족), user type 2개(부족), feedback type 집중. 타입 분포 불균형 |
+
+**종합:** 1✓4△ — 컨텍스트 효율은 양호, 나머지 4축 모두 정량화 인프라 부재.
+
+---
+
+## Q3 개선 액션 (ROI 순서)
+
+1. `make install-hooks` 재실행 → `.hook-fires.log` 활성화 → 5축 #3(거버넌스ROI) + #4(사이클타임) 동시 정량화
+2. ADR lag 추적: `scripts/_self_review.py` 로그 수집 → proposed→accepted 일수 자동화
+3. Agent 위임 강화: 비-trivial PR 착수 전 Plan subagent 호출 기본값
+
+---
+
+## 참고
+
+- 4축 rubric: `docs/senior-positioning.md`, `docs/portfolio-launch-checklist.md`
+- 5축 rubric: `docs/adr-self-interview-checklist.md`
+- 분기 보고서 생성: `/self-review-quarterly Q2-2026`


### PR DESCRIPTION
## 1. 변경 이유 (Why)

면접 H1 "Claude Code 어디까지 썼냐?" 즉답용. 역할 분담 선제 공개로 over-claim 의심 차단.

## 2. 변경 내용 (What)

- `README.md` — §"Claude Code와의 협업 (AI Collaboration Transparency)" 단락 추가
  - Claude Code (Opus 4.x) 사용 정직 명시
  - 본인 영역(ADR 설계, 의사결정 게이트, 5축 self-review 정의, 평가 경계)
  - Claude 영역(구현, 리팩터링, 문서 초안, 테스트, PR 운영)
  - `/self-review-quarterly` skill 링크 + `docs/self-review/Q2-2026.md` 링크
- `docs/self-review/Q2-2026.md` (신규) — Q2-2026 분기 보고서
  - 4축: 3✓1△ (시장가시성 △)
  - 5축: 1✓4△ (컨텍스트효율 ✓, 나머지 정량화 인프라 부재)
  - Q3 개선 액션: hook-fires.log 활성화 → 5축 #3+#4 동시 정량화

## 3. 검증

- `bash scripts/test.sh` → 945 passed, 8 skipped ✓
- `python3 scripts/_governance.py --is-load-bearing README.md` → exit:1 (non-load-bearing) ✓

## 4. Load-bearing 파일 변경 여부

N/A — README.md, docs/self-review/Q2-2026.md 모두 non-load-bearing.

## 5a. 행동 변경 → 회귀 테스트

N/A — 문서 전용 PR.

## 5b. Real-data delta

N/A — 파이프라인 무변경.

Closes #519