### PR TITLE
chore(eval): live synthetic-judge aggregate — gpt-5.4-nano (RAGAS 신호 활성화)

### DIFF
--- a/docs/eval/ablation-results.md
+++ b/docs/eval/ablation-results.md
@@ -75,7 +75,7 @@ CR=correct\_refusal / IA=incorrect\_answer / BP=boundary\_partial (ADR 0005 §ab
 - `agreement_with_verifier`: deterministic verifier 와 동의한 비율 — **drop 이 actionable signal**.
 - `by_query_type`: single_doc / comparison / follow_up / abstention 슬라이스별 같은 메트릭.
 
-현재 commit 된 aggregate 는 **stub backend** 기준 — verifier status 를 거울처럼 반사하므로 `agreement_with_verifier=1.0` 이고 RAGAS 점수는 status-derived fixture (supported→0.85, partial→0.5, insufficient→0.1) 이다. 진짜 신호가 아니다. 실제 LLM judge 수치를 보려면 live 백엔드로 다시 돌려 aggregate 를 갱신한다.
+현재 commit 된 aggregate 는 **live backend** (`openai_compatible`, `model=gpt-5.4-nano`, issue #878 첫 실행) 기준 — n=105, `agreement_with_verifier=0.343`, faithfulness 0.436 / answer_relevance 0.730 / grounded_rate 0.248. (직전 stub fixture 는 verifier status 를 거울 반사해 `agreement_with_verifier=1.0` 이었음 — 가짜 신호.) **낮은 agreement (0.343) 가 actionable signal** — nano-tier judge 의 보수적 채점 + `naive_baseline` (hashing eval) 답변과 deterministic verifier 간 calibration 차이가 합쳐진 결과. 더 강한 judge 모델 또는 production 임베딩 답변으로 재측정 시 변동 가능 (follow-up). 재현: `BIDMATE_JUDGE_BASE_URL=https://api.openai.com/v1 BIDMATE_JUDGE_API_KEY=$OPENAI_API_KEY BIDMATE_JUDGE_MODEL=gpt-5.4-nano make synthetic-judge`.
 
 ## Chunk-level retrieval (PR #147 + human-annotated gold from #175)
 
@@ -98,7 +98,7 @@ CR=correct\_refusal / IA=incorrect\_answer / BP=boundary\_partial (ADR 0005 §ab
 
 ## Pending rows
 
-- **Live synthetic judge aggregate** (ADR 0012, issue #164): stub-mode aggregate 만 commit 되어 있음. live 백엔드(openai_compatible) 로 갱신한 aggregate diff 를 별도 PR 로 commit 하면 RAGAS-style 실측 노출.
+- **Live synthetic judge aggregate** (ADR 0012, issue #164 → #878): ✅ 완료 — live `openai_compatible` (gpt-5.4-nano) 로 갱신, `agreement_with_verifier=0.343` (n=105). 위 §Synthetic LLM-judge (RAGAS-style) 참조.
 - **`hybrid_bm25`** (ADR 0010, issue #119): `eval/config.yaml` 에 추가됨. `make eval` 의 ablation 블록에는 이미 채워지지만 (`accuracy=0.906`, `groundedness=0.929` — `full` 과 동일 ceiling), 본 문서의 committed snapshot 은 `make benchmark` 의 manifest 기반이므로 다음 benchmark 실행 후 row 를 추가한다. 실측 차이는 private real-data eval (`make real-eval-delta`) 에서 드러날 가능성이 크다.
 - **KO RFP per-axis** (issue #126): `eval/ko_axes.py` 에 `detect_ko_axes()` 가 추가되어 dev 결과 CSV 를 `eval/evaluate_dev_results.py` 로 평가할 때 `summary["by_ko_axes"]` 블록으로 per-axis (`금액단위 / 날짜형식 / 한자 / 사업번호 / 약칭`) accuracy 가 emit 된다. 차기 dev-side run 결과를 본 표에 별도 row 로 누적한다. `eval/run_eval.py` (CI 표면) 으로의 승격은 후속 PR.
 - **Multi-turn decay** (issue #125): `eval/multiturn_eval.py` 에 `derive_turn_depth()` + `build_qid_parent_map()` 가 추가되어 `summary["by_turn_depth"]` 블록으로 per-turn (turn 1 / 2 / 3 / …) accuracy 가 emit 된다. ADR 0001 invariant 준수 — `naive_baseline` / `agentic_full` 위에 *측정 축* 만 추가, 어느 파이프라인도 대체하지 않음. 초기 시나리오 fixture: `eval/multiturn_scenarios_v1.jsonl` (2 시나리오 × 3 turns, entity carryover + graceful-degradation abstention 포함). 차기 dev-side run 결과로 decay 커브를 본 표에 누적.

--- a/reports/synthetic_judge.aggregate.json
+++ b/reports/synthetic_judge.aggregate.json
@@ -1,58 +1,64 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-11T10:17:51.012417Z",
-  "backend": "stub",
-  "model": "stub",
-  "n": 42,
-  "faithfulness_mean": 0.7607142857142857,
-  "answer_relevance_mean": 0.7404761904761905,
-  "grounded_rate": 0.8809523809523809,
-  "agreement_with_verifier": 1.0,
+  "generated_at": "2026-05-20T10:07:10.996093Z",
+  "backend": "openai_compatible",
+  "model": "gpt-5.4-nano",
+  "n": 105,
+  "faithfulness_mean": 0.4357142857142857,
+  "answer_relevance_mean": 0.7300000000000001,
+  "grounded_rate": 0.24761904761904763,
+  "agreement_with_verifier": 0.34285714285714286,
   "status_distribution": {
-    "supported": 37,
-    "insufficient": 5
+    "partial": 37,
+    "supported": 23,
+    "insufficient": 45
   },
   "by_query_type": {
     "abstention": {
-      "n": 9,
-      "faithfulness_mean": 0.6833333333333332,
-      "answer_relevance_mean": 0.6888888888888889,
-      "grounded_rate": 0.7777777777777778,
-      "agreement_with_verifier": 1.0,
+      "n": 22,
+      "faithfulness_mean": 0.2090909090909091,
+      "answer_relevance_mean": 0.5,
+      "grounded_rate": 0.09090909090909091,
+      "agreement_with_verifier": 0.3181818181818182,
       "status_distribution": {
-        "supported": 7,
-        "insufficient": 2
+        "insufficient": 16,
+        "partial": 4,
+        "supported": 2
       }
     },
     "comparison": {
-      "n": 10,
-      "faithfulness_mean": 0.85,
-      "answer_relevance_mean": 0.8,
-      "grounded_rate": 1.0,
-      "agreement_with_verifier": 1.0,
+      "n": 25,
+      "faithfulness_mean": 0.3008,
+      "answer_relevance_mean": 0.59,
+      "grounded_rate": 0.0,
+      "agreement_with_verifier": 0.0,
       "status_distribution": {
-        "supported": 10
+        "partial": 8,
+        "insufficient": 17
       }
     },
     "follow_up": {
-      "n": 9,
-      "faithfulness_mean": 0.6,
-      "answer_relevance_mean": 0.6333333333333333,
-      "grounded_rate": 0.6666666666666666,
-      "agreement_with_verifier": 1.0,
+      "n": 22,
+      "faithfulness_mean": 0.4104545454545455,
+      "answer_relevance_mean": 0.8181818181818182,
+      "grounded_rate": 0.22727272727272727,
+      "agreement_with_verifier": 0.45454545454545453,
       "status_distribution": {
-        "supported": 6,
-        "insufficient": 3
+        "partial": 9,
+        "supported": 4,
+        "insufficient": 9
       }
     },
     "single_doc": {
-      "n": 14,
-      "faithfulness_mean": 0.85,
-      "answer_relevance_mean": 0.8,
-      "grounded_rate": 1.0,
-      "agreement_with_verifier": 1.0,
+      "n": 36,
+      "faithfulness_mean": 0.6833333333333333,
+      "answer_relevance_mean": 0.9138888888888889,
+      "grounded_rate": 0.5277777777777778,
+      "agreement_with_verifier": 0.5277777777777778,
       "status_distribution": {
-        "supported": 14
+        "partial": 16,
+        "supported": 17,
+        "insufficient": 3
       }
     }
   }


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

issue #878 — synthetic-judge live backend 첫 실행. stub fixture(`agreement_with_verifier=1.0`, verifier 거울 반사 = 가짜 신호)를 live RAGAS 실측으로 교체. `backend=openai_compatible`, `model=gpt-5.4-nano`. **코드 변경 0줄** (OpenAI endpoint가 기존 `json_object` response_format 지원 — anthropic-compat endpoint만 `json_schema` 요구).

Closes #878

## 2. 영향 파일

- `reports/synthetic_judge.aggregate.json` (ADR 0005 allowlist, committable) — stub → live 수치
- `docs/eval/ablation-results.md` — §Synthetic LLM-judge stub→live 설명 + Pending row 해소

## 3. 리스크

data + docs only, 코드 0줄. runtime / 파이프라인 무변경. aggregate는 ADR 0005 boundary (aggregate-only, per-case 텍스트는 local 유지).

## 4. 테스트

코드 변경 없음 → 회귀 테스트 불필요. aggregate는 `make synthetic-judge` 산출물.

## 5. Eval 영향

synthetic judge aggregate(committed live) 갱신. CI eval delta 무관 (CI는 stub-only 유지, 이 PR은 수동 실행 live aggregate).

**측정 결과**: n=105, `agreement_with_verifier`=0.343 (stub 1.0 대비 실측), faithfulness 0.436 / answer_relevance 0.730 / grounded_rate 0.248.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 (data + docs only, 코드 0줄). synthetic 표면(public)의 committed aggregate 갱신뿐 — retrieval/verifier/answer/eval/ingestion 등 load-bearing path 코드 무변경, real-data path 무관.

## 6. 하위 호환

호환 OK. aggregate `schema_version=1` 유지. stub→live 값 변경만.

## 7. 범위 외

- **agreement 0.343이 낮음** — nano-tier judge의 보수적 채점 + naive_baseline(hashing) 답변과 verifier 간 calibration 차이. 더 강한 judge 모델 / production 임베딩 답변으로 재측정은 follow-up
- **n=105** (issue 본문 42는 2026-05-11 stub 스냅샷 시점 — 그 사이 public synthetic 데이터 확장)
- `.env` 기본은 anthropic(claude-haiku-4-5) — 이 PR 재현은 OpenAI endpoint override 필요 (docs에 재현 명령 명시)
