### PR TITLE
docs(adr): ADR 0043 — PR-level live LLM-judge cadence, label-gated workflow (closes #722)

### DIFF
--- a/docs/adr/0043-pr-cadence-for-live-llm-judge.md
+++ b/docs/adr/0043-pr-cadence-for-live-llm-judge.md
@@ -1,0 +1,144 @@
+# 0043: PR-level cadence for live LLM-judge signal (label-gated workflow)
+
+- **Status**: accepted
+- **Date**: 2026-05-14
+- **Related**: [ADR 0005](./0005-eval-split-public-synthetic-private-local.md) §
+  "LLM-judge gate layers" · [ADR 0012](./0012-llm-judge-on-public-synthetic.md) ·
+  [ADR 0004](./0004-verifier-retry-policy.md) · issue #722
+- **Deciders**: hskim
+
+## Context
+
+[ADR 0012](./0012-llm-judge-on-public-synthetic.md) § *Cadence* specifies:
+
+> *"A developer who wants the real signal runs `make synthetic-judge` with a live
+> backend manually, attaches the resulting committed aggregate diff to the PR, and
+> lets reviewers read the rendered table."*
+
+This works but has no enforcement mechanism.  In practice:
+
+- Reviewers cannot *request* a live judge run on-demand — they depend on the
+  author to remember.
+- Authors forget, or skip it on small PRs where they suspect no signal change.
+- There is no visible record in the PR thread of *whether* a live run was
+  performed for this change set.
+
+[ADR 0005](./0005-eval-split-public-synthetic-private-local.md) §
+"LLM-judge gate layers" (Gate 2) states the invariant:
+*"CI runs stub-only, live backend is offline opt-in."*
+Any PR-level automation must respect this: the existing `pr-eval.yml` must
+not be modified to call a live LLM.
+
+A new, **separate** workflow that fires only when explicitly requested does not
+violate Gate 2 — the trigger is a deliberate human action (label attachment),
+not an automatic CI gate on every commit.
+
+## Decision
+
+Introduce a **label-gated PR workflow** for live LLM-judge signal:
+
+- A new workflow file `.github/workflows/pr-judge.yml` fires on the
+  `labeled` event when the label `live-judge-please` is attached to a PR.
+- The workflow runs `make eval && make synthetic-judge` with
+  `BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible` using repository
+  secrets (`BIDMATE_JUDGE_API_KEY`, `BIDMATE_JUDGE_MODEL`,
+  `BIDMATE_JUDGE_BASE_URL`).
+- Results are posted as a **PR comment** (markdown table: `n`,
+  `faithfulness_mean`, `answer_relevance_mean`, `agreement_with_verifier`,
+  `by_query_type` slice) plus uploaded as a workflow artifact.
+- The aggregate is **not auto-committed** to the repository; the author may
+  choose to commit it separately after reviewing the signal.
+
+### Invariants preserved
+
+| Invariant | How preserved |
+|-----------|---------------|
+| **ADR 0004** reproducibility | `pr-eval.yml` unchanged; stub default still runs on every push. |
+| **ADR 0005** commit boundary | Workflow artifact upload only; no `git push` of per-case data. |
+| **ADR 0003** answer contract | Judge never feeds back into `run_rag_query`; comment-only surface. |
+| **ADR 0012** cadence | Manual opt-in preserved; label = explicit request, not auto-gate. |
+
+### Secrets required
+
+| Secret | Description |
+|--------|-------------|
+| `BIDMATE_JUDGE_API_KEY` | API key for the OpenAI-compatible judge endpoint |
+| `BIDMATE_JUDGE_MODEL` | Model identifier (e.g. `claude-sonnet-4-5`) |
+| `BIDMATE_JUDGE_BASE_URL` | Optional custom base URL (e.g. Anthropic-Compat) |
+
+These secrets are already used by the local `make synthetic-judge` path;
+this ADR does not introduce new credentials.
+
+### Goodhart guard
+
+The workflow runs on `labeled` but **not** on `synchronize` (new push).
+A label must be re-attached after each new push to get a fresh judge run.
+This prevents the judge signal from becoming an optimization target that
+authors game by pushing micro-commits.
+
+Fork PRs do not receive `BIDMATE_JUDGE_API_KEY` from repository secrets by
+default (GitHub isolates secrets from forks).  The workflow must use
+`pull_request_target` or explicitly check that `github.event.pull_request
+.head.repo.full_name == github.repository` — see implementation PR for details.
+
+## Alternatives considered
+
+### (a) Nightly cron on main only
+
+Run live judge nightly against the latest main commit.
+
+*Rejected*: signal arrives too late — reviewer sees the aggregate days after
+the PR was merged, not while reviewing.  Also conflates multiple PRs' changes
+in a single run.
+
+### (b) Automatic on every PR push (feature-flag gated)
+
+Run live judge on every push but skip via env var in fork contexts.
+
+*Rejected*: violates ADR 0004's *"CI never calls live LLM"* spirit even if
+framed as a "second workflow".  Token cost per push is unjustified for PRs
+that make no retrieval or answer changes.  Most critically, it creates
+Goodhart pressure: authors will tune prompts/retrieval to maximise the
+automatically-reported score rather than to improve real-world accuracy.
+
+### (c) PR template mandatory field
+
+Require authors to fill in a "live judge results" field in the PR template
+and fail CI if blank.
+
+*Rejected*: high friction, no automation.  Authors will write "N/A" or paste
+stale results.  Adds reviewer burden without adding reliability.
+
+### (d) `workflow_dispatch` author trigger
+
+Add a manual dispatch button that authors click in the GitHub Actions UI.
+
+*Rejected*: less discoverable than a label (requires navigating to Actions UI);
+does not let the reviewer request a run without author involvement; the label
+approach achieves the same explicit-trigger property with better UX.
+
+## Consequences
+
+**Wins**
+
+- Reviewers can request a live RAGAS signal by attaching a label — no
+  need to ask the author to re-run locally.
+- A persistent PR comment creates a visible record of whether the live
+  judge was consulted for this change set.
+- Token cost is bounded: one run per label-attach event, not per commit.
+- ADR 0004 / 0005 / 0012 invariants are all preserved.
+
+**Costs**
+
+- Requires repository secrets to be configured once by the repo owner.
+- Fork PRs cannot run the live judge unless the workflow is written with
+  `pull_request_target` and appropriate security checks.
+- The label must be manually re-attached after each push — slight friction
+  compared to a fully automatic trigger.
+
+**Unchanged**
+
+- `make synthetic-judge` local workflow remains the primary path for
+  developers who want live RAGAS during development (pre-PR).
+- `reports/synthetic_judge.aggregate.json` snapshot cadence is unchanged —
+  developers still commit it manually after a meaningful signal update.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -97,6 +97,7 @@ project record.
 | [0036](./0036-hwp-native-loader-pyhwp-gated-default.md) | accepted | HwpNativeLoader promoted to pyhwp-install-detection default (`with_tables=True` when `hwp5` importable); `BIDMATE_HWP_LOADER=csv` is explicit opt-out; CI minimal install (pyhwp absent) unchanged; re-open if native fallback rate > 20% on private corpus |
 | [0037](./0037-kure-v1-closes-phase-1-5.md) | accepted | KURE-v1 Phase 1.5 n=100 formal measurement: `full` Δ = **−1.3pp** accuracy / **+0.0pp** groundedness → condition 3 NOT triggered; MiniLM default lock holds across 6 embedding pivots; adds `requires_torch_min_version` gate to `eval/run_eval.ablation_runs()`; closes issue #447 |
 | [0039](./0039-hwp-structural-hardcase-taxonomy.md) | proposed | HWP structural hardcase taxonomy (`table_heavy` / `ocr_noisy` / `rotated_or_skewed` / `layout_broken`) for public synthetic surface; ADR 0001/0005/0030 compatible; activated by PR-A (fixtures) → PR-C (loader ablation) → PR-D (tagging); closes issue #646 |
+| [0043](./0043-pr-cadence-for-live-llm-judge.md) | accepted | Label-gated PR workflow (`live-judge-please`) fires `.github/workflows/pr-judge.yml` with live `BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible`; posts RAGAS aggregate as PR comment; ADR 0004/0005/0012 invariants preserved; re-attach label after each push (Goodhart guard) |
 
 ## Roadmap (proposed, not yet committed)
 


### PR DESCRIPTION
## Summary

- **ADR 0043** 추가 (`docs/adr/0043-pr-cadence-for-live-llm-judge.md`): reviewer 가 PR 에 `live-judge-please` 라벨 붙여 라이브 RAGAS 시그널 요청 가능한 label-gated PR 워크플로 정책
- `docs/adr/README.md` 에 신규 row (accepted) 업데이트
- 코드 변경 없음; 정책-only 문서

## Problem

ADR 0012 § *Cadence* 가 라이브 judge 실행을 수동, 미강제 관행으로 남김. 실제로 reviewer 가 on-demand 실행 요청 불가, PR 스레드에 라이브 judge 가 참조됐는지 가시적 record 없음.

## Decision (ADR 0043)

`.github/workflows/pr-judge.yml` 도입 (follow-up PR-D 에서 구현):

- **Trigger**: `pull_request` → `labeled` 이벤트, 라벨 = `live-judge-please`
- **Action**: `BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible` 로 `make eval && make synthetic-judge` 실행
- **Output**: PR 코멘트 (RAGAS aggregate 표) + 워크플로 artifact; **auto-commit 없음**
- **Goodhart 가드**: 각 push 후 라벨 재부착 필요 (`synchronize` 아닌 `labeled` 발동)

## Invariants preserved

| Invariant | How |
|-----------|-----|
| ADR 0004 재현성 | `pr-eval.yml` 무변경; 모든 push 에 stub 기본 |
| ADR 0005 commit 경계 | 워크플로 artifact 만; per-case 데이터의 `git push` 없음 |
| ADR 0003 답변 계약 | Judge 가 절대 `run_rag_query` 로 feedback 안 함 |
| ADR 0012 cadence | 수동 opt-in 보존; 라벨 = 명시적 요청 |

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 이 PR 은 정책-only — ADR 문서 + README row 추가. `rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, `eval/`, 기타 load-bearing 표면 무변경. 파이프라인 출력은 머지 전후 bit-identical.

## Checklist

- [x] 1 · Issue linked (`Closes #722`)
- [x] 2 · ADR 0007 매치 브랜치 (`docs/issue-722-*`)
- [x] 3 · Docs-only — 동작 변경 없음
- [x] 4 · Load-bearing 코드 미수정
- [x] 5a · N/A — 테스트 변경 없음 (정책 doc)
- [x] 5b · 위 참조 — 검색 / verifier 경로 동작 변경 없음
- [x] 6 · ADR 0001 naive_baseline 영향 없음

Closes #722
