### PR TITLE
fix(docs): remove broken blog/ link from architecture-deep-dive.md

### DIFF
--- a/docs/architecture-deep-dive.md
+++ b/docs/architecture-deep-dive.md
@@ -74,6 +74,5 @@ real-data 측정 결과는 aggregate-only commit boundary로 관리된다 (ADR 0
 ## 더 읽을 거리
 
 - [README §핵심 성능표](https://github.com/hskim-solv/BidMate-DocAgent#%ED%95%B5%EC%8B%AC-%EC%84%B1%EB%8A%A5%ED%91%9C-%EC%8B%A4%EC%B8%A1) — bootstrap CI 표 전체
-- [Blog series](./blog/) — 결정들의 *왜*
 - [ADR 인덱스](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/adr/README.md)
 - [Engineering governance](https://github.com/hskim-solv/BidMate-DocAgent/blob/main/docs/engineering-governance.md) — workflow map


### PR DESCRIPTION
## Summary

- `docs/architecture-deep-dive.md:77` — `docs/blog/` 디렉토리가 존재하지 않아 클릭 시 404 발생하는 Blog series 링크 1줄 제거
- `docs/blog/` 운영 계획 없음; blog series는 ADR 인덱스와 engineering governance 문서로 대체됨

## Test plan

- [ ] `grep -n "blog" docs/architecture-deep-dive.md` → 결과 없음 확인
- [ ] 나머지 링크 모두 유효: README, ADR 인덱스, engineering governance

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)