### PR TITLE
refactor(rag_core): extract ingestion + index I/O to rag_indexing (closes #858)

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -299,9 +299,33 @@ from rag_answer_schema import (
     KNOWN_ANSWER_STATUS_REASON_CODES,
 )
 
-DEFAULT_CHUNK_MAX_CHARS = 520
-DEFAULT_CHUNK_OVERLAP_SENTENCES = 1
-VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
+# Ingestion + chunking + index I/O extracted to rag_indexing (ADR 0045 G3, issue #858).
+# Re-exported here so existing `from rag_core import build_index_payload` /
+# `DEFAULT_CHUNK_MAX_CHARS` / `INDEX_FILENAME` call sites keep working
+# unchanged. Bodies live in rag_indexing now; this is a structural
+# relocation only and is byte-identical for the naive_baseline preset
+# (ADR 0001).
+from rag_indexing import (
+    DEFAULT_CHUNK_MAX_CHARS,
+    DEFAULT_CHUNK_OVERLAP_SENTENCES,
+    INDEX_FILENAME,
+    INDEX_SCHEMA_VERSION,
+    VALID_CHUNKING_STRATEGIES,
+    build_chunk_records,
+    build_chunks,
+    build_index_payload,
+    build_index_payload_from_documents,
+    known_entities,
+    load_index,
+    load_raw_documents,
+    make_chunk,
+    metadata_targets,
+    normalize_json_document,
+    normalize_text_document,
+    resolve_chunking_strategy,
+    validate_chunking_options,
+    write_index,
+)
 
 # Hard cap on the per-query agent loop. ``metadata_stage_sequence`` today
 # returns at most ["strict", "reduced", "relaxed"] (3 stages). This constant
@@ -309,12 +333,10 @@ VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
 # past 3 must update this value and explain why in the PR description.
 MAX_AGENT_ITERATIONS = 3
 
-INDEX_FILENAME = "index.json"
 # M2 (#207): vectors live in a sidecar .npy so the JSON stays small and a
 # future VectorStore abstraction (#176) can swap in alternate backends
 # without touching the chunk-metadata payload.
 EMBEDDINGS_FILENAME = "embeddings.npy"
-INDEX_SCHEMA_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -343,393 +365,6 @@ class QueryParams:
     rrf_k: int | None = None
     bm25_stopword_profile: str | None = None
     bm25_tokenizer: str | None = None
-
-
-def load_raw_documents(input_dir: Path) -> list[dict[str, Any]]:
-    files = sorted(
-        p
-        for p in input_dir.iterdir()
-        if p.is_file() and p.suffix.lower() in {".json", ".md", ".txt"}
-    )
-    documents: list[dict[str, Any]] = []
-    for path in files:
-        if path.name.startswith("."):
-            continue
-        if path.suffix.lower() == ".json":
-            data = json.loads(path.read_text(encoding="utf-8"))
-            documents.append(normalize_json_document(data, path))
-        else:
-            documents.append(normalize_text_document(path))
-    if not documents:
-        raise ValueError(f"No JSON/Markdown/Text documents found in {input_dir}")
-    return documents
-
-
-def normalize_json_document(data: dict[str, Any], path: Path) -> dict[str, Any]:
-    doc_id = str(data.get("doc_id") or path.stem)
-    title = str(data.get("title") or path.stem)
-    agency = str(data.get("agency") or "")
-    project = str(data.get("project") or "")
-    sections = data.get("sections") or []
-    if not isinstance(sections, list) or not sections:
-        text = str(data.get("text") or "")
-        sections = [{"heading": "본문", "text": text}]
-    normalized_sections = []
-    for idx, section in enumerate(sections, start=1):
-        heading = str(section.get("heading") or f"section-{idx}")
-        text = str(section.get("text") or "").strip()
-        if text:
-            normalized_section = {"heading": heading, "text": text}
-            if section.get("section_path"):
-                normalized_section["section_path"] = section.get("section_path")
-            regions = normalize_regions(section.get("regions"))
-            page_span = normalize_page_span(section.get("page_span"), regions)
-            if regions:
-                normalized_section["regions"] = regions
-            if page_span:
-                normalized_section["page_span"] = page_span
-            normalized_sections.append(normalized_section)
-    if not normalized_sections:
-        raise ValueError(f"Document has no text: {path}")
-    metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
-    return {
-        "doc_id": doc_id,
-        "title": title,
-        "agency": agency,
-        "project": project,
-        "metadata": metadata,
-        "sections": normalized_sections,
-        "source_path": str(path),
-    }
-
-
-def normalize_text_document(path: Path) -> dict[str, Any]:
-    text = path.read_text(encoding="utf-8").strip()
-    if not text:
-        raise ValueError(f"Document has no text: {path}")
-    lines = [line.strip() for line in text.splitlines() if line.strip()]
-    title = lines[0].lstrip("# ").strip() if lines else path.stem
-    return {
-        "doc_id": path.stem,
-        "title": title,
-        "agency": "",
-        "project": "",
-        "metadata": {},
-        "sections": [{"heading": "본문", "text": text}],
-        "source_path": str(path),
-    }
-
-
-def validate_chunking_options(
-    chunking_strategy: str,
-    max_chars: int,
-    overlap_sentences: int,
-) -> None:
-    if chunking_strategy not in VALID_CHUNKING_STRATEGIES:
-        choices = ", ".join(sorted(VALID_CHUNKING_STRATEGIES))
-        raise ValueError(f"chunking_strategy must be one of: {choices}")
-    if max_chars < 1:
-        raise ValueError("chunk_max_chars must be positive.")
-    if overlap_sentences < 0:
-        raise ValueError("chunk_overlap_sentences must be zero or positive.")
-
-
-
-
-def resolve_chunking_strategy(doc: dict[str, Any], requested_strategy: str) -> str:
-    if requested_strategy == "auto":
-        return "section" if document_has_section_structure(doc) else "fixed"
-    return requested_strategy
-
-
-def build_chunk_records(
-    documents: Iterable[dict[str, Any]],
-    max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
-    chunking_strategy: str = "auto",
-    overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
-    validate_chunking_options(chunking_strategy, max_chars, overlap_sentences)
-    chunks: list[dict[str, Any]] = []
-    parent_sections: list[dict[str, Any]] = []
-    strategy_counts = {"section": 0, "fixed": 0}
-    document_diagnostics = []
-
-    for doc in documents:
-        normalized_sections = normalize_document_sections(doc)
-        actual_strategy = resolve_chunking_strategy(doc, chunking_strategy)
-        parent_candidates = (
-            normalized_sections
-            if actual_strategy == "section"
-            else [fixed_parent_section(doc, normalized_sections)]
-        )
-        doc_chunk_count = 0
-        chunk_seq = 1
-
-        for parent in parent_candidates:
-            parent = {**parent, "chunking_strategy": actual_strategy}
-            parent_sections.append(parent)
-            section_chunks = split_section_text(parent["text"], max_chars, overlap_sentences)
-            total_chunks_in_section = len(section_chunks)
-            for chunk_seq_in_section, sentences in enumerate(section_chunks, start=1):
-                chunks.append(
-                    make_chunk(
-                        doc,
-                        parent,
-                        sentences,
-                        chunk_seq,
-                        chunk_seq_in_section,
-                        total_chunks_in_section,
-                        actual_strategy,
-                    )
-                )
-                chunk_seq += 1
-                doc_chunk_count += 1
-
-        strategy_counts[actual_strategy] += 1
-        document_diagnostics.append(
-            {
-                "doc_id": doc["doc_id"],
-                "requested_strategy": chunking_strategy,
-                "actual_strategy": actual_strategy,
-                "num_input_sections": len(normalized_sections),
-                "num_parent_sections": len(parent_candidates),
-                "num_chunks": doc_chunk_count,
-            }
-        )
-
-    total_docs = strategy_counts["section"] + strategy_counts["fixed"]
-    section_detection_rate: float | None = (
-        strategy_counts["section"] / total_docs if total_docs else None
-    )
-    diagnostics = {
-        "requested_strategy": chunking_strategy,
-        "max_chars": max_chars,
-        "overlap_sentences": overlap_sentences,
-        "num_parent_sections": len(parent_sections),
-        "actual_strategy_counts": {
-            key: value for key, value in strategy_counts.items() if value
-        },
-        "section_detection_rate": section_detection_rate,
-        "documents": document_diagnostics,
-    }
-    return chunks, parent_sections, diagnostics
-
-
-def build_chunks(
-    documents: Iterable[dict[str, Any]],
-    max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
-    chunking_strategy: str = "auto",
-    overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
-) -> list[dict[str, Any]]:
-    chunks, _, _ = build_chunk_records(
-        documents,
-        max_chars=max_chars,
-        chunking_strategy=chunking_strategy,
-        overlap_sentences=overlap_sentences,
-    )
-    return chunks
-
-
-def make_chunk(
-    doc: dict[str, Any],
-    parent_section: dict[str, Any],
-    sentences: list[str],
-    chunk_seq: int,
-    chunk_seq_in_section: int,
-    total_chunks_in_section: int,
-    chunking_strategy: str,
-) -> dict[str, Any]:
-    text = " ".join(sentences).strip()
-    section_path = parent_section.get("section_path") or [parent_section.get("section", "")]
-    section_label = str(parent_section.get("section") or section_path[-1])
-    regions = normalize_regions(parent_section.get("regions"))
-    page_span = normalize_page_span(parent_section.get("page_span"), regions)
-    chunk = {
-        "chunk_id": f"{doc['doc_id']}::chunk-{chunk_seq:03d}",
-        "section_id": parent_section["section_id"],
-        "parent_section_id": parent_section["section_id"],
-        "doc_id": doc["doc_id"],
-        "title": doc["title"],
-        "agency": doc.get("agency", ""),
-        "project": doc.get("project", ""),
-        "metadata": doc.get("metadata", {}),
-        "section": section_label,
-        "section_path": section_path,
-        "chunk_seq_in_section": chunk_seq_in_section,
-        "total_chunks_in_section": total_chunks_in_section,
-        "chunking_strategy": chunking_strategy,
-        "text": text,
-        "tokens": tokenize(
-            " ".join([doc["title"], doc.get("agency", ""), " > ".join(section_path), text])
-        ),
-    }
-    if regions:
-        chunk["regions"] = regions
-    if page_span:
-        chunk["page_span"] = page_span
-    return chunk
-
-
-def build_index_payload(
-    input_dir: Path,
-    model_name: str = DEFAULT_EMBEDDING_MODEL,
-    embedding_backend: str = "auto",
-    chunking_strategy: str = "auto",
-    chunk_max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
-    chunk_overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
-) -> dict[str, Any]:
-    documents = load_raw_documents(input_dir)
-    return build_index_payload_from_documents(
-        documents,
-        source_dir=str(input_dir),
-        model_name=model_name,
-        embedding_backend=embedding_backend,
-        chunking_strategy=chunking_strategy,
-        chunk_max_chars=chunk_max_chars,
-        chunk_overlap_sentences=chunk_overlap_sentences,
-        message="Public synthetic RFP index for local minimum E2E RAG.",
-    )
-
-
-def build_index_payload_from_documents(
-    documents: list[dict[str, Any]],
-    source_dir: str,
-    model_name: str = DEFAULT_EMBEDDING_MODEL,
-    embedding_backend: str = "auto",
-    chunking_strategy: str = "auto",
-    chunk_max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
-    chunk_overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
-    message: str = "RFP index for local minimum E2E RAG.",
-) -> dict[str, Any]:
-    chunks, parent_sections, chunking_diagnostics = build_chunk_records(
-        documents,
-        max_chars=chunk_max_chars,
-        chunking_strategy=chunking_strategy,
-        overlap_sentences=chunk_overlap_sentences,
-    )
-    embedding_inputs = [
-        " ".join(
-            [
-                chunk["title"],
-                chunk.get("agency", ""),
-                " > ".join(chunk.get("section_path") or [chunk["section"]]),
-                chunk["text"],
-            ]
-        )
-        for chunk in chunks
-    ]
-    embedding_result = embed_texts(embedding_inputs, model_name=model_name, backend=embedding_backend)
-    # M2 (#207): vectors live in a sidecar .npy. Chunks reference rows by
-    # embedding_idx — inline lists were ~85% of the JSON file size and
-    # forced a per-query Python-list → NumPy materialization.
-    # Stage 1 of #176 (#232): the matrix is wrapped in a VectorStore so
-    # future backends (Qdrant, pgvector) can slot in without touching
-    # chunk-metadata storage. InMemoryVectorStore is bit-identical.
-    vectors_matrix = np.asarray(embedding_result.vectors, dtype=np.float32)
-    for idx, chunk in enumerate(chunks):
-        chunk["embedding_idx"] = idx
-        chunk.pop("embedding", None)
-
-    public_docs = [
-        {
-            "doc_id": doc["doc_id"],
-            "title": doc["title"],
-            "agency": doc.get("agency", ""),
-            "project": doc.get("project", ""),
-            "metadata": doc.get("metadata", {}),
-            "source_path": doc["source_path"],
-        }
-        for doc in documents
-    ]
-    return {
-        "schema_version": INDEX_SCHEMA_VERSION,
-        "mode": "rag",
-        "message": message,
-        "embedding": {
-            "backend": embedding_result.backend,
-            "model": embedding_result.model,
-            "dimension": int(embedding_result.vectors.shape[1]),
-            "normalized": True,
-            "storage": "sidecar_npy",
-        },
-        "build": {
-            "num_documents": len(public_docs),
-            "num_chunks": len(chunks),
-            "num_parent_sections": len(parent_sections),
-            "source_dir": source_dir,
-            "chunking": chunking_diagnostics,
-        },
-        "documents": public_docs,
-        "parent_sections": parent_sections,
-        "chunks": chunks,
-        "_vector_store": vector_store_from_matrix(vectors_matrix),
-    }
-
-
-def load_index(index_dir: Path) -> dict[str, Any]:
-    path = index_dir / INDEX_FILENAME
-    if not path.exists():
-        raise ValueError(f"RAG index not found: {path}. Run scripts/build_index.py first.")
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if payload.get("mode") != "rag":
-        raise ValueError(f"Unsupported index mode: {payload.get('mode')}. Rebuild the index.")
-    if not payload.get("chunks"):
-        raise ValueError(f"Index has no chunks: {path}")
-    schema = int(payload.get("schema_version", 1))
-    # Stage 1 of #176 (#232): the vector matrix is now hidden behind a
-    # VectorStore. load_vector_store handles the schema-2 sidecar path
-    # and the legacy schema-1 inline-list materialization. The legacy
-    # chunk-mutation loop (embedding_idx / pop) stays here because it
-    # mutates payload["chunks"], not the store — and must run *after*
-    # load_vector_store has read the inline lists.
-    if schema < INDEX_SCHEMA_VERSION:
-        payload["_vector_store"] = load_vector_store(
-            index_dir, schema, chunks=payload["chunks"]
-        )
-        if payload["_vector_store"] is not None:
-            for idx, chunk in enumerate(payload["chunks"]):
-                chunk["embedding_idx"] = idx
-                chunk.pop("embedding", None)
-    else:
-        payload["_vector_store"] = load_vector_store(index_dir, schema)
-    return payload
-
-
-def write_index(payload: dict[str, Any], output_dir: Path) -> Path:
-    """Atomically persist an index payload + embeddings sidecar.
-
-    Pops the in-memory ``_vector_store`` from the payload, asks it to
-    persist its vectors (typically ``embeddings.npy``), and serializes
-    the remaining JSON-compatible structure to ``index.json``. The
-    caller's ``payload`` dict is mutated (the private key is removed) —
-    see scripts/build_index.py for the canonical use site.
-    """
-    output_dir.mkdir(parents=True, exist_ok=True)
-    store = payload.pop("_vector_store", None)
-    if store is not None:
-        store.persist(output_dir)
-    out_path = output_dir / INDEX_FILENAME
-    out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    return out_path
-
-
-def known_entities(index: dict[str, Any]) -> list[str]:
-    entities = []
-    for doc in index.get("documents", []):
-        agency = normalize_entity(str(doc.get("agency", "")))
-        if agency and agency not in entities:
-            entities.append(agency)
-    return entities
-
-
-def metadata_targets(index: dict[str, Any]) -> list[dict[str, Any]]:
-    targets = []
-    for doc in index.get("documents", []):
-        for field in ("agency", "project", "title"):
-            value = str(doc.get(field) or "").strip()
-            if value:
-                targets.append(make_metadata_target(doc, field, value))
-    return targets
 
 
 def retrieve(

--- a/rag_indexing.py
+++ b/rag_indexing.py
@@ -1,0 +1,467 @@
+"""Document ingestion + index build/load extracted from ``rag_core.py``.
+
+ADR 0045 G3 / issue #858 — second large extraction in the rag_core
+slim-down series after ``rag_embedding`` (G2 / issue #843).  Moves the
+raw-document → chunk → index-payload pipeline plus the index I/O
+layer into a single leaf module.
+
+Public surface:
+
+- ``load_raw_documents`` / ``normalize_json_document`` /
+  ``normalize_text_document`` — read JSON/MD/TXT under ``data/raw/``
+  and produce the normalized in-memory document shape.
+- ``validate_chunking_options`` / ``resolve_chunking_strategy`` —
+  guard rails around the ``auto`` / ``section`` / ``fixed`` choice.
+- ``build_chunk_records`` / ``build_chunks`` / ``make_chunk`` —
+  document → chunk records with section / parent_section_id /
+  chunking diagnostics.
+- ``build_index_payload`` / ``build_index_payload_from_documents`` —
+  raw / pre-loaded document path through chunking → embeddings →
+  index-payload dict.  The output is the schema-2 in-memory shape
+  consumed by ``run_rag_query`` and ``scripts/build_index.py``.
+- ``load_index`` / ``write_index`` — atomic JSON + ``embeddings.npy``
+  sidecar round-trip.
+- ``known_entities`` / ``metadata_targets`` — small index→derived-list
+  helpers used by the analysis and retrieval surface.
+
+Constants:
+
+- ``DEFAULT_CHUNK_MAX_CHARS = 520`` — naive-baseline canonical value.
+- ``DEFAULT_CHUNK_OVERLAP_SENTENCES = 1`` — naive-baseline canonical.
+- ``VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}``.
+- ``INDEX_FILENAME = "index.json"`` — the on-disk JSON shape.
+- ``INDEX_SCHEMA_VERSION = 2`` — current ``schema_version`` field.
+
+Leaf status: depends only on ``rag_text_processing`` (`tokenize`,
+``normalize_entity``), ``rag_metadata_processing`` (`normalize_regions`,
+``normalize_page_span``, ``normalize_document_sections``,
+``fixed_parent_section``, ``split_section_text``,
+``make_metadata_target``), ``rag_embedding`` (`embed_texts`,
+``DEFAULT_EMBEDDING_MODEL``), and ``rag_vector_store``
+(`vector_store_from_matrix`, ``load_vector_store``,
+``EMBEDDINGS_FILENAME``) — every one of these is itself a leaf.  Zero
+back-edges to ``rag_core`` / ``rag_retrieval`` / ``rag_query`` /
+``rag_verifier`` / ``rag_answer``.
+
+``rag_core`` re-exports every public symbol so existing call sites
+(`from rag_core import build_index_payload`, etc.) keep working
+unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+from rag_embedding import DEFAULT_EMBEDDING_MODEL, embed_texts
+from rag_metadata_processing import (
+    fixed_parent_section,
+    make_metadata_target,
+    normalize_document_sections,
+    normalize_page_span,
+    normalize_regions,
+    split_section_text,
+)
+from rag_text_processing import normalize_entity, tokenize
+from rag_vector_store import (
+    EMBEDDINGS_FILENAME,
+    load_vector_store,
+    vector_store_from_matrix,
+)
+
+
+DEFAULT_CHUNK_MAX_CHARS = 520
+DEFAULT_CHUNK_OVERLAP_SENTENCES = 1
+VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
+
+INDEX_FILENAME = "index.json"
+INDEX_SCHEMA_VERSION = 2
+
+
+def load_raw_documents(input_dir: Path) -> list[dict[str, Any]]:
+    files = sorted(
+        p
+        for p in input_dir.iterdir()
+        if p.is_file() and p.suffix.lower() in {".json", ".md", ".txt"}
+    )
+    documents: list[dict[str, Any]] = []
+    for path in files:
+        if path.name.startswith("."):
+            continue
+        if path.suffix.lower() == ".json":
+            data = json.loads(path.read_text(encoding="utf-8"))
+            documents.append(normalize_json_document(data, path))
+        else:
+            documents.append(normalize_text_document(path))
+    if not documents:
+        raise ValueError(f"No JSON/Markdown/Text documents found in {input_dir}")
+    return documents
+
+
+def normalize_json_document(data: dict[str, Any], path: Path) -> dict[str, Any]:
+    doc_id = str(data.get("doc_id") or path.stem)
+    title = str(data.get("title") or path.stem)
+    agency = str(data.get("agency") or "")
+    project = str(data.get("project") or "")
+    sections = data.get("sections") or []
+    if not isinstance(sections, list) or not sections:
+        text = str(data.get("text") or "")
+        sections = [{"heading": "본문", "text": text}]
+    normalized_sections = []
+    for idx, section in enumerate(sections, start=1):
+        heading = str(section.get("heading") or f"section-{idx}")
+        text = str(section.get("text") or "").strip()
+        if text:
+            normalized_section = {"heading": heading, "text": text}
+            if section.get("section_path"):
+                normalized_section["section_path"] = section.get("section_path")
+            regions = normalize_regions(section.get("regions"))
+            page_span = normalize_page_span(section.get("page_span"), regions)
+            if regions:
+                normalized_section["regions"] = regions
+            if page_span:
+                normalized_section["page_span"] = page_span
+            normalized_sections.append(normalized_section)
+    if not normalized_sections:
+        raise ValueError(f"Document has no text: {path}")
+    metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
+    return {
+        "doc_id": doc_id,
+        "title": title,
+        "agency": agency,
+        "project": project,
+        "metadata": metadata,
+        "sections": normalized_sections,
+        "source_path": str(path),
+    }
+
+
+def normalize_text_document(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        raise ValueError(f"Document has no text: {path}")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    title = lines[0].lstrip("# ").strip() if lines else path.stem
+    return {
+        "doc_id": path.stem,
+        "title": title,
+        "agency": "",
+        "project": "",
+        "metadata": {},
+        "sections": [{"heading": "본문", "text": text}],
+        "source_path": str(path),
+    }
+
+
+def validate_chunking_options(
+    chunking_strategy: str,
+    max_chars: int,
+    overlap_sentences: int,
+) -> None:
+    if chunking_strategy not in VALID_CHUNKING_STRATEGIES:
+        choices = ", ".join(sorted(VALID_CHUNKING_STRATEGIES))
+        raise ValueError(f"chunking_strategy must be one of: {choices}")
+    if max_chars < 1:
+        raise ValueError("chunk_max_chars must be positive.")
+    if overlap_sentences < 0:
+        raise ValueError("chunk_overlap_sentences must be zero or positive.")
+
+
+def resolve_chunking_strategy(doc: dict[str, Any], requested_strategy: str) -> str:
+    if requested_strategy == "auto":
+        from rag_metadata_processing import document_has_section_structure
+        return "section" if document_has_section_structure(doc) else "fixed"
+    return requested_strategy
+
+
+def build_chunk_records(
+    documents: Iterable[dict[str, Any]],
+    max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+    chunking_strategy: str = "auto",
+    overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    validate_chunking_options(chunking_strategy, max_chars, overlap_sentences)
+    chunks: list[dict[str, Any]] = []
+    parent_sections: list[dict[str, Any]] = []
+    strategy_counts = {"section": 0, "fixed": 0}
+    document_diagnostics = []
+
+    for doc in documents:
+        normalized_sections = normalize_document_sections(doc)
+        actual_strategy = resolve_chunking_strategy(doc, chunking_strategy)
+        parent_candidates = (
+            normalized_sections
+            if actual_strategy == "section"
+            else [fixed_parent_section(doc, normalized_sections)]
+        )
+        doc_chunk_count = 0
+        chunk_seq = 1
+
+        for parent in parent_candidates:
+            parent = {**parent, "chunking_strategy": actual_strategy}
+            parent_sections.append(parent)
+            section_chunks = split_section_text(parent["text"], max_chars, overlap_sentences)
+            total_chunks_in_section = len(section_chunks)
+            for chunk_seq_in_section, sentences in enumerate(section_chunks, start=1):
+                chunks.append(
+                    make_chunk(
+                        doc,
+                        parent,
+                        sentences,
+                        chunk_seq,
+                        chunk_seq_in_section,
+                        total_chunks_in_section,
+                        actual_strategy,
+                    )
+                )
+                chunk_seq += 1
+                doc_chunk_count += 1
+
+        strategy_counts[actual_strategy] += 1
+        document_diagnostics.append(
+            {
+                "doc_id": doc["doc_id"],
+                "requested_strategy": chunking_strategy,
+                "actual_strategy": actual_strategy,
+                "num_input_sections": len(normalized_sections),
+                "num_parent_sections": len(parent_candidates),
+                "num_chunks": doc_chunk_count,
+            }
+        )
+
+    total_docs = strategy_counts["section"] + strategy_counts["fixed"]
+    section_detection_rate: float | None = (
+        strategy_counts["section"] / total_docs if total_docs else None
+    )
+    diagnostics = {
+        "requested_strategy": chunking_strategy,
+        "max_chars": max_chars,
+        "overlap_sentences": overlap_sentences,
+        "num_parent_sections": len(parent_sections),
+        "actual_strategy_counts": {
+            key: value for key, value in strategy_counts.items() if value
+        },
+        "section_detection_rate": section_detection_rate,
+        "documents": document_diagnostics,
+    }
+    return chunks, parent_sections, diagnostics
+
+
+def build_chunks(
+    documents: Iterable[dict[str, Any]],
+    max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+    chunking_strategy: str = "auto",
+    overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
+) -> list[dict[str, Any]]:
+    chunks, _, _ = build_chunk_records(
+        documents,
+        max_chars=max_chars,
+        chunking_strategy=chunking_strategy,
+        overlap_sentences=overlap_sentences,
+    )
+    return chunks
+
+
+def make_chunk(
+    doc: dict[str, Any],
+    parent_section: dict[str, Any],
+    sentences: list[str],
+    chunk_seq: int,
+    chunk_seq_in_section: int,
+    total_chunks_in_section: int,
+    chunking_strategy: str,
+) -> dict[str, Any]:
+    text = " ".join(sentences).strip()
+    section_path = parent_section.get("section_path") or [parent_section.get("section", "")]
+    section_label = str(parent_section.get("section") or section_path[-1])
+    regions = normalize_regions(parent_section.get("regions"))
+    page_span = normalize_page_span(parent_section.get("page_span"), regions)
+    chunk = {
+        "chunk_id": f"{doc['doc_id']}::chunk-{chunk_seq:03d}",
+        "section_id": parent_section["section_id"],
+        "parent_section_id": parent_section["section_id"],
+        "doc_id": doc["doc_id"],
+        "title": doc["title"],
+        "agency": doc.get("agency", ""),
+        "project": doc.get("project", ""),
+        "metadata": doc.get("metadata", {}),
+        "section": section_label,
+        "section_path": section_path,
+        "chunk_seq_in_section": chunk_seq_in_section,
+        "total_chunks_in_section": total_chunks_in_section,
+        "chunking_strategy": chunking_strategy,
+        "text": text,
+        "tokens": tokenize(
+            " ".join([doc["title"], doc.get("agency", ""), " > ".join(section_path), text])
+        ),
+    }
+    if regions:
+        chunk["regions"] = regions
+    if page_span:
+        chunk["page_span"] = page_span
+    return chunk
+
+
+def build_index_payload(
+    input_dir: Path,
+    model_name: str = DEFAULT_EMBEDDING_MODEL,
+    embedding_backend: str = "auto",
+    chunking_strategy: str = "auto",
+    chunk_max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+    chunk_overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
+) -> dict[str, Any]:
+    documents = load_raw_documents(input_dir)
+    return build_index_payload_from_documents(
+        documents,
+        source_dir=str(input_dir),
+        model_name=model_name,
+        embedding_backend=embedding_backend,
+        chunking_strategy=chunking_strategy,
+        chunk_max_chars=chunk_max_chars,
+        chunk_overlap_sentences=chunk_overlap_sentences,
+        message="Public synthetic RFP index for local minimum E2E RAG.",
+    )
+
+
+def build_index_payload_from_documents(
+    documents: list[dict[str, Any]],
+    source_dir: str,
+    model_name: str = DEFAULT_EMBEDDING_MODEL,
+    embedding_backend: str = "auto",
+    chunking_strategy: str = "auto",
+    chunk_max_chars: int = DEFAULT_CHUNK_MAX_CHARS,
+    chunk_overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
+    message: str = "RFP index for local minimum E2E RAG.",
+) -> dict[str, Any]:
+    chunks, parent_sections, chunking_diagnostics = build_chunk_records(
+        documents,
+        max_chars=chunk_max_chars,
+        chunking_strategy=chunking_strategy,
+        overlap_sentences=chunk_overlap_sentences,
+    )
+    embedding_inputs = [
+        " ".join(
+            [
+                chunk["title"],
+                chunk.get("agency", ""),
+                " > ".join(chunk.get("section_path") or [chunk["section"]]),
+                chunk["text"],
+            ]
+        )
+        for chunk in chunks
+    ]
+    embedding_result = embed_texts(embedding_inputs, model_name=model_name, backend=embedding_backend)
+    # M2 (#207): vectors live in a sidecar .npy. Chunks reference rows by
+    # embedding_idx — inline lists were ~85% of the JSON file size and
+    # forced a per-query Python-list → NumPy materialization.
+    # Stage 1 of #176 (#232): the matrix is wrapped in a VectorStore so
+    # future backends (Qdrant, pgvector) can slot in without touching
+    # chunk-metadata storage. InMemoryVectorStore is bit-identical.
+    vectors_matrix = np.asarray(embedding_result.vectors, dtype=np.float32)
+    for idx, chunk in enumerate(chunks):
+        chunk["embedding_idx"] = idx
+        chunk.pop("embedding", None)
+
+    public_docs = [
+        {
+            "doc_id": doc["doc_id"],
+            "title": doc["title"],
+            "agency": doc.get("agency", ""),
+            "project": doc.get("project", ""),
+            "metadata": doc.get("metadata", {}),
+            "source_path": doc["source_path"],
+        }
+        for doc in documents
+    ]
+    return {
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "mode": "rag",
+        "message": message,
+        "embedding": {
+            "backend": embedding_result.backend,
+            "model": embedding_result.model,
+            "dimension": int(embedding_result.vectors.shape[1]),
+            "normalized": True,
+            "storage": "sidecar_npy",
+        },
+        "build": {
+            "num_documents": len(public_docs),
+            "num_chunks": len(chunks),
+            "num_parent_sections": len(parent_sections),
+            "source_dir": source_dir,
+            "chunking": chunking_diagnostics,
+        },
+        "documents": public_docs,
+        "parent_sections": parent_sections,
+        "chunks": chunks,
+        "_vector_store": vector_store_from_matrix(vectors_matrix),
+    }
+
+
+def load_index(index_dir: Path) -> dict[str, Any]:
+    path = index_dir / INDEX_FILENAME
+    if not path.exists():
+        raise ValueError(f"RAG index not found: {path}. Run scripts/build_index.py first.")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("mode") != "rag":
+        raise ValueError(f"Unsupported index mode: {payload.get('mode')}. Rebuild the index.")
+    if not payload.get("chunks"):
+        raise ValueError(f"Index has no chunks: {path}")
+    schema = int(payload.get("schema_version", 1))
+    # Stage 1 of #176 (#232): the vector matrix is now hidden behind a
+    # VectorStore. load_vector_store handles the schema-2 sidecar path
+    # and the legacy schema-1 inline-list materialization. The legacy
+    # chunk-mutation loop (embedding_idx / pop) stays here because it
+    # mutates payload["chunks"], not the store — and must run *after*
+    # load_vector_store has read the inline lists.
+    if schema < INDEX_SCHEMA_VERSION:
+        payload["_vector_store"] = load_vector_store(
+            index_dir, schema, chunks=payload["chunks"]
+        )
+        if payload["_vector_store"] is not None:
+            for idx, chunk in enumerate(payload["chunks"]):
+                chunk["embedding_idx"] = idx
+                chunk.pop("embedding", None)
+    else:
+        payload["_vector_store"] = load_vector_store(index_dir, schema)
+    return payload
+
+
+def write_index(payload: dict[str, Any], output_dir: Path) -> Path:
+    """Atomically persist an index payload + embeddings sidecar.
+
+    Pops the in-memory ``_vector_store`` from the payload, asks it to
+    persist its vectors (typically ``embeddings.npy``), and serializes
+    the remaining JSON-compatible structure to ``index.json``. The
+    caller's ``payload`` dict is mutated (the private key is removed) —
+    see scripts/build_index.py for the canonical use site.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    store = payload.pop("_vector_store", None)
+    if store is not None:
+        store.persist(output_dir)
+    out_path = output_dir / INDEX_FILENAME
+    out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return out_path
+
+
+def known_entities(index: dict[str, Any]) -> list[str]:
+    entities = []
+    for doc in index.get("documents", []):
+        agency = normalize_entity(str(doc.get("agency", "")))
+        if agency and agency not in entities:
+            entities.append(agency)
+    return entities
+
+
+def metadata_targets(index: dict[str, Any]) -> list[dict[str, Any]]:
+    targets = []
+    for doc in index.get("documents", []):
+        for field in ("agency", "project", "title"):
+            value = str(doc.get(field) or "").strip()
+            if value:
+                targets.append(make_metadata_target(doc, field, value))
+    return targets


### PR DESCRIPTION
## 1. 변경 내용 및 이유

ADR 0045 G3 — rag_core slim-down 시리즈에서 [#847](https://github.com/hskim-solv/BidMate-DocAgent/pull/847) (rag_embedding) 이후 두 번째 대형 추출. 순수 구조적 relocation.

신규 leaf 모듈 **`rag_indexing.py`** 가 raw-document → chunk → index-payload 파이프라인 + index I/O 계층을 소유:

| Layer | Symbols |
|-------|---------|
| Document loading | `load_raw_documents`, `normalize_json_document`, `normalize_text_document` |
| Chunking options | `validate_chunking_options`, `resolve_chunking_strategy` |
| Chunking build | `build_chunk_records`, `build_chunks`, `make_chunk` |
| Index build | `build_index_payload`, `build_index_payload_from_documents` |
| Index I/O | `load_index`, `write_index` |
| Index helpers | `known_entities`, `metadata_targets` |
| Constants | `DEFAULT_CHUNK_MAX_CHARS`, `DEFAULT_CHUNK_OVERLAP_SENTENCES`, `VALID_CHUNKING_STRATEGIES`, `INDEX_FILENAME`, `INDEX_SCHEMA_VERSION` |

의존성: stdlib (`json`) + `numpy` + `rag_text_processing` + `rag_metadata_processing` + `rag_embedding` + `rag_vector_store`. `rag_core` / `rag_retrieval` / `rag_query` / `rag_verifier` / `rag_answer` 로의 **back-edge 0** — 진정한 leaf.

`rag_core` 가 모든 public symbol 을 re-export 하므로 기존 호출 (`from rag_core import build_index_payload, load_index, DEFAULT_CHUNK_MAX_CHARS` 등) 은 변경 없이 동작.

Closes #858

## 2. 변경 파일

- `rag_indexing.py` (신규, 467 LOC) — leaf 모듈
- `rag_core.py` (load-bearing) — 13 함수 정의 + 5 상수 제거, `from rag_indexing import (...)` re-export 추가. Net 1628 → 1263 LOC (-365 LOC).

## 3. 리스크

주요 리스크는 **silent ingestion/indexing 동작 변경** — 즉 chunk record 또는 index payload 가 이전 `rag_core` 경로에서 byte-identical 하지 않게 drift. Mitigation:

- 모든 함수 verbatim 이동 (delete-from-A + paste-into-B). Re-export alias 가 identity 보존.
- retrieval / indexing / ingestion / vector_store / chunking suite 에서 233/234 pytest 케이스 pass.
- 단일 실패 (`test_mixed_format_ingestion_regression::test_text_source_counts_aggregated_by_format`) 는 **`origin/main` HEAD 에서 pre-existing** — `ingestion.py` + 테스트를 main 버전으로 교체하여 로컬 재현 확인. 이 PR 과 무관; follow-up 으로 별도 추적.
- ADR 0001 naive_baseline preset golden 유지.

## 4. 테스트

신규 테스트 없음 — 순수 relocation. 기존 regression battery 의 커버리지:

- `tests/test_naive_baseline_ranking_invariance.py` — ADR 0001 golden
- `tests/test_retrieval_loop_regression.py` — 검색 경로
- `tests/test_vector_store_qdrant.py` — vector store
- `tests/test_chunking_strategy_regression.py` 등 — 청킹 + ingestion

233/234 pass (1 실패는 pre-existing main flake, Risks 참조).

## 5. Eval 영향

전부 `·` — 순수 relocation, byte-identical 청킹 + embedding 출력.

### 5b. Real-data delta

**Pure relocation. No behavior change in retrieval / verifier / answer / ingestion / api / eval paths.**

13 relocated 함수 + 5 상수가 re-export 통해 `rag_core` 로 import 되므로 `from rag_core import build_index_payload, load_index, …` 소비자가 identical object 를 본다. 함수 본문은 이전 rag_core 구현과 byte-for-byte identical.

ADR 0045 invariant ("byte-identical chunking + index payloads — any delta is a bug") 가 naive_baseline + retrieval regression battery 로 강제됨.

## 6. 하위 호환성

Breaking 변경 없음. ingestion / indexing symbol 대한 `rag_core` 의 모든 이전 public 이름이 동일 module 경로에서 re-export 됨. `from rag_core import build_index_payload, DEFAULT_CHUNK_MAX_CHARS, …` 사용 도구는 수정 없이 계속 작동.

## 7. 범위 외

- **G4** (다음 G-axis): consumer audit 후 dependency-graph 최종 검증 + re-export shim 제거 (`grep -rn "from rag_core import.*\\(build_index\\|load_index\\|chunk\\)"`)
- **Pre-existing 테스트 실패 수정** (`test_text_source_counts_aggregated_by_format` fallback_reasons drift) — 별도 concern, follow-up 추적
- 청킹 semantics, embedding 로직, index 포맷 변경 없음 — 이전 PR 들에서 완료, 여기서는 범위 외

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Co-Authored-By: Claude
