### PR TITLE
feat(eval): nested_table_loss tracking in chunk_health (closes #902)

### DIFF
--- a/eval/scorers/chunk_health.py
+++ b/eval/scorers/chunk_health.py
@@ -14,11 +14,29 @@ stable JSON-serializable.
 
 from __future__ import annotations
 
+import re
 from statistics import mean
 from typing import Any, Iterable
 
 
 _SENTENCE_ENDERS_ASCII = (".", "!", "?", "。", "…")
+
+# Issue #902: kordoc (ADR 0049) leaves a ``[중첩 테이블 #N]`` placeholder when a
+# nested table cannot be reconstructed in markdown. 89/100 files in the private
+# real100 corpus contain at least one marker, so the loss is the dominant
+# kordoc gap. Count + sample so a regression points to specific files / lines.
+_NESTED_TABLE_RE = re.compile(r"\[중첩 테이블 #(\d+)\]")
+
+# Cap on samples folded into the report — prevents the JSON from ballooning on
+# pathological corpora while keeping enough to triage. Top-N by marker count
+# is not worth the complexity; first-N (deterministic insertion order) is
+# fine because the report's audience is "which files broke and where".
+_NESTED_TABLE_SAMPLE_LIMIT = 20
+
+# Adjacent text captured after the marker so the sample reads as "here's what
+# the nested table got flattened into". 80 chars is enough for a phrase but
+# short enough that 20 samples stay under ~2 KB.
+_NESTED_TABLE_ADJACENT_CHARS = 80
 # Heuristic Korean sentence-final endings. Conservative set — false negatives
 # (mis-flagging a clean chunk as mid-cut) are preferred over false positives
 # (silently passing a truncated chunk). Mirrors common formal RFP verb
@@ -119,6 +137,15 @@ def compute_chunk_health(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
         - ``hwp_table_chunk_ratio``: float in ``[0, 1]``,
           ``hwp_table_chunks / (total HWP chunks)``; ``0.0`` when there are no
           HWP chunks.
+        - ``nested_table_loss_count``: total ``[중첩 테이블 #N]`` markers across
+          the corpus (issue #902 — kordoc gap surface).
+        - ``nested_table_loss_files``: number of distinct ``doc_id`` values
+          that contain at least one marker.
+        - ``nested_table_loss_samples``: list of up to
+          ``_NESTED_TABLE_SAMPLE_LIMIT`` dicts with ``doc_id``, ``marker_id``,
+          and ``adjacent_text`` (first 80 chars after the marker). Insertion
+          order is deterministic — first markers encountered, which makes the
+          report stable across re-runs of the same index.
     """
     chunk_list = list(chunks)
     total = len(chunk_list)
@@ -130,6 +157,9 @@ def compute_chunk_health(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
     hwp_table = 0
     eligible_for_cut = 0
     mid_cut = 0
+    nested_total = 0
+    nested_files: set[str] = set()
+    nested_samples: list[dict[str, Any]] = []
 
     for chunk in chunk_list:
         text = str(chunk.get("text") or "")
@@ -152,6 +182,28 @@ def compute_chunk_health(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
             if _is_mid_sentence_cut(text):
                 mid_cut += 1
 
+        # Issue #902: ``[중첩 테이블 #N]`` is kordoc's marker for a nested
+        # table that could not be reconstructed in markdown. We count every
+        # occurrence (89/100 files have at least one in the real100 corpus),
+        # track distinct documents, and keep a deterministic prefix of
+        # samples so regression triage points to specific files / IDs.
+        if text:
+            doc_id = str(chunk.get("doc_id") or "")
+            for match in _NESTED_TABLE_RE.finditer(text):
+                nested_total += 1
+                if doc_id:
+                    nested_files.add(doc_id)
+                if len(nested_samples) < _NESTED_TABLE_SAMPLE_LIMIT:
+                    end = match.end()
+                    adjacent = text[end : end + _NESTED_TABLE_ADJACENT_CHARS]
+                    nested_samples.append(
+                        {
+                            "doc_id": doc_id,
+                            "marker_id": match.group(1),
+                            "adjacent_text": adjacent,
+                        }
+                    )
+
     lengths_sorted = sorted(lengths)
     length_stats = {
         "p50": _percentile(lengths_sorted, 0.5),
@@ -172,4 +224,7 @@ def compute_chunk_health(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
         "mid_sentence_cut_ratio": mid_ratio,
         "hwp_table_chunks": hwp_table,
         "hwp_table_chunk_ratio": hwp_table_ratio,
+        "nested_table_loss_count": nested_total,
+        "nested_table_loss_files": len(nested_files),
+        "nested_table_loss_samples": nested_samples,
     }

--- a/ingestion.py
+++ b/ingestion.py
@@ -56,7 +56,12 @@ REQUIRED_COLUMNS = [
 # ``scripts/build_index.py`` after the chunk-building stage). The three keys
 # are additive and downstream readers use ``dict.get``, so a v2 reader
 # silently ignores them.
-INGESTION_REPORT_SCHEMA_VERSION = 3
+#
+# Bumped 3 → 4 in issue #902: ``summary.chunk_health`` gains three additive
+# kordoc-loss fields (``nested_table_loss_count``,
+# ``nested_table_loss_files``, ``nested_table_loss_samples``). v3 readers that
+# already use ``dict.get`` on ``chunk_health`` ignore them transparently.
+INGESTION_REPORT_SCHEMA_VERSION = 4
 
 # Public, reviewer-facing failure taxonomy for ingestion. Keep keys stable;
 # downstream tooling (eval/run_eval.py, docs, dashboards) reads them.

--- a/tests/test_chunk_health.py
+++ b/tests/test_chunk_health.py
@@ -49,6 +49,9 @@ class TestComputeChunkHealth(unittest.TestCase):
         "mid_sentence_cut_ratio",
         "hwp_table_chunks",
         "hwp_table_chunk_ratio",
+        "nested_table_loss_count",
+        "nested_table_loss_files",
+        "nested_table_loss_samples",
     }
     EXPECTED_LENGTH_KEYS = {"p50", "p95", "max", "min", "mean"}
 
@@ -70,6 +73,9 @@ class TestComputeChunkHealth(unittest.TestCase):
         self.assertEqual(result["mid_sentence_cut_ratio"], 0.0)
         self.assertEqual(result["hwp_table_chunks"], 0)
         self.assertEqual(result["hwp_table_chunk_ratio"], 0.0)
+        self.assertEqual(result["nested_table_loss_count"], 0)
+        self.assertEqual(result["nested_table_loss_files"], 0)
+        self.assertEqual(result["nested_table_loss_samples"], [])
 
     def test_by_format_counts(self):
         chunks = [

--- a/tests/test_chunk_health_nested_table_regression.py
+++ b/tests/test_chunk_health_nested_table_regression.py
@@ -1,0 +1,148 @@
+"""Regression: nested-table-loss tracking in ``chunk_health`` (issue #902).
+
+Pins the three additive fields kordoc (ADR 0049) leaves visible when a nested
+HWP table cannot be reconstructed in markdown. Without this metric, a future
+loader regression that flattens *more* tables would only show up as a vague
+chunk-length shift in ``ingestion_report.json`` — this test pins the marker
+shape and report contract so triage points directly at the offending docs.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eval.scorers.chunk_health import (  # noqa: E402
+    _NESTED_TABLE_RE,
+    _NESTED_TABLE_SAMPLE_LIMIT,
+    compute_chunk_health,
+)
+
+
+def _hwp_chunk(text: str, doc_id: str = "doc-1", section: str = "본문") -> dict:
+    return {
+        "text": text,
+        "doc_id": doc_id,
+        "metadata": {"file_format": "hwp"},
+        "section": section,
+    }
+
+
+class TestNestedTableMarkerRegex(unittest.TestCase):
+    def test_matches_kordoc_marker_format(self):
+        # The exact shape kordoc emits in markdown: ``[중첩 테이블 #N]``.
+        # Real samples observed in data/files_kordoc/인천광역시_*.md and
+        # data/files_kordoc/서울특별시교육청_*.md.
+        sample = "사업개요\n[중첩 테이블 #1]\n일자리업무시스템"
+        matches = _NESTED_TABLE_RE.findall(sample)
+        self.assertEqual(matches, ["1"])
+
+    def test_does_not_match_plain_text(self):
+        # Bracketed numbers that look similar but aren't the marker shape
+        # must not be matched — false positives would inflate the metric.
+        self.assertEqual(_NESTED_TABLE_RE.findall("[표 #1]"), [])
+        self.assertEqual(_NESTED_TABLE_RE.findall("[중첩 표 #1]"), [])
+        self.assertEqual(_NESTED_TABLE_RE.findall("중첩 테이블 #1"), [])
+
+    def test_captures_multi_digit_ids(self):
+        sample = "[중첩 테이블 #45]"
+        self.assertEqual(_NESTED_TABLE_RE.findall(sample), ["45"])
+
+
+class TestComputeChunkHealthNestedTable(unittest.TestCase):
+    def test_zero_when_no_markers_present(self):
+        chunks = [
+            _hwp_chunk("이 사업은 RFP 입찰 대상입니다."),
+            _hwp_chunk("예산은 5억 원입니다."),
+        ]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["nested_table_loss_count"], 0)
+        self.assertEqual(result["nested_table_loss_files"], 0)
+        self.assertEqual(result["nested_table_loss_samples"], [])
+
+    def test_counts_markers_across_files(self):
+        chunks = [
+            _hwp_chunk("[중첩 테이블 #1]\n조직도", doc_id="doc-a"),
+            _hwp_chunk("[중첩 테이블 #2]\n단계별 워크플로", doc_id="doc-a"),
+            _hwp_chunk("normal narrative", doc_id="doc-b"),
+            _hwp_chunk("[중첩 테이블 #1]\n사업범위", doc_id="doc-c"),
+        ]
+        result = compute_chunk_health(chunks)
+        # 3 markers total across 2 distinct docs (doc-a contributes 2, doc-c 1)
+        self.assertEqual(result["nested_table_loss_count"], 3)
+        self.assertEqual(result["nested_table_loss_files"], 2)
+
+    def test_sample_payload_shape(self):
+        chunks = [
+            _hwp_chunk(
+                "[중첩 테이블 #5]\n일자리업무시스템 (이용자) 시,군,구 담당",
+                doc_id="인천광역시_일자리플랫폼",
+            ),
+        ]
+        result = compute_chunk_health(chunks)
+        samples = result["nested_table_loss_samples"]
+        self.assertEqual(len(samples), 1)
+        sample = samples[0]
+        self.assertEqual(set(sample.keys()), {"doc_id", "marker_id", "adjacent_text"})
+        self.assertEqual(sample["doc_id"], "인천광역시_일자리플랫폼")
+        self.assertEqual(sample["marker_id"], "5")
+        # Adjacent text is the slice immediately AFTER the closing bracket,
+        # capped at 80 chars. Confirms triage payload points at what the
+        # nested table was flattened into.
+        self.assertTrue(sample["adjacent_text"].startswith("\n일자리업무시스템"))
+        self.assertLessEqual(len(sample["adjacent_text"]), 80)
+
+    def test_sample_limit_caps_payload_size(self):
+        # ``_NESTED_TABLE_SAMPLE_LIMIT`` markers + 5 extra. The extras must
+        # be counted (count = 25) but not appear in the samples list (capped
+        # at 20). Keeps the JSON sidecar bounded on pathological corpora.
+        marker_count = _NESTED_TABLE_SAMPLE_LIMIT + 5
+        chunks = [
+            _hwp_chunk(f"[중첩 테이블 #{i}]\nfollow {i}", doc_id=f"doc-{i}")
+            for i in range(marker_count)
+        ]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["nested_table_loss_count"], marker_count)
+        self.assertEqual(len(result["nested_table_loss_samples"]), _NESTED_TABLE_SAMPLE_LIMIT)
+        # First N preserved deterministically (insertion order) — important
+        # so re-running the same index produces the same report.
+        first_ids = [s["marker_id"] for s in result["nested_table_loss_samples"]]
+        self.assertEqual(first_ids, [str(i) for i in range(_NESTED_TABLE_SAMPLE_LIMIT)])
+
+    def test_multiple_markers_in_one_chunk_all_counted(self):
+        # Chunk-boundary heuristics sometimes pack 2-3 markers into one chunk
+        # (e.g. consecutive nested tables in an organigram section). All
+        # occurrences inside a chunk must be counted, not just the first.
+        chunk = _hwp_chunk(
+            "[중첩 테이블 #1]\nA\n[중첩 테이블 #2]\nB\n[중첩 테이블 #3]\nC",
+            doc_id="doc-multi",
+        )
+        result = compute_chunk_health([chunk])
+        self.assertEqual(result["nested_table_loss_count"], 3)
+        self.assertEqual(result["nested_table_loss_files"], 1)
+        marker_ids = [s["marker_id"] for s in result["nested_table_loss_samples"]]
+        self.assertEqual(marker_ids, ["1", "2", "3"])
+
+    def test_missing_doc_id_does_not_inflate_files(self):
+        # If a synthetic / test chunk omits ``doc_id``, the marker still
+        # counts toward the total but the file count must not be inflated
+        # by an empty key.
+        chunks = [
+            {
+                "text": "[중첩 테이블 #1]\nno doc id",
+                "metadata": {"file_format": "hwp"},
+                "section": "본문",
+            },
+            _hwp_chunk("[중첩 테이블 #2]\nwith doc id", doc_id="doc-x"),
+        ]
+        result = compute_chunk_health(chunks)
+        self.assertEqual(result["nested_table_loss_count"], 2)
+        # Only ``doc-x`` is a real doc_id; the empty-string chunk is excluded.
+        self.assertEqual(result["nested_table_loss_files"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mixed_format_ingestion_regression.py
+++ b/tests/test_mixed_format_ingestion_regression.py
@@ -263,7 +263,10 @@ class MixedFormatIngestionTest(unittest.TestCase):
             _, report = load_documents_from_metadata_csv(csv_path, files_dir)
 
             summary = report["summary"]
-            self.assertEqual(3, summary["schema_version"])
+            # Bumped 3 → 4 in issue #902 (additive nested_table_loss_* fields
+            # on summary.chunk_health). Existing summary fields below are
+            # unchanged.
+            self.assertEqual(4, summary["schema_version"])
             self.assertEqual(
                 {
                     "pdf": {"data_list_csv_text": 2},


### PR DESCRIPTION
## Summary

ADR 0049 (kordoc, [#895](https://github.com/hskim-solv/BidMate-DocAgent/pull/895)) 는 nested HWP table 을 markdown 으로 복원 못 할 때 `[중첩 테이블 #N]` placeholder 남김. private real100 corpus 에서 이게 **dominant loss 패턴 (89/100 파일)** 이지만 `ingestion_report.json` 에 invisible — `chunk_health` 가 length/cuts/hwp-table ratio 만 측정.

본 PR: `summary.chunk_health` 에 additive 3 필드 추가. regression 시 vague metric drift 가 아니라 specific file 을 가리키도록:

```
nested_table_loss_count    # 총 marker 발생
nested_table_loss_files    # ≥1 marker 가진 distinct doc_id
nested_table_loss_samples  # 첫 20개: { doc_id, marker_id, adjacent_text[:80] }
```

`INGESTION_REPORT_SCHEMA_VERSION` 3 → 4 (additive — `dict.get` reader 영향 없음).

## Stacked on

[#901](https://github.com/hskim-solv/BidMate-DocAgent/pull/901) (4-PR kordoc-gap stack PR-1). **#901 머지 전 squash-merge 금지.**

### 5b. Real-data delta

Observability-only — `compute_chunk_health` 는 index-build-time, retrieval/answer/verifier path 미포함. ADR 0001 baseline bit-identical (답변 텍스트 변경 불가). real100 rebuild 수치:

| metric | before | after | delta |
|---|---|---|---|
| `schema_version` | 3 | 4 | additive |
| `nested_table_loss_count` | (없음) | 762 | new |
| `nested_table_loss_files` | (없음) | 89 / 100 | new |
| `nested_table_loss_samples` (len) | (없음) | 20 | new (capped) |
| `total_chunks` | 26446 | 26446 | 0 (ingestion 동작 무변) |
| naive_baseline 답변 텍스트 | unchanged | unchanged | 0 |

Ground-truth cross-check:
```
$ jq '{schema_version: .summary.schema_version, files: .summary.chunk_health.nested_table_loss_files, markers: .summary.chunk_health.nested_table_loss_count}' \
    data/index/real100/ingestion_report.json
{
  "schema_version": 4,
  "files": 89,    # `grep -lc '\[중첩 테이블 #'` ground truth 와 일치 (89/100)
  "markers": 762  # raw grep=681; +81 chunk-overlap duplication, 예상치
}
```

Sample payload preview (20개 중 top 3):

```
[
  {
    "doc_id": "20241002912-0.0",
    "marker_id": "1",
    "adjacent_text": "<br>구 분<br>암 호 화 기 준<br>송ㆍ수신시<br>모든 정보 암호화 전송<br>..."
  },
  {
    "doc_id": "20241002912-0.0",
    "marker_id": "2",
    "adjacent_text": "\n대상업체\n사업금액의 하한\n매출액 8천억원 이상인 대기업\n80억원 이상\n..."
  }
]
```

→ 각 sample 이 doc + marker ID + nested table 이 flatten 된 snippet 식별. triage 초 단위.

## Why observability-only

`compute_chunk_health` 는 index-build-time 호출, `ingestion_report.json` 에 fold. retrieval/answer/verifier surface 가 `chunk_health` 미참조 → ADR 0001 baseline bit-identical. 본 PR 에 load-bearing 파일 없음 (`chunk_health.py`, `ingestion.py` schema constant 만, test fixture).

## Test plan

- [x] `pytest tests/test_chunk_health.py tests/test_chunk_health_nested_table_regression.py -v` → 25 passed
- [x] `pytest tests/test_mixed_format_ingestion_regression.py` → 7 passed (schema_version 3 → 4 assertion 업데이트)
- [x] `pytest tests/test_bm25_cache_invalidation.py tests/test_run_eval_by_format_text_source.py` → 12 passed (무관 schema_version 사용, 변경 불요)
- [x] real100 rebuild → `nested_table_loss_files=89` (== ground-truth grep), sample non-empty
- [ ] CI green (#901 머지 후 main 자동 rebase 시)

## Out of scope

- Nested table 자체 복구 (kordoc backend 한계; parent plan P4, 별 ADR/RFC)
- Heading-promotion 정규화 (stack PR-3)
- ToC leader-dots / page-footer stripping (stack PR-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #902
