### PR TITLE
fix(governance): add ADR deletion/rename guard to pre-commit + CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,6 +31,33 @@ ALLOWED_PATTERNS=(
   '^reports/real100/history/[^/]+\.aggregate\.json$'
 )
 
+# Guard: ADR file deletion/rename (CLAUDE.md Prohibited).
+# ADR files must not be deleted or renamed — mark Superseded in Status block
+# and keep the file. This is the first line of defence; the CI workflow
+# branch-and-issue-check.yml is the backup gate that catches --no-verify bypasses.
+adr_dr=$(git diff --cached --name-status --diff-filter=DR -- 'docs/adr/*.md' 2>/dev/null || true)
+if [[ -n "$adr_dr" ]]; then
+  cat >&2 <<'EOFERR'
+
+❌ Pre-commit hook blocked: ADR files may not be deleted or renamed.
+
+   CLAUDE.md Prohibited: "Deleting or renaming ADR files. Mark Superseded
+   in the Status block; keep the file."
+
+   Affected files:
+EOFERR
+  echo "$adr_dr" | sed 's/^/     /' >&2
+  cat >&2 <<'EOFERR'
+
+   To fix: restore the file and add "Status: Superseded by ADR XXXX"
+   to its header instead of deleting it.
+
+       git restore --staged <file>
+
+EOFERR
+  exit 1
+fi
+
 staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
 
 if [[ -z "$staged" ]]; then

--- a/.github/workflows/branch-and-issue-check.yml
+++ b/.github/workflows/branch-and-issue-check.yml
@@ -50,3 +50,24 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           python scripts/check_branch_and_issue.py --check-5b ${{ github.event.pull_request.number }}
+
+      - name: Guard ADR file deletion/rename (CLAUDE.md Prohibited)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          # Backup CI gate for the pre-commit ADR guard (issue #619).
+          # Catches --no-verify bypasses. Uses PR file list from GitHub API
+          # so no git history fetch is needed.
+          adr_violations=$(gh api \
+            "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '[.[] | select(.filename | test("^docs/adr/.+\\.md$")) | select(.status == "removed" or .status == "renamed")] | length')
+          if [[ "$adr_violations" -gt 0 ]]; then
+            echo "❌ ADR files may not be deleted/renamed (CLAUDE.md Prohibited)." >&2
+            echo "   Mark Superseded in the Status block and keep the file." >&2
+            gh api \
+              "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
+              --jq '.[] | select(.filename | test("^docs/adr/.+\\.md$")) | select(.status == "removed" or .status == "renamed") | "  " + .status + ": " + .filename' >&2
+            exit 1
+          fi
+          echo "✅ No ADR file deletions/renames in this PR."


### PR DESCRIPTION
## Summary

CLAUDE.md Prohibited 첫 항목("ADR 파일 삭제/리네임 금지")이 기존에는 자동화 없이 텍스트로만 명시되어 있었음. 이 PR로 두 레이어에서 자동 차단:

1. **`.githooks/pre-commit`** (local first-line defence):
   - `git diff --cached --diff-filter=DR -- 'docs/adr/*.md'`로 staged D/R 감지
   - 위반 시 exit 1 + `git restore --staged <file>` 안내
   - 기존 ADR 0005 eval-split 가드 앞에 배치

2. **`.github/workflows/branch-and-issue-check.yml`** (CI backup gate):
   - `--no-verify` bypass 차단
   - GitHub PR files API로 `status == removed|renamed && filename matches docs/adr/*.md` 검사
   - 기존 §5b 가드 뒤에 새 step으로 추가

## Test plan

- [x] `bash -n .githooks/pre-commit` → syntax OK
- [ ] 수동 검증: `git rm docs/adr/0001-*.md && git commit` → pre-commit exit 1
- [ ] CI: 이 PR 자체는 ADR 파일 D/R 없으므로 backup gate pass 예상

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)