### PR TITLE
feat(eval): HWP loader 3-way ablation preset (ADR 0039 PR-C)

### DIFF
--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -40,6 +40,21 @@ latency_budgets:
   full_khaiii:
     # Issue #561 / ADR 0031 — Khaiii tokenizer. Same budget as full_kiwi.
     p95_ms: 200
+  hwp_csv_text:
+    # Issue #652 / ADR 0039 — HWP loader ablation (csv-text loader, text only).
+    # Per-query latency mirrors `full`; actual HWP parsing is ingest-time.
+    # Operator-side: build index with scripts/build_index.py --hwp_loader csv.
+    p95_ms: 200
+  hwp_native:
+    # Issue #652 / ADR 0039 — HWP loader ablation (native loader, no tables).
+    # Requires pyhwp installed; CI pyhwp-absent fallback is csv-text (loader-
+    # invariant for hashing backend). Operator: --hwp_loader native.
+    p95_ms: 200
+  hwp_native_tables:
+    # Issue #652 / ADR 0039 — HWP loader ablation (native loader, with tables).
+    # Default when pyhwp is installed (ADR 0036 default). Operator: --hwp_loader
+    # native_tables or omit flag.
+    p95_ms: 200
 # Per-stage latency budgets used by scripts/check_latency_slo.py (check_stage).
 # Issue #625: stage_latency is measured but was unguarded — silent per-stage
 # drift was possible even when total p95 stayed within ablation ceiling.
@@ -307,6 +322,33 @@ ablation_runs:
     pipeline: naive_baseline
     embedding_model: nlpai-lab/KURE-v1
     embedding_lora_adapter: bidmate/embedding-lora-kure-rfp-ko-v1@<sha>
+  # Issue #652 / ADR 0039 — HWP loader 3-way ablation.
+  # These three rows require separate pre-built indexes (one per loader);
+  # operator-side: `scripts/build_index.py --hwp_loader {csv,native,native_tables}`.
+  # CI hashing backend is loader-invariant (ingest is text-only); real
+  # measurement needs pyhwp installed + native-parsed index (ADR 0005 boundary).
+  # ADR 0001: naive_baseline row is unchanged; all three rows ride agentic_full.
+  - name: hwp_csv_text
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    hwp_loader: csv
+  - name: hwp_native
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    hwp_loader: native
+  - name: hwp_native_tables
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    hwp_loader: native_tables
 cases:
   - id: single_doc_security
     query_type: single_doc

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -101,6 +101,19 @@ def parse_args() -> argparse.Namespace:
             "'suffix' deterministically appends -2/-3/... to keep both rows."
         ),
     )
+    parser.add_argument(
+        "--hwp_loader",
+        default=None,
+        choices=["csv", "native", "native_tables"],
+        help=(
+            "HWP loader selection for ADR 0039 ablation (issue #652). Sets "
+            "BIDMATE_HWP_LOADER env var before ingestion so _resolve_loader in "
+            "ingestion.py picks the correct backend. 'csv': text-only CSV loader; "
+            "'native': pyhwp native without tables; 'native_tables': pyhwp native "
+            "with table reconstruction (ADR 0036 default when pyhwp installed). "
+            "Omit to use the ADR 0036 runtime default."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -142,8 +155,12 @@ def validate_args(args: argparse.Namespace) -> None:
 def main() -> int:
     ingestion_report = None
     try:
+        import os
+
         args = parse_args()
         validate_args(args)
+        if args.hwp_loader is not None:
+            os.environ["BIDMATE_HWP_LOADER"] = args.hwp_loader
         output_dir = Path(args.output_dir)
         visual_artifact_dir = (
             Path(args.visual_artifact_dir)

--- a/tests/test_hwp_loader_ablation_preset.py
+++ b/tests/test_hwp_loader_ablation_preset.py
@@ -1,0 +1,81 @@
+"""Regression test for HWP loader 3-way ablation preset (issue #652 / ADR 0039).
+
+Verifies that eval/config.yaml contains the three required ablation rows
+(hwp_csv_text / hwp_native / hwp_native_tables) with the expected structure,
+and that scripts/build_index.py exposes the --hwp_loader flag.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT_DIR / "eval" / "config.yaml"
+BUILD_INDEX_PATH = ROOT_DIR / "scripts" / "build_index.py"
+
+
+class TestHwpAblationRows(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        with open(CONFIG_PATH) as f:
+            cls.config = yaml.safe_load(f)
+        cls.ablation_runs: list[dict] = cls.config.get("ablation_runs", [])
+        cls.ablation_by_name = {row["name"]: row for row in cls.ablation_runs}
+        cls.latency_budgets: dict = cls.config.get("latency_budgets", {})
+
+    def test_three_hwp_rows_exist(self) -> None:
+        for name in ("hwp_csv_text", "hwp_native", "hwp_native_tables"):
+            self.assertIn(name, self.ablation_by_name, f"Ablation row '{name}' missing")
+
+    def test_all_hwp_rows_use_agentic_full(self) -> None:
+        for name in ("hwp_csv_text", "hwp_native", "hwp_native_tables"):
+            row = self.ablation_by_name[name]
+            self.assertEqual(row.get("pipeline"), "agentic_full", f"{name}: pipeline must be agentic_full")
+
+    def test_hwp_rows_have_loader_key(self) -> None:
+        expected = {
+            "hwp_csv_text": "csv",
+            "hwp_native": "native",
+            "hwp_native_tables": "native_tables",
+        }
+        for name, loader_val in expected.items():
+            row = self.ablation_by_name[name]
+            self.assertEqual(row.get("hwp_loader"), loader_val, f"{name}: hwp_loader mismatch")
+
+    def test_latency_budgets_present(self) -> None:
+        for name in ("hwp_csv_text", "hwp_native", "hwp_native_tables"):
+            self.assertIn(name, self.latency_budgets, f"latency_budgets entry for '{name}' missing")
+            self.assertIsNotNone(self.latency_budgets[name].get("p95_ms"))
+
+    def test_naive_baseline_unchanged(self) -> None:
+        row = self.ablation_by_name.get("naive_baseline", {})
+        self.assertEqual(row.get("pipeline"), "naive_baseline")
+        self.assertNotIn("hwp_loader", row, "hwp_loader must not appear on naive_baseline row")
+
+
+class TestBuildIndexHwpLoaderFlag(unittest.TestCase):
+    """Verify --hwp_loader flag is wired in scripts/build_index.py."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        with open(BUILD_INDEX_PATH) as f:
+            cls.source = f.read()
+        cls.tree = ast.parse(cls.source)
+
+    def test_hwp_loader_in_source(self) -> None:
+        self.assertIn("hwp_loader", self.source)
+        self.assertIn("BIDMATE_HWP_LOADER", self.source)
+
+    def test_choices_are_correct(self) -> None:
+        self.assertIn('"csv"', self.source)
+        self.assertIn('"native"', self.source)
+        self.assertIn('"native_tables"', self.source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- ADR 0036 HWP 로더 3-way 비교를 `eval/config.yaml` ablation_runs에 등재
- `scripts/build_index.py`에 `--hwp_loader {csv,native,native_tables}` flag 추가
- latency_budgets 3 엔트리 신설

## Changes

- `eval/config.yaml`: `hwp_csv_text` / `hwp_native` / `hwp_native_tables` ablation rows + latency_budgets
- `scripts/build_index.py`: `--hwp_loader` flag → `BIDMATE_HWP_LOADER` env set
- `tests/test_hwp_loader_ablation_preset.py`: 5 assertions (row existence / pipeline / hwp_loader / latency / naive_baseline invariant)

## Architecture

실측 모델은 `full_llm`(ADR 0011)과 동일: operator-side에서 3개 인덱스를 별도 빌드(`--hwp_loader {csv,native,native_tables}`), 동일 eval suite에서 비교. CI hashing backend는 loader-invariant. ADR 0001 `naive_baseline` 행 미변경.

### 1. What does this PR do?
ADR 0036 로더 선택지 3가지를 named ablation으로 등재해, 향후 `by_format.hwp.accuracy`와 함께 citation_precision/groundedness delta를 정량 측정 가능하게 한다.

### 2. Why?
ADR 0039 카테고리(table_heavy 등)와 로더 선택의 교차 분석이 시니어 시그널 데이터 포인트가 됨. "native_tables가 citation_precision에 미치는 영향 ±Npp" 정량 주장의 기반.

### 3. How was it tested?
YAML 파싱 + AST 구문 검증. CI `bash scripts/test.sh`에서 test_hwp_loader_ablation_preset.py 실행.

### 5. Load-bearing change?

#### 5a.
- [x] `eval/config.yaml` (ablation_runs 추가)

#### 5b. Real-data delta?
ablation rows는 새로운 측정 surface 등록만. 기존 케이스 accuracy 변화 0. 실 측정은 operator-side 사전-빌드 인덱스 필요(ADR 0005 boundary — 미포함).

Closes #652
Stacked on #651 (by_format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)