### PR TITLE
feat(governance): PreToolUse plan-slug race detector hook (closes #779)

### DIFF
--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -274,3 +274,54 @@ notes the PR template item 5b requirement.
 
 Hook script: [`scripts/claude-hooks/pretooluse-loadbearing.sh`](../scripts/claude-hooks/pretooluse-loadbearing.sh).
 Never blocks — pure awareness layer.
+
+### Claude Code hook (opt-in, user-global) — plan-slug race detector
+
+When multiple concurrent worktrees run Claude Code sessions in parallel,
+the harness writes plan files into a user-global directory
+(`~/.claude/plans/<random-slug>.md`). The slug space is large but
+collisions are not zero on 10+ concurrent worktrees (observed
+2026-05-15 — issue [#779](https://github.com/hskim-solv/BidMate-DocAgent/issues/779)).
+
+[`scripts/claude-hooks/plan-slug-race.sh`](../scripts/claude-hooks/plan-slug-race.sh)
+is a **user-global** `PreToolUse` hook that blocks a `Write` to a plan
+file when:
+
+- the target file exists,
+- its mtime is within the last 5 min (`PLAN_SLUG_RACE_THRESHOLD`,
+  default 300 s),
+- its first 200 bytes declare a different worktree slug than the
+  caller's cwd-derived slug.
+
+Convention enforced on the writer side: the first 200 chars of every
+plan file should contain a marker such as
+`` 본 plan은 worktree `<slug>` 의 deliverable. `` so the hook can detect
+the race. Plans without a marker are not blocked (pre-convention
+files / false-positive avoidance).
+
+Override (only when you genuinely intend to overwrite another
+worktree's plan): set `PLAN_SLUG_RACE_THRESHOLD=0` for the invocation.
+
+The hook is **not** auto-registered (it lives outside the repo's
+`.claude/settings.json` because the same Claude Code session may
+span many repos). Wire it once in `~/.claude/settings.json`:
+
+```jsonc
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "<absolute path to>/scripts/claude-hooks/plan-slug-race.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Regression coverage: `tests/test_plan_slug_race_hook_regression.py`.

--- a/scripts/claude-hooks/plan-slug-race.sh
+++ b/scripts/claude-hooks/plan-slug-race.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook — plan-slug race detector (issue #779).
+#
+# Registered (user-globally) in `~/.claude/settings.json` with matcher
+# `Write`. Fires before Claude writes any file. Refuses to overwrite a
+# `~/.claude/plans/<slug>.md` that was last touched within the past 5
+# minutes by a *different* worktree, blocking the silent overwrite
+# pattern observed on 2026-05-15 (multiple worktree sessions racing on
+# the same random slug).
+#
+# Behavior:
+#   - exit 0 : safe / not applicable / fail-open
+#   - exit 2 : refuse the Write, print rationale + remediation to stderr
+#
+# Fail-open philosophy: a buggy hook silently letting one bad write
+# through is recoverable (the user notices the wrong content); a buggy
+# hook silently blocking every plan write is not.
+#
+# Hook input (stdin, JSON):
+#   { "tool_name": "Write",
+#     "tool_input": { "file_path": "...", "content": "..." }, ... }
+
+set -u
+
+THRESHOLD_SECONDS=${PLAN_SLUG_RACE_THRESHOLD:-300}
+SNIFF_BYTES=${PLAN_SLUG_RACE_SNIFF_BYTES:-200}
+
+# Read tool input from stdin and extract tool name + target path. We
+# bail (exit 0) on any parsing problem — the hook must never become a
+# noisy blocker.
+input=$(cat)
+
+read_field() {
+  printf '%s' "$input" | python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    v = d.get('$1', '') if '$1' in ('tool_name',) else d.get('tool_input', {}).get('$1', '')
+    print(v)
+except Exception:
+    pass
+" 2>/dev/null
+}
+
+tool_name=$(read_field tool_name)
+target=$(read_field file_path)
+
+if [[ "$tool_name" != "Write" ]]; then
+  exit 0
+fi
+if [[ -z "$target" ]]; then
+  exit 0
+fi
+
+# Resolve `~` and relative paths so the matcher works regardless of cwd.
+case "$target" in
+  "~"|"~/"*)
+    target="${HOME}${target:1}"
+    ;;
+esac
+if [[ "$target" != /* ]]; then
+  target="$(pwd)/$target"
+fi
+
+# Only fire for plans dir.  Use a glob so different home dirs work.
+plans_dir="${HOME}/.claude/plans"
+case "$target" in
+  "${plans_dir}/"*.md) ;;
+  *) exit 0 ;;
+esac
+
+# No existing file → no race.
+if [[ ! -f "$target" ]]; then
+  exit 0
+fi
+
+# Recent mtime check (portable: BSD `stat -f %m` on macOS, GNU `stat -c %Y` on Linux).
+if mtime=$(stat -f %m "$target" 2>/dev/null); then
+  :
+elif mtime=$(stat -c %Y "$target" 2>/dev/null); then
+  :
+else
+  exit 0
+fi
+now=$(date +%s)
+age=$(( now - mtime ))
+if (( age >= THRESHOLD_SECONDS )); then
+  exit 0
+fi
+
+# Sniff the first chunk for a worktree marker. The convention (see
+# `project_code_polish_backlog.md` 2026-05-15 entry) is to declare
+# the writing worktree in the first 200 chars, e.g.:
+#
+#   본 plan은 worktree `gifted-turing-c2761d` 의 deliverable.
+#
+# A fingerprint that's `worktree` followed (within ~30 chars) by a
+# backtick-quoted slug is enough — we tolerate language/punctuation.
+head_chunk=$(head -c "$SNIFF_BYTES" "$target" 2>/dev/null)
+marker_slug=$(printf '%s' "$head_chunk" | python3 -c "
+import re, sys
+text = sys.stdin.read()
+m = re.search(r'worktree[^a-zA-Z0-9_\\-]{0,30}\`([A-Za-z0-9_\\-]+)\`', text)
+if m:
+    print(m.group(1))
+" 2>/dev/null)
+
+if [[ -z "$marker_slug" ]]; then
+  # No marker — we can't prove a cross-worktree race. Stay quiet to keep
+  # the false-positive rate low; same-session re-writes are common.
+  exit 0
+fi
+
+# Resolve the current worktree slug from CWD. Pattern:
+#   .../<project>/.claude/worktrees/<slug>/...
+cwd_slug=$(pwd | python3 -c "
+import re, sys
+m = re.search(r'/\\.claude/worktrees/([A-Za-z0-9_\\-]+)(?:/|$)', sys.stdin.read().strip())
+print(m.group(1) if m else '')
+" 2>/dev/null)
+
+if [[ -z "$cwd_slug" ]]; then
+  # Caller is the main checkout (not a worktree) or an unrecognized path.
+  # Don't block — let main-checkout edits proceed silently.
+  exit 0
+fi
+
+if [[ "$cwd_slug" == "$marker_slug" ]]; then
+  # Same worktree → same author → not a race.
+  exit 0
+fi
+
+# Different worktree wrote it < THRESHOLD_SECONDS ago — block.
+{
+  echo "❌ plan-slug race: '$target' was written ${age}s ago by"
+  echo "   worktree '${marker_slug}' (declared in its first ${SNIFF_BYTES} chars)."
+  echo "   Current worktree '${cwd_slug}' is about to overwrite it."
+  echo ""
+  echo "   Convention (issue #779): write to a suffixed path like"
+  echo "     ${target%.md}-${cwd_slug}.md"
+  echo "   or pick a different filename entirely."
+  echo ""
+  echo "   Override (only when you genuinely intend to replace the other"
+  echo "   worktree's plan): set PLAN_SLUG_RACE_THRESHOLD=0 in the hook"
+  echo "   environment for this invocation."
+} >&2
+exit 2

--- a/tests/test_plan_slug_race_hook_regression.py
+++ b/tests/test_plan_slug_race_hook_regression.py
@@ -1,0 +1,177 @@
+"""Regression: PreToolUse plan-slug race hook (issue #779).
+
+Pins the exit-code contract (0 allow / 2 block) for the six matrix
+scenarios identified in the issue:
+
+  1. tool_name != Write                       → 0
+  2. file_path outside ~/.claude/plans        → 0
+  3. plan file does not yet exist             → 0
+  4. plan exists + recent + foreign worktree
+     marker + cwd inside a different worktree → 2 (block)
+  5. plan exists + recent + same worktree
+     marker                                   → 0
+  6. plan exists + stale mtime (> threshold)  → 0
+
+Each scenario isolates the plans dir into a per-test temp directory by
+overriding ``HOME`` (the hook resolves the plans dir from ``$HOME``).
+The cwd is set so the hook's worktree detection can be deterministic.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+HOOK = REPO / "scripts" / "claude-hooks" / "plan-slug-race.sh"
+
+
+class _BaseHookCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="plan-slug-race-")
+        self._home = Path(self._tmp) / "home"
+        self._plans = self._home / ".claude" / "plans"
+        self._plans.mkdir(parents=True)
+        # Simulate a worktree-style cwd so the hook's regex parses it.
+        self._wt_root = Path(self._tmp) / "project" / ".claude" / "worktrees" / "alpha-1"
+        self._wt_root.mkdir(parents=True)
+        # The "other" worktree for cross-worktree race scenarios.
+        self._wt_other = Path(self._tmp) / "project" / ".claude" / "worktrees" / "beta-2"
+        self._wt_other.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _run(self, payload: dict, *, cwd: Path | None = None) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env["HOME"] = str(self._home)
+        return subprocess.run(
+            ["bash", str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env=env,
+            cwd=str(cwd or self._wt_root),
+            check=False,
+        )
+
+
+class TestPlanSlugRaceHook(_BaseHookCase):
+    def test_non_write_tool_is_allowed(self) -> None:
+        result = self._run({"tool_name": "Edit", "tool_input": {"file_path": "x"}})
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_write_outside_plans_dir_is_allowed(self) -> None:
+        target = Path(self._tmp) / "outside.md"
+        result = self._run({"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_plan_file_missing_is_allowed(self) -> None:
+        target = self._plans / "no-such-plan.md"
+        result = self._run({"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_recent_foreign_worktree_marker_is_blocked(self) -> None:
+        target = self._plans / "racy.md"
+        target.write_text(
+            "본 plan은 worktree `beta-2` 의 deliverable.\n\n내용 일부.\n",
+            encoding="utf-8",
+        )
+        # mtime is current (~now), so within the default 300s window.
+        # cwd is wt_root (slug "alpha-1") — different worktree from
+        # the marker ("beta-2"); we expect a block.
+        result = self._run(
+            {"tool_name": "Write", "tool_input": {"file_path": str(target)}},
+            cwd=self._wt_root,
+        )
+        self.assertEqual(2, result.returncode, f"stderr={result.stderr}")
+        self.assertIn("plan-slug race", result.stderr)
+        self.assertIn("beta-2", result.stderr)
+        self.assertIn("alpha-1", result.stderr)
+
+    def test_recent_same_worktree_marker_is_allowed(self) -> None:
+        target = self._plans / "same.md"
+        target.write_text(
+            "본 plan은 worktree `alpha-1` 의 deliverable.\n",
+            encoding="utf-8",
+        )
+        result = self._run(
+            {"tool_name": "Write", "tool_input": {"file_path": str(target)}},
+            cwd=self._wt_root,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_stale_mtime_is_allowed(self) -> None:
+        target = self._plans / "stale.md"
+        target.write_text(
+            "본 plan은 worktree `beta-2` 의 deliverable.\n",
+            encoding="utf-8",
+        )
+        # Push mtime well past the default 300s window.
+        old = time.time() - 10_000
+        os.utime(target, (old, old))
+        result = self._run(
+            {"tool_name": "Write", "tool_input": {"file_path": str(target)}},
+            cwd=self._wt_root,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_no_marker_is_allowed_even_when_recent(self) -> None:
+        # Older plans (pre-convention) have no marker → we can't prove a
+        # cross-worktree race; stay quiet to keep false-positives low.
+        target = self._plans / "no-marker.md"
+        target.write_text(
+            "# Some plan without a worktree declaration.\n\nbody.\n",
+            encoding="utf-8",
+        )
+        result = self._run(
+            {"tool_name": "Write", "tool_input": {"file_path": str(target)}},
+            cwd=self._wt_root,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_caller_outside_worktree_pattern_is_allowed(self) -> None:
+        # Main checkout (cwd has no `/.claude/worktrees/<slug>/` segment).
+        target = self._plans / "racy2.md"
+        target.write_text(
+            "본 plan은 worktree `beta-2` 의 deliverable.\n",
+            encoding="utf-8",
+        )
+        main_cwd = Path(self._tmp) / "project"
+        result = self._run(
+            {"tool_name": "Write", "tool_input": {"file_path": str(target)}},
+            cwd=main_cwd,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_override_via_threshold_zero(self) -> None:
+        # PLAN_SLUG_RACE_THRESHOLD=0 makes (age >= threshold) always true → allow.
+        target = self._plans / "override.md"
+        target.write_text(
+            "본 plan은 worktree `beta-2` 의 deliverable.\n",
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env["HOME"] = str(self._home)
+        env["PLAN_SLUG_RACE_THRESHOLD"] = "0"
+        result = subprocess.run(
+            ["bash", str(HOOK)],
+            input=json.dumps({"tool_name": "Write", "tool_input": {"file_path": str(target)}}),
+            text=True,
+            capture_output=True,
+            env=env,
+            cwd=str(self._wt_root),
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 1. Issue & motivation

Closes #779.

여러 동시 worktree 가 Claude Code 를 병렬 실행할 때, 하네스가 user-global 디렉터리 (`~/.claude/plans/<random-slug>.md`) 에 plan 파일 작성. slug 공간은 크지만 10+ 동시 worktree 에서 collision 이 0 은 아님 — 2026-05-15 live 관찰: `fizzy-splashing-cherny.md` 가 같은 분 내 cross-worktree 덮어쓰기, 한 세션이 *덮어쓰기 후* 본문에 race 를 기록.

## 2. Change

- **`scripts/claude-hooks/plan-slug-race.sh`** — 신규 user-global `PreToolUse` 훅. 다음 모두 만족 시 `Write` to `~/.claude/plans/<slug>.md` 차단:
  1. 대상 파일 존재
  2. mtime 이 `PLAN_SLUG_RACE_THRESHOLD` 초 이내 (기본 300)
  3. 첫 `PLAN_SLUG_RACE_SNIFF_BYTES` 바이트 (기본 200) 에 ``` worktree `<slug>` ``` 마커 포함 AND 그 slug 가 cwd 도출 worktree slug 와 다름
- **`tests/test_plan_slug_race_hook_regression.py`** — 전체 exit-code 매트릭스 9 단위 테스트
- **`docs/engineering-governance.md`** — §"Hook setup" 에 `~/.claude/settings.json` 등록 JSON snippet 추가

## 3. Verification

```
$ python3 -m unittest tests.test_plan_slug_race_hook_regression -v
...
Ran 9 tests in 6.667s
OK
```

이 세션에서 manual smoke:

- 비-Write 도구 입력 → exit 0 ✓
- `~/.claude/plans/` 밖 Write → exit 0 ✓
- plan 파일 없음 → exit 0 ✓
- 최근 (1s mtime) + foreign worktree 마커 + 다른 cwd slug → exit 2 ✓
- 최근 + 같은 worktree 마커 → exit 0 ✓
- Stale mtime → exit 0 ✓
- `PLAN_SLUG_RACE_THRESHOLD=0` override → exit 0 ✓

## 4. Invariants preserved

- **Repo `.claude/settings.json` 미접촉**: 훅은 design 상 user-global (같은 Claude Code 세션이 여러 repo 가능). 본 repo 설정에 자동 등록 없음; docs 가 `~/.claude/settings.json` 배선 가이드.
- **Fail-open 철학**: 파싱 에러 / 미인식 cwd → exit 0 (allow). 버그 훅이 잘못된 write 한 건 통과는 복구 가능; 모든 plan write 무음 차단은 불가능.
- **Convention enforcement** 는 마커 기반 opt-in. 마커 없는 pre-convention plan 은 절대 차단 안됨 → 기존 corpus 의 false-positive rate 0 유지.

## 5. PR template — required sections

### 5a. Risk

Trivial. 훅 자동 등록 없음 — 사용자가 `~/.claude/settings.json` JSON snippet 추가로 opt-in. opt-in 후에도 `Write` to `~/.claude/plans/*.md` 의 좁은 케이스에서만 발화.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. 이 PR 은 신규 governance 훅 + 테스트 + docs 추가 — retrieval / ingestion / eval 코드 경로 미접촉.

### 5c. Out of scope

- 자동 등록 (사용자 opt-in 마찰 관찰 시 별도 follow-up)
- plan 파일의 `Edit` 검출 (하네스는 `Write` 로 plan 작성, `Edit` 아님; matcher 가 좁게 의도됨)
- pre-write convention enforcer (별도 관심사 — 이 PR 은 *수신* 쪽 포착)

## 6. Provenance

직접 경험: 이 loop 세션 (`condescending-mccarthy-0b2fa8`) 이 `project_code_polish_backlog.md` (2026-05-15 "Multi-worktree plan-slug 충돌") 에 기록된 `fizzy-splashing-cherny` collision 관찰. Issue #779 가 5-why + 구현 제안 캡처. 본 PR 은 제안 A 구현.

Generated with [Claude Code](https://claude.com/claude-code)
