### PR TITLE
fix(governance): §5b escape sentinel accepts Korean attestation (closes #1048)

### DIFF
--- a/scripts/check_branch_and_issue.py
+++ b/scripts/check_branch_and_issue.py
@@ -41,8 +41,19 @@ ALLOWED_PREFIXES = "feat, fix, docs, chore, refactor, test, ci, perf, build, sty
 HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 FIVE_B_HEADER_RE = re.compile(r"###\s+5b\.\s*Real-data delta", re.IGNORECASE)
 FIVE_B_TABLE_RE = re.compile(r"^\s*\|.+\|.+\|", re.MULTILINE)
+# Accepts the §5b "no behavior change" attestation in EITHER language so the
+# gate matches the (Korean-first) PR template example, not just the English
+# sentinel (issue #1048 — template↔gate drift made template-following PRs fail
+# CI). The Korean branch anchors "변(화|경|동)" immediately before "없(음|다|습니다)"
+# (only whitespace allowed between) so a sentence asserting that behavior DID
+# change cannot accidentally satisfy the escape — that false-escape is exactly
+# the PR #69 regression class §5b guards against.
 FIVE_B_ESCAPE_RE = re.compile(
-    r"No behavior change in\s+(?:retrieval|verifier|eval|api|ingestion)\b",
+    r"No behavior change in\s+(?:retrieval|verifier|eval|api|ingestion)\b"
+    r"|"
+    r"(?:검색|검증|수집|평가|retrieval|verifier|eval|api|ingestion)"
+    r"[^\n]{0,16}?"
+    r"(?:변화|변경|변동)\s*없(?:음|다|습니다)",
     re.IGNORECASE,
 )
 
@@ -233,8 +244,9 @@ def check_5b_mode(pr_number: int) -> int:
       3. If none match → exit 0 (skip; non-load-bearing PR).
       4. If any match → require body to contain the '### 5b. Real-data delta'
          header AND, beneath it (HTML comments stripped), either a markdown
-         table row OR the escape sentence
-         'No behavior change in retrieval/verifier/eval/api/ingestion path'.
+         table row OR the escape sentence in English ('No behavior change in
+         retrieval/verifier/eval/api/ingestion path') or Korean ('검색/검증
+         path 동작 변화 없음.') — see FIVE_B_ESCAPE_RE.
       5. On failure: print actionable error pointing to PR #69 lesson.
     """
     if not gh_available():
@@ -274,7 +286,8 @@ def check_5b_mode(pr_number: int) -> int:
         "   Either:\n"
         "     (a) attach the `make real-eval-delta` aggregate table under\n"
         "         '### 5b. Real-data delta', or\n"
-        "     (b) state explicitly: 'No behavior change in retrieval / verifier path.'\n"
+        "     (b) state explicitly, e.g. '검색/검증 path 동작 변화 없음.'\n"
+        "         (English also accepted: 'No behavior change in retrieval / verifier path.')\n"
         "   See: .github/pull_request_template.md and CLAUDE.md.\n"
     )
     if section is None:

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -149,12 +149,21 @@ def test_five_b_table_regex_matches_real_eval_delta_aggregate():
 
 
 @pytest.mark.parametrize("sentence", [
+    # English sentinel (original contract).
     "No behavior change in retrieval path.",
     "No behavior change in verifier path.",
     "No behavior change in retrieval / verifier path.",
     "no behavior change in eval path",
     "No behavior change in API path.",
     "No behavior change in ingestion path.",
+    # Korean attestation — must be accepted too, because the PR template's
+    # §5b example is Korean (issue #1048). The first item is verbatim the
+    # template example.
+    "검색/검증 path 동작 변화 없음.",
+    "검증 path 동작 변경 없음",
+    "검색 경로 동작 변화 없습니다",
+    "수집 path 변동 없음",
+    "eval path 동작 변화 없음",
 ])
 def test_five_b_escape_regex_accepts_documented_escape(sentence):
     assert cbi.FIVE_B_ESCAPE_RE.search(sentence), (
@@ -163,13 +172,56 @@ def test_five_b_escape_regex_accepts_documented_escape(sentence):
 
 
 @pytest.mark.parametrize("sentence", [
+    # English off-pattern (original contract).
     "No behavior change anywhere.",
     "We changed retrieval behavior.",
     "TODO: add real-eval delta.",
+    # Korean false-escapes — these assert behavior DID/MIGHT change, so they
+    # must NOT satisfy the escape. The anchor 변(화|경|동)\s*없(음|다|습니다)
+    # keeps the PR #69 guard intact for Korean bodies.
+    "검증 동작이 대폭 변화했다.",
+    "검증 path 동작 변화 분석 예정",
+    "retrieval 동작 변경 있음",
+    "검색 결과가 변했지만 회귀는 없음",
+    "검증 로직 일부 변경, 그러나 외부 schema 변동 없음",
 ])
 def test_five_b_escape_regex_rejects_off_pattern(sentence):
     assert not cbi.FIVE_B_ESCAPE_RE.search(sentence), (
         f"Should not match escape: {sentence!r}"
+    )
+
+
+# `명시:` 다음 줄의 따옴표 예시를 뽑는다. PR #1030 이 §5b 코멘트에 텍스트를
+# 덧붙여도 이 추출 위치는 안정적이다.
+_TEMPLATE_5B_EXAMPLE_RE = re.compile(r"명시[:：]\s*\n\s*\"([^\"]+)\"")
+
+
+def test_pr_template_5b_escape_example_matches_regex():
+    """The §5b escape example shown to authors must be one the gate accepts.
+
+    Root cause of issue #1048: the PR template's §5b example was Korean
+    ('검색/검증 path 동작 변화 없음.') but `FIVE_B_ESCAPE_RE` matched English
+    only — so authors who followed the template verbatim failed CI, and no
+    test caught the template↔gate drift. This guard ties the two together:
+    if either side changes such that the documented example no longer
+    satisfies the gate, this fails at PR time instead of in a contributor's
+    CI run.
+    """
+    template = (
+        ROOT_DIR / ".github" / "pull_request_template.md"
+    ).read_text(encoding="utf-8")
+    m = _TEMPLATE_5B_EXAMPLE_RE.search(template)
+    assert m, (
+        "Could not find the §5b escape example (a quoted string after '명시:') "
+        "in .github/pull_request_template.md. If the template wording moved, "
+        "update _TEMPLATE_5B_EXAMPLE_RE here too."
+    )
+    example = m.group(1)
+    assert cbi.FIVE_B_ESCAPE_RE.search(example), (
+        f"PR template §5b escape example {example!r} is NOT accepted by "
+        f"FIVE_B_ESCAPE_RE — template↔gate drift (issue #1048). Fix by aligning "
+        f"the regex in scripts/check_branch_and_issue.py with the example in "
+        f".github/pull_request_template.md (or vice-versa)."
     )
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1048

PR template 의 §5b 예시는 한국어("검색/검증 path 동작 변화 없음.")인데
`FIVE_B_ESCAPE_RE` 는 영문 sentinel 만 매치 → template 을 글자대로 따른
사용자는 `--check-5b` CI gate 에서 fail. PR #1029/#1035 가 이 함정에 걸려
영문 sentinel 로 바꿔 통과한 사례. 문서화된 contract ↔ 실제 gate drift.

정규식이 **영문 OR 한국어** 둘 다 수용하도록 확장. 한국어 분기는
변(화|경|동) 을 없(음|다|습니다) 바로 앞에 앵커(사이 whitespace 만 허용)해서,
behavior 가 실제 변했다는 문장이 escape 로 오인되는 false-escape(PR #69
가드 핵심)를 배제.

## 2. 영향 파일

- `scripts/check_branch_and_issue.py` — `FIVE_B_ESCAPE_RE` 한국어 분기 추가 + remediation 문구·docstring 정합 (**load-bearing 아님**)
- `tests/test_governance.py` — 한국어 accept/reject 케이스 + template↔regex drift-guard 회귀 테스트 (**load-bearing 아님**)

template(`.github/pull_request_template.md`)은 **무변경** — 같은 §5b 코멘트
블록을 편집 중인 in-flight PR #1030 과의 머지 충돌 회피.

## 3. 리스크

가장 가능성 높은 깨짐: 한국어 정규식이 너무 느슨해 false-escape 허용(PR #69
회귀 클래스). 배제 확인 — 변(화|경|동)\s*없(음|다|습니다) 인접 앵커 + component
토큰까지 거리 16자 제한. reject 테스트 5종("변화했다", "변화 분석 예정",
"변경 있음", "변했지만 회귀는 없음", gap>16) 으로 고정. 너무 빡빡해 자연스러운
한국어를 놓치는 역방향 risk 는 accept 테스트 5종(template 예시 verbatim 포함)으로 커버.

## 4. 테스트

- accept parametrize 에 한국어 5종 추가(첫 항목 = template 예시 verbatim)
- reject parametrize 에 한국어 false-escape 5종 추가
- 신규 `test_pr_template_5b_escape_example_matches_regex` — 실제 template 에서
  §5b 따옴표 예시를 추출해 `FIVE_B_ESCAPE_RE` 가 수용하는지 검증. **근본 원인
  (template↔gate drift 를 잡는 테스트 부재)을 닫음** — 한쪽이 바뀌어 어긋나면
  contributor CI 가 아니라 PR 시점에 fail.
- `pytest tests/test_governance.py` 57 passed / 3 skipped. 인접 90 passed
  (branch_convention + ship_pr_body + ship_lock_check). ruff clean.

## 5. Eval 영향

All `·` — eval surface 무변경. governance 정규식 + 테스트만.

### 5b. Real-data delta

N/A — load-bearing path 무변경 (`check_branch_and_issue.py` + `tests/` 만,
둘 다 `LOAD_BEARING_PATHS` 비포함). runtime RAG path(검색/검증/eval/api/
ingestion) 동작 변화 없음. `--check-5b` 는 이 PR 에 대해 "changes no
load-bearing path; §5b not required" 로 skip.

## 6. 하위 호환

깨짐 없음. 기존 영문 sentinel 6종은 그대로 매치(정규식 alternation 의 첫 분기로
보존), 기존 reject 3종도 그대로 거부. 한국어 수용은 순수 additive.

## 7. 범위 외

- §5b 강제 범위 명시(PR #1030 / issue #1027) — 별도 PR 진행 중
- template↔`LOAD_BEARING_PATHS` parity 테스트(PR #1042 / issue #1041) — 별도 PR, 본 PR 의 escape-regex drift-guard 와 비중복
- ADR 불필요 — §5b 계약(table OR 무변경 attestation)은 그대로, *어떤 문자열이 attestation 으로 인정되나*만 문서와 일치시키는 버그 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)