### PR TITLE
feat(react): ReAct orchestrator + LLMPlanner + agent_react preset (closes #673)

### DIFF
--- a/docs/adr/0040-react-agent-loop-additive-preset.md
+++ b/docs/adr/0040-react-agent-loop-additive-preset.md
@@ -1,0 +1,117 @@
+# 0040: ReAct agent loop as additive pipeline preset
+
+- **Status**: accepted
+- **Date**: 2026-05-14
+- **Deciders**: hskim
+- **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) (naive_baseline invariant),
+  [ADR 0011](./0011-llm-synthesis-as-additive-ablation.md) (additive opt-in pattern),
+  [ADR 0020](./0020-protocol-based-pluggability.md) (4-axis pluggability),
+  [ADR 0022](./0022-langgraph-orchestration-stage-1.md) (LangGraph integration),
+  [ADR 0023](./0023-hyde-query-expansion-ablation.md) (query expansion pattern),
+  [ADR 0024](./0024-agentic-full-llm-as-api-default.md) (3-layer default policy),
+  [ADR 0041](./0041-agent-budget-cap-contract.md) (budget cap),
+  issue #673
+
+## Context
+
+Phase 1 audit (2026-05-14) found that BidMate-DocAgent is at stage (B)
+"agentic RAG" — LangGraph orchestration and bounded verifier retry exist,
+but `make_plan` is a deterministic static function and there is no
+query-time LLM-driven action selection (ReAct pattern).
+
+The project name "DocAgent" implies autonomous evidence-retrieval agency.
+To close the gap between the name and the implementation, and to produce
+a senior-engineering portfolio signal (trade-off documentation +
+extensible architecture + evaluation discipline), a ReAct agent loop is
+introduced as an **additive** fourth pipeline preset.
+
+External reviewer critique (ADR 0024 context) and the senior-positioning
+rubric (docs/senior-positioning.md) both flag "when would you upgrade to
+a real agent?" as a key signal question — this ADR is the documented
+answer.
+
+## Decision
+
+Introduce `agent_react` as the fourth `PIPELINE_PRESETS` entry
+(`rag_pipeline_presets.py`), alias `"react"`, and a parallel
+`rag_graph_react.py` LangGraph module alongside `rag_graph_agentic_full.py`.
+
+**Three invariants from earlier ADRs are preserved unchanged:**
+
+1. **ADR 0001**: `naive_baseline` golden is bit-identical.
+   `_skip_graph=True` and direct-path guard (`pipeline != "naive_baseline"`)
+   remain; `agent_react` adds a new branch before the `BIDMATE_ORCHESTRATOR`
+   check, not inside it.
+
+2. **ADR 0003**: answer dict contract (`schema_version: 2`) is unchanged.
+   `_phase_build_answer` is reused; `react_loop` only populates
+   `ctx.evidence` and `ctx.plan` — it does not produce the answer.
+
+3. **ADR 0024 3-layer default policy**:
+   - CLI default stays `naive_baseline`.
+   - Function default stays `agentic_full`.
+   - API surface default stays `agentic_full_llm`.
+   `agent_react` is opt-in only (explicit `pipeline="agent_react"` or
+   alias `"react"`).
+
+**`Planner` Protocol (ADR 0020 extension):**
+`rag_planner.Planner` is the fifth Protocol-based pluggable axis, joining
+`VectorStore`, `QueryExpander`, `Reranker`, and the future `Synthesizer`.
+`StaticPlanner` delegates to `make_plan` (deterministic default).
+`LLMPlanner` activates via `BIDMATE_PLANNER_BACKEND=anthropic`.
+
+**CI contract:**
+`BIDMATE_PLANNER_BACKEND=static` (default) keeps every `agent_react`
+test deterministic — no Anthropic API calls in CI.
+
+## Consequences
+
+### Positive
+
+- "DocAgent" name is now backed by a genuine ReAct agent loop.
+- ADR 0020 4-axis pluggability is extended to 5-axis (Planner).
+- The `agent_react` preset produces an independent eval row that can
+  be compared against `agentic_full` side-by-side.
+- `BIDMATE_PLANNER_BACKEND` env-var pattern is consistent with ADR 0011
+  and ADR 0023 opt-in conventions.
+
+### Negative / Trade-offs
+
+- **Non-determinism when `BIDMATE_PLANNER_BACKEND=anthropic`**: LLM
+  sampling introduces variance. Mitigated by `temperature=0.0` and
+  ADR 0041 budget cap; real-eval n=100 ±2pp tolerance is the acceptance
+  criterion.
+- **Latency increase**: multi-turn LLM planning adds p95 latency.
+  ADR 0041 enforces `max_iterations=5` / `max_latency_ms=8000` caps.
+- **Cost**: each planning turn is a billable API call. Mitigated by
+  `cache_control: ephemeral` on tool definitions and ADR 0015 cost
+  telemetry.
+- **Attack surface**: tool_use results could carry injected instructions.
+  Mitigated by ADR 0042 evidence-boundary defense (PR-E).
+
+## Alternatives considered
+
+1. **Rewrite `_phase_retrieve_loop` as a ReAct loop**: rejected. Would
+   modify a load-bearing path (ADR 0001 risk) and break the JSON-identity
+   regression in `tests/test_langgraph_orchestrator_regression.py`.
+
+2. **Use a separate agent framework (CrewAI, AutoGen)**: rejected. Adds
+   a new paid/maintained dependency, breaks the LangGraph investment
+   (ADR 0022), and is disproportionate for a single-pipeline preset.
+
+3. **Full multi-agent system (planner + retriever + verifier agents)**:
+   deferred. Requires multi-document streaming, inter-agent state
+   synchronization, and a new eval surface — better scoped as a
+   follow-up milestone once `agent_react` proves the single-agent loop.
+
+## Upgrade path
+
+`agent_react` is the "when would you upgrade?" answer.  The upgrade
+conditions from `agentic_full`:
+- External reviewer confirms p95 latency ≤ budget cap on real eval.
+- Cost telemetry shows per-query cost is within operator budget.
+- `agent_react` beats `agentic_full` on the LLM-judge recall@20 metric
+  by ≥ 2pp on the public synthetic slice (ADR 0012 eval surface).
+
+Until all three conditions are met, `agentic_full` remains the function-
+level default (ADR 0024).

--- a/docs/adr/0041-agent-budget-cap-contract.md
+++ b/docs/adr/0041-agent-budget-cap-contract.md
@@ -1,0 +1,95 @@
+# 0041: Agent budget cap contract
+
+- **Status**: accepted
+- **Date**: 2026-05-14
+- **Deciders**: hskim
+- **Related**: [ADR 0040](./0040-react-agent-loop-additive-preset.md) (ReAct preset),
+  [ADR 0003](./0003-structured-answer-citation-contract.md) (answer contract),
+  [ADR 0015](./0015-cost-model-telemetry.md) (cost telemetry),
+  issue #673
+
+## Context
+
+The `react_loop` node introduced in ADR 0040 iterates until evidence
+is grounded or the planner calls `abstain`.  Without an explicit cap,
+a pathological query could trigger unbounded LLM calls, causing latency
+spikes, runaway API cost, and non-deterministic CI behavior.
+
+Three independent budget axes need explicit contracts:
+- **Iteration count** — LLM planning turns per query.
+- **Latency** — wall-clock time the loop may consume.
+- **Tokens** — not enforced by the loop but exposed in telemetry for
+  cost attribution (ADR 0015).
+
+## Decision
+
+The `react_loop` node enforces a **two-axis hard cap** and a
+**one-axis soft telemetry** contract:
+
+### Hard caps (enforced by `react_loop`)
+
+| Parameter | Env var | Default | Enforcement |
+|---|---|---|---|
+| `max_iterations` | `BIDMATE_PLANNER_MAX_ITERATIONS` | 5 | Loop exits after N calls to `plan_next` |
+| `max_latency_ms` | `BIDMATE_PLANNER_MAX_LATENCY_MS` | 8000 | Checked at start of each iteration; exits if elapsed ≥ cap |
+
+When either cap is reached:
+- The loop sets `ctx.evidence` to whatever was retrieved in the last
+  successful `retrieve_evidence` call (may be empty).
+- `_phase_build_answer` emits `status: insufficient` + `reason: agent_budget_exceeded`
+  if `ctx.evidence` is empty, consistent with ADR 0003 abstention.
+- `stage_attempts` records the cap-exit event for telemetry.
+
+### Soft telemetry (not enforced)
+
+`input_tokens` / `output_tokens` are recorded in each `planner_meta`
+dict inside `stage_attempts`.  ADR 0015 cost telemetry aggregates these
+per-query.  A per-query token cap is deferred until cost telemetry
+confirms the distribution on real queries.
+
+### Budget dict passed to `Planner.plan_next`
+
+```python
+budget = {
+    "iterations_left": max_iterations - iteration,  # int
+    "ms_left": max(0.0, max_latency_ms - elapsed_ms),  # float
+}
+```
+
+`LLMPlanner` surfaces this in the user prompt so the LLM can self-
+regulate (prefer `abstain` when `iterations_left == 1`).
+
+### Non-determinism tolerance
+
+When `BIDMATE_PLANNER_BACKEND=anthropic` and `temperature=0.0`:
+- Real-eval n=100 score variance ≤ ±2 percentage points is the
+  acceptance criterion for `agent_react` (vs. `agentic_full` baseline).
+- Variance above ±2pp triggers a forced `temperature=0.0` check and
+  seed-pinning investigation before the preset is promoted to
+  function-level default.
+
+## Consequences
+
+### Positive
+
+- Budget cap guarantees bounded latency (p95 ≤ `max_latency_ms` + one
+  planning turn overhead) and bounded cost per query.
+- Caps are env-var configurable — operators can tune for their latency /
+  cost target without code changes.
+- `BIDMATE_PLANNER_BACKEND=static` (default) makes `max_iterations`
+  effectively a retrieval retry count, not an LLM call count — CI is
+  always LLM-free.
+
+### Negative / Trade-offs
+
+- Hard cap means the loop may exit before full grounding. Accepted:
+  ADR 0003 abstention (`status: insufficient`) is a valid first-class
+  answer, not an error.
+- Different operators may want different defaults — deferred to a
+  per-tenant config surface as a follow-up.
+
+## Rollback
+
+Remove `agent_react` from `eval/config.yaml` and `PIPELINE_PRESETS`.
+`react_loop` is never reached for other presets; cap enforcement code
+is contained in `rag_graph_react._react_loop_node`.

--- a/rag_core.py
+++ b/rag_core.py
@@ -1570,6 +1570,37 @@ def run_rag_query(
     params: QueryParams | None = None,
     _skip_graph: bool = False,
 ) -> dict[str, Any]:
+    # ADR 0040 — agent_react preset dispatches to the ReAct orchestrator
+    # unconditionally (pipeline-name routing takes priority over
+    # BIDMATE_ORCHESTRATOR so the ReAct loop is always used when requested,
+    # regardless of the env var). naive_baseline stays on the direct path
+    # (ADR 0001); BIDMATE_PLANNER_BACKEND controls the planner backend.
+    _requested_pipeline = str(
+        (params.pipeline if params else None) or pipeline or ""
+    )
+    if not _skip_graph and _requested_pipeline in ("agent_react", "react"):
+        from rag_graph_react import run_via_langgraph_react
+
+        return run_via_langgraph_react(
+            index,
+            query,
+            top_k=top_k,
+            context_entities=context_entities,
+            metadata_first=metadata_first,
+            rerank=rerank,
+            verifier_retry=verifier_retry,
+            retrieval_mode=retrieval_mode,
+            retrieval_backend=retrieval_backend,
+            pipeline=_requested_pipeline,
+            prompt_profile=prompt_profile,
+            conversation_state=conversation_state,
+            comparison_balance=comparison_balance,
+            rrf_k=rrf_k,
+            bm25_stopword_profile=bm25_stopword_profile,
+            bm25_tokenizer=bm25_tokenizer,
+            params=params,
+        )
+
     # ADR 0022 — opt-in LangGraph orchestrator dispatch.
     # ``BIDMATE_ORCHESTRATOR=langgraph`` (default ``direct``) routes
     # through :func:`rag_graph_agentic_full.run_via_langgraph` which

--- a/rag_graph_react.py
+++ b/rag_graph_react.py
@@ -1,0 +1,312 @@
+"""LangGraph orchestrator for the agent_react preset — ReAct loop (#673).
+
+ADR 0040 adds a fourth LangGraph node ``react_loop`` that runs between
+``analyze`` and ``build_answer``.  When ``pipeline == "agent_react"``
+the router in ``rag_core.run_rag_query`` calls
+:func:`run_via_langgraph_react` instead of the standard direct or
+``agentic_full`` paths.
+
+Graph shape::
+
+    START → analyze → [react_loop | retrieve_loop | end] → build_answer → END
+
+* ``analyze`` — same node as ``rag_graph_agentic_full`` (calls
+  ``rag_core._phase_analyze``).
+* ``react_loop`` — NEW: runs the ``Planner.plan_next`` → executor →
+  verifier cycle until evidence is grounded or the ADR 0041 budget cap
+  is reached, then mutates ``ctx.evidence`` / ``ctx.plan`` so
+  ``build_answer`` can read them.
+* ``retrieve_loop`` — re-used from ``rag_graph_agentic_full`` as fallback
+  when ``BIDMATE_PLANNER_BACKEND=static`` with ``analyze`` early-exit.
+* ``build_answer`` — same node as ``rag_graph_agentic_full``.
+
+Budget cap (ADR 0041):
+  ``max_iterations`` (env ``BIDMATE_PLANNER_MAX_ITERATIONS``, default 5),
+  ``max_latency_ms`` (env ``BIDMATE_PLANNER_MAX_LATENCY_MS``, default 8000).
+  When the cap is reached the loop sets ``ctx.evidence`` to whatever was
+  retrieved and ``build_answer`` emits ``status: insufficient`` via the
+  existing ADR 0003 abstention path.
+
+LangGraph is an opt-in dependency (``requirements-graph.txt``).
+``BIDMATE_ORCHESTRATOR`` does not need to be set for ``agent_react`` —
+``rag_core`` dispatches directly on pipeline name.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, TypedDict
+
+from rag_planner import (
+    DEFAULT_MAX_ITERATIONS,
+    DEFAULT_MAX_LATENCY_MS,
+    ENV_PLANNER_MAX_ITERATIONS,
+    ENV_PLANNER_MAX_LATENCY_MS,
+    default_planner,
+)
+
+
+class ReactState(TypedDict, total=False):
+    """LangGraph state for the agent_react multi-node graph.
+
+    ``ctx`` is a mutable :class:`rag_core._RunContext` threaded through
+    every node exactly as in ``rag_graph_agentic_full.AgenticFullState``.
+    ``result`` is set by ``analyze`` on early-exit or by ``build_answer``.
+    """
+
+    ctx: Any
+    result: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Shared nodes (delegate to same phase functions as agentic_full)
+# ---------------------------------------------------------------------------
+
+
+def _analyze_node(state: ReactState) -> ReactState:
+    from rag_core import _phase_analyze
+
+    early_result = _phase_analyze(state["ctx"])
+    if early_result is not None:
+        return {"result": early_result}
+    return {}
+
+
+def _build_answer_node(state: ReactState) -> ReactState:
+    from rag_core import _phase_build_answer
+
+    result = _phase_build_answer(state["ctx"])
+    return {"result": result}
+
+
+# ---------------------------------------------------------------------------
+# react_loop node
+# ---------------------------------------------------------------------------
+
+
+def _react_loop_node(state: ReactState) -> ReactState:
+    """Run the ReAct planning loop and populate ctx.evidence / ctx.plan.
+
+    Calls ``Planner.plan_next`` in a loop.  Each iteration dispatches the
+    chosen tool via ``rag_agent_tools.execute_*``, appends to history,
+    and checks budget.  Loop exits when the planner selects ``abstain``
+    or when the ADR 0041 cap is hit; ``ctx.evidence`` and ``ctx.plan``
+    are set so ``_phase_build_answer`` can read them.
+    """
+    from rag_agent_tools import (
+        execute_abstain,
+        execute_expand_query_hyde,
+        execute_retrieve_evidence,
+        execute_verify_grounding,
+    )
+    from rag_verifier import verification_topics
+
+    ctx = state["ctx"]
+    analysis = ctx.analysis or {}
+
+    max_iterations = int(
+        os.environ.get(ENV_PLANNER_MAX_ITERATIONS, DEFAULT_MAX_ITERATIONS)
+    )
+    max_latency_ms = float(
+        os.environ.get(ENV_PLANNER_MAX_LATENCY_MS, DEFAULT_MAX_LATENCY_MS)
+    )
+
+    # Build preset_kwargs from ctx so StaticPlanner / LLMPlanner produce
+    # a plan consistent with the preset configuration.
+    preset_kwargs: dict[str, Any] = {
+        "rerank": ctx.rerank,
+        "metadata_first": ctx.metadata_first,
+        "verifier_retry": ctx.verifier_retry,
+        "retrieval_mode": ctx.retrieval_mode,
+        "retrieval_backend": ctx.retrieval_backend,
+        "rrf_k": ctx.rrf_k,
+        "bm25_stopword_profile": ctx.bm25_stopword_profile,
+        "bm25_tokenizer": ctx.bm25_tokenizer,
+        "pipeline": ctx.pipeline_name,
+        "prompt_profile": ctx.prompt_profile,
+    }
+    planner = default_planner(preset_kwargs=preset_kwargs)
+
+    history: list[dict[str, Any]] = []
+    loop_started = time.perf_counter()
+    topics = verification_topics(analysis)
+    evidence: list[dict[str, Any]] = []
+    last_plan: dict[str, Any] = {}
+
+    for iteration in range(max_iterations):
+        elapsed_ms = (time.perf_counter() - loop_started) * 1000.0
+        if elapsed_ms >= max_latency_ms:
+            history.append(
+                {
+                    "iteration": iteration,
+                    "tool": "budget_exhausted",
+                    "reason": f"max_latency_ms={max_latency_ms} exceeded",
+                }
+            )
+            break
+
+        budget: dict[str, Any] = {
+            "iterations_left": max_iterations - iteration,
+            "ms_left": max(0.0, max_latency_ms - elapsed_ms),
+        }
+
+        next_action, planner_meta = planner.plan_next(
+            analysis=analysis,
+            history=history,
+            budget=budget,
+        )
+
+        tool = next_action.get("tool", "abstain")
+        tool_input = next_action.get("args", {})
+
+        attempt: dict[str, Any] = {
+            "iteration": iteration,
+            "tool": tool,
+            "planner_meta": planner_meta,
+        }
+
+        if tool == "retrieve_evidence":
+            tool_result = execute_retrieve_evidence(
+                tool_input,
+                index=ctx.index,
+                analysis=analysis,
+                plan_kwargs=preset_kwargs,
+            )
+            new_chunks = tool_result.get("chunks") or []
+            evidence = new_chunks  # replace (not extend) for clean grounding
+            last_plan = tool_input.get("args", tool_input)
+            attempt["result"] = {
+                "chunk_count": len(new_chunks),
+                "meta": tool_result.get("meta", {}),
+            }
+
+        elif tool == "expand_query_hyde":
+            tool_result = execute_expand_query_hyde(tool_input, plan=last_plan)
+            expanded_query = tool_result.get("expanded_query", ctx.retrieval_query)
+            ctx.retrieval_query = expanded_query
+            attempt["result"] = {
+                "expanded_query": expanded_query,
+                "meta": tool_result.get("meta", {}),
+            }
+
+        elif tool == "verify_grounding":
+            chunk_ids = [str(c.get("chunk_id", "")) for c in evidence]
+            tool_result = execute_verify_grounding(
+                {"evidence_ids": chunk_ids},
+                query=ctx.query,
+                topics=topics,
+                evidence_pool=evidence,
+                plan=last_plan,
+            )
+            attempt["result"] = tool_result
+            if tool_result.get("verdict") == "grounded":
+                history.append(attempt)
+                break  # Grounded — exit loop
+
+        elif tool == "abstain":
+            execute_abstain(tool_input)
+            attempt["result"] = {"reason": tool_input.get("reason", "agent_abstain")}
+            history.append(attempt)
+            evidence = []
+            break
+
+        else:
+            attempt["result"] = {"error": f"unknown tool: {tool}"}
+
+        history.append(attempt)
+
+    # Populate ctx so build_answer can consume without modification.
+    ctx.evidence = evidence if evidence else []
+    ctx.plan = last_plan
+    # Expose react_loop history as a stage attempt so telemetry captures it.
+    ctx.stage_attempts = history
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+def _route_after_analyze(state: ReactState) -> str:
+    """Route to react_loop normally; short-circuit to end on early analyze exit."""
+    return "end" if state.get("result") is not None else "react_loop"
+
+
+# ---------------------------------------------------------------------------
+# Graph construction (process-cached)
+# ---------------------------------------------------------------------------
+
+
+def _build_react_graph() -> Any:
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(ReactState)
+    builder.add_node("analyze", _analyze_node)
+    builder.add_node("react_loop", _react_loop_node)
+    builder.add_node("build_answer", _build_answer_node)
+    builder.add_edge(START, "analyze")
+    builder.add_conditional_edges(
+        "analyze",
+        _route_after_analyze,
+        {"end": END, "react_loop": "react_loop"},
+    )
+    builder.add_edge("react_loop", "build_answer")
+    builder.add_edge("build_answer", END)
+    return builder.compile()
+
+
+_REACT_GRAPH_CACHE: Any = None
+
+
+def _react_graph() -> Any:
+    global _REACT_GRAPH_CACHE
+    if _REACT_GRAPH_CACHE is None:
+        _REACT_GRAPH_CACHE = _build_react_graph()
+    return _REACT_GRAPH_CACHE
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_via_langgraph_react(
+    index: dict[str, Any],
+    query: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Entry point with the same return shape as :func:`rag_core.run_rag_query`.
+
+    Called by ``rag_core.run_rag_query`` when ``pipeline == "agent_react"``.
+    Builds a :class:`rag_core._RunContext`, feeds it into the react graph,
+    and returns the assembled answer dict.
+
+    Raises:
+        ModuleNotFoundError: if ``langgraph`` is not installed.
+    """
+    from rag_core import _build_run_context
+
+    ctx = _build_run_context(
+        index,
+        query,
+        top_k=kwargs.get("top_k"),
+        context_entities=kwargs.get("context_entities"),
+        metadata_first=kwargs.get("metadata_first"),
+        rerank=kwargs.get("rerank"),
+        verifier_retry=kwargs.get("verifier_retry"),
+        retrieval_mode=kwargs.get("retrieval_mode"),
+        retrieval_backend=kwargs.get("retrieval_backend"),
+        pipeline=kwargs.get("pipeline"),
+        prompt_profile=kwargs.get("prompt_profile"),
+        conversation_state=kwargs.get("conversation_state"),
+        comparison_balance=kwargs.get("comparison_balance"),
+        rrf_k=kwargs.get("rrf_k"),
+        bm25_stopword_profile=kwargs.get("bm25_stopword_profile"),
+        bm25_tokenizer=kwargs.get("bm25_tokenizer"),
+        params=kwargs.get("params"),
+    )
+
+    state: ReactState = {"ctx": ctx}
+    result_state = _react_graph().invoke(state)
+    return result_state["result"]

--- a/rag_pipeline_presets.py
+++ b/rag_pipeline_presets.py
@@ -68,6 +68,13 @@ PIPELINE_CONFIG_KEYS = (
     # the dense-embedding target). See ``rag_query_expansion.py`` and
     # ADR 0023.
     "query_expansion",
+    # Issue #673 / ADR 0040 — planner backend discriminator for the
+    # agent_react preset.  "static" (default) delegates to
+    # ``rag_query.make_plan`` — deterministic, no LLM call, CI-safe.
+    # "anthropic" activates ``LLMPlanner`` via the Anthropic SDK.
+    # Mirrors the ``BIDMATE_QUERY_EXPANSION_BACKEND`` / ``BIDMATE_SYNTHESIS_BACKEND``
+    # env-var opt-in pattern (ADR 0011, ADR 0023).
+    "planner_backend",
 )
 
 DEFAULT_COMPARISON_BALANCE: dict[str, Any] = {
@@ -144,9 +151,47 @@ PIPELINE_PRESETS: dict[str, dict[str, Any]] = {
         "comparison_balance": dict(DEFAULT_COMPARISON_BALANCE),
         "description": "agentic_full retrieval; LLM-synthesized summary under ADR 0011 guard.",
     },
+    # ADR 0040 — additive ReAct agent loop preset.  Same retrieval/verifier
+    # stack as agentic_full; planner_backend controls the orchestration
+    # implementation (ADR 0041 budget cap contract).
+    # BIDMATE_PLANNER_BACKEND=static (default) → deterministic CI path.
+    # BIDMATE_PLANNER_BACKEND=anthropic → LLMPlanner multi-turn planning.
+    "agent_react": {
+        "top_k": None,
+        "metadata_first": True,
+        "rerank": True,
+        "rerank_cross_encoder": False,
+        "verifier_retry": True,
+        "retrieval_mode": "flat",
+        "retrieval_backend": "dense",
+        "prompt_profile": "structured_grounded_claims",
+        "rrf_k": RRF_K,
+        "bm25_stopword_profile": "shared",
+        # ADR 0031 invariant — keep regex so the agent_react eval row
+        # does not conflate tokenizer change with agent-loop effect.
+        "bm25_tokenizer": "regex",
+        # ADR 0023 — identity default preserves retrievals comparability
+        # with agentic_full baseline (agent adds planning, not expansion).
+        "query_expansion": "identity",
+        # ADR 0040 / ADR 0041 — "static" is CI-safe (no LLM call).
+        # Set BIDMATE_PLANNER_BACKEND=anthropic for real agent runs.
+        "planner_backend": "static",
+        "comparison_balance": dict(DEFAULT_COMPARISON_BALANCE),
+        "description": (
+            "ReAct agent loop: LLMPlanner selects retrieval actions until "
+            "evidence is grounded or budget is exhausted (ADR 0040/0041). "
+            "BIDMATE_PLANNER_BACKEND=static (default, CI-safe) or "
+            "anthropic (opt-in, real LLM planning)."
+        ),
+    },
 }
 
-PIPELINE_ALIASES = {"full": "agentic_full", "full_llm": "agentic_full_llm"}
+PIPELINE_ALIASES = {
+    "full": "agentic_full",
+    "full_llm": "agentic_full_llm",
+    # ADR 0040 — short alias for the ReAct preset.
+    "react": "agent_react",
+}
 
 
 def is_pipeline_name(value: Any) -> bool:
@@ -206,6 +251,10 @@ VALID_BM25_TOKENIZERS = {"regex", "kiwi", "mecab", "khaiii"}
 # tolerates unknown values for runtime safety, but config-time
 # validation prefers an explicit allow-list.
 VALID_QUERY_EXPANSIONS = {"identity", "hyde"}
+# Issue #673 / ADR 0040 — pluggable Planner backend discriminator.
+# "static" (default) → StaticPlanner (make_plan, deterministic, no LLM).
+# "anthropic" → LLMPlanner (Anthropic SDK multi-turn, BIDMATE_PLANNER_BACKEND=anthropic).
+VALID_PLANNER_BACKENDS = {"static", "anthropic"}
 
 
 def resolve_pipeline_config(

--- a/rag_planner.py
+++ b/rag_planner.py
@@ -1,4 +1,4 @@
-"""Planner Protocol — pluggable next-action planning stage (#659).
+"""Planner Protocol — pluggable next-action planning stage (#659, #673).
 
 The ``Planner`` Protocol decouples the ReAct agent loop from the specific
 planning backend, so future strategies (LLM-based multi-turn planning,
@@ -29,8 +29,25 @@ loop is untouched.
 """
 from __future__ import annotations
 
+import json
+import os
 import time
 from typing import Any, Protocol, runtime_checkable
+
+# Env-var contract (mirrors rag_query_expansion.py / rag_synthesis.py).
+ENV_PLANNER_BACKEND = "BIDMATE_PLANNER_BACKEND"
+ENV_PLANNER_MODEL = "BIDMATE_PLANNER_MODEL"
+ENV_PLANNER_MAX_TOKENS = "BIDMATE_PLANNER_MAX_TOKENS"
+ENV_PLANNER_MAX_ITERATIONS = "BIDMATE_PLANNER_MAX_ITERATIONS"
+ENV_PLANNER_MAX_LATENCY_MS = "BIDMATE_PLANNER_MAX_LATENCY_MS"
+
+DEFAULT_PLANNER_BACKEND = "static"
+# Sonnet is the right cost/quality point for single-step planning decisions.
+DEFAULT_PLANNER_MODEL = "claude-sonnet-4-6"
+DEFAULT_PLANNER_MAX_TOKENS = 1024
+# ADR 0041 budget cap defaults
+DEFAULT_MAX_ITERATIONS = 5
+DEFAULT_MAX_LATENCY_MS = 8000
 
 _REQUIRED_META_KEYS = frozenset(
     {"backend", "model", "fell_back", "fallback_reason", "latency_ms"}
@@ -129,14 +146,123 @@ class StaticPlanner:
         return next_action, meta
 
 
-def default_planner(*, preset_kwargs: dict[str, Any] | None = None) -> Planner:
-    """The planner the agent loop uses unless a future plan-level override
-    is wired in.  Returns a fresh ``StaticPlanner`` instance so callers
-    can swap implementations in tests without module-level state.
+class LLMPlanner:
+    """Opt-in ``Planner`` — Anthropic SDK multi-turn planning (ADR 0040).
 
-    When ``LLMPlanner`` lands (PR-C), this function gains a
-    ``BIDMATE_PLANNER_BACKEND`` env-var read — identical to the
-    ``BIDMATE_QUERY_EXPANSION_BACKEND`` dispatch in
-    ``rag_query_expansion.py``.
+    On each ``plan_next`` call the LLM receives the current analysis,
+    prior attempt history, and remaining budget, then chooses the next
+    action from the registered tool set (``AGENT_REACT_TOOLS``).
+
+    Activation: set ``BIDMATE_PLANNER_BACKEND=anthropic``.  The default
+    is ``"static"`` so CI and smoke runs are LLM-free and deterministic.
+
+    Never-raise: every failure path (missing SDK, missing API key, parse
+    error, API error) falls back to ``StaticPlanner`` with
+    ``meta["fell_back"] = True``.  This preserves ADR 0003 answer
+    contract reachability — the agent loop always gets a valid action.
+
+    ADR 0041 budget cap: callers (react_loop node) are responsible for
+    passing ``budget`` with ``iterations_left``, ``tokens_left``, and
+    ``ms_left`` populated; ``LLMPlanner`` does not enforce caps itself
+    but reads them for the user prompt so the LLM can self-regulate.
     """
+
+    def __init__(
+        self,
+        *,
+        preset_kwargs: dict[str, Any] | None = None,
+        model: str | None = None,
+        max_tokens: int | None = None,
+    ) -> None:
+        self._preset_kwargs: dict[str, Any] = preset_kwargs or {}
+        self._model = model or os.environ.get(ENV_PLANNER_MODEL, DEFAULT_PLANNER_MODEL)
+        self._max_tokens = max_tokens or int(
+            os.environ.get(ENV_PLANNER_MAX_TOKENS, DEFAULT_PLANNER_MAX_TOKENS)
+        )
+        self._static_fallback = StaticPlanner(preset_kwargs=preset_kwargs)
+
+    def plan_next(
+        self,
+        *,
+        analysis: dict[str, Any],
+        history: list[dict[str, Any]],
+        budget: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        t0 = time.perf_counter()
+        try:
+            import anthropic  # type: ignore[import-not-found]
+            from rag_agent_tools import AGENT_REACT_SYSTEM_PROMPT, AGENT_REACT_TOOLS
+
+            client = anthropic.Anthropic()
+            user_content = (
+                f"Query analysis:\n{json.dumps(analysis, ensure_ascii=False, indent=2)}\n\n"
+                f"Previous attempts ({len(history)}):\n"
+                f"{json.dumps(history, ensure_ascii=False, indent=2)}\n\n"
+                f"Budget remaining: {json.dumps(budget, ensure_ascii=False)}\n\n"
+                "Select the next action to retrieve grounded evidence for the query."
+            )
+            response = client.messages.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                system=AGENT_REACT_SYSTEM_PROMPT,
+                tools=AGENT_REACT_TOOLS,
+                tool_choice={"type": "any"},
+                messages=[{"role": "user", "content": user_content}],
+            )
+            # Extract the first tool_use block.
+            tool_block = next(
+                (b for b in response.content if getattr(b, "type", None) == "tool_use"),
+                None,
+            )
+            if tool_block is None:
+                raise ValueError("LLM returned no tool_use block")
+            next_action: dict[str, Any] = {
+                "tool": tool_block.name,
+                "args": dict(tool_block.input or {}),
+            }
+            latency_ms = (time.perf_counter() - t0) * 1000.0
+            meta: dict[str, Any] = {
+                "backend": "anthropic",
+                "model": self._model,
+                "fell_back": False,
+                "fallback_reason": None,
+                "latency_ms": latency_ms,
+                "input_tokens": getattr(response.usage, "input_tokens", None),
+                "output_tokens": getattr(response.usage, "output_tokens", None),
+            }
+            return next_action, meta
+        except Exception as exc:
+            # Fall back to StaticPlanner — never-raise contract.
+            fallback_action, fallback_meta = self._static_fallback.plan_next(
+                analysis=analysis, history=history, budget=budget
+            )
+            latency_ms = (time.perf_counter() - t0) * 1000.0
+            fallback_meta.update(
+                {
+                    "backend": "anthropic_fallback",
+                    "fell_back": True,
+                    "fallback_reason": f"{type(exc).__name__}: {exc}",
+                    "latency_ms": latency_ms,
+                }
+            )
+            return fallback_action, fallback_meta
+
+
+def default_planner(*, preset_kwargs: dict[str, Any] | None = None) -> Planner:
+    """Factory for the planner the agent loop uses.
+
+    Dispatches on ``BIDMATE_PLANNER_BACKEND`` (mirrors
+    ``BIDMATE_QUERY_EXPANSION_BACKEND`` in ``rag_query_expansion.py``):
+
+    - ``"static"`` (default) → :class:`StaticPlanner` — deterministic,
+      no LLM call, CI-safe.
+    - ``"anthropic"`` → :class:`LLMPlanner` — Anthropic SDK multi-turn
+      planning (ADR 0040/0041).
+
+    Returns a fresh instance each call so test code can swap
+    implementations without module-level state side effects.
+    """
+    backend = os.environ.get(ENV_PLANNER_BACKEND, DEFAULT_PLANNER_BACKEND).strip().lower()
+    if backend == "anthropic":
+        return LLMPlanner(preset_kwargs=preset_kwargs)
     return StaticPlanner(preset_kwargs=preset_kwargs)

--- a/tests/test_agent_react_planner_regression.py
+++ b/tests/test_agent_react_planner_regression.py
@@ -1,0 +1,239 @@
+"""Regression tests for PR-C — ReAct orchestrator + LLMPlanner + agent_react preset (#673).
+
+Verifies:
+1. agent_react preset is registered in PIPELINE_PRESETS + alias "react".
+2. VALID_PLANNER_BACKENDS validation set.
+3. ADR 0024 3-layer default policy is unchanged.
+4. ADR 0001 naive_baseline default is unchanged.
+5. LLMPlanner falls back to StaticPlanner when SDK is absent (never-raise).
+6. default_planner() env-var dispatch.
+7. rag_graph_react module imports cleanly (no LangGraph call at import time).
+8. rag_core agent_react dispatch (unit-level, no real index).
+
+No real index, LLM, or network calls.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_pipeline_presets import (  # noqa: E402
+    DEFAULT_CLI_PIPELINE_NAME,
+    DEFAULT_RAG_PIPELINE_NAME,
+    PIPELINE_ALIASES,
+    PIPELINE_PRESETS,
+    VALID_PLANNER_BACKENDS,
+    canonical_pipeline_name,
+)
+from rag_planner import (  # noqa: E402
+    DEFAULT_PLANNER_BACKEND,
+    LLMPlanner,
+    StaticPlanner,
+    default_planner,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. agent_react preset registration
+# ---------------------------------------------------------------------------
+
+def test_agent_react_in_pipeline_presets():
+    assert "agent_react" in PIPELINE_PRESETS
+
+
+def test_react_alias_resolves_to_agent_react():
+    assert PIPELINE_ALIASES.get("react") == "agent_react"
+    assert canonical_pipeline_name("react") == "agent_react"
+
+
+def test_agent_react_preset_required_keys():
+    preset = PIPELINE_PRESETS["agent_react"]
+    required = {
+        "top_k", "metadata_first", "rerank", "verifier_retry",
+        "retrieval_mode", "retrieval_backend", "prompt_profile",
+        "rrf_k", "bm25_tokenizer", "query_expansion", "planner_backend",
+    }
+    missing = required - preset.keys()
+    assert not missing, f"agent_react preset missing keys: {missing}"
+
+
+def test_agent_react_planner_backend_default_is_static():
+    assert PIPELINE_PRESETS["agent_react"]["planner_backend"] == "static"
+
+
+# ---------------------------------------------------------------------------
+# 2. VALID_PLANNER_BACKENDS
+# ---------------------------------------------------------------------------
+
+def test_valid_planner_backends_contains_static_and_anthropic():
+    assert "static" in VALID_PLANNER_BACKENDS
+    assert "anthropic" in VALID_PLANNER_BACKENDS
+
+
+# ---------------------------------------------------------------------------
+# 3. ADR 0024 3-layer default policy is unchanged
+# ---------------------------------------------------------------------------
+
+def test_cli_default_unchanged():
+    assert DEFAULT_CLI_PIPELINE_NAME == "naive_baseline"
+
+
+def test_function_default_unchanged():
+    assert DEFAULT_RAG_PIPELINE_NAME == "agentic_full"
+
+
+def test_api_default_unchanged():
+    # api/main.py sets DEFAULT_API_PIPELINE = "agentic_full_llm" — verify
+    # that agent_react is NOT the API default (would violate ADR 0024).
+    sys.path.insert(0, str(ROOT / "api"))
+    try:
+        import importlib
+        api_main = importlib.import_module("main")
+        api_default = getattr(api_main, "DEFAULT_API_PIPELINE", None)
+        if api_default is not None:
+            assert api_default != "agent_react", (
+                "agent_react must not be the API surface default (ADR 0024)"
+            )
+    except (ImportError, ModuleNotFoundError):
+        pass  # api/main.py may not be importable in minimal envs
+
+
+# ---------------------------------------------------------------------------
+# 4. ADR 0001 — naive_baseline invariant unchanged
+# ---------------------------------------------------------------------------
+
+def test_naive_baseline_still_in_presets():
+    assert "naive_baseline" in PIPELINE_PRESETS
+
+
+def test_naive_baseline_query_expansion_is_identity():
+    assert PIPELINE_PRESETS["naive_baseline"]["query_expansion"] == "identity"
+
+
+def test_naive_baseline_has_no_planner_backend():
+    # naive_baseline does NOT set planner_backend — agent_react-only key.
+    assert "planner_backend" not in PIPELINE_PRESETS["naive_baseline"]
+
+
+# ---------------------------------------------------------------------------
+# 5. LLMPlanner falls back gracefully when anthropic SDK is absent
+# ---------------------------------------------------------------------------
+
+def _analysis() -> dict[str, Any]:
+    return {"query_type": "single_doc", "entities": [], "metadata_filters_by_stage": {}}
+
+
+def _budget() -> dict[str, Any]:
+    return {"iterations_left": 5, "ms_left": 8000.0}
+
+
+def test_llm_planner_fallback_when_sdk_missing():
+    with patch.dict("sys.modules", {"anthropic": None}):
+        planner = LLMPlanner()
+        next_action, meta = planner.plan_next(
+            analysis=_analysis(),
+            history=[],
+            budget=_budget(),
+        )
+    # Must not raise; fell_back tells us SDK was absent
+    assert isinstance(next_action, dict)
+    assert meta.get("fell_back") is True
+    assert meta.get("backend") in {"anthropic_fallback", "static"}
+
+
+def test_llm_planner_never_raises():
+    with patch.dict("sys.modules", {"anthropic": None}):
+        planner = LLMPlanner()
+        try:
+            next_action, meta = planner.plan_next(
+                analysis=_analysis(),
+                history=[],
+                budget=_budget(),
+            )
+        except Exception as exc:
+            raise AssertionError(f"LLMPlanner raised: {exc}") from exc
+    assert isinstance(next_action, dict)
+
+
+# ---------------------------------------------------------------------------
+# 6. default_planner() env-var dispatch
+# ---------------------------------------------------------------------------
+
+def test_default_planner_static_backend():
+    with patch.dict(os.environ, {"BIDMATE_PLANNER_BACKEND": "static"}):
+        planner = default_planner()
+    assert isinstance(planner, StaticPlanner)
+
+
+def test_default_planner_anthropic_backend():
+    with patch.dict(os.environ, {"BIDMATE_PLANNER_BACKEND": "anthropic"}):
+        planner = default_planner()
+    assert isinstance(planner, LLMPlanner)
+
+
+def test_default_planner_default_is_static():
+    env = {k: v for k, v in os.environ.items() if k != "BIDMATE_PLANNER_BACKEND"}
+    with patch.dict(os.environ, env, clear=True):
+        planner = default_planner()
+    assert isinstance(planner, StaticPlanner)
+
+
+# ---------------------------------------------------------------------------
+# 7. rag_graph_react imports cleanly (no LangGraph call at import time)
+# ---------------------------------------------------------------------------
+
+def test_rag_graph_react_import_side_effect_free():
+    """Importing rag_graph_react must not call LangGraph (no langgraph needed)."""
+    # Remove from sys.modules if already imported so we get a fresh import.
+    sys.modules.pop("rag_graph_react", None)
+    # Mock langgraph to confirm it is not called during import.
+    import types
+    mock_lg = types.ModuleType("langgraph")
+    mock_lg.graph = types.ModuleType("langgraph.graph")  # type: ignore[attr-defined]
+    with patch.dict("sys.modules", {"langgraph": mock_lg, "langgraph.graph": mock_lg.graph}):
+        import rag_graph_react  # noqa: F401
+    # If we get here without error, the import was side-effect-free.
+    assert True
+
+
+# ---------------------------------------------------------------------------
+# 8. rag_core dispatch for agent_react (unit-level)
+# ---------------------------------------------------------------------------
+
+def test_rag_core_dispatches_agent_react_to_graph():
+    """run_rag_query with pipeline="agent_react" must call run_via_langgraph_react.
+
+    rag_core does a lazy ``from rag_graph_react import run_via_langgraph_react``
+    inside run_rag_query, so we patch the function on the rag_graph_react module
+    (after ensuring it is loaded) rather than on rag_core.
+    """
+    import rag_core
+    import rag_graph_react  # ensure module is in sys.modules before patch
+
+    sentinel = {"status": "ok", "query": "test"}
+    with patch.object(rag_graph_react, "run_via_langgraph_react", return_value=sentinel) as mock_fn:
+        try:
+            rag_core.run_rag_query({}, "테스트 쿼리", pipeline="agent_react")
+        except Exception:
+            pass  # may fail after dispatch — we only check mock was called
+    assert mock_fn.called, "run_via_langgraph_react was not dispatched for agent_react"
+
+
+def test_rag_core_react_alias_dispatches():
+    """pipeline="react" alias also dispatches to run_via_langgraph_react."""
+    import rag_core
+    import rag_graph_react
+
+    with patch.object(rag_graph_react, "run_via_langgraph_react", return_value={"status": "ok"}) as mock_fn:
+        try:
+            rag_core.run_rag_query({}, "쿼리", pipeline="react")
+        except Exception:
+            pass
+    assert mock_fn.called, "react alias did not dispatch to run_via_langgraph_react"


### PR DESCRIPTION
## Summary

(B) agentic RAG → (A) real agent 전환의 핵심 PR. 5개 파일 변경 + ADR 2개:

- `rag_graph_react.py` **신규**: `react_loop` LangGraph 노드 — Planner → executor → verifier 반복 루프
- `rag_planner.py` **수정**: `LLMPlanner` 추가 (Anthropic SDK multi-turn, `BIDMATE_PLANNER_BACKEND=anthropic` opt-in), `default_planner()` env-var 분기
- `rag_pipeline_presets.py` **수정**: `agent_react` preset + `react` alias + `VALID_PLANNER_BACKENDS`
- `rag_core.py` **수정**: `agent_react` / `react` 분기 (28줄 — before langgraph gate)
- `docs/adr/0040-react-agent-loop-additive-preset.md` **신규**: ADR 0040 accepted
- `docs/adr/0041-agent-budget-cap-contract.md` **신규**: ADR 0041 accepted
- `tests/test_agent_react_planner_regression.py` **신규**: 19 테스트

## Invariants preserved

| ADR | Invariant | Verification |
|---|---|---|
| ADR 0001 | naive_baseline golden 무변경 | `DEFAULT_CLI_PIPELINE_NAME == "naive_baseline"` test ✓ |
| ADR 0003 | schema_version=2, answer dict | `_phase_build_answer` 무변경 재사용 ✓ |
| ADR 0024 | 3-layer 기본 정책 | CLI/function/API 기본 모두 테스트 ✓ |

## CI contract

`BIDMATE_PLANNER_BACKEND=static` (기본) → `StaticPlanner` → `make_plan` → 결정론적, LLM 호출 없음. 테스트: 19/19 passed.

## Test plan

- [x] `pytest tests/test_agent_react_planner_regression.py -v` → 19 passed
- [x] `pytest tests/test_planner_protocol_regression.py tests/test_agent_tools_regression.py -q` → 28 passed (PR-A + PR-B 무영향)

## PR template checklist

1. **Issue link**: Closes #673
2. **Branch**: `feat/issue-673-react-orchestrator` ✓
3. **One concern**: ReAct orchestrator (Planner + graph + preset + dispatch) ✓
4. **Behavior change ↔ test**: 신규 회귀 19 테스트 ✓
5. **Load-bearing files changed**: `rag_core.py`, `rag_pipeline_presets.py`
   - 5b (real-data delta): `BIDMATE_PLANNER_BACKEND=static` → 기존 경로와 동작 동일; `BIDMATE_PLANNER_BACKEND=anthropic` real-eval delta 는 PR-E (eval row) 로 보류
6. **ADR**: ADR 0040 + ADR 0041 이 PR 에서 accepted ✓
7. **Backward compatibility**: ADR 0024 3-layer 기본 보존; `agent_react` 는 opt-in only ✓

## Stack

PR-A (#660, merged) → PR-B (#672, merged) → **PR-C (this)** → PR-D (verifier feedback injection) → PR-E (eval row + ADR 0042)
