### PR TITLE
feat(eval): retrieval_only ablation preset 추가 (closes #721)

### DIFF
--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -141,6 +141,18 @@ ablation_runs:
     rerank: true
     verifier_retry: false
     retrieval_mode: flat
+  # Issue #721 — retrieval-only ablation: rerank=false + verifier_retry=false.
+  # Completes the 2×2 (rerank × verifier_retry) ablation matrix alongside
+  # `no_rerank` (rerank=false, retry=true) and `no_verifier_retry` (rerank=true,
+  # retry=false). Enables naive_baseline vs retrieval_only vs full 3-way
+  # comparison to isolate retrieval contribution from reranking and verifier
+  # retry. Forward-only addition; ADR 0001 naive_baseline preserved.
+  - name: retrieval_only
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: false
+    verifier_retry: false
+    retrieval_mode: flat
   - name: hybrid_bm25
     pipeline: agentic_full
     metadata_first: true


### PR DESCRIPTION
## Summary

- `eval/config.yaml` `ablation_runs`에 `retrieval_only` 행 추가 (12줄, 코멘트 포함)
- `rerank: false` + `verifier_retry: false` 조합 — 기존 `no_rerank`(retry=true) · `no_verifier_retry`(rerank=true)와 함께 2×2 ablation matrix 완성
- `naive_baseline` vs `retrieval_only` vs `full` 3-way 비교로 각 단계(rerank / verifier retry) 기여도 분리 가능

## PR checklist

1. Behavior change: 없음 — config에 새 preset 추가만, 기존 preset 결과 불변
2. Retrieval / verifier / answer path 코드 변경: 없음
3. ADR: 불요 (forward-only 추가, ADR 0001 naive_baseline 보존, ADR 0030 leaderboard forward-only 호환)
4. 5a. Synthetic delta: N/A (파이프라인 코드 무변경)
5. **5b. Real-data delta**: 파이프라인 코드 변경 없이 새 ablation preset 추가만이라 기존 preset의 real-data 결과 delta = 0. `make real-eval-delta`는 base/head 각각의 primary_run(`naive_baseline`) 결과를 비교하며, 그 결과는 이 PR로 변하지 않음.

Closes #721