### PR TITLE
fix(tests): replace hardcoded schema_version literals with SSoT constants

### DIFF
--- a/tests/test_case_proposer_pipeline.py
+++ b/tests/test_case_proposer_pipeline.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import yaml
 
+from rag_core import INDEX_SCHEMA_VERSION
 from eval.case_proposer import (
     CSV_COLUMN_AGENCY,
     CSV_COLUMN_FILE_FORMAT,
@@ -55,7 +56,7 @@ def _make_csv(path: Path, rows: list[dict[str, str]]) -> None:
 
 def _make_index(path: Path, doc_ids: list[str]) -> None:
     payload = {
-        "schema_version": 2,
+        "schema_version": INDEX_SCHEMA_VERSION,
         "build": {
             "documents": [{"doc_id": d} for d in doc_ids],
         },

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -1,6 +1,7 @@
 import unittest
 from pathlib import Path
 
+from rag_answer_schema import ANSWER_SCHEMA_VERSION
 from rag_core import (
     REDACTED_LIST_PLACEHOLDER,
     analyze_query,
@@ -133,7 +134,7 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
 
         self.assertEqual("comparison", result["analysis"]["query_type"])
         self.assertEqual("supported", result["answer"]["status"])
-        self.assertEqual(2, result["answer"]["schema_version"])
+        self.assertEqual(ANSWER_SCHEMA_VERSION, result["answer"]["schema_version"])
         self.assertEqual("verified", result["answer"]["status_reason"]["code"])
         self.assertEqual("comparison", result["answer"]["query_type"])
         self.assertIn("answer_text", result)
@@ -290,7 +291,7 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
         result = run_rag_query(partial_index, "기관 X와 기관 Y의 보안 요구사항 차이를 비교해줘")
 
         self.assertEqual("partial", result["answer"]["status"])
-        self.assertEqual(2, result["answer"]["schema_version"])
+        self.assertEqual(ANSWER_SCHEMA_VERSION, result["answer"]["schema_version"])
         self.assertEqual("partial_comparison", result["answer"]["status_reason"]["code"])
         self.assertFalse(result["diagnostics"]["abstained"])
         self.assertEqual(["기관 Y"], result["answer"]["insufficiency"]["missing_targets"])
@@ -314,7 +315,7 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
 
         self.assertTrue(result["diagnostics"]["abstained"])
         self.assertEqual("insufficient", result["answer"]["status"])
-        self.assertEqual(2, result["answer"]["schema_version"])
+        self.assertEqual(ANSWER_SCHEMA_VERSION, result["answer"]["schema_version"])
         self.assertEqual("insufficient_evidence", result["answer"]["status_reason"]["code"])
         self.assertEqual("abstention", result["answer"]["query_type"])
         self.assertEqual([], result["answer"]["claims"])

--- a/tests/test_llm_synthesis.py
+++ b/tests/test_llm_synthesis.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 import rag_synthesis
+from rag_answer_schema import ANSWER_SCHEMA_VERSION
 from rag_core import build_index_payload, run_rag_query
 
 
@@ -29,7 +30,7 @@ ANSWERABLE_QUERY = "기관 A의 보안 통제 요구사항은?"
 
 def _make_answer() -> dict[str, Any]:
     return {
-        "schema_version": 2,
+        "schema_version": ANSWER_SCHEMA_VERSION,
         "status": "supported",
         "status_reason": {"code": "verified", "verified": True, "verification_reasons": []},
         "query_type": "single_doc",


### PR DESCRIPTION
## Summary

ADR 0003 / rag_answer_schema.py의 `ANSWER_SCHEMA_VERSION = 2` SSoT를 우회하는 하드코딩 5곳 수정:

- `tests/test_fuzzy_retrieval.py`: `from rag_answer_schema import ANSWER_SCHEMA_VERSION` 추가 + 3곳 `assertEqual(2, ...)` → `assertEqual(ANSWER_SCHEMA_VERSION, ...)`
- `tests/test_llm_synthesis.py`: 동일 import + `_make_answer()` fixture `"schema_version": 2` → `"schema_version": ANSWER_SCHEMA_VERSION`
- `tests/test_case_proposer_pipeline.py`: `from rag_core import INDEX_SCHEMA_VERSION` + `_make_index()` fixture `"schema_version": 2` → `"schema_version": INDEX_SCHEMA_VERSION`

향후 v3 bump 시 5개 테스트가 production code와 자동으로 따라감.

trace/manifest schema_version=1 하드코딩(test_fuzzy_retrieval.py:541,557, test_run_harness.py:291)은 별도 follow-up PR에서 처리.

## Test plan

- [x] `python3 -m pytest tests/test_llm_synthesis.py tests/test_case_proposer_pipeline.py -v` → 30 passed

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)