### PR TITLE
feat(bm25): Mecab-ko + Khaiii tokenizer ablation (ADR 0031 valid-set expansion, closes #561)

### DIFF
--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -33,6 +33,13 @@ latency_budgets:
     # Same as ``naive_baseline`` — the LoRA adapter does not change
     # the per-query retrieval shape, only the vector content.
     p95_ms: 100
+  full_mecab:
+    # Issue #561 / ADR 0031 — Mecab-ko tokenizer. Same budget as
+    # full_kiwi; tokenizer fallback to regex when mecab unavailable.
+    p95_ms: 200
+  full_khaiii:
+    # Issue #561 / ADR 0031 — Khaiii tokenizer. Same budget as full_kiwi.
+    p95_ms: 200
 answer_policy:
   answerable_status: supported
   unanswerable_status: insufficient
@@ -196,6 +203,32 @@ ablation_runs:
     retrieval_mode: flat
     retrieval_backend: hybrid
     bm25_tokenizer: kiwi
+  # Issue #561 / ADR 0031 valid-set expansion — Mecab-ko BM25 tokenizer.
+  # Same retrieval + verifier as `full_kiwi` (kiwi control row); only
+  # the BM25 tokenizer swaps to Mecab-ko morpheme analysis.
+  # Never-raise: if python-mecab-ko / konlpy is missing, mecab_tokens
+  # returns None and the dispatch falls back to regex (ADR 0001 invariant).
+  # Measurement intent: lift vs kiwi ≥ +3pp → ADR 0031 default tokenizer
+  # re-evaluation; lift < +3pp → kiwi selection is measurement-justified.
+  - name: full_mecab
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    retrieval_backend: hybrid
+    bm25_tokenizer: mecab
+  # Issue #561 / ADR 0031 valid-set expansion — Khaiii BM25 tokenizer.
+  # Khaiii requires a compiled C++ shared library (optional dependency).
+  # Never-raise fallback to regex if khaiii is unavailable (ADR 0001).
+  - name: full_khaiii
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    retrieval_backend: hybrid
+    bm25_tokenizer: khaiii
   # Issue #163 / ADR 0011 pattern — additive cross-encoder reranker. The
   # existing `full` row is the natural negative (rerank_cross_encoder
   # defaults to false). Under the CI default backend (stub) the cross-

--- a/korean_lexicon.py
+++ b/korean_lexicon.py
@@ -126,3 +126,104 @@ def kiwi_tokens(text: str) -> list[str] | None:
             if form:
                 tokens.append(form)
     return tokens
+
+
+# ---------------------------------------------------------------------------
+# Mecab-ko tokenizer (issue #561 / ADR 0031 valid-set expansion)
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=1)
+def _mecab_instance() -> Any | None:
+    """Return a singleton Mecab analyzer or ``None`` if unavailable.
+
+    Tries ``python-mecab-ko`` first, then ``konlpy.tag.Mecab`` as fallback.
+    ``None`` return signals callers to fall back to the regex tokenizer
+    (never-raise contract, ADR 0001 invariant).
+    """
+    try:
+        from mecab import MeCab  # type: ignore[import-not-found]  # python-mecab-ko
+        return MeCab()
+    except (ImportError, Exception):  # noqa: BLE001
+        pass
+    try:
+        from konlpy.tag import Mecab  # type: ignore[import-not-found]
+        return Mecab()
+    except (ImportError, Exception):  # noqa: BLE001
+        return None
+
+
+def mecab_tokens(text: str) -> list[str] | None:
+    """Morpheme-tokenize ``text`` using Mecab-ko, return BM25-worthy nouns/verbs.
+
+    Returns ``None`` if Mecab is not installed — callers fall back to the
+    regex tokenizer (never-raise, ADR 0001 invariant). Same contract as
+    :func:`kiwi_tokens`.
+    """
+    if not text:
+        return []
+    mecab = _mecab_instance()
+    if mecab is None:
+        return None
+    try:
+        # python-mecab-ko returns list of (surface, tag) tuples via morphs/pos.
+        # konlpy.tag.Mecab.pos() returns the same structure.
+        pos_list = mecab.pos(text)
+    except Exception:  # noqa: BLE001
+        return None
+    # Keep open-class morphemes: NNG/NNP (nouns), VV/VA (verbs/adjectives),
+    # XR (roots), SL (foreign), SN (numbers), NR (numerals).
+    keep_prefixes = ("NN", "VV", "VA", "XR", "SL", "SN", "NR")
+    tokens: list[str] = []
+    for surface, tag in pos_list:
+        if any(tag.startswith(p) for p in keep_prefixes):
+            surface = surface.strip()
+            if surface:
+                tokens.append(surface)
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# Khaiii tokenizer (issue #561 / ADR 0031 valid-set expansion)
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=1)
+def _khaiii_instance() -> Any | None:
+    """Return a singleton KhaiiiApi instance or ``None`` if unavailable.
+
+    Khaiii requires a compiled C++ shared library. ``None`` return signals
+    callers to fall back to the regex tokenizer (never-raise contract).
+    """
+    try:
+        from khaiii import KhaiiiApi  # type: ignore[import-not-found]
+        api = KhaiiiApi()
+        api.open()
+        return api
+    except (ImportError, Exception):  # noqa: BLE001
+        return None
+
+
+def khaiii_tokens(text: str) -> list[str] | None:
+    """Morpheme-tokenize ``text`` using Khaiii, return BM25-worthy morphemes.
+
+    Returns ``None`` if Khaiii is not installed or fails to initialize —
+    callers fall back to the regex tokenizer (never-raise, ADR 0001 invariant).
+    Same contract as :func:`kiwi_tokens` and :func:`mecab_tokens`.
+    """
+    if not text:
+        return []
+    api = _khaiii_instance()
+    if api is None:
+        return None
+    try:
+        words = api.analyze(text)
+    except Exception:  # noqa: BLE001
+        return None
+    keep_prefixes = ("NN", "VV", "VA", "XR", "SL", "SN", "NR")
+    tokens: list[str] = []
+    for word in words:
+        for morpheme in word.morphs:
+            tag = getattr(morpheme, "tag", "") or ""
+            surface = (getattr(morpheme, "lex", "") or "").strip()
+            if surface and any(tag.startswith(p) for p in keep_prefixes):
+                tokens.append(surface)
+    return tokens

--- a/rag_pipeline_presets.py
+++ b/rag_pipeline_presets.py
@@ -193,7 +193,13 @@ VALID_BM25_STOPWORD_PROFILES = {"shared", "bm25_extra"}
 # into kiwipiepy morpheme tokenization (체언 / 용언 / 수식어 /
 # 외래어 POS filter). Missing kiwipiepy → silent fallback to regex,
 # enforced by `korean_lexicon.kiwi_tokens` returning ``None``.
-VALID_BM25_TOKENIZERS = {"regex", "kiwi"}
+VALID_BM25_TOKENIZERS = {"regex", "kiwi", "mecab", "khaiii"}
+# Issue #561 / ADR 0031 valid-set expansion: "mecab" (python-mecab-ko /
+# konlpy.tag.Mecab) and "khaiii" (Khaiii C++ binding) added as opt-in
+# ablation tokenizers. Both have the same never-raise contract as "kiwi":
+# if the dependency is unavailable, `korean_lexicon.mecab_tokens` /
+# `khaiii_tokens` return None and rag_retrieval silently falls back to
+# regex — ADR 0001 naive_baseline invariant preserved.
 # Issue #396 / ADR 0023 — pluggable QueryExpander discriminator. Kept
 # narrow on purpose: a typo like "hide" raises rather than silently
 # degrading retrieval. ``rag_query_expansion.default_expander`` still

--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -593,6 +593,32 @@ def _chunk_tokens_for_bm25(
             return kiwi_base
         # else: silent fallback to regex below.
 
+    # Issue #561 / ADR 0031 valid-set expansion — Mecab-ko tokenizer.
+    # Never-raise: mecab_tokens returns None if python-mecab-ko / konlpy
+    # is unavailable; falls back to regex (ADR 0001 invariant).
+    if tokenizer == "mecab":
+        from korean_lexicon import mecab_tokens
+
+        mecab_base = mecab_tokens(text)
+        if mecab_base is not None:
+            if stopword_profile == "bm25_extra":
+                mecab_base = _apply_bm25_extra_filter(mecab_base)
+            return mecab_base
+        # else: silent fallback to regex below.
+
+    # Issue #561 / ADR 0031 valid-set expansion — Khaiii tokenizer.
+    # Never-raise: khaiii_tokens returns None if Khaiii C++ binding is
+    # unavailable; falls back to regex (ADR 0001 invariant).
+    if tokenizer == "khaiii":
+        from korean_lexicon import khaiii_tokens
+
+        khaiii_base = khaiii_tokens(text)
+        if khaiii_base is not None:
+            if stopword_profile == "bm25_extra":
+                khaiii_base = _apply_bm25_extra_filter(khaiii_base)
+            return khaiii_base
+        # else: silent fallback to regex below.
+
     tokens = chunk.get("tokens")
     if isinstance(tokens, list) and tokens:
         base = [str(t) for t in tokens]
@@ -695,6 +721,20 @@ def bm25_scores_for_index(
         kiwi_query = kiwi_tokens(" ".join(effective_tokens))
         if kiwi_query is not None:
             effective_tokens = kiwi_query
+    # Issue #561 / ADR 0031 valid-set expansion — query-side Mecab-ko.
+    elif tokenizer == "mecab":
+        from korean_lexicon import mecab_tokens
+
+        mecab_query = mecab_tokens(" ".join(effective_tokens))
+        if mecab_query is not None:
+            effective_tokens = mecab_query
+    # Issue #561 / ADR 0031 valid-set expansion — query-side Khaiii.
+    elif tokenizer == "khaiii":
+        from korean_lexicon import khaiii_tokens
+
+        khaiii_query = khaiii_tokens(" ".join(effective_tokens))
+        if khaiii_query is not None:
+            effective_tokens = khaiii_query
     if stopword_profile == "bm25_extra":
         effective_tokens = _apply_bm25_extra_filter(effective_tokens)
         if not effective_tokens:

--- a/tests/test_bm25_kiwi_tokenizer.py
+++ b/tests/test_bm25_kiwi_tokenizer.py
@@ -64,7 +64,8 @@ class ConfigSurfaceTest(unittest.TestCase):
     """The new config key + validator surfaces are wired correctly."""
 
     def test_valid_tokenizers_set_has_regex_and_kiwi(self) -> None:
-        self.assertEqual(VALID_BM25_TOKENIZERS, {"regex", "kiwi"})
+        # Issue #561 / ADR 0031 valid-set expansion: mecab + khaiii added.
+        self.assertGreaterEqual(VALID_BM25_TOKENIZERS, {"regex", "kiwi", "mecab", "khaiii"})
 
     def test_all_presets_default_to_regex(self) -> None:
         """ADR 0001 invariant — every shipped preset stays at regex.
@@ -83,14 +84,29 @@ class ConfigSurfaceTest(unittest.TestCase):
                 )
 
     def test_resolve_rejects_unknown_tokenizer(self) -> None:
+        # "spacy" is not a valid tokenizer — mecab/khaiii are now valid (issue #561).
         with self.assertRaises(ValueError) as ctx:
             resolve_pipeline_config(
                 {
                     "pipeline": "agentic_full",
-                    "bm25_tokenizer": "mecab",  # not in VALID set
+                    "bm25_tokenizer": "spacy",  # not in VALID set
                 }
             )
         self.assertIn("bm25_tokenizer must be one of", str(ctx.exception))
+
+    def test_resolve_accepts_mecab_explicitly(self) -> None:
+        # Issue #561 — mecab is now a valid tokenizer.
+        config = resolve_pipeline_config(
+            {"pipeline": "agentic_full", "bm25_tokenizer": "mecab"}
+        )
+        self.assertEqual(config["bm25_tokenizer"], "mecab")
+
+    def test_resolve_accepts_khaiii_explicitly(self) -> None:
+        # Issue #561 — khaiii is now a valid tokenizer.
+        config = resolve_pipeline_config(
+            {"pipeline": "agentic_full", "bm25_tokenizer": "khaiii"}
+        )
+        self.assertEqual(config["bm25_tokenizer"], "khaiii")
 
     def test_resolve_accepts_kiwi_explicitly(self) -> None:
         config = resolve_pipeline_config(


### PR DESCRIPTION
## 1. 변경 이유 (Why)

ADR 0031이 `kiwi` 토크나이저를 accepted했지만 Mecab-ko / Khaiii와의 정량 비교 부재. 외부 리뷰(PR #487 §4.2-C2)가 "kiwi 선택은 의존성 선택 편향일 수 있다"고 지적. 측정 근거 확보를 위해 VALID_BM25_TOKENIZERS 확장.

## 2. 변경 내용 (What)

- `korean_lexicon.py` — `mecab_tokens()` + `khaiii_tokens()` + 싱글턴 lazy-init (`_mecab_instance()`, `_khaiii_instance()`). 두 함수 모두 동일한 never-raise 계약: 라이브러리 미설치 시 `None` 반환 → regex fallback (ADR 0001 invariant)
- `rag_retrieval.py` — corpus side `_chunk_tokens_for_bm25()` + query side `bm25_scores_for_index()` 에 mecab/khaiii dispatch 추가 (kiwi 패턴 동일)
- `rag_pipeline_presets.py` — `VALID_BM25_TOKENIZERS = {"regex", "kiwi", "mecab", "khaiii"}`
- `eval/config.yaml` — `full_mecab` + `full_khaiii` ablation rows + latency_budgets 항목 추가
- `tests/test_bm25_kiwi_tokenizer.py` — valid-set assertion 업데이트 + mecab/khaiii accept 테스트 추가

## 3. 검증

- `bash scripts/test.sh` → 953 passed, 8 skipped ✓
- `ruff check .` → All checks passed ✓

## 4. Load-bearing 파일 변경 여부

`eval/config.yaml` — load-bearing (CLAUDE.md). `full_mecab` + `full_khaiii` ablation 행 추가 (신규 행, 기존 행 수정 없음).
`rag_retrieval.py` — load-bearing. `bm25_tokenizer="mecab"|"khaiii"` 경로 추가; 기존 `regex`/`kiwi` 경로 변경 없음.

## 5a. 행동 변경 → 회귀 테스트

신규 tokenizer 경로가 기존 코드 경로를 수정하지 않음. Never-raise fallback이 mecab/khaiii 미설치 환경에서 regex와 bit-identical 결과를 보장. 기존 naive_baseline 골든 무변경 (ADR 0001).

### 5b. Real-data delta

No behavior change in retrieval / verifier path for existing pipelines. New tokenizer paths (mecab/khaiii) only activate when explicitly selected via bm25_tokenizer config; all existing ablation rows and naive_baseline are unmodified. Measurement of lift ≥/< +3pp requires local real-embedding run: `EMBEDDING_BACKEND=sentence_transformers make eval`.

Closes #561