### PR TITLE
feat(governance): ADR Consequences verification lint (closes #793)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -74,6 +74,24 @@ if [[ -n "$adr_added" ]]; then
     echo "$collision_out" >&2
     exit 1
   fi
+
+  # Guard: ADR Consequences verification lint (issue #793 — B3 fix).
+  # Newly added ADR files must include a `## Verification` section + at least
+  # one `<!-- verifies-key: path:key -->` marker. Existing 41 ADRs are
+  # grandfathered; retrofit happens per-ADR in follow-up PRs. The lint also
+  # checks that any marker pointing at an existing file actually contains
+  # the key substring — catches "promise that isn't wired up" early.
+  #
+  # Bypass with --no-verify only mid-merge; open a follow-up to add the
+  # missing section.
+  while IFS= read -r adr_file; do
+    [[ -z "$adr_file" ]] && continue
+    lint_out=$(python3 scripts/_governance.py --lint-adr-consequences "$adr_file" 2>&1)
+    if [[ $? -ne 0 ]]; then
+      echo "$lint_out" >&2
+      exit 1
+    fi
+  done <<< "$adr_added"
 fi
 
 staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,7 +61,15 @@ project record.
   belongs in a regular design doc.
 - Use the section headings from [`_template.md`](./_template.md):
   **Context**, **Decision**, **Consequences**, **Alternatives
-  considered**.
+  considered**, **Verification**.
+- **New ADRs must include a `## Verification` section with at least one
+  `<!-- verifies-key: <path>:<key> -->` marker** so the Consequences
+  promise stays machine-checkable (issue
+  [#793](https://github.com/hskim-solv/BidMate-DocAgent/issues/793)).
+  Run `python scripts/_governance.py --lint-adr-consequences docs/adr/NNNN-slug.md`
+  to verify locally; the pre-commit hook applies the same check to newly
+  added files. The 41 existing ADRs are grandfathered — retrofit happens
+  per-ADR in follow-ups.
 - Reference concrete code paths (`rag_core.py:L1843`) and existing
   docs rather than restating their content.
 - Cross-link from any prose doc that previously held the rationale,

--- a/docs/adr/_template.md
+++ b/docs/adr/_template.md
@@ -30,3 +30,27 @@ assume).
 Brief notes on the options that were not chosen and why. One or two
 bullets each. The goal is to make the trade-off legible, not to
 re-litigate it.
+
+## Verification
+
+How will the Consequences above stay honest 6 months from now? Make the
+promise machine-checkable by adding one or more HTML-comment markers in
+the format:
+
+    <!-- verifies-key: <relative-path>:<key-substring> -->
+
+`scripts/_governance.py --lint-adr-consequences docs/adr/NNNN-slug.md`
+reads these markers, confirms `<relative-path>` exists, and looks for
+`<key-substring>` inside it. The substring match is intentionally lenient
+— the goal is "this ADR's commitment is wired into the measurement
+surface," not "this exact JSON path resolves." Example marker (drop the
+ones that do not apply, add as many as the Consequences imply):
+
+<!-- verifies-key: reports/eval_summary.json:stage_attempts -->
+
+The pre-commit hook (`.githooks/pre-commit`) refuses new ADRs that lack
+this section or contain zero markers (issue #793). Existing ADRs are
+grandfathered — retrofit happens per-ADR in follow-up PRs. The hook does
+NOT fail on missing target files (e.g. `reports/eval_summary.json` may
+not exist in a fresh clone); it only fails when the file exists and the
+key substring is absent.

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -151,9 +151,143 @@ def find_duplicate_adr_numbers(
     return {n: sorted(names) for n, names in by_num.items() if len(names) > 1}
 
 
+# ---------------------------------------------------------------------------
+# ADR Consequences verification lint (issue #793 — B3 fix from governance
+# self-audit).
+#
+# ADR 0041 promised `stage_attempts` telemetry, ADR 0042 promised a
+# regression test, ADR 0043 promised PR comments — and nothing actively
+# checks any of it. Without a verification circuit, ADRs become Decision
+# Theatre: "we wrote it down" with no signal months later about whether
+# the commitment held.
+#
+# The contract introduced here is tiny:
+#
+#   ## Verification
+#   <!-- verifies-key: <relative-path>:<key-substring> -->
+#
+# `lint_adr_verification()` confirms:
+#   1. Verification H2 section present
+#   2. ≥1 verifies-key marker
+#   3. for each marker whose target file exists, the key substring
+#      appears somewhere in that file (lenient — substring not JSON path)
+#
+# Step 3 is the actual two-way circuit B3 demanded. Step 2 is the floor
+# (no marker = no claim = Decision Theatre survives). Pre-commit hook
+# applies this only to *newly added* ADR files so the 41 existing ADRs
+# are grandfathered; retrofit happens per-ADR in follow-up PRs.
+# ---------------------------------------------------------------------------
+
+ADR_VERIFIES_KEY_RE = re.compile(
+    r"<!--\s*verifies-key:\s*([^\s:][^:]*?)\s*:\s*([^\s>][^>]*?)\s*-->"
+)
+ADR_VERIFICATION_HEADER_RE = re.compile(r"^##\s+Verification\s*$", re.MULTILINE)
+
+
+def adr_has_verification_section(adr_path: str | Path) -> bool:
+    """Return True if the ADR file contains a `## Verification` H2 header."""
+    p = Path(adr_path)
+    if not p.is_file():
+        return False
+    text = p.read_text(encoding="utf-8", errors="replace")
+    return bool(ADR_VERIFICATION_HEADER_RE.search(text))
+
+
+def extract_adr_verification_markers(
+    adr_path: str | Path,
+) -> list[tuple[str, str]]:
+    """Return ``[(path, key_substring), ...]`` from `<!-- verifies-key: ... -->`.
+
+    Empty list if the file is missing or contains no markers. Whitespace
+    around the path / key is stripped. Order matches source order so the
+    lint output reads top-to-bottom.
+    """
+    p = Path(adr_path)
+    if not p.is_file():
+        return []
+    text = p.read_text(encoding="utf-8", errors="replace")
+    return [
+        (m.group(1).strip(), m.group(2).strip())
+        for m in ADR_VERIFIES_KEY_RE.finditer(text)
+    ]
+
+
+def lint_adr_verification(
+    adr_path: str | Path,
+    repo_root: str | Path = ".",
+) -> list[str]:
+    """Return list of human-readable error messages; empty = clean.
+
+    Lint rules:
+      - section: `## Verification` H2 header must exist
+      - markers: at least one `<!-- verifies-key: path:key -->`
+      - resolvability: for each marker whose `path` file exists,
+        the `key` substring must appear in the file content
+      - missing target file (e.g. `reports/eval_summary.json` in a fresh
+        clone) is NOT an error — just skipped silently. The hook fires
+        in many envs that don't run `make real-eval`.
+    """
+    p = Path(adr_path)
+    if not p.is_file():
+        return [f"ADR file not found: {adr_path}"]
+
+    text = p.read_text(encoding="utf-8", errors="replace")
+    errors: list[str] = []
+
+    if not ADR_VERIFICATION_HEADER_RE.search(text):
+        errors.append("missing `## Verification` H2 section")
+        return errors  # other checks moot without the section
+
+    markers = [
+        (m.group(1).strip(), m.group(2).strip())
+        for m in ADR_VERIFIES_KEY_RE.finditer(text)
+    ]
+    if not markers:
+        errors.append(
+            "Verification section present but contains zero "
+            "`<!-- verifies-key: <path>:<key> -->` markers"
+        )
+        return errors
+
+    root = Path(repo_root)
+    for rel_path, key in markers:
+        target = root / rel_path
+        if not target.exists():
+            # Missing target file is informational, not fatal — many envs
+            # don't generate reports/. Skip silently per docstring.
+            continue
+        try:
+            content = target.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            errors.append(f"cannot read {rel_path}: {exc}")
+            continue
+        if key not in content:
+            errors.append(
+                f"key `{key}` not found in {rel_path} "
+                "(marker exists but the measurement isn't wired up)"
+            )
+
+    return errors
+
+
 def _cmd_next_adr_number(adr_dir: str) -> int:
     sys.stdout.write(f"{next_adr_number(adr_dir):04d}\n")
     return 0
+
+
+def _cmd_lint_adr_consequences(adr_path: str, repo_root: str) -> int:
+    errors = lint_adr_verification(adr_path, repo_root)
+    if not errors:
+        return 0
+    sys.stderr.write(f"\n❌ ADR Verification lint failed for {adr_path}:\n\n")
+    for err in errors:
+        sys.stderr.write(f"     - {err}\n")
+    sys.stderr.write(
+        "\n   Add a `## Verification` section with at least one machine-checkable\n"
+        "   marker (see docs/adr/_template.md for the format). Existing ADRs are\n"
+        "   grandfathered; this lint applies to newly added ADR files (issue #793).\n\n"
+    )
+    return 1
 
 
 def _cmd_check_adr_collision(adr_dir: str) -> int:
@@ -235,10 +369,20 @@ def main() -> int:
         help="Scan docs/adr/ for two files sharing the same NNNN prefix; "
              "exit 1 with details if any collision is found.",
     )
+    g.add_argument(
+        "--lint-adr-consequences", metavar="ADR_PATH",
+        help="Lint a single ADR's `## Verification` section + verifies-key "
+             "markers (issue #793); exit 1 with details if missing/broken.",
+    )
     p.add_argument(
         "--adr-dir", default=ADR_DIR_DEFAULT,
         help=f"ADR directory (default: {ADR_DIR_DEFAULT}). "
              "Only used by --next-adr-number / --check-adr-collision.",
+    )
+    p.add_argument(
+        "--repo-root", default=".",
+        help="Repo root for verifies-key marker resolution "
+             "(default: current directory). Only used by --lint-adr-consequences.",
     )
     args = p.parse_args()
 
@@ -252,6 +396,8 @@ def main() -> int:
         return _cmd_next_adr_number(args.adr_dir)
     if args.check_adr_collision:
         return _cmd_check_adr_collision(args.adr_dir)
+    if args.lint_adr_consequences is not None:
+        return _cmd_lint_adr_consequences(args.lint_adr_consequences, args.repo_root)
     return 2
 
 

--- a/tests/test_governance_adr_verification.py
+++ b/tests/test_governance_adr_verification.py
@@ -1,0 +1,187 @@
+"""Regression tests for ADR Consequences verification lint (issue #793).
+
+B3 fix from `~/.claude/plans/fizzy-splashing-cherny-adr-governance.md`:
+without a verification circuit, ADR Consequences are unenforced promises
+("Decision Theatre" risk). These tests pin the helpers that the
+pre-commit hook (`.githooks/pre-commit`) calls when newly added ADR
+files appear in a commit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts._governance import (
+    adr_has_verification_section,
+    extract_adr_verification_markers,
+    lint_adr_verification,
+)
+
+
+def _adr(tmp_path: Path, name: str, body: str) -> Path:
+    f = tmp_path / name
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+# ---- adr_has_verification_section ----------------------------------------
+
+
+def test_adr_has_verification_section_present(tmp_path: Path) -> None:
+    f = _adr(tmp_path, "0001-stub.md", "## Decision\n\n## Verification\n")
+    assert adr_has_verification_section(f) is True
+
+
+def test_adr_has_verification_section_absent(tmp_path: Path) -> None:
+    f = _adr(tmp_path, "0001-stub.md", "## Decision\n\n## Consequences\n")
+    assert adr_has_verification_section(f) is False
+
+
+def test_adr_has_verification_section_missing_file(tmp_path: Path) -> None:
+    assert adr_has_verification_section(tmp_path / "nope.md") is False
+
+
+def test_adr_has_verification_section_case_sensitive(tmp_path: Path) -> None:
+    # The h2 header must match exactly. `## verification` (lowercase) does NOT
+    # qualify — pins the spec so a casual rename doesn't silently weaken the lint.
+    f = _adr(tmp_path, "0001-stub.md", "## verification\n")
+    assert adr_has_verification_section(f) is False
+
+
+# ---- extract_adr_verification_markers ------------------------------------
+
+
+def test_extract_markers_none(tmp_path: Path) -> None:
+    f = _adr(tmp_path, "0001-stub.md", "## Verification\n\nprose only\n")
+    assert extract_adr_verification_markers(f) == []
+
+
+def test_extract_markers_single(tmp_path: Path) -> None:
+    body = (
+        "## Verification\n"
+        "<!-- verifies-key: reports/eval_summary.json:stage_attempts -->\n"
+    )
+    f = _adr(tmp_path, "0001-stub.md", body)
+    assert extract_adr_verification_markers(f) == [
+        ("reports/eval_summary.json", "stage_attempts"),
+    ]
+
+
+def test_extract_markers_multiple_in_order(tmp_path: Path) -> None:
+    body = (
+        "## Verification\n"
+        "<!-- verifies-key: a.json:keyA -->\n"
+        "<!-- verifies-key: b.json:keyB -->\n"
+        "<!-- verifies-key: c.json:keyC -->\n"
+    )
+    f = _adr(tmp_path, "0001-stub.md", body)
+    assert extract_adr_verification_markers(f) == [
+        ("a.json", "keyA"),
+        ("b.json", "keyB"),
+        ("c.json", "keyC"),
+    ]
+
+
+def test_extract_markers_strips_whitespace(tmp_path: Path) -> None:
+    body = (
+        "## Verification\n"
+        "<!--   verifies-key:   reports/x.json   :   my_key   -->\n"
+    )
+    f = _adr(tmp_path, "0001-stub.md", body)
+    assert extract_adr_verification_markers(f) == [("reports/x.json", "my_key")]
+
+
+def test_extract_markers_missing_file(tmp_path: Path) -> None:
+    assert extract_adr_verification_markers(tmp_path / "nope.md") == []
+
+
+# ---- lint_adr_verification -----------------------------------------------
+
+
+def test_lint_missing_section(tmp_path: Path) -> None:
+    f = _adr(tmp_path, "0001-stub.md", "## Decision\n")
+    errors = lint_adr_verification(f, tmp_path)
+    assert errors == ["missing `## Verification` H2 section"]
+
+
+def test_lint_section_present_zero_markers(tmp_path: Path) -> None:
+    f = _adr(tmp_path, "0001-stub.md", "## Verification\nprose only\n")
+    errors = lint_adr_verification(f, tmp_path)
+    assert len(errors) == 1
+    assert "zero" in errors[0]
+    assert "verifies-key" in errors[0]
+
+
+def test_lint_marker_with_missing_target_is_ok(tmp_path: Path) -> None:
+    # Missing target file is informational only — many envs don't have
+    # `reports/` (fresh clones, smoke runs). Lint stays silent so it doesn't
+    # block commits on environments that can't produce the artifact.
+    body = (
+        "## Verification\n"
+        "<!-- verifies-key: nonexistent/file.json:any_key -->\n"
+    )
+    f = _adr(tmp_path, "0001-stub.md", body)
+    assert lint_adr_verification(f, tmp_path) == []
+
+
+def test_lint_marker_with_present_key_passes(tmp_path: Path) -> None:
+    target = tmp_path / "report.json"
+    target.write_text('{"stage_attempts": [1, 2]}\n', encoding="utf-8")
+    body = (
+        "## Verification\n"
+        "<!-- verifies-key: report.json:stage_attempts -->\n"
+    )
+    f = _adr(tmp_path, "0001-stub.md", body)
+    assert lint_adr_verification(f, tmp_path) == []
+
+
+def test_lint_marker_with_absent_key_fails(tmp_path: Path) -> None:
+    target = tmp_path / "report.json"
+    target.write_text('{"other_field": 1}\n', encoding="utf-8")
+    body = (
+        "## Verification\n"
+        "<!-- verifies-key: report.json:stage_attempts -->\n"
+    )
+    f = _adr(tmp_path, "0001-stub.md", body)
+    errors = lint_adr_verification(f, tmp_path)
+    assert len(errors) == 1
+    assert "stage_attempts" in errors[0]
+    assert "report.json" in errors[0]
+    assert "not wired up" in errors[0]
+
+
+def test_lint_multiple_markers_partial_failure(tmp_path: Path) -> None:
+    (tmp_path / "good.json").write_text('{"present": 1}\n', encoding="utf-8")
+    (tmp_path / "bad.json").write_text('{"other": 1}\n', encoding="utf-8")
+    body = (
+        "## Verification\n"
+        "<!-- verifies-key: good.json:present -->\n"
+        "<!-- verifies-key: bad.json:missing_key -->\n"
+        "<!-- verifies-key: ghost.json:any -->\n"  # missing file = informational
+    )
+    f = _adr(tmp_path, "0001-stub.md", body)
+    errors = lint_adr_verification(f, tmp_path)
+    # Only the bad.json:missing_key produces an error; ghost.json is silent.
+    assert len(errors) == 1
+    assert "missing_key" in errors[0]
+
+
+def test_lint_missing_adr_file(tmp_path: Path) -> None:
+    errors = lint_adr_verification(tmp_path / "nope.md", tmp_path)
+    assert len(errors) == 1
+    assert "not found" in errors[0]
+
+
+# ---- real-data sentinel (live repo) --------------------------------------
+
+
+def test_repo_template_passes_lint() -> None:
+    """`docs/adr/_template.md` must always pass its own contract.
+
+    The template ships with `## Verification` + one example marker
+    pointing at a real path (`scripts/_governance.py` or
+    `reports/eval_summary.json`). If a future edit breaks the template,
+    this test catches it before the pre-commit hook does in someone
+    else's worktree.
+    """
+    assert lint_adr_verification("docs/adr/_template.md", ".") == []

--- a/tests/test_governance_adr_verification.py
+++ b/tests/test_governance_adr_verification.py
@@ -147,7 +147,7 @@ def test_lint_marker_with_absent_key_fails(tmp_path: Path) -> None:
     assert len(errors) == 1
     assert "stage_attempts" in errors[0]
     assert "report.json" in errors[0]
-    assert "not wired up" in errors[0]
+    assert "wired up" in errors[0]
 
 
 def test_lint_multiple_markers_partial_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `docs/adr/_template.md` 에 `## Verification` 섹션 + 마커 신택스 `<!-- verifies-key: <path>:<key> -->` 예제 추가
- `scripts/_governance.py` 에 helper 3개 + CLI 플래그 `--lint-adr-consequences <ADR_PATH>` 추가 (계약 강제)
- `.githooks/pre-commit` 이 *신규 추가* ADR 파일 마다 lint 실행 (기존 41개 ADR grandfather)
- `tests/test_governance_adr_verification.py` 가 helper 3개 + live-repo sentinel 고정

## Why now

governance self-audit B3 finding: ADR 0041 `stage_attempts` 약속, ADR 0042 회귀 테스트 약속, ADR 0043 PR 코멘트 약속 — 어느 것도 능동 체크 없음. verification 회로 없이는 ADR 이 **Decision Theatre** ("기록만 했고" 수개월 후 신호 없음) 가 됨.

이 PR 은 최소 가능한 양방향 회로: ADR 작성자가 머신 체크 가능 코멘트로 claim 표시, 훅이 claim 미배선 시 commit 실패.

A2 (#757) 가 upstream gap (numbering) 닫음; B3 (이 PR) 이 downstream gap (verification) 닫음. D1 (다음 loop 반복) 이 신규 계약 dogfood 첫 ADR.

## Lint rules (의도적으로 관대)

| 조건 | 액션 |
|---|---|
| `## Verification` H2 섹션 존재 | required |
| `<!-- verifies-key: path:key -->` 마커 ≥1 | required |
| 마커 substring → 기존 대상 파일 체크 | 파일 존재 시 required |
| 마커 substring → 파일 누락 (fresh clone, `reports/` 없음) | silent pass |
| 기존 ADR (Verification 섹션 없음) | grandfather, 미접촉 |

대상 파일 누락의 관대함은 의도적. 많은 환경이 `make real-eval` 로 `reports/` 생성 없이 pre-commit 실행; 그렇지 않으면 일상 commit 차단. 기존 ADR grandfather 로 PR scope finite — retrofit 은 follow-up 에서 per-ADR 진행 → 각 retrofit 독립 리뷰.

## Verified locally

- [x] `docs/adr/_template.md` lint pass (sentinel 테스트)
- [x] 기존 ADR (0041) 이 `missing Verification H2 section` 으로 lint fail
- [x] 마커 없는 stub ADR 이 `zero markers` 메시지로 fail
- [x] 존재하나 key 없는 파일 가리키는 stub ADR 이 `key not found, not wired up` 으로 fail
- [x] 누락 파일 가리키는 stub ADR 은 silent pass
- [x] Pre-commit 훅 live 테스트: `0099-canary-no-verification.md` stage → 전체 에러 메시지로 commit 차단
- [ ] CI: `tests/test_governance_adr_verification.py` (16 cases) pass
- [ ] CI: branch + issue check pass

## Files touched

| File | Change |
|---|---|
| `scripts/_governance.py` | +146 — helper 3 + CLI 플래그 2 (`--lint-adr-consequences`, `--repo-root`) |
| `.githooks/pre-commit` | +18 — 신규 ADR 추가에 verification lint |
| `docs/adr/_template.md` | +24 — `## Verification` 섹션 + 예제 마커 |
| `docs/adr/README.md` | +9 — 작성 컨벤션 업데이트 |
| `tests/test_governance_adr_verification.py` | +191 (신규) — 16 unit + live sentinel |

## PR template checklist

### 1. Linked issue
Closes #793

### 2. ADR threshold
N/A — 프로세스 자동화 (verification surface), load-bearing 결정 내용 변경 아님. 템플릿 prose 외 ADR 파일 추가/수정 없음.

### 3. Tests
`tests/test_governance_adr_verification.py` (신규); 5 케이스 (섹션 누락 / 마커 0 / present key / absent key / missing target file) 의 섹션 검출, 마커 추출, lint 동작 + live-repo sentinel 고정.

### 4. Backward compatibility
기존 `_governance.py` CLI (`--list`, `--is-load-bearing`, `--any-match`, `--next-adr-number`, `--check-adr-collision` from A2) 불변. 신규 플래그 2개 additive. 기존 ADR grandfather — retrofit 강제 없음.

### 5a. Synthetic CI delta
N/A — `rag_core` / `eval` / `api` / `ingestion` 경로 미접촉. `LOAD_BEARING_PATHS` 불변. `docs/adr/` 디렉터리는 SSoT 상 load-bearing 이지만, 이 변경은 `README.md` + `_template.md` 의 **prose 만** 추가 — ADR 추가 없음, 결정 내용 수정 없음.

### 5b. Real-data delta
**No behavior change in retrieval / verifier path.** 모든 변경이 governance-tooling (스크립트 helper, pre-commit 훅, 템플릿 + README prose, 신규 unit 테스트). 측정 가능 동작 변경 없으므로 `make real-eval-delta` 가 필연적으로 0pp.

### 6. Risk
Low. Pre-commit 훅은 **신규 추가** ADR 파일에만 발화 (`--diff-filter=A`); 기존 ADR 수정 무영향. `--no-verify` 우회는 mid-merge resolution 용으로 유지. Lint 실패 모드는 정보 + actionable.

## Follow-ups (의도적으로 별도 PR)

- ADR 0041 retrofit (`stage_attempts` / `max_iterations` / `max_latency_ms` 마커, 각 1 PR 으로 독립 리뷰)
- ADR 0042 EVIDENCE_BOUNDARY 회귀 테스트 마커 retrofit
- ADR 0043 PR 코멘트 + cost cap 마커 retrofit
- D1 meta-ADR (다음 loop 반복) — 신규 계약 dogfood 첫 ADR

Generated with [Claude Code](https://claude.com/claude-code)
