### PR TITLE
fix(ci): narrow ADR 0032 embedding spread gate to embedding-keyword hunks (closes #819)

### DIFF
--- a/.github/workflows/branch-and-issue-check.yml
+++ b/.github/workflows/branch-and-issue-check.yml
@@ -82,17 +82,31 @@ jobs:
           # When an embedding-related path changes in this PR, verify that
           # reports/embedding_routed.json was also updated AND spread < threshold.
           # Non-embedding PRs: skip entirely.
-          embedding_changes=$(gh api \
-            "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '[.[] | select(.filename | test("^(rag_embeddings\\.py|eval/routed_config\\.yaml|eval/config\\.yaml)$"))] | length')
+          #
+          # Issue #819: eval/config.yaml has many non-embedding ablation bits
+          # (rerank, verifier_retry, retrieval_mode).  Hit the gate only when
+          # the changed hunks reference an embedding keyword.  rag_embeddings.py
+          # and eval/routed_config.yaml stay always-trigger paths.
+          files_json=$(gh api \
+            "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files")
+
+          strong_hits=$(echo "$files_json" | jq '[.[] | select(.filename | test("^(rag_embeddings\\.py|eval/routed_config\\.yaml)$"))] | length')
+
+          config_yaml_patch=$(echo "$files_json" | jq -r '.[] | select(.filename == "eval/config.yaml") | .patch // ""')
+          if [[ -n "$config_yaml_patch" ]] && echo "$config_yaml_patch" | grep -Eiq '\b(embedding|embedding_backend|embedding_model|minilm|kure|m3_|embed_)\b'; then
+            weak_hit=1
+          else
+            weak_hit=0
+          fi
+
+          embedding_changes=$((strong_hits + weak_hit))
+
           if [[ "$embedding_changes" -eq 0 ]]; then
             echo "✅ No embedding-related path changes — spread gate skipped."
             exit 0
           fi
           echo "ℹ️  Embedding-related paths changed; checking reports/embedding_routed.json spread."
-          routed_changed=$(gh api \
-            "/repos/$GITHUB_REPOSITORY/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '[.[] | select(.filename == "reports/embedding_routed.json")] | length')
+          routed_changed=$(echo "$files_json" | jq '[.[] | select(.filename == "reports/embedding_routed.json")] | length')
           if [[ "$routed_changed" -eq 0 ]]; then
             echo "❌ Embedding path changed but reports/embedding_routed.json was NOT updated." >&2
             echo "   Run: python scripts/run_routed_measurement.py --backend sentence-transformers" >&2


### PR DESCRIPTION
## 1. Issue & motivation

Closes #819.

The ADR 0032 embedding spread gate listed `eval/config.yaml` in its
always-trigger path matcher.  Any ablation row edit that did **not**
touch embeddings (e.g. `rerank`, `verifier_retry`, `retrieval_mode`,
`metadata_first` bits) triggered a fail demanding
`reports/embedding_routed.json` regeneration.

Immediate motivation: PR #802 (retrieval_only `rerank: true → false`)
hit this false-positive.  A one-bit rerank change is not embedding work.

## 2. Change

`.github/workflows/branch-and-issue-check.yml`:

- `rag_embeddings.py` and `eval/routed_config.yaml` remain always-trigger.
- `eval/config.yaml` triggers only when the **changed patch hunks**
  reference an embedding keyword (`embedding`, `embedding_backend`,
  `embedding_model`, `MiniLM`, `KURE`, `m3_`, `embed_`).
- Patch inspection via the GitHub API `patch` field — no repo checkout
  needed.

## 3. Verification

```
$ git diff --stat
 .github/workflows/branch-and-issue-check.yml | 26 ++++++++++++++++++++------
 1 file changed, 20 insertions(+), 6 deletions(-)
```

Logic walk-through:

| Scenario | Old gate | New gate |
|----------|----------|----------|
| `rag_embeddings.py` edited | trigger | trigger |
| `eval/routed_config.yaml` edited | trigger | trigger |
| `eval/config.yaml`: `embedding_model: MiniLM → KURE` | trigger | trigger (keyword match) |
| `eval/config.yaml`: `rerank: true → false` (retrieval_only) | trigger ❌ | skip ✓ |
| `eval/config.yaml`: new ablation row with no embedding keyword | trigger ❌ | skip ✓ |
| `eval/config.yaml`: comment-only change mentioning "embedding" | trigger | trigger (intentional — comment changes that mention embeddings still get scrutiny) |

The keyword regex is intentionally word-bounded (`\b...\b`) and
case-insensitive so substrings like `rerank` do not falsely match
"reranker_model" if a future row uses such a key.

## 4. Risk

- **False negative risk**: a future embedding-related change in
  `eval/config.yaml` that uses a key not in the keyword list (e.g.
  `vector_backend`) would skip the gate.  Acceptable cost: the gate
  is a tripwire for ADR 0032 invariant, not the only line of defense
  (`reports/embedding_routed.json` updates are still encouraged in PR
  reviews of any genuinely embedding-related change).
- **False positive risk**: a non-embedding row that happens to include
  "embedding" in a comment would still hit the gate.  Intentional —
  comment-level "embedding" mention indicates author intent and is
  worth a review-level prompt.

## 5. PR template — required sections

### 5a. Risk

CI workflow change.  Branch-and-issue-check.yml is a quality gate, not
runtime code.  Failure mode if the new logic itself is buggy: gate
either skips when it should trigger, or vice versa — both are visible
in PR check status.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

The workflow file is a CI gate, not part of the load-bearing path list
(rag_core / ingestion / eval / api / docs/adr / scripts/build_index).
`reports/embedding_routed.json` measurement procedure is unchanged.

### 5c. Out of scope

- Updating ADR 0032 with the trigger-scope clarification — separate doc PR if needed
- Adding a test for the gate logic — gate is shell + jq, would require workflow simulator (e.g. `act`); deferred

## 6. Provenance

PR #802 CI fail diagnosis. Not part of the original senior-review
critique 19-item list; surfaced as a follow-up blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)