### PR TITLE
fix(governance): repoint ADR template verifies-key example to existing stage_latency key

### DIFF
--- a/docs/adr/_template.md
+++ b/docs/adr/_template.md
@@ -46,7 +46,7 @@ reads these markers, confirms `<relative-path>` exists, and looks for
 surface," not "this exact JSON path resolves." Example marker (drop the
 ones that do not apply, add as many as the Consequences imply):
 
-<!-- verifies-key: reports/eval_summary.json:stage_attempts -->
+<!-- verifies-key: reports/eval_summary.json:stage_latency -->
 
 The pre-commit hook (`.githooks/pre-commit`) refuses new ADRs that lack
 this section or contain zero markers (issue #793). Existing ADRs are


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 템플릿의 예시 `verifies-key` 마커가 `stage_attempts` 를 가리키지만, eval writer 는 `stage_latency` (`eval/run_eval.py:1132`) 만 emit. 결과: `reports/eval_summary.json` 이 존재하는 환경에서 `tests/test_governance_adr_verification.py::test_repo_template_passes_lint` 가 fail. 신규 clone 환경에서는 파일이 gitignored 라 lint 가 missing target 으로 skip → 조용히 pass. `stage_latency` 로 repoint 하면 예시 정신 (per-stage 측정 연결) 보존 + 양 환경에서 test green.

Closes #912

## 2. Files affected

- `docs/adr/_template.md` — 1줄 수정: `stage_attempts` → `stage_latency`

Load-bearing? `docs/adr/` 는 SSoT 이지만 본 변경은 template 만 (실제 ADR 아님). retrieval/verifier/eval 동작 무변경.

## 3. Risks

가장 가능성 높은 깨짐: 새 예시 키가 `reports/eval_summary.json` 에 없음. 검증: writer 출력 시뮬 (`echo '{"stage_latency": ...}' > reports/eval_summary.json`) 후 fail test + `python3 scripts/_governance.py --lint-adr-consequences docs/adr/_template.md` 둘 다 exit 0. `stage_latency` 는 `eval/run_eval.py:1132` 에서 emit 확정.

## 4. Tests

`tests/test_governance_adr_verification.py::test_repo_template_passes_lint` 가 본 케이스 regression — `lint_adr_verification("docs/adr/_template.md", ".") == []` assertion. 모듈 17 test 모두 local green.

## 5. Eval impact

All `·` — ADR 템플릿 doc 전용. retrieval/verifier/answer surface 무변경.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. 템플릿 전용 편집, eval pipeline 무변경.

## 6. Backward compatibility

없음. 마커는 예시이며 production code path 가 소비하지 않음. tree 내 어떤 ADR 도 `stage_attempts` 참조 없음 (`git grep stage_attempts docs/adr/` 확인).

## 7. Out of scope

- 실제 `stage_attempts` counter 를 eval writer 에 wiring (diagnosis option 2). 더 큰 surface, per-stage attempt count 가 tracked metric 으로 의미 있을 때만 가치. 본 fix 에 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
