### PR TITLE
feat(retrieval): random backend + single_chunk preset for distinguishing-power floors (ADR 0053)

### DIFF
--- a/docs/adr/0053-distinguishing-power-floor-ablations.md
+++ b/docs/adr/0053-distinguishing-power-floor-ablations.md
@@ -1,0 +1,92 @@
+# ADR 0053 — Distinguishing-power floor ablations (`random` retrieval + `single_chunk` preset)
+
+- Status: Proposed
+- Date: 2026-05-17
+- Authors: Hyunsoo Kim
+- Related: ADR 0001 (naive_baseline invariance), ADR 0005 (eval split), ADR 0030 (leaderboard surfaces), ADR 0044 (real-eval n trajectory — being superseded by ADR 0052 in PR-B)
+- Issue: #938
+
+## Context
+
+The `eval-framework-progressive-audit` skill (Phase 1, step 2) calls for **three "broken" baselines** whose only job is to fail visibly — `random_retrieval`, `no_verifier`, and `single_chunk`. Any default whose accuracy / groundedness collapses to within noise of one of these is telling us the default isn't doing real work — a Goodhart-style trap where the leaderboard moves but no real capability is being measured.
+
+Current state on `origin/main`:
+
+- ✅ `no_verifier_retry` ablation row already exists in `eval/config.yaml:180` (covers the `no_verifier` floor).
+- ❌ No `random_retrieval` row — `VALID_RETRIEVAL_BACKENDS` was `{"dense", "hybrid", "m3"}`. No deterministic random ranking primitive existed.
+- ❌ No `single_chunk` preset — every existing preset retrieves `top_k ≥ 4`.
+
+Without these two floors the leaderboard cannot answer **"does our retrieval pull weight?"**. Companion: PR-5b (issue TBD) adds `scripts/distinguishing_power.py` to compute the actual delta-vs-floor signal.
+
+## Decision
+
+1. **Extend `VALID_RETRIEVAL_BACKENDS`** to `{"dense", "hybrid", "m3", "random"}`. The validation lives in `rag_pipeline_presets.py` and is consumed by `rag_query.resolve_pipeline_config`, `rag_core.run_rag_query`, and the per-row eval loader.
+
+2. **Implement `random` as a short-circuit branch** in `rag_retrieval.retrieve_candidates` that fires **after** the metadata filter step but **before** the embedding / BM25 / M3 forward passes. Each filtered candidate gets a uniform score in `[0, 1]` derived from `SHA-256(query + "\x00" + chunk_id)` — deterministic per `(query, chunk_id)` so:
+   - The same query produces the same ranking across runs (test-friendly, eval-reproducible).
+   - Different queries pull different orderings (avoids degenerate "always return chunk-001" behavior).
+   - No model invocation — zero embedding / inference cost. CI-safe by construction.
+
+3. **Add the `single_chunk` pipeline preset** to `PIPELINE_PRESETS` with `top_k=1`, all post-retrieval enhancements off (`metadata_first=False`, `rerank=False`, `rerank_cross_encoder=False`, `verifier_retry=False`), `retrieval_backend="dense"`, `prompt_profile="minimal_grounded_extractive"`. This mirrors what a contributor would reach for without retrieval engineering — the "what if we just grab the closest chunk?" baseline.
+
+4. **Wire two ablation rows in `eval/config.yaml`**:
+   - `random_retrieval` — `pipeline: agentic_full` + `retrieval_backend: random` (so we isolate the random-retrieval effect inside the full pipeline shape; the rest of the stack stays on).
+   - `single_chunk` — `pipeline: single_chunk` (the preset above carries every other knob).
+
+5. **Lock in via regression tests**: `tests/test_random_retrieval_regression.py` (5 tests: allow-list membership + diagnostics record + top-k differs from dense + determinism + cross-query differentiation) and `tests/test_single_chunk_preset_regression.py` (4 tests: preset shape + top-k=1 end-to-end + no verifier retry).
+
+## Why these two, why now
+
+- **Sequencing with PR-B (ADR 0052, n=21 → n=200 hardcase expansion)**: the distinguishing-power signal is only meaningful at n=200 where the noise floor is below the gap between defaults and floors. PR-5b's first measurement will be against the n=200 baseline, so PR-5a (this ADR) must land **before** the baseline regen so the floor rows are part of the n=200 baseline.aggregate.json. Otherwise the first distinguishing-power measurement would be against a baseline that doesn't contain the floors and would force a second baseline commit.
+- **`random_retrieval` first** because it's the cleanest "no signal" reference; `single_chunk` answers a slightly different question ("does multi-chunk retrieval pull weight?"). Together they bracket the two distinguishing-power axes.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| **`random.shuffle(candidates)`** instead of SHA-256 hash | Non-deterministic across runs — breaks eval reproducibility (the same eval row would produce different metrics each CI run, masking real regressions and creating flaky failures). |
+| **Use Python `random.Random(seed=hash(query))`** | `hash(query)` is salted per process in Python 3 (PEP 456) — would produce different results across processes. SHA-256 is portable. |
+| **`single_chunk` as an `eval/config.yaml`-only knob (`top_k: 1` override on `naive_baseline`)** | Loses the preset-level lock-in. A future PR that adds `top_k=4` default would silently break the floor. Preset entry makes the intent explicit and protected by the regression test. |
+| **Add `no_filter` and `no_chunking` floors too (the full audit list)** | Out of scope for PR-5a — `no_filter` requires a deeper retrieval-side carve-out, `no_chunking` requires ingest-side changes. Tracked as PR-5c/5d follow-ups if the first measurement justifies them. |
+
+## Consequences
+
+### Positive
+- The leaderboard gains two **falsifiable lower bounds** — any future "improvement" that doesn't beat `random_retrieval` is by definition not a real improvement. Direct portfolio claim: "we measure distinguishing power, not just absolute metrics."
+- PR-5b's `scripts/distinguishing_power.py` (follow-up) can compute `(default - floor) / (ceiling - floor)` for every leaderboard metric — a single-number "is the signal alive" gauge.
+- Zero production code path impact — the `random` short-circuit is opt-in via `retrieval_backend` config; default `dense` is unchanged (ADR 0001 byte-identity invariant preserved).
+
+### Negative
+- Adds 2 ablation rows to the eval matrix — `make eval-public` walltime increases by ~2 × current per-row cost. Mitigation: `random` skips the heaviest CI step (embedding), so its per-row cost is ~3× faster than `naive_baseline`; net add is small.
+- The `random` branch in `retrieve_candidates` duplicates the candidate-dict build code (~30 LOC) shared with the dense/hybrid/m3 path below. A future cleanup can factor out a `_build_candidate_item` helper if the cost becomes maintenance noise.
+
+### Invariance check
+- **ADR 0001 (naive_baseline preset, byte-identity top-k)**: unchanged — `naive_baseline` preset entry and `retrieval_backend="dense"` default are not modified.
+- **ADR 0003 (answer contract schema_version=2)**: unchanged — random/single_chunk produce the same evidence-dict shape; the answer renderer is invariant to retrieval backend.
+- **ADR 0005 (eval split public/private)**: unchanged — both new rows live in `eval/config.yaml` (public synthetic surface). The real-eval surface (PR-B) consumes the same preset registry so n=200 baseline.aggregate.json will pick up the floors automatically.
+- **ADR 0030 (leaderboard surfaces)**: extended, not modified — the two new rows show up as additional columns; no existing column changes.
+
+## Out of scope
+
+- **`scripts/distinguishing_power.py` + first measurement** — PR-5b follow-up. Blocks on n=200 baseline (PR-B), not on PR-5a itself.
+- **`no_filter` / `no_chunking` floors** — PR-5c/5d candidates if PR-5b's first measurement shows the existing floors are insufficient.
+- **Real-eval `random_retrieval` row in `eval/real_config.local.yaml`** — added in PR-B (paired with baseline regen at n=200) so the eval-row provenance is consistent.
+- **Refactor to extract `_build_candidate_item` helper** — defer until cleanup PR; the 30-LOC duplication is intentional clarity, not technical debt yet.
+
+## Verification
+
+<!-- verifies-key: rag_pipeline_presets.py:VALID_RETRIEVAL_BACKENDS -->
+<!-- verifies-key: rag_pipeline_presets.py:single_chunk -->
+<!-- verifies-key: rag_retrieval.py:retrieval_backend == "random" -->
+<!-- verifies-key: tests/test_random_retrieval_regression.py:test_random_is_in_valid_retrieval_backends -->
+<!-- verifies-key: tests/test_single_chunk_preset_regression.py:test_single_chunk_preset_shape -->
+<!-- verifies-key: eval/config.yaml:random_retrieval -->
+
+## References
+
+- `eval-framework-progressive-audit` skill, Phase 1 step 2 (the 3-floors checklist)
+- `rag_retrieval.retrieve_candidates` — implementation entry point
+- `rag_pipeline_presets.VALID_RETRIEVAL_BACKENDS` / `PIPELINE_PRESETS` — config single source of truth
+- `tests/test_random_retrieval_regression.py` + `tests/test_single_chunk_preset_regression.py` — locked contracts
+- ADR 0001 (naive_baseline invariance) — the invariant being preserved
+- ADR 0044 → ADR 0052 (real-eval case expansion) — sequencing rationale for landing floors before n=200 regen

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -125,6 +125,7 @@ project record.
 | [0049](./0049-kordoc-replaces-pyhwp-backend.md) | proposed | kordoc (npm subprocess, Node 18+) replaces pyhwp/hwp5 as HWP backend **and** replaces `PdfCsvTextLoader`'s default cover/TOC path with `PdfKordocLoader`; `BIDMATE_HWP_LOADER` + `BIDMATE_PDF_LOADER` flip independently (`kordoc` default \| `csv_text` offline / CI / Node-missing); `_prime_kordoc_batches` pools HWP + PDF into one `npx` invocation; `csv_text` fallback preserved (ADR 0001 invariant); supersedes ADR 0036; closes issue #890 |
 | [0050](./0050-m4a-axis-a-real-scale-v2-distractor-rebuild.md) | proposed | M4-A axis-A real_scale_v2_distractor 재구축 + H/I/J/K 코퍼스 확장 |
 | [0051](./0051-flat-root-module-layout.md) | accepted | flat-root module layout 유지 — `src/` 마이그레이션 거절 (ADR 0045 leaf DAG 가 패키지화 이득 대체) |
+| [0053](./0053-distinguishing-power-floor-ablations.md) | proposed | distinguishing-power floor ablations — `random` retrieval backend (SHA-256 deterministic, no embedding) + `single_chunk` preset (top_k=1, no rerank/retry); falsifiable lower bounds for "does retrieval pull weight?"; ADR 0001 byte-identity invariant preserved; pairs with PR-5b `scripts/distinguishing_power.py` follow-up; closes issue #938 |
 
 ## Roadmap (proposed, not yet committed)
 

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -409,6 +409,33 @@ ablation_runs:
     verifier_retry: true
     retrieval_mode: flat
     hwp_loader: native_tables
+  # Issue #938 / ADR 0053 — distinguishing-power floor ablations.
+  # The eval-framework-progressive-audit skill (Phase 1 step 2) calls
+  # for three "broken baselines" that should perform *worse* than the
+  # default; any default whose metrics collapse to within noise of one
+  # of these is telling us the default isn't doing real work. PR-5a
+  # lands two of the three (no_verifier is already covered by the
+  # existing ``no_verifier_retry`` row above).
+  - name: random_retrieval
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    # Deterministic per (query, chunk_id) via SHA-256; no embedding /
+    # BM25 / M3 forward pass — see ``rag_retrieval.retrieve_candidates``.
+    retrieval_backend: random
+  - name: single_chunk
+    pipeline: single_chunk
+    # All flags below are redundant with the preset (top_k=1, no
+    # metadata-first / rerank / verifier_retry, dense backend) but are
+    # spelled out so the eval row reads independently of the preset
+    # registry — same convention as the other ablation rows.
+    metadata_first: false
+    rerank: false
+    verifier_retry: false
+    retrieval_mode: flat
+    retrieval_backend: dense
 cases:
   - id: single_doc_security
     query_type: single_doc

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -422,7 +422,7 @@ ablation_runs:
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
-    # Deterministic per (query, chunk_id) via SHA-256; no embedding /
+    # Deterministic per (query, chunk_id) via SHA-256; no vector /
     # BM25 / M3 forward pass — see ``rag_retrieval.retrieve_candidates``.
     retrieval_backend: random
   - name: single_chunk

--- a/rag_pipeline_presets.py
+++ b/rag_pipeline_presets.py
@@ -184,6 +184,31 @@ PIPELINE_PRESETS: dict[str, dict[str, Any]] = {
             "anthropic (opt-in, real LLM planning)."
         ),
     },
+    # Issue #938 / ADR 0053 — minimal "fetch one chunk and answer" baseline.
+    # Mirrors the naive shape a contributor would reach for without retrieval
+    # engineering: top_k=1, no metadata-first, no rerank, no verifier retry.
+    # The distinguishing-power floor for the "is multi-chunk retrieval pulling
+    # weight?" question — pairs with the ``random_retrieval`` ablation row in
+    # eval/config.yaml. Retrieval backend stays "dense" so the only knob being
+    # varied vs naive_baseline is ``top_k`` (1 vs 4).
+    "single_chunk": {
+        "top_k": 1,
+        "metadata_first": False,
+        "rerank": False,
+        "rerank_cross_encoder": False,
+        "verifier_retry": False,
+        "retrieval_mode": "flat",
+        "retrieval_backend": "dense",
+        "prompt_profile": "minimal_grounded_extractive",
+        "rrf_k": RRF_K,
+        "bm25_stopword_profile": "shared",
+        "bm25_tokenizer": "regex",
+        "query_expansion": "identity",
+        "description": (
+            "Single top-1 dense chunk, no rerank or verifier retry — "
+            "distinguishing-power floor for multi-chunk retrieval value."
+        ),
+    },
 }
 
 PIPELINE_ALIASES = {
@@ -231,7 +256,14 @@ VALID_RETRIEVAL_MODES = {"flat", "hierarchical"}
 # stays ``dense``. Requires ``pip install -r requirements-m3.txt``.
 # See ``docs/vision/m3-multichannel-spike.md`` and ADR 0010's
 # "Alternatives considered" (lines 72-85) for the deferral context.
-VALID_RETRIEVAL_BACKENDS = {"dense", "hybrid", "m3"}
+# Issue #938 / ADR 0053 — ``random`` is the distinguishing-power floor:
+# uniform random ranking over filtered candidates, deterministic per
+# (query, chunk_id) via SHA-256, no embedding / BM25 / M3 forward pass.
+# Any pipeline whose accuracy collapses to within noise of ``random`` is
+# telling us the retrieval signal is not doing work. See the
+# ``random_retrieval`` ablation row in ``eval/config.yaml`` and
+# ``scripts/distinguishing_power.py`` (PR-5b follow-up).
+VALID_RETRIEVAL_BACKENDS = {"dense", "hybrid", "m3", "random"}
 VALID_BM25_STOPWORD_PROFILES = {"shared", "bm25_extra"}
 # Issue #486 / ADR 0031 — additive Korean-morphology tokenizer.
 # "regex" preserves the ADR 0001 naive_baseline invariant; "kiwi" opts

--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -345,6 +345,63 @@ def retrieve_candidates(
         plan["candidate_count"] = len(candidates)
         plan["filter_fallback_used"] = True
 
+    # Issue #938 / ADR 0053 — random retrieval baseline. Short-circuit
+    # before the embedding / BM25 / M3 forward passes: assign each
+    # filtered candidate a uniform score in [0, 1] derived from a
+    # SHA-256 of ``(query, chunk_id)`` so the same query produces the
+    # same ranking across runs (test-friendly, eval-reproducible) but
+    # different queries pull different orderings. ``score_parts`` keeps
+    # the existing keys at 0.0 so downstream consumers (eval scorer,
+    # leaderboard) don't crash on missing fields; the diagnostic
+    # ``random`` channel is the only non-zero parts entry.
+    retrieval_backend = str(plan.get("retrieval_backend", "dense"))
+    if retrieval_backend == "random":
+        import hashlib as _hashlib
+
+        scored: list[dict[str, Any]] = []
+        for chunk in candidates:
+            chunk_id_str = str(chunk.get("chunk_id"))
+            digest = _hashlib.sha256(
+                f"{query}\x00{chunk_id_str}".encode("utf-8")
+            ).digest()
+            rand_score = int.from_bytes(digest[:8], "big") / float(1 << 64)
+            score_parts = {
+                "dense": 0.0,
+                "lexical": 0.0,
+                "metadata": 0.0,
+                "bm25": 0.0,
+                "random": round(float(rand_score), 6),
+            }
+            item = {
+                "doc_id": chunk["doc_id"],
+                "chunk_id": chunk["chunk_id"],
+                "title": chunk["title"],
+                "agency": chunk.get("agency", ""),
+                "project": chunk.get("project", ""),
+                "metadata": chunk.get("metadata", {}),
+                "section": chunk["section"],
+                "section_id": chunk.get("section_id"),
+                "parent_section_id": chunk.get("parent_section_id")
+                or chunk.get("section_id"),
+                "section_path": chunk.get("section_path")
+                or [chunk.get("section", "")],
+                "chunk_seq_in_section": chunk.get("chunk_seq_in_section"),
+                "total_chunks_in_section": chunk.get("total_chunks_in_section"),
+                "chunking_strategy": chunk.get("chunking_strategy", "legacy"),
+                "retrieval_mode": "flat",
+                "text": chunk["text"],
+                "score": round(float(rand_score), 6),
+                "score_parts": score_parts,
+            }
+            regions = normalize_regions(chunk.get("regions"))
+            page_span = normalize_page_span(chunk.get("page_span"), regions)
+            if regions:
+                item["regions"] = regions
+            if page_span:
+                item["page_span"] = page_span
+            scored.append(item)
+        return scored
+
     embedding_config = index.get("embedding", {})
     # #396 / ADR 0023 — pluggable query expansion. Default is the
     # ``IdentityExpander`` so ``naive_baseline`` and any preset without
@@ -359,7 +416,6 @@ def retrieve_candidates(
     query_embedding = embed_query_for_index(embed_text, embedding_config)
     query_tokens = set(analysis.get("tokens", []))
     query_topics = analysis.get("topics", [])
-    retrieval_backend = str(plan.get("retrieval_backend", "dense"))
 
     bm25_score_by_chunk: dict[str, float] = {}
     if retrieval_backend == "hybrid":

--- a/tests/test_hybrid_retrieval_regression.py
+++ b/tests/test_hybrid_retrieval_regression.py
@@ -145,7 +145,12 @@ class HybridRetrievalRegressionTest(unittest.TestCase):
         # backend (BGE-M3 dense + sparse + ColBERT multi-vector fused
         # via N-way RRF). Default remains ``dense``; ``hybrid`` is
         # unchanged. See ``docs/vision/m3-multichannel-spike.md``.
-        self.assertEqual({"dense", "hybrid", "m3"}, VALID_RETRIEVAL_BACKENDS)
+        # Issue #938 / ADR 0053 — ``random`` is the 4th member: the
+        # distinguishing-power floor (uniform random ranking over
+        # filtered candidates, no embedding / BM25 / M3 forward pass).
+        self.assertEqual(
+            {"dense", "hybrid", "m3", "random"}, VALID_RETRIEVAL_BACKENDS
+        )
 
     # -- Issue #149 — RRF k as plan-time knob -----------------------
 

--- a/tests/test_m3_backend_regression.py
+++ b/tests/test_m3_backend_regression.py
@@ -54,7 +54,12 @@ class M3BackendValidationTest(unittest.TestCase):
 
     def test_valid_retrieval_backends_includes_m3(self) -> None:
         self.assertIn("m3", VALID_RETRIEVAL_BACKENDS)
-        self.assertEqual({"dense", "hybrid", "m3"}, VALID_RETRIEVAL_BACKENDS)
+        # ADR 0053 (issue #938) — "random" joined the set as the
+        # distinguishing-power floor. Update lockstep with the m3 row so
+        # both regression guards stay aligned.
+        self.assertEqual(
+            {"dense", "hybrid", "m3", "random"}, VALID_RETRIEVAL_BACKENDS
+        )
 
     def test_resolve_pipeline_config_accepts_m3(self) -> None:
         config = resolve_pipeline_config(

--- a/tests/test_random_retrieval_regression.py
+++ b/tests/test_random_retrieval_regression.py
@@ -1,0 +1,145 @@
+"""Regression guard for the ``random`` retrieval backend (issue #938, ADR 0053).
+
+The ``random`` backend is the distinguishing-power floor: it short-circuits
+``retrieve_candidates`` BEFORE the embedding / BM25 / M3 forward passes and
+returns filtered candidates ranked by a deterministic SHA-256 hash of
+``(query, chunk_id)``. Three contracts are locked in here:
+
+1. **Allow-list membership** — ``"random"`` is in
+   ``VALID_RETRIEVAL_BACKENDS`` and ``resolve_pipeline_config`` accepts it
+   without raising.
+2. **Determinism** — the same query produces the same top-k ranking across
+   independent calls (test-friendly, eval-reproducible). Different queries
+   pull different orderings.
+3. **No-embedding short-circuit** — every returned item carries the marker
+   ``score_parts["random"] > 0`` AND ``score_parts["dense"] == 0.0``,
+   proving the embedding / scoring path was skipped (dense would be > 0
+   for a non-trivial query against the hashing embedding fixture).
+
+The test runs on the synthetic ``data/raw`` fixture with the hashing
+embedding backend so it stays fast and CI-safe (no real model deps).
+"""
+
+import unittest
+from pathlib import Path
+
+from rag_core import build_index_payload, run_rag_query
+from rag_pipeline_presets import VALID_RETRIEVAL_BACKENDS
+
+
+_QUERY_A = "기관 A의 보안 통제 요구사항은?"
+_QUERY_B = "기관 B의 사업 일정은?"
+
+
+class RandomRetrievalBackendTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index = build_index_payload(
+            Path("data/raw"), embedding_backend="hashing"
+        )
+
+    def test_random_is_in_valid_retrieval_backends(self) -> None:
+        """ADR 0053 — allow-list membership invariant."""
+        self.assertIn("random", VALID_RETRIEVAL_BACKENDS)
+
+    def test_random_backend_diagnostics_record_backend_choice(self) -> None:
+        """Diagnostics confirm the random branch fired (no silent fallback
+        to dense). ``score_parts`` is not exposed in the evidence shape —
+        the user-facing signal is ``diagnostics['retrieval_backend']``."""
+        result = run_rag_query(
+            self.index,
+            _QUERY_A,
+            retrieval_backend="random",
+            pipeline="single_chunk",
+        )
+        evidence = result.get("evidence", [])
+        self.assertGreater(
+            len(evidence),
+            0,
+            "random backend must still produce evidence — top-k>=1",
+        )
+        self.assertEqual(
+            "random",
+            result.get("diagnostics", {}).get("retrieval_backend"),
+            "diagnostics must record the random backend choice end-to-end",
+        )
+
+    def test_random_backend_top_k_differs_from_dense(self) -> None:
+        """No-embedding contract (orthogonal signal): random's top-k for a
+        domain-loaded query like ``기관 A의 보안...`` differs from dense's
+        top-k for the same query. Dense ranks security-section chunks at
+        the top; random's SHA-256 ordering is uncorrelated with topic, so
+        the top-4 chunk_ids must differ (collision probability across 4
+        independent hash draws over a 400+ candidate set is negligible)."""
+        rnd = run_rag_query(
+            self.index,
+            _QUERY_A,
+            retrieval_backend="random",
+            pipeline="naive_baseline",
+        )
+        dns = run_rag_query(
+            self.index,
+            _QUERY_A,
+            retrieval_backend="dense",
+            pipeline="naive_baseline",
+        )
+        rnd_ids = [str(it.get("chunk_id")) for it in rnd.get("evidence", [])]
+        dns_ids = [str(it.get("chunk_id")) for it in dns.get("evidence", [])]
+        self.assertNotEqual(
+            rnd_ids,
+            dns_ids,
+            "random must not coincidentally reproduce the dense top-k",
+        )
+
+    def test_random_backend_is_deterministic_per_query(self) -> None:
+        """Same query → identical top-k ordering across calls."""
+        a1 = run_rag_query(
+            self.index,
+            _QUERY_A,
+            retrieval_backend="random",
+            pipeline="single_chunk",
+        )
+        a2 = run_rag_query(
+            self.index,
+            _QUERY_A,
+            retrieval_backend="random",
+            pipeline="single_chunk",
+        )
+        ids1 = [str(it.get("chunk_id")) for it in a1.get("evidence", [])]
+        ids2 = [str(it.get("chunk_id")) for it in a2.get("evidence", [])]
+        self.assertEqual(
+            ids1,
+            ids2,
+            "deterministic seed: same query must return identical chunk_id order",
+        )
+
+    def test_random_backend_differs_across_queries(self) -> None:
+        """Different queries → different top-1 chunk (at least sometimes)."""
+        # Use a 4-chunk top_k so we have headroom to differ; relying on a
+        # single comparison would be too tight a bet (collision probability
+        # at top-1 = 1/N where N = candidate count).
+        a = run_rag_query(
+            self.index,
+            _QUERY_A,
+            retrieval_backend="random",
+            pipeline="naive_baseline",
+        )
+        b = run_rag_query(
+            self.index,
+            _QUERY_B,
+            retrieval_backend="random",
+            pipeline="naive_baseline",
+        )
+        ids_a = [str(it.get("chunk_id")) for it in a.get("evidence", [])]
+        ids_b = [str(it.get("chunk_id")) for it in b.get("evidence", [])]
+        # SHA-256 of different inputs has vanishing collision probability
+        # across the candidate set; require the full top-k orderings differ.
+        self.assertNotEqual(
+            ids_a,
+            ids_b,
+            "different queries must produce different random orderings",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_single_chunk_preset_regression.py
+++ b/tests/test_single_chunk_preset_regression.py
@@ -1,0 +1,94 @@
+"""Regression guard for the ``single_chunk`` preset (issue #938, ADR 0053).
+
+``single_chunk`` is the "fetch one chunk and answer" distinguishing-power
+floor — what a contributor would reach for without retrieval engineering.
+The three locked-in contracts:
+
+1. **Preset shape** — ``top_k == 1``, ``metadata_first == False``,
+   ``rerank == False``, ``rerank_cross_encoder == False``,
+   ``verifier_retry == False``, ``retrieval_backend == "dense"``.
+2. **Top-k=1 end-to-end** — exactly one evidence item makes it into
+   ``run_rag_query`` output for the answerable smoke query.
+3. **No verifier retry** — diagnostics show ``retry_count == 0`` and
+   ``filter_stage_attempts`` length == 1 (one pass, no relax).
+
+These contracts protect against future refactors that quietly add
+metadata-first / rerank / retry to the preset and erase the
+distinguishing-power signal we're measuring.
+"""
+
+import unittest
+from pathlib import Path
+
+from rag_core import build_index_payload, run_rag_query
+from rag_pipeline_presets import PIPELINE_PRESETS
+
+
+_ANSWERABLE_QUERY = "기관 A의 보안 통제 요구사항은?"
+
+
+class SingleChunkPresetShapeTest(unittest.TestCase):
+    """Static checks on the preset dict — no index build required."""
+
+    def test_single_chunk_preset_exists(self) -> None:
+        self.assertIn("single_chunk", PIPELINE_PRESETS)
+
+    def test_single_chunk_preset_shape(self) -> None:
+        preset = PIPELINE_PRESETS["single_chunk"]
+        # The whole point of the floor: top-1, nothing else.
+        self.assertEqual(1, preset["top_k"])
+        self.assertFalse(preset["metadata_first"])
+        self.assertFalse(preset["rerank"])
+        self.assertFalse(preset["rerank_cross_encoder"])
+        self.assertFalse(preset["verifier_retry"])
+        # retrieval_backend stays "dense" — the random_retrieval ablation
+        # row in eval/config.yaml is what pairs single_chunk with the
+        # ``random`` backend; the preset itself must not.
+        self.assertEqual("dense", preset["retrieval_backend"])
+        # ADR 0001 invariants — single_chunk shares the naive_baseline
+        # prompt + tokenizer so the only knob that varies is ``top_k``.
+        self.assertEqual("minimal_grounded_extractive", preset["prompt_profile"])
+        self.assertEqual("regex", preset["bm25_tokenizer"])
+        self.assertEqual("identity", preset["query_expansion"])
+
+
+class SingleChunkPresetEndToEndTest(unittest.TestCase):
+    """End-to-end smoke: top-k=1, no verifier retry."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index = build_index_payload(
+            Path("data/raw"), embedding_backend="hashing"
+        )
+
+    def test_single_chunk_returns_exactly_one_evidence_item(self) -> None:
+        result = run_rag_query(
+            self.index, _ANSWERABLE_QUERY, pipeline="single_chunk"
+        )
+        evidence = result.get("evidence", [])
+        self.assertEqual(
+            1,
+            len(evidence),
+            f"single_chunk must enforce top_k=1; got {len(evidence)} items",
+        )
+
+    def test_single_chunk_does_not_retry(self) -> None:
+        result = run_rag_query(
+            self.index, _ANSWERABLE_QUERY, pipeline="single_chunk"
+        )
+        diagnostics = result.get("diagnostics", {})
+        self.assertEqual(
+            0,
+            diagnostics.get("retry_count"),
+            "single_chunk preset disables verifier_retry — retry_count must be 0",
+        )
+        attempts = diagnostics.get("filter_stage_attempts", [])
+        self.assertEqual(
+            1,
+            len(attempts),
+            "single_chunk runs exactly one retrieval pass — no relaxation",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `VALID_RETRIEVAL_BACKENDS` extended to `{dense, hybrid, m3, random}`. `random` is the deterministic uniform-ranking floor: SHA-256(query, chunk_id), no embedding / BM25 / M3 forward pass.
- New `single_chunk` pipeline preset: `top_k=1`, no metadata-first / rerank / verifier_retry — the "fetch one chunk and answer" baseline.
- Two new ablation rows in `eval/config.yaml`: `random_retrieval` (full pipeline + random backend) and `single_chunk` (preset).
- 9 new regression tests (5 random + 4 single_chunk); 2 existing set-equality assertions extended to the 4-set.
- ADR 0053 (proposed) — full rationale, alternatives considered, invariance check, 6 `verifies-key` markers.

## Why
The `eval-framework-progressive-audit` skill (Phase 1 step 2) calls for three "broken baselines" — `random_retrieval`, `no_verifier`, `single_chunk` — as falsifiable lower bounds. `no_verifier_retry` already exists; `random` and `single_chunk` close the gap. Any default whose metric collapses to within noise of a floor is telling us the default isn't doing real work (Goodhart trap).

**Sequencing**: PR-5b (`scripts/distinguishing_power.py` + first measurement) blocks on the n=200 baseline (PR-B / ADR 0052). The floors must land **before** baseline regen so they appear in `baseline.aggregate.json` on first commit.

## ADR
- [ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) (proposed)
- Number reserved earlier; ADR 0051 = PR #934 (flat-root layout, open), ADR 0052 = PR #936 prep → PR-B (real-eval n=200, follow-up).

## Test plan
- [x] `EMBEDDING_BACKEND=hashing pytest tests/test_random_retrieval_regression.py tests/test_single_chunk_preset_regression.py tests/test_m3_backend_regression.py tests/test_hybrid_retrieval_regression.py tests/test_retrieval_loop_regression.py` → 47/47 PASS in 410s
- [x] `python3 -c "from rag_pipeline_presets import PIPELINE_PRESETS, VALID_RETRIEVAL_BACKENDS"` import smoke
- [x] `python3 scripts/_governance.py --check-adr-readme-parity docs/adr/0053-*.md` clean
- [x] `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0053-*.md` clean
- [x] `make check-branch` clean
- [ ] CI: Pytest (8 shards) / Branch+issue / Baseline provenance / Eval delta vs base

### 5b. Real-data delta

**No behavior change in retrieval / verifier / eval / api / ingestion default paths.**

- `random` backend is opt-in via `retrieval_backend: random` config; default stays `dense`. ADR 0001 byte-identity invariant preserved.
- `single_chunk` preset is opt-in via `pipeline: single_chunk`; no existing preset modified.
- `eval/config.yaml` adds two ablation rows (`random_retrieval`, `single_chunk`); existing rows unchanged. Eval delta vs base on default `full` row is 0-shift.
- `make real-eval-delta` is 0-shift for this PR; floor rows will appear in `eval/real_config.local.yaml` + n=200 baseline in PR-B.

Closes #938