### PR TITLE
docs(self-review): pre-register prior for ADR 0064 openai_compatible run

### DIFF
--- a/docs/self-review/PRE-REGISTRATION-openai-anchor.md
+++ b/docs/self-review/PRE-REGISTRATION-openai-anchor.md
@@ -1,0 +1,58 @@
+# Pre-registration — ADR 0064 openai_compatible cross-rating run
+
+- Date: 2026-05-21
+- Author: Hyunsoo Kim
+- Related: ADR 0064 (self-review external-LLM cross-rating judge), PR #1087 (stub first-run), issue #1109
+- Status: locked **before** any `openai_compatible` run
+
+## Why pre-register
+
+ADR 0064 의 stub first-run 은 operator(Q2) 대비 raw 0/5 / κ −0.389 를 냈다. 이 숫자는 세 가설로 갈린다:
+
+- **(a) rubric underspecified** — 같은 SKILL.md 임계값의 두 충실한 구현이 갈린다 (operationalize 안 됨).
+- **(b) stats 시점 드리프트** — stub 과 operator 가 시점 다른 evidence 를 채점, 애초에 같은 걸 안 봤다 (confound).
+- **(c) operator self-grade inflation** — 자기채점이 부풀려졌고 mechanical 이 더 정직 (= 원 red-team 비판이 맞음).
+
+세 가설은 후속 액션이 완전히 다르다 (rubric 손봐라 / 타이밍 고쳐라 / 자기채점 폐기). `openai_compatible` 결과를 **받은 뒤** 어느 가설인지 고르면 자기참조로 회귀한다. 그래서 결과 도착 *전에* 예측과 판별 규칙을 여기 박는다 — 명시된 prior 에 데이터를 떨어뜨려야 falsifiable 하다.
+
+## 전제조건 (이게 먼저)
+
+(b) 가 살아있는 한 (a)·(c) 를 오염시켜 분리 불가다. 따라서 **시점정합이 해석가능성의 전제조건**이며, 순서 `시점정합 stats → openai_compatible run` 은 불변이다. 드리프트 안 고치고 진짜 LLM 을 돌리면 두 번째 해석불가 숫자가 하나 더 생길 뿐.
+
+- Q2 stats 는 복원 불가 (hook-fires.log·memory·git 이 그 사이 변함) → Q2 0/5 는 *교정 대상이 아니라 폐기 대상*.
+- 해석 가능한 첫 실행 = operator + stub + openai 를 **동일한 현재 스냅샷 하나**에 동시 채점.
+
+## 진단 비교 (무엇을 검정하나)
+
+**openai-vs-stub, 동일 현재 스냅샷.** operator 는 끼우지 않는다 — operator 는 timepoint + 정체성 confound 가 둘 다 붙어 진단력이 약하다. stub(결정론 rubric 구현) 과 openai(LLM rubric 구현) 는 *같은 임계값 prompt 의 두 충실한 구현*이라, 둘이 갈리면 confound 없이 "rubric 이 안 잠긴다" 만 남는다.
+
+## 예측 (점)
+
+κ(openai, stub) ∈ **0.3–0.6 (moderate)**. perfect 아님, 음수 아님.
+
+근거: 둘 다 같은 임계값 prompt → 날카로운 임계값 축(#3 fires>0 & ≥2 action, #4 numeric lag, #2 skip_rate band)은 수렴해야 정상. 모호/복합 축(#1 "Explore≥2 **AND** Read/session≤10" 의 AND + ratio 퍼지, #5 stub 이 5-B 만 구현)에서 갈릴 것.
+
+## 판별 규칙 (FROZEN — 사후 이동 금지)
+
+| κ(openai, stub) | 결론 | 후속 액션 |
+|---|---|---|
+| ≥ 0.7 | rubric operationalize 됨 → Q2 발산은 operator 고유 | **(c)** self-grade 가 outlier, mechanical 이 더 정직. 자기채점 신뢰성 재검토 |
+| ≤ 0.4 | 같은 스냅샷 두 충실한 구현도 못 수렴 | **(a)** rubric underspecified → 임계값 sharpen (자기채점 폐기까지는 아님) |
+| 0.4–0.6 | 축별 분해 | 날카로운 축 수렴 + 모호한 축 발산이면 (a) 가 특정 축에 국소화 |
+
+## (a)/(c) 사이 lean (weak prior)
+
+**(a) ~55% / (c) ~30% / mixed 15%.**
+
+이유 — Q2 operator-vs-stub 발산이 **양방향**이었다 (operator 가 #1·#2 엔 관대, #4·#5 엔 엄격). 순수 inflation (c) 면 **단방향**이어야 한다. 양방향·축별 idiosyncratic 은 underspecification (a) 의 지문. 단 #1·#2 개별로는 operator 가 약한 시그널에 관대 → (c) 냄새도 있어 (c) 를 0 으로 두지 않는다.
+
+**경고**: 이 lean 은 confound 된 Q2 데이터에서 뽑았으니 약하다 — 그래서 *prior* 지 결론이 아니다. fresh openai-vs-stub run (독립 데이터) 에 대고 떨어뜨려야 의미.
+
+## Lock
+
+데이터를 보고 위 임계값(0.4 / 0.7) 또는 lean 을 사후 이동하지 않는다. 이동이 필요하면 이 문서에 *추가 기록*으로 남기되, 원 prior 는 지우지 않는다.
+
+## 이 문서가 pre-register 하지 *않는* 것
+
+- 제시 순서 교정 (Q2-2026.json + ADR Verification 의 5행 매트릭스 head / κ 패밀리 각주 강등) — 별도 follow-up.
+- 시점정합 stats 수집 메커니즘 (collector `evidence_age_days` emit + same-snapshot 재채점) — 별도 follow-up, 단 위 전제조건상 openai run 보다 먼저.


### PR DESCRIPTION
## Summary

`openai_compatible` cross-rating(진짜 외부 LLM anchor) 실행 **전에** 예측·판별 규칙을 repo 에 timestamp 로 박는 pre-registration note 1개 추가. `docs/self-review/PRE-REGISTRATION-openai-anchor.md`.

## Why

ADR 0064 stub first-run 이 operator(Q2) 대비 raw 0/5 / κ −0.389 를 냈고, 이 숫자는 (a) rubric underspecified / (b) stats 시점 드리프트 / (c) operator self-grade inflation 세 가설로 갈린다 — 후속 액션이 완전히 다름. `openai_compatible` 결과를 **받은 뒤** 가설을 고르면 자기참조 회귀. prior 를 결과 전에 박아야 falsifiable.

핵심:
- 진단 비교 = openai-vs-stub 동일 현재 스냅샷 (operator·Q2 제외 = 시점 confound)
- 점 예측 κ ∈ 0.3–0.6, 판별 규칙 FROZEN (≥0.7 → (c) / ≤0.4 → (a))
- 전제조건: 시점정합 stats 가 openai run 보다 **먼저**. Q2 는 복원불가라 폐기.

## What changed

- `docs/self-review/PRE-REGISTRATION-openai-anchor.md` (신규, 58 LOC, 산문)

## Test plan

N/A — docs-only, 코드/동작 변화 0.

## 5b (real-data 델타)

N/A — `docs/self-review/` 는 load-bearing 경로 아님 (`LOAD_BEARING_PATHS` 미포함, `docs/adr/` 만 해당). real-data 영향 없음.

## Risk / rollback

없음 — 문서 1개. 잘못되면 revert.

Closes #1109