### PR TITLE
feat(leaderboard): agentic_full series start date caption (ADR 0030 mitigation, T5')

### DIFF
--- a/docs/adr/0030-leaderboard-headline-includes-agentic-full.md
+++ b/docs/adr/0030-leaderboard-headline-includes-agentic-full.md
@@ -46,7 +46,7 @@ By construction(`scripts/write_synthetic_history.py:42`) 각 snapshot은 **prima
 - `SAFE_TOPLEVEL_KEYS`에 엔트리 1 추가. `ablation_full` 향후 schema drift는 sub-key whitelist 갱신 필요(`judge_ragas`와 동일 유지보수 패턴).
 - `reports/leaderboard.md` width / row 수 증가. CI gate `scripts/leaderboard.py --check`가 렌더링을 계약으로 계속 pin.
 - Chart.js 페이지가 메트릭당 2 series 수용 필요. legend + tooltip 갱신.
-- pre-#476 snapshot backfill은 opt-in; 리더보드 chart가 backfill 없으면 ~21일간 `agentic_full`을 partial series로 표시.
+- pre-#476 snapshot backfill은 opt-in; 리더보드 chart가 backfill 없으면 ~21일간 `agentic_full`을 partial series로 표시. **완화 (#1028, 2026-05-19)**: `scripts/leaderboard.py:render_page`가 `_agentic_full_start_date` helper로 첫 non-null `ablation_full` 날짜(현재 2026-05-13)를 차트 캡션에 동적 inject — backfill 컴퓨트(~7-15h) 없이 외부 reviewer가 forward-only 마이그레이션을 즉시 파악. backfill PR이 머지되면 라벨은 자동 갱신.
 
 **Locked in:**
 

--- a/docs/eval/leaderboard.md
+++ b/docs/eval/leaderboard.md
@@ -6,7 +6,7 @@ permalink: /leaderboard/
 
 # Synthetic Eval Leaderboard
 
-Time-series view of headline metrics across commits to main. Two pipelines render as overlaid series: `naive_baseline` (ADR 0001 — intentionally stable extractive floor) and `agentic_full` (ADR 0029 — production surface where pipeline merges actually move metrics). Bootstrap 95% CI bands are shaded on the baseline series; wide bands mean *we cannot yet detect a difference*, which is just as informative as a narrow band showing a trend.
+Time-series view of headline metrics across commits to main. Two pipelines render as overlaid series: `naive_baseline` (ADR 0001 — intentionally stable extractive floor) and `agentic_full` (ADR 0029 — production surface where pipeline merges actually move metrics). The `agentic_full` series begins 2026-05-13 (PR #476 / ADR 0030); earlier snapshots show only `naive_baseline`, since `ablation_full` was introduced forward-only and pre-#476 snapshots predate the schema. Bootstrap 95% CI bands are shaded on the baseline series; wide bands mean *we cannot yet detect a difference*, which is just as informative as a narrow band showing a trend.
 
 Source data is in `reports/history/` and the rendering source is in `scripts/leaderboard.py`. ADR 0005 aggregate-only boundary respected.
 

--- a/scripts/leaderboard.py
+++ b/scripts/leaderboard.py
@@ -224,6 +224,22 @@ def render_markdown_table(rows: list[dict[str, Any]]) -> str:
     )
 
 
+def _agentic_full_start_date(rows: list[dict[str, Any]]) -> str | None:
+    """First date where ``ablation_full.accuracy`` is non-null.
+
+    Returns ``None`` if no snapshot ever carries an ``agentic_full``
+    measurement. ADR 0030 forward-only migration: pre-#476 snapshots
+    surface ``—`` in tables and ``null`` (gap) in charts; this helper
+    lets the chart caption name the inflection date dynamically rather
+    than hard-coding a date that drifts as backfill PRs land.
+    """
+    for row in rows:
+        full = row.get("ablation_full") or {}
+        if full.get("accuracy") is not None:
+            return row.get("date") or None
+    return None
+
+
 def _chart_data(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Build the JSON payload consumed by Chart.js.
 
@@ -284,6 +300,18 @@ def render_page(rows: list[dict[str, Any]]) -> str:
     table_md = _render_table_only(rows)
     metric_keys_js = json.dumps([k for k, _ in HEADLINE_METRICS])
     data_json = json.dumps(chart_payload, ensure_ascii=False)
+    full_start = _agentic_full_start_date(rows)
+    if full_start:
+        series_start_note = (
+            f"The `agentic_full` series begins {full_start} (PR #476 / ADR 0030); "
+            "earlier snapshots show only `naive_baseline`, since `ablation_full` "
+            "was introduced forward-only and pre-#476 snapshots predate the schema."
+        )
+    else:
+        series_start_note = (
+            "The `agentic_full` series is empty — no snapshot in `reports/history/` "
+            "carries `ablation_full` yet (pre-#476)."
+        )
 
     return f"""---
 title: Synthetic Eval Leaderboard
@@ -293,7 +321,7 @@ permalink: /leaderboard/
 
 # Synthetic Eval Leaderboard
 
-Time-series view of headline metrics across commits to main. Two pipelines render as overlaid series: `naive_baseline` (ADR 0001 — intentionally stable extractive floor) and `agentic_full` (ADR 0029 — production surface where pipeline merges actually move metrics). Bootstrap 95% CI bands are shaded on the baseline series; wide bands mean *we cannot yet detect a difference*, which is just as informative as a narrow band showing a trend.
+Time-series view of headline metrics across commits to main. Two pipelines render as overlaid series: `naive_baseline` (ADR 0001 — intentionally stable extractive floor) and `agentic_full` (ADR 0029 — production surface where pipeline merges actually move metrics). {series_start_note} Bootstrap 95% CI bands are shaded on the baseline series; wide bands mean *we cannot yet detect a difference*, which is just as informative as a narrow band showing a trend.
 
 Source data is in `reports/history/` and the rendering source is in `scripts/leaderboard.py`. ADR 0005 aggregate-only boundary respected.
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1028

ADR 0030 forward-only 마이그레이션이 21 pre-#476 snapshot 에서 `agentic_full` series를 빈 채로 그려, 외부 reviewer가 차트 보면 "왜 21일 비어있나" 즉시 파악 불가. `scripts/leaderboard.py:render_page` 캡션에 `_agentic_full_start_date` helper로 첫 non-null `ablation_full` 날짜 (현재 2026-05-13)를 동적 inject — backfill 컴퓨트 (~7-15h) 없이 forward-only 마이그레이션을 즉시 전달.

eval framework 비판 T5' (D층 가시성 회복). 21일 backfill 재계산의 1/30 비용으로 같은 가시성 회복.

## 2. 영향 파일

- `scripts/leaderboard.py` — `_agentic_full_start_date` helper 추가 + `render_page` 캡션 inject (~20 LOC)
- `docs/adr/0030-leaderboard-headline-includes-agentic-full.md` — **load-bearing (`docs/adr/`)** — Costs/locks-in 의 partial-series 항목에 mitigation 노트 1줄
- `docs/eval/leaderboard.md` — Chart.js 페이지 산출물 재생성 (1 라인 diff)

## 3. 리스크

- helper가 빈 history 또는 `ablation_full` key 부재 시 None 반환 → `series_start_note`가 fallback 텍스트 사용
- 캡션 텍스트가 1문장 길어짐. Chart.js 페이지 레이아웃은 변경 없음 — markdown 캡션만
- backfill PR이 머지되면 helper가 더 이른 날짜를 자동 inject → 라벨 자동 갱신, 수동 업데이트 불필요

## 4. 테스트

- `python3 scripts/leaderboard.py --check` 통과
- 기존 `tests/test_leaderboard.py` + `tests/test_leaderboard_by_format_render.py` **22 tests 모두 pass**

신규 회귀 테스트 미추가: caption text는 history 의존 → 헬퍼 단순 first-match-wins라 dedicated 회귀 시그널 ROI 낮음. 후속 PR에서 추가 가능.

## 5. Eval 영향

All `·`. eval 측정 surface 변경 없음 — 리더보드 시각화 캡션만.

### 5b. Real-data delta

No behavior change in retrieval / verifier path.

`docs/adr/0030` 본문 1줄 (mitigation 노트) 변경은 의사결정 기록만 — 코드 path 무영향. `scripts/leaderboard.py`는 chart rendering 전용 (eval pipeline 외).

## 6. 하위 호환

- `_agentic_full_start_date`는 새 helper — 기존 호출자 없음
- `render_page` signature 동일, 출력 markdown 만 +1 문장
- ADR 0030 본문은 추가만 (삭제/수정 없음, Status `accepted` 유지)

## 7. 범위 외

- 실제 21 pre-#476 backfill 재계산 — 별도 follow-up (compute ~7-15h). 현 PR의 mitigation이 가시성 갭을 해소하므로 backfill 우선순위 하향 가능
- `render_markdown_table`의 표 위 caveat와 캡션 redundancy — 의도적 유지 (in-repo markdown vs GitHub Pages chart 두 surface)
- T0 (ADR 0053-0056/0059 Proposed 정체 해소) — 별도 사용자 review 후 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)