### PR TITLE
docs(claude-md): ADR 참조/표면 포인터 staleness 보강

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,15 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 
 파이프라인: ingestion → 메타데이터 정규화 → 청킹 → 검색 → 재순위/계획 → 근거 집계 → 근거 기반 답변 → 검증 → 평가 → reviewer 문서.
 
-자동화 표면: `.gitignore`, CI ([`pr-eval.yml`](.github/workflows/pr-eval.yml), [`branch-and-issue-check.yml`](.github/workflows/branch-and-issue-check.yml)), `.githooks/`, [`scripts/check_branch_and_issue.py`](scripts/check_branch_and_issue.py) (브랜치+이슈 컨벤션 regex 단일 출처, ADR 0007), [`.github/pull_request_template.md`](.github/pull_request_template.md), [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/), [`.claude/settings.json`](.claude/settings.json) (load-bearing 편집 awareness 훅 + stacked dependent 있을 때 `gh pr merge --delete-branch` 차단 Bash matcher). 이 파일은 자동 강제되지 않는 원칙·포인터를 담는다.
+자동화 표면: `.gitignore`, CI ([`pr-eval.yml`](.github/workflows/pr-eval.yml), [`branch-and-issue-check.yml`](.github/workflows/branch-and-issue-check.yml), [`pr-judge.yml`](.github/workflows/pr-judge.yml) (live LLM-judge 게이트, ADR 0043), [`leaderboard.yml`](.github/workflows/leaderboard.yml), [`deploy-fly.yml`](.github/workflows/deploy-fly.yml) + [`docker-publish.yml`](.github/workflows/docker-publish.yml) (api/main.py 데모 배포 — 제품화 아님)), `.githooks/`, [`scripts/check_branch_and_issue.py`](scripts/check_branch_and_issue.py) (브랜치+이슈 컨벤션 regex 단일 출처, ADR 0007), [`.github/pull_request_template.md`](.github/pull_request_template.md), [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/), [`.claude/settings.json`](.claude/settings.json) (load-bearing 편집 awareness 훅 + stacked dependent 있을 때 `gh pr merge --delete-branch` 차단 Bash matcher). 이 파일은 자동 강제되지 않는 원칙·포인터를 담는다.
 
 ## 여기서 시작
 
 - [`docs/engineering-governance.md`](docs/engineering-governance.md) — 워크플로 맵
 - [`docs/adr/README.md`](docs/adr/README.md) — 결정 인덱스
 - [`docs/multi-agent-ownership.md`](docs/multi-agent-ownership.md) — 여러 agent 가 병행 작업할 때 조율 모델
-- retrieval / answer / eval 손볼 시 추가 필독: [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) (기준선), [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) (답변 계약), [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md) (eval 분리), [ADR 0012](docs/adr/0012-llm-judge-on-public-synthetic.md) (합성 LLM-judge)
+- [`docs/audits/`](docs/audits/) — Phase 3/4/5 eval-framework 감사 + failure inspection (retrieval-miss / verifier-false-negative / variance-source)
+- retrieval / answer / eval 손볼 시 추가 필독: [ADR 0001](docs/adr/0001-preserve-naive-baseline.md) (기준선), [ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) (답변 계약), [ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md) (eval 분리), [ADR 0012](docs/adr/0012-llm-judge-on-public-synthetic.md) (합성 LLM-judge), [ADR 0048](docs/adr/0048-realN-metrics-extension.md) (by_metadata_field + abstention calibration), [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md) (n=221), [ADR 0056](docs/adr/0056-rationality-judge-measurement-surface.md) (rationality-judge), [ADR 0058](docs/adr/0058-phase35-mode-winner.md) (hybrid 기본 전환), [ADR 0059](docs/adr/0059-failure-mode-classifier-as-measurement-surface.md) (failure-mode classifier)
 
 ## 저장소 맵
 
@@ -29,7 +30,7 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 - `app.py` — CLI 쿼리 진입점
 - `rag_vector_store.py` — `VectorStore` Protocol (#232). `BIDMATE_INDEX_BACKEND` = `memory`(기본) / `qdrant`; `pgvector` 는 Stage 3 (#176) 예약. in-memory ↔ Qdrant ranking bit-identical
 - `rag_reranker.py` — `Reranker` Protocol + 기본 `CrossEncoderReranker` (#345)
-- `rag_retrieval.py` — 검색 파이프라인 (#459 + #461). `retrieve_candidates`, 4 유사도 primitive, BM25, fusion·재순위·comparison balance·parent-section 재조립
+- `rag_retrieval.py` — 검색 파이프라인 (#459 + #461). `retrieve_candidates`, 4 유사도 primitive, BM25, fusion·재순위·comparison balance·parent-section 재조립. 기본 `retrieval_backend` = `hybrid` (RRF k=60, BGE-M3 dense + BM25; ADR 0058) — `agentic_full`/`metadata_first` 한정, `naive_baseline` 은 `dense` 유지 (ADR 0001 불변)
 - `rag_verifier.py` — 검증기 (#465, PR-J1). `verify_evidence`, topic 추출, `EVIDENCE_BOUNDARY` 상수 + 명령 패턴 regex, `neutralize_instruction_patterns` (ADR 0008)
 - `rag_answer.py` — 답변 생성 (#468, PR-J2). 20 함수가 검증된 근거를 ADR 0003 답변 dict 로 변환. `schema_version: 2` 계약 유지
 - `rag_query.py` — 쿼리 분석·계획 (#478, PR-J3). 15 함수, `analyze_query`/`make_plan`/`comparison_targets_for_analysis` 등
@@ -54,6 +55,7 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 - **읽기 다발 시 Explore subagent.** Read ≥5회 누적 또는 단일 파일 >200줄 → Explore 위임
 - **Shipping 경로는 commit-0 에 확정.** `ship-pr` skill (수동 게이트, ADR 예약 + stacked 안전) vs `make ship-arm` (Stop-hook 자동 ship) 둘은 mutually exclusive — 동시 활성화 금지
 - 5축 ↔ 4-pillar 매핑 전체: [`docs/agent-utilization.md`](docs/agent-utilization.md). `self-review-quarterly` skill 이 해당 표 기준으로 채점
+- **측정·감사 skill.** `retrieval-eval` (4-phase retrieval 측정), `eval-framework-progressive-audit` (5-phase 프레임워크 감사), `adr-portfolio-signals` (ADR→시니어 시그널 매핑) — 해당 범위 작업 시 우선 호출
 
 ## 핵심 원칙
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

작업 패턴 분석(최근 150커밋 + 3 Explore agent 조사) 중 CLAUDE.md 의 여러 포인터가 저장소 현 상태와 어긋남을 발견. ADR 참조가 0049 에서 멈췄으나 repo 는 0059 까지 진행(10개 누락, 다수가 load-bearing 측정 표면)했고, retrieval 기본 모드 전환(ADR 0058)·신규 skill 3개·CI workflow 4개·audit suite 가 미반영. Tier 1+2 (staleness 수정 + 누락 표면 포인터) 만 docs-only 로 보강. 재발 인시던트(prose 부적합)는 별도 follow-up 으로 분리.

Closes #1047

## 2. 영향 파일

- `CLAUDE.md` (load-bearing 아님 — instruction/pointer 파일, `LOAD_BEARING_PATHS` 미포함)

## 3. 리스크

가장 가능성 높은 깨짐 경로 = 잘못된 링크 경로 또는 사실 오류. 배제 확인:
- 신규 링크 전부 실재 확인: ADR `0048/0052/0056/0058/0059`, workflow `pr-judge/leaderboard/deploy-fly/docker-publish`, `docs/audits/` (`ls` 검증)
- C1 hybrid 기본 문구를 ADR 0058 본문과 대조 — `agentic_full`/`metadata_first` 한정 + `naive_baseline`=`dense` 예외(ADR 0001 불변) 정합
- CI 줄 nested paren 균형 확인 (기존 줄 스타일과 동일)

## 4. 테스트

N/A — docs-only, 런타임 동작 변경 없음. CLAUDE.md 는 instruction 파일이라 검증 대상 동작이 없음.

## 5. Eval 영향

All `·` — RAG 파이프라인/eval 코드 무변경 (CLAUDE.md 텍스트만).

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. CLAUDE.md 는 load-bearing path 아님 → `make real-eval-delta` N/A.

## 6. 하위 호환

문서 링크/포인터 추가만. 기존 링크·계약·스키마·CLI flag 무변경. answer-contract(ADR 0003) 무관 → `schema_version` bump 불필요.

## 7. 범위 외

의도적으로 안 고침 (별도 follow-up 후보):
- **C6/C7** golden regen(3회 재발)·dead-link cascade(6회 재발) — 재발 원인이 기계적 강제 부재라 prose 아닌 pre-commit/CI 게이트가 정답
- **C8** `rag_answer.py` "20 함수"→실제 21 (trivial drift)
- **C9** *MEMORY.md* "ADR 0043까지·0042 결번" stale (0042 파일 존재, 상한 0059) — memory 정리 대상