### PR TITLE
feat(eval): rerank delta meta — pre/post-rerank top-10 + MRR/NDCG delta (closes #767)

### DIFF
--- a/eval/scorers/case.py
+++ b/eval/scorers/case.py
@@ -103,6 +103,29 @@ def score_case(
     chunk_metrics["chunk_ndcg_at_10"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_for_chunks, 10)
     chunk_metrics["chunk_ndcg_at_20"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_for_chunks, 20)
 
+    # Rerank delta (issue #767): isolated cross-encoder contribution on top of
+    # the 60/25/15 dense+lexical+metadata blend. Both keys are None when the
+    # rerank stage didn't run (e.g., rerank disabled in naive_baseline, or the
+    # reranker fell back silently). Forward-compat: pre-#767 prediction dicts
+    # have no `pre_rerank_top10` / `post_rerank_top10` keys → values stay None.
+    rerank_meta = plan.get("rerank_cross_encoder_meta") or {}
+    pre_top10 = [str(c) for c in rerank_meta.get("pre_rerank_top10") or [] if c]
+    post_top10 = [str(c) for c in rerank_meta.get("post_rerank_top10") or [] if c]
+    if pre_top10 and post_top10 and gold_for_chunks:
+        pre_mrr = chunk_mrr(pre_top10, gold_for_chunks)
+        post_mrr = chunk_mrr(post_top10, gold_for_chunks)
+        pre_ndcg = chunk_ndcg_at_k(pre_top10, gold_for_chunks, 10)
+        post_ndcg = chunk_ndcg_at_k(post_top10, gold_for_chunks, 10)
+        chunk_metrics["rerank_delta_mrr"] = (
+            (post_mrr - pre_mrr) if pre_mrr is not None and post_mrr is not None else None
+        )
+        chunk_metrics["rerank_delta_ndcg_at_10"] = (
+            (post_ndcg - pre_ndcg) if pre_ndcg is not None and post_ndcg is not None else None
+        )
+    else:
+        chunk_metrics["rerank_delta_mrr"] = None
+        chunk_metrics["rerank_delta_ndcg_at_10"] = None
+
     return {
         "id": case.get("id"),
         "query_type": query_type,

--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -125,7 +125,18 @@ def apply_fusion_and_reranking(
         from rag_reranker import default_reranker
 
         top_n = min(30, max(int(plan["top_k"] or 10) * 3, int(plan["top_k"] or 10)))
+        # Capture pre-rerank top-10 chunk_ids before the reranker reorders them.
+        # The eval scorer uses these together with the post-rerank top-10 (set
+        # below) and gold_chunk_ids to compute `rerank_delta_mrr` and
+        # `rerank_delta_ndcg_at_10` — the isolated cross-encoder contribution
+        # on top of the 60/25/15 dense+lexical+metadata blend (issue #767).
+        pre_rerank_top10 = [str(item.get("chunk_id") or "") for item in scored[:10]]
         scored, rerank_meta = default_reranker().rerank(query, scored, top_n=top_n)
+        rerank_meta = dict(rerank_meta)
+        rerank_meta["pre_rerank_top10"] = pre_rerank_top10
+        rerank_meta["post_rerank_top10"] = [
+            str(item.get("chunk_id") or "") for item in scored[:10]
+        ]
         plan["rerank_cross_encoder_meta"] = rerank_meta
     top_k = int(plan["top_k"])
     if plan.get("retrieval_mode") == "hierarchical":

--- a/tests/test_rerank_delta_regression.py
+++ b/tests/test_rerank_delta_regression.py
@@ -1,0 +1,207 @@
+"""Regression guards for rerank delta meta (issue #767).
+
+Pins two contracts:
+
+* `rag_retrieval.apply_fusion_and_reranking` writes `pre_rerank_top10`
+  and `post_rerank_top10` chunk_id lists into
+  `plan["rerank_cross_encoder_meta"]` whenever the cross-encoder rerank
+  stage runs.
+* `eval.scorers.case.score_case` consumes those lists with the case's
+  gold_chunk_ids to compute `rerank_delta_mrr` /
+  `rerank_delta_ndcg_at_10`. Both must be `None` (forward-compat) when
+  the rerank stage didn't run — preserves naive_baseline / pre-#767
+  prediction-dict invariance (ADR 0001).
+
+Stub-backend invariance: with the default `BIDMATE_RERANK_BACKEND=stub`
+the post-rerank order is byte-equivalent to the pre-rerank order, so
+both delta values must be exactly 0.0 (not None) — the rerank stage
+did run, it just didn't reorder. This is the contract that lets the
+CI hashing-backend `full_reranker` row stay 0-delta against `full`.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eval.scorers.case import score_case  # noqa: E402
+
+
+_CASE = {
+    "id": "test-rerank-001",
+    "query_type": "single_doc",
+    "answerable": True,
+    "expected_doc_ids": ["doc-a"],
+    "expected_terms": ["보안"],
+    "query": "보안 요구사항",
+}
+
+
+def _minimal_prediction(
+    *,
+    retrieved_chunk_ids: list[str] | None = None,
+    rerank_meta: dict | None = None,
+    evidence: list[dict] | None = None,
+) -> dict:
+    plan: dict = {}
+    if rerank_meta is not None:
+        plan["rerank_cross_encoder_meta"] = rerank_meta
+    return {
+        "evidence": evidence or [],
+        "answer": {"status": "supported", "claims": [], "summary": ""},
+        "diagnostics": {
+            "abstained": False,
+            "latency_ms": 1.0,
+            "retry_count": 0,
+            "retrieved_chunk_ids": retrieved_chunk_ids or [],
+            "cold_start": False,
+        },
+        "plan": plan,
+        "analysis": {},
+    }
+
+
+class RerankDeltaInScoreCaseTest(unittest.TestCase):
+    """`score_case` must emit `rerank_delta_*` keys with correct values."""
+
+    def test_keys_present_when_rerank_meta_absent(self) -> None:
+        """Forward-compat: keys exist but are None when no rerank ran."""
+        pred = _minimal_prediction(
+            retrieved_chunk_ids=["doc-a::c1", "doc-a::c2"],
+            evidence=[{"doc_id": "doc-a", "text": "보안"}],
+        )
+        result = score_case(_CASE, pred, gold_chunk_ids=["doc-a::c1"])
+        self.assertIn("rerank_delta_mrr", result)
+        self.assertIn("rerank_delta_ndcg_at_10", result)
+        self.assertIsNone(result["rerank_delta_mrr"])
+        self.assertIsNone(result["rerank_delta_ndcg_at_10"])
+
+    def test_delta_zero_when_rerank_did_not_reorder(self) -> None:
+        """Stub backend contract: identical pre/post → delta = 0.0 (not None)."""
+        ids = [f"doc-a::c{i}" for i in range(1, 11)]
+        pred = _minimal_prediction(
+            retrieved_chunk_ids=ids,
+            rerank_meta={
+                "pre_rerank_top10": ids,
+                "post_rerank_top10": ids,
+            },
+            evidence=[{"doc_id": "doc-a", "text": "보안"}],
+        )
+        result = score_case(_CASE, pred, gold_chunk_ids=["doc-a::c1"])
+        self.assertEqual(result["rerank_delta_mrr"], 0.0)
+        self.assertEqual(result["rerank_delta_ndcg_at_10"], 0.0)
+
+    def test_positive_delta_when_rerank_moves_gold_up(self) -> None:
+        """If the reranker promotes a gold chunk, delta > 0."""
+        pre = [f"doc-a::c{i}" for i in range(1, 11)]
+        post = ["doc-a::c5"] + [c for c in pre if c != "doc-a::c5"]
+        pred = _minimal_prediction(
+            retrieved_chunk_ids=post,
+            rerank_meta={
+                "pre_rerank_top10": pre,
+                "post_rerank_top10": post,
+            },
+            evidence=[{"doc_id": "doc-a", "text": "보안"}],
+        )
+        # gold rank: 5 (MRR=0.2) → 1 (MRR=1.0), delta_mrr = +0.8
+        result = score_case(_CASE, pred, gold_chunk_ids=["doc-a::c5"])
+        self.assertIsNotNone(result["rerank_delta_mrr"])
+        self.assertAlmostEqual(result["rerank_delta_mrr"], 0.8, places=4)
+        # NDCG@10 also strictly improves when the single gold chunk
+        # moves to rank 1.
+        self.assertIsNotNone(result["rerank_delta_ndcg_at_10"])
+        self.assertGreater(result["rerank_delta_ndcg_at_10"], 0.0)
+
+    def test_negative_delta_when_rerank_demotes_gold(self) -> None:
+        """If the reranker demotes a gold chunk, delta < 0."""
+        pre = [f"doc-a::c{i}" for i in range(1, 11)]
+        # Move c1 (gold) to last position
+        post = [c for c in pre if c != "doc-a::c1"] + ["doc-a::c1"]
+        pred = _minimal_prediction(
+            retrieved_chunk_ids=post,
+            rerank_meta={
+                "pre_rerank_top10": pre,
+                "post_rerank_top10": post,
+            },
+            evidence=[{"doc_id": "doc-a", "text": "보안"}],
+        )
+        # gold rank: 1 (MRR=1.0) → 10 (MRR=0.1), delta_mrr = -0.9
+        result = score_case(_CASE, pred, gold_chunk_ids=["doc-a::c1"])
+        self.assertIsNotNone(result["rerank_delta_mrr"])
+        self.assertAlmostEqual(result["rerank_delta_mrr"], -0.9, places=4)
+
+    def test_delta_none_when_no_gold(self) -> None:
+        """No gold_chunk_ids → delta values stay None (no signal)."""
+        ids = [f"doc-a::c{i}" for i in range(1, 11)]
+        pred = _minimal_prediction(
+            retrieved_chunk_ids=ids,
+            rerank_meta={
+                "pre_rerank_top10": ids,
+                "post_rerank_top10": ids,
+            },
+        )
+        result = score_case(_CASE, pred, gold_chunk_ids=None)
+        self.assertIsNone(result["rerank_delta_mrr"])
+        self.assertIsNone(result["rerank_delta_ndcg_at_10"])
+
+
+class RerankMetaShapeTest(unittest.TestCase):
+    """`rag_retrieval` writes pre/post lists when rerank stage runs."""
+
+    def test_apply_fusion_writes_pre_post_top10_when_rerank_enabled(self) -> None:
+        """Stub-backend integration: meta dict must include both lists."""
+        from rag_retrieval import apply_fusion_and_reranking
+
+        scored = [
+            {
+                "chunk_id": f"doc-a::c{i}",
+                "score": 1.0 - i * 0.01,
+                "score_parts": {"dense": 1.0 - i * 0.01},
+            }
+            for i in range(1, 31)
+        ]
+        plan = {
+            "top_k": 10,
+            "rerank_cross_encoder": True,
+            "retrieval_backend": "dense",
+            "retrieval_mode": "flat",
+        }
+        index = {"documents": []}
+        analysis: dict = {}
+        apply_fusion_and_reranking(list(scored), index, "q", analysis, plan)
+        meta = plan.get("rerank_cross_encoder_meta") or {}
+        self.assertIn("pre_rerank_top10", meta)
+        self.assertIn("post_rerank_top10", meta)
+        self.assertEqual(len(meta["pre_rerank_top10"]), 10)
+        self.assertEqual(len(meta["post_rerank_top10"]), 10)
+        # Stub backend = identity, so order must match.
+        self.assertEqual(meta["pre_rerank_top10"], meta["post_rerank_top10"])
+
+    def test_no_meta_written_when_rerank_disabled(self) -> None:
+        """`rerank_cross_encoder=False` must leave plan untouched (ADR 0001)."""
+        from rag_retrieval import apply_fusion_and_reranking
+
+        scored = [
+            {
+                "chunk_id": "doc-a::c1",
+                "score": 0.9,
+                "score_parts": {"dense": 0.9},
+            }
+        ]
+        plan = {
+            "top_k": 10,
+            "rerank_cross_encoder": False,
+            "retrieval_backend": "dense",
+            "retrieval_mode": "flat",
+        }
+        apply_fusion_and_reranking(scored, {"documents": []}, "q", {}, plan)
+        self.assertNotIn("rerank_cross_encoder_meta", plan)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Closes #767

## Summary

Cross-encoder 리랭커의 격리된 기여도를 측정하는 forward-only 메트릭. PR #691(recall@20 + ndcg@20)과 PR #696(retrieval_only ablation)의 companion으로, "이 단계가 얼마나 도움이 되는가"를 leaderboard에서 정량 비교 가능하게 함.

## Changes

| 파일 | 변경 |
|---|---|
| `rag_retrieval.py` | rerank 호출 직전 `pre_rerank_top10` 캡쳐 → rerank 후 `post_rerank_top10` 캡쳐, 둘 다 `plan["rerank_cross_encoder_meta"]`에 기록 |
| `eval/scorers/case.py` | `rerank_delta_mrr` / `rerank_delta_ndcg_at_10` 계산 — gold_chunk_ids vs pre/post top-10. rerank 미실행 시 `None` |
| `tests/test_rerank_delta_regression.py` | 7개 신규 회귀 테스트 (forward-compat, stub zero-delta, positive/negative delta semantics, no-gold path, meta shape) |

## Non-regression

- **ADR 0001 naive_baseline**: `rerank_cross_encoder=False` → plan에 meta key 미작성 (`test_no_meta_written_when_rerank_disabled` 검증)
- **Stub backend (CI 기본)**: identity 재정렬 → delta = 0.0 정확 일치 (`test_delta_zero_when_rerank_did_not_reorder`)
- **ADR 0030 leaderboard**: forward-only, case-level nullable 키 2개 추가; aggregate 키 불변
- 기존 retrieval / chunk_metrics / cross_encoder / langgraph regression 모두 통과

## 1. Why

PR-2 of `/Users/hskim/.claude/plans/retrival-nifty-tulip.md`. Retrieval 진단 후속: pool recall 100%는 강하지만 rerank 단계가 추가 가치를 주는지 자체 측정이 부재 → 이 PR로 격리.

## 2. What changed

위 Changes 테이블.

## 3. How tested

- `pytest tests/test_rerank_delta_regression.py` — 7 passed
- `pytest tests/test_naive_baseline_ranking_invariance.py tests/test_chunk_metrics_regression.py tests/test_cross_encoder_rerank.py tests/test_retrieval_loop_regression.py tests/test_reranker_protocol.py tests/test_langgraph_orchestrator_regression.py` — 54 passed
- 전체 `pytest tests/`: 1240 passed (실패 11건은 pre-existing local subprocess harness 환경 이슈, CI 통과)

## 4. Risks / mitigations

- 추가 캡쳐가 hot path에 들어가지만 `list[:10]` 두 번 = O(1), 측정 불필요
- 메타 스키마는 새 키만 추가 (`rerank_schema_version` 불변; ADR 0011 invariant)

## 5. Eval impact

### 5a. Synthetic delta
forward-only 추가 키, 기존 aggregate 변경 없음. CI Eval delta vs base로 검증.

### 5b. Real-data delta

`rag_retrieval.py` + `eval/scorers/case.py` (load-bearing) 변경. Stub backend(CI 기본) 시 delta = 0.0 정확 일치 contract으로 retrieval 출력 byte-identical. No behavior change in retrieval / verifier path; 메트릭 캡쳐만 추가.

## 6. Backward compatibility

Forward-only. 두 새 키(`rerank_delta_mrr`, `rerank_delta_ndcg_at_10`)는 nullable. 기존 eval_summary.json 스냅샷 불변.

## 7. Out of scope

- Pre-rerank top-N (N > 10) 캡쳐 — 현재 NDCG@10 / MRR@10 한정
- Real reranker backend 측정 — stub 외 backend는 manual 측정 시 측정 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)