### PR TITLE
docs(adr): 0045 rag_core leaf migration plan (closes #762)

### DIFF
--- a/docs/adr/0045-rag-core-leaf-migration-plan.md
+++ b/docs/adr/0045-rag-core-leaf-migration-plan.md
@@ -1,0 +1,197 @@
+# 0045: rag_core leaf migration plan — embedding helpers + comparison_targets routing
+
+- **Status**: accepted
+- **Date**: 2026-05-15
+- **Related**: [ADR 0001](./0001-preserve-naive-baseline.md) · CLAUDE.md
+  *Repository map* (rag_retrieval / rag_verifier / rag_answer / rag_query
+  decomposition) · issue #762
+- **Deciders**: hskim
+
+## Context
+
+`rag_core.py` is 1728 LOC.  PR-H1a/b (issue #459 / #461) and PR-J1/J2/J3
+(issue #465 / #468 / #478) extracted retrieval / verifier / answer /
+query into sibling leaf modules, but the import graph is still not
+clean: `rag_retrieval.py` reaches back into `rag_core` from inside two
+functions via late-import.
+
+### Observed late-import inventory (2026-05-15, branch `main`)
+
+| Call site | Late-imported symbols |
+|-----------|----------------------|
+| [`rag_retrieval.py:168`](../../rag_retrieval.py:168) | `comparison_targets_for_analysis` |
+| [`rag_retrieval.py:490`](../../rag_retrieval.py:490) | `DEFAULT_EMBEDDING_MODEL`, `DEFAULT_HASH_DIM`, `embed_texts`, `hashing_embeddings` |
+
+Two call sites × five symbols.  The other three split modules are
+already top-level-clean:
+
+- `rag_query.py`, `rag_verifier.py`, `rag_answer.py` — **zero** rag_core
+  imports (top-level or late).
+
+CLAUDE.md itself acknowledges the unfinished state:
+
+> *"`rag_core.py` is still orchestration + many utilities → late-import
+> for cycle avoidance (not a leaf in the dependency graph)."*
+
+This ADR plans the cleanup. Actual code migration is **out of scope**
+for this ADR — it lands as a separate PR (`G2` in the GEF loop, tracked
+in `/Users/hskim/.claude/plans/gleaming-forging-dove.md`).
+
+### Why two distinct migrations, not one
+
+The five late-imported symbols split into two semantic groups:
+
+1. **Embedding primitives** — `embed_texts`, `hashing_embeddings`,
+   `_embed_with_openai`, `sentence_transformer_cache_available`,
+   `huggingface_offline`, `expand_features`, `EmbeddingResult`,
+   `DEFAULT_EMBEDDING_MODEL`, `DEFAULT_HASH_DIM`.  These are used by
+   `rag_retrieval.embed_query_for_index`, `rag_core` index-build,
+   *and* `scripts/build_index.py` — three independent consumers.  They
+   are not retrieval-specific.
+2. **Query-analysis output reader** — `comparison_targets_for_analysis`
+   is **already defined in `rag_query.py:397`** as part of the PR-J3
+   extraction; `rag_core` only re-exports it.  The late-import in
+   retrieval is therefore a stale routing decision, not a missing
+   home.
+
+These have different fixes (new leaf module vs. import-source change),
+so they belong in separate PRs.
+
+## Decision
+
+### Plan A: embedding primitives → new leaf module `rag_embedding.py`
+
+Create `rag_embedding.py` as a sibling leaf, modeled on the existing
+[`rag_text_processing.py`](../../rag_text_processing.py) /
+[`rag_metadata_processing.py`](../../rag_metadata_processing.py)
+pattern.  Move:
+
+- Constants: `DEFAULT_EMBEDDING_MODEL`, `DEFAULT_HASH_DIM`
+- Dataclasses: `EmbeddingResult`
+- Functions: `embed_texts`, `_embed_with_openai`,
+  `sentence_transformer_cache_available`, `huggingface_offline`,
+  `hashing_embeddings`, `expand_features`
+
+Update consumers:
+
+- `rag_core.py` — top-level `from rag_embedding import …`; keep
+  re-export aliases so downstream code (tests, eval scripts) does not
+  break.
+- `rag_retrieval.py` — replace the late-import block with a top-level
+  `from rag_embedding import …`.
+- `scripts/build_index.py` — replace `from rag_core import
+  DEFAULT_EMBEDDING_MODEL` with `from rag_embedding import …`.
+
+### Plan B: comparison_targets routing
+
+In `rag_retrieval.py:168`, change the late-import to a top-level import
+from `rag_query`:
+
+```python
+# old:
+from rag_core import comparison_targets_for_analysis  # inside function
+# new (top-level):
+from rag_query import comparison_targets_for_analysis
+```
+
+Verified direction-safe (2026-05-15):
+
+```
+$ grep -nE "^from rag_|^import rag_" rag_query.py
+# (no reference to rag_retrieval)
+```
+
+`rag_query` is already a leaf; `rag_retrieval → rag_query` is therefore
+a clean DAG edge.
+
+### Sequencing
+
+- Plan B is a **2-line change** (1 import move + 1 deleted late-import).
+  Bundled into the same PR as Plan A is acceptable since both target
+  the same file (`rag_retrieval.py`) and both eliminate the same
+  `rag_core` back-edge.
+- Plan A + B together = the G2 PR.
+
+## Alternatives considered
+
+### (a) Move embedding primitives into `rag_retrieval.py`
+
+*Rejected*: `scripts/build_index.py` does not need retrieval and
+should not pay the import cost of cross-encoder rerankers, query
+expanders, etc.  Embedding primitives are not retrieval-specific.
+
+### (b) Leave `rag_core` as the canonical home, document the late-import as accepted
+
+*Rejected*: CLAUDE.md already calls this out as unfinished work.  The
+late-import works at runtime but defeats static analysis (IDE
+go-to-definition, mypy reachability) and signals architectural debt to
+new contributors.  This is a senior-portfolio readability cost.
+
+### (c) Single big-bang migration that also splits text/metadata helpers
+
+*Rejected*: text/metadata helpers are *already* extracted (`rag_text_processing.py`, `rag_metadata_processing.py`).  Bundling
+embedding migration with non-existent further splits inflates the
+diff without benefit.  One concern per PR (CLAUDE.md).
+
+### (d) Use Python `__all__` / re-export instead of an actual move
+
+*Rejected*: re-export does not break the cycle; rag_core still owns
+the function bodies.  The whole point is to make `rag_core` thin.
+
+## Consequences
+
+**Wins**
+
+- `rag_retrieval.py` becomes a true leaf w.r.t. `rag_core` — no
+  back-edges.
+- `rag_core.py` shrinks by ~150 LOC (the embedding block).  Step
+  toward the ~600-LOC orchestration-only target named in the GEF loop.
+- `scripts/build_index.py` no longer needs rag_core to embed — index
+  build can in principle run without loading the full retrieval/answer
+  stack.
+- IDE / static analyzers report the true dependency graph.
+
+**Costs**
+
+- One new module file to maintain.  Mitigated: it follows the existing
+  `rag_*_processing.py` pattern, so onboarding cost is near zero.
+- Re-export aliases in `rag_core` are dead weight from a graph
+  cleanliness perspective.  They are **kept on purpose** for the first
+  migration to avoid breaking eval scripts; a follow-up ADR may
+  schedule their removal once import sites are audited.
+
+**Unchanged**
+
+- ADR 0001 naive-baseline invariant: `embed_texts` /
+  `hashing_embeddings` semantics are byte-identical after the move —
+  G2 PR is a pure relocation, not a logic change.
+- ADR 0003 answer contract: untouched (answer generation does not
+  embed).
+- `EMBEDDING_BACKEND` env contract: unchanged (the env-var dispatch
+  lives inside `embed_texts`, which moves as-is).
+
+### Out of scope for this ADR
+
+- Further `rag_core` slim-down beyond embedding (ingestion split,
+  `_RunContext` re-housing) — covered by G3 in the GEF plan.
+- Removing the re-export shims in `rag_core` — scheduled for after
+  G4 dependency-graph verification.
+- pgvector / Qdrant adapter implementations — F1/F2 in the GEF plan.
+
+## Verification
+
+This ADR is plan-only.  The two preconditions it asserts must be present
+in the working tree at PR time (G2 verifies their *removal* after the
+code move):
+
+<!-- verifies-key: rag_retrieval.py:from rag_core import -->
+<!-- verifies-key: rag_query.py:def comparison_targets_for_analysis -->
+
+The G2 implementation PR must show:
+
+1. `make smoke` passes (`EMBEDDING_BACKEND=hashing`, hashing path used)
+2. `bash scripts/test.sh` passes (full pytest)
+3. `make real-eval-delta` shows §5b parity (this ADR's invariant is
+   *bit-identical embeddings* — any delta is a bug)
+4. `git grep -nE "^\s+from rag_core" rag_retrieval.py rag_query.py rag_verifier.py rag_answer.py` returns **zero** lines
+5. ADR 0001 `naive_baseline` preset golden unchanged

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -118,6 +118,7 @@ project record.
 | [0042](./0042-tool-use-evidence-boundary-defense.md) | accepted | Tool-use attack surface audit: ADR 0008 `neutralize_instruction_patterns` coverage confirmed for all `execute_*` wrappers in `rag_agent_tools.py`; no new call sites needed; `EVIDENCE_BOUNDARY` regression gate added; closes issue #682 |
 | [0043](./0043-pr-cadence-for-live-llm-judge.md) | accepted | Label-gated PR workflow (`live-judge-please`) fires `.github/workflows/pr-judge.yml` with live `BIDMATE_SYNTHETIC_JUDGE_BACKEND=openai_compatible`; posts RAGAS aggregate as PR comment; ADR 0004/0005/0012 invariants preserved; re-attach label after each push (Goodhart guard) |
 | [0044](./0044-realN-eval-case-expansion.md) | accepted | real100 private eval cases expanded in-place (same corpus, same `reports/real100/` series) from n=21 → near-term n≥30 / long-term n≥50 to tighten Wilson 95% CI and ADR 0030 silence threshold; `num_predictions` tracked per snapshot; ADR 0005 boundary preserved (cases stay in gitignored `eval/real_config.local.yaml`); closes issue #732 |
+| [0045](./0045-rag-core-leaf-migration-plan.md) | accepted | `rag_core.py` (1728 LOC) is not a leaf — `rag_retrieval.py` late-imports 5 symbols at 2 call sites; Plan A creates new leaf `rag_embedding.py` (embed primitives + constants); Plan B reroutes `comparison_targets_for_analysis` import from `rag_core` to `rag_query` (already defined there); G2 PR lands the code move, ADR 0001 baseline preserved bit-identical; closes issue #762 |
 
 ## Roadmap (proposed, not yet committed)
 


### PR DESCRIPTION
## 1. 변경 내용 및 이유

`rag_core.py` (1728 LOC) 가 import 그래프의 leaf 가 아님 — `rag_retrieval.py` 가 2 function-local late-import (5 symbol) 통해 back-reach. 다른 3 분리 모듈 (`rag_query`, `rag_verifier`, `rag_answer`) 은 이미 top-level-clean.

ADR 0045 가 cleanup 을 두 부분으로 plan:

- **Plan A**: `embed_texts`, `hashing_embeddings`, `EmbeddingResult`, `_embed_with_openai`, `sentence_transformer_cache_available`, `huggingface_offline`, `expand_features`, `DEFAULT_EMBEDDING_MODEL`, `DEFAULT_HASH_DIM` 대한 신규 leaf `rag_embedding.py`.
- **Plan B**: `rag_retrieval.py:168` 의 `comparison_targets_for_analysis` import 를 `rag_core` 에서 `rag_query` (이미 `rag_query.py:397` 에 정의) 로 reroute.

이 PR 은 **plan-only**. 실제 코드 이동은 G2 PR (GEF stack 다음) 에 land.

Closes #762

## 2. 변경 파일

- `docs/adr/0045-rag-core-leaf-migration-plan.md` (신규)
- `docs/adr/README.md` (index 항목)

Load-bearing? `docs/adr/` 가 `scripts/_governance.LOAD_BEARING_PATHS` 에 등재 — §5b 필수, 아래 응답.

## 3. 리스크

리스크는 **결정 품질**, 런타임 아님: Plan A 의 symbol grouping 이 틀리면 G2 가 real-eval delta 로 reveal. Mitigation:

- Late-import inventory 는 메모리 아닌 working tree 에서 계산: `grep -nE "^\s+from rag_core import" rag_query.py rag_retrieval.py rag_verifier.py rag_answer.py` → `rag_retrieval.py` 에 정확히 2 site.
- Plan B 의 direction-safety 검증: `grep -nE "^from rag_|^import rag_" rag_query.py` 가 `rag_retrieval` 로의 역방향 edge 없음 표시.
- Plan A 의 symbol consumer 전체 repo grep, `scripts/build_index.py` (top-level consumer flag) 포함.

## 4. 테스트

N/A — docs-only ADR. G2 PR 이 ADR 의 §Verification 명명 검증 체크리스트 추가 (`make smoke`, `make real-eval-delta`, naive_baseline golden, residual back-edge `git grep`).

## 5. Eval 영향

전부 `·` (docs-only).

### 5b. Real-data delta

**No behavior change in retrieval / verifier / eval / api / ingestion.** 이 PR 은 ADR 파일 추가 + `docs/adr/README.md` 갱신만. `.py` 수정 0.

## 6. 하위 호환성

N/A — 계약 surface 미터치. ADR 0003 `schema_version` 미변경. ADR 0001 `naive_baseline` preset 미터치.

## 7. 범위 외

- G2 구현 PR (실제 코드 이동).
- 마이그레이션 후 `rag_core` re-export shim 제거 — G4 그래프 검증 후 예정.
- embedding 너머 `rag_core` 추가 slim-down (ingestion 경로, `_RunContext` re-housing) — G3 처리.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Co-Authored-By: Claude
