### PR TITLE
fix(governance): ADR_FILENAME_RE accepts mixed-case slugs (closes #818)

### DIFF
--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -106,7 +106,14 @@ def is_load_bearing(path: str) -> bool:
 # ---------------------------------------------------------------------------
 
 ADR_DIR_DEFAULT = "docs/adr"
-ADR_FILENAME_RE = re.compile(r"^(\d{4})-[a-z0-9][a-z0-9-]*\.md$")
+# Issue #818: detection-only relaxation. The kebab-lowercase slug remains the
+# *convention* (see ``docs/adr/README.md`` File layout), but the live bug
+# discovery on ``0044-realN-eval-case-expansion.md`` showed that a strict
+# lowercase character class silently hides legitimate-but-mixed-case ADRs from
+# the pre-commit collision scanner and from ``--next-adr-number``. We widen
+# the character class to accept ``[a-zA-Z0-9]`` so detection is robust; a
+# separate lint that warns when an ADR slug is mixed-case is out of scope.
+ADR_FILENAME_RE = re.compile(r"^(\d{4})-[a-zA-Z0-9][a-zA-Z0-9-]*\.md$")
 
 
 def existing_adr_numbers(adr_dir: str | Path = ADR_DIR_DEFAULT) -> set[int]:

--- a/tests/test_governance_adr_numbers.py
+++ b/tests/test_governance_adr_numbers.py
@@ -43,13 +43,44 @@ def test_existing_adr_numbers_ignores_non_adr_files(tmp_path: Path) -> None:
 
 
 def test_existing_adr_numbers_strict_filename_pattern(tmp_path: Path) -> None:
-    # 4 digits exactly, kebab slug starting with [a-z0-9], lowercase only.
+    # 4 digits exactly + kebab slug starting with [a-zA-Z0-9]. Issue #818
+    # widened the character class to accept uppercase so the scanner does
+    # not silently miss legitimate-but-mixed-case ADRs (e.g. 0044-realN).
     _touch(tmp_path, "001-too-short.md")
     _touch(tmp_path, "00001-too-long.md")
-    _touch(tmp_path, "0001-UPPER.md")
     _touch(tmp_path, "0001-with-dash.md")
     _touch(tmp_path, "0002-ok.md")
     assert existing_adr_numbers(tmp_path) == {1, 2}
+
+
+def test_existing_adr_numbers_accepts_mixed_case_slug(tmp_path: Path) -> None:
+    """Issue #818 regression: mixed-case slugs must be picked up.
+
+    ``0044-realN-eval-case-expansion.md`` was live on main when this fix
+    landed and was silently invisible to the previous strict-lowercase
+    regex. The scanner is detection-only — kebab-lowercase remains the
+    convention — so we accept the slug rather than refuse it.
+    """
+    _touch(tmp_path, "0044-realN-eval-case-expansion.md")
+    _touch(tmp_path, "0045-lowercase.md")
+    _touch(tmp_path, "0046-mixedCaseAgain.md")
+    assert existing_adr_numbers(tmp_path) == {44, 45, 46}
+
+
+def test_find_duplicate_adr_numbers_catches_mixed_case_collision(
+    tmp_path: Path,
+) -> None:
+    """Issue #818 regression: collision detection must still fire when one
+    side of a duplicate uses uppercase. Before the fix, a duplicate where
+    one filename was ``0044-Foo.md`` would be invisible to the scanner
+    and the pre-commit ``--check-adr-collision`` hook would let the merge
+    through silently."""
+    _touch(tmp_path, "0044-realN-eval-case-expansion.md")
+    _touch(tmp_path, "0044-conflict.md")
+    dups = find_duplicate_adr_numbers(tmp_path)
+    assert dups == {
+        44: ["0044-conflict.md", "0044-realN-eval-case-expansion.md"]
+    }
 
 
 # ---- next_adr_number -----------------------------------------------------
@@ -102,3 +133,20 @@ def test_repo_adr_dir_has_no_collisions() -> None:
     """If the repo itself ever gains a duplicate, this test catches it
     before CI runs the pre-commit hook in someone else's worktree."""
     assert find_duplicate_adr_numbers("docs/adr") == {}
+
+
+def test_repo_adr_dir_includes_mixed_case_adr_0044() -> None:
+    """Issue #818 sentinel: the live repo carries ``0044-realN-…`` on
+    main. After widening ``ADR_FILENAME_RE`` to accept uppercase, the
+    scanner must include 44 in its visible set; otherwise the bug
+    re-emerges and ``--next-adr-number`` silently collides with 0044.
+
+    This sentinel intentionally lives next to ``test_repo_adr_dir_has_no
+    _collisions`` so any future renaming of the live ADR is caught by a
+    test rather than by a silent miss in the pre-commit hook.
+    """
+    nums = existing_adr_numbers("docs/adr")
+    assert 44 in nums, (
+        "ADR 0044 (mixed-case slug) must be visible to the scanner. "
+        "Did ADR_FILENAME_RE regress to the strict lowercase pattern?"
+    )


### PR DESCRIPTION
Closes #818

## Summary

`scripts/_governance.py` `ADR_FILENAME_RE` 가 `[a-z0-9][a-z0-9-]*` — 엄격하게 소문자. `0044-realN-eval-case-expansion.md` (main 에 있음) 이 scanner 에 비가시, 두 governance 영향:

- `existing_adr_numbers('docs/adr')` 가 `{1..43, 45}` 반환 (`{1..45}` 대신) — `find_duplicate_adr_numbers` 가 향후 `0044-other.md` 충돌 flag 못해 #757 도입 pre-commit `--check-adr-collision` hook 이 자신을 노출한 그 파일에서 silent miss.
- `--next-adr-number` 가 우연히 정답 반환 (46 = max(lowercase set) + 1) — D1 (#817) 이 meta-ADR 번호 예약 시도 전까지 탐지 갭 mask.

slug 문자 클래스를 `[a-zA-Z0-9]` 로 확장. 탐지 전용: `docs/adr/README.md` 의 kebab-lowercase 컨벤션 미변경; mixed-case slug 를 surface 하는 warn-level lint 추가는 명시적으로 범위 외 (issue 의 "Fix proposal — Trade-off" 노트).

## Test plan

- [x] `python -m pytest tests/test_governance_adr_numbers.py -v` — 14/14 pass (12 였음, +2 mixed-case regression + 1 live-repo sentinel).
- [x] Live sentinel: `python scripts/_governance.py --next-adr-number` 여전히 `46` 반환; `existing_adr_numbers('docs/adr')` 가 이제 `44` 포함.
- [x] `ruff check` clean.

테스트 추가:

- `test_existing_adr_numbers_accepts_mixed_case_slug` — 버그 직접 regression.
- `test_find_duplicate_adr_numbers_catches_mixed_case_collision` — duplicate 한 쪽이 uppercase 사용 시 pre-commit hook fire 증명 (버그의 가장 구체적 결과).
- `test_repo_adr_dir_includes_mixed_case_adr_0044` — `44 in existing_adr_numbers('docs/adr')` 를 pin 하는 live-repo sentinel — 향후 regex regression 이 다른 worktree 의 pre-commit hook 도달 전 이 테스트에서 fail.

기존 `test_existing_adr_numbers_strict_filename_pattern` 가 `0001-UPPER.md` assertion 상실 (intent 변경 — 이전 lowercase-only 규칙을 인코딩한 *유일* 라인).

### 5b. Real-data delta

No behavior change in retrieval, verifier, eval, api, or ingestion paths.

| Surface     | Behavior change? | Notes                                                 |
| ----------- | ---------------- | ----------------------------------------------------- |
| Retrieval   | No               | governance/scripts/_governance.py + 테스트만.       |
| Verifier    | No               | —                                                     |
| Eval        | No               | —                                                     |
| Ingestion   | No               | —                                                     |
| API         | No               | —                                                     |
| Governance  | Yes (additive)   | 탐지 전용 regex 확장; collision scanner 가 이제 mixed-case ADR slug 인식. `--next-adr-number` 출력은 현재 main 에서 미변경 (46). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
