### PR TITLE
feat(eval): add paired_bootstrap_ci helper for Phase 2+ ablation deltas

### DIFF
--- a/eval/bootstrap.py
+++ b/eval/bootstrap.py
@@ -75,10 +75,38 @@ def format_ci_band(ci: dict[str, float | int] | None, *, digits: int = 3) -> str
     return f"{mean:.{digits}f} ({lo:.{digits}f}–{hi:.{digits}f})"
 
 
+def paired_bootstrap_ci(
+    values_a: list[float],
+    values_b: list[float],
+    *,
+    num_resamples: int = DEFAULT_NUM_RESAMPLES,
+    alpha: float = DEFAULT_ALPHA,
+    seed: int = DEFAULT_SEED,
+) -> dict[str, float | int] | None:
+    """Paired-delta CI by resampling case indices once and applying to both arrays."""
+    if not values_a or not values_b or len(values_a) != len(values_b):
+        return None
+    arr_a = np.asarray(values_a, dtype=float)
+    arr_b = np.asarray(values_b, dtype=float)
+    n = int(arr_a.shape[0])
+    rng = np.random.default_rng(seed)
+    idx = rng.integers(low=0, high=n, size=(num_resamples, n))
+    diffs = (arr_a[idx] - arr_b[idx]).mean(axis=1)
+    return {
+        "mean_diff": float(arr_a.mean() - arr_b.mean()),
+        "ci_lo": float(np.percentile(diffs, 100 * alpha / 2, method="linear")),
+        "ci_hi": float(np.percentile(diffs, 100 * (1 - alpha / 2), method="linear")),
+        "n": n,
+        "num_resamples": int(num_resamples),
+        "alpha": float(alpha),
+    }
+
+
 __all__ = [
     "DEFAULT_NUM_RESAMPLES",
     "DEFAULT_ALPHA",
     "DEFAULT_SEED",
     "bootstrap_ci",
+    "paired_bootstrap_ci",
     "format_ci_band",
 ]

--- a/tests/test_bootstrap_ci.py
+++ b/tests/test_bootstrap_ci.py
@@ -18,6 +18,7 @@ from eval.bootstrap import (
     DEFAULT_NUM_RESAMPLES,
     bootstrap_ci,
     format_ci_band,
+    paired_bootstrap_ci,
 )
 
 
@@ -89,6 +90,44 @@ class BootstrapCITest(unittest.TestCase):
     def test_format_ci_band_handles_none(self) -> None:
         self.assertEqual(format_ci_band(None), "N/A")
         self.assertEqual(format_ci_band({"mean": None}), "N/A")
+
+
+class PairedBootstrapCITest(unittest.TestCase):
+    def test_paired_bootstrap_ci_deterministic_seed(self) -> None:
+        a = [1.0, 0.0, 1.0, 0.0, 1.0]
+        b = [0.0, 1.0, 1.0, 0.0, 1.0]
+        ci_1 = paired_bootstrap_ci(a, b, seed=17)
+        ci_2 = paired_bootstrap_ci(a, b, seed=17)
+        self.assertEqual(ci_1, ci_2)
+
+    def test_paired_bootstrap_ci_zero_diff_when_identical(self) -> None:
+        # Identical per-case scores → every paired resample sees 0 → CI collapses.
+        values = [1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0]
+        ci = paired_bootstrap_ci(values, list(values), seed=17)
+        assert ci is not None
+        self.assertEqual(ci["mean_diff"], 0.0)
+        self.assertEqual(ci["ci_lo"], 0.0)
+        self.assertEqual(ci["ci_hi"], 0.0)
+
+    def test_paired_ci_brackets_mean_diff(self) -> None:
+        a = [1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0]
+        b = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+        ci = paired_bootstrap_ci(a, b, seed=17)
+        assert ci is not None
+        self.assertLessEqual(ci["ci_lo"], ci["mean_diff"])
+        self.assertGreaterEqual(ci["ci_hi"], ci["mean_diff"])
+        self.assertEqual(ci["n"], 8)
+        self.assertEqual(ci["num_resamples"], DEFAULT_NUM_RESAMPLES)
+
+    def test_paired_bootstrap_ci_invalid_inputs(self) -> None:
+        self.assertIsNone(paired_bootstrap_ci([], []))
+        self.assertIsNone(paired_bootstrap_ci([1.0], []))
+        self.assertIsNone(paired_bootstrap_ci([], [1.0]))
+        self.assertIsNone(paired_bootstrap_ci([1.0, 2.0], [1.0]))
+        ci = paired_bootstrap_ci([1.0], [2.0], seed=17)
+        assert ci is not None
+        self.assertEqual(ci["mean_diff"], -1.0)
+        self.assertEqual(ci["n"], 1)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #949

`/retrieval-eval` skill Phase 2 (chunking ablation) 진입 prerequisite. 4 chunking 변형을 동일 oracle (real100 n=221) 로 비교할 때 paired delta CI 95% 가 필요 — 두 변형이 같은 case set 을 채점하므로 inter-case variance 를 제거해야 isolation 가능. 기존 `eval/bootstrap.py:31` 의 `bootstrap_ci(values, ...)` 는 single-array mean CI 만 지원 (ADR 0001 / ADR 0005 README metrics 의 reproducibility 기준).

새 함수 `paired_bootstrap_ci(values_a, values_b, *, seed, num_resamples, alpha)` 추가. 한 번의 `rng.integers(0, n, size=(N, n))` 으로 인덱스 행렬 sample → 양쪽 array 에 동일 인덱스 적용 → `(arr_a[idx] - arr_b[idx]).mean(axis=1)` 의 percentile 로 CI. 반환 `{mean_diff, ci_lo, ci_hi, n, num_resamples, alpha}` 또는 None (empty/length mismatch).

## 2. 영향 파일

- `eval/bootstrap.py` **(load-bearing — `eval/`)** : `paired_bootstrap_ci` 함수 추가 (+28 LOC), `__all__` 에 1 entry 추가. 기존 `bootstrap_ci` / `format_ci_band` / 상수 미변경.
- `tests/test_bootstrap_ci.py` : `PairedBootstrapCITest` 클래스 추가 (+39 LOC) — 4 contract test.

## 3. 리스크

가장 가능성 높은 깨짐 경로 = 기존 `bootstrap_ci` 의 byte-identical 출력 회귀 (README CI gate). 완화:
- `bootstrap_ci` 함수 본문 / `__all__` 의 entry 위치 모두 미변경. `git diff eval/bootstrap.py` 가 새 함수 + `__all__` 1 entry 추가만 보임.
- 기존 `BootstrapCITest` 10 testcase 전부 통과 (회귀 없음).
- 공유 helper 추출 안 함 (절대 규칙 #3 — use case 1개).

부차 리스크 = numpy `rng.integers` API 가용성. numpy >= 1.17 보장 (기존 `bootstrap_ci` 가 `default_rng` 사용 중 → 같은 의존성).

## 4. 테스트

`tests/test_bootstrap_ci.py::PairedBootstrapCITest` 4 testcase:
- `test_paired_bootstrap_ci_deterministic_seed` — 동일 seed 두 번 → byte-identical dict
- `test_paired_bootstrap_ci_zero_diff_when_identical` — `values_a == values_b` → mean_diff/ci_lo/ci_hi 모두 0.0 (paired semantics 의 핵심 검증)
- `test_paired_ci_brackets_mean_diff` — CI 가 mean_diff 를 bracketing + n/num_resamples 메타데이터 노출
- `test_paired_bootstrap_ci_invalid_inputs` — empty/length-mismatch → None, n=1 degenerate → 정상 dict

실행 결과: 14/14 pass (기존 10 + 신규 4):
```
python3 -m pytest tests/test_bootstrap_ci.py -v
============================== 14 passed in 0.03s ==============================
```

## 5. Eval 영향

`paired_bootstrap_ci` 는 신규 helper, 어떤 기존 호출처도 없음 → CI eval delta 0.

### 5b. Real-data delta

No behavior change in retrieval/verifier/eval/api/ingestion path. 신규 helper 함수만 추가, 기존 `bootstrap_ci` 미변경 → `scripts/update_readme_metrics.py` 출력 동일 → README metric sync 영향 0. `make real-eval-delta` 불필요.

## 6. 하위 호환

신규 helper 만 추가. 기존 API 미변경. `schema_version` bump 불필요.

## 7. 범위 외

- Phase 2 measurement script (`scripts/phase2_chunking_ablation.py`) — 후속 PR.
- Oracle sub-queries YAML for follow_up recovery — Phase 4 영역, 후속 PR.
- `derive_gold_chunk_ids` 정책 변경 — Phase 2 kickoff 결정 Q2(A) 로 standalone 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)