### PR TITLE
test(governance): PR template load-bearing parity 회귀 + stop-ship 주석 정명

### DIFF
--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -193,6 +193,13 @@ stage_1_commit() {
   # Filter staged candidate paths through pre-commit's BLOCKED_PATTERNS.
   # We rely on `.githooks/pre-commit` as the actual second-line gate,
   # but pre-filter so we don't propose to stage obviously private files.
+  #
+  # NOTE (issue #1041): this case list is the **PRIVATE PATH EXCLUSION**
+  # (data/private files that must never reach origin), NOT a mirror of
+  # scripts/_governance.py::LOAD_BEARING_PATHS (= "needs 5b real-eval
+  # delta" surface). The two have different intent and must not be merged.
+  # When adding new private paths, update HERE; load-bearing entries do
+  # not belong in this exclusion.
   local files=()
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue

--- a/tests/test_pr_template_loadbearing_parity.py
+++ b/tests/test_pr_template_loadbearing_parity.py
@@ -1,0 +1,121 @@
+"""Regression: PR template's load-bearing textual mirror ↔ LOAD_BEARING_PATHS.
+
+거버넌스 비판 보고서 (2026-05-19) #2 부분 정정 후속 (issue #1041).
+
+원안: "Load-bearing 리스트 3중 hardcode". 재조사로 다음 확정:
+- ``scripts/_governance.py:LOAD_BEARING_PATHS`` = canonical (5b 강제 대상)
+- ``.github/pull_request_template.md`` 라인 21, 48 = **진짜 textual mirror**
+- ``scripts/claude-hooks/stop-ship.sh:201-203`` = **private path exclusion** —
+  load-bearing 과 의미 다름. 별도 surface (data/files/, eval/*.local.yaml,
+  reports/real*/ 같은 commit 자체를 막을 path)
+
+이 회귀 테스트는 PR template 의 mirror 만 검증 — 진짜 drift 가능 surface.
+
+drift 발생 시 fail message 가 어디를 update 할지 명시.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PR_TEMPLATE = REPO_ROOT / ".github" / "pull_request_template.md"
+
+
+def _load_governance():
+    spec = importlib.util.spec_from_file_location(
+        "_governance_mod", REPO_ROOT / "scripts" / "_governance.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def test_pr_template_mentions_all_loadbearing_paths():
+    """Each LOAD_BEARING_PATHS entry must appear at least once in PR template.
+
+    Two textual mirror sites currently exist (§2 영향 파일 안내 + §5b 강제
+    안내). If LOAD_BEARING_PATHS grows, both sites must be updated.
+    """
+    gov = _load_governance()
+    template_text = PR_TEMPLATE.read_text(encoding="utf-8")
+
+    missing: list[str] = []
+    for path in gov.LOAD_BEARING_PATHS:
+        # Strip trailing "/" so "eval/" and "docs/adr/" match e.g. "eval/" or "docs/adr/" in prose.
+        needle = path.rstrip("/")
+        if needle not in template_text:
+            missing.append(path)
+
+    assert not missing, (
+        "PR template (.github/pull_request_template.md) is missing the following "
+        "LOAD_BEARING_PATHS entries:\n"
+        + "\n".join(f"  - {p}" for p in missing)
+        + "\n\nDrift detected — update the two textual mirror sites in PR template "
+        "(§2 영향 파일 안내 + §5b 강제 안내) to include these paths. "
+        "Single source of truth: scripts/_governance.py:LOAD_BEARING_PATHS."
+    )
+
+
+def test_pr_template_does_not_silently_remove_paths():
+    """Detect the inverse drift: paths mentioned in PR template but removed
+    from LOAD_BEARING_PATHS — the stale text is a misleading promise.
+
+    Heuristic: each rag_*.py path mentioned in PR template should exist in
+    LOAD_BEARING_PATHS (since PR template only enumerates them as
+    load-bearing). False positives are unlikely because the prose explicitly
+    lists them under "load-bearing 으로 표시".
+    """
+    gov = _load_governance()
+    template_text = PR_TEMPLATE.read_text(encoding="utf-8")
+    canonical = set(p.rstrip("/") for p in gov.LOAD_BEARING_PATHS)
+
+    # Naive scan for rag_*.py / ingestion.py / visual_ingestion.py / scripts/build_index.py
+    # mentioned in template. Skip false-positive sources (the file paths
+    # exist nowhere else in PR template's prose context).
+    rag_pattern_names = [
+        "rag_core.py", "rag_retrieval.py", "rag_verifier.py",
+        "rag_answer.py", "rag_query.py",
+        "ingestion.py", "visual_ingestion.py",
+        "scripts/build_index.py",
+    ]
+    stale: list[str] = []
+    for name in rag_pattern_names:
+        if name in template_text and name not in canonical:
+            stale.append(name)
+
+    assert not stale, (
+        "PR template mentions the following paths but they're no longer in "
+        "LOAD_BEARING_PATHS:\n"
+        + "\n".join(f"  - {p}" for p in stale)
+        + "\n\nIf they were intentionally removed, update PR template prose too. "
+        "Stale mentions create misleading 5b expectations."
+    )
+
+
+def test_loadbearing_paths_has_minimum_invariants():
+    """Sanity: the canonical list has the 11 entries CLAUDE.md documents.
+
+    If you intentionally add/remove a load-bearing path, update CLAUDE.md
+    `## 저장소 맵` and the count here together.
+    """
+    gov = _load_governance()
+    assert len(gov.LOAD_BEARING_PATHS) >= 11, (
+        f"LOAD_BEARING_PATHS shrunk below documented minimum (11): "
+        f"now {len(gov.LOAD_BEARING_PATHS)}. Confirm CLAUDE.md '## 저장소 맵' "
+        f"is also updated."
+    )
+    # Spot-check entries that CLAUDE.md explicitly enumerates.
+    canonical = set(p.rstrip("/") for p in gov.LOAD_BEARING_PATHS)
+    must_have = {
+        "rag_core.py", "rag_retrieval.py", "rag_verifier.py",
+        "rag_answer.py", "rag_query.py",
+        "ingestion.py", "visual_ingestion.py",
+        "eval", "api", "docs/adr", "scripts/build_index.py",
+    }
+    missing = must_have - canonical
+    assert not missing, (
+        f"LOAD_BEARING_PATHS missing CLAUDE.md-documented entries: {missing}"
+    )


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

거버넌스 비판 보고서 (2026-05-19, plan file \`parsed-rolling-liskov-governance.md\`) #2 부분 정정 후속.

원안: \"Load-bearing 리스트 3중 hardcode\". 재조사 결과:

| Surface | 의미 |
|---|---|
| \`scripts/_governance.py:LOAD_BEARING_PATHS\` | **canonical** — 변경 시 5b real-eval delta 강제 |
| \`.github/pull_request_template.md\` 라인 21, 48 | **진짜 textual mirror** of (1) |
| \`scripts/claude-hooks/stop-ship.sh:201-203\` | **private path exclusion** — commit 자체를 막을 path. (1) 과 의도 다름 |

진짜 drift 가능 surface 는 PR template 한 곳. stop-ship 의 hardcode 는 별도 SSoT 라 합쳐선 안 됨.

Closes #1041

## 2. 영향 파일

- \`tests/test_pr_template_loadbearing_parity.py\` (신규, 3 회귀)
- \`scripts/claude-hooks/stop-ship.sh\` (inline 주석 7줄 추가 — load-bearing 과 별개임 명시)

Load-bearing 변경 아님.

## 3. 리스크

- 회귀 테스트가 향후 LOAD_BEARING_PATHS 변경 시 PR template 동시 update 강제 → 미 update 시 CI fail. **의도된 동작** (drift catch)
- stop-ship 주석은 동작 영향 없음 (텍스트만)
- SSoT 자동 생성 스크립트 도입 안 함 — 회귀 테스트가 fail message 로 어디 update 할지 명시. minimal + transparent

## 4. 테스트

\`tests/test_pr_template_loadbearing_parity.py\` (3 통과):
- \`test_pr_template_mentions_all_loadbearing_paths\` — drift catch
- \`test_pr_template_does_not_silently_remove_paths\` — 역방향 drift catch
- \`test_loadbearing_paths_has_minimum_invariants\` — CLAUDE.md 문서화 수준 (11 entries) 유지

## 5. Eval 영향

All ·

### 5b. Real-data delta

N/A — load-bearing path 변경 없음.

## 6. 하위 호환

- 회귀 테스트만 추가, 동작 변경 0
- stop-ship 주석 추가만, executable 변경 0
- 기존 모든 hook 동작 영향 없음

## 7. 범위 외

- stop-ship 의 private path exclusion SSoT 화 — load-bearing 과 의도 다른 surface 로 합치면 안 됨. 자체 SSoT (별도 ADR 후보) 필요 시 follow-up
- PR template 자동 생성 스크립트 — 회귀 테스트가 drift 잡으므로 ROI 약함
- LOAD_BEARING_PATHS 자체 확장
- 비판 보고서의 #2 정정 자체는 PR body 에서만 — 보고서 (plan 파일) 자체는 수정 안 함 (역사 기록 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)