### PR TITLE
chore(deps): rename fitz → pymupdf to use canonical module name

### DIFF
--- a/scripts/run_donut_spike.py
+++ b/scripts/run_donut_spike.py
@@ -61,10 +61,10 @@ class PipelineResult:
 def generate_complex_layout_pdf(path: Path) -> GroundTruth:
     """Generate a 1-page PDF with title / metadata / fields / table / paragraph.
 
-    Uses ASCII-only content so fitz base14 fonts render correctly without
+    Uses ASCII-only content so pymupdf base14 fonts render correctly without
     requiring a system Korean font. Real Korean RFPs can be passed via --input.
     """
-    import fitz  # type: ignore
+    import pymupdf  # type: ignore
 
     headings = ["1. Overview", "2. Requirements", "3. Evaluation"]
     fields_dict = {
@@ -84,7 +84,7 @@ def generate_complex_layout_pdf(path: Path) -> GroundTruth:
         "on a single complex-layout RFP page. See docs/vision/vision-spike.md for context."
     )
 
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page(width=595, height=842)
     y = 56
     page.insert_text((56, y), "RFP Visual Parsing Spike", fontsize=16)
@@ -164,7 +164,7 @@ def run_baseline(pdf_path: Path) -> PipelineResult:
 
 def run_donut(pdf_path: Path) -> PipelineResult:
     try:
-        import fitz  # type: ignore
+        import pymupdf  # type: ignore
         from PIL import Image  # type: ignore
     except Exception as exc:
         return PipelineResult(
@@ -193,10 +193,10 @@ def run_donut(pdf_path: Path) -> PipelineResult:
     page_texts: list[str] = []
     error: str | None = None
     try:
-        pdf_doc = fitz.open(str(pdf_path))
+        pdf_doc = pymupdf.open(str(pdf_path))
         with pdf_doc:
             for page in pdf_doc:
-                pixmap = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+                pixmap = page.get_pixmap(matrix=pymupdf.Matrix(2, 2), alpha=False)
                 image = Image.frombytes("RGB", (pixmap.width, pixmap.height), pixmap.samples)
                 page_texts.append(donut_ocr_provider(image))
     except Exception as exc:
@@ -233,7 +233,7 @@ def run_donut(pdf_path: Path) -> PipelineResult:
 
 def run_paddleocr(pdf_path: Path) -> PipelineResult:
     try:
-        import fitz  # type: ignore
+        import pymupdf  # type: ignore
         from PIL import Image  # type: ignore
     except Exception as exc:
         return PipelineResult(

--- a/tests/test_visual_donut_regression.py
+++ b/tests/test_visual_donut_regression.py
@@ -41,10 +41,10 @@ class GetOcrProviderFactoryTest(unittest.TestCase):
 
 
 class DonutStringOutputNormalizationTest(unittest.TestCase):
-    @unittest.skipIf(importlib.util.find_spec("fitz") is None, "pymupdf is not installed")
+    @unittest.skipIf(importlib.util.find_spec("pymupdf") is None, "pymupdf is not installed")
     def test_donut_string_output_wrapped_to_block_via_existing_pipeline(self) -> None:
         """Donut returns a single text blob per image; ensure it lands as a block."""
-        import fitz  # type: ignore
+        import pymupdf  # type: ignore
 
         donut_text = "Project: Donut Spike\nRequirement: Layout-aware extraction"
 
@@ -53,7 +53,7 @@ class DonutStringOutputNormalizationTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             pdf_path = Path(tmp_dir) / "donut_sample.pdf"
-            doc = fitz.open()
+            doc = pymupdf.open()
             page = doc.new_page()
             page.insert_text((72, 72), "")
             doc.save(pdf_path)

--- a/tests/test_visual_ingestion.py
+++ b/tests/test_visual_ingestion.py
@@ -30,13 +30,13 @@ FIELDNAMES = [
 
 
 class VisualIngestionTest(unittest.TestCase):
-    @unittest.skipIf(importlib.util.find_spec("fitz") is None, "pymupdf is not installed")
+    @unittest.skipIf(importlib.util.find_spec("pymupdf") is None, "pymupdf is not installed")
     def test_parses_synthetic_pdf_to_v2_artifact(self) -> None:
-        import fitz  # type: ignore
+        import pymupdf  # type: ignore
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             pdf_path = Path(tmp_dir) / "visual_sample.pdf"
-            doc = fitz.open()
+            doc = pymupdf.open()
             page = doc.new_page()
             page.insert_text((72, 72), "사업명: 시각 파싱 사업\n1. 보안 요구사항\n접근 통제를 포함합니다.")
             doc.save(pdf_path)

--- a/visual_ingestion.py
+++ b/visual_ingestion.py
@@ -330,13 +330,13 @@ def parse_pdf_artifact(
 ) -> dict[str, Any]:
     artifact = base_visual_artifact(source_path, doc_id, "pdf", title, agency, project, metadata)
     try:
-        import fitz  # type: ignore
+        import pymupdf  # type: ignore
     except Exception as exc:
         mark_failed(artifact, "pdf_parser_unavailable", {"dependency": "pymupdf", "error": str(exc)})
         return artifact
 
     try:
-        pdf_doc = fitz.open(str(source_path))
+        pdf_doc = pymupdf.open(str(source_path))
     except Exception as exc:
         mark_failed(artifact, "pdf_open_failed", {"error": str(exc)})
         return artifact
@@ -431,13 +431,13 @@ def ocr_pdf_page(
     ocr_provider: OcrProvider | None,
 ) -> tuple[list[dict[str, Any]], str | None]:
     try:
-        import fitz  # type: ignore
+        import pymupdf  # type: ignore
         from PIL import Image
     except Exception:
         return [], "ocr_unavailable"
 
     try:
-        pixmap = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+        pixmap = page.get_pixmap(matrix=pymupdf.Matrix(2, 2), alpha=False)
         image = Image.frombytes("RGB", (pixmap.width, pixmap.height), pixmap.samples)
         blocks = ocr_blocks_from_image(
             image,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #970

context7 audit Low #1. PyMuPDF 패키지의 canonical 모듈명은 `pymupdf` (PyPI README + Read the Docs). `fitz`는 backward-compatible alias로 여전히 동작하지만 non-idiomatic. 17 호출 사이트를 일괄 rename해 코드 가독성과 docs-alignment 회복.

## 2. 영향 파일

- `visual_ingestion.py` (load-bearing) — 4건 (import 2 + `fitz.open`/`fitz.Matrix` 2)
- `scripts/run_donut_spike.py` — 7건 (import 3 + open 2 + Matrix 1 + 주석 1)
- `tests/test_visual_ingestion.py` — 3건 (`find_spec` + import + `open`)
- `tests/test_visual_donut_regression.py` — 3건 (`find_spec` + import + `open`)

## 3. 리스크

깨질 경로: `pymupdf` 패키지 미설치 환경에서 `import pymupdf` 실패 → `pymupdf` 와 `fitz` 모두 같은 wheel이므로 영향 동일 (`requirements.txt` `pymupdf>=1.24,<2.0` 핀이 SoT). `find_spec("fitz")` → `find_spec("pymupdf")` 도 동일 wheel 검사라 같은 결과 반환.

확인: visual_ingestion + donut regression test 10개 통과.

## 4. 테스트

기존 visual test suite (`tests/test_visual_ingestion.py`, `tests/test_visual_donut_regression.py`)이 그대로 통과 — pure rename이라 새 테스트 불필요. 10 passed.

## 5. Eval 영향

CI eval delta 없음 (logic change 없음, 두 이름이 같은 wheel을 가리킴).

### 5b. Real-data delta

No behavior change in ingestion path. 검색/검증/답변 path 동작 변화 없음. `pymupdf` 와 `fitz`는 동일 wheel의 두 이름 — PDF 텍스트 추출 결과 byte-identical. Real-eval delta = 0 (자명, `make real-eval-delta` 미실행).

## 6. 하위 호환

`fitz` import는 계속 동작 (upstream alias 유지). 외부 코드가 우리 모듈을 `from visual_ingestion import fitz`처럼 잘못 import한 경우만 깨짐 — 그런 사용처는 존재하지 않음.

## 7. 범위 외

- `pymupdf.Matrix(2, 2)` → `dpi=144` 변환 (cosmetic 추가 개선) — 별도 follow-up
- context7 audit의 다른 7건 — 각각 별도 PR (A2~A8, plan: `~/.claude/plans/context7-fizzy-glade.md`)
