### PR TITLE
feat(chunking): expose auto-strategy section-detection rate in ingestion diagnostics

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -472,6 +472,10 @@ def build_chunk_records(
             }
         )
 
+    total_docs = strategy_counts["section"] + strategy_counts["fixed"]
+    section_detection_rate: float | None = (
+        strategy_counts["section"] / total_docs if total_docs else None
+    )
     diagnostics = {
         "requested_strategy": chunking_strategy,
         "max_chars": max_chars,
@@ -480,6 +484,7 @@ def build_chunk_records(
         "actual_strategy_counts": {
             key: value for key, value in strategy_counts.items() if value
         },
+        "section_detection_rate": section_detection_rate,
         "documents": document_diagnostics,
     }
     return chunks, parent_sections, diagnostics

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -226,6 +226,9 @@ def main() -> int:
         f"{num_docs} docs, {num_chunks} chunks, "
         f"embedding={embedding_backend})"
     )
+    section_rate = payload["build"]["chunking"].get("section_detection_rate")
+    if section_rate is not None:
+        print(f"[INFO] Chunking: section-detection rate = {section_rate:.1%} ({num_docs} docs, auto strategy)")
     if ingestion_report is not None:
         print(f"[OK] Ingestion report written: {report_path}")
 

--- a/tests/test_section_detection_stats_regression.py
+++ b/tests/test_section_detection_stats_regression.py
@@ -1,0 +1,105 @@
+"""Regression tests for the section_detection_rate field added to build_chunk_records diagnostics.
+
+Verifies that:
+- The rate is computed correctly for all-section, no-section, mixed, and empty inputs.
+- Chunk content/ID/ordering is not affected (bit-identical behaviour for existing fields).
+"""
+
+from rag_core import build_chunk_records
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_doc(doc_id: str, sections: list[dict]) -> dict:
+    return {
+        "doc_id": doc_id,
+        "title": f"문서 {doc_id}",
+        "agency": "테스트기관",
+        "project": "테스트사업",
+        "metadata": {},
+        "source_path": f"data/raw/{doc_id}.pdf",
+        "sections": sections,
+    }
+
+
+def _section(heading: str, text: str) -> dict:
+    return {"heading": heading, "section": heading, "text": text, "section_path": [heading]}
+
+
+def _weak_section(text: str) -> dict:
+    # Uses a WEAK_SECTION_HEADINGS value — document_has_section_structure → False
+    return {"heading": "본문", "section": "본문", "text": text, "section_path": ["본문"]}
+
+
+# ---------------------------------------------------------------------------
+# section_detection_rate correctness
+# ---------------------------------------------------------------------------
+
+def test_all_section_docs_rate_is_1():
+    docs = [
+        _make_doc("D1", [_section("§1 입찰 조건", "내용 A"), _section("§2 계약 조건", "내용 B")]),
+        _make_doc("D2", [_section("§1 사업 개요", "내용 C")]),
+        _make_doc("D3", [_section("§1 보증금", "내용 D"), _section("§2 일정", "내용 E")]),
+    ]
+    _, _, diag = build_chunk_records(docs, chunking_strategy="auto")
+    assert diag["section_detection_rate"] == 1.0
+
+
+def test_no_section_docs_rate_is_0():
+    # Single section with a WEAK heading → resolves to "fixed"
+    docs = [
+        _make_doc("D1", [_weak_section("단일 본문 A입니다.")]),
+        _make_doc("D2", [_weak_section("단일 본문 B입니다.")]),
+    ]
+    _, _, diag = build_chunk_records(docs, chunking_strategy="auto")
+    assert diag["section_detection_rate"] == 0.0
+
+
+def test_mixed_docs_rate_is_half():
+    docs = [
+        _make_doc("D1", [_section("§1 입찰 조건", "내용 A"), _section("§2 계약", "내용 B")]),
+        _make_doc("D2", [_weak_section("단일 본문 C입니다.")]),
+    ]
+    _, _, diag = build_chunk_records(docs, chunking_strategy="auto")
+    assert diag["section_detection_rate"] == 0.5
+
+
+def test_empty_docs_rate_is_none():
+    _, _, diag = build_chunk_records([], chunking_strategy="auto")
+    assert diag["section_detection_rate"] is None
+
+
+# ---------------------------------------------------------------------------
+# Bit-identical chunk output — diagnostics addition must not change chunks
+# ---------------------------------------------------------------------------
+
+def test_chunks_unchanged_by_diagnostics_addition():
+    docs = [
+        _make_doc("D1", [_section("§1 개요", "내용 가"), _section("§2 조건", "내용 나")]),
+    ]
+    chunks, parent_sections, diag = build_chunk_records(docs, chunking_strategy="auto")
+
+    # Rate field exists
+    assert "section_detection_rate" in diag
+
+    # Chunk fields that must be preserved
+    for chunk in chunks:
+        assert "chunk_id" in chunk
+        assert "text" in chunk
+        assert "chunking_strategy" in chunk
+
+    # The strategy tag on each chunk is "section" for this doc
+    assert all(c["chunking_strategy"] == "section" for c in chunks)
+
+
+def test_fixed_strategy_rate_is_none():
+    # Explicit "fixed" strategy bypasses auto detection; rate is still computed
+    # (all docs resolve to "fixed"), so rate should be 0.0 (0 section / N docs).
+    docs = [
+        _make_doc("D1", [_section("§1 입찰 조건", "내용 A")]),
+    ]
+    _, _, diag = build_chunk_records(docs, chunking_strategy="fixed")
+    # "fixed" strategy bypasses document_has_section_structure — all go to fixed
+    assert diag["section_detection_rate"] == 0.0


### PR DESCRIPTION
## Summary

Closes #664

`rag_core.py` 의 `build_chunk_records()` 가 `actual_strategy_counts: {section, fixed}` 는 이미 계산하지만 단일 비율은 노출 안 함. 이 PR 은 diagnostics dict 에 `section_detection_rate` (float 0–1, 빈 입력 시 `None`) 추가, `scripts/build_index.py` 가 각 인덱스 빌드 후 print.

## Changes

| File | Change |
|---|---|
| `rag_core.py` | `build_chunk_records()` 에 +5 — `section_detection_rate` 계산 및 diagnostics dict 추가 |
| `scripts/build_index.py` | +2 — `payload["build"]["chunking"]["section_detection_rate"]` 읽어 INFO 레벨 print |
| `tests/test_section_detection_stats_regression.py` | 신규 — 회귀 6 케이스 |

## Test Results

```
6 passed in 0.05s  (신규 테스트)
15 passed in 0.32s (test_chunk_metrics_regression + test_chunking_ablation — 무변경)
```

## PR Template Checklist

1. **Issue reference**: Closes #664
2. **Branch convention**: `feat/issue-664-section-detection-stats` ✓
3. **Load-bearing change**: `rag_core.py` + `scripts/build_index.py` 는 load-bearing
4. **Behavior change**: Diagnostics dict 에 키 1개 추가. Chunk content/ID/순서 bit-identical
5a. **Synthetic eval delta**: N/A — 검색/verifier/답변 경로 무변경. `make smoke` 통과

### 5b. Real-data delta
No behavior change in retrieval / verifier path. `build_chunk_records` 는 동일 청크 반환 (동일 bytes, IDs, 순서) — diagnostics dict 만 신규 `section_detection_rate` 키 획득. 검색, verifier, 답변 경로는 diagnostics 소비 안 함. `naive_baseline` row 에 zero delta 예상.

6. **ADR required**: 아니오 — diagnostics 추가, 아키텍처 결정 무관
7. **Backward compatibility**: Additive only — `section_detection_rate` 미사용 기존 호출자 영향 없음

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
