### PR TITLE
feat(eval): activate ADR 0039 rotated_or_skewed + ocr_noisy hardcase tags (PR-D)

### DIFF
--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -2046,6 +2046,8 @@ cases:
     query_type: single_doc
     hardcase_categories:
       - layout_broken
+      - rotated_or_skewed
+      - ocr_noisy
     query: "기관 G 교통정보 시스템 개선 사업의 계약금액은 얼마인가?"
     expected_doc_ids:
       - rfp-agency-g-traffic-hwp
@@ -2069,6 +2071,8 @@ cases:
     hardcase_categories:
       - table_heavy
       - layout_broken
+      - rotated_or_skewed
+      - ocr_noisy
     query: "기관 F 스마트팩토리 사업과 기관 G 교통정보 사업 중 어느 기관의 사업 규모가 더 큰가?"
     expected_doc_ids:
       - rfp-agency-f-smart-factory-hwp

--- a/tests/test_hwp_hardcase_category_inventory_regression.py
+++ b/tests/test_hwp_hardcase_category_inventory_regression.py
@@ -1,0 +1,62 @@
+"""Regression test: all four ADR 0039 HWP structural hardcase categories are
+present in at least one public eval case (issue #654).
+
+Categories: table_heavy / ocr_noisy / rotated_or_skewed / layout_broken.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT_DIR / "eval" / "config.yaml"
+
+ADR_0039_CATEGORIES = frozenset(
+    {"table_heavy", "ocr_noisy", "rotated_or_skewed", "layout_broken"}
+)
+
+
+class TestAdr0039CategoryInventory(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        with open(CONFIG_PATH) as f:
+            cfg = yaml.safe_load(f)
+        cls.cases: list[dict] = cfg.get("cases", [])
+
+    def _all_categories(self) -> set[str]:
+        found: set[str] = set()
+        for case in self.cases:
+            cats = case.get("hardcase_categories") or []
+            found.update(cats)
+        return found
+
+    def test_all_four_adr0039_categories_present(self) -> None:
+        found = self._all_categories()
+        missing = ADR_0039_CATEGORIES - found
+        self.assertFalse(
+            missing,
+            f"ADR 0039 categories missing from eval cases: {sorted(missing)}",
+        )
+
+    def test_table_heavy_has_hwp_cases(self) -> None:
+        tagged = [c for c in self.cases if "table_heavy" in (c.get("hardcase_categories") or [])]
+        hwp = [c for c in tagged if any("hwp" in d for d in (c.get("expected_doc_ids") or []))]
+        self.assertGreater(len(hwp), 0, "table_heavy category has no HWP fixture cases")
+
+    def test_layout_broken_has_hwp_cases(self) -> None:
+        tagged = [c for c in self.cases if "layout_broken" in (c.get("hardcase_categories") or [])]
+        hwp = [c for c in tagged if any("hwp" in d for d in (c.get("expected_doc_ids") or []))]
+        self.assertGreater(len(hwp), 0, "layout_broken category has no HWP fixture cases")
+
+    def test_no_regression_in_existing_categories(self) -> None:
+        found = self._all_categories()
+        pre_existing = {"retrieval_hardening", "ambiguous_follow_up", "chunk_boundary"}
+        for cat in pre_existing:
+            self.assertIn(cat, found, f"Pre-existing category '{cat}' disappeared")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- ADR 0039 4종 카테고리 완성: `table_heavy` + `layout_broken`(PR-A) + `rotated_or_skewed` + `ocr_noisy`(이 PR)
- 기관 G 케이스 2개(`hwp_g_layout_contract_amount`, `hwp_compare_fg_scale`)에 2종 태그 추가
- `by_hardcase_category`에 4종 ADR 0039 키 모두 노출

## Changes

- `eval/config.yaml`: hardcase_categories tagging 추가 (2 케이스, 태깅만, 코드/retrieval 미변경)
- `tests/test_hwp_hardcase_category_inventory_regression.py`: 4종 존재 단언 + pre-existing 회귀 단언

## Rationale for tagging

기관 G 교통정보 fixture는 270° 회전 스캔 노이즈를 텍스트로 표현했고, 로더가 전체 문서를 파싱해야 하므로 `rotated_or_skewed` + `ocr_noisy`가 로더 난이도를 올바르게 기술.

### 1. What does this PR do?
ADR 0039 taxonomy의 마지막 두 카테고리를 공개 케이스에 태깅해, eval_summary의 by_hardcase_category에서 4종 ADR 0039 키를 모두 볼 수 있게 한다.

### 2. Why?
PR-E(leaderboard)에서 `table_heavy` + `ocr_noisy` citation_precision 시계열을 노출하기 위한 전제 조건.

### 3. How was it tested?
YAML 파싱 검증: 4종 카테고리 모두 존재 확인. 회귀 테스트는 `bash scripts/test.sh`에서 실행.

### 5. Load-bearing change?

#### 5a.
- [x] `eval/config.yaml` (tagging only)

#### 5b. Real-data delta?
Tagging only, retrieval/verifier/answer 경로 미변경. 기존 케이스 accuracy 변화 0.

Closes #654
Stacked on #653 (HWP loader ablation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)