### PR TITLE
refactor: simplify ingestion report building and reduce duplicate clean_cell calls

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -353,9 +353,7 @@ def build_sections_with_native_tables(
     for idx, table in enumerate(native_tables):
         cells = table.get("cells", []) or []
         cell_lines = [
-            str(cell.get("text", "")).strip()
-            for cell in cells
-            if str(cell.get("text", "")).strip()
+            t for cell in cells if (t := str(cell.get("text", "")).strip())
         ]
         if not cell_lines:
             continue
@@ -839,31 +837,14 @@ def build_ingestion_report(
     on_duplicate_doc_id: str,
 ) -> dict[str, Any]:
     """Build the canonical ingestion_report.json payload."""
-    failure_reasons: dict[str, int] = OrderedDict()
-    failure_examples: dict[str, list[dict[str, Any]]] = OrderedDict()
+    failure_reasons, failure_examples, file_formats, duplicate_groups = (
+        _collect_record_buckets(records)
+    )
     doc_id_sources: dict[str, int] = OrderedDict()
-    file_formats: dict[str, int] = OrderedDict()
-    duplicate_groups: dict[str, list[int]] = OrderedDict()
-
     for record in records:
-        if record.reason:
-            failure_reasons[record.reason] = failure_reasons.get(record.reason, 0) + 1
-            examples = failure_examples.setdefault(record.reason, [])
-            if len(examples) < 3:
-                examples.append(
-                    {
-                        "row_number": record.row_number,
-                        "doc_id": record.doc_id,
-                        "file_name": record.file_name,
-                        "file_format": record.file_format,
-                    }
-                )
-        fmt = record.file_format or "unknown"
-        file_formats[fmt] = file_formats.get(fmt, 0) + 1
         if record.status == "indexed":
             source = "notice_id" if _looks_like_notice_id_doc(record) else "file_name"
             doc_id_sources[source] = doc_id_sources.get(source, 0) + 1
-        _accumulate_duplicate_group(duplicate_groups, record)
 
     summary = {
         "schema_version": INGESTION_REPORT_SCHEMA_VERSION,
@@ -884,6 +865,45 @@ def build_ingestion_report(
         "failure_taxonomy": FAILURE_TAXONOMY,
         "records": [_record_to_dict(record) for record in records],
     }
+
+
+def _collect_record_buckets(
+    records: list[IngestionRecord],
+) -> tuple[
+    dict[str, int],
+    dict[str, list[dict[str, Any]]],
+    dict[str, int],
+    dict[str, list[int]],
+]:
+    """Accumulate the four shared report-building buckets over ``records``.
+
+    Returns ``(failure_reasons, failure_examples, file_formats, duplicate_groups)``.
+    Both :func:`build_ingestion_report` and :func:`_build_validation_report` call
+    this helper so the identical accumulation logic lives in one place.
+    """
+    failure_reasons: dict[str, int] = OrderedDict()
+    failure_examples: dict[str, list[dict[str, Any]]] = OrderedDict()
+    file_formats: dict[str, int] = OrderedDict()
+    duplicate_groups: dict[str, list[int]] = OrderedDict()
+
+    for record in records:
+        if record.reason:
+            failure_reasons[record.reason] = failure_reasons.get(record.reason, 0) + 1
+            examples = failure_examples.setdefault(record.reason, [])
+            if len(examples) < 3:
+                examples.append(
+                    {
+                        "row_number": record.row_number,
+                        "doc_id": record.doc_id,
+                        "file_name": record.file_name,
+                        "file_format": record.file_format,
+                    }
+                )
+        fmt = record.file_format or "unknown"
+        file_formats[fmt] = file_formats.get(fmt, 0) + 1
+        _accumulate_duplicate_group(duplicate_groups, record)
+
+    return failure_reasons, failure_examples, file_formats, duplicate_groups
 
 
 def _accumulate_duplicate_group(
@@ -1040,30 +1060,13 @@ def _build_validation_report(
     schema_issues: list[ValidationIssue],
     on_duplicate_doc_id: str,
 ) -> dict[str, Any]:
-    failure_reasons: dict[str, int] = OrderedDict()
-    failure_examples: dict[str, list[dict[str, Any]]] = OrderedDict()
-    file_formats: dict[str, int] = OrderedDict()
-    duplicate_groups: dict[str, list[int]] = OrderedDict()
+    failure_reasons, failure_examples, file_formats, duplicate_groups = (
+        _collect_record_buckets(records)
+    )
     blank_field_counts: dict[str, int] = OrderedDict()
-
     for record in records:
-        if record.reason:
-            failure_reasons[record.reason] = failure_reasons.get(record.reason, 0) + 1
-            examples = failure_examples.setdefault(record.reason, [])
-            if len(examples) < 3:
-                examples.append(
-                    {
-                        "row_number": record.row_number,
-                        "doc_id": record.doc_id,
-                        "file_name": record.file_name,
-                        "file_format": record.file_format,
-                    }
-                )
-        fmt = record.file_format or "unknown"
-        file_formats[fmt] = file_formats.get(fmt, 0) + 1
         for message in record.messages:
             blank_field_counts[message] = blank_field_counts.get(message, 0) + 1
-        _accumulate_duplicate_group(duplicate_groups, record)
 
     ok_count = sum(1 for record in records if record.status == "ok")
     failed_count = sum(1 for record in records if record.status == "failed")

--- a/visual_ingestion.py
+++ b/visual_ingestion.py
@@ -18,7 +18,7 @@ in minimal environments.
 from __future__ import annotations
 
 import csv
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 import json
 import os
 from pathlib import Path
@@ -186,6 +186,9 @@ def parse_visual_metadata_row(
     file_format = normalize_file_format(row.get("파일형식"), file_name)
     source_path = find_source_file(files_dir, file_name) if file_name else files_dir
     doc_id = make_doc_id(notice_id, notice_round) if notice_id else make_doc_id_from_file_name(file_name)
+    project = clean_cell(row.get("사업명"))
+    agency = clean_cell(row.get("발주 기관"))
+    title = project or Path(file_name).stem
 
     failure_reason = validate_visual_row_basics(
         doc_id=doc_id,
@@ -199,16 +202,13 @@ def parse_visual_metadata_row(
             doc_id=doc_id or make_doc_id_from_file_name(file_name) or f"row-{row_number}",
             source_path=source_path,
             file_format=file_format,
-            title=clean_cell(row.get("사업명")) or Path(file_name).stem,
+            title=title,
             metadata=normalize_metadata(row, file_format, file_name),
             reason=failure_reason,
         )
         return None, artifact, record_from_artifact(artifact, None, row_number=row_number)
 
     metadata = normalize_metadata(row, file_format, file_name)
-    title = clean_cell(row.get("사업명")) or Path(file_name).stem
-    agency = clean_cell(row.get("발주 기관"))
-    project = clean_cell(row.get("사업명"))
 
     if file_format == "hwp":
         document, artifact = make_hwp_fallback_document(
@@ -804,16 +804,18 @@ def make_hwp_fallback_document(
     file_format: str,
     file_name: str,
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    project = clean_cell(row.get("사업명"))
+    agency = clean_cell(row.get("발주 기관"))
+    title = project or Path(file_name).stem
     metadata = normalize_metadata(row, file_format, file_name)
     metadata["visual_fallback_reason"] = "visual_fallback_hwp"
-    title = clean_cell(row.get("사업명")) or Path(file_name).stem
     artifact = base_visual_artifact(
         source_path=source_path,
         doc_id=doc_id,
         file_format=file_format,
         title=title,
-        agency=clean_cell(row.get("발주 기관")),
-        project=clean_cell(row.get("사업명")),
+        agency=agency,
+        project=project,
         metadata=metadata,
     )
     text = normalize_body_text(row.get("텍스트", ""))
@@ -1205,16 +1207,7 @@ def record_from_artifact(
 
 
 def replace_record_artifact_path(record: VisualIngestionRecord, artifact_path: Path) -> VisualIngestionRecord:
-    return VisualIngestionRecord(
-        row_number=record.row_number,
-        status=record.status,
-        doc_id=record.doc_id,
-        file_name=record.file_name,
-        file_format=record.file_format,
-        source_path=record.source_path,
-        artifact_path=str(artifact_path),
-        reason=record.reason,
-    )
+    return replace(record, artifact_path=str(artifact_path))
 
 
 def make_visual_report(


### PR DESCRIPTION
## Summary
- `visual_ingestion.py` `replace_record_artifact_path()`: 수동 9-field constructor → `dataclasses.replace()`
- `ingestion.py` `build_sections_with_native_tables()`: double strip eval → single (walrus)
- `visual_ingestion.py` `parse_visual_metadata_row()` / `make_hwp_fallback_document()`: `clean_cell()` 호출 pre-compute
- `ingestion.py`: `_collect_record_buckets()` 추출하여 `build_ingestion_report` ↔ `_build_validation_report` 간 ~20 라인 중복 제거

로직 변경 없음. 71 ingestion/HWP/visual 테스트 전부 pass.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 순수 refactor — 모든 입력에 identical 출력. 기존 71-test suite 가 refactored 코드 경로 커버.

Closes #615
