### PR TITLE
feat(self-review): flag lag_days==0 ADR retrofits (closes #1063)

### DIFF
--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -388,6 +388,13 @@ def _compute_adr_lags(repo: str, start: str, end: str) -> list[dict[str, Any]]:
             "proposed_date": proposed_dt.date().isoformat(),
             "accepted_date": accepted_dt.date().isoformat(),
             "lag_days": lag_days,
+            # lag_days == 0 means proposed and accepted commits land the same
+            # day. That is either a genuine same-day decision or a *retrofit*
+            # (the `-S "**Status**: accepted"` search finds the original
+            # acceptance commit, so a later Verification-surface add looks
+            # zero-lag). Flag it so the LLM rubric layer can separate the two
+            # instead of silently averaging retrofits into the lag p50/p90.
+            "is_retrofit": lag_days == 0,
         })
     return results
 
@@ -574,7 +581,14 @@ def compute_adr_lag_summary(adr_lags: list[dict[str, Any]]) -> dict[str, Any]:
         v = entry.get("lag_days")
         if isinstance(v, (int, float)):
             days.append(float(v))
-    return _summary_p50_p90(days)
+    summary = _summary_p50_p90(days)
+    # Axis #4 honesty: a lag p50 near 0 can be inflated by retrofits (see
+    # `_compute_adr_lags`). Surface the count so the rubric can subtract
+    # them rather than read a flattering near-zero median at face value.
+    summary["retrofit_count"] = sum(
+        1 for e in adr_lags if e.get("is_retrofit")
+    )
+    return summary
 
 
 def compute_axis_2_skip_rate(

--- a/tests/test_self_review_axis_4_regression.py
+++ b/tests/test_self_review_axis_4_regression.py
@@ -100,6 +100,24 @@ class TestComputeAdrLagSummary(unittest.TestCase):
         result = sr.compute_adr_lag_summary(lags)
         self.assertEqual(result["count"], 0)
 
+    def test_retrofit_count_from_is_retrofit_flag(self) -> None:
+        lags = [
+            {"adr_id": "0040", "lag_days": 0, "is_retrofit": True},
+            {"adr_id": "0041", "lag_days": 0, "is_retrofit": True},
+            {"adr_id": "0042", "lag_days": 5, "is_retrofit": False},
+        ]
+        result = sr.compute_adr_lag_summary(lags)
+        self.assertEqual(result["retrofit_count"], 2)
+        # retrofit flag must not perturb the existing lag aggregation
+        self.assertEqual(result["count"], 3)
+
+    def test_retrofit_count_absent_flag_counts_zero(self) -> None:
+        # Defensive: entries without is_retrofit (e.g. older callers) must
+        # not raise and contribute 0 to the retrofit count.
+        lags = [{"adr_id": "0040", "lag_days": 3}]
+        result = sr.compute_adr_lag_summary(lags)
+        self.assertEqual(result["retrofit_count"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_self_review_regression.py
+++ b/tests/test_self_review_regression.py
@@ -109,6 +109,9 @@ class TestRuleToAutomationLagBasic(unittest.TestCase):
         self.assertEqual(len(lags), 1)
         self.assertEqual(lags[0]["adr_id"], "0001")
         self.assertEqual(lags[0]["lag_days"], 10)
+        # is_retrofit must be present and False for a genuine multi-day lag.
+        self.assertIn("is_retrofit", lags[0])
+        self.assertFalse(lags[0]["is_retrofit"])
 
 
 class TestRuleToAutomationLagSkipsUnaccepted(unittest.TestCase):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1063

5축 self-review #4(사이클 타임)의 `_compute_adr_lags()` 는 ADR proposed→accepted lag_days 를 이미 emit 하지만, `lag_days == 0` 이 정상 same-day 결정인지 **retrofit**(이미 accepted 된 ADR 에 나중에 Verification 추가 → `-S` 검색이 원래 acceptance commit 을 잡아 zero-lag 로 보임)인지 구분 불가. 2026-05-19 critique m1(ADR 0049 retrofit)을 telemetry 에서 가시화하려고 `is_retrofit` flag + `retrofit_count` 추가.

## 2. 영향 파일

- `scripts/claude-hooks/_self_review.py` (load-bearing 아님 — `LOAD_BEARING_PATHS` 미포함)
- `tests/test_self_review_axis_4_regression.py`, `tests/test_self_review_regression.py`

## 3. 리스크

낮음. 기존 p50/p90 lag 계약 불변(additive 필드 2개). 기존 테스트(`count`/`mean` 검증)는 영향 없음 확인.

## 4. 테스트

- `test_retrofit_count_from_is_retrofit_flag`: is_retrofit=True 2개 + False 1개 → retrofit_count=2, count=3 불변
- `test_retrofit_count_absent_flag_counts_zero`: 방어적 (flag 없는 old caller → 0)
- `test_lag_days_computed_correctly` 통합 테스트에 is_retrofit field 존재 + 다일 lag 시 False assert 추가
- 로컬 `pytest tests/test_self_review_axis_4_regression.py tests/test_self_review_regression.py` 통과 (exit 0)

## 5. Eval 영향

All `·` — eval surface 무변.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion path. self-review telemetry 의 additive 필드 — runtime RAG path 무관.

## 6. 하위 호환

깨짐 없음. `compute_adr_lag_summary` 반환 dict 에 `retrofit_count` 키 additive 추가, 기존 키 보존. 새 ADR 불필요(기존 측정 표면 refinement).

## 7. 범위 외

- H(cross-worktree ADR collision PreToolUse 훅) — 별도 PR (enforcement surface)
- retrofit=True path 의 `_compute_adr_lags` 통합 테스트 — unit 레벨(compute_adr_lag_summary)로 충분히 커버

🤖 Generated with [Claude Code](https://claude.com/claude-code)