### PR TITLE
feat(react): verifier feedback injection for ReAct self-correction (closes #679)

### DIFF
--- a/rag_graph_react.py
+++ b/rag_graph_react.py
@@ -202,6 +202,15 @@ def _react_loop_node(state: ReactState) -> ReactState:
             if tool_result.get("verdict") == "grounded":
                 history.append(attempt)
                 break  # Grounded — exit loop
+            else:
+                # Self-correction: inject verifier feedback so LLMPlanner
+                # can adjust retrieval in the next planning turn (PR-D, #679).
+                from rag_verifier import format_verifier_feedback
+
+                attempt["feedback_message"] = format_verifier_feedback(
+                    reasons=tool_result.get("reasons", []),
+                    evidence=evidence,
+                )
 
         elif tool == "abstain":
             execute_abstain(tool_input)

--- a/rag_verifier.py
+++ b/rag_verifier.py
@@ -261,3 +261,34 @@ def evidence_has_topic(item: dict[str, Any], topics: list[str]) -> bool:
         for topic in topics
         for form in expand_forms(topic.lower())
     )
+
+
+def format_verifier_feedback(
+    reasons: list[str],
+    evidence: list[dict[str, Any]],
+) -> str:
+    """Format verifier failure reasons into a coaching message for the next planning turn.
+
+    Called by ``rag_graph_react._react_loop_node`` after a ``verify_grounding``
+    tool call returns a non-grounded verdict.  The returned string is stored in
+    ``attempt["feedback_message"]`` in the history dict, so ``LLMPlanner`` can
+    read it in the next ``plan_next`` call and adjust retrieval parameters.
+
+    ``reasons`` are internal diagnostic strings produced by ``verify_evidence``,
+    not external evidence text, so ``neutralize_instruction_patterns`` is not
+    applied here.  If ``reasons`` is empty (unexpected) a generic fallback is
+    returned.
+    """
+    if not reasons:
+        return (
+            "이전 검색 결과의 근거가 부족합니다. "
+            "다른 stage(relaxed) 또는 키워드로 retrieve_evidence를 재시도해주세요."
+        )
+    chunk_count = len(evidence)
+    reasons_text = "\n".join(f"- {r}" for r in reasons)
+    return (
+        f"이전 검색 결과 검증 실패 ({chunk_count}개 chunk):\n"
+        f"{reasons_text}\n"
+        "위 원인을 참고해 검색 stage/필터/top_k를 조정한 뒤 retrieve_evidence를 다시 호출하거나, "
+        "evidence가 확실히 없으면 abstain을 선택하세요."
+    )

--- a/tests/test_verifier_feedback_regression.py
+++ b/tests/test_verifier_feedback_regression.py
@@ -1,0 +1,108 @@
+"""Regression tests for PR-D — verifier feedback injection (#679).
+
+Verifies:
+1. format_verifier_feedback exists in rag_verifier.
+2. Empty reasons → fallback string (non-empty, Korean).
+3. Reasons list → formatted string containing each reason.
+4. verify_evidence is unchanged (JSON-identity proxy).
+5. rag_graph_react imports format_verifier_feedback without error.
+
+No real index or LLM calls.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_verifier import format_verifier_feedback  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 1. format_verifier_feedback exists
+# ---------------------------------------------------------------------------
+
+def test_format_verifier_feedback_importable():
+    assert callable(format_verifier_feedback)
+
+
+# ---------------------------------------------------------------------------
+# 2. Empty reasons → fallback
+# ---------------------------------------------------------------------------
+
+def test_empty_reasons_returns_nonempty_string():
+    result = format_verifier_feedback(reasons=[], evidence=[])
+    assert isinstance(result, str)
+    assert len(result) > 10
+
+
+def test_empty_reasons_mentions_retrieve_action():
+    result = format_verifier_feedback(reasons=[], evidence=[])
+    assert "retrieve" in result.lower() or "검색" in result
+
+
+# ---------------------------------------------------------------------------
+# 3. Reasons list → formatted output
+# ---------------------------------------------------------------------------
+
+def test_reasons_are_included_in_output():
+    reasons = ["topic_not_grounded: 보안 요구사항", "verifier_strict_miss"]
+    result = format_verifier_feedback(reasons=reasons, evidence=[])
+    for r in reasons:
+        assert r in result, f"reason '{r}' not found in feedback"
+
+
+def test_chunk_count_is_mentioned():
+    evidence: list[dict[str, Any]] = [
+        {"chunk_id": "c1", "text": "테스트1"},
+        {"chunk_id": "c2", "text": "테스트2"},
+    ]
+    result = format_verifier_feedback(reasons=["topic_not_grounded"], evidence=evidence)
+    assert "2" in result  # chunk count mentioned
+
+
+def test_feedback_is_string():
+    result = format_verifier_feedback(
+        reasons=["partial_topic: 사업비"],
+        evidence=[{"chunk_id": "c1", "text": "예산 항목"}],
+    )
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# 4. verify_evidence JSON-identity proxy — signature unchanged
+# ---------------------------------------------------------------------------
+
+def test_verify_evidence_signature_unchanged():
+    """verify_evidence signature must be unchanged — format_verifier_feedback is additive."""
+    import inspect
+    from rag_verifier import verify_evidence
+
+    sig = inspect.signature(verify_evidence)
+    params = set(sig.parameters.keys())
+    # Actual signature: analysis, evidence, allow_partial_topic
+    required = {"analysis", "evidence"}
+    assert required <= params, f"verify_evidence signature changed: {params}"
+    # format_verifier_feedback must NOT appear as a parameter (additive, separate func)
+    assert "format_verifier_feedback" not in params
+
+
+# ---------------------------------------------------------------------------
+# 5. rag_graph_react imports feedback cleanly
+# ---------------------------------------------------------------------------
+
+def test_rag_graph_react_imports_feedback_without_error():
+    sys.modules.pop("rag_graph_react", None)
+    import types
+    mock_lg = types.ModuleType("langgraph")
+    mock_lg.graph = types.ModuleType("langgraph.graph")  # type: ignore[attr-defined]
+    from unittest.mock import patch
+
+    with patch.dict("sys.modules", {"langgraph": mock_lg, "langgraph.graph": mock_lg.graph}):
+        import rag_graph_react  # noqa: F401
+    # If we get here the import succeeded (format_verifier_feedback late-imported)
+    assert True


### PR DESCRIPTION
## Summary

ReAct self-correction loop 완성 — verify_grounding 실패 시 reasons를 다음 planning turn에 주입.

- `rag_verifier.py` **수정**: `format_verifier_feedback(reasons, evidence) → str` 신규. `verify_evidence` 무변경 (JSON-identity).
- `rag_graph_react.py` **수정**: `_react_loop_node`에서 verify_grounding 비-grounded 시 `attempt["feedback_message"]` 추가 → `LLMPlanner`가 history에서 읽어 다음 행동 조정.
- `tests/test_verifier_feedback_regression.py` **신규**: 8 테스트.

## Changes

| File | Change |
|---|---|
| `rag_verifier.py` | format_verifier_feedback() 추가 (verify_evidence 무변경) |
| `rag_graph_react.py` | verify_grounding 실패 시 feedback_message 주입 |
| `tests/test_verifier_feedback_regression.py` | NEW — 8 unit tests |

## Test plan

- [x] `pytest tests/test_verifier_feedback_regression.py -v` → 8 passed

## PR template checklist

1. **Issue link**: Closes #679
2. **Branch**: `feat/issue-679-verifier-feedback-injection` ✓
3. **One concern**: Verifier feedback injection only ✓
4. **Behavior change ↔ test**: 8 regression tests ✓
5. **Load-bearing files changed**: `rag_verifier.py` (additive — new function only, verify_evidence unchanged)
   - 5b (real-data delta): N/A — verify_evidence JSON-identity preserved
6. **ADR required**: N/A — follows ADR 0040 (react_loop self-correction)
7. **Backward compatibility**: full — format_verifier_feedback is new, no call site changes outside react_loop

## Stack

PR-A (#660) → PR-B (#672) → PR-C (#678) → **PR-D (this)** → PR-E (eval row + ADR 0042)