### PR TITLE
fix(eval): Phase 3 mode ablation — wire apply_fusion_and_reranking + hashing retraction (#983)

### DIFF
--- a/scripts/phase3_mode_ablation.py
+++ b/scripts/phase3_mode_ablation.py
@@ -63,7 +63,7 @@ from eval.scorers.chunk_metrics import (  # noqa: E402
     derive_gold_chunk_ids,
 )
 from rag_indexing import load_index  # noqa: E402
-from rag_retrieval import retrieve_candidates  # noqa: E402
+from rag_retrieval import apply_fusion_and_reranking, retrieve_candidates  # noqa: E402
 from rag_text_processing import tokenize  # noqa: E402
 from scripts._ablation_common import (  # noqa: E402
     _fmt_ci,
@@ -118,10 +118,22 @@ def run_single_case(
     analysis = _analysis_stub(query)
     plan = _plan_for_variant(spec, top_k)
     t0 = time.perf_counter()
-    retrieved = retrieve_candidates(index, query, analysis, plan)
+    # ``retrieve_candidates`` is the candidate-generation stage only; for
+    # the hybrid backend it returns ``score=0.0`` placeholders with the
+    # raw per-channel signals living in ``score_parts``. The RRF fusion +
+    # final top-k truncation live in ``apply_fusion_and_reranking`` —
+    # without this second call hybrid ranks degenerate to chunk_id
+    # alphabetic order (every score equal so Python's stable sort falls
+    # back to insertion order). The original PR #956 commit omitted the
+    # fusion call, which is why all 3 ``hybrid_bm25_k{30,60,100}``
+    # variants looked byte-identical in the first run — the chunk_id
+    # insertion order was the same for every k. Phase 3.5 PR #966 fixed
+    # the same omission in its runner; issue #983 backports the fix
+    # here.
+    candidates = retrieve_candidates(index, query, analysis, plan)
+    final = apply_fusion_and_reranking(candidates, index, query, analysis, plan)
     latency_ms = (time.perf_counter() - t0) * 1000.0
-    retrieved_sorted = sorted(retrieved, key=lambda c: c["score"], reverse=True)[:top_k]
-    return [str(c["chunk_id"]) for c in retrieved_sorted], latency_ms
+    return [str(c["chunk_id"]) for c in final[:top_k]], latency_ms
 
 
 def measure_variant(


### PR DESCRIPTION
# PR-H body (Phase 3 mode ablation runner — apply_fusion_and_reranking 누락 fix + hashing 재측정)

## 1. 무엇을 왜 바꿨는가

Phase 3 PR #956 의 `scripts/phase3_mode_ablation.py:121` 가 `retrieve_candidates` (candidate generation only) 만 호출하고 `apply_fusion_and_reranking` (RRF fusion + final top-k) 미호출 → hybrid backend 가 `score=0.0` placeholder 만 반환 → chunk_id insertion order 로 ranking collapse → 모든 hybrid_k variants byte-identical. Phase 3 PR #956 의 "BM25 channel dominance" 결론은 wrong (runner bug). Phase 3.5 PR #966 의 runner 가 같은 패턴 fix 함. 본 PR 은 (a) Phase 3 의 same fix 적용 + (b) hashing 인덱스에서 4 variants × 221 cases 재측정 + (c) REPORT.md 에 retraction note + 수정된 paired CI delta.

Closes #983

## 2. 영향 파일

- `scripts/phase3_mode_ablation.py` — line 121 1줄 fix + import 추가 (~5 LOC). **scripts/ 는 LOAD_BEARING_PATHS 아님**.
- `reports/retrieval/phase3_mode_<TS>_rerun/` — 신규 measurement 산출물 (REPORT.md, raw_results.json, deltas.json, mode_specs.json). 기존 `phase3_mode_20260518T032404Z/REPORT.md` 끝에 "## RETRACTION (2026-05-18)" 섹션 추가.

## 3. 리스크

- hashing 인덱스 측정 결과가 Phase 3.5 의 BGE-M3 인덱스 결과와 다를 가능성 — 그것이 evidence. cross-backend delta (hashing vs BGE-M3) 산출 금지 (confounded by embedding family swap).
- 기존 `phase3_mode_20260518T032404Z/` 디렉터리는 그대로 유지 (retraction note 만 append) — 이력 보존.

## 4. 테스트

`tests/test_phase3_mode_ablation.py` 의 2 smoke tests 통과 확인 (runner 의 _resolve_specs + reaggregate dry-run 미변경). 측정 결과의 MD5 sanity check (4 variants distinct per-case `chunk_recall@10`) — Phase 3 PR #956 의 byte-identical 결과가 retraction 되었음을 입증.

## 5. Eval 영향

eval CI 영향 없음 — standalone runner under scripts/. 기존 eval pipeline 미변경.

### 5b. Real-data delta

`N/A — scripts/ 는 LOAD_BEARING_PATHS 아님. 측정 산출물 (`reports/retrieval/phase3_mode_<TS>_rerun/`) 은 aggregate-only (qid + categories + metric values, ADR 0005 boundary).`

## 6. 하위 호환

- `scripts/phase3_mode_ablation.py` 의 CLI 인터페이스 미변경
- `tests/test_phase3_mode_ablation.py` 의 reaggregate dry-run 호환 (raw_results.json schema 미변경)

## 7. 범위 외

- ADR 0010 / 0056 의 결정 변경 (PR-H 는 evidence supply only, decision 은 ADR 0056 의 책임)
- Phase 3.5 의 m3 measurement 재측정 (이미 PR #966 의 closeout 으로 완료)
- BGE-M3 인덱스에서 Phase 3 와 같은 hybrid_k sweep (별도 phase)
