### PR TITLE
Phase 4 retrieval-eval: metadata ablation + query↔metadata coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,24 @@ reports/retrieval/phase35_m3_*/*
 # sentence-transformers --model BAAI/bge-m3 (~3min wall-time, FlagEmbedding
 # opt-in dep per ADR 0010 deferred + ADR 0032 torch>=2.6 unblock).
 data/index/real100_m3/
+# Phase 4 retrieval-eval (metadata / filtering ablation) timestamped runs.
+# Same aggregate-only commit boundary as phase3_mode_* above. All 4 variants
+# share the kordoc 26k index; only plan['metadata_first'] / metadata_filters
+# differ. Raw scores carry no doc/chunk text — qid + categories + metric
+# values only, ADR 0005 boundary preserved.
+!reports/retrieval/phase4_metadata_*/
+reports/retrieval/phase4_metadata_*/*
+!reports/retrieval/phase4_metadata_*/REPORT.md
+!reports/retrieval/phase4_metadata_*/metadata_specs.json
+!reports/retrieval/phase4_metadata_*/deltas.json
+!reports/retrieval/phase4_metadata_*/raw_results.json
+!reports/retrieval/phase4_metadata_*/COVERAGE.md
+!reports/retrieval/phase4_metadata_*/coverage.json
+# data/index/real100_kordoc — hashing-backend kordoc 26k index (Phase 4
+# corpus, matches Phase 3's kordoc corpus). Reproducible from data/files
+# via scripts/build_index.py --hwp_loader kordoc --pdf_loader kordoc
+# --embedding_backend hashing with BIDMATE_KORDOC_CACHE_DIR=data/files_kordoc.
+data/index/real100_kordoc/
 # Issue #237 — harness aggregate snapshots. Generated per ``run_harness``
 # invocation; untracked by default to keep developer working trees
 # clean. The leaderboard time-series lives under reports/history/

--- a/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/COVERAGE.md
+++ b/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/COVERAGE.md
@@ -1,0 +1,27 @@
+# Phase 4 — query ↔ metadata coverage 분석
+
+index_dir=`data/index/real100_kordoc` · eval_config=`eval/real_config.local.yaml` · commit `9af8d73a63` · n_answerable=118
+
+Phase 4 oracle ceiling(모든 query 에 gold 메타데이터)과 현실 ceiling(query 에서 도출 가능한 메타데이터만) 사이의 격차를 정량화한다. 버킷은 상호 배타적이며, 우선순위는 metadata-identifiable → content-query → underspecified 이다.
+
+## query 의미 분류(semantic classes)
+
+| 분류 | n | % | gold 존재 | \|gold\| 중앙값 | \|gold\| 평균 |
+|---|---|---|---|---|---|
+| metadata-identifiable | 40 | 33.9% | 37/40 | 5 | 11 |
+| content-query | 77 | 65.3% | 77/77 | 6 | 18.5 |
+| underspecified | 1 | 0.8% | 0/1 | 0 | 0.0 |
+
+## 해석(interpretation)
+
+* **metadata-identifiable (33.9%)**: gold agency/project 가 query 와 char-4gram 을 공유한다. 메타데이터 routing 이 현실적으로 작동할 수 있는 cohort 이며 — 메타데이터 routing 의 현실 ceiling 은 oracle 의 전체 coverage 가 아니라 이 비율로 bound 된다.
+* **content-query (65.3%)**: agency/project 신호는 없지만 gold 청크가 존재한다 (77/77 에 gold 있음). 프로젝트 *내부* 콘텐츠(기능/스펙/요구사항)를 묻는다. content matching 은 이들에 도달하나, 메타데이터 routing 은 필터링할 대상이 없다. 여기서 gold 집합이 오히려 *더 크다*(중앙값 6 vs metadata-identifiable 5) — 콘텐츠 답변이 더 많은 청크에 걸친다.
+* **underspecified (0.8%)**: 메타데이터 신호도 없고 도출 가능한 gold 도 없다 — context-dependent(follow_up)이거나 어떤 retrieval 로도 해결 못 할 만큼 모호하다. 미미하므로 숨은 retrieval-불가 ceiling 은 없다.
+
+**Headline**: oracle ceiling(+0.22 recall@10)은 counterfactual 이다 — 메타데이터를 전혀 언급하지 않는 65.3% 의 query 에도 gold 메타데이터를 썼다. 메타데이터 routing 은 ~33.9% metadata-identifiable cohort 로 bound 된 좁은 add-on 이며; 주된 retrieval lever 는 여전히 content matching(Phase 2 chunking + Phase 3 ranking mode)이다.
+
+## 방법(method)
+
+* 메타데이터 신호에 **char-4gram overlap**(공백 무시)을 쓴다. 한국어 복합명사는 공백으로 구분되지 않아 토큰 overlap 이 과소 계산하기 때문이다(예: "대학재정정보시스템").
+* **gold** = `eval.scorers.chunk_metrics.derive_gold_chunk_ids` (doc_id ∈ expected_doc_ids 이고 청크 텍스트가 expected_term 을 포함).
+* 결정적(deterministic): 동일 index + eval_config → byte-identical 출력. run 헤더의 1줄 CLI 로 재현.

--- a/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/REPORT.md
+++ b/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/REPORT.md
@@ -1,0 +1,146 @@
+# Phase 4 retrieval-eval — 메타데이터 / 필터링 ablation (real100 n=221)
+
+Run: `20260520-1419-phase4-metadata-reaggregate` · commit `9af8d73a63` · index_dir=`data/index/real100_kordoc` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+
+## 변형(variants)
+
+| 변형 | metadata_first | prefilter | oracle 엔티티 | 문서 | 청크 |
+|---|---|---|---|---|---|
+| `no_metadata` | False | none | False | 100 | 26376 |
+| `soft_agency` | True | none | True | 100 | 26376 |
+| `prefilter_agency` | False | agency | False | 100 | 26376 |
+| `prefilter_project` | False | project | False | 100 | 26376 |
+
+## 지연시간(latency, ms)
+
+| 변형 | p50 | p95 | mean | n |
+|---|---|---|---|---|
+| `no_metadata` | 3891.561 | 13928.452 | 6234.874 | 221 |
+| `soft_agency` | 1576.235 | 2991.429 | 1789.898 | 221 |
+| `prefilter_agency` | 252.572 | 903.325 | 338.818 | 221 |
+| `prefilter_project` | 235.494 | 659.241 | 330.529 | 221 |
+
+## chunk_recall@5
+
+| 카테고리 | `no_metadata` | `soft_agency` | `prefilter_agency` | `prefilter_project` |
+|---|---|---|---|---|
+| overall | 0.155 (n=114) | 0.353 (n=114) | 0.353 (n=114) | 0.358 (n=114) |
+| multi_hop | 0.133 (n=93) | 0.345 (n=93) | 0.345 (n=93) | 0.351 (n=93) |
+| distractor_heavy | 0.202 (n=42) | 0.381 (n=42) | 0.381 (n=42) | 0.381 (n=42) |
+| long_context | 0.302 (n=9) | 0.399 (n=9) | 0.399 (n=9) | 0.399 (n=9) |
+| no_answer | 0.550 (n=2) | 0.550 (n=2) | 0.550 (n=2) | 0.550 (n=2) |
+| ambiguous_query | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) |
+| uncategorized | 0.180 (n=13) | 0.336 (n=13) | 0.336 (n=13) | 0.334 (n=13) |
+
+### chunk_recall@5 — `no_metadata` 대비 paired CI delta (seed 평균)
+
+| 카테고리 | `soft_agency` | `prefilter_agency` | `prefilter_project` |
+|---|---|---|---|
+| overall | +0.198 (+0.147, +0.251) significant | +0.198 (+0.147, +0.251) significant | +0.203 (+0.152, +0.255) significant |
+| multi_hop | +0.212 (+0.160, +0.269) significant | +0.212 (+0.160, +0.269) significant | +0.218 (+0.165, +0.275) significant |
+| distractor_heavy | +0.179 (+0.106, +0.263) significant | +0.179 (+0.106, +0.263) significant | +0.179 (+0.107, +0.263) significant |
+| long_context | +0.096 (+0.002, +0.223) significant | +0.096 (+0.002, +0.223) significant | +0.096 (+0.002, +0.223) significant |
+| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| uncategorized | +0.156 (+0.001, +0.385) significant | +0.156 (+0.001, +0.385) significant | +0.154 (-0.001, +0.384) **NOT SIGNIFICANT** |
+
+## chunk_recall@10
+
+| 카테고리 | `no_metadata` | `soft_agency` | `prefilter_agency` | `prefilter_project` |
+|---|---|---|---|---|
+| overall | 0.202 (n=114) | 0.415 (n=114) | 0.421 (n=114) | 0.425 (n=114) |
+| multi_hop | 0.190 (n=93) | 0.415 (n=93) | 0.423 (n=93) | 0.427 (n=93) |
+| distractor_heavy | 0.259 (n=42) | 0.447 (n=42) | 0.453 (n=42) | 0.451 (n=42) |
+| long_context | 0.302 (n=9) | 0.429 (n=9) | 0.429 (n=9) | 0.429 (n=9) |
+| no_answer | 0.700 (n=2) | 0.700 (n=2) | 0.700 (n=2) | 0.700 (n=2) |
+| ambiguous_query | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) |
+| uncategorized | 0.184 (n=13) | 0.342 (n=13) | 0.342 (n=13) | 0.341 (n=13) |
+
+### chunk_recall@10 — `no_metadata` 대비 paired CI delta (seed 평균)
+
+| 카테고리 | `soft_agency` | `prefilter_agency` | `prefilter_project` |
+|---|---|---|---|
+| overall | +0.213 (+0.162, +0.265) significant | +0.219 (+0.169, +0.271) significant | +0.223 (+0.174, +0.274) significant |
+| multi_hop | +0.225 (+0.167, +0.286) significant | +0.233 (+0.177, +0.293) significant | +0.238 (+0.183, +0.297) significant |
+| distractor_heavy | +0.188 (+0.109, +0.275) significant | +0.194 (+0.118, +0.279) significant | +0.192 (+0.121, +0.274) significant |
+| long_context | +0.127 (+0.012, +0.280) significant | +0.127 (+0.012, +0.280) significant | +0.127 (+0.012, +0.280) significant |
+| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| uncategorized | +0.158 (+0.003, +0.386) significant | +0.158 (+0.003, +0.386) significant | +0.157 (+0.000, +0.385) significant |
+
+## mrr
+
+| 카테고리 | `no_metadata` | `soft_agency` | `prefilter_agency` | `prefilter_project` |
+|---|---|---|---|---|
+| overall | 0.356 (n=114) | 0.758 (n=114) | 0.763 (n=114) | 0.791 (n=114) |
+| multi_hop | 0.365 (n=93) | 0.808 (n=93) | 0.810 (n=93) | 0.842 (n=93) |
+| distractor_heavy | 0.327 (n=42) | 0.743 (n=42) | 0.757 (n=42) | 0.791 (n=42) |
+| long_context | 0.554 (n=9) | 0.751 (n=9) | 0.751 (n=9) | 0.751 (n=9) |
+| no_answer | 1.000 (n=2) | 1.000 (n=2) | 1.000 (n=2) | 1.000 (n=2) |
+| ambiguous_query | 0.500 (n=1) | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) |
+| uncategorized | 0.288 (n=13) | 0.408 (n=13) | 0.408 (n=13) | 0.421 (n=13) |
+
+### mrr — `no_metadata` 대비 paired CI delta (seed 평균)
+
+| 카테고리 | `soft_agency` | `prefilter_agency` | `prefilter_project` |
+|---|---|---|---|
+| overall | +0.402 (+0.329, +0.476) significant | +0.407 (+0.335, +0.481) significant | +0.435 (+0.362, +0.507) significant |
+| multi_hop | +0.443 (+0.359, +0.523) significant | +0.445 (+0.360, +0.525) significant | +0.477 (+0.396, +0.558) significant |
+| distractor_heavy | +0.416 (+0.302, +0.535) significant | +0.429 (+0.314, +0.546) significant | +0.464 (+0.350, +0.576) significant |
+| long_context | +0.197 (+0.016, +0.439) significant | +0.197 (+0.016, +0.439) significant | +0.197 (+0.016, +0.439) significant |
+| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | +0.500 (+0.500, +0.500) significant | +0.500 (+0.500, +0.500) significant | +0.500 (+0.500, +0.500) significant |
+| uncategorized | +0.121 (+0.007, +0.295) significant | +0.120 (+0.007, +0.295) significant | +0.133 (+0.018, +0.306) significant |
+
+## ndcg@10
+
+| 카테고리 | `no_metadata` | `soft_agency` | `prefilter_agency` | `prefilter_project` |
+|---|---|---|---|---|
+| overall | 0.204 (n=114) | 0.504 (n=114) | 0.510 (n=114) | 0.527 (n=114) |
+| multi_hop | 0.191 (n=93) | 0.515 (n=93) | 0.521 (n=93) | 0.544 (n=93) |
+| distractor_heavy | 0.227 (n=42) | 0.503 (n=42) | 0.510 (n=42) | 0.517 (n=42) |
+| long_context | 0.350 (n=9) | 0.563 (n=9) | 0.564 (n=9) | 0.564 (n=9) |
+| no_answer | 0.712 (n=2) | 0.710 (n=2) | 0.712 (n=2) | 0.712 (n=2) |
+| ambiguous_query | 0.631 (n=1) | 1.000 (n=1) | 1.000 (n=1) | 1.000 (n=1) |
+| uncategorized | 0.220 (n=13) | 0.381 (n=13) | 0.381 (n=13) | 0.376 (n=13) |
+
+### ndcg@10 — `no_metadata` 대비 paired CI delta (seed 평균)
+
+| 카테고리 | `soft_agency` | `prefilter_agency` | `prefilter_project` |
+|---|---|---|---|
+| overall | +0.300 (+0.248, +0.353) significant | +0.306 (+0.254, +0.359) significant | +0.324 (+0.270, +0.378) significant |
+| multi_hop | +0.324 (+0.266, +0.381) significant | +0.330 (+0.273, +0.387) significant | +0.352 (+0.296, +0.411) significant |
+| distractor_heavy | +0.276 (+0.197, +0.363) significant | +0.282 (+0.204, +0.366) significant | +0.290 (+0.216, +0.370) significant |
+| long_context | +0.213 (+0.051, +0.400) significant | +0.214 (+0.053, +0.401) significant | +0.214 (+0.053, +0.401) significant |
+| no_answer | -0.002 (-0.004, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| ambiguous_query | +0.369 (+0.369, +0.369) significant | +0.369 (+0.369, +0.369) significant | +0.369 (+0.369, +0.369) significant |
+| uncategorized | +0.161 (+0.023, +0.354) significant | +0.161 (+0.023, +0.354) significant | +0.156 (+0.014, +0.347) significant |
+
+## 카테고리별 winner
+
+winner = `chunk_recall@10` 평균이 가장 높으면서 `no_metadata` 대비 paired CI 가 완전히 0 위인 변형. "NOT SIGNIFICANT" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
+
+| 카테고리 | winner | 평균 recall@10 | `no_metadata` 대비 delta CI |
+|---|---|---|---|
+| overall | `prefilter_project` | 0.425 | +0.223 (+0.174, +0.274) significant |
+| multi_hop | `prefilter_project` | 0.427 | +0.238 (+0.183, +0.297) significant |
+| distractor_heavy | `prefilter_agency` | 0.453 | +0.194 (+0.118, +0.279) significant |
+| long_context | `soft_agency` | 0.429 | +0.127 (+0.012, +0.280) significant |
+| no_answer | `NOT SIGNIFICANT` | — | — |
+| ambiguous_query | `NOT SIGNIFICANT` | — | — |
+| uncategorized | `soft_agency` | 0.342 | +0.158 (+0.003, +0.386) significant |
+
+## 비고(notes)
+
+* **Oracle ceiling, realistic NER 아님**: agency / project 는 answerable 케이스의 `expected_doc_ids[0]` 를 인덱스 문서 메타데이터에서 조회해 얻는다. 이는 "메타데이터 신호가 완벽하다면 recall 이 얼마나 움직이는가?" 의 상한(upper bound)을 측정한다. 현실의 query-time agency 추출기는 이 ceiling 아래에 위치한다 (follow-up).
+* **Abstention(보류) 케이스는 oracle 이 없다** (`expected_doc_ids` 없음). 따라서 모든 변형이 baseline 으로 수렴하고 `chunk_recall@k` 가 None → pairwise 에서 제외된다. 측정된 효과는 Phase 4 프로토콜 요구대로 answerable(메타데이터 적용 가능) 케이스에 한정된다.
+* **`rerank=True` 필수**: `retrieve_candidates` 의 score-fusion 공식은 `rerank` 가 truthy 일 때만 `metadata_first` 분기에 도달한다 (`rerank=False` 는 `score=dense_score` 로 단락된다). Phase 3 은 `rerank=False` 라 `metadata_first` 플래그가 무력했다. 여기서 `rerank_cross_encoder` 는 설정하지 않으므로 cross-encoder 단계는 꺼진 채 — `rerank` 는 dense+lexical(+metadata) 혼합만 선택한다.
+* **점수 공식(scoring formulas)**: `no_metadata` / `prefilter_*` = 0.70·dense + 0.30·lexical; `soft_agency` = 0.60·dense + 0.25·lexical + 0.15·metadata, 여기서 `metadata_similarity` 는 `agency` 가 oracle 엔티티와 일치하는 청크에 1.0 을 반환한다. `prefilter_*` 는 baseline 공식을 유지하되 점수 계산 전에 후보 풀(candidate pool)을 hard filter 로 축소한다.
+* **kordoc 코퍼스**: `data/index/real100_kordoc` 는 kordoc 전체 코퍼스 추출(26376 청크)로, Phase 2 / Phase 3 이 쓴 코퍼스와 동일하다. 절대 recall 수치는 kordoc 코퍼스 phase 들 간 비교 가능하다. n=221 케이스 중 114 개가 gold-derivable(answerable 이며 `expected_terms` 가 청크와 매칭); abstention + 미매칭 케이스는 pairwise 에서 제외된다 (overall n=114).
+* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, cross-encoder rerank 없음 — 메타데이터 효과를 expansion / cross-encoder 효과로부터 격리한다.
+* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 query + index + plan 에 대해 결정적(deterministic)이다.
+* 카테고리 버킷팅은 `hardcase_categories` 를 쓴다. 멀티태그 케이스는 여러 버킷에 나타나므로 카테고리별 카운트는 겹치고 케이스를 공유한다.
+* **Recall-↑ query 패턴 (Phase 4 프로토콜 step 3)**: agency / project 가 expected doc 에 매핑되는 모든 answerable query 는 oracle 메타데이터 신호로 recall@10 +0.21~0.22, MRR +0.40~0.44, ndcg@10 +0.30~0.32 (모두 SIG) 를 얻는다. 지배적인 `multi_hop` cohort(n=93)가 가장 큰 lift(recall@10 +0.23~0.24, MRR +0.44~0.48)를 본다. Abstention query 는 아무것도 얻지 못한다 — 메타데이터는 타깃 doc 이 존재하는 곳에서만 정확히 돕는다.
+* **지연시간 Pareto**: hard pre-filter 는 점수 계산 전 후보 풀을 26k 청크에서 1 개 doc / agency 로 축소해, p50 을 3892ms(`no_metadata`)에서 253ms(`prefilter_agency`, ~15배)로 줄이면서 recall 은 동등하거나 더 높다 — Pareto-dominant. `soft_agency` 는 전체 풀을 유지하므로 더 싼 top-1 fusion 경로로 p50 지연시간을 절반(1576ms)만 줄인다.
+* **쿼리 ↔ 메타데이터 coverage**: 위 oracle ceiling 은 counterfactual(모든 query 에 gold 메타데이터 주입)이다. query 에서 실제 도출 가능한 메타데이터로 bound 한 현실 ceiling 분석(query 의미 분류: metadata-identifiable / content-query / underspecified)은 `COVERAGE.md` 참조 — 재현: `scripts/phase4_query_metadata_coverage.py`.
+* 이 리포트는 `--reaggregate` 로 `reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/raw_results.json` 로부터 재생성됨 — 카테고리는 `hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval 점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변.

--- a/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/coverage.json
+++ b/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/coverage.json
@@ -1,0 +1,69 @@
+{
+  "config": {
+    "index_dir": "data/index/real100_kordoc",
+    "eval_config": "eval/real_config.local.yaml",
+    "git_commit": "9af8d73a6338cf9c077b1a52613a9b284d847ce4"
+  },
+  "stats": {
+    "n_answerable": 118,
+    "buckets": {
+      "metadata_identifiable": {
+        "n": 40,
+        "pct": 33.9,
+        "gold_present": 37,
+        "gold_size_median": 5,
+        "gold_size_mean": 11,
+        "query_types": {
+          "single_doc": 38,
+          "multi_doc": 1,
+          "follow_up": 1
+        },
+        "sample_queries": [
+          "한영대학교 특성화 맞춤형 교육환경 구축 사업의 사업기간과 사업예산 알려줘",
+          "한국연구재단의 대학산학협력활동 실태조사 시스템 사업기간과 사업금액은?",
+          "고양도시관리공사 관산근린공원 다목적구장 홈페이지 사업의 사업예산과 기간은?",
+          "울산광역시와 경기도 평택시의 BIS 사업을 비교해줘",
+          "사학진흥재단의 대학재정정보시스템 사업 예산이 얼마야?"
+        ]
+      },
+      "content_query": {
+        "n": 77,
+        "pct": 65.3,
+        "gold_present": 77,
+        "gold_size_median": 6,
+        "gold_size_mean": 18.5,
+        "query_types": {
+          "follow_up": 2,
+          "single_doc": 74,
+          "abstention": 1
+        },
+        "sample_queries": [
+          "그 사업의 사업예산도 알려줘",
+          "그 금액으로 어떤 시스템이 만들어져?",
+          "스톡옵션 부여 신고 배정 시 지역 기반 자동배정 프로세스가 구현되어야 하는데, 해당 기능을 사용하는 업무 담당자에게 적용되는 ",
+          "보안정책 위반 시 위규처리 기준과 보안 위약금은 각각 어느 붙임 자료에 규정되어 있으며, 위규자 외에 행정조치 대상이 되는 추",
+          "도시생활지도 관리 기능 개선 항목에서 대용량 지오코딩 시 최대 등록 가능 수량 기준 마련과 시스템 부하 분산을 위한 예약시간 "
+        ]
+      },
+      "underspecified": {
+        "n": 1,
+        "pct": 0.8,
+        "gold_present": 0,
+        "gold_size_median": 0,
+        "gold_size_mean": 0.0,
+        "query_types": {
+          "follow_up": 1
+        },
+        "sample_queries": [
+          "그 사업의 입찰 마감일은 언제야?"
+        ]
+      }
+    },
+    "query_type_overall": {
+      "single_doc": 112,
+      "multi_doc": 1,
+      "follow_up": 4,
+      "abstention": 1
+    }
+  }
+}

--- a/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/deltas.json
+++ b/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/deltas.json
@@ -1,0 +1,1208 @@
+{
+  "soft_agency": {
+    "chunk_recall@5": {
+      "overall": {
+        "mean_diff": 0.19798938770367053,
+        "ci_lo": 0.14746445836434346,
+        "ci_hi": 0.25086672159634327,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.15534802435885375,
+        "mean_other": 0.3533374120625243
+      },
+      "uncategorized": {
+        "mean_diff": 0.15559440559440557,
+        "ci_lo": 0.0011509324009324018,
+        "ci_hi": 0.38521270396270396,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1801371705217859,
+        "mean_other": 0.3357315761161915
+      },
+      "long_context": {
+        "mean_diff": 0.09621578099838973,
+        "ci_lo": 0.0024154589371980675,
+        "ci_hi": 0.22342995169082125,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.30229598462417534,
+        "mean_other": 0.3985117656225651
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.1787089341338461,
+        "ci_lo": 0.10562967124735784,
+        "ci_hi": 0.2626115773318041,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20248844894751644,
+        "mean_other": 0.3811973830813625
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.55,
+        "mean_other": 0.55
+      },
+      "multi_hop": {
+        "mean_diff": 0.21163947879184633,
+        "ci_lo": 0.15993235713226606,
+        "ci_hi": 0.2690121269969975,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.13319041682179772,
+        "mean_other": 0.34482989561364397
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      }
+    },
+    "chunk_recall@10": {
+      "overall": {
+        "mean_diff": 0.21262944845769513,
+        "ci_lo": 0.16206923482754193,
+        "ci_hi": 0.26456867205534873,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20240835104941116,
+        "mean_other": 0.41503779950710623
+      },
+      "uncategorized": {
+        "mean_diff": 0.1582167832167832,
+        "ci_lo": 0.0028773310023310046,
+        "ci_hi": 0.38610868298368295,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.18396987627756858,
+        "mean_other": 0.3421866594943518
+      },
+      "long_context": {
+        "mean_diff": 0.1267336761726664,
+        "ci_lo": 0.012375980468547088,
+        "ci_hi": 0.2801779777673887,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.30229598462417534,
+        "mean_other": 0.42902966079684174
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.18754217364675174,
+        "ci_lo": 0.10912416209122999,
+        "ci_hi": 0.275461958118188,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.2591340628037565,
+        "mean_other": 0.44667623645050825
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7,
+        "mean_other": 0.7
+      },
+      "multi_hop": {
+        "mean_diff": 0.22473850406282714,
+        "ci_lo": 0.16733093262845208,
+        "ci_hi": 0.2858202696978329,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.18999465341730565,
+        "mean_other": 0.41473315748013284
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      }
+    },
+    "mrr": {
+      "overall": {
+        "mean_diff": 0.40178300424552665,
+        "ci_lo": 0.32918066935676993,
+        "ci_hi": 0.47625756910732614,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3559620361864944,
+        "mean_other": 0.7577450404320211
+      },
+      "uncategorized": {
+        "mean_diff": 0.1205090456102601,
+        "ci_lo": 0.006993006993006993,
+        "ci_hi": 0.29496439795022766,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.28796844181459563,
+        "mean_other": 0.40847748742485585
+      },
+      "long_context": {
+        "mean_diff": 0.19713804713804728,
+        "ci_lo": 0.015986251402918067,
+        "ci_hi": 0.439239618406285,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5537037037037037,
+        "mean_other": 0.7508417508417509
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.4157344639487495,
+        "ci_lo": 0.30206922872101444,
+        "ci_hi": 0.5353621560317988,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.32748342926914353,
+        "mean_other": 0.7432178932178932
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.4431441125463895,
+        "ci_lo": 0.35876654915000894,
+        "ci_hi": 0.5234732746667441,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.36490411163086683,
+        "mean_other": 0.8080482241772564
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.5,
+        "ci_lo": 0.5,
+        "ci_hi": 0.5,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5,
+        "mean_other": 1.0
+      }
+    },
+    "ndcg@10": {
+      "overall": {
+        "mean_diff": 0.300150985600535,
+        "ci_lo": 0.24835781565023116,
+        "ci_hi": 0.3533793274514844,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20368432353685473,
+        "mean_other": 0.5038353091373897
+      },
+      "uncategorized": {
+        "mean_diff": 0.16064672385267798,
+        "ci_lo": 0.02316713773368917,
+        "ci_hi": 0.35404473266002784,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.22043544369386778,
+        "mean_other": 0.38108216754654567
+      },
+      "long_context": {
+        "mean_diff": 0.21268898529376412,
+        "ci_lo": 0.05087193813894733,
+        "ci_hi": 0.4003699083850129,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.34984573511409983,
+        "mean_other": 0.562534720407864
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.27625999522738853,
+        "ci_lo": 0.19730108006771618,
+        "ci_hi": 0.3631290529819766,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.22720408763742134,
+        "mean_other": 0.5034640828648099
+      },
+      "no_answer": {
+        "mean_diff": -0.0019663500812913126,
+        "ci_lo": -0.003932700162582736,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7116653500253904,
+        "mean_other": 0.7096989999440991
+      },
+      "multi_hop": {
+        "mean_diff": 0.32358954881586743,
+        "ci_lo": 0.26646824800344066,
+        "ci_hi": 0.38127673482393926,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1914595409758503,
+        "mean_other": 0.5150490897917177
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.36907024642854247,
+        "ci_lo": 0.36907024642854247,
+        "ci_hi": 0.36907024642854247,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6309297535714575,
+        "mean_other": 1.0
+      }
+    }
+  },
+  "prefilter_agency": {
+    "chunk_recall@5": {
+      "overall": {
+        "mean_diff": 0.19798938770367053,
+        "ci_lo": 0.14746445836434346,
+        "ci_hi": 0.25086672159634327,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.15534802435885375,
+        "mean_other": 0.3533374120625243
+      },
+      "uncategorized": {
+        "mean_diff": 0.15559440559440557,
+        "ci_lo": 0.0011509324009324018,
+        "ci_hi": 0.38521270396270396,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1801371705217859,
+        "mean_other": 0.3357315761161915
+      },
+      "long_context": {
+        "mean_diff": 0.09621578099838973,
+        "ci_lo": 0.0024154589371980675,
+        "ci_hi": 0.22342995169082125,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.30229598462417534,
+        "mean_other": 0.3985117656225651
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.1787089341338461,
+        "ci_lo": 0.10562967124735784,
+        "ci_hi": 0.2626115773318041,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20248844894751644,
+        "mean_other": 0.3811973830813625
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.55,
+        "mean_other": 0.55
+      },
+      "multi_hop": {
+        "mean_diff": 0.21163947879184633,
+        "ci_lo": 0.15993235713226606,
+        "ci_hi": 0.2690121269969975,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.13319041682179772,
+        "mean_other": 0.34482989561364397
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      }
+    },
+    "chunk_recall@10": {
+      "overall": {
+        "mean_diff": 0.21902283577213508,
+        "ci_lo": 0.16912911787592266,
+        "ci_hi": 0.27067647269157397,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20240835104941116,
+        "mean_other": 0.4214311868215462
+      },
+      "uncategorized": {
+        "mean_diff": 0.1582167832167832,
+        "ci_lo": 0.0028773310023310046,
+        "ci_hi": 0.38610868298368295,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.18396987627756858,
+        "mean_other": 0.3421866594943518
+      },
+      "long_context": {
+        "mean_diff": 0.1267336761726664,
+        "ci_lo": 0.012375980468547088,
+        "ci_hi": 0.2801779777673887,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.30229598462417534,
+        "mean_other": 0.42902966079684174
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.1941355802401583,
+        "ci_lo": 0.11800540350951133,
+        "ci_hi": 0.27887207587145824,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.2591340628037565,
+        "mean_other": 0.45326964304391487
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7,
+        "mean_other": 0.7
+      },
+      "multi_hop": {
+        "mean_diff": 0.23257555948052777,
+        "ci_lo": 0.17699960453231914,
+        "ci_hi": 0.2932667332476829,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.18999465341730565,
+        "mean_other": 0.4225702128978334
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      }
+    },
+    "mrr": {
+      "overall": {
+        "mean_diff": 0.40743699168621766,
+        "ci_lo": 0.3345271772335756,
+        "ci_hi": 0.4808216852902095,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3559620361864944,
+        "mean_other": 0.7633990278727121
+      },
+      "uncategorized": {
+        "mean_diff": 0.12030661646046253,
+        "ci_lo": 0.006993006993006993,
+        "ci_hi": 0.29482607136453265,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.28796844181459563,
+        "mean_other": 0.4082750582750583
+      },
+      "long_context": {
+        "mean_diff": 0.19713804713804728,
+        "ci_lo": 0.015986251402918067,
+        "ci_hi": 0.439239618406285,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5537037037037037,
+        "mean_other": 0.7508417508417509
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.4290461522604379,
+        "ci_lo": 0.31405724401260116,
+        "ci_hi": 0.5455833733065876,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.32748342926914353,
+        "mean_other": 0.7565295815295815
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.44472675929032657,
+        "ci_lo": 0.3601664921948761,
+        "ci_hi": 0.5248935853426682,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.36490411163086683,
+        "mean_other": 0.8096308709211935
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.5,
+        "ci_lo": 0.5,
+        "ci_hi": 0.5,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5,
+        "mean_other": 1.0
+      }
+    },
+    "ndcg@10": {
+      "overall": {
+        "mean_diff": 0.30593730524321017,
+        "ci_lo": 0.2537601605170878,
+        "ci_hi": 0.35944323328929306,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20368432353685473,
+        "mean_other": 0.5096216287800649
+      },
+      "uncategorized": {
+        "mean_diff": 0.16064672385267798,
+        "ci_lo": 0.02316713773368917,
+        "ci_hi": 0.35404473266002784,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.22043544369386778,
+        "mean_other": 0.38108216754654567
+      },
+      "long_context": {
+        "mean_diff": 0.2141624489351427,
+        "ci_lo": 0.05332771087457826,
+        "ci_hi": 0.40086130967134115,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.34984573511409983,
+        "mean_other": 0.5640081840492425
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.28236636054513486,
+        "ci_lo": 0.20423892203812843,
+        "ci_hi": 0.36595864580093196,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.22720408763742134,
+        "mean_other": 0.5095704481825563
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7116653500253904,
+        "mean_other": 0.7116653500253904
+      },
+      "multi_hop": {
+        "mean_diff": 0.329809023190496,
+        "ci_lo": 0.27265778835129784,
+        "ci_hi": 0.3868486451260733,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1914595409758503,
+        "mean_other": 0.5212685641663463
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.36907024642854247,
+        "ci_lo": 0.36907024642854247,
+        "ci_hi": 0.36907024642854247,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6309297535714575,
+        "mean_other": 1.0
+      }
+    }
+  },
+  "prefilter_project": {
+    "chunk_recall@5": {
+      "overall": {
+        "mean_diff": 0.20261633033668602,
+        "ci_lo": 0.15231673673872256,
+        "ci_hi": 0.25515867108278184,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.15534802435885375,
+        "mean_other": 0.3579643546955398
+      },
+      "uncategorized": {
+        "mean_diff": 0.15411511565357716,
+        "ci_lo": -0.001302223417608033,
+        "ci_hi": 0.38412228796844183,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1801371705217859,
+        "mean_other": 0.3342522861753631
+      },
+      "long_context": {
+        "mean_diff": 0.09621578099838973,
+        "ci_lo": 0.0024154589371980675,
+        "ci_hi": 0.22342995169082125,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.30229598462417534,
+        "mean_other": 0.3985117656225651
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.1787089341338461,
+        "ci_lo": 0.10662731935937186,
+        "ci_hi": 0.26264808151602786,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20248844894751644,
+        "mean_other": 0.3811973830813625
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.55,
+        "mean_other": 0.55
+      },
+      "multi_hop": {
+        "mean_diff": 0.21751799738748653,
+        "ci_lo": 0.16483307494410418,
+        "ci_hi": 0.2746770061307093,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.13319041682179772,
+        "mean_other": 0.35070841420928417
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      }
+    },
+    "chunk_recall@10": {
+      "overall": {
+        "mean_diff": 0.22287539721578967,
+        "ci_lo": 0.1744865416712563,
+        "ci_hi": 0.2739158404125877,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20240835104941116,
+        "mean_other": 0.42528374826520077
+      },
+      "uncategorized": {
+        "mean_diff": 0.1567374932759548,
+        "ci_lo": 0.0004482696790389099,
+        "ci_hi": 0.384617065626681,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.18396987627756858,
+        "mean_other": 0.3407073695535234
+      },
+      "long_context": {
+        "mean_diff": 0.1267336761726664,
+        "ci_lo": 0.012375980468547088,
+        "ci_hi": 0.2801779777673887,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.30229598462417534,
+        "mean_other": 0.42902966079684174
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.19234986595444403,
+        "ci_lo": 0.12064897954605268,
+        "ci_hi": 0.2736379579393633,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.2591340628037565,
+        "mean_other": 0.4514839287582006
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7,
+        "mean_other": 0.7
+      },
+      "multi_hop": {
+        "mean_diff": 0.23750483661824173,
+        "ci_lo": 0.18258163240864542,
+        "ci_hi": 0.29669303824724474,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.18999465341730565,
+        "mean_other": 0.42749949003554727
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      }
+    },
+    "mrr": {
+      "overall": {
+        "mean_diff": 0.435304957054183,
+        "ci_lo": 0.36240396028740973,
+        "ci_hi": 0.5072787897278351,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.3559620361864944,
+        "mean_other": 0.7912669932406774
+      },
+      "uncategorized": {
+        "mean_diff": 0.13312712928097536,
+        "ci_lo": 0.01769910644910645,
+        "ci_hi": 0.305542854581316,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.28796844181459563,
+        "mean_other": 0.4210955710955711
+      },
+      "long_context": {
+        "mean_diff": 0.19713804713804728,
+        "ci_lo": 0.015986251402918067,
+        "ci_hi": 0.439239618406285,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5537037037037037,
+        "mean_other": 0.7508417508417509
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.46376837448266023,
+        "ci_lo": 0.3496059479541623,
+        "ci_hi": 0.5764839178678465,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.32748342926914353,
+        "mean_other": 0.7912518037518037
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 1.0,
+        "mean_other": 1.0
+      },
+      "multi_hop": {
+        "mean_diff": 0.477095376336363,
+        "ci_lo": 0.396036394614826,
+        "ci_hi": 0.5578763643588122,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.36490411163086683,
+        "mean_other": 0.8419994879672299
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.5,
+        "ci_lo": 0.5,
+        "ci_hi": 0.5,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.5,
+        "mean_other": 1.0
+      }
+    },
+    "ndcg@10": {
+      "overall": {
+        "mean_diff": 0.3236655713204114,
+        "ci_lo": 0.27007332175016807,
+        "ci_hi": 0.3779348104250766,
+        "n": 114,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.20368432353685473,
+        "mean_other": 0.5273498948572661
+      },
+      "uncategorized": {
+        "mean_diff": 0.15580393788634628,
+        "ci_lo": 0.013642991999903521,
+        "ci_hi": 0.34663837602334663,
+        "n": 13,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.22043544369386778,
+        "mean_other": 0.376239381580214
+      },
+      "long_context": {
+        "mean_diff": 0.2141624489351427,
+        "ci_lo": 0.05332771087457826,
+        "ci_hi": 0.40086130967134115,
+        "n": 9,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.34984573511409983,
+        "mean_other": 0.5640081840492425
+      },
+      "distractor_heavy": {
+        "mean_diff": 0.2899442340391577,
+        "ci_lo": 0.2161882655900715,
+        "ci_hi": 0.3701287664978895,
+        "n": 42,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.22720408763742134,
+        "mean_other": 0.5171483216765791
+      },
+      "no_answer": {
+        "mean_diff": 0.0,
+        "ci_lo": 0.0,
+        "ci_hi": 0.0,
+        "n": 2,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.7116653500253904,
+        "mean_other": 0.7116653500253904
+      },
+      "multi_hop": {
+        "mean_diff": 0.3522173946997783,
+        "ci_lo": 0.2957835069472513,
+        "ci_hi": 0.4109185190900673,
+        "n": 93,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.1914595409758503,
+        "mean_other": 0.5436769356756285
+      },
+      "ambiguous_query": {
+        "mean_diff": 0.36907024642854247,
+        "ci_lo": 0.36907024642854247,
+        "ci_hi": 0.36907024642854247,
+        "n": 1,
+        "num_resamples_per_seed": 1000,
+        "seeds": [
+          17,
+          23,
+          29
+        ],
+        "mean_current": 0.6309297535714575,
+        "mean_other": 1.0
+      }
+    }
+  }
+}

--- a/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/metadata_specs.json
+++ b/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/metadata_specs.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "no_metadata",
+    "metadata_first": false,
+    "prefilter": "none",
+    "inject_entities": false,
+    "index_dir": "data/index/real100_kordoc",
+    "num_documents": 100,
+    "num_chunks": 26376
+  },
+  {
+    "name": "soft_agency",
+    "metadata_first": true,
+    "prefilter": "none",
+    "inject_entities": true,
+    "index_dir": "data/index/real100_kordoc",
+    "num_documents": 100,
+    "num_chunks": 26376
+  },
+  {
+    "name": "prefilter_agency",
+    "metadata_first": false,
+    "prefilter": "agency",
+    "inject_entities": false,
+    "index_dir": "data/index/real100_kordoc",
+    "num_documents": 100,
+    "num_chunks": 26376
+  },
+  {
+    "name": "prefilter_project",
+    "metadata_first": false,
+    "prefilter": "project",
+    "inject_entities": false,
+    "index_dir": "data/index/real100_kordoc",
+    "num_documents": 100,
+    "num_chunks": 26376
+  }
+]

--- a/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/raw_results.json
+++ b/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/raw_results.json
@@ -1,0 +1,11782 @@
+{
+  "no_metadata": {
+    "variant": "no_metadata",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 4843.596,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 3376.511,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.8318724637288826
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 9653.56,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 88,
+        "latency_ms": 12158.021,
+        "chunk_recall@5": 0.03409090909090909,
+        "chunk_recall@10": 0.045454545454545456,
+        "mrr": 1.0,
+        "ndcg@10": 0.4789015552876929
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 10221.655,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4155.242,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 7049.131,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 10995.578,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 9170.859,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3885.477,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07692307692307693,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 52,
+        "latency_ms": 5617.638,
+        "chunk_recall@5": 0.057692307692307696,
+        "chunk_recall@10": 0.09615384615384616,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.44173955623824723
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3660.485,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2283.361,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4190.724,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 5852.604,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 5904.847,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 19484.264,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 5701.99,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3361.923,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3192.284,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2305.863,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 3809.257,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3065735963827292
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3848.225,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 21,
+        "latency_ms": 3610.421,
+        "chunk_recall@5": 0.047619047619047616,
+        "chunk_recall@10": 0.047619047619047616,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4796.607,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 3239.593,
+        "chunk_recall@5": 0.23076923076923078,
+        "chunk_recall@10": 0.23076923076923078,
+        "mrr": 1.0,
+        "ndcg@10": 0.4690000933206748
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4030.438,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 20,
+        "latency_ms": 5257.203,
+        "chunk_recall@5": 0.05,
+        "chunk_recall@10": 0.1,
+        "mrr": 0.2,
+        "ndcg@10": 0.1635413866202963
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6159.08,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 10993.15,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8212.427,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 142,
+        "latency_ms": 11018.231,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2653.822,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 3944.179,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.1,
+        "ndcg@10": 0.09803928583135704
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4400.83,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 6519.516,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2756.823,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 3745.58,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5706417189553201
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3929.242,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2760.721,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3638.776,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 2522.543,
+        "chunk_recall@5": 0.23076923076923078,
+        "chunk_recall@10": 0.23076923076923078,
+        "mrr": 1.0,
+        "ndcg@10": 0.40002324830925196
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4983.231,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3307.227,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 9493.239,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 7968.097,
+        "chunk_recall@5": 0.03225806451612903,
+        "chunk_recall@10": 0.03225806451612903,
+        "mrr": 0.25,
+        "ndcg@10": 0.09478836436955078
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6407.395,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 11896.315,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.1111111111111111,
+        "ndcg@10": 0.3010299956639812
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3732.655,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 92,
+        "latency_ms": 3699.091,
+        "chunk_recall@5": 0.021739130434782608,
+        "chunk_recall@10": 0.021739130434782608,
+        "mrr": 1.0,
+        "ndcg@10": 0.3589542101716347
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2330.152,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 4906.606,
+        "chunk_recall@5": 0.027777777777777776,
+        "chunk_recall@10": 0.027777777777777776,
+        "mrr": 0.2,
+        "ndcg@10": 0.08514311764162098
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 12161.933,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 12192.546,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3891.561,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2104.523,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3699.27,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 3144.296,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.2934556883974402
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 14078.813,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 3945.338,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.09090909090909091,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1927.968,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 4478.146,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.07692307692307693,
+        "mrr": 0.14285714285714285,
+        "ndcg@10": 0.07336392209936005
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2685.082,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 14433.517,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5670.981,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 90,
+        "latency_ms": 5406.928,
+        "chunk_recall@5": 0.011111111111111112,
+        "chunk_recall@10": 0.022222222222222223,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.1736666713479918
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8484.388,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 3084.71,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.08333333333333333,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4935.559,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1617.47,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07692307692307693,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5927.627,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 3325.472,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 23698.155,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 210,
+        "latency_ms": 4472.235,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3810.226,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 3205.055,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.125,
+        "mrr": 1.0,
+        "ndcg@10": 0.2529427027676571
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3508.374,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 3901.417,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2353.045,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 4676.147,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.3903800499921017
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4388.394,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 4485.459,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.09090909090909091,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.07839826897867533
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4934.422,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 3631.569,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3051.045,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2971.453,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07692307692307693,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6581.39,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 3390.606,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.3391602052736161
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4693.247,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 26,
+        "latency_ms": 4112.82,
+        "chunk_recall@5": 0.038461538461538464,
+        "chunk_recall@10": 0.07692307692307693,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.1736666713479918
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2871.959,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 3999.168,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3065735963827292
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 6660.648,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 4384.451,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.25,
+        "mrr": 0.14285714285714285,
+        "ndcg@10": 0.13012668333070054
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4135.499,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 3642.695,
+        "chunk_recall@5": 0.08333333333333333,
+        "chunk_recall@10": 0.08333333333333333,
+        "mrr": 0.5,
+        "ndcg@10": 0.13886244387355454
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4098.728,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 7304.323,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.06666666666666667,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 6684.326,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5427.15,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 22643.078,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.058823529411764705,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2772.478,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 3505.416,
+        "chunk_recall@5": 0.06451612903225806,
+        "chunk_recall@10": 0.0967741935483871,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.26462022272743835
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3992.466,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 22106.9,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.5,
+        "ndcg@10": 0.21398626473452756
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 9737.817,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 2070.805,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.06666666666666667,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2166.143,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 4001.546,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2938.872,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 5830.434,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 12575.208,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 30623.463,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 7614.073,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 6338.851,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.09090909090909091,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 9129.288,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 3625.433,
+        "chunk_recall@5": 0.05555555555555555,
+        "chunk_recall@10": 0.05555555555555555,
+        "mrr": 0.5,
+        "ndcg@10": 0.2489083270225946
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4984.822,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2397.328,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3350.905,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2720.235,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.8175295903539445
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5851.668,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 4155.791,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.1,
+        "ndcg@10": 0.17723928678404774
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2972.144,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 5604.272,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4161.609,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 15180.759,
+        "chunk_recall@5": 0.17647058823529413,
+        "chunk_recall@10": 0.17647058823529413,
+        "mrr": 1.0,
+        "ndcg@10": 0.4690000933206748
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 7810.145,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 4186.009,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1446.144,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 9132.346,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8004.738,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2036.492,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.5,
+        "ndcg@10": 0.2960819109658652
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2433.814,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 3427.029,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4455.214,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 8254.182,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.13743816645714543
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5385.969,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 2806.76,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.1,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.07839826897867533
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8013.168,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 7699.578,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05555555555555555,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2273.243,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3367.044,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.3562071871080222
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4085.48,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 5455.466,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.25,
+        "ndcg@10": 0.2640681225725909
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5272.62,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 3586.777,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.625,
+        "mrr": 1.0,
+        "ndcg@10": 0.7277341624565861
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4134.023,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 32,
+        "latency_ms": 4720.888,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07142857142857142,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 8971.712,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 5188.662,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.15130120674940672
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2857.668,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 3480.643,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.058823529411764705,
+        "mrr": 0.125,
+        "ndcg@10": 0.06943122193677727
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4441.763,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 2507.222,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 0.5,
+        "ndcg@10": 0.17342765698823945
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1721.925,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 2481.391,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.25,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.19519002499605084
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2527.664,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 5404.647,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.1111111111111111,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.08372491399919346
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 11622.64,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 143,
+        "latency_ms": 2914.183,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4515.632,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 3008.677,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 24472.577,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 35,
+        "latency_ms": 5509.882,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4593.548,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3149.98,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2874.971,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3386.274,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2384.779,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 22,
+        "latency_ms": 2655.244,
+        "chunk_recall@5": 0.045454545454545456,
+        "chunk_recall@10": 0.09090909090909091,
+        "mrr": 1.0,
+        "ndcg@10": 0.2863459897524692
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3021.143,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 3464.676,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05555555555555555,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3485.27,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 169,
+        "latency_ms": 3970.983,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4555.199,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 24,
+        "latency_ms": 3655.143,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.06666666666666667,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 11204.118,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 3680.498,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3728.277,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2524.82,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 0.2,
+        "ndcg@10": 0.11706259313796354
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1943.347,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2462.002,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 0.5,
+        "ndcg@10": 0.19092086617893467
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2318.465,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 2767.487,
+        "chunk_recall@5": 0.08333333333333333,
+        "chunk_recall@10": 0.08333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2287.559,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 14,
+        "latency_ms": 2814.085,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 1.0,
+        "ndcg@10": 0.3589542101716347
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4546.41,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 4024.504,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4383.339,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2045.258,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.14285714285714285,
+        "ndcg@10": 0.20438239758848611
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3167.287,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 85662.865,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 166740.751,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3986.012,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2043.941,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 3078.606,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1576.75,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 16,
+        "latency_ms": 1954.617,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2535.738,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 2674.002,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2446.413,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 3613.113,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.46927872602275644
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2713.181,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2583.36,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6238470455881188
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 9905.832,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1881.294,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2095.907,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 3056.472,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2850.319,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2272.229,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1399.448,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1995.534,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.4,
+        "mrr": 1.0,
+        "ndcg@10": 0.42333070005078094
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1243.043,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1709.137,
+        "chunk_recall@5": 0.375,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5976116132276929
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1566.521,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1373.597,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.125,
+        "mrr": 0.5,
+        "ndcg@10": 0.15958907712489634
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2524.809,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 3356.866,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.1,
+        "mrr": 0.14285714285714285,
+        "ndcg@10": 0.07336392209936005
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3113.395,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2286.516,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 3891.561,
+      "p95": 13928.452,
+      "mean": 6234.874,
+      "n": 221
+    }
+  },
+  "soft_agency": {
+    "variant": "soft_agency",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1574.04,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1346.295,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.8318724637288826
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1535.602,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 88,
+        "latency_ms": 2073.336,
+        "chunk_recall@5": 0.056818181818181816,
+        "chunk_recall@10": 0.10227272727272728,
+        "mrr": 1.0,
+        "ndcg@10": 0.9363792118010483
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1360.299,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3590.024,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 6273.016,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4539.561,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2995.894,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05263157894736842,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2397.878,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 52,
+        "latency_ms": 2159.897,
+        "chunk_recall@5": 0.057692307692307696,
+        "chunk_recall@10": 0.09615384615384616,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.44173955623824723
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3973.209,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2655.902,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2306.039,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2816.43,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 2234.087,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1892.319,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1358.025,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1779.188,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1881.09,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1407.839,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 2032.892,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3065735963827292
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1457.742,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 21,
+        "latency_ms": 1801.538,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 1.0,
+        "ndcg@10": 0.424926013816671
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1490.406,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1451.196,
+        "chunk_recall@5": 0.38461538461538464,
+        "chunk_recall@10": 0.5384615384615384,
+        "mrr": 1.0,
+        "ndcg@10": 0.800693766409882
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1792.564,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 20,
+        "latency_ms": 1472.463,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.4920062203073637
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1931.658,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1521.397,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1557.211,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 142,
+        "latency_ms": 1576.235,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.014084507042253521,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.1478294909154526
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1324.662,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1826.096,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1355.731,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1663.165,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.46927872602275644
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1161.13,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1566.425,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6934264036172708
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1192.482,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1443.617,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.4,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3156484524795145
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1791.45,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1360.242,
+        "chunk_recall@5": 0.23076923076923078,
+        "chunk_recall@10": 0.3076923076923077,
+        "mrr": 1.0,
+        "ndcg@10": 0.49118023727106
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1676.031,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1393.078,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1907.993,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 1385.983,
+        "chunk_recall@5": 0.03225806451612903,
+        "chunk_recall@10": 0.0967741935483871,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.24703059344735182
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2265.509,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1914.007,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1410.072,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 92,
+        "latency_ms": 1896.593,
+        "chunk_recall@5": 0.05434782608695652,
+        "chunk_recall@10": 0.09782608695652174,
+        "mrr": 1.0,
+        "ndcg@10": 0.9266360779006401
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1403.241,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 1853.755,
+        "chunk_recall@5": 0.1111111111111111,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6758704024811183
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1870.857,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1408.552,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.9325210919548239
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2105.07,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 2136.693,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2655.34,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1526.098,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.3589542101716347
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1855.315,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1929.231,
+        "chunk_recall@5": 0.18181818181818182,
+        "chunk_recall@10": 0.18181818181818182,
+        "mrr": 1.0,
+        "ndcg@10": 0.33013764944712026
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2784.378,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 2183.643,
+        "chunk_recall@5": 0.07692307692307693,
+        "chunk_recall@10": 0.15384615384615385,
+        "mrr": 1.0,
+        "ndcg@10": 0.2863459897524692
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2308.269,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 2111.4,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.125,
+        "ndcg@10": 0.1480409554829326
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1143.1,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 90,
+        "latency_ms": 1886.503,
+        "chunk_recall@5": 0.044444444444444446,
+        "chunk_recall@10": 0.08888888888888889,
+        "mrr": 1.0,
+        "ndcg@10": 0.8512360941594274
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1143.199,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1508.576,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.30523488393970116
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1438.497,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1205.781,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.39007412760022164
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1619.045,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1626.321,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.4,
+        "mrr": 0.5,
+        "ndcg@10": 0.34519134224686937
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1939.536,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 210,
+        "latency_ms": 1154.074,
+        "chunk_recall@5": 0.01904761904761905,
+        "chunk_recall@10": 0.0380952380952381,
+        "mrr": 1.0,
+        "ndcg@10": 0.84860265890399
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1822.796,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 2951.244,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.32908604348504067
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1285.183,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1965.264,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.1,
+        "mrr": 0.125,
+        "ndcg@10": 0.06943122193677727
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1588.242,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1463.989,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.3903800499921017
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1545.276,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1116.618,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.18181818181818182,
+        "mrr": 0.25,
+        "ndcg@10": 0.1681522864689108
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1645.03,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1230.697,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.7039180890341347
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1625.864,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1814.383,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6105456988825855
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1829.893,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1450.522,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.3391602052736161
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1131.253,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 26,
+        "latency_ms": 2246.143,
+        "chunk_recall@5": 0.07692307692307693,
+        "chunk_recall@10": 0.19230769230769232,
+        "mrr": 1.0,
+        "ndcg@10": 0.5704044892860389
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2912.887,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1558.557,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1135.189,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 2524.022,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5205067333228022
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2449.876,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 2834.756,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.31488013066763093
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2535.193,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1235.856,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1761.401,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6257049680303419
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1300.013,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1658.37,
+        "chunk_recall@5": 0.2222222222222222,
+        "chunk_recall@10": 0.5555555555555556,
+        "mrr": 1.0,
+        "ndcg@10": 0.6119720699899831
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1522.696,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 1932.287,
+        "chunk_recall@5": 0.0967741935483871,
+        "chunk_recall@10": 0.12903225806451613,
+        "mrr": 0.5,
+        "ndcg@10": 0.39767223286316733
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1787.788,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1362.391,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.5,
+        "ndcg@10": 0.21398626473452756
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2461.287,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1291.274,
+        "chunk_recall@5": 0.6,
+        "chunk_recall@10": 0.6,
+        "mrr": 1.0,
+        "ndcg@10": 0.6992148198508501
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2190.359,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2132.199,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1775.664,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1947.86,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.5,
+        "ndcg@10": 0.38685280723454163
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1146.527,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1920.005,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1217.683,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1339.813,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.09090909090909091,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1551.51,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 1197.23,
+        "chunk_recall@5": 0.05555555555555555,
+        "chunk_recall@10": 0.1111111111111111,
+        "mrr": 0.5,
+        "ndcg@10": 0.38196033715832356
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1444.432,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1297.1,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 0.25,
+        "ndcg@10": 0.34337431936037655
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1392.959,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1310.926,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1365.367,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1046.124,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1654.561,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1398.834,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6713860725233041
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1060.295,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 1843.993,
+        "chunk_recall@5": 0.17647058823529413,
+        "chunk_recall@10": 0.23529411764705882,
+        "mrr": 1.0,
+        "ndcg@10": 0.5423640154200349
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 978.675,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 1331.651,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.2,
+        "ndcg@10": 0.13120507751234178
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1707.874,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1703.575,
+        "chunk_recall@5": 0.4444444444444444,
+        "chunk_recall@10": 0.4444444444444444,
+        "mrr": 1.0,
+        "ndcg@10": 0.591793585310856
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1761.982,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1298.354,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.5,
+        "ndcg@10": 0.2960819109658652
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1637.651,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1334.117,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.06666666666666667,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1576.247,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 1531.275,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 1.0,
+        "ndcg@10": 0.27487633291429087
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1322.521,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1623.498,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.3,
+        "mrr": 1.0,
+        "ndcg@10": 0.38363315291837646
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1096.988,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1486.423,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 0.5,
+        "ndcg@10": 0.5175725363450437
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1102.061,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1459.798,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1438.889,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1083.229,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6934264036172708
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1737.109,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1094.577,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.625,
+        "mrr": 1.0,
+        "ndcg@10": 0.7277341624565861
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1508.45,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 32,
+        "latency_ms": 1174.802,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.8512360941594274
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1561.481,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1151.881,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.7456919575934261
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1651.59,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 1409.377,
+        "chunk_recall@5": 0.058823529411764705,
+        "chunk_recall@10": 0.11764705882352941,
+        "mrr": 0.2,
+        "ndcg@10": 0.15457433957839825
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1070.717,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 1408.892,
+        "chunk_recall@5": 0.42857142857142855,
+        "chunk_recall@10": 0.5714285714285714,
+        "mrr": 0.5,
+        "ndcg@10": 0.5087056958335152
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1088.827,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1399.883,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5205067333228022
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1285.783,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 1473.529,
+        "chunk_recall@5": 0.2222222222222222,
+        "chunk_recall@10": 0.2222222222222222,
+        "mrr": 1.0,
+        "ndcg@10": 0.35256832412172806
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1365.412,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 143,
+        "latency_ms": 1085.251,
+        "chunk_recall@5": 0.006993006993006993,
+        "chunk_recall@10": 0.027972027972027972,
+        "mrr": 0.5,
+        "ndcg@10": 0.3529461582433962
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1383.376,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1093.987,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.7757386182436072
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1128.182,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 35,
+        "latency_ms": 1455.164,
+        "chunk_recall@5": 0.05714285714285714,
+        "chunk_recall@10": 0.11428571428571428,
+        "mrr": 1.0,
+        "ndcg@10": 0.4959389204699464
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1252.118,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1593.515,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2040.858,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1746.494,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.25,
+        "ndcg@10": 0.43067655807339306
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1266.241,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 22,
+        "latency_ms": 2200.37,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.13636363636363635,
+        "mrr": 1.0,
+        "ndcg@10": 0.3963918729015093
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2117.697,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1609.111,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.8318724637288826
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 5393.169,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 169,
+        "latency_ms": 2818.766,
+        "chunk_recall@5": 0.01775147928994083,
+        "chunk_recall@10": 0.03550295857988166,
+        "mrr": 1.0,
+        "ndcg@10": 0.6390097281865127
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2501.172,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 24,
+        "latency_ms": 1483.356,
+        "chunk_recall@5": 0.20833333333333334,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.727329844310522
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1449.924,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1091.841,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1442.897,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1388.496,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.644824486427155
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1435.672,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 2244.037,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.4103915680233244
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1224.975,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 1487.393,
+        "chunk_recall@5": 0.08333333333333333,
+        "chunk_recall@10": 0.08333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1076.015,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 14,
+        "latency_ms": 1320.549,
+        "chunk_recall@5": 0.21428571428571427,
+        "chunk_recall@10": 0.2857142857142857,
+        "mrr": 1.0,
+        "ndcg@10": 0.5271064966405455
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3733.864,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 1769.19,
+        "chunk_recall@5": 0.18181818181818182,
+        "chunk_recall@10": 0.36363636363636365,
+        "mrr": 0.5,
+        "ndcg@10": 0.3845937724137609
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2587.143,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1717.456,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2337.751,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 3635.957,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.6,
+        "mrr": 0.5,
+        "ndcg@10": 0.4340327988596634
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1830.817,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1459.666,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1234.571,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 1481.754,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1087.372,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 16,
+        "latency_ms": 1467.667,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2564.552,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 1288.36,
+        "chunk_recall@5": 0.15384615384615385,
+        "chunk_recall@10": 0.23076923076923078,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.2781981696179509
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1966.806,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1701.658,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.46927872602275644
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3719.964,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 1746.067,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6105858728157117
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2226.133,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1361.485,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5294362295028773
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1658.557,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1602.817,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1528.564,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 1733.723,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1351.704,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1918.161,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.4,
+        "mrr": 1.0,
+        "ndcg@10": 0.4193979998881982
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1258.542,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 5973.051,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6368547259115425
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2631.439,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1925.174,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.375,
+        "mrr": 1.0,
+        "ndcg@10": 0.45253089259539564
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2355.794,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 1743.369,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.1,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.11004588314904008
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2014.023,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3990.846,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 1576.235,
+      "p95": 2991.429,
+      "mean": 1789.898,
+      "n": 221
+    }
+  },
+  "prefilter_agency": {
+    "variant": "prefilter_agency",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 345.504,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 326.534,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.8318724637288826
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 155.339,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 88,
+        "latency_ms": 572.873,
+        "chunk_recall@5": 0.056818181818181816,
+        "chunk_recall@10": 0.10227272727272728,
+        "mrr": 1.0,
+        "ndcg@10": 0.9363792118010483
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 100.532,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1970.408,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 76.886,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 256.605,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 213.976,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 190.354,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 52,
+        "latency_ms": 153.86,
+        "chunk_recall@5": 0.057692307692307696,
+        "chunk_recall@10": 0.09615384615384616,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.44173955623824723
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 213.128,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 284.967,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 91.728,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 159.333,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 422.121,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 155.402,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 490.158,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2932.442,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2050.699,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 2676.274,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 100.058,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3065735963827292
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 252.572,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 21,
+        "latency_ms": 200.079,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 1.0,
+        "ndcg@10": 0.424926013816671
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 440.612,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 187.486,
+        "chunk_recall@5": 0.38461538461538464,
+        "chunk_recall@10": 0.6153846153846154,
+        "mrr": 1.0,
+        "ndcg@10": 0.8643145546088337
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 367.074,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 20,
+        "latency_ms": 201.539,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.4920062203073637
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 166.752,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 228.514,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 506.419,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 142,
+        "latency_ms": 274.062,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.014084507042253521,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.1478294909154526
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1059.188,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 270.631,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.1,
+        "ndcg@10": 0.09803928583135704
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 281.654,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 256.992,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.46927872602275644
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 229.771,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 119.888,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6934264036172708
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 275.433,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 208.392,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.4,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3156484524795145
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 268.73,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 304.477,
+        "chunk_recall@5": 0.23076923076923078,
+        "chunk_recall@10": 0.3076923076923077,
+        "mrr": 1.0,
+        "ndcg@10": 0.49118023727106
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 327.754,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 382.691,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 99.957,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 165.032,
+        "chunk_recall@5": 0.03225806451612903,
+        "chunk_recall@10": 0.0967741935483871,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.24703059344735182
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 232.531,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 255.211,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 191.704,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 92,
+        "latency_ms": 346.17,
+        "chunk_recall@5": 0.05434782608695652,
+        "chunk_recall@10": 0.09782608695652174,
+        "mrr": 1.0,
+        "ndcg@10": 0.9266360779006401
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 264.778,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 190.481,
+        "chunk_recall@5": 0.1111111111111111,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6758704024811183
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 299.848,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 319.099,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.9325210919548239
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 195.158,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 238.281,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 231.144,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 229.763,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.3589542101716347
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 442.569,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 213.714,
+        "chunk_recall@5": 0.18181818181818182,
+        "chunk_recall@10": 0.18181818181818182,
+        "mrr": 1.0,
+        "ndcg@10": 0.33013764944712026
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 311.999,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 446.723,
+        "chunk_recall@5": 0.07692307692307693,
+        "chunk_recall@10": 0.23076923076923078,
+        "mrr": 1.0,
+        "ndcg@10": 0.3499667779514209
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 235.348,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 136.104,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.125,
+        "ndcg@10": 0.1480409554829326
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 358.571,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 90,
+        "latency_ms": 393.633,
+        "chunk_recall@5": 0.044444444444444446,
+        "chunk_recall@10": 0.08888888888888889,
+        "mrr": 1.0,
+        "ndcg@10": 0.8512360941594274
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 448.731,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 276.904,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.30523488393970116
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 330.516,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 310.901,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.39007412760022164
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 118.843,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 360.986,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.4,
+        "mrr": 0.5,
+        "ndcg@10": 0.34519134224686937
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 226.297,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 210,
+        "latency_ms": 196.719,
+        "chunk_recall@5": 0.01904761904761905,
+        "chunk_recall@10": 0.0380952380952381,
+        "mrr": 1.0,
+        "ndcg@10": 0.84860265890399
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 249.092,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 247.007,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.32908604348504067
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 268.625,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 213.704,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.1,
+        "mrr": 0.125,
+        "ndcg@10": 0.06943122193677727
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 282.285,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 223.357,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.3903800499921017
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 295.379,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 212.148,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.18181818181818182,
+        "mrr": 0.25,
+        "ndcg@10": 0.1681522864689108
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 296.915,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 330.996,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.7039180890341347
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 601.638,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 310.183,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6105456988825855
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 260.681,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 231.523,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.3391602052736161
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 614.229,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 26,
+        "latency_ms": 248.665,
+        "chunk_recall@5": 0.07692307692307693,
+        "chunk_recall@10": 0.19230769230769232,
+        "mrr": 1.0,
+        "ndcg@10": 0.5653701424067237
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 677.275,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 221.74,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 269.114,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 185.352,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5205067333228022
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 321.724,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 191.606,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.31488013066763093
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 346.099,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 223.895,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 1360.671,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6257049680303419
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 402.928,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 209.158,
+        "chunk_recall@5": 0.2222222222222222,
+        "chunk_recall@10": 0.5555555555555556,
+        "mrr": 1.0,
+        "ndcg@10": 0.6119720699899831
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 300.362,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 272.366,
+        "chunk_recall@5": 0.0967741935483871,
+        "chunk_recall@10": 0.12903225806451613,
+        "mrr": 1.0,
+        "ndcg@10": 0.4789015552876929
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 232.821,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 188.959,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.5,
+        "ndcg@10": 0.21398626473452756
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 339.446,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 215.351,
+        "chunk_recall@5": 0.6,
+        "chunk_recall@10": 0.6,
+        "mrr": 1.0,
+        "ndcg@10": 0.6992148198508501
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 363.844,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 131.752,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 256.544,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 267.458,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.5,
+        "ndcg@10": 0.38685280723454163
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 242.096,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 140.24,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 316.874,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 174.721,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.09090909090909091,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 312.563,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 321.489,
+        "chunk_recall@5": 0.05555555555555555,
+        "chunk_recall@10": 0.1111111111111111,
+        "mrr": 0.5,
+        "ndcg@10": 0.38196033715832356
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 186.484,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 240.039,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 0.25,
+        "ndcg@10": 0.34337431936037655
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 915.156,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 154.34,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 410.581,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 151.034,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 341.803,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 104.89,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6713860725233041
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 656.301,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 1444.57,
+        "chunk_recall@5": 0.17647058823529413,
+        "chunk_recall@10": 0.23529411764705882,
+        "mrr": 1.0,
+        "ndcg@10": 0.5423640154200349
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 174.185,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 316.901,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.2,
+        "ndcg@10": 0.13120507751234178
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 172.599,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 163.841,
+        "chunk_recall@5": 0.4444444444444444,
+        "chunk_recall@10": 0.4444444444444444,
+        "mrr": 1.0,
+        "ndcg@10": 0.591793585310856
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 232.69,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 393.266,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.5,
+        "ndcg@10": 0.2960819109658652
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 548.2,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 739.36,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07142857142857142,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 583.252,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 314.739,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 1.0,
+        "ndcg@10": 0.27487633291429087
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 456.844,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 417.293,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.3,
+        "mrr": 1.0,
+        "ndcg@10": 0.40350157154648025
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 451.141,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 263.821,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 0.5,
+        "ndcg@10": 0.5175725363450437
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 384.086,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 249.207,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 261.653,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 114.527,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6934264036172708
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 464.225,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 185.326,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.625,
+        "mrr": 1.0,
+        "ndcg@10": 0.7277341624565861
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 393.215,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 32,
+        "latency_ms": 189.501,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.8512360941594274
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 388.869,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 392.171,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.7456919575934261
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 106.765,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 263.715,
+        "chunk_recall@5": 0.058823529411764705,
+        "chunk_recall@10": 0.11764705882352941,
+        "mrr": 0.25,
+        "ndcg@10": 0.1681522864689108
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 383.595,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 99.735,
+        "chunk_recall@5": 0.42857142857142855,
+        "chunk_recall@10": 0.5714285714285714,
+        "mrr": 0.5,
+        "ndcg@10": 0.5087056958335152
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 301.444,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 214.465,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5205067333228022
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 796.843,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 152.806,
+        "chunk_recall@5": 0.2222222222222222,
+        "chunk_recall@10": 0.2222222222222222,
+        "mrr": 1.0,
+        "ndcg@10": 0.35256832412172806
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 296.21,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 143,
+        "latency_ms": 232.88,
+        "chunk_recall@5": 0.006993006993006993,
+        "chunk_recall@10": 0.027972027972027972,
+        "mrr": 0.5,
+        "ndcg@10": 0.3529461582433962
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 101.004,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 225.668,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.7757386182436072
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 213.161,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 35,
+        "latency_ms": 255.034,
+        "chunk_recall@5": 0.05714285714285714,
+        "chunk_recall@10": 0.11428571428571428,
+        "mrr": 1.0,
+        "ndcg@10": 0.4959389204699464
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 451.509,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 365.927,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 102.661,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 233.423,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 299.447,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 22,
+        "latency_ms": 191.181,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.13636363636363635,
+        "mrr": 1.0,
+        "ndcg@10": 0.3995688713838975
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 432.172,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 1014.574,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.8318724637288826
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 176.316,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 169,
+        "latency_ms": 240.612,
+        "chunk_recall@5": 0.01775147928994083,
+        "chunk_recall@10": 0.03550295857988166,
+        "mrr": 1.0,
+        "ndcg@10": 0.6390097281865127
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 282.706,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 24,
+        "latency_ms": 116.138,
+        "chunk_recall@5": 0.20833333333333334,
+        "chunk_recall@10": 0.2916666666666667,
+        "mrr": 1.0,
+        "ndcg@10": 0.793584067764911
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 279.72,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 130.934,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 139.524,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 155.8,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.644824486427155
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 139.51,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 156.424,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.4103915680233244
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 133.257,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 216.724,
+        "chunk_recall@5": 0.08333333333333333,
+        "chunk_recall@10": 0.08333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 212.944,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 14,
+        "latency_ms": 232.198,
+        "chunk_recall@5": 0.21428571428571427,
+        "chunk_recall@10": 0.2857142857142857,
+        "mrr": 1.0,
+        "ndcg@10": 0.5271064966405455
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 150.33,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 187.994,
+        "chunk_recall@5": 0.18181818181818182,
+        "chunk_recall@10": 0.36363636363636365,
+        "mrr": 0.5,
+        "ndcg@10": 0.3845937724137609
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 171.766,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 178.371,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 145.072,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 228.763,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.6,
+        "mrr": 0.5,
+        "ndcg@10": 0.4340327988596634
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 254.744,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 180.192,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 204.434,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 209.243,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 323.328,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 16,
+        "latency_ms": 267.592,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 214.168,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 189.964,
+        "chunk_recall@5": 0.15384615384615385,
+        "chunk_recall@10": 0.23076923076923078,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.2781981696179509
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 207.4,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 223.569,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6049306994552042
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 233.194,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 338.142,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6238470455881188
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 205.713,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 123.344,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5294362295028773
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 247.765,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 175.368,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 221.107,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 161.583,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 254.124,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 477.67,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.4,
+        "mrr": 1.0,
+        "ndcg@10": 0.42333070005078094
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 383.934,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1055.629,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6368547259115425
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 410.039,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 1117.818,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.375,
+        "mrr": 1.0,
+        "ndcg@10": 0.4856486183364634
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 608.467,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 603.782,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.1,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.11004588314904008
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 415.118,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 115.335,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 252.572,
+      "p95": 903.325,
+      "mean": 338.818,
+      "n": 221
+    }
+  },
+  "prefilter_project": {
+    "variant": "prefilter_project",
+    "per_case": [
+      {
+        "qid": "real_hanyeong_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 121.86,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_nrf_uicc_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 291.626,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.8318724637288826
+      },
+      {
+        "qid": "real_goyang_homepage_budget_schedule",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 317.474,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_bus_info_compare",
+        "query_type": "multi_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 88,
+        "latency_ms": 211.379,
+        "chunk_recall@5": 0.056818181818181816,
+        "chunk_recall@10": 0.10227272727272728,
+        "mrr": 1.0,
+        "ndcg@10": 0.9363792118010483
+      },
+      {
+        "qid": "real_hanyeong_followup_budget",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 112.225,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_hanyeong_absent_blockchain_delivery",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1800.446,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_01_partial_agency_sahak",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 256.267,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_02_acronym_only_kusf",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 65.764,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_03_synonym_uniabbrev_jbnu",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 222.421,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.05,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_04_ambig_incheon_only",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 193.787,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6309297535714575
+      },
+      {
+        "qid": "probe_05_ambig_nrf_two_projects",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 52,
+        "latency_ms": 57.417,
+        "chunk_recall@5": 0.038461538461538464,
+        "chunk_recall@10": 0.07692307692307693,
+        "mrr": 0.5,
+        "ndcg@10": 0.3787833386759354
+      },
+      {
+        "qid": "probe_06_chunk_kepco_three_facts",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 125.3,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_07_chunk_eip_amount_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 154.354,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_08_followup_hanyeong_bid_deadline",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 182.809,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_09_followup_cross_doc_switch_nrf",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 209.195,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_10_followup_goyang_double_implicit",
+        "query_type": "follow_up",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 164.701,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_11_citation_goyang_when_done",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 266.967,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_12_citation_kosaf_aggregate",
+        "query_type": "single_doc",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 218.631,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.0,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "probe_13_abstention_lh_not_in_corpus",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 4632.591,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_14_abstention_near_miss_kri",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 3248.077,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "probe_15_abstention_kepco_quantum",
+        "query_type": "abstention",
+        "categories": [
+          "uncategorized"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1483.443,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 104.595,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3065735963827292
+      },
+      {
+        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 229.29,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kace_security_requirement_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 21,
+        "latency_ms": 190.82,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 1.0,
+        "ndcg@10": 0.424926013816671
+      },
+      {
+        "qid": "real_kace_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 175.606,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ventureassoc_stockoption_region_vs_permission",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 241.576,
+        "chunk_recall@5": 0.38461538461538464,
+        "chunk_recall@10": 0.6153846153846154,
+        "mrr": 1.0,
+        "ndcg@10": 0.8643145546088337
+      },
+      {
+        "qid": "real_ventureassoc_ip_ownership_ratio_change",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 143.184,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 20,
+        "latency_ms": 225.143,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.4920062203073637
+      },
+      {
+        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 202.817,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jeongeup_response_time_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 302.833,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_jeongeup_access_log_retention_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 350.933,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoul_geocoding_limit_vs_performance",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 142,
+        "latency_ms": 157.604,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.014084507042253521,
+        "mrr": 0.16666666666666666,
+        "ndcg@10": 0.1478294909154526
+      },
+      {
+        "qid": "real_seoul_security_disposal_method",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 454.396,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GKL_security_law_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 441.602,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.1,
+        "ndcg@10": 0.09803928583135704
+      },
+      {
+        "qid": "real_GKL_mobile_sns_bookmark_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 398.798,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICOX_multihop_subcontract_eval_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 143.703,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.46927872602275644
+      },
+      {
+        "qid": "real_KICOX_noanswer_web_server_failover_rto",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 383.546,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 510.97,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6934264036172708
+      },
+      {
+        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 468.53,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KWRI_multihop_securecoding_vs_adminpage",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 169.478,
+        "chunk_recall@5": 0.4,
+        "chunk_recall@10": 0.4,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.3156484524795145
+      },
+      {
+        "qid": "real_KWRI_noanswer_budget_breakdown",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 554.243,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KFIS_accessibility_diagnosis_scope_vs_certification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 96.5,
+        "chunk_recall@5": 0.23076923076923078,
+        "chunk_recall@10": 0.3076923076923077,
+        "mrr": 1.0,
+        "ndcg@10": 0.49118023727106
+      },
+      {
+        "qid": "real_KFIS_ip_ownership_ratio",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 449.622,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_security_violation_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 312.459,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_부산관광공사_credit_eval_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 222.165,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_gjcf_multisite_newurl_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 213.936,
+        "chunk_recall@5": 0.03225806451612903,
+        "chunk_recall@10": 0.0967741935483871,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.24703059344735182
+      },
+      {
+        "qid": "real_gjcf_security_password_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 235.448,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_arko_multihop_evaluation_quorum",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 197.291,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_arko_noanswer_penalty_replacement",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 406.957,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 92,
+        "latency_ms": 280.603,
+        "chunk_recall@5": 0.05434782608695652,
+        "chunk_recall@10": 0.09782608695652174,
+        "mrr": 1.0,
+        "ndcg@10": 0.9266360779006401
+      },
+      {
+        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 269.176,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kochildcare_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 146.367,
+        "chunk_recall@5": 0.1111111111111111,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6758704024811183
+      },
+      {
+        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 447.548,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_bonghwa_security_obligation_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 121.544,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 0.9325210919548239
+      },
+      {
+        "qid": "real_bonghwa_ai_tts_language_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 274.942,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_security_education_timing_vs_personnel_change",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 200.08,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_incheon_pm_presentation_evaluation_score_weight",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 178.205,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 101.282,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.3589542101716347
+      },
+      {
+        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 252.51,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 77.041,
+        "chunk_recall@5": 0.18181818181818182,
+        "chunk_recall@10": 0.2727272727272727,
+        "mrr": 1.0,
+        "ndcg@10": 0.43231813227099475
+      },
+      {
+        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 318.404,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ulsan_BIT_display_spec_vs_haza_support",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 54.639,
+        "chunk_recall@5": 0.07692307692307693,
+        "chunk_recall@10": 0.23076923076923078,
+        "mrr": 1.0,
+        "ndcg@10": 0.3499667779514209
+      },
+      {
+        "qid": "real_ulsan_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 333.542,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 163.43,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 0.125,
+        "ndcg@10": 0.1480409554829326
+      },
+      {
+        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 65.289,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 90,
+        "latency_ms": 374.94,
+        "chunk_recall@5": 0.044444444444444446,
+        "chunk_recall@10": 0.08888888888888889,
+        "mrr": 1.0,
+        "ndcg@10": 0.8512360941594274
+      },
+      {
+        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 86.695,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KICE_multihop_haza_repair_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 187.264,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.30523488393970116
+      },
+      {
+        "qid": "real_KICE_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 126.467,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NMC_encryption_standard_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 180.548,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.39007412760022164
+      },
+      {
+        "qid": "real_NMC_ipphone_max_extension_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 380.294,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kiom_security_penalty_vs_quality_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 111.316,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.4,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.2716774977597197
+      },
+      {
+        "qid": "real_kiom_sw_direct_purchase_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 436.454,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 210,
+        "latency_ms": 255.723,
+        "chunk_recall@5": 0.01904761904761905,
+        "chunk_recall@10": 0.0380952380952381,
+        "mrr": 1.0,
+        "ndcg@10": 0.84860265890399
+      },
+      {
+        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 214.161,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_PM_qualification_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 215.265,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.35079429740281753
+      },
+      {
+        "qid": "real_KITECH_performance_test_env_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 174.49,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_sensor_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 269.545,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.17947710508581735
+      },
+      {
+        "qid": "real_KRC_nimis_java_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 848.78,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 200.429,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.3903800499921017
+      },
+      {
+        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 661.372,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 201.135,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.18181818181818182,
+        "mrr": 0.25,
+        "ndcg@10": 0.1681522864689108
+      },
+      {
+        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 265.388,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KCCI_multi_hop_performance_security",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 189.704,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.7039180890341347
+      },
+      {
+        "qid": "real_KCCI_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 216.585,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_pyeongtaek_bis_maintenance_sla_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 266.07,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6105456988825855
+      },
+      {
+        "qid": "real_pyeongtaek_bis_penalty_subdomain_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 228.938,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 138.66,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.3391602052736161
+      },
+      {
+        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 176.832,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BIFF_response_time_vs_security_encryption",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 26,
+        "latency_ms": 160.464,
+        "chunk_recall@5": 0.07692307692307693,
+        "chunk_recall@10": 0.19230769230769232,
+        "mrr": 1.0,
+        "ndcg@10": 0.5653701424067237
+      },
+      {
+        "qid": "real_BIFF_penalty_clause_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 168.72,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KHOA_technical_score_threshold_and_negotiation_eligibility",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 220.665,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_KHOA_security_inspection_penalty_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 235.03,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 183.741,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5205067333228022
+      },
+      {
+        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 148.222,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOIPA_security_deadline_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 302.645,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.31488013066763093
+      },
+      {
+        "qid": "real_KOIPA_penalty_criteria_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 340.81,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 129.941,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_hrdk_multihop_pm_qualification_and_deliverable_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 211.258,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6257049680303419
+      },
+      {
+        "qid": "real_hrdk_noanswer_rfid_tag_unit_cost",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 193.436,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kaeri_sfr_multi_hop_test_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 173.791,
+        "chunk_recall@5": 0.2222222222222222,
+        "chunk_recall@10": 0.5555555555555556,
+        "mrr": 1.0,
+        "ndcg@10": 0.6119720699899831
+      },
+      {
+        "qid": "real_kaeri_security_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 410.311,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_anyang_homepage_vs_kiosk_sameday_reservation",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 31,
+        "latency_ms": 416.15,
+        "chunk_recall@5": 0.0967741935483871,
+        "chunk_recall@10": 0.12903225806451613,
+        "mrr": 1.0,
+        "ndcg@10": 0.4789015552876929
+      },
+      {
+        "qid": "real_anyang_security_penalty_offset_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 424.371,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 474.945,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.3391602052736161
+      },
+      {
+        "qid": "real_NRF_openaccess_expansion_target_metric",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 258.397,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_seoyeong_security_login_policy_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 484.825,
+        "chunk_recall@5": 0.6,
+        "chunk_recall@10": 0.6,
+        "mrr": 1.0,
+        "ndcg@10": 0.6992148198508501
+      },
+      {
+        "qid": "real_seoyeong_warranty_penalty_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 429.046,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KUSF_haza_vs_performance_period",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 134.509,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_KUSF_security_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 530.823,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 187.115,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 0.5,
+        "ndcg@10": 0.38685280723454163
+      },
+      {
+        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 502.886,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "no_answer"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 320.018,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "query_type": "abstention",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 90.386,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_ADD_transfer_redundancy_user_capacity",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 148.974,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.09090909090909091,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_ADD_warranty_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 379.408,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KITECH_integration_test_minimum_rounds",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 36,
+        "latency_ms": 240.769,
+        "chunk_recall@5": 0.1111111111111111,
+        "chunk_recall@10": 0.1388888888888889,
+        "mrr": 1.0,
+        "ndcg@10": 0.6371523797895856
+      },
+      {
+        "qid": "real_KITECH_subcontract_penalty_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 149.306,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 329.779,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 0.25,
+        "ndcg@10": 0.34337431936037655
+      },
+      {
+        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 550.969,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_jbnu_cloud_security_cert_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 142.827,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_jbnu_ip_ownership_contractor",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 250.89,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_khidi_webcapacity_vs_responsetime_requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 180.232,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_khidi_penalty_clause_ip_violation",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 335.06,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_gumi2025_registration_access_control_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 396.666,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6713860725233041
+      },
+      {
+        "qid": "real_gumi2025_response_time_concurrent_users_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 134.158,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_koreaexim_its_pm_evaluation_scoring_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 161.398,
+        "chunk_recall@5": 0.17647058823529413,
+        "chunk_recall@10": 0.23529411764705882,
+        "mrr": 1.0,
+        "ndcg@10": 0.5423640154200349
+      },
+      {
+        "qid": "real_koreaexim_its_local_tax_subcontract_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 138.618,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 109.893,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.2,
+        "ndcg@10": 0.13120507751234178
+      },
+      {
+        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 274.059,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국립민속박물관_security_contract_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 200.073,
+        "chunk_recall@5": 0.4444444444444444,
+        "chunk_recall@10": 0.4444444444444444,
+        "mrr": 1.0,
+        "ndcg@10": 0.591793585310856
+      },
+      {
+        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 204.537,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NRF_security_education_frequency_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 233.313,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.46927872602275644
+      },
+      {
+        "qid": "real_NRF_IP_ownership_contractor_usage_condition",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 112.346,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 173.325,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.07142857142857142,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 262.176,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 558.444,
+        "chunk_recall@5": 0.14285714285714285,
+        "chunk_recall@10": 0.14285714285714285,
+        "mrr": 1.0,
+        "ndcg@10": 0.27487633291429087
+      },
+      {
+        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1476.493,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_광주연구원_security_password_vs_access_control",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 84.565,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.3,
+        "mrr": 1.0,
+        "ndcg@10": 0.40350157154648025
+      },
+      {
+        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 302.823,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_haja_bojeung_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 169.065,
+        "chunk_recall@5": 0.6666666666666666,
+        "chunk_recall@10": 0.8333333333333334,
+        "mrr": 1.0,
+        "ndcg@10": 0.8760157235037966
+      },
+      {
+        "qid": "real_GIST_rcms_security_vendor_year",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 148.917,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_chosun_security_penalty_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 181.969,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_chosun_remote_maintenance_approval_criteria",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 290.866,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 121.526,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.5,
+        "ndcg@10": 0.6934264036172708
+      },
+      {
+        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 291.503,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_IBS_cryogenic_responsibility_boundary",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 350.15,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.625,
+        "mrr": 1.0,
+        "ndcg@10": 0.7277341624565861
+      },
+      {
+        "qid": "real_IBS_cryogenic_penalty_formula",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 231.105,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_aT_multiHop_security_audit_timing",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 32,
+        "latency_ms": 140.219,
+        "chunk_recall@5": 0.125,
+        "chunk_recall@10": 0.25,
+        "mrr": 1.0,
+        "ndcg@10": 0.8512360941594274
+      },
+      {
+        "qid": "real_aT_noAnswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 247.816,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 400.876,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.7456919575934261
+      },
+      {
+        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 151.257,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_eulji_haja_period_conflict",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy",
+          "multi_hop"
+        ],
+        "gold_chunk_n": 17,
+        "latency_ms": 440.201,
+        "chunk_recall@5": 0.058823529411764705,
+        "chunk_recall@10": 0.11764705882352941,
+        "mrr": 0.25,
+        "ndcg@10": 0.1681522864689108
+      },
+      {
+        "qid": "real_eulji_pm_replacement_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 1772.262,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 7,
+        "latency_ms": 118.029,
+        "chunk_recall@5": 0.42857142857142855,
+        "chunk_recall@10": 0.5714285714285714,
+        "mrr": 0.5,
+        "ndcg@10": 0.5087056958335152
+      },
+      {
+        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 457.07,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "query_type": "single_doc",
+        "categories": [
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 245.055,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5205067333228022
+      },
+      {
+        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 516.747,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kevinlab_interface_requirement_vs_functional_overlap",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 9,
+        "latency_ms": 251.183,
+        "chunk_recall@5": 0.2222222222222222,
+        "chunk_recall@10": 0.2222222222222222,
+        "mrr": 1.0,
+        "ndcg@10": 0.35256832412172806
+      },
+      {
+        "qid": "real_kevinlab_ip_ownership_penalty_clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 215.405,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_GIST_defect_warranty_vs_advance_payment",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 143,
+        "latency_ms": 347.778,
+        "chunk_recall@5": 0.027972027972027972,
+        "chunk_recall@10": 0.055944055944055944,
+        "mrr": 1.0,
+        "ndcg@10": 0.7917063341896681
+      },
+      {
+        "qid": "real_GIST_project_duration_basis",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 112.843,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KIRIA_multihop_eval_exclusion_threshold",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 231.742,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.7757386182436072
+      },
+      {
+        "qid": "real_KIRIA_noanswer_security_penalty_grade_amount",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 355.787,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 35,
+        "latency_ms": 135.488,
+        "chunk_recall@5": 0.05714285714285714,
+        "chunk_recall@10": 0.11428571428571428,
+        "mrr": 1.0,
+        "ndcg@10": 0.4959389204699464
+      },
+      {
+        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 360.636,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_BioIN_webcapacity_vs_responsetime_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 136.079,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_BioIN_security_penalty_clause_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 308.999,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KOICA_multihop_budget_year_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 493.347,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.5
+      },
+      {
+        "qid": "real_KOICA_noanswer_pmc_contractor_name",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 285.063,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 22,
+        "latency_ms": 227.812,
+        "chunk_recall@5": 0.09090909090909091,
+        "chunk_recall@10": 0.13636363636363635,
+        "mrr": 1.0,
+        "ndcg@10": 0.3995688713838975
+      },
+      {
+        "qid": "real_KESCO_통신서버_SLA기준",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 444.695,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 111.109,
+        "chunk_recall@5": 0.75,
+        "chunk_recall@10": 0.75,
+        "mrr": 1.0,
+        "ndcg@10": 0.8318724637288826
+      },
+      {
+        "qid": "real_충북연구원_penalty_grade_threshold",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 376.463,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KRC_PMC_multihop_evaluation_score",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 169,
+        "latency_ms": 189.097,
+        "chunk_recall@5": 0.029585798816568046,
+        "chunk_recall@10": 0.05917159763313609,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_KRC_PMC_noanswer_consortium_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 281.904,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_isp_multihop_pm_qualification",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 24,
+        "latency_ms": 387.169,
+        "chunk_recall@5": 0.20833333333333334,
+        "chunk_recall@10": 0.2916666666666667,
+        "mrr": 1.0,
+        "ndcg@10": 0.7967610662472993
+      },
+      {
+        "qid": "real_incheon_isp_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 711.245,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_ADD_security_compliance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 147.193,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.16666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.30260241349881345
+      },
+      {
+        "qid": "real_ADD_manual_ui_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 536.044,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 678.283,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.644824486427155
+      },
+      {
+        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 200.15,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_incheon_donggu_beacon_zonning_vs_db_standard",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 213.616,
+        "chunk_recall@5": 0.16666666666666666,
+        "chunk_recall@10": 0.3333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.4103915680233244
+      },
+      {
+        "qid": "real_incheon_donggu_cloud_private_vendor_sla",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 527.472,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_KSSA_multihop_evaluation_scoring",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 12,
+        "latency_ms": 313.537,
+        "chunk_recall@5": 0.08333333333333333,
+        "chunk_recall@10": 0.08333333333333333,
+        "mrr": 1.0,
+        "ndcg@10": 0.22009176629808017
+      },
+      {
+        "qid": "real_KSSA_noans_local_counterpart_budget",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 514.191,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 14,
+        "latency_ms": 241.872,
+        "chunk_recall@5": 0.21428571428571427,
+        "chunk_recall@10": 0.35714285714285715,
+        "mrr": 1.0,
+        "ndcg@10": 0.5983950669742499
+      },
+      {
+        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 475.561,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 11,
+        "latency_ms": 346.738,
+        "chunk_recall@5": 0.18181818181818182,
+        "chunk_recall@10": 0.36363636363636365,
+        "mrr": 0.5,
+        "ndcg@10": 0.3845937724137609
+      },
+      {
+        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 181.292,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 113.747,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 235.494,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_NTIS_security_penalty_calculation",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 5,
+        "latency_ms": 260.953,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 0.25,
+        "ndcg@10": 0.14606834984270645
+      },
+      {
+        "qid": "real_NTIS_sw_quality_test_scope",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 258.652,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 151.519,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 283.581,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 1,
+        "latency_ms": 219.108,
+        "chunk_recall@5": 1.0,
+        "chunk_recall@10": 1.0,
+        "mrr": 1.0,
+        "ndcg@10": 1.0
+      },
+      {
+        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 138.627,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 16,
+        "latency_ms": 214.857,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.125,
+        "mrr": 0.14285714285714285,
+        "ndcg@10": 0.13698471029831175
+      },
+      {
+        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 300.793,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 13,
+        "latency_ms": 580.944,
+        "chunk_recall@5": 0.15384615384615385,
+        "chunk_recall@10": 0.23076923076923078,
+        "mrr": 0.3333333333333333,
+        "ndcg@10": 0.2781981696179509
+      },
+      {
+        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 495.716,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 3,
+        "latency_ms": 231.532,
+        "chunk_recall@5": 0.3333333333333333,
+        "chunk_recall@10": 0.6666666666666666,
+        "mrr": 1.0,
+        "ndcg@10": 0.6049306994552042
+      },
+      {
+        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 731.82,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kogas_erp_hana_infra_server_spec_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 6,
+        "latency_ms": 341.819,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6238470455881188
+      },
+      {
+        "qid": "real_kogas_erp_warranty_penalty_no_answer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 295.006,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 125.714,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.5294362295028773
+      },
+      {
+        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "long_context"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 349.864,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_cms_security_penalty_grade",
+        "query_type": "single_doc",
+        "categories": [
+          "long_context",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 4,
+        "latency_ms": 178.445,
+        "chunk_recall@5": 0.0,
+        "chunk_recall@10": 0.0,
+        "mrr": 0.09090909090909091,
+        "ndcg@10": 0.0
+      },
+      {
+        "qid": "real_kwater_cms_cts_external_access",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "ambiguous_query"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 517.993,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_kwater_iwater-hmi-sites-crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "long_context"
+        ],
+        "gold_chunk_n": 2,
+        "latency_ms": 147.78,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.5,
+        "mrr": 1.0,
+        "ndcg@10": 0.6131471927654584
+      },
+      {
+        "qid": "real_kwater_sourcecode-security-contradiction",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 623.646,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 119.508,
+        "chunk_recall@5": 0.1,
+        "chunk_recall@10": 0.4,
+        "mrr": 1.0,
+        "ndcg@10": 0.42333070005078094
+      },
+      {
+        "qid": "real_한국수자원공사_yongji-abstention",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 412.152,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_multi_hop_safety_analysis_scope",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 413.893,
+        "chunk_recall@5": 0.5,
+        "chunk_recall@10": 0.625,
+        "mrr": 1.0,
+        "ndcg@10": 0.7129980666289261
+      },
+      {
+        "qid": "real_korail_no_answer_defect_penalty_rate",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 280.744,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_network-dualization-cc-cert-requirement",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop"
+        ],
+        "gold_chunk_n": 8,
+        "latency_ms": 299.946,
+        "chunk_recall@5": 0.25,
+        "chunk_recall@10": 0.375,
+        "mrr": 1.0,
+        "ndcg@10": 0.5026317885449211
+      },
+      {
+        "qid": "real_korail_slowquery-tuning-penalty-clause",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 640.062,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_korail_산출물_보안준수_crossref",
+        "query_type": "single_doc",
+        "categories": [
+          "multi_hop",
+          "distractor_heavy"
+        ],
+        "gold_chunk_n": 10,
+        "latency_ms": 115.642,
+        "chunk_recall@5": 0.2,
+        "chunk_recall@10": 0.2,
+        "mrr": 1.0,
+        "ndcg@10": 0.30523488393970116
+      },
+      {
+        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "query_type": "abstention",
+        "categories": [
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 309.895,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      },
+      {
+        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "query_type": "abstention",
+        "categories": [
+          "multi_hop",
+          "no_answer"
+        ],
+        "gold_chunk_n": 0,
+        "latency_ms": 366.896,
+        "chunk_recall@5": null,
+        "chunk_recall@10": null,
+        "mrr": null,
+        "ndcg@10": null
+      }
+    ],
+    "latency_ms": {
+      "p50": 235.494,
+      "p95": 659.241,
+      "mean": 330.529,
+      "n": 221
+    }
+  }
+}

--- a/scripts/phase4_metadata_ablation.py
+++ b/scripts/phase4_metadata_ablation.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""Phase 4 retrieval-eval — metadata / filtering ablation on real100.
+
+Runs 4 metadata-handling variants against the same ``data/index/real100``
+index (no reindexing) and computes paired bootstrap CI deltas vs the
+``no_metadata`` baseline per category:
+
+* ``no_metadata``       — dense + lexical only (``metadata_first=False``,
+  no candidate filter). Score = 0.70·dense + 0.30·lexical.
+* ``soft_agency``       — ``metadata_first=True`` with the oracle agency
+  injected into ``analysis['entities']``. Score = 0.60·dense + 0.25·lexical
+  + 0.15·metadata, where ``metadata_similarity`` returns 1.0 for chunks
+  whose ``agency`` matches the oracle. Soft boost, full candidate pool.
+* ``prefilter_agency``  — hard candidate pre-filter by oracle agency
+  (``metadata_filters={"agencies": [oracle]}``). Same dense+lexical
+  scoring as the baseline; only the candidate pool changes.
+* ``prefilter_project`` — hard candidate pre-filter by oracle project
+  (``metadata_filters={"projects": [oracle]}``). Tighter than agency
+  (one project ≈ one doc), so this is close to the recall ceiling.
+
+The oracle agency / project come from the answerable case's
+``expected_doc_ids[0]`` looked up in the index's document metadata. This
+is a **ceiling measurement** ("if the metadata signal were perfect, how
+much does recall move?") — not a realistic query-time NER. Abstention
+cases (no ``expected_doc_ids``) get no oracle, so every variant collapses
+to the baseline for them; ``chunk_recall@k`` is None for those cases and
+they drop pairwise, which restricts the measured effect to answerable
+("metadata-applicable") cases as the protocol requires.
+
+All variants use ``retrieval_backend="dense"`` and ``rerank=True`` (the
+flag that selects the score-fusion formula in ``retrieve_candidates`` —
+NOT ``rerank_cross_encoder``, which stays off). Phase 3 used
+``rerank=False``, which short-circuits to ``score=dense_score`` and never
+exercises the ``metadata_first`` branch — Phase 4 must enable it to
+measure the metadata signal at all.
+
+Output lives under ``reports/retrieval/phase4_metadata_<TIMESTAMP>/``:
+
+* ``metadata_specs.json`` — variant metadata
+* ``raw_results.json``    — per-case scores for all 4 variants
+* ``deltas.json``         — paired CI vs no_metadata per (variant, metric, category)
+* ``REPORT.md``           — <=200 line markdown with per-category winner or
+  ``NOT SIGNIFICANT`` (CI crosses 0) per absolute rule #5
+
+Reuses (no new abstraction — absolute rule #3):
+
+* ``rag_retrieval.{retrieve_candidates, apply_fusion_and_reranking}``
+* ``rag_indexing.load_index``
+* ``eval.scorers.chunk_metrics.{derive_gold_chunk_ids, chunk_recall_at_k,
+  chunk_mrr, chunk_ndcg_at_k}``
+* ``scripts._ablation_common`` — paired CI aggregation + report formatting
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from eval.scorers.chunk_metrics import (  # noqa: E402
+    chunk_mrr,
+    chunk_ndcg_at_k,
+    chunk_recall_at_k,
+    derive_gold_chunk_ids,
+)
+from rag_indexing import load_index  # noqa: E402
+from rag_retrieval import apply_fusion_and_reranking, retrieve_candidates  # noqa: E402
+from rag_text_processing import tokenize  # noqa: E402
+from scripts._ablation_common import (  # noqa: E402
+    _fmt_ci,
+    _fmt_mean,
+    categories_from_case,
+    compute_deltas,
+)
+
+
+@dataclass(frozen=True)
+class VariantSpec:
+    name: str
+    metadata_first: bool      # selects the score-fusion formula
+    prefilter: str            # "none" | "agency" | "project"
+    inject_entities: bool     # put oracle agency into analysis['entities']
+    index_dir: Path           # all 4 variants share the same dir
+
+
+def _oracle_agency_project(
+    case: dict[str, Any], doc_meta: dict[str, dict[str, Any]]
+) -> tuple[str | None, str | None]:
+    """Oracle (agency, project) from the answerable case's first
+    ``expected_doc_ids`` looked up in document metadata. Returns
+    ``(None, None)`` when the case has no expected doc (abstention) or
+    the doc is absent from the index.
+    """
+    eids = case.get("expected_doc_ids") or []
+    if not eids:
+        return None, None
+    doc = doc_meta.get(str(eids[0]))
+    if doc is None:
+        return None, None
+    agency = doc.get("agency") or None
+    project = doc.get("project") or None
+    return agency, project
+
+
+def _plan_for_variant(
+    spec: VariantSpec,
+    oracle_agency: str | None,
+    oracle_project: str | None,
+    top_k: int,
+) -> dict[str, Any]:
+    """Build a plan exercising exactly this variant's metadata handling.
+    ``retrieval_backend='dense'`` + ``rerank=True`` are held flat so the
+    only thing that moves is the metadata filter / fusion. ``rerank``
+    here selects the fusion formula; ``rerank_cross_encoder`` is never
+    set, so the cross-encoder stage stays off.
+    """
+    metadata_filters: dict[str, Any] = {}
+    if spec.prefilter == "agency" and oracle_agency:
+        metadata_filters = {"agencies": [oracle_agency]}
+    elif spec.prefilter == "project" and oracle_project:
+        metadata_filters = {"projects": [oracle_project]}
+    return {
+        "retrieval_backend": "dense",
+        "metadata_filters": metadata_filters,
+        "metadata_first": spec.metadata_first,
+        "rerank": True,
+        "query_expansion": "identity",
+        "bm25_stopword_profile": "shared",
+        "bm25_tokenizer": "regex",
+        "top_k": top_k,
+    }
+
+
+def _analysis_stub(
+    query: str, spec: VariantSpec, oracle_agency: str | None
+) -> dict[str, Any]:
+    entities: list[str] = []
+    if spec.inject_entities and oracle_agency:
+        entities = [oracle_agency]
+    return {
+        "query_type": "single_doc",
+        "tokens": list(tokenize(query)),
+        "topics": [],
+        "entities": entities,
+        "metadata_filters_by_stage": {"strict": {}, "reduced": {}, "relaxed": {}},
+    }
+
+
+def run_single_case(
+    index: dict[str, Any],
+    case: dict[str, Any],
+    spec: VariantSpec,
+    top_k: int,
+    doc_meta: dict[str, dict[str, Any]],
+) -> tuple[list[str], float]:
+    query = str(case.get("query") or "")
+    oracle_agency, oracle_project = _oracle_agency_project(case, doc_meta)
+    analysis = _analysis_stub(query, spec, oracle_agency)
+    plan = _plan_for_variant(spec, oracle_agency, oracle_project, top_k)
+    t0 = time.perf_counter()
+    candidates = retrieve_candidates(index, query, analysis, plan)
+    final = apply_fusion_and_reranking(candidates, index, query, analysis, plan)
+    latency_ms = (time.perf_counter() - t0) * 1000.0
+    return [str(c["chunk_id"]) for c in final[:top_k]], latency_ms
+
+
+def measure_variant(
+    spec: VariantSpec,
+    index: dict[str, Any],
+    cases: list[dict[str, Any]],
+    top_k: int,
+    ks: list[int],
+    warmup_n: int,
+    doc_meta: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Run ``cases`` through ``index`` for ``spec`` and return per-case +
+    aggregate scores. Per-case rows preserve list order so paired CI in
+    ``compute_deltas`` aligns across variants.
+    """
+    print(f"[measure] {spec.name}: {len(cases)} cases (warmup {warmup_n})", flush=True)
+    for case in cases[:warmup_n]:
+        run_single_case(index, case, spec, top_k, doc_meta)
+
+    per_case_rows: list[dict[str, Any]] = []
+    latency_vals: list[float] = []
+    for idx, case in enumerate(cases, 1):
+        qid = case.get("id") or case.get("qid") or f"?#{idx}"
+        qt = case.get("query_type") or "unknown"
+        gold_chunk_ids = derive_gold_chunk_ids(case, index)
+        retrieved_chunk_ids, latency_ms = run_single_case(
+            index, case, spec, top_k, doc_meta
+        )
+        latency_vals.append(latency_ms)
+        row: dict[str, Any] = {
+            "qid": qid,
+            "query_type": qt,
+            "categories": categories_from_case(case),
+            "gold_chunk_n": len(gold_chunk_ids),
+            "latency_ms": round(latency_ms, 3),
+        }
+        for k in ks:
+            row[f"chunk_recall@{k}"] = chunk_recall_at_k(
+                retrieved_chunk_ids, gold_chunk_ids, k
+            )
+        row["mrr"] = chunk_mrr(retrieved_chunk_ids, gold_chunk_ids)
+        row["ndcg@10"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_chunk_ids, 10)
+        per_case_rows.append(row)
+        if idx % 50 == 0:
+            print(f"[measure] {spec.name}: {idx}/{len(cases)}", flush=True)
+
+    return {
+        "variant": spec.name,
+        "per_case": per_case_rows,
+        "latency_ms": {
+            "p50": round(statistics.median(latency_vals), 3) if latency_vals else None,
+            "p95": (
+                round(statistics.quantiles(latency_vals, n=20)[-1], 3)
+                if len(latency_vals) > 1
+                else (round(latency_vals[0], 3) if latency_vals else None)
+            ),
+            "mean": round(statistics.mean(latency_vals), 3) if latency_vals else None,
+            "n": len(latency_vals),
+        },
+    }
+
+
+def render_report(
+    out_dir: Path,
+    specs: list[dict[str, Any]],
+    measurements: dict[str, dict[str, Any]],
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]],
+    config: dict[str, Any],
+) -> None:
+    """Write REPORT.md (<=200 lines). ``deltas`` shape:
+    ``{other_name: {metric: {category: ci}}}``.
+    """
+    baseline = config["baseline"]
+    lines: list[str] = []
+    lines.append(
+        f"# Phase 4 retrieval-eval — 메타데이터 / 필터링 ablation "
+        f"(real100 n={config['num_cases']})"
+    )
+    lines.append("")
+    lines.append(
+        f"Run: `{config['run_id']}` · commit `{config['git_commit'][:10]}` · "
+        f"index_dir=`{config['index_dir']}` · "
+        f"eval_config=`{config['eval_config']}` · "
+        f"seeds={config['seeds']} · top_k={config['top_k']} · ks={config['ks']}"
+    )
+    lines.append("")
+    lines.append("## 변형(variants)")
+    lines.append("")
+    lines.append("| 변형 | metadata_first | prefilter | oracle 엔티티 | 문서 | 청크 |")
+    lines.append("|---|---|---|---|---|---|")
+    for spec in specs:
+        lines.append(
+            f"| `{spec['name']}` | {spec['metadata_first']} | {spec['prefilter']} | "
+            f"{spec['inject_entities']} | {spec['num_documents']} | {spec['num_chunks']} |"
+        )
+    lines.append("")
+    lines.append("## 지연시간(latency, ms)")
+    lines.append("")
+    lines.append("| 변형 | p50 | p95 | mean | n |")
+    lines.append("|---|---|---|---|---|")
+    for variant_name in [s["name"] for s in specs]:
+        lat = measurements[variant_name]["latency_ms"]
+        lines.append(
+            f"| `{variant_name}` | {lat['p50']} | {lat['p95']} | {lat['mean']} | {lat['n']} |"
+        )
+    lines.append("")
+
+    metrics_to_report = ["chunk_recall@5", "chunk_recall@10", "mrr", "ndcg@10"]
+    categories = [
+        "overall",
+        "multi_hop",
+        "distractor_heavy",
+        "long_context",
+        "no_answer",
+        "ambiguous_query",
+        "uncategorized",
+    ]
+
+    for metric in metrics_to_report:
+        lines.append(f"## {metric}")
+        lines.append("")
+        header_cols = ["카테고리"] + [f"`{s['name']}`" for s in specs]
+        lines.append("| " + " | ".join(header_cols) + " |")
+        lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
+        for category in categories:
+            cells = [category]
+            for spec in specs:
+                cat_arg = None if category == "overall" else category
+                cells.append(
+                    _fmt_mean(measurements[spec["name"]]["per_case"], metric, cat_arg)
+                )
+            lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+        lines.append(f"### {metric} — `{baseline}` 대비 paired CI delta (seed 평균)")
+        lines.append("")
+        header_cols = ["카테고리"] + [
+            f"`{s['name']}`" for s in specs if s["name"] != baseline
+        ]
+        lines.append("| " + " | ".join(header_cols) + " |")
+        lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
+        for category in categories:
+            cells = [category]
+            for spec in specs:
+                if spec["name"] == baseline:
+                    continue
+                ci = deltas.get(spec["name"], {}).get(metric, {}).get(category)
+                cells.append(_fmt_ci(ci))
+            lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+
+    lines.append("## 카테고리별 winner")
+    lines.append("")
+    lines.append(
+        f"winner = `chunk_recall@10` 평균이 가장 높으면서 `{baseline}` 대비 paired CI "
+        f"가 완전히 0 위인 변형. \"NOT SIGNIFICANT\" = 어떤 변형의 CI 도 0 을 넘지 "
+        f"못함 (절대 규칙 #5)."
+    )
+    lines.append("")
+    lines.append("| 카테고리 | winner | 평균 recall@10 | " + f"`{baseline}` 대비 delta CI |")
+    lines.append("|---|---|---|---|")
+    for category in categories:
+        winner = "NOT SIGNIFICANT"
+        winner_mean: float | None = None
+        winner_ci: dict[str, Any] | None = None
+        for spec in specs:
+            if spec["name"] == baseline:
+                continue
+            ci = deltas.get(spec["name"], {}).get("chunk_recall@10", {}).get(category)
+            if ci is None:
+                continue
+            if ci["ci_lo"] > 0 and (winner_mean is None or ci["mean_other"] > winner_mean):
+                winner = spec["name"]
+                winner_mean = ci["mean_other"]
+                winner_ci = ci
+        mean_str = f"{winner_mean:.3f}" if winner_mean is not None else "—"
+        ci_str = _fmt_ci(winner_ci) if winner_ci is not None else "—"
+        lines.append(f"| {category} | `{winner}` | {mean_str} | {ci_str} |")
+    lines.append("")
+    lines.append("## 비고(notes)")
+    lines.append("")
+    lines.append(
+        "* **Oracle ceiling, realistic NER 아님**: agency / project 는 answerable "
+        "케이스의 `expected_doc_ids[0]` 를 인덱스 문서 메타데이터에서 조회해 얻는다. "
+        "이는 \"메타데이터 신호가 완벽하다면 recall 이 얼마나 움직이는가?\" 의 "
+        "상한(upper bound)을 측정한다. 현실의 query-time agency 추출기는 이 "
+        "ceiling 아래에 위치한다 (follow-up)."
+    )
+    lines.append(
+        "* **Abstention(보류) 케이스는 oracle 이 없다** (`expected_doc_ids` 없음). "
+        "따라서 모든 변형이 baseline 으로 수렴하고 `chunk_recall@k` 가 None → "
+        "pairwise 에서 제외된다. 측정된 효과는 Phase 4 프로토콜 요구대로 "
+        "answerable(메타데이터 적용 가능) 케이스에 한정된다."
+    )
+    lines.append(
+        "* **`rerank=True` 필수**: `retrieve_candidates` 의 score-fusion 공식은 "
+        "`rerank` 가 truthy 일 때만 `metadata_first` 분기에 도달한다 (`rerank=False` "
+        "는 `score=dense_score` 로 단락된다). Phase 3 은 `rerank=False` 라 "
+        "`metadata_first` 플래그가 무력했다. 여기서 `rerank_cross_encoder` 는 "
+        "설정하지 않으므로 cross-encoder 단계는 꺼진 채 — `rerank` 는 "
+        "dense+lexical(+metadata) 혼합만 선택한다."
+    )
+    lines.append(
+        "* **점수 공식(scoring formulas)**: `no_metadata` / `prefilter_*` = "
+        "0.70·dense + 0.30·lexical; `soft_agency` = 0.60·dense + 0.25·lexical + "
+        "0.15·metadata, 여기서 `metadata_similarity` 는 `agency` 가 oracle 엔티티와 "
+        "일치하는 청크에 1.0 을 반환한다. `prefilter_*` 는 baseline 공식을 유지하되 "
+        "점수 계산 전에 후보 풀(candidate pool)을 hard filter 로 축소한다."
+    )
+    corpus_chunks = specs[0].get("num_chunks", 0) if specs else 0
+    if corpus_chunks and corpus_chunks < 5000:
+        lines.append(
+            f"* **csv_text 코퍼스 caveat**: `{config['index_dir']}` 는 "
+            f"`data_list_csv_text` fallback 빌드({corpus_chunks} 청크)이며 kordoc "
+            "전체 코퍼스 추출(~26k 청크)이 아니다. 변형들이 같은 코퍼스를 공유하므로 "
+            "paired CI delta 는 편향 없으나, 절대 recall 수치는 kordoc 코퍼스 "
+            "phase 들과 비교 불가다."
+        )
+    else:
+        lines.append(
+            f"* **kordoc 코퍼스**: `{config['index_dir']}` 는 kordoc 전체 코퍼스 "
+            f"추출({corpus_chunks} 청크)로, Phase 2 / Phase 3 이 쓴 코퍼스와 "
+            "동일하다. 절대 recall 수치는 kordoc 코퍼스 phase 들 간 비교 가능하다. "
+            "n=221 케이스 중 114 개가 gold-derivable(answerable 이며 "
+            "`expected_terms` 가 청크와 매칭); abstention + 미매칭 케이스는 "
+            "pairwise 에서 제외된다 (overall n=114)."
+        )
+    lines.append(
+        "* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, "
+        "cross-encoder rerank 없음 — 메타데이터 효과를 expansion / cross-encoder "
+        "효과로부터 격리한다."
+    )
+    lines.append(
+        "* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 query + index + "
+        "plan 에 대해 결정적(deterministic)이다."
+    )
+    lines.append(
+        "* 카테고리 버킷팅은 `hardcase_categories` 를 쓴다. 멀티태그 케이스는 여러 "
+        "버킷에 나타나므로 카테고리별 카운트는 겹치고 케이스를 공유한다."
+    )
+    lines.append(
+        "* **Recall-↑ query 패턴 (Phase 4 프로토콜 step 3)**: agency / project 가 "
+        "expected doc 에 매핑되는 모든 answerable query 는 oracle 메타데이터 신호로 "
+        "recall@10 +0.21~0.22, MRR +0.40~0.44, ndcg@10 +0.30~0.32 (모두 SIG) 를 "
+        "얻는다. 지배적인 `multi_hop` cohort(n=93)가 가장 큰 lift(recall@10 "
+        "+0.23~0.24, MRR +0.44~0.48)를 본다. Abstention query 는 아무것도 얻지 "
+        "못한다 — 메타데이터는 타깃 doc 이 존재하는 곳에서만 정확히 돕는다."
+    )
+    lines.append(
+        "* **지연시간 Pareto**: hard pre-filter 는 점수 계산 전 후보 풀을 26k "
+        "청크에서 1 개 doc / agency 로 축소해, p50 을 3892ms(`no_metadata`)에서 "
+        "253ms(`prefilter_agency`, ~15배)로 줄이면서 recall 은 동등하거나 더 높다 "
+        "— Pareto-dominant. `soft_agency` 는 전체 풀을 유지하므로 더 싼 top-1 "
+        "fusion 경로로 p50 지연시간을 절반(1576ms)만 줄인다."
+    )
+    lines.append(
+        "* **쿼리 ↔ 메타데이터 coverage**: 위 oracle ceiling 은 counterfactual"
+        "(모든 query 에 gold 메타데이터 주입)이다. query 에서 실제 도출 가능한 "
+        "메타데이터로 bound 한 현실 ceiling 분석(query 의미 분류: "
+        "metadata-identifiable / content-query / underspecified)은 `COVERAGE.md` "
+        "참조 — 재현: `scripts/phase4_query_metadata_coverage.py`."
+    )
+    if config.get("reaggregate_source"):
+        lines.append(
+            "* 이 리포트는 `--reaggregate` 로 "
+            f"`{config['reaggregate_source']}` 로부터 재생성됨 — 카테고리는 "
+            "`hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval "
+            "점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변."
+        )
+
+    report_path = out_dir / "REPORT.md"
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[report] wrote {report_path} ({len(lines)} lines)", flush=True)
+
+
+def _git_state() -> tuple[str, bool]:
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        dirty = bool(
+            subprocess.check_output(["git", "status", "--porcelain"], text=True).strip()
+        )
+        return commit, dirty
+    except Exception:
+        return "unknown", True
+
+
+def _resolve_specs(args: argparse.Namespace) -> list[VariantSpec]:
+    index_dir = Path(args.index_dir)
+    return [
+        VariantSpec("no_metadata", False, "none", False, index_dir),
+        VariantSpec("soft_agency", True, "none", True, index_dir),
+        VariantSpec("prefilter_agency", False, "agency", False, index_dir),
+        VariantSpec("prefilter_project", False, "project", False, index_dir),
+    ]
+
+
+def _spec_meta(spec: VariantSpec, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": spec.name,
+        "metadata_first": spec.metadata_first,
+        "prefilter": spec.prefilter,
+        "inject_entities": spec.inject_entities,
+        "index_dir": str(spec.index_dir),
+        "num_documents": len(payload.get("documents", [])),
+        "num_chunks": len(payload.get("chunks", [])),
+    }
+
+
+def _doc_meta_map(index: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(d.get("doc_id")): d for d in index.get("documents", [])}
+
+
+def _run_reaggregate(
+    args: argparse.Namespace,
+    out_dir: Path,
+    seeds: list[int],
+    ks: list[int],
+) -> int:
+    """Re-derive ``row['categories']`` from ``hardcase_categories`` and
+    regenerate deltas + REPORT.md without re-running retrieval.
+    """
+    raw_path = Path(args.reaggregate)
+    if not raw_path.exists():
+        print(f"[ERROR] --reaggregate path not found: {raw_path}", file=sys.stderr)
+        return 2
+    print(f"[reaggregate] loading {raw_path}", flush=True)
+    measurements = json.loads(raw_path.read_text(encoding="utf-8"))
+
+    cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
+    cases = cfg.get("cases", []) or []
+    cases_by_qid = {str(c.get("id")): c for c in cases}
+
+    for variant_name, m in measurements.items():
+        rows = m.get("per_case", []) or []
+        untagged = 0
+        for row in rows:
+            case = cases_by_qid.get(str(row.get("qid")))
+            tags = categories_from_case(case or {})
+            row["categories"] = tags
+            if tags == ["uncategorized"]:
+                untagged += 1
+        print(
+            f"[reaggregate] {variant_name}: {len(rows)} rows, {untagged} uncategorized",
+            flush=True,
+        )
+
+    specs_path = raw_path.parent / "metadata_specs.json"
+    if not specs_path.exists():
+        print(
+            f"[ERROR] metadata_specs.json not found beside raw: {specs_path}",
+            file=sys.stderr,
+        )
+        return 2
+    spec_metas = json.loads(specs_path.read_text(encoding="utf-8"))
+    (out_dir / "metadata_specs.json").write_text(
+        json.dumps(spec_metas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (out_dir / "raw_results.json").write_text(
+        json.dumps(measurements, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    print("[phase] deltas (reaggregate)", flush=True)
+    metrics_to_delta = [f"chunk_recall@{k}" for k in ks] + ["mrr", "ndcg@10"]
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]] = {}
+    baseline = args.baseline
+    baseline_rows = measurements[baseline]["per_case"]
+    for variant_name in measurements:
+        if variant_name == baseline:
+            continue
+        deltas[variant_name] = {
+            metric: compute_deltas(
+                baseline_rows, measurements[variant_name]["per_case"], metric, seeds
+            )
+            for metric in metrics_to_delta
+        }
+    (out_dir / "deltas.json").write_text(
+        json.dumps(deltas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    git_commit, git_dirty = _git_state()
+    run_id = (
+        datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")
+        + "-phase4-metadata-reaggregate"
+    )
+    baseline_spec = next(
+        (s for s in spec_metas if s.get("name") == baseline),
+        {"index_dir": "unknown"},
+    )
+    config = {
+        "run_id": run_id,
+        "git_commit": git_commit,
+        "git_dirty": git_dirty,
+        "index_dir": baseline_spec.get("index_dir", "unknown"),
+        "eval_config": args.eval_config,
+        "seeds": seeds,
+        "top_k": args.top_k,
+        "ks": ks,
+        "num_cases": len(baseline_rows),
+        "baseline": baseline,
+        "reaggregate_source": str(raw_path),
+    }
+    print("[phase] render (reaggregate)", flush=True)
+    render_report(out_dir, spec_metas, measurements, deltas, config)
+    print(f"[done] output_dir={out_dir}", flush=True)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--index_dir",
+        default="data/index/real100",
+        help="Shared index for all 4 variants (default: data/index/real100).",
+    )
+    parser.add_argument("--eval_config", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument(
+        "--reaggregate",
+        default=None,
+        help=(
+            "Path to an existing raw_results.json. Skips measurement, "
+            "re-derives row['categories'] from hardcase_categories in "
+            "--eval_config, and regenerates deltas + REPORT.md into "
+            "--output_dir. Companion metadata_specs.json must sit beside it."
+        ),
+    )
+    parser.add_argument("--seeds", default="17,23,29")
+    parser.add_argument("--top_k", type=int, default=20)
+    parser.add_argument("--ks", default="5,10")
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument(
+        "--cases_subset_n",
+        type=int,
+        default=None,
+        help="Truncate to first N cases (for pre-flight dry-runs).",
+    )
+    parser.add_argument(
+        "--baseline",
+        default="no_metadata",
+        choices=["no_metadata", "soft_agency", "prefilter_agency", "prefilter_project"],
+        help="Baseline variant for paired CI deltas (default: no_metadata).",
+    )
+    args = parser.parse_args(argv)
+
+    seeds = [int(x) for x in args.seeds.split(",")]
+    ks = [int(x) for x in args.ks.split(",")]
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.reaggregate:
+        return _run_reaggregate(args, out_dir, seeds, ks)
+
+    specs = _resolve_specs(args)
+
+    print("[phase] measure", flush=True)
+    cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
+    cases = cfg.get("cases", []) or []
+    if args.cases_subset_n is not None:
+        cases = cases[: args.cases_subset_n]
+        print(f"[measure] truncated to first {len(cases)} cases", flush=True)
+    print(f"[measure] {len(cases)} cases", flush=True)
+
+    print(f"[measure] loading shared index from {args.index_dir}", flush=True)
+    index = load_index(Path(args.index_dir))
+    doc_meta = _doc_meta_map(index)
+    spec_metas = [_spec_meta(spec, index) for spec in specs]
+    (out_dir / "metadata_specs.json").write_text(
+        json.dumps(spec_metas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    measurements: dict[str, dict[str, Any]] = {}
+    for spec in specs:
+        measurements[spec.name] = measure_variant(
+            spec, index, cases, args.top_k, ks, args.warmup, doc_meta
+        )
+
+    raw_path = out_dir / "raw_results.json"
+    raw_path.write_text(
+        json.dumps(measurements, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(f"[measure] wrote {raw_path}", flush=True)
+
+    print("[phase] deltas", flush=True)
+    metrics_to_delta = [f"chunk_recall@{k}" for k in ks] + ["mrr", "ndcg@10"]
+    deltas: dict[str, dict[str, dict[str, dict[str, Any] | None]]] = {}
+    baseline = args.baseline
+    baseline_rows = measurements[baseline]["per_case"]
+    for spec in specs:
+        if spec.name == baseline:
+            continue
+        deltas[spec.name] = {
+            metric: compute_deltas(
+                baseline_rows, measurements[spec.name]["per_case"], metric, seeds
+            )
+            for metric in metrics_to_delta
+        }
+    (out_dir / "deltas.json").write_text(
+        json.dumps(deltas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    git_commit, git_dirty = _git_state()
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M") + "-phase4-metadata"
+    config = {
+        "run_id": run_id,
+        "git_commit": git_commit,
+        "git_dirty": git_dirty,
+        "index_dir": str(specs[0].index_dir),
+        "eval_config": args.eval_config,
+        "seeds": seeds,
+        "top_k": args.top_k,
+        "ks": ks,
+        "num_cases": len(cases),
+        "baseline": baseline,
+    }
+
+    print("[phase] render", flush=True)
+    render_report(out_dir, spec_metas, measurements, deltas, config)
+    print(f"[done] output_dir={out_dir}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase4_query_metadata_coverage.py
+++ b/scripts/phase4_query_metadata_coverage.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Phase 4 query ↔ metadata coverage analysis.
+
+The Phase 4 metadata ablation measured an oracle ceiling (recall@10
++0.22 over no-metadata) by pre-filtering on the *gold* agency / project
+of each answerable case. But the oracle used metadata for ALL queries,
+including ones whose text never mentions an agency or project. Production
+retrieval only has the query text — this script measures how much of the
+oracle's signal is actually query-derivable, i.e. the realistic ceiling.
+
+It classifies the answerable cases into three semantic buckets:
+
+* **metadata-identifiable** — the gold agency or project shares a
+  character 4-gram with the query (whitespace-ignored, so Korean compound
+  nouns like "대학재정정보시스템" match even when token-split misses them).
+  Metadata routing can plausibly fire here.
+* **content-query** — no agency/project signal in the query, but gold
+  chunks exist (the query asks about content *inside* a project —
+  features, specs, requirements). Content matching reaches these; metadata
+  routing has nothing to filter on.
+* **underspecified** — no metadata signal AND no derivable gold (the
+  query is context-dependent or too vague for any retrieval to resolve).
+
+Why this matters for the ADR: the oracle ceiling is a counterfactual
+("if the query had stated the metadata"), not the realistic potential of
+metadata routing. The realistic ceiling is bounded by the
+metadata-identifiable fraction.
+
+Reuses ``eval.scorers.chunk_metrics.derive_gold_chunk_ids`` — no new deps
+(stdlib json/yaml/re/statistics only). Deterministic: same index +
+eval_config → byte-identical output.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from eval.scorers.chunk_metrics import derive_gold_chunk_ids  # noqa: E402
+from rag_indexing import load_index  # noqa: E402
+
+
+def _char_ngrams(text: str, n: int = 4) -> set[str]:
+    """Whitespace-ignored character n-grams. Korean compound nouns are
+    not whitespace-delimited, so token overlap under-counts; char n-grams
+    catch substring matches like query "대학재정정보시스템" ↔ project
+    "...대학재정정보시스템 고도화"."""
+    squashed = re.sub(r"\s+", "", text)
+    if len(squashed) < n:
+        return set()
+    return {squashed[i : i + n] for i in range(len(squashed) - n + 1)}
+
+
+def _metadata_signal(query: str, agency: str, project: str) -> bool:
+    """True if the gold agency or project shares a char-4gram with the
+    query — i.e. the query carries a metadata signal a router could use."""
+    q = _char_ngrams(query)
+    if not q:
+        return False
+    if agency and (q & _char_ngrams(agency)):
+        return True
+    if project and (q & _char_ngrams(project)):
+        return True
+    return False
+
+
+def analyze_coverage(
+    cases: list[dict[str, Any]], index: dict[str, Any]
+) -> dict[str, Any]:
+    """Classify answerable cases into metadata-identifiable / content-query
+    / underspecified and return aggregate stats + per-bucket counts."""
+    doc_meta = {str(d.get("doc_id")): d for d in index.get("documents", [])}
+    answerable = [
+        c
+        for c in cases
+        if c.get("answerable")
+        and (c.get("expected_doc_ids") or [""])[0] in doc_meta
+    ]
+
+    buckets: dict[str, list[dict[str, Any]]] = {
+        "metadata_identifiable": [],
+        "content_query": [],
+        "underspecified": [],
+    }
+    gold_sizes: dict[str, list[int]] = {k: [] for k in buckets}
+    query_type_by_bucket: dict[str, Counter] = {k: Counter() for k in buckets}
+
+    for case in answerable:
+        query = str(case.get("query") or "")
+        doc = doc_meta[str(case["expected_doc_ids"][0])]
+        agency = str(doc.get("agency") or "").strip()
+        project = str(doc.get("project") or "").strip()
+        gold = derive_gold_chunk_ids(case, index)
+        qt = str(case.get("query_type") or "unknown")
+
+        if _metadata_signal(query, agency, project):
+            bucket = "metadata_identifiable"
+        elif gold:
+            bucket = "content_query"
+        else:
+            bucket = "underspecified"
+        buckets[bucket].append(case)
+        gold_sizes[bucket].append(len(gold))
+        query_type_by_bucket[bucket][qt] += 1
+
+    n = len(answerable)
+
+    def _bucket_stats(name: str) -> dict[str, Any]:
+        cases_b = buckets[name]
+        sizes = gold_sizes[name]
+        nonzero = [s for s in sizes if s > 0]
+        return {
+            "n": len(cases_b),
+            "pct": round(100.0 * len(cases_b) / n, 1) if n else 0.0,
+            "gold_present": sum(1 for s in sizes if s > 0),
+            "gold_size_median": statistics.median(nonzero) if nonzero else 0,
+            "gold_size_mean": round(statistics.mean(nonzero), 1) if nonzero else 0.0,
+            "query_types": dict(query_type_by_bucket[name]),
+            "sample_queries": [
+                str(c.get("query") or "")[:70] for c in cases_b[:5]
+            ],
+        }
+
+    return {
+        "n_answerable": n,
+        "buckets": {name: _bucket_stats(name) for name in buckets},
+        "query_type_overall": dict(Counter(str(c.get("query_type")) for c in answerable)),
+    }
+
+
+def render_markdown(stats: dict[str, Any], config: dict[str, Any]) -> str:
+    n = stats["n_answerable"]
+    b = stats["buckets"]
+    lines: list[str] = []
+    lines.append("# Phase 4 — query ↔ metadata coverage 분석")
+    lines.append("")
+    lines.append(
+        f"index_dir=`{config['index_dir']}` · eval_config=`{config['eval_config']}` · "
+        f"commit `{config['git_commit'][:10]}` · n_answerable={n}"
+    )
+    lines.append("")
+    lines.append(
+        "Phase 4 oracle ceiling(모든 query 에 gold 메타데이터)과 현실 ceiling"
+        "(query 에서 도출 가능한 메타데이터만) 사이의 격차를 정량화한다. 버킷은 "
+        "상호 배타적이며, 우선순위는 metadata-identifiable → content-query → "
+        "underspecified 이다."
+    )
+    lines.append("")
+    lines.append("## query 의미 분류(semantic classes)")
+    lines.append("")
+    lines.append("| 분류 | n | % | gold 존재 | \\|gold\\| 중앙값 | \\|gold\\| 평균 |")
+    lines.append("|---|---|---|---|---|---|")
+    labels = {
+        "metadata_identifiable": "metadata-identifiable",
+        "content_query": "content-query",
+        "underspecified": "underspecified",
+    }
+    for key, label in labels.items():
+        s = b[key]
+        lines.append(
+            f"| {label} | {s['n']} | {s['pct']}% | "
+            f"{s['gold_present']}/{s['n']} | {s['gold_size_median']} | {s['gold_size_mean']} |"
+        )
+    lines.append("")
+    lines.append("## 해석(interpretation)")
+    lines.append("")
+    mi = b["metadata_identifiable"]
+    cq = b["content_query"]
+    us = b["underspecified"]
+    lines.append(
+        f"* **metadata-identifiable ({mi['pct']}%)**: gold agency/project 가 query "
+        "와 char-4gram 을 공유한다. 메타데이터 routing 이 현실적으로 작동할 수 있는 "
+        "cohort 이며 — 메타데이터 routing 의 현실 ceiling 은 oracle 의 전체 coverage "
+        "가 아니라 이 비율로 bound 된다."
+    )
+    lines.append(
+        f"* **content-query ({cq['pct']}%)**: agency/project 신호는 없지만 gold "
+        f"청크가 존재한다 ({cq['gold_present']}/{cq['n']} 에 gold 있음). 프로젝트 "
+        "*내부* 콘텐츠(기능/스펙/요구사항)를 묻는다. content matching 은 이들에 "
+        "도달하나, 메타데이터 routing 은 필터링할 대상이 없다. 여기서 gold 집합이 "
+        f"오히려 *더 크다*(중앙값 {cq['gold_size_median']} vs metadata-identifiable "
+        f"{mi['gold_size_median']}) — 콘텐츠 답변이 더 많은 청크에 걸친다."
+    )
+    lines.append(
+        f"* **underspecified ({us['pct']}%)**: 메타데이터 신호도 없고 도출 가능한 "
+        "gold 도 없다 — context-dependent(follow_up)이거나 어떤 retrieval 로도 "
+        "해결 못 할 만큼 모호하다. 미미하므로 숨은 retrieval-불가 ceiling 은 없다."
+    )
+    lines.append("")
+    lines.append(
+        "**Headline**: oracle ceiling(+0.22 recall@10)은 counterfactual 이다 — "
+        "메타데이터를 전혀 언급하지 않는 "
+        f"{cq['pct']}% 의 query 에도 gold 메타데이터를 썼다. 메타데이터 routing 은 "
+        f"~{mi['pct']}% metadata-identifiable cohort 로 bound 된 좁은 add-on 이며; "
+        "주된 retrieval lever 는 여전히 content matching(Phase 2 chunking + "
+        "Phase 3 ranking mode)이다."
+    )
+    lines.append("")
+    lines.append("## 방법(method)")
+    lines.append("")
+    lines.append(
+        "* 메타데이터 신호에 **char-4gram overlap**(공백 무시)을 쓴다. 한국어 "
+        "복합명사는 공백으로 구분되지 않아 토큰 overlap 이 과소 계산하기 때문이다"
+        "(예: \"대학재정정보시스템\")."
+    )
+    lines.append(
+        "* **gold** = `eval.scorers.chunk_metrics.derive_gold_chunk_ids` "
+        "(doc_id ∈ expected_doc_ids 이고 청크 텍스트가 expected_term 을 포함)."
+    )
+    lines.append(
+        "* 결정적(deterministic): 동일 index + eval_config → byte-identical 출력. "
+        "run 헤더의 1줄 CLI 로 재현."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _git_commit() -> str:
+    import subprocess
+
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
+    import yaml
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--index_dir", default="data/index/real100_kordoc")
+    parser.add_argument("--eval_config", required=True)
+    parser.add_argument(
+        "--output_dir",
+        required=True,
+        help="Writes coverage.json + COVERAGE.md here.",
+    )
+    args = parser.parse_args(argv)
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[coverage] loading index {args.index_dir}", flush=True)
+    index = load_index(Path(args.index_dir))
+    cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
+    cases = cfg.get("cases", []) or []
+
+    print(f"[coverage] analyzing {len(cases)} cases", flush=True)
+    stats = analyze_coverage(cases, index)
+
+    config = {
+        "index_dir": args.index_dir,
+        "eval_config": args.eval_config,
+        "git_commit": _git_commit(),
+    }
+    (out_dir / "coverage.json").write_text(
+        json.dumps({"config": config, "stats": stats}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    md = render_markdown(stats, config)
+    (out_dir / "COVERAGE.md").write_text(md, encoding="utf-8")
+    print(f"[coverage] wrote {out_dir}/coverage.json + COVERAGE.md", flush=True)
+    print("", flush=True)
+    print(md, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_phase4_query_metadata_coverage.py
+++ b/tests/test_phase4_query_metadata_coverage.py
@@ -1,0 +1,157 @@
+"""Unit tests for ``scripts/phase4_query_metadata_coverage`` — pin the
+load-bearing classification logic the ADR cites: (a) whitespace-ignored
+char n-grams, (b) the Korean-compound-noun metadata signal, and (c)
+bucket precedence + answerable-case filtering in ``analyze_coverage``.
+
+These are pure-stdlib (no index load, no FlagEmbedding) so they stay
+default-CI safe. The full n=221 run is exercised by the measurement
+itself (``COVERAGE.md`` byte-identical determinism check), not here.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.phase4_query_metadata_coverage import (  # noqa: E402
+    _char_ngrams,
+    _metadata_signal,
+    analyze_coverage,
+)
+
+
+class CharNgramsTest(unittest.TestCase):
+    def test_whitespace_ignored(self) -> None:
+        # Whitespace is squashed before windowing, so a space-split
+        # Korean phrase yields the same n-grams as its compound form.
+        self.assertEqual(_char_ngrams("대학 재정", n=4), _char_ngrams("대학재정", n=4))
+
+    def test_short_text_yields_empty_set(self) -> None:
+        # Fewer than n squashed chars → no n-gram (a 3-char agency like
+        # "조달청" cannot form a 4-gram, so it carries no signal).
+        self.assertEqual(_char_ngrams("조달청", n=4), set())
+        self.assertEqual(_char_ngrams("", n=4), set())
+
+    def test_expected_windows(self) -> None:
+        self.assertEqual(
+            _char_ngrams("재정정보시스템", n=4),
+            {"재정정보", "정정보시", "정보시스", "보시스템"},
+        )
+
+
+class MetadataSignalTest(unittest.TestCase):
+    def test_korean_compound_noun_match(self) -> None:
+        # The motivating case: token-split misses it, char-4gram catches
+        # the substring overlap between query and project.
+        self.assertTrue(
+            _metadata_signal(
+                query="대학재정정보시스템 고도화 예산은?",
+                agency="한국교육부",
+                project="2024년 대학재정정보시스템 고도화 용역",
+            )
+        )
+
+    def test_no_overlap_is_false(self) -> None:
+        self.assertFalse(
+            _metadata_signal(
+                query="보안 요구사항 정리해줘",
+                agency="조달청",
+                project="통합관리체계",
+            )
+        )
+
+    def test_empty_query_is_false(self) -> None:
+        self.assertFalse(_metadata_signal(query="", agency="한국대학교", project="재정"))
+
+
+class AnalyzeCoverageTest(unittest.TestCase):
+    def _index(self) -> dict:
+        return {
+            "documents": [
+                {"doc_id": "d1", "agency": "한국대학교정보원", "project": "재정시스템 고도화"},
+                {"doc_id": "d2", "agency": "조달청", "project": "통합관리체계"},
+                {"doc_id": "d3", "agency": "국세청", "project": "과세체계"},
+            ],
+            "chunks": [
+                {"doc_id": "d1", "chunk_id": "d1-c1", "text": "예산편성 내역 표"},
+                {"doc_id": "d2", "chunk_id": "d2-c1", "text": "보안 통제 항목"},
+                {"doc_id": "d3", "chunk_id": "d3-c1", "text": "일반 내용"},
+            ],
+        }
+
+    def _cases(self) -> list[dict]:
+        return [
+            # metadata-identifiable: query overlaps agency AND has gold →
+            # precedence puts it in metadata_identifiable, not content_query.
+            {
+                "query": "한국대학교정보원 예산 알려줘",
+                "answerable": True,
+                "expected_doc_ids": ["d1"],
+                "expected_terms": ["예산편성"],
+                "query_type": "single_doc",
+            },
+            # content-query: no agency/project overlap, gold exists.
+            {
+                "query": "보안 요구사항 정리해줘",
+                "answerable": True,
+                "expected_doc_ids": ["d2"],
+                "expected_terms": ["보안"],
+                "query_type": "single_doc",
+            },
+            # underspecified: no metadata overlap, no derivable gold
+            # (expected_term matches no chunk text).
+            {
+                "query": "그것도 포함돼?",
+                "answerable": True,
+                "expected_doc_ids": ["d3"],
+                "expected_terms": ["존재하지않는용어"],
+                "query_type": "follow_up",
+            },
+            # filtered: not answerable.
+            {
+                "query": "무엇이든",
+                "answerable": False,
+                "expected_doc_ids": ["d1"],
+                "expected_terms": ["예산편성"],
+                "query_type": "single_doc",
+            },
+            # filtered: expected doc not in index metadata.
+            {
+                "query": "유령 문서",
+                "answerable": True,
+                "expected_doc_ids": ["d_missing"],
+                "expected_terms": ["예산편성"],
+                "query_type": "single_doc",
+            },
+        ]
+
+    def test_bucket_precedence_and_filtering(self) -> None:
+        stats = analyze_coverage(self._cases(), self._index())
+        # Only the 3 answerable + resolvable cases count.
+        self.assertEqual(stats["n_answerable"], 3)
+        b = stats["buckets"]
+        self.assertEqual(b["metadata_identifiable"]["n"], 1)
+        self.assertEqual(b["content_query"]["n"], 1)
+        self.assertEqual(b["underspecified"]["n"], 1)
+        # content_query gold is present by definition; underspecified has none.
+        self.assertEqual(b["content_query"]["gold_present"], 1)
+        self.assertEqual(b["underspecified"]["gold_present"], 0)
+        # Buckets exhaustively partition the answerable set (mutually
+        # exclusive — the real invariant; per-bucket pct is rounded to
+        # 1 decimal so the displayed pcts need not sum to exactly 100).
+        self.assertEqual(sum(b[k]["n"] for k in b), stats["n_answerable"])
+
+    def test_metadata_identifiable_wins_over_gold(self) -> None:
+        # The metadata-identifiable case also HAS gold; precedence must
+        # route it to metadata_identifiable (the ADR's core claim that
+        # the bucket is a strict signal, not a residual).
+        stats = analyze_coverage(self._cases(), self._index())
+        self.assertEqual(stats["buckets"]["content_query"]["n"], 1)
+        self.assertEqual(stats["buckets"]["metadata_identifiable"]["gold_present"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1107

retrieval-eval 4-phase 프로토콜의 **Phase 4 (metadata / filtering ablation)**. real100 kordoc 26k 인덱스에서 oracle metadata 신호(gold agency/project)가 retrieval 에 미치는 효과를 4 variants × paired CI 95% (seed 17/23/29, planner-bypass) 로 측정한다. oracle ceiling 은 recall@10 **+0.21~0.22 SIG** (multi_hop +0.23~0.24), latency Pareto (hard pre-filter ~15x 빠르면서 recall 동등/우위) 로 크지만, 이는 **counterfactual** (모든 query 에 gold metadata 주입)이다. 이를 드러내기 위해 재현 가능한 `phase4_query_metadata_coverage.py` 로 answerable n=118 을 의미 분류했다: metadata-identifiable **33.9%** / content-query **65.3%** / underspecified **0.8%**. 결론 — 현실 metadata routing 의 ceiling 은 ~34% cohort 로 bound 되고, 나머지 66% 의 주된 lever 는 여전히 content matching (Phase 2 chunking + Phase 3 ranking).

## 2. 영향 파일

- `scripts/phase4_metadata_ablation.py` (신규) — 4-variant oracle 측정 runner. **load-bearing 아님** (scripts/ 중 build_index.py 만 load-bearing).
- `scripts/phase4_query_metadata_coverage.py` (신규) — query↔metadata coverage 분석. load-bearing 아님.
- `tests/test_phase4_query_metadata_coverage.py` (신규) — 8 unit tests.
- `.gitignore` — `phase4_metadata_*` aggregate allowlist + `data/index/real100_kordoc/` ignore.
- `reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/{REPORT.md, COVERAGE.md, coverage.json, deltas.json, metadata_specs.json, raw_results.json}` — 집계 산출물 (한국어 prose).

## 3. 리스크

신규 standalone 스크립트 + 신규 테스트 + 보고서만 추가. runtime 모듈(`rag_*`, `eval/scorers`, `ingestion`) **미변경**. 가장 가능성 높은 깨짐 = coverage 분류 로직 오류 → 8 unit test 가 char-4gram / 한국어 복합명사 signal / bucket precedence·answerable filtering 핀. 결정성 = `COVERAGE.md`/`coverage.json` byte-identical 재생성 확인. REPORT.md 의 coverage 포인터는 `render_report` 템플릿에 baked-in (숫자 없음) 이라 `--reaggregate` 에도 보존.

## 4. 테스트

- `tests/test_phase4_query_metadata_coverage.py` 8개 (신규 동작 검증): `_char_ngrams`(공백무시/짧은텍스트), `_metadata_signal`(한국어 복합명사 매칭/무overlap/빈query), `analyze_coverage`(bucket precedence + answerable filtering). 로컬 green.
- 전체 suite: 1990 passed. 로컬 macOS 에서 11 실패(harness E2E returncode-2 + M3 `atol=1e-5` 수치 드리프트)는 **이 PR 무관 + 로컬 환경 한정** — origin/main(db089db) 의 CI pytest 8 shard 전부 green 으로 확인. 신규/변경 파일은 해당 테스트를 import 하지 않음.

## 5. Eval 영향

All `·` — synthetic CI eval delta 없음. 신규 measurement 스크립트는 `eval/run_eval.py` 파이프라인과 독립 (`retrieve_candidates` planner-bypass 직접 호출, eval preset 미변경).

### 5b. Real-data delta

N/A — net-new scripts under `scripts/` (LOAD_BEARING_PATHS 아님); runtime 모듈 미변경. **No behavior change in retrieval / verifier path.** 측정 산출물(REPORT.md/COVERAGE.md, n=114/n=118)은 기존 `retrieve_candidates` 를 호출만 한다.

## 6. 하위 호환

계약/스키마/CLI flag/doc link 변경 없음. 신규 스크립트 + 보고서만 추가.

## 7. 범위 외

- **Phase 2/3/3.5 리포트 소급 한국어화** — 별도 follow-up PR (사용자 결정 B). 공유 helper `_ablation_common._fmt_ci` 의 `significant`/`NOT SIGNIFICANT` 토큰도 그 PR 에서 `유의함`/`유의하지 않음` 일괄 통일 (지금 바꾸면 다른 phase 리포트까지 영향).
- **ADR (Phase 4 metadata routing decision)** — 합의된 시퀀스 다음 단계.
- **dense metadata routing follow-up 측정** (realistic extractor, follow_up cohort 분리 + soft vs hard filter) — ADR 이후.
- `data/files`/`data/files_kordoc` 워크트리 symlink ignore 정합성 — main 에 규칙은 있으나 symlink 라 무효; 별도 task.