### PR TITLE
feat(eval): expose hwp_native_rate / hwp_fallback_rate in by_format (closes #769)

### DIFF
--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -579,11 +579,75 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
     return block
 
 
+def _load_text_source_counts(index_dir: Path | None) -> dict[str, dict[str, int]]:
+    """Pass-through read of ``ingestion_report.json`` text_source_counts (issue #769).
+
+    Reads ``<index_dir>/ingestion_report.json`` produced by ``scripts/build_index.py``
+    (PR #744, ``INGESTION_REPORT_SCHEMA_VERSION>=3``) and returns the per-format
+    text-source histogram.  Returns ``{}`` on any failure — eval must never break
+    on a missing or malformed ingestion report, since the report is optional
+    (e.g. the ``--input_dir`` ingestion path never writes one).
+    """
+    if index_dir is None:
+        return {}
+    report_path = Path(index_dir) / "ingestion_report.json"
+    if not report_path.is_file():
+        return {}
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(
+            f"[WARN] Could not read text_source_counts from {report_path}: {exc}",
+            file=sys.stderr,
+        )
+        return {}
+    raw = (payload.get("summary") or {}).get("text_source_counts") or {}
+    if not isinstance(raw, dict):
+        return {}
+    cleaned: dict[str, dict[str, int]] = {}
+    for fmt, sources in raw.items():
+        if not isinstance(sources, dict):
+            continue
+        cleaned[str(fmt)] = {
+            str(source): int(count)
+            for source, count in sources.items()
+            if isinstance(count, (int, float))
+        }
+    return cleaned
+
+
+def _inject_text_source_rates(
+    by_format: dict[str, dict[str, Any]],
+    text_source_counts: dict[str, dict[str, int]],
+) -> None:
+    """Merge per-format text_source data into the ``by_format`` aggregate in-place.
+
+    For every format present in ``by_format``, attach the raw ``text_source_counts``
+    sub-dict (for transparency).  For ``hwp`` specifically, derive
+    ``hwp_native_rate`` and ``hwp_fallback_rate`` as a convenience for operators
+    scanning the eval summary at a glance.
+    """
+    for fmt, block in by_format.items():
+        sources = text_source_counts.get(fmt)
+        if not sources:
+            continue
+        total = sum(sources.values())
+        if total <= 0:
+            continue
+        block["text_source_counts"] = dict(sources)
+        if fmt == "hwp":
+            native = int(sources.get("hwp_native", 0))
+            block["hwp_native_rate"] = native / total
+            block["hwp_fallback_rate"] = (total - native) / total
+
+
 def summarize_run(
     name: str,
     run_config: dict[str, Any],
     case_results: list[dict[str, Any]],
     include_cases: bool = False,
+    *,
+    index_dir: Path | None = None,
 ) -> dict[str, Any]:
     summary = {
         "name": name,
@@ -629,6 +693,12 @@ def summarize_run(
             fmt: metric_block(format_grouped[fmt])
             for fmt in sorted(format_grouped)
         }
+        # Issue #769: enrich by_format with the pass-through text_source mix from
+        # ingestion_report.json so operators can see "X% of HWP cases parsed via
+        # the pyhwp native path" without joining two artifacts by hand.
+        text_source_counts = _load_text_source_counts(index_dir)
+        if text_source_counts:
+            _inject_text_source_rates(summary["by_format"], text_source_counts)
     if include_cases:
         summary["case_results"] = case_results
     return summary
@@ -885,6 +955,7 @@ def main() -> int:
                 run_config,
                 case_results,
                 include_cases=is_primary,
+                index_dir=Path(args.index_dir),
             )
             run_summaries.append(run_summary)
             if is_primary:

--- a/tests/test_run_eval_by_format_text_source.py
+++ b/tests/test_run_eval_by_format_text_source.py
@@ -1,0 +1,192 @@
+"""eval/run_eval.py by_format text_source pass-through regression (issue #769).
+
+PR #744 (issue #715) wrote ``text_source_counts`` to
+``ingestion_report.json``; this test pins the consumer side — that
+``summarize_run`` reads it back into ``by_format`` and derives
+``hwp_native_rate`` / ``hwp_fallback_rate`` without altering any existing
+metric block field.
+
+The tests use direct dict fixtures (no full RAG pipeline) because the
+contract under test is the JSON shape of ``by_format``, not the eval logic.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from eval.run_eval import (
+    _inject_text_source_rates,
+    _load_text_source_counts,
+    summarize_run,
+)
+
+
+def _case(query_type: str, fmt: str) -> dict:
+    """Minimal case_result shape that ``metric_block`` and ``summarize_run`` accept.
+
+    Only the fields read via ``r["..."]`` (non-``.get``) are required; everything
+    else falls back to ``None``.  Keeping this list short is intentional — the
+    contract under test is text_source pass-through, not metric_block internals.
+    """
+    return {
+        "query_type": query_type,
+        "case_source_format": fmt,
+        "accuracy": 1.0,
+        "groundedness": 1.0,
+        "citation_precision": 1.0,
+        "abstention": 1.0,
+        "latency_ms": 0.0,
+        "retry_count": 0,
+    }
+
+
+def _write_report(index_dir: Path, text_source_counts: dict | None) -> None:
+    summary = {"schema_version": 3}
+    if text_source_counts is not None:
+        summary["text_source_counts"] = text_source_counts
+    (index_dir / "ingestion_report.json").write_text(
+        json.dumps({"summary": summary}), encoding="utf-8"
+    )
+
+
+class LoadTextSourceCountsTest(unittest.TestCase):
+    def test_returns_empty_when_index_dir_is_none(self) -> None:
+        self.assertEqual({}, _load_text_source_counts(None))
+
+    def test_returns_empty_when_report_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual({}, _load_text_source_counts(Path(tmp)))
+
+    def test_returns_empty_when_report_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "ingestion_report.json").write_text("not json", encoding="utf-8")
+            self.assertEqual({}, _load_text_source_counts(Path(tmp)))
+
+    def test_returns_empty_when_summary_missing_text_source_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_report(Path(tmp), text_source_counts=None)
+            self.assertEqual({}, _load_text_source_counts(Path(tmp)))
+
+    def test_returns_per_format_counts_on_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_report(
+                Path(tmp),
+                text_source_counts={
+                    "hwp": {"hwp_native": 4, "data_list_csv_text": 1},
+                    "pdf": {"data_list_csv_text": 3},
+                },
+            )
+            self.assertEqual(
+                {
+                    "hwp": {"hwp_native": 4, "data_list_csv_text": 1},
+                    "pdf": {"data_list_csv_text": 3},
+                },
+                _load_text_source_counts(Path(tmp)),
+            )
+
+
+class InjectTextSourceRatesTest(unittest.TestCase):
+    def test_hwp_native_and_fallback_rates_split_correctly(self) -> None:
+        by_format = {"hwp": {}, "pdf": {}}
+        _inject_text_source_rates(
+            by_format,
+            {
+                "hwp": {"hwp_native": 3, "data_list_csv_text": 1},
+                "pdf": {"data_list_csv_text": 2},
+            },
+        )
+        self.assertAlmostEqual(0.75, by_format["hwp"]["hwp_native_rate"])
+        self.assertAlmostEqual(0.25, by_format["hwp"]["hwp_fallback_rate"])
+        self.assertEqual(
+            {"hwp_native": 3, "data_list_csv_text": 1},
+            by_format["hwp"]["text_source_counts"],
+        )
+
+    def test_pdf_gets_passthrough_but_no_native_rate(self) -> None:
+        by_format = {"pdf": {}}
+        _inject_text_source_rates(
+            by_format, {"pdf": {"data_list_csv_text": 2}}
+        )
+        self.assertEqual(
+            {"data_list_csv_text": 2}, by_format["pdf"]["text_source_counts"]
+        )
+        self.assertNotIn("hwp_native_rate", by_format["pdf"])
+        self.assertNotIn("hwp_fallback_rate", by_format["pdf"])
+
+    def test_skips_formats_absent_in_text_source_counts(self) -> None:
+        by_format = {"doc": {"accuracy": 1.0}}
+        _inject_text_source_rates(by_format, {"hwp": {"hwp_native": 1}})
+        self.assertEqual({"accuracy": 1.0}, by_format["doc"])
+
+    def test_hwp_all_fallback_yields_zero_native_rate(self) -> None:
+        by_format = {"hwp": {}}
+        _inject_text_source_rates(by_format, {"hwp": {"data_list_csv_text": 5}})
+        self.assertEqual(0.0, by_format["hwp"]["hwp_native_rate"])
+        self.assertEqual(1.0, by_format["hwp"]["hwp_fallback_rate"])
+
+    def test_hwp_all_native_yields_one_native_rate(self) -> None:
+        by_format = {"hwp": {}}
+        _inject_text_source_rates(by_format, {"hwp": {"hwp_native": 5}})
+        self.assertEqual(1.0, by_format["hwp"]["hwp_native_rate"])
+        self.assertEqual(0.0, by_format["hwp"]["hwp_fallback_rate"])
+
+
+class SummarizeRunEndToEndTest(unittest.TestCase):
+    """summarize_run integrates the loader + injector. We supply a synthetic
+    case_results list and a temp index_dir holding the ingestion report."""
+
+    def _run_with(self, index_dir: Path | None) -> dict:
+        case_results = [
+            _case("single_doc", "hwp"),
+            _case("single_doc", "hwp"),
+            _case("comparison", "pdf"),
+        ]
+        return summarize_run(
+            "test-run",
+            {"pipeline": "naive_baseline"},
+            case_results,
+            include_cases=False,
+            index_dir=index_dir,
+        )
+
+    def test_by_format_carries_rates_when_report_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_report(
+                Path(tmp),
+                text_source_counts={
+                    "hwp": {"hwp_native": 2, "data_list_csv_text": 1},
+                    "pdf": {"data_list_csv_text": 1},
+                },
+            )
+            summary = self._run_with(Path(tmp))
+            self.assertIn("by_format", summary)
+            hwp_block = summary["by_format"]["hwp"]
+            self.assertAlmostEqual(2 / 3, hwp_block["hwp_native_rate"])
+            self.assertAlmostEqual(1 / 3, hwp_block["hwp_fallback_rate"])
+            self.assertEqual(
+                {"hwp_native": 2, "data_list_csv_text": 1},
+                hwp_block["text_source_counts"],
+            )
+            pdf_block = summary["by_format"]["pdf"]
+            self.assertEqual(
+                {"data_list_csv_text": 1}, pdf_block["text_source_counts"]
+            )
+            self.assertNotIn("hwp_native_rate", pdf_block)
+
+    def test_by_format_unchanged_when_report_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = self._run_with(Path(tmp))
+            self.assertIn("by_format", summary)
+            self.assertNotIn("hwp_native_rate", summary["by_format"]["hwp"])
+            self.assertNotIn("text_source_counts", summary["by_format"]["hwp"])
+
+    def test_by_format_unchanged_when_index_dir_is_none(self) -> None:
+        summary = self._run_with(None)
+        self.assertNotIn("hwp_native_rate", summary["by_format"]["hwp"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #769

PR #744 (issue #715) 가 `text_source_counts` 를 `ingestion_report.json` 에 작성했지만 eval 파이프라인이 되읽지 않음. 결과로 `reports/eval_summary.json` 의 `by_format` 블록이 원래 PR 동기인 운영 질문에 답 못함: **"이 eval 이 채점한 HWP 케이스 중 pyhwp native 경로 vs CSV-text fallback 로 파싱된 비율은?"**

이 PR 은 순수 pass-through 로 consumer side 배선. `summarize_run` 이 `<index_dir>/ingestion_report.json` 옵션 읽기, 존재 시 `by_format` 모든 포맷에 `text_source_counts` 부착, `hwp` 블록 한정으로 `hwp_native_rate` / `hwp_fallback_rate` 도출.

## 2. Files affected

- `eval/run_eval.py` — **load-bearing**. 신규 private helper 2개 (`_load_text_source_counts`, `_inject_text_source_rates`); `summarize_run` 가 옵션 `index_dir` kwarg 받아 채워졌을 때 injector 호출; line ~883 의 단일 호출 site 가 `Path(args.index_dir)` 전달.
- `tests/test_run_eval_by_format_text_source.py` — 신규 (13 tests; loader corner case, injector 산술, 합성 end-to-end summarize_run roundtrip).

## 3. Risks

최대 가능 break: `by_format[fmt]` 의 정확한 키 set 을 hard-assert 하는 downstream consumer. 감사:

- `tests/test_eval_by_format_aggregate_regression.py::test_no_forbidden_keys_in_output` 가 #692 에서 substring 매칭 대신 정확한 키 멤버십 사용으로 수정됨 — forbidden set 이 `hwp_native_rate` / `hwp_fallback_rate` / `text_source_counts` 와 충돌 없음.
- 신규 키는 `metric_block` 필드의 sibling, nested 아님. 기존 `block["accuracy"]` / `block["groundedness"]` 읽기 미접촉.
- `ingestion_report.json` 누락/malformed 시 함수 `{}` 반환, eval 이 원래 `by_format` shape 로 진행. `test_by_format_unchanged_when_report_missing` 검증.

Secondary risk: 미래 `summarize_run` refactor 가 `index_dir` kwarg 무음 드롭. 완화: kwarg 가 keyword-only (`*`), line 883 호출 site 가 의존성 명시.

## 4. Tests

- 신규 `tests/test_run_eval_by_format_text_source.py` — 13 tests:
  - `LoadTextSourceCountsTest` × 5 — `None` dir, missing file, malformed JSON, missing summary key, success path.
  - `InjectTextSourceRatesTest` × 5 — split / pdf-only / unknown format / all-fallback / all-native.
  - `SummarizeRunEndToEndTest` × 3 — report present, report missing, `index_dir=None`.

전부 pass: `13 passed in 0.77s`. 인접 suite (`tests/test_eval_by_format_aggregate_regression.py`, `tests/test_chunk_health.py`, `tests/test_mixed_format_ingestion_regression.py`, `tests/test_hwp_native_loader_regression.py`) 도 green: `65 passed`.

## 5. Eval impact

전부 `·`. 순수 pass-through; `metric_block` 계산 메트릭 미접촉. 신규 키는 `by_format` JSON shape 에 additive.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 수정된 load-bearing 파일 하나 (`eval/run_eval.py`) 가 하는 일:

- `<index_dir>/ingestion_report.json` (`scripts/build_index.py` 가 이미 작성) 읽기
- `by_format[fmt]` 에 sibling 키 3개 추가 (`text_source_counts`, `hwp` 한정 `hwp_native_rate` / `hwp_fallback_rate`)

기존 메트릭 rename / 제거 / retype 없음. Real-eval accuracy / groundedness / citation_precision / latency 수학적으로 미접촉.

## 6. Backward compatibility

Additive only. `ingestion_report.json` 존재 시 `by_format[fmt]` 에 신규 키 등장; 그 외 부재. schema_version 증가 불필요 (eval summary 에 top-level 스키마 버전 없음; `by_format` 은 open map 으로 문서화).

답변 계약 (ADR 0003) 변경 없음.

## 7. Out of scope

- README 리더보드 표 업데이트 — `hwp_native_rate` 는 Goodhart-protected slot 아님.
- eval 에 `chunk_health` 집계 — chunk_health 는 corpus 레벨 (ingest 시점), per-case (eval 시점) 아님; 합치면 축 혼동.
- HWP 파서 개선 (#543, #652).
