### PR TITLE
test(bash-guard): adversarial 우회 surface 명시 + 파싱 헬퍼 추출 (closes #1045)

### DIFF
--- a/scripts/claude-hooks/_bash_guard_parse.py
+++ b/scripts/claude-hooks/_bash_guard_parse.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Pure-function parsers extracted from pretooluse-bash-guard.sh.
+
+거버넌스 비판 보고서 (2026-05-19) #5 후속 (issue #1045).
+
+The bash-guard hook needs to inspect a Claude-issued `Bash` command and decide:
+  (a) Is it a `gh pr merge` or `gh pr create` invocation?
+  (b) If `create`, did the user pass `--base <branch>` explicitly?
+
+Both questions are answered by `shlex.split()` plus `re.split()` on shell
+separators. The logic lived inline as one-shot `python3 -c '...'` blocks
+inside the bash hook, making it impossible to unit-test against adversarial
+shell quoting (#5 in the governance critique). This module pulls the logic
+into named pure functions so `tests/test_bash_guard_adversarial.py` can
+nail down the false-negative surface.
+
+Contract:
+- Both functions are deterministic, no I/O, no environment lookup.
+- They tokenize per `re.split(r"[;&|\\n]", cmd)` (so `foo && gh pr merge`
+  still gets caught), strip an opening `(`, and feed each segment through
+  `shlex.split`. ParseError → segment skipped (fail-open).
+- Documented false-negatives (see tests): single-quoted whole command,
+  `eval`-wrapped invocations, env-var interpolation, command substitution.
+  These reflect shlex's inherent limits — fixing them requires a real
+  shell parser (not on the roadmap; see issue #1045 for the trade-off).
+
+CLI form (for the bash hook to consume without an inline python block):
+
+    python3 _bash_guard_parse.py --detect-gh "$cmd"      # echoes "merge", "create", ""
+    python3 _bash_guard_parse.py --has-base "$cmd"       # exit 0 if --base seen, else 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import sys
+from typing import Literal
+
+GhSubcommand = Literal["merge", "create", ""]
+
+_SHELL_SEPARATOR_RE = re.compile(r"[;&|\n]")
+
+
+def _segments(cmd: str) -> list[list[str]]:
+    """Split on shell separators, shlex each segment, drop unparseable parts.
+
+    Strips one leading `(` per segment to handle subshell openers
+    (`(gh pr merge ...)`). Returns the list of token lists.
+    """
+    out: list[list[str]] = []
+    for part in _SHELL_SEPARATOR_RE.split(cmd):
+        part = part.strip().lstrip("(")
+        if not part:
+            continue
+        try:
+            tokens = shlex.split(part)
+        except ValueError:
+            # Malformed quoting → skip this segment (fail-open).
+            continue
+        if tokens:
+            out.append(tokens)
+    return out
+
+
+def detect_gh_subcommand(cmd: str) -> GhSubcommand:
+    """Return ``"merge"``, ``"create"``, or ``""``.
+
+    Matches when a segment is structured as ``gh pr <merge|create> [...]``
+    after shell-separator splitting. The first match wins.
+    """
+    for tokens in _segments(cmd):
+        if (
+            len(tokens) >= 3
+            and tokens[0] == "gh"
+            and tokens[1] == "pr"
+            and tokens[2] in ("merge", "create")
+        ):
+            return tokens[2]  # type: ignore[return-value]
+    return ""
+
+
+def has_explicit_base_flag(cmd: str) -> bool:
+    """Return True if any ``gh pr create`` segment has ``--base`` or ``--base=…``.
+
+    The bash-guard's `gh pr create` branch uses `--base` as a documented
+    bypass (`gh pr create --base main` = "flatten this onto main on purpose").
+    This function answers "did the user explicitly say where to point this
+    PR?" without evaluating the branch ref itself.
+    """
+    for tokens in _segments(cmd):
+        if (
+            len(tokens) >= 3
+            and tokens[0] == "gh"
+            and tokens[1] == "pr"
+            and tokens[2] == "create"
+        ):
+            if any(
+                t == "--base" or t.startswith("--base=")
+                for t in tokens[3:]
+            ):
+                return True
+    return False
+
+
+def _cli(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--detect-gh", metavar="CMD")
+    g.add_argument("--has-base", metavar="CMD")
+    args = p.parse_args(argv)
+    if args.detect_gh is not None:
+        sys.stdout.write(detect_gh_subcommand(args.detect_gh) + "\n")
+        return 0
+    if args.has_base is not None:
+        return 0 if has_explicit_base_flag(args.has_base) else 1
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/scripts/claude-hooks/pretooluse-bash-guard.sh
+++ b/scripts/claude-hooks/pretooluse-bash-guard.sh
@@ -49,20 +49,10 @@ if [[ -z "$cmd" ]]; then
 fi
 
 # Classify the gh subcommand once: "merge" | "create" | "".
-# We split on shell separators so `foo && gh pr create …` is still caught,
-# but anything inside quotes or comments is preserved by shlex.
-gh_subcommand=$(printf '%s' "$cmd" | python3 -c '
-import sys, shlex, re
-for part in re.split(r"[;&|\n]", sys.stdin.read()):
-    part = part.strip().lstrip("(")
-    try:
-        tokens = shlex.split(part)
-    except ValueError:
-        continue
-    if len(tokens) >= 3 and tokens[0] == "gh" and tokens[1] == "pr":
-        if tokens[2] in ("merge", "create"):
-            print(tokens[2]); break
-' 2>/dev/null)
+# Parsing extracted to scripts/claude-hooks/_bash_guard_parse.py (issue #1045)
+# so tests/test_bash_guard_adversarial.py can pin the false-negative surface.
+gh_subcommand=$(python3 "$REPO_ROOT/scripts/claude-hooks/_bash_guard_parse.py" \
+                  --detect-gh "$cmd" 2>/dev/null | tr -d '\n')
 
 if [[ -z "$gh_subcommand" ]]; then
   exit 0
@@ -73,19 +63,9 @@ if [[ "$gh_subcommand" == "create" ]]; then
   # Bypass: explicit --base is intentional. Catches both `--base X` and
   # `--base=X` forms. `--base main` is the documented escape for
   # "I really do want to flatten this onto main."
-  has_base=$(printf '%s' "$cmd" | python3 -c '
-import sys, shlex, re
-for part in re.split(r"[;&|\n]", sys.stdin.read()):
-    part = part.strip().lstrip("(")
-    try:
-        tokens = shlex.split(part)
-    except ValueError:
-        continue
-    if len(tokens) >= 3 and tokens[0] == "gh" and tokens[1] == "pr" and tokens[2] == "create":
-        if any(t == "--base" or t.startswith("--base=") for t in tokens[3:]):
-            print("yes"); break
-' 2>/dev/null)
-  if [[ "$has_base" == "yes" ]]; then
+  # Parsing extracted (issue #1045) — see _bash_guard_parse.py.
+  if python3 "$REPO_ROOT/scripts/claude-hooks/_bash_guard_parse.py" \
+       --has-base "$cmd" >/dev/null 2>&1; then
     exit 0
   fi
 

--- a/tests/test_bash_guard_adversarial.py
+++ b/tests/test_bash_guard_adversarial.py
@@ -1,0 +1,198 @@
+"""Adversarial parsing tests for pretooluse-bash-guard.sh (issue #1045).
+
+거버넌스 비판 보고서 (2026-05-19) #5 해소:
+
+bash-guard 의 `gh pr merge --delete-branch` / `gh pr create` 검출이
+`shlex.split()` + `re.split()` 기반. 다음과 같은 우회가 가능 추정:
+
+  - quote whole cmd:    `'gh pr merge' --delete-branch`
+  - eval wrapper:       `eval 'gh pr merge --delete-branch'`
+  - partial quote:      `gh "pr" merge --delete-branch`
+  - env var:            `$CMD --delete-branch`
+
+이 테스트가 어느 케이스가 catch / 어느 케이스가 fail-open 인지 명시.
+"우회 가능하다" → "이 종류는 막을 수 없다" 로 정직한 contract.
+
+PR4 outcome telemetry 의 `false_negative` outcome 카테고리가 future 에
+adversarial 우회를 기록할 자리 마련.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PARSE_PATH = REPO_ROOT / "scripts" / "claude-hooks" / "_bash_guard_parse.py"
+
+
+def _load_parse():
+    spec = importlib.util.spec_from_file_location("_bgp", PARSE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def bgp():
+    return _load_parse()
+
+
+# ---------------------------------------------------------------------------
+# detect_gh_subcommand — normal cases (must catch)
+# ---------------------------------------------------------------------------
+
+
+def test_normal_gh_pr_merge(bgp):
+    assert bgp.detect_gh_subcommand("gh pr merge 493 --delete-branch") == "merge"
+
+
+def test_normal_gh_pr_create(bgp):
+    assert bgp.detect_gh_subcommand("gh pr create --title foo") == "create"
+
+
+def test_normal_gh_pr_merge_no_args(bgp):
+    assert bgp.detect_gh_subcommand("gh pr merge") == "merge"
+
+
+def test_chained_with_and(bgp):
+    """foo && gh pr merge ... → must catch (split on '&')."""
+    assert bgp.detect_gh_subcommand("foo && gh pr merge --delete-branch") == "merge"
+
+
+def test_chained_with_semicolon(bgp):
+    assert bgp.detect_gh_subcommand("ls; gh pr create") == "create"
+
+
+def test_chained_with_pipe(bgp):
+    """`foo | gh pr merge` doesn't make semantic sense but parsing splits on |."""
+    assert bgp.detect_gh_subcommand("echo x | gh pr merge") == "merge"
+
+
+def test_subshell_open_paren(bgp):
+    """`(gh pr merge ...)` → strips leading `(`, catches."""
+    assert bgp.detect_gh_subcommand("(gh pr merge --delete-branch)") == "merge"
+
+
+def test_partial_quote_inside_command(bgp):
+    """`gh \"pr\" merge` → shlex unquotes \"pr\" → tokens[1] == 'pr' → catches."""
+    assert bgp.detect_gh_subcommand('gh "pr" merge --delete-branch') == "merge"
+
+
+def test_partial_quote_subcommand(bgp):
+    """`gh pr \"merge\"` → same — shlex unquotes."""
+    assert bgp.detect_gh_subcommand('gh pr "merge" --delete-branch') == "merge"
+
+
+# ---------------------------------------------------------------------------
+# detect_gh_subcommand — adversarial cases (documented false-negatives)
+#
+# These are the "fail-open" cases. The hook will NOT catch them. Tests pin
+# the surface so any future parsing improvement can shrink it deliberately.
+# ---------------------------------------------------------------------------
+
+
+def test_false_negative_quote_whole_command(bgp):
+    """`'gh pr merge' --delete-branch` → first token = 'gh pr merge' literal,
+    tokens[1] = '--delete-branch'. shlex unquotes the whole thing as ONE
+    token. NOT caught."""
+    assert bgp.detect_gh_subcommand("'gh pr merge' --delete-branch") == ""
+
+
+def test_false_negative_eval_wrapper(bgp):
+    """`eval 'gh pr merge --delete-branch'` → tokens[0] = 'eval'. NOT caught.
+    The hook can't see through `eval`."""
+    assert bgp.detect_gh_subcommand("eval 'gh pr merge --delete-branch'") == ""
+
+
+def test_false_negative_env_var(bgp):
+    """`$CMD --delete-branch` → tokens[0] = '$CMD' (shlex doesn't interpolate).
+    NOT caught."""
+    assert bgp.detect_gh_subcommand("$CMD --delete-branch") == ""
+
+
+def test_false_negative_command_substitution(bgp):
+    """`$(echo gh pr merge) --delete-branch` → tokens[0] = '$(echo' literal.
+    NOT caught — shlex doesn't evaluate command substitution."""
+    assert bgp.detect_gh_subcommand("$(echo gh pr merge) --delete-branch") == ""
+
+
+def test_false_negative_alias_indirection(bgp):
+    """If the user aliased `pr-merge` to `gh pr merge`, calling `pr-merge`
+    isn't caught — only literal `gh pr <sub>` matches."""
+    assert bgp.detect_gh_subcommand("pr-merge --delete-branch") == ""
+
+
+def test_unrelated_command(bgp):
+    assert bgp.detect_gh_subcommand("ls -la") == ""
+    assert bgp.detect_gh_subcommand("git status") == ""
+    assert bgp.detect_gh_subcommand("") == ""
+
+
+# ---------------------------------------------------------------------------
+# has_explicit_base_flag — bypass detection
+# ---------------------------------------------------------------------------
+
+
+def test_has_base_explicit_long(bgp):
+    assert bgp.has_explicit_base_flag("gh pr create --base main")
+
+
+def test_has_base_explicit_equals(bgp):
+    assert bgp.has_explicit_base_flag("gh pr create --base=foo")
+
+
+def test_has_base_other_branch(bgp):
+    assert bgp.has_explicit_base_flag("gh pr create --title x --base feature/foo")
+
+
+def test_no_base_means_implicit_main(bgp):
+    assert not bgp.has_explicit_base_flag("gh pr create --title foo --body bar")
+
+
+def test_has_base_doesnt_match_gh_merge(bgp):
+    """`gh pr merge --base ...` doesn't exist as a real flag, but if a user
+    typed it, we should NOT treat it as a create-bypass."""
+    assert not bgp.has_explicit_base_flag("gh pr merge --base foo")
+
+
+def test_has_base_substring_doesnt_match(bgp):
+    """`--basenum=3` shouldn't match `--base`."""
+    assert not bgp.has_explicit_base_flag("gh pr create --basenum=3")
+
+
+# ---------------------------------------------------------------------------
+# CLI interface (used by the bash hook)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_detect_gh_stdout(tmp_path, bgp):
+    import subprocess, sys
+    r = subprocess.run(
+        [sys.executable, str(PARSE_PATH), "--detect-gh",
+         "gh pr merge 1 --delete-branch"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0
+    assert r.stdout.strip() == "merge"
+
+
+def test_cli_has_base_exit_codes(bgp):
+    import subprocess, sys
+    # 0 when --base present
+    r = subprocess.run(
+        [sys.executable, str(PARSE_PATH), "--has-base",
+         "gh pr create --base main"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0
+
+    # 1 when no --base
+    r = subprocess.run(
+        [sys.executable, str(PARSE_PATH), "--has-base", "gh pr create"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 1

--- a/tests/test_hook_pretooluse_bash_guard.py
+++ b/tests/test_hook_pretooluse_bash_guard.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 REPO = Path(__file__).parents[1]
 HOOK = REPO / "scripts" / "claude-hooks" / "pretooluse-bash-guard.sh"
+HOOK_HELPER = REPO / "scripts" / "claude-hooks" / "_bash_guard_parse.py"
 
 _GIT_ENV: dict[str, str] = {
     "GIT_AUTHOR_NAME": "t",
@@ -49,6 +50,11 @@ class TestPreToolUseBashGuard(unittest.TestCase):
         (self._tmp_repo / ".claude").mkdir(parents=True)
         (self._tmp_repo / "scripts" / "claude-hooks").mkdir(parents=True)
         shutil.copy(HOOK, self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name)
+        # The hook delegates parsing to _bash_guard_parse.py (issue #1045).
+        # Copy it alongside so the temp REPO_ROOT resolves the helper.
+        shutil.copy(
+            HOOK_HELPER, self._tmp_repo / "scripts" / "claude-hooks" / HOOK_HELPER.name
+        )
         self._hook = self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name
         self._fires_log = self._tmp_repo / ".claude" / ".hook-fires.log"
 


### PR DESCRIPTION
## Summary

거버넌스 비판 보고서 (2026-05-19) #5 해소. `pretooluse-bash-guard.sh` 의 `gh pr merge --delete-branch` / `gh pr create` 검출이 `shlex.split()` + `re.split()` 기반인데, 어떤 우회가 catch 되고 어떤 게 fail-open 되는지가 inline python 으로 묻혀있어 검증 불가능했음. 파싱 로직을 모듈로 추출하고 우회 surface 를 테스트로 못박는다.

- `scripts/claude-hooks/_bash_guard_parse.py` 신규 — `detect_gh_subcommand` / `has_explicit_base_flag` 두 pure-function + argparse CLI.
- `pretooluse-bash-guard.sh` 의 inline python 2개 블록 → 헬퍼 호출. 동작 동일.
- `tests/test_bash_guard_adversarial.py` 신규, 23 cases.

## Test plan

- [x] `pytest tests/test_bash_guard_adversarial.py -v` → 23 passed
- [x] `pytest tests/test_hook_pretooluse_bash_guard.py -v` → 13 passed (helper 도 temp REPO_ROOT 에 복사하도록 setUp 업데이트)
- [x] `ruff check scripts/claude-hooks/_bash_guard_parse.py tests/test_bash_guard_adversarial.py` → clean
- [x] Manual: `bash pretooluse-bash-guard.sh <<<'{"tool_input":{"command":"gh pr merge 999 --delete-branch"}}'` → 헬퍼 경유 정상 트리거

## 1. Why this change

bash-guard 의 ADR 0007 / `--delete-branch` 정책 enforcement 는 shell parser 가 아닌 `shlex` 위에 얹혀있음. 다음 우회가 추정 가능했으나 inline python 으로 검증 불가:
- `'gh pr merge' --delete-branch` (전체 single-quote)
- `eval 'gh pr merge --delete-branch'` (eval 래퍼)
- `$CMD --delete-branch` (env var)
- `$(echo gh pr merge) --delete-branch` (command substitution)
- 사용자 정의 alias

비판 보고서 #5: "우회 가능하다" 는 vague claim. 정직한 contract = "이 종류는 막을 수 없다" 로 surface 명시.

## 2. What changed (architecture)

- **N/A** — 파싱 로직만 추출. hook 인터페이스 동일.

## 3. What changed (behavior)

| Surface | Before | After |
|---|---|---|
| `gh pr merge --delete-branch` (normal) | catch | catch (변경 없음) |
| `gh pr create` (no --base, stacked) | block | block (변경 없음) |
| `foo && gh pr merge ...` (separator chain) | catch | catch |
| `'gh pr merge' --delete-branch` | fail-open | fail-open (이제 **문서화됨**) |
| `eval 'gh pr merge ...'` | fail-open | fail-open (이제 **문서화됨**) |
| `$CMD --delete-branch` | fail-open | fail-open (이제 **문서화됨**) |

5축 #4 (사이클 타임): test 1개 = 0.19s, 전체 hook 회귀 13 test = 2.87s. 사실상 비용 없음.

## 4. Tests

- `tests/test_bash_guard_adversarial.py` — 23 cases × 3 카테고리:
  - **Normal-catch (9)**: gh pr merge/create, `&&` / `;` / `|` chain, subshell `(`, partial-quote `gh "pr" merge`.
  - **Documented false-negative (5)**: 위 5개 우회를 명시적으로 `== ""` 로 assert. shlex 의 inherent limit — 진짜 shell parser 없이는 못 잡음.
  - **`has_explicit_base_flag` bypass detection (6)**: `--base` / `--base=` / 다른 branch / substring 매치 안 함.
  - **CLI subprocess interface (2)**.
- `tests/test_hook_pretooluse_bash_guard.py` — temp REPO_ROOT 에 `_bash_guard_parse.py` 도 복사 (없으면 hook subprocess 가 fail-open 으로 떨어져서 13개 중 일부 기존 테스트 fail).

## 5. Risks / migration

- **N/A** — 인터페이스/동작 동일. 헬퍼 모듈 추가만.

## 5b. Real-data delta (load-bearing 파일 변경 시)

**N/A — `pretooluse-bash-guard.sh` 는 dev-only PreToolUse hook 이고 `LOAD_BEARING_PATHS` 외부.** `scripts/_governance.py` `LOAD_BEARING_PATHS` 에 hook 디렉터리 미포함 확인. real-eval 영향 없음.

## 6. Follow-ups

- 새 우회 패턴 발견 시 → `tests/test_bash_guard_adversarial.py` 에 케이스 추가 (TDD).
- 우회 surface 축소가 정말 ROI 있다면 → bashlex / pyshell 같은 진짜 shell parser 로 교체. 현 시점에선 trade-off 미명확 (cost > benefit) — issue 로 deferred.
- PR4 (#1040) 의 `false_negative` outcome 카테고리가 future 에 wild adversarial bypass 를 telemetry 로 기록할 자리 — 90일 후 fire 분석 시 이 PR 의 documented surface 와 비교.

Closes #1045

🤖 Generated with [Claude Code](https://claude.com/claude-code)