### PR TITLE
docs(docs): move vision/multichannel docs to docs/vision/

### DIFF
--- a/docs/vision/m3-multichannel-spike.md
+++ b/docs/vision/m3-multichannel-spike.md
@@ -30,7 +30,7 @@ deferred.
   - sparse (SPLADE-style `{token_id: weight}` dict per text)
   - multi-vector / ColBERT (per-token `(T_i, 1024)` matrix per text;
     late-interaction max-sim sum at scoring time)
-- **N-way RRF fusion** in [`rag_core.apply_fusion_and_reranking`](../rag_core.py)
+- **N-way RRF fusion** in [`rag_core.apply_fusion_and_reranking`](../../rag_core.py)
   — the existing 2-way `hybrid` math (`rrf_k / 2.0` normalization)
   generalizes to `rrf_k / N` for N=3.
 - **Opt-in, in-memory only.** Sparse + colbert outputs are computed once

--- a/docs/vision/vision-spike.md
+++ b/docs/vision/vision-spike.md
@@ -1,6 +1,6 @@
 # Layout-aware visual ingestion spike (Donut)
 
-Tracks issue #168. Honest 1-page comparison of the OCR baseline (`pymupdf` text layer + `pytesseract` fallback) against a layout-aware vision encoder-decoder (`Donut`). Closes the "no layout-aware vision foundation model evaluated" gap called out in [`visual_ingestion.py`](../visual_ingestion.py)'s module docstring (lines 4-10).
+Tracks issue #168. Honest 1-page comparison of the OCR baseline (`pymupdf` text layer + `pytesseract` fallback) against a layout-aware vision encoder-decoder (`Donut`). Closes the "no layout-aware vision foundation model evaluated" gap called out in [`visual_ingestion.py`](../../visual_ingestion.py)'s module docstring (lines 4-10).
 
 ## Scope
 
@@ -55,10 +55,10 @@ See the vulnerability report here https://nvd.nist.gov/vuln/detail/CVE-2025-3243
 
 **Keep the OCR baseline as the default.** Donut adoption is gated on the following criteria, none yet met:
 
-1. Measured ≥X percentage-point lift on the **private 100-doc RFP corpus** (not synthetic), per [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md)'s real-data discipline.
+1. Measured ≥X percentage-point lift on the **private 100-doc RFP corpus** (not synthetic), per [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)'s real-data discipline.
 2. GPU available in the production / CI path (CPU latency is prohibitive).
 3. Stable Korean-finetuned model checkpoint with `.safetensors` weights (avoids the torch≥2.6 friction).
-4. ADR proposed and accepted to displace the extractive OCR path per [ADR 0001](adr/0001-preserve-naive-baseline.md)'s preserve-baseline invariant.
+4. ADR proposed and accepted to displace the extractive OCR path per [ADR 0001](../adr/0001-preserve-naive-baseline.md)'s preserve-baseline invariant.
 
 For now, Donut is a **diagnostic option** the reviewer can switch on for exploration:
 
@@ -69,6 +69,6 @@ parse_visual_document(pdf, ocr_provider=get_ocr_provider("donut"))
 
 ## Reproduce / extend
 
-Both pipelines are pluggable via the `OcrProvider` interface ([`visual_ingestion.py:44`](../visual_ingestion.py)). Adding another vision model (e.g. `pix2struct`, ColPali, LayoutLMv3) is a new provider function returning either `str` or `list[dict[text, bbox, confidence]]` — the existing `normalize_ocr_result` ([`visual_ingestion.py:577-581`](../visual_ingestion.py)) handles both shapes.
+Both pipelines are pluggable via the `OcrProvider` interface ([`visual_ingestion.py:44`](../../visual_ingestion.py)). Adding another vision model (e.g. `pix2struct`, ColPali, LayoutLMv3) is a new provider function returning either `str` or `list[dict[text, bbox, confidence]]` — the existing `normalize_ocr_result` ([`visual_ingestion.py:577-581`](../../visual_ingestion.py)) handles both shapes.
 
-The regression test [`tests/test_visual_donut_regression.py`](../tests/test_visual_donut_regression.py) guards the wiring without loading any model; CI runs it as part of `bash scripts/test.sh`.
+The regression test [`tests/test_visual_donut_regression.py`](../../tests/test_visual_donut_regression.py) guards the wiring without loading any model; CI runs it as part of `bash scripts/test.sh`.

--- a/docs/vision/visual-ingestion-v2.md
+++ b/docs/vision/visual-ingestion-v2.md
@@ -63,11 +63,11 @@ python3 eval/run_parser_eval.py \
 - Field: key-value candidate precision, recall, F1.
 - Bbox/page-region: anchor block의 bbox 존재율과, gold bbox가 있을 때 IoU threshold 충족률.
 
-QA 단계에서는 `eval/run_eval.py`의 선택 gold 필드(`expected_citation_pages`, `expected_citation_regions`)로 citation이 올바른 page/region을 가리키는지 추가 평가할 수 있다. 자세한 기준과 drift 예시는 [`citation-grounding-eval.md`](citation-grounding-eval.md)에 둔다.
+QA 단계에서는 `eval/run_eval.py`의 선택 gold 필드(`expected_citation_pages`, `expected_citation_regions`)로 citation이 올바른 page/region을 가리키는지 추가 평가할 수 있다. 자세한 기준과 drift 예시는 [`citation-grounding-eval.md`](../eval/citation-grounding-eval.md)에 둔다.
 
 실패 taxonomy는 `ocr_missing_text`, `layout_type_mismatch`, `section_boundary_missing`, `table_cell_mismatch`, `field_missing`, `field_value_mismatch`, `bbox_missing`, `bbox_misaligned`를 포함한다. 이 코드는 downstream 분석에서 retrieval miss, noisy chunking, wrong field grounding, weak bbox citation 같은 QA 실패 원인과 연결한다.
 
-private hard-case gold에는 문서별 `hardcase_categories`를 둘 수 있다. `eval/run_parser_eval.py`는 `summary.by_hardcase_category`를 생성해 scanned PDF, rotated/skewed, table-heavy, mixed-layout, noisy OCR 조건별 parser metric과 failure count를 분리한다. 비공개 원문과 raw artifact는 커밋하지 않고 aggregate만 [`docs/private-hardcase-benchmark.md`](private-hardcase-benchmark.md) 방식으로 기록한다.
+private hard-case gold에는 문서별 `hardcase_categories`를 둘 수 있다. `eval/run_parser_eval.py`는 `summary.by_hardcase_category`를 생성해 scanned PDF, rotated/skewed, table-heavy, mixed-layout, noisy OCR 조건별 parser metric과 failure count를 분리한다. 비공개 원문과 raw artifact는 커밋하지 않고 aggregate만 [`docs/real-data/private-hardcase-benchmark.md`](../real-data/private-hardcase-benchmark.md) 방식으로 기록한다.
 
 ## 실행 예시
 ```bash


### PR DESCRIPTION
## Summary

vision/multichannel spike 문서 3개를 전용 `docs/vision/` 하위 디렉터리로 이동. `docs/` flat 구조 병렬 일괄 재편의 일부.

**이동 파일:**
- `docs/vision-spike.md` → `docs/vision/vision-spike.md`
- `docs/visual-ingestion-v2.md` → `docs/vision/visual-ingestion-v2.md`
- `docs/m3-multichannel-spike.md` → `docs/vision/m3-multichannel-spike.md`

깊이 증가에 맞춰 내부 상대 링크 업데이트 (`../adr/`, `../../visual_ingestion.py`, `../eval/`, `../real-data/`).

**외부 참조** (`scripts/run_donut_spike.py`, `.py` docstring, 동료 docs) 미변경 — 모든 subdir unit 착륙 후 follow-up 일괄 PR 에서 수정.

Closes #700

---

## PR Checklist

1. [ ] Issue 참조 (`Closes #700`)
2. [ ] 브랜치가 `docs/issue-700-vision-subdir` 매치 (ADR 0007)
3. [ ] 테스트 pass (`bash scripts/test.sh`)
4. [ ] Behavior change ↔ test change: N/A — docs-only 재배치
5. [ ] ADR 필요: N/A — load-bearing 결정 변경 없음
   - **5b real-data delta: N/A — docs-only 재배치**
6. [ ] Backward compatibility: N/A — 외부 참조는 follow-up PR 에서 수정
