### PR TITLE
docs(claude): karpathy-guidelines conflict policy + upstream fetched-at pin (closes #805)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Supporting:
 - **Backward compatibility.** Breaking changes need an explicit reason. Answer-contract break (ADR 0003) requires `schema_version` bump.
 - **ADR threshold.** Removing or replacing a load-bearing decision (baseline / pipeline / answer contract / eval surface) needs an ADR. Criteria: [`docs/adr/README.md`](docs/adr/README.md).
 - **Reserve ADR numbers up front.** Before drafting a new ADR, check both `ls docs/adr/` and `gh pr list --search "ADR" --state open` to find the next available number. Propose it and wait for user confirmation before creating the file — concurrent worktree work has produced repeat collisions (0022→0023, 0023→0025, 0029→0030).
-- **LLM coding bias guard.** See the `karpathy-guidelines` skill ([upstream](https://github.com/multica-ai/andrej-karpathy-skills)) for the 4-principle override (Think Before / Simplicity First / Surgical Changes / Goal-Driven) layered on top of the project-specific rules above.
+- **LLM coding bias guard.** See the `karpathy-guidelines` skill ([upstream](https://github.com/multica-ai/andrej-karpathy-skills), fetched 2026-05-15 — re-fetch with an explicit PR if upstream HEAD changes) for the 4-principle default (Think Before / Simplicity First / Surgical Changes / Goal-Driven). **Conflict policy**: the project-specific rules above (incident-derived) take precedence over the karpathy 4-principle (generic) — karpathy is a default to lean on when project rules are silent, not an override.
 
 ## PR description
 


### PR DESCRIPTION
## 1. Issue & 동기

Closes #805.

Senior-review 비판 E2 + E3:

- **E2 (충돌 정책)**: CLAUDE.md `LLM coding bias guard` 가 karpathy 4-principle 을 "layered on top" 이라고 했으나 tiebreaker 없음. 충돌 원칙 (예: "Reuse over invent" vs "Simplicity First") 이 양방향 가능.
- **E3 (upstream drift)**: 참조가 `multica-ai/andrej-karpathy-skills` HEAD 를 가리키는데 commit pin 없음. Upstream 변경이 CLAUDE.md 의미를 조용히 shift.

## 2. 변경

[CLAUDE.md:84](CLAUDE.md#L84) 1줄 편집:

- "4-principle override … layered on top" → "4-principle default" + 명시적 충돌 정책
- upstream 링크 옆 `fetched 2026-05-15` 추가 + upstream 변경 시 명시 PR 열라는 지시

## 3. 왜 ADR 없는가

비판 E1 대로 원 PR #726 은 Core principles 편집임에도 ADR 없이 karpathy 참조 추가. 이 PR 은 기존 참조 위 wording 명확화 — 신규 load-bearing 결정 아님. 향후 팀이 override 계층을 (wording 이 아닌) 정책으로 formalize 하려는 시점이 ADR-worthy 순간. 다음 senior review 가 그 판단을 challenge 할 수 있도록 명시.

## 4. 검증

```
$ grep -n karpathy CLAUDE.md
84:- **LLM coding bias guard.** See the `karpathy-guidelines` skill ([upstream](https://github.com/multica-ai/andrej-karpathy-skills), fetched 2026-05-15 — re-fetch with an explicit PR if upstream HEAD changes) for the 4-principle default (Think Before / Simplicity First / Surgical Changes / Goal-Driven). **Conflict policy**: the project-specific rules above (incident-derived) take precedence over the karpathy 4-principle (generic) — karpathy is a default to lean on when project rules are silent, not an override.
```

## 5. PR 템플릿 — 필수 섹션

### 5a. 리스크

Doc-only. 코드 경로 미터치. ADR/테스트 invariant 변경 없음.

### 5b. Real-data delta

**N/A — CLAUDE.md 문서만 변경.** SSoT 목록의 load-bearing 파일 미수정.

### 5c. Out of scope

- wording 의 ADR 승격은 의도적 유예 (섹션 3 참조).

## 6. Provenance

Senior-review 비판 (`/Users/hskim/.claude/plans/fizzy-splashing-cherny.md`) 항목 E2 + E3. PR #726 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
