### PR TITLE
fix(verifier): WH-query token exclusion from verification_topics (closes #674)

### DIFF
--- a/data/lexicon/ko_default.yaml
+++ b/data/lexicon/ko_default.yaml
@@ -147,6 +147,39 @@ verification_intent_tokens:
   - "주요"
   - "확인"
 
+# ─── Verification topic exclusions (issue #674) ───────────────────────
+# Loaded as `frozenset[str]`. Tokens that must NOT become verification
+# topics — they are query-form words (WH-interrogatives, postpositions,
+# verb endings) that never appear verbatim in RFP document text.
+# Applied inside `rag_verifier.verification_topics` only; no effect on
+# tokenise / BM25 / embedding paths.
+verification_topic_exclusions:
+  # WH-interrogatives (의문사)
+  - "며칠"       # how many days
+  - "몇일"       # how many days (variant)
+  - "언제"       # when
+  - "어디"       # where
+  - "어디서"     # from where
+  - "왜"         # why
+  - "얼마"       # how much (normalize_metadata_token("얼마나") → "얼마")
+  - "몇"         # how many
+  - "뭐"         # what (informal)
+  - "어느"       # which
+  # Postpositions that bleed into topics (조사 단독)
+  - "안에"       # within / inside
+  - "이내"       # within (duration)
+  - "이후"       # after
+  - "이전"       # before
+  - "까지"       # until
+  - "부터"       # from
+  - "에서"       # at / from
+  - "으로"       # to / by
+  # Verb-ending forms that surface as whole tokens (동사 어미)
+  - "마무리돼"   # (be) completed
+  - "마무리되"   # (be) completed (stem form)
+  - "완료돼"     # (be) done
+  - "끝나"       # end / finish
+
 # ─── Metadata evidence labels ─────────────────────────────────────────
 # Loaded as `dict[str, tuple[str, ...]]`. Maps metadata field id to
 # Korean evidence labels surfaced in answer schema (ADR 0003).

--- a/korean_lexicon.py
+++ b/korean_lexicon.py
@@ -47,6 +47,9 @@ METADATA_CLAIM_TOPIC_LABELS: dict[str, tuple[str, ...]] = {
 KOREAN_PARTICLE_SUFFIXES: tuple[str, ...] = tuple(_data["korean_particle_suffixes"])
 BM25_EXTRA_PARTICLE_SUFFIXES: tuple[str, ...] = tuple(_data["bm25_extra_particle_suffixes"])
 BM25_EXTRA_STOPWORDS: frozenset[str] = frozenset(_data["bm25_extra_stopwords"])
+VERIFICATION_TOPIC_EXCLUSIONS: frozenset[str] = frozenset(
+    _data["verification_topic_exclusions"]
+)
 
 
 # KIWI morphological tokenizer (issue #486, ADR 0031) — additive

--- a/rag_verifier.py
+++ b/rag_verifier.py
@@ -51,6 +51,7 @@ from korean_lexicon import (
     METADATA_GENERIC_TOKENS,
     TOPIC_KEYWORDS,
     VERIFICATION_INTENT_TOKENS,
+    VERIFICATION_TOPIC_EXCLUSIONS,
 )
 from rag_metadata_processing import metadata_tokens
 from rag_text_processing import normalize_metadata_token, ordered_unique
@@ -183,6 +184,8 @@ def verification_topics(analysis: dict[str, Any]) -> list[str]:
         if normalized in metadata_terms and normalized not in keyword_terms:
             continue
         if normalized in METADATA_GENERIC_TOKENS or normalized in VERIFICATION_INTENT_TOKENS:
+            continue
+        if normalized in VERIFICATION_TOPIC_EXCLUSIONS:
             continue
         topics.append(normalized)
     return ordered_unique(topics)

--- a/tests/test_partial_topic_grounding.py
+++ b/tests/test_partial_topic_grounding.py
@@ -156,5 +156,88 @@ class OutOfCorpusAbstentionPreservedTest(unittest.TestCase):
         self.assertEqual(result["evidence"], [])
 
 
+class WhQueryTokenExclusionTest(unittest.TestCase):
+    """Regression guards for issue #674 — WH-interrogatives, postpositions,
+    and verb endings must not become verification topics (they never appear
+    verbatim in RFP document text, so they inflate the topic list and push
+    the grounded fraction below PARTIAL_TOPIC_GROUNDING_MIN_FRACTION).
+
+    probe_11 scenario: "고양도시관리공사 다목적구장 홈페이지 사업이 며칠 안에 마무리돼?"
+    - raw topics include '며칠', '안에', '마무리돼'  (WH / postposition / verb ending)
+    - gold chunk contains '착수일로부터 90일 이내' but NOT the WH-form words
+    - before fix: 2/6 = 0.33 < 0.5 → topic_not_grounded (wrong abstention)
+    - after fix:  2/3 = 0.67 ≥ 0.5 AND matched ≥ 2 → partial_topic_grounding pass
+    """
+
+    def test_wh_tokens_excluded_from_verification_topics(self) -> None:
+        """며칠 / 안에 / 마무리돼 are filtered out of verification_topics."""
+        from rag_verifier import verification_topics
+
+        analysis = {
+            "topics": [
+                "고양도시관리공사", "다목적구장", "홈페이지",
+                "며칠", "안에", "마무리돼",
+            ]
+        }
+        result = verification_topics(analysis)
+        for excluded in ("며칠", "안에", "마무리돼"):
+            self.assertNotIn(
+                excluded, result,
+                f"WH/postposition/verb token {excluded!r} should be excluded",
+            )
+        for kept in ("고양도시관리공사", "다목적구장"):
+            self.assertIn(kept, result, f"substantive topic {kept!r} should be kept")
+
+    def test_other_wh_words_excluded(self) -> None:
+        """Sample of other WH-query tokens that must not become topics."""
+        from rag_verifier import verification_topics
+
+        wh_words = ["언제", "어디", "왜", "몇", "뭐", "어느", "이내", "이후", "이전"]
+        analysis = {"topics": ["예산", "기관명"] + wh_words}
+        result = verification_topics(analysis)
+        for wh in wh_words:
+            self.assertNotIn(wh, result, f"WH token {wh!r} should be excluded")
+        self.assertIn("예산", result)
+        self.assertIn("기관명", result)
+
+    def test_probe11_partial_grounding_passes_after_wh_exclusion(self) -> None:
+        """End-to-end: probe_11 scenario resolves with partial_topic_grounding.
+
+        Simulates the exact failure case from real100 eval — retrieval succeeded
+        (chunk_recall@10=1.0) but verifier was abstaining due to WH tokens.
+        """
+        evidence = [
+            {
+                "doc_id": "20240903676-1.0",
+                "chunk_id": "20240903676-1.0::chunk-002",
+                "score": 0.8,
+                "text": "과업기간 : 착수일로부터 90일 이내",
+                "title": (
+                    "고양도시관리공사 관산근린공원 다목적구장 "
+                    "회원 통합운영관리 시스템 구축"
+                ),
+                "agency": "고양도시관리공사",
+                "project": "",
+                "section": "",
+            }
+        ]
+        # Raw topics as analyze_query produces for the probe_11 query
+        analysis = {
+            "topics": [
+                "고양도시관리공사", "다목적구장", "홈페이지",
+                "며칠", "안에", "마무리돼",
+            ]
+        }
+        verified, reasons = verify_evidence(
+            analysis, evidence, allow_partial_topic=True
+        )
+        self.assertTrue(
+            verified,
+            f"probe_11 should pass partial_topic_grounding after WH exclusion; reasons={reasons}",
+        )
+        self.assertIn(PARTIAL_TOPIC_GROUNDING_REASON, reasons)
+        self.assertNotIn("topic_not_grounded", reasons)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `data/lexicon/ko_default.yaml`에 `verification_topic_exclusions` 섹션 추가 (24 tokens)
- `korean_lexicon.py`에 `VERIFICATION_TOPIC_EXCLUSIONS: frozenset` 상수 추가
- `rag_verifier.verification_topics`에 1줄 필터 추가
- `tests/test_partial_topic_grounding.py`에 `WhQueryTokenExclusionTest` 3개 케이스 추가

## Root Cause (probe_11 — real100 case breakdown #661)

```
쿼리: "고양도시관리공사 다목적구장 홈페이지 사업이 며칠 안에 마무리돼?"
gold chunk: "과업기간 : 착수일로부터 90일 이내"
chunk_recall@10 = 1.0  ← retrieval 성공
evidence count = 0      ← verifier가 전부 reject
```

`verification_topics` 출력: `['고양도시관리공사', '다목적구장', '홈페이지', '며칠', '안에', '마무리돼']`

gold chunk 매칭: 2/6 = 0.33 < `PARTIAL_TOPIC_GROUNDING_MIN_FRACTION(0.5)` → `topic_not_grounded` → wrong abstention

## Fix 후

의문사·조사·동사 어미 제거 → topics: `['고양도시관리공사', '다목적구장', '홈페이지']`
2/3 = 0.67 ≥ 0.5 AND matched ≥ 2 → `partial_topic_grounding` (non-blocking) → 통과

## PR checklist

1. Behavior change: `verification_topics` 필터 추가 → wrong_abstention 감소 가능
2. ADR: 불요 — ADR 0004 threshold 변경 없음, lexicon 보완
3. Test: `WhQueryTokenExclusionTest` 3개 (token 제거 확인 + probe_11 end-to-end)
4. Smoke: ✅ 통과
5a. Synthetic delta: N/A (eval pipeline 구조 변경 없음)
5b. Real-data delta: `make real-eval-delta` 필요 (rag_verifier.py load-bearing)

Closes #674