### PR TITLE
docs: 핵심 문서 5개 한국어 번역 + 압축 (PR-A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,133 +1,113 @@
 # CLAUDE.md
 
-RFP-focused DocAgent system. **Bid/RFP document intelligence, not a generic AI playground.**
+RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전스 전용, 범용 AI 실험장 아님.**
 
-Pipeline: ingestion → metadata normalization → chunking → retrieval →
-reranking/planning → evidence aggregation → grounded answer → verification →
-evaluation → reviewer-facing docs.
+파이프라인: ingestion → 메타데이터 정규화 → 청킹 → 검색 → 재순위/계획 → 근거 집계 → 근거 기반 답변 → 검증 → 평가 → reviewer 문서.
 
-Automation surface: `.gitignore`,
-CI ([`pr-eval.yml`](.github/workflows/pr-eval.yml),
-[`branch-and-issue-check.yml`](.github/workflows/branch-and-issue-check.yml)),
-`.githooks/`,
-[`scripts/check_branch_and_issue.py`](scripts/check_branch_and_issue.py)
-(single-source regex for branch + issue convention, ADR 0007),
-[`.github/pull_request_template.md`](.github/pull_request_template.md),
-[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/),
-[`.claude/settings.json`](.claude/settings.json) (PreToolUse awareness hook
-for load-bearing edits + Bash matcher refusing `gh pr merge --delete-branch`
-when stacked dependents exist). This file captures the principles and pointers
-that aren't auto-enforced.
+자동화 표면: `.gitignore`, CI ([`pr-eval.yml`](.github/workflows/pr-eval.yml), [`branch-and-issue-check.yml`](.github/workflows/branch-and-issue-check.yml)), `.githooks/`, [`scripts/check_branch_and_issue.py`](scripts/check_branch_and_issue.py) (브랜치+이슈 컨벤션 regex 단일 출처, ADR 0007), [`.github/pull_request_template.md`](.github/pull_request_template.md), [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/), [`.claude/settings.json`](.claude/settings.json) (load-bearing 편집 awareness 훅 + stacked dependent 있을 때 `gh pr merge --delete-branch` 차단 Bash matcher). 이 파일은 자동 강제되지 않는 원칙·포인터를 담는다.
 
-## Start here
+## 여기서 시작
 
-- [`docs/engineering-governance.md`](docs/engineering-governance.md) — workflow map.
-- [`docs/adr/README.md`](docs/adr/README.md) — decision index.
-- [`docs/multi-agent-ownership.md`](docs/multi-agent-ownership.md) — coordination model when multiple agents work in parallel.
-- If touching retrieval / answer / eval, also read:
-  [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) (naive baseline),
-  [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) (answer contract),
-  [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md) (eval split),
-  [ADR 0012](docs/adr/0012-llm-judge-on-public-synthetic.md) (synthetic LLM-judge).
+- [`docs/engineering-governance.md`](docs/engineering-governance.md) — 워크플로 맵
+- [`docs/adr/README.md`](docs/adr/README.md) — 결정 인덱스
+- [`docs/multi-agent-ownership.md`](docs/multi-agent-ownership.md) — 여러 agent 가 병행 작업할 때 조율 모델
+- retrieval / answer / eval 손볼 시 추가 필독: [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) (기준선), [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) (답변 계약), [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md) (eval 분리), [ADR 0012](docs/adr/0012-llm-judge-on-public-synthetic.md) (합성 LLM-judge)
 
-## Repository map
+## 저장소 맵
 
-Load-bearing — changes here require PR template **item 5b (real-data delta)** filled in. Canonical machine-readable list lives in [`scripts/_governance.py`](scripts/_governance.py) `LOAD_BEARING_PATHS` (single source of truth read by `.githooks/pre-push`, `scripts/claude-hooks/pretooluse-loadbearing.sh`, and the `--check-5b` CI gate); add or remove entries there first so the three consumers pick it up automatically. The bullets below are the human reading guide.
+**Load-bearing** — 변경 시 PR 템플릿 **5b (real-data 델타)** 필수. 기계 판독 가능 단일 출처는 [`scripts/_governance.py`](scripts/_governance.py) 의 `LOAD_BEARING_PATHS` ([.githooks/pre-push](.githooks/pre-push), [scripts/claude-hooks/pretooluse-loadbearing.sh](scripts/claude-hooks/pretooluse-loadbearing.sh), `--check-5b` CI gate 가 함께 읽음). 추가/제거 시 그 파일 먼저 수정.
 
-- `rag_core.py` — core RAG pipeline (retrieval, verifier, answer generation).
-- `ingestion.py`, `visual_ingestion.py` — document loading + parsing. HWP **and** PDF backends are `HwpKordocLoader` / `PdfKordocLoader` (ADR 0049, npm subprocess via `npx`); `csv_text` is the unconditional fallback for both formats when Node is missing or the subprocess fails. `_prime_kordoc_batches` pools HWP + PDF paths into one `npx` invocation per ingestion run.
-- `eval/` — eval scripts and configs (`eval/config.yaml` defines the `naive_baseline` ablation preset).
-- `api/main.py` — FastAPI demo server (the whole `api/` directory is in the SSoT).
-- `docs/adr/` — accepted decision records.
-- `scripts/build_index.py` — index builder; downstream of `ingestion` + `rag_core`, surfaces ablation regressions before they reach eval.
+- `rag_core.py` — RAG 파이프라인 코어 (검색·검증·답변 오케스트레이션)
+- `ingestion.py`, `visual_ingestion.py` — 문서 로딩/파싱. HWP/PDF backend = `HwpKordocLoader`/`PdfKordocLoader` (ADR 0049, `npx` 서브프로세스); `csv_text` 가 Node 부재/실패 시 무조건 fallback
+- `eval/` — eval 스크립트·설정 (`eval/config.yaml` 에 `naive_baseline` 분석 변형 preset)
+- `api/main.py` — FastAPI 데모 서버 (`api/` 전체가 SSoT)
+- `docs/adr/` — accepted 결정 기록
+- `scripts/build_index.py` — 인덱스 빌더, eval 도달 전에 분석 변형 회귀를 표면화
 
-Supporting:
+**Supporting** (rag_core 에서 분리된 leaf 모듈, ADR 0045 검증 — `rag_core` 로의 back-edge 0):
 
-- `app.py` — CLI query entry point.
-- `rag_vector_store.py` — `VectorStore` Protocol behind the embeddings sidecar (issue #232). `BIDMATE_INDEX_BACKEND` accepts `memory` (default) or `qdrant`; `pgvector` is reserved for Stage 3 (#176). Qdrant connection target: `BIDMATE_QDRANT_URL` selects `http(s)://...` (production server), `/path` (file persistence), or `:memory:` / unset (default in-process). In-memory ↔ Qdrant ranking is bit-identical (`tests/test_vector_store_qdrant.py`), so ADR 0001 baseline holds across backends.
-- `rag_reranker.py` — `Reranker` Protocol + default `CrossEncoderReranker` adapter (issue #345, follow-up to #332). Wraps `rag_rerank.rerank` so future HyDE / LLM-as-reranker impls plug in without touching `rag_retrieval.apply_fusion_and_reranking`.
-- `rag_retrieval.py` — retrieval pipeline extracted from `rag_core.py` across PR-H1a (issue #459) + PR-H1b (issue #461). Owns `retrieve_candidates` (candidate generation), the four similarity primitives (`embed_query_for_index`, `dense_similarity`, `lexical_similarity`, `metadata_similarity`), BM25 surface (`bm25_scores_for_index`, `get_or_build_bm25` + `_*` helpers), and the post-retrieval stack (`apply_fusion_and_reranking`, `apply_comparison_balance`, `reassemble_parent_sections`). **ADR 0045 leaf: 0 back-edges to `rag_core`**, top-level or function-level (regression-tested by `tests/test_dependency_graph_invariance.py`, issue #872). Embedding primitives relocated to `rag_embedding` in PR-G2 (#847); ingestion helpers to `rag_indexing` in PR-G3 (#861).
-- `rag_verifier.py` — verifier path extracted from `rag_core.py` (issue #465, PR-J1). Owns `verify_evidence` (main verifier + partial-topic grounding policy per ADR 0004), the topic-extraction helpers (`verification_topics`, `specific_topics`, `metadata_terms_for_verification`), the `EVIDENCE_BOUNDARY` constant + 3 instruction-pattern regexes, `neutralize_instruction_patterns` (ADR 0008 evidence-side defense), `evidence_text_for_verification`, `evidence_has_topic`, and the `PARTIAL_TOPIC_GROUNDING_*` policy constants. Direct imports: `korean_lexicon` (METADATA_EVIDENCE_LABELS / METADATA_GENERIC_TOKENS / TOPIC_KEYWORDS / VERIFICATION_INTENT_TOKENS) + `text_normalize` (expand_forms / normalize_text). **ADR 0045 leaf: 0 back-edges to `rag_core`** (#872). `rag_core` re-exports every public name + 3 constants so `tests/test_synthetic_judge.py` / `tests/test_prompt_injection_regression.py` / `scripts/llm_judge.py` / `eval/synthetic_judge.py` (which import `EVIDENCE_BOUNDARY` and `neutralize_instruction_patterns` from `rag_core`) keep working unchanged.
-- `rag_answer.py` — answer generation extracted from `rag_core.py` (issue #468, PR-J2). Owns the 20 functions that turn verified evidence into the ADR 0003 answer dict: `generate_answer` (main entry), `build_claims` / `build_comparison_claims` / `build_extract_claims`, `make_claim` / `make_citation` / `claim_target`, `answer_status` / `answer_status_reason` / `answer_query_type` / `answer_summary` / `answer_verification_reasons`, `build_insufficiency`, `render_answer_text`, `best_sentence` / `metadata_claim_sentences` / `metadata_field_requested` / `format_metadata_claim_value` / `sentence_has_verification_topic` / `select_supporting_evidence`. ADR 0003 dict contract (`schema_version: 2` literal) stays here; CLAUDE.md prohibition against parallel Pydantic models still applies. Direct imports: `korean_lexicon` (METADATA_CLAIM_*), `rag_answer_schema` (ANSWER_STATUS_* / ANSWER_SCHEMA_VERSION), `rag_verifier` (specific_topics / verification_topics / evidence_text_for_verification / PARTIAL_TOPIC_GROUNDING_REASON). **ADR 0045 leaf: 0 back-edges to `rag_core`** (#872). `rag_core` re-exports every public name so orchestration (`_phase_build_answer`) keeps working.
-- `rag_query.py` — query analysis + planning extracted from `rag_core.py` (issue #478, PR-J3). Owns the 15 functions that turn the raw user query into the `plan` dict retrieval consumes: `analyze_query` (main analyzer), `resolve_conversation_context` + `make_context_resolution` + 7 query-inspection / state helpers (`is_metadata_ambiguous` / `has_implicit_reference` / `has_comparison_request` / `extract_requested_agencies` / `active_state_terms` / `active_state_size` / `inject_entities_into_query`), `comparison_targets_for_analysis` (called via re-export by rag_retrieval / rag_answer), `summarize_metadata_match` / `metadata_resolution_diagnostics`, `query_type_default_top_k` / `make_plan`. Direct imports: `korean_lexicon` (IMPLICIT_REFERENCE_PATTERNS / STOPWORDS / TOPIC_KEYWORDS), `rag_conversation_state` (CONTEXT_RESOLUTION_THRESHOLD), `rag_pipeline_presets` (preset / validation constants), `text_normalize` (normalize_text). **ADR 0045 leaf: 0 back-edges to `rag_core`** (#872). `rag_core` re-exports all 15 public names.
-- `rag_query_expansion.py` — `QueryExpander` Protocol + default `IdentityExpander` + opt-in `HyDEExpander` (issue #396, ADR 0023). Plugs in before the dense-embedding call in `rag_retrieval.retrieve_candidates`; BM25 / lexical / metadata paths consume `analysis.tokens` and remain invariant. Identity default preserves the ADR 0001 `naive_baseline` bit-identical golden.
-- `scripts/` — `build_index.py`, `update_readme_metrics.py`, `run_real_eval_delta.py`, etc.
-- `data/raw/` → `data/index/` → `outputs/` → `reports/` (pipeline artifacts).
-- `docs/` — design notes, ADRs, failure analyses, reviewer artifacts.
+- `app.py` — CLI 쿼리 진입점
+- `rag_vector_store.py` — `VectorStore` Protocol (#232). `BIDMATE_INDEX_BACKEND` = `memory`(기본) / `qdrant`; `pgvector` 는 Stage 3 (#176) 예약. in-memory ↔ Qdrant ranking bit-identical
+- `rag_reranker.py` — `Reranker` Protocol + 기본 `CrossEncoderReranker` (#345)
+- `rag_retrieval.py` — 검색 파이프라인 (#459 + #461). `retrieve_candidates`, 4 유사도 primitive, BM25, fusion·재순위·comparison balance·parent-section 재조립
+- `rag_verifier.py` — 검증기 (#465, PR-J1). `verify_evidence`, topic 추출, `EVIDENCE_BOUNDARY` 상수 + 명령 패턴 regex, `neutralize_instruction_patterns` (ADR 0008)
+- `rag_answer.py` — 답변 생성 (#468, PR-J2). 20 함수가 검증된 근거를 ADR 0003 답변 dict 로 변환. `schema_version: 2` 계약 유지
+- `rag_query.py` — 쿼리 분석·계획 (#478, PR-J3). 15 함수, `analyze_query`/`make_plan`/`comparison_targets_for_analysis` 등
+- `rag_query_expansion.py` — `QueryExpander` Protocol + 기본 `IdentityExpander` + opt-in `HyDEExpander` (#396, ADR 0023)
+- `scripts/` — `build_index.py`, `update_readme_metrics.py`, `run_real_eval_delta.py` 등
+- `data/raw/` → `data/index/` → `outputs/` → `reports/` (파이프라인 산출물)
+- `docs/` — 설계 노트, ADR, 실패 분석, reviewer 문서
 
-## Communication
+## 소통
 
-- **Respond in Korean when the user writes in Korean.** Reserve English for English-language prompts or an explicit "respond in English" request. Code, identifiers, commit messages, file/directory names stay in English.
-- **Lead summaries with a 2-3 line TL;DR; details below.** One decision per turn — do not dump multiple PRs / issues / branches in a single message.
+- **사용자가 한국어로 쓰면 한국어로 응답.** 영어 프롬프트 또는 "respond in English" 명시 시만 영어. 코드·식별자·커밋 메시지·파일/디렉터리명은 영문 유지
+- **2-3줄 TL;DR 후 상세.** 한 턴에 한 결정 — 여러 PR/issue/branch 를 한 메시지에 묶지 않음
 
-## Autonomy & Approvals
+## 자율성 & 승인
 
-- **State-changing actions require explicit approval.** `git push`, `gh pr merge`, `gh pr create`, `git branch -D`, `gh issue create` only after the user gives an explicit go-ahead (e.g. "진행", "go", "merge it", "ok"). Short interrogatives like `"머지?"`, `"PR?"`, `"?"` are **questions** — answer them, do not act on them.
-- **For chained side effects** (stacked-PR merge, ADR-then-PR, multi-issue triage), get a separate approval per step instead of bundling.
+- **상태 변경 액션은 명시 승인 필요.** `git push`, `gh pr merge`, `gh pr create`, `git branch -D`, `gh issue create` 는 사용자 "진행/go/merge it/ok" 명시 후만. "머지?", "PR?", "?" 같은 짧은 의문은 **질문** — 답변만 하고 실행 금지
+- **연쇄 부수효과** (stacked-PR merge, ADR-then-PR, multi-issue triage) 는 단계별 별도 승인
 
-## Delegation defaults
+## 위임 기본값
 
-- **Plan subagent before non-trivial change.** Any change touching >1 file or >50 LOC, or any plan-mode entry, dispatches a Plan subagent first. Skip only for typo / single-line fixes.
-- **Explore subagent for read-heavy probes.** ≥5 Read calls accumulated, or any single-file read >200 lines, hands off to Explore so the main conversation keeps tokens free.
-- **Shipping path locked at commit-0.** Decide `ship-pr` skill (manual gates, ADR reserve + stacked safety) vs `make ship-arm` (Stop-hook auto-ship). They are mutually exclusive — never arm both.
-- Full 5-axis ↔ 4-pillar mapping lives in [`docs/agent-utilization.md`](docs/agent-utilization.md). `self-review-quarterly` skill scores against that table.
+- **non-trivial 변경 전 Plan subagent.** >1 파일 또는 >50 LOC, 또는 plan mode 진입 시 Plan subagent 우선. 오타/단일 라인만 예외
+- **읽기 다발 시 Explore subagent.** Read ≥5회 누적 또는 단일 파일 >200줄 → Explore 위임
+- **Shipping 경로는 commit-0 에 확정.** `ship-pr` skill (수동 게이트, ADR 예약 + stacked 안전) vs `make ship-arm` (Stop-hook 자동 ship) 둘은 mutually exclusive — 동시 활성화 금지
+- 5축 ↔ 4-pillar 매핑 전체: [`docs/agent-utilization.md`](docs/agent-utilization.md). `self-review-quarterly` skill 이 해당 표 기준으로 채점
 
-## Core principles
+## 핵심 원칙
 
-- **Issue first; convention-matched branch.** Every PR must reference an issue (`Closes #N` in body) and its branch must match `<type>/issue-<N>[-<slug>]` (ADR 0007). The CI workflow `branch-and-issue-check.yml` enforces both at PR time.
-- **Reuse over invent.** Inspect existing implementation before coding. Search for reusable utilities first.
-- **One PR, one concern.** Out-of-scope fixes → separate issue / follow-up PR. Same domain decomposed into N PRs on the same day is a valid pattern (e.g. 2026-05-15 PR-A0~A3 four-PR stacked-day) — use `gh pr create --base <parent>` and avoid `--delete-branch` on the parent merge so child PRs don't auto-close.
-- **Per-area PR size heuristic.** "One PR, one concern" applies by surface, not LOC. `eval/` PRs are commonly 200–2500 LOC (dataset + config + plot bundled is one concern); `docs/` PRs typically <100 LOC. Don't reject a 2000-LOC `eval/` PR on size alone, and split a 200-LOC `docs/` PR if it mixes two ADRs. See `project_pr_size_heuristic.md` memory.
-- **Behavior change ↔ test change.** Behavior change without a test is presumed accidental. Regression tests go in `tests/test_*_regression.py` (pattern: `tests/test_retrieval_loop_regression.py`).
-- **Backward compatibility.** Breaking changes need an explicit reason. Answer-contract break (ADR 0003) requires `schema_version` bump.
-- **ADR threshold.** Removing or replacing a load-bearing decision (baseline / pipeline / answer contract / eval surface) needs an ADR — also covers introducing a *new* measurement surface (eval slice, leaderboard signal cadence, self-review axis) since that pins a contract reviewers will rely on. Criteria: [`docs/adr/README.md`](docs/adr/README.md).
-- **Reserve ADR numbers up front.** Before drafting a new ADR, check both `ls docs/adr/` and `gh pr list --search "ADR" --state open` to find the next available number. Propose it and wait for user confirmation before creating the file — concurrent worktree work has produced repeat collisions (0022→0023, 0023→0025, 0029→0030).
-- **LLM coding bias guard.** See the `karpathy-guidelines` skill ([upstream](https://github.com/multica-ai/andrej-karpathy-skills), fetched 2026-05-15 — re-fetch with an explicit PR if upstream HEAD changes) for the 4-principle default (Think Before / Simplicity First / Surgical Changes / Goal-Driven). **Conflict policy**: the project-specific rules above (incident-derived) take precedence over the karpathy 4-principle (generic) — karpathy is a default to lean on when project rules are silent, not an override.
+- **Issue first, 컨벤션 브랜치.** 모든 PR 은 issue 참조 (`Closes #N` in body) + 브랜치 `<type>/issue-<N>[-<slug>]` (ADR 0007). `branch-and-issue-check.yml` 이 PR 시점에 강제
+- **새로 만들기보다 재사용.** 코딩 전 기존 구현 확인. 재사용 유틸리티 먼저 검색
+- **One PR, one concern.** 범위 밖 수정 → 별도 issue/follow-up PR. 같은 도메인을 같은 날 N PR 로 분해는 valid 패턴 (예: 2026-05-15 PR-A0~A3 4-PR stacked-day). `gh pr create --base <parent>` 사용 + 부모 머지 시 `--delete-branch` 회피 (child auto-close 방지)
+- **PR 크기는 surface 별.** "one concern" 은 LOC 가 아니라 surface 기준. `eval/` PR 은 200–2500 LOC 정상 (dataset + config + plot 한 묶음 = 한 concern); `docs/` PR 은 보통 <100 LOC. 2000-LOC `eval/` PR 을 크기만으로 reject 금지, 두 ADR 섞인 200-LOC `docs/` PR 은 분할. memory `project_pr_size_heuristic.md` 참조
+- **동작 변경 ↔ 테스트 변경.** 테스트 없는 동작 변경은 실수로 간주. 회귀 테스트는 `tests/test_*_regression.py` (예: `tests/test_retrieval_loop_regression.py`)
+- **하위 호환성.** Breaking 변경은 명시적 사유 필요. 답변 계약 (ADR 0003) 깨질 시 `schema_version` 증가
+- **ADR 임계값.** load-bearing 결정 (기준선/파이프라인/답변 계약/eval 표면) 제거·교체 시 ADR 필요. **새 측정 표면** (eval 슬라이스, 리더보드 신호, self-review 축) 도입도 포함 (reviewer 가 의존할 계약 고정). 기준: [`docs/adr/README.md`](docs/adr/README.md)
+- **ADR 번호 사전 예약.** ADR 작성 전 `ls docs/adr/` + `gh pr list --search "ADR" --state open` 양쪽 확인. 사용자 확인 후 파일 생성 — 동시 worktree 작업으로 0022→0023, 0023→0025, 0029→0030 충돌 반복 발생
+- **LLM 코딩 편향 가드.** `karpathy-guidelines` skill ([upstream](https://github.com/multica-ai/andrej-karpathy-skills), 2026-05-15 fetch) 의 4 원칙 (Think Before / Simplicity First / Surgical Changes / Goal-Driven). **충돌 정책**: 위 프로젝트 규칙 (인시던트 유래) 이 karpathy 4 원칙 (범용) 보다 우선 — karpathy 는 프로젝트 규칙이 침묵할 때 leaning 기본값
 
-## PR description
+## PR 설명
 
-Fill in [`.github/pull_request_template.md`](.github/pull_request_template.md).
-Every section is required — write "N/A" with a reason rather than deleting.
-When load-bearing files change, **item 5b (real-data delta)** is the most
-important — the synthetic CI delta alone missed #69's intended-abstention regression.
+[`.github/pull_request_template.md`](.github/pull_request_template.md) 채워야 함. 모든 섹션 필수 — 삭제 대신 "N/A" + 사유. load-bearing 파일 변경 시 **5b (real-data 델타)** 가 가장 중요 — 합성 CI 델타만으로 #69 의도된 보류 회귀를 놓친 사례
 
-## Frequently used commands
+## 자주 쓰는 명령
 
-- `make install-hooks` — one-time per clone: activates `.githooks/` (pre-commit ADR 0005 boundary, pre-push branch/eval checks).
-- `make smoke` — quick sanity check (few minutes, `EMBEDDING_BACKEND=hashing`).
-- `bash scripts/test.sh` — `pytest -q`; same as the CI gate.
-- `make check-branch` — ad-hoc validation of the current branch against ADR 0007.
-- `make real-eval` + `make real-eval-delta` — private 100-doc eval; required when load-bearing files change.
-- `make ship-arm` — Stop-hook–driven auto-ship pipeline (commit → push → PR → CI → squash-merge). See [`docs/operations/auto-ship.md`](docs/operations/auto-ship.md) for gates, stages, and `STACKED=ack` discipline.
-- Latency numbers come from `reports/eval_summary.json` `stage_latency` block — not ad-hoc measurement.
+- `make install-hooks` — clone 당 1회, `.githooks/` 활성화 (pre-commit ADR 0005 경계, pre-push 브랜치/eval 체크)
+- `make smoke` — 빠른 sanity check (수분, `EMBEDDING_BACKEND=hashing`)
+- `bash scripts/test.sh` — `pytest -q`, CI gate 와 동일
+- `make check-branch` — 현재 브랜치 ADR 0007 검증
+- `make real-eval` + `make real-eval-delta` — 비공개 100-doc eval, load-bearing 변경 시 필수
+- `make ship-arm` — Stop-hook 자동 ship 파이프라인 (commit → push → PR → CI → squash-merge). 게이트/단계/`STACKED=ack` 규율: [`docs/operations/auto-ship.md`](docs/operations/auto-ship.md)
+- Latency 수치는 `reports/eval_summary.json` `stage_latency` 블록 — ad-hoc 측정 금지
 
-## Prohibited (not enforced by automation)
+## 금지 (자동화 비강제)
 
-- Deleting or renaming ADR files. Mark **Superseded** in the Status block; keep the file.
-- Adding a parallel pydantic / TypedDict model that shadows `run_rag_query`'s answer dict — the dict is the contract (ADR 0003).
-- Removing the `naive_baseline` preset from `eval/config.yaml` (ADR 0001).
-- Adding unrelated commits mid-review — open a follow-up PR.
-- Running `gh pr merge --delete-branch` without first verifying `gh pr list --base <this-PR-head-branch> --state open --json number` is empty. Open results mean a stacked dependent exists — drop `--delete-branch` or rebase the children onto main first. (A follow-up PreToolUse Bash guard hook automates this; the rule is stated here so it survives even if the hook is disabled.)
+- ADR 파일 삭제/이름변경. Status 블록에 **Superseded** 표시하고 파일은 유지
+- `run_rag_query` 답변 dict 를 그림자처럼 가리는 parallel pydantic/TypedDict 모델 추가 — dict 가 계약 (ADR 0003)
+- `eval/config.yaml` 에서 `naive_baseline` preset 제거 (ADR 0001)
+- 리뷰 중 무관한 커밋 추가 — follow-up PR 분리
+- `gh pr list --base <this-PR-head> --state open --json number` 확인 없이 `gh pr merge --delete-branch` 실행. 결과가 비어있지 않으면 stacked dependent 존재 — `--delete-branch` 빼거나 child 를 main 위로 rebase 먼저. (후속 PreToolUse Bash 가드 훅이 자동화하지만, 훅 비활성화 시도 살아남도록 규칙 명시)
 
-## Non-goals (unless explicitly requested)
+## Non-goals (명시 요청 없을 시)
 
-- UI additions, web-service productization.
-- Large architectural rewrites.
-- New paid-API dependencies.
-- Reconstructing private RFP data.
+- UI 추가, 웹 서비스 제품화
+- 대규모 아키텍처 재작성
+- 신규 paid-API 의존성
+- 비공개 RFP 데이터 재구성
 
-## When blocked
+## 막혔을 때
 
-Don't guess large. Instead:
+크게 추측 금지. 대신:
 
-1. State 2-3 failure hypotheses.
-2. Summarize the repro command + observed error.
-3. Propose a minimal fix.
-4. Describe a fallback path if the minimal fix doesn't apply.
+1. 실패 가설 2-3개 명시
+2. 재현 명령 + 관측된 에러 요약
+3. 최소 수정 제안
+4. 최소 수정이 안 통할 fallback 경로 설명
 
-## Domain glossary
+## 도메인 용어
 
-- **Evidence** — retrieved chunk(s) cited as support for a claim.
-- **Grounding** — the claim ↔ evidence ↔ source-document linkage requirement.
-- **Abstention** — first-class answer status (ADR 0003 `status: insufficient`) when retrieved evidence is inadequate; not a fallback or error.
-- **Naive baseline** — minimal-pipeline ablation preset preserved alongside `agentic_full` for side-by-side comparison (ADR 0001).
+- **Evidence (근거)** — 주장을 지지하는 retrieved chunk
+- **Grounding (근거 연결)** — claim ↔ evidence ↔ 원문 연결 요구사항
+- **Abstention (보류)** — ADR 0003 `status: insufficient`, 근거 불충분 시 일급 답변 상태. fallback/error 아님
+- **Naive baseline (기준선)** — `agentic_full` 과 side-by-side 비교용 최소 파이프라인 분석 변형 preset (ADR 0001)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 ![BidMate-DocAgent live demo (5s walkthrough — comparison query, extractive, no LLM)](docs/assets/demo.gif)
 
-> 한국 공공·B2B 입찰 RFP에서 비교·요건 추출 질의를 **근거 있는 답변**으로 돌려주는 한국어 도메인 특화 RAG — 외부 LLM 호출 없이 extractive grounding으로 hallucination을 구조적으로 차단.
-> **차별점**: 비교 질의에서 두 기관 문서를 균등 인용하는 [comparison-aware balanced retrieval](#key-technical-contribution--comparison-aware-balanced-top-k), metadata-first 검색([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), 근거 부족 시 abstention 명시([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
-> **측정**: accuracy 0.718 ± 0.10, citation_precision 0.705 ± 0.08 (`agentic_full`, 95% CI, n=100) — 공개 합성 + 비공개 real-data 분리 평가([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 33개 설계 결정(ADR).
+> 한국 공공·B2B 입찰 RFP 에서 비교·요건 추출 질의를 **근거 기반 답변**으로 돌려주는 한국어 도메인 특화 RAG. 외부 LLM 호출 없이 추출형(extractive) grounding 으로 hallucination 을 구조적으로 차단.
+> **차별점**: 비교 질의에서 두 기관 문서를 균등 인용하는 [comparison-aware balanced retrieval](#key-technical-contribution--comparison-aware-balanced-top-k), 메타데이터 우선 검색 ([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), 근거 불충분 시 보류(abstention) 명시 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
+> **측정**: accuracy 0.718 ± 0.10, citation_precision 0.705 ± 0.08 (`agentic_full`, 95% CI, n=100). 공개 합성 + 비공개 real-data 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 33개 설계 결정 (ADR).
 
-### 🎬 5초 비주얼 훅 — 실제 `comparison` 질의 한 건 (extractive, no LLM)
+### 5초 비주얼 훅 — 실제 `comparison` 질의 한 건 (extractive, no LLM)
 
-다음은 본 시스템이 실제로 출력하는 `agentic_full` 파이프라인 결과입니다. *외부 LLM 호출 없이*, retrieved evidence에서 claim을 추출하고 citation으로 잠급니다 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
+본 시스템의 실제 `agentic_full` 파이프라인 출력. *외부 LLM 호출 없이* retrieved evidence 에서 claim 추출 + citation 잠금 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
 
 ```text
 $ make ask
@@ -33,76 +33,77 @@ INFO bidmate.rag_core: query_complete  status='supported'  query_type='compariso
 ────────────────────────────────────────────────────────────────────────────
 ```
 
-- 두 기관이 **모두** 인용된 점이 핵심 — [comparison-aware balanced top-k](#key-technical-contribution--comparison-aware-balanced-top-k)가 한쪽 문서 starvation을 막은 결과.
-- 외부 API 호출 없음 (extractive). 위 5.79 ms는 in-memory index · n=2 docs 기준 실측치.
-- 5초 터미널 재생 (asciinema 설치 시): `asciinema play docs/assets/demo.cast`. 풀 워크스루 가이드: [`docs/operations/deployment.md`](docs/operations/deployment.md#recording-the-demo-video).
+- 두 기관이 **모두** 인용된 점이 핵심 — [comparison-aware balanced top-k](#key-technical-contribution--comparison-aware-balanced-top-k) 가 한쪽 문서 starvation 방지
+- 외부 API 호출 없음 (extractive). 5.79 ms 는 in-memory index, n=2 docs 실측
+- 5초 터미널 재생: `asciinema play docs/assets/demo.cast`. 풀 워크스루: [`docs/operations/deployment.md`](docs/operations/deployment.md#recording-the-demo-video)
 
-## 🚀 Live demo
+## Live demo
 
 | 경로 | 상태 | 비고 |
 |---|---|---|
-| **Colab 5분 quickstart** | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/hskim-solv/BidMate-DocAgent/blob/main/demo/bidmate_quickstart.ipynb) | 클론 / 설치 없이 브라우저에서 바로 grounded answer 1건 실행 |
-| **🟢 Live demo (Fly.io)** | [https://bidmate-docagent-demo.fly.dev/](https://bidmate-docagent-demo.fly.dev/) | 메인 머지마다 자동 재배포 ([deploy-fly.yml](.github/workflows/deploy-fly.yml)). 첫 요청 cold-start 약 5–10s. 운영: [`docs/operations/deployment.md`](docs/operations/deployment.md) |
-| **Streamlit on HF Spaces** | [![Open in HF Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-sm.svg)](https://huggingface.co/spaces/hskim-solv/bidmate-docagent) | Fly.io 다운 시 fallback. Space sleep 시 cold-start 약 30–60s |
-| **One-line docker run** | `docker run -p 8501:8501 -p 8000:8000 -e BIDMATE_DEMO_MODE=both ghcr.io/hskim-solv/bidmate-demo:latest` | 클론 없이 Streamlit + FastAPI 동시 실행 |
-| **FastAPI Swagger** | `make api` 후 [/docs](http://localhost:8000/docs) | 프로그래매틱 사용·통합 테스트용 |
+| **Colab 5분 quickstart** | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/hskim-solv/BidMate-DocAgent/blob/main/demo/bidmate_quickstart.ipynb) | 클론/설치 없이 브라우저에서 grounded answer 1건 실행 |
+| **Live demo (Fly.io)** | [https://bidmate-docagent-demo.fly.dev/](https://bidmate-docagent-demo.fly.dev/) | 메인 머지마다 자동 재배포 ([deploy-fly.yml](.github/workflows/deploy-fly.yml)). 첫 요청 cold-start 5–10s. 운영: [`docs/operations/deployment.md`](docs/operations/deployment.md) |
+| **Streamlit on HF Spaces** | [![Open in HF Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/open-in-hf-spaces-sm.svg)](https://huggingface.co/spaces/hskim-solv/bidmate-docagent) | Fly.io 다운 시 fallback. Space sleep 시 cold-start 30–60s |
+| **One-line docker** | `docker run -p 8501:8501 -p 8000:8000 -e BIDMATE_DEMO_MODE=both ghcr.io/hskim-solv/bidmate-demo:latest` | 클론 없이 Streamlit + FastAPI 동시 |
+| **FastAPI Swagger** | `make api` 후 [/docs](http://localhost:8000/docs) | 프로그래매틱 사용·통합 테스트 |
 | **로컬 1분 시작** | `make index && make demo` | `http://localhost:8501` |
-| **📈 Live leaderboard** | [https://hskim-solv.github.io/BidMate-DocAgent/leaderboard/](https://hskim-solv.github.io/BidMate-DocAgent/leaderboard/) | 메인 브랜치 머지마다 자동 누적 headline metric time-series (ADR 0030) |
+| **Live leaderboard** | [https://hskim-solv.github.io/BidMate-DocAgent/leaderboard/](https://hskim-solv.github.io/BidMate-DocAgent/leaderboard/) | 메인 머지마다 누적 headline metric time-series (ADR 0030) |
 
-데모 UI는 3개 pipeline preset(`naive_baseline` · `agentic_full` · `agentic_full_llm`)을 라디오 버튼으로 전환하고 extractive vs LLM 합성 답변을 side-by-side로 비교합니다.
+데모 UI 는 3 파이프라인 preset (`naive_baseline` · `agentic_full` · `agentic_full_llm`) 을 라디오 버튼으로 전환, extractive vs LLM 합성 답변 side-by-side 비교.
 
-## Why extractive, not generative?
+## 왜 추출형(extractive)인가, 생성형(generative)이 아닌가?
 
-기본 pipeline(`naive_baseline`, `agentic_full`)은 외부 LLM 호출 없이 retrieved evidence에서 claim을 추출하는 **extractive grounded-answer**입니다. Generator를 의도적으로 extractive로 한정한 4가지 이유:
+기본 파이프라인 (`naive_baseline`, `agentic_full`) 은 외부 LLM 호출 없이 retrieved evidence 에서 claim 을 추출하는 **추출형 근거 답변**. 생성기를 의도적으로 추출형으로 한정한 4가지 이유:
 
-1. **재현성**: 외부 API 키 / 네트워크 / 모델 버전 의존이 0. CI에서 매 PR마다 동일 평가셋을 같은 결과로 재실행 가능.
-2. **비용 영점**: query당 LLM token cost = 0. retry policy의 cost-quality trade-off가 latency 1축으로 단순화됨.
-3. **LLM-as-judge confound 제거**: generator와 verifier가 같은 LLM이 아니므로 self-consistency 편향 없음.
-4. **Citation grounding 내재화**: claim이 retrieved evidence에서만 도출되므로 hallucination이 구조적으로 불가능.
+1. **재현성**: 외부 API 키 / 네트워크 / 모델 버전 의존 0. 매 PR CI 가 동일 평가셋을 같은 결과로 재실행
+2. **비용 영점**: query 당 LLM token cost = 0. 재시도 정책의 cost-quality trade-off 가 latency 1축으로 단순화
+3. **LLM-as-judge confound 제거**: 생성기와 검증기가 같은 LLM 이 아니므로 self-consistency 편향 없음
+4. **Citation grounding 내재화**: claim 이 retrieved evidence 에서만 도출되므로 hallucination 구조적 불가능
 
-**한계 / Trade-off**: 생성 유창성에 제약. RFP 도메인은 정확도와 근거 추적이 우선이므로 수용 가능한 trade-off. 결정 계약: [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) + [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md).
+**한계 / Trade-off**: 생성 유창성 제약. RFP 도메인은 정확도와 근거 추적이 우선이라 수용 가능. 결정 계약: [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) + [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md).
 
-LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md))과 LLM Ops observability([ADR 0013](docs/adr/0013-observability-as-additive-pluggable-surface.md))는 extractive 파이프라인을 *교체하지 않고* additive ablation으로 추가됩니다 — [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md) / [`docs/operations/observability.md`](docs/operations/observability.md).
+LLM synthesis opt-in (`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md)) 과 LLM Ops observability ([ADR 0013](docs/adr/0013-observability-as-additive-pluggable-surface.md)) 는 추출형 파이프라인을 *교체하지 않고* additive 분석 변형으로 추가 — [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md) / [`docs/operations/observability.md`](docs/operations/observability.md).
 
-> **완료 ([issue #570](https://github.com/hskim-solv/BidMate-DocAgent/issues/570))**: 공개 synthetic n=42 → **n=100 확장** 완료 (single_doc 34 / comparison 24 / follow_up 21 / abstention 21). Bootstrap CI 폭 이론적 수축 ×0.65 (√42/100). Detection-blind ablation 재측정은 real-eval 기준으로 후속 실행 예정.
+> **완료 ([issue #570](https://github.com/hskim-solv/BidMate-DocAgent/issues/570))**: 공개 합성 n=42 → **n=100 확장** (single_doc 34 / comparison 24 / follow_up 21 / abstention 21). Bootstrap CI 폭 이론 수축 ×0.65 (√42/100). Detection-blind 분석 변형 재측정은 real-eval 기준 후속
 
 ## TL;DR
-- **문제**: 길고 복잡한 RFP 문서에서 실무 의사결정에 필요한 핵심 조건(예산/일정/요구사항/제출조건)을 빠르게 찾기 어렵습니다.
-- **해결**: 질문 유형 분석 + metadata-first 검색 + local dense retrieval/reranking + 근거 검증/retry를 결합한 Agentic RAG 파이프라인.
-- **시스템 설계**: 외부 LLM 호출 없이 evidence에서 claim을 추출하고 citation을 연결하는 **extractive grounded-answer 파이프라인** ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
-- **성과**: 공개 synthetic 평가셋 **n=100** (single_doc 34 / comparison 24 / follow_up 21 / abstention 21) 기준 근거 기반 응답 품질 검증. Abstention **+77.8pp** / Citation Precision **+39.3pp** (CI 분리, 통계적으로 유의). [평가셋 상세 spec](docs/eval/eval-dataset-spec.md)
-- **Latency** (naive_baseline, hashing, macOS CPU, n=100): p50 1.7ms / p95 3.1ms.
+
+- **문제**: 길고 복잡한 RFP 문서에서 실무 의사결정용 핵심 조건 (예산/일정/요구사항/제출조건) 을 빠르게 찾기 어려움
+- **해결**: 질문 유형 분석 + 메타데이터 우선 검색 + local dense retrieval/reranking + 근거 검증/재시도를 결합한 Agentic RAG
+- **시스템 설계**: 외부 LLM 호출 없이 evidence 에서 claim 추출 + citation 연결하는 **추출형 근거 답변 파이프라인** ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md))
+- **성과**: 공개 합성 n=100 (single_doc 34 / comparison 24 / follow_up 21 / abstention 21) 기준 근거 기반 응답 품질 검증. Abstention **+77.8pp** / Citation Precision **+39.3pp** (CI 분리, 통계 유의). [평가셋 spec](docs/eval/eval-dataset-spec.md)
+- **Latency** (naive_baseline, hashing, macOS CPU, n=100): p50 1.7ms / p95 3.1ms
 
 ---
 
 ## Key technical contribution — comparison-aware balanced top-k
 
-본 프로젝트의 가장 큰 차별점은 RFP 비교 질의(`query_type == "comparison"`)에서 발생하는 한쪽 문서 starvation을 막는 **balanced top-k retrieval ranking** 입니다. 일반 agentic RAG 튜토리얼에는 없는 RFP 도메인-특화 ranking 결정입니다.
+RFP 비교 질의 (`query_type == "comparison"`) 에서 발생하는 한쪽 문서 starvation 을 막는 **balanced top-k 검색 ranking**. 일반 agentic RAG 튜토리얼에 없는 RFP 도메인 특화 결정.
 
-**문제 패턴**: 단순 global top-k 컷은 score가 높은 한 문서가 결과 슬롯을 과점하면 다른 비교 대상 문서가 evidence에서 누락됩니다. 이로 인해 verifier가 근거 부족을 감지해 불필요한 retry를 트리거하거나 abstention으로 응답하는 실패가 발생합니다.
+**문제 패턴**: 단순 global top-k cut 은 score 가 높은 한 문서가 결과 슬롯 과점 → 다른 비교 대상 문서가 evidence 누락 → verifier 가 근거 부족 감지해 불필요 재시도 또는 보류 응답
 
-**설계**: Query Analyzer가 추출한 비교 target 별로 `min_per_target=1` 이상 evidence를 보장한 뒤, 남은 슬롯을 글로벌 score 순으로 채웁니다. 단일 문서 질의에서는 no-op으로 동작해 추가 비용이 없습니다.
+**설계**: Query Analyzer 가 추출한 비교 target 별로 `min_per_target=1` 이상 evidence 보장, 남은 슬롯은 글로벌 score 순. 단일 문서 질의에서는 no-op (추가 비용 0)
 
 - 구현: [`apply_comparison_balance()` (rag_core.py)](rag_core.py), 기본 설정 [`DEFAULT_COMPARISON_BALANCE` (rag_core.py)](rag_core.py)
-- 테스트: [tests/test_fuzzy_retrieval.py](tests/test_fuzzy_retrieval.py) — asymmetric corpus 균형 보장, disabled 시 global ordering 보존, single-doc no-op
-- 설계 문서: [`docs/retrieval/comparison-ranking.md`](docs/retrieval/comparison-ranking.md)
+- 테스트: [tests/test_fuzzy_retrieval.py](tests/test_fuzzy_retrieval.py) — asymmetric corpus 균등 보장, disabled 시 global ordering 보존, single-doc no-op
+- 설계: [`docs/retrieval/comparison-ranking.md`](docs/retrieval/comparison-ranking.md)
 
-> **One-line pitch**: RFP 비교 질의의 실패 패턴(한쪽 문서 starvation → verifier retry → abstention)을 발견하고, 이를 막는 retrieval ranking 전략을 설계·구현·테스트로 검증한 것이 본 프로젝트의 핵심 기여입니다.
+> **One-line pitch**: RFP 비교 질의 실패 패턴 (한쪽 문서 starvation → verifier 재시도 → 보류) 을 발견하고, 이를 막는 검색 ranking 전략을 설계·구현·테스트로 검증한 것이 본 프로젝트의 핵심 기여
 
 ---
 
 ## 핵심 성능표 (실측)
 
 **측정 환경**:
-- **시스템 타입**: Extractive-only — 외부 LLM(GPT/Claude 등) 호출 없음, 의도된 설계입니다.
-- **임베딩 백엔드**: 아래 metric table은 `hashing` (CI source of truth) 측정값입니다. `MiniLM-L12-v2` 비교: [`docs/benchmarking.md`](docs/benchmarking.md).
-- **측정 범위**: `Latency p95` 컬럼은 query_analysis + context_resolution + answer_generation 합의 walltime. retrieve/verify stage는 `reports/eval_summary.json`의 `stage_latency` 블록.
-- **실행 환경**: macOS / CPU-only / Python 3.11 / 단일 워커.
-- **Cold start 분리**: hashing ≈ 2.1ms / sentence-transformers ≈ 5.7s.
-- **평가셋**: 공개 synthetic n=100 (single_doc 34 / comparison 24 / follow_up 21 / abstention 21). 비공개 RFP eval은 [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)에 따라 분리합니다. 평가셋 구성 상세: [docs/eval/eval-dataset-spec.md](docs/eval/eval-dataset-spec.md)
-- **헤드라인 latency 기준 preset**: naive_baseline Latency p95 (3.1ms)가 CI source of truth. `agentic_full_llm`은 LLM 레이턴시 포함해 환경 의존적이므로 CI 고정 대상 아님.
-- **`agentic_full_llm` 백엔드 구분**: ablation 표의 `full_llm` 행은 `BIDMATE_SYNTHESIS_BACKEND=stub`(token-less, deterministic; [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md)) 기준. stub은 pass-through 합성이라 `full`과 동일 metric이 *정상*.
-- **Rerank 종류 구분**: `Rerank on` 행 대부분은 weighted-score rerank. `full_reranker`만 cross-encoder rerank([rag_rerank.py](rag_rerank.py)) — CI default `stub`이라 `full`과 수치 일치.
+- **시스템 타입**: 추출형 only — 외부 LLM (GPT/Claude 등) 호출 없음, 의도된 설계
+- **임베딩 backend**: 메트릭 표는 `hashing` (CI source of truth). `MiniLM-L12-v2` 비교: [`docs/benchmarking.md`](docs/benchmarking.md)
+- **측정 범위**: `Latency p95` 컬럼 = query_analysis + context_resolution + answer_generation walltime 합. retrieve/verify stage = `reports/eval_summary.json` `stage_latency` 블록
+- **실행 환경**: macOS / CPU-only / Python 3.11 / 단일 워커
+- **Cold start 분리**: hashing ≈ 2.1ms / sentence-transformers ≈ 5.7s
+- **평가셋**: 공개 합성 n=100. 비공개 RFP eval 은 [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md) 분리. 상세: [docs/eval/eval-dataset-spec.md](docs/eval/eval-dataset-spec.md)
+- **헤드라인 latency 기준**: naive_baseline p95 (3.1ms) 가 CI source of truth. `agentic_full_llm` 은 LLM 레이턴시 포함 환경 의존이라 CI 고정 대상 아님
+- **`agentic_full_llm` backend**: 분석 변형 표의 `full_llm` 행은 `BIDMATE_SYNTHESIS_BACKEND=stub` (token-less, deterministic; [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md)). stub 은 pass-through 합성이라 `full` 과 동일 메트릭이 *정상*
+- **Rerank 종류**: `Rerank on` 행 대부분 weighted-score rerank. `full_reranker` 만 cross-encoder rerank ([rag_rerank.py](rag_rerank.py)) — CI default `stub` 이라 `full` 과 수치 일치
 
 <!-- METRICS_TABLE:START -->
 | Category | Metric | agentic_full (95% CI) | naive_baseline (95% CI) | Δ |
@@ -127,7 +128,7 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 | no_metadata_first | agentic_full | auto | off | on | on | 0.692±0.10 | 0.740±0.09 | 0.595±0.07 | 0.965±0.04 | 0.600 | 0.818 (18/4/0) | 0.000 | 3.6ms |
 | no_verifier_retry | agentic_full | auto | on | on | off | 0.821±0.09 | 0.720±0.09 | 0.705±0.09 | 0.983±0.03 | 0.660 | 0.273 (6/16/0) | 0.000 | 2.7ms |
 
-<details><summary>Detection-blind ablations — statistically inseparable from <code>full</code> at n=42 (CI bands overlapping; n=42 was the statistical limit). Dataset expanded to n=100 (issue #570 완료); real-eval re-measurement pending. <strong>19 ablations · ≥5pp + non-overlap CI = 0 winners</strong> — null-result는 [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) baseline 결정성의 mechanical proof로 surface한다 ([docs/eval/ablation-discriminability.md](docs/eval/ablation-discriminability.md), [issue #782](https://github.com/hskim-solv/BidMate-DocAgent/issues/782)).</summary>
+<details><summary>Detection-blind 분석 변형 — n=42 에서 <code>full</code> 과 통계 분리 불가 (CI band 겹침). n=100 확장 완료 (issue #570); real-eval 재측정 대기. <strong>19개 분석 변형 · ≥5pp + non-overlap CI = 0 winners</strong> — null-result 는 [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) 기준선 결정성의 mechanical proof 로 표면화 ([docs/eval/ablation-discriminability.md](docs/eval/ablation-discriminability.md), [issue #782](https://github.com/hskim-solv/BidMate-DocAgent/issues/782)).</summary>
 
 | Run | Pipeline | Top-k | Metadata-first | Rerank | Verifier/Retry | Accuracy | Groundedness | Citation | Claim Align | Format | Abstention | Retry | Latency p95 |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
@@ -149,29 +150,29 @@ LLM synthesis opt-in(`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis-
 
 </details>
 
-> Values shown as `mean±half-width` for the 95% bootstrap CI (n=cases, 1000 resamples, seed=17). CI overlap between rows = statistical detection limit at that n, not equivalence. At n=42 the half-width was ~±0.12; n=100 narrows it by ×0.65 (√42/100). The non-CI columns (Format, Abstention, Retry) are point estimates; their CIs appear in the detailed main table above.
+> 수치는 `mean±half-width` (95% bootstrap CI, n=cases, 1000 resample, seed=17). 행 간 CI 겹침 = 해당 n 에서의 통계 검출 한계, equivalence 아님. n=42 half-width ≈ ±0.12; n=100 으로 ×0.65 (√42/100) 수축. 비-CI 컬럼 (Format, Abstention, Retry) 은 point estimate; 그 CI 는 위 main 표 참조
 <!-- METRICS_TABLE:END -->
 
-> **Ablation → ADR Status mapping** ([issue #813](https://github.com/hskim-solv/BidMate-DocAgent/issues/813)) — each ablation row above is governed by an ADR; this column tells external readers which rows are *accepted decisions* vs. *proposed/superseded ablations under measurement*:
+> **분석 변형 → ADR Status 매핑** ([issue #813](https://github.com/hskim-solv/BidMate-DocAgent/issues/813)) — 각 행이 어느 ADR 의 지배를 받는지, 외부 reader 에게 *accepted 결정* vs *제안/superseded 측정 중* 표시:
 >
-> | Ablation row(s) | ADR | Status |
+> | 분석 변형 행 | ADR | Status |
 > |---|---|---|
 > | `full`, `naive_baseline` | [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) | accepted |
-> | `no_metadata_first` (inverse ablation) | [ADR 0002](docs/adr/0002-metadata-first-retrieval.md) | accepted |
-> | `no_verifier_retry` (inverse ablation) | [ADR 0004](docs/adr/0004-verifier-retry-policy.md) | accepted |
+> | `no_metadata_first` (역 분석 변형) | [ADR 0002](docs/adr/0002-metadata-first-retrieval.md) | accepted |
+> | `no_verifier_retry` (역 분석 변형) | [ADR 0004](docs/adr/0004-verifier-retry-policy.md) | accepted |
 > | `hybrid_bm25*` family | [ADR 0010](docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md) | accepted |
 > | `full_llm`, `full_llm_metadata` | [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md) | **proposed** |
 > | `full_hyde` | [ADR 0023](docs/adr/0023-hyde-query-expansion-ablation.md) | **proposed** |
 > | `full_reranker` | [ADR 0026](docs/adr/0026-cross-encoder-reranker-deferral.md) | superseded (deferral) |
 > | `agentic_full_finetuned`, `naive_baseline_finetuned` | [ADR 0027](docs/adr/0027-lora-finetuned-embedding-additive.md) | superseded |
 > | `full_kiwi` | [ADR 0031](docs/adr/0031-bm25-korean-morphology-additive.md) | superseded |
-> | `hierarchical`, `no_rerank` | (chunking / rerank toggles; no dedicated ADR) | n/a |
+> | `hierarchical`, `no_rerank` | (청킹/rerank 토글, 전용 ADR 없음) | n/a |
 >
-> Reading guide: a *proposed* ablation row has not yet earned accepted status — typically it sits on the additive-ablation side of [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) until n=100 real-eval re-measurement separates its CI from `full`. A *superseded* row was either subsumed by a later decision (e.g. ADR 0027 → ADR 0037 KURE v1) or deferred until baseline conditions are met. Status drift here = ADR not synced; this footnote is a manual reminder until a `scripts/check_ablation_adr_sync.py` lints the mapping (issue #813 § 시정 액션 ②).
+> *proposed* 행은 accepted 미진입 — 보통 [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) additive 분석 변형 측에 머물다 n=100 real-eval 재측정으로 `full` 과 CI 분리되어야 진입. *superseded* 는 후속 결정 (ADR 0027 → ADR 0037 KURE v1) 에 흡수 또는 기준선 조건 미충족 시 보류. Status drift = ADR 미동기 — `scripts/check_ablation_adr_sync.py` 가 매핑 lint 할 때까지 수동 reminder (issue #813 § 시정 액션 ②)
 
-> **더 읽기**: [docs/rag-challenges-solved.md](docs/rag-challenges-solved.md) — 이 숫자를 만든 3가지 핵심 결정(STAR 회고). [docs/performance-evolution.md](docs/performance-evolution.md) — n=42→n=100 CI 수축 히스토리 + 기능별 ablation 효과 분해.
+> **더 읽기**: [docs/rag-challenges-solved.md](docs/rag-challenges-solved.md) — 이 숫자를 만든 3가지 핵심 결정 (STAR 회고). [docs/performance-evolution.md](docs/performance-evolution.md) — n=42→n=100 CI 수축 히스토리 + 기능별 분석 변형 효과 분해
 
-> **Ablation 해석 — CI가 말해주는 검출 한계 vs 실측 trade-off**: `no_rerank` / `hierarchical` / `full_llm`이 `full`과 동일 metric을 보이는 것은 *기능이 동등해서가 아니라 n=42 + bootstrap CI가 차이를 검출하지 못해서*였습니다 — CI 폭이 너무 넓어 미세 차이는 noise에 묻혔습니다. 현재 n=100 확장 완료(issue #570); real-eval 재측정으로 통계적 분리 가능성 확인 예정. **CI가 분리되는 진짜 효과**: `no_metadata_first` citation 0.679±0.11 (CI 0.571–0.786) vs `full` 0.905±0.08 (0.821–0.976) — CI 비겹침으로 metadata-first 효용 통계적 입증. `no_verifier_retry` groundedness 0.762±0.14 (CI 0.619–0.881) vs `full` 0.929±0.07 — verifier loop 효용 시사. 상세 latency·embedding backend 비교: [`docs/benchmarking.md`](docs/benchmarking.md).
+> **분석 변형 해석 — CI 검출 한계 vs 실측 trade-off**: `no_rerank` / `hierarchical` / `full_llm` 이 `full` 과 동일 메트릭을 보이는 것은 *기능 동등* 이 아니라 *n=42 + bootstrap CI 가 차이 미검출* 때문 — CI 폭이 너무 넓어 미세 차이가 noise 에 묻힘. n=100 확장 완료 (issue #570); real-eval 재측정으로 통계 분리 가능성 확인 예정. **CI 분리되는 진짜 효과**: `no_metadata_first` citation 0.679±0.11 (CI 0.571–0.786) vs `full` 0.905±0.08 (0.821–0.976) — CI 비겹침으로 메타데이터 우선 효용 통계 입증. `no_verifier_retry` groundedness 0.762±0.14 (CI 0.619–0.881) vs `full` 0.929±0.07 — verifier loop 효용 시사. 상세: [`docs/benchmarking.md`](docs/benchmarking.md)
 
 ---
 
@@ -197,9 +198,9 @@ flowchart TD
     class P,G highlight
 ```
 
-> 강조된 두 노드: Planner의 `comparison-aware top_k` → [Key technical contribution](#key-technical-contribution--comparison-aware-balanced-top-k), Answer Generator의 `extractive — no LLM` → [Why extractive?](#why-extractive-not-generative)
+> 강조 2 노드: Planner 의 `comparison-aware top_k` → [Key technical contribution](#key-technical-contribution--comparison-aware-balanced-top-k), Answer Generator 의 `extractive — no LLM` → [Why extractive?](#왜-추출형extractive인가-생성형generative이-아닌가)
 
-비교 질의(`query_type == "comparison"`)에서는 balanced top-k 컷을 적용해 각 비교 대상에 최소 1개 이상의 evidence를 보장합니다. Metadata filter staging, alias lexicon, follow-up carryover 상세: [`docs/retrieval/retrieval-hardening.md`](docs/retrieval/retrieval-hardening.md). `retrieval_backend` hybrid(BM25+RRF) 근거: [ADR 0010](docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md). "agentic"의 의미 (bounded retry vs ReAct/Reflexion 비교): [`docs/agentic/agentic-definition.md`](docs/agentic/agentic-definition.md).
+비교 질의 (`query_type == "comparison"`) 에서는 balanced top-k cut 으로 각 비교 대상에 최소 1개 evidence 보장. 메타데이터 filter staging, alias lexicon, follow-up carryover: [`docs/retrieval/retrieval-hardening.md`](docs/retrieval/retrieval-hardening.md). `retrieval_backend` hybrid (BM25+RRF) 근거: [ADR 0010](docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md). "agentic" 의 의미 (bounded 재시도 vs ReAct/Reflexion 비교): [`docs/agentic/agentic-definition.md`](docs/agentic/agentic-definition.md).
 
 ---
 
@@ -213,7 +214,7 @@ python3 eval/run_eval.py --index_dir data/index --output_dir reports --config ev
 python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md
 ```
 
-상세 실행 방법 (FastAPI demo, PDF/HWP ingestion, visual parsing v2, private 100-doc eval, harness): [`docs/operations/api-demo.md`](docs/operations/api-demo.md).
+상세 실행 (FastAPI 데모, PDF/HWP ingestion, visual parsing v2, 비공개 100-doc eval, harness): [`docs/operations/api-demo.md`](docs/operations/api-demo.md).
 
 ---
 
@@ -222,40 +223,40 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 | 목적 | 링크 |
 |---|---|
 | ADR 인덱스 (43개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |
-| Ablation results + benchmarking + latency 비교 | [`docs/benchmarking.md`](docs/benchmarking.md) / [`docs/eval/ablation-results.md`](docs/eval/ablation-results.md) |
-| 설계 배경 (Korean RFP adaptations, 5가지) | [`docs/design-background.md`](docs/design-background.md) |
+| 분석 변형 결과 + benchmarking + latency 비교 | [`docs/benchmarking.md`](docs/benchmarking.md) / [`docs/eval/ablation-results.md`](docs/eval/ablation-results.md) |
+| 설계 배경 (한국 RFP 적응 5가지) | [`docs/design-background.md`](docs/design-background.md) |
 | 답변 출력 정책 + Evidence boundary + Baseline policy | [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md) |
 | 한계 + 실패 사례 (real-data taxonomy) | [`docs/real-data/failure-cases.md`](docs/real-data/failure-cases.md) / [`docs/real-data/real-data-failure-taxonomy.md`](docs/real-data/real-data-failure-taxonomy.md) |
-| 공개 평가셋 상세 spec (n=100, 7-doc corpus, 방법론) | [`docs/eval/eval-dataset-spec.md`](docs/eval/eval-dataset-spec.md) |
+| 공개 평가셋 spec (n=100, 7-doc corpus, 방법론) | [`docs/eval/eval-dataset-spec.md`](docs/eval/eval-dataset-spec.md) |
 | 비공개 100-doc aggregate 정책 + placeholder | [`docs/real-data/private-100-doc-experiments.md`](docs/real-data/private-100-doc-experiments.md) |
 | 엔지니어링 블로그 (GitHub Pages) | [hskim-solv.github.io/BidMate-DocAgent](https://hskim-solv.github.io/BidMate-DocAgent/) |
 | 전체 문서 인덱스 | [`docs/README.md`](docs/README.md) |
+| 번역 용어집 (한국어 docs 번역 규약) | [`docs/translation-glossary.md`](docs/translation-glossary.md) |
 
 ---
 
-## Claude Code와의 협업 (AI Collaboration Transparency)
+## Claude Code 와의 협업 (AI 협업 투명성)
 
-이 프로젝트는 [Claude Code](https://claude.ai/code)(Opus 4.x)를 개발 파트너로 사용합니다. 과잉 주장(over-claim) 방지를 위해 역할 분담을 명시합니다.
+이 프로젝트는 [Claude Code](https://claude.ai/code) (Opus 4.x) 를 개발 파트너로 사용. 과잉 주장 (over-claim) 방지를 위한 역할 분담:
 
-**본인 영역 (사람)**
-- ADR 설계 및 의사결정 게이트 — 어떤 문제를, 언제, 왜 해결할지
+**사람 영역**
+- ADR 설계 및 의사결정 게이트 — 어떤 문제를, 언제, 왜 해결
 - 포트폴리오 플랜 + 우선순위 (채용 funnel 4층 프레임워크)
 - 5축 협업 self-review 기준 정의 및 분기별 진단
 - 평가 설계 (공개/비공개 분리 경계, ADR 0005) 및 회귀 기준
 
-**Claude Code 영역 (AI)**
+**Claude Code 영역**
 - 코드 구현, 리팩터링, 문서 초안, 테스트 작성
 - 브랜치/PR/이슈 생성 및 CI gate 운영 보조
-- 탐색(Explore subagent), 설계 검토(Plan subagent), 반복 작업 자동화
+- 탐색 (Explore subagent), 설계 검토 (Plan subagent), 반복 작업 자동화
 
-**Governance가 막은 실제 인시던트 3건** — synthetic-CI가 놓친 abstention 회귀(#69), stacked-PR child auto-close, ADR 번호 worktree 충돌. 각 사고와 사후 보강 hook/rule: [`docs/engineering-governance.md` Governance saves](docs/engineering-governance.md#governance-saves-real-incidents-prevented). 거버넌스가 *있다*는 신호보다 *rent를 냈다*는 신호를 우선합니다.
+**Governance 가 막은 실제 인시던트 3건** — 합성 CI 가 놓친 보류 회귀 (#69), stacked-PR child auto-close, ADR 번호 worktree 충돌. 각 사고와 사후 보강 hook/rule: [`docs/engineering-governance.md` Governance saves](docs/engineering-governance.md#governance-saves-실제-막은-인시던트). 거버넌스가 *있다* 는 신호보다 *rent 를 냈다* 는 신호 우선.
 
-**분기별 협업 자가진단** — `/self-review-quarterly` skill로 4축(포트폴리오 진행도) + 5축(Claude 협업 효율)을 한 보고서로 생성.
-최신 보고서: [`docs/self-review/Q2-2026.md`](docs/self-review/Q2-2026.md)
+**분기별 협업 자가진단** — `/self-review-quarterly` skill 로 4축 (포트폴리오 진행도) + 5축 (Claude 협업 효율) 을 한 보고서로 생성. 최신: [`docs/self-review/Q2-2026.md`](docs/self-review/Q2-2026.md)
 
 ---
 
 ## Notice
-- 원본 RFP 문서는 외부 공유 제한으로 저장소에 포함하지 않았습니다.
-- `data/raw` 문서는 공개 재현을 위해 작성한 synthetic RFP 샘플입니다.
-- 본 저장소는 재현 가능한 구조/평가 관점의 포트폴리오 문서화를 목표로 합니다.
+- 원본 RFP 문서는 외부 공유 제한으로 저장소 미포함
+- `data/raw` 는 공개 재현용 합성 RFP 샘플
+- 본 저장소 = 재현 가능 구조/평가 관점의 포트폴리오 문서화 목표

--- a/docs/agent-utilization.md
+++ b/docs/agent-utilization.md
@@ -1,58 +1,58 @@
 # Agent Utilization Strategy
 
-> Q3-2026 KPI: Claude 협업 5축 중 ≥3축을 ✓로 끌어올린다. Q2-2026 self-review 결과는 1✓4△ — 컨텍스트 효율만 ✓.
+> **Q3-2026 KPI**: Claude 협업 5축 중 ≥3축을 ✓로 끌어올린다. Q2-2026 self-review = 1✓4△ (컨텍스트 효율만 ✓).
 >
-> 이 문서는 `self-review-quarterly` skill이 다음 분기에 5축을 채점할 때 직접 참조한다. 트리거·도구·측정이 빠짐없이 명시돼야 평가 가능하다.
+> 이 문서는 `self-review-quarterly` skill 이 다음 분기 5축을 채점할 때 직접 참조 — 트리거·도구·측정이 모두 명시돼야 평가 가능.
 
 ## TL;DR
 
-- 도구 면적은 이미 풍부하다 — PreToolUse 훅 3개, git 훅 2개, CI 2개, Make 타깃 10+, 프로젝트 skill 3개, 시스템 서브에이전트 5종. **문제는 카탈로그·트리거 부재**라서 호출되지 않는다.
-- 이 문서는 4 pillar(룰/스킬/서브에이전트/커맨드)을 5축 KPI에 reverse-mapping한 운영 가이드다. 새 코드 0줄.
-- 측정 인프라(`.hook-fires.log` 활성화 등 follow-up issues #718–#720)는 별도 PR이지만, 이 PR 머지 직후 `make install-hooks` 1회로 자동화 ROI 측정이 시작된다.
+- 도구 면적은 풍부 (PreToolUse 훅 3, git 훅 2, CI 2, Make 타깃 10+, 프로젝트 skill 3, 시스템 서브에이전트 5). **문제는 카탈로그·트리거 부재**라 호출되지 않음
+- 본 문서 = 4 pillar (룰/스킬/서브에이전트/커맨드) 를 5축 KPI 에 reverse-mapping 한 운영 가이드. 신규 코드 0줄
+- 측정 인프라 (`.hook-fires.log` 활성화 등 follow-up #718–#720) 는 별도 PR; 머지 직후 `make install-hooks` 1회로 자동화 ROI 측정 시작
 
 ## 4 Pillar — 책임 분담
 
 | Pillar | 정의 | 강제력 | 예 |
 |---|---|---|---|
-| **규칙(Rules)** | 자동 강제 invariant | 훅·CI 차단 | PreToolUse load-bearing edit, branch naming, ADR 0005 경계 |
+| **규칙(Rules)** | 자동 강제 invariant | 훅·CI 차단 | PreToolUse load-bearing edit, 브랜치 명명, ADR 0005 경계 |
 | **스킬(Skills)** | workflow 묶음 + 승인 게이트 | 사람·Claude 수동 호출 | `ship-pr`, `self-review-quarterly`, `adr-portfolio-signals` |
-| **커맨드(Commands)** | 수동 트리거(평가·shipping·검증) | Make 타깃 / 스크립트 | `make smoke`, `make real-eval`, `make ship-arm`, `make governance-check` |
-| **서브에이전트(Subagents)** | 컨텍스트 격리(읽기 전용 탐색·설계 외주) | 메인 컨버세이션에서 위임 | Explore, Plan, general-purpose |
+| **커맨드(Commands)** | 수동 트리거 (평가·shipping·검증) | Make 타깃 / 스크립트 | `make smoke`, `make real-eval`, `make ship-arm`, `make governance-check` |
+| **서브에이전트(Subagents)** | 컨텍스트 격리 (읽기 전용 탐색·설계 외주) | 메인 대화에서 위임 | Explore, Plan, general-purpose |
 
-원칙: **규칙은 자동, 나머지 셋은 트리거 조건이 만족될 때만 호출.** 트리거가 모호하면 도구는 사장된다.
+원칙: **규칙은 자동, 나머지 셋은 트리거 만족 시만 호출.** 트리거가 모호하면 도구는 사장.
 
 ## 5축 × 4 Pillar 매핑
 
 | 축 | Q2 | 트리거 조건 | 도구 조합 (4 pillar) | 측정 지표 | Follow-up |
 |---|---|---|---|---|---|
 | **#1 컨텍스트 효율** | ✓ | Read 5회 누적 / 단일 파일 200줄↑ | **서브에이전트:** Explore 위임 (병렬 ≤3) · **커맨드:** `/clear` 후 작업 분리 | 대화당 평균 token, Explore 호출 수/분기 | — |
-| **#2 Agent 위임** | △ | 비-trivial 변경(>1 파일 or >50 LOC) 시작 전 · plan mode 진입 | **서브에이전트:** Plan 기본 호출 · **규칙:** `## Delegation defaults` (CLAUDE.md) · **스킬:** multi-agent-ownership 역할 분담 | PR diff>50 LOC 중 Plan 호출 0회 비율 | #718 |
-| **#3 자동화 ROI** | △ | worktree clone 직후 · 분기 시작 | **커맨드:** `make install-hooks` · `make ship-arm` · `make governance-check` · **규칙:** PreToolUse 훅 3개 · **스킬:** `ship-pr` | `.hook-fires.log` 라인 수, ship-* 경유 PR 비율 | #719 |
-| **#4 사이클 타임** | △ | ADR proposed→accepted >7일 · PR open→merge >3일 | **스킬:** `ship-pr`(ADR 번호 예약 + stacked 안전) · **커맨드:** `make ship-arm`(Stop훅 자동 배송) | ADR lag 평균, PR turnaround p90 | #724 |
-| **#5 메모리 위생** | △ | memory 파일 추가·수정 · 인덱스 라인 >20 | **스킬:** `anthropic-skills:consolidate-memory` · `productivity:memory-management` · **규칙:** PreToolUse Edit 매처 (예정) | 인덱스 라인 수, stale(>2분기 미참조) 비율 | #720 |
+| **#2 Agent 위임** | △ | 비-trivial 변경 (>1 파일 or >50 LOC) 시작 전 · plan mode 진입 | **서브에이전트:** Plan 기본 호출 · **규칙:** `## Delegation defaults` (CLAUDE.md) · **스킬:** multi-agent-ownership 역할 분담 | PR diff>50 LOC 중 Plan 호출 0회 비율 | #718 |
+| **#3 자동화 ROI** | △ | worktree clone 직후 · 분기 시작 | **커맨드:** `make install-hooks` · `make ship-arm` · `make governance-check` · **규칙:** PreToolUse 훅 3 · **스킬:** `ship-pr` | `.hook-fires.log` 라인 수, ship-* 경유 PR 비율 | #719 |
+| **#4 사이클 타임** | △ | ADR proposed→accepted >7일 · PR open→merge >3일 | **스킬:** `ship-pr` (ADR 번호 예약 + stacked 안전) · **커맨드:** `make ship-arm` (Stop훅 자동 ship) | ADR lag 평균, PR turnaround p90 | #724 |
+| **#5 메모리 위생** | △ | memory 파일 추가·수정 · 인덱스 라인 >20 | **스킬:** `anthropic-skills:consolidate-memory` · `productivity:memory-management` · **규칙:** PreToolUse Edit matcher (예정) | 인덱스 라인 수, stale (>2분기 미참조) 비율 | #720 |
 
 ## Shipping 경로 — `ship-pr` skill vs `make ship-arm`
 
-둘은 **mutually exclusive**. PR 시작 시(commit-0) 결정해서 commit message에 명시한다:
+둘은 **mutually exclusive**. PR commit-0 에 결정 + commit message 명시.
 
-- **`ship-pr` skill** — 수동 게이트. push와 merge 각 단계에서 명시적 승인. ADR 번호 예약·stacked-PR 감사 포함. **결정이 무겁거나 stacked PR이면 이쪽**.
-- **`make ship-arm`** — Stop훅 기반 자동 배송. 8-step 사전검사 통과 시 commit → push → PR → CI 대기 → squash-merge까지 자동. **소형/독립 PR이면 이쪽**.
+- **`ship-pr` skill** — 수동 게이트. push/merge 각 단계 명시 승인. ADR 번호 예약·stacked-PR 감사 포함. **결정이 무겁거나 stacked PR 이면 이쪽**
+- **`make ship-arm`** — Stop훅 기반 자동 ship. 8-step 사전검사 통과 시 commit → push → PR → CI 대기 → squash-merge 자동. **소형/독립 PR 이면 이쪽**
 
-동시 사용 금지(skill 설명 `ship-pr` 트리거 조항 명시). 자세한 단계는 [`auto-ship.md`](operations/auto-ship.md) 참조.
+자세한 단계: [`auto-ship.md`](operations/auto-ship.md).
 
 ## Follow-up Issues
 
-- **#718** — `scripts/_self_review.py`에 "diff>50 LOC + Plan 호출 0회" 카운터 (축 #2)
+- **#718** — `scripts/_self_review.py` "diff>50 LOC + Plan 호출 0회" 카운터 (축 #2)
 - **#719** — `Makefile` `smoke` 타깃의 `install-hooks` prerequisite (축 #3)
-- **#720** — `.claude/settings.json` PreToolUse Edit 매처(MEMORY.md 인덱스 라인 수) (축 #5)
+- **#720** — `.claude/settings.json` PreToolUse Edit matcher (MEMORY.md 인덱스 라인 수) (축 #5)
 - **#724** — `scripts/_cycle_time.py` ADR lag + PR turnaround collector (축 #4)
 
-각 follow-up은 1 PR / 1 concern 원칙에 따라 분리한다. 이번 PR은 **전략 + 활성화 가이드**까지만.
+각 follow-up = 1 PR / 1 concern. 본 PR 은 **전략 + 활성화 가이드**까지만.
 
 ## References
 
 - [`docs/self-review/Q2-2026.md`](self-review/Q2-2026.md) — 5축 진단 원본
 - [`docs/multi-agent-ownership.md`](multi-agent-ownership.md) — 7역할 owner 모델
 - [`docs/operations/auto-ship.md`](operations/auto-ship.md) — `make ship-arm` 8-step 파이프라인
-- [`docs/engineering-governance.md`](engineering-governance.md) — workflow map
+- [`docs/engineering-governance.md`](engineering-governance.md) — 워크플로 맵
 - `MEMORY.md` 항목: `feedback_collaboration_axes.md`, `feedback_agent_delegation.md`, `feedback_q2_2026_collaboration_review.md`

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -1,310 +1,169 @@
-# Engineering governance
+# 엔지니어링 거버넌스
 
-This page is the **single navigation point** for how engineering work
-flows through this repo. It ties together the rule book
-([`CLAUDE.md`](../CLAUDE.md)), decision records
-([`docs/adr/`](./adr/README.md)), tests, evaluation, and
-reviewer-facing artifacts.
+엔지니어링 작업이 본 저장소를 어떻게 흘러가는지 안내하는 **단일 진입점**. 규칙서 ([`CLAUDE.md`](../CLAUDE.md)), 결정 기록 ([`docs/adr/`](./adr/README.md)), 테스트, 평가, reviewer 문서를 묶는다. 신규 기여자 또는 reviewer 온보딩은 여기서 시작.
 
-If you are new to the repo or onboarding a reviewer, start here.
+## 무엇이 어디에 있나
 
-## Where each thing lives
-
-| Concern | Source of truth | Notes |
+| 관심사 | 단일 출처 | 비고 |
 |---|---|---|
-| Coding & review rules | [`CLAUDE.md`](../CLAUDE.md) | Pre-PR checklist, prohibited shortcuts, performance expectations. |
-| Multi-agent coordination | [`docs/multi-agent-ownership.md`](./multi-agent-ownership.md) | 7-way ownership split, `rag_core.py` lock holder, conflict-resolution rules when several agents work in parallel. |
-| Load-bearing decisions | [`docs/adr/`](./adr/README.md) | One short file per decision; status-tracked. |
-| Behavior contracts | [ADR 0003](./adr/0003-structured-answer-citation-contract.md), [`docs/agentic/answer-policy.md`](./agentic/answer-policy.md) | Answer JSON shape, `schema_version`, status values. |
-| Eval surfaces | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`eval/config.yaml`](../eval/config.yaml), `eval/*.example.yaml` | Public synthetic is committed; private local is `.gitignore`d. |
-| Reviewer-facing metrics | `reports/eval_summary.json`, README headline table | The PR eval delta workflow upserts a PR comment with the diff. |
-| Failure analysis | [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md), [`docs/real-data/failure-cases.md`](./real-data/failure-cases.md) | Drives the prioritized backlog. |
-| API demo | [`docs/operations/api-demo.md`](./operations/api-demo.md), `api/main.py` | Reviewer playground; never the source of truth for measurement. |
-| Issue/PR triage | This page, ["Milestones & issue lifecycle"](#milestones--issue-lifecycle) | Milestones, stale policy, current categorisation snapshot. |
+| 코딩 & 리뷰 규칙 | [`CLAUDE.md`](../CLAUDE.md) | Pre-PR 체크리스트, 금지 shortcut, 성능 기대치 |
+| Multi-agent 조율 | [`docs/multi-agent-ownership.md`](./multi-agent-ownership.md) | 7-way 소유권, `rag_core.py` lock holder, 병행 작업 충돌 해결 |
+| Load-bearing 결정 | [`docs/adr/`](./adr/README.md) | 결정 당 짧은 파일 1개, status 추적 |
+| 동작 계약 | [ADR 0003](./adr/0003-structured-answer-citation-contract.md), [`docs/agentic/answer-policy.md`](./agentic/answer-policy.md) | 답변 JSON shape, `schema_version`, status 값 |
+| Eval 표면 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`eval/config.yaml`](../eval/config.yaml), `eval/*.example.yaml` | 공개 합성은 commit, 비공개 local 은 `.gitignore` |
+| Reviewer 메트릭 | `reports/eval_summary.json`, README headline 표 | PR eval 델타 워크플로가 PR 코멘트에 diff upsert |
+| 실패 분석 | [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md), [`docs/real-data/failure-cases.md`](./real-data/failure-cases.md) | 우선순위 백로그의 원천 |
+| API 데모 | [`docs/operations/api-demo.md`](./operations/api-demo.md), `api/main.py` | reviewer 놀이터, 측정 기준 아님 |
+| Issue/PR triage | 본 페이지 ["Milestones & 이슈 lifecycle"](#milestones--이슈-lifecycle) | 마일스톤, stale 정책, 현재 카테고리 스냅샷 |
 
-## Change lifecycle
+## 변경 lifecycle
 
-The expected flow for any non-trivial change, written as a checklist
-a contributor (human or AI) can walk through:
+non-trivial 변경의 체크리스트 (사람·AI 공용):
 
-1. **Open or pick an issue. (Required, ADR 0007.)** Real-data failure
-   taxonomy entries (`docs/real-data/real-data-failure-taxonomy.md`) and the
-   prioritized backlog are the primary feed. Use the templates in
-   [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/). The
-   branch + PR are required to reference this issue number; the
-   convention check (CI) will block merge otherwise.
-2. **Decide if it needs an ADR.** Use the criteria in
-   [`docs/adr/README.md`](./adr/README.md). Most changes do **not**;
-   when in doubt, ask in the issue.
-3. **Inspect what exists.** Per `CLAUDE.md` ("Before coding,
-   inspect..."). Name the files you read, the functions you intend
-   to reuse, and what you found that surprised you.
-4. **Branch + worktree if parallel.** Name the branch
-   `<type>/issue-<N>[-<slug>]` per ADR 0007 — e.g.
-   `feat/issue-79-hybrid-retrieval`. Claude Code's default
-   worktree names (`claude/<auto>`) must be renamed before the PR
-   (`git branch -m feat/issue-<N>-<slug>`). Two independent tracks
-   → two worktrees, two PRs. Coupled tracks → one PR, one branch.
-5. **Make the change.** Reuse over invent. One concern per PR.
-6. **Add or update tests.** Behavior change without a test is
-   presumed accidental. Regressions get a guard test in
-   `tests/test_*_regression.py`.
-7. **Run the eval locally if relevant.** `make eval` for the public
-   synthetic surface. Compare against `main`'s
-   `reports/eval_summary.json` if you have it.
-8. **Push, open PR.** PR body fills in
-   [`.github/pull_request_template.md`](../.github/pull_request_template.md)
-   (what / files / risks / tests / eval impact / back-compat / out-of-scope).
-9. **CI verifies.** Three checks run on every PR:
-   - `Pytest` (in `pr-eval.yml`).
-   - `Eval delta vs base` (in `pr-eval.yml`) — upserts a comment with
-     the metrics table; expect `·` across the board for non-RAG changes.
-   - `Validate branch name + issue link` (in `branch-and-issue-check.yml`,
-     ADR 0007) — enforces the convention. Required status check.
-10. **Address review.** No mid-review scope creep — open a follow-up
-    issue instead.
-11. **Merge.** Squash-merge, delete the branch, remove the worktree
-    if used.
-12. **Update docs** if the change changed something a reviewer needs
-    to know (README headline metrics, ADR status, taxonomy entry).
+1. **Issue 열기 또는 픽업 (필수, ADR 0007).** 실패 taxonomy + 우선순위 백로그가 1차 source. [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/) 사용. 브랜치+PR 은 이 issue 번호 참조 필수 — 컨벤션 체크 (CI) 가 merge 차단
+2. **ADR 필요한지 판단.** [`docs/adr/README.md`](./adr/README.md) 기준 사용. 대부분 불필요, 모호하면 issue 에 질문
+3. **기존 코드 점검.** 읽은 파일, 재사용 함수, 놀란 점 명시
+4. **Branch + worktree (병렬 시).** `<type>/issue-<N>[-<slug>]` (ADR 0007) — 예: `feat/issue-79-hybrid-retrieval`. Claude Code 기본 worktree 명 (`claude/<auto>`) 은 PR 전 rename (`git branch -m feat/issue-<N>-<slug>`)
+5. **변경 + 테스트.** 재사용 우선, one concern per PR. 동작 변경 무 테스트 = 사고. 회귀는 `tests/test_*_regression.py`
+6. **Eval 로컬 실행 (해당 시).** `make eval` 공개 합성. `main` 의 `reports/eval_summary.json` 과 비교
+7. **Push + PR.** PR body 는 [`.github/pull_request_template.md`](../.github/pull_request_template.md) 채움
+8. **CI 검증.** 3개 체크 (모든 PR): `Pytest` + `Eval delta vs base` + `Validate branch name + issue link` (ADR 0007, required status check)
+9. **리뷰 응답.** 리뷰 중 scope 추가 금지 — follow-up issue
+10. **Merge.** Squash-merge, 브랜치 삭제, worktree 정리
+11. **문서 갱신** (reviewer 가 알아야 할 변경 시): README headline 메트릭, ADR status, taxonomy entry
 
-## Milestones & issue lifecycle
+## Milestones & 이슈 lifecycle
 
-Open issues are grouped into milestones so the backlog scans cleanly
-and a reviewer can see what is planned vs. parked. Milestones are
-manually maintained on GitHub; the snapshot below is illustrative —
-the GitHub milestone pages are authoritative.
+Open issue 는 마일스톤으로 그룹화 — 백로그가 깨끗이 스캔되고 계획 vs 보류 구분 가능. 마일스톤은 GitHub 에서 수동 관리; 아래 스냅샷은 예시, GitHub 마일스톤 페이지가 authoritative.
 
-### Milestones
+### 마일스톤
 
-| Milestone | Purpose | Typical issue kind |
+| 마일스톤 | 목적 | 일반적 issue 종류 |
 |---|---|---|
-| `v3-release` | Concrete work toward the next release of the RAG stack — ingestion v3, retrieval/ranking changes, new core utilities. | `feat`, `fix` that ship behavior. |
-| `portfolio-review-readiness` | Reviewer-facing polish: README clarity, case-study narrative, deploy artifacts, structured-output docs, ablation visualisation. | `docs`, `chore`, `eval` work whose audience is the portfolio reviewer. |
-| `real-data-evaluation` | Private 100-doc real-data eval health: failures observed in [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md), Korean-specific axes, abstention regressions. | `eval`, `fix` that lands a measurable real-data delta. |
+| `v3-release` | RAG 스택 차기 릴리즈 작업 — ingestion v3, 검색·순위 변경, 신규 코어 유틸 | 동작 ship 하는 `feat`, `fix` |
+| `portfolio-review-readiness` | Reviewer 폴리시: README 명확성, 케이스 스터디, 배포 산출물, 구조화 출력 docs, 분석 변형 시각화 | 포트폴리오 reviewer 대상 `docs`, `chore`, `eval` |
+| `real-data-evaluation` | 비공개 100-doc real-data eval 건강성: [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md) 관측 실패, 한국어 축, 보류 회귀 | 측정 가능한 real-data 델타 ship 하는 `eval`, `fix` |
 
-Meta/parent issues (e.g. #118 portfolio review readiness, #187 phase
-enhancement backlog) do **not** carry a milestone — they group child
-issues which themselves are milestoned.
+Meta/parent issue (예: #118 포트폴리오, #187 phase 향상 백로그) 는 마일스톤 미할당 — 자식 issue 가 마일스톤 보유.
 
-### Stale-issue policy
+### Stale 정책
 
-- **60 days without activity** → label `stale`. Comment with a one-line
-  prompt: "still planned? close or rescope." Triage weekly.
-- **90 days without activity after `stale`** → close with a comment
-  pointing at the milestone the work would have lived in. Reopen if the
-  work is picked up.
-- **Never auto-close** — closure is a human decision, the label is the
-  automation-friendly signal.
+- **60일 무활동** → `stale` 라벨 + "still planned? close or rescope" 코멘트. 주간 triage
+- **`stale` 후 90일 무활동** → 마일스톤 포인터와 함께 close. 작업 재개 시 reopen
+- **Auto-close 절대 금지** — 종결은 사람 결정, 라벨이 자동화 친화 신호
 
-The labels and milestones are managed manually for now; no GitHub
-Action wires this. Promotion to automation lands as a separate change
-if backlog growth justifies it.
+라벨/마일스톤 현재 수동 관리, GitHub Action 미연결.
 
-### Snapshot (2026-05-11)
+### 스냅샷 (2026-05-11)
 
-| Milestone | Open issues |
+| 마일스톤 | Open issue |
 |---|---|
 | `v3-release` | #121, #167, #168, #170 |
 | `portfolio-review-readiness` | #122, #123, #124, #125, #127, #128, #164, #172 |
 | `real-data-evaluation` | #126 |
 
-Issues without a clear home stay milestone-less until categorised.
+분류되지 않은 issue 는 마일스톤 없이 유지.
 
-## How the documents reinforce each other
+## 문서들의 상호 강화
 
 ```
                 ┌───────────────────────────┐
-                │        CLAUDE.md          │  (the rules)
+                │        CLAUDE.md          │  (규칙)
                 └─────────────┬─────────────┘
                               │
               ┌───────────────┼────────────────┐
               ▼               ▼                ▼
         ┌──────────┐    ┌──────────┐     ┌──────────┐
-        │  ADRs    │    │  Tests   │     │   Eval   │
-        │ (why)    │    │ (guard)  │     │ (proof)  │
+        │  ADR     │    │  Test    │     │   Eval   │
+        │ (왜)     │    │ (가드)   │     │ (증명)   │
         └────┬─────┘    └────┬─────┘     └────┬─────┘
              │               │                │
              └───────────────┼────────────────┘
                              ▼
                 ┌───────────────────────────┐
-                │ Reviewer-facing artifacts │
-                │ (README, docs/*, PR diff) │
+                │   Reviewer 문서           │
+                │  (README, docs/*, PR diff)│
                 └───────────────────────────┘
 ```
 
-- **CLAUDE.md** says what every change must satisfy.
-- **ADRs** record why a load-bearing choice was made, so future
-  changes don't unknowingly invert it.
-- **Tests** prevent the rules and decisions from silently rotting.
-- **Eval** turns the rules and decisions into numbers a reviewer can
-  read.
-- **Reviewer artifacts** (README, design docs, PR descriptions,
-  ablation reports) point back into the above so the system can be
-  understood end-to-end without DM'ing the author.
+- **CLAUDE.md** = 모든 변경이 만족할 규칙
+- **ADR** = load-bearing 선택의 *왜*, 향후 무의식적 반전 방지
+- **Test** = 규칙·결정의 silent rot 방지
+- **Eval** = 규칙·결정을 reviewer 가 읽을 수치로 변환
+- **Reviewer 문서** (README, design docs, PR description, 분석 변형 report) 가 위를 가리켜 작성자 DM 없이 end-to-end 이해 가능
 
-## Anti-patterns this governance is designed to prevent
+## 본 거버넌스가 막는 안티패턴
 
-- Silent contract drift — an answer field disappears and no test
-  catches it. *Prevented by:* ADR 0003 + `score_answer_format` in
-  `eval/run_eval.py`.
-- Headline-metric inflation — README claims a number that no
-  artifact backs. *Prevented by:* `scripts/update_readme_metrics.py
-  --check` in `make check`, plus the public/private eval split (ADR
-  0005).
-- Baseline rot — the naive baseline still imports but no one runs
-  it. *Prevented by:* `naive_baseline` is a named ablation in
-  `eval/config.yaml`; every eval run reports it.
-- Decision laundering — a load-bearing choice is buried in a
-  refactor PR. *Prevented by:* ADR threshold in `CLAUDE.md` Core
-  principles + [`docs/adr/README.md`](./adr/README.md); the PR
-  template forces the question.
-- Review-time scope creep — a PR grows to include "while I was
-  here" fixes. *Prevented by:* "one PR, one concern" in
-  `CLAUDE.md`; spawn a follow-up issue instead.
+- **Silent 계약 drift** — 답변 필드가 사라져도 테스트가 못 잡음. *방지*: ADR 0003 + `score_answer_format` (`eval/run_eval.py`)
+- **Headline 메트릭 인플레이션** — README 가 산출물 없는 숫자 주장. *방지*: `scripts/update_readme_metrics.py --check` (in `make check`) + 공개/비공개 eval 분리 (ADR 0005)
+- **기준선 rot** — naive_baseline 이 import 되지만 아무도 안 돌림. *방지*: `naive_baseline` = `eval/config.yaml` 의 named 분석 변형, 매 eval run 마다 보고
+- **결정 세탁** — load-bearing 선택이 리팩터 PR 에 묻힘. *방지*: CLAUDE.md Core principles 의 ADR 임계값 + [`docs/adr/README.md`](./adr/README.md); PR 템플릿이 질문 강제
+- **리뷰 중 scope 증가** — "while I was here" fix 가 PR 비대화. *방지*: CLAUDE.md "one PR, one concern"; follow-up issue spawn
 
-## Governance saves: real incidents prevented
+## Governance saves: 실제 막은 인시던트
 
-The list above is the *design* — the rules and the guards. This
-section is the *evidence*: incidents that actually happened in this
-repo, and the hook/ADR/rule that was added afterward so the same
-class of failure cannot recur silently.
+위 목록은 *설계* — 규칙과 가드. 이 섹션은 *증거* — 실제 발생한 인시던트와 사후 추가된 hook/ADR/규칙. 거버넌스가 *있다* 가 아니라 *rent 를 냈다* 가 reviewer 의 30초 질문. 각 항목 = rent 1회.
 
-The point of recording these is to make the governance auditable.
-In an AI-assisted workflow where every layer (CLAUDE.md, hooks,
-ADRs, eval split) accretes by default, the question a reviewer
-should be able to answer in 30 seconds is *not* "is governance
-present?" but "did it pay rent?". Each entry below is one rent
-payment.
+- **#69 의도된 보류 회귀 — 합성 CI 의 real-data 사각.** 합성 n=42 CI 델타는 녹색이었으나 비공개 100-doc real-eval 에서 근거 불충분 시 의도된 보류 손실. eval 분리 규율 ([ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md)) 은 이미 있었지만 PR 시점 gate 가 advisory. *사후 추가*: PR 템플릿 **5b (real-data 델타)** 필수 CI 체크 ([`scripts/check_branch_and_issue.py --check-5b`](../scripts/check_branch_and_issue.py), [`scripts/_governance.py`](../scripts/_governance.py) load-bearing 경로 리스트 경유 강제). `rag_*.py` / `ingestion.py` / `eval/` / `api/` / `docs/adr/` 손대는 PR 은 real-data aggregate 첨부 또는 behavior-no-op 사유 명시 필요
 
-- **`#69` intended-abstention regression — synthetic-CI blind spot
-  on real data.** The synthetic n=42 CI delta was green, but the
-  private 100-doc real-eval lost intended abstentions on insufficient
-  evidence. The eval-split discipline ([ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md))
-  was already in place, but the PR-time gate was advisory. *Added
-  afterward:* PR template **item 5b (real-data delta)** is now a
-  required CI check
-  ([`scripts/check_branch_and_issue.py --check-5b`](../scripts/check_branch_and_issue.py),
-  enforced via the load-bearing path list in
-  [`scripts/_governance.py`](../scripts/_governance.py)). Any PR
-  touching `rag_*.py` / `ingestion.py` / `eval/` / `api/` / `docs/adr/`
-  must now attach the real-data aggregate or state a behavior-no-op
-  reason; the synthetic delta alone no longer clears merge.
+- **Stacked-PR child auto-close on `--delete-branch` merge.** base 브랜치를 `gh pr merge --delete-branch` 로 머지하면서 stacked dependent PR 이 여전히 그 브랜치를 target 으로 함 → GitHub 기본 동작이 dependent PR auto-close, 진행 중 리뷰 상태 손실. *사후 추가*: [`.claude/settings.json`](../.claude/settings.json) 의 `PreToolUse` Bash matcher 가 `gh pr list --base <this-PR-head> --state open --json number` 비어있지 않을 때 `gh pr merge --delete-branch` 거부. 명령이 GitHub 에 도달 전 차단. 규칙 텍스트는 `CLAUDE.md > Prohibited` 에 살아남도록 명시
 
-- **Stacked-PR child auto-close on `--delete-branch` merge.** Merging
-  a base branch with `gh pr merge --delete-branch` while a stacked
-  dependent PR was still targeting that branch closed the dependent
-  PR automatically (GitHub default behavior), losing the in-progress
-  child's review state. *Added afterward:* a `PreToolUse` Bash matcher
-  in [`.claude/settings.json`](../.claude/settings.json) refuses
-  `gh pr merge --delete-branch` whenever
-  `gh pr list --base <this-PR-head> --state open --json number` is
-  non-empty. The matcher fires before the command runs, so the merge
-  never reaches GitHub if a child exists. The textual rule lives in
-  `CLAUDE.md > Prohibited` so it survives even if the hook is later
-  disabled.
+- **ADR 번호 worktree 충돌.** 관측 페어 3개 — 0022→0023, 0023→0025, 0029→0030 — 두 worktree 가 독립적으로 `ls docs/adr/` 에서 같은 ADR 번호 예약 후 머지 시점 충돌. 수정은 procedural (번호는 공유 자원). *사후 추가*: `CLAUDE.md > Core principles > "Reserve ADR numbers up front"` 가 dual check (`ls docs/adr/` + `gh pr list --search "ADR" --state open`) 강제 + 사용자 확인 요구 (worktree 간 직렬화)
 
-- **ADR number collisions between concurrent worktrees.** Three
-  observed pairs — 0022→0023, 0023→0025, 0029→0030 — where two
-  worktrees independently reserved the same ADR number from
-  `ls docs/adr/`, then collided at merge. The fix is procedural
-  (numbers are a shared resource, not a per-tree allocation) rather
-  than a runtime gate. *Added afterward:* `CLAUDE.md > Core
-  principles > "Reserve ADR numbers up front"` makes the dual check
-  (`ls docs/adr/` + `gh pr list --search "ADR" --state open`)
-  mandatory before drafting, and requires user confirmation on the
-  proposed number to serialize the reservation across worktrees.
+각 인시던트 = 1회 지불된 실제 비용. 신규 인시던트 (거버넌스 갭 → 수정 → 무재발) 는 여기 추가.
 
-Each of these is a real cost paid once. New incidents that fit this
-shape (governance gap → fix → no recurrence) land here.
+## 온보딩 shortcut
 
-## Onboarding shortcuts
+신규 기여자 reading order:
 
-Reading order for a new contributor:
+1. [`CLAUDE.md`](../CLAUDE.md) — 규칙
+2. 본 파일 — 규칙들의 연결
+3. [`docs/adr/README.md`](./adr/README.md) + 현재 ADR 6개 훑기 — load-bearing 결정
+4. [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md) — 백로그 원천
 
-1. [`CLAUDE.md`](../CLAUDE.md) — the rules.
-2. This file — how the rules connect.
-3. [`docs/adr/README.md`](./adr/README.md) and skim the 6 current
-   ADRs — the load-bearing decisions.
-4. [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md)
-   — what the backlog comes from.
+10분 짜리 reviewer 는 step 3 부터.
 
-A reviewer who has 10 minutes should start at step 3.
+## 훅 설정
 
-## Hook setup
+### Git 훅 (opt-in, 개발자당 1회)
 
-### Git hooks (opt-in, one-time per developer)
-
-Activate:
+활성화:
 
     make install-hooks
-    # or equivalently:
+    # 또는:
     git config core.hooksPath .githooks
 
-This enables two hooks under `.githooks/`:
+`.githooks/` 의 2개 훅 활성:
 
-- **`pre-commit`** — **hard-blocks** commits that include files from the
-  private side of the eval split (ADR 0005). Aligned with `.gitignore`;
-  catches `git add -f` and other force-paths. Bypass with `git commit
-  --no-verify` only when intentionally committing an aggregate artifact
-  that the hook's allowlist missed — and fix the allowlist in the same
-  change.
+- **`pre-commit`** — eval 분리 (ADR 0005) 비공개측 파일 포함 commit 을 **hard-block**. `.gitignore` 정렬, `git add -f` + force-path 잡음. `git commit --no-verify` 우회는 훅 allowlist 가 놓친 aggregate 산출물 의도 commit 시만 + 같은 변경에서 allowlist 수정
 
-- **`pre-push`** — two checks:
-  1. **Branch + issue convention (ADR 0007)** — **hard-fails** if the
-     current branch doesn't match `<type>/issue-<N>[-<slug>]`. Mirror of
-     the CI check so violations surface before push round-trip. If `gh`
-     is installed and authed, also verifies issue #N exists.
-  2. **Real-data eval reminder** — **soft-warns** when a push touches
-     retrieval / verifier / eval / api paths, reminding you to attach
-     `make real-eval-delta` to the PR (PR template item 5b). Exits 0 —
-     never blocks.
+- **`pre-push`** — 2개 체크:
+  1. **브랜치 + 이슈 컨벤션 (ADR 0007)** — 현 브랜치가 `<type>/issue-<N>[-<slug>]` 미매치 시 **hard-fail**. CI 체크의 미러, push round-trip 전 위반 표면화. `gh` 설치+인증 시 issue #N 존재 확인 추가
+  2. **Real-data eval 리마인더** — 검색/검증기/eval/api 경로 touch 시 **soft-warn**, PR 템플릿 5b 의 `make real-eval-delta` 첨부 reminder. Exit 0, 차단 안 함
 
-  Skip both with `git push --no-verify` only with a documented reason
-  (e.g. doc-only follow-up of a measured PR).
+  `git push --no-verify` 우회는 문서화된 사유 (예: 측정된 PR 의 doc-only follow-up) 시만
 
-### Claude Code hook (auto-loaded, no setup)
+### Claude Code 훅 (자동 로드)
 
-`.claude/settings.json` is committed in this repo and auto-loaded by Claude
-Code. It registers a **`PreToolUse`** hook on `Edit` / `MultiEdit` / `Write`
-that prints a stderr awareness reminder when Claude is about to modify a
-load-bearing file (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`,
-`eval/`, `api/`, `docs/adr/`). The reminder lists ADRs to consider and
-notes the PR template item 5b requirement.
+`.claude/settings.json` commit 되어 Claude Code 자동 로드. `Edit`/`MultiEdit`/`Write` 의 **`PreToolUse`** 훅 등록 — Claude 가 load-bearing 파일 (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`) 수정 직전 stderr awareness reminder. 고려할 ADR 리스트 + PR 템플릿 5b 요구사항 noting.
 
-Hook script: [`scripts/claude-hooks/pretooluse-loadbearing.sh`](../scripts/claude-hooks/pretooluse-loadbearing.sh).
-Never blocks — pure awareness layer.
+훅 스크립트: [`scripts/claude-hooks/pretooluse-loadbearing.sh`](../scripts/claude-hooks/pretooluse-loadbearing.sh). 차단 안 함 — 순수 awareness layer.
 
-### Claude Code hook (opt-in, user-global) — plan-slug race detector
+### Claude Code 훅 (opt-in, user-global) — plan-slug race detector
 
-When multiple concurrent worktrees run Claude Code sessions in parallel,
-the harness writes plan files into a user-global directory
-(`~/.claude/plans/<random-slug>.md`). The slug space is large but
-collisions are not zero on 10+ concurrent worktrees (observed
-2026-05-15 — issue [#779](https://github.com/hskim-solv/BidMate-DocAgent/issues/779)).
+병행 worktree 의 Claude Code 세션들이 user-global 디렉터리 (`~/.claude/plans/<random-slug>.md`) 에 plan 파일 write. slug 공간은 크지만 10+ 동시 worktree 에서 충돌 0 아님 (2026-05-15 관측, issue [#779](https://github.com/hskim-solv/BidMate-DocAgent/issues/779)).
 
-[`scripts/claude-hooks/plan-slug-race.sh`](../scripts/claude-hooks/plan-slug-race.sh)
-is a **user-global** `PreToolUse` hook that blocks a `Write` to a plan
-file when:
+[`scripts/claude-hooks/plan-slug-race.sh`](../scripts/claude-hooks/plan-slug-race.sh) = **user-global** `PreToolUse` 훅. plan 파일 `Write` 차단 조건:
 
-- the target file exists,
-- its mtime is within the last 5 min (`PLAN_SLUG_RACE_THRESHOLD`,
-  default 300 s),
-- its first 200 bytes declare a different worktree slug than the
-  caller's cwd-derived slug.
+- 대상 파일 존재
+- mtime 이 최근 5 min 내 (`PLAN_SLUG_RACE_THRESHOLD`, 기본 300 s)
+- 처음 200 바이트가 caller cwd 와 다른 worktree slug 선언
 
-Convention enforced on the writer side: the first 200 chars of every
-plan file should contain a marker such as
-`` 본 plan은 worktree `<slug>` 의 deliverable. `` so the hook can detect
-the race. Plans without a marker are not blocked (pre-convention
-files / false-positive avoidance).
+writer 측 컨벤션: 모든 plan 파일 처음 200 자에 `` 본 plan은 worktree `<slug>` 의 deliverable. `` 같은 마커 포함 → 훅이 race 검출. 마커 없는 plan 은 차단 안 함 (false-positive 회피).
 
-Override (only when you genuinely intend to overwrite another
-worktree's plan): set `PLAN_SLUG_RACE_THRESHOLD=0` for the invocation.
+Override (다른 worktree plan 의도적 덮어쓰기): `PLAN_SLUG_RACE_THRESHOLD=0`.
 
-The hook is **not** auto-registered (it lives outside the repo's
-`.claude/settings.json` because the same Claude Code session may
-span many repos). Wire it once in `~/.claude/settings.json`:
+훅은 **자동 등록 안 됨** (Claude Code 세션이 여러 repo 걸칠 수 있음). `~/.claude/settings.json` 에 1회 wire:
 
 ```jsonc
 {
@@ -315,7 +174,7 @@ span many repos). Wire it once in `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "<absolute path to>/scripts/claude-hooks/plan-slug-race.sh"
+            "command": "<절대경로>/scripts/claude-hooks/plan-slug-race.sh"
           }
         ]
       }
@@ -324,4 +183,4 @@ span many repos). Wire it once in `~/.claude/settings.json`:
 }
 ```
 
-Regression coverage: `tests/test_plan_slug_race_hook_regression.py`.
+회귀 커버리지: `tests/test_plan_slug_race_hook_regression.py`.

--- a/docs/multi-agent-ownership.md
+++ b/docs/multi-agent-ownership.md
@@ -1,116 +1,98 @@
-# Multi-agent ownership model
+# Multi-agent 소유권 모델
 
-> **Tracked in [#245](https://github.com/hskim-solv/BidMate-DocAgent/issues/245).**
-> Owner roles: [#238](https://github.com/hskim-solv/BidMate-DocAgent/issues/238) · [#239](https://github.com/hskim-solv/BidMate-DocAgent/issues/239) · [#240](https://github.com/hskim-solv/BidMate-DocAgent/issues/240) · [#241](https://github.com/hskim-solv/BidMate-DocAgent/issues/241) · [#242](https://github.com/hskim-solv/BidMate-DocAgent/issues/242) · [#243](https://github.com/hskim-solv/BidMate-DocAgent/issues/243) · [#244](https://github.com/hskim-solv/BidMate-DocAgent/issues/244)
+> **추적: [#245](https://github.com/hskim-solv/BidMate-DocAgent/issues/245).**
+> 역할별 owner: [#238](https://github.com/hskim-solv/BidMate-DocAgent/issues/238) · [#239](https://github.com/hskim-solv/BidMate-DocAgent/issues/239) · [#240](https://github.com/hskim-solv/BidMate-DocAgent/issues/240) · [#241](https://github.com/hskim-solv/BidMate-DocAgent/issues/241) · [#242](https://github.com/hskim-solv/BidMate-DocAgent/issues/242) · [#243](https://github.com/hskim-solv/BidMate-DocAgent/issues/243) · [#244](https://github.com/hskim-solv/BidMate-DocAgent/issues/244)
 
-## Why this exists
+## 왜 필요한가
 
-The RAG pipeline is logically staged (ingestion → retrieval → planning → verification → answer → eval), but the hub module [`rag_core.py`](../rag_core.py) (~4,227 LOC) concentrates retrieval, planning, verification, chunking, and answer assembly into one file imported by 26 other files. Fourteen ADRs lock specific contracts (answer schema, naive baseline preservation, eval split, evidence boundary). [`CLAUDE.md`](../CLAUDE.md) insists on "one PR, one concern" with stacked-PR discipline.
+RAG 파이프라인은 단계별 (ingestion → 검색 → 계획 → 검증 → 답변 → eval) 로 나뉘지만, 허브 모듈 [`rag_core.py`](../rag_core.py) (~4,227 LOC) 가 검색·계획·검증·청킹·답변 조립을 한 파일에 집중하고 26개 파일이 이를 import. 14개 ADR 이 계약 (답변 스키마, 기준선 보존, eval 분리, 근거 경계) 을 고정. [`CLAUDE.md`](../CLAUDE.md) 는 "one PR, one concern" + stacked-PR 규율 요구.
 
-When several agents work in parallel, three collision points emerge:
+여러 agent 가 병행 작업 시 3개 충돌 지점:
 
-1. The single file `rag_core.py`.
-2. The answer-dict schema (ADR 0003) — every consumer in `eval/`, `api/`, `demo/` depends on it.
-3. `eval/config.yaml` — the `naive_baseline` preset must be preserved (ADR 0001).
+1. 단일 파일 `rag_core.py`
+2. 답변 dict 스키마 (ADR 0003) — `eval/`, `api/`, `demo/` 의 모든 소비자가 의존
+3. `eval/config.yaml` — `naive_baseline` preset 보존 의무 (ADR 0001)
 
-The split below resolves these by combining **ADR ownership** with a **hub lock-holder**: one agent per ADR cluster, with `rag_core.py` changes routed through a single owner.
+해법: **ADR 소유권** + **허브 lock-holder** — ADR cluster 당 agent 1명, `rag_core.py` 변경은 단일 owner 경유.
 
-## Principles
+## 원칙
 
-1. **ADR ownership.** One agent = the sole author of one or more ADR contracts. That ADR can only be amended through that agent's PR.
-2. **Hub lock holder.** `rag_core.py` is modified by the Pipeline Core owner only. Other owners affect it via hooks, callbacks, or the `run_rag_query` public surface.
-3. **Additive only.** New features ship as ablation or extension presets (see ADRs 0001 / 0011 / 0014). The extractive baseline is never replaced.
-4. **Stacked PRs.** Dependent work is rebased onto an upstream PR with `gh pr create --base <upstream>`. Independent work targets `main` directly.
+1. **ADR 소유권.** agent 1명 = ADR 계약 1개 이상의 단독 저자. 해당 ADR 수정은 그 agent 의 PR 으로만
+2. **허브 lock holder.** `rag_core.py` 는 Pipeline Core owner 만 수정. 다른 owner 는 hook, callback, `run_rag_query` public surface 경유
+3. **Additive only.** 신규 기능은 분석 변형 또는 확장 preset (ADR 0001/0011/0014). 추출형 기준선은 절대 교체 금지
+4. **Stacked PR.** 의존 작업은 상위 PR 위로 rebase, `gh pr create --base <upstream>`. 독립 작업은 `main` 으로 직접
 
-## The seven ownership roles
+## 7개 소유권 역할
 
 ### 1. Pipeline Core — [#238](https://github.com/hskim-solv/BidMate-DocAgent/issues/238)
 
-- **Files:** [`rag_core.py`](../rag_core.py)
-  - chunking: lines 889–1100
-  - planning: lines 1750–2025
-  - retrieval: lines 2027–2320
-  - verification: lines 2528–2750
-  - answer assembly: lines 2749–2950, 4155–4190
-- **ADRs owned:** 0001 (naive baseline), 0002 (metadata-first), 0003 (answer contract), 0004 (verifier-retry), 0008 (evidence boundary), 0010 (hybrid retrieval).
-- **Don'ts.** Remove `naive_baseline` from `pipeline_cli_choices()`; silently change keys in the `run_rag_query` return dict; skip `schema_version` bumps when the answer contract changes.
+- **파일**: [`rag_core.py`](../rag_core.py) (청킹 889–1100, 계획 1750–2025, 검색 2027–2320, 검증 2528–2750, 답변 조립 2749–2950 + 4155–4190)
+- **ADR**: 0001 (기준선), 0002 (메타데이터 우선), 0003 (답변 계약), 0004 (검증기·재시도), 0008 (근거 경계), 0010 (하이브리드 검색)
+- **금지**: `pipeline_cli_choices()` 에서 `naive_baseline` 제거; `run_rag_query` 반환 dict 키 무단 변경; 답변 계약 변경 시 `schema_version` bump 누락
 
 ### 2. Ingestion — [#239](https://github.com/hskim-solv/BidMate-DocAgent/issues/239)
 
-- **Files:** [`ingestion.py`](../ingestion.py), [`visual_ingestion.py`](../visual_ingestion.py), [`rag_normalize.py`](../rag_normalize.py), [`text_normalize.py`](../text_normalize.py).
-- **ADRs owned:** 0008 (evidence boundary — input side).
-- **Examples of in-scope work.** New document formats (HWPX, etc.), OCR / visual extraction improvements, Korean normalization rules, parser metrics.
+- **파일**: [`ingestion.py`](../ingestion.py), [`visual_ingestion.py`](../visual_ingestion.py), [`rag_normalize.py`](../rag_normalize.py), [`text_normalize.py`](../text_normalize.py)
+- **ADR**: 0008 (근거 경계 — 입력측)
+- **범위 예시**: 신규 문서 포맷 (HWPX 등), OCR/visual 추출 개선, 한국어 정규화 규칙, 파서 메트릭
 
 ### 3. Synthesis — [#240](https://github.com/hskim-solv/BidMate-DocAgent/issues/240)
 
-- **Files:** [`rag_synthesis.py`](../rag_synthesis.py); one synthesis hook inside `rag_core.py` (changes routed through Pipeline Core).
-- **ADRs owned:** 0011 (LLM synthesis as additive).
-- **Don'ts.** Generate `claims` / `citations` from the LLM — they must stay extractive (ADR 0003 + ADR 0011). Synthesis must remain opt-in, not on by default.
+- **파일**: [`rag_synthesis.py`](../rag_synthesis.py); `rag_core.py` 안 synthesis 훅 1개 (Pipeline Core 경유)
+- **ADR**: 0011 (LLM synthesis additive)
+- **금지**: `claims`/`citations` 를 LLM 에서 생성 (추출형 유지 — ADR 0003+0011). Synthesis 는 opt-in 유지, 기본 활성 금지
 
 ### 4. Evaluation — [#241](https://github.com/hskim-solv/BidMate-DocAgent/issues/241)
 
-- **Files:** [`eval/`](../eval/) (entire directory), [`scripts/run_real_eval_delta.py`](../scripts/run_real_eval_delta.py), [`scripts/compare_eval.py`](../scripts/compare_eval.py), [`scripts/compare_external_baselines.py`](../scripts/compare_external_baselines.py), [`scripts/leaderboard.py`](../scripts/leaderboard.py), [`scripts/update_readme_metrics.py`](../scripts/update_readme_metrics.py), [`scripts/write_real_eval_baseline.py`](../scripts/write_real_eval_baseline.py), [`scripts/write_synthetic_history.py`](../scripts/write_synthetic_history.py).
-- **ADRs owned:** 0005 (eval split), 0006 (real-only judge), 0009 (external baseline), 0012 (synthetic judge stub-default), 0014 (RAGAS additive).
-- **Don'ts.** Remove the `naive_baseline` ablation preset from `eval/config.yaml` (ADR 0001); enable a live LLM judge by default in public CI (ADR 0012); commit private real-data artifacts (ADR 0005).
+- **파일**: [`eval/`](../eval/) 전체, [`scripts/run_real_eval_delta.py`](../scripts/run_real_eval_delta.py), [`scripts/compare_eval.py`](../scripts/compare_eval.py), [`scripts/compare_external_baselines.py`](../scripts/compare_external_baselines.py), [`scripts/leaderboard.py`](../scripts/leaderboard.py), [`scripts/update_readme_metrics.py`](../scripts/update_readme_metrics.py), [`scripts/write_real_eval_baseline.py`](../scripts/write_real_eval_baseline.py), [`scripts/write_synthetic_history.py`](../scripts/write_synthetic_history.py)
+- **ADR**: 0005 (eval 분리), 0006 (real-only judge), 0009 (외부 baseline), 0012 (합성 judge stub-default), 0014 (RAGAS additive)
+- **금지**: `eval/config.yaml` 에서 `naive_baseline` 제거 (ADR 0001); 공개 CI 에서 live LLM judge 기본 활성 (ADR 0012); 비공개 real-data 산출물 commit (ADR 0005)
 
 ### 5. Observability — [#242](https://github.com/hskim-solv/BidMate-DocAgent/issues/242)
 
-- **Files:** [`rag_observability.py`](../rag_observability.py); trace-hook insertion points inside `rag_core.py` (changes routed through Pipeline Core).
-- **ADRs owned:** 0013 (pluggable observability).
-- **Examples of in-scope work.** New trace backends (Otel exporters, custom sinks), redaction policy, span enrichment.
+- **파일**: [`rag_observability.py`](../rag_observability.py); `rag_core.py` trace 훅 삽입점 (Pipeline Core 경유)
+- **ADR**: 0013 (pluggable observability)
+- **범위 예시**: 신규 trace backend (Otel exporter, custom sink), redaction 정책, span enrichment
 
 ### 6. API & Demo — [#243](https://github.com/hskim-solv/BidMate-DocAgent/issues/243)
 
-- **Files:** [`api/main.py`](../api/main.py), [`app.py`](../app.py), [`demo/`](../demo/).
-- **ADRs owned:** none — this layer only consumes the `run_rag_query` public surface.
-- **Constraint.** Use the `run_rag_query` return-dict keys only. Do not import internal helpers from `rag_core.py`; any new interface need is routed through the Pipeline Core owner.
+- **파일**: [`api/main.py`](../api/main.py), [`app.py`](../app.py), [`demo/`](../demo/)
+- **ADR**: 없음 — `run_rag_query` public surface 만 소비
+- **제약**: `run_rag_query` 반환 dict 키만 사용. `rag_core.py` 내부 헬퍼 import 금지; 신규 인터페이스 필요 시 Pipeline Core owner 경유
 
 ### 7. Infra & CI — [#244](https://github.com/hskim-solv/BidMate-DocAgent/issues/244)
 
-- **Files:** [`.github/workflows/`](../.github/workflows), [`.githooks/`](../.githooks), [`scripts/check_branch_and_issue.py`](../scripts/check_branch_and_issue.py), [`.github/pull_request_template.md`](../.github/pull_request_template.md), [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE), [`.claude/settings.json`](../.claude/settings.json).
-- **ADRs owned:** 0007 (issue-linked branch naming).
-- **Examples of in-scope work.** New CI gates (e.g. `schema_version` assertions), pre-commit / pre-push hook additions, PR / issue template updates.
+- **파일**: [`.github/workflows/`](../.github/workflows), [`.githooks/`](../.githooks), [`scripts/check_branch_and_issue.py`](../scripts/check_branch_and_issue.py), [`.github/pull_request_template.md`](../.github/pull_request_template.md), [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE), [`.claude/settings.json`](../.claude/settings.json)
+- **ADR**: 0007 (issue-linked 브랜치 명명)
+- **범위 예시**: 신규 CI gate (예: `schema_version` assertion), pre-commit/pre-push 훅 추가, PR/issue 템플릿 갱신
 
-## Conflict-resolution rules
+## 충돌 해결 규칙
 
-- **`rag_core.py` concurrent edits.** Pipeline Core owner is the sole lock holder. When another owner needs hub changes that don't fit a hook or public-surface extension, they open an interface-change PR via Pipeline Core first; their downstream PR stacks on top with `gh pr create --base`.
-- **Answer-dict schema change (ADR 0003).** Always shipped as a standalone PR — ADR amendment + `schema_version` bump + broadcast to eval / api / demo consumers. Never bundled with feature work.
-- **`eval/config.yaml`.** Evaluation owner only. Other owners request new ablation presets; they do not edit the file directly.
-- **`docs/adr/` files.** The relevant area owner authors new ADRs. Existing ADR files are never deleted or renamed — they are marked **Superseded** in the Status block.
+- **`rag_core.py` 동시 편집**: Pipeline Core owner 가 단독 lock holder. 다른 owner 가 hook/public surface 로 안 되는 hub 변경 필요 시 Pipeline Core 경유 interface-change PR 먼저 → downstream PR 은 `gh pr create --base` 로 stack
+- **답변 dict 스키마 변경 (ADR 0003)**: 항상 standalone PR — ADR 수정 + `schema_version` bump + eval/api/demo 소비자 broadcast. feature 작업과 묶지 않음
+- **`eval/config.yaml`**: Evaluation owner 단독. 다른 owner 는 신규 분석 변형 preset 요청, 직접 편집 금지
+- **`docs/adr/` 파일**: 해당 영역 owner 가 신규 ADR 작성. 기존 ADR 파일 삭제·이름변경 금지 — Status 블록에 **Superseded** 표시
 
-## Scenario → owner mapping
+## 시나리오 → owner 매핑
 
-| Scenario | Owner(s) | Stacking |
+| 시나리오 | owner | Stacking |
 | --- | --- | --- |
-| New retrieval backend (e.g. ColBERT) | Pipeline Core + Evaluation | Eval PR stacked on Pipeline Core PR |
-| New document format (e.g. HWPX) | Ingestion | Standalone |
-| LLM-judge / RAGAS metric improvement | Evaluation | Standalone |
-| New demo screen or Colab notebook | API & Demo | Standalone |
-| New CI gate (e.g. `schema_version` assertion) | Infra & CI | Standalone |
-| Answer-schema extension | Pipeline Core → API & Demo + Evaluation | Consumer PRs stacked on the schema PR |
-| New Otel exporter | Observability | Standalone |
+| 신규 검색 backend (예: ColBERT) | Pipeline Core + Evaluation | Eval PR 이 Pipeline Core PR 위로 stack |
+| 신규 문서 포맷 (예: HWPX) | Ingestion | Standalone |
+| LLM-judge / RAGAS 메트릭 개선 | Evaluation | Standalone |
+| 신규 데모 화면 또는 Colab 노트북 | API & Demo | Standalone |
+| 신규 CI gate (예: `schema_version` assertion) | Infra & CI | Standalone |
+| 답변 스키마 확장 | Pipeline Core → API & Demo + Evaluation | 소비자 PR 이 스키마 PR 위로 stack |
+| 신규 Otel exporter | Observability | Standalone |
 
-## Verification
+## 검증
 
-Before every PR:
+매 PR 전: `make smoke` + `bash scripts/test.sh`. load-bearing 파일 (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/main.py`) 변경 시 `make real-eval` + `make real-eval-delta` + PR 템플릿 5b 채움.
 
-- `make smoke` — fast end-to-end sanity check (`EMBEDDING_BACKEND=hashing`).
-- `bash scripts/test.sh` — `pytest -q` (the CI gate).
+CI gate: [`pr-eval.yml`](../.github/workflows/pr-eval.yml), [`branch-and-issue-check.yml`](../.github/workflows/branch-and-issue-check.yml). 답변 계약 PR 은 추가로 `schema_version` 증가 + ADR 0003 갱신 확인.
 
-When load-bearing files (`rag_core.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/main.py`) change:
+## 참고
 
-- `make real-eval` + `make real-eval-delta`.
-- Fill in PR-template item 5b (real-data delta).
-
-All PRs pass the standing CI gates:
-
-- [`pr-eval.yml`](../.github/workflows/pr-eval.yml)
-- [`branch-and-issue-check.yml`](../.github/workflows/branch-and-issue-check.yml)
-
-Answer-contract PRs additionally verify a `schema_version` increment and an updated ADR 0003 entry.
-
-## See also
-
-- [`docs/engineering-governance.md`](engineering-governance.md) — broader workflow map.
-- [`docs/adr/README.md`](adr/README.md) — ADR index.
-- [`CLAUDE.md`](../CLAUDE.md) — repository conventions.
+- [`docs/engineering-governance.md`](engineering-governance.md) — 워크플로 맵
+- [`docs/adr/README.md`](adr/README.md) — ADR 인덱스
+- [`CLAUDE.md`](../CLAUDE.md) — 저장소 컨벤션

--- a/docs/translation-glossary.md
+++ b/docs/translation-glossary.md
@@ -1,0 +1,65 @@
+# 번역 용어집
+
+PR-A~E (가독성 개선 5-PR stacked, issue [#916](https://github.com/hskim-solv/BidMate-DocAgent/issues/916)~[#920](https://github.com/hskim-solv/BidMate-DocAgent/issues/920)) 에서 영문→한국어 번역 시 일관성을 위한 단일 출처. PR-D (ADR 50개 번역) 시 LLM system prompt 로 강제 주입.
+
+## 영문 유지 (번역 금지)
+
+- **코드/식별자**: 함수명, 변수, 클래스, 파일·디렉터리명 (`rag_core.py`, `run_rag_query`, `naive_baseline`, `EVIDENCE_BOUNDARY`)
+- **CLI/명령어**: `make smoke`, `git push`, `gh pr create`, `pytest`, `bash scripts/test.sh`
+- **컨벤션 키워드**: `Closes #N`, `<type>/issue-<N>-<slug>`, `BREAKING CHANGE`
+- **약어**: RFP, RAG, ADR, BM25, RRF, HyDE, LLM, CI/CD, PR, API, CLI, OCR, MLOps, MiniLM, KURE, LoRA, JSON, YAML, regex
+- **URL / anchor**: `#key-technical-contribution-*`, badge 이미지, 외부 링크
+- **메트릭 단위 / 수치**: `p50 1.7ms`, `0.718±0.10`, `95% CI`, `n=100`
+
+## 한국어 매핑 (도메인 용어)
+
+| 영문 | 한국어 | 비고 |
+|---|---|---|
+| evidence | 근거 | "지지하는 증거" 의 의미. citation 과 짝 |
+| grounded answer | 근거 기반 답변 | extractive grounding 결과 |
+| grounding | 근거 연결 | claim ↔ evidence ↔ source 연결 |
+| abstention | 보류 | ADR 0003 `status: insufficient`. "회피"·"기권" 아님 |
+| verifier | 검증기 | rag_verifier.py |
+| claim | 주장 | answer dict 의 `claims` 배열 |
+| citation | 인용 | `citations` 배열, evidence 출처 |
+| baseline | 기준선 | naive_baseline preset |
+| retrieval | 검색 | document retrieval |
+| ranking | 순위 매기기 / 순위 | retrieval ranking |
+| reranking | 재순위 | cross-encoder reranker |
+| ablation | 분석 변형 | "절제" 아님. preset 단위 비교 |
+| top-k | top-k | 영문 유지 (수치 의미) |
+| starvation | 누락 | retrieval starvation |
+| balanced | 균등 | balanced top-k |
+| pipeline | 파이프라인 | |
+| preset | 프리셋 | eval/config.yaml |
+| ingestion | 수집 | 문서 수집 단계 |
+| chunking | 청킹 | 청크 분할 |
+| metadata-first | 메타데이터 우선 | ADR 0002 |
+| extractive | 추출형 | 추출 기반 답변 |
+| generative | 생성형 | LLM 합성 답변 |
+| synthesis | 합성 | LLM synthesis |
+| evaluation / eval | 평가 / eval | "eval" 은 디렉터리·CLI 명칭이므로 영문 |
+| judge | 평가자 | LLM-as-judge |
+| leaderboard | 리더보드 | |
+| stacked PR | stacked PR | 영문 유지 (관용어) |
+| retry | 재시도 | |
+| load-bearing | load-bearing | 영문 유지 (관용어) |
+| worktree | worktree | 영문 유지 (git 개념) |
+| hook | 훅 | pre-commit hook, PreToolUse hook |
+| invariant | invariant | 영문 유지 |
+| follow-up | follow-up | |
+| stale | stale | 라벨명 |
+
+## 문체 규약
+
+- **본문**: "~다/~한다/~된다" 종결. "~합니다/~입니다" 금지 (장황)
+- **헤더**: 명사구 또는 짧은 동사구
+- **표 / 리스트**: 한 줄 한 문장. 마침표 생략 가능
+- **TL;DR**: 2-3 줄 bullet. 매 문서 최상단에 배치
+- **수치 / 메트릭**: 영문 형식 유지 (`+57.1pp`, `n=100`, `p95 3.1ms`)
+
+## 압축 원칙
+
+- **유지**: 표, 코드 블록, mermaid 다이어그램, 결정 사유, 식별자
+- **제거**: 같은 내용 반복, 영어 원문 보존용 paraphrase, 외부 reviewer 가 링크 따라가면 알 수 있는 배경 설명
+- **링크 위임**: 자세한 설명은 ADR / 별도 docs 로 링크하고 본문은 요점만


### PR DESCRIPTION
## 1. What changed and why

PR-A (5-PR stacked 시리즈 1/5). 한국어 화자 reviewer 진입 장벽 완화 + ~50% 압축 목적. 핵심 문서 5개 한국어 번역 + 신규 용어집 1개. 코드/식별자/CLI/ADR 번호/`make` 타깃은 영문 유지.

후속 PR: B(템플릿) → C(머지 PR 10개 본문) → D(ADR 50개) → E(open issue). 각각 issue #917~#920.

Closes #916

## 2. Files affected

- `CLAUDE.md` 133→113줄 (-15%)
- `README.md` 261→262줄 (영문 prose 압축 vs `METRICS_TABLE` 자동영역·표·badge 보존)
- `docs/engineering-governance.md` 327→186줄 (-43%)
- `docs/multi-agent-ownership.md` 116→98줄 (-16%)
- `docs/agent-utilization.md` 58줄 (이미 한국어 — 미세 정리)
- `docs/translation-glossary.md` **신규** 65줄 — PR-D ADR 50개 번역 시 LLM system prompt 강제 주입용 단일 출처

Load-bearing 없음.

## 3. Risks

- **anchor link 깨짐 가능성** — README 의 `#key-technical-contribution-*` anchor, 외부 링크, badge 이미지 URL 모두 보존했다. \`grep -E '\[!\[|http|#[a-z-]+\)'\` 로 사전 마스킹 후 번역.
- **CLI/명령 오역** — `make smoke`, `gh pr create`, `Closes #N` 같은 컨벤션 키워드는 `translation-glossary.md` 의 '영문 유지' 섹션에 명시. 번역 누락 0.
- **검색·검증 코드 0-line diff** — `rag_*.py`, `eval/`, `api/`, `docs/adr/` 무변경.

## 4. Tests

N/A — 문서 전용. 사람 검수 + `make check-branch` (브랜치 컨벤션) + grep anchor 살아있는지 확인으로 검증.

## 5. Eval impact

All `·` — 비-RAG 변경 (문서·번역 전용).

### 5b. Real-data delta

N/A — load-bearing path 무변경 (`scripts/_governance.py` `LOAD_BEARING_PATHS` 의 어떤 항목도 건드리지 않음).

## 6. Backward compatibility

깨지지 않음. anchor link, badge URL, ADR 번호 모두 보존. `Closes #N` / `<type>/issue-<N>` 컨벤션 키워드 영문 유지로 CI gate (`scripts/check_branch_and_issue.py`) 동작 유지.

## 7. Out of scope

- PR-B (템플릿) / PR-C (머지 PR 10개) / PR-D (ADR 50개) / PR-E (open issue) — 각각 별 PR 으로 stack
- 다른 `docs/*.md` (failure analysis, reviewer artifacts 등) — 핵심 5개로 한정

🤖 Generated with [Claude Code](https://claude.com/claude-code)