### PR TITLE
docs(agent-utilization): register eval-anomaly-investigator in component matrix

### DIFF
--- a/docs/agent-utilization.md
+++ b/docs/agent-utilization.md
@@ -59,20 +59,23 @@
 
 | 컴포넌트 | 종류 | 5축 cover | 트리거 | 위치 |
 |---|---|---|---|---|
+| `eval-anomaly-investigator` | agent | #3 (closed error loop) + #4 (anomaly→audit) | `make real-eval` 후 dominant/이상 failure category · variance 의심 · 사용자 명시 | [`.claude/agents/eval-anomaly-investigator.md`](../.claude/agents/eval-anomaly-investigator.md) |
 | `eval-to-adr-bridge` | agent | #3 (부분) + #4 (trigger→proposed lag) | `/retrieval-eval` Phase STOP / `/eval-framework-progressive-audit` phase / `make real-eval` 후 | [`.claude/agents/eval-to-adr-bridge.md`](../.claude/agents/eval-to-adr-bridge.md) |
 | `memory-curator` | agent | #5 (incremental gate) | 메모리 저장 직전 / `MEMORY.md` ≥180줄 / 사용자 명시 | [`.claude/agents/memory-curator.md`](../.claude/agents/memory-curator.md) |
 | `agent-delegation-gate` | hook | #2 (prompt-time delegation nudge) | UserPromptSubmit (모든 prompt, 키워드 매치 시 메시지 emit + fires.log append) | [`scripts/claude-hooks/userpromptsubmit-delegation-gate.sh`](../scripts/claude-hooks/userpromptsubmit-delegation-gate.sh) |
 
-### 갭 분석 (왜 이 3개만)
+### 갭 분석 (왜 이 컴포넌트만)
 
 외부 191개 검토 결과 채택 0개. 근본 원인은 enterprise persona vs research 1인 RAG 결 미스매치. 보편 원칙은 이미 `karpathy-guidelines` skill + CLAUDE.md 로 cover. 자체 갭만 1:1 보강:
 
 - **#2 위임 부족**: UserPromptSubmit hook 0개였음 → prompt 시점 위임 권유 강제 (CLAUDE.md "위임 기본값" 인용). `_self_review.py` `collect_governance_hooks` 가 4-field 포맷의 `agent-delegation` reason 카운터를 기존 `memory-lines` / `load-bearing` 옆에 자동 인식
 - **#3 자동화 ROI 일부 + #4 사이클 타임 trigger→proposed**: 측정 결과 → ADR 후보 변환 빈 칸. `reports/cycle_time.json` 에 `adr_proposed` 이벤트 + `trigger_to_proposal_seconds` append 로 정량화. PR open→merge / ADR proposed→accepted lag 는 `_self_review.py` git history 기반 사후 측정으로 이미 가동
 - **#5 메모리 위생**: `anthropic-skills:consolidate-memory` skill 은 batch consolidation (주기적). per-save dedup / type 균형 / stale 판단은 LLM judgment 필요한 incremental gate → agent 영역
+- **(2026-05-20 추가) #3 closed error loop**: 측정 이상치 → root-cause audit 수작업 3회 반복 (#1003/#1008/#1021) → `eval-anomaly-investigator` 로 코드화. `eval-to-adr-bridge` 의 앞단 (anomaly→audit→ADR 후보 체인 완성). issue #1050, PR-C 묶음 외 별도 후속
 
 ### 사용 가이드
 
+- `eval-anomaly-investigator`: `make real-eval` 후 failure category 이상치를 ADR 0005-safe slice + 가설 ranking → `docs/audits/*-inspection.md`. 산출 audit 는 `eval-to-adr-bridge` 의 입력. 실 fix / 측정 실행은 영역 외
 - `eval-to-adr-bridge`: 측정 후 ADR 작성 결정 단계에서 호출. commit / PR / Status 변경은 영역 외 (`ship-pr` skill 영역)
 - `memory-curator`: 메모리 저장 결정 게이트. batch 정리는 `consolidate-memory` skill 영역 (호출 권유만)
 - `agent-delegation-gate`: 자동 (사용자 prompt 시점). 항상 exit 0, fail-safe. 트리거 키워드 false-positive 시 description 어휘 조정


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/agent-utilization.md` 의 "Q3-2026 보강 컴포넌트 × 5축 cover" 매트릭스가 머지된 `eval-anomaly-investigator` (#1050 → #1053) 를 누락해 stale. 매트릭스 행 + 사용 가이드 bullet + 갭 분석 노트 추가, "왜 이 3개만" → "왜 이 컴포넌트만" 헤딩 정합.

Closes #1064

## 2. 영향 파일

- `docs/agent-utilization.md` (비-load-bearing; docs/adr/ 아님)

## 3. 리스크

문서 전용, 동작 변화 0. 가능한 깨짐: 매트릭스 행 컬럼 수 불일치 → 5컬럼 헤더와 정합 확인. 링크 경로 `../.claude/agents/eval-anomaly-investigator.md` 는 main 에 존재(#1053 머지)하는 파일 가리킴.

## 4. 테스트

N/A — 문서 변경. 실행 가능한 동작·테스트 대상 없음.

## 5. Eval 영향

All `·` — RAG/eval 무관.

### 5b. Real-data delta

N/A — load-bearing path 미변경. 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

깨짐 없음. 문서 내용 추가만, 기존 링크/계약 무관.

## 7. 범위 외

- shortlist 의 `ablation-comparison-analyst` / `dependency-doc-drift-auditor` agent — 별 issue
- agent 자체 dogfood (다음 `make real-eval` 산출에서 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)