### PR TITLE
feat(eval): recall@20 + ndcg@20 chunk retrieval 지표 추가 (closes #685)

### DIFF
--- a/eval/scorers/case.py
+++ b/eval/scorers/case.py
@@ -101,6 +101,7 @@ def score_case(
     }
     chunk_metrics["chunk_mrr"] = chunk_mrr(retrieved_chunk_ids, gold_for_chunks)
     chunk_metrics["chunk_ndcg_at_10"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_for_chunks, 10)
+    chunk_metrics["chunk_ndcg_at_20"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_for_chunks, 20)
 
     return {
         "id": case.get("id"),

--- a/eval/scorers/chunk_metrics.py
+++ b/eval/scorers/chunk_metrics.py
@@ -5,7 +5,7 @@ import math
 from typing import Any
 
 
-CHUNK_METRIC_KS = (5, 10)
+CHUNK_METRIC_KS = (5, 10, 20)
 
 
 def derive_gold_chunk_ids(


### PR DESCRIPTION
## Summary

- `eval/scorers/chunk_metrics.py`: `CHUNK_METRIC_KS = (5, 10)` → `(5, 10, 20)` (1줄)
- `eval/scorers/case.py`: `chunk_ndcg_at_20` 추가 (1줄, 기존 `chunk_ndcg_at_k` 재사용)
- forward-only schema 변경 — 기존 시계열 호환, ADR 0030 leaderboard 영향 없음

## Motivation

PR-1(#665) case breakdown 결과에서 probe_11·probe_12가 `chunk_recall@10=1.0`임에도 abstain → retrieval은 되지만 verifier/answer에서 실패. k=20을 추가하면 gold chunk가 rank 몇에 있는지 전체 recall curve를 볼 수 있다.

## Pre-existing failures (not introduced by this PR)

`bash scripts/test.sh`에서 3개 실패가 있으나 모두 main에서도 동일하게 발생:
- `test_no_forbidden_keys_in_output` — `answer_format_compliance` 키에 `answer` 문자열 포함 판정 문제 (pre-existing)
- `test_retry_relaxes_filters_when_verifier_rejects_evidence` (pre-existing)
- `test_top_k_chunk_ids_match_golden` SUBFAILED — naive_baseline golden drift (pre-existing)

## PR checklist

1. Behavior change: 없음 (eval 지표 추가만, 파이프라인 무변경)
2. ADR: 불요 (forward-only metric 추가)
3. 5a. Synthetic delta: N/A
4. 5b. Real-data delta: N/A (파이프라인 무변경)

Closes #685