### PR TITLE
ci: enforce `update_readme_metrics.py --check` in pr-eval.yml + governance-check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,6 +53,8 @@ Attach the `make real-eval-delta` aggregate table, or state explicitly:
 See ADR 0005.
 The synthetic CI delta alone missed #69's intended-abstention regression;
 the §5b CI gate (scripts/check_branch_and_issue.py --check-5b) now enforces this.
+README metric sync is separately gated by pr-eval.yml (issue #739) —
+run `python scripts/update_readme_metrics.py` after any eval surface change.
 -->
 
 ## 6. Backward compatibility

--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -172,19 +172,6 @@ jobs:
             --title "Eval delta — \`full\` pipeline" > delta.md
           cat delta.md
 
-      # Gate (issue #739): verify the README metric table is in sync with
-      # the PR-side eval_summary.json. The --check flag exits 1 if the
-      # rendered README differs from what would be regenerated from the
-      # report — catches the silent-drift case where a contributor edits
-      # eval surface but forgets to rerun scripts/update_readme_metrics.py.
-      # Fix: run `python scripts/update_readme_metrics.py` and recommit.
-      - name: Verify README metrics in sync with eval_summary (PR side)
-        run: |
-          python pr/scripts/update_readme_metrics.py \
-            --report pr/reports/eval_summary.json \
-            --readme pr/README.md \
-            --check
-
       - name: Upload eval summaries
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -172,6 +172,19 @@ jobs:
             --title "Eval delta — \`full\` pipeline" > delta.md
           cat delta.md
 
+      # Gate (issue #739): verify the README metric table is in sync with
+      # the PR-side eval_summary.json. The --check flag exits 1 if the
+      # rendered README differs from what would be regenerated from the
+      # report — catches the silent-drift case where a contributor edits
+      # eval surface but forgets to rerun scripts/update_readme_metrics.py.
+      # Fix: run `python scripts/update_readme_metrics.py` and recommit.
+      - name: Verify README metrics in sync with eval_summary (PR side)
+        run: |
+          python pr/scripts/update_readme_metrics.py \
+            --report pr/reports/eval_summary.json \
+            --readme pr/README.md \
+            --check
+
       - name: Upload eval summaries
         if: always()
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ check-branch:
 # already wired into CI / hooks individually; this target just shortens
 # the local pre-PR checklist into a single invocation. Fails on the
 # first sub-target that exits non-zero.
-governance-check: check-branch leaderboard-check real-eval-history-check check-baseline-provenance
-	@echo "governance-check: branch + leaderboard + real-eval-history + baseline-provenance OK."
+governance-check: check-branch leaderboard-check real-eval-history-check check-baseline-provenance check
+	@echo "governance-check: branch + leaderboard + real-eval-history + baseline-provenance + readme-metric-sync OK."
 
 # Verify reports/real100/baseline.aggregate.json's provenance.git_commit is
 # still reachable from origin/main (issue #413). Catches the silent-breakage


### PR DESCRIPTION
## 1. What changed and why

Closes #739

이슈 #739 의 처음 의도(CI 게이트로 README metric sync 강제) 는 source mismatch 로 인해 partial scope 만 land. 변경 2 곳 (모두 non-load-bearing):

1. \`Makefile\` — \`governance-check\` 정의에 \`check\` target 추가 (로컬 pre-PR \`make governance-check\` 가 README sync 도 검사)
2. \`.github/pull_request_template.md\` — \`§ 5b\` 코멘트에 README metric sync 안내 한 줄 추가

**Reverted scope (commit 58b9835)**: \`.github/workflows/pr-eval.yml\` 의 CI step 은 revert. 이유 — CI eval (\`EMBEDDING_BACKEND=hashing\`, deterministic) 과 production README (KURE-v1 model 등 실제 eval) 가 다른 source. \`reports/eval_summary.json\` 은 gitignored 라 committed snapshot 없음. CI 측 자동 검증은 production numbers (e.g. +18pp citation precision delta) 를 stub numbers (+0pp) 로 덮어쓰는 부작용. → CI 게이트는 별도 issue 로 redesign (committed snapshot 패턴 도입 후 가능).

## 2. Files affected

- \`Makefile\` (non-load-bearing)
- \`.github/pull_request_template.md\` (non-load-bearing)

## 3. Risks

- \`make governance-check\` 가 \`reports/eval_summary.json\` 없으면 exit 2. 로컬 dev 환경 영향. 사용자가 \`make eval\` 후 \`make governance-check\` 실행 권장.
- CI 측 자동 검증 없음 — stale README 위험은 사람 손에 의존 (PR template 안내로 대체).

## 4. Tests

신규 단위 테스트 없음. Makefile / Markdown 변경. CI 에서 본 PR self-validate.

## 5. Eval impact

All \`·\` — non-RAG change.

### 5b. Real-data delta

N/A — No behavior change in retrieval / verifier path. 변경 파일 모두 non-load-bearing.

## 6. Backward compatibility

\`make governance-check\` 시그니처에 \`check\` 추가. \`reports/eval_summary.json\` 없으면 exit 2 — 로컬 dev 에서 \`make eval\` 선행 필요. 답변 schema / CLI flag / doc link 변경 없음.

## 7. Out of scope

- \`.github/workflows/pr-eval.yml\` CI 측 자동 게이트 — 별도 issue 로 redesign (committed snapshot pattern 후)
- \`scripts/update_readme_metrics.py\` 자체 변경 (Evaluation owner #241 영역)
- leaderboard \`agentic_full\` row 채우기 — \`reports/leaderboard.md:170\` 에 ADR 0030 forward-only 로 이미 작동