### PR TITLE
fix(ci): pr-judge aggregate upload hard-fails on missing file (closes #823)

### DIFF
--- a/.github/workflows/pr-judge.yml
+++ b/.github/workflows/pr-judge.yml
@@ -100,7 +100,15 @@ jobs:
         with:
           name: synthetic-judge-aggregate
           path: reports/synthetic_judge.aggregate.json
-          if-no-files-found: warn
+          # Issue #823 (senior-review B4): the aggregate JSON is the only
+          # justification for running this workflow. If `make synthetic-judge`
+          # silently produces no file (API-key miss, judge timeout, transient
+          # network failure that the Makefile target swallows), the upload
+          # step previously warned and the job stayed green — letting the
+          # comment renderer ship a "judge passed" message with empty cells.
+          # Hard-fail instead so reviewers see ❌ pr-judge / live-judge on
+          # the check list rather than a misleading comment.
+          if-no-files-found: error
 
       - name: Upsert PR comment
         env:

--- a/tests/test_pr_judge_workflow_regression.py
+++ b/tests/test_pr_judge_workflow_regression.py
@@ -118,6 +118,38 @@ class WorkflowStructureTest(unittest.TestCase):
             "Per-case local JSON must not be uploaded (ADR 0005 boundary)",
         )
 
+    def test_aggregate_upload_step_hard_fails_on_missing_file(self) -> None:
+        """Issue #823 regression (senior-review B4).
+
+        If ``make synthetic-judge`` silently produces no aggregate JSON
+        (e.g. missing API key, judge backend timeout, swallowed network
+        error), the upload step previously had ``if-no-files-found: warn``
+        and the job stayed green — letting ``render_judge_comment.py``
+        ship a "judge passed" comment with empty cells. The aggregate is
+        the *only* justification for running this workflow, so the upload
+        must hard-fail when it's missing.
+        """
+        steps = self.workflow["jobs"]["live-judge"]["steps"]
+        aggregate_uploads = [
+            s for s in steps
+            if isinstance(s, dict)
+            and s.get("uses", "").startswith("actions/upload-artifact")
+            and "synthetic_judge.aggregate.json" in s.get("with", {}).get("path", "")
+        ]
+        self.assertEqual(
+            1,
+            len(aggregate_uploads),
+            "expected exactly one upload-artifact step for the aggregate JSON",
+        )
+        self.assertEqual(
+            "error",
+            aggregate_uploads[0]["with"].get("if-no-files-found"),
+            "Aggregate upload must hard-fail on missing file (issue #823). "
+            "Reverting to 'warn' lets the PR comment render with empty cells "
+            "and the job stay green — exactly the silent-pass failure mode "
+            "B4 surfaced.",
+        )
+
     def test_no_pull_request_target(self) -> None:
         # `pull_request_target` runs on the *base* repo with secrets exposed,
         # which would let fork PRs exfiltrate BIDMATE_JUDGE_API_KEY.  ADR 0043


### PR DESCRIPTION
Closes #823

## Summary

`.github/workflows/pr-judge.yml` 의 aggregate-upload step 이 `if-no-files-found: warn` 이었음. `make synthetic-judge` 가 `reports/synthetic_judge.aggregate.json` 을 못 만들 때 (API key 누락, judge 타임아웃, Makefile 타깃이 삼킨 transient 네트워크 실패) upload 가 warn → job green → `render_judge_comment.py` 가 빈 셀로 "judge passed" PR 코멘트 전송. 리뷰어가 green check + 코멘트로 live judge 동의로 결론 — senior-review B4 가 지목한 silent-pass 실패 모드.

수정: `if-no-files-found: error`. aggregate JSON 은 이 워크플로 실행의 *유일한* 정당화 — 부재는 PR check list 에 ❌ pr-judge / live-judge 로 surface 해야지, 오해 유발 green 코멘트 안됨.

ADR 0043 § Operating constraints (#809 추가) 가 이 실패 모드 미커버; 이 PR 은 ADR 수정 없이 (한 줄 + 회귀 테스트) 갭 메움 — 정책 동일, enforcement 만 강화.

## Test plan

- [x] `python -m pytest tests/test_pr_judge_workflow_regression.py -v` — 15/15 pass (이전 14, `error` 계약 회귀 +1)
- [x] 신규 테스트 `test_aggregate_upload_step_hard_fails_on_missing_file` 가 `error` 계약 고정. YAML 을 `warn` 으로 되돌리면 CI 워크플로 실행 전에 이 테스트가 실패.

## Out of scope

- `scripts/render_judge_comment.py` 의 empty/absent aggregate 방어 체크 (defense-in-depth) — 본 PR 수정이 실무에서 불충분으로 판명될 때만 (issue #823 "Out of scope" 첫 bullet)
- B5 actionlint CI 통합 — 별도 워크플로 PR

### 5b. Real-data delta

No behavior change in retrieval / verifier path. retrieval, verifier, eval, api, ingestion 경로 동작 변경 없음.

| Surface     | Behavior change? | Notes                                                 |
| ----------- | ---------------- | ----------------------------------------------------- |
| Retrieval   | No               | CI 워크플로 + 워크플로 회귀 테스트만                 |
| Verifier    | No               | —                                                     |
| Eval        | No               | Live-judge 워크플로 엄격성, eval 로직 아님            |
| Ingestion   | No               | —                                                     |
| API         | No               | —                                                     |
| CI          | Yes (additive)   | Aggregate-upload step 이 파일 누락 시 warn 대신 hard-fail. aggregate 생성된 run 에는 무영향 (happy path 불변). |

Generated with [Claude Code](https://claude.com/claude-code)
