### PR TITLE
docs(adr): clarify ADR 0003 contract scope — shape vs distribution

### DIFF
--- a/docs/adr/0003-structured-answer-citation-contract.md
+++ b/docs/adr/0003-structured-answer-citation-contract.md
@@ -29,6 +29,17 @@
 
 [`docs/agentic/answer-policy.md`](../agentic/answer-policy.md) 가 working reference; 이 ADR 이 load-bearing 결정.
 
+## 계약의 범위 — shape vs 분포
+
+이 계약은 **shape**(필드·enum 값·back-pointing 구조)만 lock 한다. status 분류의 **분포**(비율·평균 개수)는 lock 하지 **않는다**.
+
+- **Lock (shape — `schema_version` bump 트리거)**: `status` enum 집합, `claims[].citations[]` → top-level `evidence[]` back-pointing, `evidence[]`·`status_reason` shape, `schema_version` integer. 이 중 하나라도 깨지면 `schema_version` 을 올린다.
+- **Lock 안 함 (분포 — eval 표면에 위임)**: `insufficient`/`partial`/`supported` 의 *비율*, `claims` 평균 개수, `evidence` 평균 길이.
+
+따라서 verifier 강화(예: #1008 unanswerable hardening), answer-policy 개정, 새 abstention 패턴이 status *분포* 를 크게 흔들어도 — 그것은 이 계약의 **위반이 아니며** `schema_version` bump 트리거도 아니다. shape 이 동일하면 계약은 유지된다.
+
+분포 변화의 *측정* 은 [ADR 0005](0005-eval-split-public-synthetic-private-local.md) 의 두 eval 표면(public synthetic + private local)에 위임한다. eval delta 가 의미 있는 분포 이동을 보이면 reviewer 가 그 변화를 정당화하면 되고, 이 ADR 은 그 정당화가 딛고 설 *형식 계약* 만 강제한다.
+
 ## 결과
 
 **Wins**


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0003 (답변/인용 계약) 에 "계약의 범위 — shape vs 분포" 섹션 추가. shape(필드·enum·back-pointing)만 lock 하고 status 분류 분포는 ADR 0005 eval 표면에 위임함을 명시. verifier hardening(#1008)이 abstention 분포를 흔들어도 계약 위반/`schema_version` bump 트리거가 아님을 lock.

Closes #1068

## 2. 영향 파일

- `docs/adr/0003-structured-answer-citation-contract.md` (LOAD-BEARING) — "계약의 범위" 섹션 1개 추가 (11줄). Status/결정/결과/대안 본문 미변경

## 3. 리스크

ADR 의 load-bearing 의미(답변 dict 계약) 미변경 — shape 항목·enum·back-pointing 그대로. 추가된 것은 *분포는 계약 밖* 이라는 명시적 경계뿐. governance linter(verifies-key markers) 영향 없음 — ADR 0003 에는 해당 marker 부재.

## 4. 테스트

Docs-only. 새 동작/코드 경로 없음 → 회귀 테스트 불필요. (계약 shape 자체는 기존 `tests/` answer-format 검증이 이미 lock)

## 5. Eval 영향

All `·` — runtime / eval surface 변경 없음.

### 5b. Real-data delta

검색/검증/답변 path 동작 변화 없음. ADR 0003 문서에 scope 경계 명시만 추가 — 어떤 runtime module 도 미변경.

## 6. 하위 호환

호환 OK. `schema_version` 변경 없음(shape 미변경). 이 PR 은 오히려 *언제 bump 해야 하는지* 의 경계를 명확히 함.

## 7. 범위 외

- ADR 0005 본문 측 역방향 cross-ref 보강 — A.4 follow-up (별도 PR)
- #1008 verifier hardening 자체의 분포 측정 — 해당 PR scope