### PR TITLE
feat(eval): by_format aggregate in eval_summary (ADR 0005-safe)

### DIFF
--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -619,6 +619,16 @@ def summarize_run(
             category: metric_block(hardcase_grouped[category])
             for category in sorted(hardcase_grouped)
         }
+    format_grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for result in case_results:
+        fmt = result.get("case_source_format")
+        if fmt:
+            format_grouped[fmt].append(result)
+    if format_grouped:
+        summary["by_format"] = {
+            fmt: metric_block(format_grouped[fmt])
+            for fmt in sorted(format_grouped)
+        }
     if include_cases:
         summary["case_results"] = case_results
     return summary
@@ -679,6 +689,30 @@ def write_prediction_trace(
     return str(path)
 
 
+def _build_doc_format_map(index: dict[str, Any]) -> dict[str, str]:
+    """Map doc_id → source_format (fallback: document_type)."""
+    result: dict[str, str] = {}
+    for doc in index.get("documents") or []:
+        doc_id = doc.get("doc_id")
+        if not doc_id:
+            continue
+        metadata = doc.get("metadata") or {}
+        fmt = metadata.get("source_format") or metadata.get("document_type") or "unknown"
+        result[str(doc_id)] = str(fmt)
+    return result
+
+
+def _case_source_format(
+    expected_doc_ids: list[str], doc_format_map: dict[str, str]
+) -> str | None:
+    """Return the source_format of the first expected doc, or None if unavailable."""
+    for doc_id in expected_doc_ids:
+        fmt = doc_format_map.get(str(doc_id))
+        if fmt:
+            return fmt
+    return None
+
+
 def evaluate_run(
     index: dict[str, Any],
     cases: list[dict[str, Any]],
@@ -688,6 +722,7 @@ def evaluate_run(
     redact_options: dict[str, bool] | None = None,
 ) -> list[dict[str, Any]]:
     case_results = []
+    doc_format_map = _build_doc_format_map(index)
     for case in cases:
         conversation_state: dict[str, Any] = {}
         for turn in case.get("prior_turns") or []:
@@ -749,6 +784,9 @@ def evaluate_run(
         result["tokens_out"] = synth.get("tokens_out")
         result["cost_estimate_usd"] = synth.get("cost_estimate_usd")
         result["llm_model"] = synth.get("model")
+        result["case_source_format"] = _case_source_format(
+            result.get("expected_doc_ids") or [], doc_format_map
+        )
         case_results.append(result)
     return case_results
 
@@ -897,6 +935,7 @@ def main() -> int:
         "by_query_type": primary_summary["by_query_type"],
         "by_slice": primary_summary.get("by_slice", {}),
         "by_hardcase_category": primary_summary.get("by_hardcase_category", {}),
+        "by_format": primary_summary.get("by_format", {}),
         "retry_cost": primary_summary["retry_cost"],
         "retry_reason_counts": primary_summary["retry_reason_counts"],
         "retry_effectiveness": retry_effectiveness,

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -116,8 +116,18 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         # The extractor below explicitly whitelists each scalar + the
         # CI sub-block; case-level fields are dropped.
         "ablation_full",
+        # Issue #650 / ADR 0039: per-format accuracy breakdown keyed by
+        # document source_format (hwp / pdf / synthetic_public_sample).
+        # Bucket keys are whitelisted in SAFE_FORMAT_BUCKET_KEYS (fail-closed);
+        # metric sub-keys mirror SAFE_ABLATION_FULL_SCALAR_KEYS; no per-case
+        # payload crosses the boundary.
+        "by_format",
     }
 )
+
+# Allowed bucket keys inside ``by_format``. Fail-closed: any key not in
+# this set is silently dropped before the aggregate is committed.
+SAFE_FORMAT_BUCKET_KEYS = frozenset({"hwp", "pdf", "synthetic_public_sample"})
 
 # Whitelisted bin names for ``abstention_outcomes``. Integer counts only.
 SAFE_ABSTENTION_OUTCOME_KEYS = ("correct_refusal", "incorrect_answer", "boundary_partial")
@@ -456,6 +466,37 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                     extracted_slice[m] = raw
             slice_out[str(slice_name)] = extracted_slice
         out["by_query_type"] = slice_out
+
+    # Issue #650 / ADR 0039 — by_format aggregate. Fail-closed: only bucket
+    # keys in SAFE_FORMAT_BUCKET_KEYS are retained; unknown formats are dropped
+    # so new source_format values added to fixtures cannot leak payload.
+    by_format = summary.get("by_format")
+    if isinstance(by_format, dict):
+        format_out: dict[str, dict[str, Any]] = {}
+        for bucket_name, bucket_summary in by_format.items():
+            if str(bucket_name) not in SAFE_FORMAT_BUCKET_KEYS:
+                continue
+            if not isinstance(bucket_summary, dict):
+                continue
+            extracted_bucket: dict[str, Any] = {}
+            for m in SAFE_SLICE_METRICS:
+                raw = bucket_summary.get(m)
+                if raw is None:
+                    continue
+                if m == "abstention_outcomes" and isinstance(raw, dict):
+                    bin_out = {
+                        sub: int(raw[sub])
+                        for sub in SAFE_ABSTENTION_OUTCOME_KEYS
+                        if isinstance(raw.get(sub), (int, float))
+                    }
+                    if bin_out:
+                        extracted_bucket[m] = bin_out
+                else:
+                    extracted_bucket[m] = raw
+            if extracted_bucket:
+                format_out[str(bucket_name)] = extracted_bucket
+        if format_out:
+            out["by_format"] = format_out
 
     _assert_no_forbidden(out)
     return out

--- a/tests/test_eval_by_format_aggregate_regression.py
+++ b/tests/test_eval_by_format_aggregate_regression.py
@@ -1,0 +1,226 @@
+"""Regression tests for by_format aggregate in eval_summary (issue #650 / ADR 0039).
+
+Verifies that:
+1. `evaluate_run` attaches `case_source_format` to each result when the index
+   contains documents with `metadata.source_format`.
+2. `summarize_run` produces a `by_format` dict grouped by source_format.
+3. `extract_aggregate` in run_real_eval_delta allows only SAFE_FORMAT_BUCKET_KEYS
+   and drops unknown bucket names (fail-closed).
+4. No per-case payload (FORBIDDEN_KEYS) appears in the by_format output.
+"""
+from __future__ import annotations
+
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+from eval.run_eval import (
+    _build_doc_format_map,
+    _case_source_format,
+    summarize_run,
+)
+from scripts.run_real_eval_delta import (
+    FORBIDDEN_KEYS,
+    SAFE_FORMAT_BUCKET_KEYS,
+    extract_aggregate,
+)
+
+
+def _make_index(docs: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"documents": docs}
+
+
+def _make_result(
+    case_id: str,
+    expected_doc_ids: list[str],
+    case_source_format: str | None = None,
+    *,
+    accuracy: float | None = 1.0,
+    answerable: bool = True,
+) -> dict[str, Any]:
+    return {
+        "id": case_id,
+        "query_type": "single_doc",
+        "hardcase_categories": [],
+        "query": "테스트 쿼리",
+        "answerable": answerable,
+        "expected_doc_ids": expected_doc_ids,
+        "evidence_doc_ids": expected_doc_ids,
+        "gold_chunk_ids": [],
+        "retrieved_chunk_ids": [],
+        "doc_match": True,
+        "term_match": True,
+        "citation_term_match": True,
+        "citation_doc_precision": 1.0,
+        "accuracy": accuracy,
+        "groundedness": 1.0 if answerable else None,
+        "citation_precision": 1.0,
+        "citation_grounding": None,
+        "citation_grounding_errors": [],
+        "claim_citation_alignment": None,
+        "claim_citation_errors": [],
+        "abstention": None if answerable else 1.0,
+        "comparison_target_recall": None,
+        "comparison_pool_recall": None,
+        "latency_ms": 1.0,
+        "retry_count": 0,
+        "retry_trigger_reasons": [],
+        "last_attempt_verified": None,
+        "filter_stage": None,
+        "selected_top_k": None,
+        "retrieval_budget": {},
+        "metadata_ambiguous": False,
+        "ambiguity_decision": None,
+        "ambiguity_reason": None,
+        "metadata_candidate_count": None,
+        "cold_start": False,
+        "stage_latency": {},
+        "attempt_latency": [],
+        "chunk_recall_at_5": None,
+        "chunk_recall_at_10": None,
+        "chunk_mrr": None,
+        "chunk_ndcg_at_10": None,
+        "citation_page_precision": None,
+        "citation_region_precision": None,
+        "case_source_format": case_source_format,
+    }
+
+
+class TestBuildDocFormatMap(unittest.TestCase):
+    def test_source_format_takes_priority_over_document_type(self) -> None:
+        index = _make_index(
+            [
+                {
+                    "doc_id": "doc-hwp",
+                    "metadata": {
+                        "source_format": "hwp",
+                        "document_type": "synthetic_public_sample",
+                    },
+                },
+                {
+                    "doc_id": "doc-json",
+                    "metadata": {"document_type": "synthetic_public_sample"},
+                },
+            ]
+        )
+        fmt_map = _build_doc_format_map(index)
+        self.assertEqual(fmt_map["doc-hwp"], "hwp")
+        self.assertEqual(fmt_map["doc-json"], "synthetic_public_sample")
+
+    def test_unknown_fallback(self) -> None:
+        index = _make_index([{"doc_id": "bare", "metadata": {}}])
+        self.assertEqual(_build_doc_format_map(index)["bare"], "unknown")
+
+    def test_empty_index(self) -> None:
+        self.assertEqual(_build_doc_format_map({}), {})
+
+
+class TestCaseSourceFormat(unittest.TestCase):
+    def test_returns_first_match(self) -> None:
+        fmt_map = {"doc-a": "hwp", "doc-b": "pdf"}
+        self.assertEqual(_case_source_format(["doc-a", "doc-b"], fmt_map), "hwp")
+
+    def test_returns_none_for_empty_expected_docs(self) -> None:
+        self.assertIsNone(_case_source_format([], {"doc-a": "hwp"}))
+
+    def test_returns_none_for_unknown_doc(self) -> None:
+        self.assertIsNone(_case_source_format(["ghost"], {}))
+
+
+class TestSummarizeRunByFormat(unittest.TestCase):
+    def _run_config(self) -> dict[str, Any]:
+        return {
+            "name": "naive_baseline",
+            "pipeline": "naive_baseline",
+            "metadata_first": False,
+            "rerank": False,
+            "verifier_retry": False,
+            "retrieval_mode": "flat",
+            "retrieval_backend": "dense",
+        }
+
+    def test_by_format_grouped_correctly(self) -> None:
+        case_results = [
+            _make_result("hwp-case-1", ["doc-hwp"], "hwp"),
+            _make_result("hwp-case-2", ["doc-hwp"], "hwp"),
+            _make_result("json-case", ["doc-json"], "synthetic_public_sample"),
+        ]
+        summary = summarize_run("naive_baseline", self._run_config(), case_results)
+        self.assertIn("by_format", summary)
+        self.assertIn("hwp", summary["by_format"])
+        self.assertIn("synthetic_public_sample", summary["by_format"])
+        self.assertEqual(summary["by_format"]["hwp"]["num_predictions"], 2)
+        self.assertEqual(summary["by_format"]["synthetic_public_sample"]["num_predictions"], 1)
+
+    def test_by_format_absent_when_no_source_format(self) -> None:
+        case_results = [_make_result("case", ["doc-a"], None)]
+        summary = summarize_run("naive_baseline", self._run_config(), case_results)
+        self.assertNotIn("by_format", summary)
+
+    def test_no_case_results_in_by_format(self) -> None:
+        case_results = [_make_result("hwp-case", ["doc-hwp"], "hwp")]
+        summary = summarize_run("naive_baseline", self._run_config(), case_results)
+        by_format = summary.get("by_format", {})
+        for bucket in by_format.values():
+            for forbidden in FORBIDDEN_KEYS:
+                self.assertNotIn(forbidden, bucket, f"Forbidden key '{forbidden}' in by_format")
+
+
+class TestExtractAggregateByFormat(unittest.TestCase):
+    def _minimal_summary(self, by_format: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "num_predictions": 3,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_grounding": None,
+            "claim_citation_alignment": None,
+            "answer_format_compliance": 1.0,
+            "abstention": None,
+            "retry": 0.0,
+            "by_format": by_format,
+        }
+
+    def test_allowed_buckets_pass_through(self) -> None:
+        summary = self._minimal_summary(
+            {
+                "hwp": {"num_predictions": 2, "accuracy": 1.0},
+                "pdf": {"num_predictions": 1, "accuracy": 0.5},
+            }
+        )
+        out = extract_aggregate(summary)
+        self.assertIn("by_format", out)
+        self.assertIn("hwp", out["by_format"])
+        self.assertIn("pdf", out["by_format"])
+
+    def test_unknown_bucket_dropped_fail_closed(self) -> None:
+        summary = self._minimal_summary(
+            {
+                "hwp": {"num_predictions": 1, "accuracy": 1.0},
+                "secret_format": {"num_predictions": 99, "accuracy": 0.0},
+            }
+        )
+        out = extract_aggregate(summary)
+        self.assertIn("by_format", out)
+        self.assertNotIn("secret_format", out.get("by_format", {}))
+
+    def test_no_forbidden_keys_in_output(self) -> None:
+        summary = self._minimal_summary(
+            {"hwp": {"num_predictions": 1, "accuracy": 1.0, "case_results": "should_be_dropped"}}
+        )
+        out = extract_aggregate(summary)
+        for forbidden in FORBIDDEN_KEYS:
+            self.assertNotIn(
+                forbidden,
+                str(out),
+                f"Forbidden key '{forbidden}' leaked into aggregate output",
+            )
+
+    def test_safe_format_bucket_keys_coverage(self) -> None:
+        self.assertIn("hwp", SAFE_FORMAT_BUCKET_KEYS)
+        self.assertIn("pdf", SAFE_FORMAT_BUCKET_KEYS)
+        self.assertIn("synthetic_public_sample", SAFE_FORMAT_BUCKET_KEYS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `eval_summary.json`에 `by_format` 집계 키 추가: HWP / PDF / synthetic_public_sample 정확도를 독립 추적
- ADR 0005 화이트리스트(SAFE_FORMAT_BUCKET_KEYS) fail-closed: 미허용 bucket은 자동 drop
- per-case payload 차단 유지(FORBIDDEN_KEYS 그대로)
- 회귀 테스트 12 단언 추가

## Changes

- `eval/run_eval.py`: `_build_doc_format_map` + `_case_source_format` 헬퍼 신설; `evaluate_run`에서 각 result에 `case_source_format` 추가; `summarize_run`에 `by_format` 집계 추가
- `scripts/run_real_eval_delta.py`: `SAFE_TOPLEVEL_KEYS`에 `by_format` 추가; `SAFE_FORMAT_BUCKET_KEYS = {"hwp","pdf","synthetic_public_sample"}` 상수; `extract_aggregate`에 by_format 슬라이스 처리(by_query_type 패턴 복제)
- `tests/test_eval_by_format_aggregate_regression.py`: 신규 회귀 테스트 4 클래스

### 1. What does this PR do?
인덱스 문서의 `metadata.source_format` (없으면 `document_type`) 기준으로 eval 결과를 포맷별 집계해 by_format 키로 노출한다.

### 2. Why?
ADR 0036(HwpNativeLoader) 효과와 ADR 0039(HWP fixture)의 측정 가능성을 위해 필요. leaderboard(PR-E)에서 `by_format.hwp.accuracy` 시계열을 노출하기 위한 전제 조건.

### 3. How was it tested?
AST 구문 검증 통과. 회귀 테스트는 CI `bash scripts/test.sh`에서 실행됨.

### 4. Alternatives considered?
Case config에서 `source_format` 직접 태깅: fixture의 source_format이 바뀌면 두 곳을 수정해야 하므로 거부. 인덱스 단일 소스 기준이 ADR 0036 로더 선택과 일관적.

### 5. Load-bearing change?

#### 5a. Load-bearing files changed?
- [x] `eval/run_eval.py` (eval 경로)
- [x] `scripts/run_real_eval_delta.py` (SAFE 화이트리스트)

#### 5b. Real-data delta?
`by_format` 키가 `eval_summary.json`에 추가됨. 기존 메트릭 수치 변화 없음(corpus additive, retrieval 미변경). 실 데이터 delta: `make real-eval-delta`로 by_format.hwp 키 등장 확인 후 PR comment 첨부 예정.

Closes #650
Stacked on #649 (HWP fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)