### PR TITLE
feat(vector_store): add query_by_indices Protocol method to skip full-index dense fetch (closes #795)

### DIFF
--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -410,10 +410,36 @@ def retrieve_candidates(
     # ``tests/test_vector_store_qdrant.py::test_qdrant_query_matches_in_memory_top_k_ranking``
     # (PR #296, 1e-5 tolerance). Inline-embedding fixtures fall back
     # to the per-chunk ``dense_similarity`` path below.
+    #
+    # Issue #795 (RAG senior-review critique #3): when the metadata
+    # filter actually narrowed candidates to a strict subset of the
+    # index, fetch dense scores ONLY for those candidates via
+    # ``query_by_indices``. The previous unconditional
+    # ``query(top_k=len(vector_store))`` defeated server-side top-K
+    # backends (Qdrant) and wasted O(N) work on every filtered query.
+    # We retain the full-fetch path for the no-filter / fallback case
+    # because the loop still needs scores for every candidate.
     raw_cosine_by_idx: dict[int, float] = {}
     if vector_store is not None and len(vector_store) > 0:
-        for idx, raw in vector_store.query(query_embedding, top_k=len(vector_store)):
-            raw_cosine_by_idx[int(idx)] = float(raw)
+        candidate_indices = [
+            int(c["embedding_idx"])
+            for c in candidates
+            if c.get("embedding_idx") is not None
+        ]
+        filter_narrowed = (
+            not plan.get("filter_fallback_used", False)
+            and 0 < len(candidate_indices) < len(vector_store)
+        )
+        if filter_narrowed:
+            for idx, raw in vector_store.query_by_indices(
+                query_embedding, candidate_indices
+            ):
+                raw_cosine_by_idx[int(idx)] = float(raw)
+        else:
+            for idx, raw in vector_store.query(
+                query_embedding, top_k=len(vector_store)
+            ):
+                raw_cosine_by_idx[int(idx)] = float(raw)
     scored = []
     for chunk in candidates:
         embedding_idx = chunk.get("embedding_idx")

--- a/rag_vector_store.py
+++ b/rag_vector_store.py
@@ -77,6 +77,28 @@ class VectorStore(Protocol):
         self, qvec: np.ndarray, top_k: int
     ) -> list[tuple[int, float]]: ...
 
+    def query_by_indices(
+        self, qvec: np.ndarray, indices: list[int]
+    ) -> list[tuple[int, float]]:
+        """Score the requested indices against ``qvec``; preserve order.
+
+        Issue #795 — RAG senior-review critique #3. The retrieval loop
+        previously called ``query(top_k=len(self))`` to build a full
+        ``raw_cosine_by_idx`` map even when the metadata filter had
+        narrowed candidates to a small subset. ``query_by_indices``
+        lets the loop fetch dense scores for **only** the surfaced
+        candidate indices, restoring the cost benefit of a filtered
+        retrieval path.
+
+        Returns ``(idx, score)`` pairs in the SAME order as
+        ``indices`` (callers build a per-index dict). Out-of-range
+        indices raise ``IndexError`` to surface index/chunk drift at
+        the failing call site rather than silently producing zero
+        scores (mirrors the critique #4 ``dense_similarity`` change
+        from issue #784).
+        """
+        ...
+
     def persist(self, output_dir: Path) -> None: ...
 
 
@@ -126,6 +148,28 @@ class InMemoryVectorStore:
             partition = np.argpartition(-scores, k - 1)[:k]
             order = partition[np.argsort(-scores[partition], kind="stable")]
         return [(int(i), float(scores[i])) for i in order]
+
+    def query_by_indices(
+        self, qvec: np.ndarray, indices: list[int]
+    ) -> list[tuple[int, float]]:
+        # Issue #795 — see Protocol docstring. Local matrix slice +
+        # dot product is the cheapest scoring path; identical to a
+        # per-index loop of ``get(idx)`` + cosine, just vectorized.
+        if not indices:
+            return []
+        qvec_f32 = np.asarray(qvec, dtype=np.float32)
+        if qvec_f32.shape[-1] != self.dimension:
+            raise ValueError(
+                f"Query vector dim {qvec_f32.shape[-1]} does not match "
+                f"index dim {self.dimension}."
+            )
+        # IndexError surfaces drift instead of silent zero scores —
+        # the chunk's ``embedding_idx`` was supposed to point into
+        # this matrix.
+        idx_array = np.asarray(indices, dtype=np.int64)
+        rows = self.vectors[idx_array]
+        scores = rows @ qvec_f32
+        return [(int(i), float(s)) for i, s in zip(indices, scores)]
 
     def persist(self, output_dir: Path) -> None:
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -190,6 +234,30 @@ class QdrantVectorStore:
             limit=top_k,
         )
         return [(int(p.id), float(p.score)) for p in response.points]
+
+    def query_by_indices(
+        self, qvec: np.ndarray, indices: list[int]
+    ) -> list[tuple[int, float]]:
+        # Issue #795 — see Protocol docstring. Qdrant's value-add is
+        # the search path (server-side top-K); for "score these N
+        # specific points against this vector" the matrix dot is
+        # both faster (no round-trip) and bit-identical to the
+        # in-memory backend (the dataclass owns the same matrix as
+        # the source of truth — see ``_build_qdrant_store``). This
+        # keeps the in-memory ↔ Qdrant ranking parity guarantee
+        # asserted by ``test_qdrant_query_matches_in_memory_top_k_ranking``.
+        if not indices:
+            return []
+        qvec_f32 = np.asarray(qvec, dtype=np.float32)
+        if qvec_f32.shape[-1] != self.dimension:
+            raise ValueError(
+                f"Query vector dim {qvec_f32.shape[-1]} does not match "
+                f"index dim {self.dimension}."
+            )
+        idx_array = np.asarray(indices, dtype=np.int64)
+        rows = self.vectors[idx_array]
+        scores = rows @ qvec_f32
+        return [(int(i), float(s)) for i, s in zip(indices, scores)]
 
     def persist(self, output_dir: Path) -> None:
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_vector_store_protocol.py
+++ b/tests/test_vector_store_protocol.py
@@ -120,6 +120,75 @@ def test_in_memory_query_dim_mismatch_raises(matrix: np.ndarray) -> None:
         store.query(np.zeros(99, dtype=np.float32), top_k=3)
 
 
+# ---------------------------------------------------------------------------
+# Issue #795 — query_by_indices(qvec, indices)
+# ---------------------------------------------------------------------------
+
+
+def test_in_memory_query_by_indices_returns_scores_for_subset(
+    matrix: np.ndarray,
+) -> None:
+    """RAG senior-review critique #3 fix: only score the requested
+    indices. Output order matches input order, scores match what
+    ``self.vectors @ qvec`` would produce."""
+    store = vector_store_from_matrix(matrix)
+    qvec = matrix[2]
+    # Pick a non-monotonic subset to confirm output order tracks input.
+    indices = [4, 1, 2]
+    result = store.query_by_indices(qvec, indices)
+    assert [i for i, _ in result] == indices
+    # The score for self (index 2) must be ~1.0; the others are dot
+    # products against matrix[2]. Compare to the bulk dot product.
+    expected = (matrix[indices] @ qvec).tolist()
+    actual = [s for _, s in result]
+    np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-6)
+
+
+def test_in_memory_query_by_indices_empty_indices_returns_empty(
+    matrix: np.ndarray,
+) -> None:
+    store = vector_store_from_matrix(matrix)
+    assert store.query_by_indices(matrix[0], []) == []
+
+
+def test_in_memory_query_by_indices_dim_mismatch_raises(
+    matrix: np.ndarray,
+) -> None:
+    store = vector_store_from_matrix(matrix)
+    with pytest.raises(ValueError, match="dim"):
+        store.query_by_indices(np.zeros(99, dtype=np.float32), [0, 1])
+
+
+def test_in_memory_query_by_indices_out_of_range_raises(
+    matrix: np.ndarray,
+) -> None:
+    """The bug we are NOT introducing: out-of-range indices used to
+    silently produce zero scores under the old loop. Now they raise
+    ``IndexError`` — drift surfaces at the failing call site."""
+    store = vector_store_from_matrix(matrix)
+    with pytest.raises(IndexError):
+        store.query_by_indices(matrix[0], [0, 999])
+
+
+def test_in_memory_query_by_indices_matches_per_index_get_loop(
+    matrix: np.ndarray,
+) -> None:
+    """Bulk path must agree bit-for-bit with the per-chunk
+    ``store.get(idx)`` + dot product loop the old retrieval used."""
+    store = vector_store_from_matrix(matrix)
+    qvec = matrix[2]
+    indices = list(range(len(store)))
+    bulk = store.query_by_indices(qvec, indices)
+    per_index = [(i, float(np.dot(store.get(i), qvec))) for i in indices]
+    assert [i for i, _ in bulk] == [i for i, _ in per_index]
+    np.testing.assert_allclose(
+        [s for _, s in bulk],
+        [s for _, s in per_index],
+        rtol=0,
+        atol=1e-6,
+    )
+
+
 def test_in_memory_query_stable_tie_break(matrix: np.ndarray) -> None:
     """Two rows with the same score must be returned in ascending
     row-index order — the brute-force loop in ``rag_core.retrieve``


### PR DESCRIPTION
## Summary

- `rag_retrieval.retrieve_candidates` 가 그동안 `store.query(qvec, top_k=len(vector_store))` 를 무조건 호출, 메타데이터 필터가 실제로 surface 한 청크 수와 무관하게 모든 청크의 dense score fetch. Qdrant 에서 server-side top-K 무력화 — 필터된 쿼리마다 bandwidth 낭비.
- 이 PR 은 `VectorStore.query_by_indices(qvec, indices)` 를 단일 Protocol 메서드로 추가. 두 backend 모두 local matrix slice + dot product 로 구현 (Qdrant 도 의도적으로 네트워크 round-trip 아님 — `retrieve(ids=[...])` 는 동일 dot 를 local 로 계산하려 point 만 fetch).
- `retrieve_candidates` 는 이제 분기: 필터가 candidate 좁혔을 때 (`filter_fallback_used is False` AND `len(indices) < len(vector_store)`) `query_by_indices` 사용; 아니면 `query(top_k=len)` 유지.
- Out-of-range index 는 `IndexError` raise (#784 cycle 2 와 일치하는 loud-failure 규율).

Closes #795. `/Users/hskim/.claude/plans/fizzy-splashing-cherny.md` (RAG senior-review) 비판 #3. dynamic-loop fix sequence Cycle 3.

## Surface

- `rag_vector_store.py` — Protocol + `InMemoryVectorStore` + `QdrantVectorStore` 가 `query_by_indices` 획득. 세 구현 모두 dataclass-owned `vectors` 필드 대상 matrix-slice + dot product; Qdrant round-trip 불필요.
- `rag_retrieval.py` — `retrieve_candidates` 가 `candidate_indices` 구성, 필터가 pool 좁혔을 때 `query_by_indices` 선택; no-filter / fallback 케이스는 기존 `query(top_k=len)` 경로 유지.
- `tests/test_vector_store_protocol.py` — 신규 5 케이스, 계약 고정: 입력 순서 보존, 빈 입력, dim-mismatch raise, out-of-range raise (도입하지 *않는* 버그), per-index `get(idx)` + dot 루프와의 parity.

## Test plan

- [x] `pytest tests/test_vector_store_protocol.py` — 15 passed (신규 5 + 기존 10).
- [x] `pytest tests/test_retrieval_loop_regression.py tests/test_naive_baseline_ranking_invariance.py tests/test_partial_topic_grounding.py tests/test_fuzzy_retrieval.py tests/test_metadata_extraction_regression.py tests/test_vector_store_qdrant.py` — 70 passed, 1 skipped (qdrant-client 미설치로 로컬 Qdrant 테스트 skip; CI 에서 실행).
- [x] 전체 `pytest -q` (사전 실패 `test_harness_observability`, `test_run_harness`, `test_ship_dispatcher_gates`, `test_mixed_format_ingestion_regression` 제외): 1278 passed; `test_mixed_format_ingestion_regression` 의 무관 1건 실패는 `git stash` bisect 로 origin/main HEAD 사전 존재 확인.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path** — 모든 well-formed 인덱스에 대해 검색 ranking 미변경.

`rag_vector_store.py` 와 `rag_retrieval.py` 는 load-bearing. Bit-identity 논거:

- `InMemoryVectorStore.query_by_indices(qvec, indices)` 는 `self.vectors[indices] @ qvec` element-wise 반환. 기존 full-fetch 경로는 `self.vectors @ qvec` 반환 후 루프가 인덱싱. 수치적으로 동일 (같은 matrix rows, 같은 query vector, 같은 dot product).
- `QdrantVectorStore.query_by_indices` 는 dataclass-owned `vectors` matrix (`InMemoryVectorStore` 와 같은 source of truth) 사용, 기존 `test_qdrant_query_matches_in_memory_top_k_ranking` (1e-5 tolerance, PR #296) 가 assert 하는 in-memory ↔ Qdrant ranking parity 보존.
- 신규 경로 분기는 `filter_fallback_used` False AND candidate 수가 인덱스 크기보다 strictly less 일 때만 trigger; no-filter / fallback 케이스는 기존 코드 경로 unchanged 실행.
- Downstream `apply_fusion_and_reranking` 는 embedding_idx keyed `raw_cosine_by_idx` 소비; 신규 경로는 candidate subset 에 대해 identical map 생성, 어차피 scored 되지 않을 청크의 per-index dict entry 만 빠짐.

따라서 `make real-eval-delta` 는 0pp delta 예상. 필터된 쿼리의 latency 는 Qdrant 에서 개선 (적은 데이터 fetch), InMemory 에서 flat 유지 (matrix slice 는 full multiply 보다 느리지 않음); flat-or-faster 가 `reports/eval_summary.json` `stage_latency` 가 보여줄 결과.

## PR 템플릿 (inline)

1. **Issue**: #795.
2. **동작 변경?** unhappy 경로만 방어적: `query_by_indices` 가 out-of-range index 에 `IndexError` raise, #784 `dense_similarity` raise 반영. healthy 필터 쿼리의 검색 / verifier ranking 은 이전과 bit-identical.
3. **하위 호환성**: 동일 answer-dict 형태, 동일 검색 순서. Protocol 은 신규 메서드 1개 획득; 기존 소비자 미터치.
4. **테스트**: 확장된 `tests/test_vector_store_protocol.py` + 인접 retrieval suite green.
5. **Real-data delta**: 위 `### 5b. Real-data delta` 참조.
6. **ADR**: 신규 ADR 없음. Protocol 확장은 기존 `query()` 메서드 (#176) 와 동일 Stage 2b 패턴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
