### PR TITLE
docs(adr)+test: ADR 0044 real100 eval case expansion policy + structural invariant guard

### DIFF
--- a/docs/adr/0044-realN-eval-case-expansion.md
+++ b/docs/adr/0044-realN-eval-case-expansion.md
@@ -1,0 +1,106 @@
+# ADR 0044 — real100 Eval Case Expansion: In-Place n-Increase Policy
+
+| Field       | Value                                     |
+|-------------|-------------------------------------------|
+| **Status**  | Accepted                                  |
+| **Date**    | 2026-05-14                                |
+| **Issue**   | #732                                      |
+| **Authors** | hskim-solv                                |
+| **Tags**    | eval, real-data, dataset-cardinality      |
+
+## Context
+
+The real100 private eval surface (`eval/real_config.local.yaml`,
+`reports/real100/`) indexes 100 private RFP documents but evaluates
+only **n = 21 cases**. At n = 21 the statistical signal is weak:
+
+- Pool-recall 100% confidence interval is ±21 pp (Wilson 95%).
+- Single-case accuracy flip swings the headline by +4.8 pp.
+- Silence threshold `max(5e-4, 0.5 / n_min)` (ADR 0030) resolves
+  to 0.024 — far larger than intended convergence signal.
+
+All 100 documents are already ingested into `data/index/real100/`;
+the gap is cases, not documents. Expanding n using the existing corpus
+is low-risk and high-signal.
+
+## Decision
+
+**Expand the case set in-place** (same `reports/real100/` series,
+same `eval/real_config.local.yaml` path) rather than starting a new
+parallel eval series.
+
+Rationale:
+
+1. **Same corpus, same index.** The 100-document corpus and index are
+   unchanged. Cardinality refers to _cases_ (queries), not documents.
+   Adding cases does not invalidate historical retrieval measurements —
+   it improves their statistical power.
+
+2. **`num_predictions` tracks n.** Every `eval_summary.json` snapshot
+   already records `num_predictions`, which is the authoritative n for
+   any baseline comparison. The `reports/real100/baseline.aggregate.json`
+   also records `num_predictions` at commit time, so delta comparisons
+   are always n-aware.
+
+3. **Silence threshold self-adjusts.** ADR 0030 defines
+   `δ_silence = max(5e-4, 0.5 / n_min)`. Increasing n automatically
+   tightens the threshold without config changes.
+
+4. **ADR 0005 boundary preserved.** Case definitions (queries +
+   expected answers referencing private RFP content) stay in
+   `eval/real_config.local.yaml` (gitignored). Only aggregate
+   statistics are committed publicly per ADR 0005. This ADR records
+   the expansion decision; the operator applies case additions locally.
+
+## Target Cardinality
+
+**n ≥ 30** as the near-term target (from n = 21). At n = 30:
+
+- Wilson 95% CI on recall narrows from ±21 pp → ±18 pp.
+- Single-case flip swings headline by +3.3 pp (vs +4.8 pp at n = 21).
+- Silence threshold tightens to 0.017 (vs 0.024).
+
+Longer-term target: n ≥ 50 (silence threshold ≤ 0.010, CI ≤ ±14 pp).
+
+## Case Selection Criteria
+
+New cases must satisfy:
+
+1. **Verifiable expected terms** — the expected_terms must appear
+   verbatim in indexed chunk text (not synthesized or paraphrased).
+2. **Diverse query types** — include single_doc, comparison, and
+   abstention cases to balance the distribution.
+3. **Document coverage** — prefer documents not yet covered by
+   existing cases to maximize corpus utilization.
+4. **Stable ground truth** — expected answers must be factual (budget
+   amounts, dates, technical requirements) rather than subjective.
+
+## Consequences
+
+- `reports/real100/eval_summary.json` will show higher `num_predictions`
+  after each expansion run. Downstream scripts (leaderboard, delta
+  reports) automatically read `num_predictions` from the summary.
+- The committed `reports/real100/baseline.aggregate.json` must be
+  updated via `make real-eval-baseline-update` after each expansion
+  run to record the new n in the public provenance chain.
+- Historical baselines with lower n remain valid for sign-comparison
+  (direction of delta) but not for magnitude comparison — reviewers
+  should note the n-change in PR descriptions when baseline is bumped.
+
+## Alternatives Considered
+
+**New separate series (`reports/real30/`)**: Rejected. Splits the
+leaderboard time-series without benefit; the 100-doc corpus is shared
+so retrieval measurements are directly comparable.
+
+**Increase only via private data expansion** (new documents):
+Deferred. New document ingestion requires ADR 0005 review + index
+rebuild. Case expansion within the existing 100-doc corpus is a
+lower-friction immediate improvement.
+
+## References
+
+- ADR 0001 — naive_baseline invariant (unaffected; public synthetic eval)
+- ADR 0005 — eval split boundary (private data stays gitignored)
+- ADR 0030 — leaderboard silence threshold + n-aware formula
+- Issue #732 — implementation tracking

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -101,6 +101,7 @@ project record.
 | [0041](./0041-agent-budget-cap-contract.md) | accepted | Agent budget cap: `max_iterations=5` + `max_latency_ms=8000` hard caps; ADR 0003 `status: insufficient` on exhaustion; ±2pp non-determinism tolerance for real-agent runs; closes issue #673 |
 | [0042](./0042-tool-use-evidence-boundary-defense.md) | accepted | Tool-use attack surface audit: ADR 0008 `neutralize_instruction_patterns` coverage confirmed for all `execute_*` wrappers in `rag_agent_tools.py`; no new call sites needed; `EVIDENCE_BOUNDARY` regression gate added; closes issue #682 |
 | [0043](./0043-pr-cadence-for-live-llm-judge.md) | accepted | Label-gated PR workflow (`live-judge-please`) fires `.github/workflows/pr-judge.yml` with live `BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible`; posts RAGAS aggregate as PR comment; ADR 0004/0005/0012 invariants preserved; re-attach label after each push (Goodhart guard) |
+| [0044](./0044-realN-eval-case-expansion.md) | accepted | real100 private eval cases expanded in-place (same corpus, same `reports/real100/` series) from n=21 → near-term n≥30 / long-term n≥50 to tighten Wilson 95% CI and ADR 0030 silence threshold; `num_predictions` tracked per snapshot; ADR 0005 boundary preserved (cases stay in gitignored `eval/real_config.local.yaml`); closes issue #732 |
 
 ## Roadmap (proposed, not yet committed)
 

--- a/tests/test_real_eval_case_expansion.py
+++ b/tests/test_real_eval_case_expansion.py
@@ -1,0 +1,102 @@
+"""Regression guard for real100 eval case expansion (ADR 0044, issue #732).
+
+Verifies structural invariants of eval/real_config.local.yaml when the
+file is present (operator-side private file, gitignored per ADR 0005).
+Tests are skipped silently when the file does not exist — CI runs on the
+public synthetic surface and has no access to the private config.
+
+Invariants checked:
+1. Case count meets the ADR 0044 minimum (≥ 25 after first expansion,
+   targeting ≥ 30).
+2. All case IDs are unique.
+3. Each case has required fields (id, query_type, query, expected_doc_ids,
+   answerable).
+4. expected_terms is non-empty for answerable cases.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+REAL_CONFIG_PATH = ROOT_DIR / "eval" / "real_config.local.yaml"
+
+# ADR 0044 minimum: at least 25 cases (first expansion target is 30+).
+# This threshold is conservative so CI of other developers who may have
+# older local configs still passes.
+MIN_CASE_COUNT = 25
+
+
+def _load_config() -> dict | None:
+    """Return parsed config or None if file is absent."""
+    if not REAL_CONFIG_PATH.exists():
+        return None
+    try:
+        import yaml  # type: ignore
+        with REAL_CONFIG_PATH.open(encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception:
+        return None
+
+
+@unittest.skipUnless(REAL_CONFIG_PATH.exists(), "eval/real_config.local.yaml not present (operator-side private file)")
+class TestRealConfigCaseExpansion(unittest.TestCase):
+    """Structural invariants for the expanded real100 eval case set."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cfg = _load_config()
+        if cfg is None:
+            raise RuntimeError(f"Failed to parse {REAL_CONFIG_PATH}")
+        cls.cases: list[dict] = cfg.get("cases", [])
+
+    def test_case_count_meets_adr0044_minimum(self) -> None:
+        """ADR 0044: n ≥ 25 (near-term target 30+)."""
+        self.assertGreaterEqual(
+            len(self.cases),
+            MIN_CASE_COUNT,
+            f"real_config.local.yaml has {len(self.cases)} cases; ADR 0044 requires ≥ {MIN_CASE_COUNT}",
+        )
+
+    def test_case_ids_are_unique(self) -> None:
+        ids = [c.get("id") for c in self.cases]
+        duplicates = {cid for cid in ids if ids.count(cid) > 1}
+        self.assertEqual(
+            len(duplicates), 0,
+            f"Duplicate case IDs found: {duplicates}",
+        )
+
+    def test_all_cases_have_required_fields(self) -> None:
+        required = {"id", "query_type", "query", "expected_doc_ids", "answerable"}
+        for case in self.cases:
+            missing = required - set(case.keys())
+            self.assertEqual(
+                len(missing), 0,
+                f"Case '{case.get('id')}' missing required fields: {missing}",
+            )
+
+    def test_answerable_cases_have_expected_terms(self) -> None:
+        """Answerable cases must have at least one expected_term to be evaluable."""
+        for case in self.cases:
+            if not case.get("answerable", True):
+                continue
+            terms = case.get("expected_terms") or []
+            self.assertGreater(
+                len(terms), 0,
+                f"Answerable case '{case.get('id')}' has no expected_terms",
+            )
+
+    def test_expected_doc_ids_non_empty_for_answerable(self) -> None:
+        for case in self.cases:
+            if not case.get("answerable", True):
+                continue
+            doc_ids = case.get("expected_doc_ids") or []
+            self.assertGreater(
+                len(doc_ids), 0,
+                f"Answerable case '{case.get('id')}' has no expected_doc_ids",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 변경 내용 및 이유

ADR 0044 가 real100 eval 케이스 **in-place** 확장 결정 (n=21→≥30, 장기 ≥50 목표) 을 codify — 신규 병렬 eval 시리즈 (`reports/realN/`) 시작 대신. 100-document 코퍼스/index 미변경; gap 은 _query_, 문서 아님. 100 문서 모두 이미 `data/index/real100/` 에 ingest. 케이스 추가로 통계 검정력 증가 (pool-recall Wilson 95% CI 가 n=30 에서 ±21pp → ±18pp 로 narrow), 기존 측정 무효화 없음 — `num_predictions` 가 모든 `eval_summary.json` snapshot 에 이미 n 기록.

`tests/test_real_eval_case_expansion.py` 가 `eval/real_config.local.yaml` 에 5 구조 invariant 강제 (케이스 수 ≥25, unique ID, 필수 필드, answerable 의 non-empty expected_terms/doc_ids). 모든 테스트 파일 존재 시 `@skipUnless` 라서 공개 synthetic surface CI 영향 0 (ADR 0005 경계). Operator 가 9 신규 케이스 추가를 local 에 적용하여 n=30 도달; 테스트는 검증 게이트.

Closes #732

## 2. 변경 파일

- `docs/adr/0044-realN-eval-case-expansion.md` — 신규 ADR (**load-bearing**: docs/adr/)
- `tests/test_real_eval_case_expansion.py` — 신규 구조 invariant 테스트 (CI skip)

파이프라인 코드 변경 없음.

## 3. 리스크

- **ADR 번호 충돌**: 생성 전 `ls docs/adr/` + open PR 확인. ADR 0043 은 #727 (2026-05-14 머지); 0044 가 다음 사용 가능.
- **파일이 stale 해질 시 테스트 false-positive**: `MIN_CASE_COUNT = 25` 가 보수적 (1차 확장 목표 30+) — 목표 근처 구형 local config 도 pass.
- **CI mis-trigger**: pre-push hook 이 `docs/adr/` 에서 "load-bearing path changed" fire — 예상; 5b 섹션이 커버.

## 4. 테스트

`tests/test_real_eval_case_expansion.py` — 5 신규 테스트 (전부 CI `@skipUnless`):
- `test_case_count_meets_adr0044_minimum` — n ≥ 25
- `test_case_ids_are_unique`
- `test_all_cases_have_required_fields`
- `test_answerable_cases_have_expected_terms`
- `test_expected_doc_ids_non_empty_for_answerable`

Local 검증: 9 신규 케이스 추가 후 (n=21→30) 5/5 PASSED.

## 5. Eval 영향

파이프라인 동작 변경 없음. CI synthetic eval delta: 전부 `·` (retrieval/answer 코드 미터치).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. ADR doc + CI skip 테스트만 추가. `eval/real_config.local.yaml` 확장 자체 (9 신규 케이스, n=21→30) 는 operator-side + ADR 0005 따라 gitignore — 이 커밋 비포함. Operator 가 local 확장 적용 + `make real-eval` + `make real-eval-baseline-update` 실행 후, 신규 n 이 다음 커밋된 `reports/real100/baseline.aggregate.json` 의 `num_predictions` 에 나타남.

## 6. 하위 호환성

계약 변경 없음. 기존 케이스 미수정. `@skipUnless` 가드로 private config 없는 머신에서 CI 영향 0.

## 7. 범위 외

- 9 신규 케이스로 `make real-eval` 실제 실행 — local config 갱신 후 operator 액션.
- ADR 0032 false-positive: `docs/adr/` 파일 추가가 embedding-spread CI gate 도 trigger; pre-existing scoping issue 로 별도 추적.
