### PR TITLE
chore(make): smoke depends on install-hooks (axis #3 자동화 ROI)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,12 @@ external-baselines-ollama:
 	fi
 	BIDMATE_EXTERNAL_BACKEND=ollama $(PYTHON) scripts/compare_external_baselines.py
 
-smoke:
+# `install-hooks` is a prerequisite so the first `make smoke` on a fresh
+# worktree activates `.githooks/` (closes #719). install-hooks is
+# idempotent (`git config` only, ~5ms), so transitively re-running adds
+# negligible cost. Restores axis #3 (자동화 ROI) measurement by
+# guaranteeing `.hook-fires.log` is writable from the first dev action.
+smoke: install-hooks
 	bash scripts/smoke.sh
 
 # Cross-machine reproducibility hash. Runs the smoke eval and prints a

--- a/tests/test_smoke_hooks_dependency_regression.py
+++ b/tests/test_smoke_hooks_dependency_regression.py
@@ -1,0 +1,39 @@
+"""Regression: `make smoke` depends on `install-hooks` (issue #719).
+
+Pins that the first `make smoke` on a fresh worktree automatically
+activates `.githooks/` so `.hook-fires.log` (axis #3 자동화 ROI signal)
+starts being written without a separate manual step.
+"""
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+
+
+class TestSmokeDependsOnInstallHooks(unittest.TestCase):
+    def test_make_smoke_dryrun_triggers_install_hooks_recipe(self) -> None:
+        r = subprocess.run(
+            ["make", "-n", "smoke"],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            r.returncode, 0,
+            f"`make -n smoke` failed: stdout={r.stdout!r} stderr={r.stderr!r}",
+        )
+        self.assertIn(
+            "git config core.hooksPath .githooks",
+            r.stdout,
+            "smoke target must depend on install-hooks so a fresh worktree "
+            "activates .githooks/ before the first eval run.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #719

PR #723 5축 매핑의 follow-up. Fresh worktree에서 `make install-hooks`를 잊어 `.hook-fires.log`가 안 만들어지는 휴먼 실수를 0번째 명령에서 차단. `make smoke`가 가장 자연스러운 첫 dev 액션이므로 거기에 prerequisite 추가.

`make smoke: install-hooks` 한 줄. install-hooks는 `git config core.hooksPath .githooks` 만 호출하므로 idempotent (~5ms), 매번 호출되어도 무해. worktree에서도 `git config --local` 동작.

## 2. Files affected

- `Makefile` (smoke 타깃 prerequisite + 5줄 주석)
- `tests/test_smoke_hooks_dependency_regression.py` (new, 41 lines)

Load-bearing 아님.

## 3. Risks

- `smoke-with-judge: smoke` 가 자동 전파 → judge run 전에도 hooks 활성화. 바람직.
- `make -n` dry-run 출력 형식이 GNU make 3.81+ 표준이라 GH Actions 4.x runner와 호환. macOS stock 3.81에서도 검증.
- 향후 install-hooks recipe 변경 시 회귀 테스트가 `git config core.hooksPath .githooks` substring을 보므로 robust.

## 4. Tests

- `pytest tests/test_smoke_hooks_dependency_regression.py -q` — **1 passed locally**
- `make -n smoke` 출력에서 `git config core.hooksPath .githooks` 가 `bash scripts/smoke.sh` 전에 등장 확인

## 5. Eval impact

All `·` — RAG 미터치, eval pipeline 자체 미수정.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

영향 없음. install-hooks가 이미 활성화된 worktree에서도 무해 (idempotent).

## 7. Out of scope

- `scripts/smoke_real.sh` 같은 다른 smoke entry — 별도 issue
- #720 MEMORY.md PreToolUse line-count matcher — 별도 PR
- #724 ADR lag + PR turnaround collector — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)