### PR TITLE
docs(rag_core): document _phase_* mutation contracts + AST-based regression test (closes #840)

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -1132,6 +1132,18 @@ def _phase_analyze(ctx: _RunContext) -> dict[str, Any] | None:
     context-clarification or metadata-ambiguity reply, otherwise ``None``
     after mutating ``ctx`` with the analysis outputs that
     :func:`_phase_retrieve_loop` and :func:`_phase_build_answer` consume.
+
+    **Mutation contract** (issue #840 — RAG senior-review critique #5,
+    pinned by ``tests/test_phase_mutation_contract.py``):
+
+    Writes to ``ctx`` (only when returning ``None`` — early-exit branches
+    return without writing): ``retrieval_query``,
+    ``effective_context_entities``, ``context_resolution``, ``analysis``,
+    ``stage_sequence``.
+
+    Adding or removing a write here without updating both this docstring
+    and the regression test is the contract drift the critique flagged
+    (shared mutable dict with no contract surface).
     """
     with _StageTimer(ctx.stage_timings, "query_analysis_ms", trace=ctx.trace_handle, attrs={"iteration": 1}):
         initial_analysis = analyze_query(ctx.query, ctx.targets)
@@ -1251,9 +1263,20 @@ def _phase_analyze(ctx: _RunContext) -> dict[str, Any] | None:
 def _phase_retrieve_loop(ctx: _RunContext) -> None:
     """Run the metadata-stage retry loop (ADR 0022 stage 2).
 
-    Mutates ``ctx`` with ``stage_attempts``, ``retry_count``, ``plan``,
+    **Mutation contract** (issue #840 — RAG senior-review critique #5,
+    pinned by ``tests/test_phase_mutation_contract.py``):
+
+    Writes to ``ctx``: ``stage_attempts``, ``retry_count``, ``plan``,
     ``evidence``, ``verified``, ``verification_reasons``,
     ``retrieved_chunk_ids``.
+
+    Adding or removing a write here without updating both this docstring
+    and the regression test is the contract drift the critique flagged.
+    The "feedback loop with stage attempts" naming would be more honest
+    than "phase" — this function legitimately mutates plan after each
+    retry attempt and is not a pure linear pipeline step. Documented at
+    the call-site contract layer rather than refactored to a state
+    machine (the latter is ADR-grade scope).
     """
     stage_attempts: list[dict[str, Any]] = []
     retry_count = 0
@@ -1348,6 +1371,15 @@ def _phase_build_answer(ctx: _RunContext) -> dict[str, Any]:
     in the same key order as the legacy ``run_rag_query`` body — the
     JSON-identity contract pinned by
     ``tests/test_langgraph_orchestrator_regression.py``.
+
+    **Mutation contract** (issue #840 — RAG senior-review critique #5,
+    pinned by ``tests/test_phase_mutation_contract.py``):
+
+    Writes to ``ctx``: none. This phase is read-only against ``ctx`` —
+    it consumes phase-1/2 outputs and produces the return-value result
+    dict. The "no ctx writes" property is what justifies the
+    ``_phase_*`` naming for THIS function (vs the loop-shaped
+    :func:`_phase_retrieve_loop` which legitimately mutates).
     """
     analysis = ctx.analysis or {}
     evidence = ctx.evidence or []

--- a/tests/test_phase_mutation_contract.py
+++ b/tests/test_phase_mutation_contract.py
@@ -1,0 +1,164 @@
+"""Regression: each ``_phase_*`` writes only the ``ctx`` fields its docstring documents (issue #840).
+
+RAG senior-review critique #5 flagged that ``_phase_*`` functions
+*look like* a functional pipeline (named "phase") but actually
+mutate a shared ``_RunContext`` dataclass passed by reference. With
+no contract surface, accidental cross-phase coupling — adding a
+mutation in one phase that another phase depends on — is invisible
+in code review.
+
+The full fix would be an explicit state machine with named
+transitions and immutable per-stage payloads (ADR-grade refactor;
+tracked as part of #840). The surgical fix in this PR is to
+**document** the mutation contract per phase and **pin** it via
+this regression test:
+
+1. Inspect each ``_phase_*`` function's source for ``ctx.<attr> = ...``
+   assignments via the ``ast`` module (no runtime fixture needed).
+2. Compare the discovered set of ctx attribute writes against the
+   set the phase's docstring claims (parsed from the
+   "Writes to ``ctx``" line).
+3. Fail if the two sets diverge — forces every PR that adds or
+   removes a phase-level write to update the docstring (which is
+   the contract surface the critique flagged as missing).
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import textwrap
+import unittest
+
+import rag_core
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_DOCSTRING_WRITES_RE = re.compile(
+    r"Writes to ``ctx``[^:]*:\s*(.+?)(?:\.\s|\.$|\n\n)",
+    re.DOTALL,
+)
+# Match either ``backticked`` attribute names or bare attribute names
+# in the comma-separated "Writes to ctx:" list.
+_ATTR_NAME_RE = re.compile(r"``([A-Za-z_][A-Za-z0-9_]*)``")
+
+
+def _ctx_attribute_writes(func: object) -> set[str]:
+    """Return the set of ``ctx.<name>`` attribute assignments inside ``func``.
+
+    Walks the AST and collects the names of every ``ctx.X = ...``
+    assignment. Augmented assignments (``ctx.X += ...``) and attribute
+    deletions are out of scope (none currently exist in the phases).
+    """
+    source = inspect.getsource(func)
+    # ``inspect.getsource`` returns the function with whatever
+    # indentation it had at definition site. Module-level functions
+    # are at column 0 already; nested funcs (none in this codebase
+    # for ``_phase_*``) would need ``textwrap.dedent``. Defensive
+    # dedent costs nothing.
+    tree = ast.parse(textwrap.dedent(source))
+    writes: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "ctx"
+            ):
+                writes.add(target.attr)
+    return writes
+
+
+def _docstring_documented_writes(func: object) -> set[str]:
+    """Return the set of ``ctx`` attributes the function docstring claims to write.
+
+    Parses the "Writes to ``ctx``" line of the docstring's
+    ``Mutation contract`` block. Returns an empty set for functions
+    whose docstring documents "Writes to ``ctx``: none." (that's
+    the explicit no-write contract).
+    """
+    doc = inspect.getdoc(func) or ""
+    match = _DOCSTRING_WRITES_RE.search(doc)
+    if not match:
+        return set()
+    fragment = match.group(1)
+    if "none" in fragment.lower():
+        return set()
+    return set(_ATTR_NAME_RE.findall(fragment))
+
+
+# ---------------------------------------------------------------------------
+# Contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseMutationContract(unittest.TestCase):
+    def _assert_phase_contract(self, func: object) -> None:
+        actual = _ctx_attribute_writes(func)
+        documented = _docstring_documented_writes(func)
+        self.assertEqual(
+            actual,
+            documented,
+            msg=(
+                f"\n{func.__name__} ctx-write contract drift:\n"
+                f"  AST-discovered writes: {sorted(actual)}\n"
+                f"  Docstring-claimed   : {sorted(documented)}\n"
+                f"  In actual but not documented: {sorted(actual - documented)}\n"
+                f"  Documented but not in actual: {sorted(documented - actual)}\n"
+                f"Update the docstring's 'Writes to ``ctx``' line to match "
+                f"the AST, then update this test only if the mutation is "
+                f"intentional (RAG senior-review critique #5 fix, #840)."
+            ),
+        )
+
+    def test_phase_analyze_contract(self) -> None:
+        self._assert_phase_contract(rag_core._phase_analyze)
+
+    def test_phase_retrieve_loop_contract(self) -> None:
+        self._assert_phase_contract(rag_core._phase_retrieve_loop)
+
+    def test_phase_build_answer_contract(self) -> None:
+        # This phase's documented contract is "Writes to ``ctx``: none.",
+        # so the AST set should be empty.
+        self.assertEqual(
+            _ctx_attribute_writes(rag_core._phase_build_answer),
+            set(),
+            msg=(
+                "_phase_build_answer is documented as ctx-read-only but "
+                "the AST found ctx attribute assignments. Either remove "
+                "the assignments or update the docstring's mutation "
+                "contract (RAG senior-review critique #5 fix, #840)."
+            ),
+        )
+        self._assert_phase_contract(rag_core._phase_build_answer)
+
+    def test_all_phases_have_mutation_contract_section(self) -> None:
+        # The docstring marker must be present on every _phase_* — so
+        # a future PR that adds a new _phase_X function gets caught
+        # by the test even before they wire up the regression.
+        for name, func in inspect.getmembers(rag_core, inspect.isfunction):
+            if not name.startswith("_phase_"):
+                continue
+            doc = inspect.getdoc(func) or ""
+            self.assertIn(
+                "Mutation contract",
+                doc,
+                msg=(
+                    f"{name} is missing the 'Mutation contract' "
+                    "docstring section (RAG senior-review critique #5 "
+                    "fix, #840). Every _phase_* function must document "
+                    "its ctx-write set so the regression test in "
+                    "tests/test_phase_mutation_contract.py can pin it."
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Senior-review 비판 #5: `rag_core.run_rag_query` 의 ``_phase_*`` 함수들은 functional 파이프라인처럼 *보이지만* 참조로 전달된 공유 ``_RunContext`` dataclass 를 mutate. 계약 표면이 없어 의도치 않은 phase 간 결합이 코드 리뷰에서 invisible.
- 완전한 수정은 ADR 급 state-machine 리팩토링 (범위 밖, #840). 이 PR 은 surgical 수정 적용: docstring 의 phase 별 mutation 계약 명시 + 실제 write 가 docstring 주장에서 drift 시 실패하는 AST 기반 회귀 테스트.
- 문서 + 단일 회귀 테스트. 동작 변경, rename, 리팩토링 없음.

Closes #840. `/Users/hskim/.claude/plans/fizzy-splashing-cherny.md` (RAG senior-review) 비판 #5. dynamic-loop fix sequence Cycle 9.

## Surface

- `rag_core.py` — ``_phase_analyze`` / ``_phase_retrieve_loop`` / ``_phase_build_answer`` 각각 ``**Mutation contract**`` docstring 섹션 획득. 함수가 write 하는 정확한 ``ctx`` 속성 나열.
- `tests/test_phase_mutation_contract.py` (신규) — ``ast`` 모듈로 각 phase 검사, 모든 ``ctx.<attr> = ...`` 할당 추출, 발견 집합이 docstring 과 일치하는지 assert. 4번째 테스트는 ``rag_core`` 의 모든 ``_phase_*`` 함수가 contract docstring 마커를 갖는지 assert.

## Pinned 계약

- ``_phase_analyze`` 는 ``retrieval_query``, ``effective_context_entities``, ``context_resolution``, ``analysis``, ``stage_sequence`` write — ``None`` 반환 시에 한해; early-exit branch 는 write 없이 반환.
- ``_phase_retrieve_loop`` 는 ``stage_attempts``, ``retry_count``, ``plan``, ``evidence``, ``verified``, ``verification_reasons``, ``retrieved_chunk_ids`` write. docstring 은 "phase" 보다 "feedback loop with stage attempts" 가 더 정직하다고 인정 — 이 함수는 각 retry 후 plan 을 정당하게 mutate 하므로 linear 파이프라인 step 이 아니다.
- ``_phase_build_answer`` 는 ctx 에 write 안 함; phase-1/2 출력 소비해 반환 dict 생성.

## Test plan

- [x] `pytest tests/test_phase_mutation_contract.py -v` — 4 passed.
- [x] `pytest tests/test_langgraph_orchestrator_regression.py tests/test_retrieval_loop_regression.py tests/test_naive_baseline_ranking_invariance.py tests/test_phase_mutation_contract.py` — 21 passed + 17 subtests (orchestrator 회귀는 의도치 않은 phase-output drift 를 잡는 JSON-identity gate).

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

`rag_core.py` 는 load-bearing. 변경은 문서만 — docstring 3개 확장, 함수 본문 미수정. 신규 테스트는 ``ast`` 로 기존 source 검사; 파이프라인 미실행. `make real-eval-delta` 는 0pp delta 예상.

## PR 템플릿 (inline)

1. **Issue**: #840.
2. **동작 변경?** 없음. 순수 문서 + 회귀 테스트.
3. **하위 호환성**: 동일. 공개 API 변경 없음. ``_phase_*`` 함수는 underscore-prefix 유지 (여전히 ``rag_graph_agentic_full`` 와 직접 경로에서만 소비).
4. **테스트**: 신규 회귀 `tests/test_phase_mutation_contract.py` (4 케이스) + 인접 orchestrator/retrieval suite green.
5. **Real-data delta**: 위 `### 5b. Real-data delta` 참조.
6. **ADR**: 신규 ADR 없음. 이 PR 이 문서화한 계약 표면이 향후 state-machine 리팩토링 (#5 의 proper 수정) 이 시작점으로 상속할 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
