### PR TITLE
fix(ingestion): HwpNativeLoader falls back on AttributeError (closes #785)

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -213,9 +213,18 @@ def _hwp_native_fallback_exceptions() -> tuple[type[BaseException], ...]:
     ``InvalidOleStorageError``) when ``hwp5`` is installed. Built lazily so
     the handler is still well-formed when ``hwp5`` is absent (CI case),
     where ``_extract_hwp_native`` raises ``ImportError`` and falls back.
+
+    ``AttributeError`` is included (issue #785) because pyhwp's public API
+    changes across point releases — e.g. the 0.1b15 ``Sections`` object
+    exposes a ``sections`` list attribute rather than the ``section_list()``
+    method our extractor was written against. Without this entry, a single
+    API-drift document aborted the entire build rather than falling back
+    gracefully; with it, the failure is recorded in
+    ``ingestion_report.json.fallback_reasons`` and the build proceeds.
     """
     base: tuple[type[BaseException], ...] = (
         ImportError,
+        AttributeError,
         OSError,
         RuntimeError,
         ValueError,

--- a/tests/test_hwp_native_loader_regression.py
+++ b/tests/test_hwp_native_loader_regression.py
@@ -198,6 +198,32 @@ class HwpNativeLoaderRegressionTest(unittest.TestCase):
         runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
         self.assertEqual(1, len(runtime_warnings))
 
+    def test_native_loader_falls_back_when_parser_raises_attribute_error(self) -> None:
+        """Issue #785: pyhwp API drift (e.g. 0.1b15 ``Sections.sections`` list vs
+        legacy ``section_list()`` method) used to abort the entire build because
+        ``AttributeError`` was not in the fallback tuple. Now the per-document
+        failure is recorded and the build proceeds with CSV text."""
+        loader = HwpNativeLoader()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with mock.patch(
+                "ingestion._extract_hwp_native",
+                side_effect=AttributeError(
+                    "'OleStorage' object has no attribute 'section_list'"
+                ),
+            ):
+                text = loader.load_text(
+                    {"텍스트": "csv text after attr drift"},
+                    Path("/nonexistent.hwp"),
+                )
+        self.assertEqual("csv text after attr drift", text)
+        self.assertEqual("data_list_csv_text", loader.last_text_source)
+        self.assertIsNotNone(loader.last_fallback_reason)
+        self.assertIn("AttributeError", loader.last_fallback_reason)
+        self.assertIn("section_list", loader.last_fallback_reason)
+        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+        self.assertEqual(1, len(runtime_warnings))
+
     def test_native_loader_records_hwp_native_source_on_success(self) -> None:
         loader = HwpNativeLoader()
         with warnings.catch_warnings(record=True) as caught:


### PR DESCRIPTION
## 1. What changed and why

Closes #785

#715 측정 loop 을 private 100-doc real corpus 에 돌리다 발견. pyhwp 0.1b15 (최신 릴리스) 설치 후 `BIDMATE_HWP_LOADER=native` 가 **첫 HWP 파일에서 전체 build 중단**:

```
[ERROR] Index build failed: 'OleStorage' object has no attribute 'section_list'
```

근본 원인: pyhwp 0.1b15 의 `hwp5.xmlmodel.Sections` 가 `section_list()` 메서드가 아닌 `sections` 리스트 속성 노출. 우리 `_extract_hwp_native` 는 구 API 기준 작성됨. 결과 `AttributeError` 가 `_hwp_native_fallback_exceptions` 에 미포함 → `HwpNativeLoader.load_text` 통해 전파 → build 사망. pyhwp 없는 상태 (100% silent CSV fallback, 모든 문서 인덱싱) 보다 strictly 나쁨.

이 PR 은 fallback tuple 에 `AttributeError` 추가 → per-document API drift 가 `fallback_reason` 기록하고 build 가 CSV text 로 진행. pyhwp 0.1b15 의 iteration 모델 (`section.models` 순회) 전체 적응은 별도 큰 작업.

## 2. Files affected

- `ingestion.py` — **load-bearing**. `_hwp_native_fallback_exceptions` 에 한 줄 추가 (`AttributeError`) + 사유와 API-drift trigger docstring.
- `tests/test_hwp_native_loader_regression.py` — 기존 `OSError` 테스트 미러링한 신규 `test_native_loader_falls_back_when_parser_raises_attribute_error`.

## 3. Risks

최대 가능 break: 우리 코드의 진짜 버그 (`loader.last_text_source` 오타 등) 의 `AttributeError` 마스킹. 감사:

- `_extract_hwp_native` 와 `_extract_hwp_native_with_tables` 가 유일 호출 site; 둘 다 가드 대상인 pyhwp 객체의 API surface 접촉.
- 그 함수들의 다른 `AttributeError` 원천은 테스트 중 여전히 raise (suite 의 mock 기반 테스트가 런타임 전 오타 포착).
- 관측성 유지: 모든 fallback 이 `last_fallback_reason` 작성 + `RuntimeWarning` (issue #363 invariant). 신규 `AttributeError` 와 기존 `OSError` 경로 모두 같은 관측성 코드 — `AttributeError` fallback 폭증은 **loud**, silent 아님.

Risk: low. `HwpNativeLoader` 의 본질이 graceful degradation; abort-vs-degrade 비율 tightening 이 design intent.

## 4. Tests

- 신규 `tests/test_hwp_native_loader_regression.py::test_native_loader_falls_back_when_parser_raises_attribute_error` — 기존 `OSError` 테스트 정확히 미러 → 테스트 패턴 일관.
- 전체 HWP loader 회귀 suite: 15/15 pass (`pytest tests/test_hwp_native_loader_regression.py`).
- Real-data 검증: `BIDMATE_HWP_LOADER=native scripts/build_index.py --metadata_csv data/data_list.csv --files_dir data/files` 가 exit 0 으로 완료, `fallback_reasons={"AttributeError: ... 'section_list'": 96}` 작성 (모든 HWP graceful degrade).

## 5. Eval impact

전부 `·`. 순수 error-handling widening. CI 기본인 pyhwp 부재 상태에서는 `_extract_hwp_native` 가 먼저 `ImportError` raise 하므로 동작 불변.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. `ingestion.py` 는 load-bearing 이지만 변경은 HWP native fallback handler 의 **exception catch list 전용** — catch + `fallback_reasons` 기록을 넓힐 뿐, 좁히지 않음. 인덱싱 문서 수 동일 (수정 대상 실패 모드는 build-abort = 문서 0; 이제 no-pyhwp baseline 과 동일한 100 CSV-fallback 문서).

Real-eval accuracy / groundedness / citation_precision / latency 수학적으로 미접촉.

## 6. Backward compatibility

Additive only — catch list 확대만, 축소 없음. 스키마 변경 없음, 계약 변경 없음, 플래그 변경 없음. `fallback_reasons` downstream consumer (issue #715, schema 3) 가 임의 문자열 키 처리 — `AttributeError` 엔트리 자연 삽입.

답변 계약 (ADR 0003) 변경 없음.

## 7. Out of scope

- **pyhwp 0.1b15 API 적응** — `_extract_hwp_native` 가 legacy `section_list()` + `paragraphs` API 대신 `bodytext.sections` (리스트) + `section.models` (이벤트 스트림) 으로 rewrite 필요. #785 follow-up 추적.
- `requirements*.txt` 의 `pyhwp` 버전 pin — 현재 `pyhwp` dep 자체 없음; loader 가 진정 best-effort. Pinning 은 별도 결정 (cost: dev-env 복잡도 vs. 일관 동작).
- HWPX 지원 (#543).
