### PR TITLE
fix(governance): enforce ADR 0032 embedding spread gate in CI

### DIFF
--- a/.github/workflows/branch-and-issue-check.yml
+++ b/.github/workflows/branch-and-issue-check.yml
@@ -31,6 +31,8 @@ jobs:
           sparse-checkout: |
             scripts/check_branch_and_issue.py
             scripts/_governance.py
+            scripts/check_embedding_routed_spread.py
+            reports/embedding_routed.json
           sparse-checkout-cone-mode: false
 
       - uses: actions/setup-python@v6
@@ -71,3 +73,30 @@ jobs:
             exit 1
           fi
           echo "✅ No ADR file deletions/renames in this PR."
+
+      - name: ADR 0032 embedding spread gate (issue #626)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          # When an embedding-related path changes in this PR, verify that
+          # reports/embedding_routed.json was also updated AND spread < threshold.
+          # Non-embedding PRs: skip entirely.
+          embedding_changes=$(gh api \
+            "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '[.[] | select(.filename | test("^(rag_embeddings\\.py|eval/routed_config\\.yaml|eval/config\\.yaml)$"))] | length')
+          if [[ "$embedding_changes" -eq 0 ]]; then
+            echo "✅ No embedding-related path changes — spread gate skipped."
+            exit 0
+          fi
+          echo "ℹ️  Embedding-related paths changed; checking reports/embedding_routed.json spread."
+          routed_changed=$(gh api \
+            "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '[.[] | select(.filename == "reports/embedding_routed.json")] | length')
+          if [[ "$routed_changed" -eq 0 ]]; then
+            echo "❌ Embedding path changed but reports/embedding_routed.json was NOT updated." >&2
+            echo "   Run: python scripts/run_routed_measurement.py --backend sentence-transformers" >&2
+            echo "   Then commit the updated reports/embedding_routed.json." >&2
+            exit 1
+          fi
+          python scripts/check_embedding_routed_spread.py --report reports/embedding_routed.json

--- a/scripts/check_embedding_routed_spread.py
+++ b/scripts/check_embedding_routed_spread.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""ADR 0032 routed-subset spread gate (issue #626).
+
+Reads ``reports/embedding_routed.json`` and checks whether the top-vs-bottom
+embedding accuracy spread on the routed subset has crossed the ADR 0032
+re-open threshold of +3pp.
+
+Exit codes:
+  0 — spread < threshold (saturation cross-validated; MiniLM default lock
+      empirically justified; no ADR 0019 re-open trigger needed)
+  1 — spread ≥ threshold (ADR 0019 re-open trigger justified; reviewer must
+      decide whether to re-open the ADR or acknowledge the measurement)
+  2 — file missing / unparseable (measurement not yet run; non-fatal warning
+      by default; use --strict to fail on missing file)
+
+Usage:
+    python scripts/check_embedding_routed_spread.py
+    python scripts/check_embedding_routed_spread.py --report reports/embedding_routed.json
+    python scripts/check_embedding_routed_spread.py --strict   # fail if file missing
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_REPORT = "reports/embedding_routed.json"
+DEFAULT_THRESHOLD_PP = 3.0
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--report",
+        default=DEFAULT_REPORT,
+        help=f"Path to embedding_routed.json (default: {DEFAULT_REPORT})",
+    )
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 2 (failure) when the report file is missing instead of warning.",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report_path = Path(args.report)
+
+    if not report_path.exists():
+        msg = (
+            f"⚠️  {report_path} not found. "
+            "Run `python scripts/run_routed_measurement.py` to generate it."
+        )
+        if args.strict:
+            print(f"❌ {msg}", file=sys.stderr)
+            return 2
+        print(msg)
+        return 0
+
+    try:
+        data = json.loads(report_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"❌ Could not parse {report_path}: {exc}", file=sys.stderr)
+        return 2
+
+    spread_block = data.get("spread") or {}
+    spread_pp = spread_block.get("spread_pp")
+    threshold_pp = spread_block.get("threshold_pp") or data.get("threshold_pp") or DEFAULT_THRESHOLD_PP
+    verdict = spread_block.get("verdict", "unknown")
+
+    if not isinstance(spread_pp, (int, float)):
+        print(
+            f"⚠️  spread.spread_pp is missing or non-numeric in {report_path}. "
+            "Re-run the routed measurement.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"ADR 0032 routed-subset spread: {spread_pp:.1f}pp "
+        f"(threshold {threshold_pp:.1f}pp, verdict: {verdict})"
+    )
+
+    if spread_pp >= threshold_pp:
+        print(
+            f"\n❌ Spread {spread_pp:.1f}pp ≥ threshold {threshold_pp:.1f}pp — "
+            "ADR 0019 re-open trigger justified.\n"
+            "   Action required: re-open ADR 0019 or acknowledge in the PR body with\n"
+            "   [ALLOW_SPREAD_REGRESSION: <reason>] and update reports/embedding_routed.json.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✅ Spread {spread_pp:.1f}pp < threshold {threshold_pp:.1f}pp — saturation cross-validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

ADR 0032의 routed-subset spread ≥ +3pp re-open trigger가 기존에는 자동화 없이 텍스트로만 명시되어 있었음. 이 PR로 자동 enforcement:

1. **`scripts/check_embedding_routed_spread.py`** (신규):
   - `reports/embedding_routed.json`의 `spread.spread_pp` vs `threshold_pp` 비교
   - spread ≥ threshold → exit 1 (ADR 0019 re-open 트리거 메시지)
   - 파일 미존재 → warning (기본값); `--strict`로 fail
   
2. **`.github/workflows/branch-and-issue-check.yml`** 신규 step:
   - `rag_embeddings.py`, `eval/routed_config.yaml`, `eval/config.yaml` 변경 감지 (PR files API)
   - 변경 있으면: `reports/embedding_routed.json`도 동일 PR에 업데이트되었는지 확인
   - 갱신된 경우 `check_embedding_routed_spread.py` 실행 → spread ≥ 3pp면 fail

비-embedding PR: 게이트 완전 스킵 (overhead 없음).

## Test plan

- [x] `python3 scripts/check_embedding_routed_spread.py` → 현재 0.0pp < 3.0pp → exit 0
- [x] embedding_routed.json 없을 때 → warning 출력, exit 0 (non-strict)
- [ ] CI: 이 PR 자체는 embedding-related path 변경 없으므로 spread gate 스킵 예상

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)