### PR TITLE
docs(readme): sync ADR count to repo 59 (was stale 34/43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > 한국 공공·B2B 입찰 RFP 에서 비교·요건 추출 질의를 **근거 기반 답변**으로 돌려주는 한국어 도메인 특화 RAG. 외부 LLM 호출 없이 추출형(extractive) grounding 으로 hallucination 을 구조적으로 차단.
 > **차별점**: 비교 질의에서 두 기관 문서를 균등 인용하는 [comparison-aware balanced retrieval](#key-technical-contribution--comparison-aware-balanced-top-k), 메타데이터 우선 검색 ([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), 근거 불충분 시 보류(abstention) 명시 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
-> **측정**: 공개 합성 (`agentic_full`, n=100): accuracy 0.718 ± 0.10, citation_precision 0.705 ± 0.08 (95% CI). 비공개 real-eval (100-doc RFP, n=221 hardcase, [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md)): accuracy 29.66%, **distinguishing-power gauge 4/5 signal alive** (groundedness +31.36pp · citation_precision +22.06pp · accuracy +27.12pp · claim_citation_alignment +8.04pp vs random_retrieval; answer_format_compliance −0.64pp 남은 false-negative) — Goodhart 함정 ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) 첫 측정에서 발견 → [ADR 0054](docs/adr/0054-conditional-on-answer-scorer-semantics.md) 에서 scorer 정정) 폐루프 ([reports/real100/distinguishing_power.md](reports/real100/distinguishing_power.md)). 공개 합성 + 비공개 real-data 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 34개 설계 결정 (ADR).
+> **측정**: 공개 합성 (`agentic_full`, n=100): accuracy 0.718 ± 0.10, citation_precision 0.705 ± 0.08 (95% CI). 비공개 real-eval (100-doc RFP, n=221 hardcase, [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md)): accuracy 29.66%, **distinguishing-power gauge 4/5 signal alive** (groundedness +31.36pp · citation_precision +22.06pp · accuracy +27.12pp · claim_citation_alignment +8.04pp vs random_retrieval; answer_format_compliance −0.64pp 남은 false-negative) — Goodhart 함정 ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) 첫 측정에서 발견 → [ADR 0054](docs/adr/0054-conditional-on-answer-scorer-semantics.md) 에서 scorer 정정) 폐루프 ([reports/real100/distinguishing_power.md](reports/real100/distinguishing_power.md)). 공개 합성 + 비공개 real-data 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 59개 설계 결정 (ADR).
 
 ### 5초 비주얼 훅 — 실제 `comparison` 질의 한 건 (extractive, no LLM)
 
@@ -222,7 +222,7 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 
 | 목적 | 링크 |
 |---|---|
-| ADR 인덱스 (43개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |
+| ADR 인덱스 (59개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |
 | 분석 변형 결과 + benchmarking + latency 비교 | [`docs/benchmarking.md`](docs/benchmarking.md) / [`docs/eval/ablation-results.md`](docs/eval/ablation-results.md) |
 | 설계 배경 (한국 RFP 적응 5가지) | [`docs/design-background.md`](docs/design-background.md) |
 | 답변 출력 정책 + Evidence boundary + Baseline policy | [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md) |


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

README hero(L12) "34개" + 주요 링크표(L225) "43개" 두 표기가 서로 다르고 둘 다 repo 실제 ADR 수(`origin/main` 59)와 어긋나 동기화. CLAUDE.md 는 PR #1049(closes #1047)로 ADR 0059 까지 갱신됐으나 README 는 미동기였음.

Closes #1055

## 2. 영향 파일

- `README.md` — 2 라인 (L12 hero 카운트, L225 ADR 인덱스 링크 레이블)
- **load-bearing 아님** — `scripts/_governance.py` 가 root `README.md` 를 명시 제외(L122). load-bearing 목록(rag_*.py, ingestion.py, eval/, api/, docs/adr/, scripts/build_index.py)에 root README 부재

## 3. 리스크

순수 표기 정정, 깨짐 경로 없음. ADR 카운트는 동적(#1040 이 ADR 0060 추가 중) → 본 정정은 스냅샷. 동적 lint 강제는 #792/#813 후속에 위임(범위 외).

## 4. 테스트

docs-only, behavior change 없음 → 테스트 N/A.

## 5. Eval 영향

All \`·\` — RAG 파이프라인 무관, 문서 표기만.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 (README 문서 카운트 표기만). root README 는 load-bearing path 아님.

## 6. 하위 호환

doc link / 답변 계약(ADR 0003) / CLI flag 변경 없음.

## 7. 범위 외

- quickstart \`make ask\`(naive_baseline) vs README L19-22 표시(agentic_full comparison) **동작 불일치** — Makefile ask 타겟 수정 동반, 별도 issue
- ADR 0058 hybrid 기본 — accepted 지만 코드 \`rag_retrieval.py default="dense"\`, ADR 이 "구현 follow-up PR" 명시 → README 미반영이 현 코드와 정합
- ADR 0049 status / ingestion kordoc 명시 — proposed, accept 조건이 비공개 real-eval 델타(#890 §7)
- 메트릭 표 / README metric CI sync — #792 (committed snapshot 패턴)