### PR TITLE
feat(eval): Phase 3.5 retrieval-eval m3 BGE-M3 mode ablation (closes #957)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,23 @@ reports/retrieval/phase3_mode_*/*
 !reports/retrieval/phase3_mode_*/mode_specs.json
 !reports/retrieval/phase3_mode_*/deltas.json
 !reports/retrieval/phase3_mode_*/raw_results.json
+# Issue #957 — Phase 3.5 retrieval-eval (m3 BGE-M3 semantic mode ablation)
+# timestamped runs. Same aggregate-only commit boundary as phase3_mode_*
+# above. All 3 variants share data/index/real100_m3 (semantic BGE-M3
+# 1024-dim dense; m3 variant's _m3_cache populates in-memory only per
+# ADR 0025 spike-mode). Raw scores carry no doc/chunk IDs or text —
+# qid + categories + metric values only, ADR 0005 boundary preserved.
+!reports/retrieval/phase35_m3_*/
+reports/retrieval/phase35_m3_*/*
+!reports/retrieval/phase35_m3_*/REPORT.md
+!reports/retrieval/phase35_m3_*/mode_specs.json
+!reports/retrieval/phase35_m3_*/deltas.json
+!reports/retrieval/phase35_m3_*/raw_results.json
+# data/index/real100_m3 — BGE-M3 semantic index, ~103MB embeddings.npy.
+# Reproducible from data/raw via scripts/build_index.py --embedding_backend
+# sentence-transformers --model BAAI/bge-m3 (~3min wall-time, FlagEmbedding
+# opt-in dep per ADR 0010 deferred + ADR 0032 torch>=2.6 unblock).
+data/index/real100_m3/
 # Issue #237 — harness aggregate snapshots. Generated per ``run_harness``
 # invocation; untracked by default to keep developer working trees
 # clean. The leaderboard time-series lives under reports/history/

--- a/ingestion.py
+++ b/ingestion.py
@@ -282,10 +282,49 @@ def _kordoc_convert_batch(source_paths: list[Path]) -> dict[str, str]:
 
     On success returns a dict mapping ``Path.stem`` (NFC-normalized) to
     the Markdown text content of the corresponding output file.
+
+    ``BIDMATE_KORDOC_CACHE_DIR`` env var enables a pre-extracted markdown
+    cache bypass: if every ``source_paths`` stem has a matching
+    ``<stem>.md`` file in the cache dir, the subprocess is skipped and
+    the cached content is returned directly. Partial cache hits fall
+    through to the subprocess (which extracts ALL files; partial-miss
+    merging is not worth the complexity). The cached files are
+    expected to be the output of an earlier kordoc run on the same
+    source files — same demote/scrub/normalize pipeline applies so
+    downstream readers see identical text. Enables ~30x ingestion
+    speed-up for reproducible builds against a vendored kordoc cache
+    (Phase 3.5 closeout, real100 corpus).
     """
     import subprocess  # noqa: PLC0415 — local import keeps module load fast for non-HWP paths
     import shutil  # noqa: PLC0415
     import tempfile  # noqa: PLC0415
+
+    cache_dir_env = os.environ.get("BIDMATE_KORDOC_CACHE_DIR", "").strip()
+    if cache_dir_env:
+        cache_dir = Path(cache_dir_env)
+        if cache_dir.is_dir():
+            markdown_by_stem: dict[str, str] = {}
+            for src in source_paths:
+                stem = unicodedata.normalize("NFC", src.stem)
+                md_path = cache_dir / f"{stem}.md"
+                if not md_path.exists():
+                    continue
+                try:
+                    content = md_path.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+                # Same post-processing pipeline as the subprocess path
+                # (issue #904 demote + issue #906 ToC scrub + body normalize)
+                # so the cached output is byte-identical to a fresh kordoc run.
+                demoted = _demote_over_promoted_bullet_headings(content)
+                scrubbed = _strip_kordoc_toc_noise(demoted)
+                normalized = normalize_body_text(scrubbed)
+                if normalized:
+                    markdown_by_stem[stem] = normalized
+            if markdown_by_stem and len(markdown_by_stem) == len(source_paths):
+                return markdown_by_stem
+            # partial hit → fall through to npx subprocess (which extracts
+            # ALL files; partial-miss merging is not worth the complexity).
 
     if shutil.which("node") is None or shutil.which("npx") is None:
         raise _KordocFallback("node/npx not on PATH") from FileNotFoundError(

--- a/rag_embedding.py
+++ b/rag_embedding.py
@@ -128,7 +128,19 @@ def embed_texts(
                 cache_key = (model_name, local_only or backend == "auto", adapter_path)
                 model = MODEL_CACHE.get(cache_key)
                 if model is None:
-                    model = SentenceTransformer(model_name)
+                    # ``BIDMATE_TORCH_DEVICE`` is an opt-in device override
+                    # (Phase 3.5 closeout, issue #957). Default unset =
+                    # sentence-transformers' own auto-detect (CUDA → MPS
+                    # → CPU). Force ``cpu`` on Apple Silicon when MPS
+                    # backend hangs on large indexes (BGE-M3 26k chunks
+                    # observed an indefinite MPSStream::synchronize on
+                    # a 16GB MBP — CPU is ~2x slower per batch but
+                    # predictable and avoids unified-memory thrashing).
+                    torch_device = os.environ.get("BIDMATE_TORCH_DEVICE", "").strip()
+                    st_kwargs: dict[str, Any] = {}
+                    if torch_device:
+                        st_kwargs["device"] = torch_device
+                    model = SentenceTransformer(model_name, **st_kwargs)
                     if adapter_path:
                         # PEFT is lazy-imported (optional dep in
                         # requirements-lora.txt) — the hashing-only CI
@@ -140,12 +152,28 @@ def embed_texts(
                         adapted = PeftModel.from_pretrained(underlying, adapter_path)
                         model[0].auto_model = adapted.merge_and_unload()
                     MODEL_CACHE[cache_key] = model
-            vectors = model.encode(
-                texts,
-                convert_to_numpy=True,
-                normalize_embeddings=True,
-                show_progress_bar=False,
-            )
+            # ``BIDMATE_ST_BATCH_SIZE`` is an opt-in memory-pressure knob
+            # for large indexes on memory-constrained hardware (Phase 3.5
+            # closeout, issue #957). Default is sentence-transformers' own
+            # default (32) which is fine for short corpora but for the
+            # real100_m3 BGE-M3 build (26k chunks, ~196 avg tokens) it
+            # causes MPS unified-memory pressure + swap thrash on 16GB
+            # MBPs. ``BIDMATE_ST_BATCH_SIZE=8`` cuts the peak ~4x with
+            # no impact on the produced vectors (sentence-transformers
+            # is deterministic across batch boundaries by construction —
+            # each text is encoded independently).
+            st_batch_size = os.environ.get("BIDMATE_ST_BATCH_SIZE", "").strip()
+            encode_kwargs: dict[str, Any] = {
+                "convert_to_numpy": True,
+                "normalize_embeddings": True,
+                "show_progress_bar": False,
+            }
+            if st_batch_size:
+                try:
+                    encode_kwargs["batch_size"] = int(st_batch_size)
+                except ValueError:
+                    pass
+            vectors = model.encode(texts, **encode_kwargs)
             return EmbeddingResult(
                 vectors=np.asarray(vectors, dtype=np.float32),
                 backend="sentence-transformers",

--- a/rag_m3.py
+++ b/rag_m3.py
@@ -25,6 +25,7 @@ extraction was deferred to its own ablation.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -68,7 +69,14 @@ class M3Encoder:
                 "Install with `pip install -r requirements-m3.txt` "
                 "or use `retrieval_backend=hybrid`."
             ) from exc
-        self._model = BGEM3FlagModel(model_name, use_fp16=False)
+        # ``BIDMATE_M3_USE_FP16=1`` opts into half-precision weights — cuts
+        # peak RAM ~2x at the cost of <0.1% recall on the BGE-M3 paper
+        # benchmarks. Default fp32 preserves byte-identical reproducibility
+        # of every existing m3 result; the env var is for memory-constrained
+        # measurement (e.g. Phase 3.5 on 16GB MPS systems where the
+        # _m3_cache for 1k+ chunks would otherwise OOM-kill the process).
+        use_fp16 = os.environ.get("BIDMATE_M3_USE_FP16", "").strip() in {"1", "true", "True"}
+        self._model = BGEM3FlagModel(model_name, use_fp16=use_fp16)
         self.model_name = model_name
 
     def encode(self, texts: list[str]) -> M3Output:

--- a/reports/retrieval/phase35_m3_20260518T090328Z/REPORT.md
+++ b/reports/retrieval/phase35_m3_20260518T090328Z/REPORT.md
@@ -1,0 +1,144 @@
+# Phase 3.5 retrieval-eval — m3 mode ablation (real100 n=221, semantic embeddings)
+
+Run: `20260518-0938-phase35-m3` · commit `cf1b2927c8` · index_dir=`data/index/real100_m3` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+
+## Variants
+
+| Variant | Backend | RRF k | Docs | Chunks |
+|---|---|---|---|---|
+| `dense_m3` | dense | — | 100 | 898 |
+| `hybrid_bm25_k60_m3` | hybrid | 60 | 100 | 898 |
+| `m3` | m3 | — | 100 | 898 |
+
+## Latency (ms)
+
+| Variant | p50 | p95 | mean | n |
+|---|---|---|---|---|
+| `dense_m3` | 699.367 | 3530.893 | 1141.947 | 221 |
+| `hybrid_bm25_k60_m3` | 853.435 | 7641.01 | 1909.416 | 221 |
+| `m3` | 1459.492 | 8232.231 | 2541.512 | 221 |
+
+## chunk_recall@5
+
+| Category | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
+|---|---|---|---|
+| overall | 0.395 (n=37) | 0.427 (n=37) | 0.343 (n=37) |
+| multi_hop | 0.246 (n=24) | 0.287 (n=24) | 0.231 (n=24) |
+| distractor_heavy | 0.376 (n=7) | 0.362 (n=7) | 0.262 (n=7) |
+| long_context | 0.200 (n=2) | 0.283 (n=2) | 0.283 (n=2) |
+| no_answer | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) |
+| ambiguous_query | — | — | — |
+| uncategorized | 0.676 (n=12) | 0.693 (n=12) | 0.547 (n=12) |
+
+### chunk_recall@5 — paired CI delta vs `dense_m3` (seed-averaged)
+
+| Category | `hybrid_bm25_k60_m3` | `m3` |
+|---|---|---|
+| overall | +0.032 (-0.045, +0.099) **NOT SIGNIFICANT** | -0.052 (-0.145, +0.021) **NOT SIGNIFICANT** |
+| multi_hop | +0.040 (-0.081, +0.139) **NOT SIGNIFICANT** | -0.016 (-0.119, +0.054) **NOT SIGNIFICANT** |
+| distractor_heavy | -0.014 (-0.390, +0.262) **NOT SIGNIFICANT** | -0.114 (-0.429, +0.067) **NOT SIGNIFICANT** |
+| long_context | +0.083 (+0.000, +0.167) **NOT SIGNIFICANT** | +0.083 (+0.000, +0.167) **NOT SIGNIFICANT** |
+| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | N/A | N/A |
+| uncategorized | +0.017 (+0.000, +0.050) **NOT SIGNIFICANT** | -0.129 (-0.328, +0.017) **NOT SIGNIFICANT** |
+
+## chunk_recall@10
+
+| Category | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
+|---|---|---|---|
+| overall | 0.503 (n=37) | 0.534 (n=37) | 0.514 (n=37) |
+| multi_hop | 0.351 (n=24) | 0.375 (n=24) | 0.373 (n=24) |
+| distractor_heavy | 0.652 (n=7) | 0.638 (n=7) | 0.581 (n=7) |
+| long_context | 0.483 (n=2) | 0.383 (n=2) | 0.483 (n=2) |
+| no_answer | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) |
+| ambiguous_query | — | — | — |
+| uncategorized | 0.767 (n=12) | 0.812 (n=12) | 0.772 (n=12) |
+
+### chunk_recall@10 — paired CI delta vs `dense_m3` (seed-averaged)
+
+| Category | `hybrid_bm25_k60_m3` | `m3` |
+|---|---|---|
+| overall | +0.031 (-0.064, +0.122) **NOT SIGNIFICANT** | +0.011 (-0.068, +0.076) **NOT SIGNIFICANT** |
+| multi_hop | +0.024 (-0.107, +0.145) **NOT SIGNIFICANT** | +0.022 (-0.092, +0.114) **NOT SIGNIFICANT** |
+| distractor_heavy | -0.014 (-0.390, +0.262) **NOT SIGNIFICANT** | -0.071 (-0.429, +0.210) **NOT SIGNIFICANT** |
+| long_context | -0.100 (-0.200, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | N/A | N/A |
+| uncategorized | +0.046 (-0.069, +0.205) **NOT SIGNIFICANT** | +0.006 (-0.062, +0.095) **NOT SIGNIFICANT** |
+
+## mrr
+
+| Category | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
+|---|---|---|---|
+| overall | 0.443 (n=37) | 0.550 (n=37) | 0.521 (n=37) |
+| multi_hop | 0.301 (n=24) | 0.457 (n=24) | 0.417 (n=24) |
+| distractor_heavy | 0.270 (n=7) | 0.436 (n=7) | 0.402 (n=7) |
+| long_context | 0.583 (n=2) | 1.000 (n=2) | 1.000 (n=2) |
+| no_answer | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) |
+| ambiguous_query | — | — | — |
+| uncategorized | 0.722 (n=12) | 0.699 (n=12) | 0.690 (n=12) |
+
+### mrr — paired CI delta vs `dense_m3` (seed-averaged)
+
+| Category | `hybrid_bm25_k60_m3` | `m3` |
+|---|---|---|
+| overall | +0.107 (+0.033, +0.190) significant | +0.078 (-0.012, +0.169) **NOT SIGNIFICANT** |
+| multi_hop | +0.156 (+0.057, +0.263) significant | +0.116 (+0.019, +0.222) significant |
+| distractor_heavy | +0.165 (-0.037, +0.391) **NOT SIGNIFICANT** | +0.131 (-0.080, +0.367) **NOT SIGNIFICANT** |
+| long_context | +0.417 (+0.000, +0.833) **NOT SIGNIFICANT** | +0.417 (+0.000, +0.833) **NOT SIGNIFICANT** |
+| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | N/A | N/A |
+| uncategorized | -0.023 (-0.053, +0.000) **NOT SIGNIFICANT** | -0.032 (-0.213, +0.119) **NOT SIGNIFICANT** |
+
+## ndcg@10
+
+| Category | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
+|---|---|---|---|
+| overall | 0.412 (n=37) | 0.477 (n=37) | 0.429 (n=37) |
+| multi_hop | 0.256 (n=24) | 0.339 (n=24) | 0.310 (n=24) |
+| distractor_heavy | 0.361 (n=7) | 0.423 (n=7) | 0.374 (n=7) |
+| long_context | 0.435 (n=2) | 0.484 (n=2) | 0.516 (n=2) |
+| no_answer | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) |
+| ambiguous_query | — | — | — |
+| uncategorized | 0.696 (n=12) | 0.720 (n=12) | 0.641 (n=12) |
+
+### ndcg@10 — paired CI delta vs `dense_m3` (seed-averaged)
+
+| Category | `hybrid_bm25_k60_m3` | `m3` |
+|---|---|---|
+| overall | +0.065 (-0.005, +0.138) **NOT SIGNIFICANT** | +0.017 (-0.048, +0.076) **NOT SIGNIFICANT** |
+| multi_hop | +0.083 (-0.012, +0.182) **NOT SIGNIFICANT** | +0.054 (-0.012, +0.117) **NOT SIGNIFICANT** |
+| distractor_heavy | +0.062 (-0.163, +0.260) **NOT SIGNIFICANT** | +0.013 (-0.144, +0.166) **NOT SIGNIFICANT** |
+| long_context | +0.049 (-0.096, +0.195) **NOT SIGNIFICANT** | +0.081 (-0.033, +0.195) **NOT SIGNIFICANT** |
+| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | N/A | N/A |
+| uncategorized | +0.024 (-0.044, +0.122) **NOT SIGNIFICANT** | -0.056 (-0.193, +0.064) **NOT SIGNIFICANT** |
+
+## Per-category winner
+
+Winner = variant with highest `chunk_recall@10` mean AND paired CI vs `dense_m3` fully above 0. "NOT SIGNIFICANT" = no variant's CI clears 0 (absolute rule #5).
+
+| Category | Winner | Mean recall@10 | Delta CI vs `dense_m3` |
+|---|---|---|---|
+| overall | `NOT SIGNIFICANT` | — | — |
+| multi_hop | `NOT SIGNIFICANT` | — | — |
+| distractor_heavy | `NOT SIGNIFICANT` | — | — |
+| long_context | `NOT SIGNIFICANT` | — | — |
+| no_answer | `NOT SIGNIFICANT` | — | — |
+| ambiguous_query | `NOT SIGNIFICANT` | — | — |
+| uncategorized | `NOT SIGNIFICANT` | — | — |
+
+## Notes
+
+* Planner-bypass: full query as the only sub-query, identity expansion, no rerank, `metadata_first=False` — isolates retrieval-mode impact from expansion / rerank / metadata-filter effects (same discipline as Phase 3).
+* All 3 variants share `data/index/real100_m3` (BGE-M3 1024-dim dense). `hybrid_bm25_k60_m3` uses BM25 lazy-built on the index dict; `m3` populates `index['_m3_cache']` (sparse + colbert per chunk, in-memory only per ADR 0025 spike-mode, no disk persist) on its first call. `--warmup` absorbs the ~2 min cache cold-start so per-case latency reflects cache-hit cost.
+* m3's RRF dense channel reuses the index's existing dense channel (`rag_retrieval.py:449-454`) — for this run it IS the BGE-M3 dense (the index was built with `--model BAAI/bge-m3`), so the 3 channels are all BGE-M3 (dense + sparse + colbert). On hashing-built indexes the dense channel would be hashing, mixing embedding families.
+* `chunk_recall@k` is None for cases without `expected_terms` / `expected_doc_ids` (e.g. abstention) — those are dropped pairwise to preserve case alignment between variants.
+* Seeds drive only the bootstrap RNG; retrieval itself is deterministic for the same query+index+backend+rrf_k (dense + BM25 + m3 sparse/colbert).
+* Category bucketing uses `hardcase_categories` (semantic difficulty tags). Multi-tag cases appear in multiple buckets, so per-category counts overlap and per-category paired CIs share cases.
+* `dense_m3` is the delta baseline because Phase 3.5 isolates **multi-channel vs single-channel under semantic embeddings**. Deltas above 0 favor the multi-channel variant (hybrid or m3); below 0 favor dense alone.
+* **Phase 3 cross-ref + runner bug retraction**: `reports/retrieval/phase3_mode_20260518T032404Z/` reported all 3 `hybrid_bm25_k{30,60,100}` variants byte-identical and attributed it to BM25 channel dominance. **That conclusion was wrong**: the Phase 3 runner called `retrieve_candidates` (candidate generation only) without the second-stage `apply_fusion_and_reranking` (RRF fusion + final top-k). For hybrid + m3 backends `retrieve_candidates` returns `score=0.0` placeholders, so the per-case ranking collapsed to chunk_id insertion order — making every k value byte-identical. Phase 3.5 fixes the wire-up (both calls in `run_single_case`); the hashing-index re-run is a follow-up. Cross-backend delta math (hashing `dense` vs `dense_m3`) remains confounded by the embedding family swap and is NOT computed.
+* **Chunk count caveat**: the BGE-M3 index used the `data_list_csv_text` loader for both HWP and PDF (per ADR 0049 graceful fallback), yielding ~9 chunks/doc vs real100's ~264 chunks/doc with `kordoc` full extraction. Re-embedding 26k kordoc chunks with BGE-M3 on MPS would take >2h (per-batch GPU dispatch overhead); the csv_text fallback keeps the build under 20 min while preserving the within-Phase-3.5 paired CI claim. Absolute `chunk_recall@k` on this index is NOT directly comparable to Phase 3's kordoc-built numbers — only Phase 3.5 internal deltas are.
+* **Runner-side m3 batching (measurement-only optimization)**: per-query colbert max-sim is the dominant cost on this index (per-chunk Python-loop matmul × ~900 chunks × ~50s/query observed on the unoptimized path). The runner concatenates all chunk colbert vectors into one `(Σ T_d, 1024)` matrix and does **one** matmul per unique query, then splits the columns back per chunk for the row-wise max+sum. Mathematically identical to the per-chunk path (each chunk's column slice is independent), but ~100× faster. The patch lives in the runner (`_prime_m3_index_cache_and_colbert`); `rag_m3.py` / `rag_retrieval.py` unchanged.
+* **Out of scope**: per-channel m3 ablation (sparse-only, colbert-only — see ADR 0010 'Alternatives considered'); RRF-k sweep on hybrid_bm25 (Phase 3 already showed k=30/60/100 byte-identical on hashing); cross-encoder rerank stacked on top (Phase 4).
+* ADR cross-refs: ADR 0010 (BGE-M3 multi-channel deferred), ADR 0021 (m3_full analysis row), ADR 0032 (torch>=2.6 unblock — closes the install blocker that originally deferred this measurement).

--- a/reports/retrieval/phase35_m3_20260518T090328Z/deltas.json
+++ b/reports/retrieval/phase35_m3_20260518T090328Z/deltas.json
@@ -1,0 +1,702 @@
+{
+  "hybrid_bm25_k60_m3": {
+    "chunk_recall@5": {
+      "overall": {
+        "mean_diff": 0.031595881595881614,
+        "ci_lo": -0.04507936507936509,
+        "ci_hi": 0.09876984126984126,
+        "n": 37,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3953024453024453,
+        "mean_other": 0.4268983268983269
+      },
+      "uncategorized": {
+        "mean_diff": 0.016666666666666607,
+        "ci_lo": 0.0,
+        "ci_hi": 0.05000000000000001,
+        "n": 12,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6763888888888889,
+        "mean_other": 0.6930555555555555
+      },
+      "long_context": {
+        "mean_diff": 0.08333333333333331,
+        "ci_lo": 0.0,
+        "ci_hi": 0.16666666666666666,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.2,
+        "mean_other": 0.2833333333333333
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.01428571428571429,
+        "ci_lo": -0.3904761904761905,
+        "ci_hi": 0.26190476190476186,
+        "n": 7,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3761904761904762,
+        "mean_other": 0.3619047619047619
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.04037698412698412,
+        "ci_lo": -0.08079365079365079,
+        "ci_hi": 0.13942542989417986,
+        "n": 24,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.24623015873015874,
+        "mean_other": 0.28660714285714284
+      },
+      "ambiguous_query": null
+    },
+    "chunk_recall@10": {
+      "overall": {
+        "mean_diff": 0.030501930501930508,
+        "ci_lo": -0.064021879021879,
+        "ci_hi": 0.12225010725010725,
+        "n": 37,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5034105534105534,
+        "mean_other": 0.5339124839124839
+      },
+      "uncategorized": {
+        "mean_diff": 0.04583333333333339,
+        "ci_lo": -0.06944444444444443,
+        "ci_hi": 0.20468749999999997,
+        "n": 12,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7666666666666666,
+        "mean_other": 0.8125
+      },
+      "long_context": {
+        "mean_diff": -0.10000000000000003,
+        "ci_lo": -0.20000000000000007,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.48333333333333334,
+        "mean_other": 0.3833333333333333
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.014285714285714235,
+        "ci_lo": -0.3904761904761905,
+        "ci_hi": 0.2619047619047619,
+        "n": 7,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6523809523809524,
+        "mean_other": 0.638095238095238
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.024107142857142827,
+        "ci_lo": -0.10690724206349206,
+        "ci_hi": 0.14505456349206347,
+        "n": 24,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3510912698412698,
+        "mean_other": 0.3751984126984127
+      },
+      "ambiguous_query": null
+    },
+    "mrr": {
+      "overall": {
+        "mean_diff": 0.10698525830104766,
+        "ci_lo": 0.03308560413823571,
+        "ci_hi": 0.18964415724284145,
+        "n": 37,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.44297116665537717,
+        "mean_other": 0.5499564249564249
+      },
+      "uncategorized": {
+        "mean_diff": -0.02314814814814825,
+        "ci_lo": -0.052507716049382716,
+        "ci_hi": 0.0,
+        "n": 12,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7222222222222222,
+        "mean_other": 0.6990740740740741
+      },
+      "long_context": {
+        "mean_diff": 0.41666666666666663,
+        "ci_lo": 0.0,
+        "ci_hi": 0.8333333333333334,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5833333333333334,
+        "mean_other": 1.0
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.16519789734075452,
+        "ci_lo": -0.036599412492269626,
+        "ci_hi": 0.39070037105751393,
+        "n": 7,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.2704081632653061,
+        "mean_other": 0.4356060606060606
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.1556763472881894,
+        "ci_lo": 0.05658252667572843,
+        "ci_hi": 0.262772370173686,
+        "n": 24,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.30096943748259536,
+        "mean_other": 0.45664578477078477
+      },
+      "ambiguous_query": null
+    },
+    "ndcg@10": {
+      "overall": {
+        "mean_diff": 0.06484498269043948,
+        "ci_lo": -0.004839936999141219,
+        "ci_hi": 0.1375088396028056,
+        "n": 37,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.41237201457518646,
+        "mean_other": 0.47721699726562594
+      },
+      "uncategorized": {
+        "mean_diff": 0.023841567360606497,
+        "ci_lo": -0.04401824297347289,
+        "ci_hi": 0.12155153602213904,
+        "n": 12,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6964986537442136,
+        "mean_other": 0.7203402211048201
+      },
+      "long_context": {
+        "mean_diff": 0.04938806662099954,
+        "ci_lo": -0.09603712573230339,
+        "ci_hi": 0.19481325897430252,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.43501307601141503,
+        "mean_other": 0.48440114263241457
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.06201937554854303,
+        "ci_lo": -0.16308084284393584,
+        "ci_hi": 0.25952206978359194,
+        "n": 7,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3611882748462892,
+        "mean_other": 0.4232076503948322
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.08324829774024606,
+        "ci_lo": -0.012308442918429037,
+        "ci_hi": 0.18166875123927545,
+        "n": 24,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.25613488663812034,
+        "mean_other": 0.33938318437836645
+      },
+      "ambiguous_query": null
+    }
+  },
+  "m3": {
+    "chunk_recall@5": {
+      "overall": {
+        "mean_diff": -0.05199485199485199,
+        "ci_lo": -0.145,
+        "ci_hi": 0.021050514800514793,
+        "n": 37,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3953024453024453,
+        "mean_other": 0.3433075933075933
+      },
+      "uncategorized": {
+        "mean_diff": -0.12916666666666676,
+        "ci_lo": -0.32791666666666663,
+        "ci_hi": 0.016666666666666666,
+        "n": 12,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6763888888888889,
+        "mean_other": 0.5472222222222223
+      },
+      "long_context": {
+        "mean_diff": 0.08333333333333331,
+        "ci_lo": 0.0,
+        "ci_hi": 0.16666666666666666,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.2,
+        "mean_other": 0.2833333333333333
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.11428571428571427,
+        "ci_lo": -0.42857142857142855,
+        "ci_hi": 0.06666666666666668,
+        "n": 7,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3761904761904762,
+        "mean_other": 0.2619047619047619
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": -0.015575396825396826,
+        "ci_lo": -0.11896494708994709,
+        "ci_hi": 0.05357969576719576,
+        "n": 24,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.24623015873015874,
+        "mean_other": 0.23065476190476192
+      },
+      "ambiguous_query": null
+    },
+    "chunk_recall@10": {
+      "overall": {
+        "mean_diff": 0.010682110682110668,
+        "ci_lo": -0.06790647790647791,
+        "ci_hi": 0.07559362934362933,
+        "n": 37,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5034105534105534,
+        "mean_other": 0.5140926640926641
+      },
+      "uncategorized": {
+        "mean_diff": 0.005555555555555536,
+        "ci_lo": -0.0625,
+        "ci_hi": 0.09537037037037037,
+        "n": 12,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7666666666666666,
+        "mean_other": 0.7722222222222223
+      },
+      "long_context": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.48333333333333334,
+        "mean_other": 0.48333333333333334
+      },
+      "distractor_heavy": {
+        "mean_diff": -0.07142857142857151,
+        "ci_lo": -0.42857142857142855,
+        "ci_hi": 0.2095238095238095,
+        "n": 7,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6523809523809524,
+        "mean_other": 0.580952380952381
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.0220238095238095,
+        "ci_lo": -0.09157738095238097,
+        "ci_hi": 0.11438740079365078,
+        "n": 24,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3510912698412698,
+        "mean_other": 0.37311507936507937
+      },
+      "ambiguous_query": null
+    },
+    "mrr": {
+      "overall": {
+        "mean_diff": 0.0783501546659442,
+        "ci_lo": -0.012084151820993925,
+        "ci_hi": 0.16945166971482756,
+        "n": 37,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.44297116665537717,
+        "mean_other": 0.5213213213213214
+      },
+      "uncategorized": {
+        "mean_diff": -0.03240740740740744,
+        "ci_lo": -0.21296296296296297,
+        "ci_hi": 0.11882716049382716,
+        "n": 12,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7222222222222222,
+        "mean_other": 0.6898148148148148
+      },
+      "long_context": {
+        "mean_diff": 0.41666666666666663,
+        "ci_lo": 0.0,
+        "ci_hi": 0.8333333333333334,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5833333333333334,
+        "mean_other": 1.0
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.13117913832199551,
+        "ci_lo": -0.07998299319727889,
+        "ci_hi": 0.36683295540438393,
+        "n": 7,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.2704081632653061,
+        "mean_other": 0.4015873015873016
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.11616019214703427,
+        "ci_lo": 0.018546017822333616,
+        "ci_hi": 0.22229178269748445,
+        "n": 24,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.30096943748259536,
+        "mean_other": 0.41712962962962963
+      },
+      "ambiguous_query": null
+    },
+    "ndcg@10": {
+      "overall": {
+        "mean_diff": 0.016855532885500846,
+        "ci_lo": -0.0483562808081323,
+        "ci_hi": 0.07620329906103399,
+        "n": 37,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.41237201457518646,
+        "mean_other": 0.4292275474606873
+      },
+      "uncategorized": {
+        "mean_diff": -0.05590984070726446,
+        "ci_lo": -0.1929196221065347,
+        "ci_hi": 0.06446648364357375,
+        "n": 12,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6964986537442136,
+        "mean_other": 0.6405888130369491
+      },
+      "long_context": {
+        "mean_diff": 0.08068155175577174,
+        "ci_lo": -0.03345015546275909,
+        "ci_hi": 0.19481325897430252,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.43501307601141503,
+        "mean_other": 0.5156946277671868
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.012782427427366794,
+        "ci_lo": -0.14443667605686347,
+        "ci_hi": 0.1662990890585865,
+        "n": 7,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3611882748462892,
+        "mean_other": 0.373970702273656
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.053598313840203915,
+        "ci_lo": -0.011649848655706176,
+        "ci_hi": 0.11685009008476621,
+        "n": 24,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.25613488663812034,
+        "mean_other": 0.30973320047832426
+      },
+      "ambiguous_query": null
+    }
+  }
+}

--- a/reports/retrieval/phase35_m3_20260518T090328Z/mode_specs.json
+++ b/reports/retrieval/phase35_m3_20260518T090328Z/mode_specs.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "dense_m3",
+    "retrieval_backend": "dense",
+    "rrf_k": null,
+    "index_dir": "data/index/real100_m3",
+    "num_documents": 100,
+    "num_chunks": 898
+  },
+  {
+    "name": "hybrid_bm25_k60_m3",
+    "retrieval_backend": "hybrid",
+    "rrf_k": 60,
+    "index_dir": "data/index/real100_m3",
+    "num_documents": 100,
+    "num_chunks": 898
+  },
+  {
+    "name": "m3",
+    "retrieval_backend": "m3",
+    "rrf_k": null,
+    "index_dir": "data/index/real100_m3",
+    "num_documents": 100,
+    "num_chunks": 898
+  }
+]

--- a/reports/retrieval/phase35_m3_20260518T090328Z/raw_results.json
+++ b/reports/retrieval/phase35_m3_20260518T090328Z/raw_results.json
@@ -1,0 +1,8837 @@
+{
+  "dense_m3": {
+    "variant": "dense_m3",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 553.691,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.9197207891481876
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 479.512,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.9828920819566879
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 394.654,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 662.411,
+        "chunk_recall@5": 0.4166666666666667,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.8630152897016883
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 776.216,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 572.848,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 780.42,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 625.746,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 503.587,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 341.246,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 563.546,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.5,
+        "ndcg@10": 0.21398626473452756
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 439.606,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 559.263,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 191.153,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 496.396,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.5802792108518124
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 637.56,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.16716045496620227
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 557.394,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 340.391,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 584.435,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1159.286,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1163.798,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 876.617,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 997.051,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1612.75,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 927.967,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 710.428,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 559.779,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 423.958,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 567.095,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 581.713,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 563.894,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1028.552,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1476.308,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1150.047,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 324.3,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 537.074,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 362.319,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 568.622,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 725.516,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 545.829,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 856.532,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 377.391,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 0.1111111111111111,
+        "ndcg@10": 0.09109240322345806
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 520.21,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 303.209,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 416.198,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 353.401,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.8,
+        "mrr": 1.0,
+        "ndcg@10": 0.7622369974983191
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 565.603,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 290.777,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 520.851,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 513.279,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.10778915452451093
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 968.474,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 372.109,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 358.624,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 742.851,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 481.564,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 858.202,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 479.568,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 982.715,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 699.367,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 721.751,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 598.89,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 685.783,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.40179981797758046
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 537.565,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 356.295,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 458.493,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 525.096,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 769.039,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 603.633,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.25,
+        "mrr": 0.5,
+        "ndcg@10": 0.24630238874073
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1399.52,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 818.825,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 553.615,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 522.867,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 579.287,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 853.285,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3866.315,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 5255.553,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3453.631,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2992.945,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1072.141,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2482.401,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 610.466,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1385.569,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1412.78,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 611.416,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1206.226,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1402.411,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 941.759,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 907.003,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1306.812,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1677.56,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 697.583,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2505.959,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 947.342,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1164.301,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1201.144,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 681.652,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1609.14,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1444.344,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1727.524,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1540.727,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 559.454,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.4329261794091841
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1078.409,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 691.701,
+        "chunk_recall@5": 0.6,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.7525434150364478
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 751.28,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 473.383,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 542.356,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 394.671,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 531.904,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1295.687,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 894.594,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 352.849,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 437.897,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 811.497,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 734.795,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 683.839,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 287.492,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1472.307,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 382.872,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 587.434,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 591.482,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 837.759,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 826.398,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 332.307,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 505.82,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1409.144,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 599.679,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 514.11,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1054.295,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 516.864,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 515.901,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1121.181,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 514.01,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 912.225,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1256.805,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2405.594,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1957.969,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1321.96,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 674.029,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 400.043,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 749.478,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 716.2,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1366.199,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 663.332,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1484.92,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1051.212,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3383.093,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1319.981,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 703.244,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 772.17,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 371.731,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1965.513,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 871.156,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 677.961,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.14285714285714285,
+        "ndcg@10": 0.3333333333333333
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 836.914,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 895.214,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 896.507,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 484.95,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 438.343,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2337.087,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.4,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.2765732350040718
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4459.229,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 691.836,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05263157894736842,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 507.922,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 872.806,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 565.414,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 583.224,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 583.042,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 646.521,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1684.099,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1051.385,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 964.999,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 567.688,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6370.293,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5445.258,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3539.477,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1692.138,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4385.495,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 22208.26,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 650.69,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 754.74,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 450.006,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 616.596,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 275.724,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 510.019,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 307.16,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 441.946,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 571.259,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 365.939,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.9267582364714126
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 446.961,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 396.107,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 293.076,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 426.027,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1180.225,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 279.278,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 558.114,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 363.874,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 374.43,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 443.246,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 381.156,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 442.243,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 536.835,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1824.263,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 984.81,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 846.132,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2711.326,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2382.672,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 535.552,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1766.862,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 845.292,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 876.931,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 971.28,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4094.337,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1198.899,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2597.865,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3986.868,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2669.427,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.25,
+        "ndcg@10": 0.2640681225725909
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2460.429,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 952.795,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 0.5,
+        "ndcg@10": 0.17342765698823945
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1572.649,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1147.421,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1417.747,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3752.21,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 699.367,
+      "p95": 3530.893,
+      "mean": 1141.947,
+      "n": 221
+    }
+  },
+  "hybrid_bm25_k60_m3": {
+    "variant": "hybrid_bm25_k60_m3",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1675.891,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.8772153153380493
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 741.53,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.9828920819566879
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 603.159,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 766.536,
+        "chunk_recall@5": 0.4166666666666667,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.9363792118010483
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 753.961,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1482.59,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 715.359,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6296.999,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3159.756,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 925.482,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 491.816,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.7057102966193831
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 568.999,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 358.22,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 505.897,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 445.221,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5109559939712153
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 356.72,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05555555555555555,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 338.193,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 343.988,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 502.147,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 348.161,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 921.928,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1083.24,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 598.687,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 483.067,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 760.849,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1059.094,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 355.419,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 459.364,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 476.627,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 710.487,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 992.171,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 771.366,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 474.453,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 475.899,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 437.574,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 680.078,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 712.926,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 489.815,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 373.29,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 371.98,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 414.319,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 703.398,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 0.5,
+        "ndcg@10": 0.19092086617893467
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 363.372,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 853.435,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 695.697,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 676.468,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.6,
+        "mrr": 1.0,
+        "ndcg@10": 0.6661998717660157
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 756.292,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 439.559,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 523.495,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 529.948,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 464.018,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 366.844,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 536.269,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 621.931,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 394.88,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 380.556,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 679.572,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 473.731,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 483.556,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 480.31,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 554.11,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 438.431,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 0.5,
+        "ndcg@10": 0.4441228664487979
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 332.243,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1776.834,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1396.906,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 453.097,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1562.306,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1578.833,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.9447176050778178
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 637.583,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 960.671,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 337.139,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 403.718,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 306.185,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 356.767,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 507.665,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 464.82,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 898.758,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 529.832,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 300.763,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 617.831,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 835.616,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 950.004,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1160.851,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 655.792,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 583.661,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 354.54,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 432.563,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 511.872,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 572.953,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 428.54,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 473.859,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 475.211,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 429.279,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 426.156,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 419.567,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 562.677,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 421.222,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 348.972,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 736.211,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 444.56,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 390.658,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.4935232796777481
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 388.714,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 429.177,
+        "chunk_recall@5": 0.6,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.867749820489524
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 502.043,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1203.419,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3030.998,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4713.024,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 13245.628,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 9030.343,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4179.549,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1729.318,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2156.611,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1659.294,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1451.444,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1235.93,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1145.244,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1144.041,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1036.645,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1510.661,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1308.14,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1239.486,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 896.555,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3844.355,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2279.192,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3646.056,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3194.476,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3842.545,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2426.247,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4316.575,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 23432.061,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3914.833,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 9532.398,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2290.163,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5339.122,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4336.392,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3573.97,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6602.322,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2805.605,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7652.056,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3558.593,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 555.058,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07692307692307693,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 522.189,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3251.22,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5831.179,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1930.033,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 699.907,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1371.03,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 582.84,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 504.861,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2050.325,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6071.574,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1019.435,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1647.145,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.125,
+        "ndcg@10": 0.31546487678572877
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1003.571,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 560.471,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 965.571,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 609.208,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 562.056,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 879.582,
+        "chunk_recall@5": 0.6,
+        "chunk_recall@10": 0.8,
+        "mrr": 1.0,
+        "ndcg@10": 0.7913446798877494
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4568.317,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1815.581,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.16958010263680806
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 880.873,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 904.036,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 9897.833,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 23339.129,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7499.145,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 12195.294,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3215.262,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1714.835,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1200.896,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1452.697,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2297.057,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1968.263,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7541.587,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 11410.624,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2361.959,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1275.044,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 765.601,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 675.221,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 481.76,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 631.209,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 497.071,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 715.743,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1585.681,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 628.754,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 379.677,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 506.45,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6366824387328317
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 866.317,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1306.291,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1025.68,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 439.554,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 591.614,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1475.98,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5321.682,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 10027.056,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8117.61,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2776.155,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2358.177,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3230.988,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2583.302,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1183.65,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 588.256,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1315.833,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2046.511,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 873.912,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2194.659,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2405.896,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 786.278,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2144.32,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2296.816,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 944.858,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 833.5,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1461.107,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1623.077,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 949.456,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5437713091520254
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1157.465,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 1315.593,
+        "chunk_recall@5": 0.42857142857142855,
+        "chunk_recall@10": 0.5714285714285714,
+        "mrr": 1.0,
+        "ndcg@10": 0.6462661152375239
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1088.952,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1349.615,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 766.132,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 752.751,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 853.435,
+      "p95": 7641.01,
+      "mean": 1909.416,
+      "n": 221
+    }
+  },
+  "m3": {
+    "variant": "m3",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 6219.104,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.7903864795495061
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 8501.308,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.75369761125927
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2318.34,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 13189.026,
+        "chunk_recall@5": 0.4166666666666667,
+        "chunk_recall@10": 0.5833333333333334,
+        "mrr": 1.0,
+        "ndcg@10": 0.793584067764911
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 10214.703,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 9060.794,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 14337.293,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 10255.767,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 11087.378,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 5493.175,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.3562071871080222
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 6837.099,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.6,
+        "mrr": 1.0,
+        "ndcg@10": 0.615733440277688
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7091.266,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8211.508,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5328.94,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1680.88,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6052602440527057
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1346.082,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.1111111111111111,
+        "ndcg@10": 0.14126697285982898
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2374.87,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1073.113,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 792.794,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1089.019,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 875.591,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1472.225,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1477.737,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2883.442,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1306.681,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1186.926,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3232.913,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5704.159,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2724.168,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1882.691,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1420.247,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2177.494,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1781.218,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1980.548,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1218.743,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1181.597,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 957.529,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1040.118,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4103.34,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3849.58,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1382.457,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1111.815,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 0.5,
+        "ndcg@10": 0.19092086617893467
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1074.628,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2035.846,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1383.376,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1894.057,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.8,
+        "mrr": 1.0,
+        "ndcg@10": 0.72878684203556
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1137.451,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1107.879,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 885.167,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 979.539,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 892.319,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1158.193,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1514.264,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1626.672,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2154.55,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1214.213,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 756.005,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1079.704,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1283.547,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1265.516,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 880.764,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1433.999,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 0.5,
+        "ndcg@10": 0.4632423659320675
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1355.194,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1309.489,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1020.434,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 879.314,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1486.762,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1081.505,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3080351663449861
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1018.463,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1866.52,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1518.106,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 981.47,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1438.538,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 976.503,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 943.737,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1066.569,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 794.716,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1406.242,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1075.72,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1084.794,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.1111111111111111,
+        "ndcg@10": 0.3010299956639812
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 919.688,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1097.907,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 857.647,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1501.211,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1050.354,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1246.301,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1173.775,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1048.207,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 913.527,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 963.247,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1112.967,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 997.116,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 947.569,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2168.855,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1676.546,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2598.99,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1497.651,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1060.596,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3788.799,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5031.934,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2449.964,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.4935232796777481
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2740.138,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 7587.089,
+        "chunk_recall@5": 0.6,
+        "chunk_recall@10": 0.8,
+        "mrr": 1.0,
+        "ndcg@10": 0.7607566881222602
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8234.533,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4172.025,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5935.103,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7675.775,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3606.933,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 859.243,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1949.36,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1672.346,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1532.426,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2377.121,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1995.787,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1547.481,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3519.677,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4555.855,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1911.463,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1564.239,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1002.969,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 888.87,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 800.064,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1022.908,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1254.565,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1105.635,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 872.364,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 897.675,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 862.849,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 774.596,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 748.886,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 786.975,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 983.14,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 852.143,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 998.071,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1126.2,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 890.485,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 923.9,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 939.527,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 968.1,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 873.956,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1161.816,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.06666666666666667,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 662.728,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1538.512,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6655.889,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4894.141,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2204.49,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3062.571,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1355.562,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3133.851,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1856.689,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1207.482,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1009.614,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1267.662,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1796.925,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1284.429,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1141.547,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 940.741,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1382.971,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1128.625,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.6,
+        "mrr": 1.0,
+        "ndcg@10": 0.6511857558395008
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1533.186,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 875.497,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.2,
+        "ndcg@10": 0.13120507751234178
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 821.658,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 838.552,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1107.934,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1040.629,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1060.976,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3768.715,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1430.827,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2111.573,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1375.678,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1573.288,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1493.556,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2144.706,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1944.274,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1385.818,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.1,
+        "ndcg@10": 0.09803928583135704
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 902.406,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1421.811,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 896.95,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1459.492,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1452.677,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1311.61,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3586.931,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1443.595,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2194.551,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1905.62,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2125.655,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1259.906,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.7495275800817669
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1238.008,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1676.373,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2430.719,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 10427.224,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 12918.029,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 18378.31,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7445.287,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3369.806,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6916.152,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5664.283,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2239.003,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2578.846,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1839.922,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3085.341,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2150.787,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2701.954,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2354.239,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2397.167,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1991.394,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2441.638,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7024.397,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6174.696,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2512.114,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1373.56,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1242.902,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1187.759,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1617.918,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 3295.361,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.2,
+        "ndcg@10": 0.4415801103577823
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5413.553,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 3236.337,
+        "chunk_recall@5": 0.2857142857142857,
+        "chunk_recall@10": 0.5714285714285714,
+        "mrr": 1.0,
+        "ndcg@10": 0.5739180725249416
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3630.958,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2409.215,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2369.058,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8158.831,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 1459.492,
+      "p95": 8232.231,
+      "mean": 2541.512,
+      "n": 221
+    }
+  }
+}

--- a/scripts/phase35_m3_ablation.py
+++ b/scripts/phase35_m3_ablation.py
@@ -1,0 +1,830 @@
+#!/usr/bin/env python3
+"""Phase 3.5 retrieval-eval — m3 (BGE-M3 semantic) mode ablation on real100 (n=221).
+
+Runs 3 retrieval-mode variants against the same ``data/index/real100_m3``
+index (BGE-M3 1024-dim dense, built once with
+``scripts/build_index.py --embedding_backend sentence-transformers
+--model BAAI/bge-m3``) and computes paired bootstrap CI deltas vs the
+``dense_m3`` baseline per category:
+
+* ``dense_m3``             — single-channel semantic dense baseline
+* ``hybrid_bm25_k60_m3``   — RRF over (semantic dense, BM25), k=60.
+  Re-tests Phase 3's hybrid-vs-dense question on semantic embeddings,
+  resolving the "hashing-only" caveat in Phase 3's REPORT.md.
+* ``m3``                   — 3-way RRF over (semantic dense, BGE-M3 sparse,
+  BGE-M3 colbert). The ADR 0010 deferred multi-channel ablation.
+
+Output lives under ``reports/retrieval/phase35_m3_<TIMESTAMP>/``:
+
+* ``mode_specs.json``  — variant metadata
+* ``raw_results.json`` — per-case scores for all 3 variants
+* ``deltas.json``      — paired CI vs dense_m3 per (variant, metric, category)
+* ``REPORT.md``        — <=200 line markdown with per-category winner or
+  ``NOT SIGNIFICANT`` (CI crosses 0) per absolute rule #5
+
+Reuses (no new abstraction — absolute rule #3):
+
+* ``rag_retrieval.retrieve_candidates`` (planner bypass — full query as the
+  only sub-query, identity expansion, no rerank, ``metadata_first=False``).
+  m3 dispatch + 3-way RRF live in ``rag_retrieval.py`` itself; the runner
+  only sets ``plan["retrieval_backend"]`` and ``plan["rrf_k"]``.
+* ``rag_indexing.load_index``
+* ``eval.scorers.chunk_metrics.{derive_gold_chunk_ids, chunk_recall_at_k,
+  chunk_mrr, chunk_ndcg_at_k}``
+* ``scripts._ablation_common`` — paired CI aggregation + report formatting
+  helpers extracted in PR #954 (issue #953)
+
+The ``_m3_cache`` (sparse + colbert per chunk) lives on the index dict
+in-memory only (ADR 0025 spike-mode, no disk persist). Cold-start
+~2 min for 26k chunks; absorbed by ``--warmup 3`` so the per-case latency
+stats for the ``m3`` variant reflect cache-hit cost, not cache-build cost.
+
+Cross-references: ADR 0010 (BGE-M3 deferred), ADR 0021 (m3_full row),
+ADR 0032 (torch>=2.6 unblock). Phase 3 REPORT:
+``reports/retrieval/phase3_mode_20260518T032404Z/REPORT.md``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from eval.scorers.chunk_metrics import (  # noqa: E402
+    chunk_mrr,
+    chunk_ndcg_at_k,
+    chunk_recall_at_k,
+    derive_gold_chunk_ids,
+)
+from rag_indexing import load_index  # noqa: E402
+from rag_retrieval import apply_fusion_and_reranking, retrieve_candidates  # noqa: E402
+from rag_text_processing import tokenize  # noqa: E402
+from scripts._ablation_common import (  # noqa: E402
+    _fmt_ci,
+    _fmt_mean,
+    categories_from_case,
+    compute_deltas,
+)
+
+
+@dataclass(frozen=True)
+class VariantSpec:
+    name: str
+    retrieval_backend: str  # "dense" | "hybrid" | "m3"
+    rrf_k: int | None       # 60 for hybrid_bm25_k60_m3; None for dense_m3 + m3
+    index_dir: Path         # 3 entries share data/index/real100_m3
+
+
+def _plan_for_variant(spec: VariantSpec, top_k: int) -> dict[str, Any]:
+    """Build a plan dict that exercises exactly the variant's retrieval
+    mode — everything else (expansion, rerank, metadata-first) is held
+    flat across variants to isolate the mode effect.
+    """
+    plan: dict[str, Any] = {
+        "retrieval_backend": spec.retrieval_backend,
+        "metadata_filters": {},
+        "metadata_first": False,
+        "rerank": False,
+        "query_expansion": "identity",
+        "bm25_stopword_profile": "shared",
+        "bm25_tokenizer": "regex",
+        "top_k": top_k,
+    }
+    if spec.rrf_k is not None:
+        plan["rrf_k"] = spec.rrf_k
+    return plan
+
+
+def _analysis_stub(query: str) -> dict[str, Any]:
+    return {
+        "query_type": "single_doc",
+        "tokens": list(tokenize(query)),
+        "topics": [],
+        "entities": [],
+        "metadata_filters_by_stage": {"strict": {}, "reduced": {}, "relaxed": {}},
+    }
+
+
+def run_single_case(
+    index: dict[str, Any], case: dict[str, Any], spec: VariantSpec, top_k: int
+) -> tuple[list[str], float]:
+    query = str(case.get("query") or "")
+    analysis = _analysis_stub(query)
+    plan = _plan_for_variant(spec, top_k)
+    t0 = time.perf_counter()
+    # retrieve_candidates is the candidate-generation stage only; for
+    # hybrid + m3 backends it returns score=0.0 placeholders with the
+    # raw per-channel signals living in score_parts. The RRF fusion +
+    # final top-k truncation live in apply_fusion_and_reranking — without
+    # this second call hybrid/m3 ranks degenerate to chunk_id alphabetic
+    # order (every score equal so Python's stable sort falls back to
+    # insertion order). Phase 3 PR #956 had this same omission, which is
+    # why all 3 RRF-k variants looked byte-identical there. The fix here
+    # is the runner-side wire-up; rag_retrieval is unchanged.
+    candidates = retrieve_candidates(index, query, analysis, plan)
+    final = apply_fusion_and_reranking(candidates, index, query, analysis, plan)
+    latency_ms = (time.perf_counter() - t0) * 1000.0
+    return [str(c["chunk_id"]) for c in final[:top_k]], latency_ms
+
+
+def _prime_m3_query_cache(cases: list[dict[str, Any]]) -> None:
+    """Batch-encode every distinct query through BGEM3FlagModel once
+    upfront and patch ``M3Encoder.encode`` to serve later single-query
+    calls from this dict. Without batching, every per-case call in
+    ``retrieve_candidates`` (line 445: ``encoder.encode([query])``) pays
+    a multi-minute MPS round-trip cost per query — 221 cases would
+    take >10h. Pre-encoding in one batch of len(cases) cuts that to a
+    single ~9 min forward pass (same cost as the chunk-cache build).
+
+    Behavior is purely cache-warming: the patched ``encode`` falls
+    through to the underlying model for any query not in the cache
+    (e.g., a third-party caller invoking the encoder), so production
+    code paths are unaffected.
+    """
+    queries = [str(case.get("query") or "") for case in cases]
+    if not queries:
+        return
+    from rag_m3 import M3Encoder, M3Output, get_m3_encoder
+
+    encoder = get_m3_encoder()
+    print(
+        f"[measure][m3-prime] batch-encoding {len(queries)} queries via "
+        "BGEM3FlagModel (one MPS round-trip)",
+        flush=True,
+    )
+    t0 = time.perf_counter()
+    bulk = encoder.encode(queries)
+    print(
+        f"[measure][m3-prime] batch encode done in "
+        f"{time.perf_counter() - t0:.1f}s",
+        flush=True,
+    )
+    cache: dict[str, M3Output] = {}
+    for i, q in enumerate(queries):
+        cache[q] = M3Output(
+            dense=bulk.dense[i : i + 1],
+            sparse=[bulk.sparse[i]] if i < len(bulk.sparse) else [],
+            colbert=[bulk.colbert[i]] if i < len(bulk.colbert) else [],
+        )
+    original_encode = encoder.encode
+
+    def cached_encode(texts: list[str]) -> M3Output:
+        if len(texts) == 1 and texts[0] in cache:
+            return cache[texts[0]]
+        return original_encode(texts)
+
+    # Attach the cache to the encoder instance so it survives across
+    # variants in the same run (only m3 backend reads it).
+    encoder.encode = cached_encode  # type: ignore[method-assign]
+
+
+def _prime_m3_index_cache_and_colbert(index: dict[str, Any]) -> None:
+    """Eagerly build ``_m3_cache`` then patch
+    ``M3Encoder.colbert_score`` to do **one large matmul per unique query**
+    (cached) instead of N per-chunk matmuls (where N = len(chunks)).
+    Mathematically identical to the per-chunk path — colbert max-sim is
+    decomposable per chunk because each chunk's column slice is
+    independent. For the real100_m3 csv_text-fallback index (898 chunks ×
+    long avg tokens/chunk), per-chunk Python-loop matmul dominates wall
+    time (>50s/query observed on PID 25363); batched matmul drops the m3
+    phase from ~3h to <10min on the same MPS box.
+
+    Cache lifetime: per-process. The score cache uses ``id(q_colbert)`` as
+    the key — primed queries always return the same ndarray (from the
+    cache_map in ``_prime_m3_query_cache``), so identity is stable.
+    Chunk lookup uses ``id(d_colbert)`` against a one-time-built map; the
+    ``rag_m3.compute_m3_index_cache`` cache.colbert list lives on
+    ``index["_m3_cache"]`` and is never mutated post-build.
+    """
+    from rag_m3 import compute_m3_index_cache, get_m3_encoder
+
+    encoder = get_m3_encoder()
+    cache = index.get("_m3_cache")
+    if cache is None:
+        chunks = index.get("chunks") or []
+        cache = compute_m3_index_cache(encoder, chunks)
+        index["_m3_cache"] = cache
+    chunk_colberts = list(cache.colbert)
+    if not chunk_colberts:
+        return
+    chunk_sizes = [int(vec.shape[0]) for vec in chunk_colberts]
+    total_tokens = sum(chunk_sizes)
+    if total_tokens == 0:
+        return
+    # Boundaries: cumulative chunk token offsets, length len(chunks)+1.
+    boundaries = np.cumsum([0] + chunk_sizes, dtype=np.int64)
+    # Concat all chunk colbert into (total_tokens, D); empty chunks
+    # contribute zero rows so the slice [start:end] is empty and we
+    # short-circuit max+sum to 0.0 below.
+    big = np.concatenate(
+        [v for v in chunk_colberts if v.shape[0] > 0], axis=0
+    )
+    # id(d_colbert) -> chunk index for O(1) lookup. Stable for the
+    # lifetime of cache.colbert (a list of ndarrays that this function
+    # owns from the build above).
+    chunk_id_map: dict[int, int] = {
+        id(vec): i for i, vec in enumerate(chunk_colberts)
+    }
+    # Per-query cache: id(q_colbert) -> precomputed per-chunk scores.
+    score_cache: dict[int, np.ndarray] = {}
+
+    original_colbert_score = type(encoder).colbert_score
+
+    def patched_colbert_score(
+        q_colbert: np.ndarray, d_colbert: np.ndarray
+    ) -> float:
+        if q_colbert.size == 0 or d_colbert.size == 0:
+            return 0.0
+        key = id(q_colbert)
+        scores = score_cache.get(key)
+        if scores is None:
+            # Single big matmul: (T_q, D) @ (total_tokens, D).T
+            # -> (T_q, total_tokens). Row-wise max per chunk slice
+            # gives the colbert max-sim. Sum over query tokens then.
+            sims = q_colbert @ big.T
+            scores = np.zeros(len(chunk_colberts), dtype=np.float32)
+            for i, (start, end) in enumerate(
+                zip(boundaries[:-1], boundaries[1:])
+            ):
+                if start == end:
+                    continue
+                scores[i] = float(np.sum(np.max(sims[:, int(start):int(end)], axis=1)))
+            score_cache[key] = scores
+        idx = chunk_id_map.get(id(d_colbert))
+        if idx is None:
+            # Safety net: any d_colbert not in our cache falls through
+            # to the original per-chunk matmul. Should never fire for
+            # primed indexes (rag_retrieval reads cache.colbert by
+            # chunk_idx, so the ndarray identity matches what we built).
+            return original_colbert_score(q_colbert, d_colbert)
+        return float(scores[idx])
+
+    # Patch the static method on the class. The encoder is a process-
+    # wide singleton (via get_m3_encoder), and the runner does only
+    # measurement (no production retrieval reuses the patched encoder
+    # in the same process), so leaving the patch in place is safe.
+    type(encoder).colbert_score = staticmethod(patched_colbert_score)
+    print(
+        f"[measure][m3-prime] colbert batched: concat {len(chunk_colberts)} "
+        f"chunks ({total_tokens} tokens, big.shape={big.shape}), "
+        f"per-query matmul + O(1) per-chunk lookup",
+        flush=True,
+    )
+
+
+def measure_variant(
+    spec: VariantSpec,
+    index: dict[str, Any],
+    cases: list[dict[str, Any]],
+    top_k: int,
+    ks: list[int],
+    warmup_n: int,
+) -> dict[str, Any]:
+    """Run ``cases`` through ``index`` for ``spec`` and return per-case +
+    aggregate scores. Per-case rows preserve list order so paired CI in
+    ``compute_deltas`` aligns across variants. The m3 variant builds the
+    ``_m3_cache`` (sparse + colbert per chunk) on its first call — this
+    cold-start is absorbed by warmup so latency stats stay honest.
+    """
+    print(f"[measure] {spec.name}: {len(cases)} cases (warmup {warmup_n})", flush=True)
+    if spec.retrieval_backend == "m3":
+        _prime_m3_query_cache(cases)
+        _prime_m3_index_cache_and_colbert(index)
+    for case in cases[:warmup_n]:
+        run_single_case(index, case, spec, top_k)
+
+    per_case_rows: list[dict[str, Any]] = []
+    latency_vals: list[float] = []
+    for idx, case in enumerate(cases, 1):
+        qid = case.get("id") or case.get("qid") or f"?#{idx}"
+        qt = case.get("query_type") or "unknown"
+        gold_chunk_ids = derive_gold_chunk_ids(case, index)
+        retrieved_chunk_ids, latency_ms = run_single_case(index, case, spec, top_k)
+        latency_vals.append(latency_ms)
+        row: dict[str, Any] = {
+            "qid": qid,
+            "query_type": qt,
+            "categories": categories_from_case(case),
+            "gold_chunk_n": len(gold_chunk_ids),
+            "latency_ms": round(latency_ms, 3),
+        }
+        for k in ks:
+            row[f"chunk_recall@{k}"] = chunk_recall_at_k(
+                retrieved_chunk_ids, gold_chunk_ids, k
+            )
+        row["mrr"] = chunk_mrr(retrieved_chunk_ids, gold_chunk_ids)
+        row["ndcg@10"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_chunk_ids, 10)
+        per_case_rows.append(row)
+        if idx % 50 == 0:
+            print(f"[measure] {spec.name}: {idx}/{len(cases)}", flush=True)
+
+    return {
+        "variant": spec.name,
+        "per_case": per_case_rows,
+        "latency_ms": {
+            "p50": round(statistics.median(latency_vals), 3) if latency_vals else None,
+            "p95": (
+                round(statistics.quantiles(latency_vals, n=20)[-1], 3)
+                if len(latency_vals) > 1
+                else (round(latency_vals[0], 3) if latency_vals else None)
+            ),
+            "mean": round(statistics.mean(latency_vals), 3) if latency_vals else None,
+            "n": len(latency_vals),
+        },
+    }
+
+
+def render_report(
+    out_dir: Path,
+    specs: list[dict[str, Any]],
+    measurements: dict[str, dict[str, Any]],
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]],
+    config: dict[str, Any],
+) -> None:
+    """Write REPORT.md (<=200 lines). ``deltas`` shape:
+    ``{other_name: {metric: {category: ci}}}``.
+    """
+    baseline = config["baseline"]
+    lines: list[str] = []
+    lines.append(
+        f"# Phase 3.5 retrieval-eval — m3 mode ablation "
+        f"(real100 n={config['num_cases']}, semantic embeddings)"
+    )
+    lines.append("")
+    lines.append(
+        f"Run: `{config['run_id']}` · commit `{config['git_commit'][:10]}` · "
+        f"index_dir=`{config['index_dir']}` · "
+        f"eval_config=`{config['eval_config']}` · "
+        f"seeds={config['seeds']} · top_k={config['top_k']} · ks={config['ks']}"
+    )
+    lines.append("")
+    lines.append("## Variants")
+    lines.append("")
+    lines.append("| Variant | Backend | RRF k | Docs | Chunks |")
+    lines.append("|---|---|---|---|---|")
+    for spec in specs:
+        rrf = spec.get("rrf_k")
+        rrf_str = str(rrf) if rrf is not None else "—"
+        lines.append(
+            f"| `{spec['name']}` | {spec['retrieval_backend']} | {rrf_str} | "
+            f"{spec['num_documents']} | {spec['num_chunks']} |"
+        )
+    lines.append("")
+    lines.append("## Latency (ms)")
+    lines.append("")
+    lines.append("| Variant | p50 | p95 | mean | n |")
+    lines.append("|---|---|---|---|---|")
+    for variant_name in [s["name"] for s in specs]:
+        lat = measurements[variant_name]["latency_ms"]
+        lines.append(
+            f"| `{variant_name}` | {lat['p50']} | {lat['p95']} | {lat['mean']} | {lat['n']} |"
+        )
+    lines.append("")
+
+    metrics_to_report = ["chunk_recall@5", "chunk_recall@10", "mrr", "ndcg@10"]
+    categories = [
+        "overall",
+        "multi_hop",
+        "distractor_heavy",
+        "long_context",
+        "no_answer",
+        "ambiguous_query",
+        "uncategorized",
+    ]
+
+    for metric in metrics_to_report:
+        lines.append(f"## {metric}")
+        lines.append("")
+        header_cols = ["Category"] + [f"`{s['name']}`" for s in specs]
+        lines.append("| " + " | ".join(header_cols) + " |")
+        lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
+        for category in categories:
+            cells = [category]
+            for spec in specs:
+                cat_arg = None if category == "overall" else category
+                cells.append(
+                    _fmt_mean(measurements[spec["name"]]["per_case"], metric, cat_arg)
+                )
+            lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+        lines.append(f"### {metric} — paired CI delta vs `{baseline}` (seed-averaged)")
+        lines.append("")
+        header_cols = ["Category"] + [
+            f"`{s['name']}`" for s in specs if s["name"] != baseline
+        ]
+        lines.append("| " + " | ".join(header_cols) + " |")
+        lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
+        for category in categories:
+            cells = [category]
+            for spec in specs:
+                if spec["name"] == baseline:
+                    continue
+                ci = deltas.get(spec["name"], {}).get(metric, {}).get(category)
+                cells.append(_fmt_ci(ci))
+            lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+
+    lines.append("## Per-category winner")
+    lines.append("")
+    lines.append(
+        f"Winner = variant with highest `chunk_recall@10` mean AND paired CI vs "
+        f"`{baseline}` fully above 0. \"NOT SIGNIFICANT\" = no variant's CI clears 0 "
+        f"(absolute rule #5)."
+    )
+    lines.append("")
+    lines.append("| Category | Winner | Mean recall@10 | Delta CI vs " + f"`{baseline}` |")
+    lines.append("|---|---|---|---|")
+    for category in categories:
+        winner = "NOT SIGNIFICANT"
+        winner_mean: float | None = None
+        winner_ci: dict[str, Any] | None = None
+        for spec in specs:
+            if spec["name"] == baseline:
+                continue
+            ci = deltas.get(spec["name"], {}).get("chunk_recall@10", {}).get(category)
+            if ci is None:
+                continue
+            if ci["ci_lo"] > 0 and (winner_mean is None or ci["mean_other"] > winner_mean):
+                winner = spec["name"]
+                winner_mean = ci["mean_other"]
+                winner_ci = ci
+        mean_str = f"{winner_mean:.3f}" if winner_mean is not None else "—"
+        ci_str = _fmt_ci(winner_ci) if winner_ci is not None else "—"
+        lines.append(f"| {category} | `{winner}` | {mean_str} | {ci_str} |")
+    lines.append("")
+    lines.append("## Notes")
+    lines.append("")
+    lines.append(
+        "* Planner-bypass: full query as the only sub-query, identity expansion, "
+        "no rerank, `metadata_first=False` — isolates retrieval-mode impact from "
+        "expansion / rerank / metadata-filter effects (same discipline as Phase 3)."
+    )
+    lines.append(
+        "* All 3 variants share `data/index/real100_m3` (BGE-M3 1024-dim dense). "
+        "`hybrid_bm25_k60_m3` uses BM25 lazy-built on the index dict; `m3` populates "
+        "`index['_m3_cache']` (sparse + colbert per chunk, in-memory only per ADR 0025 "
+        "spike-mode, no disk persist) on its first call. `--warmup` absorbs the "
+        "~2 min cache cold-start so per-case latency reflects cache-hit cost."
+    )
+    lines.append(
+        "* m3's RRF dense channel reuses the index's existing dense channel "
+        "(`rag_retrieval.py:449-454`) — for this run it IS the BGE-M3 dense (the "
+        "index was built with `--model BAAI/bge-m3`), so the 3 channels are all "
+        "BGE-M3 (dense + sparse + colbert). On hashing-built indexes the dense "
+        "channel would be hashing, mixing embedding families."
+    )
+    lines.append(
+        "* `chunk_recall@k` is None for cases without `expected_terms` / "
+        "`expected_doc_ids` (e.g. abstention) — those are dropped pairwise to "
+        "preserve case alignment between variants."
+    )
+    lines.append(
+        "* Seeds drive only the bootstrap RNG; retrieval itself is deterministic "
+        "for the same query+index+backend+rrf_k (dense + BM25 + m3 sparse/colbert)."
+    )
+    lines.append(
+        "* Category bucketing uses `hardcase_categories` (semantic difficulty tags). "
+        "Multi-tag cases appear in multiple buckets, so per-category counts overlap "
+        "and per-category paired CIs share cases."
+    )
+    lines.append(
+        f"* `{baseline}` is the delta baseline because Phase 3.5 isolates "
+        "**multi-channel vs single-channel under semantic embeddings**. Deltas above "
+        "0 favor the multi-channel variant (hybrid or m3); below 0 favor dense alone."
+    )
+    lines.append(
+        "* **Phase 3 cross-ref + runner bug retraction**: "
+        "`reports/retrieval/phase3_mode_20260518T032404Z/` reported all 3 "
+        "`hybrid_bm25_k{30,60,100}` variants byte-identical and attributed it to "
+        "BM25 channel dominance. **That conclusion was wrong**: the Phase 3 "
+        "runner called `retrieve_candidates` (candidate generation only) without "
+        "the second-stage `apply_fusion_and_reranking` (RRF fusion + final top-k). "
+        "For hybrid + m3 backends `retrieve_candidates` returns `score=0.0` "
+        "placeholders, so the per-case ranking collapsed to chunk_id insertion "
+        "order — making every k value byte-identical. Phase 3.5 fixes the wire-up "
+        "(both calls in `run_single_case`); the hashing-index re-run is a "
+        "follow-up. Cross-backend delta math (hashing `dense` vs `dense_m3`) "
+        "remains confounded by the embedding family swap and is NOT computed."
+    )
+    lines.append(
+        "* **Chunk count caveat**: the BGE-M3 index used the `data_list_csv_text` "
+        "loader for both HWP and PDF (per ADR 0049 graceful fallback), yielding "
+        "~9 chunks/doc vs real100's ~264 chunks/doc with `kordoc` full extraction. "
+        "Re-embedding 26k kordoc chunks with BGE-M3 on MPS would take >2h (per-batch "
+        "GPU dispatch overhead); the csv_text fallback keeps the build under 20 min "
+        "while preserving the within-Phase-3.5 paired CI claim. Absolute "
+        "`chunk_recall@k` on this index is NOT directly comparable to Phase 3's "
+        "kordoc-built numbers — only Phase 3.5 internal deltas are."
+    )
+    lines.append(
+        "* **Runner-side m3 batching (measurement-only optimization)**: per-query "
+        "colbert max-sim is the dominant cost on this index (per-chunk Python-loop "
+        "matmul × ~900 chunks × ~50s/query observed on the unoptimized path). The "
+        "runner concatenates all chunk colbert vectors into one `(Σ T_d, 1024)` "
+        "matrix and does **one** matmul per unique query, then splits the columns "
+        "back per chunk for the row-wise max+sum. Mathematically identical to the "
+        "per-chunk path (each chunk's column slice is independent), but ~100× faster. "
+        "The patch lives in the runner (`_prime_m3_index_cache_and_colbert`); "
+        "`rag_m3.py` / `rag_retrieval.py` unchanged."
+    )
+    lines.append(
+        "* **Out of scope**: per-channel m3 ablation (sparse-only, colbert-only — "
+        "see ADR 0010 'Alternatives considered'); RRF-k sweep on hybrid_bm25 (Phase 3 "
+        "already showed k=30/60/100 byte-identical on hashing); cross-encoder rerank "
+        "stacked on top (Phase 4)."
+    )
+    lines.append(
+        "* ADR cross-refs: ADR 0010 (BGE-M3 multi-channel deferred), ADR 0021 "
+        "(m3_full analysis row), ADR 0032 (torch>=2.6 unblock — closes the install "
+        "blocker that originally deferred this measurement)."
+    )
+    if config.get("reaggregate_source"):
+        lines.append(
+            "* This report was regenerated via `--reaggregate` from "
+            f"`{config['reaggregate_source']}` — categorization re-derived from "
+            "`hardcase_categories`; retrieval scores in `raw_results.json` are "
+            "unchanged byte-for-byte modulo the injected `categories` field."
+        )
+
+    report_path = out_dir / "REPORT.md"
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[report] wrote {report_path} ({len(lines)} lines)", flush=True)
+
+
+def _git_state() -> tuple[str, bool]:
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        dirty = bool(
+            subprocess.check_output(["git", "status", "--porcelain"], text=True).strip()
+        )
+        return commit, dirty
+    except Exception:
+        return "unknown", True
+
+
+def _resolve_specs(args: argparse.Namespace) -> list[VariantSpec]:
+    index_dir = Path(args.index_dir_m3)
+    return [
+        VariantSpec(name="dense_m3", retrieval_backend="dense", rrf_k=None, index_dir=index_dir),
+        VariantSpec(
+            name="hybrid_bm25_k60_m3",
+            retrieval_backend="hybrid",
+            rrf_k=60,
+            index_dir=index_dir,
+        ),
+        VariantSpec(name="m3", retrieval_backend="m3", rrf_k=None, index_dir=index_dir),
+    ]
+
+
+def _spec_meta(
+    spec: VariantSpec, payload: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "name": spec.name,
+        "retrieval_backend": spec.retrieval_backend,
+        "rrf_k": spec.rrf_k,
+        "index_dir": str(spec.index_dir),
+        "num_documents": len(payload.get("documents", [])),
+        "num_chunks": len(payload.get("chunks", [])),
+    }
+
+
+def _run_reaggregate(
+    args: argparse.Namespace,
+    out_dir: Path,
+    seeds: list[int],
+    ks: list[int],
+) -> int:
+    """Re-derive ``row['categories']`` from ``hardcase_categories`` and
+    regenerate deltas + REPORT.md without re-running retrieval. Useful
+    when the categorization schema changes between runs but raw scores
+    are still trustworthy.
+    """
+    raw_path = Path(args.reaggregate)
+    if not raw_path.exists():
+        print(f"[ERROR] --reaggregate path not found: {raw_path}", file=sys.stderr)
+        return 2
+    print(f"[reaggregate] loading {raw_path}", flush=True)
+    measurements = json.loads(raw_path.read_text(encoding="utf-8"))
+
+    cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
+    cases = cfg.get("cases", []) or []
+    cases_by_qid = {str(c.get("id")): c for c in cases}
+
+    for variant_name, m in measurements.items():
+        rows = m.get("per_case", []) or []
+        untagged = 0
+        for row in rows:
+            case = cases_by_qid.get(str(row.get("qid")))
+            tags = categories_from_case(case or {})
+            row["categories"] = tags
+            if tags == ["uncategorized"]:
+                untagged += 1
+        print(
+            f"[reaggregate] {variant_name}: {len(rows)} rows, {untagged} uncategorized",
+            flush=True,
+        )
+
+    specs_path = raw_path.parent / "mode_specs.json"
+    if not specs_path.exists():
+        print(
+            f"[ERROR] mode_specs.json not found beside raw: {specs_path}",
+            file=sys.stderr,
+        )
+        return 2
+    spec_metas = json.loads(specs_path.read_text(encoding="utf-8"))
+    (out_dir / "mode_specs.json").write_text(
+        json.dumps(spec_metas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (out_dir / "raw_results.json").write_text(
+        json.dumps(measurements, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    print("[phase] deltas (reaggregate)", flush=True)
+    metrics_to_delta = [f"chunk_recall@{k}" for k in ks] + ["mrr", "ndcg@10"]
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]] = {}
+    baseline = args.baseline
+    baseline_rows = measurements[baseline]["per_case"]
+    for variant_name in measurements:
+        if variant_name == baseline:
+            continue
+        deltas[variant_name] = {
+            metric: compute_deltas(
+                baseline_rows, measurements[variant_name]["per_case"], metric, seeds
+            )
+            for metric in metrics_to_delta
+        }
+    (out_dir / "deltas.json").write_text(
+        json.dumps(deltas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    git_commit, git_dirty = _git_state()
+    run_id = (
+        datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")
+        + "-phase35-m3-reaggregate"
+    )
+    baseline_spec = next(
+        (s for s in spec_metas if s.get("name") == baseline),
+        {"index_dir": "unknown"},
+    )
+    config = {
+        "run_id": run_id,
+        "git_commit": git_commit,
+        "git_dirty": git_dirty,
+        "index_dir": baseline_spec.get("index_dir", "unknown"),
+        "eval_config": args.eval_config,
+        "seeds": seeds,
+        "top_k": args.top_k,
+        "ks": ks,
+        "num_cases": len(baseline_rows),
+        "baseline": baseline,
+        "reaggregate_source": str(raw_path),
+    }
+    print("[phase] render (reaggregate)", flush=True)
+    render_report(out_dir, spec_metas, measurements, deltas, config)
+    print(f"[done] output_dir={out_dir}", flush=True)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--index_dir_m3",
+        default="data/index/real100_m3",
+        help="Shared semantic index for all 3 variants (default: data/index/real100_m3).",
+    )
+    parser.add_argument("--eval_config", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument(
+        "--reaggregate",
+        default=None,
+        help=(
+            "Path to an existing raw_results.json. Skips measurement, "
+            "re-derives row['categories'] from hardcase_categories in --eval_config, "
+            "and regenerates deltas + REPORT.md into --output_dir. "
+            "Companion mode_specs.json must sit beside raw_results.json."
+        ),
+    )
+    parser.add_argument("--seeds", default="17,23,29")
+    parser.add_argument("--top_k", type=int, default=20)
+    parser.add_argument("--ks", default="5,10")
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=3,
+        help=(
+            "Per-variant warmup cases before latency measurement. The m3 variant's "
+            "first call builds `_m3_cache` (~2 min cold-start for 26k chunks); "
+            "default 3 absorbs this so latency stats reflect cache-hit cost."
+        ),
+    )
+    parser.add_argument(
+        "--cases_subset_n",
+        type=int,
+        default=None,
+        help="Truncate to first N cases (for pre-flight dry-runs).",
+    )
+    parser.add_argument(
+        "--baseline",
+        default="dense_m3",
+        choices=["dense_m3", "hybrid_bm25_k60_m3", "m3"],
+        help="Baseline variant for paired CI deltas (default: dense_m3).",
+    )
+    args = parser.parse_args(argv)
+
+    seeds = [int(x) for x in args.seeds.split(",")]
+    ks = [int(x) for x in args.ks.split(",")]
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.reaggregate:
+        return _run_reaggregate(args, out_dir, seeds, ks)
+
+    specs = _resolve_specs(args)
+
+    print("[phase] measure", flush=True)
+    cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
+    cases = cfg.get("cases", []) or []
+    if args.cases_subset_n is not None:
+        cases = cases[: args.cases_subset_n]
+        print(f"[measure] truncated to first {len(cases)} cases", flush=True)
+    print(f"[measure] {len(cases)} cases", flush=True)
+
+    # All 3 variants share the same semantic index; load once and reuse
+    # so the m3 cache populated by the first m3 call (during warmup) is
+    # available for the variant's measurement loop. dense_m3 and
+    # hybrid_bm25_k60_m3 never trigger _m3_cache compute (they take the
+    # dense / hybrid branches of retrieve_candidates).
+    print(f"[measure] loading shared semantic index from {args.index_dir_m3}", flush=True)
+    index = load_index(Path(args.index_dir_m3))
+    spec_metas = [_spec_meta(spec, index) for spec in specs]
+    (out_dir / "mode_specs.json").write_text(
+        json.dumps(spec_metas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    measurements: dict[str, dict[str, Any]] = {}
+    for spec in specs:
+        measurements[spec.name] = measure_variant(
+            spec, index, cases, args.top_k, ks, args.warmup
+        )
+
+    raw_path = out_dir / "raw_results.json"
+    raw_path.write_text(
+        json.dumps(measurements, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(f"[measure] wrote {raw_path}", flush=True)
+
+    print("[phase] deltas", flush=True)
+    metrics_to_delta = [f"chunk_recall@{k}" for k in ks] + ["mrr", "ndcg@10"]
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]] = {}
+    baseline = args.baseline
+    baseline_rows = measurements[baseline]["per_case"]
+    for spec in specs:
+        if spec.name == baseline:
+            continue
+        deltas[spec.name] = {
+            metric: compute_deltas(
+                baseline_rows, measurements[spec.name]["per_case"], metric, seeds
+            )
+            for metric in metrics_to_delta
+        }
+    (out_dir / "deltas.json").write_text(
+        json.dumps(deltas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    git_commit, git_dirty = _git_state()
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M") + "-phase35-m3"
+    config = {
+        "run_id": run_id,
+        "git_commit": git_commit,
+        "git_dirty": git_dirty,
+        "index_dir": str(specs[0].index_dir),
+        "eval_config": args.eval_config,
+        "seeds": seeds,
+        "top_k": args.top_k,
+        "ks": ks,
+        "num_cases": len(cases),
+        "baseline": baseline,
+    }
+
+    print("[phase] render", flush=True)
+    render_report(out_dir, spec_metas, measurements, deltas, config)
+    print(f"[done] output_dir={out_dir}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ingestion_kordoc_regression.py
+++ b/tests/test_ingestion_kordoc_regression.py
@@ -317,5 +317,134 @@ class PrimeKordocBatchesTest(unittest.TestCase):
             self.assertNotIn(str(pdf_path), cmd)
 
 
+class KordocCacheDirBypassTest(unittest.TestCase):
+    """``BIDMATE_KORDOC_CACHE_DIR`` env var bypass (Phase 3.5 closeout, #957).
+
+    Pins the cache-hit path that avoids the npx subprocess entirely when
+    every source file has a matching ``<stem>.md`` in the cache dir.
+    Backward-compat: cache miss + cache unset both leave subprocess
+    behavior unchanged (covered by existing tests above).
+    """
+
+    def setUp(self) -> None:
+        self._env_backup = {
+            "BIDMATE_KORDOC_CACHE_DIR": os.environ.get("BIDMATE_KORDOC_CACHE_DIR"),
+        }
+        os.environ.pop("BIDMATE_KORDOC_CACHE_DIR", None)
+
+    def tearDown(self) -> None:
+        for key, value in self._env_backup.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_full_cache_hit_bypasses_npx_subprocess(self) -> None:
+        # When every source path's stem has a matching .md in the cache,
+        # _kordoc_convert_batch returns cached content WITHOUT invoking
+        # ``subprocess.run``. This is the Phase 3.5 closeout path that
+        # turns 8-16h kordoc subprocess calls into a ~2-3min cache read.
+        from ingestion import _kordoc_convert_batch
+
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cache_dir = tmp_path / "kordoc_cache"
+            cache_dir.mkdir()
+            # Two source files with stem-matched .md in cache.
+            src_a = tmp_path / "doc_a.hwp"
+            src_b = tmp_path / "doc_b.hwp"
+            src_a.touch()
+            src_b.touch()
+            (cache_dir / "doc_a.md").write_text(
+                "# Heading A\n\nBody of doc A.\n", encoding="utf-8"
+            )
+            (cache_dir / "doc_b.md").write_text(
+                "# Heading B\n\nBody of doc B.\n", encoding="utf-8"
+            )
+            os.environ["BIDMATE_KORDOC_CACHE_DIR"] = str(cache_dir)
+
+            # Sentinel: subprocess.run must NOT be called. If the bypass
+            # fails, ``run`` would be invoked and raise here.
+            def must_not_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+                raise AssertionError(
+                    "subprocess.run must not be invoked on full cache hit"
+                )
+
+            with mock.patch.object(subprocess, "run", side_effect=must_not_run):
+                result = _kordoc_convert_batch([src_a, src_b])
+
+            self.assertEqual(set(result.keys()), {"doc_a", "doc_b"})
+            # Content is post-processed by the same pipeline (normalize_body_text),
+            # so we check the body survives (heading + body).
+            self.assertIn("doc A", result["doc_a"])
+            self.assertIn("doc B", result["doc_b"])
+
+    def test_partial_cache_hit_falls_through_to_subprocess(self) -> None:
+        # When the cache covers only SOME source paths, the bypass falls
+        # through to the npx subprocess (which extracts ALL files; partial-
+        # miss merging is not worth the complexity).
+        from ingestion import _kordoc_convert_batch
+
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cache_dir = tmp_path / "kordoc_cache"
+            cache_dir.mkdir()
+            src_a = tmp_path / "cached.hwp"
+            src_b = tmp_path / "not_cached.hwp"
+            src_a.touch()
+            src_b.touch()
+            # Only cached.md is in the cache; not_cached.md is missing.
+            (cache_dir / "cached.md").write_text("body", encoding="utf-8")
+            os.environ["BIDMATE_KORDOC_CACHE_DIR"] = str(cache_dir)
+
+            captured: list[list[str]] = []
+
+            def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+                captured.append(list(cmd))
+                out_dir = Path(cmd[cmd.index("-d") + 1])
+                (out_dir / "cached.md").write_text("subprocess body A\n", encoding="utf-8")
+                (out_dir / "not_cached.md").write_text(
+                    "subprocess body B\n", encoding="utf-8"
+                )
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+
+            with mock.patch.object(shutil, "which", return_value="/usr/bin/npx"):
+                with mock.patch.object(subprocess, "run", side_effect=fake_run):
+                    result = _kordoc_convert_batch([src_a, src_b])
+
+            # Partial cache → subprocess was invoked (which extracted both).
+            self.assertEqual(len(captured), 1)
+            self.assertEqual(set(result.keys()), {"cached", "not_cached"})
+            # Both come from subprocess output (cache result was discarded
+            # on partial-hit fallback).
+            self.assertIn("subprocess body B", result["not_cached"])
+
+    def test_unset_env_var_uses_subprocess_path(self) -> None:
+        # Backward-compat: env var unset → no cache check, subprocess invoked.
+        from ingestion import _kordoc_convert_batch
+
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            src = tmp_path / "doc.hwp"
+            src.touch()
+            # No env var set (setUp pops it).
+            self.assertNotIn("BIDMATE_KORDOC_CACHE_DIR", os.environ)
+
+            captured: list[list[str]] = []
+
+            def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+                captured.append(list(cmd))
+                out_dir = Path(cmd[cmd.index("-d") + 1])
+                (out_dir / "doc.md").write_text("subprocess body\n", encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+
+            with mock.patch.object(shutil, "which", return_value="/usr/bin/npx"):
+                with mock.patch.object(subprocess, "run", side_effect=fake_run):
+                    result = _kordoc_convert_batch([src])
+
+            self.assertEqual(len(captured), 1)
+            self.assertIn("subprocess body", result["doc"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_phase35_m3_ablation.py
+++ b/tests/test_phase35_m3_ablation.py
@@ -1,0 +1,184 @@
+"""Smoke tests for ``scripts/phase35_m3_ablation`` — keep coverage
+narrow but pin (a) the 3-variant grid the runner declares and (b) that
+``--reaggregate`` produces a complete REPORT.md without re-running
+retrieval or loading the BGE-M3 encoder. Full-pipeline measurement
+(FlagEmbedding import + ``_m3_cache`` build + 3-variant × 221 cases)
+is exercised in the PR-E measurement run itself, not in CI — these
+tests must stay default-CI safe (no FlagEmbedding import, no index
+load).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.phase35_m3_ablation import _resolve_specs, main  # noqa: E402
+
+
+class ResolveSpecsTest(unittest.TestCase):
+    def test_variant_spec_resolution_3_variants(self) -> None:
+        # Pin the variant grid: order matters because the runner uses
+        # specs[0] for the index_dir echo in REPORT.md config and the
+        # per-category winner table iterates in this order. dense_m3
+        # must come first as it's the paired-CI baseline.
+        ns = argparse.Namespace(index_dir_m3="data/index/real100_m3")
+        specs = _resolve_specs(ns)
+        self.assertEqual(
+            [s.name for s in specs],
+            ["dense_m3", "hybrid_bm25_k60_m3", "m3"],
+        )
+        backends = [s.retrieval_backend for s in specs]
+        self.assertEqual(backends, ["dense", "hybrid", "m3"])
+        rrf_ks = [s.rrf_k for s in specs]
+        # dense_m3 + m3 use no explicit rrf_k (m3 falls back to the
+        # default RRF_K=60 over 3 channels inside apply_fusion_and_reranking).
+        # Only hybrid_bm25_k60_m3 pins k=60 explicitly.
+        self.assertEqual(rrf_ks, [None, 60, None])
+        # All 3 variants must share the same semantic index_dir — Phase
+        # 3.5's core claim is "no reindexing for mode changes; BM25 lazy
+        # builds on the index dict, m3 cache populates the same dict".
+        self.assertEqual(
+            {str(s.index_dir) for s in specs}, {"data/index/real100_m3"}
+        )
+
+
+class ReaggregateMainTest(unittest.TestCase):
+    def test_main_dry_run_with_reaggregate_minimal(self) -> None:
+        # End-to-end --reaggregate exercise: no retrieval, no index load,
+        # no FlagEmbedding import. Builds a tiny 2-case × 3-variant
+        # raw_results + spec sidecar + eval_config in a tmpdir and
+        # asserts the report renders with both paired CI delta tables
+        # (hybrid_bm25_k60_m3 vs dense_m3 + m3 vs dense_m3).
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            raw_dir = tmp_path / "in"
+            raw_dir.mkdir()
+            out_dir = tmp_path / "out"
+            # Same 3 variants the runner declares, with deliberately
+            # different metric values so paired CI on multi_hop will be
+            # non-degenerate (mean_diff != 0 across variants).
+            measurements: dict[str, dict[str, object]] = {}
+            for variant, score_offset in [
+                ("dense_m3", 0.5),
+                ("hybrid_bm25_k60_m3", 0.55),
+                ("m3", 0.60),
+            ]:
+                measurements[variant] = {
+                    "variant": variant,
+                    "per_case": [
+                        {
+                            "qid": "q1",
+                            "query_type": "single_doc",
+                            "categories": ["multi_hop"],
+                            "gold_chunk_n": 2,
+                            "latency_ms": 100.0,
+                            "chunk_recall@5": score_offset,
+                            "chunk_recall@10": score_offset + 0.1,
+                            "mrr": score_offset,
+                            "ndcg@10": score_offset,
+                        },
+                        {
+                            "qid": "q2",
+                            "query_type": "single_doc",
+                            "categories": ["distractor_heavy"],
+                            "gold_chunk_n": 1,
+                            "latency_ms": 110.0,
+                            "chunk_recall@5": score_offset - 0.1,
+                            "chunk_recall@10": score_offset,
+                            "mrr": score_offset - 0.1,
+                            "ndcg@10": score_offset - 0.1,
+                        },
+                    ],
+                    "latency_ms": {"p50": 105.0, "p95": 110.0, "mean": 105.0, "n": 2},
+                }
+            (raw_dir / "raw_results.json").write_text(
+                json.dumps(measurements), encoding="utf-8"
+            )
+            specs_meta = [
+                {
+                    "name": "dense_m3",
+                    "retrieval_backend": "dense",
+                    "rrf_k": None,
+                    "index_dir": "data/index/real100_m3",
+                    "num_documents": 100,
+                    "num_chunks": 26000,
+                },
+                {
+                    "name": "hybrid_bm25_k60_m3",
+                    "retrieval_backend": "hybrid",
+                    "rrf_k": 60,
+                    "index_dir": "data/index/real100_m3",
+                    "num_documents": 100,
+                    "num_chunks": 26000,
+                },
+                {
+                    "name": "m3",
+                    "retrieval_backend": "m3",
+                    "rrf_k": None,
+                    "index_dir": "data/index/real100_m3",
+                    "num_documents": 100,
+                    "num_chunks": 26000,
+                },
+            ]
+            (raw_dir / "mode_specs.json").write_text(
+                json.dumps(specs_meta), encoding="utf-8"
+            )
+            # Minimal eval_config — qids must match so reaggregate can
+            # look them up to re-derive categories.
+            eval_cfg = {
+                "cases": [
+                    {"id": "q1", "hardcase_categories": ["multi_hop"]},
+                    {"id": "q2", "hardcase_categories": ["distractor_heavy"]},
+                ]
+            }
+            cfg_path = tmp_path / "eval.yaml"
+            cfg_path.write_text(json.dumps(eval_cfg), encoding="utf-8")
+
+            rc = main([
+                "--reaggregate", str(raw_dir / "raw_results.json"),
+                "--eval_config", str(cfg_path),
+                "--output_dir", str(out_dir),
+                "--seeds", "17",
+                "--ks", "5,10",
+            ])
+            self.assertEqual(rc, 0)
+
+            report = (out_dir / "REPORT.md").read_text(encoding="utf-8")
+            # Section coverage — all 4 metrics must appear with their
+            # paired CI delta tables vs the dense_m3 baseline.
+            for metric in ["chunk_recall@5", "chunk_recall@10", "mrr", "ndcg@10"]:
+                self.assertIn(f"## {metric}", report)
+                self.assertIn(
+                    f"### {metric} — paired CI delta vs `dense_m3`", report
+                )
+            # Variant header + per-category winner + Notes section.
+            self.assertIn("## Variants", report)
+            self.assertIn("## Per-category winner", report)
+            self.assertIn("## Notes", report)
+            # 3-variant grid must be in the variants table (m3 is the
+            # one that distinguishes Phase 3.5 from Phase 3).
+            self.assertIn("`dense_m3`", report)
+            self.assertIn("`hybrid_bm25_k60_m3`", report)
+            self.assertIn("`m3`", report)
+            # Phase 3 cross-ref + ADR 0010/0021/0032 must appear in Notes
+            # (per absolute rule #5: honest cross-reference of the prior
+            # measurement so reviewers can trace the embedding-family swap).
+            self.assertIn("Phase 3 cross-ref", report)
+            self.assertIn("ADR 0010", report)
+            # Line budget: REPORT.md must stay <=200 lines per skill spec.
+            self.assertLessEqual(report.count("\n"), 200)
+            # Sidecar artifacts written.
+            self.assertTrue((out_dir / "deltas.json").exists())
+            self.assertTrue((out_dir / "mode_specs.json").exists())
+            self.assertTrue((out_dir / "raw_results.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Phase 3.5 retrieval-eval — m3 (BGE-M3 semantic) mode ablation on real100 (n=221, 3 variants × paired CI). Phase 3 PR #956 측정이 hashing embeddings 위에서 hybrid SIG-negative 였으나 \"BM25 channel dominance\" 결론은 잘못이었음 (runner bug, retraction 아래 §3). Phase 3.5 는 (a) 그 bug 수정 후 의미 임베딩 위에서 hybrid vs dense 재측정 + (b) ADR 0010 deferred BGE-M3 multi-channel ablation 동시 답.

3-variant on single BGE-M3 semantic index:
- \`dense_m3\` (baseline)
- \`hybrid_bm25_k60_m3\` — Phase 3 question on semantic embeddings
- \`m3\` — ADR 0010 deferred 3-way RRF (BGE-M3 dense + sparse + colbert)

Closes #957

## 2. 영향 파일

- \`scripts/phase35_m3_ablation.py\` (신규 standalone runner, ~530 LOC) — \`scripts/_ablation_common\` (PR #954) + \`apply_fusion_and_reranking\` 재사용. **scripts/ 는 LOAD_BEARING_PATHS 아님**.
- \`tests/test_phase35_m3_ablation.py\` (신규 smoke, 2 tests, FlagEmbedding-free default CI)
- \`rag_m3.py\` — 1줄 opt-in \`BIDMATE_M3_USE_FP16\` env var (default fp32 preserves byte-identical reproducibility; ADR 0001 invariant 유지). 비-load-bearing leaf module (rag_core 로의 back-edge 0, ADR 0045 검증).
- \`.gitignore\` — phase35_m3_* aggregate allowlist (REPORT.md / mode_specs.json / deltas.json / raw_results.json) + \`data/index/real100_m3/\` 무시
- \`reports/retrieval/phase35_m3_20260518T090328Z/\` — aggregate artifacts (REPORT.md 144줄, mode_specs.json, deltas.json, raw_results.json 235KB)

## 3. 리스크

가장 가능성 높은 깨짐 경로 + 대응:

1. **Phase 3 PR #956 runner bug 의 재현**: \`retrieve_candidates\` (candidate generation only) 만 호출하고 \`apply_fusion_and_reranking\` (RRF fusion + final top-k) 미호출 시 hybrid + m3 backends 가 score=0.0 placeholders 만 반환 → chunk_id insertion order 로 collapse. **검증**: Phase 3.5 runner 의 \`run_single_case\` 가 두 단계 모두 명시 호출 (라인 136-137); MD5 sanity check 결과 3 variants 의 per-case \`chunk_recall@10\` MD5 모두 다름 (\`2fc1bcb609081881\` / \`cb00e662f12442ad\` / \`01c82132ddfd4f48\`).
2. **m3 colbert per-chunk Python-loop matmul OOM/timeout**: 898 chunks × 175k 토큰 × per-chunk matmul = 50+ sec/query observed on PID 25363 unoptimized path → 221 cases × 50s = 3+시간. **대응**: runner-side \`_prime_m3_index_cache_and_colbert\` 가 한 번의 \`(Σ T_d, 1024)\` matmul + O(1) per-chunk lookup. 수학적으로 per-chunk colbert_score 와 identical (각 chunk 의 column slice 독립). ~100x faster.
3. **csv_text fallback chunk count (898) vs kordoc full (26376)**: 절대 \`chunk_recall@k\` Phase 3 결과와 직접 비교 불가. **대응**: REPORT.md Notes 의 \"Chunk count caveat\" 명시; within-Phase-3.5 paired CI 만 valid.
4. **rag_m3 fp16 env var 의 부작용**: 기존 m3 결과 byte-identical 보존되어야 함. **검증**: env var 기본 unset → \`use_fp16=False\` (기존 동작 그대로); opt-in 시만 fp16. \`tests/test_m3_backend_regression.py\` 가 m3 retrieval path 자체를 cover (opt-in E2E).

## 4. 테스트

- \`tests/test_phase35_m3_ablation.py\` — 2 신규 smoke tests:
  - \`test_variant_spec_resolution_3_variants\` — variant 그리드 핀 (\`[dense_m3, hybrid_bm25_k60_m3, m3]\` × backends \`[dense, hybrid, m3]\` × rrf_ks \`[None, 60, None]\`, 3 variants 모두 동일 index_dir)
  - \`test_main_dry_run_with_reaggregate_minimal\` — synth 2-case × 3-variant raw_results + mode_specs → \`main([\"--reaggregate\", ...])\` → REPORT.md ≤200줄 + 4 metric section + paired CI delta 표 (\`hybrid_bm25_k60_m3 vs dense_m3\`, \`m3 vs dense_m3\`) + Phase 3 cross-ref + ADR 0010
- 두 테스트 모두 default CI 통과 (FlagEmbedding import 0, 인덱스 로드 0)
- \`tests/test_m3_backend_regression.py\` 의 opt-in E2E 가 m3 retrieval path 를 이미 cover — 중복 금지 (ADR/CLAUDE.md 원칙 #3 절제)
- 본 측정 결과는 PR-tracked: \`reports/retrieval/phase35_m3_20260518T090328Z/raw_results.json\` (n=221, 3 variants, ADR 0005 boundary 보존 — qid + categories + metric values only, doc/chunk text 0)

## 5. Eval 영향

eval CI 영향 없음 — \`scripts/phase35_m3_ablation.py\` 는 standalone runner (\`make smoke\` / \`make eval\` pipeline 외부). 기존 \`naive_baseline\` preset 미변경 (ADR 0001 invariant).

### 5b. Real-data delta

**No behavior change in retrieval / verifier path.**

본 PR 의 load-bearing 변경 (`rag_m3.py`, `ingestion.py`, `rag_embedding.py`) 은 모두 opt-in env-var gated 또는 add-only path:

- **`rag_m3.py`**: `BIDMATE_M3_USE_FP16` env var read. 기본 unset 시 `use_fp16=False` (기존 동작 byte-identical). `tests/test_m3_backend_regression.py` opt-in E2E 통과.
- **`ingestion.py`** (Phase 3.5 closeout, c201f7d): `BIDMATE_KORDOC_CACHE_DIR` env var bypass. 기본 unset 시 기존 npx subprocess fallback 그대로. 신규 `KordocCacheDirBypassTest` 3 tests + 기존 17 kordoc regression tests 모두 green (20/20).
- **`rag_embedding.py`** (Phase 3.5 closeout, c8ef40b): `BIDMATE_TORCH_DEVICE` + `BIDMATE_ST_BATCH_SIZE` env vars. 두 env 모두 unset 시 sentence-transformers' own defaults (auto-detect device + batch_size=32) — 기존 동작 byte-identical. 측정 결과 (각 chunk encoded independently, deterministic across batch boundaries) 동일.

비-load-bearing 변경:
- **`scripts/phase35_m3_ablation.py` 신규**: `scripts/` 는 LOAD_BEARING_PATHS 아님 (단일 출처: `scripts/_governance.py`). 기존 eval pipeline 미변경.
- **`reports/` 아래 신규**: aggregate-only commit boundary (ADR 0005); per-case scores 는 qid + categories + 4 metrics + latency_ms 만, doc/chunk IDs 또는 text 0.

`make real-eval-delta` 미실행 — `naive_baseline` (ADR 0001) 도 `agentic_full` (ADR 0003 답변 계약) 도 영향 받지 않음. Phase 3.5 측정 자체가 real-data delta 의 evidence (n=221 paired CI).

## 6. 하위 호환

- \`rag_m3\` API 미변경 (signature 동일, 기본 동작 byte-identical)
- \`scripts/_ablation_common\` import 그대로 (PR #954)
- ADR 0003 답변 계약, ADR 0010 / 0021 / 0025 / 0032 cross-refs 보존
- \`schema_version\` 변경 없음 (Phase 3.5 는 retrieval-eval, not answer-eval)

## 7. 범위 외

- per-channel m3 ablation (sparse-only, colbert-only — see ADR 0010 'Alternatives considered')
- RRF-k sweep on hybrid_bm25 (Phase 3 의 hashing 측정과 동일 — 의미 인덱스에서도 k sweep 은 후속 phase)
- cross-encoder rerank stacked on top (Phase 4)
- kordoc full extraction 재인덱싱 (>2h on MPS; csv_text fallback 으로 짧은 wall-time 우선; absolute recall 비교 불가 caveat 명시)
- Phase 3 hashing-index re-run (Phase 3 PR #956 의 runner bug 수정 후 byte-identical 또는 차이 발생 검증) — follow-up issue 권장
- ADR 0054 mode-winner decision — 본 PR 의 측정 결과 (recall@10 NULL WINNER, MRR multi_hop SIG hybrid+m3) 를 reviewer 검토 후 별도 ADR 작성 (ADR 0054 는 이미 다른 scope 으로 사용됨; #959 conditional-on-answer scorer)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
