### PR TITLE
chore(deps): unify openai SDK import style

### DIFF
--- a/rag_embedding.py
+++ b/rag_embedding.py
@@ -164,7 +164,7 @@ def embed_texts(
 
 def _embed_with_openai(texts: list[str], *, model_name: str) -> EmbeddingResult:
     try:
-        import openai  # type: ignore[import-not-found]
+        from openai import OpenAI  # type: ignore[import-not-found]
     except Exception as exc:
         raise RuntimeError(
             "openai backend requires the openai SDK. "
@@ -175,7 +175,7 @@ def _embed_with_openai(texts: list[str], *, model_name: str) -> EmbeddingResult:
         raise RuntimeError(
             "BIDMATE_OPENAI_API_KEY (or OPENAI_API_KEY) is not set for embedding_backend=openai."
         )
-    client = openai.OpenAI(api_key=api_key)
+    client = OpenAI(api_key=api_key)
     vectors: list[list[float]] = []
     batch_size = 100
     for start in range(0, len(texts), batch_size):

--- a/scripts/compare_external_baselines.py
+++ b/scripts/compare_external_baselines.py
@@ -362,7 +362,7 @@ def _llamaindex_backend_query(state: dict[str, Any], case: dict[str, Any]) -> di
 def _ollama_backend_init(corpus: list[dict[str, Any]]) -> dict[str, Any]:  # pragma: no cover - external SDK
     try:
         import numpy as np
-        import openai
+        from openai import OpenAI
         from sentence_transformers import SentenceTransformer
     except ImportError as exc:
         raise RuntimeError(
@@ -386,7 +386,7 @@ def _ollama_backend_init(corpus: list[dict[str, Any]]) -> dict[str, Any]:  # pra
         normalize_embeddings=True,
         show_progress_bar=True,
     )
-    client = openai.OpenAI(base_url=base_url, api_key="ollama")
+    client = OpenAI(base_url=base_url, api_key="ollama")
 
     return {
         "client": client,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #974

context7 audit Low #6. openai SDK 임포트 스타일이 두 가지로 혼재 (`import openai` + `openai.OpenAI(...)` vs `from openai import OpenAI` + `OpenAI(...)`). OpenAI Python SDK 1.x+ docs는 `from openai import OpenAI` 패턴을 client class 사용 시 권장. 변환 가능한 2 사이트만 통일.

## 2. 영향 파일

- `rag_embedding.py` — `_embed_with_openai` 함수 내 import + 호출 2줄 (opt-in `--embedding_backend openai` 경로)
- `scripts/compare_external_baselines.py` — `_ollama_backend_init` import + 호출 2줄 (외부 baseline 비교 스크립트, CI 미실행)

**제외**: `tests/test_llm_fault_injection.py` — `openai.RateLimitError`, `openai.InternalServerError`, `openai.APITimeoutError`, `openai.APIConnectionError`, `mock.patch("openai.OpenAI")` 다수 사용. 변환 시 깨짐.

## 3. 리스크

깨질 경로: `from openai import OpenAI` 가 동작하지 않는 SDK 버전 — `openai>=2.36.0` pin에서 모두 지원 (1.x+ 표준 패턴).

확인: tests/test_embedding_backends.py 8개 통과 (network-free path).

## 4. 테스트

기존 embedding 테스트 (8 passed). 새 테스트 불필요 — import 스타일 변경은 same-object 참조라 동작 동일.

## 5. Eval 영향

CI eval delta 없음. openai 임베딩 backend는 opt-in (`--embedding_backend openai`); CI default는 `hashing`.

### 5b. Real-data delta

N/A — 검색/검증/답변 path 동작 변화 없음. openai backend는 opt-in이며 default eval에서 호출되지 않음. real-eval delta = 0 (자명).

## 6. 하위 호환

`from openai import OpenAI` 와 `import openai; openai.OpenAI` 둘 다 같은 객체 — 외부 호출자 영향 없음.

## 7. 범위 외

- `tests/test_llm_fault_injection.py` — module attributes 의존이라 의도적으로 미변환 (commit message + this PR body에 명시)
- 다른 SDK import 스타일 통일 (cohere, langfuse 등) — 별도 cleanup
- 다른 context7 findings — `~/.claude/plans/context7-fizzy-glade.md` (A4~A8)