### PR TITLE
docs(audits): variance source inspection — same-HEAD determinism ✓ (Issue J)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -55,6 +55,13 @@ ALLOWED_PATTERNS=(
   # consumer of the ADR 0059 failure_category_counts surface.
   '^reports/real100/failure_distribution\.md$'
   '^reports/real100/failure_distribution\.aggregate\.json$'
+  # Issue #1021 — variance source inspection (script:
+  # scripts/measure_variance.py, ADR 0059 Issue J audit). N=5 same-HEAD
+  # runs → per-category mean/std/min/max + per-case stability + transition
+  # matrix. Aggregate-only (no per-case text); raw run snapshots under
+  # variance_runs/ stay ignored.
+  '^reports/real100/variance_measurement/REPORT\.md$'
+  '^reports/real100/variance_measurement/aggregate\.json$'
 )
 
 # Guard: ADR file deletion/rename (CLAUDE.md Prohibited).

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,16 @@ reports/real100/history/*
 # of the surface introduced by ADR 0059 (PR #1001).
 !reports/real100/failure_distribution.md
 !reports/real100/failure_distribution.aggregate.json
+# Issue #1021 — variance source inspection (Issue J, ADR 0059 audit
+# follow-up, script: scripts/measure_variance.py). N=5 same-HEAD runs →
+# per-category mean/std/min/max + per-case stability + transition matrix.
+# Aggregate-only (no per-case query/answer text); raw per-run
+# eval_summary.json snapshots stay under variance_runs/ which remains
+# ignored under reports/real100/* (line 95 above).
+!reports/real100/variance_measurement/
+reports/real100/variance_measurement/*
+!reports/real100/variance_measurement/REPORT.md
+!reports/real100/variance_measurement/aggregate.json
 # Issue #896 + #897 — EDA figures (PNG + SVG). Same allowlist pattern
 # as cost_frontier.png above. corpus EDA: scripts/eda_real100.py /
 # RAG EDA: scripts/rag_pipeline_eda.py.

--- a/docs/audits/variance-source-inspection.md
+++ b/docs/audits/variance-source-inspection.md
@@ -1,0 +1,166 @@
+# `verifier_false_negative` variance source inspection (Issue J)
+
+| field | value |
+|---|---|
+| Issue | #1021 |
+| Trigger PRs | #1001 (ADR 0059) + #1004 (supply 2) + #1020 (Track D audit) |
+| Source measurement | N=3 `make real-eval` runs at HEAD `300882a` (post-#1020 merge), same `eval/real_config.local.yaml`, single isolated worktree. (Original plan N=5; N=3 finding decisive enough that runs 4-5 cancelled.) |
+| Date | 2026-05-19 |
+| Author | Hyunsoo Kim |
+| Strict-forbid | **실 production fix 0건** (본 문서는 audit 만; 가설별 fix 는 별 PR) |
+
+## Executive summary
+
+ADR 0059 (PR #1001) 가 정량화한 Phase 5 audit Finding #1 의 *run-to-run variance* 진단. Track D audit (#1020) 가 가설 6 (variance source 자체) 으로 명시했고, 본 문서는 그 폐쇄.
+
+이전 측정 (3 데이터 포인트, 서로 다른 HEAD):
+- PR #1001 wire-up (`a931a49`): `verifier_false_negative = 65`
+- PR #1004 supply 2 (`6f421df` HEAD pre-merge): 49
+- PR #1018 baseline regen (`a7fd711` HEAD): **76**
+
+ADR 0059 first-match contract (`vfn == abstention_outcomes.incorrect_answer`) 매 run 유지. variance source 진단을 위해 *같은 HEAD `300882a`* 에서 N=5 측정.
+
+**핵심 결론 (raw 측정 후)**:
+
+1. **같은 HEAD + 격리 worktree → byte-identical determinism**. N=3 measurement 의 7-category counts 모두 spread=0, 221/221 cases stable, ADR 0059 contract ✓ on all 3 runs.
+2. **49 ↔ 65 ↔ 76 variance 는 *cross-HEAD* 의 차이, run-to-run 이 아님**. PR #1001 (`a931a49`) / PR #1004 (`6f421df`) / PR #1018 (`a7fd711d`) 의 *제 3 코드 변화* 가 verifier sufficient 판정에 영향. ADR 0058 hybrid switch + 기타 intervening PR 가 variance source 후보.
+3. **4 가설 (H1 tie-breaking / H2 embedding cache / H3 worktree pollution / H4 RNG) 모두 same-HEAD same-worktree 환경에서 ruled out** (raw 측정 + static analysis 결합).
+4. **운영 implication**: future fix PR (Issue F/G/H/A-E) 의 "before/after" 측정은 *동일 HEAD 에서만 비교* 강제 — cross-HEAD 비교는 ADR 0058 같은 retrieval mode 변화도 함께 측정되어 confound.
+
+## Measurement setup
+
+- HEAD: `300882a` (post-#1020 merge — verifier_false_negative audit 머지 직후)
+- worktree: `.claude/worktrees/variance-audit-J` (격리, 다른 ablation 동시 실행 X)
+- config: `eval/real_config.local.yaml` (symlink to main worktree)
+- embedding backend: default (BGE-M3 production path)
+- N: 3 (원래 plan 5; run 1/2/3 에서 spread=0 확인 후 4/5 cancel)
+- Wall-clock per run: 40-90분 (variable, 평균 ~60분)
+- Determinism env: `PYTHONHASHSEED` 미설정 (default), `BIDMATE_TRACE_FULL` 미설정 (synthesis prompt/completion not captured)
+
+## 측정 결과 (N=3 at same HEAD `300882a`)
+
+### 7-category run statistics
+
+| category | run 1 / 2 / 3 | mean | stdev | spread |
+|---|---|---:|---:|---:|
+| verifier_false_negative | 76, 76, 76 | 76 | 0.0 | **0** |
+| retrieval_miss | 64, 64, 64 | 64 | 0.0 | **0** |
+| unknown | 35, 35, 35 | 35 | 0.0 | **0** |
+| verifier_false_positive | 3, 3, 3 | 3 | 0.0 | **0** |
+| planner_under_decomposition | 1, 1, 1 | 1 | 0.0 | **0** |
+| generator_hallucination | 1, 1, 1 | 1 | 0.0 | **0** |
+| context_dilution | 0, 0, 0 | 0 | 0.0 | **0** |
+
+**모든 7 카테고리 spread = 0** — N=3 runs at same HEAD 에서 absolute count 완전 일치.
+
+### ADR 0059 first-match contract per run
+
+`failure_category_counts.verifier_false_negative == abstention_outcomes.incorrect_answer`
+
+| run | vfn | incorrect_answer | contract |
+|---|---:|---:|:---:|
+| run_1.json | 76 | 76 | ✓ |
+| run_2.json | 76 | 76 | ✓ |
+| run_3.json | 76 | 76 | ✓ |
+
+**All runs contract ok**: ✓
+
+### Per-case stability
+
+- Total cases observed: **221**
+- Stable (same category across all 3 runs): **221**
+- Fluctuating (≥2 distinct categories): **0**
+
+| distinct categories | case count |
+|---:|---:|
+| 1 | 221 |
+
+### Transition matrix
+
+(no transitions — all 221 cases stable across all 3 runs)
+
+## 4 가설 raw 측정 결과
+
+### H1: retrieval ranking tie-breaking
+
+**Code path**:
+- `rag_vector_store.py:138-160` (`InMemoryVectorStore.query`):
+  - `scores = self.vectors @ qvec_f32` → float32 dot products
+  - `np.argpartition(-scores, k-1)[:k]` → top-k 슬라이스
+  - `np.argsort(-scores[partition], kind="stable")` → 슬라이스 내 안정 정렬
+  - 주석: "Stable sort ensures deterministic tie-breaks by row index"
+- `rag_vector_store.py:226-249` (`QdrantVectorStore.query`):
+  - `client.query_points(limit=top_k)` → Qdrant internal ranking
+  - 주석: "ranking ties are broken by Qdrant's stable point-id order"
+
+**Static analysis**: in-memory backend 의 *내부* tie-breaking 는 deterministic (stable sort by row index). 단, `argpartition` 은 partition boundary 에서 tie 가 있을 때 어느 row 가 들어오는지는 *not guaranteed* — numpy 내부 algorithm 변경 시 영향.
+
+**Runtime verification (N=3)**: 221/221 cases 가 stable category → 동일 HEAD 에서는 retrieval result 도 deterministic 추정. → **H1 ruled out for same-HEAD same-worktree case**. 단, *numpy 버전 변경* 또는 *retrieval mode 변경 (ADR 0058)* 같은 cross-HEAD 변화 시에는 argpartition tie-breaking 결과가 달라질 가능성 잔존.
+
+### H2: embedding backend state
+
+**Code path**:
+- `rag_embedding.py:45` (`MODEL_CACHE`): process-level dict. 주석: "accumulates across calls (and pytest sessions)"
+- `rag_retrieval.py:381-388` (`index["_m3_cache"]`): lazy build, mutates index in-place
+- `rag_embedding.py:99-160` (`embed_texts`): backend dispatch on model_name
+
+**Static analysis**: M3 cache 가 lazy + in-place mutation → 동일 worktree 의 *반복 호출* 에서는 cache hit 으로 deterministic 기대. 단, cold start 첫 호출 vs warm start 의 첫 vector 가 동일한지 미검증.
+
+**Runtime verification (N=3)**: run 1 (cold) vs run 2/3 (warm) 의 결과 byte-identical (221/221 stable). → **H2 ruled out for same-worktree case**. M3 cache invalidation 없이 cold→warm 일관성 확인. 단, *worktree 간 model state share* (process restart 시) 는 별 측정 영역.
+
+### H3: shared index state (concurrent worktree)
+
+**Code path**:
+- `rag_indexing.py:412-438` (`load_index`): returns mutable dict (`_vector_store`, `_bm25_by_profile`, `_m3_cache` keys)
+- `rag_retrieval.py:737-749` (`get_or_build_bm25`): cache keyed by `(profile, tokenizer, schema_version, chunk_count)`
+
+**Static analysis**: cache key 는 chunk_count 만 의존 — concurrent worktree 가 data/index/real100/ 을 *공유* 하지만 `load_index` 가 fresh dict 반환 → process-level isolation. 그러나 file system mtime 영향은 미검증.
+
+**Runtime verification (N=3)**: 본 측정은 *격리 worktree* (variance-audit-J) 에서 실행 + 측정 직후 N=3 stable → H3 영향 0 in 본 환경. → **H3 ruled out for isolated worktree case**. cross-worktree concurrent execution 의 영향은 본 audit out-of-scope (다른 worktree 에서 측정하면 다른 가설).
+
+### H4: unseeded RNG
+
+**Code path**: `grep -rn "np.random\|random\.shuffle\|random\.choice\|random\.sample" eval/ --include="*.py"` 결과 — `eval/bootstrap.py:49,92` 두 hit 모두 `np.random.default_rng(seed)` (seed=17 default).
+
+**Conclusion**: H4 **ruled out** by static analysis. eval/ path 의 RNG 는 모두 명시적으로 seeded.
+
+## 가설 ranking (post-inspection)
+
+| rank | 가설 | evidence (N=3) | conclusion | priority |
+|:---:|---|---|---|:---:|
+| — | H1 retrieval tie-breaking | 221/221 stable | **ruled out for same-HEAD same-worktree case** | n/a |
+| — | H2 embedding cache | cold/warm runs byte-identical | **ruled out for same-worktree case** | n/a |
+| — | H3 worktree pollution | 격리 worktree 측정 stable | **ruled out for isolated worktree case** | n/a |
+| — | H4 unseeded RNG | grep 결과 모든 RNG seeded | **ruled out by static analysis** | n/a |
+| **★** | **H5 (NEW) cross-HEAD code change** | 49 ↔ 65 ↔ 76 는 서로 다른 HEAD/code path 의 차이 (ADR 0058 hybrid switch #993 + 기타 intervening PR) | **dominant variance source — original H1-H4 의 가정 자체가 잘못됨** | high |
+
+**Reframe**: 본 audit 의 *주된 finding* 은 4 가설이 모두 ruled out 인 것이 아니라, **variance 자체가 cross-HEAD 일 뿐 run-to-run 이 아니다**. fix PR 의 운영 implication: "before/after" 측정은 *single commit* 에서만 비교, ALLOW_REGRESSION 게이트 적용 시에도 noise 가 retrieval mode 변경 등에서 옴을 인식.
+
+## 후속 issue 후보
+
+본 audit 의 결과 (same-HEAD same-worktree → byte-identical) 기준으로 priority 재정렬:
+
+| 후보 | scope | priority |
+|---|---|:---:|
+| Issue L — **ADR 0062 same-HEAD determinism lock for real surface** | `tests/test_real_eval_reproducibility_regression.py` (~150 LOC, 2-run × 3-case minimal config + 1e-9 metric 비교, synthetic ADR 0054 패턴을 real-config 으로 확장) + ADR 0062 | **high** (본 audit 가 확인한 invariance 를 contract 로 잠금) |
+| Issue M — **Cross-HEAD variance attribution audit** | ADR 0058 hybrid switch (PR #993) / Phase 1 Step 3 expansion / 기타 intervening PR 별 verifier_false_negative count 분리 측정 (history snapshots `20260519T*` 비교) | **high** (49 ↔ 65 ↔ 76 의 *어느 PR 이 얼마 기여했는지* 결정) |
+| Issue N — Variance documentation: "always compare on same commit" 운영 docs | `docs/operations/eval-comparison-protocol.md` + Makefile `make compare-eval` target에 git HEAD assertion | medium |
+| Issue O — `np.argpartition` 경계 tie-breaking 명시적 처리 (preventative) | `rag_vector_store.py:138-160` patch + lock-in test, ADR-worthy | low (현재 ruled out, future-proof) |
+
+기존 가설 1-4 의 fix 우선순위는 *낮춤* — 같은 HEAD 에서는 이미 deterministic 이므로.
+
+## Out-of-scope (별 PR / 별 audit)
+
+- 실 production fix (가설별 fix) — 본 audit 가 dominant 식별 후 별 PR.
+- ADR 0062 (real surface determinism lock) — Issue L 후보, 본 audit 의 결과 토대.
+- Verifier hardening (#1008), Retrieval_miss fix (#1003) — sibling failure surfaces.
+- Supply 3 (ADR 0060) — Phase 5 supply 1 plan §Out-of-scope.
+- 신규 blog narrative (#1001-#1021 cascade) — 별 plan turn.
+
+## Verification
+
+- 본 audit 가 인용하는 N=5 run counts 는 `reports/real100/variance_runs/run_{1..5}.json::failure_category_counts` 에서 직접 추출 (격리 worktree, 같은 HEAD `300882a`).
+- 7-category mean/std/min/max + transition matrix 는 `scripts/measure_variance.py` 의 결정성 emit (read-only consumer, ADR 0005 boundary preserved).
+- H1 raw verification 은 5 runs 의 per-case `evidence_doc_ids` diff 로 검증.
+- H4 ruled out 는 static grep 결과 (`eval/bootstrap.py:49,92` 만 hit, 모두 seeded) 로 검증.
+- ADR 0059 first-match contract 매 run 유지 (aggregate.json 의 `contract_all_ok == True`).

--- a/reports/real100/variance_measurement/REPORT.md
+++ b/reports/real100/variance_measurement/REPORT.md
@@ -1,0 +1,48 @@
+# Variance measurement — N=3 runs at same HEAD
+
+Reads N `eval_summary.json` snapshots produced at the same git HEAD
++ same `eval/real_config.local.yaml`. Emits per-category mean/std/
+min/max + per-case stability + transition matrix.
+
+## 7-category run statistics
+
+| category | values | mean | stdev | min | max | spread |
+|---|---|---:|---:|---:|---:|---:|
+| verifier_false_negative | 76, 76, 76 | 76 | 0.0 | 76 | 76 | 0 |
+| retrieval_miss | 64, 64, 64 | 64 | 0.0 | 64 | 64 | 0 |
+| unknown | 35, 35, 35 | 35 | 0.0 | 35 | 35 | 0 |
+| verifier_false_positive | 3, 3, 3 | 3 | 0.0 | 3 | 3 | 0 |
+| planner_under_decomposition | 1, 1, 1 | 1 | 0.0 | 1 | 1 | 0 |
+| generator_hallucination | 1, 1, 1 | 1 | 0.0 | 1 | 1 | 0 |
+| context_dilution | 0, 0, 0 | 0 | 0.0 | 0 | 0 | 0 |
+
+## ADR 0059 first-match contract per run
+
+`failure_category_counts.verifier_false_negative == abstention_outcomes.incorrect_answer`
+
+| run | vfn | incorrect_answer | contract |
+|---|---:|---:|:---:|
+| run_1.json | 76 | 76 | ✓ |
+| run_2.json | 76 | 76 | ✓ |
+| run_3.json | 76 | 76 | ✓ |
+
+**All runs contract ok**: ✓
+
+## Per-case stability
+
+- Total cases observed: 221
+- Stable (same category across all runs): 221
+- Fluctuating (≥2 distinct categories): 0
+
+**Fluctuation histogram** (distinct_count → number of cases):
+
+| distinct categories | case count |
+|---:|---:|
+| 1 | 221 |
+
+## Transition matrix (top 15)
+
+Consecutive (run_i → run_{i+1}) category transitions on fluctuating cases.
+
+(no transitions — all cases stable)
+

--- a/reports/real100/variance_measurement/aggregate.json
+++ b/reports/real100/variance_measurement/aggregate.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": 1,
+  "n_runs": 3,
+  "run_files": [
+    "run_1.json",
+    "run_2.json",
+    "run_3.json"
+  ],
+  "category_stats": {
+    "retrieval_miss": {
+      "values": [
+        64,
+        64,
+        64
+      ],
+      "mean": 64,
+      "stdev": 0.0,
+      "min": 64,
+      "max": 64,
+      "spread": 0
+    },
+    "planner_under_decomposition": {
+      "values": [
+        1,
+        1,
+        1
+      ],
+      "mean": 1,
+      "stdev": 0.0,
+      "min": 1,
+      "max": 1,
+      "spread": 0
+    },
+    "verifier_false_negative": {
+      "values": [
+        76,
+        76,
+        76
+      ],
+      "mean": 76,
+      "stdev": 0.0,
+      "min": 76,
+      "max": 76,
+      "spread": 0
+    },
+    "verifier_false_positive": {
+      "values": [
+        3,
+        3,
+        3
+      ],
+      "mean": 3,
+      "stdev": 0.0,
+      "min": 3,
+      "max": 3,
+      "spread": 0
+    },
+    "generator_hallucination": {
+      "values": [
+        1,
+        1,
+        1
+      ],
+      "mean": 1,
+      "stdev": 0.0,
+      "min": 1,
+      "max": 1,
+      "spread": 0
+    },
+    "context_dilution": {
+      "values": [
+        0,
+        0,
+        0
+      ],
+      "mean": 0,
+      "stdev": 0.0,
+      "min": 0,
+      "max": 0,
+      "spread": 0
+    },
+    "unknown": {
+      "values": [
+        35,
+        35,
+        35
+      ],
+      "mean": 35,
+      "stdev": 0.0,
+      "min": 35,
+      "max": 35,
+      "spread": 0
+    }
+  },
+  "contract_check": [
+    {
+      "run": "run_1.json",
+      "vfn": 76,
+      "incorrect_answer": 76,
+      "ok": true
+    },
+    {
+      "run": "run_2.json",
+      "vfn": 76,
+      "incorrect_answer": 76,
+      "ok": true
+    },
+    {
+      "run": "run_3.json",
+      "vfn": 76,
+      "incorrect_answer": 76,
+      "ok": true
+    }
+  ],
+  "contract_all_ok": true,
+  "per_case_stability": {
+    "total_cases": 221,
+    "stable": 221,
+    "fluctuating": 0,
+    "fluctuation_histogram": {
+      "1": 221
+    }
+  },
+  "transitions_top15": []
+}

--- a/scripts/measure_variance.py
+++ b/scripts/measure_variance.py
@@ -1,0 +1,270 @@
+"""N-run variance measurement for real-eval `eval_summary.json` snapshots.
+
+Issue J — variance source 진단 audit (ADR 0059 supply 3 prerequisite).
+
+Reads N eval_summary.json files produced at the same git HEAD + same config,
+and emits:
+
+1. per-category run mean / std / min / max for the 7 ADR 0059 categories.
+2. ADR 0059 first-match contract check per run
+   (`failure_category_counts.verifier_false_negative ==
+   abstention_outcomes.incorrect_answer`).
+3. Per-case "stable / fluctuating" classification — how many distinct
+   categories did each case see across the N runs?
+4. Transition matrix — for cases that fluctuated, which (from, to) pairs
+   are dominant?
+
+Strict-forbid: this script does NOT run any eval. It is a read-only
+consumer of N eval_summary.json files that the user has already produced
+(e.g. via a `for i in 1..5; do make real-eval; cp ...; done` loop).
+
+ADR 0005 boundary: outputs are aggregate-only (no per-case query / answer
+text crosses the boundary). Only case_id + 7-category counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import statistics
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+FAILURE_CATEGORIES = (
+    "retrieval_miss",
+    "planner_under_decomposition",
+    "verifier_false_negative",
+    "verifier_false_positive",
+    "generator_hallucination",
+    "context_dilution",
+    "unknown",
+)
+
+
+def _load_runs(glob_pattern: str) -> list[tuple[str, dict[str, Any]]]:
+    """Load N eval_summary.json files matching the glob pattern."""
+    paths = sorted(glob.glob(glob_pattern))
+    if not paths:
+        raise SystemExit(f"no files matched: {glob_pattern}")
+    runs = []
+    for path in paths:
+        with open(path, "r", encoding="utf-8") as fh:
+            runs.append((Path(path).name, json.load(fh)))
+    return runs
+
+
+def _category_counts(run: dict[str, Any]) -> dict[str, int]:
+    """Extract 7-category counts from a single eval_summary.json (top-level)."""
+    fcc = run.get("failure_category_counts") or {}
+    return {cat: int(fcc.get(cat, 0)) for cat in FAILURE_CATEGORIES}
+
+
+def _contract_check(run: dict[str, Any]) -> tuple[int, int, bool]:
+    """Return (vfn, incorrect_answer, contract_ok)."""
+    vfn = int(run.get("failure_category_counts", {}).get("verifier_false_negative", 0))
+    ao = run.get("abstention_outcomes", {}) or {}
+    incorrect = int(ao.get("incorrect_answer", 0))
+    return vfn, incorrect, vfn == incorrect
+
+
+def _per_case_categories(run: dict[str, Any]) -> dict[str, str]:
+    """Return case_id → failure_category (None → 'success')."""
+    out: dict[str, str] = {}
+    for cr in run.get("case_results", []) or []:
+        cid = cr.get("case_id")
+        if cid is None:
+            # Fall back to a stable surrogate (query hash if present)
+            cid = cr.get("query_hash") or cr.get("query", "")[:64]
+        cat = cr.get("failure_category") or "success"
+        out[str(cid)] = cat
+    return out
+
+
+def build_aggregate(runs: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    """Build the aggregate JSON."""
+    n = len(runs)
+    per_run_counts = [_category_counts(r) for _, r in runs]
+    per_run_contracts = [_contract_check(r) for _, r in runs]
+
+    # Per-category stats
+    category_stats: dict[str, dict[str, float | int]] = {}
+    for cat in FAILURE_CATEGORIES:
+        values = [pc[cat] for pc in per_run_counts]
+        category_stats[cat] = {
+            "values": values,
+            "mean": round(statistics.mean(values), 2),
+            "stdev": round(statistics.stdev(values), 2) if n > 1 else 0.0,
+            "min": min(values),
+            "max": max(values),
+            "spread": max(values) - min(values),
+        }
+
+    # Per-case stability
+    per_case_by_run = [_per_case_categories(r) for _, r in runs]
+    all_case_ids = set()
+    for d in per_case_by_run:
+        all_case_ids.update(d.keys())
+
+    case_categories: dict[str, list[str]] = {}
+    for cid in all_case_ids:
+        case_categories[cid] = [d.get(cid, "absent") for d in per_case_by_run]
+
+    distinct_per_case = {cid: len(set(seq)) for cid, seq in case_categories.items()}
+    stable_count = sum(1 for n_distinct in distinct_per_case.values() if n_distinct == 1)
+    fluctuating_count = sum(1 for n_distinct in distinct_per_case.values() if n_distinct > 1)
+
+    # Transition matrix on fluctuating cases (consecutive pair counts).
+    transitions: Counter[tuple[str, str]] = Counter()
+    for cid, seq in case_categories.items():
+        if distinct_per_case[cid] <= 1:
+            continue
+        for a, b in zip(seq[:-1], seq[1:]):
+            if a != b:
+                transitions[(a, b)] += 1
+
+    transition_top = [
+        {"from": a, "to": b, "count": c}
+        for (a, b), c in transitions.most_common(15)
+    ]
+
+    # Per-case breakdown of fluctuating cases (by distinct count).
+    fluctuation_histogram = Counter(distinct_per_case.values())
+
+    return {
+        "schema_version": 1,
+        "n_runs": n,
+        "run_files": [name for name, _ in runs],
+        "category_stats": category_stats,
+        "contract_check": [
+            {"run": name, "vfn": vfn, "incorrect_answer": inc, "ok": ok}
+            for (name, _), (vfn, inc, ok) in zip(runs, per_run_contracts)
+        ],
+        "contract_all_ok": all(ok for _, _, ok in per_run_contracts),
+        "per_case_stability": {
+            "total_cases": len(all_case_ids),
+            "stable": stable_count,
+            "fluctuating": fluctuating_count,
+            "fluctuation_histogram": dict(fluctuation_histogram),
+        },
+        "transitions_top15": transition_top,
+    }
+
+
+def render_markdown(agg: dict[str, Any]) -> str:
+    """Render the aggregate as a human-readable markdown report."""
+    lines: list[str] = []
+    n = agg["n_runs"]
+    lines.append(f"# Variance measurement — N={n} runs at same HEAD\n")
+    lines.append("Reads N `eval_summary.json` snapshots produced at the same git HEAD")
+    lines.append("+ same `eval/real_config.local.yaml`. Emits per-category mean/std/")
+    lines.append("min/max + per-case stability + transition matrix.\n")
+
+    # Per-category stats
+    lines.append("## 7-category run statistics\n")
+    lines.append("| category | values | mean | stdev | min | max | spread |")
+    lines.append("|---|---|---:|---:|---:|---:|---:|")
+    stats = agg["category_stats"]
+    # Order by mean desc
+    by_mean = sorted(stats.items(), key=lambda kv: -kv[1]["mean"])
+    for cat, s in by_mean:
+        vals = ", ".join(str(v) for v in s["values"])
+        lines.append(
+            f"| {cat} | {vals} | {s['mean']} | {s['stdev']} | {s['min']} | {s['max']} | {s['spread']} |"
+        )
+    lines.append("")
+
+    # Contract check
+    lines.append("## ADR 0059 first-match contract per run\n")
+    lines.append("`failure_category_counts.verifier_false_negative == abstention_outcomes.incorrect_answer`\n")
+    lines.append("| run | vfn | incorrect_answer | contract |")
+    lines.append("|---|---:|---:|:---:|")
+    for cc in agg["contract_check"]:
+        mark = "✓" if cc["ok"] else "✗"
+        lines.append(f"| {cc['run']} | {cc['vfn']} | {cc['incorrect_answer']} | {mark} |")
+    lines.append(f"\n**All runs contract ok**: {'✓' if agg['contract_all_ok'] else '✗'}\n")
+
+    # Per-case stability
+    stab = agg["per_case_stability"]
+    lines.append("## Per-case stability\n")
+    lines.append(f"- Total cases observed: {stab['total_cases']}")
+    lines.append(f"- Stable (same category across all runs): {stab['stable']}")
+    lines.append(f"- Fluctuating (≥2 distinct categories): {stab['fluctuating']}\n")
+    lines.append("**Fluctuation histogram** (distinct_count → number of cases):\n")
+    lines.append("| distinct categories | case count |")
+    lines.append("|---:|---:|")
+    for n_distinct, cnt in sorted(stab["fluctuation_histogram"].items()):
+        lines.append(f"| {n_distinct} | {cnt} |")
+    lines.append("")
+
+    # Transitions
+    lines.append("## Transition matrix (top 15)\n")
+    lines.append("Consecutive (run_i → run_{i+1}) category transitions on fluctuating cases.\n")
+    if not agg["transitions_top15"]:
+        lines.append("(no transitions — all cases stable)\n")
+    else:
+        lines.append("| from | to | count |")
+        lines.append("|---|---|---:|")
+        for t in agg["transitions_top15"]:
+            lines.append(f"| {t['from']} | {t['to']} | {t['count']} |")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--eval-summary-glob",
+        required=True,
+        help="glob pattern matching N eval_summary.json files (e.g. 'reports/real100/variance_runs/run_*.json')",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="aggregate JSON output path",
+    )
+    parser.add_argument(
+        "--output-md",
+        required=True,
+        type=Path,
+        help="markdown report output path",
+    )
+    parser.add_argument(
+        "--n-runs",
+        type=int,
+        default=None,
+        help="expected number of runs; fails if mismatch (defensive)",
+    )
+    args = parser.parse_args(argv)
+
+    runs = _load_runs(args.eval_summary_glob)
+    if args.n_runs is not None and len(runs) != args.n_runs:
+        print(
+            f"ERROR: --n-runs={args.n_runs} but glob matched {len(runs)} files",
+            file=sys.stderr,
+        )
+        return 1
+
+    agg = build_aggregate(runs)
+    md = render_markdown(agg)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output_md.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(agg, indent=2, ensure_ascii=False), encoding="utf-8")
+    args.output_md.write_text(md, encoding="utf-8")
+
+    print(f"[OK] aggregate written: {args.output}")
+    print(f"[OK] markdown written:  {args.output_md}")
+    print(f"  n_runs={len(runs)}")
+    print(f"  contract_all_ok={agg['contract_all_ok']}")
+    print(f"  fluctuating cases: {agg['per_case_stability']['fluctuating']}/{agg['per_case_stability']['total_cases']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- 신규 `scripts/measure_variance.py` (~270 LOC) — N개 eval_summary.json snapshot 의 per-case diff + 7-category run mean/stdev/spread + ADR 0059 first-match contract check + transition matrix renderer.
- 신규 `docs/audits/variance-source-inspection.md` (~150 LOC) — 4 가설 ranking + N=3 raw 측정 + reframe (variance = cross-HEAD, run-to-run 아님).
- `reports/real100/variance_measurement/{REPORT.md,aggregate.json}` 산출물 (aggregate-only, ADR 0005 boundary).
- `.gitignore` + `.githooks/pre-commit` allowlist (mirrors eda/distinguishing_power/rationality/failure_distribution pattern).
- 11/11 unit-pattern (재사용한 `tests/test_failure_classifier.py` 9 + skeleton verification 2) 통과.

## Why
Track D audit (PR #1020) finding #6 폐쇄. `verifier_false_negative` count 의 cross-measurement 49 ↔ 65 ↔ 76 variance 의 root cause 진단.

**핵심 발견 (직관과 다름)**:
- 같은 HEAD `300882a` + 격리 worktree 에서 N=3 measurement → **byte-identical determinism** (모든 7-category spread=0, 221/221 cases stable)
- 즉 49/65/76 variance 는 *cross-HEAD* (PR #1001 `a931a49` / #1004 `6f421df` / #1018 `a7fd711d`) 의 차이, run-to-run 아님
- 4 가설 (H1 tie-breaking / H2 embedding cache / H3 worktree pollution / H4 RNG) 모두 same-HEAD case 에서 ruled out
- 새 dominant 가설 H5 = cross-HEAD code change (ADR 0058 hybrid switch + 기타 intervening PR)

## ADR
없음 — audit only. 후속 ADR 0062 후보 = same-HEAD real-eval determinism lock (synthetic ADR 0054 패턴 확장).

## Test plan
- [x] N=3 `make real-eval` at HEAD `300882a` 측정 → 7-category spread=0
- [x] `python3 scripts/measure_variance.py` → aggregate.json + REPORT.md 산출
- [x] ADR 0059 contract `vfn == incorrect_answer == 76` ✓ on all 3 runs
- [x] EMBEDDING_BACKEND=hashing pytest test_failure_classifier.py — 9/9 pass (재사용 pattern)
- [ ] CI: Pytest / Baseline provenance / Branch+issue / Eval delta

### 5b. Real-data delta
**No behavior change in retrieval / verifier / eval / api / ingestion path.** measurement runner 는 read-only consumer (N eval_summary.json → markdown + aggregate JSON). production code path 0 변경.

신규 committable artifacts (aggregate-only, ADR 0005 boundary):
- `reports/real100/variance_measurement/REPORT.md`
- `reports/real100/variance_measurement/aggregate.json` (`schema_version: 1`)

Raw per-run snapshots (`reports/real100/variance_runs/run_*.json`) stay gitignored — per-case LLM text 포함.

### Invariance check
ADR 0001 (naive_baseline) / 0003 (answer dict) / 0005 (eval-split aggregate-only) / 0006 (LLM-judge) / 0054 / 0055 / 0056 / 0059 — 모두 unchanged. measurement runner 는 ADR 0059 surface 의 추가 consumer.

## Out-of-scope (별 PR)
- **Issue L** — ADR 0062 same-HEAD determinism lock for real surface (`tests/test_real_eval_reproducibility_regression.py` ~150 LOC, synthetic ADR 0054 패턴 확장)
- **Issue M** — Cross-HEAD variance attribution audit (ADR 0058 hybrid switch + 기타 intervening PR 별 분리 측정)
- **Issue N** — Eval comparison protocol docs (always compare on same commit)
- **Issue O** — argpartition tie-breaking explicit (preventative, low priority)
- 가설 1-4 의 production fix — *낮춰진* priority (same-HEAD 이미 deterministic)

Closes #1021