### PR TITLE
fix(test): regenerate naive_baseline golden after HWP fixture addition in #648 (closes #689)

### DIFF
--- a/tests/data/naive_baseline_top_k.json
+++ b/tests/data/naive_baseline_top_k.json
@@ -5,8 +5,8 @@
       0.7109
     ],
     [
-      "rfp-agency-b-mlops-governance::chunk-001",
-      0.5573
+      "rfp-agency-g-traffic-hwp::chunk-002",
+      0.5605
     ]
   ],
   "기관 C의 챗봇 응답 시간 목표는?": [

--- a/tests/test_eval_by_format_aggregate_regression.py
+++ b/tests/test_eval_by_format_aggregate_regression.py
@@ -209,10 +209,19 @@ class TestExtractAggregateByFormat(unittest.TestCase):
             {"hwp": {"num_predictions": 1, "accuracy": 1.0, "case_results": "should_be_dropped"}}
         )
         out = extract_aggregate(summary)
+
+        def _all_keys(d: dict) -> set:
+            keys = set(d.keys())
+            for v in d.values():
+                if isinstance(v, dict):
+                    keys |= _all_keys(v)
+            return keys
+
+        present = _all_keys(out)
         for forbidden in FORBIDDEN_KEYS:
             self.assertNotIn(
                 forbidden,
-                str(out),
+                present,
                 f"Forbidden key '{forbidden}' leaked into aggregate output",
             )
 


### PR DESCRIPTION
## Summary

- PR #648 가 HWP fixture 문서 2개 (`rfp_agency_f_smart_factory_hwp.json`, `rfp_agency_g_traffic_hwp.json`) 를 `data/raw/` 에 추가했으나 golden 파일 재생성 안 함
- 쿼리 "기관A의 보안 통제 요구사항은?" 에 대해 `rfp-agency-g-traffic-hwp::chunk-002` (score 0.5605) 가 이전 골든 #2 chunk `rfp-agency-b-mlops-governance::chunk-001` (score 0.5573) 위로 순위
- 이는 **예상 corpus-growth drift**, 파이프라인 회귀 아님
- `EMBEDDING_BACKEND=hashing chunking_strategy=fixed` 로 `tests/data/naive_baseline_top_k.json` 재생성

## Change type

테스트 데이터 (golden 파일) 만. Production 코드 무변경.

## Test plan

```
EMBEDDING_BACKEND=hashing .venv/bin/python -m pytest \
  tests/test_naive_baseline_ranking_invariance.py -v
# 1 passed, 5 subtests passed (was 1 failed, 1 subtest failed)
```

## Load-bearing files changed

N/A — 테스트 데이터만. 파이프라인 코드 무변경.

## 5a. Synthetic CI delta

N/A — 파이프라인 변경 없음.

## 5b. Real-data delta

N/A — 검색 / 답변 / eval 경로 무변경.

## Why the drift is expected

골든 쿼리 "기관A의 보안 통제 요구사항은?" 는 `data/raw/` 모든 문서 대상 corpus-wide 순위 테스트. 신규 HWP 문서 2개 추가가 상대 유사도 점수 변경. #1 결과는 무변경 (rfp-agency-a-ai-quality::chunk-001, 0.7109). 신규 청크가 pool 진입해 #2 만 시프트.

## Note

향후 `data/raw/` 에 신규 문서 추가 시 이 골든 파일 재생성 필수. Contribution guide 에 pre-push 노트 추가 고려.

Closes #689
