### PR TITLE
feat(eval): table_extraction_metrics — cell F1 + table recall + merge preservation (PR-A3, closes #790)

### DIFF
--- a/eval/data/table_extraction_golden.schema.json
+++ b/eval/data/table_extraction_golden.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bidmate.local/schemas/table_extraction_golden.json",
+  "title": "Table extraction golden record",
+  "description": "One labeled table from an RFP source document. Used as ground truth for HWP/Upstage parser comparison (issue #728, PR-A0). One JSONL line = one table.",
+  "type": "object",
+  "required": [
+    "doc_id",
+    "source_path",
+    "table_index",
+    "rows",
+    "cols",
+    "cells",
+    "extractor",
+    "extracted_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "doc_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Document identifier (typically source file stem)."
+    },
+    "source_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the source document the table was extracted from."
+    },
+    "page": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "description": "1-indexed source page. Null when the parser does not expose page mappings (pyhwp event stream)."
+    },
+    "table_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "0-indexed table position within the document."
+    },
+    "rows": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Declared row count from the parser."
+    },
+    "cols": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Declared column count from the parser."
+    },
+    "caption": {
+      "type": ["string", "null"],
+      "description": "Caption text immediately preceding the table (e.g., '표 3.1 평가 배점'). Null in dumped drafts; filled by the labeler."
+    },
+    "table_kind": {
+      "type": ["string", "null"],
+      "enum": ["evaluation", "requirement", "schedule", "other", null],
+      "description": "Semantic table category. Null in dumped drafts; filled by the labeler. Used by axis #2 of the table-handling plan to drive per-kind chunking policy."
+    },
+    "cells": {
+      "type": "array",
+      "minItems": 0,
+      "description": "Flat list of cells preserving HWP-native row/col coordinates and span info.",
+      "items": {
+        "type": "object",
+        "required": ["row", "col", "rowspan", "colspan", "text"],
+        "additionalProperties": false,
+        "properties": {
+          "row": {"type": "integer", "minimum": 0},
+          "col": {"type": "integer", "minimum": 0},
+          "rowspan": {"type": "integer", "minimum": 1},
+          "colspan": {"type": "integer", "minimum": 1},
+          "text": {"type": "string"}
+        }
+      }
+    },
+    "extractor": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the extractor that produced this draft (e.g., 'pyhwp_native_tables', 'upstage_document_parser')."
+    },
+    "extracted_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp of extraction."
+    },
+    "notes": {
+      "type": ["string", "null"],
+      "description": "Free-form labeler notes. Null in dumped drafts."
+    }
+  }
+}

--- a/eval/table_extraction_metrics.py
+++ b/eval/table_extraction_metrics.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Table extraction metrics (issue #790, PR-A3).
+
+Scores an extractor JSONL (PR-A0 ``pyhwp_native_tables`` or PR-A1
+``upstage_document_parser``) against a human-labeled golden JSONL. Both
+inputs share ``eval/data/table_extraction_golden.schema.json``.
+
+Computed metrics (parser-intrinsic, all micro-aggregated across the
+intersection of ``(doc_id, table_index)`` pairs):
+
+* **Cell-level F1** — Levenshtein-similarity match (default threshold
+  0.9, NFKC + whitespace-collapse + casefold) over the intersection of
+  ``(row, col)`` coordinates.
+* **Table-level recall / precision / F1** — does the extractor find
+  each golden table? Does it fabricate any?
+* **Merge-cell preservation rate** — fraction of golden cells with
+  ``rowspan > 1`` or ``colspan > 1`` that the extractor reproduces at
+  the same coordinate with matching span dimensions.
+
+PR-B consumes the output JSON when evaluating the preregistered
+decision criteria (Δ ≥ +5%p threshold for adopting the Upstage opt-in
+ablation).
+
+Off-pipeline. Pure stdlib (no Levenshtein library); load-bearing paths
+untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import unicodedata
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+DEFAULT_SIMILARITY_THRESHOLD = 0.9
+PER_PAIR_SAMPLE_CAP = 50
+
+
+# --- text normalization + Levenshtein (stdlib, no deps) ---------------
+
+
+def _normalize_text(text: Any) -> str:
+    """NFKC + whitespace-collapse + casefold. Preserves punctuation.
+
+    RFP IDs (``FR-007``, ``R3.1``) and scores (``60점``) carry meaning
+    in punctuation, so we do not strip it.
+    """
+    if text is None:
+        return ""
+    nfkc = unicodedata.normalize("NFKC", str(text))
+    return " ".join(nfkc.split()).casefold()
+
+
+def levenshtein(a: str, b: str) -> int:
+    """Wagner-Fischer edit distance. O(len(a)*len(b)) time, O(min(...)) space."""
+    if a == b:
+        return 0
+    if len(a) < len(b):
+        a, b = b, a
+    if len(b) == 0:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i]
+        for j, cb in enumerate(b, start=1):
+            ins = curr[j - 1] + 1
+            dele = prev[j] + 1
+            sub = prev[j - 1] + (0 if ca == cb else 1)
+            curr.append(min(ins, dele, sub))
+        prev = curr
+    return prev[-1]
+
+
+def similarity(a: Any, b: Any) -> float:
+    """Levenshtein similarity in ``[0, 1]`` after normalization."""
+    na = _normalize_text(a)
+    nb = _normalize_text(b)
+    if not na and not nb:
+        return 1.0
+    m = max(len(na), len(nb))
+    if m == 0:
+        return 1.0
+    return 1.0 - levenshtein(na, nb) / m
+
+
+# --- JSONL + indexing ------------------------------------------------
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+    return records
+
+
+def _index_records(records: Iterable[dict[str, Any]]) -> dict[tuple[str, int], dict[str, Any]]:
+    out: dict[tuple[str, int], dict[str, Any]] = {}
+    for rec in records:
+        doc_id = str(rec.get("doc_id", ""))
+        table_index = int(rec.get("table_index", 0) or 0)
+        out[(doc_id, table_index)] = rec
+    return out
+
+
+def _cells_by_coord(rec: dict[str, Any]) -> dict[tuple[int, int], dict[str, Any]]:
+    out: dict[tuple[int, int], dict[str, Any]] = {}
+    for cell in rec.get("cells") or []:
+        coord = (int(cell.get("row", 0) or 0), int(cell.get("col", 0) or 0))
+        out[coord] = cell
+    return out
+
+
+# --- per-table metrics ------------------------------------------------
+
+
+def _p_r_f1(tp: int, fp: int, fn: int) -> tuple[float, float, float]:
+    p = tp / (tp + fp) if (tp + fp) else (1.0 if fn == 0 else 0.0)
+    r = tp / (tp + fn) if (tp + fn) else (1.0 if fp == 0 else 0.0)
+    f1 = (2 * p * r) / (p + r) if (p + r) else 0.0
+    return p, r, f1
+
+
+def cell_f1(
+    golden_rec: dict[str, Any],
+    extracted_rec: dict[str, Any],
+    *,
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+) -> dict[str, Any]:
+    """Cell-level F1 over coord intersection with fuzzy text match.
+
+    TP = golden coord present in extracted AND similarity ≥ threshold.
+    FP = extracted coord absent from golden OR fails similarity.
+    FN = golden coord absent from extracted OR fails similarity.
+    """
+    g_cells = _cells_by_coord(golden_rec)
+    e_cells = _cells_by_coord(extracted_rec)
+    tp = 0
+    for coord, g_cell in g_cells.items():
+        e_cell = e_cells.get(coord)
+        if not e_cell:
+            continue
+        if similarity(g_cell.get("text", ""), e_cell.get("text", "")) >= similarity_threshold:
+            tp += 1
+    fp = len(e_cells) - tp
+    fn = len(g_cells) - tp
+    p, r, f1 = _p_r_f1(tp, fp, fn)
+    return {
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "precision": round(p, 4),
+        "recall": round(r, 4),
+        "f1": round(f1, 4),
+    }
+
+
+def merge_cell_preservation(
+    golden_rec: dict[str, Any],
+    extracted_rec: dict[str, Any],
+) -> dict[str, Any]:
+    """Fraction of golden merged cells reproduced with matching span dims."""
+    g_cells = _cells_by_coord(golden_rec)
+    e_cells = _cells_by_coord(extracted_rec)
+    g_merged = {
+        coord: cell
+        for coord, cell in g_cells.items()
+        if int(cell.get("rowspan", 1) or 1) > 1
+        or int(cell.get("colspan", 1) or 1) > 1
+    }
+    if not g_merged:
+        return {"golden_merge_count": 0, "preserved": 0, "rate": 1.0}
+    preserved = 0
+    for coord, g_cell in g_merged.items():
+        e_cell = e_cells.get(coord)
+        if not e_cell:
+            continue
+        if int(e_cell.get("rowspan", 1) or 1) == int(g_cell.get("rowspan", 1) or 1) and int(
+            e_cell.get("colspan", 1) or 1
+        ) == int(g_cell.get("colspan", 1) or 1):
+            preserved += 1
+    return {
+        "golden_merge_count": len(g_merged),
+        "preserved": preserved,
+        "rate": round(preserved / len(g_merged), 4),
+    }
+
+
+# --- aggregate -------------------------------------------------------
+
+
+def table_level_metrics(
+    golden: Iterable[dict[str, Any]],
+    extracted: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    g_keys = set(_index_records(golden))
+    e_keys = set(_index_records(extracted))
+    tp = len(g_keys & e_keys)
+    fp = len(e_keys - g_keys)
+    fn = len(g_keys - e_keys)
+    p, r, f1 = _p_r_f1(tp, fp, fn)
+    return {
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "precision": round(p, 4),
+        "recall": round(r, 4),
+        "f1": round(f1, 4),
+    }
+
+
+def compute(
+    golden: list[dict[str, Any]],
+    extracted: list[dict[str, Any]],
+    *,
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+) -> dict[str, Any]:
+    """Run all metrics and return a summary dict."""
+    g_index = _index_records(golden)
+    e_index = _index_records(extracted)
+    common = sorted(set(g_index) & set(e_index))
+
+    per_pair: list[dict[str, Any]] = []
+    total_tp = total_fp = total_fn = 0
+    total_merge_g = total_merge_p = 0
+    for key in common:
+        cell = cell_f1(
+            g_index[key],
+            e_index[key],
+            similarity_threshold=similarity_threshold,
+        )
+        merge = merge_cell_preservation(g_index[key], e_index[key])
+        per_pair.append(
+            {
+                "doc_id": key[0],
+                "table_index": key[1],
+                "cell_f1": cell,
+                "merge_preservation": merge,
+            }
+        )
+        total_tp += cell["tp"]
+        total_fp += cell["fp"]
+        total_fn += cell["fn"]
+        total_merge_g += merge["golden_merge_count"]
+        total_merge_p += merge["preserved"]
+
+    micro_p, micro_r, micro_f1 = _p_r_f1(total_tp, total_fp, total_fn)
+    merge_rate = (total_merge_p / total_merge_g) if total_merge_g else 1.0
+
+    return {
+        "similarity_threshold": similarity_threshold,
+        "table_level": table_level_metrics(golden, extracted),
+        "cell_level_micro": {
+            "tp": total_tp,
+            "fp": total_fp,
+            "fn": total_fn,
+            "precision": round(micro_p, 4),
+            "recall": round(micro_r, 4),
+            "f1": round(micro_f1, 4),
+        },
+        "merge_cell_preservation_micro": {
+            "golden_merge_count": total_merge_g,
+            "preserved": total_merge_p,
+            "rate": round(merge_rate, 4),
+        },
+        "common_table_pair_count": len(common),
+        "per_pair_sample": per_pair[:PER_PAIR_SAMPLE_CAP],
+    }
+
+
+# --- CLI -------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute table-extraction metrics (issue #790, PR-A3). "
+            "Inputs share eval/data/table_extraction_golden.schema.json. "
+            "Off-pipeline."
+        )
+    )
+    parser.add_argument(
+        "--golden",
+        type=Path,
+        required=True,
+        help="Human-labeled golden JSONL.",
+    )
+    parser.add_argument(
+        "--extracted",
+        type=Path,
+        required=True,
+        help="Extractor JSONL (PR-A0 native or PR-A1 upstage output).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=REPO_ROOT / "reports" / "table_extraction_metrics.json",
+        help=(
+            "Output metrics JSON path "
+            "(default: reports/table_extraction_metrics.json)."
+        ),
+    )
+    parser.add_argument(
+        "--similarity-threshold",
+        type=float,
+        default=DEFAULT_SIMILARITY_THRESHOLD,
+        help=(
+            "Levenshtein similarity threshold for cell text match "
+            "(default: 0.9)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    for label, path in (("--golden", args.golden), ("--extracted", args.extracted)):
+        if not path.exists() or not path.is_file():
+            print(
+                f"error: {label} does not exist or is not a file: {path}",
+                file=sys.stderr,
+            )
+            return 2
+    golden = load_jsonl(args.golden)
+    extracted = load_jsonl(args.extracted)
+    report = compute(
+        golden,
+        extracted,
+        similarity_threshold=args.similarity_threshold,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    summary = {k: v for k, v in report.items() if k != "per_pair_sample"}
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    print(f"\nWrote {args.out}.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare_table_parsers.py
+++ b/scripts/compare_table_parsers.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Compare two table-extractor dumps (issue #781, PR-A2).
+
+Reads two JSONL files produced by ``scripts/dump_hwp_tables.py`` (PR-A0)
+and ``scripts/extract_hwp_via_upstage.py`` (PR-A1) — or any extractor
+that emits the shared
+``eval/data/table_extraction_golden.schema.json`` shape — and produces
+a side-by-side diff so the labeler can spot disagreements before the
+golden labeling pass.
+
+This script intentionally computes only **basic** stats (exact-match
+rate, cell-count delta, missing-on-left, missing-on-right). PR-A3 adds
+the full RFP-specific metrics (cell F1, boundary F1, merge-cell
+preservation, caption attachment).
+
+Off-pipeline. Default HWP loader (ADR 0036) unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import unicodedata
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _normalize_text(text: str) -> str:
+    """NFKC + whitespace-collapse + casefold for cell-text matching.
+
+    Conservative: collapses runs of whitespace and trims, but does not
+    drop punctuation (RFP tables use punctuation as meaningful
+    separators — e.g. '60점', 'FR-007').
+    """
+    if text is None:
+        return ""
+    nfkc = unicodedata.normalize("NFKC", str(text))
+    collapsed = " ".join(nfkc.split())
+    return collapsed.casefold()
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file into a list of records. Skips blank lines."""
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+    return records
+
+
+def index_records(records: Iterable[dict[str, Any]]) -> dict[tuple[str, int], dict[str, Any]]:
+    """Index by ``(doc_id, table_index)`` for stable join."""
+    out: dict[tuple[str, int], dict[str, Any]] = {}
+    for rec in records:
+        doc_id = str(rec.get("doc_id", ""))
+        table_index = int(rec.get("table_index", 0) or 0)
+        out[(doc_id, table_index)] = rec
+    return out
+
+
+def _cells_by_coord(rec: dict[str, Any]) -> dict[tuple[int, int], str]:
+    """Index a record's cells by ``(row, col)`` → text (normalized)."""
+    out: dict[tuple[int, int], str] = {}
+    for cell in rec.get("cells") or []:
+        row = int(cell.get("row", 0) or 0)
+        col = int(cell.get("col", 0) or 0)
+        text = _normalize_text(cell.get("text", ""))
+        out[(row, col)] = text
+    return out
+
+
+def diff_pair(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
+    """Compute per-table diff between two records of the same key.
+
+    Returns a dict with cell-count delta, exact-match rate over the
+    intersection of coordinates, and lists of left-only / right-only
+    coordinates (cap at 50 entries each to keep the report bounded).
+    """
+    left_cells = _cells_by_coord(left)
+    right_cells = _cells_by_coord(right)
+    left_coords = set(left_cells)
+    right_coords = set(right_cells)
+    common = left_coords & right_coords
+
+    matches = sum(
+        1 for coord in common if left_cells[coord] == right_cells[coord]
+    )
+    exact_match_rate = (matches / len(common)) if common else 0.0
+
+    only_left = sorted(left_coords - right_coords)[:50]
+    only_right = sorted(right_coords - left_coords)[:50]
+    mismatched = sorted(
+        coord for coord in common if left_cells[coord] != right_cells[coord]
+    )[:50]
+
+    return {
+        "doc_id": left.get("doc_id"),
+        "table_index": left.get("table_index"),
+        "left_cell_count": len(left_cells),
+        "right_cell_count": len(right_cells),
+        "cell_count_delta": len(right_cells) - len(left_cells),
+        "common_coord_count": len(common),
+        "exact_match_count": matches,
+        "exact_match_rate": round(exact_match_rate, 4),
+        "only_left_coords_sample": [list(c) for c in only_left],
+        "only_right_coords_sample": [list(c) for c in only_right],
+        "mismatched_coords_sample": [list(c) for c in mismatched],
+    }
+
+
+def compare(left: list[dict[str, Any]], right: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compare two extractor dumps and return a summary + per-pair diffs.
+
+    Summary fields:
+      * ``left_table_count`` / ``right_table_count``
+      * ``common_table_count`` (keys present in both)
+      * ``only_left_table_count`` / ``only_right_table_count``
+      * ``per_doc`` — table count by doc on each side
+      * ``aggregate_exact_match_rate`` — micro-average over common coords
+    """
+    left_index = index_records(left)
+    right_index = index_records(right)
+    common_keys = sorted(set(left_index) & set(right_index))
+    only_left_keys = sorted(set(left_index) - set(right_index))
+    only_right_keys = sorted(set(right_index) - set(left_index))
+
+    per_pair: list[dict[str, Any]] = []
+    total_common = 0
+    total_matches = 0
+    for key in common_keys:
+        pair_diff = diff_pair(left_index[key], right_index[key])
+        per_pair.append(pair_diff)
+        total_common += pair_diff["common_coord_count"]
+        total_matches += pair_diff["exact_match_count"]
+
+    aggregate_rate = (total_matches / total_common) if total_common else 0.0
+
+    per_doc_left: dict[str, int] = defaultdict(int)
+    per_doc_right: dict[str, int] = defaultdict(int)
+    for (doc, _idx) in left_index:
+        per_doc_left[doc] += 1
+    for (doc, _idx) in right_index:
+        per_doc_right[doc] += 1
+
+    summary = {
+        "left_table_count": len(left_index),
+        "right_table_count": len(right_index),
+        "common_table_count": len(common_keys),
+        "only_left_table_count": len(only_left_keys),
+        "only_right_table_count": len(only_right_keys),
+        "only_left_keys_sample": [list(k) for k in only_left_keys[:50]],
+        "only_right_keys_sample": [list(k) for k in only_right_keys[:50]],
+        "aggregate_common_coord_count": total_common,
+        "aggregate_exact_match_count": total_matches,
+        "aggregate_exact_match_rate": round(aggregate_rate, 4),
+        "per_doc_table_counts": {
+            doc: {
+                "left": per_doc_left.get(doc, 0),
+                "right": per_doc_right.get(doc, 0),
+            }
+            for doc in sorted(set(per_doc_left) | set(per_doc_right))
+        },
+    }
+    return {"summary": summary, "per_pair": per_pair}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare two table-extractor JSONL dumps (issue #781, PR-A2). "
+            "Inputs share the eval/data/table_extraction_golden.schema.json "
+            "schema. Off-pipeline."
+        )
+    )
+    parser.add_argument(
+        "--left",
+        type=Path,
+        required=True,
+        help="Left extractor JSONL (e.g. outputs/table_golden_draft.jsonl).",
+    )
+    parser.add_argument(
+        "--right",
+        type=Path,
+        required=True,
+        help="Right extractor JSONL (e.g. outputs/table_golden_draft_upstage.jsonl).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=REPO_ROOT / "outputs" / "table_parser_compare.json",
+        help=(
+            "Output comparison JSON path "
+            "(default: outputs/table_parser_compare.json, gitignored)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    for label, path in (("--left", args.left), ("--right", args.right)):
+        if not path.exists() or not path.is_file():
+            print(
+                f"error: {label} does not exist or is not a file: {path}",
+                file=sys.stderr,
+            )
+            return 2
+
+    left = load_jsonl(args.left)
+    right = load_jsonl(args.right)
+    report = compare(left, right)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    print(json.dumps(report["summary"], ensure_ascii=False, indent=2))
+    print(
+        f"\nWrote {args.out} ({len(report['per_pair'])} matched table pairs).",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dump_hwp_tables.py
+++ b/scripts/dump_hwp_tables.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Dump pyhwp native table extraction as draft golden JSONL (issue #728).
+
+Walks a directory of HWP files, runs
+``ingestion._extract_hwp_native_with_tables`` on each, and emits one JSONL
+line per non-empty table conforming to
+``eval/data/table_extraction_golden.schema.json``.
+
+Output is a **draft**: ``table_kind``, ``caption``, and ``notes`` are left
+``null`` for the human labeler to fill in. ``page`` is ``null`` because
+pyhwp's event stream does not expose page mappings.
+
+Off-pipeline measurement tool. Default HWP loader (ADR 0036) is unchanged.
+Gracefully skips when pyhwp is unavailable so CI minimal installs remain
+green. Per-file extraction errors are reported in the summary, never
+re-raised.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+EXTRACTOR_TAG = "pyhwp_native_tables"
+SKIP_REASON_PYHWP_MISSING = "pyhwp_not_installed"
+
+
+def _pyhwp_available() -> bool:
+    """Return True iff the optional ``hwp5`` package is importable."""
+    return importlib.util.find_spec("hwp5") is not None
+
+
+def _now_iso() -> str:
+    """Return current UTC time in ISO-8601 (seconds precision)."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _has_nonempty_cells(table: dict[str, Any]) -> bool:
+    """True iff at least one cell has non-whitespace text."""
+    for cell in table.get("cells") or []:
+        if str(cell.get("text", "")).strip():
+            return True
+    return False
+
+
+def dump_record(
+    doc_id: str,
+    source_path: Path,
+    table: dict[str, Any],
+    *,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    """Build one golden draft record from a pyhwp-extracted table.
+
+    ``now_iso`` is injectable so tests can pin a deterministic timestamp.
+    """
+    return {
+        "doc_id": doc_id,
+        "source_path": str(source_path),
+        "page": None,
+        "table_index": int(table.get("table_index", 0) or 0),
+        "rows": int(table.get("rows", 0) or 0),
+        "cols": int(table.get("cols", 0) or 0),
+        "caption": None,
+        "table_kind": None,
+        "cells": [
+            {
+                "row": int(cell.get("row", 0) or 0),
+                "col": int(cell.get("col", 0) or 0),
+                "rowspan": int(cell.get("rowspan", 1) or 1),
+                "colspan": int(cell.get("colspan", 1) or 1),
+                "text": str(cell.get("text", "")),
+            }
+            for cell in (table.get("cells") or [])
+        ],
+        "extractor": EXTRACTOR_TAG,
+        "extracted_at": now_iso or _now_iso(),
+        "notes": None,
+    }
+
+
+def iter_hwp_files(hwp_dir: Path) -> Iterable[Path]:
+    """Yield ``.hwp`` files in ``hwp_dir`` in deterministic (sorted) order."""
+    return sorted(p for p in hwp_dir.glob("*.hwp") if p.is_file())
+
+
+def dump_directory(hwp_dir: Path, out_path: Path) -> dict[str, Any]:
+    """Iterate ``hwp_dir`` and emit one JSONL line per non-empty table.
+
+    Returns a summary dict for the CLI to print. Never raises on per-file
+    extraction errors — each failure is reported in the summary's
+    ``failures`` list instead.
+    """
+    if not _pyhwp_available():
+        return {
+            "status": "skipped",
+            "reason": SKIP_REASON_PYHWP_MISSING,
+            "files_seen": 0,
+            "tables_dumped": 0,
+            "failures": [],
+        }
+
+    # Late import: pyhwp is opt-in (ADR 0036). Importing ``ingestion`` only
+    # after the availability check keeps ``--help`` working in minimal envs.
+    from ingestion import _extract_hwp_native_with_tables  # type: ignore[import-not-found]
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    files = list(iter_hwp_files(hwp_dir))
+    tables_dumped = 0
+    failures: list[dict[str, str]] = []
+
+    with out_path.open("w", encoding="utf-8") as fh:
+        for source in files:
+            try:
+                _text, tables = _extract_hwp_native_with_tables(source)
+            except Exception as exc:  # noqa: BLE001 — per-file isolation
+                failures.append({"file": source.name, "error": repr(exc)})
+                continue
+            for table in tables:
+                if not _has_nonempty_cells(table):
+                    continue
+                record = dump_record(
+                    doc_id=source.stem,
+                    source_path=source,
+                    table=table,
+                )
+                fh.write(json.dumps(record, ensure_ascii=False))
+                fh.write("\n")
+                tables_dumped += 1
+
+    return {
+        "status": "ok",
+        "files_seen": len(files),
+        "tables_dumped": tables_dumped,
+        "failures": failures,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Dump pyhwp native table extraction as draft golden JSONL "
+            "(issue #728, PR-A0 of HWP RAG table experiment). "
+            "Off-pipeline measurement only; the default HWP loader is unchanged."
+        )
+    )
+    parser.add_argument(
+        "--hwp-dir",
+        type=Path,
+        required=True,
+        help="Directory containing .hwp files (local-only; ADR 0005 boundary).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=REPO_ROOT / "outputs" / "table_golden_draft.jsonl",
+        help=(
+            "Output JSONL path "
+            "(default: outputs/table_golden_draft.jsonl, gitignored)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    hwp_dir = args.hwp_dir
+    if not hwp_dir.exists() or not hwp_dir.is_dir():
+        print(
+            f"error: --hwp-dir does not exist or is not a directory: {hwp_dir}",
+            file=sys.stderr,
+        )
+        return 2
+    summary = dump_directory(hwp_dir, args.out)
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if summary["status"] == "skipped":
+        print(
+            "pyhwp not installed — install via `pip install pyhwp` to dump tables.",
+            file=sys.stderr,
+        )
+        return 0
+    print(
+        f"\nWrote {args.out} ({summary['tables_dumped']} tables from "
+        f"{summary['files_seen']} files).",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/extract_hwp_via_upstage.py
+++ b/scripts/extract_hwp_via_upstage.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Extract HWP tables via Upstage Document Parser (issue #773, PR-A1).
+
+Companion to ``scripts/dump_hwp_tables.py`` (PR-A0). Produces the same
+golden-draft JSONL shape but via Upstage's layout-aware Document Parser
+instead of pyhwp's event stream. Used downstream by PR-A2's comparison
+script (``pyhwp_native_tables`` vs ``upstage_document_parser``) on the
+human-labeled golden.
+
+Off-pipeline tool. Default HWP loader (ADR 0036) is unchanged.
+``ingestion.py`` is **not** touched on purpose: keeping the Upstage path
+out of the load-bearing dispatch avoids the §5b friction and means the
+script can be iterated independently of the runtime path.
+
+Gracefully skips when ``UPSTAGE_API_KEY`` is unset so the script can be
+imported / ``--help``-ed without secrets. Per-file API failures are
+isolated; the failing file's name + error appear in the summary's
+``failures`` list instead of being raised.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import requests
+from bs4 import BeautifulSoup
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+UPSTAGE_API_URL = "https://api.upstage.ai/v1/document-ai/document-parse"
+DEFAULT_MODEL = "document-parse"
+DEFAULT_TIMEOUT_S = 120.0
+EXTRACTOR_TAG = "upstage_document_parser"
+SKIP_REASON_KEY_MISSING = "upstage_api_key_missing"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _get_api_key() -> str | None:
+    key = os.environ.get("UPSTAGE_API_KEY", "").strip()
+    return key or None
+
+
+def _has_nonempty_cells(table: dict[str, Any]) -> bool:
+    for cell in table.get("cells") or []:
+        if str(cell.get("text", "")).strip():
+            return True
+    return False
+
+
+def parse_table_html(html: str) -> tuple[int, int, list[dict[str, Any]]]:
+    """Parse one ``<table>`` HTML fragment into ``(rows, cols, cells)``.
+
+    ``cells`` is a flat list of
+    ``{"row", "col", "rowspan", "colspan", "text"}`` matching the PR-A0
+    schema. An internal occupancy grid handles ``rowspan`` so that a
+    later cell in the same row gets the right ``col`` index.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table") or soup
+    grid: list[list[bool]] = []
+    cells: list[dict[str, Any]] = []
+    max_cols = 0
+
+    rows = table.find_all("tr")
+    for row_idx, tr in enumerate(rows):
+        while len(grid) <= row_idx:
+            grid.append([])
+
+        col_idx = 0
+        for td in tr.find_all(["td", "th"]):
+            # Skip past columns already occupied by an earlier rowspan.
+            while col_idx < len(grid[row_idx]) and grid[row_idx][col_idx]:
+                col_idx += 1
+
+            rowspan = int(td.get("rowspan", 1) or 1)
+            colspan = int(td.get("colspan", 1) or 1)
+            text = td.get_text(separator=" ", strip=True)
+
+            # Mark this cell and any spanned rows/cols as occupied.
+            for dr in range(rowspan):
+                rr = row_idx + dr
+                while len(grid) <= rr:
+                    grid.append([])
+                while len(grid[rr]) < col_idx + colspan:
+                    grid[rr].append(False)
+                for dc in range(colspan):
+                    grid[rr][col_idx + dc] = True
+
+            cells.append(
+                {
+                    "row": row_idx,
+                    "col": col_idx,
+                    "rowspan": rowspan,
+                    "colspan": colspan,
+                    "text": text,
+                }
+            )
+            max_cols = max(max_cols, col_idx + colspan)
+            col_idx += colspan
+
+    return len(rows), max_cols, cells
+
+
+def extract_tables_from_response(response: dict[str, Any]) -> list[dict[str, Any]]:
+    """Walk an Upstage response and return per-table records.
+
+    Tolerates two known shape variants:
+      * top-level ``elements[*].html`` (newer responses)
+      * nested ``elements[*].content.html`` (older responses)
+
+    Each returned record has the keys consumed by ``dump_record``:
+    ``table_index`` (0-indexed within the doc), ``rows``, ``cols``,
+    ``page`` (or None), ``cells``.
+    """
+    elements = response.get("elements") or []
+    tables: list[dict[str, Any]] = []
+    table_index = 0
+    for element in elements:
+        if not isinstance(element, dict):
+            continue
+        category = element.get("category") or element.get("type") or ""
+        if str(category).lower() != "table":
+            continue
+        html = element.get("html") or ""
+        if not html:
+            content = element.get("content")
+            if isinstance(content, dict):
+                html = content.get("html") or ""
+        if not html:
+            continue
+        rows, cols, cells = parse_table_html(html)
+        if not cells:
+            continue
+        page = element.get("page")
+        tables.append(
+            {
+                "table_index": table_index,
+                "rows": rows,
+                "cols": cols,
+                "page": int(page) if isinstance(page, int) else None,
+                "cells": cells,
+            }
+        )
+        table_index += 1
+    return tables
+
+
+def dump_record(
+    doc_id: str,
+    source_path: Path,
+    table: dict[str, Any],
+    *,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    """Build one golden-draft record. Same schema as PR-A0."""
+    return {
+        "doc_id": doc_id,
+        "source_path": str(source_path),
+        "page": table.get("page"),
+        "table_index": int(table.get("table_index", 0) or 0),
+        "rows": int(table.get("rows", 0) or 0),
+        "cols": int(table.get("cols", 0) or 0),
+        "caption": None,
+        "table_kind": None,
+        "cells": [
+            {
+                "row": int(cell.get("row", 0) or 0),
+                "col": int(cell.get("col", 0) or 0),
+                "rowspan": int(cell.get("rowspan", 1) or 1),
+                "colspan": int(cell.get("colspan", 1) or 1),
+                "text": str(cell.get("text", "")),
+            }
+            for cell in (table.get("cells") or [])
+        ],
+        "extractor": EXTRACTOR_TAG,
+        "extracted_at": now_iso or _now_iso(),
+        "notes": None,
+    }
+
+
+def call_upstage(
+    source_path: Path,
+    *,
+    api_key: str,
+    api_url: str = UPSTAGE_API_URL,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    session: requests.Session | None = None,
+) -> dict[str, Any]:
+    """POST one file to the Upstage Document Parse endpoint.
+
+    Returns the parsed JSON body. Raises ``requests.HTTPError`` on
+    non-2xx status; callers in ``extract_directory`` catch and convert
+    to per-file failures.
+    """
+    http = session or requests.Session()
+    with source_path.open("rb") as fh:
+        files = {
+            "document": (source_path.name, fh, "application/octet-stream"),
+        }
+        data = {
+            "model": DEFAULT_MODEL,
+            "ocr": "auto",
+            "output_formats": json.dumps(["html"]),
+            "coordinates": "false",
+        }
+        headers = {"Authorization": f"Bearer {api_key}"}
+        resp = http.post(
+            api_url,
+            headers=headers,
+            files=files,
+            data=data,
+            timeout=timeout_s,
+        )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def iter_hwp_files(hwp_dir: Path) -> Iterable[Path]:
+    return sorted(p for p in hwp_dir.glob("*.hwp") if p.is_file())
+
+
+def extract_directory(
+    hwp_dir: Path,
+    out_path: Path,
+    *,
+    api_key: str | None = None,
+    api_url: str = UPSTAGE_API_URL,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    session: requests.Session | None = None,
+) -> dict[str, Any]:
+    """Iterate ``hwp_dir`` and emit one JSONL line per non-empty table.
+
+    Returns a summary dict (``status``, ``files_seen``, ``tables_dumped``,
+    ``failures``). Never raises on per-file errors.
+    """
+    resolved_key = api_key if api_key is not None else _get_api_key()
+    if not resolved_key:
+        return {
+            "status": "skipped",
+            "reason": SKIP_REASON_KEY_MISSING,
+            "files_seen": 0,
+            "tables_dumped": 0,
+            "failures": [],
+        }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    files = list(iter_hwp_files(hwp_dir))
+    tables_dumped = 0
+    failures: list[dict[str, str]] = []
+
+    with out_path.open("w", encoding="utf-8") as fh:
+        for source in files:
+            try:
+                response = call_upstage(
+                    source,
+                    api_key=resolved_key,
+                    api_url=api_url,
+                    timeout_s=timeout_s,
+                    session=session,
+                )
+                tables = extract_tables_from_response(response)
+            except Exception as exc:  # noqa: BLE001 — per-file isolation
+                failures.append({"file": source.name, "error": repr(exc)})
+                continue
+            for table in tables:
+                if not _has_nonempty_cells(table):
+                    continue
+                record = dump_record(
+                    doc_id=source.stem,
+                    source_path=source,
+                    table=table,
+                )
+                fh.write(json.dumps(record, ensure_ascii=False))
+                fh.write("\n")
+                tables_dumped += 1
+
+    return {
+        "status": "ok",
+        "files_seen": len(files),
+        "tables_dumped": tables_dumped,
+        "failures": failures,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract HWP tables via Upstage Document Parser as draft golden "
+            "JSONL (issue #773, PR-A1 of HWP RAG table experiment). "
+            "Off-pipeline; companion to scripts/dump_hwp_tables.py. "
+            "Requires UPSTAGE_API_KEY env var to actually call the API."
+        )
+    )
+    parser.add_argument(
+        "--hwp-dir",
+        type=Path,
+        required=True,
+        help="Directory containing .hwp files (local-only; ADR 0005 boundary).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=REPO_ROOT / "outputs" / "table_golden_draft_upstage.jsonl",
+        help=(
+            "Output JSONL path "
+            "(default: outputs/table_golden_draft_upstage.jsonl, gitignored)."
+        ),
+    )
+    parser.add_argument(
+        "--api-url",
+        default=UPSTAGE_API_URL,
+        help="Override the Upstage Document Parse endpoint URL.",
+    )
+    parser.add_argument(
+        "--timeout-s",
+        type=float,
+        default=DEFAULT_TIMEOUT_S,
+        help="Per-file timeout in seconds (default: 120).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    hwp_dir = args.hwp_dir
+    if not hwp_dir.exists() or not hwp_dir.is_dir():
+        print(
+            f"error: --hwp-dir does not exist or is not a directory: {hwp_dir}",
+            file=sys.stderr,
+        )
+        return 2
+    summary = extract_directory(
+        hwp_dir,
+        args.out,
+        api_url=args.api_url,
+        timeout_s=args.timeout_s,
+    )
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if summary["status"] == "skipped":
+        print(
+            "UPSTAGE_API_KEY not set — export the key to enable Upstage calls.",
+            file=sys.stderr,
+        )
+        return 0
+    print(
+        f"\nWrote {args.out} ({summary['tables_dumped']} tables from "
+        f"{summary['files_seen']} files).",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_compare_table_parsers.py
+++ b/tests/test_compare_table_parsers.py
@@ -1,0 +1,209 @@
+"""Unit tests for scripts/compare_table_parsers.py (issue #781, PR-A2)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import compare_table_parsers as cmp  # noqa: E402
+
+
+def _record(
+    doc_id: str,
+    table_index: int,
+    cells: list[tuple[int, int, str]],
+    *,
+    extractor: str = "pyhwp_native_tables",
+) -> dict[str, Any]:
+    return {
+        "doc_id": doc_id,
+        "source_path": f"/tmp/{doc_id}.hwp",
+        "page": None,
+        "table_index": table_index,
+        "rows": max((r for r, _, _ in cells), default=-1) + 1,
+        "cols": max((c for _, c, _ in cells), default=-1) + 1,
+        "caption": None,
+        "table_kind": None,
+        "cells": [
+            {"row": r, "col": c, "rowspan": 1, "colspan": 1, "text": t}
+            for r, c, t in cells
+        ],
+        "extractor": extractor,
+        "extracted_at": "2026-05-14T00:00:00+00:00",
+        "notes": None,
+    }
+
+
+# --- normalize_text ----------------------------------------------------
+
+
+def test_normalize_text_nfkc_and_whitespace() -> None:
+    # full-width "６０" → ascii "60"; surrounding spaces collapse.
+    assert cmp._normalize_text("  ６０ ") == "60"
+
+
+def test_normalize_text_casefold() -> None:
+    assert cmp._normalize_text("Mixed") == "mixed"
+
+
+def test_normalize_text_preserves_punctuation() -> None:
+    # FR-007 keeps the hyphen — RFP IDs are meaningful with punctuation.
+    assert cmp._normalize_text("FR-007") == "fr-007"
+
+
+# --- diff_pair ---------------------------------------------------------
+
+
+def test_diff_pair_exact_match() -> None:
+    a = _record("doc1", 0, [(0, 0, "a"), (0, 1, "b")])
+    b = _record("doc1", 0, [(0, 0, "A"), (0, 1, "b")])  # casefold matches
+    result = cmp.diff_pair(a, b)
+    assert result["left_cell_count"] == 2
+    assert result["right_cell_count"] == 2
+    assert result["common_coord_count"] == 2
+    assert result["exact_match_count"] == 2
+    assert result["exact_match_rate"] == 1.0
+    assert result["only_left_coords_sample"] == []
+    assert result["only_right_coords_sample"] == []
+    assert result["mismatched_coords_sample"] == []
+
+
+def test_diff_pair_text_mismatch_recorded() -> None:
+    a = _record("doc1", 0, [(0, 0, "a"), (0, 1, "b")])
+    b = _record("doc1", 0, [(0, 0, "a"), (0, 1, "different")])
+    result = cmp.diff_pair(a, b)
+    assert result["common_coord_count"] == 2
+    assert result["exact_match_count"] == 1
+    assert result["exact_match_rate"] == 0.5
+    assert result["mismatched_coords_sample"] == [[0, 1]]
+
+
+def test_diff_pair_only_left_and_only_right_coords() -> None:
+    a = _record("doc1", 0, [(0, 0, "a"), (1, 0, "left-only")])
+    b = _record("doc1", 0, [(0, 0, "a"), (0, 1, "right-only")])
+    result = cmp.diff_pair(a, b)
+    assert result["left_cell_count"] == 2
+    assert result["right_cell_count"] == 2
+    assert result["cell_count_delta"] == 0
+    assert result["common_coord_count"] == 1
+    assert result["exact_match_count"] == 1
+    assert result["only_left_coords_sample"] == [[1, 0]]
+    assert result["only_right_coords_sample"] == [[0, 1]]
+
+
+def test_diff_pair_empty_both_sides_handles_zero_division() -> None:
+    a = _record("doc1", 0, [])
+    b = _record("doc1", 0, [])
+    result = cmp.diff_pair(a, b)
+    assert result["common_coord_count"] == 0
+    assert result["exact_match_rate"] == 0.0
+
+
+# --- compare (top-level) ----------------------------------------------
+
+
+def test_compare_micro_average_match_rate() -> None:
+    left = [
+        _record("doc1", 0, [(0, 0, "a"), (0, 1, "b")]),
+        _record("doc1", 1, [(0, 0, "x")]),
+    ]
+    right = [
+        _record("doc1", 0, [(0, 0, "a"), (0, 1, "b")]),
+        _record("doc1", 1, [(0, 0, "different")]),
+    ]
+    report = cmp.compare(left, right)
+    summary = report["summary"]
+    assert summary["left_table_count"] == 2
+    assert summary["right_table_count"] == 2
+    assert summary["common_table_count"] == 2
+    # 3 common coords (2 match in table 0 + 0 match in table 1) / 3 coords
+    assert summary["aggregate_common_coord_count"] == 3
+    assert summary["aggregate_exact_match_count"] == 2
+    assert summary["aggregate_exact_match_rate"] == round(2 / 3, 4)
+
+
+def test_compare_lists_tables_missing_on_each_side() -> None:
+    left = [_record("doc1", 0, [(0, 0, "a")]), _record("doc1", 1, [(0, 0, "b")])]
+    right = [_record("doc1", 0, [(0, 0, "a")]), _record("doc1", 2, [(0, 0, "c")])]
+    report = cmp.compare(left, right)
+    summary = report["summary"]
+    assert summary["only_left_table_count"] == 1
+    assert summary["only_right_table_count"] == 1
+    assert ["doc1", 1] in summary["only_left_keys_sample"]
+    assert ["doc1", 2] in summary["only_right_keys_sample"]
+
+
+def test_compare_per_doc_table_counts() -> None:
+    left = [
+        _record("docA", 0, [(0, 0, "x")]),
+        _record("docA", 1, [(0, 0, "y")]),
+        _record("docB", 0, [(0, 0, "z")]),
+    ]
+    right = [
+        _record("docA", 0, [(0, 0, "x")]),
+        _record("docB", 0, [(0, 0, "z")]),
+        _record("docB", 1, [(0, 0, "w")]),
+    ]
+    report = cmp.compare(left, right)
+    per_doc = report["summary"]["per_doc_table_counts"]
+    assert per_doc["docA"] == {"left": 2, "right": 1}
+    assert per_doc["docB"] == {"left": 1, "right": 2}
+
+
+# --- I/O -------------------------------------------------------------
+
+
+def test_load_jsonl_skips_blank_lines(tmp_path: Path) -> None:
+    path = tmp_path / "in.jsonl"
+    path.write_text(
+        json.dumps({"doc_id": "a", "table_index": 0, "cells": []}) + "\n\n"
+        + json.dumps({"doc_id": "b", "table_index": 0, "cells": []}) + "\n",
+        encoding="utf-8",
+    )
+    records = cmp.load_jsonl(path)
+    assert len(records) == 2
+    assert records[0]["doc_id"] == "a"
+
+
+def test_cli_writes_summary_and_returns_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    left_path = tmp_path / "left.jsonl"
+    right_path = tmp_path / "right.jsonl"
+    out_path = tmp_path / "cmp.json"
+
+    rec_left = _record("doc1", 0, [(0, 0, "match"), (0, 1, "left")])
+    rec_right = _record("doc1", 0, [(0, 0, "match"), (0, 1, "right")])
+    left_path.write_text(json.dumps(rec_left) + "\n", encoding="utf-8")
+    right_path.write_text(json.dumps(rec_right) + "\n", encoding="utf-8")
+
+    rc = cmp.main([
+        "--left", str(left_path),
+        "--right", str(right_path),
+        "--out", str(out_path),
+    ])
+    assert rc == 0
+    assert out_path.exists()
+    report = json.loads(out_path.read_text(encoding="utf-8"))
+    assert report["summary"]["common_table_count"] == 1
+    assert report["summary"]["aggregate_common_coord_count"] == 2
+    assert report["summary"]["aggregate_exact_match_count"] == 1
+
+
+def test_cli_returns_2_when_input_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    left = tmp_path / "missing_left.jsonl"
+    right = tmp_path / "missing_right.jsonl"
+    right.write_text("", encoding="utf-8")
+    rc = cmp.main(["--left", str(left), "--right", str(right), "--out", str(tmp_path / "o.json")])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "--left does not exist" in captured.err

--- a/tests/test_dump_hwp_tables.py
+++ b/tests/test_dump_hwp_tables.py
@@ -1,0 +1,200 @@
+"""Unit tests for scripts/dump_hwp_tables.py (issue #728, PR-A0).
+
+These tests:
+
+* Verify the dumper's record shape validates against the published JSON
+  Schema at ``eval/data/table_extraction_golden.schema.json``.
+* Confirm graceful skip when pyhwp is unavailable (CI minimal install
+  safe, per ADR 0036).
+* Confirm the dumper writes one JSONL line per non-empty table when
+  pyhwp is present (verified via a monkey-patched ``ingestion`` module
+  so the test does not require a real HWP fixture).
+
+The tests never import pyhwp directly — they only check the dumper's
+behavior at the boundary it exposes.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import dump_hwp_tables as dumper  # noqa: E402
+
+SCHEMA_PATH = REPO_ROOT / "eval" / "data" / "table_extraction_golden.schema.json"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _sample_table(table_index: int = 0) -> dict[str, Any]:
+    return {
+        "table_index": table_index,
+        "rows": 2,
+        "cols": 2,
+        "cells": [
+            {"row": 0, "col": 0, "rowspan": 1, "colspan": 1, "text": "항목"},
+            {"row": 0, "col": 1, "rowspan": 1, "colspan": 1, "text": "배점"},
+            {"row": 1, "col": 0, "rowspan": 1, "colspan": 1, "text": "기술"},
+            {"row": 1, "col": 1, "rowspan": 1, "colspan": 1, "text": "60"},
+        ],
+    }
+
+
+def test_dump_record_shape_validates_against_schema(schema: dict[str, Any]) -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    record = dumper.dump_record(
+        doc_id="sample",
+        source_path=Path("/tmp/sample.hwp"),
+        table=_sample_table(table_index=3),
+        now_iso="2026-05-14T00:00:00+00:00",
+    )
+    assert record["doc_id"] == "sample"
+    assert record["table_index"] == 3
+    assert record["table_kind"] is None
+    assert record["caption"] is None
+    assert record["notes"] is None
+    assert record["cells"][0]["text"] == "항목"
+    assert record["extractor"] == "pyhwp_native_tables"
+    jsonschema.validate(instance=record, schema=schema)
+
+
+def test_has_nonempty_cells_filters_whitespace_only() -> None:
+    empty = {
+        "table_index": 0,
+        "rows": 1,
+        "cols": 1,
+        "cells": [{"row": 0, "col": 0, "rowspan": 1, "colspan": 1, "text": "  "}],
+    }
+    assert not dumper._has_nonempty_cells(empty)
+    assert dumper._has_nonempty_cells(_sample_table())
+
+
+def test_dump_directory_skipped_when_pyhwp_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dumper, "_pyhwp_available", lambda: False)
+    out = tmp_path / "out.jsonl"
+    summary = dumper.dump_directory(tmp_path, out)
+    assert summary["status"] == "skipped"
+    assert summary["reason"] == dumper.SKIP_REASON_PYHWP_MISSING
+    assert summary["tables_dumped"] == 0
+    assert not out.exists()
+
+
+def test_dump_directory_writes_jsonl_when_pyhwp_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    schema: dict[str, Any],
+) -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    monkeypatch.setattr(dumper, "_pyhwp_available", lambda: True)
+
+    # A dummy file on disk so ``iter_hwp_files`` returns one path; the
+    # contents do not matter because the extractor is monkey-patched.
+    fake_hwp = tmp_path / "fake.hwp"
+    fake_hwp.write_bytes(b"\x00")
+
+    def fake_extract(source_path: Path):
+        return None, [_sample_table(table_index=0), _sample_table(table_index=1)]
+
+    fake_module = types.ModuleType("ingestion")
+    fake_module._extract_hwp_native_with_tables = fake_extract  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "ingestion", fake_module)
+
+    out = tmp_path / "draft.jsonl"
+    summary = dumper.dump_directory(tmp_path, out)
+    assert summary["status"] == "ok"
+    assert summary["files_seen"] == 1
+    assert summary["tables_dumped"] == 2
+    assert summary["failures"] == []
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        record = json.loads(line)
+        jsonschema.validate(instance=record, schema=schema)
+        assert record["doc_id"] == "fake"
+        assert record["table_kind"] is None
+
+
+def test_dump_directory_isolates_per_file_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dumper, "_pyhwp_available", lambda: True)
+
+    (tmp_path / "good.hwp").write_bytes(b"\x00")
+    (tmp_path / "bad.hwp").write_bytes(b"\x00")
+
+    def fake_extract(source_path: Path):
+        if source_path.name == "bad.hwp":
+            raise RuntimeError("simulated pyhwp parse failure")
+        return None, [_sample_table(table_index=0)]
+
+    fake_module = types.ModuleType("ingestion")
+    fake_module._extract_hwp_native_with_tables = fake_extract  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "ingestion", fake_module)
+
+    out = tmp_path / "draft.jsonl"
+    summary = dumper.dump_directory(tmp_path, out)
+    assert summary["status"] == "ok"
+    assert summary["files_seen"] == 2
+    assert summary["tables_dumped"] == 1
+    assert len(summary["failures"]) == 1
+    assert summary["failures"][0]["file"] == "bad.hwp"
+    assert "simulated pyhwp parse failure" in summary["failures"][0]["error"]
+
+
+def test_dump_directory_skips_empty_tables(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dumper, "_pyhwp_available", lambda: True)
+
+    (tmp_path / "fake.hwp").write_bytes(b"\x00")
+
+    def fake_extract(source_path: Path):
+        empty = {
+            "table_index": 0,
+            "rows": 1,
+            "cols": 1,
+            "cells": [
+                {"row": 0, "col": 0, "rowspan": 1, "colspan": 1, "text": "   "},
+            ],
+        }
+        return None, [empty, _sample_table(table_index=1)]
+
+    fake_module = types.ModuleType("ingestion")
+    fake_module._extract_hwp_native_with_tables = fake_extract  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "ingestion", fake_module)
+
+    out = tmp_path / "draft.jsonl"
+    summary = dumper.dump_directory(tmp_path, out)
+    assert summary["tables_dumped"] == 1
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["table_index"] == 1
+
+
+def test_cli_returns_2_when_hwp_dir_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "nope"
+    rc = dumper.main(["--hwp-dir", str(missing), "--out", str(tmp_path / "out.jsonl")])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err

--- a/tests/test_extract_hwp_via_upstage.py
+++ b/tests/test_extract_hwp_via_upstage.py
@@ -1,0 +1,348 @@
+"""Unit tests for scripts/extract_hwp_via_upstage.py (issue #773, PR-A1).
+
+These tests:
+
+* Verify the HTML→cells parser correctly handles rowspan / colspan via
+  the internal occupancy grid (the trickiest piece of the dumper).
+* Verify both Upstage response shape variants (``elements[*].html`` and
+  ``elements[*].content.html``) are tolerated.
+* Verify the dumper's record shape validates against the published JSON
+  Schema at ``eval/data/table_extraction_golden.schema.json`` (same
+  schema as PR-A0).
+* Confirm graceful skip when ``UPSTAGE_API_KEY`` is unset.
+* Confirm per-file failures are isolated (network exception on one file
+  must not stop the others).
+
+The tests never call the real Upstage endpoint — a mock
+``requests.Session`` is injected so CI runs without secrets.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import extract_hwp_via_upstage as extractor  # noqa: E402
+
+SCHEMA_PATH = REPO_ROOT / "eval" / "data" / "table_extraction_golden.schema.json"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+# --- parse_table_html --------------------------------------------------
+
+
+def test_parse_table_html_simple_grid() -> None:
+    html = """
+    <table>
+      <tr><th>항목</th><th>배점</th></tr>
+      <tr><td>기술</td><td>60</td></tr>
+      <tr><td>가격</td><td>40</td></tr>
+    </table>
+    """
+    rows, cols, cells = extractor.parse_table_html(html)
+    assert rows == 3
+    assert cols == 2
+    assert len(cells) == 6
+    assert cells[0] == {
+        "row": 0,
+        "col": 0,
+        "rowspan": 1,
+        "colspan": 1,
+        "text": "항목",
+    }
+    assert cells[-1]["text"] == "40"
+
+
+def test_parse_table_html_rowspan_skips_occupied_column() -> None:
+    # First col spans 2 rows. The second cell on row 1 must land at col 1.
+    html = """
+    <table>
+      <tr><td rowspan="2">A</td><td>B</td></tr>
+      <tr><td>C</td></tr>
+    </table>
+    """
+    rows, cols, cells = extractor.parse_table_html(html)
+    assert rows == 2
+    assert cols == 2
+    coord = {(c["row"], c["col"]): c["text"] for c in cells}
+    assert coord[(0, 0)] == "A"
+    assert coord[(0, 1)] == "B"
+    assert coord[(1, 1)] == "C"
+    # Cell "A" should still report rowspan=2.
+    a_cell = next(c for c in cells if c["text"] == "A")
+    assert a_cell["rowspan"] == 2
+
+
+def test_parse_table_html_colspan_advances_col_idx() -> None:
+    html = """
+    <table>
+      <tr><td colspan="2">header</td></tr>
+      <tr><td>left</td><td>right</td></tr>
+    </table>
+    """
+    rows, cols, cells = extractor.parse_table_html(html)
+    assert rows == 2
+    assert cols == 2
+    header = next(c for c in cells if c["text"] == "header")
+    assert header["colspan"] == 2
+    assert header["col"] == 0
+
+
+# --- extract_tables_from_response --------------------------------------
+
+
+def test_extract_tables_from_response_tolerates_top_level_html() -> None:
+    response = {
+        "elements": [
+            {"category": "paragraph", "html": "<p>intro</p>"},
+            {
+                "category": "table",
+                "id": 0,
+                "page": 3,
+                "html": "<table><tr><td>x</td></tr></table>",
+            },
+        ]
+    }
+    tables = extractor.extract_tables_from_response(response)
+    assert len(tables) == 1
+    assert tables[0]["table_index"] == 0
+    assert tables[0]["page"] == 3
+    assert tables[0]["cells"][0]["text"] == "x"
+
+
+def test_extract_tables_from_response_tolerates_nested_content_html() -> None:
+    response = {
+        "elements": [
+            {
+                "category": "table",
+                "content": {"html": "<table><tr><td>y</td></tr></table>"},
+            }
+        ]
+    }
+    tables = extractor.extract_tables_from_response(response)
+    assert len(tables) == 1
+    assert tables[0]["cells"][0]["text"] == "y"
+
+
+def test_extract_tables_from_response_skips_non_table_categories() -> None:
+    response = {
+        "elements": [
+            {"category": "paragraph", "html": "<p>nope</p>"},
+            {"category": "figure", "html": "<img/>"},
+        ]
+    }
+    assert extractor.extract_tables_from_response(response) == []
+
+
+def test_extract_tables_from_response_skips_empty_or_missing_html() -> None:
+    response = {
+        "elements": [
+            {"category": "table", "html": ""},
+            {"category": "table"},
+            {"category": "table", "content": {}},
+        ]
+    }
+    assert extractor.extract_tables_from_response(response) == []
+
+
+# --- dump_record / schema validation -----------------------------------
+
+
+def test_dump_record_validates_against_schema(schema: dict[str, Any]) -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    table = {
+        "table_index": 2,
+        "rows": 2,
+        "cols": 2,
+        "page": 5,
+        "cells": [
+            {"row": 0, "col": 0, "rowspan": 1, "colspan": 1, "text": "항목"},
+            {"row": 0, "col": 1, "rowspan": 1, "colspan": 1, "text": "배점"},
+        ],
+    }
+    record = extractor.dump_record(
+        doc_id="sample",
+        source_path=Path("/tmp/sample.hwp"),
+        table=table,
+        now_iso="2026-05-14T00:00:00+00:00",
+    )
+    assert record["doc_id"] == "sample"
+    assert record["table_index"] == 2
+    assert record["page"] == 5
+    assert record["extractor"] == "upstage_document_parser"
+    assert record["table_kind"] is None
+    assert record["caption"] is None
+    assert record["notes"] is None
+    jsonschema.validate(instance=record, schema=schema)
+
+
+# --- extract_directory: skip / write / failure isolation ---------------
+
+
+def test_extract_directory_skipped_when_api_key_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UPSTAGE_API_KEY", raising=False)
+    out = tmp_path / "out.jsonl"
+    summary = extractor.extract_directory(tmp_path, out)
+    assert summary["status"] == "skipped"
+    assert summary["reason"] == extractor.SKIP_REASON_KEY_MISSING
+    assert summary["tables_dumped"] == 0
+    assert not out.exists()
+
+
+def _mock_session_returning(response_body: dict[str, Any]) -> MagicMock:
+    session = MagicMock()
+    fake_response = MagicMock()
+    fake_response.json.return_value = response_body
+    fake_response.raise_for_status.return_value = None
+    session.post.return_value = fake_response
+    return session
+
+
+def test_extract_directory_writes_jsonl_when_key_present(
+    tmp_path: Path,
+    schema: dict[str, Any],
+) -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    (tmp_path / "fake.hwp").write_bytes(b"\x00")
+
+    response = {
+        "elements": [
+            {
+                "category": "table",
+                "page": 1,
+                "html": "<table><tr><td>a</td><td>b</td></tr></table>",
+            },
+            {
+                "category": "table",
+                "page": 2,
+                "html": "<table><tr><td>c</td></tr></table>",
+            },
+        ]
+    }
+    session = _mock_session_returning(response)
+    out = tmp_path / "draft.jsonl"
+    summary = extractor.extract_directory(
+        tmp_path,
+        out,
+        api_key="fake-key",
+        session=session,
+    )
+    assert summary["status"] == "ok"
+    assert summary["files_seen"] == 1
+    assert summary["tables_dumped"] == 2
+    assert summary["failures"] == []
+    assert session.post.call_count == 1
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        record = json.loads(line)
+        jsonschema.validate(instance=record, schema=schema)
+        assert record["doc_id"] == "fake"
+        assert record["extractor"] == "upstage_document_parser"
+
+
+def test_extract_directory_isolates_per_file_failures(tmp_path: Path) -> None:
+    (tmp_path / "good.hwp").write_bytes(b"\x00")
+    (tmp_path / "bad.hwp").write_bytes(b"\x00")
+
+    session = MagicMock()
+
+    def fake_post(*args, **kwargs):
+        # Inspect which file is being posted by reading the in-memory
+        # ``files`` tuple. The filename is the first element.
+        files = kwargs.get("files") or {}
+        document = files.get("document")
+        name = document[0] if isinstance(document, tuple) else "?"
+        if name == "bad.hwp":
+            raise RuntimeError("simulated upstream failure")
+        resp = MagicMock()
+        resp.json.return_value = {
+            "elements": [
+                {
+                    "category": "table",
+                    "html": "<table><tr><td>ok</td></tr></table>",
+                }
+            ]
+        }
+        resp.raise_for_status.return_value = None
+        return resp
+
+    session.post.side_effect = fake_post
+
+    out = tmp_path / "draft.jsonl"
+    summary = extractor.extract_directory(
+        tmp_path,
+        out,
+        api_key="fake-key",
+        session=session,
+    )
+    assert summary["status"] == "ok"
+    assert summary["files_seen"] == 2
+    assert summary["tables_dumped"] == 1
+    assert len(summary["failures"]) == 1
+    assert summary["failures"][0]["file"] == "bad.hwp"
+    assert "simulated upstream failure" in summary["failures"][0]["error"]
+
+
+def test_extract_directory_skips_tables_with_only_whitespace_cells(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "fake.hwp").write_bytes(b"\x00")
+    response = {
+        "elements": [
+            {"category": "table", "html": "<table><tr><td>   </td></tr></table>"},
+            {"category": "table", "html": "<table><tr><td>real</td></tr></table>"},
+        ]
+    }
+    session = _mock_session_returning(response)
+    out = tmp_path / "draft.jsonl"
+    summary = extractor.extract_directory(
+        tmp_path,
+        out,
+        api_key="fake-key",
+        session=session,
+    )
+    assert summary["tables_dumped"] == 1
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["cells"][0]["text"] == "real"
+
+
+def test_cli_returns_2_when_hwp_dir_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "nope"
+    rc = extractor.main(["--hwp-dir", str(missing), "--out", str(tmp_path / "out.jsonl")])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err
+
+
+def test_cli_skips_with_message_when_api_key_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UPSTAGE_API_KEY", raising=False)
+    rc = extractor.main(["--hwp-dir", str(tmp_path), "--out", str(tmp_path / "out.jsonl")])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "UPSTAGE_API_KEY not set" in captured.err

--- a/tests/test_table_extraction_metrics.py
+++ b/tests/test_table_extraction_metrics.py
@@ -1,0 +1,261 @@
+"""Unit tests for eval/table_extraction_metrics.py (issue #790, PR-A3)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from eval import table_extraction_metrics as m  # noqa: E402
+
+
+def _record(
+    doc_id: str,
+    table_index: int,
+    cells: list[tuple[int, int, str, int, int]] | list[tuple[int, int, str]],
+) -> dict[str, Any]:
+    norm_cells = []
+    for cell in cells:
+        if len(cell) == 5:
+            r, c, t, rs, cs = cell
+        else:
+            r, c, t = cell  # type: ignore[misc]
+            rs = cs = 1
+        norm_cells.append(
+            {"row": r, "col": c, "rowspan": rs, "colspan": cs, "text": t}
+        )
+    return {
+        "doc_id": doc_id,
+        "source_path": f"/tmp/{doc_id}.hwp",
+        "page": None,
+        "table_index": table_index,
+        "rows": max((r for r, _, *_ in cells), default=-1) + 1,
+        "cols": max((c for _, c, *_ in cells), default=-1) + 1,
+        "caption": None,
+        "table_kind": None,
+        "cells": norm_cells,
+        "extractor": "test",
+        "extracted_at": "2026-05-14T00:00:00+00:00",
+        "notes": None,
+    }
+
+
+# --- Levenshtein -----------------------------------------------------
+
+
+def test_levenshtein_zero_for_equal_strings() -> None:
+    assert m.levenshtein("abc", "abc") == 0
+
+
+def test_levenshtein_substitution_insert_delete() -> None:
+    assert m.levenshtein("kitten", "sitting") == 3
+
+
+def test_levenshtein_empty_strings() -> None:
+    assert m.levenshtein("", "abc") == 3
+    assert m.levenshtein("abc", "") == 3
+    assert m.levenshtein("", "") == 0
+
+
+def test_levenshtein_swap_arguments_yields_same_distance() -> None:
+    assert m.levenshtein("foo", "foobar") == m.levenshtein("foobar", "foo")
+
+
+# --- similarity ------------------------------------------------------
+
+
+def test_similarity_exact_after_normalization() -> None:
+    # full-width "６０" → "60"; surrounding spaces collapse; casefold.
+    assert m.similarity("  ６０ ", "60") == 1.0
+
+
+def test_similarity_partial() -> None:
+    # 'abcd' vs 'abce' → 1 edit / 4 chars = 0.75.
+    assert m.similarity("abcd", "abce") == pytest.approx(0.75)
+
+
+def test_similarity_empty_both_is_one() -> None:
+    assert m.similarity("", "") == 1.0
+    assert m.similarity(None, None) == 1.0
+
+
+def test_similarity_disjoint() -> None:
+    # 'abc' vs 'xyz' → 3 edits / 3 chars = 0.0.
+    assert m.similarity("abc", "xyz") == pytest.approx(0.0)
+
+
+# --- cell_f1 ----------------------------------------------------------
+
+
+def test_cell_f1_all_match_at_threshold_0_9() -> None:
+    g = _record("doc1", 0, [(0, 0, "항목"), (0, 1, "배점")])
+    e = _record("doc1", 0, [(0, 0, "항목"), (0, 1, "배점")])
+    result = m.cell_f1(g, e)
+    assert result["tp"] == 2
+    assert result["fp"] == 0
+    assert result["fn"] == 0
+    assert result["precision"] == 1.0
+    assert result["recall"] == 1.0
+    assert result["f1"] == 1.0
+
+
+def test_cell_f1_text_below_threshold_counts_as_fp_fn() -> None:
+    # 'kitten' vs 'sitting' similarity ≈ 1 - 3/7 ≈ 0.571 < 0.9
+    g = _record("doc1", 0, [(0, 0, "kitten")])
+    e = _record("doc1", 0, [(0, 0, "sitting")])
+    result = m.cell_f1(g, e)
+    assert result["tp"] == 0
+    assert result["fp"] == 1
+    assert result["fn"] == 1
+
+
+def test_cell_f1_extra_extracted_cell_is_fp_only() -> None:
+    g = _record("doc1", 0, [(0, 0, "a")])
+    e = _record("doc1", 0, [(0, 0, "a"), (0, 1, "extra")])
+    result = m.cell_f1(g, e)
+    assert result["tp"] == 1
+    assert result["fp"] == 1
+    assert result["fn"] == 0
+
+
+def test_cell_f1_missing_extracted_cell_is_fn_only() -> None:
+    g = _record("doc1", 0, [(0, 0, "a"), (0, 1, "b")])
+    e = _record("doc1", 0, [(0, 0, "a")])
+    result = m.cell_f1(g, e)
+    assert result["tp"] == 1
+    assert result["fp"] == 0
+    assert result["fn"] == 1
+
+
+def test_cell_f1_custom_threshold_lowers_bar() -> None:
+    g = _record("doc1", 0, [(0, 0, "kitten")])
+    e = _record("doc1", 0, [(0, 0, "sitting")])  # similarity ≈ 0.571
+    result = m.cell_f1(g, e, similarity_threshold=0.5)
+    assert result["tp"] == 1
+    assert result["fp"] == 0
+    assert result["fn"] == 0
+
+
+# --- merge_cell_preservation ----------------------------------------
+
+
+def test_merge_preservation_no_merged_cells_in_golden_returns_one() -> None:
+    g = _record("doc1", 0, [(0, 0, "a", 1, 1)])
+    e = _record("doc1", 0, [(0, 0, "a", 1, 1)])
+    result = m.merge_cell_preservation(g, e)
+    assert result["golden_merge_count"] == 0
+    assert result["rate"] == 1.0
+
+
+def test_merge_preservation_exact_span_match() -> None:
+    # Two merged cells in golden; extractor reproduces both with matching dims.
+    g = _record("doc1", 0, [(0, 0, "a", 2, 1), (0, 1, "b", 1, 2)])
+    e = _record("doc1", 0, [(0, 0, "a", 2, 1), (0, 1, "b", 1, 2)])
+    result = m.merge_cell_preservation(g, e)
+    assert result["golden_merge_count"] == 2
+    assert result["preserved"] == 2
+    assert result["rate"] == 1.0
+
+
+def test_merge_preservation_partial_dim_mismatch() -> None:
+    # Golden has rowspan=2; extractor emits rowspan=1 (lost the merge).
+    g = _record("doc1", 0, [(0, 0, "a", 2, 1)])
+    e = _record("doc1", 0, [(0, 0, "a", 1, 1)])
+    result = m.merge_cell_preservation(g, e)
+    assert result["golden_merge_count"] == 1
+    assert result["preserved"] == 0
+    assert result["rate"] == 0.0
+
+
+def test_merge_preservation_missing_extracted_cell() -> None:
+    g = _record("doc1", 0, [(0, 0, "a", 2, 2)])
+    e = _record("doc1", 0, [])
+    result = m.merge_cell_preservation(g, e)
+    assert result["preserved"] == 0
+    assert result["rate"] == 0.0
+
+
+# --- table_level_metrics --------------------------------------------
+
+
+def test_table_level_metrics_all_match() -> None:
+    g = [_record("d", 0, []), _record("d", 1, [])]
+    e = [_record("d", 0, []), _record("d", 1, [])]
+    result = m.table_level_metrics(g, e)
+    assert result["tp"] == 2
+    assert result["fp"] == 0
+    assert result["fn"] == 0
+    assert result["f1"] == 1.0
+
+
+def test_table_level_metrics_missing_and_extra() -> None:
+    g = [_record("d", 0, []), _record("d", 1, [])]
+    e = [_record("d", 0, []), _record("d", 2, [])]
+    result = m.table_level_metrics(g, e)
+    assert result["tp"] == 1
+    assert result["fp"] == 1
+    assert result["fn"] == 1
+
+
+# --- compute (integration) -------------------------------------------
+
+
+def test_compute_aggregates_across_pairs() -> None:
+    golden = [
+        _record("d", 0, [(0, 0, "a"), (0, 1, "b")]),
+        _record("d", 1, [(0, 0, "x")]),
+    ]
+    extracted = [
+        _record("d", 0, [(0, 0, "a"), (0, 1, "b")]),
+        _record("d", 1, [(0, 0, "y")]),  # mismatch
+    ]
+    report = m.compute(extracted=extracted, golden=golden)
+    cell_micro = report["cell_level_micro"]
+    assert cell_micro["tp"] == 2  # 2 from table 0
+    assert cell_micro["fp"] == 1  # 1 from table 1 extraction
+    assert cell_micro["fn"] == 1  # 1 from table 1 golden
+    assert report["table_level"]["tp"] == 2
+    assert report["common_table_pair_count"] == 2
+
+
+def test_compute_returns_one_for_no_merge_cells_overall() -> None:
+    golden = [_record("d", 0, [(0, 0, "a")])]
+    extracted = [_record("d", 0, [(0, 0, "a")])]
+    report = m.compute(extracted=extracted, golden=golden)
+    assert report["merge_cell_preservation_micro"]["golden_merge_count"] == 0
+    assert report["merge_cell_preservation_micro"]["rate"] == 1.0
+
+
+# --- CLI -------------------------------------------------------------
+
+
+def test_cli_writes_summary_and_returns_zero(tmp_path: Path) -> None:
+    g_path = tmp_path / "g.jsonl"
+    e_path = tmp_path / "e.jsonl"
+    out = tmp_path / "metrics.json"
+    g_path.write_text(
+        json.dumps(_record("d", 0, [(0, 0, "a")])) + "\n", encoding="utf-8"
+    )
+    e_path.write_text(
+        json.dumps(_record("d", 0, [(0, 0, "a")])) + "\n", encoding="utf-8"
+    )
+    rc = m.main(["--golden", str(g_path), "--extracted", str(e_path), "--out", str(out)])
+    assert rc == 0
+    assert out.exists()
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["cell_level_micro"]["tp"] == 1
+
+
+def test_cli_returns_2_when_input_missing(tmp_path: Path) -> None:
+    g_path = tmp_path / "missing.jsonl"
+    e_path = tmp_path / "exists.jsonl"
+    e_path.write_text("", encoding="utf-8")
+    rc = m.main(["--golden", str(g_path), "--extracted", str(e_path), "--out", str(tmp_path / "o.json")])
+    assert rc == 2


### PR DESCRIPTION
## Summary

HWP RAG table-handling 실험 (plan: `~/.claude/plans/hwp-rag-wondrous-sutherland.md`) PR-B (experiment + ADR) 전 최종 tooling PR (PR-A3).

추출기 JSONL (PR-A0 #728/#749 또는 PR-A1 #773/#777) 을 human-labeled golden 대비 채점, PR-B 의 preregistered decision criteria (Upstage opt-in 분석 변형 채택 임계값 Δ ≥ +5%p) 가 소비할 parser-intrinsic 메트릭 생성.

## 메트릭 (전부 micro-aggregated)

- **Cell-level F1** — `(row, col)` 좌표 교집합에서 Levenshtein-similarity match (default 0.9 임계값). NFKC + whitespace-collapse + casefold; 구두점 보존.
- **Table-level recall / precision / F1** — 추출기가 각 golden table 발견? 가짜 생성?
- **Merge-cell preservation rate** — `rowspan>1` 또는 `colspan>1` golden cell 중 동일 좌표에 동일 span dim 으로 재현한 비율.

## 설계 노트

- **순수 stdlib Levenshtein** (Wagner-Fischer, `O(min(|a|,|b|))` space). 신규 의존성 없음; 대규모 RFP 에서 perf 중요시 `rapidfuzz` 로 5-line swap.
- **Caption attachment / boundary F1 보류** — 둘 다 추출기 변경 필요 (현재 추출기는 `caption: null` emit; `table_index` 외 명시적 boundary 없음).

## 파일

- `eval/table_extraction_metrics.py` — 메트릭 + CLI
- `tests/test_table_extraction_metrics.py` — 23 테스트

## Test plan

- [x] `pytest tests/test_table_extraction_metrics.py` — 23/23 pass
- [x] `ruff check eval/table_extraction_metrics.py tests/test_table_extraction_metrics.py` clean
- [ ] CI: pytest / branch-and-issue check

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

`eval/` 하위 신규 off-pipeline 메트릭 모듈 + 테스트 추가. Load-bearing 파일 (`ingestion.py`, `rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, `eval/config.yaml`, `api/main.py`) 은 byte-identical. 신규 모듈은 CLI entry point + unit test 만 load; preset / retrieval 경로 / eval run / verifier 에서 import 없음. `make real-eval-delta` 는 zero delta 생성 — explicit-opt-out clause 에 따라 생략.

## Closes

Closes #790

Generated with [Claude Code](https://claude.com/claude-code)
