### PR TITLE
feat(leaderboard): HWP slice time-series + eval gap closure doc (ADR 0039 PR-E)

### DIFF
--- a/docs/hwp-eval-closure.md
+++ b/docs/hwp-eval-closure.md
@@ -1,0 +1,123 @@
+---
+title: HWP Eval Gap Closure
+layout: page
+permalink: /hwp-eval-closure/
+---
+
+# HWP Eval Gap Closure (ADR 0039)
+
+This document records the four gaps identified in May 2026 between the
+public synthetic eval surface and the private 100-doc corpus (96% HWP),
+and the PR stack that closed them.
+
+## Background
+
+After ADR 0036 (#641) shipped `HwpNativeLoader` as the pyhwp-gated default,
+the private corpus was 96 HWP + 4 PDF
+([`data/index/real100/ingestion_report.json`](../data/index/real100/ingestion_report.json)).
+Three questions surfaced:
+
+1. Is HWP data actually exercised in the public eval?
+2. Do the public eval questions discriminate real-data quality?
+3. Is hard-case evaluation (structural defects) possible?
+
+Code-level inspection found four gaps:
+
+| # | Gap | Before | After |
+|---|-----|--------|-------|
+| 1 | Public synthetic eval에 HWP fixture 없음 | 100 cases, JSON corpus only | 105 cases (+5 HWP hardcase) |
+| 2 | `eval_summary.json`에 `by_format` 없음 | HWP vs PDF 분리 불가 | `by_format.hwp` aggregate 추가 |
+| 3 | HWP loader ablation preset 없음 | `naive_baseline` / `agentic_full`만 | `hwp_csv_text` / `hwp_native` / `hwp_native_tables` 3-way |
+| 4 | 공개 hardcase에 구조 카테고리 없음 | retrieval/abstention 변별만 (22 cases) | +4 구조 카테고리 활성 (ADR 0039) |
+
+## PR Stack (ADR 0039 Kahn-ordered)
+
+```
+main
+ └─ PR-0  ADR 0039 — HWP structural hardcase taxonomy (docs only)
+     └─ PR-A  공개 synthetic HWP fixture 2개 + 5 eval cases
+         └─ PR-B  eval_summary by_format aggregate + SAFE_FORMAT_BUCKET_KEYS
+             └─ PR-C  hwp_csv_text / hwp_native / hwp_native_tables ablation preset
+                 └─ PR-D  ADR 0039 rotated_or_skewed + ocr_noisy 카테고리 활성
+                     └─ PR-E  leaderboard HWP slice (this PR)
+```
+
+| PR | Issue | Branch | Key files |
+|----|-------|--------|-----------|
+| PR-0 | #646 | `docs/issue-646-adr-0039-hwp-hardcase` | `docs/adr/0039-hwp-structural-hardcase-taxonomy.md` |
+| PR-A | #648 | `feat/issue-648-hwp-synthetic-fixture` | `data/raw/rfp_agency_f/g_hwp.json`, `eval/config.yaml` (+5 cases) |
+| PR-B | #650 | `feat/issue-650-eval-by-format-breakdown` | `eval/run_eval.py`, `scripts/run_real_eval_delta.py`, `tests/test_eval_by_format_aggregate_regression.py` |
+| PR-C | #652 | `feat/issue-652-hwp-loader-ablation` | `eval/config.yaml` (+3 ablation rows), `scripts/build_index.py` (`--hwp_loader`) |
+| PR-D | #654 | `feat/issue-654-hwp-hardcase-tagging` | `eval/config.yaml` (tagging only) |
+| PR-E | #657 | `feat/issue-657-leaderboard-hwp-surface` | `scripts/leaderboard.py`, `docs/hwp-eval-closure.md` (this file) |
+
+## What each gap closure delivers
+
+### Gap 1: HWP fixture (PR-A)
+
+Two synthetic JSON fixtures with `metadata.source_format: "hwp"`:
+- `rfp-agency-f-smart-factory-hwp` — table-heavy budget spec (4억 3,500만원)
+- `rfp-agency-g-traffic-hwp` — layout-broken traffic management RFP (2억 8,000만원)
+
+Five new eval cases cover `single_doc`, `comparison`, `follow_up`, and
+`abstention` query types. No `.hwp` binary committed (copyright; ADR 0005
+public/private boundary).
+
+### Gap 2: by_format aggregate (PR-B)
+
+`eval/run_eval.py:summarize_run` now groups results by `metadata.source_format`.
+`eval_summary.json` gains a top-level `by_format` key:
+
+```json
+{
+  "by_format": {
+    "hwp": { "num_predictions": 2, "accuracy": 0.85, ... },
+    "synthetic_public_sample": { "num_predictions": 103, ... }
+  }
+}
+```
+
+`SAFE_FORMAT_BUCKET_KEYS = frozenset({"hwp", "pdf", "synthetic_public_sample"})`
+is the fail-closed whitelist in `run_real_eval_delta.py` (ADR 0005 guard).
+
+### Gap 3: Loader ablation preset (PR-C)
+
+`eval/config.yaml:ablation_runs` gains three rows (`hwp_csv_text`,
+`hwp_native`, `hwp_native_tables`), all built on `pipeline: agentic_full`
+(ADR 0001 baseline invariant preserved). `scripts/build_index.py` gains
+`--hwp_loader {csv,native,native_tables}` which sets `BIDMATE_HWP_LOADER`
+before `_resolve_loader` in `ingestion.py` runs.
+
+### Gap 4: Structural hardcase categories (PR-D)
+
+Four ADR 0039 categories activated in `eval/config.yaml`:
+
+| Category | Fixture cases tagged |
+|----------|---------------------|
+| `table_heavy` | hwp_f_table_budget |
+| `layout_broken` | hwp_g_layout_contract_amount |
+| `rotated_or_skewed` | hwp_g_layout_contract_amount, hwp_compare_fg_scale |
+| `ocr_noisy` | hwp_g_layout_contract_amount, hwp_compare_fg_scale |
+
+`by_hardcase_category` in `eval/run_eval.py` absorbs any category key
+automatically — no code change required.
+
+## Leaderboard visibility (PR-E)
+
+`scripts/leaderboard.py` now renders:
+- A third **HWP Slice** table (`## HWP Slice: by_format[hwp]`) in
+  `reports/leaderboard.md`
+- A `hwp_format` Chart.js series (teal line) in each headline metric chart
+  on the GitHub Pages leaderboard
+
+Past snapshots show `—` per ADR 0030 forward-only policy. New CI runs on
+`main` populate the series going forward.
+
+## Invariant checklist
+
+- [x] ADR 0001: `naive_baseline` preset unchanged; new ablation rows are additive
+- [x] ADR 0005: No per-case payload in committed aggregates; `SAFE_FORMAT_BUCKET_KEYS` is fail-closed
+- [x] ADR 0007: All branches are `<type>/issue-<N>[-<slug>]`; all PRs have `Closes #N`
+- [x] ADR 0030: Leaderboard is forward-only; pre-PR-B snapshots show `—` in HWP slice
+- [x] ADR 0036: pyhwp-absent CI safe — fixtures are JSON, `.hwp` binary not committed
+- [x] ADR 0039: Status promoted from proposed → accepted with PR-D merge

--- a/scripts/leaderboard.py
+++ b/scripts/leaderboard.py
@@ -73,6 +73,9 @@ def load_history(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]]:
     ADR 0029 adds an ``ablation_full`` sub-aggregate alongside the
     primary ``naive_baseline`` metrics — absent on pre-#476 snapshots,
     which the renderer surfaces as ``—`` rather than dropping the row.
+    Issue #650 / ADR 0039 adds ``by_format_hwp`` extracted from the
+    ``by_format.hwp`` bucket; absent on pre-#650 snapshots (shows ``—``
+    per ADR 0030 forward-only).
     """
     if not history_dir.exists():
         return []
@@ -83,6 +86,8 @@ def load_history(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]]:
         provenance = raw.get("provenance") or agg.get("run_manifest") or {}
         ci = agg.get("ci") or {}
         ablation_full = agg.get("ablation_full") or {}
+        by_format = agg.get("by_format") or {}
+        by_format_hwp = by_format.get("hwp") or {}
         rows.append(
             {
                 "file": path.name,
@@ -97,6 +102,7 @@ def load_history(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]]:
                 "retry": agg.get("retry"),
                 "ci": ci,
                 "ablation_full": ablation_full,
+                "by_format_hwp": by_format_hwp,
             }
         )
     rows.sort(key=lambda row: (row["date"], row["file"]))
@@ -123,6 +129,26 @@ def _full_row_view(row: dict[str, Any]) -> dict[str, Any]:
         "abstention": full.get("abstention"),
         "retry": full.get("retry"),
         "ci": full.get("ci") or {},
+    }
+
+
+def _hwp_format_row_view(row: dict[str, Any]) -> dict[str, Any]:
+    """Project the ``by_format_hwp`` bucket onto the leaderboard row shape.
+
+    Absent on pre-#650 snapshots (shows ``—`` per ADR 0030 forward-only).
+    """
+    hwp = row.get("by_format_hwp") or {}
+    return {
+        "date": row["date"],
+        "commit": row["commit"],
+        "num_predictions": hwp.get("num_predictions"),
+        "accuracy": hwp.get("accuracy"),
+        "groundedness": hwp.get("groundedness"),
+        "citation_precision": hwp.get("citation_precision"),
+        "answer_format_compliance": hwp.get("answer_format_compliance"),
+        "abstention": hwp.get("abstention"),
+        "retry": hwp.get("retry"),
+        "ci": {},
     }
 
 
@@ -173,6 +199,7 @@ def render_markdown_table(rows: list[dict[str, Any]]) -> str:
         "",
     ]
     full_rows = [_full_row_view(row) for row in rows]
+    hwp_rows = [_hwp_format_row_view(row) for row in rows]
     return (
         "\n".join(intro)
         + _render_table_only(rows)
@@ -185,16 +212,25 @@ def render_markdown_table(rows: list[dict[str, Any]]) -> str:
             empty_message="",
             trailing_newline=True,
         )
+        + "\n## HWP Slice: by_format[hwp] (ADR 0039 / issue #650)\n\n"
+        + "_HWP-format case accuracy extracted from `eval_summary.json:by_format.hwp`. "
+        + "`—` cells predate PR-B (#650). Forward-only per ADR 0030._\n\n"
+        + render_history_table(
+            hwp_rows,
+            TABLE_COLUMNS,
+            empty_message="",
+            trailing_newline=True,
+        )
     )
 
 
 def _chart_data(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Build the JSON payload consumed by Chart.js.
 
-    Each metric carries two series — ``baseline`` (the existing
-    `naive_baseline` time series) and ``full`` (the `agentic_full`
-    time series introduced by ADR 0029). Missing `full` points (pre-
-    #476 snapshots) render as gaps in the chart rather than zeroes.
+    Each metric carries three series:
+    - ``baseline``: ``naive_baseline`` time series
+    - ``full``: ``agentic_full`` time series (ADR 0029; gaps on pre-#476)
+    - ``hwp_format``: ``by_format.hwp`` slice (ADR 0039; gaps on pre-#650)
     """
     labels = [row["date"] for row in rows]
     commits = [row["commit"] for row in rows]
@@ -227,6 +263,11 @@ def _chart_data(rows: list[dict[str, Any]]) -> dict[str, Any]:
                     .get(key, {})
                     .get("ci_hi")
                     for row in rows
+                ],
+            },
+            "hwp_format": {
+                "values": [
+                    (row.get("by_format_hwp") or {}).get(key) for row in rows
                 ],
             },
         }
@@ -270,6 +311,7 @@ window.addEventListener('DOMContentLoaded', () => {{
     if (!el) continue;
     const baseline = LEADERBOARD_DATA.metrics[metric].baseline;
     const full = LEADERBOARD_DATA.metrics[metric].full;
+    const hwpFormat = LEADERBOARD_DATA.metrics[metric].hwp_format;
     new Chart(el, {{
       type: 'line',
       data: {{
@@ -309,6 +351,16 @@ window.addEventListener('DOMContentLoaded', () => {{
             tension: 0.1,
             spanGaps: false,
             order: 1,
+          }},
+          {{
+            label: 'hwp_format (by_format[hwp])',
+            data: hwpFormat.values,
+            borderColor: 'rgb(75, 192, 192)',
+            backgroundColor: 'rgb(75, 192, 192)',
+            fill: false,
+            tension: 0.1,
+            spanGaps: false,
+            order: 2,
           }},
         ],
       }},

--- a/tests/test_leaderboard_by_format_render.py
+++ b/tests/test_leaderboard_by_format_render.py
@@ -1,0 +1,177 @@
+"""Regression tests for leaderboard HWP slice rendering (issue #657 / ADR 0039).
+
+Verifies that:
+1. `load_history` extracts ``by_format_hwp`` from aggregate snapshots.
+2. `_chart_data` includes a ``hwp_format`` series for every headline metric.
+3. ``hwp_format.values`` carries the correct accuracy from ``by_format.hwp``.
+4. Pre-#650 rows (no ``by_format``) yield ``None`` values (ADR 0030 gaps).
+5. `render_markdown_table` contains the HWP Slice section header.
+6. `render_page` includes the ``hwp_format`` dataset label in the JS payload.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.leaderboard import (
+    HEADLINE_METRICS,
+    _chart_data,
+    _hwp_format_row_view,
+    load_history,
+    render_markdown_table,
+    render_page,
+)
+
+
+def _make_row(
+    *,
+    accuracy: float | None = 0.8,
+    by_format_hwp: dict | None = None,
+) -> dict:
+    return {
+        "file": "20260514.aggregate.json",
+        "commit": "abc123def456",
+        "date": "2026-05-14",
+        "num_predictions": 10,
+        "accuracy": accuracy,
+        "groundedness": 0.75,
+        "citation_precision": 0.9,
+        "answer_format_compliance": 1.0,
+        "abstention": None,
+        "retry": 0.0,
+        "ci": {},
+        "ablation_full": {},
+        "by_format_hwp": by_format_hwp or {},
+    }
+
+
+def _make_aggregate_file(tmp_dir: Path, by_format: dict | None = None) -> None:
+    payload = {
+        "provenance": {"git_commit": "abc123def456", "generated_at": "2026-05-14T12:00:00Z"},
+        "num_predictions": 10,
+        "accuracy": 0.8,
+        "groundedness": 0.75,
+        "citation_precision": 0.9,
+        "answer_format_compliance": 1.0,
+        "abstention": None,
+        "retry": 0.0,
+    }
+    if by_format is not None:
+        payload["by_format"] = by_format
+    (tmp_dir / "20260514.aggregate.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+class TestLoadHistoryByFormatHwp(unittest.TestCase):
+    def test_extracts_by_format_hwp_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            _make_aggregate_file(tmp_dir, by_format={"hwp": {"accuracy": 0.65, "num_predictions": 2}})
+            rows = load_history(tmp_dir)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["by_format_hwp"].get("accuracy"), 0.65)
+
+    def test_by_format_hwp_empty_when_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            _make_aggregate_file(tmp_dir, by_format=None)
+            rows = load_history(tmp_dir)
+        self.assertEqual(rows[0]["by_format_hwp"], {})
+
+    def test_unknown_format_bucket_dropped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            _make_aggregate_file(
+                tmp_dir,
+                by_format={"hwp": {"accuracy": 0.5}, "secret_format": {"accuracy": 0.0}},
+            )
+            rows = load_history(tmp_dir)
+        # extract_aggregate is fail-closed; secret_format must not appear
+        self.assertNotIn("secret_format", rows[0].get("by_format_hwp", {}))
+
+
+class TestChartDataHwpFormatSeries(unittest.TestCase):
+    def test_hwp_format_key_present_for_all_metrics(self) -> None:
+        rows = [_make_row(by_format_hwp={"accuracy": 0.6})]
+        data = _chart_data(rows)
+        for key, _ in HEADLINE_METRICS:
+            self.assertIn("hwp_format", data["metrics"][key], f"Missing hwp_format in {key}")
+
+    def test_hwp_format_accuracy_value_correct(self) -> None:
+        rows = [_make_row(by_format_hwp={"accuracy": 0.6, "groundedness": 0.55})]
+        data = _chart_data(rows)
+        self.assertEqual(data["metrics"]["accuracy"]["hwp_format"]["values"], [0.6])
+        self.assertEqual(data["metrics"]["groundedness"]["hwp_format"]["values"], [0.55])
+
+    def test_hwp_format_none_when_by_format_absent(self) -> None:
+        rows = [_make_row(by_format_hwp={})]
+        data = _chart_data(rows)
+        for key, _ in HEADLINE_METRICS:
+            values = data["metrics"][key]["hwp_format"]["values"]
+            self.assertEqual(values, [None], f"{key}: expected [None] for missing by_format_hwp")
+
+    def test_multiple_rows_correct_lengths(self) -> None:
+        rows = [
+            _make_row(by_format_hwp={"accuracy": 0.7}),
+            _make_row(by_format_hwp={}),
+        ]
+        data = _chart_data(rows)
+        values = data["metrics"]["accuracy"]["hwp_format"]["values"]
+        self.assertEqual(len(values), 2)
+        self.assertEqual(values[0], 0.7)
+        self.assertIsNone(values[1])
+
+
+class TestHwpFormatRowView(unittest.TestCase):
+    def test_projects_hwp_metrics(self) -> None:
+        row = _make_row(by_format_hwp={"accuracy": 0.6, "num_predictions": 3})
+        view = _hwp_format_row_view(row)
+        self.assertEqual(view["accuracy"], 0.6)
+        self.assertEqual(view["num_predictions"], 3)
+        self.assertEqual(view["date"], "2026-05-14")
+        self.assertEqual(view["commit"], "abc123def456")
+
+    def test_none_metrics_when_empty(self) -> None:
+        row = _make_row(by_format_hwp={})
+        view = _hwp_format_row_view(row)
+        self.assertIsNone(view["accuracy"])
+        self.assertIsNone(view["num_predictions"])
+
+
+class TestRenderMarkdownTableHwpSection(unittest.TestCase):
+    def test_hwp_slice_header_present(self) -> None:
+        rows = [_make_row(by_format_hwp={"accuracy": 0.6})]
+        md = render_markdown_table(rows)
+        self.assertIn("HWP Slice", md)
+
+    def test_hwp_slice_section_after_agentic_full(self) -> None:
+        rows = [_make_row(by_format_hwp={"accuracy": 0.6})]
+        md = render_markdown_table(rows)
+        agentic_pos = md.find("agentic_full")
+        hwp_pos = md.find("HWP Slice")
+        self.assertGreater(hwp_pos, agentic_pos)
+
+    def test_adr_0039_reference_present(self) -> None:
+        rows = [_make_row()]
+        md = render_markdown_table(rows)
+        self.assertIn("ADR 0039", md)
+
+
+class TestRenderPageHwpDataset(unittest.TestCase):
+    def test_hwp_format_dataset_label_in_js(self) -> None:
+        rows = [_make_row(by_format_hwp={"accuracy": 0.6})]
+        page = render_page(rows)
+        self.assertIn("hwp_format", page)
+
+    def test_leaderboard_data_contains_hwp_format(self) -> None:
+        rows = [_make_row(by_format_hwp={"accuracy": 0.7})]
+        page = render_page(rows)
+        # The JSON payload is inlined; verify the hwp_format key appears
+        self.assertIn('"hwp_format"', page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What / Why

ADR 0039 PR-E (stacked on PR-D #654). `by_format.hwp` aggregate가 PR-B (#650)에서 추가됐지만 `scripts/leaderboard.py`가 이를 렌더링하지 않아 HWP 처리 품질이 공개 leaderboard에 가시화되지 않았습니다.

Closes #657

## 2. Changes

### `scripts/leaderboard.py`
- `load_history`: `agg["by_format"]["hwp"]` → `by_format_hwp` 키로 각 row에 추출
- `_hwp_format_row_view`: `by_format_hwp` 버킷을 `TABLE_COLUMNS` 형태로 projection하는 헬퍼 추가
- `render_markdown_table`: `## HWP Slice: by_format[hwp]` 섹션 추가 (ADR 0030 forward-only)
- `_chart_data`: 모든 headline metric에 `hwp_format` 시계열 추가 (teal)
- `render_page`: Chart.js 템플릿에 `hwp_format` dataset 추가

### `docs/hwp-eval-closure.md`
4-gap → 6-PR closure 표 + invariant checklist (ADR 0001/0005/0007/0030/0036/0039)

### `tests/test_leaderboard_by_format_render.py`
14개 단언: load_history 추출, chart 시계열, row view, markdown 섹션, page 렌더

## 3. Test / Verification

```bash
# 문법 검증
python3 -c "import ast; ast.parse(open('scripts/leaderboard.py').read()); print('OK')"
python3 -c "import ast; ast.parse(open('tests/test_leaderboard_by_format_render.py').read()); print('OK')"
```

회귀 테스트는 `bash scripts/test.sh`로 실행 (conda env 필요).

## 4. ADR citations

- ADR 0005: `extract_aggregate` 재사용 — `SAFE_FORMAT_BUCKET_KEYS` fail-closed 유지
- ADR 0030: forward-only — 과거 snapshot은 `hwp_format` 시계열에서 `—` 표시
- ADR 0039: 본 PR이 leaderboard 가시화 단계를 완료

## 5a. Load-bearing paths changed

없음. `scripts/leaderboard.py`는 renderer — `eval/`, `rag_core.py`, `ingestion.py` 미변경.

## 5b. Real-data delta

N/A — leaderboard renderer only. 과거 snapshot에 `by_format` 없음 → hwp_format series는 `—`. 다음 `make real-eval-delta` 이후 채워짐.

## Stack position

```
main → PR-0(#646) → PR-A(#648) → PR-B(#650) → PR-C(#652) → PR-D(#654) → PR-E(this)
```