### PR TITLE
fix(makefile/readme): make ask 가 agentic_full 실행하도록 정합 (#1078)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ index:
 	$(PYTHON) scripts/build_index.py --input_dir data/raw --output_dir data/index
 
 ask:
-	$(PYTHON) app.py --input_dir data/index --output_dir outputs --query "기관 A와 기관 B의 AI 요구사항 차이 알려줘"
+	$(PYTHON) app.py --input_dir data/index --output_dir outputs --query "기관 A와 기관 B의 보안 요구사항 차이를 알려줘" --pipeline agentic_full
 
 eval:
 	$(PYTHON) eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ```text
 $ make ask
-python3 app.py --input_dir data/index --query "기관 A와 기관 B의 보안 요구사항 차이를 알려줘" --pipeline agentic_full
+python3 app.py --input_dir data/index --output_dir outputs --query "기관 A와 기관 B의 보안 요구사항 차이를 알려줘" --pipeline agentic_full
 
 INFO bidmate.rag_core: query_complete  status='supported'  query_type='comparison'
                                        latency_ms=5.79      retry_count=0
@@ -34,7 +34,7 @@ INFO bidmate.rag_core: query_complete  status='supported'  query_type='compariso
 ```
 
 - 두 기관이 **모두** 인용된 점이 핵심 — [comparison-aware balanced top-k](#key-technical-contribution--comparison-aware-balanced-top-k) 가 한쪽 문서 starvation 방지
-- 외부 API 호출 없음 (extractive). 5.79 ms 는 in-memory index, n=2 docs 실측
+- 외부 API 호출 없음 (extractive). 5.79 ms 는 in-memory index, n=2 docs 실측 — 대표 예시이며 `data/index` 전체(13-doc) 실행 시 출력·latency 상이 (hero 재현성 복원 추적: [issue #1102](https://github.com/hskim-solv/BidMate-DocAgent/issues/1102))
 - 5초 터미널 재생: `asciinema play docs/assets/demo.cast`. 풀 워크스루: [`docs/operations/deployment.md`](docs/operations/deployment.md#recording-the-demo-video)
 
 ## Live demo


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

README 5초 비주얼 훅(L19)은 `$ make ask` → `--pipeline agentic_full` comparison 출력을 보여주는데, 실제 Makefile `ask` 타겟은 `--pipeline` 없이 naive_baseline(ADR 0024 CLI default)을 실행 → 라벨/명령 불일치. make ask 를 agentic_full 로 정합 + README 명령 일치.

Closes #1078

## 2. 영향 파일

- `Makefile` — ask 타겟 1줄 (`--pipeline agentic_full` 추가 + query 를 README 5초 훅과 통일)
- `README.md` — L20 명령 정합(`--output_dir outputs` 추가), L37 출력 재현성 disclosure + #1102 링크
- **둘 다 load-bearing 아님** — `scripts/_governance.py` LOAD_BEARING_PATHS 에 Makefile / root README 부재

## 3. 리스크

`make ask` 가 agentic_full = `retrieval_backend=hybrid`(ADR 0058) 실행 → `rank_bm25` 필요. `requirements.txt` 에 pin 되어 있어(ADR 0058 load-bearing) `make setup` 후 동작; quickstart 는 setup 선행이라 영향 없음. 로컬은 `--retrieval_backend dense` override 로 agentic_full answer 구조 검증(claim 2 / citation 2 / comparison).

## 4. 테스트

Makefile 데모 편의 타겟 + README 문서, 코드 로직 무변경 → 테스트 N/A. 명령 문자열 일치(`make ask` recipe == README L20)는 diff 로 검증.

## 5. Eval 영향

All `·` — RAG 파이프라인 코드 무관 (데모 타겟 + 문서 정합).

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. `make ask` 는 데모 편의 타겟 (eval surface 무관), Makefile / root README 는 load-bearing path 아님.

## 6. 하위 호환

`make ask` 의 query(AI→보안) + pipeline(naive_baseline→agentic_full) 변경. 데모 편의 타겟이라 계약 아님; README 명령도 동반 갱신해 일관 유지.

## 7. 범위 외

- **5초 훅 출력 재현성** (chunk-001 표시 vs data/index 13-doc chunk-098 실제) → **#1102** (hero demo corpus 작업, 별도 PR)
- ADR 0058 hybrid 기본의 코드(`rag_retrieval.py default="dense"`) 반영 — 별도 구현 PR
- 메트릭/README metric CI sync — #792