### PR TITLE
feat(ingestion): aggregate HWP fallback rate + chunk health metrics (closes #715)

### DIFF
--- a/eval/scorers/__init__.py
+++ b/eval/scorers/__init__.py
@@ -6,6 +6,7 @@ remain in ``eval/run_eval.py``.
 """
 from eval.scorers.alignment import score_claim_citation_alignment
 from eval.scorers.case import score_case
+from eval.scorers.chunk_health import compute_chunk_health
 from eval.scorers.chunk_metrics import (
     chunk_mrr,
     chunk_ndcg_at_k,
@@ -19,6 +20,7 @@ __all__ = [
     "chunk_mrr",
     "chunk_ndcg_at_k",
     "chunk_recall_at_k",
+    "compute_chunk_health",
     "derive_gold_chunk_ids",
     "score_case",
     "score_citation_grounding",

--- a/eval/scorers/chunk_health.py
+++ b/eval/scorers/chunk_health.py
@@ -1,0 +1,175 @@
+"""Chunk-level corpus sanity metrics (issue #715).
+
+Bookend to ``eval/scorers/chunk_metrics.py``: that module measures *retrieval*
+quality given the gold set; this module measures the *chunks themselves* —
+length distribution, near-empty count, mid-sentence cuts, HWP table coverage.
+The two are deliberately kept in separate files so retrieval-time scorers
+and ingest-time corpus health stay independently testable.
+
+``compute_chunk_health`` is called once at index-build time by
+``scripts/build_index.py`` and the result is folded into
+``ingestion_report.json`` under ``summary.chunk_health``. The output shape is
+stable JSON-serializable.
+"""
+
+from __future__ import annotations
+
+from statistics import mean
+from typing import Any, Iterable
+
+
+_SENTENCE_ENDERS_ASCII = (".", "!", "?", "。", "…")
+# Heuristic Korean sentence-final endings. Conservative set — false negatives
+# (mis-flagging a clean chunk as mid-cut) are preferred over false positives
+# (silently passing a truncated chunk). Mirrors common formal RFP verb
+# endings; informal speech endings are intentionally excluded.
+_SENTENCE_ENDERS_KOREAN = ("다", "음", "임", "함", "됨", "요", "오", "라", "어", "지")
+
+# Closing brackets / quotes that may follow a true sentence terminator.
+# Stripping one of these before checking the terminal char lets ``'다.'`` and
+# ``'다."'`` and ``'다)'`` all register as terminated.
+_TRAILING_CLOSERS = "”\"')]}」』"
+
+
+def _percentile(sorted_values: list[int], pct: float) -> float:
+    """Linear-interpolation percentile (NIST type 7 / numpy default).
+
+    ``sorted_values`` MUST be sorted ascending. Returns 0.0 for empty input.
+    """
+    if not sorted_values:
+        return 0.0
+    if pct <= 0:
+        return float(sorted_values[0])
+    if pct >= 1:
+        return float(sorted_values[-1])
+    idx = (len(sorted_values) - 1) * pct
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = idx - lo
+    return float(sorted_values[lo]) * (1 - frac) + float(sorted_values[hi]) * frac
+
+
+def _is_hwp_table_chunk(chunk: dict[str, Any]) -> bool:
+    """Return True for chunks emitted from the HWP native-tables loader.
+
+    Pattern is set in ``ingestion.build_sections_with_native_tables`` — table
+    sections are labeled ``"표 N (HWP native)"``. We require both the prefix
+    and the marker so plain "표 ..." section headings in a PDF/HWP CSV body do
+    not get mis-flagged.
+    """
+    metadata = chunk.get("metadata") or {}
+    if metadata.get("file_format") != "hwp":
+        return False
+    section = str(chunk.get("section") or "")
+    return section.startswith("표 ") and "HWP native" in section
+
+
+def _is_mid_sentence_cut(text: str) -> bool:
+    """True if the chunk does not end in a recognized sentence terminator.
+
+    Conservative heuristic — Korean morphology means a hard answer is
+    impossible without a full parser. We treat a chunk ending in ASCII /
+    full-width sentence terminators (., !, ?, 。, …) or one of the common
+    formal Korean sentence-final morphemes (다, 음, 임, 함, 됨, …) as
+    "ended cleanly". Trailing closing brackets / quotes are stripped before
+    the check.
+
+    Empty chunks return ``False`` here — they are accounted for separately by
+    the ``empty_chunks`` metric and should not double-count.
+    """
+    stripped = text.rstrip()
+    if not stripped:
+        return False
+    while stripped and stripped[-1] in _TRAILING_CLOSERS:
+        stripped = stripped[:-1]
+    if not stripped:
+        return False
+    last = stripped[-1]
+    if last in _SENTENCE_ENDERS_ASCII:
+        return False
+    if last in _SENTENCE_ENDERS_KOREAN:
+        return False
+    return True
+
+
+def compute_chunk_health(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Compute corpus-level chunk sanity metrics.
+
+    Args:
+        chunks: iterable of chunk dicts as produced by ``rag_core.make_chunk``.
+            Each item is expected to expose ``text``, ``metadata.file_format``,
+            and ``section``. Missing fields are treated leniently (empty
+            string / ``"unknown"`` format) so the function never raises on a
+            half-formed corpus — a partially-built index should still produce
+            a usable health report.
+
+    Returns:
+        A JSON-serializable dict with keys:
+
+        - ``total_chunks``: int
+        - ``by_format``: ``{file_format: count}``
+        - ``length_chars``: ``{p50, p95, max, min, mean}`` (zero-filled when
+          there are no chunks)
+        - ``empty_chunks``: count where ``len(text) == 0``
+        - ``near_empty_chunks``: count where ``0 < len(text) < 50``
+        - ``mid_sentence_cut_ratio``: float in ``[0, 1]``, computed over
+          non-table non-empty chunks. Table chunks are excluded because they
+          have no sentence structure to terminate.
+        - ``hwp_table_chunks``: count of HWP native-tables-mode table chunks
+        - ``hwp_table_chunk_ratio``: float in ``[0, 1]``,
+          ``hwp_table_chunks / (total HWP chunks)``; ``0.0`` when there are no
+          HWP chunks.
+    """
+    chunk_list = list(chunks)
+    total = len(chunk_list)
+    by_format: dict[str, int] = {}
+    lengths: list[int] = []
+    empty = 0
+    near_empty = 0
+    hwp_total = 0
+    hwp_table = 0
+    eligible_for_cut = 0
+    mid_cut = 0
+
+    for chunk in chunk_list:
+        text = str(chunk.get("text") or "")
+        length = len(text)
+        lengths.append(length)
+        metadata = chunk.get("metadata") or {}
+        fmt = str(metadata.get("file_format") or "unknown")
+        by_format[fmt] = by_format.get(fmt, 0) + 1
+        if length == 0:
+            empty += 1
+        elif length < 50:
+            near_empty += 1
+        is_table = _is_hwp_table_chunk(chunk)
+        if fmt == "hwp":
+            hwp_total += 1
+            if is_table:
+                hwp_table += 1
+        if length > 0 and not is_table:
+            eligible_for_cut += 1
+            if _is_mid_sentence_cut(text):
+                mid_cut += 1
+
+    lengths_sorted = sorted(lengths)
+    length_stats = {
+        "p50": _percentile(lengths_sorted, 0.5),
+        "p95": _percentile(lengths_sorted, 0.95),
+        "max": float(lengths_sorted[-1]) if lengths_sorted else 0.0,
+        "min": float(lengths_sorted[0]) if lengths_sorted else 0.0,
+        "mean": float(mean(lengths)) if lengths else 0.0,
+    }
+    mid_ratio = (mid_cut / eligible_for_cut) if eligible_for_cut else 0.0
+    hwp_table_ratio = (hwp_table / hwp_total) if hwp_total else 0.0
+
+    return {
+        "total_chunks": total,
+        "by_format": by_format,
+        "length_chars": length_stats,
+        "empty_chunks": empty,
+        "near_empty_chunks": near_empty,
+        "mid_sentence_cut_ratio": mid_ratio,
+        "hwp_table_chunks": hwp_table,
+        "hwp_table_chunk_ratio": hwp_table_ratio,
+    }

--- a/ingestion.py
+++ b/ingestion.py
@@ -52,7 +52,12 @@ REQUIRED_COLUMNS = [
     "텍스트",
 ]
 
-INGESTION_REPORT_SCHEMA_VERSION = 2
+# Bumped 2 → 3 in issue #715: summary now carries ``text_source_counts``,
+# ``fallback_reasons``, and ``chunk_health`` (the last is filled by
+# ``scripts/build_index.py`` after the chunk-building stage). The three keys
+# are additive and downstream readers use ``dict.get``, so a v2 reader
+# silently ignores them.
+INGESTION_REPORT_SCHEMA_VERSION = 3
 
 # Public, reviewer-facing failure taxonomy for ingestion. Keep keys stable;
 # downstream tooling (eval/run_eval.py, docs, dashboards) reads them.
@@ -95,6 +100,16 @@ class IngestionRecord:
     reason: str | None = None
     duplicate_resolution: dict[str, Any] | None = None
     messages: tuple[str, ...] = ()
+    # Issue #715: per-document loader provenance. ``text_source`` mirrors
+    # ``HwpLoader.last_text_source`` ("hwp_native" / "data_list_csv_text"
+    # / similar); ``fallback_reason`` mirrors ``HwpLoader.last_fallback_reason``
+    # (``"ExceptionName: truncated message"`` or ``None``). Both are populated
+    # only after the loader successfully extracted text — failures upstream of
+    # the loader keep them at ``None``. Existing readers see no change because
+    # both fields default to ``None`` and downstream report consumers use
+    # ``dict.get`` (additive bump 2 → 3 of ``INGESTION_REPORT_SCHEMA_VERSION``).
+    text_source: str | None = None
+    fallback_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -583,6 +598,11 @@ def normalize_ingestion_row(
     try:
         text = loader.load_text(row, validation.source_path)
     except ValueError as exc:
+        # Issue #715: surface loader provenance even on failure — the HWP
+        # native loader may have raised mid-parse (e.g. InvalidHwp5FileError)
+        # after stashing the exception on ``last_fallback_reason``. The CSV
+        # text loader has neither attribute, so getattr defaults keep the
+        # plain PDF / CSV failure paths backward-compatible.
         return None, make_record(
             row_number,
             "failed",
@@ -592,6 +612,8 @@ def normalize_ingestion_row(
             validation.source_path,
             str(exc),
             duplicate_resolution=validation.duplicate_resolution,
+            text_source=getattr(loader, "last_text_source", None),
+            fallback_reason=getattr(loader, "last_fallback_reason", None),
         )
     # Issue #455 / ADR 0028: opt-in PII redaction. Default off keeps
     # ADR 0001 naive_baseline byte-identical; the env-var gate is the
@@ -600,6 +622,7 @@ def normalize_ingestion_row(
         text = redact_pii(text)
 
     text_source = getattr(loader, "last_text_source", "data_list_csv_text")
+    fallback_reason = getattr(loader, "last_fallback_reason", None)
     metadata = normalize_metadata(
         row, validation.file_format, validation.file_name, text_source=text_source
     )
@@ -657,6 +680,8 @@ def normalize_ingestion_row(
         validation.file_format,
         validation.source_path,
         duplicate_resolution=validation.duplicate_resolution,
+        text_source=text_source,
+        fallback_reason=fallback_reason,
     )
 
 
@@ -671,6 +696,8 @@ def make_record(
     *,
     duplicate_resolution: dict[str, Any] | None = None,
     messages: tuple[str, ...] = (),
+    text_source: str | None = None,
+    fallback_reason: str | None = None,
 ) -> IngestionRecord:
     return IngestionRecord(
         row_number=row_number,
@@ -682,6 +709,8 @@ def make_record(
         reason=reason,
         duplicate_resolution=duplicate_resolution,
         messages=messages,
+        text_source=text_source,
+        fallback_reason=fallback_reason,
     )
 
 
@@ -838,9 +867,14 @@ def build_ingestion_report(
     on_duplicate_doc_id: str,
 ) -> dict[str, Any]:
     """Build the canonical ingestion_report.json payload."""
-    failure_reasons, failure_examples, file_formats, duplicate_groups = (
-        _collect_record_buckets(records)
-    )
+    (
+        failure_reasons,
+        failure_examples,
+        file_formats,
+        duplicate_groups,
+        text_source_counts,
+        fallback_reasons,
+    ) = _collect_record_buckets(records)
     doc_id_sources: dict[str, int] = OrderedDict()
     for record in records:
         if record.status == "indexed":
@@ -858,6 +892,11 @@ def build_ingestion_report(
         "file_formats": dict(file_formats),
         "duplicate_doc_ids": {k: sorted(set(v)) for k, v in duplicate_groups.items()},
         "on_duplicate_doc_id": on_duplicate_doc_id,
+        # Issue #715 — see ``_collect_record_buckets`` docstring. These two
+        # keys are additive (v3 schema bump); v2 readers ignore them via
+        # ``dict.get``.
+        "text_source_counts": {fmt: dict(sources) for fmt, sources in text_source_counts.items()},
+        "fallback_reasons": dict(fallback_reasons),
     }
     return {
         "metadata_csv": str(metadata_csv),
@@ -875,17 +914,33 @@ def _collect_record_buckets(
     dict[str, list[dict[str, Any]]],
     dict[str, int],
     dict[str, list[int]],
+    dict[str, dict[str, int]],
+    dict[str, int],
 ]:
-    """Accumulate the four shared report-building buckets over ``records``.
+    """Accumulate the six shared report-building buckets over ``records``.
 
-    Returns ``(failure_reasons, failure_examples, file_formats, duplicate_groups)``.
-    Both :func:`build_ingestion_report` and :func:`_build_validation_report` call
-    this helper so the identical accumulation logic lives in one place.
+    Returns ``(failure_reasons, failure_examples, file_formats, duplicate_groups,
+    text_source_counts, fallback_reasons)``. Both :func:`build_ingestion_report`
+    and :func:`_build_validation_report` call this helper so the identical
+    accumulation logic lives in one place.
+
+    The last two buckets were added in issue #715:
+
+    - ``text_source_counts``: ``{file_format: {text_source: count}}`` — answers
+      "for HWP rows, how many went through the native pyhwp loader versus the
+      CSV-text fallback?". Records whose loader never ran (row-validation
+      failures upstream of ``loader.load_text``) contribute ``None`` under
+      ``text_source``; we drop those so the histogram only counts rows that
+      actually reached a loader.
+    - ``fallback_reasons``: ``{reason_string: count}`` — frequency table of
+      ``HwpLoader.last_fallback_reason`` values. ``None`` is dropped.
     """
     failure_reasons: dict[str, int] = OrderedDict()
     failure_examples: dict[str, list[dict[str, Any]]] = OrderedDict()
     file_formats: dict[str, int] = OrderedDict()
     duplicate_groups: dict[str, list[int]] = OrderedDict()
+    text_source_counts: dict[str, dict[str, int]] = OrderedDict()
+    fallback_reasons: dict[str, int] = OrderedDict()
 
     for record in records:
         if record.reason:
@@ -903,8 +958,22 @@ def _collect_record_buckets(
         fmt = record.file_format or "unknown"
         file_formats[fmt] = file_formats.get(fmt, 0) + 1
         _accumulate_duplicate_group(duplicate_groups, record)
+        if record.text_source:
+            per_format = text_source_counts.setdefault(fmt, OrderedDict())
+            per_format[record.text_source] = per_format.get(record.text_source, 0) + 1
+        if record.fallback_reason:
+            fallback_reasons[record.fallback_reason] = (
+                fallback_reasons.get(record.fallback_reason, 0) + 1
+            )
 
-    return failure_reasons, failure_examples, file_formats, duplicate_groups
+    return (
+        failure_reasons,
+        failure_examples,
+        file_formats,
+        duplicate_groups,
+        text_source_counts,
+        fallback_reasons,
+    )
 
 
 def _accumulate_duplicate_group(
@@ -1061,9 +1130,14 @@ def _build_validation_report(
     schema_issues: list[ValidationIssue],
     on_duplicate_doc_id: str,
 ) -> dict[str, Any]:
-    failure_reasons, failure_examples, file_formats, duplicate_groups = (
-        _collect_record_buckets(records)
-    )
+    (
+        failure_reasons,
+        failure_examples,
+        file_formats,
+        duplicate_groups,
+        text_source_counts,
+        fallback_reasons,
+    ) = _collect_record_buckets(records)
     blank_field_counts: dict[str, int] = OrderedDict()
     for record in records:
         for message in record.messages:
@@ -1084,6 +1158,12 @@ def _build_validation_report(
         "file_formats": dict(file_formats),
         "duplicate_doc_ids": {k: sorted(set(v)) for k, v in duplicate_groups.items()},
         "on_duplicate_doc_id": on_duplicate_doc_id,
+        # Issue #715 — text source + fallback histograms (validation mode
+        # never actually calls a loader, so both buckets stay empty in
+        # practice; we still expose the keys for schema parity with
+        # ``build_ingestion_report``).
+        "text_source_counts": {fmt: dict(sources) for fmt, sources in text_source_counts.items()},
+        "fallback_reasons": dict(fallback_reasons),
     }
     return {
         "mode": "validation",

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -23,6 +23,11 @@ from visual_ingestion import (
     load_visual_documents_from_metadata_csv,
 )
 
+# Issue #715: chunk-corpus sanity metrics folded into ingestion_report.json
+# so operators can spot mid-sentence cuts / near-empty chunks / HWP table
+# coverage at a glance.
+from eval.scorers.chunk_health import compute_chunk_health
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -229,6 +234,17 @@ def main() -> int:
     num_docs = payload["build"]["num_documents"]
     num_chunks = payload["build"]["num_chunks"]
     embedding_backend = payload["embedding"]["backend"]
+
+    # Issue #715: compute chunk-corpus sanity metrics BEFORE write_index, which
+    # mutates ``payload["chunks"]`` to prune embedding sidecars. Fold the
+    # result into ``ingestion_report["summary"]["chunk_health"]`` so a single
+    # JSON file answers "is parsing OK? is chunking OK?" without operators
+    # having to cross-reference multiple artifacts. The metric is purely
+    # observational — it does not affect any retrieval / answer surface.
+    chunk_health = compute_chunk_health(payload.get("chunks") or [])
+    if ingestion_report is not None:
+        ingestion_report.setdefault("summary", {})["chunk_health"] = chunk_health
+
     out_path = write_index(payload, output_dir)
     embeddings_path = output_dir / EMBEDDINGS_FILENAME
     if ingestion_report is not None:

--- a/tests/test_chunk_health.py
+++ b/tests/test_chunk_health.py
@@ -1,0 +1,222 @@
+"""Unit tests for ``eval/scorers/chunk_health.py`` (issue #715).
+
+Pins the shape of ``compute_chunk_health`` so the structure folded into
+``ingestion_report.json`` (``summary.chunk_health``) stays stable. The
+metric is observability-only — no retrieval / answer surface depends on
+it — so the regression bar here is "field names and rough semantics",
+not bit-identical numbers.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eval.scorers.chunk_health import (  # noqa: E402
+    _is_hwp_table_chunk,
+    _is_mid_sentence_cut,
+    _percentile,
+    compute_chunk_health,
+)
+
+
+def _hwp_chunk(text: str, section: str = "본문") -> dict:
+    return {"text": text, "metadata": {"file_format": "hwp"}, "section": section}
+
+
+def _pdf_chunk(text: str, section: str = "Section 1") -> dict:
+    return {"text": text, "metadata": {"file_format": "pdf"}, "section": section}
+
+
+def _hwp_table_chunk(text: str, idx: int = 1) -> dict:
+    return {
+        "text": text,
+        "metadata": {"file_format": "hwp"},
+        "section": f"표 {idx} (HWP native)",
+    }
+
+
+class TestComputeChunkHealth(unittest.TestCase):
+    EXPECTED_KEYS = {
+        "total_chunks",
+        "by_format",
+        "length_chars",
+        "empty_chunks",
+        "near_empty_chunks",
+        "mid_sentence_cut_ratio",
+        "hwp_table_chunks",
+        "hwp_table_chunk_ratio",
+    }
+    EXPECTED_LENGTH_KEYS = {"p50", "p95", "max", "min", "mean"}
+
+    def test_empty_input_is_safe_and_returns_full_shape(self):
+        result = compute_chunk_health([])
+        self.assertEqual(set(result.keys()), self.EXPECTED_KEYS)
+        self.assertEqual(result["total_chunks"], 0)
+        self.assertEqual(result["by_format"], {})
+        self.assertEqual(set(result["length_chars"].keys()), self.EXPECTED_LENGTH_KEYS)
+        # All length stats zero on empty input (avoid raising on a degenerate
+        # ingest before the operator can read the report).
+        self.assertEqual(result["length_chars"]["p50"], 0.0)
+        self.assertEqual(result["length_chars"]["p95"], 0.0)
+        self.assertEqual(result["length_chars"]["max"], 0.0)
+        self.assertEqual(result["length_chars"]["min"], 0.0)
+        self.assertEqual(result["length_chars"]["mean"], 0.0)
+        self.assertEqual(result["empty_chunks"], 0)
+        self.assertEqual(result["near_empty_chunks"], 0)
+        self.assertEqual(result["mid_sentence_cut_ratio"], 0.0)
+        self.assertEqual(result["hwp_table_chunks"], 0)
+        self.assertEqual(result["hwp_table_chunk_ratio"], 0.0)
+
+    def test_by_format_counts(self):
+        chunks = [
+            _hwp_chunk("이 사업은 RFP 입찰 대상입니다."),
+            _hwp_chunk("예산은 5억 원입니다."),
+            _pdf_chunk("The deliverable is a final report."),
+        ]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["by_format"], {"hwp": 2, "pdf": 1})
+        self.assertEqual(result["total_chunks"], 3)
+
+    def test_empty_vs_near_empty_distinct(self):
+        chunks = [
+            _hwp_chunk(""),  # empty
+            _hwp_chunk("short"),  # near-empty (< 50 chars, non-zero)
+            _hwp_chunk("a" * 60 + "."),  # neither
+        ]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["empty_chunks"], 1)
+        self.assertEqual(result["near_empty_chunks"], 1)
+
+    def test_mid_sentence_cut_excludes_table_and_empty(self):
+        chunks = [
+            # Eligible chunks (non-empty, non-table):
+            _hwp_chunk("이 사업은 RFP 입찰 대상입니다."),  # clean (. ending)
+            _hwp_chunk("예산은 5억 원이며"),  # mid-cut (ends with 며)
+            _pdf_chunk("The deliverable is a final report."),  # clean
+            _pdf_chunk("Budget is allocated to"),  # mid-cut (ends with `to`)
+            # Excluded:
+            _hwp_chunk(""),  # empty — not counted in eligible
+            _hwp_table_chunk("입찰 마감일 | 2026-06-01"),  # table — excluded
+        ]
+        result = compute_chunk_health(chunks)
+        # eligible = 4, mid = 2 → ratio 0.5
+        self.assertAlmostEqual(result["mid_sentence_cut_ratio"], 0.5)
+
+    def test_mid_sentence_cut_ratio_zero_when_no_eligible_chunks(self):
+        # All chunks are tables → eligible_for_cut == 0 → ratio defaults to 0.0
+        chunks = [_hwp_table_chunk("cell"), _hwp_table_chunk("cell", idx=2)]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["mid_sentence_cut_ratio"], 0.0)
+
+    def test_hwp_table_chunk_ratio(self):
+        chunks = [
+            _hwp_chunk("narrative"),
+            _hwp_chunk("more narrative"),
+            _hwp_table_chunk("table cell A"),
+            _hwp_table_chunk("table cell B", idx=2),
+            _pdf_chunk("pdf body"),  # PDF chunks don't count toward hwp totals
+        ]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["hwp_table_chunks"], 2)
+        # 2 table chunks / 4 hwp chunks = 0.5; PDF excluded from denom.
+        self.assertAlmostEqual(result["hwp_table_chunk_ratio"], 0.5)
+
+    def test_hwp_table_chunk_ratio_zero_when_no_hwp(self):
+        chunks = [_pdf_chunk("only pdf")]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["hwp_table_chunks"], 0)
+        self.assertEqual(result["hwp_table_chunk_ratio"], 0.0)
+
+    def test_length_stats_sorted_correctly(self):
+        # Lengths: 10, 50, 100, 500. p50 ≈ 75 (linear interp between 50 and 100).
+        chunks = [
+            _hwp_chunk("a" * 10),
+            _hwp_chunk("b" * 50),
+            _hwp_chunk("c" * 100),
+            _hwp_chunk("d" * 500),
+        ]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["length_chars"]["min"], 10.0)
+        self.assertEqual(result["length_chars"]["max"], 500.0)
+        # p50 at index 1.5 (between 50 and 100) → 75.0
+        self.assertAlmostEqual(result["length_chars"]["p50"], 75.0)
+        # mean = (10 + 50 + 100 + 500) / 4 = 165
+        self.assertAlmostEqual(result["length_chars"]["mean"], 165.0)
+
+
+class TestIsHwpTableChunk(unittest.TestCase):
+    def test_requires_both_prefix_and_marker(self):
+        # Both → table
+        self.assertTrue(_is_hwp_table_chunk(_hwp_table_chunk("x")))
+        # PDF format, even if section looks tabular → not a table
+        pdf_table_lookalike = {
+            "text": "x",
+            "metadata": {"file_format": "pdf"},
+            "section": "표 1 (HWP native)",
+        }
+        self.assertFalse(_is_hwp_table_chunk(pdf_table_lookalike))
+        # HWP but section is plain "표 5" without the native marker → not a table
+        plain_table_heading = {
+            "text": "x",
+            "metadata": {"file_format": "hwp"},
+            "section": "표 5",
+        }
+        self.assertFalse(_is_hwp_table_chunk(plain_table_heading))
+
+    def test_handles_missing_metadata(self):
+        self.assertFalse(_is_hwp_table_chunk({"text": "x"}))
+
+
+class TestIsMidSentenceCut(unittest.TestCase):
+    def test_ascii_terminators(self):
+        self.assertFalse(_is_mid_sentence_cut("This is a complete sentence."))
+        self.assertFalse(_is_mid_sentence_cut("Is it?"))
+        self.assertFalse(_is_mid_sentence_cut("Wow!"))
+        self.assertFalse(_is_mid_sentence_cut("끝났습니다。"))
+        # Trailing whitespace stripped before check
+        self.assertFalse(_is_mid_sentence_cut("Done.   "))
+
+    def test_korean_terminators(self):
+        self.assertFalse(_is_mid_sentence_cut("입찰 대상입니다"))  # ends with 다
+        self.assertFalse(_is_mid_sentence_cut("규정에 의함"))  # ends with 함
+        self.assertFalse(_is_mid_sentence_cut("주의 사항이 있음"))  # ends with 음
+
+    def test_mid_cut(self):
+        self.assertTrue(_is_mid_sentence_cut("This is incomplete"))
+        self.assertTrue(_is_mid_sentence_cut("예산은 5억 원이며"))  # 며 not in enders
+        self.assertTrue(_is_mid_sentence_cut("Budget is allocated to"))
+
+    def test_closing_brackets_stripped_before_check(self):
+        # Common ending: ``이다."`` / ``이다.)`` → still clean
+        self.assertFalse(_is_mid_sentence_cut('대상입니다."'))
+        self.assertFalse(_is_mid_sentence_cut("의함)"))
+
+    def test_empty_string_is_not_mid_cut(self):
+        # Empty chunks are handled by the empty_chunks metric; this fn
+        # returns False so they don't double-count.
+        self.assertFalse(_is_mid_sentence_cut(""))
+        self.assertFalse(_is_mid_sentence_cut("   "))
+
+
+class TestPercentile(unittest.TestCase):
+    def test_empty_returns_zero(self):
+        self.assertEqual(_percentile([], 0.5), 0.0)
+
+    def test_clamps_at_endpoints(self):
+        values = [10, 20, 30]
+        self.assertEqual(_percentile(values, -0.1), 10.0)
+        self.assertEqual(_percentile(values, 1.5), 30.0)
+
+    def test_linear_interpolation(self):
+        # [10, 20, 30] — p50 is the middle value 20
+        self.assertEqual(_percentile([10, 20, 30], 0.5), 20.0)
+        # [0, 10] — p50 interpolates to 5
+        self.assertEqual(_percentile([0, 10], 0.5), 5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hwp_native_loader_regression.py
+++ b/tests/test_hwp_native_loader_regression.py
@@ -285,7 +285,7 @@ class HwpNativeLoaderRegressionTest(unittest.TestCase):
                     "ingestion._extract_hwp_native",
                     return_value="native body",
                 ):
-                    documents, _ = load_documents_from_metadata_csv(
+                    documents, report = load_documents_from_metadata_csv(
                         csv_path, files_dir
                     )
                 self.assertEqual(1, len(documents))
@@ -297,6 +297,21 @@ class HwpNativeLoaderRegressionTest(unittest.TestCase):
                     "native body",
                     documents[0]["sections"][0]["text"],
                 )
+                # Issue #715: the per-doc text_source now also propagates to
+                # the IngestionRecord and the aggregate ``text_source_counts``
+                # summary. This pins the flow loader → record → report so a
+                # future refactor of ``make_record`` can't silently drop the
+                # field again.
+                summary = report["summary"]
+                self.assertEqual(
+                    {"hwp": {"hwp_native": 1}},
+                    summary["text_source_counts"],
+                )
+                self.assertEqual({}, summary["fallback_reasons"])
+                indexed = [r for r in report["records"] if r["status"] == "indexed"]
+                self.assertEqual(1, len(indexed))
+                self.assertEqual("hwp_native", indexed[0]["text_source"])
+                self.assertIsNone(indexed[0]["fallback_reason"])
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_mixed_format_ingestion_regression.py
+++ b/tests/test_mixed_format_ingestion_regression.py
@@ -225,6 +225,47 @@ class MixedFormatIngestionTest(unittest.TestCase):
                 all(chunk["metadata"]["text_source"] == "data_list_csv_text" for chunk in payload["chunks"])
             )
 
+    def test_text_source_counts_aggregated_by_format(self) -> None:
+        """Issue #715: summary.text_source_counts buckets per (format, source).
+
+        The mixed-corpus fixture only exercises the v1 CSV-text path
+        (PdfCsvTextLoader / HwpCsvTextLoader), so every indexed row reports
+        the default loader provenance. A separate fixture that opts into the
+        native HWP loader would produce ``{"hwp_native": N}`` here — covered
+        by ``tests/test_hwp_native_loader_regression.py``.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csv_path, files_dir, _ = _build_mixed_corpus(root)
+            _, report = load_documents_from_metadata_csv(csv_path, files_dir)
+
+            summary = report["summary"]
+            self.assertEqual(3, summary["schema_version"])
+            self.assertEqual(
+                {
+                    "pdf": {"data_list_csv_text": 2},
+                    "hwp": {"data_list_csv_text": 1},
+                },
+                summary["text_source_counts"],
+            )
+            # No HWP native loader was exercised → no fallback messages.
+            self.assertEqual({}, summary["fallback_reasons"])
+
+    def test_chunk_health_is_not_attached_by_ingestion_loader(self) -> None:
+        """``summary.chunk_health`` is wired in by ``scripts/build_index.py``
+        (after the chunk-building stage), not by the ingestion loader itself.
+
+        This boundary keeps ``load_documents_from_metadata_csv`` cheap and
+        side-effect-free for callers that only need the document list (e.g.
+        the validator CLI). The build-index CLI is the single integration
+        point that pays for chunk-health computation.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            csv_path, files_dir, _ = _build_mixed_corpus(root)
+            _, report = load_documents_from_metadata_csv(csv_path, files_dir)
+            self.assertNotIn("chunk_health", report["summary"])
+
     def test_validate_data_list_cli_returns_exit_code_one_for_failures(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## 1. 변경 내용 및 이유

Closes #715

`HwpLoader` 는 #363 이후 per-doc `last_text_source` / `last_fallback_reason` 보유했지만 이 signal 이 `IngestionRecord` 나 `ingestion_report.json` 에 도달하지 못했고, chunk 자체의 코퍼스 레벨 sanity 메트릭도 없었다. Operator 가 어떤 artifact 에서도 "native HWP loader 가 이 build 에서 실제 fire 했나, CSV 로 silent fallback 했나" 또는 "chunking 이 합리적 길이로 생성했나, mid-sentence cut 을 ship 하고 있나" 답할 수 없었다. 이 PR 은 두 signal 을 기존 `ingestion_report.json` surface 에 fold — `summary` 대한 단일 `jq` 로 reveal, 신규 report 파일 없음, retrieval / answer 경로 동작 변경 없음.

## 2. 변경 파일

- `ingestion.py` — **load-bearing**. `IngestionRecord` 에 `text_source` / `fallback_reason` 추가, 기존 record-creation site 에서 populate, `_collect_record_buckets` 를 6-tuple 로 확장 (신규 `text_source_counts`, `fallback_reasons` bucket), `build_ingestion_report` + `_build_validation_report` summary 블록 양쪽으로 thread, `INGESTION_REPORT_SCHEMA_VERSION` 2 → 3 bump.
- `eval/scorers/chunk_health.py` — **load-bearing** (`eval/` 아래 신규). 단일 public 함수 `compute_chunk_health(chunks)` 가 total/by_format, length p50/p95/max/min/mean, empty / near-empty count, mid-sentence-cut ratio, HWP native-tables coverage 반환.
- `eval/scorers/__init__.py` — `compute_chunk_health` re-export.
- `scripts/build_index.py` — **load-bearing**. `write_index` 전 `compute_chunk_health(payload["chunks"])` 1회 호출하여 `ingestion_report["summary"]["chunk_health"]` 에 merge.
- `tests/test_chunk_health.py` — 신규 (percentile, HWP-table 탐지, mid-cut heuristic, public 함수 18 unit 테스트).
- `tests/test_mixed_format_ingestion_regression.py` — `schema_version == 3`, `text_source_counts` shape, `chunk_health` 가 loader 에 의해 **부착되지 않음** assert 하는 2 메서드 추가 (경계 체크 — `build_index.py` 만 attach 해야 함).
- `tests/test_hwp_native_loader_regression.py` — `test_metadata_text_source_when_native_extraction_succeeds` 를 신규 summary 필드 end-to-end propagation assert 하도록 augment.

## 3. 리스크

가장 가능성 높은 break 는 `schema_version == 2` 또는 고정 `summary` key set 을 hard-assert 하는 downstream consumer. Audit consumer:

- `scripts/validate_data_list.py` 와 `tests/test_mixed_format_ingestion_regression.py` 모두 `INGESTION_REPORT_SCHEMA_VERSION` (constant, not literal) 통과 — bump propagate.
- `eval/scorers/__init__.py` `__all__` 은 append, 교체 아님.
- 신규 필드는 모든 read site 에서 `dict.get` / `setdefault` — 추가형, 엄밀한 의미의 schema break 없음.

부차적 리스크: `compute_chunk_health` 가 malformed chunk 에 panic. Mitigation: 모든 field access 가 default 가진 `chunk.get(...)`, unit test 가 empty input, all-empty-text input, missing-metadata chunk 커버.

## 4. 테스트

- 신규 `tests/test_chunk_health.py` — `compute_chunk_health`, `_is_hwp_table_chunk`, `_is_mid_sentence_cut`, `_percentile` 18 unit 테스트. Corner case (empty corpus, 100% table chunk, all mid-cut, missing metadata) 커버.
- `tests/test_mixed_format_ingestion_regression.py` 에 `test_text_source_counts_aggregated_by_format` + `test_chunk_health_is_not_attached_by_ingestion_loader` 추가 (후자는 build-time vs. ingest-time 경계 pin — 향후 refactor 가 우발적으로 `ingestion.py` 에서 chunk_health 계산 못하도록).
- `tests/test_hwp_native_loader_regression.py::test_metadata_text_source_when_native_extraction_succeeds` 를 native 경로 성공 시 `text_source_counts == {"hwp": {"hwp_native": 1}}` + empty `fallback_reasons` assert 하도록 augment.
- 전체 suite: `1187 passed, 11 failed, 12 skipped` — 11 실패 (`test_governance::test_no_unlinked_adr_files_on_disk` + 5 `test_harness_observability` + 5 `test_run_harness`) 는 `origin/main` 에 pre-existing (수정 안 한 tree 대상 실행으로 검증).

## 5. Eval 영향

전부 `·`. 이 PR 은 observability-only: chunking 파라미터 변경 없음, retrieval / verifier / answer 코드 경로 미터치. 신규 `chunk_health` dict 는 build time 에 1회 계산 + `ingestion_report.json` 에 serialize; eval scoring 경로로 read-back 없음.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer path. 수정된 4 load-bearing 파일 (`ingestion.py`, `scripts/build_index.py`, `eval/scorers/__init__.py`, `eval/scorers/chunk_health.py`) 은 다음만 수행:

- 2 `IngestionRecord` 필드 append (default `None`, downstream 미소비).
- 신규 summary key (`text_source_counts`, `fallback_reasons`, `chunk_health`) 계산 + serialize — write-only.
- 추가형 `INGESTION_REPORT_SCHEMA_VERSION` bump (downstream 은 `dict.get` 사용).

`make smoke` (EMBEDDING_BACKEND=hashing) 가 기존 `data/raw` 코퍼스 대상 end-to-end pass. Inline metadata_csv smoke (synthetic 1 PDF + 1 HWP fixture) 가 3 신규 summary key 존재 + `schema_version == 3` 확인:

```
summary keys: ['chunk_health', 'doc_id_sources', 'duplicate_doc_ids', 'failed_rows',
               'failure_examples', 'failure_reasons', 'fallback_reasons', 'file_formats',
               'indexed_documents', 'on_duplicate_doc_id', 'schema_version',
               'text_source_counts', 'total_rows']
text_source_counts: {'pdf': {'data_list_csv_text': 1}, 'hwp': {'data_list_csv_text': 1}}
chunk_health keys: ['by_format', 'empty_chunks', 'hwp_table_chunk_ratio',
                    'hwp_table_chunks', 'length_chars', 'mid_sentence_cut_ratio',
                    'near_empty_chunks', 'total_chunks']
```

Private 100-doc real-eval delta 가 자연스러운 follow-up: 프로덕션 코퍼스의 실제 `hwp_native_rate` surface — 이 PR 이 노출하도록 설계된 운영 signal.

## 6. 하위 호환성

`INGESTION_REPORT_SCHEMA_VERSION` 2 → 3 bump, 변경은 **추가형**: 3 신규 summary key (`text_source_counts`, `fallback_reasons`, `chunk_health`) + 2 신규 옵셔널 `IngestionRecord` 필드 (`None` default). 기존 필드 rename / 제거 / retype 없음. `summary.get(key)` 사용 consumer 영향 없음; exact key-set assert 하는 consumer 가 있다면 expectation 확장 필요하나 이 repo 에 없음 (`text_source_counts`, `fallback_reasons`, `chunk_health`, `schema_version` grep 으로 검증).

답변 계약 변경 없음 (ADR 0003).

## 7. 범위 외

- `eval/run_eval.py` `by_format` aggregate 확장 (원래 spike plan) — 데이터는 `ingestion_report.json` 에 이미 노출; eval 파이프라인에서 recompute 는 state 중복. Follow-up issue 로 defer.
- HWPX 지원, 신규 HWP loader, chunking 알고리즘 튜닝 — 별도 issue (#543, #652).
- LLM-judge chunk-quality scoring — 별도 axis (ADR 0012).
- README 메트릭 테이블 갱신 — 추가형 메트릭, leaderboard slot 영향 없음.
