### PR TITLE
feat(ci): pr-judge.yml label-gated live LLM-judge workflow (closes #731)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,3 +66,10 @@ If yes, what's the migration?
 ## 7. Out of scope
 
 <!-- Anything you noticed and deliberately did not fix. -->
+
+<!--
+Optional: attach the **`live-judge-please`** label to trigger
+`.github/workflows/pr-judge.yml` (ADR 0043).  The workflow runs the live
+LLM-judge once and posts the RAGAS aggregate as a PR comment.  Re-attach
+the label after each push to refresh (Goodhart guard).
+-->

--- a/.github/workflows/pr-judge.yml
+++ b/.github/workflows/pr-judge.yml
@@ -1,0 +1,122 @@
+name: PR Live LLM-Judge
+
+# ADR 0043 — label-gated live LLM-judge cadence.
+#
+# Trigger: a maintainer attaches the `live-judge-please` label to a PR.
+# Effect: run `make eval && make synthetic-judge` with the live backend
+#         (BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible) and post the
+#         RAGAS aggregate as a PR comment.  The aggregate JSON is uploaded
+#         as a workflow artifact; the comment is upserted in place.
+#
+# Invariants:
+# - pr-eval.yml (ADR 0004 stub-default CI) is **not** modified by this file.
+# - No `git push` of per-case judge text (ADR 0005 commit boundary).
+# - Fork PRs are skipped — `BIDMATE_JUDGE_API_KEY` is a repo secret that
+#   GitHub does not expose to forks, and we explicitly check head repo to
+#   avoid running a no-secret build that would silently fall back to stub.
+# - Goodhart guard: trigger is `labeled` only, not `synchronize`.  After a
+#   new push, the label must be re-attached to refresh the signal.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # One judge run at a time per PR; a re-label cancels any in-flight run
+  # for the same PR (re-labelers expect a fresh result, not a stale one).
+  group: pr-judge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  live-judge:
+    name: Live LLM-judge
+    # Three guards:
+    # 1. The label must match `live-judge-please` (workflow fires on every
+    #    labeled event so we filter here).
+    # 2. The PR must be from this repo, not a fork (fork PRs cannot see
+    #    repo secrets and a silent fallback to stub would be misleading).
+    # 3. PR must be open (re-labelling closed PRs is a no-op).
+    if: >-
+      github.event.label.name == 'live-judge-please' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    env:
+      EMBEDDING_BACKEND: hashing
+      PYTHONDONTWRITEBYTECODE: "1"
+      BIDMATE_SYNTHETIC_JUDGE_BACKEND: openai_compatible
+      BIDMATE_JUDGE_API_KEY: ${{ secrets.BIDMATE_JUDGE_API_KEY }}
+      BIDMATE_JUDGE_MODEL: ${{ secrets.BIDMATE_JUDGE_MODEL }}
+      BIDMATE_JUDGE_BASE_URL: ${{ secrets.BIDMATE_JUDGE_BASE_URL }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Verify judge secret is configured
+        run: |
+          if [ -z "$BIDMATE_JUDGE_API_KEY" ]; then
+            echo "::error::BIDMATE_JUDGE_API_KEY secret is empty. Configure" \
+                 "the repository secret per ADR 0043 § Secrets required."
+            exit 1
+          fi
+
+      - name: Build index + run eval (stub embedding, real LLM-judge)
+        run: |
+          make index
+          make eval
+
+      - name: Run live LLM-judge
+        run: make synthetic-judge
+
+      - name: Render PR-comment markdown
+        run: |
+          python scripts/render_judge_comment.py \
+            --aggregate reports/synthetic_judge.aggregate.json \
+            --output judge-comment.md
+          cat judge-comment.md
+
+      - name: Upload aggregate artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: synthetic-judge-aggregate
+          path: reports/synthetic_judge.aggregate.json
+          if-no-files-found: warn
+
+      - name: Upsert PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          marker="<!-- pr-judge-bot -->"
+          body="$(cat judge-comment.md)"
+          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$marker\")) | .id" \
+            | head -n1)
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" \
+              -f body="$body" >/dev/null
+            echo "Updated existing comment $existing"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+          fi

--- a/scripts/render_judge_comment.py
+++ b/scripts/render_judge_comment.py
@@ -1,0 +1,139 @@
+"""Render `reports/synthetic_judge.aggregate.json` as a PR-comment markdown table.
+
+Used by ``.github/workflows/pr-judge.yml`` (ADR 0043 — label-gated live LLM-judge
+cadence).  Stdlib-only so the CI step can run before any project deps are
+installed; the workflow installs deps for ``make synthetic-judge`` itself,
+but rendering the comment doesn't need them.
+
+The comment uses a stable HTML marker (``<!-- pr-judge-bot -->``) so the
+workflow can upsert in place instead of stacking duplicates on every re-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+COMMENT_MARKER = "<!-- pr-judge-bot -->"
+
+_HEADLINE_KEYS: list[tuple[str, str]] = [
+    ("n", "n"),
+    ("faithfulness_mean", "faithfulness"),
+    ("answer_relevance_mean", "answer_relevance"),
+    ("grounded_rate", "grounded_rate"),
+    ("agreement_with_verifier", "agreement_w/_verifier"),
+]
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def render(aggregate: dict[str, Any]) -> str:
+    backend = aggregate.get("backend", "unknown")
+    model = aggregate.get("model", "unknown")
+    generated_at = aggregate.get("generated_at", "—")
+    lines: list[str] = [
+        COMMENT_MARKER,
+        "## Live LLM-judge signal (ADR 0043)",
+        "",
+        f"- **backend**: `{backend}`",
+        f"- **model**: `{model}`",
+        f"- **generated_at**: `{generated_at}`",
+        "",
+        "### Headline aggregate",
+        "",
+        "| metric | value |",
+        "|--------|------:|",
+    ]
+    for json_key, label in _HEADLINE_KEYS:
+        lines.append(f"| {label} | {_fmt(aggregate.get(json_key))} |")
+
+    status_dist = aggregate.get("status_distribution") or {}
+    if status_dist:
+        lines.append("")
+        lines.append("### Status distribution")
+        lines.append("")
+        lines.append("| status | count |")
+        lines.append("|--------|------:|")
+        for status, count in sorted(status_dist.items()):
+            lines.append(f"| {status} | {count} |")
+
+    by_query_type = aggregate.get("by_query_type") or {}
+    if isinstance(by_query_type, dict) and by_query_type:
+        lines.append("")
+        lines.append("### By query type")
+        lines.append("")
+        lines.append(
+            "| query_type | n | faithfulness | answer_relevance |"
+            " grounded_rate | agreement |"
+        )
+        lines.append("|------------|--:|------------:|----------------:|"
+                     "-------------:|---------:|")
+        for query_type, slice_summary in sorted(by_query_type.items()):
+            if not isinstance(slice_summary, dict):
+                continue
+            lines.append(
+                "| {qt} | {n} | {faith} | {ans} | {gr} | {agr} |".format(
+                    qt=query_type,
+                    n=_fmt(slice_summary.get("n")),
+                    faith=_fmt(slice_summary.get("faithfulness_mean")),
+                    ans=_fmt(slice_summary.get("answer_relevance_mean")),
+                    gr=_fmt(slice_summary.get("grounded_rate")),
+                    agr=_fmt(slice_summary.get("agreement_with_verifier")),
+                )
+            )
+
+    lines.append("")
+    lines.append(
+        "<sub>Triggered by label `live-judge-please`. Re-attach the label "
+        "after each push to refresh (ADR 0043 Goodhart guard).</sub>"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--aggregate",
+        type=Path,
+        default=Path("reports/synthetic_judge.aggregate.json"),
+        help="Path to the synthetic-judge aggregate JSON.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional output path. Defaults to stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.aggregate.is_file():
+        print(f"aggregate file not found: {args.aggregate}", file=sys.stderr)
+        return 1
+
+    aggregate = json.loads(args.aggregate.read_text(encoding="utf-8"))
+    if not isinstance(aggregate, dict):
+        print("aggregate JSON must be an object", file=sys.stderr)
+        return 1
+
+    rendered = render(aggregate)
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_pr_judge_workflow_regression.py
+++ b/tests/test_pr_judge_workflow_regression.py
@@ -1,0 +1,247 @@
+"""Regression tests for `.github/workflows/pr-judge.yml` (ADR 0043).
+
+These guard the policy invariants codified in ADR 0043:
+
+- Trigger is `pull_request` `labeled` only (no `synchronize`/`push`/`opened`).
+- The `live-judge-please` label gate is enforced in the job `if:` expression.
+- The fork-repo guard (`head.repo.full_name == github.repository`) is present.
+- The live backend env var is hard-coded to `openai_compatible`.
+- The three judge secrets are wired through to `env`.
+- The aggregate JSON is uploaded as an artifact (no `git push` of per-case data).
+
+The companion comment-renderer (`scripts/render_judge_comment.py`) is exercised
+end-to-end against a minimal fixture so the workflow's `python scripts/...`
+step has a unit-test floor that fires before CI does.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "pr-judge.yml"
+PR_TEMPLATE_PATH = REPO_ROOT / ".github" / "pull_request_template.md"
+RENDER_SCRIPT = REPO_ROOT / "scripts" / "render_judge_comment.py"
+
+
+def _load_workflow() -> dict:
+    with WORKFLOW_PATH.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+class WorkflowStructureTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = _load_workflow()
+
+    def test_workflow_parses(self) -> None:
+        self.assertIsInstance(self.workflow, dict)
+        self.assertEqual(self.workflow["name"], "PR Live LLM-Judge")
+
+    def test_trigger_is_labeled_only(self) -> None:
+        # PyYAML maps the bareword `on` to True; accept either form.
+        on_block = self.workflow.get("on") or self.workflow.get(True)
+        self.assertIsNotNone(
+            on_block,
+            "workflow `on:` block missing — ADR 0043 trigger contract broken",
+        )
+        self.assertIn("pull_request", on_block)
+        types = on_block["pull_request"]["types"]
+        self.assertEqual(
+            list(types),
+            ["labeled"],
+            "ADR 0043 Goodhart guard: workflow must fire on `labeled` only, "
+            "not on `synchronize`/`push`/`opened`.  See pr-judge.yml comment.",
+        )
+
+    def test_job_has_label_gate(self) -> None:
+        job = self.workflow["jobs"]["live-judge"]
+        condition = job["if"]
+        # The label-name check is the primary gate.
+        self.assertIn("github.event.label.name == 'live-judge-please'", condition)
+
+    def test_job_has_fork_guard(self) -> None:
+        condition = self.workflow["jobs"]["live-judge"]["if"]
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            condition,
+            "ADR 0043 § Fork PR consideration: fork PRs must be excluded so "
+            "BIDMATE_JUDGE_API_KEY cannot leak via untrusted code paths.",
+        )
+
+    def test_env_pins_openai_compatible_backend(self) -> None:
+        env = self.workflow["jobs"]["live-judge"]["env"]
+        self.assertEqual(env["BIDMATE_SYNTHETIC_JUDGE_BACKEND"], "openai_compatible")
+
+    def test_env_references_three_judge_secrets(self) -> None:
+        env = self.workflow["jobs"]["live-judge"]["env"]
+        for key in ("BIDMATE_JUDGE_API_KEY", "BIDMATE_JUDGE_MODEL", "BIDMATE_JUDGE_BASE_URL"):
+            self.assertIn(key, env, f"{key} env var missing from pr-judge.yml")
+            self.assertIn("secrets.", env[key], f"{key} must come from repo secrets")
+
+    def test_concurrency_groups_per_pr(self) -> None:
+        concurrency = self.workflow["concurrency"]
+        self.assertIn("pull_request.number", concurrency["group"])
+        self.assertTrue(concurrency.get("cancel-in-progress"))
+
+    def test_permissions_minimal(self) -> None:
+        perms = self.workflow["permissions"]
+        # Read source + comment on PR.  Nothing else (no `contents: write`,
+        # no `actions:`, no `id-token:`) — ADR 0005 commit boundary.
+        self.assertEqual(perms.get("contents"), "read")
+        self.assertEqual(perms.get("pull-requests"), "write")
+
+    def test_artifact_upload_step_present(self) -> None:
+        steps = self.workflow["jobs"]["live-judge"]["steps"]
+        upload_steps = [
+            s for s in steps
+            if isinstance(s, dict) and s.get("uses", "").startswith("actions/upload-artifact")
+        ]
+        self.assertTrue(
+            upload_steps,
+            "ADR 0043 § Output: workflow must upload aggregate as artifact",
+        )
+        # Confirm the artifact path is the aggregate JSON, not the local
+        # per-case file (which would violate ADR 0005 commit boundary).
+        paths = [s["with"].get("path", "") for s in upload_steps]
+        self.assertTrue(
+            any("synthetic_judge.aggregate.json" in p for p in paths),
+            f"upload-artifact paths {paths} do not include the aggregate JSON",
+        )
+        self.assertFalse(
+            any("synthetic_judge.local.json" in p for p in paths),
+            "Per-case local JSON must not be uploaded (ADR 0005 boundary)",
+        )
+
+    def test_no_pull_request_target(self) -> None:
+        # `pull_request_target` runs on the *base* repo with secrets exposed,
+        # which would let fork PRs exfiltrate BIDMATE_JUDGE_API_KEY.  ADR 0043
+        # explicitly forbids it.
+        on_block = self.workflow.get("on") or self.workflow.get(True)
+        self.assertNotIn("pull_request_target", on_block)
+
+    def test_workflow_does_not_commit_artifacts(self) -> None:
+        # Sanity: no shell step pushes back to the repo.  A `git push` here
+        # would silently violate the ADR 0005 boundary the policy ADR
+        # promises to preserve.
+        steps = self.workflow["jobs"]["live-judge"]["steps"]
+        for step in steps:
+            run_block = step.get("run", "") if isinstance(step, dict) else ""
+            self.assertNotIn("git push", run_block)
+            self.assertNotIn("git commit", run_block)
+
+
+class PrTemplateMentionsLabelTest(unittest.TestCase):
+    """PR template should hint at the label trigger so authors discover it."""
+
+    def test_template_mentions_label(self) -> None:
+        body = PR_TEMPLATE_PATH.read_text(encoding="utf-8")
+        self.assertIn("live-judge-please", body)
+        self.assertIn("ADR 0043", body)
+
+
+class RenderCommentSmokeTest(unittest.TestCase):
+    """End-to-end smoke for scripts/render_judge_comment.py.
+
+    The workflow runs ``python scripts/render_judge_comment.py ...``; a broken
+    render would silently produce an empty PR comment, which is worse than a
+    failed CI run.  This test catches missing keys + format breakage.
+    """
+
+    FIXTURE = {
+        "schema_version": 1,
+        "generated_at": "2026-05-14T00:00:00Z",
+        "backend": "openai_compatible",
+        "model": "claude-sonnet-4-5",
+        "n": 42,
+        "faithfulness_mean": 0.81,
+        "answer_relevance_mean": 0.78,
+        "grounded_rate": 0.88,
+        "agreement_with_verifier": 0.86,
+        "status_distribution": {"supported": 36, "insufficient": 6},
+        "by_query_type": {
+            "abstention": {
+                "n": 9,
+                "faithfulness_mean": 0.70,
+                "answer_relevance_mean": 0.72,
+                "grounded_rate": 0.78,
+                "agreement_with_verifier": 0.89,
+            },
+            "comparison": {
+                "n": 10,
+                "faithfulness_mean": 0.85,
+                "answer_relevance_mean": 0.80,
+                "grounded_rate": 0.90,
+                "agreement_with_verifier": 0.80,
+            },
+        },
+    }
+
+    def test_render_emits_marker_and_table(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            agg = tmp_path / "agg.json"
+            agg.write_text(json.dumps(self.FIXTURE), encoding="utf-8")
+            out = tmp_path / "comment.md"
+            result = subprocess.run(
+                [sys.executable, str(RENDER_SCRIPT),
+                 "--aggregate", str(agg), "--output", str(out)],
+                check=True, capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            rendered = out.read_text(encoding="utf-8")
+
+        # Marker is required for the workflow's upsert step to work.
+        self.assertIn("<!-- pr-judge-bot -->", rendered)
+        # Headline metrics surfaced.
+        self.assertIn("faithfulness", rendered)
+        self.assertIn("answer_relevance", rendered)
+        self.assertIn("agreement_w/_verifier", rendered)
+        # Per-query-type slice rendered.
+        self.assertIn("abstention", rendered)
+        self.assertIn("comparison", rendered)
+        # Goodhart footnote rendered.
+        self.assertIn("Re-attach the label", rendered)
+        # Backend + model surfaced (so reviewers see live vs stub at a glance).
+        self.assertIn("openai_compatible", rendered)
+        self.assertIn("claude-sonnet-4-5", rendered)
+
+    def test_render_handles_missing_optional_blocks(self) -> None:
+        import tempfile
+
+        minimal = {
+            "schema_version": 1,
+            "generated_at": "2026-05-14T00:00:00Z",
+            "backend": "stub",
+            "model": "stub",
+            "n": 0,
+            "faithfulness_mean": None,
+            "answer_relevance_mean": None,
+            "grounded_rate": None,
+            "agreement_with_verifier": None,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            agg = tmp_path / "agg.json"
+            agg.write_text(json.dumps(minimal), encoding="utf-8")
+            out = tmp_path / "comment.md"
+            subprocess.run(
+                [sys.executable, str(RENDER_SCRIPT),
+                 "--aggregate", str(agg), "--output", str(out)],
+                check=True, capture_output=True, text=True,
+            )
+            rendered = out.read_text(encoding="utf-8")
+        self.assertIn("<!-- pr-judge-bot -->", rendered)
+        # None values render as em-dash, not "None".
+        self.assertNotIn("None", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 변경 내용 및 이유

[ADR 0043](docs/adr/0043-pr-cadence-for-live-llm-judge.md) § *Decision* 구현: reviewer 가 PR 에 `live-judge-please` 라벨 붙이면 live LLM-judge 실행하는 신규 GitHub Actions 워크플로. 워크플로는 `BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible` 로 `make eval && make synthetic-judge` 실행, aggregate JSON 을 artifact 로 업로드, RAGAS aggregate (headline 메트릭 + status 분포 + `by_query_type` 슬라이스) 담은 markdown PR 코멘트 upsert.

Closes #731

## 2. Files affected

- **NEW** `.github/workflows/pr-judge.yml` — 워크플로 (trigger: `labeled` only, fork 가드, label 게이트, 3 secrets wired)
- **NEW** `scripts/render_judge_comment.py` — stdlib-only markdown 렌더러 (`<!-- pr-judge-bot -->` upsert 마커)
- **NEW** `tests/test_pr_judge_workflow_regression.py` — 14 회귀 케이스 (PyYAML parse, label 게이트, fork 가드, env wiring, artifact 경로, no-`pull_request_target`, step 의 `git push` 없음, fixture 대상 renderer smoke)
- **Modified** `.github/pull_request_template.md` — label trigger 가리키는 1-line HTML 코멘트

Load-bearing 표면 (`rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, `rag_query.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py`) 무변경.

## 3. Risks

- **Fork PR 의 judge API 키 누출** — 완화: 워크플로 `if:` 가 `github.event.pull_request.head.repo.full_name == github.repository` 체크해서 fork PR skip; `pull_request_target` 명시적으로 사용 안 함 (fork 코드에 secrets 노출). 회귀 테스트 `test_no_pull_request_target` + `test_job_has_fork_guard` 양쪽 강제
- **Goodhart 압력** — `labeled` trigger only (not `synchronize`) 로 완화. 새 push 마다 라벨 재부착 필요 — automatic per-commit 점수가 아닌 의도적 reviewer 액션이 되도록 강제. 회귀 테스트 `test_trigger_is_labeled_only` 가 강제
- **Aggregate-only commit 경계 (ADR 0005)** — 완화: artifact 업로드는 `reports/synthetic_judge.aggregate.json` 만, 로컬 per-case 파일 절대 아님. 회귀 테스트 `test_artifact_upload_step_present` + `test_workflow_does_not_commit_artifacts` 양쪽 invariant 강제

## 4. Tests

`tests/test_pr_judge_workflow_regression.py` — 14 케이스, 로컬 전부 pass:

- `WorkflowStructureTest` (11 cases) — parsing + 모든 ADR 0043 invariant 단언화
- `PrTemplateMentionsLabelTest` (1 case) — 템플릿이 라벨 hint → 작성자가 발견 가능
- `RenderCommentSmokeTest` (2 cases) — fixture aggregate 대상 렌더러 end-to-end smoke (PR 코멘트 비어 나오는 missing key / format 깨짐 캐치)

```
============================== 14 passed in 0.47s ==============================
```

## 5. Eval impact

모두 `·` — retrieval / answer / verifier 경로 동작 변경 없음. 순수 CI plumbing.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 워크플로는 기존 표면 (`make eval`, `make synthetic-judge`) 만 호출, 그 자체는 무수정; `rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, `rag_query.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, `scripts/build_index.py` 코드 무변경.

## 6. Backward compatibility

계약 변경 없음. 워크플로는 순수 additive — 기존 `pr-eval.yml` (ADR 0004 stub-default) 무변경, 모든 push 가 여전히 동일 stub-default eval delta. `make synthetic-judge` 로컬 cadence (ADR 0012) 무변경 작동. ADR 0001 `naive_baseline` 영향 없음.

필수 Repository secrets (이미 로컬 `make synthetic-judge` 용 정의; 신규 자격증명 없음):
- `BIDMATE_JUDGE_API_KEY`
- `BIDMATE_JUDGE_MODEL`
- `BIDMATE_JUDGE_BASE_URL`

## 7. Out of scope

- `reports/synthetic_judge.aggregate.json` 의 Live first-run 스냅샷 (로드맵의 원래 "PR-A") — 워크플로가 라이브 되어 자체 스냅샷 생산 가능해질 때까지, 또는 개발자가 라이브 백엔드로 로컬 `make synthetic-judge` 실행할 때까지 보류
- Fork-PR fallback 경로 (예: "fork PR 은 live judge skip" 이라는 stub-mode 코멘트) — 현재 워크플로는 silently skip; follow-up 으로 courtesy 코멘트 추가 가능
