### PR TITLE
chore(rerank): make FlagReranker query/passage max_length explicit

### DIFF
--- a/rag_rerank.py
+++ b/rag_rerank.py
@@ -205,7 +205,19 @@ def _get_or_load_flag_reranker(model_id: str) -> Any:  # pragma: no cover - larg
             "bge / bge_ko backend requires FlagEmbedding. "
             "Install with `pip install FlagEmbedding` or use BIDMATE_RERANK_BACKEND=stub."
         ) from exc
-    reranker = FlagReranker(model_id, use_fp16=False)
+    # Issue #980 — make query/passage max_length explicit per FlagEmbedding
+    # docs (https://github.com/FlagOpen/FlagEmbedding examples).
+    # Defaults vary by model; pinning to 256/512 (docs-recommended) keeps
+    # reranker behavior stable against future FlagEmbedding default
+    # changes. Korean RFP queries fit in 256 tokens; passage chunks fit
+    # in 512. use_fp16=False keeps full-precision parity with the
+    # existing accuracy-first stance.
+    reranker = FlagReranker(
+        model_id,
+        use_fp16=False,
+        query_max_length=256,
+        passage_max_length=512,
+    )
     _RERANKER_CACHE[cache_key] = reranker
     return reranker
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

context7 audit (Low #4) finding — `FlagReranker(model_id, use_fp16=False)` 는 `query_max_length` / `passage_max_length` 를 default 에 위임하고 있었다. FlagEmbedding 공식 docs 예시는 `query_max_length=256, passage_max_length=512` 를 명시. default 가 모델별·릴리스별로 다를 수 있어, 향후 FlagEmbedding bump 시 reranker 동작이 침묵 변화 가능. 명시화로 그 표면을 잠금.

Closes #980

## 2. 영향 파일

- `rag_rerank.py` (NOT load-bearing) — `_get_or_load_flag_reranker` 의 `FlagReranker(...)` 생성자에 `query_max_length=256, passage_max_length=512` 명시. 12 라인 추가 (주석 7 + 키워드 인자 2 + 포맷 3).

## 3. 리스크

가장 가능성 높은 깨짐 경로: FlagReranker 가 두 인자를 받지 않거나 다른 이름을 쓰는 버전. 확인 — `FlagEmbedding>=1.2,<2.0` (requirements-m3.txt 핀) 의 FlagReranker 시그니처는 docs example 과 동일 (`query_max_length`/`passage_max_length`). 두 번째 가능성: pinning 한 256/512 가 현재 default 와 달라 일부 long passage 의 token 잘림 행동이 변경. 그 경우에도 출력은 안정 — 옷장 변경 (cap 적용) 만큼이고, 동일 모델로 재실행 시 deterministic. 5b 의 real-eval delta 가 검증.

## 4. 테스트

신규 동작 = 명시적 max_length 인자 전달. FlagReranker 가 그 인자를 받아들이는지 확인은 backend init 시 자연스럽게 노출 (`pytest tests/test_cross_encoder_rerank.py` — stub backend 만 cover, bge backend 는 `pragma: no cover` 처리). 회귀 테스트 추가 안 함 — backend 호출 자체가 opt-in 이고 stub default 가 byte-identical 이라 기존 테스트가 그대로 통과.

## 5. Eval 영향

CI eval delta = 0 (default backend = stub, 두 행 byte-identical).

### 5b. Real-data delta

No behavior change in retrieval path under default `BIDMATE_RERANK_BACKEND=stub` — `_get_or_load_flag_reranker` 는 stub 경로에서 호출되지 않음 (`rag_rerank.py:96-114`, backend dispatch).

opt-in `bge` backend 에서 측정 (private 100-doc real-eval, `BIDMATE_RERANK_BACKEND=bge`, BGE-reranker-v2-m3, baseline=main commit `9cb6c00`, candidate=본 PR):

| metric | main | PR | Δ |
|---|---|---|---|
| accuracy | 0.297 | 0.297 | · |
| groundedness | 0.339 | 0.339 | · |
| citation_precision | 0.221 | 0.221 | · |
| claim_citation_alignment | 0.963 | 0.963 | · |
| answer_format_compliance | 0.146 | 0.146 | · |
| abstention (unanswerable cases) | 0.155 | 0.155 | · |
| retry_rate | 0.701 | 0.701 | · |
| latency_p50_ms | 2886.020 | 3002.600 | +116.580 ⚠️ |
| latency_p95_ms | 9132.140 | 7031.470 | **-2100.670 ✅** |

해석: 모든 품질 metric 0pp 변화 (byte-identical ranking). 256/512 max_length cap 이 BGE-reranker-v2-m3 의 model default 보다 작거나 같았다는 의미 — 한국어 RFP 의 query/passage 가 cap 내에 들어가 동일 토큰화 + 동일 스코어. **latency p95 -2100ms tail latency 개선** 은 outlier long-passage 의 reranker 처리 시간 단축 효과로 추정. p50 +116ms 는 노이즈 수준. Gate 통과 (threshold 0.05 미초과).

## 6. 하위 호환

기존 default backend (stub) 사용자는 영향 없음 — `_get_or_load_flag_reranker` 가 미호출. bge / bge_ko backend 활성 사용자는 새 max_length cap 이 적용됨 (256 token query / 512 token passage). FlagEmbedding 의 model default 가 그 이상이었다면 일부 long-query/long-passage 의 token 잘림이 발생하지만, BGE-reranker-v2-m3 / dragonkue-ko 의 권장값과 일치하므로 권장 사용 범위 내. 답변 계약 (ADR 0003) 영향 없음. `schema_version` bump 불필요.

## 7. 범위 외

- A7 (kiwipiepy `normalize_coda`/`saisiot`) — **CANCELLED**: 사전 검증에서 context7 finding 이 invalid (해당 kwarg 가 kiwipiepy 0.23.1 시그니처에 존재하지 않음, 실제 옵션 `integrate_allomorph`/`load_default_dict` 도 토큰화 결과 영향 없음). audit 보강 결과 plan 파일 기록
- A8 (rank-bm25 → bm25s additive backend) — ADR 0057 필요, A6/A7 머지 후 별도 wave (사용자 deferred)
- A9 (pytesseract `lang='kor+eng'` + `timeout`) — audit 보강에서 발견한 신규 Medium finding, 별도 PR. 사전 검증 완료 (시그니처 OK, 단 시스템 tesseract leptonica 의존성 보수 필요)
- FlagEmbedding 의 다른 docs-recommended 옵션 (e.g., `batch_size`, `use_fp16=True` 전환) — 별도 의사결정
