### PR TITLE
docs(pr-template): §5b 강제 범위를 '섹션 존재만' 으로 명시

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,6 +51,11 @@ ingestion.py, visual_ingestion.py, eval/, api/, docs/adr/, scripts/build_index.p
 "검색/검증 path 동작 변화 없음."
 ADR 0005 참조. 합성 CI delta 만으로는 #69 intended-abstention regression 을
 놓쳤다. §5b CI gate (scripts/check_branch_and_issue.py --check-5b) 가 강제.
+
+**CI 강제 범위 = 섹션 존재만** (markdown 테이블 또는 escape 문장의 *존재*).
+표 안의 숫자 정확성, escape 문장의 claim 진위는 자동 검증 불가 — reviewer
+책임. CI 통과 ≠ 5b 내용 검증 완료. (issue #1027)
+
 README metric sync 는 pr-eval.yml (issue #739) 가 별도 gate — eval surface
 변경 후 `python scripts/update_readme_metrics.py` 실행.
 -->


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`pr-eval.yml` 의 \`check_5b_mode\` 가 실제로 검증하는 것은 **markdown 테이블 또는 escape 문장의 존재** 뿐 — 표 안의 숫자 정확성이나 escape 문장의 claim 진위는 자동 검증 불가. PR template 기존 표현 "§5b CI gate ... 가 강제" 가 사용자에게 자동 검증을 믿게 만드는 위험. 5b 내용 정확성은 **reviewer 책임** 임을 명시.

거버넌스 비판 보고서 (2026-05-19, plan file `parsed-rolling-liskov-governance.md`) #3 partial.

Closes #1027

## 2. 영향 파일

- \`.github/pull_request_template.md\` — 5b 섹션에 1줄 (실제로는 3줄 블록) 추가

Load-bearing 변경 아님. 본 PR 의 5b 자체도 N/A.

## 3. 리스크

- PR template 변경은 다음 PR 부터 적용 (이번 PR 은 기존 template 으로 작성)
- 기존 template 의 "강제" 문구는 그대로 두고 *그 아래에* 정확한 범위를 명시 — 모순 발생 가능
- 완화: 추가 문구가 "CI 강제 범위 = 섹션 존재만" 으로 시작하여 기존 문구 해석을 좁힘

## 4. 테스트

PR template 텍스트 변경만. 동작 변경 없음 — 테스트 없음.

## 5. Eval 영향

All ·

### 5b. Real-data delta

N/A — load-bearing path 변경 없음.

## 6. 하위 호환

- 기존 5b 섹션 양식 유지
- 추가 문구는 \`<!-- -->\` 블록 내부에 위치 — PR 작성자가 채우는 콘텐츠는 영향 없음
- 사용자 행동 변화: reviewer 가 5b 내용을 자동 검증에 의존하지 말고 직접 점검

## 7. 범위 외

- §5b *진짜 내용 검증* 자동화 — 사실상 불가능 추정 (claim parsing + baseline regen + 코드 변경 매핑 필요). 거버넌스 비판 #3 full 은 폐기 의사결정 별도 진행
- Load-bearing 리스트 hardcode 정리 — 별도 PR (#2 in critique)
- PR template 의 load-bearing 텍스트 mirror (라인 19-23, 47-49 두 곳) — 별도 PR 에서 자동 생성 스크립트로 통합 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)