### PR TITLE
docs(claude-md): rag_answer.py 함수 카운트 정정 20→21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 - `rag_reranker.py` — `Reranker` Protocol + 기본 `CrossEncoderReranker` (#345)
 - `rag_retrieval.py` — 검색 파이프라인 (#459 + #461). `retrieve_candidates`, 4 유사도 primitive, BM25, fusion·재순위·comparison balance·parent-section 재조립. 기본 `retrieval_backend` = `hybrid` (RRF k=60, BGE-M3 dense + BM25; ADR 0058) — `agentic_full`/`metadata_first` 한정, `naive_baseline` 은 `dense` 유지 (ADR 0001 불변)
 - `rag_verifier.py` — 검증기 (#465, PR-J1). `verify_evidence`, topic 추출, `EVIDENCE_BOUNDARY` 상수 + 명령 패턴 regex, `neutralize_instruction_patterns` (ADR 0008)
-- `rag_answer.py` — 답변 생성 (#468, PR-J2). 20 함수가 검증된 근거를 ADR 0003 답변 dict 로 변환. `schema_version: 2` 계약 유지
+- `rag_answer.py` — 답변 생성 (#468, PR-J2). 21 함수가 검증된 근거를 ADR 0003 답변 dict 로 변환. `schema_version: 2` 계약 유지
 - `rag_query.py` — 쿼리 분석·계획 (#478, PR-J3). 15 함수, `analyze_query`/`make_plan`/`comparison_targets_for_analysis` 등
 - `rag_query_expansion.py` — `QueryExpander` Protocol + 기본 `IdentityExpander` + opt-in `HyDEExpander` (#396, ADR 0023)
 - `scripts/` — `build_index.py`, `update_readme_metrics.py`, `run_real_eval_delta.py` 등


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

CLAUDE.md 저장소 맵의 `rag_answer.py` 줄이 "20 함수" 라고 적혀 있으나 실제 top-level 함수는 21개 (`grep -c '^def ' rag_answer.py` → 21). Issue #1047 staleness 보강(PR #1049) 때 Tier 4 로 분류해 미포함했던 잔여 drift 를 단독 정정.

Closes #1090

## 2. 영향 파일

- `CLAUDE.md` (load-bearing 아님 — instruction/pointer 파일)

## 3. 리스크

없음. 문서 텍스트 1단어(`20`→`21`). 카운트는 `grep -c '^def ' rag_answer.py` 로 검증.

## 4. 테스트

N/A — docs-only, 런타임 동작 없음.

## 5. Eval 영향

All `·` — RAG/eval 코드 무변경.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. CLAUDE.md 는 load-bearing path 아님 → N/A.

## 6. 하위 호환

문서 텍스트만. 계약/스키마/링크 무변경.

## 7. 범위 외

C9(MEMORY.md ADR staleness)는 auto-memory 라 별도 처리 완료. C6/C7(golden regen·dead-link 게이트)은 chip follow-up.