### PR TITLE
ci(test): opt-in pytest-split --store-durations env-gated flag

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -53,7 +53,22 @@ if command -v pytest >/dev/null 2>&1; then
       echo "pytest-split not importable; ignoring BIDMATE_PYTEST_SPLITS/SHARD." >&2
     fi
   fi
-  pytest -q "${XDIST_FLAGS[@]}" "${COV_FLAGS[@]}" "${SPLIT_FLAGS[@]}"
+  # Issue #978 — opt-in `--store-durations` for refreshing the
+  # `.test_durations` baseline that pytest-split consults for balanced
+  # shard partitioning. Off by default (CI runs leave `.test_durations`
+  # untouched). To refresh locally: run the FULL suite (unset
+  # BIDMATE_PYTEST_SPLITS/SHARD so the resulting file isn't partial),
+  # then commit the updated `.test_durations`:
+  #   BIDMATE_PYTEST_STORE_DURATIONS=1 bash scripts/test.sh
+  STORE_DURATIONS_FLAGS=()
+  if [[ "${BIDMATE_PYTEST_STORE_DURATIONS:-}" == "1" ]]; then
+    if python -c "import pytest_split" >/dev/null 2>&1; then
+      STORE_DURATIONS_FLAGS=(--store-durations)
+    else
+      echo "pytest-split not importable; ignoring BIDMATE_PYTEST_STORE_DURATIONS." >&2
+    fi
+  fi
+  pytest -q "${XDIST_FLAGS[@]}" "${COV_FLAGS[@]}" "${SPLIT_FLAGS[@]}" "${STORE_DURATIONS_FLAGS[@]}"
 else
   echo "pytest not found. Install dev dependencies or add pytest to requirements." >&2
   exit 1


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #978

context7 audit Low #3 — pytest-split의 `.test_durations`가 부재한 상태에서 shard 분할이 sub-optimal (mass-equal vs time-equal). 즉시 영향은 작음 (실측 3-4분) — 단 test suite 증가 시 효과 커짐. env-gated `--store-durations` opt-in으로 contributor가 로컬에서 baseline을 갱신 + commit할 수 있는 foundation 추가. CI 동작은 그대로.

## 2. 영향 파일

- `scripts/test.sh` — 15줄 추가 (env check + flag 조건부 + 사용법 주석)

load-bearing 아님 (CI test entry point, 동작 변화 없음 default).

## 3. 리스크

깨질 경로: env unset (default) 일 때 동작 변화 없는지 — `STORE_DURATIONS_FLAGS=()` 빈 배열로 초기화, env=1 가 아닐 때 pytest 호출 라인이 이전과 byte-identical.

확인: bash -n 통과; diff 봐서 `pytest` 라인에 `${STORE_DURATIONS_FLAGS[@]}` (빈 배열 expand) 만 추가됨.

## 4. 테스트

- syntax: `bash -n scripts/test.sh` OK
- 기존 동작: env unset일 때 pytest 호출 라인이 변화 없음 (빈 배열 expand)
- 신규 동작 (`BIDMATE_PYTEST_STORE_DURATIONS=1`): pytest 호출 라인에 `--store-durations` 추가됨

CI에서 별도 unit test 불필요 — bash env-gate 패턴은 동일 파일의 기존 `SPLIT_FLAGS` / `XDIST_FLAGS` / `COV_FLAGS` 와 isomorphic.

## 5. Eval 영향

CI eval delta 없음. RAG 파이프라인 미접촉. CI default env (`BIDMATE_PYTEST_STORE_DURATIONS` unset) 에서 pytest 명령 byte-identical.

### 5b. Real-data delta

N/A — CI test entry point 변경. RAG 검색/검증/답변 path 미접촉. real-eval delta = 0 (자명).

## 6. 하위 호환

env 변수 unset이 default → 기존 워크플로 변화 없음. `BIDMATE_PYTEST_STORE_DURATIONS=1` 는 신규 추가 opt-in flag.

## 7. 범위 외

- GitHub Actions cache integration — 8-shard partial `.test_durations` merge 문제 별도 설계 (single full-run job vs post-shard merge step)
- nightly full-run workflow로 자동 갱신
- `.test_durations` 초기 baseline file 생성 — 별도 commit (full pytest 실행 결과)
- 기타 context7 findings — `~/.claude/plans/context7-fizzy-glade.md` (A6~A8)