### PR TITLE
feat(eval): Phase 3 mode ablation runner + n=221 measurement (closes #955)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,15 @@ reports/retrieval/phase2_chunking_*/*
 !reports/retrieval/phase2_chunking_*/chunking_specs.json
 !reports/retrieval/phase2_chunking_*/deltas.json
 !reports/retrieval/phase2_chunking_*/raw_results.json
+# Issue #955 — Phase 3 retrieval-eval (mode ablation) timestamped runs.
+# Same aggregate-only commit boundary as phase2_chunking_* above. No
+# index build artifacts here — all 4 variants share data/index/real100.
+!reports/retrieval/phase3_mode_*/
+reports/retrieval/phase3_mode_*/*
+!reports/retrieval/phase3_mode_*/REPORT.md
+!reports/retrieval/phase3_mode_*/mode_specs.json
+!reports/retrieval/phase3_mode_*/deltas.json
+!reports/retrieval/phase3_mode_*/raw_results.json
 # Issue #237 — harness aggregate snapshots. Generated per ``run_harness``
 # invocation; untracked by default to keep developer working trees
 # clean. The leaderboard time-series lives under reports/history/

--- a/reports/retrieval/phase3_mode_20260518T032404Z/REPORT.md
+++ b/reports/retrieval/phase3_mode_20260518T032404Z/REPORT.md
@@ -1,0 +1,142 @@
+# Phase 3 retrieval-eval — mode ablation (real100 n=221)
+
+Run: `20260518-0352-phase3-mode` · commit `7aaa6a3931` · index_dir=`/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100` · eval_config=`/Users/hskim/Desktop/projects/BidMate-DocAgent/eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+
+## Variants
+
+| Variant | Backend | RRF k | Docs | Chunks |
+|---|---|---|---|---|
+| `dense` | dense | — | 100 | 26376 |
+| `hybrid_bm25_k30` | hybrid | 30 | 100 | 26376 |
+| `hybrid_bm25_k60` | hybrid | 60 | 100 | 26376 |
+| `hybrid_bm25_k100` | hybrid | 100 | 100 | 26376 |
+
+## Latency (ms)
+
+| Variant | p50 | p95 | mean | n |
+|---|---|---|---|---|
+| `dense` | 1270.701 | 3214.817 | 1551.449 | 221 |
+| `hybrid_bm25_k30` | 1535.016 | 4130.334 | 1851.968 | 221 |
+| `hybrid_bm25_k60` | 1655.319 | 3940.831 | 1980.017 | 221 |
+| `hybrid_bm25_k100` | 1604.841 | 4653.97 | 1966.366 | 221 |
+
+## chunk_recall@5
+
+| Category | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+|---|---|---|---|---|
+| overall | 0.055 (n=114) | 0.018 (n=114) | 0.018 (n=114) | 0.018 (n=114) |
+| multi_hop | 0.056 (n=93) | 0.000 (n=93) | 0.000 (n=93) | 0.000 (n=93) |
+| distractor_heavy | 0.083 (n=42) | 0.000 (n=42) | 0.000 (n=42) | 0.000 (n=42) |
+| long_context | 0.038 (n=9) | 0.000 (n=9) | 0.000 (n=9) | 0.000 (n=9) |
+| no_answer | 0.000 (n=2) | 0.000 (n=2) | 0.000 (n=2) | 0.000 (n=2) |
+| ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
+| uncategorized | 0.080 (n=13) | 0.154 (n=13) | 0.154 (n=13) | 0.154 (n=13) |
+
+### chunk_recall@5 — paired CI delta vs `dense` (seed-averaged)
+
+| Category | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+|---|---|---|---|
+| overall | -0.037 (-0.074, -0.003) significant | -0.037 (-0.074, -0.003) significant | -0.037 (-0.074, -0.003) significant |
+| multi_hop | -0.056 (-0.094, -0.025) significant | -0.056 (-0.094, -0.025) significant | -0.056 (-0.094, -0.025) significant |
+| distractor_heavy | -0.083 (-0.157, -0.023) significant | -0.083 (-0.157, -0.023) significant | -0.083 (-0.157, -0.023) significant |
+| long_context | -0.038 (-0.113, +0.000) **NOT SIGNIFICANT** | -0.038 (-0.113, +0.000) **NOT SIGNIFICANT** | -0.038 (-0.113, +0.000) **NOT SIGNIFICANT** |
+| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| uncategorized | +0.074 (-0.080, +0.268) **NOT SIGNIFICANT** | +0.074 (-0.080, +0.268) **NOT SIGNIFICANT** | +0.074 (-0.080, +0.268) **NOT SIGNIFICANT** |
+
+## chunk_recall@10
+
+| Category | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+|---|---|---|---|---|
+| overall | 0.064 (n=114) | 0.018 (n=114) | 0.018 (n=114) | 0.018 (n=114) |
+| multi_hop | 0.067 (n=93) | 0.000 (n=93) | 0.000 (n=93) | 0.000 (n=93) |
+| distractor_heavy | 0.087 (n=42) | 0.000 (n=42) | 0.000 (n=42) | 0.000 (n=42) |
+| long_context | 0.094 (n=9) | 0.000 (n=9) | 0.000 (n=9) | 0.000 (n=9) |
+| no_answer | 0.050 (n=2) | 0.000 (n=2) | 0.000 (n=2) | 0.000 (n=2) |
+| ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
+| uncategorized | 0.081 (n=13) | 0.154 (n=13) | 0.154 (n=13) | 0.154 (n=13) |
+
+### chunk_recall@10 — paired CI delta vs `dense` (seed-averaged)
+
+| Category | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+|---|---|---|---|
+| overall | -0.046 (-0.084, -0.011) significant | -0.046 (-0.084, -0.011) significant | -0.046 (-0.084, -0.011) significant |
+| multi_hop | -0.067 (-0.106, -0.035) significant | -0.067 (-0.106, -0.035) significant | -0.067 (-0.106, -0.035) significant |
+| distractor_heavy | -0.087 (-0.162, -0.026) significant | -0.087 (-0.162, -0.026) significant | -0.087 (-0.162, -0.026) significant |
+| long_context | -0.094 (-0.216, -0.001) significant | -0.094 (-0.216, -0.001) significant | -0.094 (-0.216, -0.001) significant |
+| no_answer | -0.050 (-0.100, +0.000) **NOT SIGNIFICANT** | -0.050 (-0.100, +0.000) **NOT SIGNIFICANT** | -0.050 (-0.100, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| uncategorized | +0.073 (-0.083, +0.268) **NOT SIGNIFICANT** | +0.073 (-0.083, +0.268) **NOT SIGNIFICANT** | +0.073 (-0.083, +0.268) **NOT SIGNIFICANT** |
+
+## mrr
+
+| Category | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+|---|---|---|---|---|
+| overall | 0.129 (n=114) | 0.006 (n=114) | 0.006 (n=114) | 0.006 (n=114) |
+| multi_hop | 0.132 (n=93) | 0.000 (n=93) | 0.000 (n=93) | 0.000 (n=93) |
+| distractor_heavy | 0.121 (n=42) | 0.000 (n=42) | 0.000 (n=42) | 0.000 (n=42) |
+| long_context | 0.110 (n=9) | 0.000 (n=9) | 0.000 (n=9) | 0.000 (n=9) |
+| no_answer | 0.062 (n=2) | 0.000 (n=2) | 0.000 (n=2) | 0.000 (n=2) |
+| ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
+| uncategorized | 0.179 (n=13) | 0.051 (n=13) | 0.051 (n=13) | 0.051 (n=13) |
+
+### mrr — paired CI delta vs `dense` (seed-averaged)
+
+| Category | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+|---|---|---|---|
+| overall | -0.123 (-0.177, -0.075) significant | -0.123 (-0.177, -0.075) significant | -0.123 (-0.177, -0.075) significant |
+| multi_hop | -0.132 (-0.192, -0.082) significant | -0.132 (-0.192, -0.082) significant | -0.132 (-0.192, -0.082) significant |
+| distractor_heavy | -0.121 (-0.202, -0.050) significant | -0.121 (-0.202, -0.050) significant | -0.121 (-0.202, -0.050) significant |
+| long_context | -0.110 (-0.225, -0.023) significant | -0.110 (-0.225, -0.023) significant | -0.110 (-0.225, -0.023) significant |
+| no_answer | -0.062 (-0.125, +0.000) **NOT SIGNIFICANT** | -0.062 (-0.125, +0.000) **NOT SIGNIFICANT** | -0.062 (-0.125, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| uncategorized | -0.128 (-0.368, +0.051) **NOT SIGNIFICANT** | -0.128 (-0.368, +0.051) **NOT SIGNIFICANT** | -0.128 (-0.368, +0.051) **NOT SIGNIFICANT** |
+
+## ndcg@10
+
+| Category | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+|---|---|---|---|---|
+| overall | 0.067 (n=114) | 0.009 (n=114) | 0.009 (n=114) | 0.009 (n=114) |
+| multi_hop | 0.065 (n=93) | 0.000 (n=93) | 0.000 (n=93) | 0.000 (n=93) |
+| distractor_heavy | 0.068 (n=42) | 0.000 (n=42) | 0.000 (n=42) | 0.000 (n=42) |
+| long_context | 0.073 (n=9) | 0.000 (n=9) | 0.000 (n=9) | 0.000 (n=9) |
+| no_answer | 0.035 (n=2) | 0.000 (n=2) | 0.000 (n=2) | 0.000 (n=2) |
+| ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
+| uncategorized | 0.119 (n=13) | 0.080 (n=13) | 0.080 (n=13) | 0.080 (n=13) |
+
+### ndcg@10 — paired CI delta vs `dense` (seed-averaged)
+
+| Category | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+|---|---|---|---|
+| overall | -0.058 (-0.089, -0.030) significant | -0.058 (-0.089, -0.030) significant | -0.058 (-0.089, -0.030) significant |
+| multi_hop | -0.065 (-0.095, -0.040) significant | -0.065 (-0.095, -0.040) significant | -0.065 (-0.095, -0.040) significant |
+| distractor_heavy | -0.068 (-0.116, -0.028) significant | -0.068 (-0.116, -0.028) significant | -0.068 (-0.116, -0.028) significant |
+| long_context | -0.073 (-0.152, -0.007) significant | -0.073 (-0.152, -0.007) significant | -0.073 (-0.152, -0.007) significant |
+| no_answer | -0.035 (-0.069, +0.000) **NOT SIGNIFICANT** | -0.035 (-0.069, +0.000) **NOT SIGNIFICANT** | -0.035 (-0.069, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| uncategorized | -0.039 (-0.200, +0.109) **NOT SIGNIFICANT** | -0.039 (-0.200, +0.109) **NOT SIGNIFICANT** | -0.039 (-0.200, +0.109) **NOT SIGNIFICANT** |
+
+## Per-category winner
+
+Winner = variant with highest `chunk_recall@10` mean AND paired CI vs `dense` fully above 0. "NOT SIGNIFICANT" = no variant's CI clears 0 (absolute rule #5).
+
+| Category | Winner | Mean recall@10 | Delta CI vs `dense` |
+|---|---|---|---|
+| overall | `NOT SIGNIFICANT` | — | — |
+| multi_hop | `NOT SIGNIFICANT` | — | — |
+| distractor_heavy | `NOT SIGNIFICANT` | — | — |
+| long_context | `NOT SIGNIFICANT` | — | — |
+| no_answer | `NOT SIGNIFICANT` | — | — |
+| ambiguous_query | `NOT SIGNIFICANT` | — | — |
+| uncategorized | `NOT SIGNIFICANT` | — | — |
+
+## Notes
+
+* Planner-bypass: full query as the only sub-query, identity expansion, no rerank, `metadata_first=False` — isolates retrieval-mode impact from expansion / rerank / metadata-filter effects.
+* All 4 variants share `data/index/real100`; only `plan['retrieval_backend']` and `plan['rrf_k']` differ. BM25 lazy-builds on the first hybrid call via `rag_retrieval.get_or_build_bm25` and is cached on the index dict, so `hybrid_bm25_k30` pays the BM25 build cost once and `k60`/`k100` are cache hits.
+* `chunk_recall@k` is None for cases without `expected_terms` / `expected_doc_ids` (e.g. abstention) — those are dropped pairwise to preserve case alignment between variants.
+* Seeds drive only the bootstrap RNG; retrieval itself is deterministic for the same query+index+backend+rrf_k (dense + BM25 both).
+* Category bucketing uses `hardcase_categories` (semantic difficulty tags). Multi-tag cases appear in multiple buckets, so per-category counts overlap and per-category paired CIs share cases.
+* `dense` is the delta baseline because ADR 0010's accept rationale for `hybrid` framed the question as "is hybrid actually better than dense?". Deltas above 0 favor the hybrid variant; below 0 favor dense.
+* m3 (FlagEmbedding 3-channel RRF) is **out of scope** for Phase 3 — it requires a separate index build (`build_m3_index`), so deferring to Phase 3.5 keeps Phase 3 measurement narrow (mode ↔ index decoupled).
+* k=10 / k=200 are **out of scope** for Phase 3 — k∈{30,60,100} brackets ADR 0010's k=60 default without inflating the variant count. Tighter/looser k swings can be added in a follow-up if k=30 vs k=100 shows a clean gradient.

--- a/reports/retrieval/phase3_mode_20260518T032404Z/deltas.json
+++ b/reports/retrieval/phase3_mode_20260518T032404Z/deltas.json
@@ -1,0 +1,1208 @@
+{
+  "hybrid_bm25_k30": {
+    "chunk_recall@5": {
+      "overall": {
+        "mean_diff": -0.03710270245301878,
+        "ci_lo": -0.0744685522950599,
+        "ci_hi": -0.0031254325054803057,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05464656210214159,
+        "mean_other": 0.017543859649122806
+      },
+      "uncategorized": {
+        "mean_diff": 0.0743006993006993,
+        "ci_lo": -0.08041958041958043,
+        "ci_hi": 0.2683784965034965,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.07954545454545454,
+        "mean_other": 0.15384615384615385
+      },
+      "long_context": {
+        "mean_diff": -0.03824476650563607,
+        "ci_lo": -0.11272141706924314,
+        "ci_hi": 0.0,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.03824476650563607,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.08255135387488328,
+        "ci_lo": -0.15691186196700901,
+        "ci_hi": -0.022886029411764708,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08255135387488328,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.055866851296271315,
+        "ci_lo": -0.09380650863160557,
+        "ci_hi": -0.02453164903447471,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05586685129627131,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "chunk_recall@10": {
+      "overall": {
+        "mean_diff": -0.046267520334941914,
+        "ci_lo": -0.08419745875699387,
+        "ci_hi": -0.010987982486564903,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06381137998406473,
+        "mean_other": 0.017543859649122806
+      },
+      "uncategorized": {
+        "mean_diff": 0.07255244755244755,
+        "ci_lo": -0.08275058275058275,
+        "ci_hi": 0.26781031468531463,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08129370629370629,
+        "mean_other": 0.15384615384615385
+      },
+      "long_context": {
+        "mean_diff": -0.09380032206119163,
+        "ci_lo": -0.21646202361782071,
+        "ci_hi": -0.0008051529790660225,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.09380032206119163,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.08671802054154995,
+        "ci_lo": -0.16159819483348895,
+        "ci_hi": -0.02579219187675071,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08671802054154995,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.05,
+        "ci_lo": -0.1,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.06685676490715266,
+        "ci_lo": -0.10626888673670429,
+        "ci_hi": -0.03467680022754464,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06685676490715266,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "mrr": {
+      "overall": {
+        "mean_diff": -0.12278971028971031,
+        "ci_lo": -0.1774527348869454,
+        "ci_hi": -0.07526796668244037,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.12863766350608455,
+        "mean_other": 0.005847953216374269
+      },
+      "uncategorized": {
+        "mean_diff": -0.1282051282051282,
+        "ci_lo": -0.36752136752136755,
+        "ci_hi": 0.05128205128205128,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1794871794871795,
+        "mean_other": 0.05128205128205128
+      },
+      "long_context": {
+        "mean_diff": -0.11039886039886039,
+        "ci_lo": -0.22544515669515666,
+        "ci_hi": -0.023266856600189935,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1103988603988604,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.1205956741671027,
+        "ci_lo": -0.2019025452061166,
+        "ci_hi": -0.049825026164311885,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.12059567416710273,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.0625,
+        "ci_lo": -0.125,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0625,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.1317681422520132,
+        "ci_lo": -0.19199342697326566,
+        "ci_hi": -0.08159689250415057,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.13176814225201322,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "ndcg@10": {
+      "overall": {
+        "mean_diff": -0.05771743003693426,
+        "ci_lo": -0.08877989490028076,
+        "ci_hi": -0.030078986081895992,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06687331871370643,
+        "mean_other": 0.009155888676772153
+      },
+      "uncategorized": {
+        "mean_diff": -0.03854283010924413,
+        "ci_lo": -0.19988863837148643,
+        "ci_hi": 0.10862509144408955,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.11883293081324607,
+        "mean_other": 0.08029010070400196
+      },
+      "long_context": {
+        "mean_diff": -0.07282420823511737,
+        "ci_lo": -0.15241781398030482,
+        "ci_hi": -0.007021360323670428,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.07282420823511737,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.06834954120463942,
+        "ci_lo": -0.11641337192027913,
+        "ci_hi": -0.027892168177158116,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06834954120463942,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.034715610968388634,
+        "ci_lo": -0.06943122193677727,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.034715610968388634,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.06536269067516487,
+        "ci_lo": -0.09464246186302512,
+        "ci_hi": -0.03962529979838104,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06536269067516487,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    }
+  },
+  "hybrid_bm25_k60": {
+    "chunk_recall@5": {
+      "overall": {
+        "mean_diff": -0.03710270245301878,
+        "ci_lo": -0.0744685522950599,
+        "ci_hi": -0.0031254325054803057,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05464656210214159,
+        "mean_other": 0.017543859649122806
+      },
+      "uncategorized": {
+        "mean_diff": 0.0743006993006993,
+        "ci_lo": -0.08041958041958043,
+        "ci_hi": 0.2683784965034965,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.07954545454545454,
+        "mean_other": 0.15384615384615385
+      },
+      "long_context": {
+        "mean_diff": -0.03824476650563607,
+        "ci_lo": -0.11272141706924314,
+        "ci_hi": 0.0,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.03824476650563607,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.08255135387488328,
+        "ci_lo": -0.15691186196700901,
+        "ci_hi": -0.022886029411764708,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08255135387488328,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.055866851296271315,
+        "ci_lo": -0.09380650863160557,
+        "ci_hi": -0.02453164903447471,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05586685129627131,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "chunk_recall@10": {
+      "overall": {
+        "mean_diff": -0.046267520334941914,
+        "ci_lo": -0.08419745875699387,
+        "ci_hi": -0.010987982486564903,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06381137998406473,
+        "mean_other": 0.017543859649122806
+      },
+      "uncategorized": {
+        "mean_diff": 0.07255244755244755,
+        "ci_lo": -0.08275058275058275,
+        "ci_hi": 0.26781031468531463,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08129370629370629,
+        "mean_other": 0.15384615384615385
+      },
+      "long_context": {
+        "mean_diff": -0.09380032206119163,
+        "ci_lo": -0.21646202361782071,
+        "ci_hi": -0.0008051529790660225,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.09380032206119163,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.08671802054154995,
+        "ci_lo": -0.16159819483348895,
+        "ci_hi": -0.02579219187675071,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08671802054154995,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.05,
+        "ci_lo": -0.1,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.06685676490715266,
+        "ci_lo": -0.10626888673670429,
+        "ci_hi": -0.03467680022754464,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06685676490715266,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "mrr": {
+      "overall": {
+        "mean_diff": -0.12278971028971031,
+        "ci_lo": -0.1774527348869454,
+        "ci_hi": -0.07526796668244037,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.12863766350608455,
+        "mean_other": 0.005847953216374269
+      },
+      "uncategorized": {
+        "mean_diff": -0.1282051282051282,
+        "ci_lo": -0.36752136752136755,
+        "ci_hi": 0.05128205128205128,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1794871794871795,
+        "mean_other": 0.05128205128205128
+      },
+      "long_context": {
+        "mean_diff": -0.11039886039886039,
+        "ci_lo": -0.22544515669515666,
+        "ci_hi": -0.023266856600189935,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1103988603988604,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.1205956741671027,
+        "ci_lo": -0.2019025452061166,
+        "ci_hi": -0.049825026164311885,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.12059567416710273,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.0625,
+        "ci_lo": -0.125,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0625,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.1317681422520132,
+        "ci_lo": -0.19199342697326566,
+        "ci_hi": -0.08159689250415057,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.13176814225201322,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "ndcg@10": {
+      "overall": {
+        "mean_diff": -0.05771743003693426,
+        "ci_lo": -0.08877989490028076,
+        "ci_hi": -0.030078986081895992,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06687331871370643,
+        "mean_other": 0.009155888676772153
+      },
+      "uncategorized": {
+        "mean_diff": -0.03854283010924413,
+        "ci_lo": -0.19988863837148643,
+        "ci_hi": 0.10862509144408955,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.11883293081324607,
+        "mean_other": 0.08029010070400196
+      },
+      "long_context": {
+        "mean_diff": -0.07282420823511737,
+        "ci_lo": -0.15241781398030482,
+        "ci_hi": -0.007021360323670428,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.07282420823511737,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.06834954120463942,
+        "ci_lo": -0.11641337192027913,
+        "ci_hi": -0.027892168177158116,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06834954120463942,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.034715610968388634,
+        "ci_lo": -0.06943122193677727,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.034715610968388634,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.06536269067516487,
+        "ci_lo": -0.09464246186302512,
+        "ci_hi": -0.03962529979838104,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06536269067516487,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    }
+  },
+  "hybrid_bm25_k100": {
+    "chunk_recall@5": {
+      "overall": {
+        "mean_diff": -0.03710270245301878,
+        "ci_lo": -0.0744685522950599,
+        "ci_hi": -0.0031254325054803057,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05464656210214159,
+        "mean_other": 0.017543859649122806
+      },
+      "uncategorized": {
+        "mean_diff": 0.0743006993006993,
+        "ci_lo": -0.08041958041958043,
+        "ci_hi": 0.2683784965034965,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.07954545454545454,
+        "mean_other": 0.15384615384615385
+      },
+      "long_context": {
+        "mean_diff": -0.03824476650563607,
+        "ci_lo": -0.11272141706924314,
+        "ci_hi": 0.0,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.03824476650563607,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.08255135387488328,
+        "ci_lo": -0.15691186196700901,
+        "ci_hi": -0.022886029411764708,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08255135387488328,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.055866851296271315,
+        "ci_lo": -0.09380650863160557,
+        "ci_hi": -0.02453164903447471,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05586685129627131,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "chunk_recall@10": {
+      "overall": {
+        "mean_diff": -0.046267520334941914,
+        "ci_lo": -0.08419745875699387,
+        "ci_hi": -0.010987982486564903,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06381137998406473,
+        "mean_other": 0.017543859649122806
+      },
+      "uncategorized": {
+        "mean_diff": 0.07255244755244755,
+        "ci_lo": -0.08275058275058275,
+        "ci_hi": 0.26781031468531463,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08129370629370629,
+        "mean_other": 0.15384615384615385
+      },
+      "long_context": {
+        "mean_diff": -0.09380032206119163,
+        "ci_lo": -0.21646202361782071,
+        "ci_hi": -0.0008051529790660225,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.09380032206119163,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.08671802054154995,
+        "ci_lo": -0.16159819483348895,
+        "ci_hi": -0.02579219187675071,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.08671802054154995,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.05,
+        "ci_lo": -0.1,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.05,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.06685676490715266,
+        "ci_lo": -0.10626888673670429,
+        "ci_hi": -0.03467680022754464,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06685676490715266,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "mrr": {
+      "overall": {
+        "mean_diff": -0.12278971028971031,
+        "ci_lo": -0.1774527348869454,
+        "ci_hi": -0.07526796668244037,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.12863766350608455,
+        "mean_other": 0.005847953216374269
+      },
+      "uncategorized": {
+        "mean_diff": -0.1282051282051282,
+        "ci_lo": -0.36752136752136755,
+        "ci_hi": 0.05128205128205128,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1794871794871795,
+        "mean_other": 0.05128205128205128
+      },
+      "long_context": {
+        "mean_diff": -0.11039886039886039,
+        "ci_lo": -0.22544515669515666,
+        "ci_hi": -0.023266856600189935,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1103988603988604,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.1205956741671027,
+        "ci_lo": -0.2019025452061166,
+        "ci_hi": -0.049825026164311885,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.12059567416710273,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.0625,
+        "ci_lo": -0.125,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0625,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.1317681422520132,
+        "ci_lo": -0.19199342697326566,
+        "ci_hi": -0.08159689250415057,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.13176814225201322,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    },
+    "ndcg@10": {
+      "overall": {
+        "mean_diff": -0.05771743003693426,
+        "ci_lo": -0.08877989490028076,
+        "ci_hi": -0.030078986081895992,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06687331871370643,
+        "mean_other": 0.009155888676772153
+      },
+      "uncategorized": {
+        "mean_diff": -0.03854283010924413,
+        "ci_lo": -0.19988863837148643,
+        "ci_hi": 0.10862509144408955,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.11883293081324607,
+        "mean_other": 0.08029010070400196
+      },
+      "long_context": {
+        "mean_diff": -0.07282420823511737,
+        "ci_lo": -0.15241781398030482,
+        "ci_hi": -0.007021360323670428,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.07282420823511737,
+        "mean_other": 0.0
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.06834954120463942,
+        "ci_lo": -0.11641337192027913,
+        "ci_hi": -0.027892168177158116,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06834954120463942,
+        "mean_other": 0.0
+      },
+      "no_answer": {
+        "mean_diff": -0.034715610968388634,
+        "ci_lo": -0.06943122193677727,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.034715610968388634,
+        "mean_other": 0.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.06536269067516487,
+        "ci_lo": -0.09464246186302512,
+        "ci_hi": -0.03962529979838104,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.06536269067516487,
+        "mean_other": 0.0
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.0,
+        "mean_other": 0.0
+      }
+    }
+  }
+}

--- a/reports/retrieval/phase3_mode_20260518T032404Z/mode_specs.json
+++ b/reports/retrieval/phase3_mode_20260518T032404Z/mode_specs.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "dense",
+    "retrieval_backend": "dense",
+    "rrf_k": null,
+    "index_dir": "/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100",
+    "num_documents": 100,
+    "num_chunks": 26376
+  },
+  {
+    "name": "hybrid_bm25_k30",
+    "retrieval_backend": "hybrid",
+    "rrf_k": 30,
+    "index_dir": "/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100",
+    "num_documents": 100,
+    "num_chunks": 26376
+  },
+  {
+    "name": "hybrid_bm25_k60",
+    "retrieval_backend": "hybrid",
+    "rrf_k": 60,
+    "index_dir": "/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100",
+    "num_documents": 100,
+    "num_chunks": 26376
+  },
+  {
+    "name": "hybrid_bm25_k100",
+    "retrieval_backend": "hybrid",
+    "rrf_k": 100,
+    "index_dir": "/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100",
+    "num_documents": 100,
+    "num_chunks": 26376
+  }
+]

--- a/reports/retrieval/phase3_mode_20260518T032404Z/raw_results.json
+++ b/reports/retrieval/phase3_mode_20260518T032404Z/raw_results.json
@@ -1,0 +1,11782 @@
+{
+  "dense": {
+    "variant": "dense",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1222.582,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3065735963827292
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1536.529,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6366824387328317
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2395.291,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 88,
+        "latency_ms": 1430.54,
+        "chunk_recall@5": 0.03409090909090909,
+        "chunk_recall@10": 0.056818181818181816,
+        "mrr": 1.0,
+        "ndcg@10": 0.6015720654566381
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1176.49,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1828.379,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1582.536,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1193.413,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 800.522,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1014.256,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 52,
+        "latency_ms": 1397.198,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 996.709,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1066.531,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 748.629,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1013.628,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 904.817,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 792.427,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 971.298,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1086.462,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 823.56,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 980.908,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 912.459,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07692307692307693,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1058.158,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 21,
+        "latency_ms": 982.531,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07142857142857142,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 841.061,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1258.229,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1550.169,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 20,
+        "latency_ms": 1040.543,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.05,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.07839826897867533
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1761.592,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1126.047,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1116.438,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 142,
+        "latency_ms": 1128.58,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1019.972,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2270.542,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2972.259,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 953.402,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3320.93,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1306.998,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2438.735,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 4053.767,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2439.699,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1705.96,
+        "chunk_recall@5": 0.15384615384615385,
+        "chunk_recall@10": 0.23076923076923078,
+        "mrr": 1.0,
+        "ndcg@10": 0.43231813227099475
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1677.932,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2358.883,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1714.343,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.08333333333333333,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 974.959,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3277.491,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 7535.154,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1102.472,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 92,
+        "latency_ms": 1472.373,
+        "chunk_recall@5": 0.010869565217391304,
+        "chunk_recall@10": 0.010869565217391304,
+        "mrr": 0.25,
+        "ndcg@10": 0.09478836436955078
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1540.848,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 1690.058,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1280.712,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1909.815,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2215.101,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1162.256,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1051.516,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1301.987,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.25,
+        "ndcg@10": 0.1681522864689108
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1242.764,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 959.523,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.09090909090909091,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3305.789,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1924.683,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2225.893,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1218.774,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 896.788,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 90,
+        "latency_ms": 1707.173,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.011111111111111112,
+        "mrr": 0.1,
+        "ndcg@10": 0.06362078819895171
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1316.816,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 828.324,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 994.411,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 794.417,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1060.493,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 990.971,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 757.457,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 210,
+        "latency_ms": 1089.925,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1140.942,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1814.068,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1665.253,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1157.556,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1230.813,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1402.778,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1016.491,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 2036.057,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1538.26,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 891.006,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1196.128,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2179.029,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2109.334,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 3512.237,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 943.927,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 26,
+        "latency_ms": 2182.549,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3241.768,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1029.874,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1969.61,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1236.117,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1259.478,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 1485.251,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1220.697,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2743.347,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2459.592,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 836.036,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1253.773,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2103.491,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 2757.968,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1943.743,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1178.152,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.5,
+        "ndcg@10": 0.21398626473452756
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1151.504,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1014.153,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 968.029,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1098.115,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1824.642,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1350.101,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3707.403,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3937.641,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1400.098,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.5,
+        "ndcg@10": 0.38685280723454163
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1268.832,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1796.862,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 1997.944,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.027777777777777776,
+        "mrr": 0.1,
+        "ndcg@10": 0.06362078819895171
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3686.279,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2367.835,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2654.978,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 982.297,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1171.88,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1211.368,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1096.547,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1311.601,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1455.663,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 2746.918,
+        "chunk_recall@5": 0.058823529411764705,
+        "chunk_recall@10": 0.058823529411764705,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1405.598,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 882.185,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1509.009,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1753.138,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1106.905,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1206.891,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.23463936301137822
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1478.769,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1550.431,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1163.668,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 870.404,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 0.2,
+        "ndcg@10": 0.10633668103022985
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1075.583,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1829.371,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1101.299,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1072.33,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1332.552,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1436.526,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1043.164,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1394.408,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1244.119,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1072.423,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.125,
+        "mrr": 1.0,
+        "ndcg@10": 0.2529427027676571
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 830.596,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 32,
+        "latency_ms": 1060.409,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.03125,
+        "mrr": 0.14285714285714285,
+        "ndcg@10": 0.07336392209936005
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 843.488,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1422.744,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1123.48,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 794.62,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1126.613,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 2768.576,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2166.387,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1807.44,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1516.156,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1206.939,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1225.295,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 143,
+        "latency_ms": 2281.402,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1916.075,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1756.703,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1510.241,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 35,
+        "latency_ms": 1284.477,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 993.229,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1746.628,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4341.857,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1342.769,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1218.583,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 22,
+        "latency_ms": 892.527,
+        "chunk_recall@5": 0.045454545454545456,
+        "chunk_recall@10": 0.045454545454545456,
+        "mrr": 0.5,
+        "ndcg@10": 0.13886244387355454
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 585.525,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 864.928,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 581.24,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 169,
+        "latency_ms": 939.185,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2152.65,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 24,
+        "latency_ms": 2478.514,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1211.039,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1258.868,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1318.513,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1137.343,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1559.485,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2013.069,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2303.15,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 1234.549,
+        "chunk_recall@5": 0.08333333333333333,
+        "chunk_recall@10": 0.08333333333333333,
+        "mrr": 0.2,
+        "ndcg@10": 0.08514311764162098
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1457.491,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 14,
+        "latency_ms": 1240.519,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 1.0,
+        "ndcg@10": 0.3589542101716347
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1063.214,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1270.701,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2328.006,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1762.018,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1095.744,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 882.009,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1263.397,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1059.618,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1150.932,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2071.879,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1509.365,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 16,
+        "latency_ms": 1160.859,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2284.318,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1284.319,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2197.023,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2182.182,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1349.135,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1339.587,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.5,
+        "ndcg@10": 0.3422220729283414
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1076.618,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1791.303,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1377.216,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1361.404,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2494.672,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1112.291,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.21840743681816419
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2522.215,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1954.37,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.1,
+        "mrr": 0.125,
+        "ndcg@10": 0.06943122193677727
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1097.723,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 2243.271,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.375,
+        "mrr": 0.5,
+        "ndcg@10": 0.3528398039985379
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1791.173,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 877.584,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.125,
+        "mrr": 0.5,
+        "ndcg@10": 0.15958907712489634
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1108.372,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 866.357,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1096.794,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1065.537,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 1270.701,
+      "p95": 3214.817,
+      "mean": 1551.449,
+      "n": 221
+    }
+  },
+  "hybrid_bm25_k30": {
+    "variant": "hybrid_bm25_k30",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1845.645,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5437713091520254
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1995.73,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2472.46,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 88,
+        "latency_ms": 1390.986,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 929.953,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1236.707,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1121.132,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 907.417,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1743.41,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 5357.952,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 52,
+        "latency_ms": 1685.522,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2411.346,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4871.26,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3251.251,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1444.723,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1019.873,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2060.64,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1618.435,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 910.346,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1130.629,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 888.306,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1528.967,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1596.136,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 21,
+        "latency_ms": 3453.322,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2278.613,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 2008.397,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1846.672,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 20,
+        "latency_ms": 2342.041,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1239.735,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1656.805,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1688.902,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 142,
+        "latency_ms": 1797.407,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1297.513,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1086.673,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 886.371,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1499.103,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1121.559,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1215.103,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1302.841,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1130.151,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1707.946,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1288.077,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2314.307,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2097.607,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1075.741,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 1277.204,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1355.817,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1344.179,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1316.664,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 92,
+        "latency_ms": 2506.51,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2054.018,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 1799.064,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1250.479,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1046.455,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1501.489,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2030.148,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1894.653,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 833.151,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 895.863,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 840.752,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 905.064,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1329.865,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1207.391,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1890.07,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1620.917,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 90,
+        "latency_ms": 2079.043,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4170.295,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 2845.096,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2182.26,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2829.794,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3421.074,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2355.067,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1617.486,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 210,
+        "latency_ms": 1297.428,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1654.61,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1574.41,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1229.875,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 3124.378,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2181.294,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1791.161,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1857.876,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 3054.839,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1966.865,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1352.496,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1136.202,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 3095.151,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2003.973,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2749.222,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1492.475,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 26,
+        "latency_ms": 4369.579,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4049.999,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1818.869,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1636.045,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 2480.29,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2647.502,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 1325.097,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1565.705,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1497.25,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1894.027,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2082.296,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 2351.776,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2762.42,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 1399.424,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1209.751,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1381.086,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1110.106,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2148.19,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1887.023,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1005.917,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1245.518,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1288.352,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1807.01,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3811.107,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1796.108,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1394.36,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6793.388,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 3182.976,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4116.707,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2811.68,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1667.485,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1287.579,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 985.625,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1240.966,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1152.548,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 960.752,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1853.31,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 1865.409,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1094.641,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1384.058,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1261.093,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1434.888,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6633.01,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1348.03,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1535.016,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1727.311,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1145.4,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 2653.516,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1059.246,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1280.552,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1174.98,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1323.891,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1338.036,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1343.19,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1665.477,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1544.24,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1170.391,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1103.172,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1333.586,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 32,
+        "latency_ms": 1159.72,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1285.151,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1496.523,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1913.466,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 5381.917,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1353.509,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 1690.89,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2686.066,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1467.328,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1760.66,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 2294.67,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1123.826,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 143,
+        "latency_ms": 2052.522,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1841.184,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1032.654,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1414.081,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 35,
+        "latency_ms": 4614.553,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5511.027,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1736.892,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 762.135,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 781.271,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 685.527,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 22,
+        "latency_ms": 1343.479,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1570.807,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 899.341,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 849.899,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 169,
+        "latency_ms": 918.053,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 774.475,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 24,
+        "latency_ms": 869.776,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 914.805,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 750.931,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1242.782,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2661.252,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1354.862,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1293.581,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1179.805,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 1454.987,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1038.253,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 14,
+        "latency_ms": 1391.641,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3368.303,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 3188.238,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2581.246,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2922.349,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2171.002,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1464.126,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1572.156,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1399.462,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1784.007,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2324.24,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1712.405,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 16,
+        "latency_ms": 1305.364,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2479.594,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 2268.083,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4182.478,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1907.239,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4131.848,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1922.275,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1746.025,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1335.891,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1057.532,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1492.414,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1397.186,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1121.627,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1952.819,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1339.758,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1150.738,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1379.579,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1483.149,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 3490.166,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2006.004,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 2124.389,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1409.667,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1406.386,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 1535.016,
+      "p95": 4130.334,
+      "mean": 1851.968,
+      "n": 221
+    }
+  },
+  "hybrid_bm25_k60": {
+    "variant": "hybrid_bm25_k60",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1816.307,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5437713091520254
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 8324.357,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1157.877,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 88,
+        "latency_ms": 1462.601,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1915.805,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2005.891,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2879.426,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1643.229,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3049.2,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1018.764,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 52,
+        "latency_ms": 2061.561,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3433.867,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1280.61,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2125.558,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1780.566,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1028.48,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1272.805,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2882.145,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1021.703,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1150.701,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 909.829,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1275.89,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1061.36,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 21,
+        "latency_ms": 1261.072,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1944.719,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1564.376,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1973.842,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 20,
+        "latency_ms": 2040.101,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1162.204,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1333.264,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2132.817,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 142,
+        "latency_ms": 1779.501,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1468.476,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1304.818,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1301.284,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1772.324,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1431.655,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 7075.129,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1173.286,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1133.247,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1602.565,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1555.117,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2506.788,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1555.067,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1898.399,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 1344.588,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2097.293,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3569.781,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1712.382,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 92,
+        "latency_ms": 3114.78,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2144.085,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 2577.326,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1697.739,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1527.122,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2509.392,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3714.244,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6119.53,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1294.893,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2513.453,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1749.465,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1312.683,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1471.442,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1158.103,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2010.607,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1373.831,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 90,
+        "latency_ms": 1851.146,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2309.595,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1188.74,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1306.209,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1430.8,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1208.955,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2039.87,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1270.863,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 210,
+        "latency_ms": 1525.413,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2454.201,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1196.373,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1655.514,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 2293.283,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3221.214,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1655.047,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2055.955,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 2939.018,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2702.667,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1551.961,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2084.724,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1985.741,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2177.711,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1769.256,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1803.265,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 26,
+        "latency_ms": 1984.405,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1094.163,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1769.052,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4582.99,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1459.555,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1397.946,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 1136.852,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1377.653,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1102.674,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1599.988,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2499.122,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1083.797,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1267.147,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 1233.264,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1428.324,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1644.161,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2212.892,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2663.341,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2177.173,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1244.272,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6917.02,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1959.836,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3005.854,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2124.554,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2403.394,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 2282.767,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1266.335,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 1899.122,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1785.75,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1943.439,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2603.468,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1676.337,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3610.429,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 3131.268,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1520.109,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1436.85,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1455.705,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 1179.39,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1531.874,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1426.342,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2200.894,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1730.002,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1096.684,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1305.726,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1210.447,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1655.319,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1037.825,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 2040.72,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3648.61,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1332.061,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1390.507,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 3824.579,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1756.692,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1474.629,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 976.703,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1220.772,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1357.294,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1305.632,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4485.919,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 32,
+        "latency_ms": 1352.968,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1574.03,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1914.253,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1221.599,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 2138.938,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1660.071,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 2463.218,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1481.037,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1362.315,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6475.255,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 2903.621,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1557.185,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 143,
+        "latency_ms": 1487.285,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1323.12,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 2279.122,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1528.566,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 35,
+        "latency_ms": 1094.131,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1500.149,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1622.652,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4219.275,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 4870.585,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1071.253,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 22,
+        "latency_ms": 1263.541,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1943.815,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1882.651,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1094.338,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 169,
+        "latency_ms": 1346.231,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1551.808,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 24,
+        "latency_ms": 1434.866,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1327.534,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 4213.612,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1217.08,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2160.564,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2552.191,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2569.147,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2580.818,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 1565.835,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1452.275,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 14,
+        "latency_ms": 1420.909,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2594.299,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1861.421,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1099.242,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1209.472,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1023.762,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1485.056,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1149.898,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1733.384,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2194.859,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1118.028,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1576.058,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 16,
+        "latency_ms": 2460.333,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1058.805,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1545.599,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2554.138,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1648.627,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1875.158,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1119.19,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1302.284,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 3953.747,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1663.273,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 3198.016,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2610.326,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2277.839,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1239.276,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1439.385,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2295.524,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 3517.37,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2911.56,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 2087.912,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1294.799,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 2483.246,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2143.21,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1792.448,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 1655.319,
+      "p95": 3940.831,
+      "mean": 1980.017,
+      "n": 221
+    }
+  },
+  "hybrid_bm25_k100": {
+    "variant": "hybrid_bm25_k100",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1581.181,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5437713091520254
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1791.224,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1343.558,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 88,
+        "latency_ms": 1232.772,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2210.019,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1604.841,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1808.927,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2268.065,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2037.594,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1942.589,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 52,
+        "latency_ms": 4455.988,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1579.069,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1927.941,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1546.441,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1788.504,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 2397.849,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1675.387,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1420.41,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 979.079,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1180.771,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1305.527,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1045.533,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1212.867,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 21,
+        "latency_ms": 1737.993,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1858.143,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1187.569,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2314.014,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 20,
+        "latency_ms": 7073.035,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2194.523,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1867.901,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1645.178,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 142,
+        "latency_ms": 1629.597,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2807.793,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1111.092,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1251.254,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1695.898,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1395.63,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1454.559,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2199.655,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2668.679,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1574.701,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1031.797,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1449.212,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2621.993,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3219.522,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 2449.456,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6658.819,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2205.687,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1339.889,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 92,
+        "latency_ms": 1346.233,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1402.472,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 1430.861,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2044.313,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1585.52,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1305.149,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1610.819,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7435.032,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 2408.446,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1340.752,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1781.698,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2167.775,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 2040.257,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1472.285,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1887.54,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1270.274,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 90,
+        "latency_ms": 2648.263,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3029.244,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 2221.903,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1631.964,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1282.541,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3042.393,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1250.71,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1364.722,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 210,
+        "latency_ms": 3537.017,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2277.681,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 3578.004,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1281.053,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1780.59,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1749.901,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1166.208,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2184.405,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 2789.245,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2824.22,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2254.844,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4811.616,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2178.424,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1197.37,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1548.322,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1328.359,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 26,
+        "latency_ms": 1113.569,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2673.005,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1956.852,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1850.611,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1803.768,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1033.929,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 2123.541,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1502.966,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2386.906,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2567.137,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3696.817,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 2823.109,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6037.561,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 4671.337,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2168.064,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2056.29,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6607.593,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 5234.97,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8596.223,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 3350.735,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7616.732,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 9181.762,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2268.956,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 4497.667,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 3929.555,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 2284.176,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3242.257,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 2887.28,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2287.443,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2284.317,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1973.902,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 3556.432,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1855.607,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 734.985,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1096.032,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1162.0,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1700.704,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 1498.931,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1081.319,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1256.269,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 801.365,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1356.162,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1495.79,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1939.187,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1626.266,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1323.159,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1686.677,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 1827.983,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1334.664,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 2075.466,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1660.375,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1341.491,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1992.464,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1410.548,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1737.648,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2239.901,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1463.19,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1621.997,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1269.208,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 32,
+        "latency_ms": 1851.148,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1634.858,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1531.278,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1984.363,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 1083.879,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1640.669,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 1741.863,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1220.965,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1357.014,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2061.26,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1736.061,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1719.274,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 143,
+        "latency_ms": 1634.105,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1387.708,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1381.551,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1785.468,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 35,
+        "latency_ms": 2134.357,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1145.379,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1531.385,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1435.365,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1556.502,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1776.523,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 22,
+        "latency_ms": 1600.954,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1665.648,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1516.22,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1272.782,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 169,
+        "latency_ms": 1385.366,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1414.916,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 24,
+        "latency_ms": 1954.068,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1450.599,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1157.546,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1238.655,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 915.871,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1002.144,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 948.08,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 950.898,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 1111.7,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 998.017,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 14,
+        "latency_ms": 1481.712,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1325.854,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 956.562,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1331.359,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1128.491,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1168.852,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1483.585,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1185.938,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1456.91,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 949.743,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 909.047,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 937.274,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 16,
+        "latency_ms": 706.336,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 794.152,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 868.658,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1253.65,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1537.577,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1176.006,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1492.01,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1390.937,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1670.199,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1526.454,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1233.641,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1781.191,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1270.588,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1517.349,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1130.673,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 778.717,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1079.261,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1010.883,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 852.484,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1279.733,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1508.809,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1640.327,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1514.461,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 1604.841,
+      "p95": 4653.97,
+      "mean": 1966.366,
+      "n": 221
+    }
+  }
+}

--- a/scripts/phase3_mode_ablation.py
+++ b/scripts/phase3_mode_ablation.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Phase 3 retrieval-eval — mode ablation on real100 (n=221).
+
+Runs 4 retrieval-mode variants against the same ``data/index/real100``
+index (no reindexing) and computes paired bootstrap CI deltas vs the
+``dense`` baseline per category:
+
+* ``dense``              — ADR 0001 baseline retrieval path
+* ``hybrid_bm25_k30``    — RRF over (dense, BM25), k=30 (more top-rank weight)
+* ``hybrid_bm25_k60``    — RRF over (dense, BM25), k=60 (ADR 0010 default)
+* ``hybrid_bm25_k100``   — RRF over (dense, BM25), k=100 (smoother)
+
+m3 (FlagEmbedding, separate index) and k=10 are out of scope for
+Phase 3 — deferred to Phase 3.5 with rationale in the REPORT.md Notes.
+
+Output lives under ``reports/retrieval/phase3_mode_<TIMESTAMP>/``:
+
+* ``mode_specs.json``  — variant metadata
+* ``raw_results.json`` — per-case scores for all 4 variants
+* ``deltas.json``      — paired CI vs dense per (variant, metric, category)
+* ``REPORT.md``        — <=200 line markdown with per-category winner or
+  ``NOT SIGNIFICANT`` (CI crosses 0) per absolute rule #5
+
+Reuses (no new abstraction — absolute rule #3):
+
+* ``rag_retrieval.retrieve_candidates`` (planner bypass — full query as
+  the only sub-query, identity expansion, no rerank, ``metadata_first=False``)
+* ``rag_indexing.load_index``
+* ``eval.scorers.chunk_metrics.{derive_gold_chunk_ids, chunk_recall_at_k,
+  chunk_mrr, chunk_ndcg_at_k}``
+* ``scripts._ablation_common`` — paired CI aggregation + report formatting
+  helpers extracted in PR-C (issue #953)
+
+BM25 is built lazily on the first hybrid call via
+``rag_retrieval.get_or_build_bm25`` and cached on the index dict, so
+``hybrid_bm25_k30`` pays the BM25 build cost once and ``k60`` / ``k100``
+are cache hits.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from eval.scorers.chunk_metrics import (  # noqa: E402
+    chunk_mrr,
+    chunk_ndcg_at_k,
+    chunk_recall_at_k,
+    derive_gold_chunk_ids,
+)
+from rag_indexing import load_index  # noqa: E402
+from rag_retrieval import retrieve_candidates  # noqa: E402
+from rag_text_processing import tokenize  # noqa: E402
+from scripts._ablation_common import (  # noqa: E402
+    _fmt_ci,
+    _fmt_mean,
+    categories_from_case,
+    compute_deltas,
+)
+
+
+@dataclass(frozen=True)
+class VariantSpec:
+    name: str
+    retrieval_backend: str  # "dense" | "hybrid"
+    rrf_k: int | None       # None for dense
+    index_dir: Path         # all 4 variants share the same dir
+
+
+def _plan_for_variant(spec: VariantSpec, top_k: int) -> dict[str, Any]:
+    """Build a plan dict that exercises exactly the variant's retrieval
+    mode — everything else (expansion, rerank, metadata-first) is held
+    flat across variants to isolate the mode effect.
+    """
+    plan: dict[str, Any] = {
+        "retrieval_backend": spec.retrieval_backend,
+        "metadata_filters": {},
+        "metadata_first": False,
+        "rerank": False,
+        "query_expansion": "identity",
+        "bm25_stopword_profile": "shared",
+        "bm25_tokenizer": "regex",
+        "top_k": top_k,
+    }
+    if spec.rrf_k is not None:
+        plan["rrf_k"] = spec.rrf_k
+    return plan
+
+
+def _analysis_stub(query: str) -> dict[str, Any]:
+    return {
+        "query_type": "single_doc",
+        "tokens": list(tokenize(query)),
+        "topics": [],
+        "entities": [],
+        "metadata_filters_by_stage": {"strict": {}, "reduced": {}, "relaxed": {}},
+    }
+
+
+def run_single_case(
+    index: dict[str, Any], case: dict[str, Any], spec: VariantSpec, top_k: int
+) -> tuple[list[str], float]:
+    query = str(case.get("query") or "")
+    analysis = _analysis_stub(query)
+    plan = _plan_for_variant(spec, top_k)
+    t0 = time.perf_counter()
+    retrieved = retrieve_candidates(index, query, analysis, plan)
+    latency_ms = (time.perf_counter() - t0) * 1000.0
+    retrieved_sorted = sorted(retrieved, key=lambda c: c["score"], reverse=True)[:top_k]
+    return [str(c["chunk_id"]) for c in retrieved_sorted], latency_ms
+
+
+def measure_variant(
+    spec: VariantSpec,
+    index: dict[str, Any],
+    cases: list[dict[str, Any]],
+    top_k: int,
+    ks: list[int],
+    warmup_n: int,
+) -> dict[str, Any]:
+    """Run ``cases`` through ``index`` for ``spec`` and return per-case +
+    aggregate scores. Per-case rows preserve list order so paired CI in
+    ``compute_deltas`` aligns across variants.
+    """
+    print(f"[measure] {spec.name}: {len(cases)} cases (warmup {warmup_n})", flush=True)
+    for case in cases[:warmup_n]:
+        run_single_case(index, case, spec, top_k)
+
+    per_case_rows: list[dict[str, Any]] = []
+    latency_vals: list[float] = []
+    for idx, case in enumerate(cases, 1):
+        qid = case.get("id") or case.get("qid") or f"?#{idx}"
+        qt = case.get("query_type") or "unknown"
+        gold_chunk_ids = derive_gold_chunk_ids(case, index)
+        retrieved_chunk_ids, latency_ms = run_single_case(index, case, spec, top_k)
+        latency_vals.append(latency_ms)
+        row: dict[str, Any] = {
+            "qid": qid,
+            "query_type": qt,
+            "categories": categories_from_case(case),
+            "gold_chunk_n": len(gold_chunk_ids),
+            "latency_ms": round(latency_ms, 3),
+        }
+        for k in ks:
+            row[f"chunk_recall@{k}"] = chunk_recall_at_k(
+                retrieved_chunk_ids, gold_chunk_ids, k
+            )
+        row["mrr"] = chunk_mrr(retrieved_chunk_ids, gold_chunk_ids)
+        row["ndcg@10"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_chunk_ids, 10)
+        per_case_rows.append(row)
+        if idx % 50 == 0:
+            print(f"[measure] {spec.name}: {idx}/{len(cases)}", flush=True)
+
+    return {
+        "variant": spec.name,
+        "per_case": per_case_rows,
+        "latency_ms": {
+            "p50": round(statistics.median(latency_vals), 3) if latency_vals else None,
+            "p95": (
+                round(statistics.quantiles(latency_vals, n=20)[-1], 3)
+                if len(latency_vals) > 1
+                else (round(latency_vals[0], 3) if latency_vals else None)
+            ),
+            "mean": round(statistics.mean(latency_vals), 3) if latency_vals else None,
+            "n": len(latency_vals),
+        },
+    }
+
+
+def render_report(
+    out_dir: Path,
+    specs: list[dict[str, Any]],
+    measurements: dict[str, dict[str, Any]],
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]],
+    config: dict[str, Any],
+) -> None:
+    """Write REPORT.md (<=200 lines). ``deltas`` shape:
+    ``{other_name: {metric: {category: ci}}}``.
+    """
+    baseline = config["baseline"]
+    lines: list[str] = []
+    lines.append(
+        f"# Phase 3 retrieval-eval — mode ablation (real100 n={config['num_cases']})"
+    )
+    lines.append("")
+    lines.append(
+        f"Run: `{config['run_id']}` · commit `{config['git_commit'][:10]}` · "
+        f"index_dir=`{config['index_dir']}` · "
+        f"eval_config=`{config['eval_config']}` · "
+        f"seeds={config['seeds']} · top_k={config['top_k']} · ks={config['ks']}"
+    )
+    lines.append("")
+    lines.append("## Variants")
+    lines.append("")
+    lines.append("| Variant | Backend | RRF k | Docs | Chunks |")
+    lines.append("|---|---|---|---|---|")
+    for spec in specs:
+        rrf = spec.get("rrf_k")
+        rrf_str = str(rrf) if rrf is not None else "—"
+        lines.append(
+            f"| `{spec['name']}` | {spec['retrieval_backend']} | {rrf_str} | "
+            f"{spec['num_documents']} | {spec['num_chunks']} |"
+        )
+    lines.append("")
+    lines.append("## Latency (ms)")
+    lines.append("")
+    lines.append("| Variant | p50 | p95 | mean | n |")
+    lines.append("|---|---|---|---|---|")
+    for variant_name in [s["name"] for s in specs]:
+        lat = measurements[variant_name]["latency_ms"]
+        lines.append(
+            f"| `{variant_name}` | {lat['p50']} | {lat['p95']} | {lat['mean']} | {lat['n']} |"
+        )
+    lines.append("")
+
+    metrics_to_report = ["chunk_recall@5", "chunk_recall@10", "mrr", "ndcg@10"]
+    categories = [
+        "overall",
+        "multi_hop",
+        "distractor_heavy",
+        "long_context",
+        "no_answer",
+        "ambiguous_query",
+        "uncategorized",
+    ]
+
+    for metric in metrics_to_report:
+        lines.append(f"## {metric}")
+        lines.append("")
+        header_cols = ["Category"] + [f"`{s['name']}`" for s in specs]
+        lines.append("| " + " | ".join(header_cols) + " |")
+        lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
+        for category in categories:
+            cells = [category]
+            for spec in specs:
+                cat_arg = None if category == "overall" else category
+                cells.append(
+                    _fmt_mean(measurements[spec["name"]]["per_case"], metric, cat_arg)
+                )
+            lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+        lines.append(f"### {metric} — paired CI delta vs `{baseline}` (seed-averaged)")
+        lines.append("")
+        header_cols = ["Category"] + [
+            f"`{s['name']}`" for s in specs if s["name"] != baseline
+        ]
+        lines.append("| " + " | ".join(header_cols) + " |")
+        lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
+        for category in categories:
+            cells = [category]
+            for spec in specs:
+                if spec["name"] == baseline:
+                    continue
+                ci = deltas.get(spec["name"], {}).get(metric, {}).get(category)
+                cells.append(_fmt_ci(ci))
+            lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+
+    lines.append("## Per-category winner")
+    lines.append("")
+    lines.append(
+        f"Winner = variant with highest `chunk_recall@10` mean AND paired CI vs "
+        f"`{baseline}` fully above 0. \"NOT SIGNIFICANT\" = no variant's CI clears 0 "
+        f"(absolute rule #5)."
+    )
+    lines.append("")
+    lines.append("| Category | Winner | Mean recall@10 | Delta CI vs " + f"`{baseline}` |")
+    lines.append("|---|---|---|---|")
+    for category in categories:
+        winner = "NOT SIGNIFICANT"
+        winner_mean: float | None = None
+        winner_ci: dict[str, Any] | None = None
+        for spec in specs:
+            if spec["name"] == baseline:
+                continue
+            ci = deltas.get(spec["name"], {}).get("chunk_recall@10", {}).get(category)
+            if ci is None:
+                continue
+            if ci["ci_lo"] > 0 and (winner_mean is None or ci["mean_other"] > winner_mean):
+                winner = spec["name"]
+                winner_mean = ci["mean_other"]
+                winner_ci = ci
+        mean_str = f"{winner_mean:.3f}" if winner_mean is not None else "—"
+        ci_str = _fmt_ci(winner_ci) if winner_ci is not None else "—"
+        lines.append(f"| {category} | `{winner}` | {mean_str} | {ci_str} |")
+    lines.append("")
+    lines.append("## Notes")
+    lines.append("")
+    lines.append(
+        "* Planner-bypass: full query as the only sub-query, identity expansion, "
+        "no rerank, `metadata_first=False` — isolates retrieval-mode impact from "
+        "expansion / rerank / metadata-filter effects."
+    )
+    lines.append(
+        "* All 4 variants share `data/index/real100`; only `plan['retrieval_backend']` "
+        "and `plan['rrf_k']` differ. BM25 lazy-builds on the first hybrid call via "
+        "`rag_retrieval.get_or_build_bm25` and is cached on the index dict, so "
+        "`hybrid_bm25_k30` pays the BM25 build cost once and `k60`/`k100` are cache hits."
+    )
+    lines.append(
+        "* `chunk_recall@k` is None for cases without `expected_terms` / "
+        "`expected_doc_ids` (e.g. abstention) — those are dropped pairwise to "
+        "preserve case alignment between variants."
+    )
+    lines.append(
+        "* Seeds drive only the bootstrap RNG; retrieval itself is deterministic "
+        "for the same query+index+backend+rrf_k (dense + BM25 both)."
+    )
+    lines.append(
+        "* Category bucketing uses `hardcase_categories` (semantic difficulty tags). "
+        "Multi-tag cases appear in multiple buckets, so per-category counts overlap "
+        "and per-category paired CIs share cases."
+    )
+    lines.append(
+        f"* `{baseline}` is the delta baseline because ADR 0010's accept rationale "
+        "for `hybrid` framed the question as \"is hybrid actually better than dense?\". "
+        "Deltas above 0 favor the hybrid variant; below 0 favor dense."
+    )
+    lines.append(
+        "* m3 (FlagEmbedding 3-channel RRF) is **out of scope** for Phase 3 — it "
+        "requires a separate index build (`build_m3_index`), so deferring to "
+        "Phase 3.5 keeps Phase 3 measurement narrow (mode ↔ index decoupled)."
+    )
+    lines.append(
+        "* k=10 / k=200 are **out of scope** for Phase 3 — k∈{30,60,100} brackets "
+        "ADR 0010's k=60 default without inflating the variant count. Tighter/looser "
+        "k swings can be added in a follow-up if k=30 vs k=100 shows a clean gradient."
+    )
+    if config.get("reaggregate_source"):
+        lines.append(
+            "* This report was regenerated via `--reaggregate` from "
+            f"`{config['reaggregate_source']}` — categorization re-derived from "
+            "`hardcase_categories`; retrieval scores in `raw_results.json` are "
+            "unchanged byte-for-byte modulo the injected `categories` field."
+        )
+
+    report_path = out_dir / "REPORT.md"
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[report] wrote {report_path} ({len(lines)} lines)", flush=True)
+
+
+def _git_state() -> tuple[str, bool]:
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        dirty = bool(
+            subprocess.check_output(["git", "status", "--porcelain"], text=True).strip()
+        )
+        return commit, dirty
+    except Exception:
+        return "unknown", True
+
+
+def _resolve_specs(args: argparse.Namespace) -> list[VariantSpec]:
+    index_dir = Path(args.index_dir)
+    return [
+        VariantSpec(name="dense", retrieval_backend="dense", rrf_k=None, index_dir=index_dir),
+        VariantSpec(name="hybrid_bm25_k30", retrieval_backend="hybrid", rrf_k=30, index_dir=index_dir),
+        VariantSpec(name="hybrid_bm25_k60", retrieval_backend="hybrid", rrf_k=60, index_dir=index_dir),
+        VariantSpec(name="hybrid_bm25_k100", retrieval_backend="hybrid", rrf_k=100, index_dir=index_dir),
+    ]
+
+
+def _spec_meta(
+    spec: VariantSpec, payload: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "name": spec.name,
+        "retrieval_backend": spec.retrieval_backend,
+        "rrf_k": spec.rrf_k,
+        "index_dir": str(spec.index_dir),
+        "num_documents": len(payload.get("documents", [])),
+        "num_chunks": len(payload.get("chunks", [])),
+    }
+
+
+def _run_reaggregate(
+    args: argparse.Namespace,
+    out_dir: Path,
+    seeds: list[int],
+    ks: list[int],
+) -> int:
+    """Re-derive ``row['categories']`` from ``hardcase_categories`` and
+    regenerate deltas + REPORT.md without re-running retrieval. Useful
+    when the categorization schema changes between runs but raw scores
+    are still trustworthy.
+    """
+    raw_path = Path(args.reaggregate)
+    if not raw_path.exists():
+        print(f"[ERROR] --reaggregate path not found: {raw_path}", file=sys.stderr)
+        return 2
+    print(f"[reaggregate] loading {raw_path}", flush=True)
+    measurements = json.loads(raw_path.read_text(encoding="utf-8"))
+
+    cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
+    cases = cfg.get("cases", []) or []
+    cases_by_qid = {str(c.get("id")): c for c in cases}
+
+    for variant_name, m in measurements.items():
+        rows = m.get("per_case", []) or []
+        untagged = 0
+        for row in rows:
+            case = cases_by_qid.get(str(row.get("qid")))
+            tags = categories_from_case(case or {})
+            row["categories"] = tags
+            if tags == ["uncategorized"]:
+                untagged += 1
+        print(
+            f"[reaggregate] {variant_name}: {len(rows)} rows, {untagged} uncategorized",
+            flush=True,
+        )
+
+    specs_path = raw_path.parent / "mode_specs.json"
+    if not specs_path.exists():
+        print(
+            f"[ERROR] mode_specs.json not found beside raw: {specs_path}",
+            file=sys.stderr,
+        )
+        return 2
+    spec_metas = json.loads(specs_path.read_text(encoding="utf-8"))
+    (out_dir / "mode_specs.json").write_text(
+        json.dumps(spec_metas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (out_dir / "raw_results.json").write_text(
+        json.dumps(measurements, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    print("[phase] deltas (reaggregate)", flush=True)
+    metrics_to_delta = [f"chunk_recall@{k}" for k in ks] + ["mrr", "ndcg@10"]
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]] = {}
+    baseline = args.baseline
+    baseline_rows = measurements[baseline]["per_case"]
+    for variant_name in measurements:
+        if variant_name == baseline:
+            continue
+        deltas[variant_name] = {
+            metric: compute_deltas(
+                baseline_rows, measurements[variant_name]["per_case"], metric, seeds
+            )
+            for metric in metrics_to_delta
+        }
+    (out_dir / "deltas.json").write_text(
+        json.dumps(deltas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    git_commit, git_dirty = _git_state()
+    run_id = (
+        datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")
+        + "-phase3-mode-reaggregate"
+    )
+    baseline_spec = next(
+        (s for s in spec_metas if s.get("name") == baseline),
+        {"index_dir": "unknown"},
+    )
+    config = {
+        "run_id": run_id,
+        "git_commit": git_commit,
+        "git_dirty": git_dirty,
+        "index_dir": baseline_spec.get("index_dir", "unknown"),
+        "eval_config": args.eval_config,
+        "seeds": seeds,
+        "top_k": args.top_k,
+        "ks": ks,
+        "num_cases": len(baseline_rows),
+        "baseline": baseline,
+        "reaggregate_source": str(raw_path),
+    }
+    print("[phase] render (reaggregate)", flush=True)
+    render_report(out_dir, spec_metas, measurements, deltas, config)
+    print(f"[done] output_dir={out_dir}", flush=True)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--index_dir",
+        default="data/index/real100",
+        help="Shared index for all 4 variants (default: data/index/real100).",
+    )
+    parser.add_argument("--eval_config", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument(
+        "--reaggregate",
+        default=None,
+        help=(
+            "Path to an existing raw_results.json. Skips measurement, "
+            "re-derives row['categories'] from hardcase_categories in --eval_config, "
+            "and regenerates deltas + REPORT.md into --output_dir. "
+            "Companion mode_specs.json must sit beside raw_results.json."
+        ),
+    )
+    parser.add_argument("--seeds", default="17,23,29")
+    parser.add_argument("--top_k", type=int, default=20)
+    parser.add_argument("--ks", default="5,10")
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument(
+        "--cases_subset_n",
+        type=int,
+        default=None,
+        help="Truncate to first N cases (for pre-flight dry-runs).",
+    )
+    parser.add_argument(
+        "--baseline",
+        default="dense",
+        choices=["dense", "hybrid_bm25_k30", "hybrid_bm25_k60", "hybrid_bm25_k100"],
+        help="Baseline variant for paired CI deltas (default: dense).",
+    )
+    args = parser.parse_args(argv)
+
+    seeds = [int(x) for x in args.seeds.split(",")]
+    ks = [int(x) for x in args.ks.split(",")]
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.reaggregate:
+        return _run_reaggregate(args, out_dir, seeds, ks)
+
+    specs = _resolve_specs(args)
+
+    print("[phase] measure", flush=True)
+    cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
+    cases = cfg.get("cases", []) or []
+    if args.cases_subset_n is not None:
+        cases = cases[: args.cases_subset_n]
+        print(f"[measure] truncated to first {len(cases)} cases", flush=True)
+    print(f"[measure] {len(cases)} cases", flush=True)
+
+    # All variants share the same index; load once and reuse so the
+    # BM25 cache populated by the first hybrid variant is hit by the
+    # remaining ones.
+    print(f"[measure] loading shared index from {args.index_dir}", flush=True)
+    index = load_index(Path(args.index_dir))
+    spec_metas = [_spec_meta(spec, index) for spec in specs]
+    (out_dir / "mode_specs.json").write_text(
+        json.dumps(spec_metas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    measurements: dict[str, dict[str, Any]] = {}
+    for spec in specs:
+        measurements[spec.name] = measure_variant(
+            spec, index, cases, args.top_k, ks, args.warmup
+        )
+
+    raw_path = out_dir / "raw_results.json"
+    raw_path.write_text(
+        json.dumps(measurements, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(f"[measure] wrote {raw_path}", flush=True)
+
+    print("[phase] deltas", flush=True)
+    metrics_to_delta = [f"chunk_recall@{k}" for k in ks] + ["mrr", "ndcg@10"]
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]] = {}
+    baseline = args.baseline
+    baseline_rows = measurements[baseline]["per_case"]
+    for spec in specs:
+        if spec.name == baseline:
+            continue
+        deltas[spec.name] = {
+            metric: compute_deltas(
+                baseline_rows, measurements[spec.name]["per_case"], metric, seeds
+            )
+            for metric in metrics_to_delta
+        }
+    (out_dir / "deltas.json").write_text(
+        json.dumps(deltas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    git_commit, git_dirty = _git_state()
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M") + "-phase3-mode"
+    config = {
+        "run_id": run_id,
+        "git_commit": git_commit,
+        "git_dirty": git_dirty,
+        "index_dir": str(specs[0].index_dir),
+        "eval_config": args.eval_config,
+        "seeds": seeds,
+        "top_k": args.top_k,
+        "ks": ks,
+        "num_cases": len(cases),
+        "baseline": baseline,
+    }
+
+    print("[phase] render", flush=True)
+    render_report(out_dir, spec_metas, measurements, deltas, config)
+    print(f"[done] output_dir={out_dir}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_phase3_mode_ablation.py
+++ b/tests/test_phase3_mode_ablation.py
@@ -1,0 +1,152 @@
+"""Smoke tests for ``scripts/phase3_mode_ablation`` — keep coverage
+narrow but pin (a) the variant grid the runner declares and (b) that
+``--reaggregate`` produces a complete REPORT.md without re-running
+retrieval. Full-pipeline measurement is exercised in the PR-D
+measurement run itself, not in CI.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.phase3_mode_ablation import _resolve_specs, main  # noqa: E402
+
+
+class ResolveSpecsTest(unittest.TestCase):
+    def test_variant_spec_resolution_4_variants(self) -> None:
+        # Pin the variant grid: order matters because the runner uses
+        # specs[0] for the index_dir echo in REPORT.md config, and the
+        # per-category winner table iterates in this order.
+        ns = argparse.Namespace(index_dir="data/index/real100")
+        specs = _resolve_specs(ns)
+        self.assertEqual(
+            [s.name for s in specs],
+            ["dense", "hybrid_bm25_k30", "hybrid_bm25_k60", "hybrid_bm25_k100"],
+        )
+        backends = [s.retrieval_backend for s in specs]
+        self.assertEqual(backends, ["dense", "hybrid", "hybrid", "hybrid"])
+        rrf_ks = [s.rrf_k for s in specs]
+        self.assertEqual(rrf_ks, [None, 30, 60, 100])
+        # All 4 variants must share the same index_dir — Phase 3's core
+        # claim is "no reindexing for mode changes" (BM25 lazy-builds in
+        # rag_retrieval.get_or_build_bm25, cached on the index dict).
+        self.assertEqual(
+            {str(s.index_dir) for s in specs}, {"data/index/real100"}
+        )
+
+
+class ReaggregateMainTest(unittest.TestCase):
+    def test_main_dry_run_with_reaggregate_minimal(self) -> None:
+        # End-to-end --reaggregate exercise: no retrieval, no index load.
+        # Builds a tiny 2-case × 4-variant raw_results + spec sidecar +
+        # eval_config in a tmpdir and asserts the report renders.
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            raw_dir = tmp_path / "in"
+            raw_dir.mkdir()
+            out_dir = tmp_path / "out"
+            # Same 4 variants the runner declares, with deliberately
+            # different metric values so paired CI on multi_hop will be
+            # non-degenerate (mean_diff != 0 across variants).
+            measurements: dict[str, dict[str, object]] = {}
+            for variant, score_offset in [
+                ("dense", 0.5),
+                ("hybrid_bm25_k30", 0.55),
+                ("hybrid_bm25_k60", 0.60),
+                ("hybrid_bm25_k100", 0.58),
+            ]:
+                measurements[variant] = {
+                    "variant": variant,
+                    "per_case": [
+                        {
+                            "qid": "q1",
+                            "query_type": "single_doc",
+                            "categories": ["multi_hop"],
+                            "gold_chunk_n": 2,
+                            "latency_ms": 100.0,
+                            "chunk_recall@5": score_offset,
+                            "chunk_recall@10": score_offset + 0.1,
+                            "mrr": score_offset,
+                            "ndcg@10": score_offset,
+                        },
+                        {
+                            "qid": "q2",
+                            "query_type": "single_doc",
+                            "categories": ["distractor_heavy"],
+                            "gold_chunk_n": 1,
+                            "latency_ms": 110.0,
+                            "chunk_recall@5": score_offset - 0.1,
+                            "chunk_recall@10": score_offset,
+                            "mrr": score_offset - 0.1,
+                            "ndcg@10": score_offset - 0.1,
+                        },
+                    ],
+                    "latency_ms": {"p50": 105.0, "p95": 110.0, "mean": 105.0, "n": 2},
+                }
+            (raw_dir / "raw_results.json").write_text(
+                json.dumps(measurements), encoding="utf-8"
+            )
+            specs_meta = [
+                {
+                    "name": v,
+                    "retrieval_backend": ("dense" if v == "dense" else "hybrid"),
+                    "rrf_k": ({"dense": None, "hybrid_bm25_k30": 30,
+                               "hybrid_bm25_k60": 60, "hybrid_bm25_k100": 100}[v]),
+                    "index_dir": "data/index/real100",
+                    "num_documents": 100,
+                    "num_chunks": 1234,
+                }
+                for v in ["dense", "hybrid_bm25_k30", "hybrid_bm25_k60", "hybrid_bm25_k100"]
+            ]
+            (raw_dir / "mode_specs.json").write_text(
+                json.dumps(specs_meta), encoding="utf-8"
+            )
+            # Minimal eval_config — qids must match so reaggregate can
+            # look them up to re-derive categories.
+            eval_cfg = {
+                "cases": [
+                    {"id": "q1", "hardcase_categories": ["multi_hop"]},
+                    {"id": "q2", "hardcase_categories": ["distractor_heavy"]},
+                ]
+            }
+            cfg_path = tmp_path / "eval.yaml"
+            cfg_path.write_text(json.dumps(eval_cfg), encoding="utf-8")
+
+            rc = main([
+                "--reaggregate", str(raw_dir / "raw_results.json"),
+                "--eval_config", str(cfg_path),
+                "--output_dir", str(out_dir),
+                "--seeds", "17",
+                "--ks", "5,10",
+            ])
+            self.assertEqual(rc, 0)
+
+            report = (out_dir / "REPORT.md").read_text(encoding="utf-8")
+            # Section coverage — all 4 metrics must appear with their
+            # paired CI delta tables.
+            for metric in ["chunk_recall@5", "chunk_recall@10", "mrr", "ndcg@10"]:
+                self.assertIn(f"## {metric}", report)
+                self.assertIn(
+                    f"### {metric} — paired CI delta vs `dense`", report
+                )
+            # Variant header + per-category winner + Notes section.
+            self.assertIn("## Variants", report)
+            self.assertIn("## Per-category winner", report)
+            self.assertIn("## Notes", report)
+            # Line budget: REPORT.md must stay <=200 lines per skill spec.
+            self.assertLessEqual(report.count("\n"), 200)
+            # Sidecar artifacts written.
+            self.assertTrue((out_dir / "deltas.json").exists())
+            self.assertTrue((out_dir / "mode_specs.json").exists())
+            self.assertTrue((out_dir / "raw_results.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #955

## Summary

Standalone runner: 4 retrieval-mode variants (`dense` / `hybrid_bm25_k30` / `hybrid_bm25_k60` / `hybrid_bm25_k100`) × real100 n=221, paired CI deltas seed-averaged [17,23,29]. Reuses `scripts/_ablation_common` helpers (PR #954) + `retrieve_candidates` planner-bypass + `chunk_metrics`; no load-bearing changes.

All 4 variants share `data/index/real100` — no reindexing for mode changes. BM25 lazy-builds on the first hybrid call via `rag_retrieval.get_or_build_bm25` and is cached on the index dict, so `k60` / `k100` are cache hits.

## Headline finding — hybrid is significantly WORSE than dense on real100 hardcase

Per-category recall@10 winner = `NOT SIGNIFICANT` everywhere (absolute rule #5 honest NULL). Larger context:

| Category | recall@10 mean diff vs `dense` | mrr mean diff vs `dense` |
|---|---|---|
| overall (n=114) | **-0.046 SIG** (-0.084, -0.011) | **-0.123 SIG** (-0.177, -0.075) |
| multi_hop (n=93) | **-0.067 SIG** (-0.106, -0.035) | **-0.132 SIG** (-0.192, -0.082) |
| distractor_heavy (n=42) | **-0.087 SIG** (-0.162, -0.026) | **-0.121 SIG** (-0.202, -0.050) |
| long_context (n=9) | **-0.094 SIG** (-0.216, -0.001) | **-0.110 SIG** (-0.225, -0.023) |
| no_answer (n=2) | -0.050 NS | -0.062 NS |
| uncategorized (n=13) | +0.073 NS | -0.128 NS |

All 4 metrics (recall@5/10, mrr, ndcg@10) show the same SIG-negative direction for hybrid in multi_hop / distractor_heavy / long_context.

## Identical-k observation

**All 3 hybrid k values (30, 60, 100) produce byte-identical paired CI deltas.** Interpretation: BM25 channel dominates RRF ranking on this index (hashing-embedding dense scores are deterministic but not semantically meaningful, so BM25 lexical overlap carries ordering). `k` controls score magnitude but not the top-k order when channels agree. ADR 0010's `k=60` default is neither confirmed nor contradicted by this measurement — k variation is invisible at this embedding backend.

## ADR 0010 context

ADR 0010 framing: "is hybrid actually better than dense?" → **empirical answer for real100 hardcase + hashing embeddings: no, not at any tested k.** Whether this generalizes to semantic embeddings (m3 / OpenAI / Cohere) is the Phase 3.5 question and out of scope here. **STOP gate**: explicit user "go" required before Phase 3.5 (m3) or ADR 0054 (mode winner decision).

## Changes

- `scripts/phase3_mode_ablation.py` (new, ~395 LOC) — standalone runner with `--reaggregate` cheap re-bucketing
- `tests/test_phase3_mode_ablation.py` (new, 2 smoke tests) — variant grid pinning + tmp-dir `--reaggregate` end-to-end
- `.gitignore` — phase3_mode_* aggregate allowlist (same pattern as phase2_chunking_*)
- `reports/retrieval/phase3_mode_20260518T032404Z/` — REPORT.md (142 lines) + mode_specs.json + raw_results.json (per-case scores, no doc/chunk IDs) + deltas.json (paired CI dict)

## Test plan

- [x] `pytest tests/test_phase3_mode_ablation.py tests/test_ablation_common.py tests/test_bootstrap_ci.py -v` → green
- [x] Pre-flight 5-case dry-run: 60s wall-time
- [x] Full 4×221 measurement: ~28 min wall-time
- [ ] CI green

## PR template fields

### 5a — Public-eval delta
N/A — this PR introduces a new measurement runner under `scripts/`. No edits to public-eval pipeline (`eval/scorers/`, `eval/bootstrap.py`, `eval/real_config.*.yaml`).

### 5b — Real-data delta
**This PR IS the real-data delta.** Phase 3 measurement on real100 n=221 documented above. Net-new script under `scripts/` (not in `LOAD_BEARING_PATHS` per `scripts/_governance.py`); no edits to runtime modules. No eval pipeline behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)