### PR TITLE
feat(eval): case-proposer prioritizes uncovered docs for ADR 0044 expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,8 @@ case-propose:
 	$(PYTHON) -m eval.case_proposer \
 	  --metadata-csv data/data_list.csv \
 	  --index-dir data/index/real100 \
-	  --out reports/proposed/proposed_cases.local.yaml
+	  --out reports/proposed/proposed_cases.local.yaml \
+	  --real-config eval/real_config.local.yaml
 
 case-review:
 	$(PYTHON) scripts/case_proposer_review.py \

--- a/eval/case_proposer.py
+++ b/eval/case_proposer.py
@@ -479,6 +479,71 @@ def write_proposed_yaml(cases: list[dict[str, Any]], path: Path) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def _read_real_config_covered_doc_ids(real_config_path: Path) -> set[str]:
+    """Return the doc_ids already referenced by some case's
+    ``expected_doc_ids`` in the active local real_config.
+
+    Missing file is treated as "no doc covered yet" (empty set) — the
+    local config is gitignored under ADR 0005 so a fresh clone never
+    has it. Malformed YAML or unexpected shape raises so the proposer
+    never silently widens coverage to docs that ARE already covered.
+    """
+    if not real_config_path.exists():
+        return set()
+    import yaml  # lazy: only needed when the local config exists
+
+    text = real_config_path.read_text(encoding="utf-8")
+    config = yaml.safe_load(text)
+    if config is None:
+        return set()
+    if not isinstance(config, dict):
+        # NB: ``yaml.safe_load("[]") or {}`` would silently coerce a list to
+        # an empty dict (empty-list is falsy), defeating the check below.
+        # Branch on ``is None`` explicitly so a top-level list still raises.
+        raise CaseProposerInputError(
+            f"{real_config_path} must contain a YAML mapping at top level."
+        )
+    covered: set[str] = set()
+    for case in config.get("cases") or []:
+        if not isinstance(case, dict):
+            continue
+        for doc_id in case.get("expected_doc_ids") or []:
+            value = str(doc_id).strip()
+            if value:
+                covered.add(value)
+    return covered
+
+
+def _select_uncovered_docs(
+    rows_with_ids: list[dict[str, Any]],
+    covered_doc_ids: set[str],
+    n_seed_docs: int,
+) -> list[dict[str, Any]]:
+    """Reorder ``rows_with_ids`` so uncovered docs come first, then take
+    the first ``n_seed_docs``.
+
+    Direct realization of ADR 0044 §case selection criteria #3 ("prefer
+    documents not yet covered by existing cases"). Within each group
+    (covered / uncovered) the original CSV row order is preserved, so
+    determinism survives and ``proposer.aggregate.json`` stays
+    comparable across runs.
+
+    When the uncovered pool is smaller than ``n_seed_docs``, the tail
+    is filled with covered rows rather than truncated — a small
+    uncovered pool must not starve the proposer.
+    """
+    if n_seed_docs <= 0:
+        return []
+    uncovered: list[dict[str, Any]] = []
+    covered: list[dict[str, Any]] = []
+    for row in rows_with_ids:
+        if str(row.get("doc_id") or "") in covered_doc_ids:
+            covered.append(row)
+        else:
+            uncovered.append(row)
+    return (uncovered + covered)[:n_seed_docs]
+
+
 def propose_cases_from_files(
     *,
     metadata_csv: Path = DEFAULT_METADATA_PATH,
@@ -487,14 +552,25 @@ def propose_cases_from_files(
     backend: str | None = None,
     model: str | None = None,
     now_iso: str | None = None,
+    real_config_path: Path | None = None,
+    prioritize_uncovered: bool = True,
 ) -> list[dict[str, Any]]:
     """End-to-end: read CSV + index, filter, propose, return cases.
 
-    Selects the first ``n_seed_docs`` rows whose ``canonical_doc_id``
-    is present in the active index. Deterministic sample order (first
-    N by CSV row order) — the proposer is not the place to randomize;
-    that would make ``proposer.aggregate.json`` non-comparable across
-    runs.
+    Selects ``n_seed_docs`` rows whose ``canonical_doc_id`` is present
+    in the active index. Selection order:
+
+    * Default (``real_config_path=None``): first N by CSV row order
+      — preserves the PR2 contract for callers that have no notion of
+      an existing eval set (tests, CI plumbing).
+    * Coverage-aware (``real_config_path`` set + ``prioritize_uncovered``):
+      rows whose doc_id is *not* yet referenced in the active
+      ``real_config.local.yaml`` come first, then covered rows fill
+      the tail if needed. Realizes ADR 0044 §case selection criteria #3.
+
+    Determinism is preserved in both modes — within each group the
+    original CSV row order is used. ``proposer.aggregate.json`` stays
+    byte-comparable across runs given the same inputs.
     """
     raw_rows = _read_data_list_csv(metadata_csv)
     valid_doc_ids = _read_index_doc_ids(index_dir)
@@ -504,7 +580,11 @@ def propose_cases_from_files(
             f"No CSV rows from {metadata_csv} resolve to a doc_id present in "
             f"{index_dir / 'index.json'}. Run `make build-index` first."
         )
-    selected = rows_with_ids[: max(n_seed_docs, 0)]
+    if real_config_path is not None and prioritize_uncovered:
+        covered = _read_real_config_covered_doc_ids(real_config_path)
+        selected = _select_uncovered_docs(rows_with_ids, covered, n_seed_docs)
+    else:
+        selected = rows_with_ids[: max(n_seed_docs, 0)]
     return propose_cases(
         selected, backend=backend, model=model, now_iso=now_iso
     )
@@ -575,6 +655,31 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "(always recorded as 'stub')."
         ),
     )
+    p.add_argument(
+        "--real-config",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the active real_config.local.yaml. When set, the "
+            "proposer prioritizes docs whose doc_id is NOT yet referenced "
+            "by any case's expected_doc_ids (ADR 0044 §case selection #3). "
+            "Missing file → no rows are skipped; fresh-clone behaves "
+            "identically to the default-ordered mode. ADR 0005 boundary: "
+            "the file itself is gitignored — this argument is read-only."
+        ),
+    )
+    p.add_argument(
+        "--no-prioritize-uncovered",
+        dest="prioritize_uncovered",
+        action="store_false",
+        default=True,
+        help=(
+            "Disable ADR 0044 doc_coverage prioritization even when "
+            "--real-config is set (falls back to first-N CSV row order). "
+            "Useful for byte-equal reproductions of the PR2-era proposer "
+            "behavior."
+        ),
+    )
     return p
 
 
@@ -587,6 +692,8 @@ def main(argv: Iterable[str] | None = None) -> int:
             n_seed_docs=args.n_seed_docs,
             backend=args.backend,
             model=args.model,
+            real_config_path=args.real_config,
+            prioritize_uncovered=args.prioritize_uncovered,
         )
     except CaseProposerInputError as exc:
         print(f"case_proposer: {exc}", file=sys.stderr)

--- a/tests/test_case_proposer_doc_coverage.py
+++ b/tests/test_case_proposer_doc_coverage.py
@@ -1,0 +1,321 @@
+"""Regression tests for ADR 0044 §case selection criteria #3 — doc_coverage
+prioritization in the case proposer (issue #846).
+
+Three layers:
+
+1. Pure helper ``_select_uncovered_docs``: ordering invariants, fallback when
+   the uncovered pool is smaller than ``n_seed_docs``, edge cases.
+2. Pure helper ``_read_real_config_covered_doc_ids``: missing file is empty
+   set (fresh-clone behavior), malformed YAML raises, multi-case + multi-doc
+   union semantics.
+3. Integration through ``propose_cases_from_files``: when ``real_config_path``
+   is set and ``prioritize_uncovered=True``, uncovered docs are seeded first;
+   when either knob is off, the PR2 byte-equal contract is preserved.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from eval.case_proposer import (
+    CSV_COLUMN_AGENCY,
+    CSV_COLUMN_FILE_FORMAT,
+    CSV_COLUMN_FILE_NAME,
+    CSV_COLUMN_NOTICE_ID,
+    CSV_COLUMN_PROJECT,
+    CSV_COLUMN_TEXT,
+    CaseProposerInputError,
+    REQUIRED_CSV_COLUMNS,
+    _read_real_config_covered_doc_ids,
+    _select_uncovered_docs,
+    propose_cases_from_files,
+)
+from rag_core import INDEX_SCHEMA_VERSION
+
+
+NOW_FIXED = "2026-05-15T08:00:00Z"
+
+
+def _make_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(REQUIRED_CSV_COLUMNS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _make_index(path: Path, doc_ids: list[str]) -> None:
+    payload = {
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "build": {"documents": [{"doc_id": d} for d in doc_ids]},
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _sample_row(
+    notice_id: str = "K2026-001",
+    agency: str = "A기관",
+    project: str = "사업A",
+) -> dict[str, str]:
+    return {
+        CSV_COLUMN_NOTICE_ID: notice_id,
+        CSV_COLUMN_PROJECT: project,
+        CSV_COLUMN_AGENCY: agency,
+        CSV_COLUMN_FILE_FORMAT: "pdf",
+        CSV_COLUMN_FILE_NAME: f"{notice_id}.pdf",
+        CSV_COLUMN_TEXT: "본문 텍스트",
+    }
+
+
+def _rows(doc_ids: list[str]) -> list[dict[str, Any]]:
+    return [{"doc_id": d} for d in doc_ids]
+
+
+class TestSelectUncoveredDocs(unittest.TestCase):
+    def test_uncovered_come_first_then_covered_fill_tail(self) -> None:
+        rows = _rows(["d1", "d2", "d3", "d4"])
+        out = _select_uncovered_docs(rows, {"d1", "d3"}, 4)
+        self.assertEqual([r["doc_id"] for r in out], ["d2", "d4", "d1", "d3"])
+
+    def test_preserves_within_group_original_order(self) -> None:
+        rows = _rows(["d1", "d2", "d3", "d4", "d5"])
+        out = _select_uncovered_docs(rows, {"d2", "d4"}, 5)
+        self.assertEqual(
+            [r["doc_id"] for r in out],
+            ["d1", "d3", "d5", "d2", "d4"],
+        )
+
+    def test_n_seed_docs_caps_output(self) -> None:
+        rows = _rows(["d1", "d2", "d3"])
+        out = _select_uncovered_docs(rows, set(), 2)
+        self.assertEqual([r["doc_id"] for r in out], ["d1", "d2"])
+
+    def test_zero_and_negative_n_return_empty(self) -> None:
+        rows = _rows(["d1"])
+        self.assertEqual(_select_uncovered_docs(rows, set(), 0), [])
+        self.assertEqual(_select_uncovered_docs(rows, set(), -1), [])
+
+    def test_uncovered_pool_smaller_than_n_falls_back_to_covered(self) -> None:
+        """A small uncovered pool must not starve the proposer — the tail
+        is filled with covered rows so n_seed_docs is honored when possible."""
+        rows = _rows(["d1", "d2", "d3"])
+        out = _select_uncovered_docs(rows, {"d2", "d3"}, 3)
+        self.assertEqual([r["doc_id"] for r in out], ["d1", "d2", "d3"])
+
+    def test_all_covered_returns_covered_in_original_order(self) -> None:
+        rows = _rows(["d1", "d2"])
+        out = _select_uncovered_docs(rows, {"d1", "d2"}, 2)
+        self.assertEqual([r["doc_id"] for r in out], ["d1", "d2"])
+
+    def test_empty_rows_returns_empty(self) -> None:
+        self.assertEqual(_select_uncovered_docs([], set(), 5), [])
+
+
+class TestReadRealConfigCoveredDocIds(unittest.TestCase):
+    def test_missing_file_returns_empty_set(self) -> None:
+        """ADR 0005: real_config.local.yaml is gitignored. A fresh clone
+        has no file — treat as empty coverage, not an error."""
+        with TemporaryDirectory() as td:
+            self.assertEqual(
+                _read_real_config_covered_doc_ids(Path(td) / "nope.yaml"),
+                set(),
+            )
+
+    def test_empty_cases_list_returns_empty_set(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "rc.yaml"
+            p.write_text("cases: []\n", encoding="utf-8")
+            self.assertEqual(_read_real_config_covered_doc_ids(p), set())
+
+    def test_no_cases_key_returns_empty_set(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "rc.yaml"
+            p.write_text("mode: rag\n", encoding="utf-8")
+            self.assertEqual(_read_real_config_covered_doc_ids(p), set())
+
+    def test_collects_doc_ids_across_multiple_cases(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "rc.yaml"
+            p.write_text(
+                "cases:\n"
+                "  - id: c1\n    expected_doc_ids: [doc-1, doc-2]\n"
+                "  - id: c2\n    expected_doc_ids: [doc-3]\n"
+                "  - id: c3\n    expected_doc_ids: []\n"
+                "  - id: c4\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                _read_real_config_covered_doc_ids(p),
+                {"doc-1", "doc-2", "doc-3"},
+            )
+
+    def test_strips_whitespace_and_skips_blank_ids(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "rc.yaml"
+            p.write_text(
+                "cases:\n"
+                "  - id: c1\n    expected_doc_ids: ['  doc-1  ', '', '  ']\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                _read_real_config_covered_doc_ids(p),
+                {"doc-1"},
+            )
+
+    def test_top_level_list_raises(self) -> None:
+        """A malformed top-level (list instead of mapping) must raise so the
+        proposer never silently widens coverage to docs that ARE covered."""
+        with TemporaryDirectory() as td:
+            p = Path(td) / "rc.yaml"
+            p.write_text("[]\n", encoding="utf-8")
+            with self.assertRaises(CaseProposerInputError):
+                _read_real_config_covered_doc_ids(p)
+
+
+class TestProposeCasesFromFilesDocCoverage(unittest.TestCase):
+    """Integration tests: real_config_path + prioritize_uncovered combo
+    drives propose_cases_from_files selection in line with ADR 0044."""
+
+    def _build_corpus(
+        self, td: Path, doc_ids: list[str]
+    ) -> tuple[Path, Path]:
+        csv_path = td / "data_list.csv"
+        index_dir = td / "index"
+        index_dir.mkdir()
+        _make_csv(
+            csv_path,
+            [_sample_row(d, f"기관{i}", f"사업{i}") for i, d in enumerate(doc_ids)],
+        )
+        _make_index(index_dir / "index.json", doc_ids)
+        return csv_path, index_dir
+
+    def test_uncovered_docs_seeded_first_when_real_config_given(self) -> None:
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path, index_dir = self._build_corpus(
+                td_path, ["K2026-001", "K2026-002", "K2026-003"]
+            )
+            real_config = td_path / "real_config.local.yaml"
+            real_config.write_text(
+                "cases:\n"
+                "  - id: existing\n    expected_doc_ids: [K2026-001]\n",
+                encoding="utf-8",
+            )
+
+            cases = propose_cases_from_files(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=2,
+                backend="stub",
+                now_iso=NOW_FIXED,
+                real_config_path=real_config,
+            )
+            # n_seed_docs=2 × 2 templates per doc = 4 cases.
+            self.assertEqual(len(cases), 4)
+            seed_doc_ids = sorted({c["proposer_meta"]["seed_doc_id"] for c in cases})
+            self.assertEqual(seed_doc_ids, ["K2026-002", "K2026-003"])
+            self.assertNotIn(
+                "K2026-001",
+                seed_doc_ids,
+                "Covered doc must not be seeded ahead of uncovered ones",
+            )
+
+    def test_no_real_config_preserves_pr2_default_ordering(self) -> None:
+        """Backward-compat: when real_config_path is None, selection is
+        the same first-N-by-CSV-order behavior PR2 ships."""
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path, index_dir = self._build_corpus(
+                td_path, ["K2026-001", "K2026-002", "K2026-003"]
+            )
+            cases = propose_cases_from_files(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=2,
+                backend="stub",
+                now_iso=NOW_FIXED,
+            )
+            seed_doc_ids = sorted({c["proposer_meta"]["seed_doc_id"] for c in cases})
+            self.assertEqual(seed_doc_ids, ["K2026-001", "K2026-002"])
+
+    def test_no_prioritize_uncovered_falls_back_to_default(self) -> None:
+        """Even when real_config_path is set, prioritize_uncovered=False
+        falls back to first-N CSV order — escape hatch for byte-equal
+        reproductions of the PR2-era proposer."""
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path, index_dir = self._build_corpus(
+                td_path, ["K2026-001", "K2026-002", "K2026-003"]
+            )
+            real_config = td_path / "real_config.local.yaml"
+            real_config.write_text(
+                "cases:\n"
+                "  - id: existing\n    expected_doc_ids: [K2026-001]\n",
+                encoding="utf-8",
+            )
+
+            cases = propose_cases_from_files(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=2,
+                backend="stub",
+                now_iso=NOW_FIXED,
+                real_config_path=real_config,
+                prioritize_uncovered=False,
+            )
+            seed_doc_ids = sorted({c["proposer_meta"]["seed_doc_id"] for c in cases})
+            self.assertEqual(seed_doc_ids, ["K2026-001", "K2026-002"])
+
+    def test_missing_real_config_does_not_raise(self) -> None:
+        """Fresh-clone behavior: real_config_path points at a path that
+        doesn't exist yet → empty coverage → all docs uncovered → same as
+        default ordering. The proposer must NOT raise on a missing local
+        config (it's gitignored under ADR 0005)."""
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path, index_dir = self._build_corpus(
+                td_path, ["K2026-001", "K2026-002"]
+            )
+            cases = propose_cases_from_files(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=2,
+                backend="stub",
+                now_iso=NOW_FIXED,
+                real_config_path=td_path / "does-not-exist.yaml",
+            )
+            self.assertEqual(len(cases), 4)
+
+    def test_deterministic_across_runs_with_real_config(self) -> None:
+        """Byte-equal contract preserved under coverage-aware mode."""
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path, index_dir = self._build_corpus(
+                td_path, ["K2026-001", "K2026-002", "K2026-003"]
+            )
+            real_config = td_path / "real_config.local.yaml"
+            real_config.write_text(
+                "cases:\n"
+                "  - id: existing\n    expected_doc_ids: [K2026-001]\n",
+                encoding="utf-8",
+            )
+
+            kwargs = dict(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=3,
+                backend="stub",
+                now_iso=NOW_FIXED,
+                real_config_path=real_config,
+            )
+            cases1 = propose_cases_from_files(**kwargs)
+            cases2 = propose_cases_from_files(**kwargs)
+            self.assertEqual(cases1, cases2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

ADR 0044 §case selection criteria #3 — "기존 case 가 cover 하지 않은 문서 우선" — 을 문서 정책에서 코드 경로로 승격. PR2 proposer 가 raw CSV row 순으로 seed 했기에 현재 `real_config.local.yaml` (n=21, 100 doc 중 12 cover) 으로 `make case-propose` 재실행 시 이미 cover 된 doc 만 재seed. 88 uncovered tail 은 수동 CSV reorder 없이는 도달 불가.

- `eval/case_proposer.py` 신규 private helper:
  - `_read_real_config_covered_doc_ids(path)` — local config 의 lazy PyYAML read; 파일 부재 → empty set (fresh-clone). Top-level non-mapping (예: `yaml.safe_load("[]")`) 는 `CaseProposerInputError` raise; 이를 마스킹할 `or {}` falsy-coalesce 는 의도적으로 회피.
  - `_select_uncovered_docs(rows, covered, n)` — row 를 uncovered-first / covered-second 로 partition (그룹 내 CSV 순서 보존). uncovered < n 이면 covered pool 에서 tail-fill.
- `propose_cases_from_files` 가 `real_config_path` + `prioritize_uncovered` kwarg 획득. Default (`real_config_path=None`) 는 기존 caller (CI plumbing, tests) 의 PR2 byte-equal 계약 유지. CLI 는 `--real-config` + `--no-prioritize-uncovered` escape hatch 추가.
- `Makefile` `case-propose` 타겟이 `--real-config eval/real_config.local.yaml` 픽업. local config 없는 fresh clone 은 silently fallback.

## Why

ADR 0044 `near-term n ≥ 30` 은 proposer 가 88 uncovered doc 에 도달해야 함. 이 PR 없이는 `data_list.csv` 수동 셔플 필요 — fragile, 비결정적, reviewer 가 row metadata 를 커밋 메시지 paste 시 ADR 0005 경계 리스크. 이 PR 이 정책을 기계화하고 기존 `make case-propose && make case-review && make case-promote` 워크플로의 byte-determinism 유지.

## Test plan

- [x] `pytest tests/test_case_proposer_doc_coverage.py -v` — 18 신규 테스트 통과 (helper invariant + integration coverage + missing-file + malformed YAML).
- [x] `pytest tests/test_case_proposer_pipeline.py tests/test_case_proposer_stub.py -q` — 30 인접 테스트 통과, 회귀 0. ADR 0001 import-surface 가드 (`test_importing_case_proposer_does_not_import_rag_core`) green 유지 — PyYAML 만 추가, helper 내부 lazy.
- [x] `pytest tests/test_real_eval_case_expansion.py tests/test_write_real_eval_baseline.py tests/test_run_real_eval_delta.py -q` — 53 passed, 5 skipped (조건부). 회귀 0.
- [x] `ruff check .` — clean.
- [ ] Local-only follow-up (이 diff 외, ADR 0005 경계): `make case-propose && make case-review && make case-promote` 실행으로 `eval/real_config.local.yaml` 을 n=21 → n≥30 확장 (ADR 0044 near-term silence threshold 0.017, CI ±18pp).

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

이 PR 의 변경:
1. `eval/case_proposer.py` 에 private helper 2 + optional kwarg 2 추가. Proposer 는 `run_rag_query` 의 **upstream** — eval *입력* 생성, retrieval / verifier 출력 소비 없음. `rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, `eval/run_eval.py`, `ingestion.py`, `visual_ingestion.py` 미변경.
2. Makefile `case-propose` 타겟에 arg 1 (`--real-config eval/real_config.local.yaml`) 추가. local config 없는 fresh clone 은 silently default 순서 fallback.
3. `tests/` 하위 회귀 테스트 1 추가.

`make real-eval-delta` 가 현재 `baseline.aggregate.json` 대비 zero delta 렌더 — proposer 는 eval 실행 시 invoke 되지 않음. Aggregate metric set 미변경.

## ADR boundary

- **ADR 0001**: `naive_baseline` golden invariant — proposer 는 retrieval 의 upstream; `test_case_proposer_stub.py` 의 import-surface 가드 테스트 여전히 통과.
- **ADR 0005**: `eval/real_config.local.yaml` 은 gitignored 유지; 신규 코드는 read 만, commit 없음. 테스트는 `TemporaryDirectory` fixture 사용. diff 내 per-case payload 없음.
- **ADR 0029**: 2-stage gate (propose → review → promote) 미변경. Stub 백엔드 default + opt-in live 백엔드 패턴 보존.
- **ADR 0044**: §case selection criteria #3 (doc_coverage 우선) 이 문서가 아니라 코드로 실현. `near-term n ≥ 30` 이 표준 워크플로로 도달 가능.

Closes #846.
