### PR TITLE
feat(answer): enforce status_reason.code as enum (closes #759)

### DIFF
--- a/rag_answer.py
+++ b/rag_answer.py
@@ -63,7 +63,12 @@ from rag_answer_schema import (
     ANSWER_SCHEMA_VERSION,
     ANSWER_STATUS_INSUFFICIENT,
     ANSWER_STATUS_PARTIAL,
+    ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE,
+    ANSWER_STATUS_REASON_PARTIAL_COMPARISON,
+    ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING,
+    ANSWER_STATUS_REASON_VERIFIED,
     ANSWER_STATUS_SUPPORTED,
+    KNOWN_ANSWER_STATUS_REASON_CODES,
 )
 from rag_verifier import (
     PARTIAL_TOPIC_GROUNDING_REASON,
@@ -148,17 +153,28 @@ def answer_status_reason(
 ) -> dict[str, Any]:
     if code is None:
         if status == ANSWER_STATUS_SUPPORTED:
-            code = "verified"
+            code = ANSWER_STATUS_REASON_VERIFIED
         elif status == ANSWER_STATUS_PARTIAL:
             # Disambiguate between the two partial paths so the status
             # reason is machine-readable: comparison-coverage partial
             # vs partial-topic grounding (#69 / ADR 0004).
             if PARTIAL_TOPIC_GROUNDING_REASON in verification_reasons:
-                code = "partial_topic_grounding"
+                code = ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING
             else:
-                code = "partial_comparison"
+                code = ANSWER_STATUS_REASON_PARTIAL_COMPARISON
         else:
-            code = "insufficient_evidence"
+            code = ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE
+    elif code not in KNOWN_ANSWER_STATUS_REASON_CODES:
+        # Issue #759 (RAG senior-review critique #2): the four code
+        # strings the dict may take are now a closed set. An override
+        # outside that set used to flow silently into the synthetic
+        # judge / eval scorer / dashboard layer; we raise instead so
+        # the regression surfaces at the call site.
+        raise ValueError(
+            f"answer_status_reason: unknown status_reason code "
+            f"{code!r}; expected one of "
+            f"{sorted(KNOWN_ANSWER_STATUS_REASON_CODES)}"
+        )
     return {
         "code": code,
         "verified": bool(verified),

--- a/rag_answer_schema.py
+++ b/rag_answer_schema.py
@@ -40,3 +40,47 @@ ANSWER_STATUS_PARTIAL = "partial"
 ANSWER_STATUS_INSUFFICIENT = "insufficient"
 
 ANSWER_SCHEMA_VERSION = 2
+
+# Reason codes that ``answer["status_reason"]["code"]`` may take. Issue
+# #759 (RAG senior-review critique #2) promotes the four string literals
+# previously inlined in :func:`rag_answer.answer_status_reason` to
+# canonical constants, then gates the function with
+# :data:`KNOWN_ANSWER_STATUS_REASON_CODES` so an unknown override
+# raises :class:`ValueError` instead of silently flowing into the
+# downstream synthetic judge / eval scorer / dashboard layer.
+#
+# Mapping from ``answer["status"]`` to default code (no override path):
+#   - ``ANSWER_STATUS_SUPPORTED``     → ``ANSWER_STATUS_REASON_VERIFIED``
+#   - ``ANSWER_STATUS_PARTIAL``       → ``ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING``
+#                                       (when ``PARTIAL_TOPIC_GROUNDING_REASON``
+#                                       is in verification_reasons; ADR 0004)
+#                                     → ``ANSWER_STATUS_REASON_PARTIAL_COMPARISON``
+#                                       (otherwise — comparison-coverage path)
+#   - ``ANSWER_STATUS_INSUFFICIENT``  → ``ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE``
+#
+# Two additional codes are reachable via the ``code=`` override that
+# the clarification surface (rag_clarification) uses to disambiguate
+# the *reason* a query was abstained from. Both pair with
+# ``ANSWER_STATUS_INSUFFICIENT`` because clarification is a refusal-
+# to-answer path that needs more user input:
+#   - ``ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION`` — the follow-up
+#     query references prior context that has not been resolved
+#     (rag_clarification.context_clarification_answer).
+#   - ``ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION`` —
+#     metadata-first matched multiple candidate documents
+#     (rag_clarification.metadata_ambiguity_clarification_answer).
+ANSWER_STATUS_REASON_VERIFIED = "verified"
+ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING = "partial_topic_grounding"
+ANSWER_STATUS_REASON_PARTIAL_COMPARISON = "partial_comparison"
+ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION = "context_clarification"
+ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION = "metadata_ambiguity_clarification"
+
+KNOWN_ANSWER_STATUS_REASON_CODES: frozenset[str] = frozenset({
+    ANSWER_STATUS_REASON_VERIFIED,
+    ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING,
+    ANSWER_STATUS_REASON_PARTIAL_COMPARISON,
+    ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE,
+    ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION,
+    ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION,
+})

--- a/rag_clarification.py
+++ b/rag_clarification.py
@@ -41,7 +41,12 @@ import time
 from typing import Any
 
 from rag_answer import answer_status_reason, render_answer_text
-from rag_answer_schema import ANSWER_SCHEMA_VERSION, ANSWER_STATUS_INSUFFICIENT
+from rag_answer_schema import (
+    ANSWER_SCHEMA_VERSION,
+    ANSWER_STATUS_INSUFFICIENT,
+    ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION,
+    ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION,
+)
 from rag_pipeline_presets import RRF_K
 from rag_query import metadata_resolution_diagnostics
 from rag_text_processing import QUERY_TYPE_TOP_K_DEFAULTS, ordered_unique
@@ -122,7 +127,7 @@ def make_context_clarification_result(
             ANSWER_STATUS_INSUFFICIENT,
             False,
             [reason],
-            code="context_clarification",
+            code=ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION,
         ),
         "query_type": "abstention",
         "summary": clarification_answer(query, context_resolution),
@@ -305,7 +310,7 @@ def make_metadata_clarification_result(
             ANSWER_STATUS_INSUFFICIENT,
             False,
             [reason],
-            code="metadata_ambiguity_clarification",
+            code=ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION,
         ),
         "query_type": "abstention",
         "summary": metadata_clarification_answer(query, analysis),

--- a/rag_core.py
+++ b/rag_core.py
@@ -262,7 +262,17 @@ from rag_answer_schema import (
     ANSWER_SCHEMA_VERSION,
     ANSWER_STATUS_INSUFFICIENT,
     ANSWER_STATUS_PARTIAL,
+    # Issue #759 — RAG senior-review critique #2: status_reason.code
+    # constants + closed set, re-exported here to keep the
+    # ``from rag_core import ...`` import path consumers expect.
+    ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION,
+    ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE,
+    ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION,
+    ANSWER_STATUS_REASON_PARTIAL_COMPARISON,
+    ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING,
+    ANSWER_STATUS_REASON_VERIFIED,
     ANSWER_STATUS_SUPPORTED,
+    KNOWN_ANSWER_STATUS_REASON_CODES,
 )
 
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"

--- a/tests/test_answer_status_reason_enum.py
+++ b/tests/test_answer_status_reason_enum.py
@@ -1,0 +1,157 @@
+"""Regression: answer["status_reason"]["code"] is a closed enum (issue #759).
+
+RAG senior-review critique #2: ADR 0003 names the answer dict a
+"contract" but the ``status_reason.code`` field used to accept any
+string. Downstream consumers (synthetic judge, eval scorer, dashboard)
+silently mis-bucketed unknown codes.
+
+This test pins the four-value closed set defined in
+``rag_answer_schema.KNOWN_ANSWER_STATUS_REASON_CODES`` and verifies:
+
+1. Every code is reachable from a corresponding status (no dead enum).
+2. An out-of-set override raises ``ValueError`` rather than flowing
+   into the dict (silent acceptance is the bug we are fixing).
+3. ``answer["status_reason"]["code"]`` produced by the default path
+   is always inside the closed set, regardless of which status branch
+   ``generate_answer`` takes.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from rag_answer import answer_status_reason
+from rag_answer_schema import (
+    ANSWER_STATUS_INSUFFICIENT,
+    ANSWER_STATUS_PARTIAL,
+    ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION,
+    ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE,
+    ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION,
+    ANSWER_STATUS_REASON_PARTIAL_COMPARISON,
+    ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING,
+    ANSWER_STATUS_REASON_VERIFIED,
+    ANSWER_STATUS_SUPPORTED,
+    KNOWN_ANSWER_STATUS_REASON_CODES,
+)
+from rag_verifier import PARTIAL_TOPIC_GROUNDING_REASON
+
+
+class TestAnswerStatusReasonEnum(unittest.TestCase):
+    def test_known_set_has_exactly_six_codes(self) -> None:
+        # The contract is a closed six-value set: four reachable from
+        # ``answer_status_reason``'s default branch (one per
+        # status × partial subcase) plus two reachable via the
+        # ``code=`` override the clarification surface uses. Adding a
+        # seventh value here without bumping ANSWER_SCHEMA_VERSION +
+        # updating ADR 0003 is the regression we want this test to
+        # surface.
+        self.assertEqual(
+            KNOWN_ANSWER_STATUS_REASON_CODES,
+            frozenset({
+                ANSWER_STATUS_REASON_VERIFIED,
+                ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING,
+                ANSWER_STATUS_REASON_PARTIAL_COMPARISON,
+                ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE,
+                ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION,
+                ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION,
+            }),
+        )
+
+    def test_supported_status_yields_verified_code(self) -> None:
+        result = answer_status_reason(
+            status=ANSWER_STATUS_SUPPORTED,
+            verified=True,
+            verification_reasons=[],
+        )
+        self.assertEqual(result["code"], ANSWER_STATUS_REASON_VERIFIED)
+        self.assertIn(result["code"], KNOWN_ANSWER_STATUS_REASON_CODES)
+
+    def test_partial_with_topic_grounding_yields_topic_code(self) -> None:
+        result = answer_status_reason(
+            status=ANSWER_STATUS_PARTIAL,
+            verified=True,
+            verification_reasons=[PARTIAL_TOPIC_GROUNDING_REASON],
+        )
+        self.assertEqual(
+            result["code"], ANSWER_STATUS_REASON_PARTIAL_TOPIC_GROUNDING
+        )
+        self.assertIn(result["code"], KNOWN_ANSWER_STATUS_REASON_CODES)
+
+    def test_partial_without_topic_grounding_yields_comparison_code(self) -> None:
+        # The "other" partial path: comparison-coverage gaps, no
+        # PARTIAL_TOPIC_GROUNDING_REASON in the reason list.
+        result = answer_status_reason(
+            status=ANSWER_STATUS_PARTIAL,
+            verified=False,
+            verification_reasons=["missing_requested_entity:foo"],
+        )
+        self.assertEqual(
+            result["code"], ANSWER_STATUS_REASON_PARTIAL_COMPARISON
+        )
+        self.assertIn(result["code"], KNOWN_ANSWER_STATUS_REASON_CODES)
+
+    def test_insufficient_status_yields_insufficient_evidence_code(self) -> None:
+        result = answer_status_reason(
+            status=ANSWER_STATUS_INSUFFICIENT,
+            verified=False,
+            verification_reasons=[],
+        )
+        self.assertEqual(
+            result["code"], ANSWER_STATUS_REASON_INSUFFICIENT_EVIDENCE
+        )
+        self.assertIn(result["code"], KNOWN_ANSWER_STATUS_REASON_CODES)
+
+    def test_clarification_codes_pass_through_via_override(self) -> None:
+        # rag_clarification uses the ``code=`` override to disambiguate
+        # *why* a query was abstained from. Both clarification codes
+        # must be accepted (not rejected as unknown).
+        for clarification_code in (
+            ANSWER_STATUS_REASON_CONTEXT_CLARIFICATION,
+            ANSWER_STATUS_REASON_METADATA_AMBIGUITY_CLARIFICATION,
+        ):
+            with self.subTest(code=clarification_code):
+                result = answer_status_reason(
+                    status=ANSWER_STATUS_INSUFFICIENT,
+                    verified=False,
+                    verification_reasons=["needs_clarification"],
+                    code=clarification_code,
+                )
+                self.assertEqual(result["code"], clarification_code)
+                self.assertIn(
+                    result["code"], KNOWN_ANSWER_STATUS_REASON_CODES
+                )
+
+    def test_explicit_known_code_passes_through(self) -> None:
+        # An override that names a known code should be accepted —
+        # the validator only rejects unknown codes.
+        for code in sorted(KNOWN_ANSWER_STATUS_REASON_CODES):
+            with self.subTest(code=code):
+                result = answer_status_reason(
+                    status=ANSWER_STATUS_SUPPORTED,
+                    verified=True,
+                    verification_reasons=[],
+                    code=code,
+                )
+                self.assertEqual(result["code"], code)
+
+    def test_unknown_code_override_raises_valueerror(self) -> None:
+        # The bug we are fixing: previously a typo or stale code
+        # would flow into ``answer["status_reason"]["code"]`` and
+        # downstream consumers silently mis-bucketed it. Now it
+        # surfaces at the call site.
+        with self.assertRaises(ValueError) as cm:
+            answer_status_reason(
+                status=ANSWER_STATUS_PARTIAL,
+                verified=False,
+                verification_reasons=[],
+                code="not_a_real_code",
+            )
+        # Surface should mention what was given and what's allowed —
+        # cheap diagnostic for the developer who hits this.
+        message = str(cm.exception)
+        self.assertIn("not_a_real_code", message)
+        self.assertIn("verified", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- ADR 0003 가 answer dict 를 "계약" 으로 명명하지만 `answer["status_reason"]["code"]` 는 free-form 문자열. `rag_answer.answer_status_reason()` 가 hard-coded literal 4개 반환; `rag_clarification` 이 `code=` override 로 2개 더 추가, validation 없음. Unknown / typo 코드가 synthetic judge / eval scorer / dashboard 로 silently 흘러감
- 이 PR 은 6개 문자열 literal 을 `rag_answer_schema` 의 canonical 상수로 격상, `KNOWN_ANSWER_STATUS_REASON_CODES` (closed frozenset) 로 함수 gate. Unknown override → call site 에서 `ValueError`
- ADR 0003 dict 계약 보존 (parallel pydantic / TypedDict 없음 — CLAUDE.md `Prohibited` 준수)

Closes #759. `/Users/hskim/.claude/plans/fizzy-splashing-cherny.md` (RAG senior-review) 의 Critique #2.

## Surface

- `rag_answer_schema.py` — `ANSWER_STATUS_REASON_*` 상수 6개 + `KNOWN_ANSWER_STATUS_REASON_CODES: frozenset[str]`
- `rag_answer.py` — `answer_status_reason()` 의 문자열 literal 4개 교체; `code=` override 가 closed set 놓치면 `ValueError`
- `rag_clarification.py` — 문자열 literal 2개 (`context_clarification`, `metadata_ambiguity_clarification`) 상수 참조로 교체
- `rag_core.py` — 신규 심볼 6개 + frozenset 재export (기존 `ANSWER_STATUS_*` 패턴 매치; `from rag_core import ...` 소비자 무변경)
- `tests/test_answer_status_reason_enum.py` (신규) — closed set pin; status 분기별 reachability 단언; unknown 코드에 `ValueError` 단언

## Test plan

- [x] `pytest tests/test_answer_status_reason_enum.py` — 7 cases + 6 subtests green
- [x] `pytest tests/test_answer_contract_snapshot.py tests/test_partial_topic_grounding.py tests/test_synthesis_cost_telemetry.py tests/test_llm_synthesis.py tests/test_single_turn_ambiguity.py tests/test_synthetic_judge.py tests/test_prompt_injection_regression.py` — 66 passed, 17 subtests, 회귀 없음
- [x] Full `pytest -q` — 532 passed (pre-existing harness-observability 실패 1개는 이 변경 무관; 동일 실패가 이 PR diff 없는 main HEAD 에서도 발생, git stash bisect 로 확인)

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

`rag_answer.py` 와 `rag_clarification.py` 는 load-bearing 이나, 이 PR 은 기존 필드 (`answer["status_reason"]["code"]`) 의 **value space** 만 좁힘 — 어느 코드 경로도 생산 값을 바꾸지 않음.

- 이 PR 이전 `answer_status_reason()` 가 반환하던 default-branch 코드 4개는 이제 **bit-identical** 문자열 (`"verified"`, `"partial_topic_grounding"`, `"partial_comparison"`, `"insufficient_evidence"`) 평가하는 상수
- `rag_clarification` 의 `code=` override 코드 2개 (`"context_clarification"`, `"metadata_ambiguity_clarification"`) 도 마찬가지로 bit-identical 문자열 평가 상수
- 신규 `ValueError` 는 어느 in-tree 코드 경로도 생산 안 한 코드에만 발동. 어느 production 쿼리 경로도 trigger 불가

따라서 `make real-eval-delta` 는 0pp delta 예상. 검색 순위, verifier 출력, real query 의 answer dict 직렬화 JSON 무변경.

## PR template (filled inline)

1. **Issue**: #759
2. **Behavior change?** Defensive only: unknown `code=` override 가 이제 dict 로 조용히 흘러가는 대신 raise. Known 코드 6개는 무변경 통과
3. **Backward compatibility**: 동일 answer-dict 모양. `schema_version` 무변경 (breaking 필드 add/remove/rename 없음 — 기존 필드의 value space enum 좁히기만)
4. **Tests**: 신규 회귀 `tests/test_answer_status_reason_enum.py` + 인접 suite green
5. **Real-data delta**: 위 `### 5b. Real-data delta` 참조
6. **ADR**: ADR 0003 계약 보존; 변경은 `status_reason.code` value space 좁히기, `schema_version` 증가 없음. Reviewer 가 closed-set 선언용 ADR 선호 시 follow-up 가능
7. **CLAUDE.md `Prohibited` 준수**: parallel pydantic / TypedDict 없음; dict 가 계약 유지

