### PR TITLE
docs(adr): clarify ADR 0001 preservation scope (closes #1026)

### DIFF
--- a/docs/adr/0001-preserve-naive-baseline.md
+++ b/docs/adr/0001-preserve-naive-baseline.md
@@ -34,6 +34,12 @@ knob: [`rag_core.py`](../../rag_core.py) 의 `pipeline_cli_choices()` 가 프리
 - 두 코드 경로 유지 부담. CLI(`app.py`)·API(`api/main.py`)·`eval/run_eval.py` 모두 추상화 비용 부담
 - README headline 메트릭에 baseline-vs-full gap 을 명시해야 함 — 아니면 시스템이 실제보다 약해 보임
 
+## 보존 범위
+
+- **보존되는 것**: [`rag_core.py`](../../rag_core.py) 의 `pipeline_cli_choices()` 가 dispatch 하는 `naive_baseline` ranking 함수. 같은 입력 (query, corpus index) 에 같은 (chunk_id, score) 순위 산출.
+- **보존되지 않는 것**: 평가 corpus 와 golden expected outputs (예: `tests/data/naive_baseline_top_k.json`). corpus 자체가 변경되면 새 chunk_id 가 생성되고 golden 도 같이 drift — 이는 ranking 함수 byte-identity 와 독립적인 부수효과로 이 ADR 의 보존 범위 밖.
+- 이 구분은 ADR 0050 처럼 corpus 만 변경하는 후속 ADR 이 "baseline bit-identical" 을 주장할 때 의미가 모호하지 않도록 못박는다. ranking 알고리즘은 그대로, corpus 는 갈아도 OK — 둘은 다른 축.
+
 ## 기본 선택 재평가 기준 (ADR 0019, 통합)
 
 ADR 0019 는 "default 유지" 결정을 재검토하는 패턴을 확립했다. 그 ADR 은 여기서 Superseded; 재오픈 조건만 load-bearing 으로 남는다.

--- a/docs/adr/0001-preserve-naive-baseline.md
+++ b/docs/adr/0001-preserve-naive-baseline.md
@@ -38,7 +38,7 @@ knob: [`rag_core.py`](../../rag_core.py) 의 `pipeline_cli_choices()` 가 프리
 
 - **보존되는 것**: [`rag_core.py`](../../rag_core.py) 의 `pipeline_cli_choices()` 가 dispatch 하는 `naive_baseline` ranking 함수. 같은 입력 (query, corpus index) 에 같은 (chunk_id, score) 순위 산출.
 - **보존되지 않는 것**: 평가 corpus 와 golden expected outputs (예: `tests/data/naive_baseline_top_k.json`). corpus 자체가 변경되면 새 chunk_id 가 생성되고 golden 도 같이 drift — 이는 ranking 함수 byte-identity 와 독립적인 부수효과로 이 ADR 의 보존 범위 밖.
-- 이 구분은 ADR 0050 처럼 corpus 만 변경하는 후속 ADR 이 "baseline bit-identical" 을 주장할 때 의미가 모호하지 않도록 못박는다. ranking 알고리즘은 그대로, corpus 는 갈아도 OK — 둘은 다른 축.
+- 이 구분은 ADR 0050 처럼 corpus 만 변경하는 후속 ADR 이 "baseline bit-identical" 을 주장할 때 의미가 모호하지 않도록 명시한다. ranking 알고리즘은 불변이며 corpus 는 교체 가능하다 — 서로 다른 축이다.
 
 ## 기본 선택 재평가 기준 (ADR 0019, 통합)
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1026

ADR 0050 (corpus rebuild) 본문이 "ADR 0001/0003 baseline bit-identical" 을 주장하지만 ADR 0001 본문엔 "byte-identity" 단어도, ranking algorithm vs evaluation ground 구분도 없음. 다음 reviewer / 면접관이 ADR 0050 의 "bit-identical" 주장과 golden shift 를 동시에 보면 동일한 ambiguity 의심 가능.

본문에 짧은 "## 보존 범위" 섹션 추가 — ranking 알고리즘은 보존 범위 안, corpus / golden 은 보존 범위 밖.

## 2. 영향 파일

- `docs/adr/0001-preserve-naive-baseline.md` (**load-bearing** — docs-only clarification, no decision change)

## 3. 리스크

낮음. ADR 0001 의 결정 / 재오픈 조건 / Status 모두 변경 없음. 본문 명확화만.

## 4. 테스트

N/A — docs-only, runtime path 무변. ADR-consequence linter 는 신규 ADR 에만 적용 (기존 ADR grandfathered).

## 5. Eval 영향

All `·` — eval surface 무변.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion path. docs-only ADR clarification — ranking 함수 / corpus / golden 모두 변경 없음.

## 6. 하위 호환

깨짐 없음. ADR 0001 의 Status 는 accepted 유지. 새 섹션 추가만, 기존 섹션 wording 변경 없음.

## 7. 범위 외

- ADR 0050 본문 backref 추가 (proposed 상태라 별도 결정 단계)
- ADR 0003 본문에도 비슷한 scope 섹션 필요 여부 (별도 issue 후보)

🤖 Generated with [Claude Code](https://claude.com/claude-code)