### PR TITLE
fix(docs): replace broken langgraph-orchestration.md link (closes #613)

### DIFF
--- a/docs/agentic-definition.md
+++ b/docs/agentic-definition.md
@@ -82,5 +82,5 @@ BidMate-DocAgent의 "agentic"은 **metadata filter를 단계적으로 완화하�
 ## 참고
 
 - 파이프라인 실행 흐름: [`rag_core.py`](../rag_core.py) `run_rag_query` → `_phase_retrieve_loop`
-- LangGraph Stage 1 case study: [`docs/langgraph-orchestration.md`](langgraph-orchestration.md) (issue #593 예정)
+- LangGraph Stage 1 case study: [`docs/agent-system-design-case-study.md`](agent-system-design-case-study.md)
 - 아키텍처 다이어그램: [`README.md § 아키텍처`](../README.md#아키텍처-요약)


### PR DESCRIPTION
## 1. 변경 이유 (Why)

`docs/agentic-definition.md:85`가 존재하지 않는 `docs/langgraph-orchestration.md`를 가리켜 broken link 발생. 이슈 #593이 닫혔지만 해당 파일 대신 `docs/agent-system-design-case-study.md`가 생성됨.

## 2. 변경 내용 (What)

- `docs/agentic-definition.md:85` — link target을 `langgraph-orchestration.md` → `agent-system-design-case-study.md`로 교체, "(issue #593 예정)" 텍스트 제거

## 3. 검증

- `bash scripts/test.sh` → 951 passed, 8 skipped ✓ (local)
- `test -f docs/agent-system-design-case-study.md && echo EXISTS` → EXISTS ✓

## 4. Load-bearing 파일 변경 여부

docs-only, load-bearing path 미포함.

## 5a. 행동 변경 → 회귀 테스트

N/A — docs link fix only.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. Docs-only link fix.

Closes #613