### PR TITLE
docs(claude-hooks): Enforcement 라벨 통일 + 분류표 README

### DIFF
--- a/scripts/claude-hooks/README.md
+++ b/scripts/claude-hooks/README.md
@@ -1,0 +1,55 @@
+# scripts/claude-hooks/
+
+Claude Code 의 PreToolUse / Stop / UserPromptSubmit 훅 모음. `.claude/settings.json` 의 `hooks` 섹션에서 각 스크립트가 어떤 matcher (e.g. `Edit|MultiEdit|Write`, `Bash`, `.*`) 로 trigger 되는지 정의.
+
+거버넌스 비판 보고서 (2026-05-19, issue #1033) 후속: 각 hook 의 실제 강제력이 자유 표현으로 흩어져 있던 것을 5개 표준 라벨로 통일.
+
+## Enforcement 분류
+
+| 라벨 | 의미 | 정확한 효과 |
+|---|---|---|
+| **block** | tool 호출 거부 | exit 2 + stderr 사유. Claude 가 해당 도구 사용 못 함 |
+| **awareness** | 도구 사용은 허용, 인식만 | exit 0 + stderr 경고. Claude 가 메시지 보고 결정 가능 |
+| **nudge** | 다음 턴 context 에 힌트 주입 | exit 0 + stdout. UserPromptSubmit 전용 |
+| **graduated** | 임계값 따라 awareness → block 단계 상승 | 동일 hook 내 2-stage 분기 |
+| **pipeline** | Stop-hook 시점의 외부 명령 orchestration | tool 호출 gate 아님; 실패 시 disarm + stderr |
+
+**왜 이 분류?** Q2-2026 self-review 의 거버넌스 ROI 측정이 `aware` 와 `blocked` 를 구분 못 하던 문제 (`.hook-fires.log` 57/58 줄이 `aware|*`, 0줄이 `blocked|*`) — PR4 의 outcome telemetry 가 정확한 outcome 카테고리를 emit 하려면 각 hook 의 의도된 강제력이 명시되어야 함.
+
+## 현재 hook 인벤토리
+
+| Hook | Enforcement | Matcher | 주 기능 |
+|---|---|---|---|
+| [`plan-slug-race.sh`](./plan-slug-race.sh) | block | `Write` | `~/.claude/plans/<slug>.md` 5-min 내 cross-worktree race 차단 (issue #779) |
+| [`pretooluse-adr-template.sh`](./pretooluse-adr-template.sh) | block | `Edit\|MultiEdit\|Write` | 신규 ADR 의 Verification section + verifies-key marker 누락 차단 (issue #826/#866) |
+| [`pretooluse-bash-guard.sh`](./pretooluse-bash-guard.sh) | block | `Bash` | (1) stacked-dependent 있을 때 `gh pr merge --delete-branch` 차단, (2) `gh pr create` 시 stacked-base mismatch 차단 (PR #423→#431, #470 incident) |
+| [`pretooluse-loadbearing.sh`](./pretooluse-loadbearing.sh) | awareness | `Edit\|MultiEdit\|Write` | load-bearing 파일 편집 시 ADR / PR §5b 영향 환기 (CLAUDE.md) |
+| [`pretooluse-memory-lines.sh`](./pretooluse-memory-lines.sh) | graduated | `Edit\|MultiEdit\|Write` | MEMORY.md 라인 수 ≥AWARE 경고 / ≥BLOCK 차단 (issue #720) |
+| [`stop-ship.sh`](./stop-ship.sh) | pipeline | Stop | armed 상태일 때 commit→push→PR→CI→squash-merge 5-stage 자동 실행 (auto-ship) |
+| [`userpromptsubmit-delegation-gate.sh`](./userpromptsubmit-delegation-gate.sh) | nudge | UserPromptSubmit `.*` | non-trivial 변경 키워드 감지 시 Plan/Explore 위임 힌트 주입 (issue #1014) |
+
+## 새 hook 추가 시
+
+1. 헤더 docstring 둘째 줄에 **`# Enforcement: <label>`** 1줄 + **`# Classification rationale: <한 문장>`** 1줄 추가.
+2. 위 인벤토리 표에 row 추가 (matcher + 1줄 설명 + 관련 issue/PR).
+3. `.claude/settings.json` 의 hooks 섹션에 등록.
+4. (PR4 outcome telemetry 머지 후) `.claude/.hook-fires.log` 에 emit 하는 outcome 카테고리가 위 enforcement 와 일치하는지 회귀 테스트로 확인.
+
+## Supporting helpers (hook 아님)
+
+다음 파일은 hook 자체가 아닌 hook/CLI 가 import 하는 helper 모듈. enforcement 라벨 부여 대상 아님:
+
+- `_self_review.py` — `make hook-fires-weekly` + `/self-review-quarterly` 의 raw signal collector
+- `_ship_arm.py` — `make ship-arm` 의 arm-file 생성 로직
+- `_ship_lock_check.py` — ship 표면 lock 검사 (PR6 후 본격 활용 예정)
+- `_ship_pr_body.py` — stop-ship 의 PR body 빌드 헬퍼
+
+## Telemetry 포맷
+
+현재 `.hook-fires.log` 포맷이 hook 마다 다름 (3-field `<ts>|<category>|<path>` vs 4-field `<ts>|<action>|<reason>|<path>`). PR4 (outcome telemetry, issue 별도) 에서 통일 예정. PR4 이전에는 hook 별 docstring 의 telemetry 섹션 참조.
+
+## 우회 정책
+
+- `--no-verify` (git): pre-commit/pre-push 만. PreToolUse/Stop hook 은 영향 없음.
+- `claude --dangerously-skip-permissions`: PreToolUse 전체 skip. **위험 — 사용자 명시 의도일 때만.**
+- 개별 hook 우회: hook 코드 안의 환경 변수 (e.g. `PLAN_SLUG_RACE_THRESHOLD`, `MEMORY_AWARE_OVERRIDE`) — 각 hook docstring 참조.

--- a/scripts/claude-hooks/plan-slug-race.sh
+++ b/scripts/claude-hooks/plan-slug-race.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Claude Code PreToolUse hook — plan-slug race detector (issue #779).
 #
+# Enforcement: block (exit 2 refuses Write within 5-min cross-worktree window).
+# Classification rationale: refuses tool calls. See scripts/claude-hooks/README.md.
+#
 # Registered (user-globally) in `~/.claude/settings.json` with matcher
 # `Write`. Fires before Claude writes any file. Refuses to overwrite a
 # `~/.claude/plans/<slug>.md` that was last touched within the past 5

--- a/scripts/claude-hooks/pretooluse-adr-template.sh
+++ b/scripts/claude-hooks/pretooluse-adr-template.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Claude Code PreToolUse hook for BidMate-DocAgent — ADR Verification template.
 #
+# Enforcement: block (exit 2 refuses Write of new ADR missing Verification section).
+# Classification rationale: refuses tool calls. See scripts/claude-hooks/README.md.
+#
 # Registered in `.claude/settings.json` with matcher `Edit|MultiEdit|Write`.
 # Fires before Claude writes/edits a file. Refuses Write calls that create
 # a *new* ADR file (``docs/adr/<NNNN>-*.md``) whose payload does not include

--- a/scripts/claude-hooks/pretooluse-bash-guard.sh
+++ b/scripts/claude-hooks/pretooluse-bash-guard.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Claude Code PreToolUse hook for BidMate-DocAgent — Bash matcher.
 #
+# Enforcement: block (exit 2 refuses gh pr merge/create with stacked-dependency violation).
+# Classification rationale: refuses tool calls. See scripts/claude-hooks/README.md.
+#
 # Registered in `.claude/settings.json` with matcher `Bash`. Fires before
 # Claude runs any Bash command. Two responsibilities:
 #

--- a/scripts/claude-hooks/pretooluse-loadbearing.sh
+++ b/scripts/claude-hooks/pretooluse-loadbearing.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Claude Code PreToolUse hook for BidMate-DocAgent.
 #
+# Enforcement: awareness (stderr message only, never refuses tool call).
+# Classification rationale: NEVER blocks (line below); pure reminder layer.
+# See scripts/claude-hooks/README.md for the full enforcement taxonomy.
+#
 # Registered in `.claude/settings.json` with matcher `Edit|MultiEdit|Write`.
 # Fires before Claude modifies a file; prints a stderr awareness warning
 # when the target is a load-bearing path (per CLAUDE.md), reminding Claude

--- a/scripts/claude-hooks/pretooluse-memory-lines.sh
+++ b/scripts/claude-hooks/pretooluse-memory-lines.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Claude Code PreToolUse hook for BidMate-DocAgent (issue #720).
 #
+# Enforcement: graduated (awareness ≥AWARE_THRESHOLD, block ≥BLOCK_THRESHOLD).
+# Classification rationale: dual-mode — stderr warning then exit 2 refuse.
+# See scripts/claude-hooks/README.md for the full enforcement taxonomy.
+#
 # Registered in `.claude/settings.json` with matcher `Edit|MultiEdit|Write`.
 # Fires only when the edit target is a `MEMORY.md` index file. Counts the
 # *resulting* line count (existing file lines OR Write payload lines) and:

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Auto-ship Stop hook dispatcher for BidMate-DocAgent.
 #
+# Enforcement: pipeline (orchestrates 8-gate + 5-stage ship; not a tool-call gate).
+# Classification rationale: Stop-hook only fires after Claude reply ends; runs
+# its own external commands (git/gh/test) and can fail at any gate. Failure
+# does not refuse a tool call — it disarms and surfaces stderr.
+# See scripts/claude-hooks/README.md for the full enforcement taxonomy.
+#
 # Registered in `.claude/settings.json` as a Stop hook. Fires on every
 # Claude reply termination. The dominant case is no-op (no arm-file
 # present) — that path must complete in well under 100ms.

--- a/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
+++ b/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Claude Code UserPromptSubmit hook for BidMate-DocAgent (issue #1014).
 #
+# Enforcement: nudge (stdout context injection only, never blocks).
+# Classification rationale: injects suggestion text into next-turn context;
+# user/Claude free to ignore. Always exit 0.
+# See scripts/claude-hooks/README.md for the full enforcement taxonomy.
+#
 # Registered in `.claude/settings.json` with matcher `.*`. Inspects every
 # user prompt for non-trivial change-intent keywords (Korean + English) and,
 # when matched, emits a CLAUDE.md "위임 기본값" suggestion to stdout — which


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

거버넌스 비판 보고서 (2026-05-19, plan file `parsed-rolling-liskov-governance.md`) #4 후속.

비판 보고서 원안: "CLAUDE.md 의 'guard' 단어가 실제로 nudge 인 hook 들까지 포함". 재조사 결과 **CLAUDE.md 본문은 이미 nuanced** (`awareness 훅` + `차단 Bash matcher` 구분). 진짜 빈자리는 **scripts/claude-hooks/ 자체에 통일된 enforcement 분류가 없었다는 점** — 7개 hook 의 docstring 이 자유 표현으로 강제력 묘사.

이 PR 은 5개 표준 라벨 (block / awareness / nudge / graduated / pipeline) 을 정의하고 각 hook 에 라벨을 부여. PR4 (outcome telemetry, issue 별도) 가 정확한 outcome 카테고리를 emit 하기 위한 사전 준비.

Closes #1033

## 2. 영향 파일

- \`scripts/claude-hooks/README.md\` (신규) — 5개 라벨 정의 + 7-hook 인벤토리 + 새 hook 추가 시 절차 + supporting helpers + telemetry 포맷 + 우회 정책
- \`scripts/claude-hooks/plan-slug-race.sh\` — Enforcement: block 라벨
- \`scripts/claude-hooks/pretooluse-adr-template.sh\` — Enforcement: block
- \`scripts/claude-hooks/pretooluse-bash-guard.sh\` — Enforcement: block
- \`scripts/claude-hooks/pretooluse-loadbearing.sh\` — Enforcement: awareness
- \`scripts/claude-hooks/pretooluse-memory-lines.sh\` — Enforcement: graduated
- \`scripts/claude-hooks/stop-ship.sh\` — Enforcement: pipeline
- \`scripts/claude-hooks/userpromptsubmit-delegation-gate.sh\` — Enforcement: nudge

Load-bearing 변경 아님 (\`scripts/claude-hooks/\` 는 _governance.py LOAD_BEARING_PATHS 미포함).

## 3. 리스크

- hook 동작 변경 없음 (docstring 만 수정 + README 신규)
- 향후 새 hook 추가 시 라벨 누락 가능 — README 의 "새 hook 추가 시" 절차가 enforcement 라벨 강제. 자동 검증은 없음 (PR4 이후 lint 검토)

## 4. 테스트

- 모든 hook 의 동작 라인 (\`exit 0\`/\`exit 2\`/threshold 분기) 변경 없음 — docstring 만 수정
- 동작 변경 없음 → 회귀 테스트 추가 없음
- 매뉴얼 검증: \`bash scripts/claude-hooks/<hook>.sh\` 로 syntax error 없음 확인 (shellcheck 패스)

## 5. Eval 영향

All ·

### 5b. Real-data delta

N/A — load-bearing path 변경 없음.

## 6. 하위 호환

- hook 호출 인터페이스 (stdin/stdout/exit code) 변경 없음
- \`.claude/.hook-fires.log\` 포맷 변경 없음 (PR4 에서 통일)
- README.md 는 신규 파일

## 7. 범위 외

- telemetry 포맷 통일 (3-field vs 4-field) — PR4 outcome telemetry 작업
- enforcement 라벨 누락 자동 lint — PR4 이후 검토
- CLAUDE.md 본문 수정 — 이미 nuanced 하므로 변경 불필요 확인됨
- supporting helpers (_self_review.py / _ship_arm.py / _ship_lock_check.py / _ship_pr_body.py) 의 README 분류 — hook 자체 아니므로 별도 라벨 부여 안 함 (README 의 "Supporting helpers" 섹션에 명시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)