### PR TITLE
docs(adr): add ADR 0035 — dict not Pydantic v2 (closes #451)

### DIFF
--- a/docs/adr/0035-dict-not-pydantic-v2.md
+++ b/docs/adr/0035-dict-not-pydantic-v2.md
@@ -1,0 +1,77 @@
+# 0035: Answer dict — no parallel Pydantic / TypedDict shadow model
+
+- **Status**: accepted
+- **Date**: 2026-05-13
+- **Related**: [ADR 0003](0003-structured-answer-citation-contract.md) (answer contract, `schema_version: 2`), [`CLAUDE.md` §Prohibited](../../CLAUDE.md), [`api/schemas.py`](../../api/schemas.py) (boundary-only Pydantic usage), [issue #451](https://github.com/hskim-solv/BidMate-DocAgent/issues/451)
+
+## Context
+
+`run_rag_query` returns a plain Python `dict` pinned by ADR 0003 (`schema_version: 2`,
+`status`, `claims[{target, claim, support, citations[]}]`, `evidence[…]`).
+`CLAUDE.md` §"Prohibited" states: *"Adding a parallel pydantic / TypedDict model that shadows `run_rag_query`'s answer dict — the dict is the contract."*
+
+This prohibition existed as a single prose line. External senior review (2026-05, §A2-S4)
+re-raised Pydantic v2 validation, citing runtime safety and IDE ergonomics. Without
+a written ADR the prohibition cannot survive repeated questioning — this document
+converts the one-liner into an explicit trade-off record.
+
+Two pressures collide:
+1. **Single source of truth**: ADR 0003 already pins the contract. A parallel model
+   creates two authoritative definitions that can silently diverge.
+2. **Validation safety**: callers may want type-checked access; raw dict access is
+   error-prone. The right answer is *where* validation lives, not whether it exists.
+
+## Decision
+
+The answer dict produced by `run_rag_query` is the internal contract.
+No Pydantic / TypedDict / dataclass model may shadow it *inside the pipeline*.
+
+**What is allowed:**
+
+- `api/schemas.py` may define a Pydantic model that validates the dict at the
+  FastAPI response boundary (`Answer.model_validate(result)`). This is downstream
+  of `run_rag_query` — never inside retrieval, verification, or answer-generation.
+- Internal helper functions may use `TypedDict` for IDE hints, provided the type
+  annotation is never load-bearing at runtime (no `isinstance` checks, no
+  `.model_dump()` round-trips through the pipeline).
+
+**Schema change protocol**: any new field in the answer dict first lands in the
+dict (with a default for backward compat), then in `api/schemas.py`, then in the
+eval runner. Never the reverse.
+
+## Consequences
+
+**Easier:**
+- One change to add or rename a field: edit `run_rag_query`'s return block and the
+  eval runner. No model sync step.
+- CI eval stays bit-identical: no serialization round-trip can silently drop a field.
+- `schema_version` bumps stay meaningful — they track the dict contract, not model
+  version drift.
+
+**Harder / constrained:**
+- No auto-generated OpenAPI schema from the pipeline layer. `api/schemas.py` must
+  be kept in sync manually when the dict evolves.
+- IDE autocomplete on raw dict keys is weaker than on a typed model. The TypedDict
+  escape hatch addresses this without polluting the runtime contract.
+
+**Contract locked in:**
+- `schema_version: 2` literal in `rag_answer.py` (`ANSWER_SCHEMA_VERSION`).
+- `status` enum: `supported | partial | insufficient` — callers must not branch on
+  any other string.
+- Eval pipeline (`eval/run_eval.py`) keys off `status_reason.code` and
+  `claims[].citations[].chunk_id` — changes here require a version bump and eval
+  regression check.
+
+## Alternatives considered
+
+- **Full Pydantic v2 internal model**: rejected. Every `run_rag_query` call would
+  carry a `.model_validate()` + `.model_dump()` round-trip. More critically, the
+  dict and the model become two sources of truth — a schema change touches both,
+  and a merge conflict silently produces a stale model while the dict is correct.
+- **JSON Schema external validation**: tracked as eval-side contract check, not
+  runtime pipeline guard. Does not conflict with this ADR; orthogonal to internal
+  typing.
+- **Pydantic at API boundary only (chosen pattern)**: validates the output exactly
+  once, at the surface exposed to external callers. No dual contract inside the
+  pipeline; runtime cost is O(1) per request at the FastAPI layer, not per
+  internal function call.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,6 +91,7 @@ project record.
 | [0031](./0031-bm25-korean-morphology-additive.md) | superseded by 0010 | BM25 Korean morphology tokenizer (`bm25_tokenizer: "regex" \| "kiwi"`) as additive ablation |
 | [0032](./0032-eval-saturation-routed-subset.md) | accepted | Eval-set saturation falsifier: 4-embedding × routed_subset (n=11, metadata_first=false) measurement complete; spread **0.0pp** < +3pp threshold → saturation_cross_validated. MiniLM default lock empirically justified on both `full` + `routed` surfaces. (Closes ADR 0019 deferral saturation axis.) |
 | [0034](./0034-vlm-provider-ablation.md) | accepted | VLM provider ablation — Donut defer (torch≥2.6 + GPU required) + PaddleOCR PP-OCRv4 実測 (synthetic: +0pp vs baseline, latency 2.2×); tesseract baseline kept; `paddleocr_provider` opt-in infra added (`BIDMATE_VISUAL_OCR=paddleocr`); re-open on real Korean RFP +5pp lift |
+| [0035](./0035-dict-not-pydantic-v2.md) | accepted | Answer dict is the internal contract — no Pydantic/TypedDict shadow model inside the pipeline (defends ADR 0003 single-source-of-truth; Pydantic allowed at `api/schemas.py` boundary only) |
 
 ## Roadmap (proposed, not yet committed)
 


### PR DESCRIPTION
## 1. 변경 이유 (Why)

CLAUDE.md §"Prohibited"의 dict 계약 방어 규칙이 1줄 prose였음. 외부 시니어 리뷰(2026-05 §A2-S4)가 Pydantic v2 재제안 → 방어 가능한 ADR로 변환 필요.

## 2. 변경 내용 (What)

- `docs/adr/0035-dict-not-pydantic-v2.md` (신규) — ADR 0035
  - Context: ADR 0003 single-source-of-truth vs Pydantic 이중 계약 리스크
  - Decision: pipeline 내부 dict가 계약, Pydantic은 `api/schemas.py` boundary에서만 허용
  - Consequences: 필드 추가 1곳(dict), dual sync 없음, schema_version bump 의미 보존
  - Alternatives: full Pydantic internal(rejected), JSON Schema external(orthogonal), boundary-only(chosen)
- `docs/adr/README.md` — ADR 0035 인덱스 항목 추가

## 3. 검증

- `bash scripts/test.sh` → 945 passed, 8 skipped ✓

## 4. Load-bearing 파일 변경 여부

`docs/adr/` — load-bearing (CLAUDE.md 기준). 단 신규 ADR 파일 추가이며 기존 ADR 삭제/수정 없음.

## 5a. 행동 변경 → 회귀 테스트

N/A — 문서 전용 PR. 기존 `run_rag_query` dict 계약 행동 변경 없음.

### 5b. Real-data delta

N/A — docs/ADR-only PR. No behavior change in retrieval / verifier / answer-generation path.

Closes #451