### PR TITLE
docs(adr): cross-ref ADR 0058 ↔ ADR 0005 — real100 measurement surface

### DIFF
--- a/docs/adr/0005-eval-split-public-synthetic-private-local.md
+++ b/docs/adr/0005-eval-split-public-synthetic-private-local.md
@@ -2,7 +2,7 @@
 
 - **Status**: accepted
 - **Date**: 2026-05-11
-- **Related**: [`eval/config.yaml`](../../eval/config.yaml), [`eval/real_config.example.yaml`](../../eval/real_config.example.yaml), [`docs/real-data/private-100-doc-experiments.md`](../real-data/private-100-doc-experiments.md), [`docs/real-data/private-hardcase-benchmark.md`](../real-data/private-hardcase-benchmark.md), [`docs/real-data/real-data-failure-taxonomy.md`](../real-data/real-data-failure-taxonomy.md)
+- **Related**: [ADR 0058](0058-phase35-mode-winner.md) (real100 measurement = 이 표면의 private-local slice), [`eval/config.yaml`](../../eval/config.yaml), [`eval/real_config.example.yaml`](../../eval/real_config.example.yaml), [`docs/real-data/private-100-doc-experiments.md`](../real-data/private-100-doc-experiments.md), [`docs/real-data/private-hardcase-benchmark.md`](../real-data/private-hardcase-benchmark.md), [`docs/real-data/real-data-failure-taxonomy.md`](../real-data/real-data-failure-taxonomy.md)
 
 ## TL;DR
 
@@ -27,6 +27,8 @@
 - **비공개 local** (`eval/real_config.example.yaml` 가 scaffold; 실제 config 와 corpus 는 git 외부). 실제 조달 문서에서 로컬 실행. *"어떤 실패 모드가 real 인가?"* 의 단일 출처. 출력(`reports/real100/`)·입력(`data/files/`, `data/data_list.csv`, 로컬 config)은 `.gitignore`d
 
 경계는 example 파일 컨벤션(`*.example.yaml`) + `.gitignore` 가 강제. 모든 새 eval 표면은 한쪽을 선택 — public-redistributable 또는 strictly local.
+
+예: Phase 3.5 retrieval mode-winner 결정([ADR 0058](0058-phase35-mode-winner.md))의 evidence 인 real100 measurement(kordoc 26k chunks, n=221)는 **strictly-local** surface 에 속한다 — corpus·case 텍스트는 gitignored, aggregate REPORT 만 committable. 이 cross-ref 가 없으면 새 측정 표면이 어느 slice 인지 모호해진다.
 
 ## 결과
 

--- a/docs/adr/0058-phase35-mode-winner.md
+++ b/docs/adr/0058-phase35-mode-winner.md
@@ -3,7 +3,7 @@
 - **Status**: accepted (kordoc-corpus measurement landed 2026-05-19; Scenario A finalized)
 - **Date**: 2026-05-19 (Status accepted); 2026-05-18 (Status proposed)
 - **Deciders**: hskim
-- **Related**: [ADR 0001](0001-preserve-naive-baseline.md), [ADR 0010](0010-hybrid-bm25-dense-retrieval-rrf.md), [ADR 0021](0021-real-eval-axis-design.md), [ADR 0025](0025-spike-mode-m3-channels.md), [ADR 0032](0032-torch-26-unblock.md), [ADR 0049](0049-kordoc-replaces-pyhwp-backend.md), PR #966 (Phase 3.5 measurement), PR #956 (Phase 3, retracted), issue #957, issue #997, issue #1022 (m3 cloud-GPU follow-up)
+- **Related**: [ADR 0001](0001-preserve-naive-baseline.md), [ADR 0005](0005-eval-split-public-synthetic-private-local.md), [ADR 0010](0010-hybrid-bm25-dense-retrieval-rrf.md), [ADR 0021](0021-real-eval-axis-design.md), [ADR 0025](0025-spike-mode-m3-channels.md), [ADR 0032](0032-torch-26-unblock.md), [ADR 0049](0049-kordoc-replaces-pyhwp-backend.md), PR #966 (Phase 3.5 measurement), PR #956 (Phase 3, retracted), issue #957, issue #997, issue #1022 (m3 cloud-GPU follow-up)
 
 > **ADR number renumbered 0056 → 0057 → 0058** (2026-05-19) to avoid two concurrent collisions: ADR 0056 was merged via PR #987 (`rationality_judge`, issue #969) + ADR 0057 was merged via PR #988 (`bm25s additive backend`). Final number `0058` per ADR README.md "Reserve the next number with the CLI before drafting" convention.
 
@@ -24,6 +24,8 @@ This ADR's evidence is the kordoc-rebuilt re-measurement: same 100 docs, same ch
 ### Evidence (from `reports/retrieval/phase35_m3_20260518T214937Z_kordoc_no_m3/REPORT.md`)
 
 Measurement: kordoc 26,376 chunks, n=221 cases, dense_m3 vs hybrid_bm25_k60_m3, paired bootstrap CI 95%, seeds 17/23/29.
+
+This measurement runs on the [ADR 0005](0005-eval-split-public-synthetic-private-local.md) **private-local** surface (real100 corpus, gitignored; only the aggregate REPORT is committable) — not the public-synthetic surface. Per ADR 0005, every new eval surface picks one side; this one is strictly-local, so absolute `chunk_recall@k` numbers here are not reviewer-reproducible (paired CI deltas + the committed REPORT are the audit trail).
 
 **Overall metrics** (hybrid_bm25_k60_m3 vs dense_m3, all SIG = paired CI fully above 0):
 - `chunk_recall@10`: 0.288 → 0.340 (**+0.052 SIG**, CI +0.020/+0.088)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0058 (Phase 3.5 mode-winner) 의 evidence(real100 kordoc 26k measurement)가 ADR 0005 의 어느 eval slice 에 속하는지 명시. ADR 0058 ↔ ADR 0005 양방향 Related 링크 + 각 본문 1줄 slice attribution 추가. real100 measurement = private-local surface 임을 lock.

Closes #1075

## 2. 영향 파일

- `docs/adr/0058-phase35-mode-winner.md` (LOAD-BEARING) — Related 줄 ADR 0005 추가 + Evidence 섹션 surface 명시 1줄
- `docs/adr/0005-eval-split-public-synthetic-private-local.md` (LOAD-BEARING) — Related 줄 ADR 0058 추가 + Decision 섹션 예시 1줄

## 3. 리스크

ADR 0058 의 verifies-key markers 미변경 (diff grep=0 확인) — `--lint-adr-consequences` linter 영향 없음. ADR 0005 의 Decision/Costs/대안 본문 미변경. 양쪽 모두 cross-ref + slice attribution 추가만.

## 4. 테스트

Docs-only. 새 동작/코드 경로 없음 → 회귀 테스트 불필요.

## 5. Eval 영향

All `·` — runtime / eval surface 변경 없음.

### 5b. Real-data delta

검색/검증/답변 path 동작 변화 없음. ADR cross-ref 추가만 — 어떤 runtime module 도 미변경.

## 6. 하위 호환

호환 OK. ADR 결정(Scenario A hybrid default / eval split) 자체 미변경. cross-ref 링크 추가만.

## 7. 범위 외

- 다른 최근 cluster ADR (#1000 hybrid impl, #1008 verifier) 의 상위 ADR cross-ref — A.6 (PR 템플릿 게이트) 가 향후 강제