### PR TITLE
feat(hooks): PreToolUse refuses new ADR Write without Verification (closes #866)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "bash scripts/claude-hooks/pretooluse-memory-lines.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/claude-hooks/pretooluse-adr-template.sh"
           }
         ]
       },

--- a/scripts/claude-hooks/pretooluse-adr-template.sh
+++ b/scripts/claude-hooks/pretooluse-adr-template.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook for BidMate-DocAgent — ADR Verification template.
+#
+# Registered in `.claude/settings.json` with matcher `Edit|MultiEdit|Write`.
+# Fires before Claude writes/edits a file. Refuses Write calls that create
+# a *new* ADR file (``docs/adr/<NNNN>-*.md``) whose payload does not include
+# the ``## Verification`` H2 section + at least one
+# ``<!-- verifies-key: path:key -->`` marker.
+#
+# Why this exists (issue #826 Hook C / #866):
+#   - ``scripts/_governance.py::lint_adr_verification`` already blocks the
+#     same shape at pre-commit. But by the time pre-commit fires, the ADR
+#     draft is fully written. The reject costs one round-trip + manual
+#     re-edit + re-stage.
+#   - This PreToolUse hook short-circuits at *write time* with the
+#     template body inlined in stderr, so Claude amends in the same
+#     turn it created the file.
+#
+# Scope (intentional narrowness):
+#   - Only fires on Write payloads whose ``file_path`` matches the ADR
+#     filename pattern AND whose target file does NOT yet exist (i.e.
+#     genuine new ADRs, not edits to existing ones).
+#   - Existing ADRs are grandfathered by the same convention as the
+#     pre-commit lint (``--diff-filter=A`` only).
+#   - Edit / MultiEdit on existing files: pass through. The pre-commit
+#     lint is still the authoritative gate.
+#
+# Behavior:
+#   - exit 0  : safe / not applicable / fail-open
+#   - exit 2  : refuse the Write, print template + rationale to stderr
+#
+# Hook input (stdin, JSON):
+#   { "tool_name": "Write",
+#     "tool_input": { "file_path": "...", "content": "..." }, ... }
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+input=$(cat)
+
+# Parse tool_name + file_path + content in one python pass so we don't
+# pay JSON-decode three times. Empty defaults short-circuit downstream
+# without error handling boilerplate.
+parsed=$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(0)
+tool = d.get("tool_name", "")
+ti = d.get("tool_input", {}) or {}
+fp = ti.get("file_path", "") or ""
+content = ti.get("content", "") or ""
+# Print fp on line 1, tool on line 2, content length on line 3, then content.
+# Content can have newlines, so put it last and pass through verbatim.
+print(fp)
+print(tool)
+print(len(content))
+sys.stdout.write(content)
+' 2>/dev/null)
+
+file_path=$(printf '%s' "$parsed" | sed -n '1p')
+tool_name=$(printf '%s' "$parsed" | sed -n '2p')
+
+# Fast path: not a Write tool — Edit / MultiEdit on existing files are
+# the pre-commit lint's domain.
+if [[ "$tool_name" != "Write" ]]; then
+  exit 0
+fi
+
+# Fast path: not an ADR filename. Match either an absolute path containing
+# ``docs/adr/<NNNN>-*.md`` or a repo-relative path starting with
+# ``docs/adr/...``. The 4-digit prefix mirrors the established ADR
+# numbering (``docs/adr/_template.md`` is intentionally excluded by the
+# ``[0-9]{4}`` requirement).
+if ! [[ "$file_path" =~ docs/adr/[0-9]{4}-[a-z0-9-]+\.md$ ]]; then
+  exit 0
+fi
+
+# Fast path: file already exists → it's an edit/rewrite of an existing
+# ADR. Out of scope (grandfathered, like the pre-commit lint).
+if [[ -e "$file_path" ]]; then
+  exit 0
+fi
+
+# Extract the content payload from the parsed multi-line blob. The first
+# 3 lines are metadata; the rest is the file content.
+content=$(printf '%s' "$parsed" | tail -n +4)
+
+# Required markers (mirrors scripts/_governance.py::lint_adr_verification
+# regexes verbatim — keep them in sync if either changes). We reuse the
+# Python re module here so the whitespace tolerance is identical to the
+# pre-commit lint (grep -E and the governance regex don't quite agree on
+# ``[[:space:]]`` around the path:key separator).
+checks=$(printf '%s' "$content" | python3 -c '
+import re, sys
+text = sys.stdin.read()
+section_re = re.compile(r"^##\s+Verification\s*$", re.MULTILINE)
+marker_re = re.compile(
+    r"<!--\s*verifies-key:\s*([^\s:][^:]*?)\s*:\s*([^\s>][^>]*?)\s*-->"
+)
+print("section=" + ("yes" if section_re.search(text) else "no"))
+print("marker=" + ("yes" if marker_re.search(text) else "no"))
+' 2>/dev/null)
+
+has_section="no"
+has_marker="no"
+case "$checks" in
+  *"section=yes"*) has_section="yes" ;;
+esac
+case "$checks" in
+  *"marker=yes"*) has_marker="yes" ;;
+esac
+
+if [[ "$has_section" == "yes" && "$has_marker" == "yes" ]]; then
+  exit 0
+fi
+
+# Render block reason for the .hook-fires.log row.
+missing=""
+[[ "$has_section" == "no" ]] && missing="section"
+[[ "$has_marker" == "no" ]] && missing="${missing:+${missing},}marker"
+
+adr_basename=$(basename "$file_path")
+printf '%s|blocked|adr-template|%s|missing=%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$adr_basename" "$missing" \
+  >> "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
+
+cat >&2 <<EOF
+⛔ Refusing Write of new ADR \`$adr_basename\`: missing Verification surface.
+
+    Missing: $missing
+    Required (mirrors scripts/_governance.py::lint_adr_verification):
+
+      ## Verification
+
+      <!-- verifies-key: <relative-path>:<key-substring> -->
+
+    Why: ADRs without a machine-checkable claim degrade into Decision
+    Theatre — the commitment is written down, then nothing measures
+    whether it held. The marker creates a two-way circuit: the pre-commit
+    lint walks each marker and confirms the key substring exists in the
+    referenced file. Add the marker BEFORE this Write or the pre-commit
+    lint will reject on commit anyway (with one extra round-trip).
+
+    Examples of valid markers (existing accepted ADRs):
+
+      <!-- verifies-key: scripts/_governance.py:LOAD_BEARING_PATHS -->
+      <!-- verifies-key: rag_indexing.py:def write_index_json -->
+      <!-- verifies-key: tests/test_governance.py:test_no_unlinked_adr_files_on_disk -->
+
+    Template: docs/adr/_template.md
+    Policy: ADR Verification surface (issue #793 B3 fix).
+    Bypass: this is a PreToolUse hook — re-run Write with the surface
+            included. If you genuinely have no machine-checkable claim,
+            mark the ADR ``Status: Proposed (plan-only)`` and add a
+            marker pointing at the plan document itself.
+EOF
+exit 2

--- a/tests/test_hook_pretooluse_adr_template.py
+++ b/tests/test_hook_pretooluse_adr_template.py
@@ -1,0 +1,207 @@
+"""Regression: PreToolUse ADR-template hook (issue #826 Hook C / #866).
+
+Pins the contract of ``scripts/claude-hooks/pretooluse-adr-template.sh``:
+
+  - Allow Write of any file that isn't a new ADR (other path, wrong
+    extension, existing ADR being edited).
+  - Block Write of a new ``docs/adr/<NNNN>-*.md`` when payload lacks
+    either the ``## Verification`` H2 section or any
+    ``<!-- verifies-key: path:key -->`` marker.
+  - Pass when payload has both, even minimally.
+  - Fall through for non-Write tools (Edit / MultiEdit / Bash).
+  - ``.hook-fires.log`` line format matches the bash-guard convention
+    so ``_self_review.py`` rolling-window summaries pick up the event.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+HOOK = REPO / "scripts" / "claude-hooks" / "pretooluse-adr-template.sh"
+
+
+_GOOD_BODY = (
+    "# ADR 9999 — Example\n\n"
+    "## Context\n\nx\n\n"
+    "## Decision\n\ny\n\n"
+    "## Verification\n\n"
+    "<!-- verifies-key: scripts/_governance.py:LOAD_BEARING_PATHS -->\n"
+)
+
+_MISSING_SECTION_BODY = (
+    "# ADR 9999 — Example\n\n"
+    "## Context\n\nx\n\n"
+    "## Decision\n\ny\n\n"
+    "<!-- verifies-key: scripts/_governance.py:LOAD_BEARING_PATHS -->\n"
+)
+
+_MISSING_MARKER_BODY = (
+    "# ADR 9999 — Example\n\n"
+    "## Context\n\nx\n\n"
+    "## Decision\n\ny\n\n"
+    "## Verification\n\n"
+    "Will be filled in when G2 lands.\n"
+)
+
+
+class TestPreToolUseAdrTemplate(unittest.TestCase):
+    """Contract for the new-ADR Write-time Verification guard."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp()
+        self._tmp_repo = Path(self._tmp) / "repo"
+        (self._tmp_repo / ".claude").mkdir(parents=True)
+        (self._tmp_repo / "scripts" / "claude-hooks").mkdir(parents=True)
+        (self._tmp_repo / "docs" / "adr").mkdir(parents=True)
+        shutil.copy(HOOK, self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name)
+        self._hook = self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name
+        self._fires_log = self._tmp_repo / ".claude" / ".hook-fires.log"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _run(
+        self,
+        *,
+        tool_name: str = "Write",
+        file_path: str | Path = "docs/adr/9999-example.md",
+        content: str = _GOOD_BODY,
+    ) -> subprocess.CompletedProcess:
+        payload = {
+            "tool_name": tool_name,
+            "tool_input": {"file_path": str(file_path), "content": content},
+        }
+        return subprocess.run(
+            ["bash", str(self._hook)],
+            input=json.dumps(payload), text=True,
+            capture_output=True, check=False,
+            cwd=str(self._tmp_repo),
+        )
+
+    # ------------------------------------------------------------------
+    # Pass-through cases
+    # ------------------------------------------------------------------
+
+    def test_non_write_tool_is_noop(self) -> None:
+        """Edit / MultiEdit on existing files: pre-commit lint's domain."""
+        r = self._run(tool_name="Edit",
+                      file_path=self._tmp_repo / "docs" / "adr" / "9999-x.md",
+                      content="")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr, "")
+
+    def test_non_adr_path_is_noop(self) -> None:
+        r = self._run(file_path="src/foo.py", content="print('hi')\n")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr, "")
+
+    def test_adr_directory_but_non_numbered_filename_is_noop(self) -> None:
+        """``docs/adr/_template.md`` and ``docs/adr/README.md`` are exempt."""
+        for name in ("_template.md", "README.md", "_my-notes.md"):
+            with self.subTest(name=name):
+                r = self._run(file_path=f"docs/adr/{name}",
+                              content="anything\n")
+                self.assertEqual(r.returncode, 0)
+
+    def test_existing_adr_file_is_passthrough(self) -> None:
+        """An ADR file already on disk = edit, not a new ADR. Pass through."""
+        adr = self._tmp_repo / "docs" / "adr" / "9000-already-there.md"
+        adr.write_text("stale body\n")
+        r = self._run(file_path=adr, content="rewritten body\n")
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertEqual(r.stderr, "")
+
+    def test_empty_command_payload_is_noop(self) -> None:
+        """Malformed / empty JSON should fail-open per hook contract."""
+        r = subprocess.run(
+            ["bash", str(self._hook)],
+            input="{}", text=True, capture_output=True, check=False,
+            cwd=str(self._tmp_repo),
+        )
+        self.assertEqual(r.returncode, 0)
+
+    # ------------------------------------------------------------------
+    # Block cases
+    # ------------------------------------------------------------------
+
+    def test_new_adr_missing_verification_section_is_blocked(self) -> None:
+        r = self._run(content=_MISSING_SECTION_BODY)
+        self.assertEqual(r.returncode, 2, msg=r.stderr)
+        self.assertIn("Verification", r.stderr)
+        self.assertIn("section", r.stderr)
+        self.assertTrue(self._fires_log.exists())
+        line = self._fires_log.read_text().strip()
+        self.assertIn("|blocked|adr-template|", line)
+        self.assertIn("9999-example.md", line)
+        self.assertIn("missing=section", line)
+
+    def test_new_adr_missing_marker_is_blocked(self) -> None:
+        r = self._run(content=_MISSING_MARKER_BODY)
+        self.assertEqual(r.returncode, 2, msg=r.stderr)
+        self.assertIn("verifies-key", r.stderr)
+        line = self._fires_log.read_text().strip()
+        self.assertIn("missing=marker", line)
+
+    def test_new_adr_missing_both_lists_both_in_log(self) -> None:
+        r = self._run(content="# ADR 9999\n\n## Context\n\njust prose\n")
+        self.assertEqual(r.returncode, 2)
+        line = self._fires_log.read_text().strip()
+        self.assertIn("missing=section,marker", line)
+
+    def test_block_message_quotes_template(self) -> None:
+        """Operator-facing rationale must include the template inline."""
+        r = self._run(content="# ADR 9999\n\n## Context\n\nx\n")
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("## Verification", r.stderr)
+        self.assertIn("verifies-key: <relative-path>:<key-substring>", r.stderr)
+        self.assertIn("docs/adr/_template.md", r.stderr)
+
+    # ------------------------------------------------------------------
+    # Allow cases — payload is valid
+    # ------------------------------------------------------------------
+
+    def test_new_adr_with_complete_verification_is_allowed(self) -> None:
+        r = self._run(content=_GOOD_BODY)
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertEqual(r.stderr, "")
+        # No block log entry when payload is clean.
+        self.assertFalse(self._fires_log.exists())
+
+    def test_marker_recognized_with_extra_whitespace(self) -> None:
+        """Mirrors ``_governance.py::ADR_VERIFIES_KEY_RE`` flexibility."""
+        body = (
+            "## Verification\n\n"
+            "<!--   verifies-key:   scripts/_governance.py  :  LOAD_BEARING  -->\n"
+        )
+        r = self._run(content=body)
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+
+    def test_section_header_recognized_with_trailing_whitespace(self) -> None:
+        body = (
+            "## Verification   \n\n"
+            "<!-- verifies-key: x.py:y -->\n"
+        )
+        r = self._run(content=body)
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+
+    def test_absolute_file_path_works(self) -> None:
+        """``file_path`` from Claude is typically absolute. Match both."""
+        abs_path = self._tmp_repo / "docs" / "adr" / "9999-abs.md"
+        r = self._run(file_path=abs_path, content=_GOOD_BODY)
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+
+    def test_absolute_file_path_blocks_when_missing(self) -> None:
+        abs_path = self._tmp_repo / "docs" / "adr" / "9999-abs.md"
+        r = self._run(file_path=abs_path, content=_MISSING_SECTION_BODY)
+        self.assertEqual(r.returncode, 2, msg=r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #866

## Summary

`scripts/claude-hooks/pretooluse-adr-template.sh` 추가 — `Edit|MultiEdit|Write` PreToolUse 훅. Claude 가 새 `docs/adr/<NNNN>-*.md` 를 작성할 때 다음 중 하나라도 누락이면 거부:

- `## Verification` H2 섹션
- 최소 1개 이상의 `<!-- verifies-key: path:key -->` 마커

거부 메시지에 템플릿 본문 + 유효 마커 예제를 inline 으로 포함해 같은 턴에 수정하게 한다 (`git commit` 시점이 아닌).

issue #826 훅 trio 중 Hook C (Hook A = #861 write-time load-bearing, Hook B = #871 stacked PR 가드, **Hook C = ADR 템플릿 Verification**, 이 PR).

## Why now

`scripts/_governance.py::lint_adr_verification` 가 pre-commit 에서 이미 강제 (issue #793 B3). 하지만 lint 는 ADR 초안 작성 *완료 후* 발화 → 거부 → 컨텍스트 스위치 → 재편집 → 재스테이지 = ADR 누락당 round-trip 1회 낭비.

5축 #3 (자동화 ROI): Hook A/B 와 동일한 "shift left" — pre-commit 거부를 Write 시점 거부로 전환, Claude 가 inlined stderr 만으로 자가 수정.

## Scope (intentional narrowness)

- 발화 조건: `tool_name == "Write"` AND `file_path` 가 `docs/adr/[0-9]{4}-*.md` 매치 AND 대상 미존재 (= 신규 ADR 생성)
- 기존 ADR 의 Edit / MultiEdit: pass-through (pre-commit lint 가 authoritative — lint 의 `--diff-filter=A` scope 와 grandfathering 일치)
- `docs/adr/_template.md`, `docs/adr/README.md`: 파일명 regex 로 제외
- 비-Write 도구, 비-ADR 경로: `exit 0` noop

Regex parity: 마커 검출은 governance 모듈의 정확한 regex 문자열을 inline python3 로 사용 — bash `grep -E` 는 `path:key` 구분자 주변 공백 허용에 미세 차이, 테스트 (`test_marker_recognized_with_extra_whitespace`) 가 분기 포착.

## Test plan

- [x] `pytest tests/test_hook_pretooluse_adr_template.py -v` → 14/14 pass (pass-through 4 + block 4 + allow 4 (공백 허용 변형 포함) + 절대 경로 2)
- [ ] Manual: `## Verification` 누락 ADR 초안 → 훅 차단, stderr 에 템플릿 inline
- [ ] `.hook-fires.log` 라인 포맷 `<ts>|blocked|adr-template|<basename>|missing=<reasons>` 을 `_self_review.py` rolling-window 요약이 소비

### 5b. Real-data delta

No behavior change in retrieval / verifier path. retrieval / verifier / eval / ingestion / api / embedding 경로 동작 변경 없음. 이 PR 은 새 Claude Code PreToolUse 훅 스크립트 + `.claude/settings.json` 등록 + 테스트만 추가. production 코드 (`rag_*.py`, `ingestion.py`, `eval/`, `api/`) 미접촉.

## Load-bearing files

- `scripts/claude-hooks/pretooluse-adr-template.sh` (신규, +157 LOC)
- `tests/test_hook_pretooluse_adr_template.py` (신규, +207 LOC)
- `.claude/settings.json` (+5 LOC — `Edit|MultiEdit|Write` matcher 에 훅 등록)

Generated with [Claude Code](https://claude.com/claude-code)
