### PR TITLE
feat(governance): _self_review axis-5-B memory content freshness raw signal

### DIFF
--- a/.claude/skills/self-review-quarterly/SKILL.md
+++ b/.claude/skills/self-review-quarterly/SKILL.md
@@ -110,7 +110,7 @@ This skill writes to a **committed git file**. Privacy violations cannot be retr
 | 2 | Agent 위임 패턴 | ... | `axis_2_plan_subagent_skip_rate.skip_rate` (PR #745) | ... |
 | 3 | 거버넌스 자동화 ROI | ... | `governance_hooks.pretooluse_loadbearing_fires`, `governance_hooks.fires_by_action` | ... |
 | 4 | 사이클 타임 | ... | `axis_4_cycle_time.adr_lag_days`, `axis_4_cycle_time.pr_turnaround_hours` (PR #748) | ... |
-| 5 | 메모리 위생 | ... | `governance_hooks.fires_by_action["memory-lines"]` (PR #747), `memory.by_type` | ... |
+| 5 | 메모리 위생 | ... | #5-A `governance_hooks.fires_by_action["memory-lines"]` (PR #747) + #5-B `axis_5_memory_hygiene.content_freshness.fresh_rate` (issue #877) | ... |
 
 ## 5축 채점 임계값 (Q3-2026~)
 
@@ -131,7 +131,8 @@ SoT — 두 SoT는 직교한다 (값 vs 채점 등급).
 | #3 자동화 ROI | `governance_hooks.pretooluse_loadbearing_fires` + `fires_by_action` 다양성 | fires > 0 **그리고** ≥ 2개 reason 발화 (e.g. `load-bearing` + `memory-lines`) | fires > 0 그러나 1개 reason만 | fires = 0 |
 | #4-A 사이클 타임 (ADR) | `axis_4_cycle_time.adr_lag_days.mean` (days) | ≤ 5 | 5–10 | > 10 |
 | #4-B 사이클 타임 (PR) | `axis_4_cycle_time.pr_turnaround_hours.mean` (hours) | ≤ 48 | 48–120 | > 120 |
-| #5 메모리 위생 | `governance_hooks.fires_by_action["memory-lines"]` 카운트 (action="aware" / "blocked") | blocked=0 + aware ≤ 2 | aware ≥ 3 + blocked=0 | blocked ≥ 1 (편집 차단 = 인덱스 폭발) |
+| #5-A 메모리 인덱스 위생 | `governance_hooks.fires_by_action["memory-lines"]` 카운트 (action="aware" / "blocked") | blocked=0 + aware ≤ 2 | aware ≥ 3 + blocked=0 | blocked ≥ 1 (편집 차단 = 인덱스 폭발) |
+| #5-B 메모리 콘텐츠 신선도 | `axis_5_memory_hygiene.content_freshness.fresh_rate` (분기 내 수정된 메모리 파일 비율) | ≥ 0.5 | 0.2–0.5 | < 0.2 또는 `null` |
 
 **판정 규칙:**
 - 동일 축이 sub-signal 두 개를 가질 때(예: #4-A + #4-B), **둘 다 ✓** 이어야 ✓; 하나라도 ✗면 ✗; 그 외 △.

--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -607,6 +607,41 @@ def compute_axis_2_skip_rate(
     }
 
 
+def compute_axis_5_memory_hygiene(
+    memory: dict[str, Any], quarter_start: str
+) -> dict[str, Any]:
+    """Compute memory content freshness for axis #5-B.
+
+    Pairs with the existing axis #5-A signal in
+    `governance_hooks.fires_by_action["memory-lines"]` (index hygiene).
+    This function measures *content* freshness: fraction of memory files
+    whose `mtime` falls inside `[quarter_start, ∞)`. Stale fraction is
+    `1 - fresh_rate`.
+
+    Returns None for `fresh_rate` when memory is empty so the rubric
+    layer can flag "측정 부재" instead of dividing by zero.
+    """
+    files = memory.get("files", [])
+    total = len(files)
+    if total == 0:
+        return {
+            "total": 0,
+            "fresh_in_quarter": 0,
+            "fresh_rate": None,
+            "stale_count": 0,
+            "oldest_mtime": None,
+        }
+    fresh = [f for f in files if (f.get("mtime") or "") >= quarter_start]
+    mtimes = [f.get("mtime", "") for f in files if f.get("mtime")]
+    return {
+        "total": total,
+        "fresh_in_quarter": len(fresh),
+        "fresh_rate": len(fresh) / total,
+        "stale_count": total - len(fresh),
+        "oldest_mtime": min(mtimes) if mtimes else None,
+    }
+
+
 def assemble_stats(
     quarter: str, transcripts_glob: str, memory_dir: str, repo: str
 ) -> dict[str, Any]:
@@ -623,16 +658,21 @@ def assemble_stats(
         ),
         "pr_turnaround_hours": compute_pr_turnaround_summary(pr_diff_stats),
     }
+    memory_data = collect_memory(memory_dir)
+    axis_5 = {
+        "content_freshness": compute_axis_5_memory_hygiene(memory_data, start),
+    }
     return {
         "quarter": quarter,
         "date_range": [start, end],
         "sessions": sessions,
-        "memory": collect_memory(memory_dir),
+        "memory": memory_data,
         "git": collect_git(repo, start, end),
         "governance_hooks": governance,
         "pr_diff_stats": pr_diff_stats,
         "axis_2_plan_subagent_skip_rate": axis_2,
         "axis_4_cycle_time": axis_4,
+        "axis_5_memory_hygiene": axis_5,
     }
 
 
@@ -665,6 +705,12 @@ def emit_report(stats: dict[str, Any]) -> str:
             f"{stats['axis_4_cycle_time']['pr_turnaround_hours'].get('mean')} / "
             f"{stats['axis_4_cycle_time']['pr_turnaround_hours'].get('p90')} "
             f"(n={stats['axis_4_cycle_time']['pr_turnaround_hours'].get('count')})"
+        ),
+        (
+            f"- Axis #5-B Memory freshness (fresh/total): "
+            f"{stats['axis_5_memory_hygiene']['content_freshness'].get('fresh_rate')} "
+            f"({stats['axis_5_memory_hygiene']['content_freshness'].get('fresh_in_quarter')}"
+            f"/{stats['axis_5_memory_hygiene']['content_freshness'].get('total')})"
         ),
         "",
         "## Raw stats (metadata-only — no body excerpts)",

--- a/tests/test_self_review_axis_5_regression.py
+++ b/tests/test_self_review_axis_5_regression.py
@@ -1,0 +1,128 @@
+"""Regression tests for axis #5-B (memory content freshness) collector.
+
+Pins the fresh-in-quarter rate contract: fraction of memory files whose
+`mtime` (ISO date string) falls inside `[quarter_start, ∞)`. Pairs with
+axis #5-A (governance_hooks fire counts) which is unchanged by this
+collector. Issue #877.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "claude-hooks"))
+import _self_review as sr
+
+
+class TestComputeAxis5MemoryHygiene(unittest.TestCase):
+    def test_empty_memory_returns_none_rate(self):
+        result = sr.compute_axis_5_memory_hygiene(
+            {"files": []}, quarter_start="2026-04-01"
+        )
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["fresh_in_quarter"], 0)
+        self.assertIsNone(result["fresh_rate"])
+        self.assertIsNone(result["oldest_mtime"])
+
+    def test_all_files_fresh(self):
+        memory = {
+            "files": [
+                {"filename": "a.md", "mtime": "2026-05-10"},
+                {"filename": "b.md", "mtime": "2026-04-15"},
+                {"filename": "c.md", "mtime": "2026-04-01"},
+            ]
+        }
+        result = sr.compute_axis_5_memory_hygiene(
+            memory, quarter_start="2026-04-01"
+        )
+        self.assertEqual(result["total"], 3)
+        self.assertEqual(result["fresh_in_quarter"], 3)
+        self.assertEqual(result["fresh_rate"], 1.0)
+        self.assertEqual(result["stale_count"], 0)
+        self.assertEqual(result["oldest_mtime"], "2026-04-01")
+
+    def test_all_files_stale(self):
+        memory = {
+            "files": [
+                {"filename": "a.md", "mtime": "2025-12-10"},
+                {"filename": "b.md", "mtime": "2026-01-20"},
+            ]
+        }
+        result = sr.compute_axis_5_memory_hygiene(
+            memory, quarter_start="2026-04-01"
+        )
+        self.assertEqual(result["total"], 2)
+        self.assertEqual(result["fresh_in_quarter"], 0)
+        self.assertEqual(result["fresh_rate"], 0.0)
+        self.assertEqual(result["stale_count"], 2)
+        self.assertEqual(result["oldest_mtime"], "2025-12-10")
+
+    def test_half_fresh(self):
+        memory = {
+            "files": [
+                {"filename": "a.md", "mtime": "2026-05-01"},
+                {"filename": "b.md", "mtime": "2026-04-05"},
+                {"filename": "c.md", "mtime": "2026-01-01"},
+                {"filename": "d.md", "mtime": "2025-11-01"},
+            ]
+        }
+        result = sr.compute_axis_5_memory_hygiene(
+            memory, quarter_start="2026-04-01"
+        )
+        self.assertEqual(result["total"], 4)
+        self.assertEqual(result["fresh_in_quarter"], 2)
+        self.assertEqual(result["fresh_rate"], 0.5)
+        self.assertEqual(result["stale_count"], 2)
+        self.assertEqual(result["oldest_mtime"], "2025-11-01")
+
+    def test_missing_mtime_field_treated_as_stale(self):
+        memory = {
+            "files": [
+                {"filename": "a.md", "mtime": "2026-05-01"},
+                {"filename": "b.md"},
+            ]
+        }
+        result = sr.compute_axis_5_memory_hygiene(
+            memory, quarter_start="2026-04-01"
+        )
+        self.assertEqual(result["total"], 2)
+        self.assertEqual(result["fresh_in_quarter"], 1)
+        self.assertEqual(result["fresh_rate"], 0.5)
+
+
+class TestCollectMemoryEmitsMtime(unittest.TestCase):
+    """collect_memory writes ISO-date mtime that compute_axis_5 reads."""
+
+    def test_collect_memory_then_compute_axis_5_end_to_end(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdir = Path(td)
+            fresh_file = tdir / "feedback_a.md"
+            fresh_file.write_text(
+                "---\nname: A\ntype: feedback\n---\nbody"
+            )
+            stale_file = tdir / "project_b.md"
+            stale_file.write_text(
+                "---\nname: B\ntype: project\n---\nbody"
+            )
+            stale_ts = datetime(2025, 1, 15, tzinfo=timezone.utc).timestamp()
+            os.utime(stale_file, (stale_ts, stale_ts))
+            fresh_ts = time.time()
+            os.utime(fresh_file, (fresh_ts, fresh_ts))
+
+            memory = sr.collect_memory(str(tdir))
+            result = sr.compute_axis_5_memory_hygiene(
+                memory, quarter_start="2026-04-01"
+            )
+            self.assertEqual(result["total"], 2)
+            self.assertEqual(result["fresh_in_quarter"], 1)
+            self.assertEqual(result["fresh_rate"], 0.5)
+            self.assertEqual(result["oldest_mtime"], "2025-01-15")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_self_review_no_body_leak_regression.py
+++ b/tests/test_self_review_no_body_leak_regression.py
@@ -191,6 +191,7 @@ class AssembleStatsStructuralTest(unittest.TestCase):
             "governance_hooks", "pr_diff_stats",
             "axis_2_plan_subagent_skip_rate",
             "axis_4_cycle_time",
+            "axis_5_memory_hygiene",
         }
         self.assertEqual(set(stats.keys()), expected_keys)
 


### PR DESCRIPTION
## 1. What changed and why

Q2-2026 self-review가 5축 #5 "메모리 위생"을 △로 남겼는데, 기존 SKILL.md 정의(`governance_hooks.fires_by_action["memory-lines"]`)는 인덱스 폭발 모니터링만 측정합니다. 메모리 콘텐츠 자체가 stale한지는 미측정.

`collect_memory`는 이미 ISO-date mtime emit 중이지만 axis #5 raw signal로 가공되지 않음. 이 PR이 그 격차를 메웁니다. Sub-signal 분리 (axis #4-A/#4-B 패턴):
- **#5-A** 기존 hook fires (인덱스 위생) 그대로
- **#5-B** 신규 `fresh_rate` (콘텐츠 신선도) — 분기 내 수정된 메모리 파일 / 전체

판정 룰 "동일 축 sub-signal 두 개 → 둘 다 ✓ → ✓"가 이미 SKILL.md에 있음.

Closes #877

## 2. Files affected

- `scripts/claude-hooks/_self_review.py` — `compute_axis_5_memory_hygiene` 신규, `assemble_stats`+`emit_report` 갱신
- `.claude/skills/self-review-quarterly/SKILL.md` — 진단/임계 테이블에 #5-B 행
- `tests/test_self_review_axis_5_regression.py` (new) — 6 cases
- `tests/test_self_review_no_body_leak_regression.py` — `expected_keys` 갱신 (contract update)

Non load-bearing.

## 3. Risks

- 임계값 0.5/0.2 자의적 — 파일 수가 작으면 등급 점프. Mitigation: "둘 다 ✓ → ✓" 룰이 single-signal 변동 완화.
- `mtime` Goodhart 위험 (touch로 fresh_rate 부풀리기). Mitigation: metadata-only, LLM rubric이 채점.
- collect_memory 변경 없음 → 회귀 0.

## 4. Tests

46 self_review regression cases pass (6 new + 40 existing).

## 5. Eval impact

`·` across the board.

### 5b. Real-data delta

No behavior change in retrieval/verifier path. Collector + SKILL.md only.

## 6. Backward compatibility

- `assemble_stats` 신규 키 `axis_5_memory_hygiene` 추가 — 기존 키 변경 없음.
- SKILL.md #5 → #5-A rename + #5-B 행 추가, raw signal path 유지.

## 7. Out of scope

- Per-area PR size p50/p90, ADR class breakdown, `oldest_mtime` 기반 알고리즘 (모두 별 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)