### PR TITLE
feat(hooks): pre-create §5b guard for manual gh pr create

### DIFF
--- a/scripts/claude-hooks/_bash_guard_parse.py
+++ b/scripts/claude-hooks/_bash_guard_parse.py
@@ -104,17 +104,56 @@ def has_explicit_base_flag(cmd: str) -> bool:
     return False
 
 
+def get_create_flag_value(cmd: str, flag: str) -> str:
+    """Return the value of `flag` in the first `gh pr create` segment ('' if absent).
+
+    Handles both `--flag VALUE` and `--flag=VALUE`. Same shlex-based
+    false-negative surface as the sibling parsers — a body built with
+    command substitution / heredoc (`--body "$(cat <<EOF…)"`) is NOT
+    statically extractable and returns '' (the caller treats that as
+    "skip", fail-open). Used by the §5b soft-warn (issue #1097).
+    """
+    for tokens in _segments(cmd):
+        if (
+            len(tokens) >= 3
+            and tokens[0] == "gh"
+            and tokens[1] == "pr"
+            and tokens[2] == "create"
+        ):
+            rest = tokens[3:]
+            for i, t in enumerate(rest):
+                if t == flag and i + 1 < len(rest):
+                    return rest[i + 1]
+                if t.startswith(flag + "="):
+                    return t.split("=", 1)[1]
+    return ""
+
+
 def _cli(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument("--detect-gh", metavar="CMD")
     g.add_argument("--has-base", metavar="CMD")
+    g.add_argument(
+        "--get-body", metavar="CMD",
+        help="Echo the value of --body in a `gh pr create` segment ('' if absent).",
+    )
+    g.add_argument(
+        "--get-body-file", metavar="CMD",
+        help="Echo the value of --body-file in a `gh pr create` segment ('' if absent).",
+    )
     args = p.parse_args(argv)
     if args.detect_gh is not None:
         sys.stdout.write(detect_gh_subcommand(args.detect_gh) + "\n")
         return 0
     if args.has_base is not None:
         return 0 if has_explicit_base_flag(args.has_base) else 1
+    if args.get_body is not None:
+        sys.stdout.write(get_create_flag_value(args.get_body, "--body") + "\n")
+        return 0
+    if args.get_body_file is not None:
+        sys.stdout.write(get_create_flag_value(args.get_body_file, "--body-file") + "\n")
+        return 0
     return 2
 
 

--- a/scripts/claude-hooks/_ship_pr_body.py
+++ b/scripts/claude-hooks/_ship_pr_body.py
@@ -278,16 +278,64 @@ def validate_5b(body: str, load_bearing: list[str]) -> bool:
     return bool(FIVE_B_TABLE_RE.search(section) or FIVE_B_ESCAPE_RE.search(section))
 
 
+def check_body_5b(body: str, base_ref: str) -> int:
+    """Validate an externally-provided PR body's §5b section (issue #1097).
+
+    Used by `pretooluse-bash-guard.sh` to soft-warn *before* `gh pr create`.
+    The CI `--check-5b` gate only runs post-create (via `gh pr view`), so a
+    body missing §5b is not caught until after the PR exists. This shares
+    the exact same `validate_5b` / `is_load_bearing` logic the auto-ship
+    path and the CI gate use — no duplicated regex.
+
+    Exit codes:
+        0  body OK, OR no load-bearing path changed (§5b not required)
+        3  a load-bearing path changed but the body has no valid §5b section
+    """
+    files = changed_files(base_ref)
+    load_bearing = [f for f in files if is_load_bearing(f)]
+    if not load_bearing:
+        return 0
+    return 0 if validate_5b(body, load_bearing) else 3
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--branch", required=True)
+    p.add_argument("--branch")
     p.add_argument("--base-ref", default="origin/main")
     p.add_argument(
         "--real-eval-mode", default="auto",
         choices=["auto", "skip", "async"],
     )
     p.add_argument("--extra-body", default="")
+    # Standalone §5b validation of an externally-provided body (issue #1097).
+    # Mutually exclusive with the --branch body-generation mode below.
+    p.add_argument(
+        "--check-body-file", metavar="PATH",
+        help="Validate the §5b section of the PR body read from PATH instead "
+             "of generating one; exit 3 if a load-bearing change lacks §5b.",
+    )
+    p.add_argument(
+        "--check-body-stdin", action="store_true",
+        help="Like --check-body-file but read the body from stdin.",
+    )
     args = p.parse_args()
+
+    # --- Standalone validation mode (no body generation, no --branch) ---
+    if args.check_body_file or args.check_body_stdin:
+        if args.check_body_file:
+            try:
+                with open(args.check_body_file, encoding="utf-8") as f:
+                    body = f.read()
+            except OSError as exc:
+                _log(f"cannot read --check-body-file {args.check_body_file}: {exc}")
+                return 0  # fail-open: a hook must not block on a read error
+        else:
+            body = sys.stdin.read()
+        return check_body_5b(body, args.base_ref)
+
+    # --- Body generation mode (auto-ship Stage 3; behavior unchanged) ---
+    if not args.branch:
+        p.error("--branch is required unless --check-body-file/--check-body-stdin is given")
 
     try:
         body = build_body(

--- a/scripts/claude-hooks/pretooluse-bash-guard.sh
+++ b/scripts/claude-hooks/pretooluse-bash-guard.sh
@@ -63,6 +63,57 @@ fi
 
 # --- Branch (2): gh pr create stacked guard (#826 Hook B / #865) ---
 if [[ "$gh_subcommand" == "create" ]]; then
+  # --- §5b soft-warn (issue #1097): load-bearing PR body must carry §5b ---
+  # Runs for every `gh pr create` (independent of the --base / stacked guard
+  # below): warns when a load-bearing-touching PR's body has no §5b
+  # (real-data delta) section. The CI `--check-5b` gate only runs post-create
+  # (gh pr view), so this is the pre-create early warning. Reuses the exact
+  # validate_5b + is_load_bearing logic via _ship_pr_body.py — no duplicated
+  # regex. Warns only; never exits — control falls through to the stacked
+  # guard which owns exit 0 / 2.
+  #
+  # Scope limit: only statically-extractable bodies are checked. A body built
+  # with command substitution / heredoc (`--body "$(cat <<EOF…)"`) cannot be
+  # parsed before execution, so it is skipped (fail-open, no false positive);
+  # the CI gate still catches it.
+  five_b_body_file=$(python3 "$REPO_ROOT/scripts/claude-hooks/_bash_guard_parse.py" \
+                       --get-body-file "$cmd" 2>/dev/null)
+  five_b_body_text=$(python3 "$REPO_ROOT/scripts/claude-hooks/_bash_guard_parse.py" \
+                       --get-body "$cmd" 2>/dev/null)
+  # Command-substitution / backtick bodies can't be statically inspected.
+  case "$five_b_body_text" in
+    *'$('*|*'`'*) five_b_body_text="" ;;
+  esac
+
+  five_b_rc=0
+  if [[ -n "$five_b_body_file" && -f "$five_b_body_file" ]]; then
+    python3 "$REPO_ROOT/scripts/claude-hooks/_ship_pr_body.py" \
+      --check-body-file "$five_b_body_file" --base-ref origin/main >/dev/null 2>&1
+    five_b_rc=$?
+  elif [[ -n "$five_b_body_text" ]]; then
+    printf '%s' "$five_b_body_text" | python3 \
+      "$REPO_ROOT/scripts/claude-hooks/_ship_pr_body.py" \
+      --check-body-stdin --base-ref origin/main >/dev/null 2>&1
+    five_b_rc=$?
+  fi
+
+  if [[ "$five_b_rc" == "3" ]]; then
+    python3 "$REPO_ROOT/scripts/_governance.py" --emit-fire \
+      --outcome aware --hook bash-guard --category pr-body-5b-missing \
+      --path "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)" \
+      --fire-log "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
+    cat >&2 <<'EOF'
+⚠️  load-bearing 변경 PR 인데 --body 에 §5b (real-data delta) 섹션이 없습니다.
+
+    추가하세요: `### 5b. Real-data delta` 헤더 + `make real-eval-delta` 표,
+    또는 escape 문장: `No behavior change in retrieval / verifier path.`
+
+    PR #69 교훈: 합성 CI 델타만으론 의도된 보류(abstention) 회귀를 놓침.
+    PR 생성은 그대로 진행됩니다(경고만). CI `--check-5b` 가 생성 후 hard-gate 합니다.
+EOF
+  fi
+  # NB: do NOT exit here — fall through to the stacked guard below.
+
   # Bypass: explicit --base is intentional. Catches both `--base X` and
   # `--base=X` forms. `--base main` is the documented escape for
   # "I really do want to flatten this onto main."

--- a/tests/test_bash_guard_adversarial.py
+++ b/tests/test_bash_guard_adversarial.py
@@ -196,3 +196,71 @@ def test_cli_has_base_exit_codes(bgp):
         capture_output=True, text=True,
     )
     assert r.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# get_create_flag_value — §5b body extraction (issue #1097)
+# ---------------------------------------------------------------------------
+
+
+def test_get_body_simple(bgp):
+    assert bgp.get_create_flag_value("gh pr create --title T --body hello", "--body") == "hello"
+
+
+def test_get_body_equals_form(bgp):
+    assert bgp.get_create_flag_value("gh pr create --body=hello", "--body") == "hello"
+
+
+def test_get_body_file(bgp):
+    assert bgp.get_create_flag_value(
+        "gh pr create --body-file /tmp/b.md", "--body-file"
+    ) == "/tmp/b.md"
+
+
+def test_get_body_quoted_multiword(bgp):
+    assert bgp.get_create_flag_value(
+        'gh pr create --body "hello world"', "--body"
+    ) == "hello world"
+
+
+def test_get_body_absent_returns_empty(bgp):
+    assert bgp.get_create_flag_value("gh pr create --title T", "--body") == ""
+
+
+def test_get_body_only_on_create_segment(bgp):
+    """`--body` on a non-create gh segment must not match."""
+    assert bgp.get_create_flag_value("gh pr merge --body x", "--body") == ""
+
+
+def test_get_body_compound_command(bgp):
+    assert bgp.get_create_flag_value(
+        "echo start && gh pr create --body hi", "--body"
+    ) == "hi"
+
+
+def test_get_body_does_not_confuse_body_file(bgp):
+    """`--body` must not pick up `--body-file`'s value (and vice versa)."""
+    cmd = "gh pr create --body-file /tmp/x --body inline"
+    assert bgp.get_create_flag_value(cmd, "--body") == "inline"
+    assert bgp.get_create_flag_value(cmd, "--body-file") == "/tmp/x"
+
+
+def test_cli_get_body_stdout(bgp):
+    import subprocess, sys
+    r = subprocess.run(
+        [sys.executable, str(PARSE_PATH), "--get-body", "gh pr create --body hello"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0
+    assert r.stdout.strip() == "hello"
+
+
+def test_cli_get_body_file_stdout(bgp):
+    import subprocess, sys
+    r = subprocess.run(
+        [sys.executable, str(PARSE_PATH), "--get-body-file",
+         "gh pr create --body-file /tmp/b.md"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0
+    assert r.stdout.strip() == "/tmp/b.md"

--- a/tests/test_hook_pretooluse_bash_guard.py
+++ b/tests/test_hook_pretooluse_bash_guard.py
@@ -254,5 +254,142 @@ class TestPreToolUseBashGuard(unittest.TestCase):
         self.assertEqual(r.returncode, 2, msg=r.stderr)
 
 
+# Scripts the §5b check (issue #1097) pulls in beyond the base harness.
+SHIP_PR_BODY = REPO / "scripts" / "claude-hooks" / "_ship_pr_body.py"
+CHECK_BRANCH = REPO / "scripts" / "check_branch_and_issue.py"
+
+
+class TestBashGuard5bSoftWarn(unittest.TestCase):
+    """§5b soft-warn on `gh pr create` (issue #1097).
+
+    The §5b check runs `_ship_pr_body.py --check-body-*`, which imports
+    `_governance` + `check_branch_and_issue`. We copy all of them under a
+    temp REPO_ROOT, commit a load-bearing path, and assert the warn / quiet
+    / independent-of-stacked-guard matrix. Soft-warn only (never exit on §5b).
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp()
+        self._tmp_repo = Path(self._tmp) / "repo"
+        (self._tmp_repo / ".claude").mkdir(parents=True)
+        ch = self._tmp_repo / "scripts" / "claude-hooks"
+        ch.mkdir(parents=True)
+        shutil.copy(HOOK, ch / HOOK.name)
+        shutil.copy(HOOK_HELPER, ch / HOOK_HELPER.name)
+        shutil.copy(SHIP_PR_BODY, ch / SHIP_PR_BODY.name)
+        shutil.copy(GOVERNANCE, self._tmp_repo / "scripts" / GOVERNANCE.name)
+        shutil.copy(CHECK_BRANCH, self._tmp_repo / "scripts" / CHECK_BRANCH.name)
+        self._hook = ch / HOOK.name
+        self._fires_log = self._tmp_repo / ".claude" / ".hook-fires.log"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _git(self, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+        env = {**os.environ, **_GIT_ENV}
+        return subprocess.run(
+            ["git", "-C", str(self._tmp_repo), *args],
+            check=check, capture_output=True, text=True, env=env,
+        )
+
+    def _commit(self, name: str, content: str = "x") -> str:
+        p = self._tmp_repo / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        self._git("add", name)
+        self._git("commit", "-m", name)
+        return self._git("rev-parse", "HEAD").stdout.strip()
+
+    def _set_origin_ref(self, branch: str, sha: str) -> None:
+        self._git("update-ref", f"refs/remotes/origin/{branch}", sha)
+
+    def _init_repo(self) -> str:
+        subprocess.run(
+            ["git", "init", "-b", "main", str(self._tmp_repo)],
+            check=True, capture_output=True, env={**os.environ, **_GIT_ENV},
+        )
+        m1 = self._commit("m1.txt", "m1")
+        self._set_origin_ref("main", m1)
+        return m1
+
+    def _run(self, command: str) -> subprocess.CompletedProcess:
+        payload = {"tool_input": {"command": command}}
+        return subprocess.run(
+            ["bash", str(self._hook)],
+            input=json.dumps(payload), text=True,
+            capture_output=True, check=False, cwd=str(self._tmp_repo),
+        )
+
+    def _write_body(self, text: str) -> Path:
+        # Body files live outside the repo so they aren't part of the diff.
+        path = Path(self._tmp) / "body.md"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_load_bearing_inline_body_without_5b_warns(self) -> None:
+        self._init_repo()
+        self._git("checkout", "-b", "feat/issue-1-x")
+        self._commit("rag_core.py", "behavior change")
+        r = self._run("gh pr create --title T --body 'no 5b section here'")
+        self.assertEqual(r.returncode, 0, msg=r.stderr)  # not stacked
+        self.assertIn("§5b", r.stderr)
+        self.assertTrue(self._fires_log.exists())
+        self.assertIn("|aware|bash-guard|pr-body-5b-missing|", self._fires_log.read_text())
+
+    def test_load_bearing_body_file_with_5b_is_quiet(self) -> None:
+        self._init_repo()
+        self._git("checkout", "-b", "feat/issue-1-x")
+        self._commit("rag_core.py", "behavior change")
+        body = self._write_body(
+            "### 5b. Real-data delta\n\n"
+            "No behavior change in retrieval / verifier path.\n"
+        )
+        r = self._run(f"gh pr create --title T --body-file {body}")
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertNotIn("§5b", r.stderr)
+
+    def test_load_bearing_body_file_without_5b_warns(self) -> None:
+        self._init_repo()
+        self._git("checkout", "-b", "feat/issue-1-x")
+        self._commit("rag_core.py", "behavior change")
+        body = self._write_body("## 1. What changed\n\nno 5b section\n")
+        r = self._run(f"gh pr create --title T --body-file {body}")
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertIn("§5b", r.stderr)
+
+    def test_non_load_bearing_is_quiet(self) -> None:
+        self._init_repo()
+        self._git("checkout", "-b", "feat/issue-1-x")
+        self._commit("docs/note.md", "docs only")
+        r = self._run("gh pr create --title T --body 'no 5b'")
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertNotIn("§5b", r.stderr)
+
+    def test_command_substitution_body_is_skipped(self) -> None:
+        # heredoc / command-substitution bodies can't be statically parsed →
+        # fail-open (no false-positive warning); the CI gate still catches it.
+        self._init_repo()
+        self._git("checkout", "-b", "feat/issue-1-x")
+        self._commit("rag_core.py", "behavior change")
+        r = self._run('gh pr create --title T --body "$(cat /tmp/body.md)"')
+        self.assertEqual(r.returncode, 0, msg=r.stderr)
+        self.assertNotIn("§5b", r.stderr)
+
+    def test_5b_warn_and_stacked_block_are_independent(self) -> None:
+        # THE KEY CASE: a stacked, load-bearing, no-§5b create must BOTH warn
+        # about §5b AND block (exit 2) for the stack — the two checks are
+        # independent (§5b runs first, never exits; stacked guard owns exit 2).
+        self._init_repo()
+        self._git("checkout", "-b", "feat/A")
+        a1 = self._commit("rag_core.py", "behavior on A")  # load-bearing
+        self._set_origin_ref("feat/A", a1)
+        self._git("checkout", "-b", "feat/B")
+        self._commit("b1.txt", "b1")
+        r = self._run("gh pr create --title T --body 'no 5b'")
+        self.assertEqual(r.returncode, 2, msg=r.stderr)  # stacked → block
+        self.assertIn("stacked", r.stderr.lower())
+        self.assertIn("§5b", r.stderr)  # AND §5b warned
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ship_pr_body.py
+++ b/tests/test_ship_pr_body.py
@@ -113,6 +113,38 @@ def test_validate_5b_skipped_when_no_load_bearing():
     assert pb.validate_5b(body, []) is True
 
 
+# ---- check_body_5b standalone validation (issue #1097) ----
+
+def test_check_body_5b_no_load_bearing_passes(monkeypatch):
+    monkeypatch.setattr(pb, "changed_files", lambda base: ["README.md", "docs/x.md"])
+    assert pb.check_body_5b("anything, no 5b section here", "origin/main") == 0
+
+
+def test_check_body_5b_load_bearing_with_escape_passes(monkeypatch):
+    monkeypatch.setattr(pb, "changed_files", lambda base: ["rag_core.py"])
+    body = (
+        "### 5b. Real-data delta\n\n"
+        "No behavior change in retrieval / verifier path.\n"
+    )
+    assert pb.check_body_5b(body, "origin/main") == 0
+
+
+def test_check_body_5b_load_bearing_with_table_passes(monkeypatch):
+    monkeypatch.setattr(pb, "changed_files", lambda base: ["api/main.py"])
+    body = (
+        "### 5b. Real-data delta\n\n"
+        "| metric | base | head |\n|---|---|---|\n| f1 | 0.7 | 0.8 |\n"
+        "\n## 6. Backward compatibility\n"
+    )
+    assert pb.check_body_5b(body, "origin/main") == 0
+
+
+def test_check_body_5b_load_bearing_missing_5b_returns_3(monkeypatch):
+    monkeypatch.setattr(pb, "changed_files", lambda base: ["rag_core.py"])
+    body = "## 1. What changed\n\nsome text without any 5b section\n"
+    assert pb.check_body_5b(body, "origin/main") == 3
+
+
 # ---- end-to-end build_body shape ----
 
 def test_build_body_includes_required_sections(monkeypatch):


### PR DESCRIPTION
## 1. What changed and why

`_ship_pr_body.py`의 §5b(real-data 델타) 검증이 **auto-ship 경로에서만** 동작하던 갭을 메운다. 수동/Claude `gh pr create`는 §5b 누락이 검증되지 않았고, CI `--check-5b`는 `gh pr view`(생성 **후**) 기반이라 생성 직전 빈틈이 있었다. bash-guard가 생성 전 soft-warn으로 조기 경고한다.

Closes #1097

## 2. Files affected

- `scripts/claude-hooks/_ship_pr_body.py` — `--check-body-file` / `--check-body-stdin` standalone 검증 모드 추가 (`--branch` required 제거, **auto-ship body 생성 경로 불변**)
- `scripts/claude-hooks/_bash_guard_parse.py` — `get_create_flag_value` + `--get-body` / `--get-body-file` CLI (정적 body 추출, SSoT 파서 재사용)
- `scripts/claude-hooks/pretooluse-bash-guard.sh` — `gh pr create` 진입 직후 §5b 검사 (stacked guard **앞**, 경고만 출력하고 exit 안 함 → 두 검사 독립). telemetry는 `_governance.py --emit-fire`(outcome=aware)
- `tests/test_bash_guard_adversarial.py` / `tests/test_ship_pr_body.py` / `tests/test_hook_pretooluse_bash_guard.py` — 단위 + 통합 (stacked + §5b 독립 케이스 포함)

## 3. Risks

낮음. **soft-warn only** (exit 안 함; stacked guard의 exit 0/2 동작 불변). 기존 §5b 정규식(`check_branch_and_issue.FIVE_B_*`) + `is_load_bearing` SSoT 재사용 — 신규 정규식 0. `_ship_pr_body.py`의 `--branch` 생성 경로(`make ship-arm` Stage 3)는 동작 불변.

**Scope limit**: command-substitution / heredoc body(`--body "$(cat <<EOF…)"`)는 정적 파싱 불가라 skip(fail-open, false positive 없음); CI gate가 생성 후 잡음.

## 4. Tests

69 passed (`test_bash_guard_adversarial` + `test_ship_pr_body` + `test_hook_pretooluse_bash_guard`). 핵심 케이스: load-bearing+§5b없음→경고 / +§5b→조용 / 비-load-bearing→조용 / cmd-sub body→skip / **stacked+§5b누락→§5b 경고 AND stacked exit 2 (독립 확인)**. ruff 통과.

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (`scripts/claude-hooks/` + `tests/`만 — load-bearing 경로 미변경)

## 6. Backward compatibility

No public-API change. `_ship_pr_body.py --branch` 생성 경로 불변 (새 모드는 분기 추가). bash-guard stacked/merge guard 동작 불변.

## 7. Out of scope

- pre-push hygiene hooks (PR #1096, 머지됨) — 별도 surface
- 멀티라인 inline `--body` 정적 추출 — `_segments` 개행 분리 한계, 현재 `--body-file` + 단일라인 `--body`만 검사 (의도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)