### PR TITLE
docs(readme): hero 5초 훅 출력을 data/index hybrid 실측으로 동기화 (#1102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ $ make ask
 python3 app.py --input_dir data/index --output_dir outputs --query "기관 A와 기관 B의 보안 요구사항 차이를 알려줘" --pipeline agentic_full
 
 INFO bidmate.rag_core: query_complete  status='supported'  query_type='comparison'
-                                       latency_ms=5.79      retry_count=0
+                                       latency_ms=29.63     retrieval_backend='hybrid'
                                        claim_count=2        citation_count=2
 
 [OK] Answer written: outputs/answer.json
 
 ─ Answer ───────────────────────────────────────────────────────────────────
-기관 A — 모델 품질관리, 보안 통제, 로그 추적
-        [rfp-agency-a-ai-quality::chunk-001]
-기관 B — 개인정보 비식별화, 접근 권한 분리
-        [rfp-agency-b-mlops-governance::chunk-001]
+기관 A — 연계 시스템은 보안 관제 콘솔이다.
+        [rfp-agency-a-ai-quality::chunk-056]
+기관 B — 보안 정책은 기관 B 정보보호 매뉴얼과 정합 운영된다.
+        [rfp-agency-b-mlops-governance::chunk-094]
 ────────────────────────────────────────────────────────────────────────────
 ```
 
 - 두 기관이 **모두** 인용된 점이 핵심 — [comparison-aware balanced top-k](#key-technical-contribution--comparison-aware-balanced-top-k) 가 한쪽 문서 starvation 방지
-- 외부 API 호출 없음 (extractive). 5.79 ms 는 in-memory index, n=2 docs 실측 — 대표 예시이며 `data/index` 전체(13-doc) 실행 시 출력·latency 상이 (hero 재현성 복원 추적: [issue #1102](https://github.com/hskim-solv/BidMate-DocAgent/issues/1102))
+- 외부 API 호출 없음 (extractive). 위 출력은 **현재 `data/index`(13-doc) 실측** — `make ask` 복붙 시 동일 claim·citation(chunk-056 / chunk-094) 재현. ~30 ms 는 in-memory hybrid 검색 ([ADR 0058](docs/adr/0058-phase35-mode-winner.md) 기본값) 단발 wall-clock (머신별 상이, 리포트 p95 메트릭 아님)
 - 5초 터미널 재생: `asciinema play docs/assets/demo.cast`. 풀 워크스루: [`docs/operations/deployment.md`](docs/operations/deployment.md#recording-the-demo-video)
 
 ## Live demo


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

README 5초 비주얼 훅(L18-37)의 출력 블록이 현재 `data/index`(13-doc)로 **재현 불가**였다. 표시 출력(`기관 A — 모델 품질관리, 보안 통제, 로그 추적 [chunk-001]`)은 옛 2-doc mini corpus 큐레이션이라, 사용자가 `make ask` 를 복붙하면 전혀 다른 출력을 받았다 (#1078 작업 중 발견 → #1102 분리).

근본 원인 2가지: (1) 두 소스 doc 이 ADR 0050(#914)으로 대형 distractor 문서로 재빌드돼 `chunk-001` 의미가 바뀜, (2) retrieval 기본값이 ADR 0058 로 dense→hybrid 전환됨.

같은 hero 쿼리(`기관 A와 기관 B의 보안 요구사항 차이를 알려줘`, = `make ask` 쿼리)를 **현재 코드로 3회 결정론 실행**해 나온 실측 출력으로 표시 블록을 동기화. 쿼리 변경 없이 표시값만 실측 일치 → 복붙 100% 재현. (이슈가 가정한 "FR 테이블 출력"은 dense 시절 stale — 현 hybrid 는 깔끔한 2-claim 보안 비교를 냄.)

Closes #1102

## 2. 영향 파일

- `README.md` — 5초 훅 코드 블록(출력 텍스트 + chunk-id + latency + retrieval_backend 표기) + 하단 bullet(n=2 disclosure 제거)

load-bearing 파일 없음 (`README.md` 는 `scripts/_governance.py` `LOAD_BEARING_PATHS` 에서 명시적 제외).

## 3. 리스크

- 가장 가능성 높은 깨짐: 표시 출력이 실제 파이프라인 출력과 또 어긋남. → 배제 방법: `.venv`(py3.11, numpy 2.4.4 + rank_bm25) 로 hero 쿼리 3회 실행, 출력(`기관 A: 연계 시스템은 보안 관제 콘솔이다.` [chunk-056] / `기관 B: 보안 정책은 기관 B 정보보호 매뉴얼과 정합 운영된다.` [chunk-094])·status=supported·claim/citation=2 결정론 확인.
- latency 는 단발 wall-clock(머신별 상이) — 본문에 "리포트 p95 메트릭 아님" 명시해 메트릭 표와 혼동 차단.

## 4. 테스트

테스트 미추가. 사유: docs-only 문자열 동기화, 동작 변경 없음. 옛 hero 문자열을 검증하는 테스트 부재 확인(`grep "모델 품질관리, 보안 통제\|chunk-001" tests/` → 무관 fixture 만). 재현성은 위 3회 결정론 실행으로 수동 검증.

## 5. Eval 영향

All `·` — RAG 동작/eval 표면 변경 없음, README 텍스트만.

### 5b. Real-data delta

N/A — load-bearing path 미변경 (README.md 는 LOAD_BEARING_PATHS 제외). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

깨짐 없음. 계약/스키마/CLI flag/doc link 변경 없음. `make ask` 쿼리·명령 문자열 불변(#1103 표준 유지), 표시 출력만 실측 동기화.

## 7. 범위 외

- **`docs/assets/demo.cast` / `demo.gif`(L8) 재생성** — 옛 큐레이션 narration(모델 품질관리/chunk-001) 을 여전히 표시. 텍스트 hero 블록과 불일치하나, gif 재렌더는 asciinema 레코딩 툴링이 필요해 별도 follow-up 으로 분리(이슈 #1102 핵심은 텍스트 출력 블록).