### PR TITLE
feat(hooks): PreToolUse MEMORY.md line-count matcher (axis #5 memory hygiene)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "bash scripts/claude-hooks/pretooluse-loadbearing.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/claude-hooks/pretooluse-memory-lines.sh"
           }
         ]
       },

--- a/scripts/claude-hooks/pretooluse-memory-lines.sh
+++ b/scripts/claude-hooks/pretooluse-memory-lines.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook for BidMate-DocAgent (issue #720).
+#
+# Registered in `.claude/settings.json` with matcher `Edit|MultiEdit|Write`.
+# Fires only when the edit target is a `MEMORY.md` index file. Counts the
+# *resulting* line count (existing file lines OR Write payload lines) and:
+#
+#   <  AWARE_THRESHOLD   exit 0 silently
+#   >= AWARE_THRESHOLD   exit 0 + stderr awareness ("consider consolidate-memory")
+#   >= BLOCK_THRESHOLD   exit 2 + stderr block ("run consolidate-memory before adding more")
+#
+# A line is appended to `.claude/.hook-fires.log` for every fire so the
+# `_self_review.py` axis #5 collector can quantify memory hygiene
+# automation ROI without scraping transcripts.
+#
+# Hook input (stdin, JSON):
+#   { "tool_name": "...", "tool_input": { "file_path": "...", "content": "...", ... } }
+
+set -u
+
+readonly AWARE_THRESHOLD=20
+readonly BLOCK_THRESHOLD=30
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+input=$(cat)
+
+# Extract file_path + content from tool_input.
+read -r file_path content_lines < <(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    print("", 0)
+    sys.exit(0)
+ti = d.get("tool_input") or {}
+fp = ti.get("file_path") or ""
+content = ti.get("content")
+n = content.count("\n") + (1 if content and not content.endswith("\n") else 0) if isinstance(content, str) else 0
+print(fp, n)
+' 2>/dev/null)
+
+# Match only MEMORY.md (basename) — handles project + global paths.
+case "$file_path" in
+  */MEMORY.md|MEMORY.md) ;;
+  *) exit 0 ;;
+esac
+
+# Prefer Write payload line count (new-file case where the file does not
+# exist yet); fall back to existing file lines. Use `awk` to avoid the
+# `wc -l` trailing-newline off-by-one.
+if [[ -n "${content_lines:-}" && "$content_lines" =~ ^[0-9]+$ && "$content_lines" -gt 0 ]]; then
+  lines="$content_lines"
+elif [[ -f "$file_path" ]]; then
+  lines=$(awk 'END{print NR}' "$file_path" 2>/dev/null || echo 0)
+else
+  exit 0
+fi
+
+action="ok"
+if [[ "$lines" -ge "$BLOCK_THRESHOLD" ]]; then
+  action="blocked"
+elif [[ "$lines" -ge "$AWARE_THRESHOLD" ]]; then
+  action="aware"
+fi
+
+# Log fire in the 4-field format the existing `_self_review.py`
+# `collect_governance_hooks` parser already understands:
+#   <ts>|<action>|<reason>|<path>
+# The exact line count is in stderr for the human; the ROI collector
+# only needs the action/reason counters.
+printf '%s|%s|memory-lines|%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$action" "$file_path" \
+  >> "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
+
+if [[ "$action" = "blocked" ]]; then
+  cat >&2 <<EOF
+✋ MEMORY.md index has $lines lines (≥ $BLOCK_THRESHOLD).
+
+    Run \`anthropic-skills:consolidate-memory\` to merge duplicates and
+    prune stale entries before adding more. See axis #5 memory hygiene
+    in docs/agent-utilization.md.
+EOF
+  exit 2
+elif [[ "$action" = "aware" ]]; then
+  cat >&2 <<EOF
+⚠️  MEMORY.md index has $lines lines (≥ $AWARE_THRESHOLD).
+
+    Consider running \`anthropic-skills:consolidate-memory\` soon.
+EOF
+fi
+
+exit 0

--- a/tests/test_pretooluse_memory_lines_hook_regression.py
+++ b/tests/test_pretooluse_memory_lines_hook_regression.py
@@ -1,0 +1,114 @@
+"""Regression: PreToolUse memory-lines hook (issue #720, axis #5 memory hygiene).
+
+Pins the basename match (MEMORY.md only), the aware/blocked thresholds,
+Write-payload counting (file-does-not-exist-yet path), exit code contract
+(0 silent / 0 aware / 2 blocked), and the 4-field `.hook-fires.log` format.
+
+Tests isolate `.hook-fires.log` writes into a temp dir so local self-review
+artifacts are never polluted.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+HOOK = REPO / "scripts" / "claude-hooks" / "pretooluse-memory-lines.sh"
+
+
+def _run_hook(payload: dict, env_overrides: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+class TestMemoryLinesHook(unittest.TestCase):
+    def setUp(self) -> None:
+        # Isolate .hook-fires.log into a per-test temp REPO_ROOT clone.
+        self._tmp = tempfile.mkdtemp()
+        self._tmp_repo = Path(self._tmp) / "repo"
+        (self._tmp_repo / ".claude").mkdir(parents=True)
+        (self._tmp_repo / "scripts" / "claude-hooks").mkdir(parents=True)
+        shutil.copy(HOOK, self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name)
+        self._hook = self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name
+        self._fires_log = self._tmp_repo / ".claude" / ".hook-fires.log"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _run(self, payload: dict) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(self._hook)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_non_memory_path_is_noop(self) -> None:
+        r = self._run({"tool_input": {"file_path": "/tmp/some_other.md"}})
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr, "")
+        self.assertFalse(self._fires_log.exists())
+
+    def test_existing_file_below_aware_threshold_is_silent(self) -> None:
+        target = self._tmp_repo / "MEMORY.md"
+        target.write_text("\n".join([f"- entry {i}" for i in range(10)]) + "\n")
+        r = self._run({"tool_input": {"file_path": str(target)}})
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr, "")
+        # action=ok still logs a fire so the ROI collector can count
+        # silent-OK invocations too. If we later decide to only log on
+        # ok→aware transitions, update both code and this test.
+        self.assertTrue(self._fires_log.exists())
+        line = self._fires_log.read_text().strip()
+        self.assertIn("|ok|memory-lines|", line)
+
+    def test_aware_threshold_emits_stderr_but_exits_zero(self) -> None:
+        target = self._tmp_repo / "MEMORY.md"
+        target.write_text("\n".join([f"- entry {i}" for i in range(25)]) + "\n")
+        r = self._run({"tool_input": {"file_path": str(target)}})
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("consolidate-memory", r.stderr)
+        self.assertIn("25", r.stderr)
+        self.assertIn("|aware|memory-lines|", self._fires_log.read_text())
+
+    def test_block_threshold_exits_two(self) -> None:
+        target = self._tmp_repo / "MEMORY.md"
+        target.write_text("\n".join([f"- entry {i}" for i in range(35)]) + "\n")
+        r = self._run({"tool_input": {"file_path": str(target)}})
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("consolidate-memory", r.stderr)
+        self.assertIn("35", r.stderr)
+        self.assertIn("|blocked|memory-lines|", self._fires_log.read_text())
+
+    def test_write_payload_counts_for_new_file(self) -> None:
+        """Write tool creates a new MEMORY.md — file does not exist yet,
+        but `tool_input.content` carries the future contents. Hook must
+        count lines from that payload."""
+        target = self._tmp_repo / "fresh" / "MEMORY.md"
+        # Note: file does NOT exist on disk.
+        big_content = "\n".join([f"- entry {i}" for i in range(32)])
+        r = self._run({
+            "tool_input": {"file_path": str(target), "content": big_content}
+        })
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("32", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #720

PR #723 5축 매핑 #5(메모리 위생) follow-up. MEMORY.md 인덱스 라인 수가 임계값을 넘는 순간 LLM에게 직접 awareness 경고하고, 더 넘으면 차단해서 `consolidate-memory` 실행을 강제. 분기 종료 직전이 아니라 **추가 시점에** 위생 트리거를 잡음 — Q2 △ 원인을 직접 처치.

새 hook `scripts/claude-hooks/pretooluse-memory-lines.sh`:
- basename match: `MEMORY.md` 만 발화 (project + 글로벌 user memory 둘 다 잡음; cwd가 BidMate-DocAgent 일 때만 fire).
- 라인 수: 기존 파일은 `awk 'END{print NR}'` (`wc -l` trailing-newline off-by-one 회피), 새 파일은 `tool_input.content` 파싱.
- 임계: AWARE=20 (exit 0 + stderr), BLOCK=30 (exit 2 + stderr).
- 4-field `.hook-fires.log` 포맷 (`<ts>|<action>|memory-lines|<path>`) → `_self_review.py` `collect_governance_hooks` parser와 호환.

`.claude/settings.json`: `Edit|MultiEdit|Write` matcher 그룹에 두 번째 hook 추가 (loadbearing은 그대로).

## 2. Files affected

- `.claude/settings.json` (+4 lines)
- `scripts/claude-hooks/pretooluse-memory-lines.sh` (new, 93 lines)
- `tests/test_pretooluse_memory_lines_hook_regression.py` (new, 114 lines)

Load-bearing 아님.

## 3. Risks

- **글로벌 vs project-local 책임 분리**: 글로벌 user memory(`~/.claude/...MEMORY.md`)도 잡지만 cwd가 BidMate일 때만 fire하므로 다른 repo turn에 surprise fire 없음. 의도된 scope.
- **두 hook 동시 dispatch**: Claude Code는 한 matcher 안 hooks 배열을 모두 실행. loadbearing은 항상 exit 0이라 차단 충돌 없음.
- **새 파일 케이스**: Write tool로 새 MEMORY.md 생성 시 `[ -f file_path ]`가 false → `content` 페이로드 줄 수로 fallback. 테스트로 핀.
- **threshold hard-code**: 20/30이 hook 안에 hard-code. 추후 `_governance.py` 같은 SSoT로 노출 고려 (이번 PR scope 밖).

## 4. Tests

- `pytest tests/test_pretooluse_memory_lines_hook_regression.py tests/test_self_review_*.py -q` — **23 passed locally** (~2 min)
- 각 케이스가 `.hook-fires.log` 를 per-test tmp REPO_ROOT로 격리해 로컬 self-review 산출물 미오염.

## 5. Eval impact

All `·` — RAG / eval pipeline 미터치.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

- 새 hook은 additive (기존 hooks 동작 보존).
- `.hook-fires.log` 4-field 포맷 호환 — `_self_review.py` parser가 이미 4-field action/reason/path를 파싱.

## 7. Out of scope

- threshold SSoT 노출 (`_governance.py` MEMORY_LINE_THRESHOLDS) — 별도 issue
- stale entry(>2분기 미참조) 자동 검출 — 별도 분기 작업
- `productivity:memory-management` skill에 hook 신호 연동 — 별도 PR
- #724 사이클 타임 collector — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)