### PR TITLE
feat(githooks): pre-push test-coverage gate + orphan-worktree hygiene

### DIFF
--- a/.githooks/_pre-push-test-coverage.sh
+++ b/.githooks/_pre-push-test-coverage.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Pre-push SOFT-WARN: behavior-code change pushed without a test change.
+#
+# Sourced by `.githooks/pre-push`, also runnable standalone:
+#
+#     bash .githooks/_pre-push-test-coverage.sh
+#
+# CLAUDE.md rule "동작 변경 ↔ 테스트 변경. 테스트 없는 동작 변경은 실수."
+# (a behavior change must travel with a test change) previously had no
+# enforcing hook. PR #69 is the cost precedent — a synthetic-only CI
+# delta missed an intended-abstention regression because no test pinned
+# the behavior.
+#
+# Warns (never blocks) when the pushed diff touches a load-bearing
+# behavior path (scripts/_governance.py SSoT — the same list the §5b CI
+# gate and the Claude awareness hook read) but changes zero files under
+# tests/. Soft-warn only: `exit 0` always.
+#
+# By design no `set -e`: a missing python3 should skip the check, never
+# block the push.
+
+set -u
+
+# Resolve upstream / base ref. Prefer @{upstream}; fall back to origin/main.
+# (Mirrors _pre-push-real-eval-reminder.sh so both reminders agree on base.)
+if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null); then
+  base="$upstream"
+else
+  base="origin/main"
+fi
+
+if ! changed=$(git diff --name-only "$base"...HEAD 2>/dev/null); then
+  # No upstream / new branch — fall back to diff vs origin/main if it exists.
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    changed=$(git diff --name-only origin/main...HEAD 2>/dev/null || true)
+  else
+    changed=""
+  fi
+fi
+
+[[ -z "$changed" ]] && exit 0
+
+# No python3 → conservatively skip (the load-bearing SSoT is a python module).
+command -v python3 >/dev/null 2>&1 || exit 0
+
+# Behavior-code change = any changed path matching the load-bearing SSoT.
+behavior_hit=$(printf '%s\n' "$changed" | python3 scripts/_governance.py --any-match 2>/dev/null | head -n1)
+[[ -z "$behavior_hit" ]] && exit 0
+
+# Accompanying test change? (Any path under tests/.)
+test_changes=$(printf '%s\n' "$changed" | grep -c '^tests/' || true)
+[[ "$test_changes" -gt 0 ]] && exit 0
+
+cat >&2 <<EOF
+
+⚠️  Behavior-code change pushed without an accompanying test change.
+    (first load-bearing match: $behavior_hit)
+
+    CLAUDE.md: "동작 변경 ↔ 테스트 변경. 테스트 없는 동작 변경은 실수."
+    Add or update a regression test under tests/ — convention is
+    tests/test_*_regression.py (e.g. tests/test_retrieval_loop_regression.py).
+
+    Push proceeds. Skip this reminder with --no-verify only if you have
+    a documented reason (e.g. a pure refactor with no behavior change).
+
+EOF
+
+exit 0

--- a/.githooks/_pre-push-worktree-hygiene.sh
+++ b/.githooks/_pre-push-worktree-hygiene.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Pre-push SOFT-WARN: orphan worktrees whose branch is already merged.
+#
+# Sourced by `.githooks/pre-push`, also runnable standalone:
+#
+#     bash .githooks/_pre-push-worktree-hygiene.sh
+#
+# Detects worktrees whose checked-out branch is already merged into main
+# but were never removed. Stale worktrees accumulate and are the root
+# cause of the recurring "동시 worktree → ADR 번호 충돌" failure mode
+# CLAUDE.md keeps citing. Prints the exact `git worktree remove` command
+# for each orphan — never auto-removes (a worktree may hold un-pushed
+# work the merge check can't see). Soft-warn only: `exit 0` always.
+#
+# bash 3.2 compatible (macOS default): no associative arrays — merged
+# branch membership is tested with `grep -qxF` against a newline list.
+#
+# By design no `set -e`: a fresh clone without a local `main` should skip
+# the check, never block the push.
+
+set -u
+
+# Merged-branch set: local branches already merged into main (origin/main
+# fallback for checkouts without a local main ref). The `^[*+ ]` strip
+# removes the `* ` current marker and the `+ ` worktree marker.
+merged=$(git branch --merged main 2>/dev/null | sed 's/^[*+ ]*//' || true)
+if [[ -z "$merged" ]]; then
+  merged=$(git branch --merged origin/main 2>/dev/null | sed 's/^[*+ ]*//' || true)
+fi
+[[ -z "$merged" ]] && exit 0
+
+# Current worktree root — never warn about the one we're pushing from.
+self_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+
+_is_merged() {
+  printf '%s\n' "$merged" | grep -qxF "$1"
+}
+
+orphans=""
+cur_path=""
+cur_branch=""
+
+_flush() {
+  # detached (no branch line) → skip; main → skip (it's never an orphan);
+  # current worktree → skip.
+  if [[ -n "$cur_branch" && "$cur_branch" != "main" && "$cur_path" != "$self_top" ]]; then
+    if _is_merged "$cur_branch"; then
+      orphans="${orphans}  git worktree remove \"${cur_path}\"   # branch '${cur_branch}' merged into main"$'\n'
+    fi
+  fi
+  cur_path=""
+  cur_branch=""
+}
+
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) cur_path="${line#worktree }" ;;
+    "branch refs/heads/"*) cur_branch="${line#branch refs/heads/}" ;;
+    "") _flush ;;
+  esac
+done < <(git worktree list --porcelain 2>/dev/null)
+# Flush the final block (porcelain may not end with a trailing blank line).
+_flush
+
+[[ -z "$orphans" ]] && exit 0
+
+cat >&2 <<EOF
+
+⚠️  Orphan worktrees detected — branch already merged into main, but the
+    worktree was never removed (not auto-removing):
+
+$(printf '%s' "$orphans")
+    After removing, prune stale admin files:  git worktree prune
+
+    Why this matters: stale worktrees are the root cause of the recurring
+    "동시 worktree → ADR 번호 충돌" (CLAUDE.md). Push proceeds.
+
+EOF
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,7 +5,7 @@
 #   git config core.hooksPath .githooks
 #   (or: make install-hooks)
 #
-# Behavior (two phases, in order):
+# Behavior (four phases, in order):
 #
 # 1. `_pre-push-branch-check.sh` — HARD-FAILS if the current branch does not
 #    match the ADR 0007 convention `<type>/issue-<N>[-<slug>]`. Exit code
@@ -17,10 +17,20 @@
 #    - README metrics freshness reminder when `reports/eval_summary.json`
 #      diverges from the committed README block.
 #
-# Both sub-scripts are independently runnable for manual debugging:
+# 3. `_pre-push-test-coverage.sh` — SOFT-WARNS when the push touches a
+#    load-bearing behavior path but changes zero files under tests/
+#    (CLAUDE.md "동작 변경 ↔ 테스트 변경", PR #69 lesson).
+#
+# 4. `_pre-push-worktree-hygiene.sh` — SOFT-WARNS when a worktree's branch
+#    is already merged into main but the worktree was never removed (the
+#    "동시 worktree → ADR 번호 충돌" root cause).
+#
+# All sub-scripts are independently runnable for manual debugging:
 #
 #     bash .githooks/_pre-push-branch-check.sh
 #     bash .githooks/_pre-push-real-eval-reminder.sh
+#     bash .githooks/_pre-push-test-coverage.sh
+#     bash .githooks/_pre-push-worktree-hygiene.sh
 #
 # Skip the whole hook with `git push --no-verify` only if you have a
 # documented reason (e.g. doc-only follow-up of a measured PR).
@@ -34,5 +44,11 @@ bash "$HOOK_DIR/_pre-push-branch-check.sh" || exit $?
 
 # Phase 2: soft-warn reminders (real-eval §5b + README freshness).
 bash "$HOOK_DIR/_pre-push-real-eval-reminder.sh" || true
+
+# Phase 3: soft-warn test-coverage gate (behavior change without a test).
+bash "$HOOK_DIR/_pre-push-test-coverage.sh" || true
+
+# Phase 4: soft-warn orphan-worktree hygiene.
+bash "$HOOK_DIR/_pre-push-worktree-hygiene.sh" || true
 
 exit 0

--- a/tests/test_hook_pre_push_test_coverage.py
+++ b/tests/test_hook_pre_push_test_coverage.py
@@ -1,0 +1,111 @@
+"""Regression: pre-push test-coverage gate (issue #1052).
+
+Pins the soft-warn contract (always exit 0; warning only on stderr) for
+`.githooks/_pre-push-test-coverage.sh`:
+
+  1. behavior-code change + zero tests/ change → exit 0, stderr warns
+  2. behavior-code change + a tests/ change    → exit 0, stderr quiet
+  3. docs-only change                          → exit 0, stderr quiet
+  4. no origin/main ref (fresh branch)         → exit 0, stderr quiet
+
+Each scenario runs in an isolated temp git repo. The hook calls
+`python3 scripts/_governance.py --any-match` relative to cwd, so the real
+governance module is copied into the temp repo's scripts/ dir — its
+matching is pure string logic (no file existence check), so a copied
+module against fake-named diffs is faithful.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+HOOK = REPO / ".githooks" / "_pre-push-test-coverage.sh"
+GOVERNANCE = REPO / "scripts" / "_governance.py"
+
+
+class TestPrePushTestCoverage(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="pre-push-test-cov-")
+        self.repo = Path(self._tmp) / "repo"
+        self.repo.mkdir(parents=True)
+        self._git("init", "-q")
+        self._git("config", "user.email", "t@example.com")
+        self._git("config", "user.name", "tester")
+        self._git("config", "commit.gpgsign", "false")
+        # The hook resolves `scripts/_governance.py` relative to cwd.
+        (self.repo / "scripts").mkdir()
+        shutil.copy(GOVERNANCE, self.repo / "scripts" / "_governance.py")
+        (self.repo / "README.md").write_text("base\n", encoding="utf-8")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "base")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _pin_origin_main(self) -> None:
+        head = self._git("rev-parse", "HEAD").stdout.strip()
+        self._git("update-ref", "refs/remotes/origin/main", head)
+
+    def _commit(self, *paths: str) -> None:
+        for path in paths:
+            f = self.repo / path
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("x\n", encoding="utf-8")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", f"add {' '.join(paths)}")
+
+    def _run_hook(self) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(HOOK)],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_behavior_change_without_test_warns(self) -> None:
+        self._pin_origin_main()
+        self._commit("rag_core.py")
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("without an accompanying test", r.stderr)
+        self.assertIn("rag_core.py", r.stderr)
+
+    def test_behavior_change_with_test_is_quiet(self) -> None:
+        self._pin_origin_main()
+        self._commit("rag_core.py", "tests/test_rag_core_regression.py")
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertEqual("", r.stderr.strip(), r.stderr)
+
+    def test_docs_only_change_is_quiet(self) -> None:
+        self._pin_origin_main()
+        self._commit("docs/note.md")
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertEqual("", r.stderr.strip(), r.stderr)
+
+    def test_no_origin_main_ref_is_quiet(self) -> None:
+        # No origin/main ref and no upstream → base diff is empty → quiet.
+        self._commit("rag_core.py")
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertEqual("", r.stderr.strip(), r.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_hook_pre_push_worktree_hygiene.py
+++ b/tests/test_hook_pre_push_worktree_hygiene.py
@@ -1,0 +1,106 @@
+"""Regression: pre-push orphan-worktree hygiene (issue #1052).
+
+Pins the soft-warn contract (always exit 0; warning only on stderr) for
+`.githooks/_pre-push-worktree-hygiene.sh`:
+
+  1. worktree whose branch is merged into main → exit 0, stderr names it
+  2. worktree whose branch is NOT merged       → exit 0, stderr quiet
+  3. detached-HEAD worktree                     → exit 0, stderr quiet
+  4. run from the orphan worktree itself        → exit 0, not self-flagged
+
+Each scenario runs in an isolated temp git repo with real `git worktree`
+checkouts. The hook is pure git (no python dep), so nothing is copied in.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+HOOK = REPO / ".githooks" / "_pre-push-worktree-hygiene.sh"
+
+
+class TestPrePushWorktreeHygiene(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="pre-push-wt-hygiene-")
+        self.repo = Path(self._tmp) / "repo"
+        self.repo.mkdir(parents=True)
+        self._git("init", "-q")
+        self._git("config", "user.email", "t@example.com")
+        self._git("config", "user.name", "tester")
+        self._git("config", "commit.gpgsign", "false")
+        (self.repo / "README.md").write_text("base\n", encoding="utf-8")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "base")
+        # Normalize the default branch name to `main` regardless of the
+        # host git's init.defaultBranch.
+        self._git("branch", "-M", "main")
+
+    def tearDown(self) -> None:
+        # Best-effort worktree teardown before removing the tree.
+        self._git("worktree", "prune")
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _git(self, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(cwd or self.repo),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _add_worktree(self, name: str, branch: str, *, extra_commit: bool) -> Path:
+        wt = Path(self._tmp) / name
+        self._git("worktree", "add", "-b", branch, str(wt), "main")
+        if extra_commit:
+            (wt / "extra.txt").write_text("e\n", encoding="utf-8")
+            self._git("add", "-A", cwd=wt)
+            self._git("commit", "-q", "-m", "ahead of main", cwd=wt)
+        return wt
+
+    def _run_hook(self, *, cwd: Path | None = None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(HOOK)],
+            cwd=str(cwd or self.repo),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_merged_worktree_is_flagged(self) -> None:
+        # No extra commit → branch tip == main tip → merged → orphan.
+        self._add_worktree("wt_merged", "feat-merged", extra_commit=False)
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("git worktree remove", r.stderr)
+        self.assertIn("feat-merged", r.stderr)
+        self.assertIn("wt_merged", r.stderr)
+
+    def test_unmerged_worktree_is_quiet(self) -> None:
+        self._add_worktree("wt_active", "feat-active", extra_commit=True)
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertEqual("", r.stderr.strip(), r.stderr)
+
+    def test_detached_worktree_is_ignored(self) -> None:
+        wt = Path(self._tmp) / "wt_detached"
+        self._git("worktree", "add", "--detach", str(wt))
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertEqual("", r.stderr.strip(), r.stderr)
+
+    def test_run_from_orphan_does_not_self_flag(self) -> None:
+        wt = self._add_worktree("wt_merged", "feat-merged", extra_commit=False)
+        r = self._run_hook(cwd=wt)
+        self.assertEqual(0, r.returncode, r.stderr)
+        # self_top == wt → excluded → its own branch is not reported.
+        self.assertNotIn("feat-merged", r.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 1. What changed and why

작업 패턴 분석(기존 hook 16개 매핑 + 40개 session 로그 집계)으로 발견한, 기존 자동화가 커버하지 않는 **규율 강제 갭 2개**를 메우는 soft-warn pre-push hook 2종.

- `_pre-push-test-coverage.sh` — push diff에 load-bearing 동작코드 변경이 있는데 `tests/` 변경이 0이면 경고. CLAUDE.md "동작 변경 ↔ 테스트 변경" 규율인데 강제 hook이 없었음 (PR #69: 합성 CI 델타만으론 의도된 보류 회귀를 놓침).
- `_pre-push-worktree-hygiene.sh` — merged 브랜치의 고아 worktree 감지 + `git worktree remove` 명령 제시 (자동 삭제 안 함). "동시 worktree → ADR 번호 충돌" 근본원인 (live `git worktree list` 20+개 확인).

둘 다 `_governance.py --any-match` SSoT를 재사용 — 신규 path 리스트/판정 로직 0.

Closes #1052

## 2. Files affected

- `.githooks/_pre-push-test-coverage.sh` (new)
- `.githooks/_pre-push-worktree-hygiene.sh` (new)
- `.githooks/pre-push` (phase 3/4 등록 + 헤더 4-phase 갱신)
- `tests/test_hook_pre_push_test_coverage.py` (new)
- `tests/test_hook_pre_push_worktree_hygiene.py` (new)

## 3. Risks

낮음. 두 hook 모두 **soft-warn only** (`exit 0`, push 차단 안 함). 기존 `.py` 코드 0 변경 (`.githooks/` + 새 테스트만). bash 3.2 호환(associative array 없이 `grep -qxF`).

## 4. Tests

회귀 테스트 8개 (soft-warn 매트릭스: 동작코드+테스트0→경고 / +테스트→조용 / 문서만→조용 / 신규브랜치→조용 / merged worktree→경고 / unmerged→조용 / detached→무시 / 자기 worktree→자기경고 안함). 로컬 `ruff check .` 통과. hook 2개 모두 standalone smoke 통과 (실제 고아 worktree 1건 감지 확인).

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (load-bearing 경로 미변경 — `.githooks/` + `tests/`만)

## 6. Backward compatibility

No public-API change. opt-in via `core.hooksPath .githooks` (`make install-hooks`). 기존 phase 1/2 동작 불변.

## 7. Out of scope

- PR-2 (§5b guard, `pretooluse-bash-guard.sh` 확장) — 별도 surface/PR
- SessionStart worktree-hygiene 변형 — 별도 follow-up issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)