### PR TITLE
feat(ingestion): demote kordoc over-promoted bullet headings (closes #904)

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -330,12 +330,87 @@ def _kordoc_convert_batch(source_paths: list[Path]) -> dict[str, str]:
             except OSError:
                 continue
             stem = unicodedata.normalize("NFC", md_path.stem)
-            normalized = normalize_body_text(content)
+            # Issue #904: demote over-promoted HWP bullet headings BEFORE the
+            # whitespace-collapsing ``normalize_body_text`` runs. Order matters
+            # because the bullet detector keys off the line prefix ``#+ <glyph>``
+            # which would survive normalize_body_text anyway, but doing it here
+            # keeps the cached text consistent for downstream readers.
+            demoted = _demote_over_promoted_bullet_headings(content)
+            normalized = normalize_body_text(demoted)
             if normalized:
                 markdown_by_stem[stem] = normalized
         if not markdown_by_stem:
             raise _KordocFallback("kordoc produced no readable output")
         return markdown_by_stem
+
+
+# Issue #904: kordoc (ADR 0049) promotes HWP bullet-list items to markdown
+# headings when the source paragraph carries HWP "글머리표" formatting. On the
+# private real100 corpus this inflates heading density to 16.1% (인천일자리
+# ISP) / 10.6% (한의학연) — well above the 5-7% typical of well-structured
+# specs. Over-promoted headings derail chunk-boundary detection because the
+# fixed-strategy splitter treats every heading as a candidate split point.
+#
+# Detection is bullet-glyph based, not length-based, because the dominant
+# pattern is ``# ㅇ ...`` / ``# □ ...`` / ``# ❍ ...`` — short or long, the
+# leading glyph is the high-confidence signal. We only demote within a "run"
+# of 3+ bullet headings (separated only by blank lines, no body paragraphs)
+# to preserve standalone bullet-prefixed headings that some specs use as
+# legitimate section titles.
+#
+# Glyph allowlist explicitly excludes ``[`` (brackets like ``## [부록 A]`` are
+# legitimate appendix headings) and numbers/Korean prefixes (``제1조`` etc.).
+_BULLET_HEADING_GLYPHS = "□❍○◦●▪■◆▶·ㅇ"
+_BULLET_HEADING_RE = re.compile(
+    rf"^(#+)\s+([{re.escape(_BULLET_HEADING_GLYPHS)}\-])(\s|$)"
+)
+_MIN_RUN_LENGTH_FOR_DEMOTION = 3
+
+
+def _demote_over_promoted_bullet_headings(markdown: str) -> str:
+    """Strip ``#+`` prefix from bullet-style headings appearing in runs.
+
+    A "run" is a contiguous sequence of bullet-prefixed heading lines
+    separated only by blank lines. When a run has at least
+    ``_MIN_RUN_LENGTH_FOR_DEMOTION`` headings, every heading in the run is
+    demoted to plain text by stripping the leading ``#+\\s+`` (the bullet
+    glyph itself is preserved so the original semantic — "this is a bullet
+    item" — survives). Body content between headings breaks the run.
+
+    Returns the input unchanged when no qualifying run is present, so the
+    function is safe to call on every kordoc output. Idempotent: re-running
+    on already-normalized markdown is a no-op.
+    """
+    lines = markdown.split("\n")
+    is_bullet_heading = [bool(_BULLET_HEADING_RE.match(line)) for line in lines]
+    demote_flags = [False] * len(lines)
+
+    i = 0
+    while i < len(lines):
+        if not is_bullet_heading[i]:
+            i += 1
+            continue
+        bullets_in_run: list[int] = []
+        j = i
+        while j < len(lines) and (is_bullet_heading[j] or lines[j].strip() == ""):
+            if is_bullet_heading[j]:
+                bullets_in_run.append(j)
+            j += 1
+        if len(bullets_in_run) >= _MIN_RUN_LENGTH_FOR_DEMOTION:
+            for idx in bullets_in_run:
+                demote_flags[idx] = True
+        i = max(j, i + 1)
+
+    if not any(demote_flags):
+        return markdown
+
+    out: list[str] = []
+    for idx, line in enumerate(lines):
+        if demote_flags[idx]:
+            out.append(re.sub(r"^#+\s+", "", line, count=1))
+        else:
+            out.append(line)
+    return "\n".join(out)
 
 
 def build_sections_with_native_tables(

--- a/tests/test_ingestion_heading_demotion_regression.py
+++ b/tests/test_ingestion_heading_demotion_regression.py
@@ -1,0 +1,222 @@
+"""Regression: kordoc HWP bullet-heading demotion (issue #904).
+
+Pins the heuristic that strips ``#+`` from over-promoted HWP bullet headings
+(``# ㅇ ...`` / ``# □ ...`` / ``# ❍ ...``) when they appear in runs of 3+
+separated only by blank lines. Without demotion, chunk-boundary detection
+treats every bullet item as a heading split point, fragmenting the index.
+
+The bar is bidirectional:
+1. Real bullet-runs ARE demoted (the kordoc gap we're fixing).
+2. Standalone bullet-prefixed headings + numbered / bracketed / Korean-prefix
+   headings are NOT demoted (false-positive guard for legitimate sections).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ingestion import (  # noqa: E402
+    _BULLET_HEADING_RE,
+    _MIN_RUN_LENGTH_FOR_DEMOTION,
+    _demote_over_promoted_bullet_headings,
+)
+
+
+class BulletHeadingRegexTest(unittest.TestCase):
+    def test_matches_korean_hwp_bullets(self):
+        # Glyphs observed in real100 (sorted by frequency):
+        # □(2208), ❍(2033), -(2807), ㅇ(1146), ○(512)
+        for glyph in ["□", "❍", "○", "◦", "●", "▪", "■", "◆", "▶", "·", "ㅇ", "-"]:
+            with self.subTest(glyph=glyph):
+                self.assertIsNotNone(
+                    _BULLET_HEADING_RE.match(f"# {glyph} 사업 개요"),
+                    f"Expected bullet glyph {glyph!r} to match",
+                )
+
+    def test_matches_at_any_heading_depth(self):
+        self.assertIsNotNone(_BULLET_HEADING_RE.match("# ㅇ x"))
+        self.assertIsNotNone(_BULLET_HEADING_RE.match("## ❍ x"))
+        self.assertIsNotNone(_BULLET_HEADING_RE.match("### □ x"))
+
+    def test_does_not_match_legitimate_headings(self):
+        # Numbered / Korean-prefix / bracketed headings stay headings.
+        for line in [
+            "# 1. 사업 개요",
+            "## 제1조 (목적)",
+            "### 제3장 사업 범위",
+            "## [부록 A] 제출서류",
+            "# 사업 개요",
+            "## 본문",
+        ]:
+            with self.subTest(line=line):
+                self.assertIsNone(
+                    _BULLET_HEADING_RE.match(line),
+                    f"Expected legitimate heading not to match: {line!r}",
+                )
+
+    def test_requires_space_after_glyph(self):
+        # ``# ㅇ`` (glyph then space or EOL) matches; ``# ㅇabc`` (no space)
+        # does not — guards against false positives like ``# 0xff`` or
+        # ``# -infinity`` words that happen to start with one of the glyphs.
+        self.assertIsNotNone(_BULLET_HEADING_RE.match("# ㅇ"))
+        self.assertIsNotNone(_BULLET_HEADING_RE.match("# ㅇ "))
+        self.assertIsNotNone(_BULLET_HEADING_RE.match("# ㅇ 텍스트"))
+        self.assertIsNone(_BULLET_HEADING_RE.match("# ㅇ가나다"))
+
+
+class DemoteBulletHeadingsRunDetectionTest(unittest.TestCase):
+    def test_demotes_run_of_three_or_more_bullet_headings(self):
+        # Real pattern from 한국한의학연구원_*.md lines 48-60.
+        md = "\n".join(
+            [
+                "# ㅇ 임상연구 심의, 심의결과 통보",
+                "",
+                "",
+                "# □ 동물실험계획 업무 프로세스 구축",
+                "",
+                "",
+                "# ㅇ 기관 동물실험운영규정에 위한 동물실험 업무",
+            ]
+        )
+        result = _demote_over_promoted_bullet_headings(md)
+        # All three demoted — bullet glyph + text preserved, leading `#+ ` gone.
+        self.assertIn("ㅇ 임상연구 심의, 심의결과 통보", result)
+        self.assertIn("□ 동물실험계획 업무 프로세스 구축", result)
+        self.assertIn("ㅇ 기관 동물실험운영규정에 위한 동물실험 업무", result)
+        # `# ` prefix removed on the demoted lines.
+        self.assertNotIn("# ㅇ", result)
+        self.assertNotIn("# □", result)
+
+    def test_preserves_run_below_threshold(self):
+        # 2 bullet headings (< 3) → both stay headings.
+        md = "\n".join(
+            [
+                "# ㅇ 항목 1",
+                "",
+                "# □ 항목 2",
+            ]
+        )
+        result = _demote_over_promoted_bullet_headings(md)
+        self.assertEqual(result, md)
+
+    def test_body_paragraph_breaks_the_run(self):
+        # The 2nd bullet group is interrupted by a body paragraph, so each
+        # sub-run is length 2 (< 3) → no demotion anywhere.
+        md = "\n".join(
+            [
+                "# ㅇ A",
+                "",
+                "# ㅇ B",
+                "사업 개요 본문 단락이다.",
+                "# ❍ C",
+                "",
+                "# ❍ D",
+            ]
+        )
+        result = _demote_over_promoted_bullet_headings(md)
+        self.assertEqual(result, md)
+
+    def test_threshold_constant_is_three(self):
+        # Pin the contract so future tuning is intentional, not accidental.
+        self.assertEqual(_MIN_RUN_LENGTH_FOR_DEMOTION, 3)
+
+    def test_real_headings_in_run_not_demoted(self):
+        # Numbered headings adjacent to bullet headings: the numbered ones
+        # are not bullet-prefixed, so they don't extend the run AND they
+        # are not demoted themselves.
+        md = "\n".join(
+            [
+                "# ㅇ A",
+                "",
+                "# 1. 진짜 섹션",
+                "",
+                "# ㅇ B",
+            ]
+        )
+        result = _demote_over_promoted_bullet_headings(md)
+        # Each bullet run is length 1, so nothing changes.
+        self.assertEqual(result, md)
+        # And the numbered heading is preserved either way.
+        self.assertIn("# 1. 진짜 섹션", result)
+
+
+class DemoteBulletHeadingsTransformTest(unittest.TestCase):
+    def test_preserves_inline_html_tables_and_other_content(self):
+        # The transform only touches qualifying heading lines. HTML tables,
+        # body paragraphs, and code blocks must round-trip unchanged.
+        md = "\n".join(
+            [
+                "# ㅇ A",
+                "# ㅇ B",
+                "# ㅇ C",
+                "",
+                "<table>",
+                "<tr><td>cell</td></tr>",
+                "</table>",
+                "",
+                "본문 단락이 여기 있습니다.",
+            ]
+        )
+        result = _demote_over_promoted_bullet_headings(md)
+        self.assertIn("<table>", result)
+        self.assertIn("<tr><td>cell</td></tr>", result)
+        self.assertIn("</table>", result)
+        self.assertIn("본문 단락이 여기 있습니다.", result)
+        # Headings demoted.
+        self.assertIn("ㅇ A", result)
+        self.assertIn("ㅇ B", result)
+        self.assertIn("ㅇ C", result)
+        self.assertNotIn("# ㅇ", result)
+
+    def test_idempotent_on_normalized_input(self):
+        # Running twice produces the same output — important because the
+        # function is called once per kordoc batch, but a re-build of the
+        # same source should never accumulate transforms.
+        md = "\n".join(
+            [
+                "# ❍ A",
+                "",
+                "# ❍ B",
+                "",
+                "# ❍ C",
+            ]
+        )
+        first = _demote_over_promoted_bullet_headings(md)
+        second = _demote_over_promoted_bullet_headings(first)
+        self.assertEqual(first, second)
+
+    def test_returns_unchanged_when_no_bullet_headings(self):
+        md = "# 사업 개요\n\n본문 단락입니다.\n\n## 제1조"
+        self.assertEqual(_demote_over_promoted_bullet_headings(md), md)
+
+    def test_empty_input_safe(self):
+        self.assertEqual(_demote_over_promoted_bullet_headings(""), "")
+
+    def test_mixed_depth_run_all_demoted(self):
+        # ``# ㅇ`` + ``## ❍`` + ``### □`` in a run — all bullet-style at
+        # any depth count toward the run, all get demoted.
+        md = "\n".join(
+            [
+                "# ㅇ A",
+                "",
+                "## ❍ B",
+                "",
+                "### □ C",
+            ]
+        )
+        result = _demote_over_promoted_bullet_headings(md)
+        self.assertIn("ㅇ A", result)
+        self.assertIn("❍ B", result)
+        self.assertIn("□ C", result)
+        for prefix in ("# ㅇ", "## ❍", "### □"):
+            self.assertNotIn(prefix, result, f"Prefix {prefix!r} should be stripped")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

ADR 0049 (kordoc, [#895](https://github.com/hskim-solv/BidMate-DocAgent/pull/895)) 가 HWP "글머리표" 포맷의 bullet item 을 markdown heading (``# ㅇ ...`` / ``# □ ...`` / ``# ❍ ...``) 으로 promote. private real100 corpus 에서 heading density 가 **16.1% (인천일자리 ISP)** / **10.7% (한의학연)** 로 폭주 (clean spec 일반 5-7% 대비).

본 PR: ``_demote_over_promoted_bullet_headings(markdown)`` 를 ``ingestion.py`` 에 추가. heuristic — bullet-glyph heading (``□❍○◦●▪■◆▶·ㅇ-``) 이 **3개+ 연속** (blank line 만 사이) 출현 시 각 heading 의 leading ``#+\s+`` 제거 (bullet glyph 는 본문에 보존). standalone bullet heading (연속 < 3) 은 heading 유지 — 의도적 ``## ❍ 사업 개요`` 형 section title false positive 방지.

``_kordoc_convert_batch`` 의 ``normalize_body_text`` 전 단계에 wiring.

## Stacked on

[#903](https://github.com/hskim-solv/BidMate-DocAgent/pull/903) (P1) → [#901](https://github.com/hskim-solv/BidMate-DocAgent/pull/901) (P0). parent land 전 squash-merge 금지.

### 5b. Real-data delta

5개 raw kordoc 출력 heading density (전/후):

| 파일 | Before | After | Δ heading 제거 |
|---|---|---|---|
| 한국한의학연구원 | 10.7% | **5.2%** | -124 |
| 서울교육청 ISP | 11.9% | 8.9% | -75 |
| 인천일자리 ISP | 16.2% | 15.2% | -23 |
| 서울시립대 학업성취도 | 17.5% | 17.0% | -22 |
| 고려대 차세대 포털 | 7.3% | 7.3% | -3 (이미 clean) |

real100 index rebuild: 26446 → 26410 chunks (-36). chunk 내 잔류 bullet heading: 1,270 / 13,513 = 9.4% (heuristic 이 의도적으로 보존하는 짧은 연속).

``ingestion_report.json`` chunk_health (rebuild 후):

```
{
  "schema": 4,
  "total_chunks": 26410,
  "mid_sentence_cut_ratio": 0.6315,
  "nested_table_loss_files": 89    # ← from PR #903
}
```

mid_sentence_cut_ratio 무변 (fixed chunking 이 heading 구조 소비 안 함). demotion 은 section-strategy user 향 observability 준비 위주. 즉각 효과는 작으나 correctness-preserving + bullet glyph 본문 보존.

## Honest scope

plan 의 "5 파일 <7% heading density" 목표는 한의학연 + 고려대 만 달성. 나머지는 non-bullet heading (``※``, ``# 1. ...``, ``[참고]``, ``제1조``) 비중 — 본 heuristic 이 의도적으로 안 건드림 (false-positive guard). 더 압박하면 별도 위험 heuristic 필요.

## Test plan

- [x] ``pytest tests/test_ingestion_heading_demotion_regression.py -v`` → 14 passed
- [x] ``pytest tests/test_ingestion_kordoc_regression.py tests/test_mixed_format_ingestion_regression.py`` → 24 passed (regression 없음)
- [x] real100 index rebuild → chunk_health.nested_table_loss_files 무변 (89), total_chunks -36 (소음 감소 예상치)
- [ ] CI green (stack land 후)

## Out of scope

- numbered/bracketed heading 연속 압박 (위험 프로파일 다름, 별 PR)
- ToC leader-dots / page-footer stripping (stack PR-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #904
