### PR TITLE
feat(governance): pre-commit guard for ADR ↔ README index parity (closes #803)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -92,6 +92,32 @@ if [[ -n "$adr_added" ]]; then
       exit 1
     fi
   done <<< "$adr_added"
+
+  # Guard: ADR ↔ README index parity (issue #803 — shift-left of the
+  # tests/test_governance.py::test_no_unlinked_adr_files_on_disk CI gate).
+  # An ADR PR that lands without a matching `| [NNNN](./NNNN-*.md) |` row
+  # in docs/adr/README.md reds main on merge and cascades red Pytest across
+  # every open PR (see #730 / #732 / #750 recurrence trail). The pre-commit
+  # check uses the *staged* README content (`git show :docs/adr/README.md`)
+  # so the row must be staged in the same commit — not just sitting in the
+  # working tree.
+  #
+  # Pass all newly added ADR paths in one call (argparse nargs='+') so the
+  # error message lists everything that's missing instead of stopping at
+  # the first violator.
+  adr_added_args=()
+  while IFS= read -r adr_file; do
+    [[ -z "$adr_file" ]] && continue
+    adr_added_args+=("$adr_file")
+  done <<< "$adr_added"
+  if [[ ${#adr_added_args[@]} -gt 0 ]]; then
+    parity_out=$(python3 scripts/_governance.py --check-adr-readme-parity \
+      --readme-staged "${adr_added_args[@]}" 2>&1)
+    if [[ $? -ne 0 ]]; then
+      echo "$parity_out" >&2
+      exit 1
+    fi
+  fi
 fi
 
 staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -205,6 +205,52 @@ ADR_VERIFIES_KEY_RE = re.compile(
 ADR_VERIFICATION_HEADER_RE = re.compile(r"^##\s+Verification\s*$", re.MULTILINE)
 
 
+# ---------------------------------------------------------------------------
+# ADR ↔ README index parity (issue #803).
+#
+# `tests/test_governance.py::test_no_unlinked_adr_files_on_disk` enforces
+# parity in CI Pytest. That runs *after* push, so a missing index row
+# reds main on merge and cascades a red Pytest gate across every open PR
+# until someone authors a fix. The pre-commit hook calls
+# ``adr_readme_parity_violations`` to shift this same check left so the
+# author finds out at ``git commit`` time.
+#
+# The check is deliberately string-grep on the staged README text rather
+# than a markdown parser — it must match exactly the row format the
+# Pytest gate parses (``| [NNNN](./NNNN-slug.md) |``) and stay zero-dep
+# (Python stdlib + git).
+# ---------------------------------------------------------------------------
+
+
+_ADR_INDEX_ROW_RE = re.compile(
+    r"\|\s*\[(\d{4})\]\(\./(\d{4}-[^)]+\.md)\)\s*\|"
+)
+
+
+def adr_readme_parity_violations(
+    adr_filenames: list[str],
+    readme_text: str,
+) -> list[str]:
+    """Return the ADR filenames that have no matching row in ``readme_text``.
+
+    A "matching row" follows the canonical index format::
+
+        | [NNNN](./NNNN-slug.md) | status | title |
+
+    which is what ``test_no_unlinked_adr_files_on_disk`` already parses
+    (see ``tests/test_governance.py::_ADR_INDEX_ROW_RE``). Empty input
+    returns an empty list — the caller should only invoke this when at
+    least one ADR file is staged for add/rename.
+    """
+    rows = {filename for _, filename in _ADR_INDEX_ROW_RE.findall(readme_text)}
+    missing: list[str] = []
+    for path in adr_filenames:
+        name = Path(path).name
+        if name not in rows:
+            missing.append(name)
+    return missing
+
+
 def adr_has_verification_section(adr_path: str | Path) -> bool:
     """Return True if the ADR file contains a `## Verification` H2 header."""
     p = Path(adr_path)
@@ -311,6 +357,68 @@ def _cmd_lint_adr_consequences(adr_path: str, repo_root: str) -> int:
     return 1
 
 
+def _cmd_check_adr_readme_parity(
+    adr_paths: list[str],
+    readme_staged: bool,
+    readme_path: str,
+) -> int:
+    """Hook-side parity check (issue #803).
+
+    When ``readme_staged`` is true, the README content is read from the
+    git index (``git show :docs/adr/README.md``) — that is the version
+    the upcoming commit will publish. Otherwise the working-tree file
+    at ``readme_path`` is read (useful for ad-hoc CLI calls and tests).
+    """
+    if readme_staged:
+        import subprocess
+
+        try:
+            readme_text = subprocess.check_output(
+                ["git", "show", f":{readme_path}"],
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            sys.stderr.write(
+                f"\n❌ Could not read staged {readme_path} via "
+                f"`git show :{readme_path}`: {exc}\n"
+                "   Is docs/adr/README.md present in the index?\n\n"
+            )
+            return 1
+    else:
+        try:
+            readme_text = Path(readme_path).read_text(encoding="utf-8")
+        except OSError as exc:
+            sys.stderr.write(
+                f"\n❌ Could not read {readme_path}: {exc}\n\n"
+            )
+            return 1
+
+    missing = adr_readme_parity_violations(adr_paths, readme_text)
+    if not missing:
+        return 0
+
+    sys.stderr.write(
+        "\n❌ ADR ↔ README index parity check failed (issue #803):\n\n"
+    )
+    for name in missing:
+        sys.stderr.write(f"     - {name} has no row in docs/adr/README.md\n")
+    sys.stderr.write(
+        "\n   Add a row of the form\n"
+        "       | [NNNN](./NNNN-slug.md) | proposed | one-line title |\n"
+        "   under the Index section of docs/adr/README.md, stage it in\n"
+        "   the same commit, then re-commit.\n\n"
+        "   Why this hook fires at commit time:\n"
+        "     - The CI gate `test_no_unlinked_adr_files_on_disk` is the\n"
+        "       canonical check, but it only runs after push — a missing\n"
+        "       row reds main on merge and cascades a red Pytest gate\n"
+        "       across every open PR until a fix-up PR lands.\n"
+        "     - Issues #730 / #732 / #750 are the recurrence trail.\n\n"
+        "   Bypass with --no-verify only mid-merge; open a follow-up to\n"
+        "   add the missing row.\n\n"
+    )
+    return 1
+
+
 def _cmd_check_adr_collision(adr_dir: str) -> int:
     dups = find_duplicate_adr_numbers(adr_dir)
     if not dups:
@@ -413,6 +521,26 @@ def main() -> int:
         help="Lint a single ADR's `## Verification` section + verifies-key "
              "markers (issue #793); exit 1 with details if missing/broken.",
     )
+    g.add_argument(
+        "--check-adr-readme-parity",
+        nargs="+",
+        metavar="ADR_PATH",
+        help="Check that each ADR path has a matching row in "
+             "docs/adr/README.md (issue #803). Used by the pre-commit hook "
+             "to shift-left the test_no_unlinked_adr_files_on_disk CI gate.",
+    )
+    p.add_argument(
+        "--readme-staged", action="store_true",
+        help="When set with --check-adr-readme-parity, read README content "
+             "from the git index (`git show :<readme-path>`) instead of the "
+             "working tree. Used by the pre-commit hook so the check sees "
+             "exactly what the upcoming commit will publish.",
+    )
+    p.add_argument(
+        "--readme-path", default="docs/adr/README.md",
+        help="README path for --check-adr-readme-parity "
+             "(default: docs/adr/README.md).",
+    )
     p.add_argument(
         "--adr-dir", default=ADR_DIR_DEFAULT,
         help=f"ADR directory (default: {ADR_DIR_DEFAULT}). "
@@ -439,6 +567,12 @@ def main() -> int:
         return _cmd_check_adr_collision(args.adr_dir)
     if args.lint_adr_consequences is not None:
         return _cmd_lint_adr_consequences(args.lint_adr_consequences, args.repo_root)
+    if args.check_adr_readme_parity is not None:
+        return _cmd_check_adr_readme_parity(
+            args.check_adr_readme_parity,
+            readme_staged=args.readme_staged,
+            readme_path=args.readme_path,
+        )
     return 2
 
 

--- a/tests/test_governance_adr_readme_parity.py
+++ b/tests/test_governance_adr_readme_parity.py
@@ -1,0 +1,195 @@
+"""Regression tests for ADR ↔ README index parity (issue #803).
+
+The CI gate ``tests/test_governance.py::test_no_unlinked_adr_files_on_disk``
+fires *after* push and cascades red Pytest across every open PR when an
+ADR PR merges with the row missing from ``docs/adr/README.md`` (see
+#730 / #732 / #750 recurrence trail). The pre-commit hook calls
+``adr_readme_parity_violations`` to shift the same check left so the
+author finds out at ``git commit`` time.
+
+These tests pin the helper behavior + the CLI wrapper so a refactor of
+either side cannot silently regress the pre-commit guard.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts._governance import adr_readme_parity_violations
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOVERNANCE_CLI = REPO_ROOT / "scripts" / "_governance.py"
+
+
+# ---- adr_readme_parity_violations ----------------------------------------
+
+
+def _readme_with(rows: list[tuple[str, str, str]]) -> str:
+    """Build a minimal README fragment with the canonical row format.
+
+    Each row tuple is ``(NNNN, filename, "status | title")``.
+    """
+    body = ["# ADRs\n", "## Index\n"]
+    body.append("| ADR | Status | Title |\n")
+    body.append("|---|---|---|\n")
+    for num, filename, suffix in rows:
+        body.append(f"| [{num}](./{filename}) | {suffix} |\n")
+    return "".join(body)
+
+
+def test_parity_empty_input_returns_empty() -> None:
+    # Empty ADR list should never report violations even if README is empty.
+    assert adr_readme_parity_violations([], "") == []
+    assert adr_readme_parity_violations([], "no rows here") == []
+
+
+def test_parity_matching_row_passes() -> None:
+    readme = _readme_with(
+        [("0044", "0044-realN-eval-case-expansion.md", "proposed | realN")]
+    )
+    missing = adr_readme_parity_violations(
+        ["docs/adr/0044-realN-eval-case-expansion.md"],
+        readme,
+    )
+    assert missing == []
+
+
+def test_parity_missing_row_returns_filename() -> None:
+    readme = _readme_with([("0001", "0001-other.md", "accepted | other")])
+    missing = adr_readme_parity_violations(
+        ["docs/adr/0044-realN-eval-case-expansion.md"],
+        readme,
+    )
+    assert missing == ["0044-realN-eval-case-expansion.md"]
+
+
+def test_parity_accepts_just_basename() -> None:
+    # Helper must use only the basename so callers can pass full paths
+    # (pre-commit hook) or bare filenames (CLI tests) interchangeably.
+    readme = _readme_with([("0044", "0044-realN.md", "proposed | x")])
+    assert adr_readme_parity_violations(["0044-realN.md"], readme) == []
+    assert (
+        adr_readme_parity_violations(
+            ["docs/adr/0044-realN.md"], readme,
+        )
+        == []
+    )
+
+
+def test_parity_reports_only_missing_subset() -> None:
+    readme = _readme_with(
+        [
+            ("0001", "0001-alpha.md", "accepted | a"),
+            ("0002", "0002-beta.md", "accepted | b"),
+        ]
+    )
+    missing = adr_readme_parity_violations(
+        [
+            "docs/adr/0001-alpha.md",
+            "docs/adr/0002-beta.md",
+            "docs/adr/0003-gamma.md",
+        ],
+        readme,
+    )
+    assert missing == ["0003-gamma.md"]
+
+
+def test_parity_row_must_use_canonical_format() -> None:
+    # A bare `0044-x.md` mention in prose does NOT count — the row must
+    # use the canonical `| [NNNN](./...md) |` pipe-table form because
+    # that is what the CI gate parses.
+    prose_only = "See 0044-x.md for details.\n"
+    missing = adr_readme_parity_violations(["0044-x.md"], prose_only)
+    assert missing == ["0044-x.md"]
+
+
+# ---- CLI wrapper (working-tree mode) -------------------------------------
+
+
+def _run_cli(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GOVERNANCE_CLI), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=cwd,
+    )
+
+
+def test_cli_passes_when_readme_has_row(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        _readme_with([("0099", "0099-test.md", "proposed | test")]),
+        encoding="utf-8",
+    )
+    result = _run_cli(
+        "--check-adr-readme-parity",
+        "docs/adr/0099-test.md",
+        "--readme-path",
+        str(readme),
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_fails_with_message_when_missing(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(_readme_with([]), encoding="utf-8")
+    result = _run_cli(
+        "--check-adr-readme-parity",
+        "docs/adr/0099-test.md",
+        "--readme-path",
+        str(readme),
+    )
+    assert result.returncode == 1
+    assert "0099-test.md has no row" in result.stderr
+    # The error must point the author at the canonical row format and
+    # explain the cascade rationale — losing either is a docs regression.
+    assert "| [NNNN](./NNNN-slug.md) |" in result.stderr
+    assert "issue #803" in result.stderr
+
+
+# ---- Real-repo smoke ------------------------------------------------------
+
+
+def test_repo_adr_dir_parity_today() -> None:
+    """Sentinel: every ADR file on disk has a matching README row right
+    now. This is the same invariant the CI gate enforces; we duplicate
+    it here so a parity drift fails this faster, isolated test before
+    failing the slower governance suite.
+    """
+    adr_dir = REPO_ROOT / "docs" / "adr"
+    readme = (adr_dir / "README.md").read_text(encoding="utf-8")
+    on_disk = [str(p) for p in sorted(adr_dir.glob("[0-9][0-9][0-9][0-9]-*.md"))]
+    missing = adr_readme_parity_violations(on_disk, readme)
+    assert missing == [], (
+        "ADR ↔ README parity drift on main:\n  - "
+        + "\n  - ".join(missing)
+    )
+
+
+# ---- argparse mutex sanity ------------------------------------------------
+
+
+def test_cli_mutex_with_other_governance_modes(tmp_path: Path) -> None:
+    """``--check-adr-readme-parity`` must live in the same mutually
+    exclusive group as the other governance commands. Combining two
+    modes should fail argparse, not silently run one. This pins the
+    group placement so a future refactor cannot accidentally move it
+    to a separate group (which would let the hook + CI gate diverge
+    on which mode "wins").
+    """
+    result = _run_cli(
+        "--check-adr-readme-parity",
+        "docs/adr/0099-x.md",
+        "--next-adr-number",
+    )
+    assert result.returncode != 0
+    assert "not allowed with" in result.stderr or "argument" in result.stderr
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #803

## Summary

`tests/test_governance.py::test_no_unlinked_adr_files_on_disk` 는 push *후* 실행. ADR PR 이 `docs/adr/README.md` 의 `| [NNNN](./NNNN-*.md) |` row 없이 머지되면 main 이 red 되고 모든 open PR 이 fix-up PR 머지 전까지 red Pytest gate 를 cascade. 재발 흔적 (issue #803):

- #730 → ADR 0040/0041 머지 후 index 누락. 8 무관 PR 이 CI collateral fail.
- #732 → ADR 0044 가 index row 없이 디스크 추가.

같은 체크를 `.githooks/pre-commit` 으로 shift-left:

1. **`scripts/_governance.py`** — CI gate 가 이미 파싱하는 canonical row regex 재사용한 순수 함수 `adr_readme_parity_violations(adr_paths, readme_text)` 신설. 신규 CLI 모드 `--check-adr-readme-parity` + `--readme-staged` 로 git index 에서 README 읽기 (author 가 row 를 working tree 에만 두고 통과 못하도록).
2. **`.githooks/pre-commit`** — 기존 collision + consequences 블록 (이미 신규 ADR 파일이 stage 될 때만 fire) 후, 새로 추가된 ADR 경로 전체로 parity CLI 1회 호출. 에러 메시지가 canonical row 포맷 가리키고, 모든 누락 파일 나열, 재발 흔적 cite.
3. **`tests/test_governance_adr_readme_parity.py`** — 10 케이스: 순수 함수 happy/sad/edge 경로, CLI wrapper pass/fail with cascade rationale, real-repo parity sentinel, argparse mutex placement.

CI gate `test_no_unlinked_adr_files_on_disk` 는 canonical 로 유지; hook 은 더 이른 surface 일 뿐. 기존 hook 컨벤션대로 머지 중에만 `--no-verify` 로 bypass.

## Test plan

- [x] `pytest tests/test_governance_adr_readme_parity.py -v` — 10/10 pass.
- [x] `pytest tests/test_governance.py tests/test_governance_adr_numbers.py tests/test_pr_judge_workflow_regression.py -q` — 75 passed, 3 skipped (기존 governance surface regression 0).
- [x] `ruff check scripts/_governance.py tests/test_governance_adr_readme_parity.py` — clean.

## Acceptance criteria (issue #803)

- [x] `.githooks/pre-commit` 가 *staged* `docs/adr/README.md` 의 매칭 row 없이 `docs/adr/NNNN-*.md` 추가/rename 하는 staged 변경 reject.
- [x] 에러 메시지가 `docs/adr/README.md` Index 섹션 가리키고 누락 파일명 표시.
- [x] 문서화된 `--no-verify` 로만 bypass.
- [x] CI parity 보존 — `test_no_unlinked_adr_files_on_disk` 가 canonical gate 유지.
- [x] 테스트 커버리지: (a) row 있는 신규 ADR → pass, (b) row 없는 신규 ADR → fail, (c) ADR edit only → pass (hook 블록은 `--diff-filter=A` 일 때만 실행), (d) ADR 파일 없이 README row 추가 → `test_adr_index_rows_resolve_to_files` 가 이미 커버.

## Out of scope

- row 자동 생성 (templating). Author 가 여전히 1-line 결정 요약 선택.
- proposed/roadmap 섹션 mirror 체크 (실패 위험 낮음; 문제 되면 별도 issue).

### 5b. Real-data delta

No behavior change in retrieval, verifier, eval, api, or ingestion paths.

| Surface     | Behavior change? | Notes                                                 |
| ----------- | ---------------- | ----------------------------------------------------- |
| Retrieval   | No               | `.githooks/pre-commit` + `scripts/_governance.py` + 신규 테스트만. |
| Verifier    | No               | —                                                     |
| Eval        | No               | —                                                     |
| Ingestion   | No               | —                                                     |
| API         | No               | —                                                     |
| Governance  | Yes (additive)   | ADR ↔ README parity 신규 pre-commit guard. CI gate `test_no_unlinked_adr_files_on_disk` 미변경 유지. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
