### PR TITLE
fix(governance): hook fire-log을 REPO_ROOT 기준 고정 (cwd-relative 분산 방지)

### DIFF
--- a/scripts/claude-hooks/pretooluse-adr-template.sh
+++ b/scripts/claude-hooks/pretooluse-adr-template.sh
@@ -129,7 +129,8 @@ adr_basename=$(basename "$file_path")
 # v2-5field telemetry (ADR 0060).
 python3 "$REPO_ROOT/scripts/_governance.py" --emit-fire \
   --outcome blocked --hook adr-template --category missing-verification \
-  --path "$adr_basename" --extra "missing=$missing" 2>/dev/null || true
+  --path "$adr_basename" --extra "missing=$missing" \
+  --fire-log "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
 
 cat >&2 <<EOF
 ⛔ Refusing Write of new ADR \`$adr_basename\`: missing Verification surface.

--- a/scripts/claude-hooks/pretooluse-bash-guard.sh
+++ b/scripts/claude-hooks/pretooluse-bash-guard.sh
@@ -114,7 +114,8 @@ if [[ "$gh_subcommand" == "create" ]]; then
   # v2-5field telemetry (ADR 0060) — hook field added to canonical pattern.
   python3 "$REPO_ROOT/scripts/_governance.py" --emit-fire \
     --outcome blocked --hook bash-guard --category gh-pr-create-stacked \
-    --path "$current_branch" --extra "on=$stacked_on" 2>/dev/null || true
+    --path "$current_branch" --extra "on=$stacked_on" \
+    --fire-log "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
 
   cat >&2 <<EOF
 ⛔ Refusing \`gh pr create\` without \`--base\`: current branch is stacked.
@@ -188,7 +189,8 @@ except Exception:
 # v2-5field telemetry (ADR 0060) — hook field added to canonical pattern.
 python3 "$REPO_ROOT/scripts/_governance.py" --emit-fire \
   --outcome blocked --hook bash-guard --category gh-merge-delete-branch \
-  --path "$head_branch" 2>/dev/null || true
+  --path "$head_branch" \
+  --fire-log "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
 
 cat >&2 <<EOF
 ⛔ Refusing \`gh pr merge --delete-branch\`: stacked dependents exist on \`$head_branch\`.

--- a/scripts/claude-hooks/pretooluse-loadbearing.sh
+++ b/scripts/claude-hooks/pretooluse-loadbearing.sh
@@ -41,7 +41,8 @@ if python3 "$REPO_ROOT/scripts/_governance.py" --is-load-bearing "$file_path" 2>
   # v2-5field format per ADR 0060 (issue #1039). Gitignored via `.claude/*`.
   python3 "$REPO_ROOT/scripts/_governance.py" --emit-fire \
     --outcome aware --hook loadbearing --category file-edit \
-    --path "$file_path" 2>/dev/null || true
+    --path "$file_path" \
+    --fire-log "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
   cat >&2 <<EOF
 ⚠️  Load-bearing file: $file_path
 

--- a/scripts/claude-hooks/pretooluse-memory-lines.sh
+++ b/scripts/claude-hooks/pretooluse-memory-lines.sh
@@ -81,7 +81,8 @@ fi
 # v2-5field telemetry (ADR 0060). action ∈ {ok, aware, blocked}.
 python3 "$REPO_ROOT/scripts/_governance.py" --emit-fire \
   --outcome "$action" --hook memory-lines --category line-count \
-  --path "$file_path" 2>/dev/null || true
+  --path "$file_path" \
+  --fire-log "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
 
 if [[ "$action" = "blocked" ]]; then
   cat >&2 <<EOF

--- a/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
+++ b/scripts/claude-hooks/userpromptsubmit-delegation-gate.sh
@@ -60,7 +60,8 @@ EOF
   # v2-5field telemetry (ADR 0060).
   python3 "$REPO_ROOT/scripts/_governance.py" --emit-fire \
     --outcome nudged --hook delegation-gate --category agent-delegation \
-    --path "<user-prompt>" 2>/dev/null || true
+    --path "<user-prompt>" \
+    --fire-log "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
 fi
 
 exit 0

--- a/tests/test_hook_telemetry.py
+++ b/tests/test_hook_telemetry.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -253,6 +254,55 @@ def test_no_hook_uses_legacy_printf_fire_log():
             assert ".hook-fires.log" not in line or "emit-fire" in content, (
                 f"{relpath} contains legacy fire-log redirect: {line}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Fire-log path anchored to REPO_ROOT, not the caller's cwd
+#
+# The bash hooks pass an explicit `--fire-log "$REPO_ROOT/.claude/.hook-fires.log"`,
+# so a hook invoked from a subdirectory or sibling worktree still routes its
+# fire into the repo it belongs to — not into whatever cwd the Bash command
+# happened to run in (which would scatter fires past collect_governance_hooks).
+# Without the explicit flag the CLI default (`.claude/.hook-fires.log`,
+# relative) resolves against cwd. All five REPO_ROOT-resolving hooks share the
+# identical arg; loadbearing is the simplest representative (no git/helper dep).
+# (plan-slug-race is intentionally cwd-local — it has no REPO_ROOT, registered
+# user-globally — and is deliberately excluded.)
+# ---------------------------------------------------------------------------
+
+
+def test_hook_fire_log_anchored_to_repo_root_not_cwd(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "scripts" / "claude-hooks").mkdir(parents=True)
+    hook_name = "pretooluse-loadbearing.sh"
+    shutil.copy(
+        REPO_ROOT / "scripts" / "claude-hooks" / hook_name,
+        repo / "scripts" / "claude-hooks" / hook_name,
+    )
+    shutil.copy(GOVERNANCE_PATH, repo / "scripts" / GOVERNANCE_PATH.name)
+
+    # Invoke the hook from a foreign cwd that is NOT the repo root.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    result = subprocess.run(
+        ["bash", str(repo / "scripts" / "claude-hooks" / hook_name)],
+        input='{"tool_input": {"file_path": "rag_core.py"}}',
+        cwd=str(elsewhere),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    repo_log = repo / ".claude" / ".hook-fires.log"
+    cwd_log = elsewhere / ".claude" / ".hook-fires.log"
+    # Fire lands in the repo the hook belongs to …
+    assert repo_log.is_file(), f"fire-log not under REPO_ROOT; stderr={result.stderr!r}"
+    assert "|aware|loadbearing|" in repo_log.read_text(encoding="utf-8")
+    # … and NOT in the unrelated caller cwd (the relative-default scatter bug).
+    assert not cwd_log.exists(), (
+        "fire-log leaked into the caller's cwd — --fire-log not anchored to "
+        "REPO_ROOT"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pretooluse_memory_lines_hook_regression.py
+++ b/tests/test_pretooluse_memory_lines_hook_regression.py
@@ -57,9 +57,10 @@ class TestMemoryLinesHook(unittest.TestCase):
         shutil.rmtree(self._tmp, ignore_errors=True)
 
     def _run(self, payload: dict) -> subprocess.CompletedProcess:
-        # cwd=tmp_repo so the hook's `--emit-fire` (which uses the default
-        # relative --fire-log `.claude/.hook-fires.log`) writes into this
-        # isolated REPO_ROOT rather than the developer's cwd (issue #1039).
+        # cwd is tmp_repo, but the hook now passes an explicit
+        # `--fire-log "$REPO_ROOT/.claude/.hook-fires.log"` (issue #1039), so
+        # the fire-log is anchored to REPO_ROOT (= tmp_repo here) regardless
+        # of cwd. test_hook_telemetry.py pins that cwd-independence directly.
         return subprocess.run(
             ["bash", str(self._hook)],
             input=json.dumps(payload),


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0060 / PR #1040 이 도입한 `emit_hook_fire()` + `--emit-fire` CLI 의 `--fire-log` 기본값이 상대경로 `.claude/.hook-fires.log` 다. 5개 hook 이 `--fire-log` 없이 `--emit-fire` 를 호출해 fire-log 경로가 **Bash 명령의 cwd 기준**으로 해석된다. worktree(30개+)/서브디렉토리에서 명령이 실행되면 fires 가 분산 기록되고 `scripts/_self_review.py::collect_governance_hooks` (한 곳의 `.hook-fires.log` 만 읽음) 가 다른 cwd 의 fires 를 놓쳐 ADR 0060 outcome telemetry 정확성이 훼손된다. 각 hook 상단의 `REPO_ROOT` 는 hook 파일 위치 기준이라 cwd 무관하게 정확하므로, `--emit-fire` 호출에 `--fire-log "$REPO_ROOT/.claude/.hook-fires.log"` 를 명시한다.

Closes #1079

## 2. 영향 파일

- `scripts/claude-hooks/pretooluse-loadbearing.sh`
- `scripts/claude-hooks/pretooluse-memory-lines.sh`
- `scripts/claude-hooks/pretooluse-adr-template.sh`
- `scripts/claude-hooks/pretooluse-bash-guard.sh` (gh-pr-create-stacked + gh-merge-delete-branch, 2 sites)
- `scripts/claude-hooks/userpromptsubmit-delegation-gate.sh`
- `tests/test_hook_telemetry.py` (회귀 테스트 추가)
- `tests/test_pretooluse_memory_lines_hook_regression.py` (stale 주석 정정)

**load-bearing 파일 없음** (governance hook + 테스트만).

## 3. 리스크

- 가장 가능성 높은 깨짐: bash line-continuation 문법 오류 → hook 무력화. → 5개 hook `bash -n` 통과 + 기존 hook 회귀(bash-guard / memory-lines / adr-template) green 으로 배제.
- `--fire-log` arg 가 `2>/dev/null || true` 앞으로 이동 — redirect/예외 처리 동일 유지 확인.
- **plan-slug-race 제외**: `REPO_ROOT` 없음(user-global 등록) + 의도적 cwd-local (PR #1040 주석 "cwd inside a worktree is where the fire-log belongs"). 건드리면 그 설계 위반.

## 4. 테스트

- **신규**: `tests/test_hook_telemetry.py::test_hook_fire_log_anchored_to_repo_root_not_cwd` — foreign cwd 에서 loadbearing hook 발사 시 fire 가 `$REPO_ROOT/.claude/.hook-fires.log` 에 기록되고 cwd 엔 안 남는지 검증. **pre-fix(상대 default) 코드에서 fail, 본 변경 후 pass** (behavior-change regression).
- 기존 telemetry contract + hook 회귀 테스트 그대로 통과 (local: `test_hook_telemetry.py` 20 passed; hook 스위트 81 passed).

## 5. Eval 영향

All `·` — RAG 파이프라인(검색/검증/답변/계획) 무관, governance hook telemetry 표면만 변경.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 (load-bearing 아님, runtime path 미접촉 — governance/hook 인프라). real-eval delta = N/A.

## 6. 하위 호환

호환 유지. fire-log v2-5field 포맷 불변, `emit_hook_fire`/CLI 기본값 불변. 변경은 호출부가 명시 경로를 넘기는 것뿐. legacy `.hook-fires.log` entries grandfathered 그대로.

## 7. 범위 외

- `emit_hook_fire`/CLI 의 상대 default 자체를 cwd-독립(git toplevel 탐색)으로 바꾸기 — 모든 실호출이 명시 경로를 넘기고 그 default 가 plan-slug-race 의 cwd-local 설계를 지지하므로 의도적 유지.
- worktree 간 fires 중앙집계 — 본 PR 은 cwd drift 만 해소(`$REPO_ROOT`=worktree 루트). 중앙집계는 plan-slug-race 철학과 동일한 별개 사안.
- orphan 브랜치 `feat/issue-1039-outcome-telemetry` 정리 (#1040 머지 후 잔존, 별도 cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)