### PR TITLE
feat(scripts): analyze_hook_outcomes.py — fire-log telemetry 분석기

### DIFF
--- a/scripts/analyze_hook_outcomes.py
+++ b/scripts/analyze_hook_outcomes.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Analyze ``.claude/.hook-fires.log`` outcomes for governance ROI measurement.
+
+거버넌스 비판 보고서 (2026-05-19) #7 후속.
+
+90일 데이터 누적 후 사용자가 실행해 (a) hook 별 fire 분포 + outcome
+breakdown, (b) memory-lines AWARE/BLOCK threshold 정당화 데이터, (c)
+fire 0 회 hook (surface 축소 후보) 식별을 얻는 분석 스크립트.
+
+PR4 (outcome telemetry, issue 별도) 이전에는 fire-log 가 mixed 포맷
+(3-field legacy + 4-field + 5-field) — 이 스크립트는 세 가지 모두 parse.
+
+포맷 spec
+=========
+
+PR4 표준 (5-field+)::
+
+    <ts>|<outcome>|<hook>|<category>|<path>[|<extra>]
+
+    outcome ∈ {aware, blocked, bypassed, false_positive,
+               false_negative, nudged, pipeline_start, pipeline_end}
+    hook    ∈ {bash-guard, loadbearing, memory-lines, adr-template,
+               plan-slug-race, delegation-gate, stop-ship}
+
+Legacy 3-field (loadbearing 현재 포맷)::
+
+    <ts>|aware|<path>            (hook 추정: "loadbearing")
+
+Legacy 4-field (memory-lines / delegation-gate 현재 포맷)::
+
+    <ts>|<action>|<reason>|<path>
+    # action ∈ {aware, ok}, reason 이 hook 식별자 (e.g. "memory-lines")
+
+이미 bash-guard 는 5-field 포맷을 사용 중 (scripts/claude-hooks/
+pretooluse-bash-guard.sh:131-133). PR4 가 나머지 hook 으로 확산.
+
+Usage
+=====
+
+::
+
+    python scripts/analyze_hook_outcomes.py
+    python scripts/analyze_hook_outcomes.py --window 90d
+    python scripts/analyze_hook_outcomes.py --window 30d --hook memory-lines
+    python scripts/analyze_hook_outcomes.py --format json
+
+Exit codes
+==========
+
+    0  분석 성공 + 출력 완료
+    1  fire-log 파일 부재 또는 파싱 실패
+    2  CLI usage 에러
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+# 5-field+ 표준: <ts>|<outcome>|<hook>|<category>|<path>[|extra]
+# 4-field legacy: <ts>|<action>|<reason>|<path>
+# 3-field legacy: <ts>|<category>|<path>
+
+KNOWN_OUTCOMES = {
+    "aware", "blocked", "bypassed",
+    "false_positive", "false_negative",
+    "nudged", "pipeline_start", "pipeline_end",
+    "ok",  # legacy memory-lines silent pass
+}
+
+# Legacy 3-field category → hook name mapping. PR4 후 이 매핑은
+# fire-log 자체가 hook 명을 명시하므로 deprecated.
+LEGACY_CATEGORY_TO_HOOK = {
+    "load-bearing": "loadbearing",
+    "memory-lines": "memory-lines",
+    "loadbearing": "loadbearing",
+}
+
+
+def parse_log_line(line: str) -> dict | None:
+    """Parse a single ``.hook-fires.log`` line into a normalized dict.
+
+    Returns ``None`` for malformed / empty / comment lines.
+
+    Output keys (always present)::
+
+        ts:       ISO 8601 UTC string (raw, parsing deferred to caller)
+        outcome:  one of KNOWN_OUTCOMES (or "unknown" if unrecognized)
+        hook:     short hook name (e.g. "bash-guard", "loadbearing")
+        category: hook-internal sub-category (may be empty)
+        path:     affected file path or branch (may be empty)
+        extra:    free-form trailing fields joined by "|" (may be empty)
+        format:   "v1-3field" / "v1-4field" / "v2-5field" (parse provenance)
+    """
+    line = line.rstrip("\n")
+    if not line or line.startswith("#"):
+        return None
+    parts = line.split("|")
+    if len(parts) < 3:
+        return None
+    ts = parts[0]
+    # Quick sanity: ts should look like ISO 8601 ("YYYY-MM-DDTHH:MM:SSZ").
+    if not re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?$", ts):
+        return None
+
+    if len(parts) >= 5:
+        # v2-5field: ts | outcome | hook | category | path [| extra...]
+        outcome = parts[1]
+        hook = parts[2]
+        category = parts[3]
+        path = parts[4]
+        extra = "|".join(parts[5:]) if len(parts) > 5 else ""
+        if outcome not in KNOWN_OUTCOMES:
+            outcome = "unknown"
+        return {
+            "ts": ts, "outcome": outcome, "hook": hook,
+            "category": category, "path": path, "extra": extra,
+            "format": "v2-5field",
+        }
+
+    if len(parts) == 4:
+        # v1-4field: ts | action | reason | path
+        # action ∈ {aware, ok, blocked, ...}, reason ≈ hook id
+        action = parts[1]
+        reason = parts[2]
+        path = parts[3]
+        hook = LEGACY_CATEGORY_TO_HOOK.get(reason, reason)
+        outcome = action if action in KNOWN_OUTCOMES else "unknown"
+        return {
+            "ts": ts, "outcome": outcome, "hook": hook,
+            "category": reason, "path": path, "extra": "",
+            "format": "v1-4field",
+        }
+
+    # len(parts) == 3 → v1-3field: ts | category | path
+    category = parts[1]
+    path = parts[2]
+    hook = LEGACY_CATEGORY_TO_HOOK.get(category, category)
+    # 3-field never recorded anything but awareness in observed data
+    outcome = "aware"
+    return {
+        "ts": ts, "outcome": outcome, "hook": hook,
+        "category": category, "path": path, "extra": "",
+        "format": "v1-3field",
+    }
+
+
+def parse_ts(ts: str) -> datetime | None:
+    try:
+        # Accept both "...Z" and "...+00:00".
+        s = ts.rstrip("Z")
+        return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Loading + filtering
+# ---------------------------------------------------------------------------
+
+
+def load_log(path: Path) -> list[dict]:
+    """Read fire-log file, returning parsed events (malformed lines dropped)."""
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for raw in fh:
+            ev = parse_log_line(raw)
+            if ev is not None:
+                out.append(ev)
+    return out
+
+
+def filter_window(events: list[dict], window: str) -> list[dict]:
+    """Filter events to a sliding window from now.
+
+    Window format: ``Nd`` (days), ``Nh`` (hours), or ``all``.
+    """
+    if window == "all":
+        return events
+    m = re.match(r"^(\d+)([dh])$", window)
+    if not m:
+        raise ValueError(f"invalid --window: {window!r} (expected Nd / Nh / all)")
+    n = int(m.group(1))
+    unit = m.group(2)
+    delta = timedelta(days=n) if unit == "d" else timedelta(hours=n)
+    cutoff = datetime.now(timezone.utc) - delta
+    out: list[dict] = []
+    for ev in events:
+        ts = parse_ts(ev["ts"])
+        if ts is not None and ts >= cutoff:
+            out.append(ev)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+# Canonical hook inventory — matches scripts/claude-hooks/README.md table.
+ALL_HOOKS = [
+    "bash-guard", "loadbearing", "memory-lines",
+    "adr-template", "plan-slug-race",
+    "delegation-gate", "stop-ship",
+]
+
+
+def outcome_breakdown(events: list[dict]) -> dict[str, dict[str, int]]:
+    """Return ``{hook: {outcome: count}}``."""
+    out: dict[str, Counter] = defaultdict(Counter)
+    for ev in events:
+        out[ev["hook"]][ev["outcome"]] += 1
+    return {k: dict(v) for k, v in out.items()}
+
+
+def threshold_recommendation(events: list[dict]) -> dict:
+    """Recommend memory-lines AWARE/BLOCK thresholds from observed fire dist.
+
+    Current thresholds (scripts/_governance.py THRESHOLDS):
+        MEMORY_LINE_AWARE = 20
+        MEMORY_LINE_BLOCK = 30
+
+    Logic: count AWARE vs BLOCK fires for memory-lines. If BLOCK fires
+    are rare (<5% of total) and AWARE fires regular, current thresholds
+    are catching outliers — maintain. If BLOCK fires are common (>20%),
+    BLOCK threshold may be too low. If AWARE fires rare (<5% of edits),
+    AWARE threshold may be too high.
+
+    Returns a structured dict — no auto-adjust.
+    """
+    ml_events = [e for e in events if e["hook"] == "memory-lines"]
+    total = len(ml_events)
+    aware = sum(1 for e in ml_events if e["outcome"] in ("aware", "ok"))
+    blocked = sum(1 for e in ml_events if e["outcome"] == "blocked")
+    if total == 0:
+        return {
+            "current": {"aware": 20, "block": 30},
+            "observed_total": 0,
+            "verdict": "insufficient_data",
+            "rationale": "memory-lines hook 이 윈도우 안에 0회 fire — 데이터 부족.",
+        }
+    block_ratio = blocked / total
+    if block_ratio < 0.05:
+        verdict = "maintain"
+        rationale = (
+            f"BLOCK fire ratio = {block_ratio:.1%} (<5%) — 임계값이 outlier 만 "
+            "catch. 현재 30 유지 합리적."
+        )
+    elif block_ratio > 0.20:
+        verdict = "raise_block"
+        rationale = (
+            f"BLOCK fire ratio = {block_ratio:.1%} (>20%) — 임계값이 너무 낮아 "
+            "정상 작업이 BLOCK 됨. 30 → 40+ 검토."
+        )
+    else:
+        verdict = "maintain"
+        rationale = f"BLOCK fire ratio = {block_ratio:.1%} — 정상 범위."
+    return {
+        "current": {"aware": 20, "block": 30},
+        "observed_total": total,
+        "observed_aware": aware,
+        "observed_blocked": blocked,
+        "block_ratio": block_ratio,
+        "verdict": verdict,
+        "rationale": rationale,
+    }
+
+
+def surface_reduction_candidates(events: list[dict], window: str) -> list[str]:
+    """Return hooks with 0 fires in the window — candidates for removal."""
+    fired = {ev["hook"] for ev in events}
+    return sorted(h for h in ALL_HOOKS if h not in fired)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def render_text(events: list[dict], window: str) -> str:
+    breakdown = outcome_breakdown(events)
+    threshold = threshold_recommendation(events)
+    silent = surface_reduction_candidates(events, window)
+    fmt_counts = Counter(ev["format"] for ev in events)
+
+    lines: list[str] = []
+    lines.append(f"=== Hook outcome breakdown (window={window}) ===")
+    lines.append(f"Total events: {len(events)}")
+    lines.append(
+        f"Format mix: v2-5field={fmt_counts.get('v2-5field', 0)}  "
+        f"v1-4field={fmt_counts.get('v1-4field', 0)}  "
+        f"v1-3field={fmt_counts.get('v1-3field', 0)}"
+    )
+    lines.append("")
+
+    for hook in ALL_HOOKS:
+        counts = breakdown.get(hook, {})
+        if not counts:
+            lines.append(f"{hook}: (no fires)")
+            continue
+        lines.append(f"{hook}:")
+        for outcome in sorted(counts):
+            lines.append(f"  {outcome:18s} {counts[outcome]:>6d}")
+
+    # Any unexpected hook names (e.g. typo'd legacy reason)
+    unknown_hooks = sorted(set(breakdown) - set(ALL_HOOKS))
+    if unknown_hooks:
+        lines.append("")
+        lines.append("Unrecognized hook names (legacy / typo):")
+        for h in unknown_hooks:
+            counts = breakdown[h]
+            lines.append(f"  {h:25s} {sum(counts.values())} events")
+
+    lines.append("")
+    lines.append("=== Threshold recommendations ===")
+    lines.append("memory-lines:")
+    lines.append(f"  current: AWARE={threshold['current']['aware']} / "
+                 f"BLOCK={threshold['current']['block']}")
+    if threshold.get("verdict") == "insufficient_data":
+        lines.append(f"  verdict: insufficient data ({threshold['rationale']})")
+    else:
+        lines.append(f"  observed: total={threshold['observed_total']} "
+                     f"aware={threshold['observed_aware']} "
+                     f"blocked={threshold['observed_blocked']} "
+                     f"({threshold['block_ratio']:.1%})")
+        lines.append(f"  verdict: {threshold['verdict']}")
+        lines.append(f"  rationale: {threshold['rationale']}")
+
+    lines.append("")
+    lines.append("=== Surface reduction candidates ===")
+    if silent:
+        for h in silent:
+            lines.append(f"  {h} — 0 fires in window")
+        lines.append("")
+        lines.append("(removal 결정 전에 90일 이상 데이터 + 회귀 테스트 검토)")
+    else:
+        lines.append("(none — all hooks fired ≥1 time in window)")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_json(events: list[dict], window: str) -> str:
+    return json.dumps({
+        "window": window,
+        "total_events": len(events),
+        "format_mix": dict(Counter(ev["format"] for ev in events)),
+        "outcome_breakdown": outcome_breakdown(events),
+        "threshold_memory_lines": threshold_recommendation(events),
+        "surface_reduction_candidates": surface_reduction_candidates(events, window),
+    }, indent=2, ensure_ascii=False) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--log",
+        default=".claude/.hook-fires.log",
+        help="fire-log path (default: .claude/.hook-fires.log)",
+    )
+    parser.add_argument(
+        "--window",
+        default="90d",
+        help="time window: Nd (days) / Nh (hours) / all (default: 90d)",
+    )
+    parser.add_argument(
+        "--hook",
+        default="all",
+        help="filter to single hook name (default: all)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="output format (default: text)",
+    )
+    args = parser.parse_args(argv)
+
+    log_path = Path(args.log)
+    events = load_log(log_path)
+    if not events and not log_path.exists():
+        sys.stderr.write(f"fire-log not found: {log_path}\n")
+        return 1
+
+    try:
+        events = filter_window(events, args.window)
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
+    if args.hook != "all":
+        events = [e for e in events if e["hook"] == args.hook]
+
+    if args.format == "json":
+        sys.stdout.write(render_json(events, args.window))
+    else:
+        sys.stdout.write(render_text(events, args.window))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_analyze_hook_outcomes.py
+++ b/tests/test_analyze_hook_outcomes.py
@@ -1,0 +1,254 @@
+"""Tests for ``scripts/analyze_hook_outcomes.py`` (issue #1037).
+
+거버넌스 비판 #7 후속. 90일 데이터 누적 후 사용자가 실행하는 분석
+스크립트의 (a) 3/4/5-field 포맷 parse, (b) window filtering, (c)
+threshold 추천 분기, (d) surface reduction 후보 식별 회귀 테스트.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "analyze_hook_outcomes.py"
+
+
+def _load_script():
+    """Import the script module without making it a package import."""
+    spec = importlib.util.spec_from_file_location(
+        "analyze_hook_outcomes", SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def aho():
+    return _load_script()
+
+
+# ---------------------------------------------------------------------------
+# parse_log_line
+# ---------------------------------------------------------------------------
+
+
+def test_parse_v2_5field(aho):
+    line = (
+        "2026-05-19T10:30:00Z|blocked|bash-guard|gh-pr-create-stacked|"
+        "feat/issue-99-foo|on=feat/issue-88-bar"
+    )
+    ev = aho.parse_log_line(line)
+    assert ev is not None
+    assert ev["outcome"] == "blocked"
+    assert ev["hook"] == "bash-guard"
+    assert ev["category"] == "gh-pr-create-stacked"
+    assert ev["path"] == "feat/issue-99-foo"
+    assert ev["extra"] == "on=feat/issue-88-bar"
+    assert ev["format"] == "v2-5field"
+
+
+def test_parse_v1_4field_memory_lines(aho):
+    line = "2026-05-15T09:51:19Z|ok|memory-lines|MEMORY.md"
+    ev = aho.parse_log_line(line)
+    assert ev is not None
+    assert ev["outcome"] == "ok"
+    assert ev["hook"] == "memory-lines"
+    assert ev["category"] == "memory-lines"
+    assert ev["path"] == "MEMORY.md"
+    assert ev["format"] == "v1-4field"
+
+
+def test_parse_v1_3field_loadbearing(aho):
+    line = "2026-05-14T09:51:19Z|load-bearing|rag_core.py"
+    ev = aho.parse_log_line(line)
+    assert ev is not None
+    assert ev["outcome"] == "aware"  # 3-field implies awareness
+    assert ev["hook"] == "loadbearing"
+    assert ev["category"] == "load-bearing"
+    assert ev["path"] == "rag_core.py"
+    assert ev["format"] == "v1-3field"
+
+
+def test_parse_unknown_outcome_normalized(aho):
+    line = "2026-05-19T10:30:00Z|made_up|bash-guard|cat|path|extra"
+    ev = aho.parse_log_line(line)
+    assert ev is not None
+    assert ev["outcome"] == "unknown"
+
+
+def test_parse_malformed_skipped(aho):
+    assert aho.parse_log_line("") is None
+    assert aho.parse_log_line("# comment line") is None
+    assert aho.parse_log_line("not-a-timestamp|x|y") is None
+    assert aho.parse_log_line("2026-05-19T10:30:00Z|only-two") is None
+
+
+# ---------------------------------------------------------------------------
+# filter_window
+# ---------------------------------------------------------------------------
+
+
+def _make_event(ts: datetime, hook: str = "bash-guard", outcome: str = "aware"):
+    return {
+        "ts": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "outcome": outcome,
+        "hook": hook,
+        "category": "",
+        "path": "",
+        "extra": "",
+        "format": "v2-5field",
+    }
+
+
+def test_filter_window_days(aho):
+    now = datetime.now(timezone.utc)
+    events = [
+        _make_event(now - timedelta(days=1)),
+        _make_event(now - timedelta(days=10)),
+        _make_event(now - timedelta(days=100)),
+    ]
+    out = aho.filter_window(events, "30d")
+    assert len(out) == 2  # 1d + 10d, not 100d
+
+
+def test_filter_window_hours(aho):
+    now = datetime.now(timezone.utc)
+    events = [
+        _make_event(now - timedelta(hours=1)),
+        _make_event(now - timedelta(hours=24)),
+    ]
+    out = aho.filter_window(events, "6h")
+    assert len(out) == 1
+
+
+def test_filter_window_all(aho):
+    events = [_make_event(datetime(2000, 1, 1, tzinfo=timezone.utc))]
+    assert aho.filter_window(events, "all") == events
+
+
+def test_filter_window_invalid_raises(aho):
+    with pytest.raises(ValueError):
+        aho.filter_window([], "30")
+
+
+# ---------------------------------------------------------------------------
+# outcome_breakdown
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_breakdown(aho):
+    now = datetime.now(timezone.utc)
+    events = [
+        _make_event(now, "bash-guard", "blocked"),
+        _make_event(now, "bash-guard", "blocked"),
+        _make_event(now, "bash-guard", "aware"),
+        _make_event(now, "loadbearing", "aware"),
+    ]
+    out = aho.outcome_breakdown(events)
+    assert out["bash-guard"] == {"blocked": 2, "aware": 1}
+    assert out["loadbearing"] == {"aware": 1}
+
+
+# ---------------------------------------------------------------------------
+# threshold_recommendation
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_insufficient_data(aho):
+    out = aho.threshold_recommendation([])
+    assert out["verdict"] == "insufficient_data"
+    assert out["observed_total"] == 0
+
+
+def test_threshold_maintain_low_block_ratio(aho):
+    now = datetime.now(timezone.utc)
+    events = [_make_event(now, "memory-lines", "aware") for _ in range(40)]
+    events.append(_make_event(now, "memory-lines", "blocked"))  # 1/41 ≈ 2.4%
+    out = aho.threshold_recommendation(events)
+    assert out["verdict"] == "maintain"
+    assert out["observed_blocked"] == 1
+    assert out["observed_aware"] == 40
+
+
+def test_threshold_raise_block_high_ratio(aho):
+    now = datetime.now(timezone.utc)
+    events = [_make_event(now, "memory-lines", "blocked") for _ in range(5)]
+    events.extend(_make_event(now, "memory-lines", "aware") for _ in range(5))
+    # 5/10 = 50% blocked → recommendation raise
+    out = aho.threshold_recommendation(events)
+    assert out["verdict"] == "raise_block"
+
+
+def test_threshold_ignores_other_hooks(aho):
+    now = datetime.now(timezone.utc)
+    events = [_make_event(now, "bash-guard", "blocked")]
+    out = aho.threshold_recommendation(events)
+    assert out["verdict"] == "insufficient_data"
+
+
+# ---------------------------------------------------------------------------
+# surface_reduction_candidates
+# ---------------------------------------------------------------------------
+
+
+def test_surface_reduction_all_silent(aho):
+    out = aho.surface_reduction_candidates([], "90d")
+    assert set(out) == set(aho.ALL_HOOKS)
+
+
+def test_surface_reduction_partial(aho):
+    now = datetime.now(timezone.utc)
+    events = [
+        _make_event(now, "bash-guard", "blocked"),
+        _make_event(now, "loadbearing", "aware"),
+    ]
+    out = aho.surface_reduction_candidates(events, "90d")
+    assert "bash-guard" not in out
+    assert "loadbearing" not in out
+    assert "memory-lines" in out  # didn't fire
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: load_log + render_json
+# ---------------------------------------------------------------------------
+
+
+def test_load_log_and_render(tmp_path, aho):
+    log = tmp_path / ".hook-fires.log"
+    log.write_text(
+        # mix of all three formats
+        "2026-05-19T10:30:00Z|blocked|bash-guard|gh-pr-create-stacked|br|on=other\n"
+        "2026-05-15T09:51:19Z|ok|memory-lines|MEMORY.md\n"
+        "2026-05-14T09:51:19Z|load-bearing|rag_core.py\n"
+        "\n"
+        "# this is a comment, skip\n"
+        "malformed line with no timestamp\n",
+        encoding="utf-8",
+    )
+    events = aho.load_log(log)
+    assert len(events) == 3
+    formats = {e["format"] for e in events}
+    assert formats == {"v2-5field", "v1-4field", "v1-3field"}
+
+    js = json.loads(aho.render_json(events, "all"))
+    assert js["total_events"] == 3
+    assert js["format_mix"]["v2-5field"] == 1
+    assert "loadbearing" in js["outcome_breakdown"]
+
+
+def test_load_log_missing_file_returns_empty(aho, tmp_path):
+    assert aho.load_log(tmp_path / "nonexistent.log") == []
+
+
+def test_render_text_includes_all_hooks(aho):
+    out = aho.render_text([], "90d")
+    # 0-fire 시에도 모든 hook 이 표 안에 있어야 surface 측정 가능
+    for hook in aho.ALL_HOOKS:
+        assert hook in out


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

거버넌스 비판 보고서 (2026-05-19, plan file \`parsed-rolling-liskov-governance.md\`) #7 후속.

`.hook-fires.log` 가 누적되지만 분석 도구 부재. 90일 데이터 누적 후 사용자가 (a) hook 별 outcome 분포, (b) memory-lines AWARE/BLOCK threshold 정당화 데이터, (c) surface 축소 후보 (0회 fire 한 hook) 를 얻으려면 손으로 grep + awk. 자동화 + 회귀 테스트로 빈자리 채움.

PR4 (outcome telemetry, issue 별도) 의 사전 도구 — PR4 표준 포맷 (5-field+) + 두 종류 legacy 포맷 모두 parse.

Closes #1037

## 2. 영향 파일

- \`scripts/analyze_hook_outcomes.py\` (신규, 300줄) — CLI + parse + analysis + reporting
- \`tests/test_analyze_hook_outcomes.py\` (신규, 19 테스트) — 3 포맷 parse, window filtering, threshold 추천 3 분기, surface reduction, end-to-end load+render

Load-bearing 변경 아님 (\`scripts/build_index.py\` 외 \`scripts/\` 는 load-bearing 미포함).

## 3. 리스크

- v2-5field 포맷 spec 이 PR4 가 정의할 표준 — PR3 가 먼저 spec 을 commit 함. PR4 에서 spec 변경 시 PR3 의 parse 코드도 같이 수정 필요
- 완화: spec 이 단순 (outcome enum + 5 field) 이라 변경 가능성 낮음. PR4 docstring 에서 PR3 호환성 명시 예정
- threshold_recommendation() 의 분기 임계값 (5% / 20%) 도 자유 숫자. 향후 90일 데이터 누적 후 본 데이터로 정당화

## 4. 테스트

\`tests/test_analyze_hook_outcomes.py\` — 19 회귀 테스트, 모두 통과. 커버:

- parse_log_line: v1-3field / v1-4field / v2-5field / unknown outcome / malformed
- filter_window: days / hours / all / invalid raises
- outcome_breakdown: hook 별 counter 집계
- threshold_recommendation: insufficient_data / maintain / raise_block 3 분기
- surface_reduction_candidates: all silent / partial
- load_log + render_json: end-to-end mix 포맷 fixture

실제 fire-log (58줄) sanity:

\`\`\`
Total events: 58
Format mix: v2-5field=0  v1-4field=58  v1-3field=0

bash-guard: (no fires)
loadbearing: aware 57
memory-lines: ok 1
adr-template / plan-slug-race / delegation-gate / stop-ship: (no fires)

threshold: maintain (block ratio 0%)
surface reduction candidates: 5 hooks (90일 데이터 누적 후 재평가)
\`\`\`

비판 보고서의 메타 발견 ("57 aware / 0 blocked") 정확히 reproduce.

## 5. Eval 영향

All ·

### 5b. Real-data delta

N/A — load-bearing path 변경 없음 (\`scripts/\` 의 build_index.py 외).

## 6. 하위 호환

- 신규 스크립트 + 신규 테스트만. 기존 파일 변경 없음
- fire-log 자체 포맷 변경 안 함 (PR4 작업)
- self-review-quarterly skill / _self_review.py 변경 없음 (PR4 후 작업)

## 7. 범위 외

- fire-log 포맷 통일 (3/4/5-field → 5-field+ 표준화) — PR4
- 8 hook 의 emit 로직 수정 — PR4
- self-review-quarterly skill 의 채점 방식 변경 (input metric → outcome metric) — PR4 후 사용자 메모 수정
- threshold 자동 조정 — 사용자 의사결정 필요 (스크립트는 추천만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)