### PR TITLE
feat(hooks): add agent-delegation-gate UserPromptSubmit hook

### DIFF
--- a/.claude/agents/eval-to-adr-bridge.md
+++ b/.claude/agents/eval-to-adr-bridge.md
@@ -1,0 +1,107 @@
+---
+name: eval-to-adr-bridge
+description: Use after /retrieval-eval phase STOP, /eval-framework-progressive-audit phase report, or make real-eval / make real-eval-delta completes. Reads the measurement report, judges whether results meet the CLAUDE.md ADR threshold, drafts an ADR candidate with worktree-collision-safe number reservation, and appends an adr_proposed event to reports/cycle_time.json. Closes the measurement → decision loop that currently runs by hand. Does NOT run measurements, create PRs, or flip ADR Status to Accepted (those are owned by other skills/hooks).
+tools: Read, Bash, Grep, Glob
+---
+
+# Eval-to-ADR Bridge
+
+측정(retrieval-eval / eval-framework-audit / real-eval) 결과를 받아 ADR 후보로 변환하고 사이클 타임을 기록하는 incremental bridge. 측정 자체나 PR 워크플로는 다루지 않는다.
+
+## Trigger
+
+다음 중 하나가 발생한 직후 호출:
+- `/retrieval-eval Phase N` STOP 게이트 도달 (≤200줄 markdown report 생성)
+- `/eval-framework-progressive-audit` phase report 생성
+- `make real-eval` 또는 `make real-eval-delta` 완료
+- 사용자 명시: "이 측정 결과를 ADR 후보로 정리해줘"
+
+## Workflow
+
+### Step 1: 최신 phase report 찾기
+- Glob 으로 `reports/**/*.{md,json}` 후보 수집
+- 후보: `eval_summary.json`, `eval-framework-audit-phase-N.md`, `retrieval-eval-phase-N.md`, `real_eval_delta.json`, `audits/*.md`
+- mtime 최신 1개 자동 선택. 동률 또는 모호하면 사용자 확인
+
+### Step 2: Dispositional signal 추출
+report 본문에서 다음 신호 파싱:
+- paired bootstrap CI 95% (대조군 vs 처리군 lift 범위)
+- saturation 의심 (ceiling 근접, 표본 부족, 효과 크기 < 1pp)
+- 변별력 단정: **양성 / 음성 / 불충분** 중 하나로 명시
+
+수치는 인용만 — 추측·해석 금지.
+
+### Step 3: ADR threshold check (CLAUDE.md 원문 인용)
+CLAUDE.md "ADR 임계값" 섹션의 두 조건 적용:
+- load-bearing 결정(기준선/파이프라인/답변 계약/eval 표면) 제거·교체?
+- 새 측정 표면(eval 슬라이스, 리더보드 신호, self-review 축) 도입?
+
+- 둘 다 No → STOP: "신호 양성이지만 ADR 불요. follow-up issue 만 생성 권고." (cycle_time append 도 안 함)
+- 어느 하나 Yes → Step 4
+
+### Step 4: ADR 번호 사전 예약
+충돌 패턴(0022→0023, 0023→0025, 0029→0030)을 회피해야 함:
+
+```bash
+ls docs/adr/ | grep -oE '^[0-9]{4}' | sort -u | tail -5
+gh pr list --search "ADR" --state open --json number,title,headRefName
+```
+
+두 출력을 보고 후보 번호 제시. open PR 의 ADR 번호와 충돌 가능성을 표 형식으로 사용자에게 명시한 뒤 확인 대기.
+
+### Step 5: ADR draft 생성
+파일: `docs/adr/NNNN-<slug>.md`. 필수 섹션:
+- **Status**: Proposed
+- **Context**: 트리거 측정 + 신호 (Step 2 수치 그대로 인용)
+- **Decision**: 가장 작은 단위의 제안. 임의 확장 금지
+- **Consequences**: **reviewer 가 의존할 계약** 명시 — 이게 ADR 의 정체성
+- **Alternative considered**: 1-2개 (실행 안 함 표시)
+
+slug 은 kebab-case 5단어 이내.
+
+### Step 6: cycle_time stat append
+`reports/cycle_time.json` (없으면 빈 `[]` 로 생성):
+
+```json
+{
+  "timestamp": "2026-05-19T15:23:00Z",
+  "event": "adr_proposed",
+  "adr_number": "NNNN",
+  "trigger_report": "reports/retrieval-eval-phase-2.md",
+  "trigger_report_mtime": "2026-05-19T14:58:00Z",
+  "trigger_to_proposal_seconds": 1500
+}
+```
+
+추후 `adr_accepted` 이벤트는 별도 hook(cycle-time-watcher) 이 Status 변경 감지 시 append. 본 agent 책임 아님.
+
+### Step 7: Handoff
+보고:
+- ADR draft 경로
+- cycle_time append 결과
+- 다음 단계는 사용자 또는 `ship-pr` skill (commit / PR 생성)
+
+본 agent 는 `git commit`, `gh pr create`, ADR Status 변경 어느 것도 수행하지 않는다.
+
+## Success Metrics
+
+- ADR 작성 사이클: trigger_report mtime → adr_proposed timestamp 평균 시간 정량화 (5축 #4)
+- ADR 번호 충돌: 0 (Step 4 사전 예약 효과)
+- 측정 → 결정 빈 칸: 수작업 → agent 호출 1회로 단축
+
+## Constraints
+
+- ADR 본문에 추측·의견 금지. 측정 수치 그대로 인용
+- ADR threshold 해석은 CLAUDE.md 원문 인용 (Decision 임의 확장 금지)
+- `git commit` / `gh pr create` / ADR Status 변경 — 본 agent 영역 아님
+- 100-doc real-eval 결과 인용 시 PR 5b real-data 델타 섹션 강제 명시
+
+## Out-of-scope
+
+- 측정 자체 실행 (`/retrieval-eval`, `/eval-framework-progressive-audit` skill 영역)
+- PR 생성 (`ship-pr` skill 영역)
+- ADR Status: Proposed → Accepted 변경 감지 (별도 `cycle-time-watcher` hook)
+
+## 출처
+
+자체 제작 (BidMate-DocAgent, 2026-05-19, issue #1011, plan `~/.claude/plans/https-github-com-msitarzewski-agency-age-misty-tulip.md`). 외부 agency-agents 191개 검토 후 0개 채택 결론을 거쳐 자체 갭(측정→결정 빈 칸) 보강 목적으로 설계.

--- a/.claude/agents/memory-curator.md
+++ b/.claude/agents/memory-curator.md
@@ -1,0 +1,84 @@
+---
+name: memory-curator
+description: Use as an incremental gate right before saving a new memory entry, or when MEMORY.md exceeds 180 lines (approaching the 200-line truncation limit). Checks dedup against existing slugs and bodies, suggests type rebalance when reference/user types are underrepresented, and detects stale entries already reflected in merged code/PRs. Complements anthropic-skills:consolidate-memory (which is a batch consolidation pass) by acting per-save instead of periodically. Does NOT auto-delete stale entries — user confirmation required.
+tools: Read, Grep, Glob, Bash
+---
+
+# Memory Curator (incremental gate)
+
+새 메모리를 저장하기 직전, 혹은 MEMORY.md 가 한계에 근접할 때 호출되는 게이트. dedup/type 균형/stale 판단을 LLM judgment 로 처리. batch consolidation 은 `anthropic-skills:consolidate-memory` 영역.
+
+## Trigger
+
+- 사용자 명시: "기억해줘", "메모리에 저장해줘"
+- Claude 자율 저장 직전 (system 프롬프트 "auto memory" 규칙 발동 시)
+- MEMORY.md 라인 수 180+ 도달 (200줄 트런케이션 한계 근접 alert)
+- 사용자: "이거 이미 메모리에 있어?"
+
+## Workflow
+
+### Step 1: 메모리 폴더 스캔
+- 경로: `~/.claude/projects/-Users-hskim-Desktop-projects-BidMate-DocAgent/memory/`
+- `ls` 로 전체 파일 목록 수집
+- `wc -l` 로 MEMORY.md 라인 수 측정 → 180+ 이면 alert 표시 (200 한계 근접)
+- 각 메모리 파일 frontmatter (`name`, `description`, `metadata.type`) 만 head 로 읽어 인덱스 구성. body 전체 읽지 않음 (토큰 절약).
+
+### Step 2: Dedup 검사
+신규 메모리 후보 입력 시:
+- 신규 slug 와 기존 `name:` 슬러그 fuzzy match (편집 거리, 공통 substring)
+- 신규 body 키워드 5-10개 추출 → 기존 `description:` 와 grep 매칭
+- 유사도 높은 항목(예: `feedback_pr_discipline` ↔ `feedback_commit_convention`) 발견 시:
+  - 표 형태로 후보 + 유사도 근거 제시
+  - "기존 메모리 업데이트" vs "별도 저장 정당화" 사용자 선택 요청
+
+### Step 3: Type 균형 진단
+- 모든 메모리의 `metadata.type` 카운트 (frontmatter grep)
+- 비율 계산: user / feedback / project / reference
+- 휴리스틱:
+  - feedback > 50% → 과적 alert ("feedback 5건 중 3건은 project 가 더 적합한지 재검토")
+  - reference < 10% → 부족 alert ("외부 시스템 참조는 reference type 권장")
+  - user < 5% → 부족 alert
+- 신규 메모리가 부족 type 이면 type 명시 권고
+
+### Step 4: Stale 검출
+신규 메모리 또는 기존 메모리 검토 시:
+- body 의 `file_path`, PR# (`#\d{2,5}`), commit hash 참조 추출
+- 각 참조 확인:
+  - file_path: `test -f <path>` 또는 git history 검사
+  - PR#: `gh pr view <num> --json state,mergedAt --jq '.state'` (MERGED 면 stale 후보)
+  - commit hash: `git cat-file -e <hash>` (존재 여부)
+- stale 의심 목록 → 사용자 확인 후 제거 또는 업데이트 (자율 제거 금지)
+
+### Step 5: 저장 또는 거절
+- 모든 검사 통과:
+  - Write tool 호출 권유 + MEMORY.md 인덱스 1줄 draft 제공
+  - 형식: `- [Title](file.md) — one-line hook`
+- 검사 실패 (중복/stale/type 불균형):
+  - 저장 중단 권고
+  - **반드시 대안 제시** — 기존 메모리 ID + 업데이트 방법, 또는 다른 type 으로 재저장 권고
+  - 사용자 최종 결정 존중 (명시적 "그래도 저장" 시 진행)
+
+## Success Metrics
+
+- 메모리 중복 (slug/body 유사): 0건
+- type 균형: reference ≥ 10%, user ≥ 5%
+- MEMORY.md 인덱스 200줄 트런케이션 도달: 0회
+- "이거 이미 메모리에 있는데" 사용자 피드백: 0회
+
+## Constraints
+
+- 자율 stale 제거 금지 — 사용자 확인 필수
+- 신규 메모리 거절 시 반드시 대안 (기존 항목 ID + 업데이트 방법) 제시
+- `consolidate-memory` skill 영역(batch 정리) 침범 금지 — 호출 권유만
+- body 전체 읽기 금지 (frontmatter + grep 만으로 판단). 토큰 예산 < 5k 목표
+
+## Out-of-scope
+
+- Batch consolidation (consolidate-memory skill 영역)
+- 메모리 폴더 외부(CLAUDE.md, docs/) 정합성 검사
+- 자율 stale 제거
+- 사용자 명시 저장 요청 거절 (검사 실패해도 사용자 우선)
+
+## 출처
+
+자체 제작 (BidMate-DocAgent, 2026-05-19, issue #1011, plan `~/.claude/plans/https-github-com-msitarzewski-agency-age-misty-tulip.md`). 5축 #5 메모리 위생 △ 약점 직접 보강. consolidate-memory skill 의 incremental gate 보완.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/claude-hooks/userpromptsubmit-delegation-gate.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,14 @@ venv/
 
 # Claude Code: local state (worktrees, transcripts, per-user permissions)
 # is ignored; the shared `.claude/settings.json` (hooks etc.) IS committed.
-# `.claude/skills/` is also committed — project-local skills shared across
-# clones and worktrees, alongside settings.json.
+# `.claude/skills/` and `.claude/agents/` are also committed — project-local
+# skills/agents shared across clones and worktrees, alongside settings.json.
 .claude/*
 !.claude/settings.json
 !.claude/skills/
 !.claude/skills/**
+!.claude/agents/
+!.claude/agents/**
 
 # Local/private source data
 data/files/

--- a/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
+++ b/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Claude Code UserPromptSubmit hook for BidMate-DocAgent (issue #1014).
+#
+# Registered in `.claude/settings.json` with matcher `.*`. Inspects every
+# user prompt for non-trivial change-intent keywords (Korean + English) and,
+# when matched, emits a CLAUDE.md "위임 기본값" suggestion to stdout — which
+# Claude receives as additional context for the next turn. Never blocks the
+# user; only nudges (always exits 0).
+#
+# Why this hook exists: Q2-2026 self-review axis #2 (Agent 위임) graded △
+# because Plan/Explore subagents were under-called on non-trivial diffs.
+# CLAUDE.md already documents the rule; this hook makes the rule visible
+# right at prompt time instead of relying on Claude to remember.
+#
+# A line is appended to `.claude/.hook-fires.log` in the existing 4-field
+# format (`<ts>|<action>|<reason>|<path>`) so the `_self_review.py`
+# `collect_governance_hooks` parser can count fires alongside the existing
+# `memory-lines` / `load-bearing` reasons.
+#
+# Hook input (stdin, JSON):
+#   { "session_id": "...", "transcript_path": "...", "prompt": "..." }
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+input=$(cat)
+
+prompt=$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    print("")
+    sys.exit(0)
+# UserPromptSubmit payload key may vary; try common variants.
+p = d.get("prompt") or d.get("user_prompt") or d.get("user_message") or ""
+print(p)
+' 2>/dev/null)
+
+# Non-trivial change-intent keywords (Korean + English). Tuned conservatively
+# to keep the false-positive rate low — single typo fixes and one-liner
+# question prompts should NOT trigger.
+if printf '%s' "$prompt" | grep -qiE "리팩토링|refactor|구현해|implement|다 고쳐|전체.*수정|all files|새 기능|new feature|마이그레이션|migrat[ei]|레거시|legacy|아키텍처|architectur|재설계|redesign"; then
+  # stdout → prepended to Claude's next-turn context.
+  cat <<'EOF'
+
+[agent-delegation-gate]: 비-trivial 변경 의도 감지. CLAUDE.md "위임 기본값" 적용 권장:
+  • Plan subagent: >1 파일 또는 >50 LOC 예상 시 — 설계 검증 + 대안 평가
+  • Explore subagent: 누적 Read ≥5회 또는 단일 파일 >200줄 예상 시 — 컨텍스트 보호
+
+Trivial 변경(오타/단일 라인/단일 함수)은 직접 진행 OK.
+EOF
+
+  printf '%s|nudged|agent-delegation|<user-prompt>\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    >> "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
+fi
+
+exit 0


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1014

`/self-review-quarterly` Q2-2026 진단 1✓4△ 중 **5축 #2 Agent 위임** △ 직접 보강. plan(`~/.claude/plans/https-github-com-msitarzewski-agency-age-misty-tulip.md`) PR-B 의 scope 재정의 결과:

- `.hook-fires.log` writer(PreToolUse 4개) + `cycle_time` 측정(`_compute_adr_lags` + `compute_pr_turnaround_summary` git history 기반): **#745-#748 머지로 이미 가동**
- 진짜 갭: UserPromptSubmit hook **0개** → `agent-delegation-gate` 신규
- ADR 불요 (새 측정 표면 아님 — 기존 surface 위 추가 hook)

**Stacked on PR #1013** (PR-A: agent 2개). 머지 시 base 자동 rebase to main.

## 2. 영향 파일

- `scripts/claude-hooks/userpromptsubmit-delegation-gate.sh` (신규, 실행권한 +x)
- `.claude/settings.json` (UserPromptSubmit 섹션 hook 1개 등록)

load-bearing 파일 변경 없음. `.claude/settings.json` 은 load-bearing 표면이지만 hook 등록 1줄 추가만 — 기존 hook 4개 + Stop 1개 변경 없음.

## 3. 리스크

- **False-positive 트리거** (정상 작업도 위임 권유) → 키워드를 보수적으로 선정(아키텍처/리팩토링/마이그레이션 등 명백한 비-trivial). 트리거 검증 완료:
  - `"리팩토링 좀 해줘"` → 권유 메시지 출력 ✓
  - `"오타 하나 고쳐"` → 출력 없음 ✓
- **항상 exit 0** — 사용자 차단 0 (fail-safe). 스크립트 에러 시 stderr 무시
- **30일 monitoring** 후 트리거 어휘 조정 (호출 빈도 + false-positive 비율 측정)

## 4. 테스트

- 자동화 테스트: 없음 (hook 본문은 declarative)
- 검증 시나리오 (commit 전 수동 실행 완료):
  - `echo '{"prompt":"리팩토링 좀 해줘"}' | bash scripts/claude-hooks/userpromptsubmit-delegation-gate.sh` → 권유 메시지 + `.hook-fires.log` append
  - `echo '{"prompt":"오타 하나 고쳐"}' | bash scripts/claude-hooks/userpromptsubmit-delegation-gate.sh` → 출력 없음 + fires.log 변화 없음
- `_self_review.py` `collect_governance_hooks` 와 호환: 4-field 포맷 (`<ts>|nudged|agent-delegation|<path>`) 으로 기존 `memory-lines` / `load-bearing` reason 옆에 `agent-delegation` 카운터 자동 인식

## 5. Eval 영향

All `·` — eval surface 변경 없음. hook 추가는 사용자 워크플로 자동화이지 RAG/평가 동작 영향 0.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing 파일 변경 0 → `make real-eval-delta` 불요. ADR 0005 경계 준수.

## 6. 하위 호환

- 기존 hook 4개 (PreToolUse) + Stop 1개: 변경 없음
- `.hook-fires.log` 4-field 포맷: 변경 없음 (기존 포맷 그대로 활용)
- 기존 PR 머지 워크플로 영향 0

## 7. 범위 외

- **PR-C**: `docs/agent-utilization.md` Q3-2026 보강 섹션 (5 컴포넌트 5축 cover 매트릭스). PR-A + PR-B 머지 후 별도 진행
- **Agent/Skill 호출 `.hook-fires.log` 추적**: PreToolUse matcher 를 `Agent|Skill|Task` 까지 확장하는 별도 PR (본 PR 의 5축 #2 보강과 분리 — "One PR, one concern")
- **트리거 키워드 ML 학습**: 30일 monitoring 후 false-positive 통계 기반으로 어휘 조정 — 별도 PR