### PR TITLE
feat(eval): whitelist by_hardcase_category in ADR 0005 commit boundary

### DIFF
--- a/eval/real_config.example.yaml
+++ b/eval/real_config.example.yaml
@@ -26,6 +26,13 @@ cases:
     expected_claim_targets:
       - "replace-with-agency"
     answerable: true
+    # Optional: ADR 0039 hardcase taxonomy tags (multi-label list).
+    # Allowed values: table_heavy / ocr_noisy / rotated_or_skewed / layout_broken.
+    # Unknown values are dropped by scripts/run_real_eval_delta.py before any
+    # aggregate crosses the ADR 0005 commit boundary, so the private 5-slice
+    # taxonomy (scanned_pdf / mixed_layout / noisy_ocr) stays local-only.
+    # hardcase_categories:
+    #   - table_heavy
 
   - id: replace_absent_fact
     query_type: abstention

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -122,12 +122,29 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         # metric sub-keys mirror SAFE_ABLATION_FULL_SCALAR_KEYS; no per-case
         # payload crosses the boundary.
         "by_format",
+        # Issue #845 / ADR 0039: per-hardcase-category accuracy breakdown,
+        # populated by run_eval.py:677-685 when cases carry the
+        # ``hardcase_categories`` field. Bucket keys are whitelisted in
+        # SAFE_HARDCASE_CATEGORY_BUCKET_KEYS (fail-closed) so the public
+        # taxonomy can never be silently widened on the committable surface.
+        "by_hardcase_category",
     }
 )
 
 # Allowed bucket keys inside ``by_format``. Fail-closed: any key not in
 # this set is silently dropped before the aggregate is committed.
 SAFE_FORMAT_BUCKET_KEYS = frozenset({"hwp", "pdf", "synthetic_public_sample"})
+
+# Allowed bucket keys inside ``by_hardcase_category``. Mirrors ADR 0039's
+# public 4-category enum (same set as ADR_0039_CATEGORIES in
+# tests/test_hwp_hardcase_category_inventory_regression.py). Fail-closed:
+# any unknown category — including private 5-slice names like
+# ``scanned_pdf`` / ``mixed_layout`` / ``noisy_ocr`` — is silently dropped
+# before the aggregate is committed, so the private taxonomy in
+# docs/real-data/private-hardcase-benchmark.md cannot leak through.
+SAFE_HARDCASE_CATEGORY_BUCKET_KEYS = frozenset(
+    {"table_heavy", "ocr_noisy", "rotated_or_skewed", "layout_broken"}
+)
 
 # Whitelisted bin names for ``abstention_outcomes``. Integer counts only.
 SAFE_ABSTENTION_OUTCOME_KEYS = ("correct_refusal", "incorrect_answer", "boundary_partial")
@@ -497,6 +514,38 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                 format_out[str(bucket_name)] = extracted_bucket
         if format_out:
             out["by_format"] = format_out
+
+    # Issue #845 / ADR 0039 — by_hardcase_category aggregate. Fail-closed
+    # against the public 4-category enum so private 5-slice category names
+    # (scanned_pdf / mixed_layout / noisy_ocr) cannot leak even if a
+    # local-only real_config.local.yaml mistakenly tags them.
+    by_hardcase_category = summary.get("by_hardcase_category")
+    if isinstance(by_hardcase_category, dict):
+        hardcase_out: dict[str, dict[str, Any]] = {}
+        for bucket_name, bucket_summary in by_hardcase_category.items():
+            if str(bucket_name) not in SAFE_HARDCASE_CATEGORY_BUCKET_KEYS:
+                continue
+            if not isinstance(bucket_summary, dict):
+                continue
+            extracted_bucket = {}
+            for m in SAFE_SLICE_METRICS:
+                raw = bucket_summary.get(m)
+                if raw is None:
+                    continue
+                if m == "abstention_outcomes" and isinstance(raw, dict):
+                    bin_out = {
+                        sub: int(raw[sub])
+                        for sub in SAFE_ABSTENTION_OUTCOME_KEYS
+                        if isinstance(raw.get(sub), (int, float))
+                    }
+                    if bin_out:
+                        extracted_bucket[m] = bin_out
+                else:
+                    extracted_bucket[m] = raw
+            if extracted_bucket:
+                hardcase_out[str(bucket_name)] = extracted_bucket
+        if hardcase_out:
+            out["by_hardcase_category"] = hardcase_out
 
     _assert_no_forbidden(out)
     return out

--- a/tests/test_eval_by_hardcase_category_aggregate_regression.py
+++ b/tests/test_eval_by_hardcase_category_aggregate_regression.py
@@ -1,0 +1,153 @@
+"""Regression tests for by_hardcase_category aggregate (issue #845 / ADR 0039).
+
+Companion to test_eval_by_format_aggregate_regression.py — same fail-closed
+contract, different bucket dimension. Verifies that:
+
+1. ``extract_aggregate`` in ``scripts/run_real_eval_delta`` retains buckets
+   whose name is in :data:`SAFE_HARDCASE_CATEGORY_BUCKET_KEYS` (the public
+   ADR 0039 4-category enum).
+2. Unknown bucket names — including the private 5-slice category names from
+   ``docs/real-data/private-hardcase-benchmark.md`` (``scanned_pdf``,
+   ``mixed_layout``, ``noisy_ocr``) — are silently dropped (fail-closed),
+   so a misconfigured local-only ``real_config.local.yaml`` cannot leak
+   the private taxonomy through the ADR 0005 commit boundary.
+3. No per-case payload (``FORBIDDEN_KEYS``) appears in the by_hardcase_category
+   output.
+4. The bucket key set agrees with the inventory regression in
+   ``test_hwp_hardcase_category_inventory_regression.py`` (single source of
+   truth for the public 4-category enum).
+"""
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from scripts.run_real_eval_delta import (
+    FORBIDDEN_KEYS,
+    SAFE_HARDCASE_CATEGORY_BUCKET_KEYS,
+    extract_aggregate,
+)
+
+
+class TestExtractAggregateByHardcaseCategory(unittest.TestCase):
+    def _minimal_summary(self, by_hardcase_category: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "num_predictions": 3,
+            "accuracy": 1.0,
+            "groundedness": 1.0,
+            "citation_precision": 1.0,
+            "citation_grounding": None,
+            "claim_citation_alignment": None,
+            "answer_format_compliance": 1.0,
+            "abstention": None,
+            "retry": 0.0,
+            "by_hardcase_category": by_hardcase_category,
+        }
+
+    def test_allowed_buckets_pass_through(self) -> None:
+        summary = self._minimal_summary(
+            {
+                "table_heavy": {"num_predictions": 5, "accuracy": 0.6},
+                "ocr_noisy": {"num_predictions": 2, "accuracy": 0.5},
+                "rotated_or_skewed": {"num_predictions": 1, "accuracy": 1.0},
+                "layout_broken": {"num_predictions": 3, "accuracy": 0.33},
+            }
+        )
+        out = extract_aggregate(summary)
+        self.assertIn("by_hardcase_category", out)
+        buckets = out["by_hardcase_category"]
+        self.assertIn("table_heavy", buckets)
+        self.assertIn("ocr_noisy", buckets)
+        self.assertIn("rotated_or_skewed", buckets)
+        self.assertIn("layout_broken", buckets)
+        self.assertEqual(buckets["table_heavy"]["num_predictions"], 5)
+        self.assertEqual(buckets["layout_broken"]["accuracy"], 0.33)
+
+    def test_private_5_slice_names_dropped_fail_closed(self) -> None:
+        """Private taxonomy names from docs/real-data/private-hardcase-benchmark.md
+        must never cross the commit boundary, even if a local-only
+        real_config.local.yaml uses them by mistake."""
+        summary = self._minimal_summary(
+            {
+                "table_heavy": {"num_predictions": 1, "accuracy": 1.0},
+                "scanned_pdf": {"num_predictions": 99, "accuracy": 0.0},
+                "mixed_layout": {"num_predictions": 99, "accuracy": 0.0},
+                "noisy_ocr": {"num_predictions": 99, "accuracy": 0.0},
+            }
+        )
+        out = extract_aggregate(summary)
+        buckets = out.get("by_hardcase_category", {})
+        self.assertIn("table_heavy", buckets)
+        self.assertNotIn("scanned_pdf", buckets)
+        self.assertNotIn("mixed_layout", buckets)
+        self.assertNotIn("noisy_ocr", buckets)
+
+    def test_unknown_arbitrary_bucket_dropped(self) -> None:
+        summary = self._minimal_summary(
+            {
+                "table_heavy": {"num_predictions": 1, "accuracy": 1.0},
+                "secret_category": {"num_predictions": 99, "accuracy": 0.0},
+            }
+        )
+        out = extract_aggregate(summary)
+        self.assertNotIn("secret_category", out.get("by_hardcase_category", {}))
+
+    def test_absent_when_no_buckets(self) -> None:
+        """When no case is tagged with a hardcase_category, run_eval omits the
+        ``by_hardcase_category`` key entirely (run_eval.py:677-685 only assigns
+        when ``hardcase_grouped`` is non-empty). The extractor must mirror that:
+        no empty dict in the committable aggregate."""
+        summary = {
+            "num_predictions": 3,
+            "accuracy": 1.0,
+        }
+        out = extract_aggregate(summary)
+        self.assertNotIn("by_hardcase_category", out)
+
+    def test_no_forbidden_keys_in_output(self) -> None:
+        summary = self._minimal_summary(
+            {
+                "table_heavy": {
+                    "num_predictions": 1,
+                    "accuracy": 1.0,
+                    "case_results": "should_be_dropped",
+                }
+            }
+        )
+        out = extract_aggregate(summary)
+
+        def _all_keys(d: dict) -> set:
+            keys = set(d.keys())
+            for v in d.values():
+                if isinstance(v, dict):
+                    keys |= _all_keys(v)
+            return keys
+
+        present = _all_keys(out)
+        for forbidden in FORBIDDEN_KEYS:
+            self.assertNotIn(
+                forbidden,
+                present,
+                f"Forbidden key '{forbidden}' leaked into aggregate output",
+            )
+
+    def test_safe_hardcase_category_bucket_keys_match_adr_0039(self) -> None:
+        """Single source of truth: the bucket whitelist here must agree with
+        ``ADR_0039_CATEGORIES`` in
+        ``tests/test_hwp_hardcase_category_inventory_regression.py``. Drift
+        between the two means either a new public category was added without
+        an extractor update (silent drop) or a private category was promoted
+        without an inventory test update (silent leak)."""
+        from tests.test_hwp_hardcase_category_inventory_regression import (
+            ADR_0039_CATEGORIES,
+        )
+
+        self.assertEqual(
+            SAFE_HARDCASE_CATEGORY_BUCKET_KEYS,
+            ADR_0039_CATEGORIES,
+            "Extractor whitelist drifted from ADR 0039 4-category enum",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `scripts/run_real_eval_delta.py::extract_aggregate` 의 `SAFE_TOPLEVEL_KEYS` whitelist 에 `by_hardcase_category` 추가하여 `eval/run_eval.py:677-685` 가 emit 하는 per-category 메트릭 블록이 ADR 0005 commit 경계를 통과하도록 함.
- 공개 ADR 0039 4-카테고리 enum (`table_heavy` / `ocr_noisy` / `rotated_or_skewed` / `layout_broken`) 에 대한 fail-closed. `docs/real-data/private-hardcase-benchmark.md` 의 private 5-slice 이름 (`scanned_pdf` / `mixed_layout` / `noisy_ocr`) 은 local-only `real_config.local.yaml` 이 tag 해도 silent 하게 drop.
- `eval/real_config.example.yaml` scaffold 에 옵셔널 `hardcase_categories` 필드 문서화.

## Why

`reports/real100/eval_summary.json::by_hardcase_category` 는 오늘 real100 surface 에서 항상 비어 있다. 두 이유: (1) `real_config.local.yaml` 의 21 케이스가 `hardcase_categories` 필드를 가지지 않음 — 이 부분은 contributor 가 local 에서 채울 영역 (ADR 0005 경계), (2) 채웠더라도 extractor whitelist 에 `by_hardcase_category` entry 가 없어 slice 가 `baseline.aggregate.json` 또는 leaderboard 에 도달하지 못함. 이 PR 은 (2) 를 닫아 향후 local tagging 이 즉시 committable aggregate 에 surface 되도록 한다.

Fail-closed bucket whitelist 는 issue #650 / ADR 0039 가 `by_format` 에 도입한 패턴을 mirror, private 5-slice taxonomy 가 우발적으로 public surface 에 promote 되지 않도록 하는 제약을 추가.

## Test plan

- [x] `pytest tests/test_eval_by_hardcase_category_aggregate_regression.py -v` — 6 신규 테스트 pass (private taxonomy 대상 fail-closed, ADR 0039 inventory 테스트 대상 drift guard).
- [x] `pytest tests/test_eval_by_format_aggregate_regression.py tests/test_run_real_eval_delta.py tests/test_hwp_hardcase_category_inventory_regression.py tests/test_write_real_eval_baseline.py tests/test_real_eval_case_expansion.py -q` — 113 인접 테스트 pass, 0 regression.
- [x] `ruff check .` — clean.
- [ ] Local-only follow-up (이 diff 비포함, ADR 0005 경계): `eval/real_config.local.yaml` 의 real100 21 케이스에 적용 가능한 `hardcase_categories` tag, `make real-eval` 실행, `jq '.by_hardcase_category | keys' reports/real100/eval_summary.json` 가 4-카테고리 enum 의 non-empty subset 반환 확인.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

이 PR 은:
1. `scripts/run_real_eval_delta.py` 의 ADR 0005 extractor allowlist 에 `by_hardcase_category` (및 fail-closed bucket whitelist) 추가. `eval/run_eval.py` 가 이미 emit 하는 aggregate key 에 대한 gate-widening 변경 — eval 파이프라인 자체는 미변경.
2. `eval/real_config.example.yaml` scaffold 에 docs-only 주석 블록 추가 (§5b 체크가 load-bearing 으로 flag 한 파일). 커밋된 예제 케이스는 여전히 `hardcase_categories` entry 0 — 주석은 예시.
3. `tests/` 아래 신규 regression 테스트 추가.

`rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, `eval/run_eval.py`, `ingestion.py`, `visual_ingestion.py`, `api/`, `scripts/build_index.py` 미변경. `make real-eval-delta` 는 현재 `baseline.aggregate.json` 대비 zero delta — 현재 어떤 케이스도 필드를 가지지 않으므로 slice 가 diff 양쪽에 부재.

## ADR 경계

- **ADR 0005**: diff 가 extractor whitelist + docs-only schema 예제 + 신규 regression 테스트만 포함. per-case payload 없음, doc_id 없음, query 텍스트 없음.
- **ADR 0039**: 4-카테고리 enum 이 단일 public source of truth 로 강화 (extractor whitelist == inventory 테스트의 `ADR_0039_CATEGORIES`; drift 시 CI fail).
- **ADR 0030**: `by_hardcase_category` 가 `by_format` / `by_query_type` 와 동일 메트릭 4-tuple shape 의 per-bucket aggregate slice 로 합류. Leaderboard schema 추가형, breaking 아님.
- **ADR 0001**: `naive_baseline` golden invariant — `run_eval.py` 미터치; aggregator 는 케이스가 필드를 가질 때만 key emit, public synthetic config 는 케이스에 real100-style hardcase 카테고리 tag 하지 않음.

Closes #845.
