### PR TITLE
feat(self-review): axis #2 Plan-subagent skip-rate collector

### DIFF
--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -32,6 +32,20 @@ from typing import Any
 QUARTER_RE = re.compile(r"^Q([1-4])-(\d{4})$")
 ADR_FILENAME_RE = re.compile(r"^(\d{4})-.+\.md$")
 PR_MERGE_RE = re.compile(r"\(#(\d+)\)\s*$")
+# Matches both ADR-0007 branch names (`feat/issue-718-…`) and worktree dir
+# names (`.claude/worktrees/feat-718-…`). The leading type prefix is
+# accepted with or without an `issue-` separator, mirroring how `git
+# worktree add` typically renames the slash.
+BRANCH_ISSUE_RE = re.compile(
+    r"(?:issue|feat|fix|docs|chore|refactor|test|perf|ci|build|style)-(\d+)"
+)
+
+# Axis #2 (Agent delegation) measurement: a PR is considered "non-trivial"
+# when additions + deletions > AXIS_2_LOC_THRESHOLD. Non-trivial PRs are
+# expected to have at least one Plan-subagent call per the CLAUDE.md
+# `## Delegation defaults` rule. The skip rate is computed as
+# (PRs with zero Plan calls) / (non-trivial PRs).
+AXIS_2_LOC_THRESHOLD = 50
 
 DEFAULT_TRANSCRIPTS_GLOB = (
     "~/.claude/projects/-Users-hskim-Desktop-projects-BidMate-DocAgent/*.jsonl"
@@ -108,6 +122,11 @@ def collect_sessions(transcripts_glob: str, start: str, end: str) -> dict[str, A
     tool_counter: Counter[str] = Counter()
     agent_counter: Counter[str] = Counter()
     session_ids: set[str] = set()
+    # Per-issue Plan-subagent call count. Key is the issue number parsed
+    # from the record's `cwd` worktree path (e.g. `feat-718-…` → 718).
+    # Records with no recognizable issue number contribute to `unmatched`.
+    plan_calls_by_issue: Counter[int] = Counter()
+    plan_calls_unmatched = 0
 
     start_dt = datetime.fromisoformat(start).replace(tzinfo=timezone.utc)
     end_dt = datetime.fromisoformat(end).replace(
@@ -158,6 +177,17 @@ def collect_sessions(transcripts_glob: str, start: str, end: str) -> dict[str, A
                                 sub = inp.get("subagent_type")
                                 if isinstance(sub, str) and sub:
                                     agent_counter[sub] += 1
+                                    if sub == "Plan":
+                                        cwd = rec.get("cwd")
+                                        m = (
+                                            BRANCH_ISSUE_RE.search(cwd)
+                                            if isinstance(cwd, str)
+                                            else None
+                                        )
+                                        if m:
+                                            plan_calls_by_issue[int(m.group(1))] += 1
+                                        else:
+                                            plan_calls_unmatched += 1
         except OSError:
             continue
 
@@ -165,6 +195,8 @@ def collect_sessions(transcripts_glob: str, start: str, end: str) -> dict[str, A
         "count": len(session_ids),
         "tool_call_distribution": dict(tool_counter.most_common()),
         "agent_delegations": dict(agent_counter.most_common()),
+        "plan_calls_by_issue": dict(plan_calls_by_issue),
+        "plan_calls_unmatched_worktree": plan_calls_unmatched,
     }
 
 
@@ -407,17 +439,101 @@ def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
     }
 
 
+def collect_pr_diff_stats(repo: str, start: str, end: str) -> list[dict[str, Any]]:
+    """List merged PRs in the quarter with additions + deletions counts.
+
+    Uses `gh pr list --search merged:<start>..<end>` so only PR-shaped
+    merges are counted. Fails soft: returns `[]` if `gh` is missing or
+    unauthenticated. Only the headRefName + numeric LOC are kept; PR
+    titles and bodies are not stored to honor the metadata-only contract.
+    """
+    try:
+        r = subprocess.run(
+            [
+                "gh", "pr", "list",
+                "--state", "merged",
+                "--search", f"merged:{start}..{end}",
+                "--json", "number,headRefName,additions,deletions,mergedAt",
+                "--limit", "200",
+            ],
+            cwd=repo, capture_output=True, text=True, check=False,
+        )
+        if r.returncode != 0 or not r.stdout.strip():
+            return []
+        data = json.loads(r.stdout)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in data if isinstance(data, list) else []:
+        if not isinstance(item, dict):
+            continue
+        num = item.get("number")
+        head = item.get("headRefName") or ""
+        add = item.get("additions") or 0
+        rem = item.get("deletions") or 0
+        if not isinstance(num, int) or not isinstance(head, str):
+            continue
+        loc = int(add) + int(rem)
+        m = BRANCH_ISSUE_RE.search(head)
+        issue = int(m.group(1)) if m else None
+        out.append({
+            "number": num,
+            "head": head,
+            "issue": issue,
+            "loc": loc,
+            "merged_at": item.get("mergedAt"),
+        })
+    return out
+
+
+def compute_axis_2_skip_rate(
+    prs: list[dict[str, Any]], plan_calls_by_issue: dict[int, int]
+) -> dict[str, Any]:
+    """Compute Plan-subagent skip rate over non-trivial (LOC > 50) PRs.
+
+    A PR is "covered" when its issue number has ≥1 Plan-subagent call in
+    the quarter's transcripts. PRs whose branch lacks `issue-<N>` are
+    counted under `unmatched` and excluded from the denominator — they
+    cannot be evaluated either way.
+
+    Returns rate in [0.0, 1.0] plus the supporting counts so the LLM
+    rubric layer can show its work.
+    """
+    nontrivial = [p for p in prs if p.get("loc", 0) > AXIS_2_LOC_THRESHOLD]
+    evaluated = [p for p in nontrivial if p.get("issue") is not None]
+    unmatched = len(nontrivial) - len(evaluated)
+    skip_count = sum(
+        1 for p in evaluated if plan_calls_by_issue.get(p["issue"], 0) == 0
+    )
+    rate = (skip_count / len(evaluated)) if evaluated else None
+    return {
+        "loc_threshold": AXIS_2_LOC_THRESHOLD,
+        "prs_nontrivial": len(nontrivial),
+        "prs_evaluated": len(evaluated),
+        "prs_unmatched_branch": unmatched,
+        "prs_with_zero_plan_calls": skip_count,
+        "skip_rate": rate,
+    }
+
+
 def assemble_stats(
     quarter: str, transcripts_glob: str, memory_dir: str, repo: str
 ) -> dict[str, Any]:
     start, end = parse_quarter(quarter)
+    sessions = collect_sessions(transcripts_glob, start, end)
+    pr_diff_stats = collect_pr_diff_stats(repo, start, end)
+    axis_2 = compute_axis_2_skip_rate(
+        pr_diff_stats, sessions.get("plan_calls_by_issue", {})
+    )
     return {
         "quarter": quarter,
         "date_range": [start, end],
-        "sessions": collect_sessions(transcripts_glob, start, end),
+        "sessions": sessions,
         "memory": collect_memory(memory_dir),
         "git": collect_git(repo, start, end),
         "governance_hooks": collect_governance_hooks(repo, start, end),
+        "pr_diff_stats": pr_diff_stats,
+        "axis_2_plan_subagent_skip_rate": axis_2,
     }
 
 
@@ -433,6 +549,12 @@ def emit_report(stats: dict[str, Any]) -> str:
         f"- Load-bearing touches: {stats['git'].get('load_bearing_touches', 0)}",
         f"- ADR changes: {len(stats['git'].get('adr_changes', []))}",
         f"- PRs merged: {len(stats['git'].get('prs_merged', []))}",
+        (
+            f"- Axis #2 Plan-subagent skip rate: "
+            f"{stats['axis_2_plan_subagent_skip_rate'].get('skip_rate')} "
+            f"({stats['axis_2_plan_subagent_skip_rate'].get('prs_with_zero_plan_calls')}"
+            f"/{stats['axis_2_plan_subagent_skip_rate'].get('prs_evaluated')})"
+        ),
         "",
         "## Raw stats (metadata-only — no body excerpts)",
         "",

--- a/tests/test_self_review_axis_2_regression.py
+++ b/tests/test_self_review_axis_2_regression.py
@@ -1,0 +1,158 @@
+"""Regression tests for axis #2 (Agent delegation) skip-rate collector.
+
+Pins the LOC threshold, the branch-name → issue-number join, the
+plan-call ↔ issue match via the transcript record's `cwd` field, and
+the unmatched-PR exclusion contract (issue #718, follow-up to PR #723).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "claude-hooks"))
+import _self_review as sr
+
+
+def _write_transcript(path: Path, records: list[dict]) -> None:
+    with path.open("w") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _plan_record(cwd: str, ts: str = "2026-04-15T10:00:00Z") -> dict:
+    return {
+        "timestamp": ts,
+        "sessionId": f"sess-{cwd}",
+        "cwd": cwd,
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Agent",
+                    "input": {"subagent_type": "Plan"},
+                }
+            ]
+        },
+    }
+
+
+class TestCollectSessionsPlanCallsByIssue(unittest.TestCase):
+    def test_plan_call_grouped_by_worktree_issue_number(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdir = Path(td)
+            _write_transcript(
+                tdir / "a.jsonl",
+                [
+                    _plan_record(
+                        "/repo/.claude/worktrees/feat-718-plan-skip-rate"
+                    ),
+                    _plan_record(
+                        "/repo/.claude/worktrees/feat-719-smoke-hooks"
+                    ),
+                ],
+            )
+            result = sr.collect_sessions(
+                str(tdir / "*.jsonl"), "2026-04-01", "2026-06-30"
+            )
+        self.assertEqual(result["plan_calls_by_issue"], {718: 1, 719: 1})
+        self.assertEqual(result["plan_calls_unmatched_worktree"], 0)
+        self.assertEqual(result["agent_delegations"]["Plan"], 2)
+
+    def test_plan_call_without_issue_in_cwd_goes_unmatched(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdir = Path(td)
+            _write_transcript(
+                tdir / "a.jsonl",
+                [_plan_record("/repo/.claude/worktrees/ecstatic-bose-a315c1")],
+            )
+            result = sr.collect_sessions(
+                str(tdir / "*.jsonl"), "2026-04-01", "2026-06-30"
+            )
+        self.assertEqual(result["plan_calls_by_issue"], {})
+        self.assertEqual(result["plan_calls_unmatched_worktree"], 1)
+
+
+class TestComputeAxis2SkipRate(unittest.TestCase):
+    def test_loc_threshold_excludes_small_prs(self):
+        prs = [
+            {"number": 100, "head": "fix/issue-100-typo", "issue": 100, "loc": 5},
+            {"number": 101, "head": "feat/issue-101-big", "issue": 101, "loc": 120},
+        ]
+        result = sr.compute_axis_2_skip_rate(prs, {101: 1})
+        self.assertEqual(result["prs_nontrivial"], 1)
+        self.assertEqual(result["prs_evaluated"], 1)
+        self.assertEqual(result["prs_with_zero_plan_calls"], 0)
+        self.assertEqual(result["skip_rate"], 0.0)
+
+    def test_skip_rate_counts_zero_plan_call_prs(self):
+        prs = [
+            {"number": 200, "head": "feat/issue-200-a", "issue": 200, "loc": 80},
+            {"number": 201, "head": "feat/issue-201-b", "issue": 201, "loc": 90},
+            {"number": 202, "head": "feat/issue-202-c", "issue": 202, "loc": 75},
+        ]
+        # 200 has a Plan call; 201 / 202 do not.
+        result = sr.compute_axis_2_skip_rate(prs, {200: 3})
+        self.assertEqual(result["prs_evaluated"], 3)
+        self.assertEqual(result["prs_with_zero_plan_calls"], 2)
+        self.assertAlmostEqual(result["skip_rate"], 2 / 3)
+
+    def test_unmatched_branch_excluded_from_denominator(self):
+        prs = [
+            {"number": 300, "head": "main-hotfix-no-issue", "issue": None, "loc": 100},
+            {"number": 301, "head": "feat/issue-301-x", "issue": 301, "loc": 100},
+        ]
+        result = sr.compute_axis_2_skip_rate(prs, {301: 1})
+        self.assertEqual(result["prs_nontrivial"], 2)
+        self.assertEqual(result["prs_evaluated"], 1)
+        self.assertEqual(result["prs_unmatched_branch"], 1)
+        self.assertEqual(result["skip_rate"], 0.0)
+
+    def test_none_rate_when_no_evaluable_prs(self):
+        result = sr.compute_axis_2_skip_rate([], {})
+        self.assertIsNone(result["skip_rate"])
+        self.assertEqual(result["prs_evaluated"], 0)
+
+
+class TestCollectPrDiffStatsParsing(unittest.TestCase):
+    def test_parses_gh_json_into_loc_and_issue_fields(self):
+        gh_output = json.dumps([
+            {
+                "number": 718,
+                "headRefName": "feat/issue-718-plan-skip-rate",
+                "additions": 90,
+                "deletions": 10,
+                "mergedAt": "2026-05-14T12:00:00Z",
+            },
+            {
+                "number": 901,
+                "headRefName": "main-revert",
+                "additions": 5,
+                "deletions": 5,
+                "mergedAt": "2026-05-14T12:30:00Z",
+            },
+        ])
+
+        class FakeProc:
+            returncode = 0
+            stdout = gh_output
+
+        original_run = sr.subprocess.run
+        sr.subprocess.run = lambda *a, **kw: FakeProc()  # type: ignore[assignment]
+        try:
+            result = sr.collect_pr_diff_stats("/repo", "2026-04-01", "2026-06-30")
+        finally:
+            sr.subprocess.run = original_run
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["number"], 718)
+        self.assertEqual(result[0]["issue"], 718)
+        self.assertEqual(result[0]["loc"], 100)
+        self.assertIsNone(result[1]["issue"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_review_no_body_leak_regression.py
+++ b/tests/test_self_review_no_body_leak_regression.py
@@ -186,7 +186,11 @@ class AssembleStatsStructuralTest(unittest.TestCase):
                 memory_dir=str(tmp / "memory"),
                 repo=repo,
             )
-        expected_keys = {"quarter", "date_range", "sessions", "memory", "git", "governance_hooks"}
+        expected_keys = {
+            "quarter", "date_range", "sessions", "memory", "git",
+            "governance_hooks", "pr_diff_stats",
+            "axis_2_plan_subagent_skip_rate",
+        }
         self.assertEqual(set(stats.keys()), expected_keys)
 
     def test_sessions_keys_are_metadata_only(self) -> None:
@@ -200,7 +204,10 @@ class AssembleStatsStructuralTest(unittest.TestCase):
                 repo=repo,
             )
         session_keys = set(stats["sessions"].keys())
-        allowed = {"count", "tool_call_distribution", "agent_delegations"}
+        allowed = {
+            "count", "tool_call_distribution", "agent_delegations",
+            "plan_calls_by_issue", "plan_calls_unmatched_worktree",
+        }
         self.assertLessEqual(session_keys, allowed,
                              f"sessions block has unexpected keys: {session_keys - allowed}")
 


### PR DESCRIPTION
## 1. What changed and why

Closes #718

PR #723 (`docs/agent-utilization.md` + CLAUDE.md `## Delegation defaults`) 의 follow-up. 협업 5축 #2(Agent 위임) 자동 채점에 필요한 측정 인프라를 `scripts/claude-hooks/_self_review.py` 에 추가.

핵심 측정: 분기 머지 PR 중 LOC>50 인 non-trivial PR + 각 PR의 transcript에 Plan-subagent 호출 0회였던 비율 = skip rate. 다음 분기 `self-review-quarterly` skill이 이 raw signal로 ✓/△/✗ 판정.

## 2. Files affected

- `scripts/claude-hooks/_self_review.py` (+125 lines): `BRANCH_ISSUE_RE`, `AXIS_2_LOC_THRESHOLD`, `collect_sessions` 확장(plan_calls_by_issue/unmatched), `collect_pr_diff_stats`, `compute_axis_2_skip_rate`, `assemble_stats` wiring, `emit_report` 한 줄.
- `tests/test_self_review_axis_2_regression.py` (new, 165 lines): 6 cases — worktree-issue grouping / unmatched cwd / LOC threshold / multi-PR skip rate / unmatched branch 제외 / none rate.
- `tests/test_self_review_no_body_leak_regression.py` (+8 lines): expected_keys 두 곳에 새 키 추가.

Load-bearing 아님. `scripts/_governance.py` LOAD_BEARING_PATHS 미터치.

## 3. Risks

- `gh` CLI 401/auth 누락 시 `collect_pr_diff_stats`가 빈 리스트로 fail-soft → skip rate가 `None`. self-review 전체 실행은 막지 않음 (위에서 자체 catch).
- `BRANCH_ISSUE_RE` regex가 너무 넓을 위험: 합법 PR branch만 매칭되도록 prefix를 `issue/feat/fix/docs/chore/refactor/test/perf/ci/build/style` 화이트리스트로 제한 (ADR 0007 branch types와 동일).
- `cwd` 필드가 없는 transcripts(legacy) → unmatched 카운트로 흘러 분모에서 빠짐, 분자에 영향 없음.

## 4. Tests

- `pytest tests/test_self_review_axis_2_regression.py tests/test_self_review_no_body_leak_regression.py tests/test_self_review_regression.py -q` — **18 passed locally**
- `pytest tests/test_governance.py -q` — **46 passed, 3 skipped**

## 5. Eval impact

All `·` — RAG 미터치.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

- `collect_sessions` 반환 dict는 additive (기존 3 키 유지). emit_report 한 줄 추가는 markdown 포맷이라 downstream 영향 없음.
- `assemble_stats` 새 키 2개(`pr_diff_stats`, `axis_2_plan_subagent_skip_rate`) — 기존 metadata-only contract 테스트의 expected_keys 갱신으로 호환.

## 7. Out of scope

- #719 Makefile `install-hooks` smoke 의존 — 별도 PR
- #720 MEMORY.md PreToolUse line-count matcher — 별도 PR
- #724 ADR lag + PR turnaround collector — 별도 PR
- `self-review-quarterly` SKILL.md 갱신 (axis #2 raw signal 읽기) — Q3 분기 시작 시 별도 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)