### PR TITLE
feat(governance): proposed-ADR 30-day SLA collector

### DIFF
--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from datetime import date
 from pathlib import Path
+from typing import Callable, NamedTuple
 
 
 # Canonical load-bearing path list. The order is not significant; add
@@ -58,6 +60,9 @@ THRESHOLDS: dict[str, int] = {
     "MEMORY_LINE_BLOCK": 30,
     # PR #745 axis #2 (Agent delegation) non-trivial-PR LOC cut-off
     "AXIS_2_LOC": 50,
+    # ADR 0047 proposed-status lifecycle SLA, in days. proposed_adr_age()
+    # flags proposed ADRs first committed on/after 2026-05-15 that exceed it.
+    "ADR_PROPOSED_SLA_DAYS": 30,
 }
 
 
@@ -412,6 +417,142 @@ def lint_adr_verification(
     return errors
 
 
+# ---------------------------------------------------------------------------
+# Proposed-ADR lifecycle SLA collector (ADR 0047 — deferred follow-up).
+#
+# ADR 0047 declared a 30-day SLA: a `Status: proposed` ADR first committed
+# on/after 2026-05-15 must resolve (accepted / superseded by NNNN /
+# deprecated) within 30 days. 0047 fixed the contract but explicitly
+# deferred the measurement collector ("proposed_adr_age(); 측정 collector 는
+# 나중에"). This implements that collector — reporting only (exit 0). The
+# promote/supersede *decision* is a judgment layer (the adr-lifecycle-manager
+# skill); any hard CI gate is a separate later policy choice.
+#
+# Pure/I-O split mirrors the readme-parity pair: status parsing is
+# filesystem-pure, and the git first-commit-date lookup is injected via
+# `date_resolver` so the core is unit-testable without a git repo.
+# ---------------------------------------------------------------------------
+
+# ADR 0047 acceptance date. Proposed ADRs first committed before this are
+# grandfathered: reported, but never flagged OVER_SLA.
+ADR_SLA_GRANDFATHER_DATE = date(2026, 5, 15)
+
+# Tolerant of the two formats live in docs/adr/ — `- **Status**: proposed`
+# and `- Status: Proposed`. First match on the file wins.
+ADR_STATUS_RE = re.compile(
+    r"^\s*[-*]?\s*(?:\*\*)?status(?:\*\*)?\s*:\s*(.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class ProposedADR(NamedTuple):
+    number: int
+    filename: str
+    status: str
+    first_commit: date | None
+    age_days: int | None
+    grandfathered: bool
+    over_sla: bool
+
+
+def parse_adr_status(adr_path: str | Path) -> str | None:
+    """Return the first `Status:` meta-line value (lowercased), or None.
+
+    None if the file is missing or has no Status meta-line. Tolerant of
+    the bold (`- **Status**: proposed`) and plain (`- Status: Proposed`)
+    variants both present in docs/adr/.
+    """
+    p = Path(adr_path)
+    if not p.is_file():
+        return None
+    text = p.read_text(encoding="utf-8", errors="replace")
+    m = ADR_STATUS_RE.search(text)
+    return m.group(1).strip().lower() if m else None
+
+
+def _git_first_commit_date(path: str | Path) -> date | None:
+    """First-add author date of `path` via git, or None if untracked/unknown."""
+    import subprocess
+
+    try:
+        out = subprocess.check_output(
+            ["git", "log", "--diff-filter=A", "--reverse",
+             "--format=%aI", "--", str(path)],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    if not lines:
+        return None
+    try:
+        return date.fromisoformat(lines[0][:10])
+    except ValueError:
+        return None
+
+
+def proposed_adr_age(
+    adr_dir: str | Path = ADR_DIR_DEFAULT,
+    *,
+    date_resolver: Callable[[Path], date | None] | None = None,
+    now: date | None = None,
+    sla_days: int | None = None,
+    grandfather_date: date = ADR_SLA_GRANDFATHER_DATE,
+) -> list[ProposedADR]:
+    """Return one ``ProposedADR`` per `Status: proposed` ADR, oldest first.
+
+    ``over_sla`` is True iff the ADR was first committed on/after
+    ``grandfather_date`` AND its age exceeds ``sla_days`` (ADR 0047). ADRs
+    first committed earlier carry ``grandfathered=True`` and are never
+    flagged. Uncommitted files (no first-commit date) get ``age_days=None``
+    and ``over_sla=False``.
+
+    ``date_resolver`` defaults to a git lookup; inject a stub for testing.
+    ``sla_days`` defaults to ``THRESHOLDS["ADR_PROPOSED_SLA_DAYS"]``.
+    """
+    resolver = date_resolver or _git_first_commit_date
+    today = now or date.today()
+    sla = THRESHOLDS["ADR_PROPOSED_SLA_DAYS"] if sla_days is None else sla_days
+
+    records: list[ProposedADR] = []
+    p = Path(adr_dir)
+    if not p.is_dir():
+        return records
+    for entry in sorted(p.iterdir()):
+        if not entry.is_file():
+            continue
+        m = ADR_FILENAME_RE.match(entry.name)
+        if not m:
+            continue
+        status = parse_adr_status(entry)
+        if status is None or not status.startswith("proposed"):
+            continue
+        first_commit = resolver(entry)
+        if first_commit is None:
+            age_days: int | None = None
+            grandfathered = False
+            over_sla = False
+        else:
+            age_days = (today - first_commit).days
+            grandfathered = first_commit < grandfather_date
+            over_sla = (not grandfathered) and age_days > sla
+        records.append(
+            ProposedADR(
+                number=int(m.group(1)),
+                filename=entry.name,
+                status=status,
+                first_commit=first_commit,
+                age_days=age_days,
+                grandfathered=grandfathered,
+                over_sla=over_sla,
+            )
+        )
+    # Oldest first; uncommitted (age None) sort last.
+    records.sort(key=lambda r: (r.age_days is None, -(r.age_days or 0)))
+    return records
+
+
 def _cmd_next_adr_number(adr_dir: str) -> int:
     sys.stdout.write(f"{next_adr_number(adr_dir):04d}\n")
     return 0
@@ -519,6 +660,29 @@ def _cmd_check_adr_collision(adr_dir: str) -> int:
         "   discipline.\n\n"
     )
     return 1
+
+
+def _cmd_proposed_adr_age(adr_dir: str) -> int:
+    records = proposed_adr_age(adr_dir)
+    if not records:
+        sys.stdout.write("(no proposed-status ADRs)\n")
+        return 0
+    for r in records:
+        fc = r.first_commit.isoformat() if r.first_commit else "uncommitted"
+        age = "?" if r.age_days is None else str(r.age_days)
+        flag = (
+            "OVER_SLA" if r.over_sla
+            else ("grandfathered" if r.grandfathered else "ok")
+        )
+        sys.stdout.write(f"{r.number:04d}\t{age}\t{flag}\t{fc}\t{r.filename}\n")
+    n_over = sum(1 for r in records if r.over_sla)
+    sla = THRESHOLDS["ADR_PROPOSED_SLA_DAYS"]
+    sys.stderr.write(
+        f"\n{len(records)} proposed ADR(s); {n_over} over the {sla}-day SLA "
+        "(ADR 0047). Reporting only — resolve via the adr-lifecycle-manager "
+        "skill (promote / supersede / deprecate).\n"
+    )
+    return 0
 
 
 def _cmd_is_load_bearing(path: str) -> int:
@@ -629,6 +793,13 @@ def main() -> int:
              "(ADR 0060). Requires --outcome and --hook. Optional: "
              "--category --path --extra --fire-log.",
     )
+    g.add_argument(
+        "--proposed-adr-age", action="store_true",
+        help="Report each proposed-status ADR's age + 30-day SLA flag "
+             "(ADR 0047). Tab-separated columns: NNNN, age_days, flag "
+             "(OVER_SLA/grandfathered/ok), first_commit, filename. "
+             "Reporting only; exit 0.",
+    )
     p.add_argument(
         "--outcome",
         help="Outcome enum for --emit-fire. "
@@ -671,7 +842,8 @@ def main() -> int:
     p.add_argument(
         "--adr-dir", default=ADR_DIR_DEFAULT,
         help=f"ADR directory (default: {ADR_DIR_DEFAULT}). "
-             "Only used by --next-adr-number / --check-adr-collision.",
+             "Only used by --next-adr-number / --check-adr-collision / "
+             "--proposed-adr-age.",
     )
     p.add_argument(
         "--repo-root", default=".",
@@ -710,6 +882,8 @@ def main() -> int:
             args.outcome, args.hook, args.category,
             args.path, args.extra, args.fire_log,
         )
+    if args.proposed_adr_age:
+        return _cmd_proposed_adr_age(args.adr_dir)
     return 2
 
 

--- a/tests/test_governance_proposed_adr_age.py
+++ b/tests/test_governance_proposed_adr_age.py
@@ -1,0 +1,193 @@
+"""Regression tests for the proposed-ADR lifecycle SLA collector (ADR 0047).
+
+ADR 0047 declared a 30-day proposed-status SLA but explicitly deferred the
+measurement collector. `proposed_adr_age()` implements that follow-up. These
+tests pin the status parsing, grandfather cutoff, and SLA arithmetic with an
+injected date resolver so they run without a git repo.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from scripts._governance import (
+    ADR_SLA_GRANDFATHER_DATE,
+    THRESHOLDS,
+    parse_adr_status,
+    proposed_adr_age,
+)
+
+
+def _adr(dir_: Path, name: str, status: str) -> None:
+    (dir_ / name).write_text(
+        f"# {name}\n\n- **Status**: {status}\n\n## Context\nstub\n",
+        encoding="utf-8",
+    )
+
+
+# ---- parse_adr_status ----------------------------------------------------
+
+
+def test_parse_status_bold_format(tmp_path: Path) -> None:
+    _adr(tmp_path, "0001-a.md", "proposed")
+    assert parse_adr_status(tmp_path / "0001-a.md") == "proposed"
+
+
+def test_parse_status_plain_mixed_case(tmp_path: Path) -> None:
+    (tmp_path / "0002-b.md").write_text(
+        "# t\n\n- Status: Proposed\n", encoding="utf-8"
+    )
+    assert parse_adr_status(tmp_path / "0002-b.md") == "proposed"
+
+
+def test_parse_status_missing_file_returns_none(tmp_path: Path) -> None:
+    assert parse_adr_status(tmp_path / "nope.md") is None
+
+
+def test_parse_status_no_status_line_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "0003-c.md").write_text("# t\n\nno meta here\n", encoding="utf-8")
+    assert parse_adr_status(tmp_path / "0003-c.md") is None
+
+
+# ---- proposed_adr_age: status filtering ----------------------------------
+
+
+def test_only_proposed_status_returned(tmp_path: Path) -> None:
+    _adr(tmp_path, "0001-a.md", "proposed")
+    _adr(tmp_path, "0002-b.md", "accepted")
+    _adr(tmp_path, "0003-c.md", "superseded by 0009")
+    _adr(tmp_path, "0004-d.md", "deprecated")
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 6, 1),
+        now=date(2026, 6, 2),
+    )
+    assert [r.number for r in recs] == [1]
+
+
+def test_non_adr_files_ignored(tmp_path: Path) -> None:
+    _adr(tmp_path, "0001-a.md", "proposed")
+    (tmp_path / "README.md").write_text("- **Status**: proposed\n", encoding="utf-8")
+    (tmp_path / "_template.md").write_text("- **Status**: proposed\n", encoding="utf-8")
+    recs = proposed_adr_age(
+        tmp_path, date_resolver=lambda p: date(2026, 6, 1), now=date(2026, 6, 2)
+    )
+    assert [r.number for r in recs] == [1]
+
+
+# ---- proposed_adr_age: SLA + grandfather arithmetic ----------------------
+
+
+def test_over_sla_flagged_when_past_grandfather(tmp_path: Path) -> None:
+    _adr(tmp_path, "0050-x.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 16),  # after grandfather
+        now=date(2026, 6, 25),  # 40 days > 30
+    )
+    assert recs[0].age_days == 40
+    assert recs[0].grandfathered is False
+    assert recs[0].over_sla is True
+
+
+def test_within_sla_not_flagged(tmp_path: Path) -> None:
+    _adr(tmp_path, "0050-x.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 16),
+        now=date(2026, 6, 10),  # 25 days <= 30
+    )
+    assert recs[0].age_days == 25
+    assert recs[0].over_sla is False
+
+
+def test_exactly_sla_days_not_over(tmp_path: Path) -> None:
+    # Boundary: age == sla is NOT over (strict >).
+    _adr(tmp_path, "0050-x.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 16),
+        now=date(2026, 6, 15),  # exactly 30 days
+    )
+    assert recs[0].age_days == 30
+    assert recs[0].over_sla is False
+
+
+def test_grandfathered_never_flagged(tmp_path: Path) -> None:
+    _adr(tmp_path, "0011-old.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 1),  # before grandfather
+        now=date(2026, 7, 1),  # 61 days, but grandfathered
+    )
+    assert recs[0].grandfathered is True
+    assert recs[0].over_sla is False
+
+
+def test_uncommitted_age_none_not_over(tmp_path: Path) -> None:
+    _adr(tmp_path, "0099-new.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path, date_resolver=lambda p: None, now=date(2026, 6, 1)
+    )
+    assert recs[0].age_days is None
+    assert recs[0].over_sla is False
+    assert recs[0].grandfathered is False
+
+
+def test_sorted_oldest_first_uncommitted_last(tmp_path: Path) -> None:
+    _adr(tmp_path, "0001-a.md", "proposed")  # newer
+    _adr(tmp_path, "0002-b.md", "proposed")  # older
+    _adr(tmp_path, "0003-c.md", "proposed")  # uncommitted
+    dates = {
+        "0001-a.md": date(2026, 5, 20),
+        "0002-b.md": date(2026, 5, 16),
+        "0003-c.md": None,
+    }
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: dates[Path(p).name],
+        now=date(2026, 6, 1),
+    )
+    assert [r.number for r in recs] == [2, 1, 3]
+
+
+def test_custom_sla_days_override(tmp_path: Path) -> None:
+    _adr(tmp_path, "0050-x.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 16),
+        now=date(2026, 5, 26),  # 10 days
+        sla_days=7,
+    )
+    assert recs[0].over_sla is True
+
+
+def test_missing_dir_returns_empty(tmp_path: Path) -> None:
+    assert proposed_adr_age(tmp_path / "nope") == []
+
+
+# ---- constants -----------------------------------------------------------
+
+
+def test_sla_days_threshold_is_30() -> None:
+    assert THRESHOLDS["ADR_PROPOSED_SLA_DAYS"] == 30
+
+
+def test_grandfather_date_is_adr_0047_acceptance() -> None:
+    assert ADR_SLA_GRANDFATHER_DATE == date(2026, 5, 15)
+
+
+# ---- live-repo smoke -----------------------------------------------------
+
+
+def test_repo_proposed_adr_age_runs() -> None:
+    """Sentinel: the collector runs against the live docs/adr without
+    crashing and only returns proposed-status records. Robust to repo
+    evolution — asserts invariants, not specific ADR numbers/ages (which
+    change as ADRs resolve)."""
+    recs = proposed_adr_age("docs/adr")
+    for r in recs:
+        assert r.status.startswith("proposed")
+        assert r.number > 0
+        assert (r.age_days is None) or (r.age_days >= 0)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0047이 proposed-status ADR의 **30일 lifecycle SLA**를 normative로 선언했으나, 측정 collector(`proposed_adr_age()`)는 명시적으로 follow-up으로 미뤘다("자동 강제는 follow-up; 측정 collector 는 나중에"). 그 결과 **선언됐으나 추적·강제되지 않는 계약**이 됐다(proposed 13+개, 추적 도구 0). 이 PR이 0047이 약속한 collector를 구현한다. 다음 `adr-lifecycle-manager` 스킬(별도 PR)의 prerequisite.

Closes #1092

## 2. 영향 파일

- `scripts/_governance.py` — **NOT load-bearing** (`--is-load-bearing` exit 1). `parse_adr_status` / `proposed_adr_age` / `_cmd_proposed_adr_age` / `--proposed-adr-age` CLI / `THRESHOLDS["ADR_PROPOSED_SLA_DAYS"]=30` 추가
- `tests/test_governance_proposed_adr_age.py` — 신규 (17 cases)

## 3. 리스크

- Status 형식 drift → bold(`- **Status**: proposed`) + plain(`- Status: Proposed`) 둘 다 파싱하는 tolerant regex + 양 형식 테스트.
- git shallow-clone에서 first-commit 미해결 → `first_commit=None` → `age_days=None`, `over_sla=False`(violation 오탐 없음). 라이브 스모크는 나이 수치가 아닌 invariant만 단언.
- #1040(emit-fire) argparse/dispatch와 인접 편집 → `--next-adr-number`/emit-fire CLI 회귀 없음 확인, 38 tests pass.

## 4. 테스트

`tests/test_governance_proposed_adr_age.py` 신규 17 cases: status 파싱(4), proposed 필터링(2), SLA/grandfather 산술(over/within/경계=30/grandfathered/uncommitted/sorted/custom-sla/missing-dir, 8), 상수(2), 라이브 repo 스모크(1). Behavior change에 대응하는 테스트 동반(변경 전 부재 → 후 pass).

## 5. Eval 영향

All `·` — governance 도구, RAG 파이프라인 무변경.

### 5b. Real-data delta

N/A — `scripts/_governance.py` not load-bearing (`python scripts/_governance.py --is-load-bearing scripts/_governance.py` → exit 1). 검색/검증/답변 path 동작 변화 없음.

## 6. 하위 호환

Additive only — 새 함수 + 새 CLI 플래그 + 새 THRESHOLDS 키. 기존 계약/스키마/CLI 변경 없음. #1040 emit-fire 경로 intact 확인.

## 7. 범위 외

- promote/supersede **판단**: 후속 `adr-lifecycle-manager` 스킬(별도 PR).
- SLA 초과 시 하드 CI gate(exit 1): 별도 정책 결정. 지금은 reporting only.
- grandfathered ADR(0011/0016/0023/0029/0039) retrofit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)