### PR TITLE
test(chunking): lock-in Korean sentence_split behavior on abbreviations, decimals, ellipsis

### DIFF
--- a/tests/test_korean_sentence_split_regression.py
+++ b/tests/test_korean_sentence_split_regression.py
@@ -1,0 +1,97 @@
+"""Regression tests locking in sentence_split() golden behaviour for Korean edge cases.
+
+SENTENCE_RE = r"(?<=[.!?。])\\s+" — splits only at punctuation followed by whitespace,
+so decimals and bracket-abbreviations that lack a trailing space stay intact.
+"""
+
+import pytest
+
+from rag_text_processing import sentence_split
+
+
+# ---------------------------------------------------------------------------
+# Corporate-prefix abbreviations
+# ---------------------------------------------------------------------------
+
+def test_abbreviation_bracket_prefix():
+    # "(주)" is a bracket abbreviation, not a sentence-boundary punctuation char.
+    # The "." after the first sentence is followed by a space, so it does split.
+    text = "(주)가나다는 입찰에 참여한다. 마감은 5월이다."
+    assert sentence_split(text) == ["(주)가나다는 입찰에 참여한다.", "마감은 5월이다."]
+
+
+def test_abbreviation_jusikhwesa_inline():
+    # "주식회사" in the middle of a sentence — no punctuation boundary here.
+    text = "주식회사 ABC는 낙찰자이다. 계약 기간은 180일이다."
+    assert sentence_split(text) == ["주식회사 ABC는 낙찰자이다.", "계약 기간은 180일이다."]
+
+
+# ---------------------------------------------------------------------------
+# Decimal numbers and unit suffixes
+# ---------------------------------------------------------------------------
+
+def test_decimal_not_split():
+    # "3.14억원" — decimal point has no trailing whitespace → not a boundary.
+    text = "보증금은 3.14억원이다. 추가로 1.5%를 납부한다."
+    assert sentence_split(text) == [
+        "보증금은 3.14억원이다.",
+        "추가로 1.5%를 납부한다.",
+    ]
+
+
+def test_decimal_in_list():
+    # Multiple decimal values in a single sentence.
+    text = "단가는 각각 2.5억원, 3.7억원, 4.1억원이다."
+    assert sentence_split(text) == ["단가는 각각 2.5억원, 3.7억원, 4.1억원이다."]
+
+
+# ---------------------------------------------------------------------------
+# Ellipsis
+# ---------------------------------------------------------------------------
+
+def test_ellipsis_etc_no_split():
+    # "..." followed immediately by Korean characters — no whitespace → no split.
+    text = "가, 나, 다...등 다섯 가지이다."
+    assert sentence_split(text) == ["가, 나, 다...등 다섯 가지이다."]
+
+
+# ---------------------------------------------------------------------------
+# Full-width Korean sentence terminator (。)
+# ---------------------------------------------------------------------------
+
+def test_fullwidth_terminator_with_space():
+    # 。+ space is a valid split point.
+    text = "공고합니다。 다음은 안내이다。"
+    assert sentence_split(text) == ["공고합니다。", "다음은 안내이다。"]
+
+
+def test_fullwidth_terminator_no_space():
+    # 。without a trailing space — no split.
+    text = "공고합니다。다음은 안내이다。"
+    assert sentence_split(text) == ["공고합니다。다음은 안내이다。"]
+
+
+# ---------------------------------------------------------------------------
+# Mixed terminal punctuation
+# ---------------------------------------------------------------------------
+
+def test_mixed_punctuation():
+    text = "질문? 답변! 결론."
+    assert sentence_split(text) == ["질문?", "답변!", "결론."]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_empty_string():
+    assert sentence_split("") == []
+
+
+def test_single_sentence_no_trailing_space():
+    text = "단일 문장입니다."
+    assert sentence_split(text) == ["단일 문장입니다."]
+
+
+def test_whitespace_only():
+    assert sentence_split("   ") == []


### PR DESCRIPTION
## Summary

Closes #662

`rag_text_processing.py:87` 의 `sentence_split()` 가 `SENTENCE_RE = r"(?<=[.!?。])\s+"` 사용 — 정확하지만 regression-test 커버리지 0. 향후 regex 변경이 한국어 문서 청킹 (괄호 약어, 소수점 숫자 등) 을 silent 하게 깰 수 있음.

## Changes

- **신규**: `tests/test_korean_sentence_split_regression.py` — 11 lock-in 케이스:
  - `(주)가나다` / `주식회사` 괄호 약어 무손상 유지
  - 소수점 숫자 (`3.14억원`, `1.5%`) — 소수점에서 split 없음
  - Ellipsis (`...등`) — split 없음
  - Full-width 한국어 terminator `。` 후행 공백 유/무
  - 혼합 구두점 (`? ! .`)
  - Edge case: 빈 문자열, whitespace-only

## Test Results

```
11 passed in 0.14s
```

## PR Template Checklist

1. **Issue reference**: Closes #662
2. **Branch convention**: `test/issue-662-korean-sentence-split-regression` ✓
3. **Load-bearing change**: No — `tests/` only. `LOAD_BEARING_PATHS` 미영향.
4. **Behavior change**: None — tests only.
5a. **Synthetic eval delta**: N/A — runtime 코드 변경 없음.
5b. **Real-data delta**: N/A — retrieval/verifier/answer 경로 변경 없음.
6. **ADR required**: No.
7. **Backward compatibility**: N/A.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
