### PR TITLE
feat(eval): retrieval_only ablation preset for chunk_recall@k tracking (closes #694)

### DIFF
--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -141,6 +141,23 @@ ablation_runs:
     rerank: true
     verifier_retry: false
     retrieval_mode: flat
+  # Issue #694 — dedicated retrieval-quality time-series slot.
+  # Uses the full retrieval stack (metadata_first, rerank) with
+  # verifier_retry=false so the first-pass chunk ranking is measured
+  # without the retry-and-relax feedback loop.  Evaluation focus:
+  # chunk_recall_at_5/10/20 and chunk_ndcg_at_10/20; accuracy and
+  # groundedness are expected to be lower than `full` since the verifier
+  # retry that recovers from weak first-pass evidence is absent.
+  # Distinct from `no_verifier_retry` in intent: this row is the
+  # canonical leaderboard slot for tracking retrieval quality over time
+  # (ADR 0030 forward-only series pattern); `no_verifier_retry` remains
+  # the verifier-retry-contribution ablation reference.
+  - name: retrieval_only
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: false
+    retrieval_mode: flat
   - name: hybrid_bm25
     pipeline: agentic_full
     metadata_first: true

--- a/tests/test_retrieval_only_ablation_preset.py
+++ b/tests/test_retrieval_only_ablation_preset.py
@@ -1,0 +1,97 @@
+"""Regression test for retrieval_only ablation preset (issue #694).
+
+Verifies that eval/config.yaml contains the ``retrieval_only`` row with the
+expected config (full retrieval stack, verifier_retry=False) and that the
+ADR 0001 invariants are preserved (naive_baseline unchanged,
+no_verifier_retry not removed).
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT_DIR / "eval" / "config.yaml"
+
+
+class TestRetrievalOnlyAblationRow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        with open(CONFIG_PATH) as f:
+            cls.config = yaml.safe_load(f)
+        cls.ablation_runs: list[dict] = cls.config.get("ablation_runs", [])
+        cls.ablation_by_name = {row["name"]: row for row in cls.ablation_runs}
+
+    def test_retrieval_only_row_exists(self) -> None:
+        self.assertIn(
+            "retrieval_only",
+            self.ablation_by_name,
+            "Ablation row 'retrieval_only' missing from eval/config.yaml",
+        )
+
+    def test_retrieval_only_uses_agentic_full(self) -> None:
+        row = self.ablation_by_name["retrieval_only"]
+        self.assertEqual(
+            row.get("pipeline"),
+            "agentic_full",
+            "retrieval_only: pipeline must be agentic_full (full retrieval stack)",
+        )
+
+    def test_retrieval_only_verifier_retry_false(self) -> None:
+        """verifier_retry=False so first-pass chunk ranking is measured without retry."""
+        row = self.ablation_by_name["retrieval_only"]
+        self.assertFalse(
+            row.get("verifier_retry", True),
+            "retrieval_only: verifier_retry must be False",
+        )
+
+    def test_retrieval_only_metadata_first_and_rerank(self) -> None:
+        """Full retrieval stack — metadata_first and rerank must be True."""
+        row = self.ablation_by_name["retrieval_only"]
+        self.assertTrue(
+            row.get("metadata_first", True),
+            "retrieval_only: metadata_first must be True (full retrieval stack)",
+        )
+        self.assertTrue(
+            row.get("rerank", True),
+            "retrieval_only: rerank must be True (full retrieval stack)",
+        )
+
+    def test_retrieval_only_flat_retrieval_mode(self) -> None:
+        row = self.ablation_by_name["retrieval_only"]
+        mode = row.get("retrieval_mode", "flat")
+        self.assertEqual(mode, "flat", "retrieval_only: retrieval_mode must be flat")
+
+    # ADR 0001 invariant: naive_baseline preserved and no_verifier_retry not removed.
+
+    def test_naive_baseline_preserved(self) -> None:
+        row = self.ablation_by_name.get("naive_baseline", {})
+        self.assertEqual(
+            row.get("pipeline"),
+            "naive_baseline",
+            "ADR 0001: naive_baseline row must remain with pipeline=naive_baseline",
+        )
+
+    def test_no_verifier_retry_still_present(self) -> None:
+        """retrieval_only is additive; no_verifier_retry must NOT be removed."""
+        self.assertIn(
+            "no_verifier_retry",
+            self.ablation_by_name,
+            "no_verifier_retry must remain — it is the verifier-retry-contribution ablation reference",
+        )
+
+    def test_retrieval_only_is_distinct_named_slot(self) -> None:
+        """Ablation run names must be unique (run_eval.py enforces at runtime)."""
+        names = [row["name"] for row in self.ablation_runs]
+        self.assertEqual(
+            len(names),
+            len(set(names)),
+            "Duplicate ablation run names found in eval/config.yaml",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 변경 내용 및 이유

`eval/config.yaml` 에 `retrieval_only` 분석 변형 row 추가. 설정: `pipeline=agentic_full`, `metadata_first=True`, `rerank=True`, `verifier_retry=False`, `retrieval_mode=flat`. `chunk_recall_at_k` + `chunk_ndcg_at_k` 시간 추적용 안정 named leaderboard slot 제공 (ADR 0030 forward-only series 패턴), verifier-retry-contribution 분석 변형 reference 인 `no_verifier_retry` 와 구분.

Closes #694

## 2. 변경 파일

- `eval/config.yaml` — load-bearing (`eval/`): 1 신규 분석 변형 row 추가
- `tests/test_retrieval_only_ablation_preset.py` — 8 신규 테스트 추가 (config value + ADR 0001 invariant)

## 3. 리스크

추가형 only. `naive_baseline` + `no_verifier_retry` row 미변경. 신규 row 는 `make real-eval` 실행 시에만 작동; synthetic CI eval 은 hashing backend 에서 신규 분석 변형 row skip (CI 의 eval_summary.json 구조 변경 없음).

## 4. 테스트

8/8 pass: `TestRetrievalOnlyAblationRow` 가 row 존재, pipeline, verifier_retry, metadata_first, rerank, retrieval_mode, unique 이름, ADR 0001 invariant (naive_baseline 보존, no_verifier_retry 미제거) 커버.

## 5. Eval 영향

기존 메트릭에 전부 `·`. 신규 `retrieval_only` 시리즈는 전체 eval stack 으로 `make real-eval` 실행 시에만 leaderboard 에 나타남. CI synthetic harness 미영향.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 신규 분석 변형 row 의 config-only 추가. 코드 경로 변경 없음.

## 6. 하위 호환성

Forward-only. 기존 eval_summary.json snapshot 미영향. 제거/rename 분석 변형 row 없음.

## 7. 범위 외

이 변경 ADR — 순수 추가형이므로 불필요; naive_baseline + no_verifier_retry 가 ADR 0001 따라 보존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
