### PR TITLE
feat(hooks): gh pr create stacked guard (closes #865)

### DIFF
--- a/scripts/claude-hooks/pretooluse-bash-guard.sh
+++ b/scripts/claude-hooks/pretooluse-bash-guard.sh
@@ -2,11 +2,21 @@
 # Claude Code PreToolUse hook for BidMate-DocAgent — Bash matcher.
 #
 # Registered in `.claude/settings.json` with matcher `Bash`. Fires before
-# Claude runs any Bash command. Refuses `gh pr merge --delete-branch`
-# when the target branch has open stacked dependents (i.e. open PRs
-# whose `base` is this branch). Auto-enforces the policy stated in
-# CLAUDE.md `## Prohibited` after the PR #423 → #431 and PR #470
-# stacked-PR auto-close incidents.
+# Claude runs any Bash command. Two responsibilities:
+#
+#   (1) Refuses `gh pr merge --delete-branch` when the target branch has
+#       open stacked dependents (i.e. open PRs whose `base` is this
+#       branch). Auto-enforces the policy stated in CLAUDE.md
+#       `## Prohibited` after the PR #423 → #431 and PR #470 stacked-PR
+#       auto-close incidents.
+#
+#   (2) Refuses `gh pr create` (without `--base <branch>`) when the
+#       current branch appears to be stacked on another open PR's
+#       branch — i.e. when an `origin/<other-branch>` ref exists whose
+#       merge-base with HEAD is *ahead of* `origin/main`. Issue #826
+#       Hook B (split into #865): a 5-PR stack audit found multiple
+#       cases where a stacked PR was opened against `main` instead of
+#       its upstream branch, collapsing the stack base.
 #
 # Behavior:
 #   - exit 0  : safe / not applicable / fail-open
@@ -33,11 +43,15 @@ try:
 except Exception:
     pass' 2>/dev/null)
 
-# Fast path: not a destructive gh merge.
+# Fast path: empty command.
 if [[ -z "$cmd" ]]; then
   exit 0
 fi
-is_merge_cmd=$(printf '%s' "$cmd" | python3 -c '
+
+# Classify the gh subcommand once: "merge" | "create" | "".
+# We split on shell separators so `foo && gh pr create …` is still caught,
+# but anything inside quotes or comments is preserved by shlex.
+gh_subcommand=$(printf '%s' "$cmd" | python3 -c '
 import sys, shlex, re
 for part in re.split(r"[;&|\n]", sys.stdin.read()):
     part = part.strip().lstrip("(")
@@ -45,12 +59,103 @@ for part in re.split(r"[;&|\n]", sys.stdin.read()):
         tokens = shlex.split(part)
     except ValueError:
         continue
-    if len(tokens) >= 3 and tokens[0] == "gh" and tokens[1] == "pr" and tokens[2] == "merge":
-        print("yes"); break
+    if len(tokens) >= 3 and tokens[0] == "gh" and tokens[1] == "pr":
+        if tokens[2] in ("merge", "create"):
+            print(tokens[2]); break
 ' 2>/dev/null)
-if [[ "$is_merge_cmd" != "yes" ]]; then
+
+if [[ -z "$gh_subcommand" ]]; then
   exit 0
 fi
+
+# --- Branch (2): gh pr create stacked guard (#826 Hook B / #865) ---
+if [[ "$gh_subcommand" == "create" ]]; then
+  # Bypass: explicit --base is intentional. Catches both `--base X` and
+  # `--base=X` forms. `--base main` is the documented escape for
+  # "I really do want to flatten this onto main."
+  has_base=$(printf '%s' "$cmd" | python3 -c '
+import sys, shlex, re
+for part in re.split(r"[;&|\n]", sys.stdin.read()):
+    part = part.strip().lstrip("(")
+    try:
+        tokens = shlex.split(part)
+    except ValueError:
+        continue
+    if len(tokens) >= 3 and tokens[0] == "gh" and tokens[1] == "pr" and tokens[2] == "create":
+        if any(t == "--base" or t.startswith("--base=") for t in tokens[3:]):
+            print("yes"); break
+' 2>/dev/null)
+  if [[ "$has_base" == "yes" ]]; then
+    exit 0
+  fi
+
+  mb_main=$(git merge-base HEAD origin/main 2>/dev/null || true)
+  if [[ -z "$mb_main" ]]; then
+    # No origin/main ref locally (fresh clone, weird worktree). Fail open
+    # — the live `gh pr create` will likely fail too with a clearer error.
+    exit 0
+  fi
+
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  stacked_on=""
+  # Walk every local origin/* ref. We use refs that the user has already
+  # fetched — this is what `gh pr create` would see anyway. Each refers
+  # to an open or recently-closed PR branch.
+  while IFS= read -r ref; do
+    [[ -z "$ref" ]] && continue
+    case "$ref" in
+      origin/HEAD|origin/main|origin/master) continue ;;
+    esac
+    if [[ -n "$current_branch" && "$ref" == "origin/$current_branch" ]]; then
+      continue
+    fi
+    mb_other=$(git merge-base HEAD "$ref" 2>/dev/null || true)
+    if [[ -z "$mb_other" || "$mb_other" == "$mb_main" ]]; then
+      continue
+    fi
+    # mb_other ≠ mb_main, and mb_main is an ancestor of mb_other → mb_other
+    # sits on the path from main toward HEAD, i.e. our branch forks off
+    # `$ref` at a point that is ahead of `origin/main`. That's a stack.
+    if git merge-base --is-ancestor "$mb_main" "$mb_other" 2>/dev/null; then
+      stacked_on="${ref#origin/}"
+      break
+    fi
+  done < <(git for-each-ref refs/remotes/origin --format='%(refname:short)' 2>/dev/null)
+
+  if [[ -z "$stacked_on" ]]; then
+    # Branch forks off main (or off a branch we don't have a remote ref
+    # for, which gh pr create can't target anyway). Allow.
+    exit 0
+  fi
+
+  printf '%s|blocked|gh-pr-create-stacked|%s|on=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$current_branch" "$stacked_on" \
+    >> "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
+
+  cat >&2 <<EOF
+⛔ Refusing \`gh pr create\` without \`--base\`: current branch is stacked.
+
+    Branch \`$current_branch\` was forked from \`$stacked_on\` (an open
+    PR's head branch), not directly from \`main\`. Running \`gh pr create\`
+    without \`--base\` opens this PR against \`main\`, which silently
+    collapses the stack base and (on merge) auto-closes \`$stacked_on\`
+    once \`$current_branch\` lands.
+
+    Two recovery options:
+      (a) Add \`--base $stacked_on\` so the PR targets its real upstream:
+              gh pr create --base $stacked_on ...
+      (b) If you actually want this PR off main (intentional flatten),
+          pass \`--base main\` explicitly to silence this guard:
+              gh pr create --base main ...
+
+    Policy: stacked-PR discipline (project MEMORY.md feedback_pr_discipline).
+    Precedent: PR #423 → #431, PR #470 — auto-close of stacked dependents
+               when the base PR merged with --delete-branch.
+EOF
+  exit 2
+fi
+
+# --- Branch (1): gh pr merge --delete-branch stacked-dependent guard ---
 if ! grep -qE -- '--delete-branch' <<<"$cmd"; then
   exit 0
 fi

--- a/tests/test_hook_pretooluse_bash_guard.py
+++ b/tests/test_hook_pretooluse_bash_guard.py
@@ -1,0 +1,246 @@
+"""Regression: PreToolUse bash-guard hook (issue #826 Hook B / #865).
+
+Exercises the two responsibilities of
+``scripts/claude-hooks/pretooluse-bash-guard.sh``:
+
+  - **Branch (1)** ``gh pr merge --delete-branch``: smoke-regression that
+    other gh commands fall through to ``exit 0`` (the deep merge audit
+    requires a real ``gh`` and is exercised by the original PR #423→#431
+    incident; not re-asserted here).
+  - **Branch (2)** ``gh pr create`` stacked guard (issue #865): the core
+    surface added in this PR. Builds a real temp git repo, fakes
+    ``refs/remotes/origin/*`` via ``git update-ref``, and verifies the
+    block / allow matrix.
+
+The hook is copied into a per-test temp ``REPO_ROOT`` so
+``.hook-fires.log`` writes are isolated from the developer's machine.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+HOOK = REPO / "scripts" / "claude-hooks" / "pretooluse-bash-guard.sh"
+
+_GIT_ENV: dict[str, str] = {
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+class TestPreToolUseBashGuard(unittest.TestCase):
+    """Behavioral contract for the bash-guard PreToolUse hook."""
+
+    def setUp(self) -> None:
+        # Mirror the production layout (scripts/claude-hooks/ under a
+        # repo root) so the hook's ``REPO_ROOT`` resolution and
+        # ``.hook-fires.log`` writes target this temp tree.
+        self._tmp = tempfile.mkdtemp()
+        self._tmp_repo = Path(self._tmp) / "repo"
+        (self._tmp_repo / ".claude").mkdir(parents=True)
+        (self._tmp_repo / "scripts" / "claude-hooks").mkdir(parents=True)
+        shutil.copy(HOOK, self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name)
+        self._hook = self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name
+        self._fires_log = self._tmp_repo / ".claude" / ".hook-fires.log"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def _git(self, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+        env = {**os.environ, **_GIT_ENV}
+        return subprocess.run(
+            ["git", "-C", str(self._tmp_repo), *args],
+            check=check, capture_output=True, text=True, env=env,
+        )
+
+    def _commit(self, name: str, content: str = "x") -> str:
+        (self._tmp_repo / name).write_text(content)
+        self._git("add", name)
+        self._git("commit", "-m", name)
+        return self._git("rev-parse", "HEAD").stdout.strip()
+
+    def _set_origin_ref(self, branch: str, sha: str) -> None:
+        """Fake ``origin/<branch>`` without an actual remote."""
+        self._git("update-ref", f"refs/remotes/origin/{branch}", sha)
+
+    def _init_repo(self) -> str:
+        """Seed a repo with main = M1 and ``refs/remotes/origin/main``."""
+        # ``-b main`` makes the initial branch ``main`` regardless of the
+        # user's git defaultBranch config.
+        subprocess.run(
+            ["git", "init", "-b", "main", str(self._tmp_repo)],
+            check=True, capture_output=True,
+            env={**os.environ, **_GIT_ENV},
+        )
+        m1 = self._commit("m1.txt", "m1")
+        self._set_origin_ref("main", m1)
+        return m1
+
+    def _run(self, command: str) -> subprocess.CompletedProcess:
+        payload = {"tool_input": {"command": command}}
+        return subprocess.run(
+            ["bash", str(self._hook)],
+            input=json.dumps(payload), text=True,
+            capture_output=True, check=False,
+            cwd=str(self._tmp_repo),
+        )
+
+    # ------------------------------------------------------------------
+    # Pass-through cases (branch (1) / unrelated commands)
+    # ------------------------------------------------------------------
+
+    def test_non_gh_command_is_noop(self) -> None:
+        self._init_repo()
+        r = self._run("ls -la /tmp")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr, "")
+        self.assertFalse(self._fires_log.exists())
+
+    def test_other_gh_subcommand_is_noop(self) -> None:
+        """``gh repo view`` / ``gh issue list`` etc. fall through."""
+        self._init_repo()
+        r = self._run("gh repo view hskim-solv/BidMate-DocAgent")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr, "")
+
+    def test_gh_pr_merge_without_delete_branch_is_noop(self) -> None:
+        """``gh pr merge --squash`` (no --delete-branch) falls through."""
+        self._init_repo()
+        r = self._run("gh pr merge 999 --squash")
+        self.assertEqual(r.returncode, 0)
+
+    def test_empty_command_is_noop(self) -> None:
+        r = subprocess.run(
+            ["bash", str(self._hook)],
+            input=json.dumps({"tool_input": {"command": ""}}),
+            text=True, capture_output=True, check=False,
+            cwd=str(self._tmp_repo),
+        )
+        self.assertEqual(r.returncode, 0)
+
+    # ------------------------------------------------------------------
+    # gh pr create — explicit --base bypasses the guard
+    # ------------------------------------------------------------------
+
+    def test_create_with_explicit_base_branch_is_allowed(self) -> None:
+        """``gh pr create --base feat/A …`` — explicit stack target."""
+        self._init_repo()
+        r = self._run("gh pr create --base feat/A --title T --body B")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr, "")
+
+    def test_create_with_base_equals_form_is_allowed(self) -> None:
+        """``gh pr create --base=feat/A`` (equals form)."""
+        self._init_repo()
+        r = self._run("gh pr create --base=feat/A --title T")
+        self.assertEqual(r.returncode, 0)
+
+    def test_create_with_explicit_base_main_is_allowed(self) -> None:
+        """``--base main`` is the documented escape for intentional flatten."""
+        m1 = self._init_repo()
+        self._git("checkout", "-b", "feat/A")
+        a1 = self._commit("a1.txt", "a1")
+        self._set_origin_ref("feat/A", a1)
+        self._git("checkout", "-b", "feat/B")
+        self._commit("b1.txt", "b1")
+        # Even though feat/B is stacked on feat/A, --base main flattens.
+        r = self._run("gh pr create --base main --title T")
+        self.assertEqual(r.returncode, 0)
+
+    # ------------------------------------------------------------------
+    # gh pr create — branch shape decides block vs allow
+    # ------------------------------------------------------------------
+
+    def test_create_on_branch_forked_off_main_is_allowed(self) -> None:
+        """Branch directly off main — no stack, no block."""
+        self._init_repo()
+        self._git("checkout", "-b", "feat/issue-1-foo")
+        self._commit("f1.txt", "f1")
+        r = self._run("gh pr create --title T --body B")
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertEqual(r.stderr, "")
+
+    def test_create_on_stacked_branch_is_blocked(self) -> None:
+        """Branch forked off another open PR's branch — must block."""
+        self._init_repo()
+        # PR A: feat/A off main
+        self._git("checkout", "-b", "feat/A")
+        a1 = self._commit("a1.txt", "a1")
+        self._set_origin_ref("feat/A", a1)
+        # PR B: feat/B off feat/A (the stacking)
+        self._git("checkout", "-b", "feat/B")
+        self._commit("b1.txt", "b1")
+        r = self._run("gh pr create --title T --body B")
+        self.assertEqual(r.returncode, 2, msg=r.stderr)
+        self.assertIn("stacked", r.stderr.lower())
+        self.assertIn("feat/A", r.stderr)
+        # Hook fires log records the block.
+        self.assertTrue(self._fires_log.exists())
+        line = self._fires_log.read_text().strip()
+        self.assertIn("|blocked|gh-pr-create-stacked|", line)
+        self.assertIn("on=feat/A", line)
+
+    def test_block_message_quotes_recovery_options(self) -> None:
+        """Operator-facing rationale must surface both recovery paths."""
+        self._init_repo()
+        self._git("checkout", "-b", "feat/A")
+        a1 = self._commit("a1.txt", "a1")
+        self._set_origin_ref("feat/A", a1)
+        self._git("checkout", "-b", "feat/B")
+        self._commit("b1.txt", "b1")
+        r = self._run("gh pr create")
+        self.assertEqual(r.returncode, 2)
+        # Both escape hatches must be discoverable from the stderr alone.
+        self.assertIn("--base feat/A", r.stderr)
+        self.assertIn("--base main", r.stderr)
+
+    def test_create_without_origin_main_ref_fails_open(self) -> None:
+        """Fresh clone / worktree with no origin/main → don't block."""
+        # Init repo but skip setting refs/remotes/origin/main.
+        subprocess.run(
+            ["git", "init", "-b", "main", str(self._tmp_repo)],
+            check=True, capture_output=True,
+            env={**os.environ, **_GIT_ENV},
+        )
+        self._commit("m1.txt", "m1")
+        r = self._run("gh pr create --title T --body B")
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+
+    def test_create_when_only_origin_main_exists_is_allowed(self) -> None:
+        """Single origin ref = main → no other branches to be stacked on."""
+        self._init_repo()
+        # We're still on main; pretend a feature branch has been created
+        # without any other origin/* refs around. No stack possible.
+        self._git("checkout", "-b", "feat/X")
+        self._commit("x.txt", "x")
+        r = self._run("gh pr create --title T")
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+
+    def test_create_with_compound_shell_command_is_caught(self) -> None:
+        """``foo && gh pr create`` chained commands are also subject to the guard."""
+        self._init_repo()
+        self._git("checkout", "-b", "feat/A")
+        a1 = self._commit("a1.txt", "a1")
+        self._set_origin_ref("feat/A", a1)
+        self._git("checkout", "-b", "feat/B")
+        self._commit("b1.txt", "b1")
+        # Compound command: the shlex-split in the hook walks each `;|&` part.
+        r = self._run("echo starting && gh pr create --title T --body B")
+        self.assertEqual(r.returncode, 2, msg=r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 변경 내용 및 이유

`scripts/claude-hooks/pretooluse-bash-guard.sh` 는 그동안 단일 책임 — stacked dependent 존재 시 `gh pr merge --delete-branch` 거부 (#423→#431 인시던트 후) — 만 갖고 있었다. 이 PR 은 **issue #826 의 Hook B** 를 같은 훅의 두번째 branch 로 추가: 현재 브랜치가 다른 open PR 위에 stack 되어 있을 때 `--base` 없는 `gh pr create` 거부.

Stack 탐지: `refs/remotes/origin/*` 순회하며 `HEAD` 와의 merge-base 가 `origin/main` 보다 *앞선* ref 찾기. 발견되면 현재 브랜치는 main 이 아닌 그 ref 에서 분기된 것 — `--base` 없이 PR 열면 조용히 `main` 을 target 하고 (`--delete-branch` 머지 시) dependent PR 을 auto-close.

Closes #865

## 2. 영향 파일

- `scripts/claude-hooks/pretooluse-bash-guard.sh` — 리팩토링: 공유 subcommand classifier + 신규 `gh pr create` branch (~80 LOC 추가).
- `tests/test_hook_pretooluse_bash_guard.py` — **신규**, 13 unittest 케이스 (pass-through, explicit-base 두 형태, 브랜치 형태 탐지, fail-open, compound shell 명령).

## 3. 리스크

- **rebased 브랜치 false positive**: 개발자가 실수로 동료의 open PR 위에 rebase 한 경우, 훅이 이제 `gh pr create` 차단. 우회는 stderr 에 문서화 — `--base <upstream>` (의도) 또는 `--base main` (명시적 flatten) 전달.
- **프로덕션 롤아웃 리스크 없음**: PreToolUse Bash 훅. 모호한 모든 곳에서 fail-open (`origin/main` ref 없음, 잘못된 shell 명령). 기존 `gh pr merge --delete-branch` branch 미변경.

## 4. 테스트

`pytest tests/test_hook_pretooluse_bash_guard.py tests/test_pretooluse_memory_lines_hook_regression.py tests/test_hook_commit_msg.py tests/test_plan_slug_race_hook_regression.py tests/test_smoke_hooks_dependency_regression.py -q` → **39 passed** (신규 13 + 인접 훅 26).

신규 13 케이스:
- pass-through 4 (non-gh, 다른 gh subcommand, delete-branch 없는 `gh pr merge --squash`, 빈 명령)
- 명시적 `--base` 3 (feat/A space form, equals form, stacked 브랜치 main flatten)
- stacked-detection 2 (차단 + stderr 메시지)
- unstacked 2 (main 분기, origin/main 만 존재)
- fail-open 1 (origin/main ref 없음)
- compound shell 1 (`echo … && gh pr create`)

## 5. Eval 영향

CI eval delta: **전부 `·` 예상**. 훅 전용 변경. 검색, verifier, embedding, 수집 경로 미터치.

### 5b. Real-data delta

No behavior change in retrieval / verifier path. PR 은 PreToolUse 훅 스크립트 + 테스트 파일만 수정. 훅은 tool 실행 *전* 발화; runtime 측정에 영향 불가.

## 6. 하위 호환성

- `gh pr merge --delete-branch` stacked-dependent 감사 미변경 — 동일 regex, 동일 `--delete-branch` gate, 동일 dependent 리스팅.
- `gh pr create --base <X>` (명시 base) 동작 미변경 — 신규 branch 는 `--base` 존재 시 즉시 exit 0.
- 기존 `.hook-fires.log` line 포맷 (`<ts>|blocked|gh-merge-delete-branch|<head>`) 미변경. 신규 이벤트는 `<ts>|blocked|gh-pr-create-stacked|<branch>|on=<upstream>` 로 로깅 — rolling-window summary 가 자동 picking 하는 신규 fire-type.

## 7. Out of scope

- #826 의 Hook C (PreToolUse ADR template Verification injection) — #866 에서 별도 추적.
- 개발자별 override env (`BIDMATE_BASH_GUARD=off` 등) — fail-open 동작이 이미 필요한 escape hatch 커버.
