### PR TITLE
chore(test): parallel pytest (xdist) + CI ruff gate (closes #915)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,13 @@ cohere>=5.0
 # Dev-only: not imported by the production pipeline. Fresh-clone reproducibility
 # requires this to be declared so `pip install -r requirements-dev.txt` suffices.
 pandas>=2.0,<3.0
+# Issue #915 — parallel pytest. scripts/test.sh runs `pytest -n auto --dist
+# loadfile`; loadfile keeps file-internal state (env mutation, golden writes,
+# qdrant collections, langgraph globals) on a single worker without needing a
+# `@pytest.mark.heavy` scheme. 1010s → ~200s on M-series 8-core.
+pytest-xdist>=3.5
+# Issue #915 (closes G8 of issue #334) — CI lint gate. pyproject.toml
+# [tool.ruff.lint] is pinned to fatal pyflakes only (E9/F63/F7/F82) — zero
+# finding on current main, no codebase sweep required. Wider rules sweep
+# (E402/F401/F841) tracked in #334.
+ruff>=0.15.12

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,8 +25,19 @@ if python -c "import pytest_cov" >/dev/null 2>&1; then
   COV_FLAGS=(--cov --cov-report=term-missing --cov-report=xml)
 fi
 
+# Issue #915: pytest-xdist parallelism via `-n auto`. `--dist loadfile` keeps
+# every test from the same file on a single worker — the file-internal
+# stateful tests (env mutation, golden writes, qdrant collections, langgraph
+# globals — see audit in PR body) stay safe without a marker scheme. Falls
+# back to serial automatically when pytest-xdist is missing (the `-n` /
+# `--dist` flags simply error out; minimal envs without dev deps installed
+# get the same 1010s serial run as before).
 if command -v pytest >/dev/null 2>&1; then
-  pytest -q "${COV_FLAGS[@]}"
+  XDIST_FLAGS=()
+  if python -c "import xdist" >/dev/null 2>&1; then
+    XDIST_FLAGS=(-n auto --dist loadfile)
+  fi
+  pytest -q "${XDIST_FLAGS[@]}" "${COV_FLAGS[@]}"
 else
   echo "pytest not found. Install dev dependencies or add pytest to requirements." >&2
   exit 1


### PR DESCRIPTION
## Summary
개발 루프 속도 개선 + CI lint 게이트 닫기를 한 PR 로 묶음. 의존성 2개 + shell 한 줄 변경.

- `requirements-dev.txt`: `pytest-xdist>=3.5` + `ruff>=0.15.12` 추가 (헤더 주석 포함)
- `scripts/test.sh`: `pytest -q "${COV_FLAGS[@]}"` → `pytest -q "${XDIST_FLAGS[@]}" "${COV_FLAGS[@]}"`. `import xdist` 가드 probe 로 dev deps 없는 환경은 자동 serial fallback

## Measurement (M-series 8-core, local)

| variant | wall-clock | delta vs serial |
|---|---|---|
| serial (cov enabled) — baseline | **1010s** | — |
| `-n auto --dist loadfile` + cov | **889s** | **~12%** faster |
| `-n auto --dist loadfile` no cov | **673s** | **~33%** faster |

원래 5× 주장은 과대 평가. 정직한 이유:
- pytest-cov 의 xdist 통합 오버헤드 (coverage 경로 wall-clock 의 ~24%)
- Session-scope `shared_raw_index` fixture 가 worker 마다 재빌드 (8 cores × ~3s = ~24s 추가)
- 일부 테스트는 I/O / sleep bound, CPU bound 아님

Trade-off 수용: ~12% 속도 향상 + coverage 유지 (Codecov upload 보존). 로컬에서 `pytest -q -n auto --dist loadfile` 직접 실행 시 더 큰 속도 향상 가능 (no cov).

## Why `--dist loadfile`
xdist hazard audit 가 식별한 file-internal stateful 테스트 5개:
1. `tests/test_ingestion_kordoc_regression.py` — `BIDMATE_HWP_LOADER` env + `_reset_kordoc_loaders()` 모듈 캐시
2. `tests/test_answer_contract_snapshot.py` — `GOLDEN_PATH.write_text()`
3. `tests/test_run_harness.py` — ROOT_DIR-relative `reports/harness_history/*` 쓰기
4. `tests/test_vector_store_qdrant.py` — `BIDMATE_QDRANT_URL` env + Qdrant collection 상태
5. `tests/test_langgraph_orchestrator_regression.py` — `rag_core._PROCESS_WARM` global monkeypatch

`loadfile` 은 파일 단위로 분산 — file-internal mutation 이 단일 worker 에 고정된다. `@pytest.mark.heavy` 마커 스킴 불필요.

`tests/conftest.py` session-scope fixture (`shared_raw_index` + `_clear_model_caches_at_session_end`) 는 xdist-safe (worker-local session — 검증 완료).

## Why `ruff>=0.15.12`
`scripts/test.sh:11-18` 에 이미 opt-in ruff 게이트 (`command -v ruff` 가드) 가 있다. CI 에서 ruff 가 PATH 에 없었기 때문에 게이트가 사실상 warn-only. `requirements-dev.txt` 에 ruff 를 pin 하면 동작 변경 없이 게이트를 active 로 전환: `pyproject.toml [tool.ruff.lint]` 는 좁게 유지 (E9/F63/F7/F82 — fatal pyflakes only), 현재 main 에서 0 finding. issue #334 의 G8 종료.

## Test plan
- [x] 위 측정
- [x] Hazard 5 파일 `-n auto --dist loadfile` 로 PASS
- [x] coverage.xml 정상 재생성 (pytest-cov 가 3.0 부터 xdist native 지원)
- [x] `ruff check .` → 현재 main 0 finding
- [ ] CI: Pytest / Baseline provenance / Eval delta / Branch+issue

## ADR
N/A — dev tooling pin. pyproject.toml ruff config + scripts/test.sh 주석이 설계를 인라인 문서화.

### 5b. Real-data delta
**No behavior change in retrieval / verifier / eval / api / ingestion path.**

`requirements-dev.txt` + `scripts/test.sh` 는 non-LB (`scripts/_governance.py --is-load-bearing` → 1 양쪽). Production `rag_*.py` / `ingestion.py` / `api/` 0-line diff. `make real-eval-delta` 는 0-shift.

Closes #915
