### PR TITLE
fix(retrieval): include schema_version + chunk count in BM25 cache key (closes #833)

### DIFF
--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -724,12 +724,25 @@ def get_or_build_bm25(
     if stopword_profile not in VALID_BM25_STOPWORD_PROFILES:
         choices = ", ".join(sorted(VALID_BM25_STOPWORD_PROFILES))
         raise ValueError(f"bm25_stopword_profile must be one of: {choices}")
-    cache_key = (stopword_profile, tokenizer)
+    chunks = index.get("chunks") or []
+    # Issue #833 — RAG senior-review critique #7.1: the cache key used
+    # to be ``(profile, tokenizer)`` only, so a caller that reused
+    # ``index`` after mutating ``index["chunks"]`` (test fixture
+    # mutation, runtime reload, schema bump that adds/removes chunks)
+    # got the stale BM25 + stale chunk_ids → silent corruption with no
+    # exception or warning. Including ``schema_version`` + ``chunk_count``
+    # in the key lets the cache invalidate automatically when the
+    # corpus identity changes; both lookups are O(1).
+    cache_key = (
+        stopword_profile,
+        tokenizer,
+        index.get("schema_version"),
+        len(chunks),
+    )
     profile_cache = index.setdefault("_bm25_by_profile", {})
     entry = profile_cache.get(cache_key)
     if isinstance(entry, tuple) and len(entry) == 2:
         return entry  # type: ignore[return-value]
-    chunks = index.get("chunks") or []
     corpus = [_chunk_tokens_for_bm25(c, stopword_profile, tokenizer) for c in chunks]
     # rank_bm25 requires at least one non-empty document. If the corpus
     # is entirely empty (degenerate test fixture) substitute a single

--- a/tests/test_bm25_cache_invalidation.py
+++ b/tests/test_bm25_cache_invalidation.py
@@ -1,0 +1,94 @@
+"""Regression: BM25 cache invalidates on schema_version / chunk count change (issue #833).
+
+RAG senior-review critique #7.1. The cache used to be keyed by
+``(stopword_profile, tokenizer)`` only. A caller that reused the
+same ``index`` dict after mutating ``index["chunks"]`` (test fixture
+mutation, runtime reload, schema bump that adds/removes chunks) got
+the stale BM25 + stale chunk_ids — silent corruption with no
+exception or warning.
+
+This test pins the new contract:
+
+1. Same ``(profile, tokenizer)`` + same chunks → cache hit (same
+   BM25 object returned).
+2. Same ``(profile, tokenizer)`` + different ``schema_version`` →
+   cache miss (different BM25 object returned).
+3. Same ``(profile, tokenizer)`` + chunks list mutated (append) →
+   cache miss + chunk_ids in returned tuple reflect the new chunks.
+4. Different ``(profile, tokenizer)`` → cache miss (existing
+   behavior preserved).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import pytest
+
+# rank_bm25 is an optional dependency; skip the entire module if it
+# is missing rather than failing to import (matches scripts/test.sh
+# minimal-env policy).
+pytest.importorskip("rank_bm25")
+
+from rag_retrieval import get_or_build_bm25  # noqa: E402
+
+
+def _chunk(chunk_id: str, text: str) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "doc_id": "d1",
+        "title": "t",
+        "text": text,
+        # ``_chunk_tokens_for_bm25`` reads either ``tokens`` (cached)
+        # or falls back to re-tokenizing ``text``; both paths work for
+        # this test as long as one is present.
+        "tokens": text.split(),
+    }
+
+
+class TestBM25CacheInvalidation(unittest.TestCase):
+    def setUp(self) -> None:
+        # Two-chunk fixture; ``schema_version`` set explicitly so the
+        # cache key is deterministic.
+        self.chunks = [
+            _chunk("c1", "alpha bravo"),
+            _chunk("c2", "charlie delta"),
+        ]
+        self.index = {"chunks": self.chunks, "schema_version": 2}
+
+    def test_cache_hit_returns_same_object(self) -> None:
+        first = get_or_build_bm25(self.index, "shared", "regex")
+        second = get_or_build_bm25(self.index, "shared", "regex")
+        # Cache hit → same tuple returned (same BM25 object identity).
+        self.assertIs(first[0], second[0])
+        self.assertIs(first[1], second[1])
+
+    def test_schema_version_change_invalidates_cache(self) -> None:
+        first = get_or_build_bm25(self.index, "shared", "regex")
+        # Schema bump (e.g. v2 → v3 added a per-chunk field BM25
+        # tokens key off) should invalidate the cache automatically.
+        self.index["schema_version"] = 3
+        second = get_or_build_bm25(self.index, "shared", "regex")
+        self.assertIsNot(first[0], second[0])
+
+    def test_chunk_count_change_invalidates_cache(self) -> None:
+        first = get_or_build_bm25(self.index, "shared", "regex")
+        # In-place mutation of the chunks list (the failure mode this
+        # test exists to catch).
+        self.chunks.append(_chunk("c3", "echo foxtrot"))
+        second = get_or_build_bm25(self.index, "shared", "regex")
+        self.assertIsNot(first[0], second[0])
+        # The new build must reflect the new chunk_ids — this is the
+        # silent corruption symptom we are preventing.
+        self.assertEqual(second[1], ["c1", "c2", "c3"])
+
+    def test_different_profile_or_tokenizer_invalidates_cache(self) -> None:
+        # Existing behavior: orthogonal axes still produce different
+        # cache entries.
+        shared_regex = get_or_build_bm25(self.index, "shared", "regex")
+        bm25_extra_regex = get_or_build_bm25(self.index, "bm25_extra", "regex")
+        self.assertIsNot(shared_regex[0], bm25_extra_regex[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `get_or_build_bm25` 가 `(profile, tokenizer)` 키로 `(BM25Okapi, chunk_ids)` 를 캐시 — corpus identity 신호 없음. `index["chunks"]` 변이 후 같은 `index` dict 재사용 (테스트 fixture, 런타임 reload, schema bump) 시 stale BM25 + stale chunk_ids 반환 → 예외 없이 silent corruption.
- 이 PR 은 키를 `(profile, tokenizer, schema_version, chunk_count)` 로 확장. 양 추가 필드 모두 O(1) lookup; 둘 중 하나라도 변경되면 캐시 자동 무효화.
- Cycle 2/3 와 동일 테마: retrieval surface 의 silent-corruption 경로를 loud failure (여기서는 자동 무효화) 로 전환.

Closes #833. Critique #7.1 (`/Users/hskim/.claude/plans/fizzy-splashing-cherny.md`, RAG senior-review). dynamic-loop fix 시퀀스 Cycle 6.

## Surface

- `rag_retrieval.py` — `get_or_build_bm25` 캐시 키 확장; `chunks = index.get("chunks") or []` 를 키 build 위로 끌어올려 `len(chunks)` 가 키에 참여.
- `tests/test_bm25_cache_invalidation.py` (신규) — 4 케이스로 신규 계약 고정: identity 캐시 hit, schema_version 무효화, chunk count 무효화 (신규 build 의 chunk_ids 정합성), 별개 (profile, tokenizer) 직교성.

## Test plan

- [x] `pytest tests/test_bm25_cache_invalidation.py` — 4 passed
- [x] `pytest tests/test_hybrid_retrieval_regression.py tests/test_retrieval_loop_regression.py tests/test_naive_baseline_ranking_invariance.py tests/test_partial_topic_grounding.py` — 46 passed + 17 subtests
- [x] Full `pytest -q` (사전 실패하던 test_harness_observability / test_run_harness / test_ship_dispatcher_gates / test_mixed_format_ingestion_regression 제외): 1359 passed, 174 subtests, 13 skipped, 0 failed

### 5b. Real-data delta

**No behavior change in retrieval / verifier path** for any well-formed index.

`rag_retrieval.py` 는 load-bearing. 변경은 캐시를 더 안전하게 만들 뿐, well-formed index 의 BM25 점수는 변하지 않음:

- Healthy 경로 (load_index → fresh dict → empty cache → 첫 `get_or_build_bm25` 가 BM25 build): bit-identical. 키 필드 늘었지만 resolved entry 는 동일 객체.
- Cache-hit 경로 (같은 dict, 같은 key): bit-identical. 같은 BM25 인스턴스 반환.
- Stale-cache 경로 (수정 대상 버그): wrong score 대신 자동 무효화. 정의상 여기 "delta" 가 보이면 이전 코드가 silent 하게 wrong score 를 내고 있었음 — 노출이 본 PR 의 목적.

`make real-eval-delta` 0pp 예상. 델타 발생 시 이전 파이프라인 step 이 stale-cache 동작에 의존 (= 잘못된 점수) 했다는 의미 — 노출이 목적.

## PR template (filled inline)

1. **Issue**: #833
2. **Behavior change?** unhappy path 에만 방어적. Healthy retrieval 은 bit-identical.
3. **Backward compatibility**: 동일. `schema_version` 필드는 이미 `load_index` 가 채움 (현재 sidecar layout default 2). 신규 키는 그것을 읽기만; 필드 없는 legacy index 는 `None` 로 처리되어 stable key 유지.
4. **Tests**: 신규 회귀 `tests/test_bm25_cache_invalidation.py` + 인접 retrieval suite green.
5. **Real-data delta**: 위 `### 5b. Real-data delta` 참조.
6. **ADR**: 신규 ADR 없음. cache invariant 는 본 PR 시리즈 이전 #784 / #795 cycle 의 loud-failure / 자동 무효화 패턴과 동일.

Generated with [Claude Code](https://claude.com/claude-code)
