### PR TITLE
ci: narrow ADR 0032 embedding-spread gate to actual embedding diff lines (closes #810)

### DIFF
--- a/.github/workflows/branch-and-issue-check.yml
+++ b/.github/workflows/branch-and-issue-check.yml
@@ -82,14 +82,32 @@ jobs:
           # When an embedding-related path changes in this PR, verify that
           # reports/embedding_routed.json was also updated AND spread < threshold.
           # Non-embedding PRs: skip entirely.
-          embedding_changes=$(gh api \
+          #
+          # rag_embeddings.py and eval/routed_config.yaml fire unconditionally
+          # (they are purely embedding-domain files). eval/config.yaml is shared
+          # across many concerns (ablation rows, judges, retrieval knobs, etc.),
+          # so we fire only when its diff *patch* contains an embedding-routing
+          # keyword.  Keyword set (issue #810):
+          #
+          #     embedding | embed_backend | embed_model | model_key | hf_id
+          #     | sentence_transformer | routed
+          #
+          # Bypassed example: flipping `retrieval_only.rerank: true → false`
+          # (PR #802) — no keyword in the patch, gate correctly skipped.
+          unconditional_changes=$(gh api \
             "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '[.[] | select(.filename | test("^(rag_embeddings\\.py|eval/routed_config\\.yaml|eval/config\\.yaml)$"))] | length')
+            --jq '[.[] | select(.filename | test("^(rag_embeddings\\.py|eval/routed_config\\.yaml)$"))] | length')
+          config_keyword_hits=$(gh api \
+            "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[] | select(.filename == "eval/config.yaml") | .patch // ""' \
+            | grep -cE '^[+-].*\b(embedding|embed_backend|embed_model|model_key|hf_id|sentence_transformer|routed)\b' \
+            || true)
+          embedding_changes=$((unconditional_changes + config_keyword_hits))
           if [[ "$embedding_changes" -eq 0 ]]; then
             echo "✅ No embedding-related path changes — spread gate skipped."
             exit 0
           fi
-          echo "ℹ️  Embedding-related paths changed; checking reports/embedding_routed.json spread."
+          echo "ℹ️  Embedding-related paths changed (unconditional=$unconditional_changes config_keyword_hits=$config_keyword_hits); checking reports/embedding_routed.json spread."
           routed_changed=$(gh api \
             "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
             --jq '[.[] | select(.filename == "reports/embedding_routed.json")] | length')


### PR DESCRIPTION
## 1. Issue & 동기

Closes #810.

`.github/workflows/branch-and-issue-check.yml` 의 **"ADR 0032 embedding spread gate (issue #626)"** 는 `eval/config.yaml` 모든 수정을 embedding 관련으로 취급, `reports/embedding_routed.json` 재검증 요구. PR #802 (issue #800) 가 `ablation_runs[name=retrieval_only].rerank: true → false` 만 뒤집음 — embedding 라인 무변경 — 했으나 gate 가 발동, zero-impact diff 에 ~30분 sentence-transformers 재측정 강제.

## 2. Change

`.github/workflows/branch-and-issue-check.yml` step **ADR 0032 embedding spread gate**:

- `rag_embeddings.py` 와 `eval/routed_config.yaml` 는 unconditional trigger 유지 (순수 embedding-domain 파일)
- `eval/config.yaml` 은 unconditional regex 에서 제외. 대신 patch 를 가져와 embedding-routing 키워드로 grep:

  ```
  embedding | embed_backend | embed_model | model_key | hf_id
  | sentence_transformer | routed
  ```

  Patch 라인 (added or removed) 이 키워드 매치하면 gate 발동. 아니면 정상 skip.

워크플로 인라인 주석에 키워드 집합 문서화 + PR #802 / issue #810 을 trigger case 로 참조 — 미래 reader 가 embedding-routing 기준 알 수 있게.

## 3. Verification

- PR #802 diff 수동 추적: `eval/config.yaml` 에 `rerank: false` 와 `verifier_retry: false` 만 — 키워드 매치 없음 — gate 가 이제 정상 skip
- 가상: 분석 변형 row 에 `embedding_backend: kure_v1` 추가 PR 은 키워드 `embed_backend` (와 `embedding`) 매치 — 이전처럼 gate 발동
- `rag_embeddings.py` 수정: unconditional regex 매치 — `eval/config.yaml` 상태와 무관 gate 발동
- ADR 0032 spread 강제 (원래 #626 의도) 보존 — *trigger* 만 좁아짐; spread 체크 (`scripts/check_embedding_routed_spread.py`) 무변경

## 4. Invariants preserved

- **Issue #626 / ADR 0032**: 모든 embedding-routing 변경 여전히 gate 발동; `--strict` 스타일 escape hatch 도입 안 함
- **No-fly list**: ADR 파일 가드와 §5b 체크 무변경

## 5. PR template — required sections

### 5a. Risk

Trivial. Gate 는 이제 `eval/config.yaml` 에 대해 diff-aware. 향후 embedding 관련 변경이 *오직* 비키워드 필드 rename 만 한다면 slip 가능 — 그러나 키워드 집합이 현재 코드베이스 의 모든 embedding-touching 필드 커버, 필요시 키워드 추가는 one-line patch.

### 5b. Real-data delta

No behavior change in eval primary path. 이 PR 은 CI 워크플로 trigger 만 수정 — Python 소스, eval/config, ingestion 경로 무변경. Synthetic CI delta 가 무변경 primary path 커버.

### 5c. Out of scope

- Per-PR spread 측정 재실행 (#626 강제 모델 무변경)
- Trigger 집합에 파일 추가

## 6. Provenance

PR #802 (trigger case) — issue #810 은 PR #802 가 zero-impact diff 에 gate 실패 본 후 mid-loop 에 제출.

