### PR TITLE
docs(rag_core): _PROCESS_WARM multi-worker + long-tail caveat (closes #842)

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -79,7 +79,7 @@ python3 scripts/summarize_benchmark.py \
 
 - `stage_latency`: top-level stage별 ms — `query_analysis_ms`, `context_resolution_ms`, `answer_generation_ms`
 - `filter_stage_attempts[i].retrieve_ms` / `verify_ms`: strict → reduced → relaxed 각 retry 시도의 retrieval+rerank, verifier 비용
-- `cold_start`: 프로세스 첫 호출 여부. embedding/reranker lazy-load가 첫 query latency에 섞이는 것을 분리한다.
+- `cold_start`: 프로세스 첫 호출 여부. embedding/reranker lazy-load가 첫 query latency에 섞이는 것을 분리한다. **주의** (issue #842): per-process bootstrap 진단용으로, 프로세스가 오래 idle 후 model이 OS page cache에서 evict 됐을 때 재발생하는 long-tail cold-start는 잡지 못한다. 첫 호출 이후 항상 `False` — multi-worker 배포에서는 각 worker가 독립적으로 첫 호출에서 `True` 1회 기록.
 
 `latency_samples.jsonl`은 위 필드를 row 단위로도 기록한다 (`stage_latency`, `attempt_latency`, `cold_start`). 기존 컬럼은 유지되며 추가 필드는 무시해도 안전하다.
 

--- a/rag_core.py
+++ b/rag_core.py
@@ -903,6 +903,31 @@ def metadata_stage_sequence(
     return stages
 
 
+# ``_PROCESS_WARM`` semantics (issue #842, RAG senior-review critique #7.3)
+# ----------------------------------------------------------------------------
+# Module-level boolean flipped to ``True`` after the first ``run_rag_query``
+# call. Used to set the ``cold_start`` field in the ``query_start`` log event
+# and in the per-case eval diagnostic block, so warm-percentile aggregations
+# (``cold_start_samples`` in ``eval/run_eval.py`` /
+# ``scripts/run_benchmark.py``) can exclude the one-time bootstrap cost
+# (embedding/reranker lazy-load, BM25 cache warm-up — see
+# ``docs/benchmarking.md`` § Cold start).
+#
+# Multi-worker semantics: in a multi-worker FastAPI deployment, each worker
+# process owns its own ``_PROCESS_WARM`` because module-level state is
+# per-process by Python semantics. That is intentional — every fresh worker
+# pays the cold-start cost on its first request, and the diagnostic captures
+# that cost per worker.
+#
+# Long-tail caveat (NOT closed by this flag): the boolean only fires on the
+# FIRST call per process. Subsequent calls always log ``cold_start=False``,
+# even if the process was idle long enough that real cold-start latency
+# would re-emerge (model evicted from OS page cache, BM25 cache reclaimed by
+# GC, JIT caches cooled, etc.). Current consumers (``cold_start_samples``)
+# only need the per-process bootstrap diagnostic, so this is acceptable;
+# upgrading to a TTL-based "warm if active within last N min" tracker is
+# a follow-up if a long-tail latency dashboard ever needs it.
+# See issue #842 for the decision-rule rationale.
 _PROCESS_WARM = False
 
 

--- a/tests/test_process_warm_docstring_pinning.py
+++ b/tests/test_process_warm_docstring_pinning.py
@@ -1,0 +1,66 @@
+"""Regression: ``_PROCESS_WARM`` documentation caveat must remain (issue #842).
+
+RAG senior-review critique #7.3. ``rag_core._PROCESS_WARM`` is a
+module-level boolean that flips ``True`` after the first
+``run_rag_query`` call. It captures per-process bootstrap cost
+(embedding/reranker lazy-load, BM25 cache warm-up) for the
+``cold_start_samples`` warm-vs-cold latency split in
+``eval/run_eval.py``.
+
+The behavior has a long-tail caveat: subsequent calls always log
+``cold_start=False``, even if the process was idle long enough that
+real cold-start latency would re-emerge (model evicted from OS page
+cache, BM25 cache reclaimed by GC, etc.). Per #842's decision rule,
+this is acceptable because current consumers only need the per-process
+bootstrap diagnostic — but the limitation must be documented so a
+future operator who wants long-tail latency tracking knows to upgrade
+to a TTL-based "warm if active within last N min" tracker instead of
+silently relying on the boolean.
+
+This test pins the docstring caveat so a future refactor that drops or
+weakens the comment fails CI before it ships.
+"""
+from __future__ import annotations
+
+import inspect
+import unittest
+
+import rag_core
+
+
+class TestProcessWarmDocstringPinning(unittest.TestCase):
+    def test_process_warm_module_comment_documents_long_tail_caveat(self) -> None:
+        """The block-comment header above ``_PROCESS_WARM`` must mention
+        the long-tail caveat + the multi-worker semantics + the issue
+        number, so a future maintainer cannot remove the caveat without
+        tripping this test."""
+        source = inspect.getsource(rag_core)
+        idx = source.find("_PROCESS_WARM = False")
+        self.assertNotEqual(
+            idx,
+            -1,
+            "_PROCESS_WARM definition not found in rag_core.py — "
+            "definition moved or renamed; update this regression test too.",
+        )
+        # Grab the 30 lines of comment header preceding the assignment.
+        preceding = source[:idx]
+        last_n_lines = "\n".join(preceding.splitlines()[-30:])
+
+        for required_phrase in (
+            "issue #842",  # Provenance pointer.
+            "Multi-worker semantics",  # Per-process state explanation.
+            "Long-tail caveat",  # Long-tail caveat header.
+            "page cache",  # Concrete example of the failure mode.
+            "TTL",  # Pointer to the upgrade path if needed.
+        ):
+            self.assertIn(
+                required_phrase,
+                last_n_lines,
+                f"_PROCESS_WARM block comment must mention {required_phrase!r} "
+                "(issue #842 decision-rule docstring contract). "
+                f"Last 30 lines before assignment:\n{last_n_lines}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 변경 내용 및 이유

Closes #842.

RAG senior-review 비판 #7.3. `_PROCESS_WARM` (rag_core.py:906) 은 첫 `run_rag_query` 호출 후 `True` 로 뒤집히는 단일 boolean. `query_start` 로그 이벤트의 `cold_start` 설정에 사용되어 `cold_start_samples` 집계 (eval/run_eval.py + scripts/run_benchmark.py) 가 warm percentile 에서 일회성 bootstrap 비용을 제외할 수 있게 한다.

Issue 의 decision rule 에 따라 `cold_start` 소비자 감사 결과 — 그들은 per-process bootstrap 진단만 필요하지 long-tail latency 대시보드는 불필요 (issue body decision rule 참조). 따라서 옳은 수정은 **문서**, 리팩토링 아님.

3가지 변경:

1. **`rag_core.py`**: `_PROCESS_WARM` 위 25줄 블록 주석. 멀티 워커 의미론 (각 워커가 자기 flag 소유 — 의도), long-tail caveat (boolean 은 process 당 첫 호출에만 발화; 모델이 OS page cache 에서 evict 된 후 long idle 뒤 재 arm 안 됨), 향후 operator 가 long-tail tracking 필요 시 upgrade path (TTL 기반 "최근 N분 내 active 면 warm" tracker) 커버.
2. **`docs/benchmarking.md`**: `cold_start` 필드 bullet 에 1줄 caveat 추가. 진단 문서를 읽는 소비자가 메트릭과 함께 한계를 보도록.
3. **`tests/test_process_warm_docstring_pinning.py`**: 블록 주석이 5개 anchor 구절 (`issue #842`, `Multi-worker semantics`, `Long-tail caveat`, `page cache`, `TTL`) 유지하는지 assert 하는 회귀 테스트. 향후 리팩토링이 docstring 을 떨어뜨리거나 약화시키면 CI 에서 실패.

## 2. 영향 파일

- `rag_core.py` — 25줄 블록 주석, 코드 변경 없음. load-bearing 모듈 터치하지만 기존 module-level 변수 위 주석 헤더만.
- `docs/benchmarking.md` — 기존 필드 문서 1줄 편집.
- `tests/test_process_warm_docstring_pinning.py` — 신규 (1 테스트, 67 LOC).

## 3. 리스크

**가장 가능성 높은 break**: 향후 리팩토링이 `_PROCESS_WARM` 을 `rag_core.py` 밖으로 이동 (또는 rename) 하면 블록 주석 떨어지고, 회귀 테스트가 `_PROCESS_WARM = False` substring 검색에서 실패 — 정확히 의도한 동작. 테스트는 issue 를 가리키는 명확한 실패 메시지 제공.

검증: `_PROCESS_WARM = False` 는 이름의 유일한 할당; `grep -n "_PROCESS_WARM" rag_core.py` 는 4줄 반환, 모두 read-only 참조 + 정의 하나.

## 4. 테스트

`tests/test_process_warm_docstring_pinning.py` (신규, 1 테스트):

- `test_process_warm_module_comment_documents_long_tail_caveat` — `inspect.getsource(rag_core)` 파싱, `_PROCESS_WARM = False` 라인 앞 30줄 slice, 5개 anchor 구절 모두 등장 assert. 로컬 + 인접 latency / observability 테스트 (`test_latency_instrumentation.py` + `test_observability_tracing.py`, 24 테스트) green.

## 5. Eval 영향

전부 `·` 예상. 순수 문서 변경.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. `_PROCESS_WARM` 은 동일 call site 에서 동일 의미론으로 flip 유지. 설명 주석 + docstring-pinning 테스트만 변경.

## 6. 하위 호환성

Additive. 주석 + 1줄 문서 + 1 테스트. 코드 경로 미터치.

## 7. Out of scope

- Boolean 을 TTL tracker 로 교체. Decision rule (issue body) 가 long-tail latency tracking 필요 시점까지 명시적 유예 — 지금 아님. 신규 블록 주석이 upgrade path 문서화해 향후 operator 에게 hand-off 제공.
- 광범위 module-level mutable state 집합 리팩토링 (cf. #840 `phase` mutation, 방금 머지된 #841 `MODEL_CACHE`). 설계상 독립 추적 issue.
