### PR TITLE
test(concurrency): multi-threaded query determinism regression (closes #868)

### DIFF
--- a/docs/operations/concurrency.md
+++ b/docs/operations/concurrency.md
@@ -1,0 +1,65 @@
+# Concurrency contract
+
+> Issue #868 (F3) — what callers of `run_rag_query` may assume when multiple
+> threads (FastAPI workers, batch eval drivers, notebooks) hit the same
+> in-memory index dict.
+
+## Contract
+
+`run_rag_query(index, query, ...)` is **safe to call concurrently from
+multiple threads against the same `index` dict**, with one invariant:
+all concurrent callers receive byte-identical evidence rankings
+(`(chunk_id, score)` pairs in `evidence` / `citations`) regardless of
+scheduling order.
+
+This is enforced by [`tests/test_concurrency_regression.py`](../../tests/test_concurrency_regression.py)
+(8 threads × 5 queries × 4 reps for both `naive_baseline` and
+`agentic_full`, plus a first-touch BM25 cache race with 16 threads).
+
+## What this does *not* promise
+
+* **Throughput.** The pipeline is CPU-bound and holds the GIL through
+  embedding + BM25 scoring. Two threads do not give 2× QPS — they share
+  one core. Use a process pool (uvicorn workers, gunicorn) for parallel
+  serving, threads only to overlap I/O with retrieval.
+* **Concurrent index mutation.** `build_index_payload` /
+  `write_index` are *not* safe to call while queries are in flight on
+  the same dict. Treat the index as read-only after build.
+* **External resources.** Qdrant adapter (issue #832,
+  [`docs/operations/qdrant-integration.md`](qdrant-integration.md))
+  delegates concurrency to the Qdrant server itself.
+
+## Race-prone surfaces (documented, not bugs)
+
+These caches are populated lazily and *can* be touched by two threads
+simultaneously. They are safe today because every winning write
+produces an equivalent value:
+
+* **`get_or_build_bm25`** ([`rag_retrieval.py:685`](../../rag_retrieval.py))
+  — `dict.setdefault` pattern. Cache key is
+  `(stopword_profile, tokenizer, schema_version, chunk_count)`
+  (issue #833). Two threads on a cache-miss path both build a
+  `BM25Okapi` from the same `chunks`; the last writer wins, but
+  `BM25Okapi(...)` is deterministic given the same input, so the
+  surviving entry produces identical scores.
+* **`MODEL_CACHE`** ([`rag_embedding.py`](../../rag_embedding.py)) —
+  keyed by `(model, normalize, device)`. SentenceTransformer cold-load
+  is >5s; concurrent first-touch wastes work (both threads load) but
+  the resulting weights are deterministic and the dict assignment is
+  GIL-atomic.
+* **`_DONUT_MODEL_CACHE`** ([`visual_ingestion.py`](../../visual_ingestion.py))
+  — same shape as `MODEL_CACHE`, only touched during ingestion (not
+  during query), so it does not interact with `run_rag_query` at all.
+
+If a future PR introduces a lazy cache whose value is *not*
+deterministic across reloads (e.g. a learned reranker with stochastic
+init), it MUST add explicit locking or pre-build the cache at index
+load time. The regression test will catch any drift that slips
+through.
+
+## Why threading (and not just multiprocessing)
+
+The API serves requests from a `ThreadPoolExecutor` underneath
+`asyncio.to_thread` (issue #173 Stage 1, `arun_rag_query`). Without
+this contract the async path would be racy under load — the regression
+test is the durable proof that the seam holds.

--- a/tests/test_concurrency_regression.py
+++ b/tests/test_concurrency_regression.py
@@ -1,0 +1,145 @@
+"""Concurrent-query determinism regression (issue #868, F3 of GEF loop).
+
+``run_rag_query`` is called from FastAPI workers (``api/main.py``) and may
+also be fanned out from notebooks / batch eval drivers. The retrieval path
+mutates the index dict to install lazy caches:
+
+* ``index["_bm25_by_profile"]`` — :func:`rag_retrieval.get_or_build_bm25`
+  populates this on first BM25 build (issue #833 cache key includes
+  ``schema_version`` + ``chunk_count`` so corpus identity changes
+  invalidate, but two threads can still race on the *initial* build).
+* ``MODEL_CACHE`` in :mod:`rag_embedding` — keyed by ``(model, normalize,
+  device)``. ST cold-load is >5s, so concurrent callers will both attempt
+  the load; ``dict[...] = ...`` last-write-wins, but the model is
+  deterministic across loads so the *result* is unchanged.
+
+The senior contract this test guards: **regardless of how many threads
+enter ``run_rag_query`` concurrently against the same ``index`` dict,
+they MUST all return byte-identical evidence rankings + scores.** A
+ranking drift under contention would be a silent correctness bug —
+``naive_baseline`` golden (ADR 0001) catches single-threaded drift, this
+catches multi-threaded drift.
+
+We use the ``hashing`` embedding backend so the test is deterministic
+across machines and does not need a 500 MB ST model download in CI.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+from pathlib import Path
+
+import pytest
+
+from rag_core import run_rag_query
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+QUERIES = [
+    "기관 A의 보안 통제 요구사항은?",
+    "기관 C의 챗봇 응답 시간 목표는?",
+    "기관 B의 개인정보 보안 요구사항은?",
+    "공통 제출조건에서 모든 제안사가 제출해야 하는 것은?",
+    "기관 A와 기관 B의 보안 요구사항 차이는?",
+]
+
+
+def _ranking_signature(result: dict) -> tuple[tuple[str, float], ...]:
+    """Reduce a run_rag_query result to its deterministic ranking fingerprint.
+
+    We compare ``(chunk_id, score)`` pairs on ``evidence`` / ``citations``
+    — wall-clock fields (``diagnostics.latency_ms``, ``stage_latency``)
+    legitimately differ between runs and must be excluded.
+    """
+    citations = result.get("citations") or result.get("evidence") or []
+    return tuple(
+        (c.get("chunk_id"), c.get("score")) for c in citations
+    )
+
+
+@pytest.fixture(scope="module")
+def baseline_signatures(shared_raw_index) -> dict[tuple[str, str], tuple]:
+    """Serial-execution baseline — every concurrent run must match this."""
+    baseline: dict[tuple[str, str], tuple] = {}
+    for pipeline in ("naive_baseline", "agentic_full"):
+        for query in QUERIES:
+            result = run_rag_query(shared_raw_index, query, pipeline=pipeline)
+            baseline[(pipeline, query)] = _ranking_signature(result)
+    return baseline
+
+
+@pytest.mark.parametrize("pipeline", ["naive_baseline", "agentic_full"])
+def test_concurrent_queries_match_serial_baseline(
+    shared_raw_index, baseline_signatures, pipeline
+):
+    """8 threads × 5 queries × 4 reps must all match the serial baseline.
+
+    Failure modes this catches:
+      * BM25 cache corruption (two threads racing on initial build —
+        if one writes a partially-tokenized BM25Okapi, downstream
+        scores drift)
+      * MODEL_CACHE clobber (deterministic by construction with the
+        hashing backend — no cache writes — but parametrized over
+        ``agentic_full`` exercises rerank/verifier surfaces too)
+      * Any future shared-dict mutation introduced into retrieval /
+        verifier / answer that breaks read-isolation
+    """
+    expected = {q: baseline_signatures[(pipeline, q)] for q in QUERIES}
+
+    def _run(query: str) -> tuple[str, tuple]:
+        result = run_rag_query(shared_raw_index, query, pipeline=pipeline)
+        return query, _ranking_signature(result)
+
+    futures = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+        for _ in range(4):
+            for query in QUERIES:
+                futures.append(ex.submit(_run, query))
+        results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+    for query, signature in results:
+        assert signature == expected[query], (
+            f"concurrent ranking drift under pipeline={pipeline!r} "
+            f"for query {query!r}:\n"
+            f"  serial:     {expected[query]}\n"
+            f"  concurrent: {signature}\n"
+            "Two threads likely raced on a lazy-built cache "
+            "(see rag_retrieval.get_or_build_bm25 / "
+            "rag_embedding.MODEL_CACHE)."
+        )
+
+
+def test_bm25_cache_stable_under_concurrent_first_touch(shared_raw_index):
+    """Drop the BM25 cache, then race 16 threads through retrieval.
+
+    Targets the ``get_or_build_bm25`` race specifically: by deleting
+    ``index["_bm25_by_profile"]`` we force every thread to enter the
+    "first build" branch concurrently. The contract: regardless of
+    which thread wins the ``dict.setdefault``, the final cache state
+    must be a consistent ``(BM25Okapi, chunk_ids)`` tuple and all
+    threads must observe the same ranking.
+    """
+    shared_raw_index.pop("_bm25_by_profile", None)
+    shared_raw_index.pop("_bm25", None)
+    shared_raw_index.pop("_bm25_chunk_ids", None)
+
+    query = "기관 A의 보안 통제 요구사항은?"
+
+    def _run() -> tuple:
+        return _ranking_signature(
+            run_rag_query(shared_raw_index, query, pipeline="agentic_full")
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
+        signatures = list(ex.map(lambda _: _run(), range(16)))
+
+    first = signatures[0]
+    for i, sig in enumerate(signatures[1:], start=1):
+        assert sig == first, (
+            f"BM25 cache race produced divergent rankings on thread #{i}:\n"
+            f"  thread 0:  {first}\n"
+            f"  thread {i}: {sig}\n"
+            "get_or_build_bm25's setdefault is not preserving ranking "
+            "invariance under concurrent first-touch."
+        )


### PR DESCRIPTION
## 1. 변경 내용 및 이유

`run_rag_query` 의 thread-safety 계약을 공유 in-memory 인덱스에 대해 pin 하는 동시성 회귀 테스트 추가. `arun_rag_query` (#173 Stage 1) 와 FastAPI 데모는 thread pool 로 쿼리를 서빙하지만, 두 동시 쿼리가 byte-identical 순위를 내는지 단언하는 테스트가 없었다. Lazy 캐시 (BM25 build, MODEL_CACHE) 는 race-prone 표면 — 결정론적 쓰기로 오늘은 안전하지만 계약을 가드하는 게 없었다.

이는 GEF auto-loop (issue plan `gleaming-forging-dove.md`) 의 F3: backend / scale signal #3. F1 (Qdrant adapter routing, #837) + F2 (Qdrant integration tests, #857) 보완. Closes #868.

## 2. Files affected

- `tests/test_concurrency_regression.py` — **신규**, 3 테스트, 2.17 s
- `docs/operations/concurrency.md` — **신규**, durable thread-safety 계약

둘 다 load-bearing 아님 (test + ops doc).

## 3. Risks

CI 스케줄링 하 테스트 안정성. Serial baseline 은 한 번 빌드 (module fixture) 되고 모든 동시 실행이 그것과 byte 단위 비교된다. 향후 변경이 비결정론 캐시를 도입하면 이 테스트가 fast fail — 설계이지 flake 아님. 16-thread first-touch race 는 의도적으로 BM25 캐시를 클리어해서 cache-miss 경로를 실제 실행 — 약간 비싸지지만 그게 목적.

## 4. Tests

이 PR *이 곧* 테스트. 로컬 실행:

```
$ EMBEDDING_BACKEND=hashing pytest tests/test_concurrency_regression.py -v
tests/test_concurrency_regression.py::test_concurrent_queries_match_serial_baseline[naive_baseline] PASSED
tests/test_concurrency_regression.py::test_concurrent_queries_match_serial_baseline[agentic_full] PASSED
tests/test_concurrency_regression.py::test_bm25_cache_stable_under_concurrent_first_touch PASSED
============================== 3 passed in 2.17s ===============================
```

## 5. Eval impact

모두 `·` — test-only 변경, 검색 / verifier / 답변 / eval 동작 영향 없음.

### 5b. Real-data delta

No behavior change in retrieval / verifier / answer / ingestion / api / eval path. 신규 파일은 pytest 모듈 + docs/operations markdown.

## 6. Backward compatibility

영향 없음. 신규 테스트, 신규 doc.

## 7. Out of scope

- Process-pool / uvicorn-worker concurrency 벤치는 F4 (capacity bench, follow-up issue) 영역
- `get_or_build_bm25` 의 lock-based hardening — 현재 setdefault-deterministic 패턴으로 충분하고 테스트가 그것을 pin

