### PR TITLE
feat(eval): trace schema v2 — synthesis LLM full I/O env-gated (issue #967, Step 2/5 of sequence A)

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -1071,6 +1071,7 @@ def _phase_build_answer(ctx: _RunContext) -> dict[str, Any]:
         stage_attempts,
         answer,
         stage_latencies_ms=stage_latency,
+        synthesis_meta=synthesis_meta,  # issue #967 — trace v2 synthesis_llm_call
     )
     diagnostics: dict[str, Any] = {
         "latency_ms": round(latency_ms, 2),

--- a/rag_synthesis.py
+++ b/rag_synthesis.py
@@ -43,6 +43,17 @@ ENV_API_KEY = "BIDMATE_SYNTHESIS_API_KEY"
 ENV_ANTHROPIC_KEY = "ANTHROPIC_API_KEY"
 ENV_BASE_URL = "BIDMATE_SYNTHESIS_BASE_URL"
 ENV_MAX_TOKENS = "BIDMATE_SYNTHESIS_MAX_TOKENS"
+# Trace v2 surface (issue #967) — when set to "1", backends capture full
+# ``user_prompt_text`` + ``completion_text`` on the returned dict, and
+# ``rag_tracing.build_result_trace`` surfaces them as ``synthesis_llm_call``.
+# Default off so ADR 0001 run-to-run determinism + ADR 0005 commit boundary
+# are unchanged; only env=on traces add the new fields.
+ENV_TRACE_FULL = "BIDMATE_TRACE_FULL"
+
+
+def _trace_full_enabled() -> bool:
+    return os.environ.get(ENV_TRACE_FULL) == "1"
+
 
 DEFAULT_BACKEND = "stub"
 DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
@@ -236,6 +247,12 @@ def synthesize_answer(
     meta["tokens_out"] = payload.get("tokens_out")
     meta["cache_read_tokens"] = payload.get("cache_read_tokens")
     meta["cache_write_tokens"] = payload.get("cache_write_tokens")
+    # Trace v2 (issue #967) — env-gated full I/O surface for synthesis.
+    # ``meta["user_prompt_text"]`` / ``["completion_text"]`` are absent when
+    # env=off (existing consumers see no schema change).
+    if _trace_full_enabled() and "user_prompt_text" in payload:
+        meta["user_prompt_text"] = payload.get("user_prompt_text")
+        meta["completion_text"] = payload.get("completion_text")
     meta["cost_estimate_usd"] = compute_cost_usd(
         model=meta["model"],
         tokens_in=meta["tokens_in"],
@@ -411,7 +428,7 @@ def _anthropic_backend(  # pragma: no cover - network
 
     payload = _extract_tool_payload(response)
     usage = getattr(response, "usage", None)
-    return {
+    result: dict[str, Any] = {
         "summary": payload.get("summary", ""),
         "used_chunk_ids": payload.get("used_chunk_ids", []),
         "model": model,
@@ -420,6 +437,15 @@ def _anthropic_backend(  # pragma: no cover - network
         "cache_read_tokens": getattr(usage, "cache_read_input_tokens", None) if usage else None,
         "cache_write_tokens": getattr(usage, "cache_creation_input_tokens", None) if usage else None,
     }
+    if _trace_full_enabled():
+        # Trace v2 (issue #967): capture full prompt + tool-call payload JSON
+        # so rationality_judge (Step 3) can score planner/answer reasoning.
+        # ``completion_text`` is the JSON payload of the tool_use block (the
+        # actual structured answer); the raw response.content list is not
+        # serialisable as-is so we render the extracted payload.
+        result["user_prompt_text"] = user_prompt
+        result["completion_text"] = json.dumps(payload, ensure_ascii=False)
+    return result
 
 
 def _openai_compatible_backend(  # pragma: no cover - network
@@ -465,13 +491,18 @@ def _openai_compatible_backend(  # pragma: no cover - network
     content = response.choices[0].message.content or "{}"
     parsed = json.loads(content)
     usage = getattr(response, "usage", None)
-    return {
+    result: dict[str, Any] = {
         "summary": str(parsed.get("summary") or ""),
         "used_chunk_ids": list(parsed.get("used_chunk_ids") or []),
         "model": model,
         "tokens_in": getattr(usage, "prompt_tokens", None) if usage else None,
         "tokens_out": getattr(usage, "completion_tokens", None) if usage else None,
     }
+    if _trace_full_enabled():
+        # Trace v2 (issue #967): capture full prompt + JSON completion text.
+        result["user_prompt_text"] = user_prompt
+        result["completion_text"] = content
+    return result
 
 
 def _extract_tool_payload(response: Any) -> dict[str, Any]:

--- a/rag_tracing.py
+++ b/rag_tracing.py
@@ -50,7 +50,7 @@ from typing import Any
 from rag_metadata_processing import normalize_page_span, normalize_regions
 
 
-TRACE_SCHEMA_VERSION = 1
+TRACE_SCHEMA_VERSION = 2  # bumped 1→2 in issue #967 (synthesis full I/O env-gated)
 
 REDACTED_LIST_PLACEHOLDER = "<redacted>"
 
@@ -267,7 +267,18 @@ def build_result_trace(
     answer: dict[str, Any],
     *,
     stage_latencies_ms: dict[str, float] | None = None,
+    synthesis_meta: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    """Build the per-prediction trace dict.
+
+    The ``synthesis_meta`` kwarg (issue #967, trace schema v2) is the meta
+    dict returned by ``rag_synthesis.synthesize_summary``. When the
+    ``BIDMATE_TRACE_FULL=1`` env was set during the synthesis call,
+    ``synthesis_meta["user_prompt_text"]`` and ``["completion_text"]`` are
+    present and surface here as ``synthesis_llm_call``. Default (env=off)
+    keeps ``synthesis_llm_call=None`` so consumers can detect the trace
+    flavour without inspecting env state.
+    """
     return {
         "schema_version": TRACE_SCHEMA_VERSION,
         "query_rewrite": build_query_rewrite_trace(
@@ -290,6 +301,35 @@ def build_result_trace(
             "query_type": answer.get("query_type"),
             "claim_count": len(answer.get("claims") or []),
         },
+        "synthesis_llm_call": _synthesis_llm_call_payload(synthesis_meta),
+    }
+
+
+def _synthesis_llm_call_payload(meta: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return the trace v2 synthesis_llm_call payload, or None when full I/O
+    is not present in ``meta`` (env=off or synthesis fell back).
+
+    Schema (when populated):
+        {
+          "backend": str,
+          "model": str | None,
+          "tokens_in": int | None,
+          "tokens_out": int | None,
+          "user_prompt_text": str,
+          "completion_text": str,
+        }
+    """
+    if not isinstance(meta, dict):
+        return None
+    if "user_prompt_text" not in meta or "completion_text" not in meta:
+        return None
+    return {
+        "backend": meta.get("backend"),
+        "model": meta.get("model"),
+        "tokens_in": meta.get("tokens_in"),
+        "tokens_out": meta.get("tokens_out"),
+        "user_prompt_text": meta.get("user_prompt_text"),
+        "completion_text": meta.get("completion_text"),
     }
 
 

--- a/tests/test_fuzzy_retrieval.py
+++ b/tests/test_fuzzy_retrieval.py
@@ -576,7 +576,7 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
         self.assertEqual(6, follow_up["plan"]["top_k"])
         self.assertEqual("follow_up_default", follow_up["plan"]["retrieval_budget"]["reason"])
         self.assertEqual(6, follow_up["diagnostics"]["selected_top_k"])
-        self.assertEqual(1, follow_up["trace"]["schema_version"])
+        self.assertEqual(2, follow_up["trace"]["schema_version"])  # bumped 1→2 in #967
         self.assertTrue(follow_up["trace"]["query_rewrite"]["rewritten"])
         self.assertEqual(
             "conversation_state_prefix",
@@ -592,7 +592,7 @@ class FuzzyMetadataRetrievalTest(unittest.TestCase):
         )
 
         trace = result["trace"]
-        self.assertEqual(1, trace["schema_version"])
+        self.assertEqual(2, trace["schema_version"])  # bumped 1→2 in #967
         self.assertFalse(trace["query_rewrite"]["rewritten"])
         self.assertEqual("single_doc", trace["planner"]["query_type"])
         self.assertEqual("agentic_full", trace["planner"]["pipeline"])

--- a/tests/test_trace_schema_v2.py
+++ b/tests/test_trace_schema_v2.py
@@ -1,0 +1,145 @@
+"""Tests for trace schema v2 (issue #967, ADR 0001 invariant preserved).
+
+Covers:
+- ``TRACE_SCHEMA_VERSION = 2`` baked into ``build_result_trace`` output
+- ``synthesis_llm_call = None`` when ``synthesis_meta`` is absent or env=off
+- ``synthesis_llm_call`` populated when ``synthesis_meta`` carries
+  ``user_prompt_text`` + ``completion_text`` (env=on simulated by passing them)
+- Two calls with identical inputs produce byte-identical traces (ADR 0001
+  run-to-run determinism — schema bump is deterministic per-config, not
+  per-config-version)
+
+These tests do NOT exercise the real anthropic/openai backends — they
+operate on ``build_result_trace`` directly with synthetic inputs, which is
+the surgical scope of issue #967 (the LLM call sites only *populate* the
+synthesis_meta dict; ``build_result_trace`` is the consumer).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_tracing import TRACE_SCHEMA_VERSION, build_result_trace  # noqa: E402
+
+
+def _minimal_trace_args(answer_status: str = "ok") -> dict:
+    """Build the minimum positional kwargs for build_result_trace."""
+    return dict(
+        original_query="기관 A 의 사업기간은?",
+        resolved_query="기관 A 의 사업기간은?",
+        analysis={"query_type": "single_doc"},
+        plan={"top_k": 4, "pipeline": "agentic_full"},
+        metadata_resolution={"active_doc_ids": ["doc_1"]},
+        context_resolution={"rewritten": False},
+        stage_sequence=["base"],
+        stage_attempts=[
+            {"stage": "base", "verification_reasons": [], "metadata_filters": {}}
+        ],
+        answer={
+            "schema_version": 2,
+            "status": answer_status,
+            "status_reason": {},
+            "query_type": "single_doc",
+            "claims": [{"text": "사업기간은 12개월", "citations": [{"chunk_id": "c1"}]}],
+        },
+    )
+
+
+class TestSchemaVersionBumped(unittest.TestCase):
+    def test_schema_version_constant_is_2(self):
+        self.assertEqual(TRACE_SCHEMA_VERSION, 2)
+
+    def test_trace_carries_schema_version_2(self):
+        trace = build_result_trace(**_minimal_trace_args())
+        self.assertEqual(trace["schema_version"], 2)
+
+
+class TestSynthesisLlmCallEnvOff(unittest.TestCase):
+    def test_no_synthesis_meta_yields_null_llm_call(self):
+        trace = build_result_trace(**_minimal_trace_args())
+        self.assertIn("synthesis_llm_call", trace)
+        self.assertIsNone(trace["synthesis_llm_call"])
+
+    def test_synthesis_meta_without_prompt_text_yields_null(self):
+        # Simulates env=off: synthesis ran, captured tokens, but did NOT
+        # capture full prompt/completion. Trace v2 surfaces None — the
+        # presence of tokens alone does not promote the case to "llm_call
+        # captured".
+        meta_without_full_io = {
+            "backend": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "tokens_in": 1200,
+            "tokens_out": 350,
+        }
+        trace = build_result_trace(
+            **_minimal_trace_args(),
+            synthesis_meta=meta_without_full_io,
+        )
+        self.assertIsNone(trace["synthesis_llm_call"])
+
+    def test_non_dict_synthesis_meta_is_safe(self):
+        trace = build_result_trace(
+            **_minimal_trace_args(),
+            synthesis_meta="not-a-dict",  # type: ignore[arg-type]
+        )
+        self.assertIsNone(trace["synthesis_llm_call"])
+
+
+class TestSynthesisLlmCallEnvOn(unittest.TestCase):
+    def test_synthesis_meta_with_prompt_text_yields_payload(self):
+        # Simulates env=on: synthesis backend captured prompt + completion
+        # in the returned dict, top-level synthesize_summary copied them to
+        # meta. build_result_trace surfaces them as synthesis_llm_call.
+        meta_with_full_io = {
+            "backend": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "tokens_in": 1200,
+            "tokens_out": 350,
+            "user_prompt_text": "Query: 기관 A 사업기간\n\nEvidence: ...",
+            "completion_text": '{"summary": "12개월", "used_chunk_ids": ["c1"]}',
+        }
+        trace = build_result_trace(
+            **_minimal_trace_args(),
+            synthesis_meta=meta_with_full_io,
+        )
+        llm_call = trace["synthesis_llm_call"]
+        self.assertIsNotNone(llm_call)
+        self.assertEqual(llm_call["backend"], "anthropic")
+        self.assertEqual(llm_call["model"], "claude-sonnet-4-6")
+        self.assertEqual(llm_call["tokens_in"], 1200)
+        self.assertEqual(llm_call["tokens_out"], 350)
+        self.assertEqual(llm_call["user_prompt_text"], "Query: 기관 A 사업기간\n\nEvidence: ...")
+        self.assertEqual(llm_call["completion_text"], '{"summary": "12개월", "used_chunk_ids": ["c1"]}')
+
+
+class TestRunToRunDeterminism(unittest.TestCase):
+    """ADR 0001 invariant — two runs of build_result_trace with identical
+    inputs produce byte-identical JSON output. Schema bump 1→2 does NOT
+    break this; it only shifts the absolute value of schema_version."""
+
+    def test_byte_identical_traces(self):
+        args = _minimal_trace_args()
+        meta = {
+            "backend": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "tokens_in": 1200,
+            "tokens_out": 350,
+            "user_prompt_text": "same prompt",
+            "completion_text": "same completion",
+        }
+        t1 = build_result_trace(**args, synthesis_meta=meta)
+        t2 = build_result_trace(**args, synthesis_meta=meta)
+        self.assertEqual(
+            json.dumps(t1, sort_keys=True, ensure_ascii=False),
+            json.dumps(t2, sort_keys=True, ensure_ascii=False),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `TRACE_SCHEMA_VERSION` 1 → 2 (`rag_tracing.py:53`). `build_result_trace` 가 신규 `synthesis_meta` kwarg + `synthesis_llm_call` key 도입.
- `rag_synthesis.py`: `ENV_TRACE_FULL=BIDMATE_TRACE_FULL` constant + 2 backend (anthropic + openai) env-gated `user_prompt_text`/`completion_text` 추가 + meta plumb.
- `rag_core.py`: `synthesis_meta=synthesis_meta` 를 `build_result_trace` 호출에 추가 (line 1063).
- `tests/test_trace_schema_v2.py` 신규 7 cases + `tests/test_fuzzy_retrieval.py` 2 곳 assertion bump.

## Why
시퀀스 A Step 2 (3c trace v2). Phase 3 audit (#961) item 2 supply — `prediction["trace"]` 가 default 로 planner/query_rewrite/answer_schema 만 dump. **synthesis (answer LLM) full I/O 캡처** 가 Step 3 (`rationality_judge`) prerequisite.

## Scope 정정 (Pre-flight audit)
- **synthesis** (answer LLM): scope **IN** — 2 sites (`rag_synthesis.py:419`, `:475`)
- **planner**: scope **DEFER** → 별 PR (Step 2b, `rag_planner.py:204` ReactPlanner)
- **verifier**: **N/A** — `rag_verifier.py` grep `client|llm|messages|chat|invoke|generate` = 0 (rule-based)
- **query_expansion / metadata_extraction**: scope **DEFER** (rationality judge critical path 아님)

## ADR
**미발행** — env-gated default off (`BIDMATE_TRACE_FULL=1` 일 때만 prompt/completion 추가). `BIDMATE_TRACE_VERBOSE` 와 동일 패턴. ADR 0001 run-to-run 결정성 유지 (`tests/test_trace_schema_v2.py:TestRunToRunDeterminism` 가드).

## Test plan
- [x] `pytest tests/test_trace_schema_v2.py tests/test_fuzzy_retrieval.py` — 39 pass
- [x] `EMBEDDING_BACKEND=hashing pytest -x` 전체 smoke — exit 0
- [ ] CI: Pytest / Baseline provenance / Branch+issue / Eval delta

### 5b. Real-data delta
**No behavior change in retrieval / verifier / eval / api / ingestion path** when `BIDMATE_TRACE_FULL` is unset (default). `synthesis_llm_call` 키는 trace dict 에 추가됐지만 default off 시 항상 `None` 값 — 기존 consumer 가 그 키를 inspect 안 하면 무영향. `make real-eval-delta` 는 0-shift in this PR (env=off).

`tests/test_trace_schema_v2.py` 가 schema_version bump 의 deterministic 성질 (run-to-run identical) 을 가드.

Closes #967