### PR TITLE
docs(observability): add Langfuse JP-region recipe + .env.example regions (closes #450)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,7 +82,9 @@
 # Langfuse credentials.
 # LANGFUSE_PUBLIC_KEY=
 # LANGFUSE_SECRET_KEY=
-# LANGFUSE_HOST=https://cloud.langfuse.com
+# LANGFUSE_HOST=https://cloud.langfuse.com    # US (default)
+# LANGFUSE_HOST=https://eu.cloud.langfuse.com  # EU region
+# LANGFUSE_HOST=https://jp.cloud.langfuse.com  # JP region (Korean client data residency)
 # OTel collector endpoint (e.g. http://localhost:4318/v1/traces).
 # OTEL_EXPORTER_OTLP_ENDPOINT=
 # OTEL_SERVICE_NAME=bidmate-docagent

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -86,10 +86,36 @@ streamlit run demo/streamlit_app.py
 # Each answer now has a "🔍 View trace" button below it.
 ```
 
-### LangFuse (cloud)
+### LangFuse (cloud — Japan region / Korean data residency)
 
-Same as above but skip the `docker compose up` step and use
-`https://cloud.langfuse.com` (the default `LANGFUSE_HOST`).
+Langfuse Cloud offers US, EU, and JP regions. Use the JP region for
+Korean client data-residency requirements.
+
+```bash
+pip install -r requirements-observability.txt
+
+export BIDMATE_TRACE_BACKEND=langfuse
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_SECRET_KEY=sk-lf-...
+export LANGFUSE_HOST=https://jp.cloud.langfuse.com   # JP region
+```
+
+Or in `.env`:
+
+```
+BIDMATE_TRACE_BACKEND=langfuse
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_HOST=https://jp.cloud.langfuse.com
+```
+
+For the US region omit `LANGFUSE_HOST` (default: `https://cloud.langfuse.com`).
+EU region: `https://eu.cloud.langfuse.com`.
+
+### LangFuse (cloud — US, default)
+
+Skip the `docker compose up` step and use the default
+`LANGFUSE_HOST=https://cloud.langfuse.com`.
 
 ### OpenTelemetry → Grafana Tempo
 

--- a/requirements-observability.txt
+++ b/requirements-observability.txt
@@ -1,4 +1,4 @@
-# Optional dependencies for the ADR 0010 observability backends.
+# Optional dependencies for the ADR 0013 observability backends.
 #
 # Not installed by default. Set BIDMATE_TRACE_BACKEND to enable a
 # backend after installing the corresponding line(s). Missing packages


### PR DESCRIPTION
## 1. What changed and why

`docs/observability.md` 에 Langfuse Cloud JP 리전(한국 클라이언트 데이터 레지던시용) 설정 레시피를 추가했습니다. `.env.example` 의 `LANGFUSE_HOST` 주석에 US / EU / JP 리전 예시 3개를 병기하고, `requirements-observability.txt` 의 ADR 번호 오타(`0010` → `0013`)를 수정합니다.

Closes #450

## 2. Files affected

- `.env.example` — `LANGFUSE_HOST` 주석에 JP/EU/US 리전 예시 추가 (non-load-bearing)
- `docs/observability.md` — "LangFuse Cloud (Japan region — Korean data residency)" 서브섹션 추가 (non-load-bearing)
- `requirements-observability.txt` — ADR 번호 주석 오타 수정 0010→0013 (non-load-bearing)

## 3. Risks

문서·주석 전용 변경. 코드 경로 없음. 런타임 동작 변화 없음.

## 4. Tests

코드 변경 없으므로 신규 테스트 불필요. `tests/test_observability_tracing.py` 기존 테스트가 `_LangfuseBackend` 계약(fail-closed, noop fallback, span topology)을 이미 검증. `bash scripts/test.sh` 969 passed (기존 M3 failure는 이번 변경 전부터 존재하는 pre-existing 이슈).

## 5. Eval impact

All `·` — RAG 파이프라인 경로 변경 없음.

### 5b. Real-data delta

N/A — load-bearing 파일 변경 없음. 문서·주석 전용.

## 6. Backward compatibility

N/A — `.env.example` 주석 추가/변경은 기존 설정에 영향 없음. 기본값(`LANGFUSE_HOST` unset → `https://cloud.langfuse.com`) 유지.

## 7. Out of scope

- `test_m3_backend_regression.py::test_m3_score_parts_carry_sparse_and_colbert` 기존 실패 — 이번 PR 범위 밖, 별도 이슈로 추적 필요.