### PR TITLE
feat(vector_store): Qdrant docker compose integration smoke (closes #853)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,20 @@ test:
 test-regression:
 	$(PYTHON) -m pytest tests/test_retrieval_loop_regression.py -q
 
+# F2 (#853): local Qdrant container for the production HTTP server
+# integration test. Image pin is in docker-compose.qdrant.yml.
+# Default workflow: `make qdrant-up && make test-qdrant-integration && make qdrant-down`.
+.PHONY: qdrant-up qdrant-down test-qdrant-integration
+qdrant-up:
+	docker compose -f docker-compose.qdrant.yml up -d
+	@echo "Qdrant integration container starting; healthcheck polls /healthz on :6333."
+
+qdrant-down:
+	docker compose -f docker-compose.qdrant.yml down -v
+
+test-qdrant-integration:
+	$(PYTHON) -m pytest tests/test_qdrant_integration.py -m qdrant_integration -q
+
 # Run the FastAPI demo locally. Requires data/index to exist
 # (run `make index` first). See docs/operations/api-demo.md for details.
 api:

--- a/docker-compose.qdrant.yml
+++ b/docker-compose.qdrant.yml
@@ -1,0 +1,33 @@
+# Local Qdrant container for the F2 integration test surface (issue #853).
+#
+# Pairs with `BIDMATE_INDEX_BACKEND=qdrant` + `BIDMATE_QDRANT_URL=http://localhost:6333`
+# from F1 (#834). Used by `make test-qdrant-integration` and the
+# `tests/test_qdrant_integration.py::TEST_*` markers; CI never starts
+# this container so the synthetic eval delta stays unaffected.
+#
+# Image pin: keep on a stable minor tag. Do not move to `latest` —
+# parity tests (`tests/test_vector_store_qdrant.py`) assume an exact
+# cosine top-k contract that newer Qdrant builds could drift on
+# (issue #176 Stage 2b parity covenant).
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.11.0
+    container_name: bidmate-qdrant-integration
+    ports:
+      - "6333:6333"   # HTTP API
+      - "6334:6334"   # gRPC API (reserved; not consumed by qdrant-client today)
+    volumes:
+      - qdrant-data:/qdrant/storage
+    healthcheck:
+      # `/healthz` returns 200 once the HTTP listener is ready. The
+      # python integration test poll loop relies on this to know when
+      # the server is reachable.
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:6333/healthz"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+      start_period: 5s
+
+volumes:
+  qdrant-data:
+    name: bidmate-qdrant-integration-data

--- a/docs/operations/qdrant-integration.md
+++ b/docs/operations/qdrant-integration.md
@@ -1,0 +1,64 @@
+# Qdrant integration
+
+Production-server smoke for the `qdrant` index backend.  Pairs with [`rag_vector_store.QdrantVectorStore`](../../rag_vector_store.py) and the env-var routing added in PR #837.
+
+## When to run
+
+Use this surface when you need to confirm:
+
+- A real (non-`:memory:`) Qdrant HTTP server is reachable from the BidMate process.
+- Ranking parity holds between the in-memory backend and the network path (ADR 0001 baseline).
+- A Qdrant Cloud / self-hosted deployment is ready to receive traffic from the production preset.
+
+The default smoke (`make smoke`) does **not** start Qdrant.  CI does not run these tests either — they are opt-in to keep the synthetic eval delta and ADR 0001 baseline guard unaffected.
+
+## Local workflow
+
+```bash
+make qdrant-up                      # docker compose up -d
+make test-qdrant-integration        # pytest -m qdrant_integration
+make qdrant-down                    # docker compose down -v
+```
+
+The container image is pinned in [`docker-compose.qdrant.yml`](../../docker-compose.qdrant.yml) (`qdrant/qdrant:v1.11.0`).  Do not move to `latest` — the in-memory ↔ HTTP parity tests assume an exact cosine top-k contract, and newer Qdrant builds can drift the ranking math (issue #176 Stage 2b covenant).
+
+## Pointing at a different server
+
+`BIDMATE_QDRANT_INTEGRATION_URL` overrides the default `http://localhost:6333` so the same suite can drive a Qdrant Cloud instance, a remote dev server, or a different local port:
+
+```bash
+BIDMATE_QDRANT_INTEGRATION_URL=https://your-cluster.qdrant.io:6333 \
+    pytest tests/test_qdrant_integration.py -m qdrant_integration
+```
+
+The integration suite still uses `BIDMATE_INDEX_BACKEND=qdrant` + `BIDMATE_QDRANT_URL` internally (PR #837 contract); the override env var only chooses *which* server.  TLS / API-key auth is a follow-up (see ADR 0046 §"Out of scope" and the F4 capacity-bench backlog).
+
+## What is tested
+
+[`tests/test_qdrant_integration.py`](../../tests/test_qdrant_integration.py) covers, against a live server:
+
+| Check | What it proves |
+|-------|----------------|
+| Build round-trip | Collection upsert with the expected dimension + point count |
+| `get(idx)` parity | Stage 2a invariant: the matrix row, not a Qdrant fetch |
+| `query` self-similarity | The query vector matches itself with cosine ≈ 1 |
+| `query` ranking parity vs in-memory | ADR 0001 cosine top-k invariance through the HTTP path |
+| `query_by_indices` local path | The matrix-dot shortcut, not a Qdrant round-trip |
+
+Each test isolates the collection via `_drop_collection_if_exists` so back-to-back runs do not collide on point IDs.
+
+## What is *not* tested here
+
+- Concurrency / lock behaviour during index build — F3 backlog (issue TBD).
+- 1k / 10k capacity benchmarks — F4 backlog.
+- pgvector backend (ADR 0020 Stage 3).
+- Authentication / TLS — production Qdrant Cloud config is a separate concern.
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| All tests `SKIP` | Server not reachable | `make qdrant-up` and wait for the healthcheck |
+| Skip with `connection refused` | Container port mapping mismatch | Inspect `docker compose -f docker-compose.qdrant.yml ps` |
+| Parity test fails | Qdrant image drifted | Re-pin `docker-compose.qdrant.yml` to the previous known-good tag |
+| `qdrant_client` import skipped | qdrant-client not installed | `pip install qdrant-client` (optional dep, not in `requirements.txt`) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]
+# Marker registry. Tests under unregistered markers warn under
+# pytest-strict-markers. ``qdrant_integration`` flags suites that
+# need a live Qdrant HTTP server (see Makefile `qdrant-up`, issue #853).
+markers = [
+    "qdrant_integration: requires a live Qdrant HTTP server on BIDMATE_QDRANT_URL (default http://localhost:6333); not run in CI",
+]
 
 # Issue #334 (G8 of #284): opt-in ruff lint gate from scripts/test.sh.
 # Rule selection is narrowed to the fatal pyflakes subset (syntax errors,

--- a/tests/test_qdrant_integration.py
+++ b/tests/test_qdrant_integration.py
@@ -1,0 +1,184 @@
+"""Qdrant production server integration test (issue #853).
+
+Drives a real Qdrant HTTP server (typically the
+``docker-compose.qdrant.yml`` container on localhost) via the
+``BIDMATE_QDRANT_URL`` env var that PR #837 added.  This complements
+the in-memory regression suite (``tests/test_vector_store_qdrant.py``):
+that file proves the matrix/in-memory adapter math, this file proves
+the *network* path actually round-trips.
+
+Tests are guarded by ``@pytest.mark.qdrant_integration`` and an HTTP
+liveness probe, so they no-op on machines without Docker / a running
+server.  CI does not run them by default; opt in with
+``pytest -m qdrant_integration``.
+
+Local workflow::
+
+    make qdrant-up
+    make test-qdrant-integration
+    make qdrant-down
+"""
+from __future__ import annotations
+
+import os
+import socket
+import urllib.error
+import urllib.request
+
+import numpy as np
+import pytest
+
+qdrant_client = pytest.importorskip("qdrant_client")
+
+from rag_vector_store import (  # noqa: E402  (after importorskip)
+    ENV_INDEX_BACKEND,
+    ENV_QDRANT_URL,
+    QDRANT_COLLECTION_NAME,
+    InMemoryVectorStore,
+    QdrantVectorStore,
+    vector_store_from_matrix,
+)
+
+
+DEFAULT_URL = "http://localhost:6333"
+_HEALTH_PATH = "/healthz"
+
+
+def _server_reachable(url: str, timeout: float = 1.0) -> bool:
+    """Probe the Qdrant HTTP server.  Used as the per-test skip gate
+    so a missing container produces a clean skip instead of a noisy
+    connection error."""
+    try:
+        with urllib.request.urlopen(url.rstrip("/") + _HEALTH_PATH, timeout=timeout):
+            return True
+    except (urllib.error.URLError, socket.timeout, ConnectionError, OSError):
+        return False
+
+
+_URL = os.environ.get("BIDMATE_QDRANT_INTEGRATION_URL", DEFAULT_URL)
+_REACHABLE = _server_reachable(_URL)
+
+
+pytestmark = [
+    pytest.mark.qdrant_integration,
+    pytest.mark.skipif(
+        not _REACHABLE,
+        reason=(
+            f"Qdrant server at {_URL} not reachable. "
+            "Run `make qdrant-up` (issue #853) before this suite."
+        ),
+    ),
+]
+
+
+@pytest.fixture
+def matrix() -> np.ndarray:
+    """L2-normalized (8, 6) matrix — same shape pattern as the
+    in-memory regression suite so cosine ranking comparisons are
+    straightforward."""
+    rng = np.random.default_rng(seed=20260516)
+    m = rng.standard_normal((8, 6)).astype(np.float32)
+    m /= np.linalg.norm(m, axis=1, keepdims=True)
+    return m
+
+
+@pytest.fixture
+def qdrant_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activate the qdrant backend against the integration URL.
+
+    Cleanup happens via ``monkeypatch`` undo, so even a failing test
+    leaves no environment leak between tests in the same session.
+    """
+    monkeypatch.setenv(ENV_INDEX_BACKEND, "qdrant")
+    monkeypatch.setenv(ENV_QDRANT_URL, _URL)
+
+
+def _drop_collection_if_exists() -> None:
+    """Best-effort cleanup so back-to-back test runs do not collide
+    on point IDs.  Uses qdrant-client directly because the helper
+    that creates the collection lives behind the production code
+    path under test."""
+    from qdrant_client import QdrantClient
+
+    client = QdrantClient(url=_URL)
+    if client.collection_exists(QDRANT_COLLECTION_NAME):
+        client.delete_collection(QDRANT_COLLECTION_NAME)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_collection() -> None:
+    _drop_collection_if_exists()
+    yield
+    _drop_collection_if_exists()
+
+
+# ---------------------------------------------------------------------------
+# Smoke: server-side upsert + query path
+# ---------------------------------------------------------------------------
+
+
+def test_qdrant_http_store_builds_against_real_server(
+    matrix: np.ndarray, qdrant_env: None
+) -> None:
+    store = vector_store_from_matrix(matrix)
+    assert isinstance(store, QdrantVectorStore)
+    info = store.client.get_collection(QDRANT_COLLECTION_NAME)
+    assert info.points_count == matrix.shape[0]
+    assert store.dimension == matrix.shape[1]
+
+
+def test_qdrant_http_get_returns_bit_identical_vector(
+    matrix: np.ndarray, qdrant_env: None
+) -> None:
+    """``get(idx)`` must read from the in-memory matrix, not the
+    Qdrant collection — that is the Stage 2a contract.  Verifying it
+    against the HTTP path catches accidental client-state coupling."""
+    store = vector_store_from_matrix(matrix)
+    for i in range(matrix.shape[0]):
+        np.testing.assert_array_equal(store.get(i), matrix[i])
+
+
+def test_qdrant_http_query_returns_top_k_with_self_at_top(
+    matrix: np.ndarray, qdrant_env: None
+) -> None:
+    store = vector_store_from_matrix(matrix)
+    result = store.query(matrix[2], top_k=3)
+    assert len(result) == 3
+    assert result[0][0] == 2
+    assert result[0][1] == pytest.approx(1.0, abs=1e-5)
+    scores = [s for _, s in result]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_qdrant_http_query_matches_in_memory_top_k_ranking(
+    matrix: np.ndarray, qdrant_env: None
+) -> None:
+    """ADR 0001 parity check via the network path.  Both indices and
+    scores must match the in-memory backend exactly."""
+    memory_store = InMemoryVectorStore(vectors=matrix)
+    qdrant_store = vector_store_from_matrix(matrix)
+
+    for i in range(matrix.shape[0]):
+        m_result = memory_store.query(matrix[i], top_k=3)
+        q_result = qdrant_store.query(matrix[i], top_k=3)
+        assert [idx for idx, _ in m_result] == [idx for idx, _ in q_result], (
+            f"index ranking diverged via HTTP for row {i}"
+        )
+        for (m_idx, m_score), (q_idx, q_score) in zip(m_result, q_result):
+            assert m_idx == q_idx
+            assert m_score == pytest.approx(q_score, abs=1e-5)
+
+
+def test_qdrant_http_query_by_indices_uses_local_matrix(
+    matrix: np.ndarray, qdrant_env: None
+) -> None:
+    """Per the Protocol docstring + the in-memory test, the
+    ``query_by_indices`` path scores via the local matrix dot, not a
+    Qdrant round-trip — even on the HTTP backend."""
+    store = vector_store_from_matrix(matrix)
+    indices = [1, 4, 6]
+    result = store.query_by_indices(matrix[0], indices)
+    assert [idx for idx, _ in result] == indices  # order preserved
+    expected = matrix[indices] @ matrix[0]
+    for (_, score), expected_score in zip(result, expected):
+        assert score == pytest.approx(float(expected_score), abs=1e-5)


### PR DESCRIPTION
## 1. 변경 내용 및 이유

F1 ([#837](https://github.com/hskim-solv/BidMate-DocAgent/pull/837)) 가 production Qdrant 서버용 `BIDMATE_QDRANT_URL` 라우팅을 추가했으나 실제 HTTP 서버 대상 테스트가 없음 — in-memory 회귀 배터리만 matrix math 증명. 이 PR 은 network-path smoke 표면 추가.

| Component | Role |
|-----------|------|
| `docker-compose.qdrant.yml` | `qdrant/qdrant:v1.11.0` pin + `/healthz` polling |
| `tests/test_qdrant_integration.py` | `@pytest.mark.qdrant_integration` 하 5 테스트 |
| `Makefile` | `qdrant-up` / `qdrant-down` / `test-qdrant-integration` |
| `pyproject.toml` | `qdrant_integration` 마커 등록 |
| `docs/operations/qdrant-integration.md` | When / how to run, failure modes |

기본 테스트 경로 변경 없음 — 통합 suite 는 opt-in 이고 **CI 는 Qdrant 컨테이너 시작 안 함**. 서버 down 시 모든 테스트 깔끔하게 SKIP (urllib `/healthz` probe 가 게이트). `BIDMATE_QDRANT_INTEGRATION_URL` 로 동일 suite 를 Qdrant Cloud / remote dev cluster 가리키게 가능 — production smoke 용.

Closes #853

## 2. Files affected

- `docker-compose.qdrant.yml` (신규)
- `tests/test_qdrant_integration.py` (신규) — 5 테스트, 모두 `qdrant_integration` 마커
- `Makefile` — 신규 타겟 3개, 기존 타겟 무변경
- `pyproject.toml` — `qdrant_integration` 마커 등록
- `docs/operations/qdrant-integration.md` (신규)

Production 코드 무변경. Load-bearing 경로 (`rag_core.py` / `rag_retrieval.py` / `rag_vector_store.py`) 변경 없음.

## 3. Risks

- **Image drift**: 향후 `qdrant/qdrant:latest` 가 top-k 를 다르게 재점수 가능. 완화: compose 파일에 `v1.11.0` pin + 인라인 사유; 이동 금지
- **CI noise**: 마커가 통합 테스트를 기본 skip 유지. `pytest -m qdrant_integration` 으로만 실행, 서버 도달 가능시; 아니면 `/healthz` probe 가 fast fail 하고 suite no-op

## 4. Tests

신규 5 테스트가 live 서버 대상으로 커버:

| Check | What it proves |
|---|---|
| `test_qdrant_http_store_builds_against_real_server` | Collection upsert with right dimension + point count |
| `test_qdrant_http_get_returns_bit_identical_vector` | `get(idx)` 는 matrix 읽음, Qdrant 아님 (Stage 2a invariant) |
| `test_qdrant_http_query_returns_top_k_with_self_at_top` | Self-similarity ≈ 1.0 via HTTP |
| `test_qdrant_http_query_matches_in_memory_top_k_ranking` | **ADR 0001 cosine top-k parity through the network** |
| `test_qdrant_http_query_by_indices_uses_local_matrix` | `query_by_indices` shortcut, Qdrant round-trip 아님 |

추가로 무변경 회귀 55 테스트 (`naive_baseline` + `vector_store`) 도 여전히 통과.

## 5. Eval impact

모두 `·` — opt-in 테스트 표면, 기본 경로 동작 변경 없음.

### 5b. Real-data delta

**No behavior change in retrieval / verifier / answer / eval / api / ingestion path.** 신규 5 테스트는 `qdrant_integration` 마커 뒤 — CI 미실행; `BIDMATE_INDEX_BACKEND=memory` (기본) 는 이전과 byte-identical. ADR 0001 baseline 가드 보존.

## 6. Backward compatibility

순수 additive. 신규 파일 + Makefile 타겟 3 + pytest 마커 1. 기존 것 rename/이동 없음.

## 7. Out of scope

- F3 (다음 라운드 3): Qdrant 하 인덱스 빌드 시 concurrency / lock 동작
- F4: 1k / 10k capacity 벤치
- TLS / API-key auth (`BIDMATE_QDRANT_API_KEY` follow-up)
- pgvector 백엔드 (ADR 0020 Stage 3)

---
