### PR TITLE
docs: reference karpathy-guidelines skill in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Supporting:
 - **Backward compatibility.** Breaking changes need an explicit reason. Answer-contract break (ADR 0003) requires `schema_version` bump.
 - **ADR threshold.** Removing or replacing a load-bearing decision (baseline / pipeline / answer contract / eval surface) needs an ADR. Criteria: [`docs/adr/README.md`](docs/adr/README.md).
 - **Reserve ADR numbers up front.** Before drafting a new ADR, check both `ls docs/adr/` and `gh pr list --search "ADR" --state open` to find the next available number. Propose it and wait for user confirmation before creating the file — concurrent worktree work has produced repeat collisions (0022→0023, 0023→0025, 0029→0030).
+- **LLM coding bias guard.** See the `karpathy-guidelines` skill ([upstream](https://github.com/multica-ai/andrej-karpathy-skills)) for the 4-principle override (Think Before / Simplicity First / Surgical Changes / Goal-Driven) layered on top of the project-specific rules above.
 
 ## PR description
 


### PR DESCRIPTION
## 1. What changed and why

`CLAUDE.md` `## Core principles` 에 [upstream `karpathy-guidelines`](https://github.com/multica-ai/andrej-karpathy-skills) skill (사용자 측 `~/.claude/skills/karpathy-guidelines/` 설치) 교차참조 한 줄 추가. 이 skill 은 Karpathy 의 4 원칙 override (Think Before / Simplicity First / Surgical Changes / Goal-Driven) 를 패키징. 우리 기존 원칙이 각각 일부 커버 (Reuse over invent, One PR one concern, Behavior change ↔ test change, When blocked) 하므로 inline 대신 참조 — inline 중복은 drift 하는 parallel 모델 생성, 정확히 CLAUDE.md 의 "answer dict 그림자처럼 가리는 parallel pydantic / TypedDict 금지" 가 정신적으로 경고하는 바.

Closes #725

## 2. Files affected

- `CLAUDE.md` — `## Core principles` +1 line. `scripts/_governance.py` `LOAD_BEARING_PATHS` **미해당**.

## 3. Risks

- **Reference rot.** Upstream skill rename / 제거 가능. 완화: 링크가 `## Core principles` 에 있을 뿐 CI 강제 경로 아님; rot 시 fail-open.
- **다른 contributor 에 skill 미설치.** 이 PR 은 프로젝트 doc 만 수정; 각 contributor 가 `~/.claude/skills/karpathy-guidelines/` 에 직접 설치. 라인이 "skill (upstream)" 명시 → 미설치는 최악 noop, Claude 가 프로젝트 규칙으로 fallback.

## 4. Tests

N/A — docs-only, 동작 경로 미접촉. CI `branch-and-issue-check.yml` 가 ADR 0007 (issue + branch 컨벤션) 강제; local `python3 scripts/check_branch_and_issue.py --branch docs/issue-725-karpathy-skill-ref --check-issue` exit 0.

## 5. Eval impact

전부 `·` 예상. retrieval / verifier / answer / eval 경로 미접촉.

### 5b. Real-data delta

N/A — load-bearing 경로 변경 없음 (CLAUDE.md 는 `scripts/_governance.LOAD_BEARING_PATHS` 미포함).

## 6. Backward compatibility

깨짐 없음. 계약 / 스키마 / CLI 플래그 / doc 링크 제거 없음.

## 7. Out of scope

- 다른 contributor 의 skill 설치 (각자 `~/.claude/skills/` clone 또는 `/plugin install`; per-dev 셋업, repo 관심사 아님).
- 4 원칙 CLAUDE.md inline 화 (명시 거부 — "What changed and why" 사유 참조).
- ADR 작성 (CLAUDE.md 는 docs, load-bearing 결정 swap 아님; `docs/adr/README.md` 기준 ADR 임계값 미충족).
