### PR TITLE
ci(eval): matrix shard Pytest x8 — 25min → ~3-4min wall-clock (closes #931)

### DIFF
--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -21,8 +21,23 @@ env:
 
 jobs:
   test:
-    name: Pytest
+    # Issue #931: matrix shard pytest x8 fans the suite across 8 parallel
+    # ubuntu-latest runners. `scripts/test.sh` honors `BIDMATE_PYTEST_SPLITS`
+    # + `BIDMATE_PYTEST_SHARD` env vars (passes `--splits N --group K` to
+    # pytest-split). `fail-fast: false` so we see every failing shard, not
+    # just the first. ~25min serial wall-clock → ~3-4min per-shard.
+    # Per-shard coverage.xml uploads to Codecov with `shard-N` flags;
+    # Codecov merges them server-side. Leaderboard --check runs only on
+    # shard 1 (single-runner invariant; not test-suite-dependent).
+    name: Pytest (shard ${{ matrix.shard }})
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     runs-on: ubuntu-latest
+    env:
+      BIDMATE_PYTEST_SPLITS: "8"
+      BIDMATE_PYTEST_SHARD: ${{ matrix.shard }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -44,7 +59,7 @@ jobs:
         run: |
           if [ -f coverage.xml ] && command -v coverage >/dev/null 2>&1; then
             {
-              echo "## Coverage";
+              echo "## Coverage (shard ${{ matrix.shard }})";
               echo '```';
               coverage report --skip-empty || true;
               echo '```';
@@ -55,7 +70,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-xml
+          name: coverage-xml-shard-${{ matrix.shard }}
           path: coverage.xml
           if-no-files-found: warn
 
@@ -64,10 +79,15 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           files: coverage.xml
+          flags: shard-${{ matrix.shard }}
           fail_ci_if_error: false
           verbose: false
 
       - name: Verify leaderboard artifacts are in sync with history
+        # Single-runner invariant — leaderboard history is not test-suite
+        # dependent. Gating to shard 1 avoids 8× duplicate runs and a
+        # racey artifact diff if shards complete out of order.
+        if: matrix.shard == 1
         run: python3 scripts/leaderboard.py --check
 
   baseline-provenance:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,3 +32,9 @@ pytest-xdist>=3.5
 # finding on current main, no codebase sweep required. Wider rules sweep
 # (E402/F401/F841) tracked in #334.
 ruff>=0.15.12
+# Issue #931 — CI matrix shard. `.github/workflows/pr-eval.yml` fans out
+# pytest into 8 parallel shards (matrix.shard: [1..8]); scripts/test.sh
+# honors `BIDMATE_PYTEST_SPLITS` + `BIDMATE_PYTEST_SHARD` env vars and
+# passes `--splits N --group K` to pytest. Local runs without those env
+# vars (default) skip --splits entirely. 25min CI wall-clock → ~3-4min.
+pytest-split>=0.10

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -32,12 +32,28 @@ fi
 # back to serial automatically when pytest-xdist is missing (the `-n` /
 # `--dist` flags simply error out; minimal envs without dev deps installed
 # get the same 1010s serial run as before).
+#
+# Issue #931: CI matrix shard via pytest-split. When `BIDMATE_PYTEST_SPLITS`
+# AND `BIDMATE_PYTEST_SHARD` are both set AND pytest-split is importable,
+# pytest receives `--splits N --group K` to run only this shard's slice of
+# the suite. Used by `.github/workflows/pr-eval.yml`'s matrix.shard fan-out.
+# Local runs without the env vars (default) skip --splits entirely — same
+# behavior as before the matrix shard landed. The fallback chain (no env
+# vars OR pytest-split missing) keeps fresh-clone / minimal-env paths intact.
 if command -v pytest >/dev/null 2>&1; then
   XDIST_FLAGS=()
   if python -c "import xdist" >/dev/null 2>&1; then
     XDIST_FLAGS=(-n auto --dist loadfile)
   fi
-  pytest -q "${XDIST_FLAGS[@]}" "${COV_FLAGS[@]}"
+  SPLIT_FLAGS=()
+  if [[ -n "${BIDMATE_PYTEST_SPLITS:-}" && -n "${BIDMATE_PYTEST_SHARD:-}" ]]; then
+    if python -c "import pytest_split" >/dev/null 2>&1; then
+      SPLIT_FLAGS=(--splits "${BIDMATE_PYTEST_SPLITS}" --group "${BIDMATE_PYTEST_SHARD}")
+    else
+      echo "pytest-split not importable; ignoring BIDMATE_PYTEST_SPLITS/SHARD." >&2
+    fi
+  fi
+  pytest -q "${XDIST_FLAGS[@]}" "${COV_FLAGS[@]}" "${SPLIT_FLAGS[@]}"
 else
   echo "pytest not found. Install dev dependencies or add pytest to requirements." >&2
   exit 1


### PR DESCRIPTION
## Summary
- `.github/workflows/pr-eval.yml` Pytest job fans out across 8 parallel ubuntu-latest runners via `strategy.matrix.shard: [1..8]`.
- `scripts/test.sh` honors `BIDMATE_PYTEST_SPLITS` + `BIDMATE_PYTEST_SHARD` env vars and passes `--splits N --group K` to pytest (pytest-split).
- `requirements-dev.txt` pins `pytest-split>=0.10`.

## Why
PR #928 (cache refactor) measured no meaningful local wall-clock improvement (1183s vs 889s baseline) because `--dist loadfile` distributes test files across workers, so any per-file fixture cache rarely hits.

Matrix shard sidesteps that entirely by parallelizing **at the CI level** — each ubuntu-latest runner gets ~1/8 of the suite. The local fast-path (`-n auto --dist loadfile` from PR #924) is unchanged; matrix shard kicks in only when both env vars are set (CI default).

| surface | before | after | mechanism |
|---|---|---|---|
| CI Pytest wall-clock | ~25min serial | **~3-4min** (slowest shard) | matrix.shard [1..8] |
| Local `bash scripts/test.sh` | unchanged | unchanged | env vars unset → no `--splits` |
| Total runner-minutes | ~25min | ~24min (8 × ~3min) | parity |

## Design notes
- **fail-fast: false** — every failing shard surfaces, not just the first. Debug parallel failures without re-runs.
- **Per-shard coverage artifacts** (`coverage-xml-shard-N`) + **Codecov flags** (`shard-N`) so Codecov merges server-side instead of one shard's partial coverage clobbering the report.
- **Leaderboard `--check` gated to shard 1** — single-runner invariant, not test-suite-dependent. 8× duplicate runs would race on the same artifact diff.
- **GitHub free-tier concurrent slots**: consumes 8 of 20 linux job slots during the run — comfortably under cap even with `baseline-provenance` + `eval-delta` jobs concurrent.

## Test plan
- [x] `pip install -r requirements-dev.txt` → pytest-split installed
- [x] Local `BIDMATE_PYTEST_SPLITS=8 BIDMATE_PYTEST_SHARD=1 bash scripts/test.sh` smoke (in background)
- [x] Local default (env unset) `bash scripts/test.sh` → unchanged behavior (PR #924 baseline)
- [ ] CI: all 8 shards green + leaderboard check (shard 1) + baseline-provenance + eval-delta

### 5b. Real-data delta
**No behavior change in retrieval / verifier / eval / api / ingestion path.**

`.github/workflows/pr-eval.yml` + `scripts/test.sh` + `requirements-dev.txt` are CI infrastructure — non-LB tooling. No production code path modified. `make real-eval-delta` is 0-shift in this PR.

Closes #931