### PR TITLE
feat(eval): chunk_recall_at_20 + ndcg_at_20 retrieval metrics (closes #685)

### DIFF
--- a/eval/scorers/case.py
+++ b/eval/scorers/case.py
@@ -101,6 +101,7 @@ def score_case(
     }
     chunk_metrics["chunk_mrr"] = chunk_mrr(retrieved_chunk_ids, gold_for_chunks)
     chunk_metrics["chunk_ndcg_at_10"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_for_chunks, 10)
+    chunk_metrics["chunk_ndcg_at_20"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_for_chunks, 20)
 
     return {
         "id": case.get("id"),

--- a/eval/scorers/chunk_metrics.py
+++ b/eval/scorers/chunk_metrics.py
@@ -5,7 +5,7 @@ import math
 from typing import Any
 
 
-CHUNK_METRIC_KS = (5, 10)
+CHUNK_METRIC_KS = (5, 10, 20)
 
 
 def derive_gold_chunk_ids(

--- a/tests/test_chunk_metrics_regression.py
+++ b/tests/test_chunk_metrics_regression.py
@@ -20,6 +20,8 @@ from eval.scorers import (  # noqa: E402
     chunk_recall_at_k,
     derive_gold_chunk_ids,
 )
+from eval.scorers.chunk_metrics import CHUNK_METRIC_KS
+from eval.scorers.case import score_case
 
 
 class ChunkMetricsTest(unittest.TestCase):
@@ -93,6 +95,83 @@ class DeriveGoldChunkIdsTest(unittest.TestCase):
     def test_returns_empty_for_missing_index(self) -> None:
         case = {"expected_doc_ids": ["doc-a"], "expected_terms": ["보안 통제"]}
         self.assertEqual(derive_gold_chunk_ids(case, None), [])
+
+
+class ChunkMetricKsConstantTest(unittest.TestCase):
+    """Contract test: CHUNK_METRIC_KS must include k=5, k=10, k=20."""
+
+    def test_contains_5_10_20(self) -> None:
+        self.assertIn(5, CHUNK_METRIC_KS)
+        self.assertIn(10, CHUNK_METRIC_KS)
+        self.assertIn(20, CHUNK_METRIC_KS)
+
+    def test_k20_larger_than_k10(self) -> None:
+        ks = sorted(CHUNK_METRIC_KS)
+        self.assertGreater(ks[-1], ks[-2])  # 20 > 10
+
+
+def _minimal_prediction(
+    retrieved_chunk_ids: list[str] | None = None,
+    evidence: list[dict] | None = None,
+) -> dict:
+    return {
+        "evidence": evidence or [],
+        "answer": {"status": "supported", "claims": [], "summary": ""},
+        "diagnostics": {
+            "abstained": False,
+            "latency_ms": 1.0,
+            "retry_count": 0,
+            "retrieved_chunk_ids": retrieved_chunk_ids or [],
+            "cold_start": False,
+        },
+        "plan": {},
+        "analysis": {},
+    }
+
+
+class ScoreCaseChunkMetrics20Test(unittest.TestCase):
+    """Integration: score_case must emit chunk_recall_at_20 and chunk_ndcg_at_20."""
+
+    _CASE = {
+        "id": "test-001",
+        "query_type": "single_doc",
+        "answerable": True,
+        "expected_doc_ids": ["doc-a"],
+        "expected_terms": ["보안"],
+        "query": "보안 요구사항",
+    }
+
+    def test_chunk_recall_at_20_present_in_output(self) -> None:
+        pred = _minimal_prediction(
+            retrieved_chunk_ids=["doc-a::chunk-001"],
+            evidence=[{"doc_id": "doc-a", "text": "보안 요구사항"}],
+        )
+        result = score_case(self._CASE, pred, gold_chunk_ids=["doc-a::chunk-001"])
+        self.assertIn("chunk_recall_at_20", result)
+
+    def test_chunk_ndcg_at_20_present_in_output(self) -> None:
+        pred = _minimal_prediction(
+            retrieved_chunk_ids=["doc-a::chunk-001"],
+            evidence=[{"doc_id": "doc-a", "text": "보안 요구사항"}],
+        )
+        result = score_case(self._CASE, pred, gold_chunk_ids=["doc-a::chunk-001"])
+        self.assertIn("chunk_ndcg_at_20", result)
+
+    def test_chunk_recall_at_20_is_1_when_gold_in_top20(self) -> None:
+        retrieved = [f"doc-a::chunk-{i:03d}" for i in range(1, 22)]  # 21 chunks
+        gold_chunk_id = "doc-a::chunk-015"  # rank 15 — within @20 but not @10
+        pred = _minimal_prediction(
+            retrieved_chunk_ids=retrieved,
+            evidence=[{"doc_id": "doc-a", "text": "보안 요구사항"}],
+        )
+        result = score_case(self._CASE, pred, gold_chunk_ids=[gold_chunk_id])
+        self.assertEqual(result["chunk_recall_at_20"], 1.0)
+        self.assertEqual(result["chunk_recall_at_10"], 0.0)  # not in @10
+
+    def test_chunk_recall_at_20_none_when_no_gold(self) -> None:
+        pred = _minimal_prediction(retrieved_chunk_ids=["doc-a::chunk-001"])
+        result = score_case(self._CASE, pred, gold_chunk_ids=None)
+        self.assertIsNone(result.get("chunk_recall_at_20"))
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## 1. 변경 내용 및 이유

CHUNK_METRIC_KS 를 (5, 10) → (5, 10, 20) 으로 확장해 chunk_recall_at_20 자동 캡처. 기존 chunk_ndcg_at_10 와 나란히 chunk_ndcg_at_20 추가 (동일 chunk_ndcg_at_k helper). 동기: PR-1 (issue #661) 케이스 breakdown 에서 probe_11/probe_12 가 chunk_recall@10=1.0 인데 실패; @20 은 rank 10 너머로 가시성 확장.

Closes #685

## 2. 영향 파일

- `eval/scorers/chunk_metrics.py` — load-bearing (`eval/`): `CHUNK_METRIC_KS` tuple 확장
- `eval/scorers/case.py` — load-bearing (`eval/`): `chunk_ndcg_at_20` 라인 추가
- `tests/test_chunk_metrics_regression.py` — 신규 6 테스트 추가

## 3. 리스크

Forward-only key 추가. gold_chunk_ids 없는 기존 snapshot 은 `null` 표시; rename/제거된 key 없음. 리스크 최소 — 신규 key 가 어떤 것도 가리지 않고 case.py 의 loop 는 이미 CHUNK_METRIC_KS 로 parametrize.

## 4. 테스트

`test_chunk_metrics_regression.py` 18/18 pass: `ChunkMetricKsConstantTest` (CHUNK_METRIC_KS 가 5/10/20 포함하는지 pin) + `ScoreCaseChunkMetrics20Test` (통합: score_case 가 신규 key 둘 다 발화, rank-15-in-@20-but-not-@10 시나리오). main 의 사전 실패 3건은 무관 (false-positive substring match, verifier #683 회귀, HWP fixture 추가로 인한 golden drift).

## 5. Eval 영향

기존 메트릭 (accuracy, groundedness 등) 전부 `·`. 신규 nullable key 2개 등장: `chunk_recall_at_20`, `chunk_ndcg_at_20`. ADR 0030 리더보드 시리즈 영향 없음.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 신규 메트릭은 진단에 이미 존재하는 동일 retrieved_chunk_ids 에서 수집된 additive nullable key. Eval 출력 구조 forward-only 호환.

## 6. 하위 호환성

Forward-only. 신규 key 는 historical snapshot 에서 nullable. 기존 key rename/제거 없음.

## 7. Out of scope

Rerank delta (pre-rerank vs post-rerank MRR/NDCG) — 진단에 pre-rerank 청크 순서 노출 필요해 follow-up 으로 유예.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
