### PR TITLE
chore(rerank): use explicit cohere client.v2.rerank() call path

### DIFF
--- a/rag_rerank.py
+++ b/rag_rerank.py
@@ -176,7 +176,12 @@ def _cohere_backend(  # pragma: no cover - network
     model_id = model or os.environ.get(ENV_MODEL) or DEFAULT_COHERE_MODEL
     client = cohere.ClientV2(api_key=api_key)
     documents = [str(c.get("text") or "") for c in candidates]
-    response = client.rerank(model=model_id, query=query, documents=documents)
+    # Use the explicit `client.v2.rerank()` path recommended by the
+    # cohere-python 5.x reference docs. `ClientV2.rerank()` (the
+    # alias used historically) routes to the same v2 endpoint, but
+    # the explicit form is future-proof if `ClientV2` later exposes
+    # additional non-v2 methods.
+    response = client.v2.rerank(model=model_id, query=query, documents=documents)
     by_index = {item.index: float(item.relevance_score) for item in response.results}
     reordered = []
     for idx, candidate in enumerate(candidates):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #972

context7 audit Low #5 — cohere-python 5.x reference docs는 `client.v2.rerank(...)` 명시 호출 경로를 권장 (https://github.com/cohere-ai/cohere-python/blob/main/reference.md). 우리는 `ClientV2.rerank(...)` alias 호출 중 — 동일 endpoint로 라우팅되지만, ClientV2가 향후 non-v2 메서드 추가 시 모호성 위험. 명시 경로로 future-proof.

## 2. 영향 파일

- `rag_rerank.py` — 1줄 변경 (179행)

load-bearing path 아님. opt-in backend (BIDMATE_RERANK_BACKEND=cohere).

## 3. 리스크

깨질 경로: `cohere.ClientV2` 가 `.v2.rerank()` 노출 안 함 — cohere-python 5.x 공식 docs에서 명시. 우리 pin `cohere>=5.0` 이라 보장됨.

확인: tests/test_reranker_protocol.py 3개 통과.

## 4. 테스트

기존 reranker protocol 테스트 (network-free) 통과. cohere 실제 호출은 `pragma: no cover - network` 마크라 unit test 없음 (외부 API 의존). 패턴 변경만이라 새 unit test 불필요.

## 5. Eval 영향

CI eval delta 없음. cohere backend는 opt-in이며 default CI는 stub. 동일 HTTP request → 동일 response schema.

### 5b. Real-data delta

N/A — load-bearing path가 아니며 opt-in backend의 cosmetic 변경. real-eval delta 0 (cohere 호출 경로 자체가 default가 아님).

## 6. 하위 호환

cohere SDK 5.x에서 `ClientV2.rerank()` 와 `ClientV2.v2.rerank()` 둘 다 지원되므로 양 방향 호환. 외부 호출자가 우리 `_cohere_backend` 시그니처에 의존하지 않으므로 영향 없음.

## 7. 범위 외

- 다른 cohere 호출 경로 (chat, embed) — 우리는 rerank 만 사용
- 기타 context7 findings — 별도 PR (A3~A8, `~/.claude/plans/context7-fizzy-glade.md`)