### PR TITLE
chore(observability): use base_url= over host= for Langfuse constructor

### DIFF
--- a/rag_observability.py
+++ b/rag_observability.py
@@ -196,7 +196,10 @@ def _build_langfuse_backend() -> TraceBackend:
         client = Langfuse(
             public_key=public_key,
             secret_key=secret_key,
-            host=os.environ.get(ENV_LANGFUSE_HOST) or DEFAULT_LANGFUSE_HOST,
+            # Langfuse 4.x docs recommend `base_url=`; `host=` remains a
+            # backwards-compatible alias today but may be deprecated in
+            # a future major. Verified against langfuse 4.6.1 (issue #976).
+            base_url=os.environ.get(ENV_LANGFUSE_HOST) or DEFAULT_LANGFUSE_HOST,
         )
     except Exception as exc:
         return _make_unavailable(f"backend_init_error:langfuse:{type(exc).__name__}")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #976

context7 audit Medium #M (검증 후 Low로 격하). langfuse 4.6.1을 직접 설치 + signature inspect 결과 `host=`와 `base_url=` 둘 다 alias로 받음 → 즉시 깨짐 없음. 다만 4.x docs는 `base_url=` 권장이며 후속 minor에서 `host=` deprecated 가능성 있음. 1라인 cosmetic rename으로 future-proof.

## 2. 영향 파일

- `rag_observability.py` — Langfuse constructor `host=` → `base_url=` 1줄 + 검증 comment 4줄

load-bearing 아님 (opt-in observability backend, default disabled).

## 3. 리스크

깨질 경로: Langfuse가 `base_url=` 거부 — verification 단계에서 4.6.1이 받는 것 확인 (`base_url= kwarg ACCEPTED — no raise`). pin `>=4.6.1,<5.0` 범위 안에서 동일 동작.

확인: tests/test_observability_tracing.py 13개 통과.

## 4. 테스트

기존 observability tracing test 13개 통과 (Langfuse mock 경로 포함). 새 unit test 불필요 — 1라인 kwarg rename이며 alias 양쪽 모두 docs 보장.

## 5. Eval 영향

CI eval delta 없음. langfuse는 opt-in observability backend로 default CI는 `_NoneBackend` fallback. 호출 경로 자체가 default eval에 없음.

### 5b. Real-data delta

N/A — 검색/검증/답변 path 동작 변화 없음. opt-in observability backend의 cosmetic kwarg rename. real-eval delta = 0 (자명).

## 6. 하위 호환

`host=` ENV (`BIDMATE_LANGFUSE_HOST`) 변수명은 유지 — 사용자 env 설정 깨짐 없음. 내부 Python 호출만 변경. Langfuse 4.x 양 alias 모두 지원.

## 7. 범위 외

- env 변수명 `ENV_LANGFUSE_HOST` rename — 외부 영향 (대시보드 docs, 사용자 .env 파일)이라 별도 결정
- 기타 context7 findings — `~/.claude/plans/context7-fizzy-glade.md` (A5~A8)