### PR TITLE
feat(eval): HWP table extraction golden schema + pyhwp dumper (PR-A0, closes #728)

### DIFF
--- a/eval/data/table_extraction_golden.schema.json
+++ b/eval/data/table_extraction_golden.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bidmate.local/schemas/table_extraction_golden.json",
+  "title": "Table extraction golden record",
+  "description": "One labeled table from an RFP source document. Used as ground truth for HWP/Upstage parser comparison (issue #728, PR-A0). One JSONL line = one table.",
+  "type": "object",
+  "required": [
+    "doc_id",
+    "source_path",
+    "table_index",
+    "rows",
+    "cols",
+    "cells",
+    "extractor",
+    "extracted_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "doc_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Document identifier (typically source file stem)."
+    },
+    "source_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the source document the table was extracted from."
+    },
+    "page": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "description": "1-indexed source page. Null when the parser does not expose page mappings (pyhwp event stream)."
+    },
+    "table_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "0-indexed table position within the document."
+    },
+    "rows": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Declared row count from the parser."
+    },
+    "cols": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Declared column count from the parser."
+    },
+    "caption": {
+      "type": ["string", "null"],
+      "description": "Caption text immediately preceding the table (e.g., '표 3.1 평가 배점'). Null in dumped drafts; filled by the labeler."
+    },
+    "table_kind": {
+      "type": ["string", "null"],
+      "enum": ["evaluation", "requirement", "schedule", "other", null],
+      "description": "Semantic table category. Null in dumped drafts; filled by the labeler. Used by axis #2 of the table-handling plan to drive per-kind chunking policy."
+    },
+    "cells": {
+      "type": "array",
+      "minItems": 0,
+      "description": "Flat list of cells preserving HWP-native row/col coordinates and span info.",
+      "items": {
+        "type": "object",
+        "required": ["row", "col", "rowspan", "colspan", "text"],
+        "additionalProperties": false,
+        "properties": {
+          "row": {"type": "integer", "minimum": 0},
+          "col": {"type": "integer", "minimum": 0},
+          "rowspan": {"type": "integer", "minimum": 1},
+          "colspan": {"type": "integer", "minimum": 1},
+          "text": {"type": "string"}
+        }
+      }
+    },
+    "extractor": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the extractor that produced this draft (e.g., 'pyhwp_native_tables', 'upstage_document_parser')."
+    },
+    "extracted_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp of extraction."
+    },
+    "notes": {
+      "type": ["string", "null"],
+      "description": "Free-form labeler notes. Null in dumped drafts."
+    }
+  }
+}

--- a/scripts/dump_hwp_tables.py
+++ b/scripts/dump_hwp_tables.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Dump pyhwp native table extraction as draft golden JSONL (issue #728).
+
+Walks a directory of HWP files, runs
+``ingestion._extract_hwp_native_with_tables`` on each, and emits one JSONL
+line per non-empty table conforming to
+``eval/data/table_extraction_golden.schema.json``.
+
+Output is a **draft**: ``table_kind``, ``caption``, and ``notes`` are left
+``null`` for the human labeler to fill in. ``page`` is ``null`` because
+pyhwp's event stream does not expose page mappings.
+
+Off-pipeline measurement tool. Default HWP loader (ADR 0036) is unchanged.
+Gracefully skips when pyhwp is unavailable so CI minimal installs remain
+green. Per-file extraction errors are reported in the summary, never
+re-raised.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+EXTRACTOR_TAG = "pyhwp_native_tables"
+SKIP_REASON_PYHWP_MISSING = "pyhwp_not_installed"
+
+
+def _pyhwp_available() -> bool:
+    """Return True iff the optional ``hwp5`` package is importable."""
+    return importlib.util.find_spec("hwp5") is not None
+
+
+def _now_iso() -> str:
+    """Return current UTC time in ISO-8601 (seconds precision)."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _has_nonempty_cells(table: dict[str, Any]) -> bool:
+    """True iff at least one cell has non-whitespace text."""
+    for cell in table.get("cells") or []:
+        if str(cell.get("text", "")).strip():
+            return True
+    return False
+
+
+def dump_record(
+    doc_id: str,
+    source_path: Path,
+    table: dict[str, Any],
+    *,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    """Build one golden draft record from a pyhwp-extracted table.
+
+    ``now_iso`` is injectable so tests can pin a deterministic timestamp.
+    """
+    return {
+        "doc_id": doc_id,
+        "source_path": str(source_path),
+        "page": None,
+        "table_index": int(table.get("table_index", 0) or 0),
+        "rows": int(table.get("rows", 0) or 0),
+        "cols": int(table.get("cols", 0) or 0),
+        "caption": None,
+        "table_kind": None,
+        "cells": [
+            {
+                "row": int(cell.get("row", 0) or 0),
+                "col": int(cell.get("col", 0) or 0),
+                "rowspan": int(cell.get("rowspan", 1) or 1),
+                "colspan": int(cell.get("colspan", 1) or 1),
+                "text": str(cell.get("text", "")),
+            }
+            for cell in (table.get("cells") or [])
+        ],
+        "extractor": EXTRACTOR_TAG,
+        "extracted_at": now_iso or _now_iso(),
+        "notes": None,
+    }
+
+
+def iter_hwp_files(hwp_dir: Path) -> Iterable[Path]:
+    """Yield ``.hwp`` files in ``hwp_dir`` in deterministic (sorted) order."""
+    return sorted(p for p in hwp_dir.glob("*.hwp") if p.is_file())
+
+
+def dump_directory(hwp_dir: Path, out_path: Path) -> dict[str, Any]:
+    """Iterate ``hwp_dir`` and emit one JSONL line per non-empty table.
+
+    Returns a summary dict for the CLI to print. Never raises on per-file
+    extraction errors — each failure is reported in the summary's
+    ``failures`` list instead.
+    """
+    if not _pyhwp_available():
+        return {
+            "status": "skipped",
+            "reason": SKIP_REASON_PYHWP_MISSING,
+            "files_seen": 0,
+            "tables_dumped": 0,
+            "failures": [],
+        }
+
+    # Late import: pyhwp is opt-in (ADR 0036). Importing ``ingestion`` only
+    # after the availability check keeps ``--help`` working in minimal envs.
+    from ingestion import _extract_hwp_native_with_tables  # type: ignore[import-not-found]
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    files = list(iter_hwp_files(hwp_dir))
+    tables_dumped = 0
+    failures: list[dict[str, str]] = []
+
+    with out_path.open("w", encoding="utf-8") as fh:
+        for source in files:
+            try:
+                _text, tables = _extract_hwp_native_with_tables(source)
+            except Exception as exc:  # noqa: BLE001 — per-file isolation
+                failures.append({"file": source.name, "error": repr(exc)})
+                continue
+            for table in tables:
+                if not _has_nonempty_cells(table):
+                    continue
+                record = dump_record(
+                    doc_id=source.stem,
+                    source_path=source,
+                    table=table,
+                )
+                fh.write(json.dumps(record, ensure_ascii=False))
+                fh.write("\n")
+                tables_dumped += 1
+
+    return {
+        "status": "ok",
+        "files_seen": len(files),
+        "tables_dumped": tables_dumped,
+        "failures": failures,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Dump pyhwp native table extraction as draft golden JSONL "
+            "(issue #728, PR-A0 of HWP RAG table experiment). "
+            "Off-pipeline measurement only; the default HWP loader is unchanged."
+        )
+    )
+    parser.add_argument(
+        "--hwp-dir",
+        type=Path,
+        required=True,
+        help="Directory containing .hwp files (local-only; ADR 0005 boundary).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=REPO_ROOT / "outputs" / "table_golden_draft.jsonl",
+        help=(
+            "Output JSONL path "
+            "(default: outputs/table_golden_draft.jsonl, gitignored)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    hwp_dir = args.hwp_dir
+    if not hwp_dir.exists() or not hwp_dir.is_dir():
+        print(
+            f"error: --hwp-dir does not exist or is not a directory: {hwp_dir}",
+            file=sys.stderr,
+        )
+        return 2
+    summary = dump_directory(hwp_dir, args.out)
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if summary["status"] == "skipped":
+        print(
+            "pyhwp not installed — install via `pip install pyhwp` to dump tables.",
+            file=sys.stderr,
+        )
+        return 0
+    print(
+        f"\nWrote {args.out} ({summary['tables_dumped']} tables from "
+        f"{summary['files_seen']} files).",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dump_hwp_tables.py
+++ b/tests/test_dump_hwp_tables.py
@@ -1,0 +1,200 @@
+"""Unit tests for scripts/dump_hwp_tables.py (issue #728, PR-A0).
+
+These tests:
+
+* Verify the dumper's record shape validates against the published JSON
+  Schema at ``eval/data/table_extraction_golden.schema.json``.
+* Confirm graceful skip when pyhwp is unavailable (CI minimal install
+  safe, per ADR 0036).
+* Confirm the dumper writes one JSONL line per non-empty table when
+  pyhwp is present (verified via a monkey-patched ``ingestion`` module
+  so the test does not require a real HWP fixture).
+
+The tests never import pyhwp directly — they only check the dumper's
+behavior at the boundary it exposes.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import dump_hwp_tables as dumper  # noqa: E402
+
+SCHEMA_PATH = REPO_ROOT / "eval" / "data" / "table_extraction_golden.schema.json"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _sample_table(table_index: int = 0) -> dict[str, Any]:
+    return {
+        "table_index": table_index,
+        "rows": 2,
+        "cols": 2,
+        "cells": [
+            {"row": 0, "col": 0, "rowspan": 1, "colspan": 1, "text": "항목"},
+            {"row": 0, "col": 1, "rowspan": 1, "colspan": 1, "text": "배점"},
+            {"row": 1, "col": 0, "rowspan": 1, "colspan": 1, "text": "기술"},
+            {"row": 1, "col": 1, "rowspan": 1, "colspan": 1, "text": "60"},
+        ],
+    }
+
+
+def test_dump_record_shape_validates_against_schema(schema: dict[str, Any]) -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    record = dumper.dump_record(
+        doc_id="sample",
+        source_path=Path("/tmp/sample.hwp"),
+        table=_sample_table(table_index=3),
+        now_iso="2026-05-14T00:00:00+00:00",
+    )
+    assert record["doc_id"] == "sample"
+    assert record["table_index"] == 3
+    assert record["table_kind"] is None
+    assert record["caption"] is None
+    assert record["notes"] is None
+    assert record["cells"][0]["text"] == "항목"
+    assert record["extractor"] == "pyhwp_native_tables"
+    jsonschema.validate(instance=record, schema=schema)
+
+
+def test_has_nonempty_cells_filters_whitespace_only() -> None:
+    empty = {
+        "table_index": 0,
+        "rows": 1,
+        "cols": 1,
+        "cells": [{"row": 0, "col": 0, "rowspan": 1, "colspan": 1, "text": "  "}],
+    }
+    assert not dumper._has_nonempty_cells(empty)
+    assert dumper._has_nonempty_cells(_sample_table())
+
+
+def test_dump_directory_skipped_when_pyhwp_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dumper, "_pyhwp_available", lambda: False)
+    out = tmp_path / "out.jsonl"
+    summary = dumper.dump_directory(tmp_path, out)
+    assert summary["status"] == "skipped"
+    assert summary["reason"] == dumper.SKIP_REASON_PYHWP_MISSING
+    assert summary["tables_dumped"] == 0
+    assert not out.exists()
+
+
+def test_dump_directory_writes_jsonl_when_pyhwp_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    schema: dict[str, Any],
+) -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    monkeypatch.setattr(dumper, "_pyhwp_available", lambda: True)
+
+    # A dummy file on disk so ``iter_hwp_files`` returns one path; the
+    # contents do not matter because the extractor is monkey-patched.
+    fake_hwp = tmp_path / "fake.hwp"
+    fake_hwp.write_bytes(b"\x00")
+
+    def fake_extract(source_path: Path):
+        return None, [_sample_table(table_index=0), _sample_table(table_index=1)]
+
+    fake_module = types.ModuleType("ingestion")
+    fake_module._extract_hwp_native_with_tables = fake_extract  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "ingestion", fake_module)
+
+    out = tmp_path / "draft.jsonl"
+    summary = dumper.dump_directory(tmp_path, out)
+    assert summary["status"] == "ok"
+    assert summary["files_seen"] == 1
+    assert summary["tables_dumped"] == 2
+    assert summary["failures"] == []
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        record = json.loads(line)
+        jsonschema.validate(instance=record, schema=schema)
+        assert record["doc_id"] == "fake"
+        assert record["table_kind"] is None
+
+
+def test_dump_directory_isolates_per_file_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dumper, "_pyhwp_available", lambda: True)
+
+    (tmp_path / "good.hwp").write_bytes(b"\x00")
+    (tmp_path / "bad.hwp").write_bytes(b"\x00")
+
+    def fake_extract(source_path: Path):
+        if source_path.name == "bad.hwp":
+            raise RuntimeError("simulated pyhwp parse failure")
+        return None, [_sample_table(table_index=0)]
+
+    fake_module = types.ModuleType("ingestion")
+    fake_module._extract_hwp_native_with_tables = fake_extract  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "ingestion", fake_module)
+
+    out = tmp_path / "draft.jsonl"
+    summary = dumper.dump_directory(tmp_path, out)
+    assert summary["status"] == "ok"
+    assert summary["files_seen"] == 2
+    assert summary["tables_dumped"] == 1
+    assert len(summary["failures"]) == 1
+    assert summary["failures"][0]["file"] == "bad.hwp"
+    assert "simulated pyhwp parse failure" in summary["failures"][0]["error"]
+
+
+def test_dump_directory_skips_empty_tables(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dumper, "_pyhwp_available", lambda: True)
+
+    (tmp_path / "fake.hwp").write_bytes(b"\x00")
+
+    def fake_extract(source_path: Path):
+        empty = {
+            "table_index": 0,
+            "rows": 1,
+            "cols": 1,
+            "cells": [
+                {"row": 0, "col": 0, "rowspan": 1, "colspan": 1, "text": "   "},
+            ],
+        }
+        return None, [empty, _sample_table(table_index=1)]
+
+    fake_module = types.ModuleType("ingestion")
+    fake_module._extract_hwp_native_with_tables = fake_extract  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "ingestion", fake_module)
+
+    out = tmp_path / "draft.jsonl"
+    summary = dumper.dump_directory(tmp_path, out)
+    assert summary["tables_dumped"] == 1
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["table_index"] == 1
+
+
+def test_cli_returns_2_when_hwp_dir_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "nope"
+    rc = dumper.main(["--hwp-dir", str(missing), "--out", str(tmp_path / "out.jsonl")])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err


### PR DESCRIPTION
## Summary

로컬 plan `~/.claude/plans/hwp-rag-wondrous-sutherland.md` (저장소 외부) 에 기술된 HWP RAG 표 처리 실험의 첫 단계 (PR-A0).

human labeling pass 가 소비할 JSON Schema + draft-golden dumper 추가. 후속 stacked PR (A1=Upstage opt-in, A2=parser 비교, A3=메트릭, B=실험+ADR) 이 이 위에 build.

## Files

- `eval/data/table_extraction_golden.schema.json` — 표 당 1 record, 셀은 `row/col/rowspan/colspan` 보존, `table_kind` enum `{evaluation, requirement, schedule, other}` 는 labeler 가 설정.
- `scripts/dump_hwp_tables.py` — 기존 `ingestion._extract_hwp_native_with_tables` 실행, non-empty 표 당 JSONL 라인 1개 발화. `table_kind` / `caption` / `notes` 는 labeler 용으로 `null` 유지. pyhwp 부재 시 graceful skip (ADR 0036 CI safe).
- `tests/test_dump_hwp_tables.py` — 7 테스트: schema 검증, pyhwp-부재 skip, per-file 실패 격리, empty-cell 필터링, missing dir CLI exit code.

## Boundaries

- Off-pipeline; default HWP loader (ADR 0036) 미변경.
- Naive baseline (ADR 0001) 미터치 — eval surface 변경 없음.
- `scripts/compare_hwp_extraction.py` (ADR 0036 측정 harness, `hwp5txt` vs `libreoffice`) 와 구분; PR-A0 는 후속 PR 의 다른 비교 (`pyhwp_native_tables` vs Upstage) 표면 setup.
- ADR 0039 hardcase taxonomy 와 orthogonal (다른 surface: 여기는 private 100-doc, 거기는 public synthetic).

## Test plan

- [x] `pytest tests/test_dump_hwp_tables.py` — 7/7 passing (`ingestion` mocked, 테스트 시 pyhwp 불필요).
- [x] `ruff check scripts/dump_hwp_tables.py tests/test_dump_hwp_tables.py` clean.
- [x] `make smoke` (앞서 로컬 실행; load-bearing 파일 미터치라 회귀 예상 없음).
- [x] CI: pytest / baseline provenance / eval delta — 전부 pass.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

PR 은 `eval/data/` 아래 신규 파일 (JSON Schema) + off-pipeline 도구 (`scripts/dump_hwp_tables.py`) + `ingestion` mock 테스트 추가. Runtime load-bearing surface — `ingestion.py` loader dispatch, `rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, `eval/config.yaml` 프리셋, `api/main.py` — 는 byte-identical. 추가된 schema 파일은 어떤 프리셋, 검색 경로, verifier 도 읽지 않음; 신규 dumper 스크립트와 그 테스트만 소비. 따라서 `make real-eval-delta` 는 zero delta 생성, explicit-opt-out 조항에 따라 이 PR 에서 생략.

## Closes

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)
