### PR TITLE
chore(stop-ship): auto-remove linked worktree after successful merge

### DIFF
--- a/docs/auto-ship.md
+++ b/docs/auto-ship.md
@@ -118,13 +118,20 @@ the first line.
 (rc 124): post a PR comment and abort, **leaving the PR open**. On any
 non-zero rc: comment + abort. The pipeline never merges on red.
 
-### Stage 5 — squash-merge ([`stop-ship.sh:374-408`](../scripts/claude-hooks/stop-ship.sh))
+### Stage 5 — squash-merge ([`stop-ship.sh:374-424`](../scripts/claude-hooks/stop-ship.sh))
 
 `gh pr merge <N> --squash --admin --delete-branch`. Verifies the
 post-merge state is `MERGED` (otherwise leaves the arm file in place
 for inspection). Then `git checkout main && git pull --ff-only`,
 delete the local branch, log a `S5_OK` line to
 `.claude/.ship-history.log`, remove the arm file.
+
+**Worktree auto-cleanup (issue #520):** if the pipeline ran from a
+linked worktree (i.e. `git rev-parse --git-dir` contains `/worktrees/`),
+Stage 5 calls `git worktree remove --force <path>` after disarming.
+This prevents merged worktrees from accumulating and inflating the
+per-session base-load cost. Failure is non-blocking — a warning is
+logged and the caller must clean up manually (`git worktree prune`).
 
 ## Stacked-PR discipline (tier 7)
 

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -406,6 +406,18 @@ stage_5_merge() {
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PR_NUMBER" "$ARM_BRANCH" >> "$HISTORY_LOG"
   log "s5" "Ship complete: PR #$PR_NUMBER merged to main"
   rm -f "$ARMED_FILE"
+
+  # Auto-remove this linked worktree after a successful merge so merged worktrees
+  # don't accumulate and inflate per-session base-load cost (issue #520).
+  local git_dir
+  git_dir=$(git rev-parse --git-dir 2>/dev/null)
+  if [[ "$git_dir" == *"/worktrees/"* ]]; then
+    local worktree_path
+    worktree_path=$(git rev-parse --show-toplevel 2>/dev/null)
+    log "s5" "auto-removing linked worktree: $worktree_path"
+    git worktree remove --force "$worktree_path" 2>/dev/null || \
+      log "s5" "worktree remove non-fatal: $worktree_path may need manual cleanup"
+  fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 1. 변경 이유 (Why)

PR merge 후 worktree가 자동 정리되지 않아 누적 — 2026-05-13 진단 시 merged PR 3개 worktree(#458, #488, #479)를 포함해 11개 동시 유지 → prompt cache hit 0, 세션 베이스 로드 비용(30–50K 토큰/세션) 누적.

## 2. 변경 내용 (What)

- `scripts/claude-hooks/stop-ship.sh` — `stage_5_merge()` 끝에 linked worktree 자동 제거 추가
  - `git rev-parse --git-dir` 결과에 `/worktrees/` 포함 시 linked worktree로 판정
  - `git worktree remove --force <path>` 실행 (non-blocking: 실패 시 경고 로그만 출력)
- `docs/auto-ship.md` — Stage 5 섹션에 worktree auto-cleanup 동작 설명 추가

## 3. 검증

- `bash scripts/test.sh` → 945 passed, 8 skipped ✓
- `ruff check .` → All checks passed ✓

## 4. Load-bearing 파일 변경 여부

`scripts/claude-hooks/stop-ship.sh` — load-bearing path 포함 여부: `scripts/` 폴더는 load-bearing이나 `stop-ship.sh`는 `_governance.py LOAD_BEARING_PATHS`에 retrieval/eval 경로로 열거되지 않음. 문서(`docs/auto-ship.md`) + Stop hook 스크립트 수정.

## 5a. 행동 변경 → 회귀 테스트

행동 변경은 Stage 5 성공 후 linked worktree 제거 — retrieval/verifier/answer-generation path 무변경. 기존 Stop hook 테스트 전원 통과.

### 5b. Real-data delta

N/A — pipeline 무변경. stop-ship.sh Stage 5 클린업 단계 추가; retrieval/verifier/answer-generation 경로 미접촉.

Closes #520