### PR TITLE
feat(ship): ship-arm ↔ ship-pr mutex marker (코드 강제)

### DIFF
--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -20,6 +20,8 @@ ADR-aware, approval-gated single-PR shipping. The skill replaces an ad-hoc seque
 
 ## Workflow
 
+0. **Mutex guard (issue #1043).** Before any other step, check that `.claude/.ship-armed` does NOT exist. If it does, refuse and tell the user to run `make ship-disarm` first — the two ship surfaces are mutually exclusive and `make ship-arm` is currently active. Then `touch .claude/.ship-pr-active` so `make ship-arm` will refuse if invoked while this skill is running. The cleanup (step 13) removes the marker; if the skill aborts, the marker auto-expires after 6h (`_ship_arm.py` stale-marker safety).
+
 1. **Scope confirmation.** Ask the user (inline or via `AskUserQuestion`): "Which issue does this PR close, and what's the one-line summary?" If no issue exists yet, propose a title + body and require **explicit approval** before `gh issue create`.
 
 2. **ADR-necessity check.** Does this change remove or replace a load-bearing decision (baseline / pipeline / answer contract / eval surface — see `docs/adr/README.md` criteria)? If yes → steps 3-5. If no → jump to step 6.
@@ -69,7 +71,7 @@ ADR-aware, approval-gated single-PR shipping. The skill replaces an ad-hoc seque
     ```
     Wait for explicit go-ahead. Then execute.
 
-13. **Aftermath.** `git checkout main` (if the worktree owns main) or `git fetch origin main` + branch advance (worktree case). If the user has another PR stacked on top, prompt them to re-invoke the skill for the next layer.
+13. **Aftermath.** `git checkout main` (if the worktree owns main) or `git fetch origin main` + branch advance (worktree case). **Remove the mutex marker** (`rm -f .claude/.ship-pr-active`) so `make ship-arm` is unblocked. If the user has another PR stacked on top, prompt them to re-invoke the skill for the next layer (which re-touches the marker at step 0).
 
 ## Approval-gate language
 

--- a/scripts/claude-hooks/_ship_arm.py
+++ b/scripts/claude-hooks/_ship_arm.py
@@ -26,6 +26,13 @@ from check_branch_and_issue import parse_branch  # noqa: E402
 
 
 ARMED_FILE = ".claude/.ship-armed"
+
+# Mutual-exclusion marker (issue #1043 — governance critique #6).
+# `ship-pr` skill touches this at workflow step 0.5 and removes it at step 12.
+# `make ship-arm` refuses to arm while it exists (stale-safe via TTL below).
+SHIP_PR_ACTIVE_FILE = ".claude/.ship-pr-active"
+SHIP_PR_ACTIVE_STALE_SECONDS = 6 * 3600  # 6 hours
+
 TTL_RE = re.compile(r"^\s*(\d+)\s*([smhd])\s*$", re.IGNORECASE)
 PROTECTED_BRANCHES = {"main", "master", "develop", "HEAD"}
 
@@ -47,6 +54,42 @@ def current_branch() -> str:
     return r.stdout.strip()
 
 
+def check_ship_pr_mutex() -> int:
+    """Return 0 if safe to arm, 1 if ship-pr skill currently active.
+
+    Stale-marker safety: if the marker file is older than
+    ``SHIP_PR_ACTIVE_STALE_SECONDS``, clear it and allow arming. Protects
+    against `ship-pr` skill aborts that left a stale marker behind.
+    """
+    if not os.path.exists(SHIP_PR_ACTIVE_FILE):
+        return 0
+    try:
+        mtime = os.path.getmtime(SHIP_PR_ACTIVE_FILE)
+    except OSError:
+        return 0  # cannot stat — fail open
+    age = (datetime.now(timezone.utc).timestamp() - mtime)
+    if age >= SHIP_PR_ACTIVE_STALE_SECONDS:
+        try:
+            os.unlink(SHIP_PR_ACTIVE_FILE)
+        except OSError:
+            pass  # cleanup best-effort; warn user
+        sys.stderr.write(
+            f"ship-arm: cleared stale ship-pr marker ({SHIP_PR_ACTIVE_FILE}, "
+            f"age {int(age // 60)}m ≥ {SHIP_PR_ACTIVE_STALE_SECONDS // 3600}h "
+            f"threshold).\n"
+        )
+        return 0
+    sys.stderr.write(
+        f"ship-arm: refuse — ship-pr skill currently active "
+        f"({SHIP_PR_ACTIVE_FILE}, age {int(age // 60)}m).\n"
+        f"   Two ship surfaces are mutually exclusive (CLAUDE.md).\n"
+        f"   Finish or cancel the ship-pr workflow first.\n"
+        f"   If the marker is genuinely stale, delete it: "
+        f"rm {SHIP_PR_ACTIVE_FILE}\n"
+    )
+    return 1
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--ttl", default="2h")
@@ -63,6 +106,10 @@ def main() -> int:
     except ValueError as e:
         sys.stderr.write(f"ship-arm: {e}\n")
         return 2
+
+    # Mutex check: refuse if ship-pr skill is active (issue #1043).
+    if check_ship_pr_mutex() != 0:
+        return 1
 
     branch = current_branch()
     if branch in PROTECTED_BRANCHES or branch.startswith("release/"):

--- a/tests/test_ship_arm_mutex.py
+++ b/tests/test_ship_arm_mutex.py
@@ -1,0 +1,98 @@
+"""Tests for ship-arm ↔ ship-pr mutex (issue #1043).
+
+거버넌스 비판 보고서 (2026-05-19) #6 — `make ship-arm` (Stop-hook 자동 ship)
+과 `ship-pr` skill (수동 게이트) 의 mutual exclusivity 가 텍스트 only.
+`_ship_arm.py:check_ship_pr_mutex()` 가 marker 검출 시 refuse.
+
+테스트 범위:
+
+- ship-pr-active marker 없을 때 → 0 반환 (정상 진행)
+- 신선한 marker 존재 시 → 1 반환 + stderr 메시지 (refuse)
+- 6h 이상 stale marker → marker 자동 삭제 + 0 반환 (stale 우회)
+- marker 가 stat 불가 (perm error 등) → 0 반환 (fail open)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHIP_ARM_PATH = REPO_ROOT / "scripts" / "claude-hooks" / "_ship_arm.py"
+
+
+def _load_ship_arm():
+    spec = importlib.util.spec_from_file_location(
+        "_ship_arm_mod", SHIP_ARM_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture
+def ship_arm(tmp_path, monkeypatch):
+    """Load _ship_arm.py with the marker path redirected to tmp."""
+    mod = _load_ship_arm()
+    monkeypatch.setattr(
+        mod, "SHIP_PR_ACTIVE_FILE", str(tmp_path / ".ship-pr-active")
+    )
+    return mod
+
+
+def test_no_marker_allows_arming(ship_arm):
+    """No marker → 0 (safe to arm)."""
+    assert ship_arm.check_ship_pr_mutex() == 0
+
+
+def test_fresh_marker_refuses(ship_arm, capsys):
+    """Fresh marker (recent mtime) → 1 (refuse) + stderr message."""
+    Path(ship_arm.SHIP_PR_ACTIVE_FILE).write_text("")
+    result = ship_arm.check_ship_pr_mutex()
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "refuse" in captured.err
+    assert "ship-pr skill currently active" in captured.err
+
+
+def test_stale_marker_cleared_then_allows(ship_arm, capsys):
+    """Marker older than SHIP_PR_ACTIVE_STALE_SECONDS → auto-clear + 0."""
+    marker = Path(ship_arm.SHIP_PR_ACTIVE_FILE)
+    marker.write_text("")
+    # Set mtime to 7 hours ago (> 6h threshold).
+    old_ts = time.time() - 7 * 3600
+    os.utime(marker, (old_ts, old_ts))
+    result = ship_arm.check_ship_pr_mutex()
+    assert result == 0
+    assert not marker.exists(), "stale marker should be removed"
+    captured = capsys.readouterr()
+    assert "cleared stale" in captured.err
+
+
+def test_marker_at_boundary_still_refuses(ship_arm, capsys):
+    """Marker exactly at threshold edge - 1s → still refuse (strict)."""
+    marker = Path(ship_arm.SHIP_PR_ACTIVE_FILE)
+    marker.write_text("")
+    # mtime 1s less than threshold = still fresh
+    ts = time.time() - (ship_arm.SHIP_PR_ACTIVE_STALE_SECONDS - 1)
+    os.utime(marker, (ts, ts))
+    result = ship_arm.check_ship_pr_mutex()
+    assert result == 1
+    assert marker.exists()
+
+
+def test_marker_stat_failure_fails_open(ship_arm, monkeypatch):
+    """os.path.getmtime() raises → check returns 0 (fail open)."""
+    Path(ship_arm.SHIP_PR_ACTIVE_FILE).write_text("")
+
+    def _raise(_path):
+        raise OSError("simulated stat failure")
+
+    monkeypatch.setattr(os.path, "getmtime", _raise)
+    result = ship_arm.check_ship_pr_mutex()
+    assert result == 0  # fail open


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

거버넌스 비판 보고서 (2026-05-19, plan file \`parsed-rolling-liskov-governance.md\`) #6 — \`make ship-arm\` (Stop-hook 자동 ship) vs \`ship-pr\` skill (수동 게이트) 의 mutual exclusivity 가 \`CLAUDE.md\` 텍스트 only. 코드 lock 부재. 같은 worktree 에서 ship-pr 진행 중 \`make ship-arm\` 호출 시 둘 다 활성화 가능.

기존 \`_ship_lock_check.py\` 는 multi-agent ownership lock — 다른 surface. 비판 #6 의 mutex 가 아님.

이 PR 이 mutex marker (.claude/.ship-pr-active) 도입:
- ship-pr SKILL.md step 0 가 marker touch + .ship-armed 검사
- \`_ship_arm.py\` 가 marker 검출 시 refuse (6h stale-safety)
- ship-pr SKILL.md step 13 (Aftermath) 가 marker cleanup

Closes #1043

## 2. 영향 파일

- \`scripts/claude-hooks/_ship_arm.py\` (check_ship_pr_mutex() 추가)
- \`.claude/skills/ship-pr/SKILL.md\` (step 0 신규 + step 13 cleanup)
- \`tests/test_ship_arm_mutex.py\` (신규, 5 회귀)

Load-bearing 변경 아님.

## 3. 리스크

- ship-pr SKILL.md instruction 이 marker 생성/cleanup 강제 — Claude 가 워크플로 따라야 효과. SKILL.md 가 강제 아닌 instruction
- 완화: 6h stale-safety 가 ship-pr abort 시 자동 우회. 정상 워크플로 시 marker 짧게 (최대 ~수십 분)
- 사용자가 manually \`make ship-arm\` 호출 시 \`.ship-pr-active\` 가 있으면 refuse → 사용자에게 명확한 회복 경로 제공 (메시지에 명시)

## 4. 테스트

\`tests/test_ship_arm_mutex.py\` (5 통과):
- no marker → 0 (안전)
- fresh marker → 1 (refuse) + stderr "ship-pr skill currently active"
- stale marker (mtime > 6h) → 자동 삭제 + 0 + stderr "cleared stale"
- boundary -1s → still refuse (strict)
- stat 실패 → 0 (fail open)

## 5. Eval 영향

All ·

### 5b. Real-data delta

N/A — load-bearing path 변경 없음. ship 인프라.

## 6. 하위 호환

- \`_ship_arm.py\` 의 기존 동작 그대로 (branch / TTL / cross-owner check)
- \`_ship_lock_check.py\` 영향 없음 (별도 surface)
- ship-pr SKILL.md 의 step 1-13 워크플로 동일, step 0 + 13 cleanup 추가만

## 7. 범위 외

- bash-guard 또는 다른 hook 의 mutex (PR6 외)
- ship-arm 이 cross-worktree 동시 실행 막기 (다른 worktree 의 .ship-armed 가 같은 cwd 아닌 다른 cwd 라 race 없음 — multi-worktree race 는 별도 issue)
- _ship_lock_check.py 와 통합 (의도 다른 surface)
- ship-pr active marker 의 timestamp metadata 확장 (현재는 빈 파일 — mtime 만 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)