### PR TITLE
fix(eval): metadata_backend discriminator for full vs full_llm_metadata (closes #804)

### DIFF
--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -121,6 +121,13 @@ ablation_runs:
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    # ADR 0001 default: regex-based RFP metadata extraction
+    # (``rag_metadata_extraction.RegexBackend``). The discriminator is
+    # consumed by the byte-identity invariant test that pairs this row
+    # with ``full_llm_metadata`` (issue #804). The eval runner itself
+    # does not branch on this key — index-build time is where the
+    # backend is selected via ``BIDMATE_METADATA_BACKEND``.
+    metadata_backend: regex
   # ADR 0011 — additive LLM synthesis path. Default backend is `stub`
   # (deterministic, offline, free) so public CI stays per ADR 0004.
   # Real-data + live demo override `BIDMATE_SYNTHESIS_BACKEND=anthropic`.
@@ -140,12 +147,18 @@ ablation_runs:
   # so public CI / synthetic harness runs stay deterministic and free.
   # The pipeline itself is identical to ``full`` — only the
   # ``metadata["extracted"]`` sidecar in each chunk differs.
+  #
+  # Issue #804: the ``metadata_backend`` discriminator below makes the
+  # config-level difference from ``full`` explicit (without it, the two
+  # rows were byte-identical and the byte-identity invariant test could
+  # not differentiate them — same Goodhart trap as #800).
   - name: full_llm_metadata
     pipeline: agentic_full
     metadata_first: true
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    metadata_backend: anthropic_tool_use
   - name: hierarchical
     pipeline: agentic_full
     metadata_first: true

--- a/tests/test_full_llm_metadata_ablation_row.py
+++ b/tests/test_full_llm_metadata_ablation_row.py
@@ -1,0 +1,140 @@
+"""Regression tests for ``full_llm_metadata`` ablation row (issue #804).
+
+Found while investigating #800.  ``eval/config.yaml`` had two ablation rows
+— ``full`` and ``full_llm_metadata`` — that were byte-identical once the
+``name`` field was excluded.  Both shared the same
+``pipeline / metadata_first / rerank / verifier_retry / retrieval_mode``
+five-tuple, so the eval runner produced the same leaderboard values for
+two named columns.
+
+The real dimension that differentiates them is the **metadata extraction
+backend** selected at index-build time via the ``BIDMATE_METADATA_BACKEND``
+env var (ADR 0017): ``regex`` (ADR 0001 default) vs ``anthropic_tool_use``
+(LLM tool use) vs ``openai_function_call``.  That dimension is environmental
+(it happens during ``ingestion.normalize_ingestion_row``), not part of the
+runner's per-query config — so the config row was missing its discriminator.
+
+Issue #804 codified the discriminator: each row now carries an explicit
+``metadata_backend`` key.  The runner silently ignores unknown keys (see
+``eval/run_eval.py::normalize_run_config``), so this is additive — but it
+restores the property that the byte-identity invariant test from #800 can
+catch alias drift across the *entire* ablation set, not just one pair.
+
+These tests pin three properties:
+
+1.  Both rows exist (no accidental delete).
+2.  Both rows carry the ``metadata_backend`` discriminator with the
+    correct value.
+3.  Once ``name`` is stripped, the two rows are NOT byte-identical
+    (this is the same invariant the #800 test pins for
+    retrieval_only / no_verifier_retry).
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT_DIR / "eval" / "config.yaml"
+
+
+class TestFullLlmMetadataAblationRow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        with open(CONFIG_PATH) as f:
+            cls.config = yaml.safe_load(f)
+        cls.ablation_runs: list[dict] = cls.config.get("ablation_runs", [])
+        cls.ablation_by_name = {row["name"]: row for row in cls.ablation_runs}
+
+    def test_full_row_exists(self) -> None:
+        self.assertIn(
+            "full",
+            self.ablation_by_name,
+            "Ablation row 'full' missing from eval/config.yaml",
+        )
+
+    def test_full_llm_metadata_row_exists(self) -> None:
+        self.assertIn(
+            "full_llm_metadata",
+            self.ablation_by_name,
+            "Ablation row 'full_llm_metadata' missing from eval/config.yaml",
+        )
+
+    def test_full_carries_regex_metadata_backend(self) -> None:
+        """``full`` is the ADR 0001 default — regex metadata extraction."""
+        row = self.ablation_by_name["full"]
+        self.assertEqual(
+            row.get("metadata_backend"),
+            "regex",
+            "full: metadata_backend must be 'regex' (ADR 0001 default). "
+            "Without the explicit discriminator the byte-identity test "
+            "(issue #804) cannot differentiate this row from full_llm_metadata.",
+        )
+
+    def test_full_llm_metadata_carries_llm_backend(self) -> None:
+        """``full_llm_metadata`` selects the LLM tool-use backend (ADR 0017)."""
+        row = self.ablation_by_name["full_llm_metadata"]
+        backend = row.get("metadata_backend")
+        # Accept either of the two LLM backends documented in the file
+        # comment + ``rag_metadata_extraction.ENV_BACKEND`` values, but
+        # NOT regex/stub (which would re-introduce the alias).
+        self.assertIn(
+            backend,
+            {"anthropic_tool_use", "openai_function_call"},
+            "full_llm_metadata: metadata_backend must be 'anthropic_tool_use' "
+            "or 'openai_function_call' (ADR 0017). Got: "
+            f"{backend!r}. See eval/config.yaml comment block above the row.",
+        )
+
+    def test_full_llm_metadata_differs_from_full(self) -> None:
+        """Issue #804 invariant: ``full`` and ``full_llm_metadata`` must
+        NOT be byte-identical (name aside).
+
+        The original config defined both rows with identical
+        pipeline/metadata_first/rerank/verifier_retry/retrieval_mode, so
+        the ablation runner produced identical leaderboard values for
+        two named columns.  This is the same Goodhart failure mode that
+        #800 pinned for retrieval_only/no_verifier_retry, generalized to
+        the full vs full_llm_metadata pair.
+
+        Fix: explicit ``metadata_backend`` discriminator.  If a future
+        refactor removes or aliases that key, this test catches it
+        before the leaderboard ships two columns with the same number.
+        """
+        full = self.ablation_by_name["full"]
+        full_llm_metadata = self.ablation_by_name["full_llm_metadata"]
+        full_minus_name = {k: v for k, v in full.items() if k != "name"}
+        flm_minus_name = {
+            k: v for k, v in full_llm_metadata.items() if k != "name"
+        }
+        self.assertNotEqual(
+            full_minus_name,
+            flm_minus_name,
+            "full and full_llm_metadata are byte-identical (issue #804). "
+            "If you intended full_llm_metadata to be an alias, delete the "
+            "duplicate row; otherwise restore the metadata_backend "
+            "discriminator that differentiates them.",
+        )
+
+    def test_metadata_backend_does_not_break_runner_normalize(self) -> None:
+        """The new key must not crash ``normalize_run_config``.
+
+        ``normalize_run_config`` returns a fixed-shape dict and ignores
+        unknown keys, so adding ``metadata_backend`` is additive.  This
+        test pins that contract so a future refactor that tightens the
+        runner's schema validation (e.g. ``extra='forbid'``) does not
+        silently drop this row.
+        """
+        from eval.run_eval import normalize_run_config
+
+        full_llm_metadata = self.ablation_by_name["full_llm_metadata"]
+        normalized = normalize_run_config(full_llm_metadata)
+        self.assertEqual(normalized["name"], "full_llm_metadata")
+        self.assertEqual(normalized["pipeline"], "agentic_full")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 변경 내용 및 이유

Closes #804.

#800 조사 중 발견. `eval/config.yaml` ablation_runs 의 `full` / `full_llm_metadata` 두 row 가 `name` 제외 시 byte-identical. `pipeline / metadata_first / rerank / verifier_retry / retrieval_mode` 가 동일 — ablation runner 가 두 named column 에 동일 leaderboard 숫자 생성. #800 이 `retrieval_only / no_verifier_retry` 에서 잡은 동일 Goodhart 함정.

실제 두 row 를 차별화하는 dimension 은 **metadata-extraction 백엔드** (ADR 0017) — index-build time 에 `BIDMATE_METADATA_BACKEND` (`regex` ↔ `anthropic_tool_use` ↔ `openai_function_call`) 로 선택. 이 dimension 은 환경적 — `ingestion.normalize_ingestion_row` 에서 set, per-query runner config 에 없음 — 그래서 config row 가 discriminator 누락.

이 PR 이 두 row 에 explicit `metadata_backend` discriminator 추가 (issue 의 Option A):

- `full` → `metadata_backend: regex` (ADR 0001 default)
- `full_llm_metadata` → `metadata_backend: anthropic_tool_use`

## 2. 영향 파일

- `eval/config.yaml` — 두 row 에 discriminator key 추가 (load-bearing — `eval/`)
- `tests/test_full_llm_metadata_ablation_row.py` — 신규 (6 테스트)

## 3. 리스크

**가장 깨질 가능성 높은 시나리오**: `normalize_run_config` 의 향후 tightening (예: pydantic `extra='forbid'`) 이 신규 키를 return shape 에 없다는 이유로 silently drop.

체크: `eval/run_eval.py::normalize_run_config` 는 fixed-shape dict return 하고 unknown key 무시. 신규 `test_metadata_backend_does_not_break_runner_normalize` 가 이 계약 pin — 신규 키 row 구성 후 normalized 출력이 name + pipeline round-trip 됨을 assert.

## 4. 테스트

`tests/test_full_llm_metadata_ablation_row.py` (신규 6):

1. `test_full_row_exists` / `test_full_llm_metadata_row_exists` — accidental delete 가드.
2. `test_full_carries_regex_metadata_backend` — ADR 0001 default pin.
3. `test_full_llm_metadata_carries_llm_backend` — `anthropic_tool_use` / `openai_function_call` 허용, `regex` / `stub` 거부 (alias 가드).
4. `test_full_llm_metadata_differs_from_full` — **#804 invariant** (#800 의 `test_retrieval_only_differs_from_no_verifier_retry` mirror).
5. `test_metadata_backend_does_not_break_runner_normalize` — runner-schema 추가성 계약.

6 전부 통과. 동반 `tests/test_retrieval_only_ablation_preset.py` green (두 파일 16 테스트).

## 5. Eval 영향

전부 `·` 예상. Discriminator 는 metadata only; runner 가 branch 하지 않음. Public synthetic CI 는 ADR 0001 default 백엔드 (`regex`) 로 실행 — 두 row 동작 불변.

### 5b. Real-data delta

No behavior change in retrieval / verifier path — `metadata_backend` 키는 index-build time 에 (`BIDMATE_METADATA_BACKEND` env var 통해, ADR 0017) 소비, runner 는 `normalize_run_config` 에 따라 unknown row key 무시. Public-synthetic + real-data delta 모두 `·` 예상 — chunk text, retrieval logic, verifier path 미터치.

## 6. 하위 호환성

추가성. `metadata_backend` 는 신규 optional key; 다른 모든 `ablation_runs` row 는 `normalize_run_config` 가 unknown key 무시하므로 계속 동작. Schema version bump 불필요.

## 7. Out of scope

- 신규 키를 runner 가 **honor** 또는 **validate** 하도록 wiring (예: `BIDMATE_METADATA_BACKEND=regex` 로 빌드된 index 에서 `full_llm_metadata` row 스킵). 현재 상태: 두 row 가 `regex` 로 빌드된 index 에서 실행되면 config-level 에서 discrepancy 를 *announce* 하지만 leaderboard 숫자는 여전히 일치. ADR 0017 평가에 load-bearing 이 되면 follow-up.
- ADR 0030 leaderboard column 정책 갱신 — 진행 중 forward-only column 작업이 별도 커버.
