### PR TITLE
feat(eval): real100 case-level failure breakdown 진단 도구 (closes #661)

### DIFF
--- a/scripts/analyze_real100_failures.py
+++ b/scripts/analyze_real100_failures.py
@@ -1,0 +1,202 @@
+"""Real100 case-level failure breakdown. Reads eval_summary.json and writes case_breakdown.md.
+
+Usage:
+    python scripts/analyze_real100_failures.py [EVAL_SUMMARY_JSON] [OUTPUT_MD]
+
+Defaults:
+    EVAL_SUMMARY_JSON = reports/real100/eval_summary.json
+    OUTPUT_MD         = reports/real100/case_breakdown.md
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Failure bucket classification
+# ---------------------------------------------------------------------------
+
+def _classify(case: dict) -> str:
+    qt = case.get("query_type", "")
+    acc = case.get("accuracy")       # float | None
+    gnd = case.get("groundedness") or 0.0
+    status = case.get("answer_status", "")
+    abstained = case.get("abstained", False)
+
+    if qt == "abstention":
+        if abstained:
+            return "correct_abstention"
+        return "wrong_answer"          # should have abstained but produced an answer
+
+    if abstained:
+        return "wrong_abstention"      # should have answered but abstained
+
+    if acc == 1.0 and gnd >= 0.9:
+        return "pass"
+
+    if status == "supported" and acc == 0.0:
+        return "wrong_answer"
+
+    if status in ("insufficient", "partial") and acc == 0.0:
+        return "wrong_abstention"
+
+    if acc == 0.0 or gnd < 0.5:
+        return "low_quality"
+
+    return "pass"
+
+
+# ---------------------------------------------------------------------------
+# Aggregation helpers
+# ---------------------------------------------------------------------------
+
+def _mean(values: list[float]) -> float | None:
+    filtered = [v for v in values if v is not None]
+    return sum(filtered) / len(filtered) if filtered else None
+
+
+def _fmt(v: float | None, decimals: int = 3) -> str:
+    return f"{v:.{decimals}f}" if v is not None else "—"
+
+
+# ---------------------------------------------------------------------------
+# Markdown builders
+# ---------------------------------------------------------------------------
+
+def _section(title: str) -> str:
+    return f"\n## {title}\n"
+
+
+def _case_table(cases: list[dict]) -> str:
+    rows = [
+        "| id | query_type | acc | gnd | status | abstained | chunk_r@5 | chunk_r@10 | bucket | query |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for c in cases:
+        row = " | ".join([
+            c.get("id", "")[:40],
+            c.get("query_type", ""),
+            _fmt(c.get("accuracy"), 1),
+            _fmt(c.get("groundedness"), 2),
+            c.get("answer_status", ""),
+            str(c.get("abstained", False)),
+            _fmt(c.get("chunk_recall_at_5"), 2),
+            _fmt(c.get("chunk_recall_at_10"), 2),
+            _classify(c),
+            (c.get("query") or "")[:60].replace("|", "｜"),
+        ])
+        rows.append(f"| {row} |")
+    return "\n".join(rows)
+
+
+def _dim_table(cases: list[dict], dim: str) -> str:
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for c in cases:
+        key = str(c.get(dim) or "unknown")
+        groups[key].append(c)
+
+    rows = [
+        f"| {dim} | count | acc_mean | gnd_mean | pass | wrong_abstention | wrong_answer | correct_abstention | low_quality |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for key in sorted(groups):
+        g = groups[key]
+        buckets = [_classify(c) for c in g]
+        row = " | ".join([
+            key,
+            str(len(g)),
+            _fmt(_mean([c.get("accuracy") for c in g])),
+            _fmt(_mean([c.get("groundedness") for c in g])),
+            str(buckets.count("pass")),
+            str(buckets.count("wrong_abstention")),
+            str(buckets.count("wrong_answer")),
+            str(buckets.count("correct_abstention")),
+            str(buckets.count("low_quality")),
+        ])
+        rows.append(f"| {row} |")
+    return "\n".join(rows)
+
+
+def _failure_detail(cases: list[dict]) -> str:
+    failures = [c for c in cases if _classify(c) != "pass" and _classify(c) != "correct_abstention"]
+    if not failures:
+        return "_No failures._"
+    lines = []
+    for c in failures:
+        bucket = _classify(c)
+        lines.append(
+            f"**{c.get('id')}** `{bucket}` {c.get('query_type')} "
+            f"acc={_fmt(c.get('accuracy'),1)} gnd={_fmt(c.get('groundedness'),2)} "
+            f"status={c.get('answer_status')} abstained={c.get('abstained')}"
+        )
+        q = (c.get("query") or "")[:120]
+        lines.append(f"  > {q}")
+        r5 = c.get("chunk_recall_at_5")
+        r10 = c.get("chunk_recall_at_10")
+        lines.append(f"  chunk_recall@5={_fmt(r5,2)} @10={_fmt(r10,2)}\n")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def generate(eval_summary_path: Path, output_path: Path) -> None:
+    with eval_summary_path.open() as f:
+        data = json.load(f)
+
+    cases: list[dict] = data.get("case_results", [])
+    if not cases:
+        print("No case_results found.", file=sys.stderr)
+        sys.exit(1)
+
+    accs = [c["accuracy"] for c in cases if c.get("accuracy") is not None]
+    gnds = [c["groundedness"] for c in cases if c.get("groundedness") is not None]
+    buckets = [_classify(c) for c in cases]
+
+    lines: list[str] = [
+        "# Real100 Case-Level Failure Breakdown",
+        "",
+        f"Source: `{eval_summary_path}`  ",
+        f"Cases: {len(cases)}  ",
+        f"accuracy (n={len(accs)}): **{_fmt(_mean(accs))}**  ",
+        f"groundedness (n={len(gnds)}): **{_fmt(_mean(gnds))}**",
+        "",
+        "**Bucket summary**",
+        "",
+        "| bucket | count |",
+        "|---|---|",
+    ]
+    for bucket in ("pass", "correct_abstention", "wrong_abstention", "wrong_answer", "low_quality"):
+        lines.append(f"| {bucket} | {buckets.count(bucket)} |")
+
+    lines.append(_section("All Cases"))
+    lines.append(_case_table(sorted(cases, key=lambda c: (_classify(c) != "pass", c.get("query_type", "")))))
+
+    lines.append(_section("By query_type"))
+    lines.append(_dim_table(cases, "query_type"))
+
+    lines.append(_section("By answer_status"))
+    lines.append(_dim_table(cases, "answer_status"))
+
+    lines.append(_section("Failure Detail"))
+    lines.append(_failure_detail(sorted(cases, key=lambda c: c.get("query_type", ""))))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Written: {output_path}")
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    eval_path = Path(args[0]) if args else Path("reports/real100/eval_summary.json")
+    out_path = Path(args[1]) if len(args) > 1 else eval_path.parent / "case_breakdown.md"
+    generate(eval_path, out_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `scripts/analyze_real100_failures.py` 추가 — `reports/real100/eval_summary.json`의 기존 `case_results` 배열(이미 `run_eval.py`에서 dump됨)을 읽어 케이스별 실패 버킷 분류 + query_type / answer_status 집계 마크다운 출력
- dump hook 추가 없음, 파이프라인 코드 변경 없음

## First-run finding

| bucket | count |
|---|---|
| pass | 8 |
| correct_abstention | 2 |
| **wrong_abstention** | **8** |
| wrong_answer | 3 |

**probe_11, probe_12**: `chunk_recall@10=1.0`임에도 abstain → retrieval 성공 후 verifier/answer 단계에서 실패. 즉 accuracy 0.471 병목이 retrieval이 아니라 그 다음 단계에 있다는 신호.

## Failure buckets

- `wrong_abstention`: 답할 수 있는 쿼리인데 abstain (8건)
  - probe_11/12: recall 1.0이지만 verifier가 insufficient 판단
  - probe_04/05/real_nrf: recall 0.0 — retrieval 자체 실패 (ambiguity, acronym)
  - probe_09/10: follow_up context resolution 실패 → recall 0.0
- `wrong_answer`: abstention이어야 하는데 partial 답변 (probe_13, probe_15), 또는 답변했지만 틀림 (probe_08)

## Usage

```bash
python scripts/analyze_real100_failures.py \
  reports/real100/eval_summary.json \
  reports/real100/case_breakdown.md
```

## PR checklist (template items)

1. Behavior change: N/A (스크립트 추가만)
2. Retrieval / verifier / answer path 변경: 없음
3. Test: `python scripts/analyze_real100_failures.py` 실행 테스트로 확인
4. ADR: 불요
5a. Synthetic delta: N/A
5b. Real-data delta: N/A (파이프라인 무변경)

Closes #661