### PR TITLE
feat(self-review): axis #4 cycle-time signals (ADR lag + PR turnaround)

### DIFF
--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -453,7 +453,8 @@ def collect_pr_diff_stats(repo: str, start: str, end: str) -> list[dict[str, Any
                 "gh", "pr", "list",
                 "--state", "merged",
                 "--search", f"merged:{start}..{end}",
-                "--json", "number,headRefName,additions,deletions,mergedAt",
+                "--json",
+                "number,headRefName,additions,deletions,createdAt,mergedAt",
                 "--limit", "200",
             ],
             cwd=repo, capture_output=True, text=True, check=False,
@@ -481,9 +482,86 @@ def collect_pr_diff_stats(repo: str, start: str, end: str) -> list[dict[str, Any
             "head": head,
             "issue": issue,
             "loc": loc,
+            "created_at": item.get("createdAt"),
             "merged_at": item.get("mergedAt"),
         })
     return out
+
+
+def _summary_p50_p90(values: list[float]) -> dict[str, Any]:
+    """Lightweight n-sample summary used by axis #4 cycle-time signals.
+
+    Sort + index for p50/p90 — numpy-free, deterministic. Returns `None`
+    for the mean/percentile fields when the input is empty so the JSON
+    consumer knows the bucket was unmeasured rather than zero. The p90
+    index uses `min(n - 1, int(n * 0.9))`, which collapses to the max for
+    n ≤ 10 and is intentionally conservative for small samples.
+    """
+    n = len(values)
+    if n == 0:
+        return {"count": 0, "mean": None, "p50": None, "p90": None}
+    sv = sorted(values)
+    p50 = sv[n // 2]
+    p90 = sv[min(n - 1, int(n * 0.9))]
+    return {
+        "count": n,
+        "mean": sum(sv) / n,
+        "p50": p50,
+        "p90": p90,
+    }
+
+
+def _parse_gh_iso(ts: str | None) -> datetime | None:
+    """gh CLI emits `Z`-suffix UTC timestamps; coerce to aware datetime.
+
+    Python 3.11+ `datetime.fromisoformat` handles `Z` natively but earlier
+    versions don't — strip-and-replace keeps the parser portable.
+    """
+    if not isinstance(ts, str) or not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def compute_pr_turnaround_summary(prs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Axis #4 cycle-time signal: PR open→merge turnaround in hours.
+
+    Consumes the `collect_pr_diff_stats` output (which already carries
+    `created_at` / `merged_at`) so we make zero extra `gh` calls. Returns
+    `_summary_p50_p90` over hours, plus raw min/max so the LLM rubric
+    layer can spot long-stale outliers (reopened PRs, vendor branches).
+    """
+    hours: list[float] = []
+    for pr in prs:
+        ca = _parse_gh_iso(pr.get("created_at"))
+        ma = _parse_gh_iso(pr.get("merged_at"))
+        if ca is None or ma is None:
+            continue
+        delta = (ma - ca).total_seconds() / 3600.0
+        if delta < 0:
+            continue
+        hours.append(delta)
+    summary = _summary_p50_p90(hours)
+    if hours:
+        summary["min"] = min(hours)
+        summary["max"] = max(hours)
+    return summary
+
+
+def compute_adr_lag_summary(adr_lags: list[dict[str, Any]]) -> dict[str, Any]:
+    """Axis #4 cycle-time signal: ADR proposed→accepted lag in days.
+
+    Reuses `_compute_adr_lags` output (already emitted under the
+    governance_hooks block). Pure in-memory aggregator — no git calls.
+    """
+    days: list[float] = []
+    for entry in adr_lags:
+        v = entry.get("lag_days")
+        if isinstance(v, (int, float)):
+            days.append(float(v))
+    return _summary_p50_p90(days)
 
 
 def compute_axis_2_skip_rate(
@@ -525,15 +603,23 @@ def assemble_stats(
     axis_2 = compute_axis_2_skip_rate(
         pr_diff_stats, sessions.get("plan_calls_by_issue", {})
     )
+    governance = collect_governance_hooks(repo, start, end)
+    axis_4 = {
+        "adr_lag_days": compute_adr_lag_summary(
+            governance.get("rule_to_automation_lag_days", [])
+        ),
+        "pr_turnaround_hours": compute_pr_turnaround_summary(pr_diff_stats),
+    }
     return {
         "quarter": quarter,
         "date_range": [start, end],
         "sessions": sessions,
         "memory": collect_memory(memory_dir),
         "git": collect_git(repo, start, end),
-        "governance_hooks": collect_governance_hooks(repo, start, end),
+        "governance_hooks": governance,
         "pr_diff_stats": pr_diff_stats,
         "axis_2_plan_subagent_skip_rate": axis_2,
+        "axis_4_cycle_time": axis_4,
     }
 
 
@@ -554,6 +640,18 @@ def emit_report(stats: dict[str, Any]) -> str:
             f"{stats['axis_2_plan_subagent_skip_rate'].get('skip_rate')} "
             f"({stats['axis_2_plan_subagent_skip_rate'].get('prs_with_zero_plan_calls')}"
             f"/{stats['axis_2_plan_subagent_skip_rate'].get('prs_evaluated')})"
+        ),
+        (
+            f"- Axis #4 ADR lag (days) mean/p90: "
+            f"{stats['axis_4_cycle_time']['adr_lag_days'].get('mean')} / "
+            f"{stats['axis_4_cycle_time']['adr_lag_days'].get('p90')} "
+            f"(n={stats['axis_4_cycle_time']['adr_lag_days'].get('count')})"
+        ),
+        (
+            f"- Axis #4 PR turnaround (hours) mean/p90: "
+            f"{stats['axis_4_cycle_time']['pr_turnaround_hours'].get('mean')} / "
+            f"{stats['axis_4_cycle_time']['pr_turnaround_hours'].get('p90')} "
+            f"(n={stats['axis_4_cycle_time']['pr_turnaround_hours'].get('count')})"
         ),
         "",
         "## Raw stats (metadata-only — no body excerpts)",

--- a/tests/test_self_review_axis_4_regression.py
+++ b/tests/test_self_review_axis_4_regression.py
@@ -1,0 +1,105 @@
+"""Regression tests for axis #4 (사이클 타임) cycle-time signals.
+
+Pins the n-sample summary helper, the gh-ISO timestamp parser (handles
+the trailing `Z` UTC suffix), the PR turnaround aggregator (which reuses
+`collect_pr_diff_stats` output instead of issuing a second `gh` call),
+and the ADR lag summary aggregator. Issue #724, follow-up to PR #723.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "claude-hooks"))
+import _self_review as sr
+
+
+class TestSummaryHelper(unittest.TestCase):
+    def test_empty_input_returns_nones(self) -> None:
+        result = sr._summary_p50_p90([])
+        self.assertEqual(result["count"], 0)
+        self.assertIsNone(result["mean"])
+        self.assertIsNone(result["p50"])
+        self.assertIsNone(result["p90"])
+
+    def test_five_sample_mean_and_percentiles(self) -> None:
+        result = sr._summary_p50_p90([1.0, 2.0, 3.0, 4.0, 5.0])
+        self.assertEqual(result["count"], 5)
+        self.assertEqual(result["mean"], 3.0)
+        self.assertEqual(result["p50"], 3.0)
+        # int(5 * 0.9) = 4 → sv[4] = 5.0 (intentionally collapses to max
+        # for small n; doc-string pins this conservative behaviour).
+        self.assertEqual(result["p90"], 5.0)
+
+    def test_unsorted_input_is_sorted_internally(self) -> None:
+        result = sr._summary_p50_p90([10.0, 1.0, 5.0])
+        self.assertEqual(result["p50"], 5.0)
+
+
+class TestGhIsoParser(unittest.TestCase):
+    def test_z_suffix_parsed_to_aware_utc(self) -> None:
+        dt = sr._parse_gh_iso("2026-04-15T10:00:00Z")
+        self.assertIsNotNone(dt)
+        self.assertIsNotNone(dt.tzinfo)
+
+    def test_invalid_input_returns_none(self) -> None:
+        self.assertIsNone(sr._parse_gh_iso(None))
+        self.assertIsNone(sr._parse_gh_iso(""))
+        self.assertIsNone(sr._parse_gh_iso("not-a-timestamp"))
+
+
+class TestComputePrTurnaroundSummary(unittest.TestCase):
+    def test_hours_between_created_and_merged(self) -> None:
+        prs = [
+            {
+                "number": 1,
+                "created_at": "2026-04-15T10:00:00Z",
+                "merged_at": "2026-04-15T14:00:00Z",   # +4h
+            },
+            {
+                "number": 2,
+                "created_at": "2026-04-16T10:00:00Z",
+                "merged_at": "2026-04-17T10:00:00Z",   # +24h
+            },
+        ]
+        result = sr.compute_pr_turnaround_summary(prs)
+        self.assertEqual(result["count"], 2)
+        self.assertEqual(result["mean"], 14.0)
+        self.assertEqual(result["min"], 4.0)
+        self.assertEqual(result["max"], 24.0)
+
+    def test_missing_timestamps_are_dropped(self) -> None:
+        prs = [
+            {"number": 3, "created_at": None, "merged_at": "2026-04-15T10:00:00Z"},
+            {"number": 4, "created_at": "2026-04-15T10:00:00Z", "merged_at": None},
+        ]
+        result = sr.compute_pr_turnaround_summary(prs)
+        self.assertEqual(result["count"], 0)
+        self.assertIsNone(result["mean"])
+
+    def test_empty_pr_list_returns_summary_skeleton(self) -> None:
+        result = sr.compute_pr_turnaround_summary([])
+        self.assertEqual(result["count"], 0)
+        self.assertNotIn("min", result)
+
+
+class TestComputeAdrLagSummary(unittest.TestCase):
+    def test_aggregates_lag_days_field(self) -> None:
+        lags = [
+            {"adr_id": "0040", "lag_days": 1},
+            {"adr_id": "0041", "lag_days": 3},
+            {"adr_id": "0042", "lag_days": 8},
+        ]
+        result = sr.compute_adr_lag_summary(lags)
+        self.assertEqual(result["count"], 3)
+        self.assertAlmostEqual(result["mean"], 4.0)
+
+    def test_missing_lag_days_excluded(self) -> None:
+        lags = [{"adr_id": "0099", "proposed_date": "2026-04-01"}]
+        result = sr.compute_adr_lag_summary(lags)
+        self.assertEqual(result["count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_review_no_body_leak_regression.py
+++ b/tests/test_self_review_no_body_leak_regression.py
@@ -190,6 +190,7 @@ class AssembleStatsStructuralTest(unittest.TestCase):
             "quarter", "date_range", "sessions", "memory", "git",
             "governance_hooks", "pr_diff_stats",
             "axis_2_plan_subagent_skip_rate",
+            "axis_4_cycle_time",
         }
         self.assertEqual(set(stats.keys()), expected_keys)
 


### PR DESCRIPTION
## 1. What changed and why

Closes #724

PR #723 5축 매핑의 마지막 follow-up. axis #4(사이클 타임) raw 통계 자동 생성. 다음 분기 `self-review-quarterly` skill이 이 신호로 ✓/△/✗ 채점.

별도 `_cycle_time.py` 안 만듦 — `_compute_adr_lags` 가 이미 `_self_review.py`에 있어 응집도 일치. PR #745(axis #2) 패턴 그대로.

**Key reuse**: `collect_pr_diff_stats`(PR #745)의 `--json`에 `createdAt`만 추가하고 turnaround 가공은 in-memory. 추가 `gh` 호출 0.

## 2. Files affected

- `scripts/claude-hooks/_self_review.py` (+100 lines): `_summary_p50_p90`, `_parse_gh_iso`, `compute_pr_turnaround_summary`, `compute_adr_lag_summary`, `assemble_stats` 새 `axis_4_cycle_time` 키, `emit_report` +2 라인.
- `tests/test_self_review_axis_4_regression.py` (new, 105 lines): summary 빈 입력 / 5-sample 통계 / 정렬 / Z-suffix 파싱 / PR turnaround / 누락 timestamp / ADR lag summary — 9 cases.
- `tests/test_self_review_no_body_leak_regression.py` (+1 line): `expected_keys` 에 `axis_4_cycle_time` 추가 (PR #745 패턴 동일).

Load-bearing 아님.

## 3. Risks

- **Tiny-n percentile**: p90 인덱스는 `min(n-1, int(n*0.9))`이라 n≤10에서 max에 가까움. doc-string에 의도로 명시. KPI 신호용으로 conservative하게 OK.
- **`Z`-suffix 파싱**: `datetime.fromisoformat(ts.replace("Z","+00:00"))` 패턴. Python 3.10 호환.
- **reopened PR outlier**: `createdAt`이 원본 open 시점이라 reopen 케이스가 p90 왜곡 가능 → `min/max` 동봉으로 LLM rubric layer가 검출 가능.
- **bot PR**: `dependabot/...` 등은 issue=None으로 axis #2 분모에서 빠지지만 turnaround엔 포함됨 — 의도 (PR turnaround는 전체 발행 PR 통계).

## 4. Tests

- `pytest tests/test_self_review_axis_4_regression.py tests/test_self_review_axis_2_regression.py tests/test_self_review_regression.py tests/test_self_review_no_body_leak_regression.py -q` — **28 passed locally** (~70s)

## 5. Eval impact

All `·` — RAG / eval pipeline 미터치.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

- `collect_pr_diff_stats` 반환 dict는 additive (기존 `created_at` 키만 추가).
- `assemble_stats` 새 키 `axis_4_cycle_time` — `expected_keys` 갱신으로 호환.

## 7. Out of scope

- `self-review-quarterly` SKILL.md에 axis #4 threshold(✓≤5일/△5-10일/✗>10일 for ADR lag; ✓≤2일/△2-5일/✗>5일 for PR turnaround) 가이드 추가 — Q3 분기 시작 시 별도 작업.
- ADR proposed 일자가 commit-add 시각 외 다른 metadata에서 오는 경우 처리 — 별도 issue 필요 시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)