### PR TITLE
feat(ingestion): HwpNativeLoader pyhwp-gated default (ADR 0036, closes #426)

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -9,6 +9,7 @@ in the ingestion report.
 from __future__ import annotations
 
 import csv
+import importlib.util
 import os
 import warnings
 from collections import OrderedDict
@@ -376,23 +377,23 @@ LOADERS: dict[str, CsvTextDocumentLoader] = {
 def _resolve_loader(file_format: str) -> CsvTextDocumentLoader:
     """Pick the loader for ``file_format``.
 
-    For HWP, respect the ``BIDMATE_HWP_LOADER`` opt-in (spike #167 + table
-    extraction #506); everything else falls through to the registered
-    default.
+    For HWP, env-var precedence (ADR 0036, highest to lowest):
 
-    Accepted values for ``BIDMATE_HWP_LOADER`` (case-insensitive, trimmed):
-
-    * ``native`` — issue #167 spike: paragraph plain text only
-      (preserves the existing measurement baseline).
-    * ``native_tables`` — issue #506: paragraph plain text **+** table
-      cells with row/col/span metadata. Cells become additional
-      ``sections`` entries with ``metadata.is_table = True``.
+    * ``BIDMATE_HWP_LOADER=csv`` — explicit opt-out; always use CSV loader.
+    * ``BIDMATE_HWP_LOADER=native`` — paragraph plain text only.
+    * ``BIDMATE_HWP_LOADER=native_tables`` — plain text + table cells.
+    * *(unset)* + pyhwp importable — default to ``HwpNativeLoader(with_tables=True)``.
+    * *(unset)* + pyhwp absent — fall through to CSV loader (CI minimal install safe).
     """
     if file_format == "hwp":
         opt_in = os.environ.get("BIDMATE_HWP_LOADER", "").strip().lower()
+        if opt_in == "csv":
+            return LOADERS[file_format]
         if opt_in == "native":
             return HwpNativeLoader()
         if opt_in == "native_tables":
+            return HwpNativeLoader(with_tables=True)
+        if importlib.util.find_spec("hwp5") is not None:
             return HwpNativeLoader(with_tables=True)
     return LOADERS[file_format]
 

--- a/tests/test_hwp_native_loader_regression.py
+++ b/tests/test_hwp_native_loader_regression.py
@@ -111,11 +111,28 @@ class _EnvScope:
 
 
 class HwpNativeLoaderRegressionTest(unittest.TestCase):
-    def test_default_dispatch_returns_csv_loader(self) -> None:
+    # ADR 0036: pyhwp-gated default.  Use find_spec mock to control detection.
+
+    def test_default_dispatch_native_when_pyhwp_present(self) -> None:
         with _EnvScope():
-            loader = _resolve_loader("hwp")
-            self.assertIsInstance(loader, HwpCsvTextLoader)
-            self.assertNotIsInstance(loader, HwpNativeLoader)
+            with mock.patch("ingestion.importlib.util.find_spec", return_value=object()):
+                loader = _resolve_loader("hwp")
+        self.assertIsInstance(loader, HwpNativeLoader)
+
+    def test_default_dispatch_csv_when_pyhwp_absent(self) -> None:
+        with _EnvScope():
+            with mock.patch("ingestion.importlib.util.find_spec", return_value=None):
+                loader = _resolve_loader("hwp")
+        self.assertIsInstance(loader, HwpCsvTextLoader)
+        self.assertNotIsInstance(loader, HwpNativeLoader)
+
+    def test_explicit_csv_opt_out_overrides_pyhwp_detection(self) -> None:
+        with _EnvScope() as scope:
+            scope.set("csv")
+            with mock.patch("ingestion.importlib.util.find_spec", return_value=object()):
+                loader = _resolve_loader("hwp")
+        self.assertIsInstance(loader, HwpCsvTextLoader)
+        self.assertNotIsInstance(loader, HwpNativeLoader)
 
     def test_opt_in_dispatch_returns_native_loader(self) -> None:
         with _EnvScope() as scope:

--- a/tests/test_hwp_native_table_extraction.py
+++ b/tests/test_hwp_native_table_extraction.py
@@ -137,11 +137,12 @@ class _EnvScope:
 class DispatchSurfaceTest(unittest.TestCase):
     """The new ``native_tables`` env value swaps the loader correctly."""
 
-    def test_default_dispatch_returns_csv_loader(self) -> None:
+    def test_default_dispatch_csv_when_pyhwp_absent(self) -> None:
         with _EnvScope():
-            loader = _resolve_loader("hwp")
-            self.assertIsInstance(loader, HwpCsvTextLoader)
-            self.assertNotIsInstance(loader, HwpNativeLoader)
+            with mock.patch("ingestion.importlib.util.find_spec", return_value=None):
+                loader = _resolve_loader("hwp")
+        self.assertIsInstance(loader, HwpCsvTextLoader)
+        self.assertNotIsInstance(loader, HwpNativeLoader)
 
     def test_native_returns_text_only_native_loader(self) -> None:
         """#167 spike still produces ``with_tables=False`` (no regression)."""


### PR DESCRIPTION
## 1. Summary

ADR 0036 구현 (#640 머지): `_resolve_loader` 가 `importlib.util.find_spec("hwp5")` 사용 → pyhwp 존재 + `BIDMATE_HWP_LOADER` unset 시 `HwpNativeLoader(with_tables=True)` 기본.

## 2. Motivation / context

pyhwp 설치한 한국 RFP 사용자가 CSV loader 기본 사용 — `BIDMATE_HWP_LOADER=native` 설정을 알지 못하면 더 나은 파서 비가시. ADR 0036 가 자동 검출 기본으로 승격; `BIDMATE_HWP_LOADER=csv` 가 명시 opt-out.

## 3. Changes

- **`ingestion.py`**: `import importlib.util` 추가; `_resolve_loader` 를 신규 우선순위 표 (ADR 0036 §Decision) 로 업데이트.
- **`tests/test_hwp_native_loader_regression.py`**: `test_default_dispatch_*` 를 `find_spec` mock 으로 업데이트; `test_explicit_csv_opt_out_overrides_pyhwp_detection` 추가.
- **`tests/test_hwp_native_table_extraction.py`**: 같은 dispatch 테스트를 `find_spec` mock 으로 업데이트.

## 4. Tests / validation

969 passed, 8 skipped. `ruff check .` clean.

## 5. Checklist

### 5a. ADR

ADR 0036 가 PR #640 (머지) 에서 accepted.

### 5b. Real-data delta

`ingestion.py` 는 load-bearing. 기능 변경은 pyhwp 설치 시 HWP 기본 loader. private 100-doc corpus 는 PDF 만 사용 (HWP 없음); private set eval delta 0.00pp 예상.

CI 합성 eval 에서 사용되는 ingestion 경로는 CSV loader (테스트 harness 가 data_list.csv 의 사전 추출 텍스트 사용, live HWP binary 파싱 아님).

No behavior change in retrieval / verifier path.

## 6. Related

Closes #426. 결정 기록: [ADR 0036](docs/adr/0036-hwp-native-loader-pyhwp-gated-default.md).
