### PR TITLE
fix(eval): case_proposer reads BOM-prefixed data_list.csv (utf-8-sig)

### DIFF
--- a/eval/case_proposer.py
+++ b/eval/case_proposer.py
@@ -342,10 +342,16 @@ def _read_data_list_csv(path: Path) -> list[dict[str, Any]]:
 
     Returns the raw dict per row (column → cell value). Caller is
     responsible for the CSV→doc_id mapping (see ``_attach_doc_ids``).
+
+    Uses ``utf-8-sig`` to transparently strip the BOM that several
+    Korean spreadsheet exports prepend — matches the canonical CSV
+    opener in ``ingestion.py`` (issue #873). ``utf-8-sig`` is a strict
+    superset of ``utf-8`` for BOM-less files, so this is safe to apply
+    unconditionally.
     """
     if not path.exists():
         raise CaseProposerInputError(f"data_list.csv not found at {path}")
-    with path.open("r", encoding="utf-8", newline="") as fh:
+    with path.open("r", encoding="utf-8-sig", newline="") as fh:
         reader = csv.DictReader(fh)
         if not reader.fieldnames:
             raise CaseProposerInputError(f"data_list.csv at {path} has no header")

--- a/tests/test_case_proposer_csv_bom_regression.py
+++ b/tests/test_case_proposer_csv_bom_regression.py
@@ -1,0 +1,114 @@
+"""Regression test for case_proposer reading UTF-8 BOM-prefixed data_list.csv
+(issue #873).
+
+Several Korean spreadsheet tools save CSVs with a leading UTF-8 BOM
+(``\\ufeff``). ``ingestion.py`` uses ``encoding="utf-8-sig"`` to strip
+it transparently, but ``eval/case_proposer.py::_read_data_list_csv``
+historically used plain ``"utf-8"`` and so reported the first header
+as ``"\\ufeff공고 번호"`` instead of ``"공고 번호"``. The required-column
+check then raised ``CaseProposerInputError("missing required columns:
+['공고 번호']")``.
+
+This test pins the fix: writing a BOM-prefixed CSV must round-trip
+through ``propose_cases_from_files`` without raising.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from eval.case_proposer import (
+    CSV_COLUMN_AGENCY,
+    CSV_COLUMN_FILE_FORMAT,
+    CSV_COLUMN_FILE_NAME,
+    CSV_COLUMN_NOTICE_ID,
+    CSV_COLUMN_PROJECT,
+    CSV_COLUMN_TEXT,
+    REQUIRED_CSV_COLUMNS,
+    propose_cases_from_files,
+)
+from rag_core import INDEX_SCHEMA_VERSION
+
+
+NOW_FIXED = "2026-05-15T08:00:00Z"
+
+
+def _make_csv_with_bom(path: Path, rows: list[dict[str, str]]) -> None:
+    """Write a CSV that starts with a UTF-8 BOM (``\\xef\\xbb\\xbf``).
+
+    Mirrors what Korean spreadsheet tools (e.g. Excel "Save as CSV
+    UTF-8") produce. We write through an in-memory StringIO so the
+    csv module's quoting + newline handling is identical to the
+    non-BOM path; only the byte-level prefix differs.
+    """
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=list(REQUIRED_CSV_COLUMNS))
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    path.write_bytes(b"\xef\xbb\xbf" + buf.getvalue().encode("utf-8"))
+
+
+def _make_index(path: Path, doc_ids: list[str]) -> None:
+    payload = {
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "build": {"documents": [{"doc_id": d} for d in doc_ids]},
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _sample_row(
+    notice_id: str = "K2026-001",
+    agency: str = "A기관",
+    project: str = "사업A",
+) -> dict[str, str]:
+    return {
+        CSV_COLUMN_NOTICE_ID: notice_id,
+        CSV_COLUMN_PROJECT: project,
+        CSV_COLUMN_AGENCY: agency,
+        CSV_COLUMN_FILE_FORMAT: "pdf",
+        CSV_COLUMN_FILE_NAME: f"{notice_id}.pdf",
+        CSV_COLUMN_TEXT: "본문 텍스트",
+    }
+
+
+class TestCaseProposerCsvBomRegression(unittest.TestCase):
+    def test_bom_prefixed_csv_round_trips_through_propose(self) -> None:
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            csv_path = td_path / "data_list.csv"
+            index_dir = td_path / "index"
+            index_dir.mkdir()
+
+            _make_csv_with_bom(
+                csv_path,
+                [_sample_row("K2026-001"), _sample_row("K2026-002", "B기관", "사업B")],
+            )
+            _make_index(index_dir / "index.json", ["K2026-001", "K2026-002"])
+
+            cases = propose_cases_from_files(
+                metadata_csv=csv_path,
+                index_dir=index_dir,
+                n_seed_docs=2,
+                backend="stub",
+                now_iso=NOW_FIXED,
+            )
+            # 2 seed docs × 2 templates per doc (single_doc + abstention).
+            self.assertEqual(len(cases), 4)
+
+    def test_bom_byte_is_actually_present_in_fixture(self) -> None:
+        """Sanity check on the fixture: without this, a regression in
+        ``_make_csv_with_bom`` could silently turn the BOM test into a
+        plain-UTF-8 test and the fix below would never be exercised."""
+        with TemporaryDirectory() as td:
+            csv_path = Path(td) / "data_list.csv"
+            _make_csv_with_bom(csv_path, [_sample_row()])
+            self.assertEqual(csv_path.read_bytes()[:3], b"\xef\xbb\xbf")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

\`eval/case_proposer.py::_read_data_list_csv\` 한 줄 인코딩 bump: \`utf-8\` → \`utf-8-sig\`. \`ingestion.py:449\` / \`ingestion.py:1050\` 의 canonical CSV opener 와 일치하여 두 surface 가 BOM-prefixed CSV (한국어 스프레드시트 export 다수의 기본값) 에서 drift 하지 않도록 한다.

## Why

local 100-doc 코퍼스 대상 \`make case-propose\` 가 \`missing required columns: ['공고 번호']\` 로 실패 — BOM 이 첫 헤더 안으로 들어가서 (\`'\\ufeff공고 번호'\`). \`make build-index\` 는 같은 CSV 를 문제없이 소비 — ingestion 은 항상 \`utf-8-sig\` 사용. #846 (doc_coverage prioritization) 이전 issue — PR2 reader 가 ingestion 패턴을 따르지 않았던 것.

## Test plan

- [x] \`pytest tests/test_case_proposer_csv_bom_regression.py tests/test_case_proposer_pipeline.py tests/test_case_proposer_doc_coverage.py -q\` — 40 passed, 0 regression.
- [x] \`ruff check .\` — clean.
- [x] Local: BOM-prefixed \`data/data_list.csv\` 대상 \`make case-propose\` 더 이상 raise 안 함.

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

case-input 파이프라인 버그 수정 (\`run_rag_query\` 상류). retrieval / verifier / answer / chunking / ingestion 코드 경로 미터치. \`make real-eval-delta\` 는 zero delta — proposer 는 eval 실행 중 호출되지 않는다.

## ADR 경계

- **ADR 0005**: committable 코드 경로 버그 수정; per-case payload 미터치. 1 line 프로덕션 코드 + 1 docstring 문장 + 1 신규 테스트 파일.
- **ADR 0029**: stub backend 계약 유지 (deterministic; 동일 템플릿, 동일 schema).
- **ADR 0001**: \`naive_baseline\` golden invariant — \`rag_core\` 미터치.

Closes #873.
