### PR TITLE
docs: restore ADR 0020 and private-hardcase-benchmark.md (fixes broken links)

### DIFF
--- a/docs/adr/0020-protocol-based-pluggability.md
+++ b/docs/adr/0020-protocol-based-pluggability.md
@@ -1,0 +1,100 @@
+# 0020: Protocol-based pluggability for retrieval-side extension points
+
+- **Status**: accepted
+- **Date**: 2026-05-13
+- **Related**: [ADR 0013](0013-observability-as-additive-pluggable-surface.md) (additive pluggability theme), [PR #234](https://github.com/hskim-solv/BidMate-DocAgent/pull/234) (VectorStore Stage 1), [PR #358](https://github.com/hskim-solv/BidMate-DocAgent/pull/358) (Reranker), [issue #176](https://github.com/hskim-solv/BidMate-DocAgent/issues/176) (VectorStore work), [issue #345](https://github.com/hskim-solv/BidMate-DocAgent/issues/345) (Reranker work), [`rag_vector_store.py`](../../rag_vector_store.py), [`rag_reranker.py`](../../rag_reranker.py)
+
+## Context
+
+Two independent Phase 2 refactors introduced structurally identical patterns
+without a shared architectural rationale:
+
+**VectorStore Protocol** (issue #176, PR #234 + follow-ups #288 / #296 / #326):
+`rag_vector_store.py` exposes a `@runtime_checkable typing.Protocol` (VectorStore)
+with `InMemoryVectorStore` as the default and `QdrantVectorStore` as an adapter.
+`BIDMATE_INDEX_BACKEND` drives dispatch; `rag_core.py` is untouched when a new
+backend registers.
+
+**Reranker Protocol** (issue #345, PR #358):
+`rag_reranker.py` mirrors the same shape — `@runtime_checkable` Protocol,
+`CrossEncoderReranker` default adapter wrapping `rag_rerank.rerank`, and a
+`default_reranker()` factory as the single wiring hook. Future rerankers
+(HyDE, LLM-as-judge) plug in here; `rag_core.py` is untouched.
+
+The convention recurs naturally in Phase 3 (HyDE query expansion, alternative
+embedding backends, multi-query retrieval). Without a written ADR each future
+Protocol PR re-litigates the same design questions: ABC vs Protocol, factory
+vs direct import, env-var vs plan-dict routing.
+
+The ADR threshold from [`docs/adr/README.md`](README.md): *"Establishes a new
+convention that future changes must follow."* Both PRs already merged; this ADR
+converts the implicit convention into an explicit reference.
+
+## Decision
+
+Retrieval-side extension points follow a four-property convention:
+
+1. **`@runtime_checkable typing.Protocol` in a leaf module.**
+   The Protocol lives in its own file (`rag_<aspect>.py`) so the
+   dependency graph stays acyclic. `runtime_checkable` enables
+   `isinstance` guards in tests without coupling to a concrete type.
+
+2. **Default adapter wraps the existing implementation.**
+   The first concrete class in the new module (`InMemoryVectorStore`,
+   `CrossEncoderReranker`) delegates to the existing code path, keeping
+   the observable behaviour bit-identical. No eval regression on merge.
+
+3. **`default_<aspect>()` factory as the single dispatch hook.**
+   Orchestration code (`rag_core.py`, `rag_retrieval.py`) calls
+   `default_reranker()` / `default_vector_store()` exactly once.
+   Adding a second implementation requires changing one function in
+   one file; retrieval orchestration stays untouched.
+
+4. **Env-var routing inside the factory; plan-dict routing is out of scope.**
+   `BIDMATE_INDEX_BACKEND`, `BIDMATE_RERANK_BACKEND` are the dispatch
+   signals. The plan dict produced by `analyze_query` is for query-level
+   decisions; backend selection is environment-level configuration.
+
+## Consequences
+
+**Easier:**
+- New extension point (e.g. `QueryExpander`, `EmbeddingBackend`) follows
+  the same four steps. PR reviewer can cite this ADR instead of re-examining
+  the pattern from scratch.
+- `isinstance(x, VectorStore)` and `isinstance(x, Reranker)` work in tests
+  for structural duck-typing checks.
+- Eval is unaffected at merge: the default adapter wraps the existing code
+  path, so `naive_baseline` stays bit-identical (ADR 0001 invariant).
+
+**Harder / constrained:**
+- Ceremony cost: a new retrieval-side extension point requires a new leaf
+  module (Protocol + default class + factory), not just a new function.
+  Reversal cost is low — each leaf module is independent.
+- `@runtime_checkable` Protocols do not check method signatures at
+  `isinstance` time, only presence. Full type safety requires `mypy`
+  structural checking, not runtime guards alone.
+
+**Follow-up precedent already set:**
+- `rag_query_expansion.py` (ADR 0023) introduces `QueryExpander` using
+  the same four-property convention, citing this pattern.
+- Phase 3 HyDE, LLM-as-reranker, and alternative embedding backends are
+  expected to follow the same shape.
+
+## Alternatives considered
+
+- **ABC (`abc.ABC` + `@abstractmethod`) instead of Protocol**: ABCs require
+  concrete classes to register or inherit, coupling the extension point to
+  the base class. Protocols work structurally — any class with the right
+  methods satisfies the contract without importing from this module.
+  Chosen: Protocol.
+
+- **Factory-free direct import**: callers import the concrete class directly.
+  Rejected: changes the import site in orchestration code whenever the default
+  class changes. The factory pattern (one import, one call site) makes
+  future swaps transparent.
+
+- **Plan-dict routing**: the query-analysis plan dict selects the backend per
+  request. Rejected for backend selection: backends are environment-level
+  configuration (cost, availability), not per-query decisions. Plan-dict
+  routing is correct for *retrieval mode* (flat vs hierarchical, ADR 0002)
+  but not for *infrastructure wiring*.

--- a/docs/private-hardcase-benchmark.md
+++ b/docs/private-hardcase-benchmark.md
@@ -1,0 +1,85 @@
+# Private Hard-case Benchmark
+
+이 문서는 이슈 #24의 private hard-case benchmark 운영 기준을 정리한다. 목적은 공개 synthetic benchmark를 대체하는 것이 아니라, scanned PDF, rotated/skewed page, table-heavy page, mixed layout, noisy OCR 조건에서 parser/retrieval/answer failure가 얼마나 늘어나는지 aggregate로 비교하는 것이다.
+
+private 100-doc 실험처럼 corpus-level aggregate를 장기 추적할 때는 [`private-100-doc-experiments.md`](private-100-doc-experiments.md)의 naming과 commit boundary도 함께 따른다.
+
+## Commit Boundary
+
+커밋 가능한 항목은 benchmark template, 익명 case id, aggregate metric, failure taxonomy, 실행 절차뿐이다.
+
+커밋하지 않는 항목은 다음과 같다.
+
+- 원본 private RFP 문서
+- 원본 파일명, 기관명, 사업명처럼 출처를 복원할 수 있는 식별자
+- raw private predictions, traces, per-example dumps
+- OCR로 추출된 원문 snippet을 포함한 private artifact
+
+로컬 입력은 `.gitignore` 대상인 `data/files/`, `data/data_list.csv`, `eval/*.local.yaml`을 사용한다. 실행 산출물은 `artifacts/benchmarks/` 아래에만 둔다.
+
+## Case List
+
+`eval/private_hardcase.example.yaml`을 `eval/private_hardcase.local.yaml`로 복사한 뒤 로컬 환경에서만 채운다. 각 case는 익명 ID와 difficulty slice만 남긴다.
+
+지원하는 기본 slice는 다음과 같다.
+
+- `scanned_pdf`
+- `rotated_or_skewed`
+- `table_heavy`
+- `mixed_layout`
+- `noisy_ocr`
+
+한 case는 여러 slice에 속할 수 있다. `eval/run_eval.py`는 `by_hardcase_category`를 생성해 전체 평균뿐 아니라 slice별 accuracy, groundedness, citation precision, answer format, abstention, retry를 함께 보고한다.
+
+## Running Locally
+
+private suite template은 그대로 실행하지 않고 로컬 파일로 복사해 경로를 맞춘다.
+
+```bash
+cp eval/private_hardcase.example.yaml eval/private_hardcase.local.yaml
+cp benchmarks/suites/private_hardcase_rfp.example.yaml benchmarks/suites/private_hardcase_rfp.local.yaml
+```
+
+v1 text ingestion과 v2 visual parsing을 비교하려면 같은 익명 case list를 사용하고 index build command만 바꾼 suite를 각각 실행한다.
+
+```bash
+python3 scripts/run_benchmark.py \
+  --suite benchmarks/suites/private_hardcase_rfp.local.yaml \
+  --ablations benchmarks/ablations/rag_quality_axes.yaml
+```
+
+생성된 `artifacts/benchmarks/<run_id>/run_manifest.json`을 확인한 뒤 aggregate만 registry/docs에 반영한다.
+
+```bash
+python3 scripts/summarize_benchmark.py \
+  --manifest artifacts/benchmarks/<run_id>/run_manifest.json
+```
+
+## Failure Analysis
+
+parser-stage 분석은 `eval/run_parser_eval.py`의 taxonomy를 사용한다. gold YAML도 private local 파일로만 유지하고, `hardcase_categories`를 문서 단위로 기록하면 report의 `summary.by_hardcase_category`에서 OCR/layout/table/field/bbox failure count가 slice별로 집계된다.
+
+```bash
+python3 eval/run_parser_eval.py \
+  --artifact_dir data/index-private-hardcase/visual_artifacts \
+  --gold eval/private_parser_gold.local.yaml \
+  --output_dir reports \
+  --run_name private_visual_v2 \
+  --parser_version 2
+```
+
+분석 문서에는 public synthetic benchmark와 private hard-case slice의 aggregate 차이만 적는다. 예를 들어 public에서는 citation precision이 유지되지만 `table_heavy`에서 table cell F1과 citation precision이 같이 떨어지면 table reconstruction failure가 grounded answer 품질에 미치는 영향으로 분류한다.
+
+## Aggregate Comparison Report
+
+실제 private 문서가 저장소에 없기 때문에 이 저장소에는 실측 private 수치를 커밋하지 않는다. private run 이후에는 아래 형식으로 aggregate만 남긴다.
+
+| Slice | Public primary | Private hard-case primary | Delta | Likely failure stage |
+|---|---:|---:|---:|---|
+| overall accuracy | public aggregate | private aggregate | private - public | parser/retrieval/answer |
+| citation precision | public aggregate | private aggregate | private - public | retrieval/citation grounding |
+| table_heavy citation precision | N/A or public proxy | private aggregate | N/A | table/parser |
+| noisy_ocr groundedness | N/A or public proxy | private aggregate | N/A | OCR/retrieval |
+| rotated_or_skewed bbox alignment | N/A or parser fixture | private aggregate | N/A | bbox/layout |
+
+failure increase는 `summary.by_hardcase_category`, `by_hardcase_category`, `failure_counts`, `retry_reason_counts`를 함께 보고 분류한다. private aggregate가 public 대비 악화되었지만 parser failure count가 늘지 않았다면 retrieval/rerank/answer policy 쪽을 우선 의심한다.


### PR DESCRIPTION
## Summary

- `docs/adr/0020-protocol-based-pluggability.md` 를 git history (commit `663e7ae`) 에서 복원 — 누락 상태로 ADR 0023 (line 5) 와 ADR 0026 (lines 73, 102, 104, 183) 의 broken link 유발
- `docs/private-hardcase-benchmark.md` 를 git history (commit `e12307a`) 에서 복원 — PR #565/566 portfolio meta-doc cleanup 으로 제거되어 ADR 0005 (line 5) broken link 유발

두 파일 모두 verbatim 복원; 코드 또는 파이프라인 로직 미변경.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 순수 문서 복원 — git history 에서 verbatim 파일 복구, 파이프라인 코드 미수정.

## Link 무결성 검증

```
docs/adr/0023: ./0020-protocol-based-pluggability.md -> OK
docs/adr/0026: ./0020-protocol-based-pluggability.md -> OK (×3)
docs/adr/0005: ../private-hardcase-benchmark.md -> OK
```

Closes #608
