### PR TITLE
feat(governance): automate ADR number reservation + collision check (closes #757)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -58,6 +58,24 @@ EOFERR
   exit 1
 fi
 
+# Guard: ADR number collision (issue #757 — A2 fix from governance self-audit).
+# Catches the "two ADR files sharing the same NNNN prefix" failure mode that
+# concurrent worktrees + manual `Reserve ADR numbers up front` (CLAUDE.md)
+# has repeatedly produced (0022→0023, 0023→0025, 0029→0030; live PR #740
+# collision on 0044 caught 2026-05-15). Fires only when this commit adds
+# new ADR file(s); reads filesystem so it catches duplicates that any
+# previous commit / merge brought in too.
+#
+# Bypass with --no-verify only mid-merge; open a follow-up issue to fix.
+adr_added=$(git diff --cached --name-only --diff-filter=A -- 'docs/adr/[0-9]*.md' 2>/dev/null || true)
+if [[ -n "$adr_added" ]]; then
+  collision_out=$(python3 scripts/_governance.py --check-adr-collision 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$collision_out" >&2
+    exit 1
+  fi
+fi
+
 staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
 
 if [[ -z "$staged" ]]; then

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,14 @@ docs/adr/
 - `NNNN` is a 4-digit zero-padded sequence, e.g. `0001`, `0023`.
 - Numbers are **never reused or renumbered**, even if an ADR is later
   superseded. Continuity matters more than tidiness.
+- **Reserve the next number with the CLI before drafting**:
+  `python scripts/_governance.py --next-adr-number`.
+  The pre-commit hook ([`.githooks/pre-commit`](../../.githooks/pre-commit))
+  refuses to commit when two ADR files share the same `NNNN` prefix
+  (issue [#757](https://github.com/hskim-solv/BidMate-DocAgent/issues/757)),
+  but it cannot see open PRs in concurrent worktrees — also run
+  `gh pr list --search "ADR" --state open` per CLAUDE.md
+  `Reserve ADR numbers up front`.
 - `slug` is short, kebab-case, and stable. Pick a name you will not
   want to rename later (e.g. `metadata-first-retrieval`, not
   `retrieval-changes-v2`).

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -23,7 +23,9 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
+from pathlib import Path
 
 
 # Canonical load-bearing path list. The order is not significant; add
@@ -72,6 +74,115 @@ def is_load_bearing(path: str) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# ADR number reservation (issue #757 — A2 fix from governance self-audit).
+#
+# CLAUDE.md `Reserve ADR numbers up front` rule was manual + repeatedly
+# broken under concurrent worktree work (collisions 0022→0023, 0023→0025,
+# 0029→0030; live collision on 0044 caught 2026-05-15). These helpers and
+# the pre-commit hook that calls them make the rule mechanical.
+#
+# Scope deliberately small:
+#   - Filesystem scan only (no `gh pr list` — keeps the hook offline-safe).
+#   - Catches duplicate `NNNN-*.md` in the same worktree, which is the
+#     concrete failure mode after a merge from another branch that also
+#     added an ADR with the same number.
+#   - Cross-worktree / open-PR collisions still need manual `gh pr list
+#     --search "ADR" --state open` before drafting, per CLAUDE.md.
+# ---------------------------------------------------------------------------
+
+ADR_DIR_DEFAULT = "docs/adr"
+ADR_FILENAME_RE = re.compile(r"^(\d{4})-[a-z0-9][a-z0-9-]*\.md$")
+
+
+def existing_adr_numbers(adr_dir: str | Path = ADR_DIR_DEFAULT) -> set[int]:
+    """Return ADR numbers found as `NNNN-slug.md` files in `adr_dir`.
+
+    Ignores `README.md`, `_template.md`, and any file not matching the
+    canonical `NNNN-slug.md` pattern. Returns an empty set if the
+    directory is missing — callers decide whether that's an error.
+    """
+    p = Path(adr_dir)
+    if not p.is_dir():
+        return set()
+    found: set[int] = set()
+    for entry in p.iterdir():
+        if not entry.is_file():
+            continue
+        m = ADR_FILENAME_RE.match(entry.name)
+        if m:
+            found.add(int(m.group(1)))
+    return found
+
+
+def next_adr_number(adr_dir: str | Path = ADR_DIR_DEFAULT) -> int:
+    """Return the next available ADR number (max existing + 1, or 1 if empty).
+
+    Filesystem-only — does NOT inspect open PRs in concurrent worktrees.
+    Per CLAUDE.md `Reserve ADR numbers up front`, also run
+    `gh pr list --search "ADR" --state open` before drafting.
+    """
+    nums = existing_adr_numbers(adr_dir)
+    if not nums:
+        return 1
+    return max(nums) + 1
+
+
+def find_duplicate_adr_numbers(
+    adr_dir: str | Path = ADR_DIR_DEFAULT,
+) -> dict[int, list[str]]:
+    """Return ``{number: [filenames…]}`` for ADR numbers used by 2+ files.
+
+    Empty dict means no collisions. Used by the pre-commit hook to fail
+    fast when a merge or concurrent worktree drop produced two ADRs with
+    the same NNNN prefix.
+    """
+    p = Path(adr_dir)
+    if not p.is_dir():
+        return {}
+    by_num: dict[int, list[str]] = {}
+    for entry in p.iterdir():
+        if not entry.is_file():
+            continue
+        m = ADR_FILENAME_RE.match(entry.name)
+        if m:
+            num = int(m.group(1))
+            by_num.setdefault(num, []).append(entry.name)
+    return {n: sorted(names) for n, names in by_num.items() if len(names) > 1}
+
+
+def _cmd_next_adr_number(adr_dir: str) -> int:
+    sys.stdout.write(f"{next_adr_number(adr_dir):04d}\n")
+    return 0
+
+
+def _cmd_check_adr_collision(adr_dir: str) -> int:
+    dups = find_duplicate_adr_numbers(adr_dir)
+    if not dups:
+        return 0
+    sys.stderr.write(
+        "\n❌ ADR number collision detected in "
+        f"{adr_dir}:\n\n"
+    )
+    for num, names in sorted(dups.items()):
+        sys.stderr.write(f"     ADR {num:04d}:\n")
+        for name in names:
+            sys.stderr.write(f"       - {name}\n")
+    next_n = next_adr_number(adr_dir)
+    sys.stderr.write(
+        "\n   Resolve by renumbering one of the colliding files to the\n"
+        f"   next available number (suggested: {next_n:04d}). Then update\n"
+        "   the body, related ADRs, and docs/adr/README.md Index entry.\n\n"
+        "   Use:\n"
+        "       python scripts/_governance.py --next-adr-number\n\n"
+        "   This collision is exactly the failure mode CLAUDE.md\n"
+        "   `Reserve ADR numbers up front` warned about. Issue #757\n"
+        "   added this hook so the rule survives without manual\n"
+        "   discipline.\n\n"
+    )
+    return 1
+
+
 def _cmd_is_load_bearing(path: str) -> int:
     return 0 if is_load_bearing(path) else 1
 
@@ -114,6 +225,21 @@ def main() -> int:
         "--list", action="store_true",
         help="Print the canonical load-bearing list, one per line.",
     )
+    g.add_argument(
+        "--next-adr-number", action="store_true",
+        help="Print the next available ADR number (filesystem-only; "
+             "still cross-check `gh pr list --search ADR --state open`).",
+    )
+    g.add_argument(
+        "--check-adr-collision", action="store_true",
+        help="Scan docs/adr/ for two files sharing the same NNNN prefix; "
+             "exit 1 with details if any collision is found.",
+    )
+    p.add_argument(
+        "--adr-dir", default=ADR_DIR_DEFAULT,
+        help=f"ADR directory (default: {ADR_DIR_DEFAULT}). "
+             "Only used by --next-adr-number / --check-adr-collision.",
+    )
     args = p.parse_args()
 
     if args.is_load_bearing is not None:
@@ -122,6 +248,10 @@ def main() -> int:
         return _cmd_any_match()
     if args.list:
         return _cmd_list()
+    if args.next_adr_number:
+        return _cmd_next_adr_number(args.adr_dir)
+    if args.check_adr_collision:
+        return _cmd_check_adr_collision(args.adr_dir)
     return 2
 
 

--- a/tests/test_governance_adr_numbers.py
+++ b/tests/test_governance_adr_numbers.py
@@ -1,0 +1,104 @@
+"""Regression tests for ADR number reservation helpers (issue #757).
+
+A2 fix from `~/.claude/plans/fizzy-splashing-cherny-adr-governance.md`:
+CLAUDE.md `Reserve ADR numbers up front` was manual + repeatedly broken
+under concurrent worktree work. These tests pin the helpers that the
+pre-commit hook (`.githooks/pre-commit`) calls so future refactors do
+not silently break collision detection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts._governance import (
+    existing_adr_numbers,
+    find_duplicate_adr_numbers,
+    next_adr_number,
+)
+
+
+def _touch(dir_: Path, name: str) -> None:
+    (dir_ / name).write_text("# stub\n", encoding="utf-8")
+
+
+# ---- existing_adr_numbers ------------------------------------------------
+
+
+def test_existing_adr_numbers_empty_dir(tmp_path: Path) -> None:
+    assert existing_adr_numbers(tmp_path) == set()
+
+
+def test_existing_adr_numbers_missing_dir(tmp_path: Path) -> None:
+    assert existing_adr_numbers(tmp_path / "nope") == set()
+
+
+def test_existing_adr_numbers_ignores_non_adr_files(tmp_path: Path) -> None:
+    _touch(tmp_path, "README.md")
+    _touch(tmp_path, "_template.md")
+    _touch(tmp_path, "notes.txt")
+    _touch(tmp_path, "0001-naive.md")
+    _touch(tmp_path, "0002-metadata-first.md")
+    assert existing_adr_numbers(tmp_path) == {1, 2}
+
+
+def test_existing_adr_numbers_strict_filename_pattern(tmp_path: Path) -> None:
+    # 4 digits exactly, kebab slug starting with [a-z0-9], lowercase only.
+    _touch(tmp_path, "001-too-short.md")
+    _touch(tmp_path, "00001-too-long.md")
+    _touch(tmp_path, "0001-UPPER.md")
+    _touch(tmp_path, "0001-with-dash.md")
+    _touch(tmp_path, "0002-ok.md")
+    assert existing_adr_numbers(tmp_path) == {1, 2}
+
+
+# ---- next_adr_number -----------------------------------------------------
+
+
+def test_next_adr_number_empty_dir_returns_one(tmp_path: Path) -> None:
+    assert next_adr_number(tmp_path) == 1
+
+
+def test_next_adr_number_returns_max_plus_one(tmp_path: Path) -> None:
+    _touch(tmp_path, "0001-a.md")
+    _touch(tmp_path, "0005-b.md")
+    _touch(tmp_path, "0042-c.md")
+    assert next_adr_number(tmp_path) == 43
+
+
+def test_next_adr_number_ignores_gaps(tmp_path: Path) -> None:
+    # A gap in the sequence does NOT renumber — the next is still max+1.
+    # This pins ADR-README "Numbers are never reused or renumbered".
+    _touch(tmp_path, "0001-a.md")
+    _touch(tmp_path, "0010-b.md")
+    assert next_adr_number(tmp_path) == 11
+
+
+# ---- find_duplicate_adr_numbers ------------------------------------------
+
+
+def test_find_duplicate_adr_numbers_clean(tmp_path: Path) -> None:
+    _touch(tmp_path, "0001-a.md")
+    _touch(tmp_path, "0002-b.md")
+    assert find_duplicate_adr_numbers(tmp_path) == {}
+
+
+def test_find_duplicate_adr_numbers_catches_collision(tmp_path: Path) -> None:
+    _touch(tmp_path, "0044-foo.md")
+    _touch(tmp_path, "0044-bar.md")
+    _touch(tmp_path, "0045-clean.md")
+    dups = find_duplicate_adr_numbers(tmp_path)
+    assert dups == {44: ["0044-bar.md", "0044-foo.md"]}
+
+
+def test_find_duplicate_adr_numbers_missing_dir(tmp_path: Path) -> None:
+    assert find_duplicate_adr_numbers(tmp_path / "nope") == {}
+
+
+# ---- real-data smoke test (sentinel for the live repo) -------------------
+
+
+def test_repo_adr_dir_has_no_collisions() -> None:
+    """If the repo itself ever gains a duplicate, this test catches it
+    before CI runs the pre-commit hook in someone else's worktree."""
+    assert find_duplicate_adr_numbers("docs/adr") == {}


### PR DESCRIPTION
## Summary

- `scripts/_governance.py` 에 helper 3 + CLI 플래그 2 추가 → 다음 ADR 번호가 기계적: `python scripts/_governance.py --next-adr-number`
- `.githooks/pre-commit` 이 같은 `NNNN` prefix 공유하는 `docs/adr/NNNN-*.md` 두 파일 도입 commit 거부
- `docs/adr/README.md` 가 신규 CLI inline 문서화; `tests/test_governance_adr_numbers.py` 가 helper + real-data sentinel 고정

## Why now

`CLAUDE.md:83` 가 반복 collision (`0022→0023, 0023→0025, 0029→0030`) 자가 문서화하면서 작성자가 수동으로 `ls docs/adr/ && gh pr list --search "ADR" --state open` 하라고 요청. 그 규칙이 **이번 sprint 라이브로 깨짐** — PR #740 이 이미 `0044` 예약, 병렬 브랜치가 무관한 meta-ADR 에 같은 번호 사용 직전. audit 덕분에 수동으로만 포착; 자동화 없으면 다음이 ship.

`~/.claude/plans/fizzy-splashing-cherny-adr-governance.md` governance self-audit A2 수정.

## Scope (kept small)

- **In**: 파일시스템 전용 중복 검출 (post-merge / 동시 worktree drop 포착), `next_adr_number` CLI, real-data sentinel 테스트.
- **Out**: 훅에서 open PR 스캔 (pre-commit 에 네트워크 필요), "missing" 번호 백필 (아래 fact-correction — missing 번호 없음), ADR-worthy 임계값 변경.

## Fact correction

원래 audit memo 가 "0020 / 0042 missing 번호" 를 fossil 로 인용. 직접 `ls` 결과 `0001–0043` 전부 존재 — memo (`memory/project_portfolio_plan.md`) 가 stale. 메모리는 follow-up 에서 수정. collision 이력 (`0022→0023, 0023→0025, 0029→0030`) 과 live `0044` race 는 진짜.

## Test plan

- [x] `python3 scripts/_governance.py --next-adr-number` → `0044`
- [x] `python3 scripts/_governance.py --check-adr-collision` → clean repo 에서 exit 0
- [x] `0010-collision-canary.md` 주입 → CLI exit 1 + 설명
- [x] Pre-commit 훅 live 테스트: canary stage + `git commit` → stderr 메시지로 차단
- [x] 기존 CLI 회귀 (`--list`, `--is-load-bearing`) 불변
- [ ] CI: `tests/test_governance_adr_numbers.py` pass (real-data sentinel 포함 10 cases)
- [ ] CI: `branch-and-issue-check.yml` pass (branch + issue 컨벤션)

## Files touched

| File | Change |
|---|---|
| `scripts/_governance.py` | +130 — helper 3 + CLI 플래그 2 + `--adr-dir` |
| `.githooks/pre-commit` | +18 — 신규 ADR 추가 collision 가드 |
| `docs/adr/README.md` | +8 — File layout 에 reserve-step CLI |
| `tests/test_governance_adr_numbers.py` | +109 (신규) — 10 unit tests |

## PR template checklist

### 1. Linked issue
Closes #757

### 2. ADR threshold
N/A — 프로세스 자동화, load-bearing 결정 변경 아님. ADR 파일 추가/수정 없음.

### 3. Tests
`tests/test_governance_adr_numbers.py` (신규); regex, gap-tolerance, collision 검출, real-data sentinel 고정.

### 4. Backward compatibility
`_governance.py` 기존 CLI (`--list`, `--is-load-bearing`, `--any-match`) 불변. 신규 플래그 3개 additive.

### 5a. Synthetic CI delta
N/A — `rag_core` / `eval` / `api` / `ingestion` 경로 미접촉. `LOAD_BEARING_PATHS` 불변. `docs/adr/` 는 SSoT 상 load-bearing 이지만, 이 변경은 `README.md` prose (CLI 문서) + 신규 테스트 파일 **만** 추가 — 결정 내용 없음, 답변 계약 변경 없음, eval surface 변경 없음.

### 5b. Real-data delta
**No behavior change in retrieval / verifier path.** 모든 변경이 governance-tooling (governance 스크립트, pre-commit 훅, README prose, 신규 unit 테스트). `docs/adr/README.md` 수정은 "File layout" 아래 CLI 문서 8줄 추가 — ADR 추가/수정/superseded 없음; retrieval / verifier / answer / eval 코드 경로 미접촉. 측정 가능 동작 변경 없으므로 `make real-eval-delta` 가 필연적으로 0pp.

### 6. Risk
Low. Pre-commit 훅은 신규 ADR 추가에만 발화; 기존 commit 무영향. `--no-verify` 우회는 mid-merge resolution 용으로 유지.

## Follow-ups

- B3 (Consequences verification lint) — 같은 audit 의 다음 critical.
- D1 (ADR governance meta-ADR) — 이 CLI 의 다음 available 번호 사용.
- `project_portfolio_plan.md` 의 stale "0020/0042 missing" 주장 메모리 수정.

Generated with [Claude Code](https://claude.com/claude-code)
