### PR TITLE
docs(governance): document 3 incidents caught by hooks/gates

### DIFF
--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -15,10 +15,10 @@ If you are new to the repo or onboarding a reviewer, start here.
 | Coding & review rules | [`CLAUDE.md`](../CLAUDE.md) | Pre-PR checklist, prohibited shortcuts, performance expectations. |
 | Multi-agent coordination | [`docs/multi-agent-ownership.md`](./multi-agent-ownership.md) | 7-way ownership split, `rag_core.py` lock holder, conflict-resolution rules when several agents work in parallel. |
 | Load-bearing decisions | [`docs/adr/`](./adr/README.md) | One short file per decision; status-tracked. |
-| Behavior contracts | [ADR 0003](./adr/0003-structured-answer-citation-contract.md), [`docs/answer-policy.md`](./answer-policy.md) | Answer JSON shape, `schema_version`, status values. |
+| Behavior contracts | [ADR 0003](./adr/0003-structured-answer-citation-contract.md), [`docs/agentic/answer-policy.md`](./agentic/answer-policy.md) | Answer JSON shape, `schema_version`, status values. |
 | Eval surfaces | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`eval/config.yaml`](../eval/config.yaml), `eval/*.example.yaml` | Public synthetic is committed; private local is `.gitignore`d. |
 | Reviewer-facing metrics | `reports/eval_summary.json`, README headline table | The PR eval delta workflow upserts a PR comment with the diff. |
-| Failure analysis | [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), [`docs/failure-cases.md`](./failure-cases.md) | Drives the prioritized backlog. |
+| Failure analysis | [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md), [`docs/real-data/failure-cases.md`](./real-data/failure-cases.md) | Drives the prioritized backlog. |
 | API demo | [`docs/operations/api-demo.md`](./operations/api-demo.md), `api/main.py` | Reviewer playground; never the source of truth for measurement. |
 | Issue/PR triage | This page, ["Milestones & issue lifecycle"](#milestones--issue-lifecycle) | Milestones, stale policy, current categorisation snapshot. |
 
@@ -81,7 +81,7 @@ the GitHub milestone pages are authoritative.
 |---|---|---|
 | `v3-release` | Concrete work toward the next release of the RAG stack — ingestion v3, retrieval/ranking changes, new core utilities. | `feat`, `fix` that ship behavior. |
 | `portfolio-review-readiness` | Reviewer-facing polish: README clarity, case-study narrative, deploy artifacts, structured-output docs, ablation visualisation. | `docs`, `chore`, `eval` work whose audience is the portfolio reviewer. |
-| `real-data-evaluation` | Private 100-doc real-data eval health: failures observed in [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md), Korean-specific axes, abstention regressions. | `eval`, `fix` that lands a measurable real-data delta. |
+| `real-data-evaluation` | Private 100-doc real-data eval health: failures observed in [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md), Korean-specific axes, abstention regressions. | `eval`, `fix` that lands a measurable real-data delta. |
 
 Meta/parent issues (e.g. #118 portfolio review readiness, #187 phase
 enhancement backlog) do **not** carry a milestone — they group child
@@ -163,6 +163,61 @@ Issues without a clear home stay milestone-less until categorised.
   here" fixes. *Prevented by:* "one PR, one concern" in
   `CLAUDE.md`; spawn a follow-up issue instead.
 
+## Governance saves: real incidents prevented
+
+The list above is the *design* — the rules and the guards. This
+section is the *evidence*: incidents that actually happened in this
+repo, and the hook/ADR/rule that was added afterward so the same
+class of failure cannot recur silently.
+
+The point of recording these is to make the governance auditable.
+In an AI-assisted workflow where every layer (CLAUDE.md, hooks,
+ADRs, eval split) accretes by default, the question a reviewer
+should be able to answer in 30 seconds is *not* "is governance
+present?" but "did it pay rent?". Each entry below is one rent
+payment.
+
+- **`#69` intended-abstention regression — synthetic-CI blind spot
+  on real data.** The synthetic n=42 CI delta was green, but the
+  private 100-doc real-eval lost intended abstentions on insufficient
+  evidence. The eval-split discipline ([ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md))
+  was already in place, but the PR-time gate was advisory. *Added
+  afterward:* PR template **item 5b (real-data delta)** is now a
+  required CI check
+  ([`scripts/check_branch_and_issue.py --check-5b`](../scripts/check_branch_and_issue.py),
+  enforced via the load-bearing path list in
+  [`scripts/_governance.py`](../scripts/_governance.py)). Any PR
+  touching `rag_*.py` / `ingestion.py` / `eval/` / `api/` / `docs/adr/`
+  must now attach the real-data aggregate or state a behavior-no-op
+  reason; the synthetic delta alone no longer clears merge.
+
+- **Stacked-PR child auto-close on `--delete-branch` merge.** Merging
+  a base branch with `gh pr merge --delete-branch` while a stacked
+  dependent PR was still targeting that branch closed the dependent
+  PR automatically (GitHub default behavior), losing the in-progress
+  child's review state. *Added afterward:* a `PreToolUse` Bash matcher
+  in [`.claude/settings.json`](../.claude/settings.json) refuses
+  `gh pr merge --delete-branch` whenever
+  `gh pr list --base <this-PR-head> --state open --json number` is
+  non-empty. The matcher fires before the command runs, so the merge
+  never reaches GitHub if a child exists. The textual rule lives in
+  `CLAUDE.md > Prohibited` so it survives even if the hook is later
+  disabled.
+
+- **ADR number collisions between concurrent worktrees.** Three
+  observed pairs — 0022→0023, 0023→0025, 0029→0030 — where two
+  worktrees independently reserved the same ADR number from
+  `ls docs/adr/`, then collided at merge. The fix is procedural
+  (numbers are a shared resource, not a per-tree allocation) rather
+  than a runtime gate. *Added afterward:* `CLAUDE.md > Core
+  principles > "Reserve ADR numbers up front"` makes the dual check
+  (`ls docs/adr/` + `gh pr list --search "ADR" --state open`)
+  mandatory before drafting, and requires user confirmation on the
+  proposed number to serialize the reservation across worktrees.
+
+Each of these is a real cost paid once. New incidents that fit this
+shape (governance gap → fix → no recurrence) land here.
+
 ## Onboarding shortcuts
 
 Reading order for a new contributor:
@@ -171,7 +226,7 @@ Reading order for a new contributor:
 2. This file — how the rules connect.
 3. [`docs/adr/README.md`](./adr/README.md) and skim the 6 current
    ADRs — the load-bearing decisions.
-4. [`docs/real-data-failure-taxonomy.md`](./real-data-failure-taxonomy.md)
+4. [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md)
    — what the backlog comes from.
 
 A reviewer who has 10 minutes should start at step 3.


### PR DESCRIPTION
## 1. What changed and why

\`docs/engineering-governance.md\`에 새 섹션 **"Governance saves: real incidents prevented"** 추가. 기존 "Anti-patterns this governance is designed to prevent" 섹션은 설계상의 *가설*(governance가 막아야 할 anti-pattern). 신규 섹션은 그 *증거* — 실제로 이 레포에서 발생했고, 사후에 hook/ADR/rule이 추가된 인시던트 3건을 inline.

목적: AI 협업 시대에 governance layer가 누적되는 게 디폴트라서, 외부 reviewer가 30초 스캔 단계에서 "governance가 있다"는 것보다 **"governance가 rent를 냈다"**(실제 발생 사고를 막았다)는 신호가 변별력. 각 entry가 한 번의 rent payment.

기록된 인시던트:
1. \`#69\` intended-abstention regression — synthetic CI는 green이었지만 real-data 100-doc eval에서 회귀 검출. **사후 보강**: PR template item 5b 필수 CI 게이트화 (\`scripts/check_branch_and_issue.py --check-5b\` + \`scripts/_governance.py\` LOAD_BEARING_PATHS).
2. Stacked-PR child auto-close — base 머지 시 dependent PR 자동 close 사고. **사후 보강**: \`.claude/settings.json\` PreToolUse Bash matcher가 \`gh pr merge --delete-branch\` 차단 (dependent 존재 시).
3. ADR 번호 동시 worktree 충돌 (0022→0023, 0023→0025, 0029→0030). **사후 보강**: \`CLAUDE.md > Core principles\` \"Reserve ADR numbers up front\" 규칙 (\`ls docs/adr/\` + \`gh pr list --search\` 사전 점검).

Incidental: 같은 파일 안에 reorg 누락으로 남아있던 4개 dead link (`./answer-policy.md` → `./agentic/answer-policy.md` 등) 동시 갱신. 같은 commit scope에 명시.

Closes #754

## 2. Files affected

- \`docs/engineering-governance.md\` — load-bearing 아님 (LOAD_BEARING_PATHS 비대상, item 5b 게이트 비대상)

## 3. Risks

가장 가능성 높은 회귀: 인시던트 narrative가 실제 발생 사실과 어긋날 경우. 검증: 각 인시던트는 메모리·CLAUDE.md·실제 PR 로그(\`#69\` 클로저, \`PR #565\` 패턴 등)에 명시적으로 documented된 사례. ADR 번호 충돌은 \`gh pr list\` history와 메모리 \`project_code_polish_backlog.md\`에 \"stacked-PR cascade 교훈\" 항목으로 기록됨. 사고 자체를 만들어내지 않음.

부수 회귀: anti-patterns 섹션과 saves 섹션 사이의 중복. 의도적 — anti-patterns는 가설(설계), saves는 실제 발생 사례. 두 섹션이 같은 ADR/hook을 참조해도 자연. 단 saves 섹션이 \"가설\" 인시던트를 추가하면 안 됨 (재발 방지 항목 명시).

## 4. Tests

문서 전용 변경이라 단위 테스트 비추가. saves 섹션의 각 인시던트 → 실제 운영 안전망 (5b CI 게이트 / PreToolUse hook / CLAUDE.md 규칙)이 이미 ship 상태이므로 narrative 검증은 link 추적으로 충분.

## 5. Eval impact

All `·` — 비-RAG 변경. eval 파이프라인 무관.

### 5b. Real-data delta

No behavior change in retrieval / verifier / ingestion path. 거버넌스 문서 추가 단독.

## 6. Backward compatibility

- 외부 링크 호환성: 4개 stale path 갱신은 docs reorg 후 누락된 부분 정리. 신규 path는 disk 상 실존 파일.
- 신규 섹션은 anti-patterns 직후 삽입이라 기존 anchor (\`#anti-patterns-this-governance-is-designed-to-prevent\`, \`#onboarding-shortcuts\`) 모두 유지.

## 7. Out of scope

- README \"주요 링크\" 표 또는 \"Claude Code와의 협업\" 섹션에 saves 섹션 inline link 추가는 [#752](https://github.com/hskim-solv/BidMate-DocAgent/issues/752) (README dead link 정리) 머지 후 별도 PR — 동일 README 파일 충돌 회피.
- 향후 발생할 새 인시던트의 saves entry 추가는 별도 PR. 이 PR은 기 발생 3건 backlog 청산.
- \`docs/engineering-governance.md\` 내 다른 stale link가 더 있을 가능성은 별도 cross-doc 점검 issue.