### PR TITLE
fix(deps): declare pandas in requirements-dev.txt for evaluate_dev_results.py

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,7 @@ openai>=2.36.0
 # Cohere rerank-3.5-multilingual — are opt-in only.
 FlagEmbedding>=1.2
 cohere>=5.0
+# Issue #632 — eval/evaluate_dev_results.py uses pandas for result analysis.
+# Dev-only: not imported by the production pipeline. Fresh-clone reproducibility
+# requires this to be declared so `pip install -r requirements-dev.txt` suffices.
+pandas>=2.0,<3.0


### PR DESCRIPTION
## Summary

`eval/evaluate_dev_results.py`가 `pandas`를 import하지만 6개 requirements 파일 어디에도 선언되지 않아 fresh-clone 시 `ModuleNotFoundError` 발생. `requirements-dev.txt`에 `pandas>=2.0,<3.0` 추가 (dev-only 분석 스크립트, 프로덕션 파이프라인 미포함).

다른 eval/ 스크립트 sweep 결과 (`grep -rn "^import pandas" eval/ scripts/`): 추가 누락 없음.

## Test plan

- [x] `grep -rn "import pandas" eval/ scripts/` → evaluate_dev_results.py 1건만
- [x] `grep "pandas" requirements-dev.txt` → `pandas>=2.0,<3.0` 확인

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)