### PR TITLE
feat(governance): hook-fires rolling-window summary (closes #716)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@
 # rubric + 5-axis Claude collaboration rubric. See SKILL at
 # .claude/skills/self-review-quarterly/SKILL.md and privacy policy at
 # docs/self-review/README.md.
-.PHONY: self-review-quarterly
+.PHONY: self-review-quarterly hook-fires-weekly
 
 # Cleanup
 .PHONY: clean
@@ -441,3 +441,14 @@ self-review-quarterly:
 	  --emit-report \
 	  --output "docs/self-review/$(QUARTER).md"
 	@echo "Run /self-review-quarterly $(QUARTER) in Claude Code to fill verdict tables."
+
+# Rolling-window hook-fires summary (issue #716). Emits last N-day governance
+# hook stats as JSON to stdout. Q3 self-review #3·#4 (automation ROI / rule-to-
+# automation lag) progress gauge — daily-runnable companion to the quarterly
+# report.
+#
+# Example:
+#   make hook-fires-weekly           # last 7 days (default)
+#   make hook-fires-weekly DAYS=30   # last 30 days
+hook-fires-weekly:
+	@$(PYTHON) scripts/claude-hooks/_self_review.py --window-days $(or $(DAYS),7) --repo .

--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -25,7 +25,7 @@ import re
 import subprocess
 import sys
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -677,17 +677,40 @@ def emit_report(stats: dict[str, Any]) -> str:
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--quarter", required=True, help="Qx-YYYY (e.g. Q2-2026)")
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--quarter", help="Qx-YYYY (e.g. Q2-2026); full stats / report")
+    mode.add_argument("--window-days", type=int, metavar="N",
+                      help="last N days; emit hook-fires summary JSON only")
     p.add_argument("--transcripts-glob", default=DEFAULT_TRANSCRIPTS_GLOB)
     p.add_argument("--memory-dir", default=DEFAULT_MEMORY_DIR)
     p.add_argument("--repo", default=os.getcwd())
     p.add_argument("--emit-stats", action="store_true",
-                   help="emit stats.json to stdout")
+                   help="emit stats.json to stdout (quarter mode)")
     p.add_argument("--emit-report", action="store_true",
-                   help="emit Markdown report")
+                   help="emit Markdown report (quarter mode)")
     p.add_argument("--output", default="-",
                    help="report path (default stdout; ignored without --emit-report)")
     args = p.parse_args()
+
+    if args.window_days is not None:
+        if args.window_days <= 0:
+            sys.stderr.write("self-review: --window-days must be positive\n")
+            return 1
+        today = datetime.now(timezone.utc).date()
+        start = (today - timedelta(days=args.window_days)).isoformat()
+        end = today.isoformat()
+        try:
+            hooks = collect_governance_hooks(args.repo, start, end)
+        except Exception as e:  # pragma: no cover
+            sys.stderr.write(f"self-review: {e}\n")
+            return 2
+        stats = {
+            "window_days": args.window_days,
+            "date_range": [start, end],
+            "governance_hooks": hooks,
+        }
+        sys.stdout.write(json.dumps(stats, indent=2, ensure_ascii=False) + "\n")
+        return 0
 
     if not args.emit_stats and not args.emit_report:
         sys.stderr.write("self-review: pass --emit-stats or --emit-report\n")

--- a/tests/test_self_review_window_regression.py
+++ b/tests/test_self_review_window_regression.py
@@ -1,0 +1,80 @@
+"""Regression tests for `--window-days N` CLI mode (issue #716).
+
+Pins rolling-window hook-fires summary emit: positive-N parsing,
+mutex with `--quarter`, missing-mode rejection, and that fires
+outside the [today-N, today] window are excluded.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "scripts" / "claude-hooks" / "_self_review.py"
+)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestWindowDaysMode(unittest.TestCase):
+    def test_emits_fires_within_7day_window(self):
+        today = datetime.now(timezone.utc).date()
+        inside = (today - timedelta(days=1)).isoformat()
+        outside = (today - timedelta(days=14)).isoformat()
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(
+                f"{inside}T10:00:00Z|aware|load-bearing|rag_core.py\n"
+                f"{outside}T10:00:00Z|aware|load-bearing|old.py\n"
+            )
+            result = _run("--window-days", "7", "--repo", str(repo))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["window_days"], 7)
+        self.assertEqual(
+            data["governance_hooks"]["pretooluse_loadbearing_fires"], 1
+        )
+        self.assertIn("aware", data["governance_hooks"]["fires_by_action"])
+
+    def test_absent_log_emits_zero(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = _run("--window-days", "7", "--repo", td)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(
+            data["governance_hooks"]["pretooluse_loadbearing_fires"], 0
+        )
+
+    def test_quarter_and_window_mutually_exclusive(self):
+        result = _run("--quarter", "Q2-2026", "--window-days", "7")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not allowed with", result.stderr)
+
+    def test_missing_mode_rejected(self):
+        result = _run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("one of the arguments", result.stderr)
+
+    def test_non_positive_window_rejected(self):
+        for n in ("0", "-3"):
+            with self.subTest(n=n):
+                result = _run("--window-days", n, "--repo", ".")
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertIn("must be positive", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 변경 내용 및 이유

`scripts/claude-hooks/_self_review.py` 에 지난 N일 hook-fires-only JSON summary 를 emit 하는 `--window-days N` mutex CLI 모드 추가. 동반 `make hook-fires-weekly` 타깃 (default 7d, `DAYS=N` override) 으로 Q3 self-review #3·#4 (automation ROI / rule-to-automation lag) 에 daily-runnable 진행 게이지 제공 — 지금까지 이 통계는 분기 경계에서만 계산되어 Q2 (△) ~ Q3 사이 진행 가시성이 없었다.

`precious-swimming-platypus.md` plan 에서 BidMate 의 automation surface 를 Thariq 의 9-skill taxonomy 에 매핑 후 priority 1 (#9 인프라 운영 — 루틴 유지보수) 로 식별.

Closes #716

## 2. 변경 파일

- `scripts/claude-hooks/_self_review.py` — argparse: `--quarter` + `--window-days` mutex group (`required=True`); 신규 window-days 분기가 `collect_governance_hooks(repo, start, end)` 미변경 재사용
- `Makefile` — `DAYS=N` override 가진 신규 `hook-fires-weekly` 타깃 (default 7)
- `tests/test_self_review_window_regression.py` (신규) — 신규 모드 pin 하는 5 케이스

이 중 load-bearing 없음 (`scripts/_governance.py` SSoT 참조).

## 3. 리스크

가장 가능성 높은 break: `--quarter` 가 단독으로 `required=True` 가 아니게 되어 기존 `--quarter` 호출자 (`make self-review-quarterly` 워크플로 + `/self-review-quarterly` skill) fail. **Rule out** 근거:
1. `required=True` 의 argparse mutex group 이 빈 호출을 이전과 동일하게 reject (regression test `test_missing_mode_rejected`)
2. `--quarter Q2-2026 --emit-stats` 가 end-to-end 동작 유지 (기존 `test_self_review_regression.py` + `test_self_review_no_body_leak_regression.py` — 둘 다 변경 후 pass, 16 passed)
3. 이 PR 외부 호출 사이트 영향 없음 — skill 파일이 `--quarter` + `--emit-report` 호출, 미변경 quarter 분기와 일치

## 4. 테스트

`tests/test_self_review_window_regression.py` (신규) — 5 케이스:
- `test_emits_fires_within_7day_window` — 경계 필터 (안 vs. day-14 밖)
- `test_absent_log_emits_zero` — log 파일 missing → 0 fires, exit 0
- `test_quarter_and_window_mutually_exclusive` — argparse 양쪽 reject
- `test_missing_mode_rejected` — 빈 호출 reject
- `test_non_positive_window_rejected` — `--window-days 0` 와 `-3` 모두 exit 1

5 전부 pass (7.88s). 기존 self-review 테스트 미변경: 16 passed (997s, ADR lag git-log 호출 지배).

## 5. Eval 영향

전부 `·`. Non-RAG 경로 — governance tooling 만. retrieval / verifier / answer 코드 미터치.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. `scripts/_governance.py` 의 load-bearing 경로 미수정.

## 6. 하위 호환성

- `--quarter Qx-YYYY` 동일 동작 (변경 후 기존 regression test pass 로 검증)
- 신규 `--window-days` 는 추가형; flag 제거/rename 없음
- `make self-review-quarterly QUARTER=Qx-YYYY` 미변경
- quarter 모드 출력 schema 미변경 (`assemble_stats` 미터치)
- 신규 window-mode JSON 필드 `window_days`, `date_range`, `governance_hooks` — 기존 consumer 와 충돌 없음

`schema_version` bump 불필요 (ADR 0003 답변 계약 미영향).

## 7. 범위 외

- `.hook-fires.log` rotation (`logrotate`-style size/age cap) — 별도 follow-up; rotation policy 사이즈 결정에 `--window-days` 실행의 실제 fire 볼륨 먼저 필요
- 운영 runbook skill (plan #8 카테고리) — 별도 PR
- ADR Proposed-stuck alert — 별도 follow-up
- window 모드 Markdown report — v1 은 JSON 만; 필요 시 render layer 가 wrap
