### PR TITLE
docs(skill): self-review-quarterly threshold guide for axis #2/#4/#5 raw signals

### DIFF
--- a/.claude/skills/self-review-quarterly/SKILL.md
+++ b/.claude/skills/self-review-quarterly/SKILL.md
@@ -104,13 +104,33 @@ This skill writes to a **committed git file**. Privacy violations cannot be retr
 
 ## 5축 진단 (Claude 협업)
 
-| # | 축 | 평가 | 근거 | 한 줄 코멘트 |
+| # | 축 | 평가 | 근거 (raw signal) | 한 줄 코멘트 |
 |---|---|---|---|---|
-| 1 | 컨텍스트 효율 | ... | sessions.tool_call_distribution, memory hits | ... |
-| 2 | Agent 위임 패턴 | ... | sessions.agent_delegations | ... |
-| 3 | 거버넌스 자동화 ROI | ... | `scripts/_governance.py`, hook config | ... |
-| 4 | 사이클 타임 | ... | ADR proposed→accepted dates, hook lag | ... |
-| 5 | 메모리 위생 | ... | memory.by_type, files_total | ... |
+| 1 | 컨텍스트 효율 | ... | `sessions.tool_call_distribution`, `sessions.agent_delegations` | ... |
+| 2 | Agent 위임 패턴 | ... | `axis_2_plan_subagent_skip_rate.skip_rate` (PR #745) | ... |
+| 3 | 거버넌스 자동화 ROI | ... | `governance_hooks.pretooluse_loadbearing_fires`, `governance_hooks.fires_by_action` | ... |
+| 4 | 사이클 타임 | ... | `axis_4_cycle_time.adr_lag_days`, `axis_4_cycle_time.pr_turnaround_hours` (PR #748) | ... |
+| 5 | 메모리 위생 | ... | `governance_hooks.fires_by_action["memory-lines"]` (PR #747), `memory.by_type` | ... |
+
+## 5축 채점 임계값 (Q3-2026~)
+
+PR #723 → #745 / #747 / #748 시퀀스로 `scripts/claude-hooks/_self_review.py` 가
+raw signal을 자동 emit. 본 skill이 그 값을 ✓/△/✗ 로 결정하는 **단일 source of
+truth** — collector 코드에 임계 hard-code 금지.
+
+| 축 | Signal path | ✓ | △ | ✗ |
+|---|---|---|---|---|
+| #1 컨텍스트 효율 | `sessions.agent_delegations["Explore"]` 호출 / 분기 | ≥ 2 + Read 평균 ≤ 메인 대화당 10회 | 둘 중 하나 미달 | 둘 다 미달 |
+| #2 Agent 위임 | `axis_2_plan_subagent_skip_rate.skip_rate` | ≤ 0.2 | 0.2–0.5 | > 0.5 |
+| #3 자동화 ROI | `governance_hooks.pretooluse_loadbearing_fires` + `fires_by_action` 다양성 | fires > 0 **그리고** ≥ 2개 reason 발화 (e.g. `load-bearing` + `memory-lines`) | fires > 0 그러나 1개 reason만 | fires = 0 |
+| #4-A 사이클 타임 (ADR) | `axis_4_cycle_time.adr_lag_days.mean` (days) | ≤ 5 | 5–10 | > 10 |
+| #4-B 사이클 타임 (PR) | `axis_4_cycle_time.pr_turnaround_hours.mean` (hours) | ≤ 48 | 48–120 | > 120 |
+| #5 메모리 위생 | `governance_hooks.fires_by_action["memory-lines"]` 카운트 (action="aware" / "blocked") | blocked=0 + aware ≤ 2 | aware ≥ 3 + blocked=0 | blocked ≥ 1 (편집 차단 = 인덱스 폭발) |
+
+**판정 규칙:**
+- 동일 축이 sub-signal 두 개를 가질 때(예: #4-A + #4-B), **둘 다 ✓** 이어야 ✓; 하나라도 ✗면 ✗; 그 외 △.
+- raw signal 이 `null` / `count=0` 이면 측정 부재 — △ 표기 + "측정 인프라 미작동" 한 줄.
+- `p90` 이 `mean` 보다 현저히 크면 (> 2×) outlier 가능성 — `pr_turnaround_hours.max` 확인 후 reopened-PR 영향 한 줄 명시.
 
 ## 최우선 개선점 (ROI)
 


### PR DESCRIPTION
## 1. What changed and why

Closes #770

PR #723 → #745 / #747 / #748 시퀀스로 `_self_review.py` 가 axis #2 / #4 / #5 raw signal을 자동 emit. 그러나 `SKILL.md` 의 5축 진단 표는 추상적 "근거" 만 명시되어 있어 LLM이 raw signal을 ✓/△/✗로 매핑할 결정 룰이 없음.

5축 진단 표 "근거" 컬럼을 raw signal path로 구체화 + 새 섹션 **"5축 채점 임계값 (Q3-2026~)"** 추가. 단일 source of truth — collector 코드에 임계 hard-code 금지 원칙 명시.

## 2. Files affected

- `.claude/skills/self-review-quarterly/SKILL.md` (+26 / -6 lines)

Load-bearing 아님.

## 3. Risks

- **임계값 동결**: 한번 박힌 임계가 stale될 위험. 분기 종료 후 sample n이 누적되면 재교정 필요할 수 있음 — 본문 "Q3-2026~" 부제로 시점 명시, Q4 시작 시 재검토 트리거.
- **#4-B hours 단위**: 이슈 #724 는 "day" 단위로 정의(✓≤2일/△2–5일/✗>5일). collector는 hours emit 하므로 24× 환산: ✓≤48 / △48–120 / ✗>120. 변환 정합성 본문에 명시.
- **#5 측정 정확도**: PR #747 hook이 `cwd`가 BidMate일 때만 fire. 다른 repo 작업 중 글로벌 MEMORY.md 편집은 카운트 누락 — 의도된 scope.

## 4. Tests

문서 변경만 — unit test 없음. **Dogfood verification:** Q3-2026 시작 시 `/self-review-quarterly Q3-2026` 호출이 표를 자동 채우는지 확인. 그 전엔 dry-run 불가.

## 5. Eval impact

All `·` — RAG / eval pipeline 미터치.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

## 6. Backward compatibility

- 기존 5축 표 "평가" + "한 줄 코멘트" 컬럼은 그대로. "근거" 컬럼만 raw signal path로 갱신.
- 임계 섹션은 추가 — 기존 호출자 영향 없음.

## 7. Out of scope

- 4축 (포트폴리오) threshold 가이드 — 별도 issue 필요 시.
- raw signal 자체 변경 — `_self_review.py` 는 미터치.
- threshold SSoT를 `_governance.py` 같은 코드에 노출 — 다음 follow-up (project_code_polish_backlog 후보).

🤖 Generated with [Claude Code](https://claude.com/claude-code)