### PR TITLE
docs(adr): add ADR 0020 — Protocol-based pluggability (closes #394)

### DIFF
--- a/docs/adr/0013-observability-as-additive-pluggable-surface.md
+++ b/docs/adr/0013-observability-as-additive-pluggable-surface.md
@@ -2,7 +2,7 @@
 
 - **Status**: accepted
 - **Date**: 2026-05-11
-- **Related**: extends [ADR 0001](./0001-preserve-naive-baseline.md); preserves [ADR 0003](./0003-structured-answer-citation-contract.md); reuses backend pattern from [ADR 0006](./0006-llm-judge-on-real-data-only.md) and [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md); respects eval split from [ADR 0005](./0005-eval-split-public-synthetic-private-local.md)
+- **Related**: extends [ADR 0001](./0001-preserve-naive-baseline.md); preserves [ADR 0003](./0003-structured-answer-citation-contract.md); reuses backend pattern from [ADR 0006](./0006-llm-judge-on-real-data-only.md) and [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md); respects eval split from [ADR 0005](./0005-eval-split-public-synthetic-private-local.md); same "additive pluggable surface" theme as [ADR 0020](./0020-protocol-based-pluggability.md) (retrieval-side Protocols)
 - **Deciders**: hskim
 
 ## Context

--- a/docs/adr/0020-protocol-based-pluggability.md
+++ b/docs/adr/0020-protocol-based-pluggability.md
@@ -1,0 +1,100 @@
+# 0020: Protocol-based pluggability for retrieval-side extension points
+
+- **Status**: accepted
+- **Date**: 2026-05-13
+- **Related**: [ADR 0013](0013-observability-as-additive-pluggable-surface.md) (additive pluggability theme), [PR #234](https://github.com/hskim-solv/BidMate-DocAgent/pull/234) (VectorStore Stage 1), [PR #358](https://github.com/hskim-solv/BidMate-DocAgent/pull/358) (Reranker), [issue #176](https://github.com/hskim-solv/BidMate-DocAgent/issues/176) (VectorStore work), [issue #345](https://github.com/hskim-solv/BidMate-DocAgent/issues/345) (Reranker work), [`rag_vector_store.py`](../../rag_vector_store.py), [`rag_reranker.py`](../../rag_reranker.py)
+
+## Context
+
+Two independent Phase 2 refactors introduced structurally identical patterns
+without a shared architectural rationale:
+
+**VectorStore Protocol** (issue #176, PR #234 + follow-ups #288 / #296 / #326):
+`rag_vector_store.py` exposes a `@runtime_checkable typing.Protocol` (VectorStore)
+with `InMemoryVectorStore` as the default and `QdrantVectorStore` as an adapter.
+`BIDMATE_INDEX_BACKEND` drives dispatch; `rag_core.py` is untouched when a new
+backend registers.
+
+**Reranker Protocol** (issue #345, PR #358):
+`rag_reranker.py` mirrors the same shape — `@runtime_checkable` Protocol,
+`CrossEncoderReranker` default adapter wrapping `rag_rerank.rerank`, and a
+`default_reranker()` factory as the single wiring hook. Future rerankers
+(HyDE, LLM-as-judge) plug in here; `rag_core.py` is untouched.
+
+The convention recurs naturally in Phase 3 (HyDE query expansion, alternative
+embedding backends, multi-query retrieval). Without a written ADR each future
+Protocol PR re-litigates the same design questions: ABC vs Protocol, factory
+vs direct import, env-var vs plan-dict routing.
+
+The ADR threshold from [`docs/adr/README.md`](README.md): *"Establishes a new
+convention that future changes must follow."* Both PRs already merged; this ADR
+converts the implicit convention into an explicit reference.
+
+## Decision
+
+Retrieval-side extension points follow a four-property convention:
+
+1. **`@runtime_checkable typing.Protocol` in a leaf module.**
+   The Protocol lives in its own file (`rag_<aspect>.py`) so the
+   dependency graph stays acyclic. `runtime_checkable` enables
+   `isinstance` guards in tests without coupling to a concrete type.
+
+2. **Default adapter wraps the existing implementation.**
+   The first concrete class in the new module (`InMemoryVectorStore`,
+   `CrossEncoderReranker`) delegates to the existing code path, keeping
+   the observable behaviour bit-identical. No eval regression on merge.
+
+3. **`default_<aspect>()` factory as the single dispatch hook.**
+   Orchestration code (`rag_core.py`, `rag_retrieval.py`) calls
+   `default_reranker()` / `default_vector_store()` exactly once.
+   Adding a second implementation requires changing one function in
+   one file; retrieval orchestration stays untouched.
+
+4. **Env-var routing inside the factory; plan-dict routing is out of scope.**
+   `BIDMATE_INDEX_BACKEND`, `BIDMATE_RERANK_BACKEND` are the dispatch
+   signals. The plan dict produced by `analyze_query` is for query-level
+   decisions; backend selection is environment-level configuration.
+
+## Consequences
+
+**Easier:**
+- New extension point (e.g. `QueryExpander`, `EmbeddingBackend`) follows
+  the same four steps. PR reviewer can cite this ADR instead of re-examining
+  the pattern from scratch.
+- `isinstance(x, VectorStore)` and `isinstance(x, Reranker)` work in tests
+  for structural duck-typing checks.
+- Eval is unaffected at merge: the default adapter wraps the existing code
+  path, so `naive_baseline` stays bit-identical (ADR 0001 invariant).
+
+**Harder / constrained:**
+- Ceremony cost: a new retrieval-side extension point requires a new leaf
+  module (Protocol + default class + factory), not just a new function.
+  Reversal cost is low — each leaf module is independent.
+- `@runtime_checkable` Protocols do not check method signatures at
+  `isinstance` time, only presence. Full type safety requires `mypy`
+  structural checking, not runtime guards alone.
+
+**Follow-up precedent already set:**
+- `rag_query_expansion.py` (ADR 0023) introduces `QueryExpander` using
+  the same four-property convention, citing this pattern.
+- Phase 3 HyDE, LLM-as-reranker, and alternative embedding backends are
+  expected to follow the same shape.
+
+## Alternatives considered
+
+- **ABC (`abc.ABC` + `@abstractmethod`) instead of Protocol**: ABCs require
+  concrete classes to register or inherit, coupling the extension point to
+  the base class. Protocols work structurally — any class with the right
+  methods satisfies the contract without importing from this module.
+  Chosen: Protocol.
+
+- **Factory-free direct import**: callers import the concrete class directly.
+  Rejected: changes the import site in orchestration code whenever the default
+  class changes. The factory pattern (one import, one call site) makes
+  future swaps transparent.
+
+- **Plan-dict routing**: the query-analysis plan dict selects the backend per
+  request. Rejected for backend selection: backends are environment-level
+  configuration (cost, availability), not per-query decisions. Plan-dict
+  routing is correct for *retrieval mode* (flat vs hierarchical, ADR 0002)
+  but not for *infrastructure wiring*.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -80,6 +80,7 @@ project record.
 | [0017](./0017-llm-metadata-extraction-additive.md) | superseded by 0011 | LLM metadata extraction as additive backend (extends 0011) |
 | [0018](./0018-korean-public-rag-bench.md) | accepted | Korean public RAG bench as supplementary out-of-domain surface (extends 0005) |
 | [0019](./0019-embedding-default-stays-minilm.md) | superseded by 0001 | Embedding default stays MiniLM-L12-v2 with explicit re-open conditions (extends 0002) |
+| [0020](./0020-protocol-based-pluggability.md) | accepted | Retrieval-side extension points use `@runtime_checkable typing.Protocol` in a leaf module + default adapter wrapping existing impl + `default_*()` factory + env-var routing (VectorStore #176 + Reranker #345; followed by QueryExpander ADR 0023) |
 | [0021](./0021-bge-m3-completes-phase-1-3.md) | accepted | BGE-M3 closes ADR 0019 Phase 1.3 condition 2; default stays MiniLM (supplements 0019) |
 | [0022](./0022-langgraph-orchestration-stage-1.md) | accepted | LangGraph orchestrator path for agentic_full presets — stages 1 (passthrough) + 2 (multi-node analyze / retrieve_loop / build_answer; `_phase_*` helpers shared with direct path; opt-in via BIDMATE_ORCHESTRATOR=langgraph, preserves ADR 0001) |
 | [0024](./0024-agentic-full-llm-as-api-default.md) | accepted | API surface default preset = `agentic_full_llm`; backend default stays `stub` (complements 0011; CLI default stays `naive_baseline` per 0001) |

--- a/rag_reranker.py
+++ b/rag_reranker.py
@@ -16,6 +16,10 @@ fallback contract are preserved unchanged.
 a second concrete reranker (e.g. ``HydeReranker``) lands, the plan-
 based dispatch becomes a one-file change here — ``rag_core.py`` stays
 untouched.
+
+Convention: follows the four-property Protocol-based pluggability pattern
+(ADR 0020). New rerankers implement ``Reranker`` and register via
+``default_reranker()`` — retrieval orchestration is untouched.
 """
 from __future__ import annotations
 

--- a/rag_vector_store.py
+++ b/rag_vector_store.py
@@ -23,6 +23,10 @@ Stages of #176:
   ``store.query`` so both backends drive ranking through the same
   surface. Filter-pushdown (Qdrant payload filters) extends ``query``.
 * **Stage 3** (deferred) — pgvector backend for SaaS-Postgres scale.
+
+Convention: follows the four-property Protocol-based pluggability pattern
+(ADR 0020). New backends implement ``VectorStore`` and register via
+``default_vector_store()`` — ``rag_core.py`` is untouched.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## 1. 변경 이유 (Why)

VectorStore (#176, PR #234) + Reranker (#345, PR #358) 두 Phase 2 리팩터링이 동일한 구조적 패턴을 공유하지만 ADR이 없었음. Phase 3에서 동일 패턴이 재등장할 때(HyDE, embedding backend swap) PR 리뷰가 매번 패턴을 재정당화해야 하는 문제 방지.

## 2. 변경 내용 (What)

- `docs/adr/0020-protocol-based-pluggability.md` (신규) — ADR 0020
  - 4-property 컨벤션: `@runtime_checkable Protocol` + 기존 impl wrapping default adapter + `default_*()` factory + env-var routing
  - VectorStore + Reranker 두 사례를 하나의 결정으로 통합
  - 대안 비교: ABC vs Protocol, factory-free import, plan-dict routing
- `docs/adr/README.md` — 0019와 0021 사이 ADR 0020 행 추가 (gap 채움)
- `rag_vector_store.py` — 모듈 docstring에 ADR 0020 컨벤션 참조 추가
- `rag_reranker.py` — 모듈 docstring에 ADR 0020 컨벤션 참조 추가
- `docs/adr/0013-observability-as-additive-pluggable-surface.md` — Related 필드에 ADR 0020 cross-reference 추가

## 3. 검증

- `bash scripts/test.sh` → 945 passed, 8 skipped ✓

## 4. Load-bearing 파일 변경 여부

`docs/adr/` — load-bearing (CLAUDE.md). 신규 ADR 추가 + README 업데이트, 기존 ADR 삭제/수정 없음.
`rag_vector_store.py`, `rag_reranker.py` — docstring comment 추가만, 코드 변경 없음.

## 5a. 행동 변경 → 회귀 테스트

N/A — docstring 및 ADR 문서 추가만. 런타임 동작 무변경.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. docs/ADR-only PR; `rag_vector_store.py` and `rag_reranker.py` receive docstring comments only — no logic changes.

Closes #394