### PR TITLE
fix(eval): add per-stage latency SLO gate to check_latency_slo

### DIFF
--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -40,6 +40,29 @@ latency_budgets:
   full_khaiii:
     # Issue #561 / ADR 0031 — Khaiii tokenizer. Same budget as full_kiwi.
     p95_ms: 200
+# Per-stage latency budgets used by scripts/check_latency_slo.py (check_stage).
+# Issue #625: stage_latency is measured but was unguarded — silent per-stage
+# drift was possible even when total p95 stayed within ablation ceiling.
+# Ceilings set at ~25x observed CI p95 to absorb runner variance without
+# flaky failures. See: reports/eval_summary.json stage_latency block for
+# observed values. Extend to additional ablations as needed.
+stage_latency_budgets:
+  naive_baseline:
+    query_analysis_ms:
+      p95_ms: 50    # observed CI p95 ≈ 2 ms; 25x ceiling
+    retrieve_ms:
+      p95_ms: 50    # observed CI p95 ≈ 0.2 ms
+    answer_generation_ms:
+      p95_ms: 20    # observed CI p95 ≈ 0.5 ms
+  full:
+    query_analysis_ms:
+      p95_ms: 50    # observed CI p95 ≈ 1.6 ms
+    retrieve_ms:
+      p95_ms: 50    # observed CI p95 ≈ 0.2 ms
+    verify_ms:
+      p95_ms: 50    # observed CI p95 ≈ 1.4 ms
+    answer_generation_ms:
+      p95_ms: 20    # observed CI p95 ≈ 0.4 ms
 answer_policy:
   answerable_status: supported
   unanswerable_status: insufficient

--- a/scripts/check_latency_slo.py
+++ b/scripts/check_latency_slo.py
@@ -100,6 +100,56 @@ def check(
     return violations, passes, orphans
 
 
+def check_stage(
+    config: dict[str, Any],
+    summary: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    """Return (violations, passes, orphans) for per-stage latency SLO.
+
+    ``stage_latency_budgets`` layout in eval/config.yaml::
+
+        stage_latency_budgets:
+          <run_name>:
+            <stage_name>:
+              p95_ms: <ceiling>
+
+    A run without a stage budget entry is silently skipped. A run name
+    in the budget with no matching ablation run is reported as orphaned.
+    Stage keys without a matching stage_latency entry are silently
+    skipped (some stages are absent on simple pipelines).
+    """
+    stage_budgets = (config or {}).get("stage_latency_budgets") or {}
+    runs = _runs_by_name(summary)
+    violations: list[dict[str, Any]] = []
+    passes: list[dict[str, Any]] = []
+    orphans: list[str] = []
+
+    for run_name, stage_ceilings in stage_budgets.items():
+        run = runs.get(run_name)
+        if run is None:
+            orphans.append(run_name)
+            continue
+        stage_latency = run.get("stage_latency") or {}
+        for stage_name, ceiling_config in (stage_ceilings or {}).items():
+            observed = (stage_latency.get(stage_name) or {}).get("p95")
+            ceiling = (ceiling_config or {}).get("p95_ms")
+            if not isinstance(observed, (int, float)) or not isinstance(ceiling, (int, float)):
+                continue
+            row: dict[str, Any] = {
+                "name": f"{run_name}/{stage_name}",
+                "run": run_name,
+                "stage": stage_name,
+                "observed_p95_ms": float(observed),
+                "ceiling_p95_ms": float(ceiling),
+                "headroom_ms": round(float(ceiling) - float(observed), 3),
+            }
+            if observed > ceiling:
+                violations.append(row)
+            else:
+                passes.append(row)
+    return violations, passes, orphans
+
+
 def _render(violations: list[dict], passes: list[dict], orphans: list[str]) -> str:
     lines: list[str] = []
     if passes:
@@ -140,9 +190,16 @@ def main() -> int:
     args = parse_args()
     config = _load_yaml(Path(args.config))
     summary = _load_json(Path(args.summary))
+
     violations, passes, orphans = check(config, summary)
     print(_render(violations, passes, orphans))
-    return 1 if violations else 0
+
+    stage_violations, stage_passes, stage_orphans = check_stage(config, summary)
+    if stage_violations or stage_passes or stage_orphans:
+        print("\n--- Stage-level SLO ---")
+        print(_render(stage_violations, stage_passes, stage_orphans))
+
+    return 1 if (violations or stage_violations) else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_check_latency_slo.py
+++ b/tests/test_check_latency_slo.py
@@ -17,7 +17,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from check_latency_slo import check  # noqa: E402
+from check_latency_slo import check, check_stage  # noqa: E402
 
 
 def _summary(runs: list[dict]) -> dict:
@@ -87,6 +87,86 @@ class CheckLatencySloUnit(unittest.TestCase):
         self.assertEqual(violations, [])
         self.assertEqual(passes, [])
         self.assertEqual(orphans, [])
+
+
+def _stage_summary(run_name: str, stages: dict) -> dict:
+    """Build a minimal eval_summary.json with stage_latency for one run."""
+    return {"ablation": {"runs": [{"name": run_name, "stage_latency": stages}]}}
+
+
+class CheckStageSloUnit(unittest.TestCase):
+    """Issue #625 — per-stage SLO gate (check_stage)."""
+
+    def test_passing_stage_reported_as_pass(self) -> None:
+        config = {"stage_latency_budgets": {"full": {"query_analysis_ms": {"p95_ms": 50}}}}
+        summary = _stage_summary("full", {"query_analysis_ms": {"p95": 2.0}})
+        violations, passes, orphans = check_stage(config, summary)
+        self.assertEqual(violations, [])
+        self.assertEqual(len(passes), 1)
+        self.assertEqual(passes[0]["stage"], "query_analysis_ms")
+        self.assertAlmostEqual(passes[0]["headroom_ms"], 48.0)
+
+    def test_breach_reported_as_violation(self) -> None:
+        config = {"stage_latency_budgets": {"full": {"query_analysis_ms": {"p95_ms": 50}}}}
+        summary = _stage_summary("full", {"query_analysis_ms": {"p95": 75.0}})
+        violations, passes, orphans = check_stage(config, summary)
+        self.assertEqual(passes, [])
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0]["stage"], "query_analysis_ms")
+        self.assertAlmostEqual(violations[0]["headroom_ms"], -25.0)
+
+    def test_run_without_stage_budget_is_silent(self) -> None:
+        config = {"stage_latency_budgets": {"full": {"query_analysis_ms": {"p95_ms": 50}}}}
+        summary = _stage_summary("naive_baseline", {"query_analysis_ms": {"p95": 9999.0}})
+        # naive_baseline has no budget → silently skipped
+        violations, passes, orphans = check_stage(config, summary)
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+
+    def test_missing_stage_in_run_skipped_silently(self) -> None:
+        # naive pipeline may have no verify_ms — don't fail on absence
+        config = {"stage_latency_budgets": {"naive_baseline": {"verify_ms": {"p95_ms": 20}}}}
+        summary = _stage_summary("naive_baseline", {})
+        violations, passes, orphans = check_stage(config, summary)
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+
+    def test_orphan_run_name_reported(self) -> None:
+        config = {"stage_latency_budgets": {"typo_run": {"query_analysis_ms": {"p95_ms": 50}}}}
+        summary = _stage_summary("full", {"query_analysis_ms": {"p95": 2.0}})
+        violations, passes, orphans = check_stage(config, summary)
+        self.assertEqual(orphans, ["typo_run"])
+
+    def test_no_stage_latency_budgets_is_noop(self) -> None:
+        config = {}
+        summary = _stage_summary("full", {"query_analysis_ms": {"p95": 9999.0}})
+        violations, passes, orphans = check_stage(config, summary)
+        self.assertEqual(violations, [])
+        self.assertEqual(passes, [])
+        self.assertEqual(orphans, [])
+
+    def test_multiple_stages_all_checked(self) -> None:
+        config = {
+            "stage_latency_budgets": {
+                "full": {
+                    "query_analysis_ms": {"p95_ms": 50},
+                    "retrieve_ms": {"p95_ms": 50},
+                    "verify_ms": {"p95_ms": 50},
+                }
+            }
+        }
+        summary = _stage_summary(
+            "full",
+            {
+                "query_analysis_ms": {"p95": 2.0},
+                "retrieve_ms": {"p95": 100.0},  # breach
+                "verify_ms": {"p95": 1.0},
+            },
+        )
+        violations, passes, orphans = check_stage(config, summary)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0]["stage"], "retrieve_ms")
+        self.assertEqual(len(passes), 2)
 
 
 class CheckLatencySloCli(unittest.TestCase):


### PR DESCRIPTION
## Summary

- `scripts/check_latency_slo.py`: `check_stage()` 함수 추가 — `eval/config.yaml::stage_latency_budgets`를 읽어 `run.stage_latency[stage].p95` vs `p95_ms` ceiling 비교; `main()`에서 총 SLO + stage SLO 모두 체크, 어느 쪽이든 violation 시 exit 1
- `eval/config.yaml`: `stage_latency_budgets` 섹션 추가 — `naive_baseline`과 `full` ablation의 query_analysis_ms / retrieve_ms / verify_ms / answer_generation_ms에 ~25x CI 헤드룸 ceiling (관측 ~2ms → ceiling 50ms)
- `tests/test_check_latency_slo.py`: `CheckStageSloUnit` 7개 케이스 추가 (pass, breach, missing stage, orphan run, noop, multiple stages)

**Drift 시나리오 차단 (issue #625)**: query_analysis_ms p95가 2→50ms 폭증해도 다른 stage 단축으로 total p95가 ceiling 안에 머물면 기존 게이트 통과 → 새 stage gate에서 잡힘.

## Test plan

- [x] `python3 -m pytest tests/test_check_latency_slo.py -v` → 15 passed

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)