### PR TITLE
fix(test): replace FORBIDDEN_KEYS substring check with exact key set membership (closes #688)

### DIFF
--- a/tests/test_eval_by_format_aggregate_regression.py
+++ b/tests/test_eval_by_format_aggregate_regression.py
@@ -209,10 +209,19 @@ class TestExtractAggregateByFormat(unittest.TestCase):
             {"hwp": {"num_predictions": 1, "accuracy": 1.0, "case_results": "should_be_dropped"}}
         )
         out = extract_aggregate(summary)
+
+        def _all_keys(d: dict) -> set:
+            keys = set(d.keys())
+            for v in d.values():
+                if isinstance(v, dict):
+                    keys |= _all_keys(v)
+            return keys
+
+        present = _all_keys(out)
         for forbidden in FORBIDDEN_KEYS:
             self.assertNotIn(
                 forbidden,
-                str(out),
+                present,
                 f"Forbidden key '{forbidden}' leaked into aggregate output",
             )
 


### PR DESCRIPTION
## Summary

- `test_no_forbidden_keys_in_output` 이 `assertNotIn(forbidden, str(out))` 사용 — dict 문자열 표현에 대한 **substring** 매칭.
- `FORBIDDEN_KEYS` 의 `"answer"` 가 `answer_format_compliance` (PR #650) 가 top-level 집계 키로 등장하면서 false-positive 시작.
- 수정: `_all_keys()` 로 모든 dict 키 재귀 수집 + 정확한 멤버십 단정 — prefix 공유하는 정당한 메트릭 키 안 걸리고 원래 의도 (per-case payload bleed 금지) 가드.

## Change type

Test-only. production 코드 변경 없음.

## Test plan

```
.venv/bin/python -m pytest tests/test_eval_by_format_aggregate_regression.py -v
# 13 passed, 0 failed (was 1 failed)
```

## Load-bearing files changed

N/A — 테스트 파일만.

## 5a. Synthetic CI delta

N/A — 테스트 로직 수정, 파이프라인 변경 없음.

## 5b. Real-data delta

No behavior change in retrieval / verifier path. N/A — retrieval / answer / eval 경로 미접촉.

## Rollback plan

이 commit revert. 효과는 false-positive 실패 복원만; production 동작 변경 없음.

Closes #688

Generated with [Claude Code](https://claude.com/claude-code)
