### PR TITLE
fix(eval): retrieval_only redefined as raw retrieval ablation (closes #800)

### DIFF
--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -170,21 +170,22 @@ ablation_runs:
     rerank: true
     verifier_retry: false
     retrieval_mode: flat
-  # Issue #694 — dedicated retrieval-quality time-series slot.
-  # Uses the full retrieval stack (metadata_first, rerank) with
-  # verifier_retry=false so the first-pass chunk ranking is measured
-  # without the retry-and-relax feedback loop.  Evaluation focus:
-  # chunk_recall_at_5/10/20 and chunk_ndcg_at_10/20; accuracy and
-  # groundedness are expected to be lower than `full` since the verifier
-  # retry that recovers from weak first-pass evidence is absent.
-  # Distinct from `no_verifier_retry` in intent: this row is the
-  # canonical leaderboard slot for tracking retrieval quality over time
-  # (ADR 0030 forward-only series pattern); `no_verifier_retry` remains
-  # the verifier-retry-contribution ablation reference.
+  # Issue #800 (fix follow-up to #694) — re-defined as raw retrieval ablation.
+  # Original PR #694 definition was byte-identical to `no_verifier_retry`
+  # (same pipeline/metadata_first/rerank/verifier_retry/retrieval_mode) so
+  # the two leaderboard columns always produced identical values.  This row
+  # is now the canonical "post-retrieval enhancement off" slot for tracking
+  # raw retrieval quality (chunk_recall_at_5/10/20, chunk_ndcg_at_10/20);
+  # `no_verifier_retry` remains the verifier-retry-contribution reference.
+  # Difference vs `no_verifier_retry`: rerank=false (cross-encoder rerank off).
+  # Difference vs `no_rerank`: verifier_retry=false (no retry-and-relax loop).
+  # Historical values for this column prior to PR-closing #800 are stale —
+  # they reflect the duplicate (=`no_verifier_retry`) config.  Leaderboard
+  # cutoff to be tracked separately (issue D4 follow-up).
   - name: retrieval_only
     pipeline: agentic_full
     metadata_first: true
-    rerank: true
+    rerank: false
     verifier_retry: false
     retrieval_mode: flat
   - name: hybrid_bm25

--- a/tests/test_retrieval_only_ablation_preset.py
+++ b/tests/test_retrieval_only_ablation_preset.py
@@ -1,9 +1,14 @@
-"""Regression test for retrieval_only ablation preset (issue #694).
+"""Regression test for retrieval_only ablation preset (issues #694, #800).
 
 Verifies that eval/config.yaml contains the ``retrieval_only`` row with the
-expected config (full retrieval stack, verifier_retry=False) and that the
-ADR 0001 invariants are preserved (naive_baseline unchanged,
+expected config (raw retrieval ablation: rerank=False + verifier_retry=False)
+and that the ADR 0001 invariants are preserved (naive_baseline unchanged,
 no_verifier_retry not removed).
+
+Additionally enforces the differentiation invariant from issue #800:
+``retrieval_only`` and ``no_verifier_retry`` must NOT be byte-identical
+configs (name aside).  The original #694 definition violated this, which is
+why the row was re-defined to ``rerank=false``.
 """
 from __future__ import annotations
 
@@ -48,16 +53,25 @@ class TestRetrievalOnlyAblationRow(unittest.TestCase):
             "retrieval_only: verifier_retry must be False",
         )
 
-    def test_retrieval_only_metadata_first_and_rerank(self) -> None:
-        """Full retrieval stack — metadata_first and rerank must be True."""
+    def test_retrieval_only_metadata_first_true(self) -> None:
+        """metadata_first stays True — retrieval_only measures the post-prefilter stack."""
         row = self.ablation_by_name["retrieval_only"]
         self.assertTrue(
             row.get("metadata_first", True),
-            "retrieval_only: metadata_first must be True (full retrieval stack)",
+            "retrieval_only: metadata_first must be True",
         )
-        self.assertTrue(
+
+    def test_retrieval_only_rerank_false(self) -> None:
+        """Issue #800: rerank=False (raw retrieval, no cross-encoder rerank).
+
+        Differentiates retrieval_only from no_verifier_retry (which has
+        rerank=True).  Previously rerank=True, which made the two rows
+        byte-identical — see issue #800 for the redefinition rationale.
+        """
+        row = self.ablation_by_name["retrieval_only"]
+        self.assertFalse(
             row.get("rerank", True),
-            "retrieval_only: rerank must be True (full retrieval stack)",
+            "retrieval_only: rerank must be False (raw retrieval ablation, issue #800)",
         )
 
     def test_retrieval_only_flat_retrieval_mode(self) -> None:
@@ -90,6 +104,27 @@ class TestRetrievalOnlyAblationRow(unittest.TestCase):
             len(names),
             len(set(names)),
             "Duplicate ablation run names found in eval/config.yaml",
+        )
+
+    def test_retrieval_only_differs_from_no_verifier_retry(self) -> None:
+        """Issue #800 invariant: retrieval_only and no_verifier_retry must NOT
+        be byte-identical (name aside).
+
+        The original PR #694 definition violated this — both rows had
+        identical pipeline/metadata_first/rerank/verifier_retry/retrieval_mode,
+        so ablation runner produced identical leaderboard values for two
+        named columns.  This invariant prevents the regression.
+        """
+        retrieval_only = self.ablation_by_name["retrieval_only"]
+        no_verifier_retry = self.ablation_by_name["no_verifier_retry"]
+        ro_minus_name = {k: v for k, v in retrieval_only.items() if k != "name"}
+        nvr_minus_name = {k: v for k, v in no_verifier_retry.items() if k != "name"}
+        self.assertNotEqual(
+            ro_minus_name,
+            nvr_minus_name,
+            "retrieval_only and no_verifier_retry are byte-identical (issue #800). "
+            "If you intended retrieval_only to be an alias, delete the duplicate row; "
+            "otherwise differentiate at least one config bit.",
         )
 
 


### PR DESCRIPTION
## 1. Issue & motivation

Closes #800.

PR #694 가 `retrieval_only` 를 `eval/config.yaml` 에 추가했는데 config bit 가 `no_verifier_retry` 와 byte-identical:

| key | no_verifier_retry | retrieval_only (before) |
|---|---|---|
| pipeline | agentic_full | agentic_full |
| metadata_first | true | true |
| rerank | true | true |
| verifier_retry | false | false |
| retrieval_mode | flat | flat |

분석 변형 runner 가 두 row 에 동일 리더보드 값 산출 → `retrieval_only` 가 `no_verifier_retry` 의 silent alias 가 되어 별개 측정이 아님.

## 2. Change

- **`eval/config.yaml`**: `retrieval_only.rerank: true` → `false`
  - 이제 raw retrieval quality 격리 (cross-encoder rerank 없음, verifier retry 없음)
  - `no_verifier_retry` 와 구별 (그쪽은 rerank 유지)
  - `no_rerank` 와 구별 (그쪽은 verifier_retry 유지)
- **`tests/test_retrieval_only_ablation_preset.py`**:
  - `test_retrieval_only_rerank_false` (rerank=true 단정하던 `_metadata_first_and_rerank` 교체)
  - `test_retrieval_only_differs_from_no_verifier_retry` — **신규 invariant**, 향후 변경이 두 row 를 다시 byte-identical 로 만들면 fail

## 3. Verification

```
$ python3 -m unittest tests.test_retrieval_only_ablation_preset -v
Ran 10 tests in 0.396s
OK
```

## 4. Invariants preserved

- **ADR 0001 (naive_baseline)**: `test_naive_baseline_preserved` 여전히 pass
- **ADR 0030 (forward-only series)**: `retrieval_only` 컬럼이 같은 slot 유지 — semantic 정의만 변경
- **`no_verifier_retry` reference preserved**: `test_no_verifier_retry_still_present` 여전히 pass

## 5. PR template — required sections

### 5a. Risk

`retrieval_only` 리더보드 값이 본 PR 부터 변경. 이전 historical 값은 stale (= `no_verifier_retry`) — 의미 있는 비교 손실 없음.

### 5b. Real-data delta

**Primary-path delta: none.** No behavior change in retrieval / verifier path. eval primary 경로 (naive_baseline) 또는 retrieval_only 분석 변형 row 미선택 agentic 경로 동작 변경 없음. 본 PR 부터 리더보드 수치 변동 컬럼은 retrieval_only 자체뿐 — 이전 silent-alias row 재정의의 *의도된* 효과.

합성 CI delta (PR Eval Delta job) 가 불변 primary 경로 커버; ADR 0007 의 real-eval 요구는 위 명시 no-op 진술 + 섹션 1 의 byte-identical 증명으로 충족.

| Path | Before | After | Δ |
|---|---|---|---|
| naive_baseline (primary) | ADR 0001 | ADR 0001 | none |
| retrieval_only | =no_verifier_retry (silent alias) | rerank=false, vr=false (raw retrieval) | 의도된 재정의 |
| no_verifier_retry | rerank=true, vr=false | (불변) | none |
| no_rerank | rerank=false, vr=true | (불변) | none |

### 5c. Out of scope (separate issues)

- `full` 과 `full_llm_metadata` 도 byte-identical (`name` 제외) — 본 조사 중 검출; 별도 issue 로 제출 예정
- 리더보드 `chunk_recall@20` historical cutoff 주석 — senior-review D4, 별도 PR

## 6. Provenance

Senior-review critique (`/Users/hskim/.claude/plans/fizzy-splashing-cherny.md`) C2 + C3. PR #694 follow-up.

Generated with [Claude Code](https://claude.com/claude-code)
