### PR TITLE
feat(judge): disagreement diagnostics — verifier↔judge mismatch dump (closes #677)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,10 @@ reports/external_baselines.local.json
 !reports/synthetic_judge.aggregate.json
 reports/synthetic_judge.local.json
 
+# issue #677 — disagreement diagnostics per-case dump stays local
+# (ADR 0005 boundary). Only the stdout aggregate is safe to commit.
+reports/judge_disagreements.local.json
+
 # ADR 0029 — real-data case proposer aggregate is committable;
 # per-case proposed/reviewed yaml stays local. Mirrors the
 # ADR 0005 / 0006 / 0012 split.

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Synthetic eval surface (public corpus). Includes smoke, full eval, harness
 # matrix, judges, leaderboard render, pareto, korean public bench, external
 # baselines.
-.PHONY: eval smoke smoke-with-judge reproduce benchmark synthetic-judge leaderboard pareto korean-public-fetch korean-public-eval external-baselines-stub external-baselines-langchain external-baselines-llamaindex external-baselines-ollama harness-smoke harness-ablation harness-compare synthesize-multihop eval-multihop
+.PHONY: eval smoke smoke-with-judge reproduce benchmark synthetic-judge judge-disagreements leaderboard pareto korean-public-fetch korean-public-eval external-baselines-stub external-baselines-langchain external-baselines-llamaindex external-baselines-ollama harness-smoke harness-ablation harness-compare synthesize-multihop eval-multihop
 
 # Real-data eval cycle (private; ADR 0005 commit boundary).
 .PHONY: real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
@@ -336,6 +336,14 @@ synthetic-judge:
 	  --summary reports/eval_summary.json \
 	  --aggregate reports/synthetic_judge.aggregate.json \
 	  --local reports/synthetic_judge.local.json
+
+## Dump verifier↔judge disagreement cases from the synthetic judge local file.
+## Requires reports/synthetic_judge.local.json (run make synthetic-judge first).
+## Output: reports/judge_disagreements.local.json (gitignored) + stdout aggregate.
+judge-disagreements:
+	$(PYTHON) scripts/dump_judge_disagreements.py \
+	  --local reports/synthetic_judge.local.json \
+	  --output reports/judge_disagreements.local.json
 
 # Append a history snapshot of the current eval_summary.json + render
 # the leaderboard markdown table and the docs/leaderboard.md Chart.js

--- a/scripts/dump_judge_disagreements.py
+++ b/scripts/dump_judge_disagreements.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Dump verifier↔judge disagreement cases from a synthetic judge local file.
+
+Reads ``reports/synthetic_judge.local.json`` (gitignored, per-case verdicts
+produced by ``make synthetic-judge`` with a live backend), filters for cases
+where ``judge_status != verifier_status``, and writes two outputs:
+
+* ``reports/judge_disagreements.local.json`` (gitignored, ADR 0005) — full
+  per-case disagreement payload including ``judge_reason_short``.
+* stdout — committable aggregate: count by ``query_type``, top-3 status-pair
+  patterns, and overall disagreement rate.
+
+**ADR 0005 compliance**: only the stdout aggregate is safe to commit (and even
+then, it reveals no per-case query/answer text).  The local file stays
+gitignored.  Attach the stdout aggregate to your PR description so reviewers
+can see the disagreement pattern without accessing private per-case data.
+
+Purpose
+-------
+The ``agreement_with_verifier`` metric in
+``reports/synthetic_judge.aggregate.json`` gives a single number.  That number
+doesn't tell you *which* cases disagreed or *why*.  This script surfaces the
+pattern so you can:
+
+1. Identify systematic verifier/judge mismatches (Goodhart-safe quality signal).
+2. Build the raw data for human-label calibration (ADR 0016 prerequisite).
+3. Use disagreements as a targeted eval set for prompt or pipeline iteration.
+
+Usage
+-----
+    # Requires reports/synthetic_judge.local.json (run make synthetic-judge first)
+    make judge-disagreements
+
+    # Or directly:
+    python scripts/dump_judge_disagreements.py \\
+        --local reports/synthetic_judge.local.json \\
+        --output reports/judge_disagreements.local.json
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+DEFAULT_LOCAL_PATH = ROOT / "reports" / "synthetic_judge.local.json"
+DEFAULT_OUTPUT_PATH = ROOT / "reports" / "judge_disagreements.local.json"
+TOP_N_PATTERNS = 3
+
+
+# ---------------------------------------------------------------------------
+# Core analysis
+# ---------------------------------------------------------------------------
+
+
+def _disagreement_cases(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return cases where judge_status != verifier_status."""
+    return [
+        c for c in cases
+        if isinstance(c, dict)
+        and c.get("judge_status")
+        and c.get("verifier_status")
+        and c["judge_status"] != c["verifier_status"]
+    ]
+
+
+def _status_pair(case: dict[str, Any]) -> str:
+    """Return a human-readable status-pair label: 'verifier→judge'."""
+    return f"{case.get('verifier_status', '?')}→{case.get('judge_status', '?')}"
+
+
+def analyze_disagreements(
+    cases: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Analyse disagreement cases and return ``(disagreements, aggregate)``.
+
+    Args:
+        cases: Full ``cases`` list from ``synthetic_judge.local.json``.
+
+    Returns:
+        A tuple of:
+        - *disagreements*: list of disagreeing cases (never committed).
+        - *aggregate*: committable summary dict with ``n_total``,
+          ``n_disagree``, ``disagreement_rate``, ``by_query_type``,
+          ``top_status_pairs``.
+    """
+    total = len([c for c in cases if isinstance(c, dict) and c.get("judge_status")])
+    disagreements = _disagreement_cases(cases)
+
+    # Count by query_type
+    by_type: dict[str, int] = defaultdict(int)
+    pair_counter: Counter[str] = Counter()
+    for c in disagreements:
+        by_type[str(c.get("query_type") or "unknown")] += 1
+        pair_counter[_status_pair(c)] += 1
+
+    top_pairs = [
+        {"pair": pair, "count": count}
+        for pair, count in pair_counter.most_common(TOP_N_PATTERNS)
+    ]
+
+    aggregate: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "n_total": total,
+        "n_disagree": len(disagreements),
+        "disagreement_rate": (
+            round(len(disagreements) / total, 4) if total > 0 else None
+        ),
+        "by_query_type": dict(sorted(by_type.items())),
+        "top_status_pairs": top_pairs,
+    }
+    return disagreements, aggregate
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_local_payload(
+    disagreements: list[dict[str, Any]],
+    source_meta: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the gitignored per-case disagreement file payload."""
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "source_backend": source_meta.get("backend", "unknown"),
+        "source_model": source_meta.get("model", "unknown"),
+        "source_generated_at": source_meta.get("generated_at", "unknown"),
+        "cases": [
+            {
+                "id": c.get("id"),
+                "query_type": c.get("query_type"),
+                "verifier_status": c.get("verifier_status"),
+                "judge_status": c.get("judge_status"),
+                "judge_grounded": c.get("judge_grounded"),
+                "judge_reason_short": c.get("judge_reason_short", ""),
+                "faithfulness": c.get("faithfulness"),
+                "answer_relevance": c.get("answer_relevance"),
+            }
+            for c in disagreements
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--local",
+        default=str(DEFAULT_LOCAL_PATH),
+        help=(
+            "Path to reports/synthetic_judge.local.json "
+            "(gitignored per-case verdicts from make synthetic-judge)."
+        ),
+    )
+    ap.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_PATH),
+        help=(
+            "Where to write the per-case disagreement payload (gitignored). "
+            "Default: reports/judge_disagreements.local.json"
+        ),
+    )
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the aggregate JSON from stdout (useful in scripts).",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    local_path = Path(args.local)
+    if not local_path.exists():
+        print(
+            f"[ERROR] Local judge file not found: {local_path}\n"
+            "Run `make synthetic-judge` with a live backend first.\n"
+            "  export BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible\n"
+            "  make eval && make synthetic-judge",
+            file=sys.stderr,
+        )
+        return 2
+
+    local_data = json.loads(local_path.read_text(encoding="utf-8"))
+    cases = local_data.get("cases") or []
+    if not cases:
+        print("[WARN] No cases found in the local judge file.", file=sys.stderr)
+
+    disagreements, aggregate = analyze_disagreements(cases)
+
+    # Write gitignored local payload
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    local_payload = _build_local_payload(disagreements, local_data)
+    output_path.write_text(
+        json.dumps(local_payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"[OK] Disagreement cases written: {output_path}", file=sys.stderr)
+
+    if not args.quiet:
+        print(json.dumps(aggregate, ensure_ascii=False, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_judge_disagreements_regression.py
+++ b/tests/test_judge_disagreements_regression.py
@@ -1,0 +1,220 @@
+"""Regression tests for scripts/dump_judge_disagreements.py (closes #677).
+
+Guards the disagreement analysis logic:
+  - analyze_disagreements: correct filtering, aggregate shape
+  - Edge cases: all-agree, all-disagree, empty input
+  - ADR 0005: local payload fields (no raw query/answer text)
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.dump_judge_disagreements import (
+    analyze_disagreements,
+    main,
+)
+
+
+def _make_case(
+    *,
+    id_: str = "c1",
+    query_type: str = "single_doc",
+    verifier_status: str = "supported",
+    judge_status: str = "supported",
+    judge_reason_short: str = "ok",
+    faithfulness: float = 0.9,
+    answer_relevance: float = 0.85,
+) -> dict:
+    return {
+        "id": id_,
+        "query_type": query_type,
+        "verifier_status": verifier_status,
+        "judge_status": judge_status,
+        "judge_grounded": judge_status == "supported",
+        "judge_reason_short": judge_reason_short,
+        "faithfulness": faithfulness,
+        "answer_relevance": answer_relevance,
+    }
+
+
+class AnalyzeDisagreementsTest(unittest.TestCase):
+    """analyze_disagreements: filtering, aggregate shape, by_query_type."""
+
+    def test_agree_case_not_in_disagreements(self) -> None:
+        cases = [_make_case(verifier_status="supported", judge_status="supported")]
+        disagree, agg = analyze_disagreements(cases)
+        self.assertEqual([], disagree)
+        self.assertEqual(0, agg["n_disagree"])
+        self.assertEqual(1, agg["n_total"])
+
+    def test_disagree_case_included(self) -> None:
+        cases = [_make_case(verifier_status="supported", judge_status="partial")]
+        disagree, agg = analyze_disagreements(cases)
+        self.assertEqual(1, len(disagree))
+        self.assertEqual(1, agg["n_disagree"])
+
+    def test_disagreement_rate_correct(self) -> None:
+        cases = [
+            _make_case(id_="a", verifier_status="supported", judge_status="supported"),
+            _make_case(id_="b", verifier_status="supported", judge_status="partial"),
+        ]
+        _, agg = analyze_disagreements(cases)
+        self.assertAlmostEqual(0.5, agg["disagreement_rate"])
+
+    def test_all_agree_rate_zero(self) -> None:
+        cases = [
+            _make_case(id_=f"c{i}", verifier_status="supported", judge_status="supported")
+            for i in range(5)
+        ]
+        _, agg = analyze_disagreements(cases)
+        self.assertAlmostEqual(0.0, agg["disagreement_rate"])
+
+    def test_all_disagree_rate_one(self) -> None:
+        cases = [
+            _make_case(id_=f"c{i}", verifier_status="supported", judge_status="insufficient")
+            for i in range(4)
+        ]
+        _, agg = analyze_disagreements(cases)
+        self.assertAlmostEqual(1.0, agg["disagreement_rate"])
+
+    def test_empty_input(self) -> None:
+        disagree, agg = analyze_disagreements([])
+        self.assertEqual([], disagree)
+        self.assertEqual(0, agg["n_total"])
+        self.assertIsNone(agg["disagreement_rate"])
+
+    def test_non_dict_items_skipped(self) -> None:
+        cases = [None, "string", _make_case(verifier_status="supported", judge_status="partial")]
+        disagree, agg = analyze_disagreements(cases)
+        self.assertEqual(1, len(disagree))
+
+    def test_by_query_type_counts(self) -> None:
+        cases = [
+            _make_case(id_="a", query_type="comparison", verifier_status="supported", judge_status="partial"),
+            _make_case(id_="b", query_type="abstention", verifier_status="insufficient", judge_status="supported"),
+            _make_case(id_="c", query_type="comparison", verifier_status="partial", judge_status="insufficient"),
+        ]
+        _, agg = analyze_disagreements(cases)
+        self.assertEqual(2, agg["by_query_type"].get("comparison", 0))
+        self.assertEqual(1, agg["by_query_type"].get("abstention", 0))
+
+    def test_top_status_pairs_most_common_first(self) -> None:
+        cases = [
+            _make_case(id_=f"s{i}", verifier_status="supported", judge_status="partial")
+            for i in range(3)
+        ] + [
+            _make_case(id_="x", verifier_status="supported", judge_status="insufficient"),
+        ]
+        _, agg = analyze_disagreements(cases)
+        top = agg["top_status_pairs"]
+        # Most common pair should be first
+        self.assertEqual("supported→partial", top[0]["pair"])
+        self.assertEqual(3, top[0]["count"])
+
+    def test_top_status_pairs_at_most_top_n(self) -> None:
+        # Create 4 different pairs; top_status_pairs should cap at TOP_N_PATTERNS (3)
+        cases = [
+            _make_case(id_="a", verifier_status="supported", judge_status="partial"),
+            _make_case(id_="b", verifier_status="supported", judge_status="insufficient"),
+            _make_case(id_="c", verifier_status="partial", judge_status="insufficient"),
+            _make_case(id_="d", verifier_status="partial", judge_status="supported"),
+        ]
+        _, agg = analyze_disagreements(cases)
+        self.assertLessEqual(len(agg["top_status_pairs"]), 3)
+
+    def test_aggregate_has_required_keys(self) -> None:
+        _, agg = analyze_disagreements([])
+        for key in ("schema_version", "generated_at", "n_total", "n_disagree",
+                    "disagreement_rate", "by_query_type", "top_status_pairs"):
+            self.assertIn(key, agg, f"missing key: {key}")
+
+    def test_schema_version_is_one(self) -> None:
+        _, agg = analyze_disagreements([])
+        self.assertEqual(1, agg["schema_version"])
+
+    def test_missing_judge_status_case_skipped(self) -> None:
+        cases = [
+            {"id": "x", "verifier_status": "supported"},  # no judge_status
+            _make_case(id_="y", verifier_status="supported", judge_status="partial"),
+        ]
+        disagree, agg = analyze_disagreements(cases)
+        # Only the valid disagreement case should appear
+        self.assertEqual(1, len(disagree))
+
+
+class CommitBoundaryTest(unittest.TestCase):
+    """ADR 0005: local payload must not contain raw query / answer text."""
+
+    def test_local_payload_case_fields_safe(self) -> None:
+        # The _build_local_payload function should only include safe fields.
+        from scripts.dump_judge_disagreements import _build_local_payload
+
+        disagree_case = _make_case(
+            verifier_status="supported",
+            judge_status="partial",
+            judge_reason_short="reason here",
+        )
+        # Inject hypothetical query/answer (should NOT appear in output)
+        disagree_case["query"] = "SECRET QUERY"
+        disagree_case["answer"] = "SECRET ANSWER"
+        payload = _build_local_payload([disagree_case], {})
+        serialised = json.dumps(payload)
+        self.assertNotIn("SECRET QUERY", serialised)
+        self.assertNotIn("SECRET ANSWER", serialised)
+
+
+class CLITest(unittest.TestCase):
+    """CLI: exit codes, file I/O, missing input."""
+
+    def test_missing_local_file_returns_exit_2(self) -> None:
+        import sys
+        from io import StringIO
+        from unittest.mock import patch
+
+        with patch.object(sys, "argv", ["dump_judge_disagreements.py",
+                                         "--local", "/nonexistent/path.json"]):
+            with self.assertRaises(SystemExit) as ctx:
+                raise SystemExit(main())
+        self.assertEqual(2, ctx.exception.code)
+
+    def test_writes_output_file(self) -> None:
+        cases = [
+            _make_case(id_="a", verifier_status="supported", judge_status="partial"),
+            _make_case(id_="b", verifier_status="supported", judge_status="supported"),
+        ]
+        local_payload = {
+            "schema_version": 1,
+            "backend": "openai_compatible",
+            "model": "test-model",
+            "generated_at": "2026-01-01T00:00:00Z",
+            "cases": cases,
+        }
+        with TemporaryDirectory() as tmpdir:
+            local_file = Path(tmpdir) / "synthetic_judge.local.json"
+            output_file = Path(tmpdir) / "judge_disagreements.local.json"
+            local_file.write_text(json.dumps(local_payload), encoding="utf-8")
+
+            import sys
+            from unittest.mock import patch
+
+            with patch.object(sys, "argv", [
+                "dump_judge_disagreements.py",
+                "--local", str(local_file),
+                "--output", str(output_file),
+                "--quiet",
+            ]):
+                exit_code = main()
+
+            self.assertEqual(0, exit_code)
+            self.assertTrue(output_file.exists())
+            result = json.loads(output_file.read_text(encoding="utf-8"))
+            # Only disagree case in output
+            self.assertEqual(1, len(result["cases"]))
+            self.assertEqual("a", result["cases"][0]["id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stack**: PR #676 (judge_common extraction) → **이 PR**

## 1. 변경 요약

`agreement_with_verifier`가 집계 수치 하나로만 표현되어, 어떤 케이스에서
verifier(결정론적)와 LLM judge가 왜 불일치했는지 보이지 않습니다.

`make judge-disagreements`로 불일치 케이스를 추출해 PR description에 첨부하면:
- Goodhart 압력 방지 (점수 최적화 vs 실제 품질 개선 구분)
- ADR 0016 (proposed, human κ calibration) 자연스러운 전조 데이터 확보

## 2. 변경 파일

| 파일 | 종류 | load-bearing |
|------|------|-------------|
| `scripts/dump_judge_disagreements.py` | NEW | ❌ |
| `tests/test_judge_disagreements_regression.py` | NEW | ❌ |
| `Makefile` | M | target 추가만 |
| `.gitignore` | M | ADR 0005 명시적 규칙 추가 |

## 3. ADR 0005 compliance

- 출력 파일 `reports/judge_disagreements.local.json` → gitignored (per-case judge text 포함)
- stdout aggregate만 commit-safe (query/answer 텍스트 없음)
- `.gitignore`에 명시적 줄 추가

## 4. 사용법

```bash
# live backend로 judge 실행 후
make synthetic-judge    # reports/synthetic_judge.local.json 생성

# 불일치 케이스 dump
make judge-disagreements
# stdout 예시:
# {
#   "n_total": 42,
#   "n_disagree": 6,
#   "disagreement_rate": 0.1429,
#   "by_query_type": {"comparison": 3, "abstention": 2, "single_doc": 1},
#   "top_status_pairs": [
#     {"pair": "supported→partial", "count": 3},
#     ...
#   ]
# }
```

## 5. 테스트

16/16 PASSED — filtering, by_query_type, top-N pairs, commit boundary.

## 체크리스트

- [x] ADR 0005 per-case text gitignored
- [x] 16 regression tests
- [x] Makefile .PHONY 등록
- [x] PR-B (eval/judge_common) base 위에 stacked
- [x] ADR 0001/0003/0004 invariant 영향 없음

### 5b. Real-data delta

N/A — eval/rag_core 변경 없음.

Closes #677