### PR TITLE
refactor(retrieval): import comparison_targets_for_analysis directly from rag_query (closes #799)

### DIFF
--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -37,15 +37,18 @@ Internal helpers :func:`_coverage_counts`,
 :func:`_chunk_tokens_for_bm25` are module-private (underscore
 preserved from the rag_core layout).
 
-Circular-import avoidance: ``rag_core`` symbols that this module's
-functions need (``tokenize``, ``DEFAULT_EMBEDDING_MODEL`` /
-``DEFAULT_HASH_DIM``, ``embed_texts`` / ``hashing_embeddings``,
-``normalize_regions`` / ``normalize_page_span``) are late-imported at
-function-call time. These helpers serve many non-retrieval call sites
-in ``rag_core`` (ingestion path, evidence building, partial-topic
-grounding, ...), so they stay there; the late-import idiom keeps this
-module a true leaf of the dependency graph from rag_core's
-perspective while still allowing reuse.
+Circular-import avoidance: ``DEFAULT_EMBEDDING_MODEL`` /
+``DEFAULT_HASH_DIM`` / ``embed_texts`` / ``hashing_embeddings`` are
+late-imported from ``rag_core`` inside ``embed_query_for_index``.
+They live in ``rag_core`` because the index-build path also consumes
+them (and they share ``MODEL_CACHE`` state); a follow-up issue
+tracks extracting them to a leaf ``rag_embedding`` module so this
+function can drop the late-import idiom too. ``tokenize`` is now
+imported directly from ``rag_text_processing`` (a true leaf), and
+``normalize_regions`` / ``normalize_page_span`` from
+``rag_metadata_processing``. ``comparison_targets_for_analysis``
+is imported directly from ``rag_query`` (issue #799 — its prior
+late-import via ``rag_core`` was a re-export round-trip).
 
 JSON-identity guarantee: every function is moved byte-for-byte from
 ``rag_core``. ``tests/test_naive_baseline_ranking_invariance.py``,
@@ -64,6 +67,7 @@ import numpy as np
 from korean_lexicon import BM25_EXTRA_PARTICLE_SUFFIXES, BM25_EXTRA_STOPWORDS
 from rag_metadata_processing import normalize_page_span, normalize_regions
 from rag_pipeline_presets import RRF_K, VALID_BM25_STOPWORD_PROFILES
+from rag_query import comparison_targets_for_analysis
 from rag_query_expansion import default_expander
 from rag_text_processing import tokenize
 
@@ -172,12 +176,12 @@ def apply_comparison_balance(
     diagnostics on the plan dict either way (so observability is consistent
     across enabled/disabled states).
     """
-    # Late-import to avoid circular dependency: rag_core imports this
-    # module's public functions, and comparison_targets_for_analysis
-    # lives in rag_core because it is also called from
-    # rag_core.retrieve_candidates (kept there in PR-H1a).
-    from rag_core import comparison_targets_for_analysis
-
+    # Issue #799 — RAG senior-review critique #1 partial fix:
+    # ``comparison_targets_for_analysis`` actually lives in
+    # ``rag_query`` (PR-J3, issue #478). The previous late-import via
+    # ``rag_core`` was a re-export round-trip. Now imported at the
+    # module top, removing one of the two remaining late-import idioms
+    # in this leaf.
     targets, target_field = comparison_targets_for_analysis(analysis)
     is_comparison = analysis.get("query_type") == "comparison" and len(targets) >= 2
 


### PR DESCRIPTION
## Summary

- `rag_retrieval.apply_comparison_balance` 가 "circular import 회피"를 위해 함수 내부에서 `from rag_core import comparison_targets_for_analysis` 수행. 실제 함수는 `rag_query` 에 있고 `rag_core` 는 재-export 만 — late-import 는 의미 없는 re-export round-trip.
- 이 PR 이 `rag_retrieval.py` top-level 에 `from rag_query import comparison_targets_for_analysis` 추가하고 late-import 삭제.
- 모듈 docstring 의 circular-import-avoidance 섹션도 정정: PR-J1/J2/J3 가 이미 leaf module 로 마이그레이션한 이름 (`tokenize`, `normalize_regions`, `normalize_page_span`) 나열되어 있었음.
- 잔여 late-import (`embed_query_for_index` 내 4 embedding symbol) 는 별도 tracking — `MODEL_CACHE` 결합 분석 필요.

Closes #799. Critique #1 (trivial half) from `/Users/hskim/.claude/plans/fizzy-splashing-cherny.md` (RAG senior-review). Cycle 4 of the dynamic-loop fix sequence.

## Surface

- `rag_retrieval.py` — top-level import block 에 `from rag_query import comparison_targets_for_analysis` 추가. `apply_comparison_balance` 의 함수 내 late-import 제거. Docstring 의 circular-import-avoidance 섹션을 현재 상태로 갱신.

## Test plan

- [x] `python -c "import rag_retrieval, rag_query; assert rag_retrieval.comparison_targets_for_analysis is rag_query.comparison_targets_for_analysis"` — 동일 object, acyclic.
- [x] `pytest tests/test_fuzzy_retrieval.py tests/test_langgraph_orchestrator_regression.py tests/test_query_params.py` — 52 passed (comparison_balance 표면).
- [x] `pytest tests/test_retrieval_loop_regression.py tests/test_naive_baseline_ranking_invariance.py tests/test_partial_topic_grounding.py tests/test_fuzzy_retrieval.py` — 50 passed + 17 subtests.
- [x] Full `pytest -q` (기존 실패 test_harness_observability / test_run_harness / test_ship_dispatcher_gates / test_mixed_format_ingestion_regression 제외): 1300 passed, 174 subtests, 13 skipped, 0 failed.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

`rag_retrieval.py` 는 load-bearing. 변경은 순수 import-graph restructure:

- 이전: `apply_comparison_balance` 가 함수 호출 시점에 `rag_core` 의 re-export 로 `comparison_targets_for_analysis` 해결.
- 이후: 모듈 load 시점에 직접 `rag_query` import 로 동일 함수 해결.
- 동일 함수 object (`is` identity check 로 검증); 동일 call signature; 동일 return value.

`make real-eval-delta` 는 0pp delta 예상. Retrieval ranking byte-identical.

## PR template (filled inline)

1. **Issue**: #799.
2. **Behavior change?** No. 순수 import-graph restructure; 동일 함수 해결.
3. **Backward compatibility**: Same. `rag_core` 가 `comparison_targets_for_analysis` re-export 유지 — `from rag_core import comparison_targets_for_analysis` 외부 소비자 미터치.
4. **Tests**: comparison_balance + retrieval loop 표면 102+ 테스트 green; full suite clean.
5. **Real-data delta**: 위 `### 5b. Real-data delta` 참조.
6. **ADR**: 신규 ADR 없음. Follow-up embedding-symbol extraction 에 ADR 필요 (MODEL_CACHE 결합, build/read 경로 dual-use).

Generated with [Claude Code](https://claude.com/claude-code)
