### PR TITLE
docs(readme): annotate ablation table with ADR Status mapping (closes #813)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 > Values shown as `mean±half-width` for the 95% bootstrap CI (n=cases, 1000 resamples, seed=17). CI overlap between rows = statistical detection limit at that n, not equivalence. At n=42 the half-width was ~±0.12; n=100 narrows it by ×0.65 (√42/100). The non-CI columns (Format, Abstention, Retry) are point estimates; their CIs appear in the detailed main table above.
 <!-- METRICS_TABLE:END -->
 
+> **Ablation → ADR Status mapping** ([issue #813](https://github.com/hskim-solv/BidMate-DocAgent/issues/813)) — each ablation row above is governed by an ADR; this column tells external readers which rows are *accepted decisions* vs. *proposed/superseded ablations under measurement*:
+>
+> | Ablation row(s) | ADR | Status |
+> |---|---|---|
+> | `full`, `naive_baseline` | [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) | accepted |
+> | `no_metadata_first` (inverse ablation) | [ADR 0002](docs/adr/0002-metadata-first-retrieval.md) | accepted |
+> | `no_verifier_retry` (inverse ablation) | [ADR 0004](docs/adr/0004-verifier-retry-policy.md) | accepted |
+> | `hybrid_bm25*` family | [ADR 0010](docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md) | accepted |
+> | `full_llm`, `full_llm_metadata` | [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md) | **proposed** |
+> | `full_hyde` | [ADR 0023](docs/adr/0023-hyde-query-expansion-ablation.md) | **proposed** |
+> | `full_reranker` | [ADR 0026](docs/adr/0026-cross-encoder-reranker-deferral.md) | superseded (deferral) |
+> | `agentic_full_finetuned`, `naive_baseline_finetuned` | [ADR 0027](docs/adr/0027-lora-finetuned-embedding-additive.md) | superseded |
+> | `full_kiwi` | [ADR 0031](docs/adr/0031-bm25-korean-morphology-additive.md) | superseded |
+> | `hierarchical`, `no_rerank` | (chunking / rerank toggles; no dedicated ADR) | n/a |
+>
+> Reading guide: a *proposed* ablation row has not yet earned accepted status — typically it sits on the additive-ablation side of [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) until n=100 real-eval re-measurement separates its CI from `full`. A *superseded* row was either subsumed by a later decision (e.g. ADR 0027 → ADR 0037 KURE v1) or deferred until baseline conditions are met. Status drift here = ADR not synced; this footnote is a manual reminder until a `scripts/check_ablation_adr_sync.py` lints the mapping (issue #813 § 시정 액션 ②).
+
 > **더 읽기**: [docs/rag-challenges-solved.md](docs/rag-challenges-solved.md) — 이 숫자를 만든 3가지 핵심 결정(STAR 회고). [docs/performance-evolution.md](docs/performance-evolution.md) — n=42→n=100 CI 수축 히스토리 + 기능별 ablation 효과 분해.
 
 > **Ablation 해석 — CI가 말해주는 검출 한계 vs 실측 trade-off**: `no_rerank` / `hierarchical` / `full_llm`이 `full`과 동일 metric을 보이는 것은 *기능이 동등해서가 아니라 n=42 + bootstrap CI가 차이를 검출하지 못해서*였습니다 — CI 폭이 너무 넓어 미세 차이는 noise에 묻혔습니다. 현재 n=100 확장 완료(issue #570); real-eval 재측정으로 통계적 분리 가능성 확인 예정. **CI가 분리되는 진짜 효과**: `no_metadata_first` citation 0.679±0.11 (CI 0.571–0.786) vs `full` 0.905±0.08 (0.821–0.976) — CI 비겹침으로 metadata-first 효용 통계적 입증. `no_verifier_retry` groundedness 0.762±0.14 (CI 0.619–0.881) vs `full` 0.929±0.07 — verifier loop 효용 시사. 상세 latency·embedding backend 비교: [`docs/benchmarking.md`](docs/benchmarking.md).


### PR DESCRIPTION
Closes #813

## Summary

포트폴리오 senior-review 비판 #2(c) 가 README 분석 변형 표에 *proposed* 또는 *superseded* status ADR 매핑 행이 외부 독자에게 노출 안 되는 점 지적. 30초 표 스캔으로는 모든 게 측정된 완성 시스템처럼 보였다.

이 PR 은 명시적 `Ablation → ADR Status` 매핑 표를 `METRICS_TABLE:END` 직후 footnote 로 추가. live ADR 메타데이터 (`grep '^- \*\*Status\*\*' docs/adr/*.md`) 기반:

- `full`, `naive_baseline` → ADR 0001 (accepted)
- `no_metadata_first` (inverse) → ADR 0002 (accepted)
- `no_verifier_retry` (inverse) → ADR 0004 (accepted)
- `hybrid_bm25*` family → ADR 0010 (accepted)
- `full_llm`, `full_llm_metadata` → **ADR 0011 (proposed)**
- `full_hyde` → **ADR 0023 (proposed)**
- `full_reranker` → ADR 0026 (superseded, deferral)
- `agentic_full_finetuned`, `naive_baseline_finetuned` → ADR 0027 (superseded)
- `full_kiwi` → ADR 0031 (superseded)
- `hierarchical`, `no_rerank` → 전용 ADR 없음 (chunking / rerank toggle)

Footnote 는 *proposed* 행이 보통 ADR 0001 additive-ablation 측에 머무르며 n=100 real-eval 이 CI 를 `full` 과 분리할 때까지 유지됨, *superseded* 행은 후속 ADR 에 흡수 (예: ADR 0027 → ADR 0037 KURE v1) 되거나 baseline 조건 충족까지 유예되었음을 readers 에게 상기. follow-up `scripts/check_ablation_adr_sync.py` lint 경로 (issue #813 § 시정 액션 ②) 명시.

## 왜 footnote 인가, 새 칼럼 아닌가

표 자체는 `scripts/update_readme_metrics.py` 가 `METRICS_TABLE:START/END` 마커 사이에서 자동 생성. ADR 칼럼 추가는 writer 에게 ADR Status sync 가르치는 것 — 이 PR 의 가치보다 큰 변경. Footnote 는 마커 *밖* 에 위치해 writer 미터치, 일일 메트릭 refresh 계속 작동.

## Test plan

- [x] README 깔끔 렌더 (시각 + `git diff` 는 footnote 표만 추가; 기존 prose 미변경).
- [x] 참조된 9 ADR 경로 모두 resolve (`grep '^- \*\*Status\*\*'` 출력과 footnote 주장 cross-check; stale issue-body 1개 정정 — ADR 0026/0031/0027 은 *superseded*, *proposed* 아님).
- [x] METRICS_TABLE 마커 미터치 → 일일 리더보드 워크플로 영향 없음.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

| Surface     | 동작 변경? | 비고                                                 |
| ----------- | ---------------- | ----------------------------------------------------- |
| Retrieval   | No               | README 문서만.                            |
| Verifier    | No               | —                                                     |
| Eval        | No               | —                                                     |
| Ingestion   | No               | —                                                     |
| API         | No               | —                                                     |
| Docs        | Yes (additive)   | 분석 변형 행 → ADR Status 매핑 신규 footnote 표. METRICS_TABLE auto-generator 미터치. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
