### PR TITLE
chore(test): worker-local index cache for 13 setUpClass methods

### DIFF
--- a/tests/_shared_index_cache.py
+++ b/tests/_shared_index_cache.py
@@ -1,0 +1,70 @@
+"""Worker-local cached hashing-backend index for unittest.TestCase setUpClass.
+
+Issue #915 — 13 test classes (test_answer_contract_snapshot,
+test_async_rag_query_regression, test_demo_helpers,
+test_followup_entity_injection, test_fuzzy_retrieval,
+test_hybrid_retrieval_regression, test_llm_synthesis, test_m3_backend_regression
+(2 classes), test_naive_baseline_ranking_invariance, test_observability_tracing,
+test_partial_topic_grounding, test_retrieval_loop_regression,
+test_single_turn_ambiguity) each call ``build_index_payload(ROOT / "data/raw",
+embedding_backend="hashing")`` in ``setUpClass``. That signature is byte-identical
+to ``tests/conftest.py::shared_raw_index`` — every call returns the same payload
+within a single Python process.
+
+unittest.TestCase cannot consume a pytest fixture via injection, so the conftest
+fixture cannot help these classes. Instead we cache the payload at module
+scope: the first ``get_shared_raw_index()`` call in a worker process pays the
+build cost, subsequent calls (across all 13 classes scheduled to the same xdist
+worker) return the same dict.
+
+With ``-n auto --dist loadfile`` the index build is now N-workers × 1 instead of
+N-workers × 13 classes (+ a handful of method-level rebuilds elsewhere in the
+suite). The cache is intentionally module-global (not session-scoped) so it
+survives across class boundaries within a single test file and across files
+within a single worker.
+
+The payload is treated as read-only by the calling tests (``cls.index = ...``).
+Tests that need a *modified* index (different chunking strategy, different
+agency subset, ablation overrides) build their own via
+``build_index_payload_from_documents`` and are unaffected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rag_core import build_index_payload
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+_INDEX: dict | None = None
+_INDEX_FIXED: dict | None = None
+
+
+def get_shared_raw_index() -> dict:
+    """Return the worker-local cached hashing-backend index, building on first call."""
+    global _INDEX
+    if _INDEX is None:
+        _INDEX = build_index_payload(
+            ROOT_DIR / "data" / "raw", embedding_backend="hashing"
+        )
+    return _INDEX
+
+
+def get_shared_raw_index_fixed() -> dict:
+    """Return the worker-local cached ``hashing + chunking_strategy="fixed"`` index.
+
+    Three test modules (``test_naive_baseline_ranking_invariance``,
+    ``test_answer_contract_snapshot``, ``test_m3_backend_regression`` with two
+    setUpClass methods) pin the `fixed` chunker for byte-identical golden
+    reproducibility (ADR 0001 / 0003). Cached separately from the default
+    index because the chunker change yields a different chunk_id distribution.
+    """
+    global _INDEX_FIXED
+    if _INDEX_FIXED is None:
+        _INDEX_FIXED = build_index_payload(
+            ROOT_DIR / "data" / "raw",
+            embedding_backend="hashing",
+            chunking_strategy="fixed",
+        )
+    return _INDEX_FIXED

--- a/tests/test_answer_contract_snapshot.py
+++ b/tests/test_answer_contract_snapshot.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from rag_core import build_index_payload, run_rag_query
+from tests._shared_index_cache import get_shared_raw_index_fixed
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -100,11 +101,8 @@ def _build_contract_shape() -> dict[str, Any]:
     Used both by the test (compared to the committed golden) and by
     the regenerate-golden helper documented in this module's docstring.
     """
-    index = build_index_payload(
-        ROOT_DIR / "data" / "raw",
-        embedding_backend="hashing",
-        chunking_strategy="fixed",
-    )
+    # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+    index = get_shared_raw_index_fixed()
     result = run_rag_query(index, SNAPSHOT_QUERY, pipeline="naive_baseline")
     return _shape(_extract_contract_subset(result))
 
@@ -119,11 +117,8 @@ class AnswerContractShapeTest(unittest.TestCase):
         # The literal value is not in the shape signature (shape only
         # captures the type "int"), so we re-read the answer dict
         # directly to ensure the version constant matches ADR 0003.
-        index = build_index_payload(
-            ROOT_DIR / "data" / "raw",
-            embedding_backend="hashing",
-            chunking_strategy="fixed",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        index = get_shared_raw_index_fixed()
         result = run_rag_query(index, SNAPSHOT_QUERY, pipeline="naive_baseline")
         version = (result.get("answer") or {}).get("schema_version")
         self.assertEqual(

--- a/tests/test_demo_helpers.py
+++ b/tests/test_demo_helpers.py
@@ -24,6 +24,7 @@ from demo.helpers import (
     run_pipeline,
 )
 from rag_core import build_index_payload
+from tests._shared_index_cache import get_shared_raw_index
 
 
 class SampleQueriesContractTest(unittest.TestCase):
@@ -117,10 +118,8 @@ class RunPipelineIntegrationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            ROOT_DIR / "data" / "raw",
-            embedding_backend="hashing",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     def test_runs_extractive(self) -> None:
         result = run_pipeline(

--- a/tests/test_followup_entity_injection.py
+++ b/tests/test_followup_entity_injection.py
@@ -26,6 +26,7 @@ from rag_core import (
     resolve_conversation_context,
     run_rag_query,
 )
+from tests._shared_index_cache import get_shared_raw_index
 
 
 class InjectEntitiesIntoQueryTest(unittest.TestCase):
@@ -134,9 +135,8 @@ class FollowUpRetrievalAnchorRegressionTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"), embedding_backend="hashing"
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     def test_resolved_query_contains_entity_anchor(self) -> None:
         result = run_rag_query(

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -12,6 +12,7 @@ from rag_core import (
     redact_trace,
     run_rag_query,
 )
+from tests._shared_index_cache import get_shared_raw_index
 
 
 REQUIRED_QUERY_REWRITE_FIELDS = {
@@ -61,10 +62,8 @@ REQUIRED_LATENCY_KEYS = {
 class FuzzyMetadataRetrievalTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     def test_spacing_variant_matches_exact_agency(self) -> None:
         result = run_rag_query(self.index, "기관A의 보안 통제 요구사항은?")

--- a/tests/test_hybrid_retrieval_regression.py
+++ b/tests/test_hybrid_retrieval_regression.py
@@ -44,6 +44,7 @@ from rag_core import (
     retrieve,
     run_rag_query,
 )
+from tests._shared_index_cache import get_shared_raw_index
 
 
 ANSWERABLE_QUERY = "기관 A의 보안 통제 요구사항은?"
@@ -53,10 +54,8 @@ RARE_LEXICAL_QUERY = "기관 D 분광기 라만 캘리브레이션 주기는?"
 class HybridRetrievalRegressionTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     def _retrieve_with_backend(
         self,

--- a/tests/test_llm_synthesis.py
+++ b/tests/test_llm_synthesis.py
@@ -23,6 +23,7 @@ from typing import Any
 import rag_synthesis
 from rag_answer_schema import ANSWER_SCHEMA_VERSION
 from rag_core import build_index_payload, run_rag_query
+from tests._shared_index_cache import get_shared_raw_index
 
 
 ANSWERABLE_QUERY = "기관 A의 보안 통제 요구사항은?"
@@ -213,10 +214,8 @@ class SynthesisPipelineIntegrationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     def test_stub_synthesis_preserves_extractive_answer(self) -> None:
         extractive = run_rag_query(

--- a/tests/test_m3_backend_regression.py
+++ b/tests/test_m3_backend_regression.py
@@ -39,6 +39,7 @@ from rag_core import (
     metadata_targets,
     resolve_pipeline_config,
 )
+from tests._shared_index_cache import get_shared_raw_index_fixed
 
 
 def _flag_embedding_available() -> bool:
@@ -136,11 +137,8 @@ class NaiveBaselineInvariantTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-            chunking_strategy="fixed",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index_fixed()
 
     def test_dense_plan_strategy_does_not_mention_m3(self) -> None:
         analysis = analyze_query("기관 A 보안", metadata_targets(self.index))
@@ -162,11 +160,8 @@ class M3EndToEndTest(unittest.TestCase):  # pragma: no cover — opt-in, gated o
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-            chunking_strategy="fixed",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index_fixed()
 
     def test_m3_score_parts_carry_sparse_and_colbert(self) -> None:
         from rag_core import retrieve

--- a/tests/test_naive_baseline_ranking_invariance.py
+++ b/tests/test_naive_baseline_ranking_invariance.py
@@ -23,6 +23,7 @@ import unittest
 from pathlib import Path
 
 from rag_core import build_index_payload, run_rag_query
+from tests._shared_index_cache import get_shared_raw_index_fixed
 
 
 GOLDEN_PATH = Path(__file__).parent / "data" / "naive_baseline_top_k.json"
@@ -34,11 +35,8 @@ class NaiveBaselineRankingInvarianceTest(unittest.TestCase):
         # Hashing backend + fixed chunking = deterministic across machines
         # and across the Phase 3 stack — every PR's CI run reproduces the
         # same vectors.
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-            chunking_strategy="fixed",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index_fixed()
         cls.golden = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
 
     def test_top_k_chunk_ids_match_golden(self) -> None:

--- a/tests/test_observability_tracing.py
+++ b/tests/test_observability_tracing.py
@@ -36,6 +36,7 @@ from typing import Any, Iterator
 
 import rag_observability
 from rag_core import build_index_payload, run_rag_query
+from tests._shared_index_cache import get_shared_raw_index
 
 
 ANSWERABLE_QUERY = "기관 A의 보안 통제 요구사항은?"
@@ -113,10 +114,8 @@ def _unset_trace_env() -> Iterator[None]:
 class ObservabilityTracingTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     # ------------------------------------------------------------------
     # Invariant 1: default is noop

--- a/tests/test_partial_topic_grounding.py
+++ b/tests/test_partial_topic_grounding.py
@@ -29,6 +29,7 @@ from rag_core import (
     build_index_payload,
     verify_evidence,
 )
+from tests._shared_index_cache import get_shared_raw_index
 
 
 class VerifyEvidencePartialTopicTest(unittest.TestCase):
@@ -142,9 +143,8 @@ class OutOfCorpusAbstentionPreservedTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"), embedding_backend="hashing"
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     def test_out_of_corpus_query_still_abstains(self) -> None:
         from rag_core import run_rag_query

--- a/tests/test_retrieval_loop_regression.py
+++ b/tests/test_retrieval_loop_regression.py
@@ -23,6 +23,7 @@ from rag_core import (
     metadata_stage_sequence,
     run_rag_query,
 )
+from tests._shared_index_cache import get_shared_raw_index
 
 
 ANSWERABLE_QUERY = "기관 A의 보안 통제 요구사항은?"
@@ -32,10 +33,8 @@ OUT_OF_CORPUS_QUERY = "외계 행성의 우주선 검수 절차는?"
 class RetrievalLoopRegressionTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     def test_answerable_single_doc_returns_non_empty_evidence(self) -> None:
         """R2 guard: answerable single-doc query must not silently abstain.

--- a/tests/test_single_turn_ambiguity.py
+++ b/tests/test_single_turn_ambiguity.py
@@ -25,6 +25,7 @@ from rag_core import (
     metadata_clarification_answer,
     run_rag_query,
 )
+from tests._shared_index_cache import get_shared_raw_index
 
 
 class MetadataClarificationAnswerTest(unittest.TestCase):
@@ -84,9 +85,8 @@ class SingleTurnAmbiguityProbeTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"), embedding_backend="hashing"
-        )
+        # Issue #915 — worker-local cache, see tests/_shared_index_cache.py.
+        cls.index = get_shared_raw_index()
 
     def _expect_clarification(self, query: str) -> dict:
         result = run_rag_query(self.index, query)


### PR DESCRIPTION
## Summary

- New `tests/_shared_index_cache.py` — module-scope cache with `get_shared_raw_index()` (default chunker, 9 setUpClass consumers) + `get_shared_raw_index_fixed()` (`chunking_strategy="fixed"`, 4 setUpClass consumers).
- 12 test files refactored: setUpClass calls of `build_index_payload(ROOT / "data/raw", embedding_backend="hashing")` (or `+chunking_strategy="fixed"`) replaced with the cache helper.
- With pytest-xdist `-n auto --dist loadfile` (PR #924), each worker amortizes the build cost across every class scheduled to that worker — 13 builds collapse to ≤8 (one per worker) plus the conftest `shared_raw_index` session fixture.

## Why

PR #924 wired pytest-xdist parallelism but the measured local wall-clock landed at **673s (no cov) / 889s (with cov)** on M-series 8-core, well above the informal 200s target. The 13 setUpClass calls were the largest unfixed source of duplicated work — `unittest.TestCase` cannot consume `tests/conftest.py::shared_raw_index` via pytest fixture injection, so the conftest fixture (already byte-identical signature) could not help these classes.

## Affected setUpClass

| file | chunker | classes |
|---|---|---|
| `tests/test_answer_contract_snapshot.py` | fixed | 1 (+ 1 per-method rebuild) |
| `tests/test_demo_helpers.py` | default | 1 |
| `tests/test_followup_entity_injection.py` | default | 1 |
| `tests/test_fuzzy_retrieval.py` | default | 1 |
| `tests/test_hybrid_retrieval_regression.py` | default | 1 |
| `tests/test_llm_synthesis.py` | default | 1 |
| `tests/test_m3_backend_regression.py` | fixed | 2 |
| `tests/test_naive_baseline_ranking_invariance.py` | fixed | 1 |
| `tests/test_observability_tracing.py` | default | 1 |
| `tests/test_partial_topic_grounding.py` | default | 1 |
| `tests/test_retrieval_loop_regression.py` | default | 1 |
| `tests/test_single_turn_ambiguity.py` | default | 1 |

`tests/test_async_rag_query_regression.py` already uses the pytest `shared_raw_index` fixture (autouse) and is unchanged.

## Test plan

- [x] `ruff check` on all 13 modified files → All checks passed
- [ ] Local wall-clock measurement (M-series 8-core) — to be appended once `bash scripts/test.sh` finishes
- [ ] CI: Pytest / Branch+issue / Baseline provenance

### 5b. Real-data delta

**No behavior change in retrieval / verifier / eval / api / ingestion path.**

`tests/_shared_index_cache.py` lives entirely under `tests/` (non-LB per `scripts/_governance.py LOAD_BEARING_PATHS`). The cache returns the same dict that `build_index_payload(...)` would build — golden snapshots (`naive_baseline_top_k.json` / `answer_contract_shape.json`) remain bit-identical. Treated as read-only by all consumers; modified-index tests (e.g. `test_fuzzy_retrieval` ambiguity scenarios via `build_index_payload_from_documents`) are unaffected.

Closes #927