### PR TITLE
feat(eval): distinguishing-power gauge + first measurement at n=221 (ADR 0053 PR-5b)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -39,6 +39,11 @@ ALLOWED_PATTERNS=(
   '^reports/rag_pipeline\.aggregate\.json$'
   '^reports/real100/rag_pipeline\.md$'
   '^reports/real100/rag_pipeline\.aggregate\.json$'
+  # Issue #945 — distinguishing-power gauge aggregate (script:
+  # scripts/distinguishing_power.py, ADR 0053 §Consequences). Mirrors
+  # the `!`-rule in `.gitignore`.
+  '^reports/real100/distinguishing_power\.md$'
+  '^reports/real100/distinguishing_power\.aggregate\.json$'
 )
 
 # Guard: ADR file deletion/rename (CLAUDE.md Prohibited).

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,13 @@ reports/real100/history/*
 !reports/rag_pipeline.aggregate.json
 !reports/real100/rag_pipeline.md
 !reports/real100/rag_pipeline.aggregate.json
+# Issue #945 — distinguishing-power gauge aggregate (script:
+# scripts/distinguishing_power.py, ADR 0053 §Consequences gauge).
+# Reads eval_summary.json::ablation.runs, emits (default - floor) /
+# (1 - floor) per metric. Aggregate-only (no per-case data); ADR 0005
+# boundary preserved by the gauge formula itself.
+!reports/real100/distinguishing_power.md
+!reports/real100/distinguishing_power.aggregate.json
 # Issue #896 + #897 — EDA figures (PNG + SVG). Same allowlist pattern
 # as cost_frontier.png above. corpus EDA: scripts/eda_real100.py /
 # RAG EDA: scripts/rag_pipeline_eda.py.

--- a/reports/real100/distinguishing_power.aggregate.json
+++ b/reports/real100/distinguishing_power.aggregate.json
@@ -1,0 +1,88 @@
+{
+  "gauge": {
+    "accuracy": {
+      "default": 0.2966101694915254,
+      "signal_alive": true,
+      "vs_random": {
+        "gap": 0.2711864406779661,
+        "normalized": 0.2782608695652174
+      },
+      "vs_single": {
+        "gap": 0.2288135593220339,
+        "normalized": 0.24545454545454545
+      }
+    },
+    "answer_format_compliance": {
+      "default": 0.2081447963800905,
+      "signal_alive": false,
+      "vs_random": {
+        "gap": -0.2398190045248869,
+        "normalized": -0.4344262295081967
+      },
+      "vs_single": {
+        "gap": -0.2398190045248869,
+        "normalized": -0.4344262295081967
+      }
+    },
+    "citation_precision": {
+      "default": 0.19019607843137254,
+      "signal_alive": false,
+      "vs_random": {
+        "gap": -0.15822021116138762,
+        "normalized": -0.24282407407407405
+      },
+      "vs_single": {
+        "gap": 0.1358974358974359,
+        "normalized": 0.14370015948963316
+      }
+    },
+    "claim_citation_alignment": {
+      "default": 0.9627659574468085,
+      "signal_alive": true,
+      "vs_random": {
+        "gap": 0.08041301627033792,
+        "normalized": 0.6835106382978722
+      },
+      "vs_single": {
+        "gap": 0.0292553191489362,
+        "normalized": 0.44000000000000006
+      }
+    },
+    "groundedness": {
+      "default": 0.25339366515837103,
+      "signal_alive": false,
+      "vs_random": {
+        "gap": -0.1085972850678733,
+        "normalized": -0.17021276595744683
+      },
+      "vs_single": {
+        "gap": 0.17194570135746606,
+        "normalized": 0.187192118226601
+      }
+    }
+  },
+  "num_predictions": 221,
+  "runs": {
+    "full": {
+      "accuracy": 0.2966101694915254,
+      "answer_format_compliance": 0.2081447963800905,
+      "citation_precision": 0.19019607843137254,
+      "claim_citation_alignment": 0.9627659574468085,
+      "groundedness": 0.25339366515837103
+    },
+    "random_retrieval": {
+      "accuracy": 0.025423728813559324,
+      "answer_format_compliance": 0.4479638009049774,
+      "citation_precision": 0.34841628959276016,
+      "claim_citation_alignment": 0.8823529411764706,
+      "groundedness": 0.36199095022624433
+    },
+    "single_chunk": {
+      "accuracy": 0.06779661016949153,
+      "answer_format_compliance": 0.4479638009049774,
+      "citation_precision": 0.05429864253393665,
+      "claim_citation_alignment": 0.9335106382978723,
+      "groundedness": 0.08144796380090498
+    }
+  }
+}

--- a/reports/real100/distinguishing_power.md
+++ b/reports/real100/distinguishing_power.md
@@ -1,0 +1,36 @@
+# Distinguishing-power gauge (real-eval, ADR 0053 §Consequences)
+
+`num_predictions = 221` · 3 ablation_runs: `full` / `random_retrieval` / `single_chunk`
+
+Per ADR 0053 §Consequences:
+> PR-5b's `scripts/distinguishing_power.py` can compute `(default - floor) / (ceiling - floor)` for every leaderboard metric — a single-number 'is the signal alive' gauge.
+
+## Ablation raw values
+
+| metric | full | random_retrieval | single_chunk |
+|---|---:|---:|---:|
+| accuracy | 29.66% | 2.54% | 6.78% |
+| groundedness | 25.34% | 36.20% | 8.14% |
+| citation_precision | 19.02% | 34.84% | 5.43% |
+| claim_citation_alignment | 96.28% | 88.24% | 93.35% |
+| answer_format_compliance | 20.81% | 44.80% | 44.80% |
+
+## Gauge — default vs floors
+
+| metric | default | gap vs random | normalized vs random | gap vs single_chunk | normalized vs single_chunk | signal alive |
+|---|---:|---:|---:|---:|---:|:---:|
+| accuracy | 29.66% | +27.12pp | 27.83% | +22.88pp | 24.55% | yes |
+| groundedness | 25.34% | -10.86pp | -17.02% | +17.19pp | 18.72% | no |
+| citation_precision | 19.02% | -15.82pp | -24.28% | +13.59pp | 14.37% | no |
+| claim_citation_alignment | 96.28% | +8.04pp | 68.35% | +2.93pp | 44.00% | yes |
+| answer_format_compliance | 20.81% | -23.98pp | -43.44% | -23.98pp | -43.44% | no |
+
+## Verdict
+
+- **accuracy**: signal alive — default beats both floors (+27.12pp vs random, +22.88pp vs single_chunk).
+- **groundedness**: ⚠️ signal NOT alive — default does not beat both floors (-10.86pp vs random, +17.19pp vs single_chunk). Retrieval or pipeline not pulling weight on this metric.
+- **citation_precision**: ⚠️ signal NOT alive — default does not beat both floors (-15.82pp vs random, +13.59pp vs single_chunk). Retrieval or pipeline not pulling weight on this metric.
+- **claim_citation_alignment**: signal alive — default beats both floors (+8.04pp vs random, +2.93pp vs single_chunk).
+- **answer_format_compliance**: ⚠️ signal NOT alive — default does not beat both floors (-23.98pp vs random, -23.98pp vs single_chunk). Retrieval or pipeline not pulling weight on this metric.
+
+_Aggregate-only per ADR 0005. No per-case data is read by this script._

--- a/scripts/distinguishing_power.py
+++ b/scripts/distinguishing_power.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Distinguishing-power gauge for real-data eval ablations (ADR 0053 §Consequences).
+
+Reads an ``eval_summary.json`` (default ``reports/real100/eval_summary.json``)
+that contains three ablation runs — ``full``, ``random_retrieval``,
+``single_chunk`` (ADR 0053 floors) — and computes per-metric gauges:
+
+* **Raw gap** = ``default − floor`` for each (metric, floor) pair.
+* **Normalized score** = ``(default − floor) / (1 − floor)`` — what fraction
+  of the remaining headroom above the floor the default occupies. ADR 0053
+  §Consequences names this the "is the signal alive" gauge.
+
+Two outputs (both committable per ADR 0005 — aggregate-only, no per-case
+data is ever read):
+
+* ``reports/real100/distinguishing_power.md`` — markdown table for human
+  inspection / PR-D README ingestion.
+* ``reports/real100/distinguishing_power.aggregate.json`` — machine-readable
+  schema for downstream tooling (PR-D's README auto-regen).
+
+CLI::
+
+    python3 scripts/distinguishing_power.py
+    python3 scripts/distinguishing_power.py --summary path/to/eval_summary.json
+    python3 scripts/distinguishing_power.py --out-md path.md --out-json path.json
+
+Exit codes::
+
+    0 — wrote both artifacts successfully
+    1 — summary file missing / missing ablation runs / unexpected schema
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Repo root sentinel so the script works whether invoked as
+# ``python3 scripts/distinguishing_power.py`` or imported as
+# ``scripts.distinguishing_power`` from the test suite.
+ROOT = Path(__file__).resolve().parents[1]
+
+# Default I/O paths — all relative to repo root. Overridable via CLI.
+DEFAULT_SUMMARY = ROOT / "reports" / "real100" / "eval_summary.json"
+DEFAULT_OUT_MD = ROOT / "reports" / "real100" / "distinguishing_power.md"
+DEFAULT_OUT_JSON = ROOT / "reports" / "real100" / "distinguishing_power.aggregate.json"
+
+# Required ablation names. The two floors come from ADR 0053; the default
+# label is fixed to ``full`` to match eval/real_config.local.yaml convention
+# (ablation_runs[0].name).
+DEFAULT_RUN = "full"
+FLOOR_RUNS = ("random_retrieval", "single_chunk")
+REQUIRED_RUNS = (DEFAULT_RUN, *FLOOR_RUNS)
+
+# Metrics gauged. "abstention" is excluded from the gauge because it is
+# a *different objective surface* (correct refusal) — random_retrieval
+# legitimately scores high on it (e.g. 0.89 at n=221) without indicating
+# the default has lost distinguishing power. The eval_summary will still
+# include abstention numbers in its raw run aggregates.
+GAUGED_METRICS = (
+    "accuracy",
+    "groundedness",
+    "citation_precision",
+    "claim_citation_alignment",
+    "answer_format_compliance",
+)
+
+
+def _load_summary(path: Path) -> dict[str, Any]:
+    """Load ``eval_summary.json`` and verify the three ablation runs exist.
+
+    Raises ``SystemExit(1)`` with a human-readable error on any structural
+    surprise (missing file, missing ``ablation.runs``, missing required run).
+    Test-friendly: callers (including the unit test) can catch SystemExit.
+    """
+    if not path.exists():
+        sys.exit(
+            f"[ERROR] eval_summary not found: {path}\n"
+            f"        Run `make real-eval` first (writes the gitignored summary)."
+        )
+    with path.open() as fh:
+        data = json.load(fh)
+    runs = data.get("ablation", {}).get("runs")
+    if not isinstance(runs, list):
+        sys.exit(
+            f"[ERROR] eval_summary {path} has no ablation.runs list — "
+            f"distinguishing-power gauge requires the 3-row ablation surface "
+            f"(see ADR 0053 + eval/real_config.local.yaml ablation_runs)."
+        )
+    names = {r.get("name") for r in runs}
+    missing = [name for name in REQUIRED_RUNS if name not in names]
+    if missing:
+        sys.exit(
+            f"[ERROR] eval_summary {path} missing required ablation runs: "
+            f"{missing}. Expected all of {list(REQUIRED_RUNS)} per ADR 0053. "
+            f"Got: {sorted(names)}"
+        )
+    return data
+
+
+def _runs_by_name(summary: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Index ablation runs by name for O(1) lookup."""
+    return {r["name"]: r for r in summary["ablation"]["runs"]}
+
+
+def _safe_metric(run: dict[str, Any], metric: str) -> float | None:
+    """Pull a metric value from an ablation run, tolerating absence.
+
+    Some metrics (e.g. ``citation_precision``) may be ``None`` when n=0
+    for the relevant slice. Return ``None`` rather than raising — the
+    gauge row for that metric will be marked ``n/a`` in both outputs.
+    """
+    value = run.get(metric)
+    if value is None:
+        ci = run.get("ci", {}).get(metric)
+        if isinstance(ci, dict):
+            value = ci.get("mean")
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _gauge_row(default: float | None, floor: float | None) -> dict[str, Any]:
+    """Compute the raw gap + normalized headroom score for one (metric, floor).
+
+    ``normalized`` is the ADR 0053 §Consequences formula::
+
+        score = (default - floor) / (1 - floor)
+
+    which is the fraction of the remaining headroom-above-floor (ceiling
+    of 1.0 assumed since these are all 0..1 rates) that the default occupies.
+    A score > 0 means the default beats the floor; ≤ 0 means the default is
+    at or below the floor — the "signal is dead" warning state.
+
+    Returns ``{"gap": None, "normalized": None}`` if either input is missing
+    or if ``floor == 1`` (degenerate denominator).
+    """
+    if default is None or floor is None:
+        return {"gap": None, "normalized": None}
+    gap = default - floor
+    denom = 1.0 - floor
+    if denom <= 0:
+        return {"gap": gap, "normalized": None}
+    return {"gap": gap, "normalized": gap / denom}
+
+
+def compute_gauge(summary: dict[str, Any]) -> dict[str, Any]:
+    """Compute the full distinguishing-power gauge from a loaded summary.
+
+    Returns a JSON-serializable dict with this structure::
+
+        {
+          "num_predictions": int,
+          "runs": {
+            "full":             {"accuracy": 0.297, ...},
+            "random_retrieval": {"accuracy": 0.025, ...},
+            "single_chunk":     {"accuracy": 0.068, ...},
+          },
+          "gauge": {
+            "accuracy": {
+              "default":      0.297,
+              "vs_random":    {"gap": 0.272, "normalized": 0.279},
+              "vs_single":    {"gap": 0.229, "normalized": 0.245},
+              "signal_alive": True,  # both gauges > 0
+            },
+            ...
+          }
+        }
+    """
+    runs = _runs_by_name(summary)
+    default = runs[DEFAULT_RUN]
+    random_run = runs["random_retrieval"]
+    single_run = runs["single_chunk"]
+    n = default.get("num_predictions") or summary.get("num_predictions")
+
+    out_runs = {
+        name: {m: _safe_metric(runs[name], m) for m in GAUGED_METRICS}
+        for name in REQUIRED_RUNS
+    }
+    gauge: dict[str, Any] = {}
+    for metric in GAUGED_METRICS:
+        d = _safe_metric(default, metric)
+        r = _safe_metric(random_run, metric)
+        s = _safe_metric(single_run, metric)
+        vs_random = _gauge_row(d, r)
+        vs_single = _gauge_row(d, s)
+        signal_alive = (
+            vs_random["gap"] is not None
+            and vs_single["gap"] is not None
+            and vs_random["gap"] > 0
+            and vs_single["gap"] > 0
+        )
+        gauge[metric] = {
+            "default": d,
+            "vs_random": vs_random,
+            "vs_single": vs_single,
+            "signal_alive": signal_alive,
+        }
+    return {
+        "num_predictions": n,
+        "runs": out_runs,
+        "gauge": gauge,
+    }
+
+
+def _fmt_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.2f}%"
+
+
+def _fmt_pp(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value * 100:.2f}pp"
+
+
+def render_markdown(gauge: dict[str, Any]) -> str:
+    """Render the gauge as a markdown report.
+
+    Layout:
+    * Header with ``num_predictions``
+    * Raw ablation table (3 columns: full / random / single_chunk)
+    * Distinguishing-power gauge table (vs each floor)
+    * One-line verdict per metric
+    """
+    n = gauge["num_predictions"]
+    lines: list[str] = [
+        "# Distinguishing-power gauge (real-eval, ADR 0053 §Consequences)",
+        "",
+        f"`num_predictions = {n}` · 3 ablation_runs: `full` / `random_retrieval` / `single_chunk`",
+        "",
+        "Per ADR 0053 §Consequences:",
+        "> PR-5b's `scripts/distinguishing_power.py` can compute "
+        "`(default - floor) / (ceiling - floor)` for every leaderboard metric "
+        "— a single-number 'is the signal alive' gauge.",
+        "",
+        "## Ablation raw values",
+        "",
+        "| metric | full | random_retrieval | single_chunk |",
+        "|---|---:|---:|---:|",
+    ]
+    for metric in GAUGED_METRICS:
+        row = [metric]
+        for run_name in REQUIRED_RUNS:
+            row.append(_fmt_pct(gauge["runs"][run_name][metric]))
+        lines.append("| " + " | ".join(row) + " |")
+
+    lines += [
+        "",
+        "## Gauge — default vs floors",
+        "",
+        "| metric | default | gap vs random | normalized vs random | gap vs single_chunk | normalized vs single_chunk | signal alive |",
+        "|---|---:|---:|---:|---:|---:|:---:|",
+    ]
+    for metric in GAUGED_METRICS:
+        g = gauge["gauge"][metric]
+        signal_glyph = "yes" if g["signal_alive"] else "no"
+        row = [
+            metric,
+            _fmt_pct(g["default"]),
+            _fmt_pp(g["vs_random"]["gap"]),
+            _fmt_pct(g["vs_random"]["normalized"]),
+            _fmt_pp(g["vs_single"]["gap"]),
+            _fmt_pct(g["vs_single"]["normalized"]),
+            signal_glyph,
+        ]
+        lines.append("| " + " | ".join(row) + " |")
+
+    lines += [
+        "",
+        "## Verdict",
+        "",
+    ]
+    for metric in GAUGED_METRICS:
+        g = gauge["gauge"][metric]
+        if g["signal_alive"]:
+            lines.append(
+                f"- **{metric}**: signal alive — default beats both floors "
+                f"({_fmt_pp(g['vs_random']['gap'])} vs random, "
+                f"{_fmt_pp(g['vs_single']['gap'])} vs single_chunk)."
+            )
+        elif g["vs_random"]["gap"] is None or g["vs_single"]["gap"] is None:
+            lines.append(
+                f"- **{metric}**: n/a — one or both floors missing this metric."
+            )
+        else:
+            lines.append(
+                f"- **{metric}**: ⚠️ signal NOT alive — default does not beat "
+                f"both floors ({_fmt_pp(g['vs_random']['gap'])} vs random, "
+                f"{_fmt_pp(g['vs_single']['gap'])} vs single_chunk). "
+                f"Retrieval or pipeline not pulling weight on this metric."
+            )
+    lines.append("")
+    lines.append(
+        "_Aggregate-only per ADR 0005. No per-case data is read by this script._"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=DEFAULT_SUMMARY,
+        help="Path to eval_summary.json (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        default=DEFAULT_OUT_MD,
+        help="Path to markdown output (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        default=DEFAULT_OUT_JSON,
+        help="Path to JSON aggregate output (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Print markdown to stdout, do not write files.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = _load_summary(args.summary)
+    gauge = compute_gauge(summary)
+    md = render_markdown(gauge)
+
+    if args.print_only:
+        sys.stdout.write(md)
+        return 0
+
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.write_text(md)
+    args.out_json.write_text(json.dumps(gauge, indent=2, sort_keys=True))
+    print(f"[OK] Wrote {args.out_md}")
+    print(f"[OK] Wrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_distinguishing_power.py
+++ b/tests/test_distinguishing_power.py
@@ -1,0 +1,259 @@
+"""Regression tests for the distinguishing-power gauge (issue #945, ADR 0053).
+
+The script (``scripts/distinguishing_power.py``) is the "is the signal alive"
+gauge from ADR 0053 §Consequences. These tests lock in:
+
+1. **Math**: ``(default - floor) / (1 - floor)`` formula correctness on
+   hand-computable fixtures.
+2. **Schema**: the output JSON has the exact shape PR-D (README auto-regen)
+   will consume.
+3. **Verdict logic**: ``signal_alive`` is ``True`` iff default beats BOTH
+   floors on raw gap (gap > 0). Beating only one floor is ``False`` — the
+   strict version of the gauge per ADR 0053 §Decision ("falsifiable lower
+   bounds — any future improvement that doesn't beat random_retrieval is by
+   definition not a real improvement").
+4. **Missing-data tolerance**: floors with ``None`` for a metric produce
+   ``signal_alive: False`` and ``gap: None`` rather than raising.
+5. **Required-runs validation**: missing one of the 3 ablations exits
+   non-zero with a useful error message (not a stack trace).
+
+The fixtures are inline dicts — no real eval_summary.json read — so these
+tests are stable against future schema additions and have zero runtime cost.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.distinguishing_power import (
+    DEFAULT_RUN,
+    FLOOR_RUNS,
+    GAUGED_METRICS,
+    REQUIRED_RUNS,
+    compute_gauge,
+    main,
+    render_markdown,
+)
+
+
+def _make_summary(
+    full: dict[str, float | None],
+    random_retrieval: dict[str, float | None],
+    single_chunk: dict[str, float | None],
+    n: int = 221,
+) -> dict:
+    """Build a minimal eval_summary.json shape with 3 ablation runs."""
+
+    def _run(name: str, values: dict[str, float | None]) -> dict:
+        return {
+            "name": name,
+            "num_predictions": n,
+            **values,
+        }
+
+    return {
+        "num_predictions": n,
+        "ablation": {
+            "runs": [
+                _run("full", full),
+                _run("random_retrieval", random_retrieval),
+                _run("single_chunk", single_chunk),
+            ]
+        },
+    }
+
+
+class GaugeMathTest(unittest.TestCase):
+    """The (default - floor) / (1 - floor) formula on hand-computable inputs."""
+
+    def test_perfect_signal(self) -> None:
+        summary = _make_summary(
+            full={m: 0.50 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.10 for m in GAUGED_METRICS},
+            single_chunk={m: 0.20 for m in GAUGED_METRICS},
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertAlmostEqual(cell["vs_random"]["gap"], 0.40, places=6)
+            # (0.50 - 0.10) / (1 - 0.10) == 0.4444...
+            self.assertAlmostEqual(
+                cell["vs_random"]["normalized"], 0.40 / 0.90, places=6
+            )
+            self.assertAlmostEqual(cell["vs_single"]["gap"], 0.30, places=6)
+            self.assertAlmostEqual(
+                cell["vs_single"]["normalized"], 0.30 / 0.80, places=6
+            )
+            self.assertTrue(cell["signal_alive"])
+
+    def test_dead_signal_below_random(self) -> None:
+        # default LOSES to random — random_retrieval beats real pipeline.
+        # This is the Goodhart warning state the gauge exists to surface.
+        summary = _make_summary(
+            full={m: 0.10 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.30 for m in GAUGED_METRICS},
+            single_chunk={m: 0.05 for m in GAUGED_METRICS},
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertLess(cell["vs_random"]["gap"], 0)
+            self.assertFalse(
+                cell["signal_alive"],
+                f"{metric}: default 0.10 < random 0.30 must mark signal dead",
+            )
+
+    def test_partial_signal_only_beats_single(self) -> None:
+        # Beats single_chunk but loses to random — ADR 0053 strict version
+        # still says signal_alive=False (both floors must be beaten).
+        summary = _make_summary(
+            full={m: 0.15 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.20 for m in GAUGED_METRICS},
+            single_chunk={m: 0.05 for m in GAUGED_METRICS},
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertGreater(cell["vs_single"]["gap"], 0)
+            self.assertLess(cell["vs_random"]["gap"], 0)
+            self.assertFalse(cell["signal_alive"])
+
+
+class SchemaTest(unittest.TestCase):
+    """Output JSON shape is the contract PR-D (README auto-regen) will read."""
+
+    def test_top_level_keys(self) -> None:
+        summary = _make_summary(
+            full={m: 0.5 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.1 for m in GAUGED_METRICS},
+            single_chunk={m: 0.2 for m in GAUGED_METRICS},
+        )
+        g = compute_gauge(summary)
+        self.assertEqual({"num_predictions", "runs", "gauge"}, set(g.keys()))
+        self.assertEqual(set(REQUIRED_RUNS), set(g["runs"].keys()))
+        self.assertEqual(set(GAUGED_METRICS), set(g["gauge"].keys()))
+
+    def test_per_metric_keys(self) -> None:
+        summary = _make_summary(
+            full={m: 0.5 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.1 for m in GAUGED_METRICS},
+            single_chunk={m: 0.2 for m in GAUGED_METRICS},
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertEqual(
+                {"default", "vs_random", "vs_single", "signal_alive"},
+                set(cell.keys()),
+            )
+            for floor_key in ("vs_random", "vs_single"):
+                self.assertEqual(
+                    {"gap", "normalized"}, set(cell[floor_key].keys())
+                )
+
+    def test_floor_runs_constant_matches_decision(self) -> None:
+        # ADR 0053 names exactly two floors. Lock the constant against drift.
+        self.assertEqual(("random_retrieval", "single_chunk"), FLOOR_RUNS)
+        self.assertEqual("full", DEFAULT_RUN)
+
+
+class MissingDataTest(unittest.TestCase):
+    """Tolerate ``None`` metric values (slice n=0) without crashing."""
+
+    def test_none_floor_marks_signal_not_alive(self) -> None:
+        summary = _make_summary(
+            full={m: 0.5 for m in GAUGED_METRICS},
+            random_retrieval={m: None for m in GAUGED_METRICS},
+            single_chunk={m: 0.2 for m in GAUGED_METRICS},
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertIsNone(cell["vs_random"]["gap"])
+            self.assertIsNone(cell["vs_random"]["normalized"])
+            self.assertFalse(cell["signal_alive"])
+
+
+class CLITest(unittest.TestCase):
+    """End-to-end via main() — writes both artifacts to a tmpdir."""
+
+    def test_writes_both_artifacts(self) -> None:
+        summary = _make_summary(
+            full={m: 0.5 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.1 for m in GAUGED_METRICS},
+            single_chunk={m: 0.2 for m in GAUGED_METRICS},
+        )
+        with TemporaryDirectory() as td:
+            tdp = Path(td)
+            summary_path = tdp / "eval_summary.json"
+            summary_path.write_text(json.dumps(summary))
+            out_md = tdp / "distinguishing_power.md"
+            out_json = tdp / "distinguishing_power.aggregate.json"
+            rc = main(
+                [
+                    "--summary",
+                    str(summary_path),
+                    "--out-md",
+                    str(out_md),
+                    "--out-json",
+                    str(out_json),
+                ]
+            )
+            self.assertEqual(0, rc)
+            self.assertTrue(out_md.exists())
+            self.assertTrue(out_json.exists())
+            written = json.loads(out_json.read_text())
+            self.assertEqual({"num_predictions", "runs", "gauge"}, set(written.keys()))
+            md = out_md.read_text()
+            # Header + verdict section must be present.
+            self.assertIn("Distinguishing-power gauge", md)
+            self.assertIn("## Verdict", md)
+            self.assertIn("ADR 0005", md)  # privacy-boundary footer
+
+    def test_missing_required_run_exits_nonzero(self) -> None:
+        # Drop single_chunk — script must refuse with a useful error.
+        bad_summary = {
+            "num_predictions": 10,
+            "ablation": {
+                "runs": [
+                    {"name": "full", "num_predictions": 10, "accuracy": 0.5},
+                    {"name": "random_retrieval", "num_predictions": 10, "accuracy": 0.1},
+                ]
+            },
+        }
+        with TemporaryDirectory() as td:
+            tdp = Path(td)
+            summary_path = tdp / "eval_summary.json"
+            summary_path.write_text(json.dumps(bad_summary))
+            with self.assertRaises(SystemExit) as ctx:
+                main(["--summary", str(summary_path), "--print-only"])
+            # SystemExit with the human-readable error string (not exit code 0).
+            self.assertNotEqual(0, ctx.exception.code)
+
+    def test_missing_summary_file_exits_nonzero(self) -> None:
+        with TemporaryDirectory() as td:
+            missing = Path(td) / "does-not-exist.json"
+            with self.assertRaises(SystemExit) as ctx:
+                main(["--summary", str(missing), "--print-only"])
+            self.assertNotEqual(0, ctx.exception.code)
+
+
+class MarkdownRenderTest(unittest.TestCase):
+    """Render output is human-readable and surfaces the warning state."""
+
+    def test_warning_glyph_appears_for_dead_signal(self) -> None:
+        summary = _make_summary(
+            full={m: 0.10 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.30 for m in GAUGED_METRICS},
+            single_chunk={m: 0.05 for m in GAUGED_METRICS},
+        )
+        g = compute_gauge(summary)
+        md = render_markdown(g)
+        # The verdict line uses the warning glyph + 'NOT alive' phrase.
+        self.assertIn("⚠️", md)
+        self.assertIn("signal NOT alive", md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `scripts/distinguishing_power.py` — implements the ADR 0053 §Consequences `(default - floor) / (1 - floor)` gauge across `accuracy / groundedness / citation_precision / claim_citation_alignment / answer_format_compliance`. Reads `eval_summary.json::ablation.runs` (full / random_retrieval / single_chunk), emits both a human-readable `.md` and machine-readable `.aggregate.json` (aggregate-only per ADR 0005).
- New `tests/test_distinguishing_power.py` — 11 regression tests across math, output schema, missing-data tolerance, CLI exit codes, and warning-glyph render.
- First measurement at n=221 committed to `reports/real100/distinguishing_power.md` + `.aggregate.json` (using the ADR 0052 baseline as input). Allowlist (`.gitignore` + `.githooks/pre-commit`) extended to match — same pattern as `eda.*` / `rag_pipeline.*`.

## Why
ADR 0053 §Consequences names a gauge that turns the random + single_chunk floors (PR-5a / #939) and the n=221 baseline (PR-B / #944) into a single 'is the signal alive' verdict per leaderboard metric. Without it, the floors are present in `eval_summary.json` but not compared — and the gauge formula is exactly the audit primitive ADR 0053 §Decision argues for ('falsifiable lower bounds — any future improvement that doesn't beat random_retrieval is by definition not a real improvement').

## ADR
ADR 0053 (proposed) — this PR ships the §Consequences gauge implementation. No new ADR.

## First-measurement findings (real-eval n=221)

| metric                   | default | gap vs random | gap vs single_chunk | signal alive |
|--------------------------|---------|---------------|---------------------|--------------|
| accuracy                 | 29.66%  | +27.12pp      | +22.88pp            | **yes**      |
| claim_citation_alignment | 96.28%  | +8.04pp       | +2.93pp             | **yes**      |
| groundedness             | 25.34%  | -10.86pp      | +17.19pp            | NO           |
| citation_precision       | 19.02%  | -15.82pp      | +13.59pp            | NO           |
| answer_format_compliance | 20.81%  | -23.98pp      | -23.98pp            | NO           |

The gauge honestly surfaces a **Goodhart trap**: random_retrieval scores higher than default on 3/5 metrics because it abstains ~89% of the time — the remaining ~11% answered cases form a small biased sample where average groundedness / citation_precision / format compliance look artificially high. This is exactly the failure mode ADR 0053 §Decision was designed to catch.

`accuracy` (+27.12pp vs random) is the load-bearing distinguishing-power signal — the default pipeline genuinely retrieves and grounds answers that random retrieval cannot. This validates the ADR 0052 baseline (n=21→221) as having sub-noise-floor signal on accuracy.

## Test plan
- [x] `EMBEDDING_BACKEND=hashing python3 -m pytest -q tests/test_distinguishing_power.py` → 11 passed
- [x] `python3 scripts/distinguishing_power.py` against `reports/real100/eval_summary.json` (n=221) → both artifacts emitted, schema valid
- [x] `EMBEDDING_BACKEND=hashing bash scripts/test.sh` → full regression
- [ ] CI: Pytest / Branch+issue / Baseline provenance / Eval delta

### 5b. Real-data delta

**No retrieval / verifier / eval / api / ingestion code path modified.**

`scripts/distinguishing_power.py` is non-LB tooling (`scripts/_governance.py --is-load-bearing scripts/distinguishing_power.py` → 1). It is a read-only analysis script over `eval_summary.json` artifacts that already exist on `origin/main` after PR-B (#944). `make real-eval-delta` is 0-shift in this PR.

The new aggregate artifacts under `reports/real100/distinguishing_power.*` are first-time-emitted (no prior baseline to diff against). They derive deterministically from the already-committed `baseline.aggregate.json` + `eval_summary.json` at PR-B's `git_commit=c39360a`, so the values are reproducible from the gauge formula alone.

Follow-up out of scope: tighten groundedness/citation_precision scorers to penalize abstention vacuity — separate issue.

Closes #945