### PR TITLE
fix(retrieval+trace): raise on dense_similarity shape mismatch + log trace failures (closes #784)

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -1188,6 +1188,18 @@ def _build_run_context(
         except Exception as exc:
             trace_error = f"start_trace:{type(exc).__name__}:{str(exc)[:120]}"
             trace_handle = None
+            # Issue #784 — RAG senior-review critique #4: trace_error
+            # was previously only captured into the per-request
+            # diagnostics dict, so an outage of the configured trace
+            # backend (LangSmith down, mis-set token, schema drift)
+            # produced no operator-visible signal. Emit a warning so
+            # aggregate log inspection / alerting can pick it up
+            # without scraping every diagnostics block.
+            _LOGGER.warning(
+                "trace_start_failed backend=%s error=%s",
+                trace_backend_name,
+                trace_error,
+            )
 
     return _RunContext(
         index=index,
@@ -1280,8 +1292,20 @@ def _phase_analyze(ctx: _RunContext) -> dict[str, Any] | None:
     if ctx.trace_handle is not None:
         try:
             ctx.trace_handle.set_tag("query_type", str(analysis.get("query_type") or ""))
-        except Exception:
-            pass
+        except Exception as exc:
+            # Issue #784 — RAG senior-review critique #4: tag drops
+            # used to be a bare ``pass``. The ``trace_handle is not
+            # None`` guard above means start_trace already succeeded,
+            # so a set_tag failure here is rare in steady state and
+            # worth logging each time (e.g. LangSmith schema drift,
+            # tag-name length limits). The tag is still dropped so
+            # the request keeps flowing.
+            _LOGGER.warning(
+                "trace_set_tag_failed tag=%s error=%s:%s",
+                "query_type",
+                type(exc).__name__,
+                str(exc)[:120],
+            )
     if analysis.get("metadata_ambiguous") and analysis.get("query_type") != "comparison":
         result = make_metadata_clarification_result(
             ctx.index,

--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -517,10 +517,27 @@ def embed_query_for_index(query: str, embedding_config: dict[str, Any]) -> np.nd
 
 def dense_similarity(query_vector: np.ndarray, chunk_vector: Any) -> float:
     if chunk_vector is None:
+        # Legitimate "no embedding for this chunk" case (e.g. metadata-only
+        # rows in test fixtures). Returning 0.0 is the documented contract.
         return 0.0
     doc_vector = np.asarray(chunk_vector, dtype=np.float32)
     if doc_vector.shape != query_vector.shape:
-        return 0.0
+        # Issue #784 — RAG senior-review critique #4. A shape mismatch
+        # means the chunk and the query were embedded in incompatible
+        # vector spaces (e.g. sidecar built with one model, query
+        # embedded with another). Previously this returned 0.0 which
+        # silently produced a zero-similarity score across the entire
+        # index → retrieval ranking corrupted but the API still
+        # returned "successful" answers. Raising surfaces the
+        # integrity bug at the failing call site instead.
+        raise ValueError(
+            f"dense_similarity: vector shape mismatch — "
+            f"query={query_vector.shape} vs chunk={doc_vector.shape}. "
+            "This indicates the index was built with a different "
+            "embedding model / dimension than the query was embedded "
+            "with. Rebuild the index or check BIDMATE_INDEX_BACKEND / "
+            "EMBEDDING_BACKEND consistency."
+        )
     score = float(np.dot(query_vector, doc_vector))
     return max(0.0, min(1.0, (score + 1.0) / 2.0))
 

--- a/tests/test_dense_similarity_shape_validation.py
+++ b/tests/test_dense_similarity_shape_validation.py
@@ -1,0 +1,70 @@
+"""Regression: dense_similarity raises on shape mismatch (issue #784).
+
+RAG senior-review critique #4. The function used to return ``0.0`` for
+a vector-shape mismatch between query and chunk embeddings, which
+silently produced a zero-similarity score across the index when the
+sidecar was rebuilt with a different model dimension or fixture math
+disagreed with the embedding backend. The bug surfaced as flat eval
+discriminating power with no observable signal.
+
+This test pins the new contract:
+
+1. ``chunk_vector is None`` continues to return ``0.0`` (legitimate
+   "no embedding for this chunk" case for metadata-only fixture rows).
+2. Shape mismatch raises ``ValueError`` with both shapes in the
+   message (so the failing call site is grep-able from the traceback).
+3. Matching-shape vectors still return the existing ``(cosine + 1) / 2``
+   affine clamp — i.e. the happy path is unchanged.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from rag_retrieval import dense_similarity
+
+
+class TestDenseSimilarityShapeValidation(unittest.TestCase):
+    def test_none_chunk_vector_returns_zero(self) -> None:
+        # The "no embedding" contract for metadata-only chunks must
+        # be preserved — None is not a corruption signal.
+        score = dense_similarity(np.zeros(8, dtype=np.float32), None)
+        self.assertEqual(score, 0.0)
+
+    def test_matching_shape_returns_affine_clamped_cosine(self) -> None:
+        # Sanity: parallel unit vectors → cosine 1.0 → clamp = 1.0.
+        v = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        self.assertAlmostEqual(dense_similarity(v, v), 1.0, places=6)
+        # Anti-parallel → cosine -1.0 → clamp = 0.0.
+        anti = -v
+        self.assertAlmostEqual(dense_similarity(v, anti), 0.0, places=6)
+
+    def test_shape_mismatch_raises_with_both_shapes(self) -> None:
+        # The bug we are fixing: previously this returned 0.0
+        # silently, corrupting retrieval ranking. Now it raises so
+        # the index-vs-query dimension mismatch surfaces at the
+        # failing call site.
+        query = np.zeros(8, dtype=np.float32)
+        chunk = np.zeros(16, dtype=np.float32)
+        with self.assertRaises(ValueError) as cm:
+            dense_similarity(query, chunk)
+        message = str(cm.exception)
+        # Both shapes should be mentioned so the developer can tell
+        # immediately which dimension is wrong.
+        self.assertIn("(8,)", message)
+        self.assertIn("(16,)", message)
+
+    def test_shape_mismatch_chunk_as_list_also_raises(self) -> None:
+        # ``chunk_vector`` is typed ``Any`` and frequently comes in
+        # as a Python list from JSON-loaded fixtures. The shape
+        # check must still apply after np.asarray().
+        query = np.zeros(4, dtype=np.float32)
+        chunk_as_list = [0.0, 0.0, 0.0]  # length 3, mismatch
+        with self.assertRaises(ValueError):
+            dense_similarity(query, chunk_as_list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `rag_retrieval.dense_similarity` shape mismatch 가 `0.0` 반환, 실제 index-vs-query 차원 불일치 (broken sidecar, 모델 swap without rebuild) 시 검색 ranking 조용히 손상. 이제 shape 양쪽을 메시지에 포함해 `ValueError` raise.
- `rag_core` trace start 실패가 그동안 per-request 진단 dict 에 `trace_error` 캡처하되 로그 라인 미발화; trace tag-set 실패는 bare `pass`. 둘 다 이제 `_LOGGER.warning(...)` 발화해 aggregate 로그 검사가 trace-backend 장애를 picking.
- `chunk_vector is None` 분기 (정당한 "이 청크에 임베딩 없음") 미변경.
- Out of scope (별도 issue): `embed_query_for_index` SBERT/OpenAI exception → hashing fallback (blast radius 큼); `rank_bm25` import-time fail-fast (minimal env 에서 위험).

Closes #784. `/Users/hskim/.claude/plans/fizzy-splashing-cherny.md` (RAG senior-review) 비판 #4. dynamic-loop fix sequence Cycle 2.

## Surface

- `rag_retrieval.py` — `dense_similarity`: shape mismatch 가 `0.0` 반환 대신 `ValueError` raise. shape 양쪽을 메시지에 언급해 실패 call site 를 traceback 에서 grep 가능.
- `rag_core.py` — trace start 실패가 swallow 전 `_LOGGER.warning("trace_start_failed backend=%s error=%s", ...)` 추가; trace tag-set 실패가 swallow 전 `_LOGGER.warning("trace_set_tag_failed tag=%s error=%s:%s", ...)` 추가. 기존 `trace_error` 진단 흐름 + request-level fallthrough 보존.
- `tests/test_dense_similarity_shape_validation.py` (신규) — 4 케이스: None 은 여전히 0.0 반환, 일치 shape 는 affine-clamped cosine 반환, 불일치 shape 는 양쪽 shape 메시지와 함께 `ValueError` raise, list 입력 (`Any` typed) 도 여전히 체크 trigger.

## Test plan

- [x] `pytest tests/test_dense_similarity_shape_validation.py` — 4 passed.
- [x] `pytest tests/test_retrieval_loop_regression.py tests/test_partial_topic_grounding.py tests/test_naive_baseline_ranking_invariance.py tests/test_fuzzy_retrieval.py tests/test_vector_store_protocol.py` — 60 passed + 17 subtests, 회귀 없음.
- [x] 전체 `pytest -q --ignore=tests/test_harness_observability.py` — 1261 passed; `test_run_harness` + `test_ship_dispatcher_gates` 의 무관 7건 실패는 `git stash` bisect 로 origin/main HEAD 사전 존재 확인.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path** — 모든 well-formed 인덱스에 대해.

`rag_retrieval.py` 와 `rag_core.py` 는 load-bearing. 변경은 silent corruption 경로를 loud 에러로 전환. 구체적으로:

- happy 경로 (일치 shape) 는 이전과 byte-identical — 동일 `np.dot` + `(cosine + 1) / 2` clamp.
- `None` 분기 미변경.
- shape-mismatch 분기는 그동안 mismatched 청크마다 0.0 반환해 ranking 손상 → 인덱스 전체에 무의미한 score floor. 이 변경 후 실제 mismatch 는 즉시 raise — operator 가 bad score 조용히 ship 대신 인덱스 rebuild.

`rag_core.py` trace 로그 추가는 순수 observability — request 는 trace 상태와 무관하게 flow 계속. Latency-sensitive hot path 미터치.

따라서 `make real-eval-delta` 는 healthy 인덱스에서 0pp delta 예상. 만약 delta 가 나타나면, 인덱스에 그동안 masked 된 latent 차원 mismatch 가 있다는 뜻 — surface 하는 게 이 PR 의 요점.

## PR 템플릿 (inline)

1. **Issue**: #784.
2. **동작 변경?** 방어적만: `dense_similarity` shape mismatch 가 0.0 반환 대신 raise. Trace 실패가 swallow 전 warning 로그. healthy 인덱스의 검색 / verifier 코드 경로 unchanged.
3. **하위 호환성**: Healthy 검색 경로 unchanged. raise 경로는 그동안 잘못된 score 조용히 생성하던 인덱스에서만 fire 가능.
4. **테스트**: 신규 회귀 `tests/test_dense_similarity_shape_validation.py` + 인접 retrieval/verifier suite green.
5. **Real-data delta**: 위 `### 5b. Real-data delta` 참조.
6. **ADR**: 신규 ADR 없음. 변경은 기존 검색 계약 (`(cosine + 1) / 2` affine clamp) 보존하고 실패 사이트의 integrity 버그를 surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
