### PR TITLE
feat(eval): scripts/plot_cost_frontier.py — USD cost-accuracy frontier (ADR 0038, closes #798)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,11 @@ reports/real100/history/*
 reports/history/*
 !reports/history/*.aggregate.json
 !reports/leaderboard.md
+# Issue #798 — cost-accuracy frontier (ADR 0038). Markdown + PNG are
+# the rendered artifacts of scripts/plot_cost_frontier.py; check them in
+# so reviewers can see the frontier without running the script.
+!reports/cost_frontier.md
+!reports/cost_frontier.png
 # Issue #237 — harness aggregate snapshots. Generated per ``run_harness``
 # invocation; untracked by default to keep developer working trees
 # clean. The leaderboard time-series lives under reports/history/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Synthetic eval surface (public corpus). Includes smoke, full eval, harness
 # matrix, judges, leaderboard render, pareto, korean public bench, external
 # baselines.
-.PHONY: eval smoke smoke-with-judge reproduce benchmark synthetic-judge judge-disagreements leaderboard pareto korean-public-fetch korean-public-eval external-baselines-stub external-baselines-langchain external-baselines-llamaindex external-baselines-ollama harness-smoke harness-ablation harness-compare synthesize-multihop eval-multihop
+.PHONY: eval smoke smoke-with-judge reproduce benchmark synthetic-judge judge-disagreements leaderboard pareto cost-frontier korean-public-fetch korean-public-eval external-baselines-stub external-baselines-langchain external-baselines-llamaindex external-baselines-ollama harness-smoke harness-ablation harness-compare synthesize-multihop eval-multihop
 
 # Real-data eval cycle (private; ADR 0005 commit boundary).
 .PHONY: real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
@@ -112,6 +112,15 @@ eval-multihop:
 # citation_precision).
 pareto:
 	$(PYTHON) scripts/plot_pareto.py --summary reports/eval_summary.json --markdown-out reports/pareto.md --png-out reports/pareto.png
+
+# Cost-accuracy frontier (ADR 0038 / issue #798). Reads
+# reports/eval_summary.json (in-repo ablations placed at x=0 per the
+# self-hosted rule) and reports/external_baselines.json (external real-API
+# backends, cost from case_results[i].cost_estimate_usd). Writes
+# reports/cost_frontier.md + reports/cost_frontier.png (PNG when matplotlib
+# is installed; the .md is always produced).
+cost-frontier:
+	$(PYTHON) scripts/plot_cost_frontier.py
 
 # Publish the demo image to GHCR so reviewers can `docker run <image>`
 # without cloning the repo (issue #123). Requires `docker login ghcr.io`

--- a/docs/adr/0038-cost-model-and-frontier-interpretation.md
+++ b/docs/adr/0038-cost-model-and-frontier-interpretation.md
@@ -93,6 +93,26 @@ Costs / constraints:
   the constant must be updated in `rag_synthesis.py`. No auto-update mechanism is
   planned.
 
+## Follow-up status (2026-05-15)
+
+The deferred frontier plot is now implemented as `scripts/plot_cost_frontier.py`
+(issue #798, follow-up to the closed-without-script issue #177). The script reads
+both `reports/eval_summary.json` (in-repo ablations, placed at x=0 per the
+"self-hosted" rule above) and `reports/external_baselines.json` (real API
+backends, cost from `case_results[i].cost_estimate_usd`), and emits
+`reports/cost_frontier.md` plus an optional `reports/cost_frontier.png` when
+matplotlib is installed. Regression tests in
+`tests/test_plot_cost_frontier_regression.py` lock in the Pareto-frontier
+dominance rule, the stub-exclusion behaviour (external runs without per-case
+cost are dropped with a stderr note rather than plotted at x=0), and the three
+anchors (accuracy ceiling / production sweet spot / cheapest acceptable floor).
+
+The first artifact is sanity-only until a real Anthropic API run via
+`make external-baselines-langchain` populates per-case cost in
+`reports/external_baselines.json`. Until then the plot's external side is
+empty and only the in-repo accuracy ceiling is shown — by design, since this
+ADR's "no fabricated numbers" posture means we will not synthesize cost data.
+
 ## Alternatives considered
 
 - **Aggregate cost at the ablation level only (not per-case).** Simpler, avoids

--- a/reports/cost_frontier.md
+++ b/reports/cost_frontier.md
@@ -1,0 +1,41 @@
+# Cost-accuracy frontier (ADR 0038)
+
+Acceptable floor: accuracy > 0.70. CI band: 95% bootstrap (when populated). Self-hosted ablations are plotted at x=0 per ADR 0038.
+
+## Anchors
+
+- **Accuracy ceiling** (in-repo, self-hosted): `no_verifier_retry` — 0.805 [0.720–0.890]
+- **Production sweet spot** (external, lowest-cost CI_lo > 0.70): — *no qualifying external backend*
+
+## All points
+
+| On frontier | Run | Cost (USD) | Accuracy | 95% CI | Type |
+|---|---|---:|---:|---|---|
+| ✓ | no_verifier_retry | $0 (self-hosted) | 0.805 | [0.720–0.890] | self-hosted |
+| ✓ | retrieval_only | $0 (self-hosted) | 0.805 | [0.720–0.890] | self-hosted |
+|  | naive_baseline | $0 (self-hosted) | 0.744 | [0.646–0.829] | self-hosted |
+|  | naive_baseline_finetuned | $0 (self-hosted) | 0.744 | [0.646–0.829] | self-hosted |
+|  | full | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | full_llm | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | full_llm_metadata | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hierarchical | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hybrid_bm25 | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hybrid_bm25_k10 | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hybrid_bm25_k30 | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hybrid_bm25_k100 | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hybrid_bm25_extra_stopwords | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hybrid_bm25_k30_extra | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | full_kiwi | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | full_mecab | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | full_khaiii | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | full_reranker | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | full_hyde | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | agentic_full_finetuned | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hwp_csv_text | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hwp_native | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | hwp_native_tables | $0 (self-hosted) | 0.695 | [0.598–0.793] | self-hosted |
+|  | m3_full | $0 (self-hosted) | 0.683 | [0.585–0.780] | self-hosted |
+|  | no_rerank | $0 (self-hosted) | 0.671 | [0.561–0.768] | self-hosted |
+|  | no_metadata_first | $0 (self-hosted) | 0.659 | [0.549–0.768] | self-hosted |
+
+Frontier members (2): no_verifier_retry, retrieval_only.

--- a/scripts/plot_cost_frontier.py
+++ b/scripts/plot_cost_frontier.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Cost-accuracy frontier extractor (ADR 0038, follow-up to issue #177).
+
+Reads ``reports/eval_summary.json`` (in-repo ablations) and
+``reports/external_baselines.json`` (real-API backends) and emits a Markdown
+table at ``reports/cost_frontier.md``. Optionally renders
+``reports/cost_frontier.png`` when matplotlib is available; the PNG render is
+skipped cleanly otherwise so the same script runs in CI containers that don't
+install matplotlib.
+
+ADR 0038 interpretation:
+
+- **x-axis** ``sum(case_results[i].cost_estimate_usd)`` in USD. Self-hosted
+  ablations (cost = ``None`` at source) are placed at ``x = 0`` and labelled
+  "self-hosted" in the legend.
+- **y-axis** ``accuracy.mean`` with bootstrap 95% CI band (when populated).
+- **Production sweet spot** — lowest-cost external backend whose accuracy CI
+  lower bound exceeds the acceptable floor threshold (default ``0.70``).
+- **Accuracy ceiling** — best in-repo ablation accuracy at ``x = 0``.
+- **Cheapest acceptable floor** — lowest-cost external backend whose accuracy
+  mean exceeds the floor; points below the floor are plotted as grey
+  non-Pareto dots.
+
+Read-only consumer; does not modify the eval pipeline or the answer contract.
+The ADR 0001 ``naive_baseline`` invariant is preserved (no eval logic
+touched).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import NamedTuple, Optional, Sequence
+
+
+DEFAULT_ACCEPTABLE_FLOOR = 0.70
+
+
+class FrontierPoint(NamedTuple):
+    name: str
+    cost_usd: float  # 0.0 for self-hosted (cost = None at source)
+    accuracy: float  # mean
+    ci_lo: Optional[float]
+    ci_hi: Optional[float]
+    is_self_hosted: bool
+    backend: Optional[str]
+    model: Optional[str]
+    extras: dict
+
+
+def sum_case_cost(case_results: Sequence[dict]) -> Optional[float]:
+    """Sum ``cost_estimate_usd`` across case_results.
+
+    Returns ``None`` if every case has ``cost_estimate_usd is None`` (the
+    stub-backend pattern per ADR 0038) or if the input is empty. Callers
+    should treat ``None`` as "no cost data — exclude from cost axis".
+    """
+    total = 0.0
+    has_any = False
+    for cr in case_results:
+        if not isinstance(cr, dict):
+            continue
+        cost = cr.get("cost_estimate_usd")
+        if cost is None:
+            continue
+        try:
+            total += float(cost)
+            has_any = True
+        except (TypeError, ValueError):
+            continue
+    return total if has_any else None
+
+
+def _accuracy_mean(value: object) -> Optional[float]:
+    """Coerce ``accuracy`` field (float or {"mean": ...} dict) to a float."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, dict):
+        mean = value.get("mean")
+        if isinstance(mean, (int, float)):
+            return float(mean)
+    return None
+
+
+def _ci_band(
+    run_or_metric: dict, metric: str = "accuracy"
+) -> tuple[Optional[float], Optional[float]]:
+    """Extract (ci_lo, ci_hi) from a run / metric dict.
+
+    Supports two shapes:
+    - ``run["ci"]["accuracy"]`` — eval_summary ablation pattern
+    - ``run["accuracy"]`` itself when it's a dict with ci_lo/ci_hi —
+      external_baselines.json metrics pattern
+    """
+    ci_block = run_or_metric.get("ci")
+    if isinstance(ci_block, dict):
+        ci = ci_block.get(metric)
+        if isinstance(ci, dict):
+            return ci.get("ci_lo"), ci.get("ci_hi")
+    inline = run_or_metric.get(metric)
+    if isinstance(inline, dict):
+        return inline.get("ci_lo"), inline.get("ci_hi")
+    return None, None
+
+
+def extract_inrepo_points(summary: dict) -> list[FrontierPoint]:
+    """Extract one FrontierPoint per ablation run from eval_summary.json.
+
+    Per ADR 0038, in-repo ablations are placed at ``x = 0`` ("self-hosted")
+    regardless of any case-level cost data — the in-repo pipeline does not
+    pay an external API. Synthesis cost, when populated, is for opt-in
+    external-backend ablations and is handled by ``external_baselines.json``,
+    not this path.
+    """
+    points: list[FrontierPoint] = []
+    runs = summary.get("ablation", {}).get("runs") or []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        name = str(run.get("name") or "")
+        if not name:
+            continue
+        accuracy = _accuracy_mean(run.get("accuracy"))
+        if accuracy is None:
+            continue
+        ci_lo, ci_hi = _ci_band(run, "accuracy")
+        points.append(
+            FrontierPoint(
+                name=name,
+                cost_usd=0.0,
+                accuracy=accuracy,
+                ci_lo=ci_lo,
+                ci_hi=ci_hi,
+                is_self_hosted=True,
+                backend=None,
+                model=None,
+                extras={"groundedness": run.get("groundedness")},
+            )
+        )
+    return points
+
+
+def extract_external_points(external: dict) -> list[FrontierPoint]:
+    """Extract one FrontierPoint from external_baselines.json (single backend).
+
+    Per ADR 0038, cost is ``sum(case_results[i].cost_estimate_usd)``. If the
+    external file lacks per-case cost data (e.g. the langchain runner did not
+    emit ``cost_estimate_usd`` per case), the point is excluded from the plot
+    with a stderr note — without cost, there is nothing to put on the x-axis.
+    """
+    backend = external.get("backend")
+    model = external.get("model")
+    metrics = external.get("metrics") or {}
+    acc_block = metrics.get("accuracy")
+    accuracy = _accuracy_mean(acc_block)
+    if accuracy is None:
+        return []
+    ci_lo, ci_hi = _ci_band({"accuracy": acc_block}, "accuracy")
+    case_results = external.get("case_results") or []
+    cost = sum_case_cost(case_results) if case_results else None
+    if cost is None:
+        sys.stderr.write(
+            "[plot_cost_frontier] external_baselines.json has no per-case "
+            f"cost (backend={backend}, model={model}). Run "
+            "`make external-baselines-langchain` with ANTHROPIC_API_KEY to "
+            "populate case_results[i].cost_estimate_usd; external point "
+            "excluded.\n"
+        )
+        return []
+    name = (
+        f"{backend}:{model}"
+        if backend and model
+        else (backend or model or "external")
+    )
+    return [
+        FrontierPoint(
+            name=name,
+            cost_usd=cost,
+            accuracy=accuracy,
+            ci_lo=ci_lo,
+            ci_hi=ci_hi,
+            is_self_hosted=False,
+            backend=backend,
+            model=model,
+            extras={},
+        )
+    ]
+
+
+def compute_frontier(points: Sequence[FrontierPoint]) -> list[FrontierPoint]:
+    """2-D Pareto frontier: lower cost + higher accuracy dominates.
+
+    Identical rule to ``scripts/plot_pareto.compute_pareto_frontier`` but on
+    the (cost_usd, accuracy) plane: ``P`` is dominated iff some ``Q`` has
+    ``Q.cost <= P.cost`` and ``Q.accuracy >= P.accuracy`` with at least one
+    strict. Ties are kept.
+    """
+    frontier: list[FrontierPoint] = []
+    for cand in points:
+        dominated = False
+        for other in points:
+            if other is cand:
+                continue
+            if (
+                other.cost_usd <= cand.cost_usd
+                and other.accuracy >= cand.accuracy
+                and (
+                    other.cost_usd < cand.cost_usd
+                    or other.accuracy > cand.accuracy
+                )
+            ):
+                dominated = True
+                break
+        if not dominated:
+            frontier.append(cand)
+    return frontier
+
+
+def find_sweet_spot(
+    external: Sequence[FrontierPoint],
+    floor: float = DEFAULT_ACCEPTABLE_FLOOR,
+) -> Optional[FrontierPoint]:
+    """Lowest-cost external backend whose accuracy CI lower bound > floor."""
+    qualified = [p for p in external if p.ci_lo is not None and p.ci_lo > floor]
+    if not qualified:
+        return None
+    return min(qualified, key=lambda p: p.cost_usd)
+
+
+def find_accuracy_ceiling(
+    in_repo: Sequence[FrontierPoint],
+) -> Optional[FrontierPoint]:
+    """Best in-repo ablation accuracy (x = 0)."""
+    if not in_repo:
+        return None
+    return max(in_repo, key=lambda p: p.accuracy)
+
+
+def find_cheapest_floor(
+    external: Sequence[FrontierPoint],
+    floor: float = DEFAULT_ACCEPTABLE_FLOOR,
+) -> Optional[FrontierPoint]:
+    """Lowest-cost external backend whose accuracy mean > floor."""
+    qualified = [p for p in external if p.accuracy > floor]
+    if not qualified:
+        return None
+    return min(qualified, key=lambda p: p.cost_usd)
+
+
+def _fmt_cost(p: FrontierPoint) -> str:
+    return f"${p.cost_usd:.4f}" if p.cost_usd > 0 else "$0 (self-hosted)"
+
+
+def _fmt_ci(p: FrontierPoint) -> str:
+    if p.ci_lo is None or p.ci_hi is None:
+        return "—"
+    return f"[{p.ci_lo:.3f}–{p.ci_hi:.3f}]"
+
+
+def _fmt_type(p: FrontierPoint) -> str:
+    if p.is_self_hosted:
+        return "self-hosted"
+    if p.backend and p.model:
+        return f"{p.backend}/{p.model}"
+    return "external"
+
+
+def render_markdown(
+    in_repo: Sequence[FrontierPoint],
+    external: Sequence[FrontierPoint],
+    frontier: Sequence[FrontierPoint],
+    floor: float,
+) -> str:
+    """Render the cost-accuracy table + ADR 0038 anchors."""
+    frontier_names = {p.name for p in frontier}
+    sweet_spot = find_sweet_spot(external, floor)
+    ceiling = find_accuracy_ceiling(in_repo)
+    cheapest_floor = find_cheapest_floor(external, floor)
+
+    lines: list[str] = [
+        "# Cost-accuracy frontier (ADR 0038)",
+        "",
+        f"Acceptable floor: accuracy > {floor:.2f}. CI band: 95% bootstrap "
+        "(when populated). Self-hosted ablations are plotted at x=0 per "
+        "ADR 0038.",
+        "",
+        "## Anchors",
+        "",
+    ]
+
+    if ceiling is not None:
+        lines.append(
+            f"- **Accuracy ceiling** (in-repo, self-hosted): "
+            f"`{ceiling.name}` — {ceiling.accuracy:.3f} {_fmt_ci(ceiling)}"
+        )
+    else:
+        lines.append(
+            "- **Accuracy ceiling** (in-repo): — *no in-repo ablations*"
+        )
+
+    if sweet_spot is not None:
+        lines.append(
+            f"- **Production sweet spot** (external, lowest-cost CI_lo > "
+            f"{floor:.2f}): `{sweet_spot.name}` — {_fmt_cost(sweet_spot)}, "
+            f"acc {sweet_spot.accuracy:.3f} {_fmt_ci(sweet_spot)}"
+        )
+    else:
+        lines.append(
+            f"- **Production sweet spot** (external, lowest-cost CI_lo > "
+            f"{floor:.2f}): — *no qualifying external backend*"
+        )
+
+    if cheapest_floor is not None and (
+        sweet_spot is None or cheapest_floor.name != sweet_spot.name
+    ):
+        lines.append(
+            f"- **Cheapest acceptable floor** (external, lowest-cost mean > "
+            f"{floor:.2f}): `{cheapest_floor.name}` — "
+            f"{_fmt_cost(cheapest_floor)}, "
+            f"acc {cheapest_floor.accuracy:.3f}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## All points",
+            "",
+            "| On frontier | Run | Cost (USD) | Accuracy | 95% CI | Type |",
+            "|---|---|---:|---:|---|---|",
+        ]
+    )
+    all_points = sorted(
+        list(in_repo) + list(external),
+        key=lambda p: (p.cost_usd, -p.accuracy),
+    )
+    for p in all_points:
+        marker = "✓" if p.name in frontier_names else ""
+        lines.append(
+            f"| {marker} | {p.name} | {_fmt_cost(p)} | {p.accuracy:.3f} | "
+            f"{_fmt_ci(p)} | {_fmt_type(p)} |"
+        )
+    lines.append("")
+    if frontier_names:
+        lines.append(
+            f"Frontier members ({len(frontier_names)}): "
+            + ", ".join(sorted(frontier_names))
+            + "."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def try_render_png(
+    in_repo: Sequence[FrontierPoint],
+    external: Sequence[FrontierPoint],
+    frontier: Sequence[FrontierPoint],
+    floor: float,
+    out_path: Path,
+) -> bool:
+    """Attempt matplotlib PNG render; return False if matplotlib missing."""
+    try:
+        import matplotlib  # type: ignore  # noqa: F401
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt  # type: ignore
+    except ImportError:
+        return False
+
+    frontier_names = {p.name for p in frontier}
+    fig, ax = plt.subplots(figsize=(9, 6))
+
+    for p in list(in_repo) + list(external):
+        on_frontier = p.name in frontier_names
+        below_floor = (not p.is_self_hosted) and p.accuracy <= floor
+        color = (
+            "tab:orange"
+            if on_frontier
+            else "tab:gray"
+            if below_floor
+            else "tab:blue"
+        )
+        size = 120 if on_frontier else 60
+        ax.scatter(
+            p.cost_usd,
+            p.accuracy,
+            s=size,
+            facecolors=color,
+            edgecolors="black",
+            zorder=3 if on_frontier else 2,
+        )
+        ax.annotate(
+            p.name,
+            (p.cost_usd, p.accuracy),
+            textcoords="offset points",
+            xytext=(6, 6),
+            fontsize=8,
+        )
+        if p.ci_lo is not None and p.ci_hi is not None:
+            ax.errorbar(
+                p.cost_usd,
+                p.accuracy,
+                yerr=[[p.accuracy - p.ci_lo], [p.ci_hi - p.accuracy]],
+                fmt="none",
+                ecolor="black",
+                alpha=0.3,
+                zorder=1,
+            )
+
+    ax.axhline(
+        floor,
+        color="red",
+        linestyle="--",
+        alpha=0.5,
+        label=f"Acceptable floor ({floor:.2f})",
+    )
+    frontier_sorted = sorted(frontier, key=lambda p: p.cost_usd)
+    if len(frontier_sorted) >= 2:
+        ax.plot(
+            [p.cost_usd for p in frontier_sorted],
+            [p.accuracy for p in frontier_sorted],
+            color="tab:orange",
+            linestyle="--",
+            linewidth=1,
+            zorder=1,
+            label="Pareto frontier",
+        )
+
+    ax.set_xlabel("Cost (USD per eval suite; x=0 means self-hosted)")
+    ax.set_ylabel("Accuracy (mean, 95% CI band)")
+    ax.set_title("Cost-accuracy frontier — ADR 0038")
+    ax.grid(True, linestyle=":", alpha=0.4)
+    ax.legend(loc="lower right", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=144)
+    plt.close(fig)
+    return True
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--summary",
+        default="reports/eval_summary.json",
+        help="Path to eval_summary.json (default: reports/eval_summary.json).",
+    )
+    parser.add_argument(
+        "--external",
+        default="reports/external_baselines.json",
+        help=(
+            "Path to external_baselines.json "
+            "(default: reports/external_baselines.json)."
+        ),
+    )
+    parser.add_argument(
+        "--markdown-out",
+        default="reports/cost_frontier.md",
+        help="Where to write the Markdown frontier table.",
+    )
+    parser.add_argument(
+        "--png-out",
+        default="reports/cost_frontier.png",
+        help="Where to write the PNG render (if matplotlib is installed).",
+    )
+    parser.add_argument(
+        "--floor",
+        type=float,
+        default=DEFAULT_ACCEPTABLE_FLOOR,
+        help=f"Acceptable accuracy floor (default {DEFAULT_ACCEPTABLE_FLOOR}).",
+    )
+    args = parser.parse_args(argv)
+
+    in_repo: list[FrontierPoint] = []
+    external: list[FrontierPoint] = []
+
+    summary_path = Path(args.summary)
+    if summary_path.exists():
+        try:
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            sys.stderr.write(
+                f"[plot_cost_frontier] Failed to parse {summary_path}: {exc}\n"
+            )
+            return 2
+        in_repo = extract_inrepo_points(summary)
+    else:
+        sys.stderr.write(
+            f"[plot_cost_frontier] {summary_path} not found; skipping in-repo "
+            "ablations. Run `make eval` to generate.\n"
+        )
+
+    external_path = Path(args.external)
+    if external_path.exists():
+        try:
+            external_data = json.loads(external_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            sys.stderr.write(
+                f"[plot_cost_frontier] Failed to parse {external_path}: {exc}\n"
+            )
+            return 2
+        external = extract_external_points(external_data)
+    else:
+        sys.stderr.write(
+            f"[plot_cost_frontier] {external_path} not found; skipping "
+            "external baselines. Run `make external-baselines-langchain` to "
+            "generate.\n"
+        )
+
+    all_points = in_repo + external
+    if not all_points:
+        sys.stderr.write(
+            "[plot_cost_frontier] No points to plot. Generate inputs first.\n"
+        )
+        return 1
+
+    frontier = compute_frontier(all_points)
+
+    markdown_out = Path(args.markdown_out)
+    markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    markdown_out.write_text(
+        render_markdown(in_repo, external, frontier, args.floor),
+        encoding="utf-8",
+    )
+    print(f"[plot_cost_frontier] Wrote {markdown_out}")
+
+    png_out = Path(args.png_out)
+    png_out.parent.mkdir(parents=True, exist_ok=True)
+    if try_render_png(in_repo, external, frontier, args.floor, png_out):
+        print(f"[plot_cost_frontier] Wrote {png_out}")
+    else:
+        print(
+            "[plot_cost_frontier] matplotlib not installed; PNG skipped. "
+            "Install with `pip install matplotlib` and re-run.",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_plot_cost_frontier_regression.py
+++ b/tests/test_plot_cost_frontier_regression.py
@@ -1,0 +1,317 @@
+"""Regression tests for the cost-accuracy frontier helper (ADR 0038 / issue #798).
+
+PNG render goes through matplotlib (not a CI dependency); only the
+pure-Python frontier logic and the input extraction are tested here. Pattern
+mirrors ``tests/test_pareto_frontier.py`` (the sibling latency-based plotter).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts.plot_cost_frontier import (
+    DEFAULT_ACCEPTABLE_FLOOR,
+    FrontierPoint,
+    compute_frontier,
+    extract_external_points,
+    extract_inrepo_points,
+    find_accuracy_ceiling,
+    find_cheapest_floor,
+    find_sweet_spot,
+    render_markdown,
+    sum_case_cost,
+)
+
+
+def _pt(
+    name: str,
+    cost: float,
+    acc: float,
+    *,
+    ci_lo: float | None = None,
+    ci_hi: float | None = None,
+    is_self_hosted: bool = True,
+    backend: str | None = None,
+    model: str | None = None,
+) -> FrontierPoint:
+    return FrontierPoint(
+        name=name,
+        cost_usd=cost,
+        accuracy=acc,
+        ci_lo=ci_lo,
+        ci_hi=ci_hi,
+        is_self_hosted=is_self_hosted,
+        backend=backend,
+        model=model,
+        extras={},
+    )
+
+
+class TestSumCaseCost(unittest.TestCase):
+    def test_all_none_returns_none(self) -> None:
+        self.assertIsNone(
+            sum_case_cost(
+                [{"cost_estimate_usd": None}, {"cost_estimate_usd": None}]
+            )
+        )
+
+    def test_mixed_sums_only_non_none(self) -> None:
+        self.assertAlmostEqual(
+            sum_case_cost(
+                [
+                    {"cost_estimate_usd": 0.01},
+                    {"cost_estimate_usd": None},
+                    {"cost_estimate_usd": 0.005},
+                ]
+            ),
+            0.015,
+        )
+
+    def test_empty_returns_none(self) -> None:
+        # Empty input → treated as "no cost data", same as all-None.
+        self.assertIsNone(sum_case_cost([]))
+
+    def test_invalid_cost_skipped(self) -> None:
+        self.assertAlmostEqual(
+            sum_case_cost(
+                [
+                    {"cost_estimate_usd": "not a number"},
+                    {"cost_estimate_usd": 0.02},
+                ]
+            ),
+            0.02,
+        )
+
+
+class TestComputeFrontier(unittest.TestCase):
+    def test_dominated_point_removed(self) -> None:
+        # B dominates A (cheaper AND higher accuracy) → A dropped.
+        points = [_pt("A", 10.0, 0.50), _pt("B", 5.0, 0.60)]
+        frontier = compute_frontier(points)
+        self.assertEqual({p.name for p in frontier}, {"B"})
+
+    def test_undominated_kept(self) -> None:
+        # Three-point trade-off chain stays intact.
+        points = [
+            _pt("cheap_low", 0.0, 0.40),
+            _pt("medium", 5.0, 0.60),
+            _pt("expensive_high", 10.0, 0.90),
+        ]
+        frontier = compute_frontier(points)
+        self.assertEqual(
+            {p.name for p in frontier},
+            {"cheap_low", "medium", "expensive_high"},
+        )
+
+    def test_ties_kept(self) -> None:
+        # Two identical points stay together — neither strictly dominates.
+        points = [_pt("twin_a", 5.0, 0.7), _pt("twin_b", 5.0, 0.7)]
+        frontier = compute_frontier(points)
+        self.assertEqual({p.name for p in frontier}, {"twin_a", "twin_b"})
+
+    def test_empty_returns_empty(self) -> None:
+        self.assertEqual(compute_frontier([]), [])
+
+    def test_self_hosted_ceiling_dominates_lower_external(self) -> None:
+        # Self-hosted at x=0 with high accuracy dominates any external priced
+        # above it with lower accuracy — captures the ADR 0038 "any paid
+        # backend with equal-or-lower accuracy is dominated" rule.
+        ceiling = _pt("naive_baseline", 0.0, 0.82)
+        loser = _pt(
+            "external:dumb-cheap",
+            0.001,
+            0.40,
+            is_self_hosted=False,
+            backend="ext",
+            model="dumb",
+        )
+        frontier = compute_frontier([ceiling, loser])
+        self.assertEqual({p.name for p in frontier}, {"naive_baseline"})
+
+
+class TestExtractInrepoPoints(unittest.TestCase):
+    def test_self_hosted_cost_is_zero(self) -> None:
+        # Per ADR 0038, in-repo ablations are placed at x=0 regardless of
+        # any per-case cost in the summary.
+        summary = {
+            "ablation": {
+                "runs": [
+                    {"name": "naive_baseline", "accuracy": 0.78},
+                    {"name": "full", "accuracy": {"mean": 0.72}},
+                ]
+            }
+        }
+        points = extract_inrepo_points(summary)
+        self.assertEqual(len(points), 2)
+        for p in points:
+            self.assertEqual(p.cost_usd, 0.0)
+            self.assertTrue(p.is_self_hosted)
+
+    def test_missing_accuracy_dropped(self) -> None:
+        summary = {"ablation": {"runs": [{"name": "x"}]}}
+        self.assertEqual(extract_inrepo_points(summary), [])
+
+    def test_ci_band_extracted(self) -> None:
+        summary = {
+            "ablation": {
+                "runs": [
+                    {
+                        "name": "naive_baseline",
+                        "accuracy": 0.78,
+                        "ci": {"accuracy": {"ci_lo": 0.68, "ci_hi": 0.88}},
+                    }
+                ]
+            }
+        }
+        points = extract_inrepo_points(summary)
+        self.assertEqual(len(points), 1)
+        self.assertAlmostEqual(points[0].ci_lo, 0.68)
+        self.assertAlmostEqual(points[0].ci_hi, 0.88)
+
+
+class TestExtractExternalPoints(unittest.TestCase):
+    def test_no_case_results_excluded(self) -> None:
+        # Per ADR 0038, an external run without per-case cost data is
+        # excluded from the plot (nothing to put on the x-axis).
+        external = {
+            "backend": "langchain",
+            "model": "claude-sonnet-4-6",
+            "metrics": {
+                "accuracy": {"mean": 0.39, "ci_lo": 0.29, "ci_hi": 0.48}
+            },
+        }
+        self.assertEqual(extract_external_points(external), [])
+
+    def test_with_case_results_cost(self) -> None:
+        external = {
+            "backend": "langchain",
+            "model": "claude-sonnet-4-6",
+            "metrics": {
+                "accuracy": {"mean": 0.39, "ci_lo": 0.29, "ci_hi": 0.48}
+            },
+            "case_results": [
+                {"cost_estimate_usd": 0.012},
+                {"cost_estimate_usd": 0.010},
+            ],
+        }
+        points = extract_external_points(external)
+        self.assertEqual(len(points), 1)
+        self.assertAlmostEqual(points[0].cost_usd, 0.022)
+        self.assertEqual(points[0].name, "langchain:claude-sonnet-4-6")
+        self.assertFalse(points[0].is_self_hosted)
+        self.assertAlmostEqual(points[0].ci_lo, 0.29)
+        self.assertAlmostEqual(points[0].ci_hi, 0.48)
+
+
+class TestAnchors(unittest.TestCase):
+    def test_accuracy_ceiling_is_best_in_repo(self) -> None:
+        in_repo = [
+            _pt("naive_baseline", 0.0, 0.78),
+            _pt("full", 0.0, 0.72),
+            _pt("no_rerank", 0.0, 0.70),
+        ]
+        ceiling = find_accuracy_ceiling(in_repo)
+        self.assertIsNotNone(ceiling)
+        assert ceiling is not None  # for type narrowing
+        self.assertEqual(ceiling.name, "naive_baseline")
+
+    def test_sweet_spot_requires_ci_lower_above_floor(self) -> None:
+        # ADR 0038 sweet spot rule: CI_lo > floor (not just mean > floor).
+        # "good" qualifies (CI_lo = 0.72 > 0.70). "flaky" mean is above
+        # floor but CI_lo (0.65) is below → excluded.
+        external = [
+            _pt(
+                "good",
+                1.0,
+                0.80,
+                ci_lo=0.72,
+                ci_hi=0.88,
+                is_self_hosted=False,
+                backend="x",
+                model="g",
+            ),
+            _pt(
+                "flaky",
+                0.5,
+                0.75,
+                ci_lo=0.65,
+                ci_hi=0.85,
+                is_self_hosted=False,
+                backend="x",
+                model="f",
+            ),
+        ]
+        spot = find_sweet_spot(external, floor=DEFAULT_ACCEPTABLE_FLOOR)
+        self.assertIsNotNone(spot)
+        assert spot is not None
+        self.assertEqual(spot.name, "good")
+
+    def test_cheapest_floor_uses_mean(self) -> None:
+        # Both clear mean > 0.70 → cheaper wins.
+        external = [
+            _pt(
+                "expensive",
+                5.0,
+                0.80,
+                is_self_hosted=False,
+                backend="x",
+                model="e",
+            ),
+            _pt(
+                "cheap",
+                1.0,
+                0.75,
+                is_self_hosted=False,
+                backend="x",
+                model="c",
+            ),
+        ]
+        cheapest = find_cheapest_floor(external, floor=DEFAULT_ACCEPTABLE_FLOOR)
+        self.assertIsNotNone(cheapest)
+        assert cheapest is not None
+        self.assertEqual(cheapest.name, "cheap")
+
+    def test_no_qualifier_returns_none(self) -> None:
+        # All external below floor → no sweet spot, no cheapest floor.
+        external = [
+            _pt(
+                "bad",
+                1.0,
+                0.40,
+                ci_lo=0.30,
+                ci_hi=0.50,
+                is_self_hosted=False,
+                backend="x",
+                model="b",
+            )
+        ]
+        self.assertIsNone(find_sweet_spot(external))
+        self.assertIsNone(find_cheapest_floor(external))
+
+
+class TestRenderMarkdown(unittest.TestCase):
+    def test_smoke_in_repo_only(self) -> None:
+        in_repo = [
+            _pt(
+                "naive_baseline",
+                0.0,
+                0.78,
+                ci_lo=0.68,
+                ci_hi=0.88,
+            )
+        ]
+        external: list[FrontierPoint] = []
+        frontier = compute_frontier(in_repo + external)
+        out = render_markdown(
+            in_repo, external, frontier, DEFAULT_ACCEPTABLE_FLOOR
+        )
+        self.assertIn("ADR 0038", out)
+        self.assertIn("Accuracy ceiling", out)
+        self.assertIn("naive_baseline", out)
+        self.assertIn("$0 (self-hosted)", out)
+        # CI band rendered.
+        self.assertIn("[0.680–0.880]", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

Closes #798

ADR 0038 의 deferred plot 을 구현 (원래 closed-without-script 이슈 [#177](https://github.com/hskim-solv/BidMate-DocAgent/issues/177) 에서 약속). Pure-Python read-only consumer pattern — \`scripts/plot_pareto.py\` 미러링하되 cost axis 를 latency p95 → \`sum(case_results[i].cost_estimate_usd)\` USD 로 교체 (ADR 0038 interpretation).

## 2. Files affected

- \`scripts/plot_cost_frontier.py\` (new) — non-load-bearing
- \`tests/test_plot_cost_frontier_regression.py\` (new) — non-load-bearing
- \`Makefile\` — non-load-bearing (cost-frontier target + .PHONY entry)
- \`.gitignore\` — non-load-bearing (2-line exception)
- \`docs/adr/0038-cost-model-and-frontier-interpretation.md\` — load-bearing path (\`docs/adr/\` 포함). 단, **status 그대로 accepted**, "## Follow-up status (2026-05-15)" 섹션 1개 추가만. content/decision 무변경.
- \`reports/cost_frontier.md\` (new artifact) — non-load-bearing

## 3. Risks

- ADR 0038 변경이 §5b CI gate 트리거 가능 (\`docs/adr/\`가 load-bearing). 그러나 status/decision/interpretation 무변경 — follow-up status 추가만 → "No behavior change in retrieval / verifier path" 적용 가능.
- script bug — 19 regression test 통과 + 로컬 실행 정상 (\`reports/cost_frontier.md\` 산출 확인, accuracy ceiling = \`no_verifier_retry\` 0.805, external 측 stub-exclusion 정상).

## 4. Tests

\`tests/test_plot_cost_frontier_regression.py\` — 19 cases:
- \`TestSumCaseCost\` (4): all-None / mixed sum / empty / invalid skipped
- \`TestComputeFrontier\` (5): dominated removed / undominated kept / ties kept / empty / self-hosted ceiling vs external
- \`TestExtractInrepoPoints\` (3): self-hosted cost=0 / missing accuracy / CI band
- \`TestExtractExternalPoints\` (2): no case_results excluded / with cost included
- \`TestAnchors\` (4): ceiling / sweet spot CI_lo rule / cheapest floor mean rule / no qualifier
- \`TestRenderMarkdown\` (1): smoke

로컬 통과: \`PYTHONPATH=. python3 -m pytest tests/test_plot_cost_frontier_regression.py\` → 19 passed in 0.94s.

## 5. Eval impact

All \`·\` — non-RAG change. RAG 코어 (\`rag_core.py\` / retrieval / verifier / answer) 무관.

### 5b. Real-data delta

N/A — No behavior change in retrieval / verifier path. \`scripts/plot_cost_frontier.py\` 는 \`reports/eval_summary.json\` read-only consumer. ADR 0038 본문은 follow-up status 1 섹션 추가만 (status/decision/interpretation 무변경).

## 6. Backward compatibility

답변 schema / CLI flag / doc link 변경 없음. ADR 0003 \`schema_version\` 영향 없음. \`Makefile\` \`cost-frontier\` 신규 target (기존 target 무변경). \`.gitignore\` 추가 exception 2 line (기존 패턴 무변경).

## 7. Out of scope

- Real API run (\`make external-baselines-langchain\` + ANTHROPIC_API_KEY + ~\$2 비용) → 사용자 환경 별도 작업. 첫 산출물 \`reports/cost_frontier.md\` 는 external 측 비어 있음 (in-repo accuracy ceiling 만 표시) — ADR 0038 "no fabricated numbers" 원칙대로.
- matplotlib 의존성 추가 (\`requirements.txt\` 미수정) → matplotlib 없으면 PNG skip cleanly, .md만 생성.
- \`update_readme_metrics.py --check\` CI gate (issue [#792](https://github.com/hskim-solv/BidMate-DocAgent/issues/792) follow-up) — 본 PR 무관.