### PR TITLE
docs: add agentic-definition.md — bounded retry pipeline vs ReAct (closes #516)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ flowchart TD
 
 > 강조된 두 노드: Planner의 `comparison-aware top_k` → [Key technical contribution](#key-technical-contribution--comparison-aware-balanced-top-k), Answer Generator의 `extractive — no LLM` → [Why extractive?](#why-extractive-not-generative)
 
-비교 질의(`query_type == "comparison"`)에서는 balanced top-k 컷을 적용해 각 비교 대상에 최소 1개 이상의 evidence를 보장합니다. Metadata filter staging, alias lexicon, follow-up carryover 상세: [`docs/retrieval-hardening.md`](docs/retrieval-hardening.md). `retrieval_backend` hybrid(BM25+RRF) 근거: [ADR 0010](docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md).
+비교 질의(`query_type == "comparison"`)에서는 balanced top-k 컷을 적용해 각 비교 대상에 최소 1개 이상의 evidence를 보장합니다. Metadata filter staging, alias lexicon, follow-up carryover 상세: [`docs/retrieval-hardening.md`](docs/retrieval-hardening.md). `retrieval_backend` hybrid(BM25+RRF) 근거: [ADR 0010](docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md). "agentic"의 의미 (bounded retry vs ReAct/Reflexion 비교): [`docs/agentic-definition.md`](docs/agentic-definition.md).
 
 ---
 

--- a/docs/agentic-definition.md
+++ b/docs/agentic-definition.md
@@ -1,0 +1,86 @@
+# Agentic 정의 — bounded retry pipeline vs ReAct/Reflexion
+
+## 한 줄 요약
+
+BidMate-DocAgent의 "agentic"은 **metadata filter를 단계적으로 완화하는 조건부 다단계 retry 파이프라인**이다. 오픈엔드 LLM 루프(ReAct)나 자기비판 반성(Reflexion)이 아니다.
+
+---
+
+## 파이프라인 구조
+
+```
+[Query Analyzer]
+     ↓
+[metadata_stage_sequence()]     ← 최대 3단계 사전 결정
+     ↓ (strict → reduced → relaxed)
+[Retrieve(stage)]
+     ↓
+[Verifier]  → verified=True → [Answer Generator]
+     ↓ verified=False
+[Retry: 다음 stage로 이동]      ← MAX_AGENT_ITERATIONS = 3
+     ↓ 마지막 stage 도달
+[Answer Generator (allow_partial_topic=True)]
+```
+
+### 구현 위치
+
+| 컴포넌트 | 파일 | 함수 |
+|---|---|---|
+| 단계 루프 | [`rag_core.py:1315`](../rag_core.py) | `_phase_retrieve_loop` |
+| 단계 시퀀스 생성 | [`rag_core.py:868`](../rag_core.py) | `metadata_stage_sequence` |
+| 반복 횟수 상한 | [`rag_core.py:278`](../rag_core.py) | `MAX_AGENT_ITERATIONS = 3` |
+| 단계 조건 판정 | [`rag_verifier.py`](../rag_verifier.py) | `verify_evidence` |
+
+### 단계 시퀀스 (최대 3단계)
+
+1. **strict** — 쿼리에서 추출한 모든 metadata filter 적용 (기관명 + 날짜 + 사업번호 등)
+2. **reduced** — 고신뢰 filter만 유지, 약한 constraint 제거
+3. **relaxed** — metadata filter 완전 해제, pure dense/hybrid retrieval
+
+각 단계에서 `Verifier`가 근거 충분성을 판정한다. `verified=True`이면 즉시 루프 종료 — 불필요한 추가 retrieval 없음.
+
+---
+
+## ReAct / Plan-and-Solve / Reflexion 비교
+
+| 특성 | BidMate (이 시스템) | ReAct | Plan-and-Solve | Reflexion |
+|---|---|---|---|---|
+| **루프 구동** | 조건부 (verifier 결과) | LLM thought-action-observation | LLM이 plan 먼저 생성 | LLM 자기비판 |
+| **단계 결정** | 사전 결정 (static graph) | LLM이 동적 생성 | LLM이 동적 생성 | LLM이 동적 생성 |
+| **반복 상한** | 하드캡 3 (`MAX_AGENT_ITERATIONS`) | 명시적 상한 없음 | 구현별 상이 | 구현별 상이 |
+| **외부 LLM 호출** | 없음 (extractive) | 매 step LLM 호출 | LLM 호출 | LLM 호출 |
+| **tool 사용** | 없음 (retrieval만) | 임의 tool 선택 가능 | 임의 tool 선택 가능 | 임의 tool 선택 가능 |
+| **결정론** | 완전 결정론 (동일 입력 = 동일 단계) | LLM sampling 의존 | LLM sampling 의존 | LLM sampling 의존 |
+| **CI 재현성** | 완전 재현 가능 | 재현 어려움 | 재현 어려움 | 재현 어려움 |
+
+**핵심 차이**: ReAct는 LLM이 "무슨 tool을 쓸지"를 동적으로 결정한다. BidMate는 retrieval이라는 단일 도구를 사전 정의된 stage 시퀀스에 따라 반복 호출할 뿐 — LLM이 흐름을 제어하지 않는다.
+
+---
+
+## 정직한 한계
+
+- **full autonomy 없음**: tool 선택, 외부 API 호출, 웹 검색 등 열린 action space 없음
+- **자기비판/반성 없음**: 이전 답변을 LLM이 평가하고 수정하는 루프 없음 (verifier는 LLM이 아닌 deterministic rule-based)
+- **단일 도메인 특화**: RFP metadata structure를 전제한 stage 설계 — 범용 QA에는 적합하지 않음
+- **단방향 파이프라인**: 사용자 clarification 요청, tool-calling, 대화 중 plan 수정 없음
+
+이 한계들은 재현성·비용·hallucination 방지를 위한 의도된 trade-off이다 ([ADR 0003](adr/0003-structured-answer-citation-contract.md), [ADR 0001](adr/0001-preserve-naive-baseline.md)).
+
+---
+
+## 향후 진화 경로
+
+| 방향 | 접근 | ADR 참고 |
+|---|---|---|
+| LangGraph 오케스트레이션 | 현재 stage loop → LangGraph node graph로 재구성 (이미 stage 1 완료) | [ADR 0022](adr/0022-langgraph-orchestration-stage-1.md) |
+| HyDE 쿼리 확장 | `IdentityExpander` → `HyDEExpander` opt-in (파이프라인 유지, 측정 게이트) | [ADR 0023](adr/0023-hyde-query-expansion-additive.md) (proposed) |
+| LLM-as-reranker | `CrossEncoderReranker` → LLM 판정 reranker (additive ablation) | [ADR 0026](adr/0026-cross-encoder-reranker-deferral.md) |
+| ReAct 도입 | 현재 static stage → LLM-driven dynamic tool selection (큰 변경, 재현성 손실 감수) | 미정 — 현재는 ADR 0001 baseline 보존 우선 |
+
+---
+
+## 참고
+
+- 파이프라인 실행 흐름: [`rag_core.py`](../rag_core.py) `run_rag_query` → `_phase_retrieve_loop`
+- LangGraph Stage 1 case study: [`docs/langgraph-orchestration.md`](langgraph-orchestration.md) (issue #593 예정)
+- 아키텍처 다이어그램: [`README.md § 아키텍처`](../README.md#아키텍처-요약)


### PR DESCRIPTION
## 1. 변경 이유 (Why)

면접 G6("agentic이 뭔가") / G7("ReAct와 차이") / G8("왜 이 설계") 즉답용. 레포에 "agentic"의 공식 정의가 없어 구두 방어가 어려웠음.

## 2. 변경 내용 (What)

- `docs/agentic-definition.md` (신규)
  - condition-driven 다단계 retry 파이프라인 구조 (`_phase_retrieve_loop:1315`, `metadata_stage_sequence:868`, `MAX_AGENT_ITERATIONS=3`)
  - ReAct / Plan-and-Solve / Reflexion 비교 표 (5개 특성축)
  - 정직한 한계 단락 (full autonomy 없음, 자기비판 없음, 단일 도메인 특화)
  - 향후 진화 경로 (LangGraph stage 2, HyDE, LLM reranker)
- `README.md` §아키텍처 끝에 링크 1줄 추가

## 3. 검증

- `bash scripts/test.sh` → 945 passed, 8 skipped ✓

## 4. Load-bearing 파일 변경 여부

N/A — 신규 docs 파일 + README 1줄 추가. non-load-bearing.

## 5a. 행동 변경 → 회귀 테스트

N/A — 문서 전용 PR.

## 5b. Real-data delta

N/A — 파이프라인 무변경.

Closes #516