### PR TITLE
feat(planner): Planner Protocol + StaticPlanner foundation (closes #659)

### DIFF
--- a/rag_planner.py
+++ b/rag_planner.py
@@ -1,0 +1,142 @@
+"""Planner Protocol — pluggable next-action planning stage (#659).
+
+The ``Planner`` Protocol decouples the ReAct agent loop from the specific
+planning backend, so future strategies (LLM-based multi-turn planning,
+tool-use orchestration) can plug in without modifying the orchestration
+graph.  Mirrors the ``QueryExpander`` / ``Reranker`` / ``VectorStore``
+pattern (ADR 0020 four-property pluggability).
+
+``StaticPlanner`` is the default; it delegates to ``rag_query.make_plan``
+so the existing deterministic plan construction is preserved unchanged.
+History and budget are accepted but ignored — ``StaticPlanner`` makes a
+single-pass decision exactly as the current pipeline does.
+
+``LLMPlanner`` (PR-C) is the first opt-in implementation: multi-turn
+Anthropic SDK ``tools`` call that selects the next action from a
+registered tool set based on analysis + history + remaining budget.
+
+Critical contract:
+- ``plan_next`` must NEVER raise; on any failure the implementation must
+  return ``{"tool": "abstain", "args": {"reason": "planner_error"}}`` with
+  ``meta["fell_back"] = True``.
+- ``next_action["tool"]`` must be one of the registered tool names or
+  ``"abstain"``.
+- ``meta`` must include the keys defined in ``_REQUIRED_META_KEYS``.
+
+Convention: follows ADR 0020 Protocol-based pluggability.  New planners
+implement ``Planner`` and register via ``default_planner()`` — the agent
+loop is untouched.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Protocol, runtime_checkable
+
+_REQUIRED_META_KEYS = frozenset(
+    {"backend", "model", "fell_back", "fallback_reason", "latency_ms"}
+)
+
+_ABSTAIN_ACTION: dict[str, Any] = {"tool": "abstain", "args": {"reason": "planner_error"}}
+
+
+@runtime_checkable
+class Planner(Protocol):
+    """Pluggable next-action planning stage for the ReAct agent loop.
+
+    Given the current query analysis, prior attempt history, and the
+    remaining compute budget, ``plan_next`` returns the action the
+    orchestration loop should execute next.
+
+    Implementations must NEVER raise; on backend failure they must return
+    an abstain action with ``meta["fell_back"]`` set, preserving the ADR
+    0003 answer contract (``status: insufficient``) as the fallback path.
+    """
+
+    def plan_next(
+        self,
+        *,
+        analysis: dict[str, Any],
+        history: list[dict[str, Any]],
+        budget: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Return ``(next_action, meta)``.
+
+        ``next_action`` — ``{"tool": <name>, "args": {...}}`` where
+        ``<name>`` is one of the registered tool names or ``"abstain"``.
+        ``args`` for ``retrieve_evidence`` is the plan dict produced by
+        ``rag_query.make_plan``; ``args`` for ``abstain`` carries a
+        ``reason`` string.
+
+        ``meta`` — ``{"backend": str, "model": str | None,
+        "fell_back": bool, "fallback_reason": str | None,
+        "latency_ms": float}``.
+        """
+        ...
+
+
+class StaticPlanner:
+    """Default ``Planner`` — delegates to ``rag_query.make_plan``.
+
+    Deterministic, no LLM call, no env-var read.  ``history`` and
+    ``budget`` are accepted but ignored so the Protocol contract is
+    satisfied; ``StaticPlanner`` makes a single-pass decision identical
+    to the current pipeline.
+
+    ``preset_kwargs`` pre-seeds the ``make_plan`` keyword arguments
+    (e.g. ``rerank=True``, ``metadata_first=True``) so PR-C can
+    instantiate ``StaticPlanner`` with preset-specific defaults and still
+    reach the same code path as the existing pipeline does today.
+
+    Never-raise: ``make_plan`` validation errors (bad retrieval_mode,
+    invalid rrf_k, etc.) are caught and an abstain action is returned
+    with ``meta["fell_back"] = True``.  Programming errors — wrong type
+    for ``analysis`` — are allowed to propagate to surface bugs early.
+    """
+
+    def __init__(self, *, preset_kwargs: dict[str, Any] | None = None) -> None:
+        self._preset_kwargs: dict[str, Any] = preset_kwargs or {}
+
+    def plan_next(
+        self,
+        *,
+        analysis: dict[str, Any],
+        history: list[dict[str, Any]],
+        budget: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        t0 = time.perf_counter()
+        try:
+            from rag_query import make_plan as _make_plan
+
+            plan_dict = _make_plan(analysis, **self._preset_kwargs)
+            next_action: dict[str, Any] = {"tool": "retrieve_evidence", "args": plan_dict}
+            fell_back = False
+            fallback_reason = None
+        except Exception as exc:
+            next_action = {
+                "tool": "abstain",
+                "args": {"reason": f"planner_error: {type(exc).__name__}: {exc}"},
+            }
+            fell_back = True
+            fallback_reason = f"{type(exc).__name__}: {exc}"
+        latency_ms = (time.perf_counter() - t0) * 1000.0
+        meta: dict[str, Any] = {
+            "backend": "static",
+            "model": None,
+            "fell_back": fell_back,
+            "fallback_reason": fallback_reason,
+            "latency_ms": latency_ms,
+        }
+        return next_action, meta
+
+
+def default_planner(*, preset_kwargs: dict[str, Any] | None = None) -> Planner:
+    """The planner the agent loop uses unless a future plan-level override
+    is wired in.  Returns a fresh ``StaticPlanner`` instance so callers
+    can swap implementations in tests without module-level state.
+
+    When ``LLMPlanner`` lands (PR-C), this function gains a
+    ``BIDMATE_PLANNER_BACKEND`` env-var read — identical to the
+    ``BIDMATE_QUERY_EXPANSION_BACKEND`` dispatch in
+    ``rag_query_expansion.py``.
+    """
+    return StaticPlanner(preset_kwargs=preset_kwargs)

--- a/tests/test_planner_protocol_regression.py
+++ b/tests/test_planner_protocol_regression.py
@@ -1,0 +1,166 @@
+"""Regression tests for rag_planner — Planner Protocol + StaticPlanner (#659).
+
+Verifies:
+1. Protocol structural conformance (isinstance checks).
+2. StaticPlanner happy path — next_action / meta structure.
+3. StaticPlanner never-raise contract — bad preset_kwargs yields abstain.
+4. StaticPlanner preset_kwargs passthrough — args land in make_plan.
+5. default_planner() factory returns a Planner instance.
+
+No real index or LLM calls; all paths are deterministic.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_planner import (  # noqa: E402
+    Planner,
+    StaticPlanner,
+    _REQUIRED_META_KEYS,
+    default_planner,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _analysis(query_type: str = "single_doc") -> dict[str, Any]:
+    """Minimal analysis dict accepted by make_plan."""
+    return {
+        "query_type": query_type,
+        "entities": [],
+        "metadata_filters_by_stage": {},
+    }
+
+
+def _budget() -> dict[str, Any]:
+    return {"iterations_left": 5, "tokens_left": 4096, "ms_left": 8000}
+
+
+# ---------------------------------------------------------------------------
+# 1. Protocol conformance
+# ---------------------------------------------------------------------------
+
+def test_static_planner_is_planner():
+    assert isinstance(StaticPlanner(), Planner)
+
+
+def test_default_planner_is_planner():
+    assert isinstance(default_planner(), Planner)
+
+
+# ---------------------------------------------------------------------------
+# 2. StaticPlanner happy path
+# ---------------------------------------------------------------------------
+
+def test_static_planner_returns_retrieve_action():
+    planner = StaticPlanner()
+    next_action, meta = planner.plan_next(
+        analysis=_analysis(),
+        history=[],
+        budget=_budget(),
+    )
+    assert next_action["tool"] == "retrieve_evidence", next_action
+    assert "args" in next_action
+    assert isinstance(next_action["args"], dict)
+
+
+def test_static_planner_meta_structure():
+    planner = StaticPlanner()
+    _, meta = planner.plan_next(
+        analysis=_analysis(),
+        history=[],
+        budget=_budget(),
+    )
+    missing = _REQUIRED_META_KEYS - meta.keys()
+    assert not missing, f"meta is missing keys: {missing}"
+    assert meta["backend"] == "static"
+    assert meta["model"] is None
+    assert meta["fell_back"] is False
+    assert meta["fallback_reason"] is None
+    assert isinstance(meta["latency_ms"], float)
+
+
+def test_static_planner_history_and_budget_ignored():
+    planner = StaticPlanner()
+    # Non-empty history / budget must not raise or change next_action.tool
+    next_action, meta = planner.plan_next(
+        analysis=_analysis(),
+        history=[{"attempt": 1, "verifier_feedback": "topic_not_grounded"}],
+        budget={"iterations_left": 0, "tokens_left": 0, "ms_left": 0},
+    )
+    assert next_action["tool"] == "retrieve_evidence"
+    assert meta["fell_back"] is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Never-raise contract — bad preset_kwargs → abstain
+# ---------------------------------------------------------------------------
+
+def test_static_planner_invalid_retrieval_mode_abstains():
+    planner = StaticPlanner(preset_kwargs={"retrieval_mode": "INVALID_MODE"})
+    next_action, meta = planner.plan_next(
+        analysis=_analysis(),
+        history=[],
+        budget=_budget(),
+    )
+    assert next_action["tool"] == "abstain", next_action
+    assert meta["fell_back"] is True
+    assert meta["fallback_reason"] is not None
+
+
+def test_static_planner_never_raises():
+    planner = StaticPlanner(preset_kwargs={"rrf_k": -999})
+    try:
+        next_action, meta = planner.plan_next(
+            analysis=_analysis(),
+            history=[],
+            budget=_budget(),
+        )
+    except Exception as exc:  # pragma: no cover
+        raise AssertionError(f"plan_next raised unexpectedly: {exc}") from exc
+    assert next_action["tool"] == "abstain"
+    assert meta["fell_back"] is True
+
+
+# ---------------------------------------------------------------------------
+# 4. preset_kwargs passthrough — lands in plan dict
+# ---------------------------------------------------------------------------
+
+def test_static_planner_preset_kwargs_passthrough():
+    planner = StaticPlanner(preset_kwargs={"rerank": False, "top_k": 3})
+    next_action, _ = planner.plan_next(
+        analysis=_analysis(),
+        history=[],
+        budget=_budget(),
+    )
+    plan_dict = next_action["args"]
+    assert plan_dict.get("rerank") is False
+    assert plan_dict.get("top_k") == 3
+
+
+# ---------------------------------------------------------------------------
+# 5. default_planner factory
+# ---------------------------------------------------------------------------
+
+def test_default_planner_factory_returns_fresh_instances():
+    p1 = default_planner()
+    p2 = default_planner()
+    assert p1 is not p2
+
+
+def test_default_planner_preset_kwargs_forwarded():
+    planner = default_planner(preset_kwargs={"rerank": False})
+    next_action, _ = planner.plan_next(
+        analysis=_analysis(),
+        history=[],
+        budget=_budget(),
+    )
+    assert next_action["args"]["rerank"] is False


### PR DESCRIPTION
## Summary

- `rag_planner.py` 신규: `Planner` Protocol + `StaticPlanner` (현 `make_plan` 위임), `default_planner()` 팩토리.
- `tests/test_planner_protocol_regression.py` 신규: 10개 테스트 (Protocol 준수, happy path, never-raise, preset_kwargs passthrough).
- 기존 파일 변경 없음 — purely additive.

## Motivation

`(B) agentic RAG → (A) real agent` 전환 5-PR 스택의 첫번째 PR. ADR 0020 4-axis pluggability 를 Planner 축으로 확장해 PR-C 의 `LLMPlanner` 도입 자리 선반화.

## Changes

| File | Change |
|---|---|
| `rag_planner.py` | NEW — Planner Protocol + StaticPlanner + default_planner() |
| `tests/test_planner_protocol_regression.py` | NEW — 10 unit tests |

## Test plan

- [x] `pytest tests/test_planner_protocol_regression.py -v` → 10 passed
- [x] 기존 suite 무영향 (파일 추가만, import 없음)

## PR template checklist

1. **Issue link**: Closes #659
2. **Branch convention**: `feat/issue-659-planner-protocol` ✓
3. **One concern**: Planner Protocol foundation only ✓
4. **동작 변경 ↔ 테스트 변경**: additive Protocol 추가 — 10 regression tests ✓
5. **Load-bearing files changed**: None (rag_planner.py is new)
   - 5b (real-data delta): N/A — no retrieval path changed
6. **ADR required**: N/A — Protocol 확장은 기존 ADR 0020 패턴 따름; ADR 0040 는 PR-C 와 함께 (load-bearing 변경)
7. **하위 호환성**: full — 기존 call site 미변경

## Stack

PR-A (this) → PR-B (agent tool registry) → PR-C (ReAct orchestrator + ADR 0040/0041) → PR-D (verifier feedback injection) → PR-E (eval row + ADR 0042)
