### PR TITLE
docs(readme): link Governance saves section in AI collaboration block

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 - 브랜치/PR/이슈 생성 및 CI gate 운영 보조
 - 탐색(Explore subagent), 설계 검토(Plan subagent), 반복 작업 자동화
 
+**Governance가 막은 실제 인시던트 3건** — synthetic-CI가 놓친 abstention 회귀(#69), stacked-PR child auto-close, ADR 번호 worktree 충돌. 각 사고와 사후 보강 hook/rule: [`docs/engineering-governance.md` Governance saves](docs/engineering-governance.md#governance-saves-real-incidents-prevented). 거버넌스가 *있다*는 신호보다 *rent를 냈다*는 신호를 우선합니다.
+
 **분기별 협업 자가진단** — `/self-review-quarterly` skill로 4축(포트폴리오 진행도) + 5축(Claude 협업 효율)을 한 보고서로 생성.
 최신 보고서: [`docs/self-review/Q2-2026.md`](docs/self-review/Q2-2026.md)
 


### PR DESCRIPTION
## 1. What changed and why

README \"Claude Code와의 협업 (AI Collaboration Transparency)\" 섹션 안에 **1줄 inline link**를 추가해 [PR #755](https://github.com/hskim-solv/BidMate-DocAgent/pull/755)가 \`docs/engineering-governance.md\`에 박은 \"Governance saves: real incidents prevented\" 섹션을 30초 스캔 단계에서 노출.

**왜 README에 surface하는가**: AI 협업 레포에서 governance는 *있다는 신호*가 흔하고 모방 비용이 낮음(ADR / hook / 문서 누적은 디폴트). 시니어 변별점은 \"governance가 *rent를 냈는가*\" — 실제 발생 사고를 막은 흔적. 이 한 줄이 채용자에게 \"있다 vs rent를 냈다\"를 30초 안에 구분시켜줌.

내용: 3개 인시던트(synthetic-CI \`#69\` abstention 회귀 / stacked-PR child auto-close / ADR 번호 worktree 충돌)를 inline 나열 + 상세 fragment link.

Closes #761

## 2. Files affected

- \`README.md\` (+2/-0) — load-bearing 아님

## 3. Risks

가장 가능성 높은 회귀: anchor 잘못. GitHub markdown anchor 규칙(lowercase, colon 제거, space → hyphen)에 따라 \"Governance saves: real incidents prevented\" → \`#governance-saves-real-incidents-prevented\`. \`git show origin/main:docs/engineering-governance.md | grep \"Governance saves\"\` 결과로 섹션 존재 확인 (line 166). 머지 후 GitHub UI에서 fragment 직접 검증 가능.

부수 회귀: PR2와 PR4가 같은 \"Governance saves\" narrative를 노출하면서 표현 중복. 의도적 — PR2(\`docs/engineering-governance.md\`)는 *상세*, PR4(README)는 *진입점*. 같은 사실을 두 surface에서 노출.

## 4. Tests

문서 단독 변경 — 단위 테스트 비추가. anchor 검증은 PR 머지 후 GitHub UI에서 직접 클릭.

## 5. Eval impact

All \`·\` — 비-RAG 변경.

### 5b. Real-data delta

No behavior change in retrieval / verifier / ingestion path. README link 단독.

## 6. Backward compatibility

- 신규 fragment link 1개 추가. 기존 link 변경 없음.
- README의 다른 anchor / link 모두 보존.

## 7. Out of scope

- README \"주요 링크\" 표에 docs/engineering-governance.md 행 추가는 별도 small PR (시니어 변별력 ROI는 \"Claude Code와의 협업\" 섹션 inline이 더 큼).
- 향후 발생할 새 인시던트를 Governance saves에 추가하면 README inline 항목도 갱신 (PR2 본문에 명시된 maintenance 정책).