### PR TITLE
refactor: remove redundant calls in rag_verifier and rag_answer

### DIFF
--- a/rag_answer.py
+++ b/rag_answer.py
@@ -384,7 +384,7 @@ def metadata_field_requested(key: str, value: Any, analysis: dict[str, Any]) -> 
     labels = METADATA_CLAIM_TOPIC_LABELS.get(key) or METADATA_EVIDENCE_LABELS.get(key, (key,))
     label_text = " ".join(str(label) for label in labels)
     value_text = str(value)
-    searchable = compact_metadata_text(" ".join([label_text, value_text]))
+    searchable = compact_metadata_text(f"{label_text} {value_text}")
     for term in terms:
         compact_term = compact_metadata_text(str(term))
         if compact_term and compact_term in searchable:

--- a/rag_verifier.py
+++ b/rag_verifier.py
@@ -170,9 +170,10 @@ def specific_topics(analysis: dict[str, Any]) -> list[str]:
 def verification_topics(analysis: dict[str, Any]) -> list[str]:
     metadata_terms = metadata_terms_for_verification(analysis)
     keyword_terms = {
-        normalize_metadata_token(keyword)
+        norm
         for keyword in TOPIC_KEYWORDS
-        if normalize_metadata_token(keyword).lower() != "ai"
+        for norm in (normalize_metadata_token(keyword),)
+        if norm.lower() != "ai"
     }
     topics = []
     for topic in analysis.get("topics", []):
@@ -249,7 +250,7 @@ def evidence_text_for_verification(item: dict[str, Any]) -> str:
                 continue
             parts.extend(METADATA_EVIDENCE_LABELS.get(str(key), (str(key),)))
             parts.append(neutralize_instruction_patterns(str(value)))
-    return " ".join(str(part) for part in parts if str(part).strip())
+    return " ".join(part for part in parts if part.strip())
 
 
 def evidence_has_topic(item: dict[str, Any], topics: list[str]) -> bool:


### PR DESCRIPTION
## Summary
- `rag_verifier.py` `verification_topics()`: double `normalize_metadata_token` 호출 → set comprehension 의 helper var 통한 단일 호출
- `rag_verifier.py` `evidence_text_for_verification()`: 중복 `str()` wrapping 제거
- `rag_answer.py` `metadata_field_requested()`: `" ".join([a, b])` → `f"{a} {b}"` f-string

로직 변경 없음. verifier/answer 46 테스트 전부 pass.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 순수 micro-refactor — 모든 입력에 동일 출력. 46 테스트가 변경된 모든 코드 경로 cover.

## Test plan
- [x] `EMBEDDING_BACKEND=hashing pytest -k "partial_topic or answer_contract or prompt_injection or synthetic_judge or verif"` → 46 passed

Closes #614
