### PR TITLE
chore(eval): automate naive_baseline golden regen + drift soft-warn

### DIFF
--- a/.githooks/_pre-push-real-eval-reminder.sh
+++ b/.githooks/_pre-push-real-eval-reminder.sh
@@ -99,4 +99,39 @@ EOF
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# 3. naive_baseline golden freshness reminder.
+# ---------------------------------------------------------------------------
+#
+# tests/data/naive_baseline_top_k.json drifts when the data/raw/ corpus changes
+# (PR #648 HWP fixtures, PR #914 H/I/J/K corpus). Content drift is hard-gated
+# by tests/test_naive_baseline_ranking_invariance.py, but that signal only
+# fires at test time; this surfaces it earlier — and ONLY when the corpus
+# changed without a co-committed golden update AND a rebuild confirms real
+# drift (so a no-op corpus edit never nags). Uses `$changed` from reminder 1.
+
+if [[ -n "$changed" ]] && command -v python3 >/dev/null 2>&1; then
+  raw_changed=$(printf '%s\n' "$changed" | grep -E '^data/raw/.+\.json$' || true)
+  golden_changed=$(printf '%s\n' "$changed" | grep -Fx 'tests/data/naive_baseline_top_k.json' || true)
+  if [[ -n "$raw_changed" && -z "$golden_changed" ]]; then
+    if ! python3 scripts/regen_naive_baseline_golden.py --check >/dev/null 2>&1; then
+      cat >&2 <<EOF
+
+⚠️  data/raw/ corpus changed but the naive_baseline golden was not updated,
+    and a rebuild shows the ranking drifted.
+
+    Refresh the committed snapshot before reviewers see a red invariance test:
+
+        make regen-golden
+        git add tests/data/naive_baseline_top_k.json
+
+    ADR 0001: this only refreshes the snapshot — the naive_baseline pipeline
+    is untouched. Push proceeds; skip with --no-verify if the drift is
+    intentional and handled in this PR.
+
+EOF
+    fi
+  fi
+fi
+
 exit 0

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Governance gates (branch + issue, README metrics, latency SLO, leaderboard
 # freshness, real-eval history freshness, benchmark manifest check). Run
 # `make governance-check` to invoke the pre-PR subset in sequence.
-.PHONY: check-branch governance-check check check-latency leaderboard-check real-eval-history-check benchmark-check check-baseline-provenance
+.PHONY: check-branch governance-check check check-latency leaderboard-check real-eval-history-check benchmark-check check-baseline-provenance regen-golden check-golden
 
 # Index build + ad-hoc ask
 .PHONY: index ask
@@ -152,6 +152,19 @@ benchmark-check:
 
 check:
 	$(PYTHON) scripts/update_readme_metrics.py --report reports/eval_summary.json --readme README.md --check
+
+# naive_baseline ranking golden (tests/data/naive_baseline_top_k.json) regen +
+# staleness check. The golden drifts when the data/raw/ corpus changes (PR #648,
+# #914); content drift is hard-gated by
+# tests/test_naive_baseline_ranking_invariance.py. `regen-golden` refreshes the
+# committed snapshot in place (ADR 0001: pipeline code untouched); `check-golden`
+# exits non-zero if the committed golden is stale (also used by the pre-push
+# soft-warn reminder in .githooks/_pre-push-real-eval-reminder.sh).
+regen-golden:
+	$(PYTHON) scripts/regen_naive_baseline_golden.py
+
+check-golden:
+	$(PYTHON) scripts/regen_naive_baseline_golden.py --check
 
 # Absolute p95 latency SLO gate. Reads per-ablation budgets from
 # eval/config.yaml::latency_budgets and fails if any observed p95

--- a/scripts/regen_naive_baseline_golden.py
+++ b/scripts/regen_naive_baseline_golden.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Regenerate (or --check) the naive_baseline ranking golden (ADR 0001).
+
+``tests/data/naive_baseline_top_k.json`` pins the top-K ``(chunk_id, score)``
+for a fixed query set, built from ``data/raw/`` through the ``naive_baseline``
+pipeline with the deterministic hashing backend + fixed chunking. It drifts
+whenever the ``data/raw/`` corpus changes (e.g. PR #648 HWP fixtures, PR #914
+H/I/J/K corpus), and until now each drift was repaired by hand with tribal
+``EMBEDDING_BACKEND=hashing chunking_strategy=fixed`` commands.
+
+Write mode (default): rebuild and overwrite the golden in place, preserving the
+committed query set and each query's top-K length. To add/remove a query, edit
+the golden's keys first (a deliberate act), then regenerate to fill the values.
+
+``--check`` mode: rebuild and exit 1 if the committed golden is stale (used by
+the pre-push reminder and ``make check-golden``).
+
+This module is the single source of truth for *how* the golden is built;
+``tests/test_naive_baseline_ranking_invariance.py`` imports ``build_golden`` so
+the test and the regenerator can never drift apart. ADR 0001: this only
+refreshes the snapshot — the ``naive_baseline`` pipeline code is never touched
+here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from rag_core import build_index_payload, run_rag_query  # noqa: E402
+
+GOLDEN_PATH = REPO_ROOT / "tests" / "data" / "naive_baseline_top_k.json"
+CORPUS_DIR = REPO_ROOT / "data" / "raw"
+
+# Hashing backend + fixed chunking = deterministic across machines and across
+# the Phase 3 stack (see the invariance test docstring). These must stay in
+# lockstep with what the test reproduces.
+EMBEDDING_BACKEND = "hashing"
+CHUNKING_STRATEGY = "fixed"
+
+
+def build_golden(reference: dict[str, list]) -> dict[str, list]:
+    """Rebuild the naive_baseline top-K snapshot for ``reference``'s query set.
+
+    Each query is re-run through the ``naive_baseline`` pipeline; the result is
+    truncated to the same length the query has in ``reference``, so the curated
+    query set + per-query K are preserved. Adding/removing a query is therefore
+    a deliberate edit to the golden, never a side effect of regeneration.
+    """
+    index = build_index_payload(
+        CORPUS_DIR,
+        embedding_backend=EMBEDDING_BACKEND,
+        chunking_strategy=CHUNKING_STRATEGY,
+    )
+    rebuilt: dict[str, list] = {}
+    for query, golden_top in reference.items():
+        result = run_rag_query(index, query, pipeline="naive_baseline")
+        citations = result.get("citations") or result.get("evidence") or []
+        rebuilt[query] = [
+            [c.get("chunk_id"), c.get("score")] for c in citations[: len(golden_top)]
+        ]
+    return rebuilt
+
+
+def _serialize(golden: dict[str, list]) -> str:
+    # 2-space indent + ensure_ascii=False + trailing newline = byte-identical to
+    # the committed golden, so a no-op regeneration is a clean (empty) git diff.
+    return json.dumps(golden, ensure_ascii=False, indent=2) + "\n"
+
+
+def run(check: bool, golden_path: Path = GOLDEN_PATH) -> int:
+    committed = json.loads(golden_path.read_text(encoding="utf-8"))
+    rebuilt = build_golden(committed)
+
+    if check:
+        if rebuilt != committed:
+            drifted = sorted(q for q in committed if committed[q] != rebuilt.get(q))
+            print(
+                f"[FAIL] naive_baseline golden is stale ({golden_path}).\n"
+                f"       Drifted queries: {drifted}\n"
+                f"       Regenerate with: make regen-golden",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"[OK] naive_baseline golden is up-to-date ({golden_path})")
+        return 0
+
+    golden_path.write_text(_serialize(rebuilt), encoding="utf-8")
+    print(f"[OK] Regenerated {golden_path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Regenerate (or --check) the naive_baseline ranking golden (ADR 0001)."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if the committed golden is stale instead of rewriting it.",
+    )
+    args = parser.parse_args(argv)
+    return run(check=args.check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_naive_baseline_ranking_invariance.py
+++ b/tests/test_naive_baseline_ranking_invariance.py
@@ -13,48 +13,41 @@ pipeline against a freshly built hashing-backend index (deterministic
 across machines) and asserts the top-K chunk_ids + scores match a
 committed golden file (`tests/data/naive_baseline_top_k.json`).
 
+The rebuild is delegated to `scripts.regen_naive_baseline_golden.build_golden`
+— the single source of truth for *how* the golden is built — so this guard
+and the `make regen-golden` regenerator can never drift apart.
+
 If a later PR legitimately needs to change `naive_baseline` ranking
-(e.g. a chunking-strategy default change), regenerate the golden
-intentionally inside that PR and call it out in the PR body.
+(e.g. a chunking-strategy default change), run `make regen-golden`
+inside that PR and call it out in the PR body.
 """
 
 import json
 import unittest
-from pathlib import Path
 
-from rag_core import build_index_payload, run_rag_query
-
-
-GOLDEN_PATH = Path(__file__).parent / "data" / "naive_baseline_top_k.json"
+from scripts.regen_naive_baseline_golden import GOLDEN_PATH, build_golden
 
 
 class NaiveBaselineRankingInvarianceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        # Hashing backend + fixed chunking = deterministic across machines
-        # and across the Phase 3 stack — every PR's CI run reproduces the
-        # same vectors.
-        cls.index = build_index_payload(
-            Path("data/raw"),
-            embedding_backend="hashing",
-            chunking_strategy="fixed",
-        )
+        # build_golden rebuilds with the hashing backend + fixed chunking
+        # (deterministic across machines and across the Phase 3 stack), keyed
+        # to the committed golden's query set.
         cls.golden = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+        cls.rebuilt = build_golden(cls.golden)
 
     def test_top_k_chunk_ids_match_golden(self) -> None:
         for query, golden_top in self.golden.items():
             with self.subTest(query=query):
-                result = run_rag_query(self.index, query, pipeline="naive_baseline")
-                citations = result.get("citations") or result.get("evidence") or []
-                observed = [[c.get("chunk_id"), c.get("score")] for c in citations[: len(golden_top)]]
                 self.assertEqual(
                     golden_top,
-                    observed,
+                    self.rebuilt[query],
                     f"naive_baseline ranking drifted for query: {query!r}.\n"
                     f"  golden:   {golden_top}\n"
-                    f"  observed: {observed}\n"
-                    f"If this drift is intentional, regenerate "
-                    f"{GOLDEN_PATH} inside the PR and explain in the PR body.",
+                    f"  observed: {self.rebuilt[query]}\n"
+                    f"If this drift is intentional, run `make regen-golden` "
+                    f"inside the PR and explain in the PR body.",
                 )
 
 

--- a/tests/test_regen_naive_baseline_golden.py
+++ b/tests/test_regen_naive_baseline_golden.py
@@ -1,0 +1,89 @@
+"""Regression guard for the naive_baseline golden regenerator CLI wiring.
+
+Covers the ``--check`` exit codes, the write round-trip, query-set/length
+preservation, and the committed serialization style of
+``scripts/regen_naive_baseline_golden.py`` WITHOUT building a real index —
+``build_golden`` is monkeypatched so these stay fast + deterministic. The real
+index-build correctness is covered by
+``tests/test_naive_baseline_ranking_invariance.py``, which imports the same
+``build_golden``.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from scripts import regen_naive_baseline_golden as regen
+
+
+_REFERENCE = {
+    "q1": [["doc::chunk-1", 0.9], ["doc::chunk-2", 0.8]],
+    "q2": [["doc::chunk-3", 0.7]],
+}
+
+
+def _write_golden(tmp: Path, data: dict) -> Path:
+    path = tmp / "golden.json"
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+class RegenGoldenCliTest(unittest.TestCase):
+    def test_check_passes_when_fresh(self) -> None:
+        with TemporaryDirectory() as d, mock.patch.object(regen, "build_golden", return_value=_REFERENCE):
+            golden = _write_golden(Path(d), _REFERENCE)
+            self.assertEqual(0, regen.run(check=True, golden_path=golden))
+
+    def test_check_fails_when_stale(self) -> None:
+        stale = {
+            "q1": [["doc::chunk-1", 0.9], ["doc::chunk-2", 0.8]],
+            "q2": [["doc::chunk-99", 0.1]],
+        }
+        with TemporaryDirectory() as d, mock.patch.object(regen, "build_golden", return_value=_REFERENCE):
+            golden = _write_golden(Path(d), stale)
+            self.assertEqual(1, regen.run(check=True, golden_path=golden))
+
+    def test_write_round_trips(self) -> None:
+        stale = {"q1": [["x", 0.0], ["y", 0.0]], "q2": [["z", 0.0]]}
+        with TemporaryDirectory() as d, mock.patch.object(regen, "build_golden", return_value=_REFERENCE):
+            golden = _write_golden(Path(d), stale)
+            self.assertEqual(0, regen.run(check=False, golden_path=golden))
+            self.assertEqual(_REFERENCE, json.loads(golden.read_text(encoding="utf-8")))
+
+    def test_run_passes_committed_golden_as_reference(self) -> None:
+        # run() must hand the committed golden to build_golden so the curated
+        # query set + per-query K are preserved on regeneration.
+        captured: dict = {}
+
+        def fake_build(reference):
+            captured["ref"] = reference
+            return _REFERENCE
+
+        with TemporaryDirectory() as d, mock.patch.object(regen, "build_golden", side_effect=fake_build):
+            golden = _write_golden(Path(d), _REFERENCE)
+            regen.run(check=True, golden_path=golden)
+        self.assertEqual(_REFERENCE, captured["ref"])
+
+    def test_serialize_korean_literal_2space_indent_trailing_newline(self) -> None:
+        out = regen._serialize({"기관": [["c", 0.5]]})
+        self.assertTrue(out.endswith("\n"))
+        self.assertIn("기관", out)  # ensure_ascii=False keeps Korean keys literal
+        self.assertNotIn("\\u", out)
+        self.assertIn('\n  "기관"', out)  # 2-space indent
+        self.assertEqual({"기관": [["c", 0.5]]}, json.loads(out))
+
+    def test_main_check_flag_dispatches_to_run(self) -> None:
+        with mock.patch.object(regen, "run", return_value=0) as run_mock:
+            self.assertEqual(0, regen.main(["--check"]))
+        run_mock.assert_called_once_with(check=True)
+
+    def test_main_default_is_write(self) -> None:
+        with mock.patch.object(regen, "run", return_value=0) as run_mock:
+            self.assertEqual(0, regen.main([]))
+        run_mock.assert_called_once_with(check=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

naive_baseline golden (`tests/data/naive_baseline_top_k.json`) 은 `data/raw/` 코퍼스가 바뀔 때마다 (PR #648 HWP fixtures, PR #914 H/I/J/K corpus) 손으로 재생성돼 왔다. content drift **감지**는 `test_naive_baseline_ranking_invariance.py` 가 이미 hard-gate 하지만, 재생성 헬퍼가 없어 tribal `EMBEDDING_BACKEND=hashing` 명령으로 매번 수동 편집했고, 신호가 CI test-runtime 에야 떠 fixture/golden 이 별도 PR 로 갈라졌다 (#648 → #693, 5시간 간격). `update_readme_metrics.py` 의 write + `--check` 듀얼을 golden 에도 적용해 toil 을 제거하고 신호를 pre-push 로 당긴다.

Closes #1062

## 2. 영향 파일

- `scripts/regen_naive_baseline_golden.py` (신규) — write/`--check` 듀얼, `build_golden` SSoT. **load-bearing 아님** (load-bearing 은 `scripts/build_index.py` 만 해당).
- `tests/test_naive_baseline_ranking_invariance.py` — `build_golden` import 로 리팩터 (DRY, 의미 보존).
- `tests/test_regen_naive_baseline_golden.py` (신규) — CLI 회귀 테스트.
- `.githooks/_pre-push-real-eval-reminder.sh` — soft-warn 리마인더 #3.
- `Makefile` — `regen-golden` / `check-golden` 타겟.
- **load-bearing path 변경 없음.**

## 3. 리스크

- **멱등성 깨짐** (재생성 출력이 committed golden 과 byte 불일치 → 매 regen 마다 spurious diff). 확인: `make regen-golden` 후 `git diff` 빈 결과 — 2-space indent + `ensure_ascii=False` + trailing newline 이 committed 와 동일.
- **SSoT 추출이 invariance 테스트 의미 변경**. per-query subTest + drift 메시지 보존, 테스트 통과 (8 passed, 5 subtests).
- **훅 reminder #3 가 무관 push 에서 nag**. `data/raw` 변경 + golden 미변경 + `--check` 실제 drift 3중 조건일 때만 발화 — 매 push 인덱스 빌드 회피, no-op 코퍼스 편집엔 침묵.

## 4. 테스트

- 신규 `tests/test_regen_naive_baseline_golden.py` (7 케이스): `--check` exit 0/1, write round-trip, query-set/per-query K 보존, 직렬화 스타일(한글 literal·2-space·trailing newline), `main` dispatch. `build_golden` monkeypatch 로 실제 인덱스 빌드 회피 → 빠르고 결정론적.
- `tests/test_naive_baseline_ranking_invariance.py`: `build_golden` 경유 실제 인덱스 빌드 정확성 (기존 hard-gate 의미 유지).
- 전체: `python3 -m pytest tests/test_naive_baseline_ranking_invariance.py tests/test_regen_naive_baseline_golden.py -q` → **8 passed, 5 subtests, 22.6s**. ruff clean. `make check-golden` → `[OK] up-to-date`. `make regen-golden` → 빈 diff (멱등).

## 5. Eval 영향

All `·` (no eval delta). golden snapshot 재생성 tooling only — 검색/계획/답변 파이프라인·eval 산출물 산식 미변경.

### 5b. Real-data delta

N/A — 검색/검증 path 동작 변화 없음. load-bearing path 미변경 (golden snapshot tooling only), ADR 0001 baseline invariant 유지. (§5b CI gate 는 load-bearing 변경 시에만 강제되며 이 PR 은 해당 없음.)

## 6. 하위 호환

깨짐 없음. golden 파일 포맷·query set·answer-contract (ADR 0003) 불변. `build_golden` 은 신규 public 헬퍼라 기존 CLI flag/스키마 영향 없음.

## 7. 범위 외

- `reports/real100/baseline.aggregate.json` staleness — §5b + baseline-provenance 로 **다르게** 게이트되는 별도 surface. 필요 시 follow-up issue.
- `make check-golden` 을 `governance-check` 합성에 포함 — 보류 (현재 pytest 가 hard-gate, pre-push 가 조기 신호; governance-check 에 ~22s 인덱스 빌드 추가는 별도 판단).
- content drift 감지 로직 신규 작성 — 이미 invariance 테스트가 수행 (중복 회피).