### PR TITLE
docs(eval): Korean-ize Phase 2/3/3.5/4 retrieval reports + unify significance tokens

### DIFF
--- a/reports/retrieval/phase2_chunking_20260518-0202-reaggregate/REPORT.md
+++ b/reports/retrieval/phase2_chunking_20260518-0202-reaggregate/REPORT.md
@@ -1,19 +1,19 @@
-# Phase 2 retrieval-eval — chunking ablation (real100 n=221)
+# Phase 2 retrieval-eval — 청킹(chunking) ablation (real100 n=221)
 
-Run: `20260518-0202-phase2-chunking-reaggregate` · commit `af461b1a90` · index_dir_current=`/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100` · eval_config=`/Users/hskim/Desktop/projects/BidMate-DocAgent/eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+Run: `20260521-0333-phase2-chunking-reaggregate` · commit `5e5f07bc96` · index_dir_current=`/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
 
-## Variants
+## 변형(variants)
 
-| Variant | Strategy | Max chars | Overlap | Docs | Chunks | Section detect | Heuristic engaged |
+| 변형 | 전략(strategy) | max chars | overlap | 문서 | 청크 | 섹션 감지 | heuristic 발화 |
 |---|---|---|---|---|---|---|---|
 | `current` | fixed | 520 | 1 | 100 | 26376 | 0.0% | — |
 | `smaller` | fixed | 260 | 1 | 100 | 55281 | 0.0% | — |
 | `larger` | fixed | 1040 | 1 | 100 | 12843 | 0.0% | — |
 | `structure_aware` | section | 520 | 1 | 100 | 30937 | 100.0% | 100.0% |
 
-## Latency (ms)
+## 지연시간(latency, ms)
 
-| Variant | p50 | p95 | mean | n |
+| 변형 | p50 | p95 | mean | n |
 |---|---|---|---|---|
 | `current` | 389.616 | 588.575 | 431.721 | 221 |
 | `smaller` | 764.095 | 863.732 | 710.538 | 221 |
@@ -22,7 +22,7 @@ Run: `20260518-0202-phase2-chunking-reaggregate` · commit `af461b1a90` · index
 
 ## chunk_recall@5
 
-| Category | `current` | `smaller` | `larger` | `structure_aware` |
+| 카테고리 | `current` | `smaller` | `larger` | `structure_aware` |
 |---|---|---|---|---|
 | overall | 0.055 (n=114) | 0.065 (n=114) | 0.051 (n=114) | 0.041 (n=114) |
 | multi_hop | 0.056 (n=93) | 0.068 (n=93) | 0.050 (n=93) | 0.049 (n=93) |
@@ -32,21 +32,21 @@ Run: `20260518-0202-phase2-chunking-reaggregate` · commit `af461b1a90` · index
 | ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
 | uncategorized | 0.080 (n=13) | 0.065 (n=13) | 0.091 (n=13) | 0.003 (n=13) |
 
-### chunk_recall@5 — paired CI delta vs `current` (seed-averaged)
+### chunk_recall@5 — `current` 대비 paired CI delta (seed 평균)
 
-| Category | `smaller` | `larger` | `structure_aware` |
+| 카테고리 | `smaller` | `larger` | `structure_aware` |
 |---|---|---|---|
-| overall | +0.010 (-0.008, +0.034) **NOT SIGNIFICANT** | -0.004 (-0.033, +0.024) **NOT SIGNIFICANT** | -0.014 (-0.031, +0.000) **NOT SIGNIFICANT** |
-| multi_hop | +0.012 (-0.010, +0.041) **NOT SIGNIFICANT** | -0.006 (-0.040, +0.029) **NOT SIGNIFICANT** | -0.006 (-0.021, +0.005) **NOT SIGNIFICANT** |
-| distractor_heavy | +0.035 (-0.008, +0.098) **NOT SIGNIFICANT** | -0.012 (-0.086, +0.057) **NOT SIGNIFICANT** | -0.020 (-0.048, -0.000) significant |
-| long_context | -0.016 (-0.056, +0.007) **NOT SIGNIFICANT** | -0.038 (-0.113, +0.000) **NOT SIGNIFICANT** | -0.001 (-0.004, +0.000) **NOT SIGNIFICANT** |
-| no_answer | +0.045 (+0.000, +0.091) **NOT SIGNIFICANT** | +0.125 (+0.000, +0.250) **NOT SIGNIFICANT** | +0.111 (+0.000, +0.222) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | -0.014 (-0.040, +0.000) **NOT SIGNIFICANT** | +0.011 (-0.005, +0.038) **NOT SIGNIFICANT** | -0.077 (-0.192, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.010 (-0.008, +0.034) **유의하지 않음** | -0.004 (-0.033, +0.024) **유의하지 않음** | -0.014 (-0.031, +0.000) **유의하지 않음** |
+| multi_hop | +0.012 (-0.010, +0.041) **유의하지 않음** | -0.006 (-0.040, +0.029) **유의하지 않음** | -0.006 (-0.021, +0.005) **유의하지 않음** |
+| distractor_heavy | +0.035 (-0.008, +0.098) **유의하지 않음** | -0.012 (-0.086, +0.057) **유의하지 않음** | -0.020 (-0.048, -0.000) 유의함 |
+| long_context | -0.016 (-0.056, +0.007) **유의하지 않음** | -0.038 (-0.113, +0.000) **유의하지 않음** | -0.001 (-0.004, +0.000) **유의하지 않음** |
+| no_answer | +0.045 (+0.000, +0.091) **유의하지 않음** | +0.125 (+0.000, +0.250) **유의하지 않음** | +0.111 (+0.000, +0.222) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | -0.014 (-0.040, +0.000) **유의하지 않음** | +0.011 (-0.005, +0.038) **유의하지 않음** | -0.077 (-0.192, +0.000) **유의하지 않음** |
 
 ## chunk_recall@10
 
-| Category | `current` | `smaller` | `larger` | `structure_aware` |
+| 카테고리 | `current` | `smaller` | `larger` | `structure_aware` |
 |---|---|---|---|---|
 | overall | 0.064 (n=114) | 0.078 (n=114) | 0.081 (n=114) | 0.061 (n=114) |
 | multi_hop | 0.067 (n=93) | 0.083 (n=93) | 0.086 (n=93) | 0.074 (n=93) |
@@ -56,21 +56,21 @@ Run: `20260518-0202-phase2-chunking-reaggregate` · commit `af461b1a90` · index
 | ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
 | uncategorized | 0.081 (n=13) | 0.066 (n=13) | 0.093 (n=13) | 0.004 (n=13) |
 
-### chunk_recall@10 — paired CI delta vs `current` (seed-averaged)
+### chunk_recall@10 — `current` 대비 paired CI delta (seed 평균)
 
-| Category | `smaller` | `larger` | `structure_aware` |
+| 카테고리 | `smaller` | `larger` | `structure_aware` |
 |---|---|---|---|
-| overall | +0.014 (-0.007, +0.040) **NOT SIGNIFICANT** | +0.017 (-0.011, +0.050) **NOT SIGNIFICANT** | -0.003 (-0.022, +0.017) **NOT SIGNIFICANT** |
-| multi_hop | +0.016 (-0.010, +0.048) **NOT SIGNIFICANT** | +0.019 (-0.015, +0.060) **NOT SIGNIFICANT** | +0.007 (-0.012, +0.028) **NOT SIGNIFICANT** |
-| distractor_heavy | +0.042 (-0.001, +0.104) **NOT SIGNIFICANT** | +0.035 (-0.024, +0.113) **NOT SIGNIFICANT** | +0.009 (-0.012, +0.038) **NOT SIGNIFICANT** |
-| long_context | -0.072 (-0.184, +0.005) **NOT SIGNIFICANT** | -0.092 (-0.216, +0.001) **NOT SIGNIFICANT** | -0.057 (-0.168, +0.000) **NOT SIGNIFICANT** |
-| no_answer | +0.041 (+0.000, +0.082) **NOT SIGNIFICANT** | +0.138 (+0.000, +0.275) **NOT SIGNIFICANT** | +0.172 (+0.000, +0.344) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | -0.015 (-0.042, +0.000) **NOT SIGNIFICANT** | +0.011 (-0.007, +0.040) **NOT SIGNIFICANT** | -0.077 (-0.192, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.014 (-0.007, +0.040) **유의하지 않음** | +0.017 (-0.011, +0.050) **유의하지 않음** | -0.003 (-0.022, +0.017) **유의하지 않음** |
+| multi_hop | +0.016 (-0.010, +0.048) **유의하지 않음** | +0.019 (-0.015, +0.060) **유의하지 않음** | +0.007 (-0.012, +0.028) **유의하지 않음** |
+| distractor_heavy | +0.042 (-0.001, +0.104) **유의하지 않음** | +0.035 (-0.024, +0.113) **유의하지 않음** | +0.009 (-0.012, +0.038) **유의하지 않음** |
+| long_context | -0.072 (-0.184, +0.005) **유의하지 않음** | -0.092 (-0.216, +0.001) **유의하지 않음** | -0.057 (-0.168, +0.000) **유의하지 않음** |
+| no_answer | +0.041 (+0.000, +0.082) **유의하지 않음** | +0.138 (+0.000, +0.275) **유의하지 않음** | +0.172 (+0.000, +0.344) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | -0.015 (-0.042, +0.000) **유의하지 않음** | +0.011 (-0.007, +0.040) **유의하지 않음** | -0.077 (-0.192, +0.000) **유의하지 않음** |
 
 ## mrr
 
-| Category | `current` | `smaller` | `larger` | `structure_aware` |
+| 카테고리 | `current` | `smaller` | `larger` | `structure_aware` |
 |---|---|---|---|---|
 | overall | 0.129 (n=114) | 0.198 (n=114) | 0.103 (n=114) | 0.102 (n=114) |
 | multi_hop | 0.132 (n=93) | 0.207 (n=93) | 0.099 (n=93) | 0.120 (n=93) |
@@ -80,21 +80,21 @@ Run: `20260518-0202-phase2-chunking-reaggregate` · commit `af461b1a90` · index
 | ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
 | uncategorized | 0.179 (n=13) | 0.173 (n=13) | 0.192 (n=13) | 0.035 (n=13) |
 
-### mrr — paired CI delta vs `current` (seed-averaged)
+### mrr — `current` 대비 paired CI delta (seed 평균)
 
-| Category | `smaller` | `larger` | `structure_aware` |
+| 카테고리 | `smaller` | `larger` | `structure_aware` |
 |---|---|---|---|
-| overall | +0.070 (+0.020, +0.122) significant | -0.025 (-0.059, +0.002) **NOT SIGNIFICANT** | -0.026 (-0.070, +0.015) **NOT SIGNIFICANT** |
-| multi_hop | +0.075 (+0.021, +0.134) significant | -0.032 (-0.072, +0.003) **NOT SIGNIFICANT** | -0.012 (-0.056, +0.032) **NOT SIGNIFICANT** |
-| distractor_heavy | +0.065 (-0.003, +0.150) **NOT SIGNIFICANT** | -0.031 (-0.092, +0.013) **NOT SIGNIFICANT** | -0.046 (-0.095, -0.007) significant |
-| long_context | +0.089 (-0.038, +0.231) **NOT SIGNIFICANT** | -0.098 (-0.211, -0.017) significant | -0.048 (-0.112, +0.006) **NOT SIGNIFICANT** |
-| no_answer | +0.438 (+0.000, +0.875) **NOT SIGNIFICANT** | +0.062 (+0.000, +0.125) **NOT SIGNIFICANT** | +0.469 (+0.062, +0.875) significant |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | -0.006 (-0.173, +0.154) **NOT SIGNIFICANT** | +0.013 (+0.000, +0.038) **NOT SIGNIFICANT** | -0.144 (-0.333, +0.001) **NOT SIGNIFICANT** |
+| overall | +0.070 (+0.020, +0.122) 유의함 | -0.025 (-0.059, +0.002) **유의하지 않음** | -0.026 (-0.070, +0.015) **유의하지 않음** |
+| multi_hop | +0.075 (+0.021, +0.134) 유의함 | -0.032 (-0.072, +0.003) **유의하지 않음** | -0.012 (-0.056, +0.032) **유의하지 않음** |
+| distractor_heavy | +0.065 (-0.003, +0.150) **유의하지 않음** | -0.031 (-0.092, +0.013) **유의하지 않음** | -0.046 (-0.095, -0.007) 유의함 |
+| long_context | +0.089 (-0.038, +0.231) **유의하지 않음** | -0.098 (-0.211, -0.017) 유의함 | -0.048 (-0.112, +0.006) **유의하지 않음** |
+| no_answer | +0.438 (+0.000, +0.875) **유의하지 않음** | +0.062 (+0.000, +0.125) **유의하지 않음** | +0.469 (+0.062, +0.875) 유의함 |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | -0.006 (-0.173, +0.154) **유의하지 않음** | +0.013 (+0.000, +0.038) **유의하지 않음** | -0.144 (-0.333, +0.001) **유의하지 않음** |
 
 ## ndcg@10
 
-| Category | `current` | `smaller` | `larger` | `structure_aware` |
+| 카테고리 | `current` | `smaller` | `larger` | `structure_aware` |
 |---|---|---|---|---|
 | overall | 0.067 (n=114) | 0.092 (n=114) | 0.060 (n=114) | 0.054 (n=114) |
 | multi_hop | 0.065 (n=93) | 0.093 (n=93) | 0.060 (n=93) | 0.062 (n=93) |
@@ -104,39 +104,39 @@ Run: `20260518-0202-phase2-chunking-reaggregate` · commit `af461b1a90` · index
 | ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
 | uncategorized | 0.119 (n=13) | 0.103 (n=13) | 0.098 (n=13) | 0.034 (n=13) |
 
-### ndcg@10 — paired CI delta vs `current` (seed-averaged)
+### ndcg@10 — `current` 대비 paired CI delta (seed 평균)
 
-| Category | `smaller` | `larger` | `structure_aware` |
+| 카테고리 | `smaller` | `larger` | `structure_aware` |
 |---|---|---|---|
-| overall | +0.025 (+0.001, +0.051) significant | -0.007 (-0.026, +0.012) **NOT SIGNIFICANT** | -0.013 (-0.030, +0.004) **NOT SIGNIFICANT** |
-| multi_hop | +0.028 (+0.002, +0.059) significant | -0.006 (-0.028, +0.017) **NOT SIGNIFICANT** | -0.003 (-0.018, +0.012) **NOT SIGNIFICANT** |
-| distractor_heavy | +0.048 (+0.000, +0.112) significant | -0.002 (-0.039, +0.034) **NOT SIGNIFICANT** | -0.012 (-0.029, +0.001) **NOT SIGNIFICANT** |
-| long_context | -0.014 (-0.074, +0.037) **NOT SIGNIFICANT** | -0.065 (-0.147, -0.002) significant | -0.035 (-0.083, +0.000) **NOT SIGNIFICANT** |
-| no_answer | +0.107 (+0.000, +0.214) **NOT SIGNIFICANT** | +0.107 (+0.000, +0.214) **NOT SIGNIFICANT** | +0.209 (+0.000, +0.419) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | -0.016 (-0.092, +0.054) **NOT SIGNIFICANT** | -0.021 (-0.084, +0.019) **NOT SIGNIFICANT** | -0.085 (-0.195, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.025 (+0.001, +0.051) 유의함 | -0.007 (-0.026, +0.012) **유의하지 않음** | -0.013 (-0.030, +0.004) **유의하지 않음** |
+| multi_hop | +0.028 (+0.002, +0.059) 유의함 | -0.006 (-0.028, +0.017) **유의하지 않음** | -0.003 (-0.018, +0.012) **유의하지 않음** |
+| distractor_heavy | +0.048 (+0.000, +0.112) 유의함 | -0.002 (-0.039, +0.034) **유의하지 않음** | -0.012 (-0.029, +0.001) **유의하지 않음** |
+| long_context | -0.014 (-0.074, +0.037) **유의하지 않음** | -0.065 (-0.147, -0.002) 유의함 | -0.035 (-0.083, +0.000) **유의하지 않음** |
+| no_answer | +0.107 (+0.000, +0.214) **유의하지 않음** | +0.107 (+0.000, +0.214) **유의하지 않음** | +0.209 (+0.000, +0.419) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | -0.016 (-0.092, +0.054) **유의하지 않음** | -0.021 (-0.084, +0.019) **유의하지 않음** | -0.085 (-0.195, +0.000) **유의하지 않음** |
 
-## Per-category winner
+## 카테고리별 winner
 
-Winner = variant with highest `chunk_recall@10` mean AND paired CI vs `current` fully above 0. "NOT SIGNIFICANT" = no variant's CI clears 0 (absolute rule #5).
+winner = `chunk_recall@10` 평균이 가장 높으면서 `current` 대비 paired CI 가 완전히 0 위인 변형. "유의하지 않음" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
 
-| Category | Winner | Mean recall@10 | Delta CI vs current |
+| 카테고리 | winner | 평균 recall@10 | `current` 대비 delta CI |
 |---|---|---|---|
-| overall | `NOT SIGNIFICANT` | — | — |
-| multi_hop | `NOT SIGNIFICANT` | — | — |
-| distractor_heavy | `NOT SIGNIFICANT` | — | — |
-| long_context | `NOT SIGNIFICANT` | — | — |
-| no_answer | `NOT SIGNIFICANT` | — | — |
-| ambiguous_query | `NOT SIGNIFICANT` | — | — |
-| uncategorized | `NOT SIGNIFICANT` | — | — |
+| overall | `유의하지 않음` | — | — |
+| multi_hop | `유의하지 않음` | — | — |
+| distractor_heavy | `유의하지 않음` | — | — |
+| long_context | `유의하지 않음` | — | — |
+| no_answer | `유의하지 않음` | — | — |
+| ambiguous_query | `유의하지 않음` | — | — |
+| uncategorized | `유의하지 않음` | — | — |
 
-## Notes
+## 비고(notes)
 
-* Planner-bypass: full query as the only sub-query, identity expansion, no rerank — isolates chunking impact from query expansion / rerank effects.
-* `chunk_recall@k` is None for cases without `expected_terms` / `expected_doc_ids` (e.g. abstention) — those are dropped pairwise to preserve case alignment between current and the variant.
-* Seeds drive only the bootstrap RNG; retrieval itself is deterministic for the same query+index (hashing-backend / dense backend both).
-* Index storage: `data/index/phase2_smaller`, `phase2_larger`, `phase2_structure_aware`.
-* Category bucketing uses `hardcase_categories` (semantic difficulty tags) from the eval config. The legacy `query_type` field (single_doc / multi_doc / follow_up / abstention) is **not** used here. A case tagged with N categories appears in N buckets, so per-category counts overlap and per-category paired CIs share cases — combining multiple categories via OR inflates family-wise error rate.
-* `uncategorized` covers cases without `hardcase_categories` tags (typically the initial seed + probe cases authored before the tag schema). They still contribute to `overall`.
-* Phase 1 baseline (`UNIFIED_PHASE1_REPORT.md`) categorized by `query_type` (e.g. `multi_doc → multi_hop` with n=1); direct cross-phase category-by-category trend comparison is not meaningful until Phase 1 is re-aggregated against the same `hardcase_categories` field.
-* This report was regenerated via `--reaggregate` from `reports/retrieval/phase2_chunking_20260518-0740/raw_results.json` — categorization re-derived from `hardcase_categories`; retrieval scores in `raw_results.json` are unchanged byte-for-byte modulo the injected `categories` field.
+* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, rerank 없음 — 청킹 효과를 query expansion / rerank 효과로부터 격리한다.
+* `chunk_recall@k` 는 `expected_terms` / `expected_doc_ids` 가 없는 케이스(예: abstention(보류))에서 None 이다 — current 와 변형 간 케이스 정렬을 보존하기 위해 pairwise 에서 제외된다.
+* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 query+index 에 대해 결정적(deterministic)이다 (hashing-backend / dense backend 모두).
+* 인덱스 저장 위치: `data/index/phase2_smaller`, `phase2_larger`, `phase2_structure_aware`.
+* 카테고리 버킷팅은 eval config 의 `hardcase_categories`(의미 난이도 태그)를 쓴다. 레거시 `query_type` 필드(single_doc / multi_doc / follow_up / abstention)는 여기서 **쓰지 않는다**. N 개 카테고리로 태깅된 케이스는 N 개 버킷에 나타나므로 카테고리별 카운트는 겹치고 paired CI 가 케이스를 공유한다 — 여러 카테고리를 OR 로 합치면 family-wise 오류율이 부풀려진다.
+* `uncategorized` 는 `hardcase_categories` 태그가 없는 케이스(보통 태그 스키마 이전에 작성된 초기 seed + probe 케이스)를 포함한다. 이들도 `overall` 에는 기여한다.
+* Phase 1 baseline(`UNIFIED_PHASE1_REPORT.md`)은 `query_type` 으로 분류했다 (예: `multi_doc → multi_hop` n=1); Phase 1 을 동일 `hardcase_categories` 필드로 재집계하기 전에는 phase 간 카테고리별 추세 직접 비교는 의미가 없다.
+* 이 리포트는 `--reaggregate` 로 `reports/retrieval/phase2_chunking_20260518-0202-reaggregate/raw_results.json` 로부터 재생성됨 — 카테고리는 `hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval 점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변.

--- a/reports/retrieval/phase35_m3_20260518T090328Z/REPORT.md
+++ b/reports/retrieval/phase35_m3_20260518T090328Z/REPORT.md
@@ -1,18 +1,18 @@
-# Phase 3.5 retrieval-eval — m3 mode ablation (real100 n=221, semantic embeddings)
+# Phase 3.5 retrieval-eval — m3 검색 모드(mode) ablation (real100 n=221, 의미 임베딩(semantic embeddings))
 
-Run: `20260518-0938-phase35-m3` · commit `cf1b2927c8` · index_dir=`data/index/real100_m3` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+Run: `20260521-0334-phase35-m3-reaggregate` · commit `5e5f07bc96` · index_dir=`data/index/real100_m3` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
 
-## Variants
+## 변형(variants)
 
-| Variant | Backend | RRF k | Docs | Chunks |
+| 변형 | backend | RRF k | 문서 | 청크 |
 |---|---|---|---|---|
 | `dense_m3` | dense | — | 100 | 898 |
 | `hybrid_bm25_k60_m3` | hybrid | 60 | 100 | 898 |
 | `m3` | m3 | — | 100 | 898 |
 
-## Latency (ms)
+## 지연시간(latency, ms)
 
-| Variant | p50 | p95 | mean | n |
+| 변형 | p50 | p95 | mean | n |
 |---|---|---|---|---|
 | `dense_m3` | 699.367 | 3530.893 | 1141.947 | 221 |
 | `hybrid_bm25_k60_m3` | 853.435 | 7641.01 | 1909.416 | 221 |
@@ -20,7 +20,7 @@ Run: `20260518-0938-phase35-m3` · commit `cf1b2927c8` · index_dir=`data/index/
 
 ## chunk_recall@5
 
-| Category | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
+| 카테고리 | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
 |---|---|---|---|
 | overall | 0.395 (n=37) | 0.427 (n=37) | 0.343 (n=37) |
 | multi_hop | 0.246 (n=24) | 0.287 (n=24) | 0.231 (n=24) |
@@ -30,21 +30,21 @@ Run: `20260518-0938-phase35-m3` · commit `cf1b2927c8` · index_dir=`data/index/
 | ambiguous_query | — | — | — |
 | uncategorized | 0.676 (n=12) | 0.693 (n=12) | 0.547 (n=12) |
 
-### chunk_recall@5 — paired CI delta vs `dense_m3` (seed-averaged)
+### chunk_recall@5 — `dense_m3` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k60_m3` | `m3` |
+| 카테고리 | `hybrid_bm25_k60_m3` | `m3` |
 |---|---|---|
-| overall | +0.032 (-0.045, +0.099) **NOT SIGNIFICANT** | -0.052 (-0.145, +0.021) **NOT SIGNIFICANT** |
-| multi_hop | +0.040 (-0.081, +0.139) **NOT SIGNIFICANT** | -0.016 (-0.119, +0.054) **NOT SIGNIFICANT** |
-| distractor_heavy | -0.014 (-0.390, +0.262) **NOT SIGNIFICANT** | -0.114 (-0.429, +0.067) **NOT SIGNIFICANT** |
-| long_context | +0.083 (+0.000, +0.167) **NOT SIGNIFICANT** | +0.083 (+0.000, +0.167) **NOT SIGNIFICANT** |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.032 (-0.045, +0.099) **유의하지 않음** | -0.052 (-0.145, +0.021) **유의하지 않음** |
+| multi_hop | +0.040 (-0.081, +0.139) **유의하지 않음** | -0.016 (-0.119, +0.054) **유의하지 않음** |
+| distractor_heavy | -0.014 (-0.390, +0.262) **유의하지 않음** | -0.114 (-0.429, +0.067) **유의하지 않음** |
+| long_context | +0.083 (+0.000, +0.167) **유의하지 않음** | +0.083 (+0.000, +0.167) **유의하지 않음** |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
 | ambiguous_query | N/A | N/A |
-| uncategorized | +0.017 (+0.000, +0.050) **NOT SIGNIFICANT** | -0.129 (-0.328, +0.017) **NOT SIGNIFICANT** |
+| uncategorized | +0.017 (+0.000, +0.050) **유의하지 않음** | -0.129 (-0.328, +0.017) **유의하지 않음** |
 
 ## chunk_recall@10
 
-| Category | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
+| 카테고리 | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
 |---|---|---|---|
 | overall | 0.503 (n=37) | 0.534 (n=37) | 0.514 (n=37) |
 | multi_hop | 0.351 (n=24) | 0.375 (n=24) | 0.373 (n=24) |
@@ -54,21 +54,21 @@ Run: `20260518-0938-phase35-m3` · commit `cf1b2927c8` · index_dir=`data/index/
 | ambiguous_query | — | — | — |
 | uncategorized | 0.767 (n=12) | 0.812 (n=12) | 0.772 (n=12) |
 
-### chunk_recall@10 — paired CI delta vs `dense_m3` (seed-averaged)
+### chunk_recall@10 — `dense_m3` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k60_m3` | `m3` |
+| 카테고리 | `hybrid_bm25_k60_m3` | `m3` |
 |---|---|---|
-| overall | +0.031 (-0.064, +0.122) **NOT SIGNIFICANT** | +0.011 (-0.068, +0.076) **NOT SIGNIFICANT** |
-| multi_hop | +0.024 (-0.107, +0.145) **NOT SIGNIFICANT** | +0.022 (-0.092, +0.114) **NOT SIGNIFICANT** |
-| distractor_heavy | -0.014 (-0.390, +0.262) **NOT SIGNIFICANT** | -0.071 (-0.429, +0.210) **NOT SIGNIFICANT** |
-| long_context | -0.100 (-0.200, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.031 (-0.064, +0.122) **유의하지 않음** | +0.011 (-0.068, +0.076) **유의하지 않음** |
+| multi_hop | +0.024 (-0.107, +0.145) **유의하지 않음** | +0.022 (-0.092, +0.114) **유의하지 않음** |
+| distractor_heavy | -0.014 (-0.390, +0.262) **유의하지 않음** | -0.071 (-0.429, +0.210) **유의하지 않음** |
+| long_context | -0.100 (-0.200, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
 | ambiguous_query | N/A | N/A |
-| uncategorized | +0.046 (-0.069, +0.205) **NOT SIGNIFICANT** | +0.006 (-0.062, +0.095) **NOT SIGNIFICANT** |
+| uncategorized | +0.046 (-0.069, +0.205) **유의하지 않음** | +0.006 (-0.062, +0.095) **유의하지 않음** |
 
 ## mrr
 
-| Category | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
+| 카테고리 | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
 |---|---|---|---|
 | overall | 0.443 (n=37) | 0.550 (n=37) | 0.521 (n=37) |
 | multi_hop | 0.301 (n=24) | 0.457 (n=24) | 0.417 (n=24) |
@@ -78,21 +78,21 @@ Run: `20260518-0938-phase35-m3` · commit `cf1b2927c8` · index_dir=`data/index/
 | ambiguous_query | — | — | — |
 | uncategorized | 0.722 (n=12) | 0.699 (n=12) | 0.690 (n=12) |
 
-### mrr — paired CI delta vs `dense_m3` (seed-averaged)
+### mrr — `dense_m3` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k60_m3` | `m3` |
+| 카테고리 | `hybrid_bm25_k60_m3` | `m3` |
 |---|---|---|
-| overall | +0.107 (+0.033, +0.190) significant | +0.078 (-0.012, +0.169) **NOT SIGNIFICANT** |
-| multi_hop | +0.156 (+0.057, +0.263) significant | +0.116 (+0.019, +0.222) significant |
-| distractor_heavy | +0.165 (-0.037, +0.391) **NOT SIGNIFICANT** | +0.131 (-0.080, +0.367) **NOT SIGNIFICANT** |
-| long_context | +0.417 (+0.000, +0.833) **NOT SIGNIFICANT** | +0.417 (+0.000, +0.833) **NOT SIGNIFICANT** |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.107 (+0.033, +0.190) 유의함 | +0.078 (-0.012, +0.169) **유의하지 않음** |
+| multi_hop | +0.156 (+0.057, +0.263) 유의함 | +0.116 (+0.019, +0.222) 유의함 |
+| distractor_heavy | +0.165 (-0.037, +0.391) **유의하지 않음** | +0.131 (-0.080, +0.367) **유의하지 않음** |
+| long_context | +0.417 (+0.000, +0.833) **유의하지 않음** | +0.417 (+0.000, +0.833) **유의하지 않음** |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
 | ambiguous_query | N/A | N/A |
-| uncategorized | -0.023 (-0.053, +0.000) **NOT SIGNIFICANT** | -0.032 (-0.213, +0.119) **NOT SIGNIFICANT** |
+| uncategorized | -0.023 (-0.053, +0.000) **유의하지 않음** | -0.032 (-0.213, +0.119) **유의하지 않음** |
 
 ## ndcg@10
 
-| Category | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
+| 카테고리 | `dense_m3` | `hybrid_bm25_k60_m3` | `m3` |
 |---|---|---|---|
 | overall | 0.412 (n=37) | 0.477 (n=37) | 0.429 (n=37) |
 | multi_hop | 0.256 (n=24) | 0.339 (n=24) | 0.310 (n=24) |
@@ -102,43 +102,44 @@ Run: `20260518-0938-phase35-m3` · commit `cf1b2927c8` · index_dir=`data/index/
 | ambiguous_query | — | — | — |
 | uncategorized | 0.696 (n=12) | 0.720 (n=12) | 0.641 (n=12) |
 
-### ndcg@10 — paired CI delta vs `dense_m3` (seed-averaged)
+### ndcg@10 — `dense_m3` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k60_m3` | `m3` |
+| 카테고리 | `hybrid_bm25_k60_m3` | `m3` |
 |---|---|---|
-| overall | +0.065 (-0.005, +0.138) **NOT SIGNIFICANT** | +0.017 (-0.048, +0.076) **NOT SIGNIFICANT** |
-| multi_hop | +0.083 (-0.012, +0.182) **NOT SIGNIFICANT** | +0.054 (-0.012, +0.117) **NOT SIGNIFICANT** |
-| distractor_heavy | +0.062 (-0.163, +0.260) **NOT SIGNIFICANT** | +0.013 (-0.144, +0.166) **NOT SIGNIFICANT** |
-| long_context | +0.049 (-0.096, +0.195) **NOT SIGNIFICANT** | +0.081 (-0.033, +0.195) **NOT SIGNIFICANT** |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.065 (-0.005, +0.138) **유의하지 않음** | +0.017 (-0.048, +0.076) **유의하지 않음** |
+| multi_hop | +0.083 (-0.012, +0.182) **유의하지 않음** | +0.054 (-0.012, +0.117) **유의하지 않음** |
+| distractor_heavy | +0.062 (-0.163, +0.260) **유의하지 않음** | +0.013 (-0.144, +0.166) **유의하지 않음** |
+| long_context | +0.049 (-0.096, +0.195) **유의하지 않음** | +0.081 (-0.033, +0.195) **유의하지 않음** |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
 | ambiguous_query | N/A | N/A |
-| uncategorized | +0.024 (-0.044, +0.122) **NOT SIGNIFICANT** | -0.056 (-0.193, +0.064) **NOT SIGNIFICANT** |
+| uncategorized | +0.024 (-0.044, +0.122) **유의하지 않음** | -0.056 (-0.193, +0.064) **유의하지 않음** |
 
-## Per-category winner
+## 카테고리별 winner
 
-Winner = variant with highest `chunk_recall@10` mean AND paired CI vs `dense_m3` fully above 0. "NOT SIGNIFICANT" = no variant's CI clears 0 (absolute rule #5).
+winner = `chunk_recall@10` 평균이 가장 높으면서 `dense_m3` 대비 paired CI 가 완전히 0 위인 변형. "유의하지 않음" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
 
-| Category | Winner | Mean recall@10 | Delta CI vs `dense_m3` |
+| 카테고리 | winner | 평균 recall@10 | `dense_m3` 대비 delta CI |
 |---|---|---|---|
-| overall | `NOT SIGNIFICANT` | — | — |
-| multi_hop | `NOT SIGNIFICANT` | — | — |
-| distractor_heavy | `NOT SIGNIFICANT` | — | — |
-| long_context | `NOT SIGNIFICANT` | — | — |
-| no_answer | `NOT SIGNIFICANT` | — | — |
-| ambiguous_query | `NOT SIGNIFICANT` | — | — |
-| uncategorized | `NOT SIGNIFICANT` | — | — |
+| overall | `유의하지 않음` | — | — |
+| multi_hop | `유의하지 않음` | — | — |
+| distractor_heavy | `유의하지 않음` | — | — |
+| long_context | `유의하지 않음` | — | — |
+| no_answer | `유의하지 않음` | — | — |
+| ambiguous_query | `유의하지 않음` | — | — |
+| uncategorized | `유의하지 않음` | — | — |
 
-## Notes
+## 비고(notes)
 
-* Planner-bypass: full query as the only sub-query, identity expansion, no rerank, `metadata_first=False` — isolates retrieval-mode impact from expansion / rerank / metadata-filter effects (same discipline as Phase 3).
-* All 3 variants share `data/index/real100_m3` (BGE-M3 1024-dim dense). `hybrid_bm25_k60_m3` uses BM25 lazy-built on the index dict; `m3` populates `index['_m3_cache']` (sparse + colbert per chunk, in-memory only per ADR 0025 spike-mode, no disk persist) on its first call. `--warmup` absorbs the ~2 min cache cold-start so per-case latency reflects cache-hit cost.
-* m3's RRF dense channel reuses the index's existing dense channel (`rag_retrieval.py:449-454`) — for this run it IS the BGE-M3 dense (the index was built with `--model BAAI/bge-m3`), so the 3 channels are all BGE-M3 (dense + sparse + colbert). On hashing-built indexes the dense channel would be hashing, mixing embedding families.
-* `chunk_recall@k` is None for cases without `expected_terms` / `expected_doc_ids` (e.g. abstention) — those are dropped pairwise to preserve case alignment between variants.
-* Seeds drive only the bootstrap RNG; retrieval itself is deterministic for the same query+index+backend+rrf_k (dense + BM25 + m3 sparse/colbert).
-* Category bucketing uses `hardcase_categories` (semantic difficulty tags). Multi-tag cases appear in multiple buckets, so per-category counts overlap and per-category paired CIs share cases.
-* `dense_m3` is the delta baseline because Phase 3.5 isolates **multi-channel vs single-channel under semantic embeddings**. Deltas above 0 favor the multi-channel variant (hybrid or m3); below 0 favor dense alone.
-* **Phase 3 cross-ref + runner bug retraction**: `reports/retrieval/phase3_mode_20260518T032404Z/` reported all 3 `hybrid_bm25_k{30,60,100}` variants byte-identical and attributed it to BM25 channel dominance. **That conclusion was wrong**: the Phase 3 runner called `retrieve_candidates` (candidate generation only) without the second-stage `apply_fusion_and_reranking` (RRF fusion + final top-k). For hybrid + m3 backends `retrieve_candidates` returns `score=0.0` placeholders, so the per-case ranking collapsed to chunk_id insertion order — making every k value byte-identical. Phase 3.5 fixes the wire-up (both calls in `run_single_case`); the hashing-index re-run is a follow-up. Cross-backend delta math (hashing `dense` vs `dense_m3`) remains confounded by the embedding family swap and is NOT computed.
-* **Chunk count caveat**: the BGE-M3 index used the `data_list_csv_text` loader for both HWP and PDF (per ADR 0049 graceful fallback), yielding ~9 chunks/doc vs real100's ~264 chunks/doc with `kordoc` full extraction. Re-embedding 26k kordoc chunks with BGE-M3 on MPS would take >2h (per-batch GPU dispatch overhead); the csv_text fallback keeps the build under 20 min while preserving the within-Phase-3.5 paired CI claim. Absolute `chunk_recall@k` on this index is NOT directly comparable to Phase 3's kordoc-built numbers — only Phase 3.5 internal deltas are.
-* **Runner-side m3 batching (measurement-only optimization)**: per-query colbert max-sim is the dominant cost on this index (per-chunk Python-loop matmul × ~900 chunks × ~50s/query observed on the unoptimized path). The runner concatenates all chunk colbert vectors into one `(Σ T_d, 1024)` matrix and does **one** matmul per unique query, then splits the columns back per chunk for the row-wise max+sum. Mathematically identical to the per-chunk path (each chunk's column slice is independent), but ~100× faster. The patch lives in the runner (`_prime_m3_index_cache_and_colbert`); `rag_m3.py` / `rag_retrieval.py` unchanged.
-* **Out of scope**: per-channel m3 ablation (sparse-only, colbert-only — see ADR 0010 'Alternatives considered'); RRF-k sweep on hybrid_bm25 (Phase 3 already showed k=30/60/100 byte-identical on hashing); cross-encoder rerank stacked on top (Phase 4).
-* ADR cross-refs: ADR 0010 (BGE-M3 multi-channel deferred), ADR 0021 (m3_full analysis row), ADR 0032 (torch>=2.6 unblock — closes the install blocker that originally deferred this measurement).
+* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, rerank 없음, `metadata_first=False` — 검색 모드 효과를 expansion / rerank / metadata-filter 효과로부터 격리한다 (Phase 3 과 동일 규율).
+* 3 변형 모두 `data/index/real100_m3`(BGE-M3 1024-dim dense)를 공유한다. `hybrid_bm25_k60_m3` 는 index dict 에 lazy-build 된 BM25 를 쓰고; `m3` 는 첫 호출 시 `index['_m3_cache']`(청크별 sparse + colbert, ADR 0025 spike-mode 라 in-memory only, 디스크 미persist)를 채운다. `--warmup` 이 ~2 분 캐시 cold-start 를 흡수하므로 케이스별 지연시간은 캐시 hit 비용을 반영한다.
+* m3 의 RRF dense 채널은 인덱스의 기존 dense 채널을 재사용한다(`rag_retrieval.py:449-454`) — 이 run 에서는 그것이 BGE-M3 dense 다(인덱스가 `--model BAAI/bge-m3` 로 빌드됨), 따라서 3 채널 모두 BGE-M3(dense + sparse + colbert)다. hashing 으로 빌드된 인덱스에서는 dense 채널이 hashing 이라 임베딩 패밀리가 섞이게 된다.
+* `chunk_recall@k` 는 `expected_terms` / `expected_doc_ids` 가 없는 케이스(예: abstention(보류))에서 None 이다 — 변형 간 케이스 정렬을 보존하기 위해 pairwise 에서 제외된다.
+* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 query+index+backend+rrf_k 에 대해 결정적(deterministic)이다 (dense + BM25 + m3 sparse/colbert).
+* 카테고리 버킷팅은 `hardcase_categories`(의미 난이도 태그)를 쓴다. 멀티태그 케이스는 여러 버킷에 나타나므로 카테고리별 카운트는 겹치고 paired CI 가 케이스를 공유한다.
+* `dense_m3` 이 delta baseline 인 이유: Phase 3.5 는 **의미 임베딩 위에서 multi-channel vs single-channel** 을 격리하기 때문이다. 0 위 delta 는 multi-channel 변형(hybrid 또는 m3)에, 0 아래는 dense 단독에 유리하다.
+* **Phase 3 cross-ref + runner 버그 retraction(철회)**: `reports/retrieval/phase3_mode_20260518T032404Z/` 는 3 개 `hybrid_bm25_k{30,60,100}` 변형이 byte-identical 이라 보고하고 이를 BM25 채널 dominance 로 귀인했다. **그 결론은 틀렸다**: Phase 3 runner 가 `retrieve_candidates`(후보 생성만)를 호출하고 2단계 `apply_fusion_and_reranking`(RRF fusion + 최종 top-k)를 누락했다. hybrid + m3 backend 에서 `retrieve_candidates` 는 `score=0.0` placeholder 를 반환하므로 케이스별 순위가 chunk_id 삽입 순서로 붕괴해 모든 k 값이 byte-identical 이 됐다. Phase 3.5 는 wire-up 을 고친다(`run_single_case` 에 두 호출 모두); hashing 인덱스 재측정은 후속이다. Cross-backend delta(hashing `dense` vs `dense_m3`)는 임베딩 패밀리 교체로 confounded 되어 산출하지 않는다.
+* **청크 수 caveat**: BGE-M3 인덱스가 HWP/PDF 모두에 `data_list_csv_text` loader 를 썼고(ADR 0049 graceful fallback), doc 당 ~9 청크였다(`kordoc` 전체 추출의 real100 ~264 청크/doc 대비). 26k kordoc 청크를 BGE-M3 로 MPS 에서 재임베딩하면 >2h 걸린다(배치별 GPU dispatch overhead); csv_text fallback 은 build 를 20 분 미만으로 유지하면서 Phase 3.5 내부 paired CI 주장을 보존한다. 이 인덱스의 절대 `chunk_recall@k` 는 Phase 3 의 kordoc 빌드 수치와 직접 비교 불가 — Phase 3.5 내부 delta 만 비교 가능하다.
+* **Runner 측 m3 batching (측정 전용 최적화)**: 이 인덱스에서 query 별 colbert max-sim 이 지배적 비용이다(청크별 Python-loop matmul × ~900 청크 × 최적화 전 경로에서 관측된 ~50s/query). runner 는 모든 청크 colbert 벡터를 하나의 `(Σ T_d, 1024)` 행렬로 concat 해 unique query 당 **1회** matmul 후 행별 max+sum 을 위해 컬럼을 청크별로 다시 split 한다. 청크별 경로와 수학적으로 동일하나(각 청크의 컬럼 슬라이스는 독립) ~100× 빠르다. 패치는 runner 에 있다(`_prime_m3_index_cache_and_colbert`); `rag_m3.py` / `rag_retrieval.py` 는 미변경.
+* **범위 외**: 채널별 m3 ablation(sparse-only, colbert-only — ADR 0010 'Alternatives considered' 참조); hybrid_bm25 의 RRF-k sweep(Phase 3 이 이미 hashing 에서 k=30/60/100 byte-identical 을 보임); 위에 stack 된 cross-encoder rerank(Phase 4).
+* ADR cross-ref: ADR 0010(BGE-M3 multi-channel deferred), ADR 0021(m3_full 분석 행), ADR 0032(torch>=2.6 unblock — 본 측정을 원래 미뤘던 install blocker 를 해소).
+* 이 리포트는 `--reaggregate` 로 `reports/retrieval/phase35_m3_20260518T090328Z/raw_results.json` 로부터 재생성됨 — 카테고리는 `hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval 점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변.

--- a/reports/retrieval/phase35_m3_20260518T214937Z_kordoc_no_m3/REPORT.md
+++ b/reports/retrieval/phase35_m3_20260518T214937Z_kordoc_no_m3/REPORT.md
@@ -1,24 +1,24 @@
-# Phase 3.5 retrieval-eval — m3 mode ablation (real100 n=221, semantic embeddings)
+# Phase 3.5 retrieval-eval — m3 검색 모드(mode) ablation (real100 n=221, 의미 임베딩(semantic embeddings))
 
-Run: `20260518-2156-phase35-m3` · commit `f4e30cd544` · index_dir=`data/index/real100_m3` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+Run: `20260521-0334-phase35-m3-reaggregate` · commit `5e5f07bc96` · index_dir=`data/index/real100_m3` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
 
-## Variants
+## 변형(variants)
 
-| Variant | Backend | RRF k | Docs | Chunks |
+| 변형 | backend | RRF k | 문서 | 청크 |
 |---|---|---|---|---|
 | `dense_m3` | dense | — | 100 | 26376 |
 | `hybrid_bm25_k60_m3` | hybrid | 60 | 100 | 26376 |
 
-## Latency (ms)
+## 지연시간(latency, ms)
 
-| Variant | p50 | p95 | mean | n |
+| 변형 | p50 | p95 | mean | n |
 |---|---|---|---|---|
 | `dense_m3` | 558.865 | 2220.352 | 847.273 | 221 |
 | `hybrid_bm25_k60_m3` | 757.248 | 1236.946 | 801.259 | 221 |
 
 ## chunk_recall@5
 
-| Category | `dense_m3` | `hybrid_bm25_k60_m3` |
+| 카테고리 | `dense_m3` | `hybrid_bm25_k60_m3` |
 |---|---|---|
 | overall | 0.248 (n=114) | 0.296 (n=114) |
 | multi_hop | 0.196 (n=93) | 0.248 (n=93) |
@@ -28,21 +28,21 @@ Run: `20260518-2156-phase35-m3` · commit `f4e30cd544` · index_dir=`data/index/
 | ambiguous_query | 1.000 (n=1) | 1.000 (n=1) |
 | uncategorized | 0.530 (n=13) | 0.538 (n=13) |
 
-### chunk_recall@5 — paired CI delta vs `dense_m3` (seed-averaged)
+### chunk_recall@5 — `dense_m3` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k60_m3` |
+| 카테고리 | `hybrid_bm25_k60_m3` |
 |---|---|
-| overall | +0.048 (+0.013, +0.088) significant |
-| multi_hop | +0.052 (+0.021, +0.092) significant |
-| distractor_heavy | +0.062 (+0.003, +0.138) significant |
-| long_context | +0.060 (+0.000, +0.172) significant |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.008 (-0.171, +0.219) **NOT SIGNIFICANT** |
+| overall | +0.048 (+0.013, +0.088) 유의함 |
+| multi_hop | +0.052 (+0.021, +0.092) 유의함 |
+| distractor_heavy | +0.062 (+0.003, +0.138) 유의함 |
+| long_context | +0.060 (+0.000, +0.172) 유의함 |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.008 (-0.171, +0.219) **유의하지 않음** |
 
 ## chunk_recall@10
 
-| Category | `dense_m3` | `hybrid_bm25_k60_m3` |
+| 카테고리 | `dense_m3` | `hybrid_bm25_k60_m3` |
 |---|---|---|
 | overall | 0.288 (n=114) | 0.340 (n=114) |
 | multi_hop | 0.240 (n=93) | 0.283 (n=93) |
@@ -52,21 +52,21 @@ Run: `20260518-2156-phase35-m3` · commit `f4e30cd544` · index_dir=`data/index/
 | ambiguous_query | 1.000 (n=1) | 1.000 (n=1) |
 | uncategorized | 0.559 (n=13) | 0.620 (n=13) |
 
-### chunk_recall@10 — paired CI delta vs `dense_m3` (seed-averaged)
+### chunk_recall@10 — `dense_m3` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k60_m3` |
+| 카테고리 | `hybrid_bm25_k60_m3` |
 |---|---|
-| overall | +0.052 (+0.020, +0.088) significant |
-| multi_hop | +0.043 (+0.018, +0.073) significant |
-| distractor_heavy | +0.067 (+0.015, +0.131) significant |
-| long_context | +0.133 (+0.017, +0.278) significant |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.060 (-0.110, +0.256) **NOT SIGNIFICANT** |
+| overall | +0.052 (+0.020, +0.088) 유의함 |
+| multi_hop | +0.043 (+0.018, +0.073) 유의함 |
+| distractor_heavy | +0.067 (+0.015, +0.131) 유의함 |
+| long_context | +0.133 (+0.017, +0.278) 유의함 |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.060 (-0.110, +0.256) **유의하지 않음** |
 
 ## mrr
 
-| Category | `dense_m3` | `hybrid_bm25_k60_m3` |
+| 카테고리 | `dense_m3` | `hybrid_bm25_k60_m3` |
 |---|---|---|
 | overall | 0.515 (n=114) | 0.625 (n=114) |
 | multi_hop | 0.501 (n=93) | 0.631 (n=93) |
@@ -76,21 +76,21 @@ Run: `20260518-2156-phase35-m3` · commit `f4e30cd544` · index_dir=`data/index/
 | ambiguous_query | 1.000 (n=1) | 0.500 (n=1) |
 | uncategorized | 0.579 (n=13) | 0.596 (n=13) |
 
-### mrr — paired CI delta vs `dense_m3` (seed-averaged)
+### mrr — `dense_m3` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k60_m3` |
+| 카테고리 | `hybrid_bm25_k60_m3` |
 |---|---|
-| overall | +0.110 (+0.056, +0.165) significant |
-| multi_hop | +0.130 (+0.073, +0.192) significant |
-| distractor_heavy | +0.082 (+0.016, +0.159) significant |
-| long_context | +0.082 (+0.011, +0.183) significant |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | -0.500 (-0.500, -0.500) significant |
-| uncategorized | +0.018 (-0.191, +0.215) **NOT SIGNIFICANT** |
+| overall | +0.110 (+0.056, +0.165) 유의함 |
+| multi_hop | +0.130 (+0.073, +0.192) 유의함 |
+| distractor_heavy | +0.082 (+0.016, +0.159) 유의함 |
+| long_context | +0.082 (+0.011, +0.183) 유의함 |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | -0.500 (-0.500, -0.500) 유의함 |
+| uncategorized | +0.018 (-0.191, +0.215) **유의하지 않음** |
 
 ## ndcg@10
 
-| Category | `dense_m3` | `hybrid_bm25_k60_m3` |
+| 카테고리 | `dense_m3` | `hybrid_bm25_k60_m3` |
 |---|---|---|
 | overall | 0.318 (n=114) | 0.383 (n=114) |
 | multi_hop | 0.277 (n=93) | 0.347 (n=93) |
@@ -100,43 +100,44 @@ Run: `20260518-2156-phase35-m3` · commit `f4e30cd544` · index_dir=`data/index/
 | ambiguous_query | 1.000 (n=1) | 0.631 (n=1) |
 | uncategorized | 0.544 (n=13) | 0.573 (n=13) |
 
-### ndcg@10 — paired CI delta vs `dense_m3` (seed-averaged)
+### ndcg@10 — `dense_m3` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k60_m3` |
+| 카테고리 | `hybrid_bm25_k60_m3` |
 |---|---|
-| overall | +0.065 (+0.032, +0.099) significant |
-| multi_hop | +0.070 (+0.040, +0.106) significant |
-| distractor_heavy | +0.063 (+0.007, +0.126) significant |
-| long_context | +0.117 (+0.032, +0.223) significant |
-| no_answer | -0.005 (-0.010, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | -0.369 (-0.369, -0.369) significant |
-| uncategorized | +0.029 (-0.140, +0.189) **NOT SIGNIFICANT** |
+| overall | +0.065 (+0.032, +0.099) 유의함 |
+| multi_hop | +0.070 (+0.040, +0.106) 유의함 |
+| distractor_heavy | +0.063 (+0.007, +0.126) 유의함 |
+| long_context | +0.117 (+0.032, +0.223) 유의함 |
+| no_answer | -0.005 (-0.010, +0.000) **유의하지 않음** |
+| ambiguous_query | -0.369 (-0.369, -0.369) 유의함 |
+| uncategorized | +0.029 (-0.140, +0.189) **유의하지 않음** |
 
-## Per-category winner
+## 카테고리별 winner
 
-Winner = variant with highest `chunk_recall@10` mean AND paired CI vs `dense_m3` fully above 0. "NOT SIGNIFICANT" = no variant's CI clears 0 (absolute rule #5).
+winner = `chunk_recall@10` 평균이 가장 높으면서 `dense_m3` 대비 paired CI 가 완전히 0 위인 변형. "유의하지 않음" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
 
-| Category | Winner | Mean recall@10 | Delta CI vs `dense_m3` |
+| 카테고리 | winner | 평균 recall@10 | `dense_m3` 대비 delta CI |
 |---|---|---|---|
-| overall | `hybrid_bm25_k60_m3` | 0.340 | +0.052 (+0.020, +0.088) significant |
-| multi_hop | `hybrid_bm25_k60_m3` | 0.283 | +0.043 (+0.018, +0.073) significant |
-| distractor_heavy | `hybrid_bm25_k60_m3` | 0.354 | +0.067 (+0.015, +0.131) significant |
-| long_context | `hybrid_bm25_k60_m3` | 0.434 | +0.133 (+0.017, +0.278) significant |
-| no_answer | `NOT SIGNIFICANT` | — | — |
-| ambiguous_query | `NOT SIGNIFICANT` | — | — |
-| uncategorized | `NOT SIGNIFICANT` | — | — |
+| overall | `hybrid_bm25_k60_m3` | 0.340 | +0.052 (+0.020, +0.088) 유의함 |
+| multi_hop | `hybrid_bm25_k60_m3` | 0.283 | +0.043 (+0.018, +0.073) 유의함 |
+| distractor_heavy | `hybrid_bm25_k60_m3` | 0.354 | +0.067 (+0.015, +0.131) 유의함 |
+| long_context | `hybrid_bm25_k60_m3` | 0.434 | +0.133 (+0.017, +0.278) 유의함 |
+| no_answer | `유의하지 않음` | — | — |
+| ambiguous_query | `유의하지 않음` | — | — |
+| uncategorized | `유의하지 않음` | — | — |
 
-## Notes
+## 비고(notes)
 
-* Planner-bypass: full query as the only sub-query, identity expansion, no rerank, `metadata_first=False` — isolates retrieval-mode impact from expansion / rerank / metadata-filter effects (same discipline as Phase 3).
-* All 3 variants share `data/index/real100_m3` (BGE-M3 1024-dim dense). `hybrid_bm25_k60_m3` uses BM25 lazy-built on the index dict; `m3` populates `index['_m3_cache']` (sparse + colbert per chunk, in-memory only per ADR 0025 spike-mode, no disk persist) on its first call. `--warmup` absorbs the ~2 min cache cold-start so per-case latency reflects cache-hit cost.
-* m3's RRF dense channel reuses the index's existing dense channel (`rag_retrieval.py:449-454`) — for this run it IS the BGE-M3 dense (the index was built with `--model BAAI/bge-m3`), so the 3 channels are all BGE-M3 (dense + sparse + colbert). On hashing-built indexes the dense channel would be hashing, mixing embedding families.
-* `chunk_recall@k` is None for cases without `expected_terms` / `expected_doc_ids` (e.g. abstention) — those are dropped pairwise to preserve case alignment between variants.
-* Seeds drive only the bootstrap RNG; retrieval itself is deterministic for the same query+index+backend+rrf_k (dense + BM25 + m3 sparse/colbert).
-* Category bucketing uses `hardcase_categories` (semantic difficulty tags). Multi-tag cases appear in multiple buckets, so per-category counts overlap and per-category paired CIs share cases.
-* `dense_m3` is the delta baseline because Phase 3.5 isolates **multi-channel vs single-channel under semantic embeddings**. Deltas above 0 favor the multi-channel variant (hybrid or m3); below 0 favor dense alone.
-* **Phase 3 cross-ref + runner bug retraction**: `reports/retrieval/phase3_mode_20260518T032404Z/` reported all 3 `hybrid_bm25_k{30,60,100}` variants byte-identical and attributed it to BM25 channel dominance. **That conclusion was wrong**: the Phase 3 runner called `retrieve_candidates` (candidate generation only) without the second-stage `apply_fusion_and_reranking` (RRF fusion + final top-k). For hybrid + m3 backends `retrieve_candidates` returns `score=0.0` placeholders, so the per-case ranking collapsed to chunk_id insertion order — making every k value byte-identical. Phase 3.5 fixes the wire-up (both calls in `run_single_case`); the hashing-index re-run is a follow-up. Cross-backend delta math (hashing `dense` vs `dense_m3`) remains confounded by the embedding family swap and is NOT computed.
-* **Chunk count caveat**: the BGE-M3 index used the `data_list_csv_text` loader for both HWP and PDF (per ADR 0049 graceful fallback), yielding ~9 chunks/doc vs real100's ~264 chunks/doc with `kordoc` full extraction. Re-embedding 26k kordoc chunks with BGE-M3 on MPS would take >2h (per-batch GPU dispatch overhead); the csv_text fallback keeps the build under 20 min while preserving the within-Phase-3.5 paired CI claim. Absolute `chunk_recall@k` on this index is NOT directly comparable to Phase 3's kordoc-built numbers — only Phase 3.5 internal deltas are.
-* **Runner-side m3 batching (measurement-only optimization)**: per-query colbert max-sim is the dominant cost on this index (per-chunk Python-loop matmul × ~900 chunks × ~50s/query observed on the unoptimized path). The runner concatenates all chunk colbert vectors into one `(Σ T_d, 1024)` matrix and does **one** matmul per unique query, then splits the columns back per chunk for the row-wise max+sum. Mathematically identical to the per-chunk path (each chunk's column slice is independent), but ~100× faster. The patch lives in the runner (`_prime_m3_index_cache_and_colbert`); `rag_m3.py` / `rag_retrieval.py` unchanged.
-* **Out of scope**: per-channel m3 ablation (sparse-only, colbert-only — see ADR 0010 'Alternatives considered'); RRF-k sweep on hybrid_bm25 (Phase 3 already showed k=30/60/100 byte-identical on hashing); cross-encoder rerank stacked on top (Phase 4).
-* ADR cross-refs: ADR 0010 (BGE-M3 multi-channel deferred), ADR 0021 (m3_full analysis row), ADR 0032 (torch>=2.6 unblock — closes the install blocker that originally deferred this measurement).
+* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, rerank 없음, `metadata_first=False` — 검색 모드 효과를 expansion / rerank / metadata-filter 효과로부터 격리한다 (Phase 3 과 동일 규율).
+* 3 변형 모두 `data/index/real100_m3`(BGE-M3 1024-dim dense)를 공유한다. `hybrid_bm25_k60_m3` 는 index dict 에 lazy-build 된 BM25 를 쓰고; `m3` 는 첫 호출 시 `index['_m3_cache']`(청크별 sparse + colbert, ADR 0025 spike-mode 라 in-memory only, 디스크 미persist)를 채운다. `--warmup` 이 ~2 분 캐시 cold-start 를 흡수하므로 케이스별 지연시간은 캐시 hit 비용을 반영한다.
+* m3 의 RRF dense 채널은 인덱스의 기존 dense 채널을 재사용한다(`rag_retrieval.py:449-454`) — 이 run 에서는 그것이 BGE-M3 dense 다(인덱스가 `--model BAAI/bge-m3` 로 빌드됨), 따라서 3 채널 모두 BGE-M3(dense + sparse + colbert)다. hashing 으로 빌드된 인덱스에서는 dense 채널이 hashing 이라 임베딩 패밀리가 섞이게 된다.
+* `chunk_recall@k` 는 `expected_terms` / `expected_doc_ids` 가 없는 케이스(예: abstention(보류))에서 None 이다 — 변형 간 케이스 정렬을 보존하기 위해 pairwise 에서 제외된다.
+* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 query+index+backend+rrf_k 에 대해 결정적(deterministic)이다 (dense + BM25 + m3 sparse/colbert).
+* 카테고리 버킷팅은 `hardcase_categories`(의미 난이도 태그)를 쓴다. 멀티태그 케이스는 여러 버킷에 나타나므로 카테고리별 카운트는 겹치고 paired CI 가 케이스를 공유한다.
+* `dense_m3` 이 delta baseline 인 이유: Phase 3.5 는 **의미 임베딩 위에서 multi-channel vs single-channel** 을 격리하기 때문이다. 0 위 delta 는 multi-channel 변형(hybrid 또는 m3)에, 0 아래는 dense 단독에 유리하다.
+* **Phase 3 cross-ref + runner 버그 retraction(철회)**: `reports/retrieval/phase3_mode_20260518T032404Z/` 는 3 개 `hybrid_bm25_k{30,60,100}` 변형이 byte-identical 이라 보고하고 이를 BM25 채널 dominance 로 귀인했다. **그 결론은 틀렸다**: Phase 3 runner 가 `retrieve_candidates`(후보 생성만)를 호출하고 2단계 `apply_fusion_and_reranking`(RRF fusion + 최종 top-k)를 누락했다. hybrid + m3 backend 에서 `retrieve_candidates` 는 `score=0.0` placeholder 를 반환하므로 케이스별 순위가 chunk_id 삽입 순서로 붕괴해 모든 k 값이 byte-identical 이 됐다. Phase 3.5 는 wire-up 을 고친다(`run_single_case` 에 두 호출 모두); hashing 인덱스 재측정은 후속이다. Cross-backend delta(hashing `dense` vs `dense_m3`)는 임베딩 패밀리 교체로 confounded 되어 산출하지 않는다.
+* **청크 수 caveat**: BGE-M3 인덱스가 HWP/PDF 모두에 `data_list_csv_text` loader 를 썼고(ADR 0049 graceful fallback), doc 당 ~9 청크였다(`kordoc` 전체 추출의 real100 ~264 청크/doc 대비). 26k kordoc 청크를 BGE-M3 로 MPS 에서 재임베딩하면 >2h 걸린다(배치별 GPU dispatch overhead); csv_text fallback 은 build 를 20 분 미만으로 유지하면서 Phase 3.5 내부 paired CI 주장을 보존한다. 이 인덱스의 절대 `chunk_recall@k` 는 Phase 3 의 kordoc 빌드 수치와 직접 비교 불가 — Phase 3.5 내부 delta 만 비교 가능하다.
+* **Runner 측 m3 batching (측정 전용 최적화)**: 이 인덱스에서 query 별 colbert max-sim 이 지배적 비용이다(청크별 Python-loop matmul × ~900 청크 × 최적화 전 경로에서 관측된 ~50s/query). runner 는 모든 청크 colbert 벡터를 하나의 `(Σ T_d, 1024)` 행렬로 concat 해 unique query 당 **1회** matmul 후 행별 max+sum 을 위해 컬럼을 청크별로 다시 split 한다. 청크별 경로와 수학적으로 동일하나(각 청크의 컬럼 슬라이스는 독립) ~100× 빠르다. 패치는 runner 에 있다(`_prime_m3_index_cache_and_colbert`); `rag_m3.py` / `rag_retrieval.py` 는 미변경.
+* **범위 외**: 채널별 m3 ablation(sparse-only, colbert-only — ADR 0010 'Alternatives considered' 참조); hybrid_bm25 의 RRF-k sweep(Phase 3 이 이미 hashing 에서 k=30/60/100 byte-identical 을 보임); 위에 stack 된 cross-encoder rerank(Phase 4).
+* ADR cross-ref: ADR 0010(BGE-M3 multi-channel deferred), ADR 0021(m3_full 분석 행), ADR 0032(torch>=2.6 unblock — 본 측정을 원래 미뤘던 install blocker 를 해소).
+* 이 리포트는 `--reaggregate` 로 `reports/retrieval/phase35_m3_20260518T214937Z_kordoc_no_m3/raw_results.json` 로부터 재생성됨 — 카테고리는 `hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval 점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변.

--- a/reports/retrieval/phase3_mode_20260518T032404Z/REPORT.md
+++ b/reports/retrieval/phase3_mode_20260518T032404Z/REPORT.md
@@ -1,19 +1,19 @@
-# Phase 3 retrieval-eval — mode ablation (real100 n=221)
+# Phase 3 retrieval-eval — 검색 모드(mode) ablation (real100 n=221)
 
-Run: `20260518-0352-phase3-mode` · commit `7aaa6a3931` · index_dir=`/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100` · eval_config=`/Users/hskim/Desktop/projects/BidMate-DocAgent/eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+Run: `20260521-0334-phase3-mode-reaggregate` · commit `5e5f07bc96` · index_dir=`/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
 
-## Variants
+## 변형(variants)
 
-| Variant | Backend | RRF k | Docs | Chunks |
+| 변형 | backend | RRF k | 문서 | 청크 |
 |---|---|---|---|---|
 | `dense` | dense | — | 100 | 26376 |
 | `hybrid_bm25_k30` | hybrid | 30 | 100 | 26376 |
 | `hybrid_bm25_k60` | hybrid | 60 | 100 | 26376 |
 | `hybrid_bm25_k100` | hybrid | 100 | 100 | 26376 |
 
-## Latency (ms)
+## 지연시간(latency, ms)
 
-| Variant | p50 | p95 | mean | n |
+| 변형 | p50 | p95 | mean | n |
 |---|---|---|---|---|
 | `dense` | 1270.701 | 3214.817 | 1551.449 | 221 |
 | `hybrid_bm25_k30` | 1535.016 | 4130.334 | 1851.968 | 221 |
@@ -22,7 +22,7 @@ Run: `20260518-0352-phase3-mode` · commit `7aaa6a3931` · index_dir=`/Users/hsk
 
 ## chunk_recall@5
 
-| Category | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+| 카테고리 | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
 |---|---|---|---|---|
 | overall | 0.055 (n=114) | 0.018 (n=114) | 0.018 (n=114) | 0.018 (n=114) |
 | multi_hop | 0.056 (n=93) | 0.000 (n=93) | 0.000 (n=93) | 0.000 (n=93) |
@@ -32,21 +32,21 @@ Run: `20260518-0352-phase3-mode` · commit `7aaa6a3931` · index_dir=`/Users/hsk
 | ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
 | uncategorized | 0.080 (n=13) | 0.154 (n=13) | 0.154 (n=13) | 0.154 (n=13) |
 
-### chunk_recall@5 — paired CI delta vs `dense` (seed-averaged)
+### chunk_recall@5 — `dense` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+| 카테고리 | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
 |---|---|---|---|
-| overall | -0.037 (-0.074, -0.003) significant | -0.037 (-0.074, -0.003) significant | -0.037 (-0.074, -0.003) significant |
-| multi_hop | -0.056 (-0.094, -0.025) significant | -0.056 (-0.094, -0.025) significant | -0.056 (-0.094, -0.025) significant |
-| distractor_heavy | -0.083 (-0.157, -0.023) significant | -0.083 (-0.157, -0.023) significant | -0.083 (-0.157, -0.023) significant |
-| long_context | -0.038 (-0.113, +0.000) **NOT SIGNIFICANT** | -0.038 (-0.113, +0.000) **NOT SIGNIFICANT** | -0.038 (-0.113, +0.000) **NOT SIGNIFICANT** |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.074 (-0.080, +0.268) **NOT SIGNIFICANT** | +0.074 (-0.080, +0.268) **NOT SIGNIFICANT** | +0.074 (-0.080, +0.268) **NOT SIGNIFICANT** |
+| overall | -0.037 (-0.074, -0.003) 유의함 | -0.037 (-0.074, -0.003) 유의함 | -0.037 (-0.074, -0.003) 유의함 |
+| multi_hop | -0.056 (-0.094, -0.025) 유의함 | -0.056 (-0.094, -0.025) 유의함 | -0.056 (-0.094, -0.025) 유의함 |
+| distractor_heavy | -0.083 (-0.157, -0.023) 유의함 | -0.083 (-0.157, -0.023) 유의함 | -0.083 (-0.157, -0.023) 유의함 |
+| long_context | -0.038 (-0.113, +0.000) **유의하지 않음** | -0.038 (-0.113, +0.000) **유의하지 않음** | -0.038 (-0.113, +0.000) **유의하지 않음** |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.074 (-0.080, +0.268) **유의하지 않음** | +0.074 (-0.080, +0.268) **유의하지 않음** | +0.074 (-0.080, +0.268) **유의하지 않음** |
 
 ## chunk_recall@10
 
-| Category | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+| 카테고리 | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
 |---|---|---|---|---|
 | overall | 0.064 (n=114) | 0.018 (n=114) | 0.018 (n=114) | 0.018 (n=114) |
 | multi_hop | 0.067 (n=93) | 0.000 (n=93) | 0.000 (n=93) | 0.000 (n=93) |
@@ -56,21 +56,21 @@ Run: `20260518-0352-phase3-mode` · commit `7aaa6a3931` · index_dir=`/Users/hsk
 | ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
 | uncategorized | 0.081 (n=13) | 0.154 (n=13) | 0.154 (n=13) | 0.154 (n=13) |
 
-### chunk_recall@10 — paired CI delta vs `dense` (seed-averaged)
+### chunk_recall@10 — `dense` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+| 카테고리 | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
 |---|---|---|---|
-| overall | -0.046 (-0.084, -0.011) significant | -0.046 (-0.084, -0.011) significant | -0.046 (-0.084, -0.011) significant |
-| multi_hop | -0.067 (-0.106, -0.035) significant | -0.067 (-0.106, -0.035) significant | -0.067 (-0.106, -0.035) significant |
-| distractor_heavy | -0.087 (-0.162, -0.026) significant | -0.087 (-0.162, -0.026) significant | -0.087 (-0.162, -0.026) significant |
-| long_context | -0.094 (-0.216, -0.001) significant | -0.094 (-0.216, -0.001) significant | -0.094 (-0.216, -0.001) significant |
-| no_answer | -0.050 (-0.100, +0.000) **NOT SIGNIFICANT** | -0.050 (-0.100, +0.000) **NOT SIGNIFICANT** | -0.050 (-0.100, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.073 (-0.083, +0.268) **NOT SIGNIFICANT** | +0.073 (-0.083, +0.268) **NOT SIGNIFICANT** | +0.073 (-0.083, +0.268) **NOT SIGNIFICANT** |
+| overall | -0.046 (-0.084, -0.011) 유의함 | -0.046 (-0.084, -0.011) 유의함 | -0.046 (-0.084, -0.011) 유의함 |
+| multi_hop | -0.067 (-0.106, -0.035) 유의함 | -0.067 (-0.106, -0.035) 유의함 | -0.067 (-0.106, -0.035) 유의함 |
+| distractor_heavy | -0.087 (-0.162, -0.026) 유의함 | -0.087 (-0.162, -0.026) 유의함 | -0.087 (-0.162, -0.026) 유의함 |
+| long_context | -0.094 (-0.216, -0.001) 유의함 | -0.094 (-0.216, -0.001) 유의함 | -0.094 (-0.216, -0.001) 유의함 |
+| no_answer | -0.050 (-0.100, +0.000) **유의하지 않음** | -0.050 (-0.100, +0.000) **유의하지 않음** | -0.050 (-0.100, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.073 (-0.083, +0.268) **유의하지 않음** | +0.073 (-0.083, +0.268) **유의하지 않음** | +0.073 (-0.083, +0.268) **유의하지 않음** |
 
 ## mrr
 
-| Category | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+| 카테고리 | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
 |---|---|---|---|---|
 | overall | 0.129 (n=114) | 0.006 (n=114) | 0.006 (n=114) | 0.006 (n=114) |
 | multi_hop | 0.132 (n=93) | 0.000 (n=93) | 0.000 (n=93) | 0.000 (n=93) |
@@ -80,21 +80,21 @@ Run: `20260518-0352-phase3-mode` · commit `7aaa6a3931` · index_dir=`/Users/hsk
 | ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
 | uncategorized | 0.179 (n=13) | 0.051 (n=13) | 0.051 (n=13) | 0.051 (n=13) |
 
-### mrr — paired CI delta vs `dense` (seed-averaged)
+### mrr — `dense` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+| 카테고리 | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
 |---|---|---|---|
-| overall | -0.123 (-0.177, -0.075) significant | -0.123 (-0.177, -0.075) significant | -0.123 (-0.177, -0.075) significant |
-| multi_hop | -0.132 (-0.192, -0.082) significant | -0.132 (-0.192, -0.082) significant | -0.132 (-0.192, -0.082) significant |
-| distractor_heavy | -0.121 (-0.202, -0.050) significant | -0.121 (-0.202, -0.050) significant | -0.121 (-0.202, -0.050) significant |
-| long_context | -0.110 (-0.225, -0.023) significant | -0.110 (-0.225, -0.023) significant | -0.110 (-0.225, -0.023) significant |
-| no_answer | -0.062 (-0.125, +0.000) **NOT SIGNIFICANT** | -0.062 (-0.125, +0.000) **NOT SIGNIFICANT** | -0.062 (-0.125, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | -0.128 (-0.368, +0.051) **NOT SIGNIFICANT** | -0.128 (-0.368, +0.051) **NOT SIGNIFICANT** | -0.128 (-0.368, +0.051) **NOT SIGNIFICANT** |
+| overall | -0.123 (-0.177, -0.075) 유의함 | -0.123 (-0.177, -0.075) 유의함 | -0.123 (-0.177, -0.075) 유의함 |
+| multi_hop | -0.132 (-0.192, -0.082) 유의함 | -0.132 (-0.192, -0.082) 유의함 | -0.132 (-0.192, -0.082) 유의함 |
+| distractor_heavy | -0.121 (-0.202, -0.050) 유의함 | -0.121 (-0.202, -0.050) 유의함 | -0.121 (-0.202, -0.050) 유의함 |
+| long_context | -0.110 (-0.225, -0.023) 유의함 | -0.110 (-0.225, -0.023) 유의함 | -0.110 (-0.225, -0.023) 유의함 |
+| no_answer | -0.062 (-0.125, +0.000) **유의하지 않음** | -0.062 (-0.125, +0.000) **유의하지 않음** | -0.062 (-0.125, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | -0.128 (-0.368, +0.051) **유의하지 않음** | -0.128 (-0.368, +0.051) **유의하지 않음** | -0.128 (-0.368, +0.051) **유의하지 않음** |
 
 ## ndcg@10
 
-| Category | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+| 카테고리 | `dense` | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
 |---|---|---|---|---|
 | overall | 0.067 (n=114) | 0.009 (n=114) | 0.009 (n=114) | 0.009 (n=114) |
 | multi_hop | 0.065 (n=93) | 0.000 (n=93) | 0.000 (n=93) | 0.000 (n=93) |
@@ -104,39 +104,40 @@ Run: `20260518-0352-phase3-mode` · commit `7aaa6a3931` · index_dir=`/Users/hsk
 | ambiguous_query | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) | 0.000 (n=1) |
 | uncategorized | 0.119 (n=13) | 0.080 (n=13) | 0.080 (n=13) | 0.080 (n=13) |
 
-### ndcg@10 — paired CI delta vs `dense` (seed-averaged)
+### ndcg@10 — `dense` 대비 paired CI delta (seed 평균)
 
-| Category | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
+| 카테고리 | `hybrid_bm25_k30` | `hybrid_bm25_k60` | `hybrid_bm25_k100` |
 |---|---|---|---|
-| overall | -0.058 (-0.089, -0.030) significant | -0.058 (-0.089, -0.030) significant | -0.058 (-0.089, -0.030) significant |
-| multi_hop | -0.065 (-0.095, -0.040) significant | -0.065 (-0.095, -0.040) significant | -0.065 (-0.095, -0.040) significant |
-| distractor_heavy | -0.068 (-0.116, -0.028) significant | -0.068 (-0.116, -0.028) significant | -0.068 (-0.116, -0.028) significant |
-| long_context | -0.073 (-0.152, -0.007) significant | -0.073 (-0.152, -0.007) significant | -0.073 (-0.152, -0.007) significant |
-| no_answer | -0.035 (-0.069, +0.000) **NOT SIGNIFICANT** | -0.035 (-0.069, +0.000) **NOT SIGNIFICANT** | -0.035 (-0.069, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | -0.039 (-0.200, +0.109) **NOT SIGNIFICANT** | -0.039 (-0.200, +0.109) **NOT SIGNIFICANT** | -0.039 (-0.200, +0.109) **NOT SIGNIFICANT** |
+| overall | -0.058 (-0.089, -0.030) 유의함 | -0.058 (-0.089, -0.030) 유의함 | -0.058 (-0.089, -0.030) 유의함 |
+| multi_hop | -0.065 (-0.095, -0.040) 유의함 | -0.065 (-0.095, -0.040) 유의함 | -0.065 (-0.095, -0.040) 유의함 |
+| distractor_heavy | -0.068 (-0.116, -0.028) 유의함 | -0.068 (-0.116, -0.028) 유의함 | -0.068 (-0.116, -0.028) 유의함 |
+| long_context | -0.073 (-0.152, -0.007) 유의함 | -0.073 (-0.152, -0.007) 유의함 | -0.073 (-0.152, -0.007) 유의함 |
+| no_answer | -0.035 (-0.069, +0.000) **유의하지 않음** | -0.035 (-0.069, +0.000) **유의하지 않음** | -0.035 (-0.069, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | -0.039 (-0.200, +0.109) **유의하지 않음** | -0.039 (-0.200, +0.109) **유의하지 않음** | -0.039 (-0.200, +0.109) **유의하지 않음** |
 
-## Per-category winner
+## 카테고리별 winner
 
-Winner = variant with highest `chunk_recall@10` mean AND paired CI vs `dense` fully above 0. "NOT SIGNIFICANT" = no variant's CI clears 0 (absolute rule #5).
+winner = `chunk_recall@10` 평균이 가장 높으면서 `dense` 대비 paired CI 가 완전히 0 위인 변형. "유의하지 않음" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
 
-| Category | Winner | Mean recall@10 | Delta CI vs `dense` |
+| 카테고리 | winner | 평균 recall@10 | `dense` 대비 delta CI |
 |---|---|---|---|
-| overall | `NOT SIGNIFICANT` | — | — |
-| multi_hop | `NOT SIGNIFICANT` | — | — |
-| distractor_heavy | `NOT SIGNIFICANT` | — | — |
-| long_context | `NOT SIGNIFICANT` | — | — |
-| no_answer | `NOT SIGNIFICANT` | — | — |
-| ambiguous_query | `NOT SIGNIFICANT` | — | — |
-| uncategorized | `NOT SIGNIFICANT` | — | — |
+| overall | `유의하지 않음` | — | — |
+| multi_hop | `유의하지 않음` | — | — |
+| distractor_heavy | `유의하지 않음` | — | — |
+| long_context | `유의하지 않음` | — | — |
+| no_answer | `유의하지 않음` | — | — |
+| ambiguous_query | `유의하지 않음` | — | — |
+| uncategorized | `유의하지 않음` | — | — |
 
-## Notes
+## 비고(notes)
 
-* Planner-bypass: full query as the only sub-query, identity expansion, no rerank, `metadata_first=False` — isolates retrieval-mode impact from expansion / rerank / metadata-filter effects.
-* All 4 variants share `data/index/real100`; only `plan['retrieval_backend']` and `plan['rrf_k']` differ. BM25 lazy-builds on the first hybrid call via `rag_retrieval.get_or_build_bm25` and is cached on the index dict, so `hybrid_bm25_k30` pays the BM25 build cost once and `k60`/`k100` are cache hits.
-* `chunk_recall@k` is None for cases without `expected_terms` / `expected_doc_ids` (e.g. abstention) — those are dropped pairwise to preserve case alignment between variants.
-* Seeds drive only the bootstrap RNG; retrieval itself is deterministic for the same query+index+backend+rrf_k (dense + BM25 both).
-* Category bucketing uses `hardcase_categories` (semantic difficulty tags). Multi-tag cases appear in multiple buckets, so per-category counts overlap and per-category paired CIs share cases.
-* `dense` is the delta baseline because ADR 0010's accept rationale for `hybrid` framed the question as "is hybrid actually better than dense?". Deltas above 0 favor the hybrid variant; below 0 favor dense.
-* m3 (FlagEmbedding 3-channel RRF) is **out of scope** for Phase 3 — it requires a separate index build (`build_m3_index`), so deferring to Phase 3.5 keeps Phase 3 measurement narrow (mode ↔ index decoupled).
-* k=10 / k=200 are **out of scope** for Phase 3 — k∈{30,60,100} brackets ADR 0010's k=60 default without inflating the variant count. Tighter/looser k swings can be added in a follow-up if k=30 vs k=100 shows a clean gradient.
+* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, rerank 없음, `metadata_first=False` — 검색 모드 효과를 expansion / rerank / metadata-filter 효과로부터 격리한다.
+* 4 변형 모두 `data/index/real100` 을 공유한다; `plan['retrieval_backend']` 와 `plan['rrf_k']` 만 다르다. BM25 는 첫 hybrid 호출 시 `rag_retrieval.get_or_build_bm25` 로 lazy-build 되어 index dict 에 캐시되므로 `hybrid_bm25_k30` 가 BM25 build 비용을 1회 지불하고 `k60`/`k100` 은 캐시 hit 이다.
+* `chunk_recall@k` 는 `expected_terms` / `expected_doc_ids` 가 없는 케이스(예: abstention(보류))에서 None 이다 — 변형 간 케이스 정렬을 보존하기 위해 pairwise 에서 제외된다.
+* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 query+index+backend+rrf_k 에 대해 결정적(deterministic)이다 (dense + BM25 모두).
+* 카테고리 버킷팅은 `hardcase_categories`(의미 난이도 태그)를 쓴다. 멀티태그 케이스는 여러 버킷에 나타나므로 카테고리별 카운트는 겹치고 paired CI 가 케이스를 공유한다.
+* `dense` 이 delta baseline 인 이유: ADR 0010 의 `hybrid` 채택 근거가 질문을 "hybrid 가 실제로 dense 보다 나은가?" 로 프레이밍했기 때문이다. 0 위 delta 는 hybrid 변형에, 0 아래는 dense 에 유리하다.
+* m3 (FlagEmbedding 3-channel RRF)는 Phase 3 **범위 외**다 — 별도 인덱스 빌드(`build_m3_index`)가 필요하므로 Phase 3.5 로 미뤄 Phase 3 측정을 좁게 유지한다 (mode ↔ index 분리).
+* k=10 / k=200 은 Phase 3 **범위 외**다 — k∈{30,60,100} 이 변형 수를 부풀리지 않으면서 ADR 0010 의 k=60 default 를 감싼다. k=30 vs k=100 이 깔끔한 gradient 를 보이면 후속에서 더 좁은/넓은 k 를 추가할 수 있다.
+* 이 리포트는 `--reaggregate` 로 `reports/retrieval/phase3_mode_20260518T032404Z/raw_results.json` 로부터 재생성됨 — 카테고리는 `hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval 점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변.

--- a/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/REPORT.md
+++ b/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/REPORT.md
@@ -1,6 +1,6 @@
 # Phase 4 retrieval-eval — 메타데이터 / 필터링 ablation (real100 n=221)
 
-Run: `20260520-1419-phase4-metadata-reaggregate` · commit `9af8d73a63` · index_dir=`data/index/real100_kordoc` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+Run: `20260521-0334-phase4-metadata-reaggregate` · commit `5e5f07bc96` · index_dir=`data/index/real100_kordoc` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
 
 ## 변형(variants)
 
@@ -36,13 +36,13 @@ Run: `20260520-1419-phase4-metadata-reaggregate` · commit `9af8d73a63` · index
 
 | 카테고리 | `soft_agency` | `prefilter_agency` | `prefilter_project` |
 |---|---|---|---|
-| overall | +0.198 (+0.147, +0.251) significant | +0.198 (+0.147, +0.251) significant | +0.203 (+0.152, +0.255) significant |
-| multi_hop | +0.212 (+0.160, +0.269) significant | +0.212 (+0.160, +0.269) significant | +0.218 (+0.165, +0.275) significant |
-| distractor_heavy | +0.179 (+0.106, +0.263) significant | +0.179 (+0.106, +0.263) significant | +0.179 (+0.107, +0.263) significant |
-| long_context | +0.096 (+0.002, +0.223) significant | +0.096 (+0.002, +0.223) significant | +0.096 (+0.002, +0.223) significant |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.156 (+0.001, +0.385) significant | +0.156 (+0.001, +0.385) significant | +0.154 (-0.001, +0.384) **NOT SIGNIFICANT** |
+| overall | +0.198 (+0.147, +0.251) 유의함 | +0.198 (+0.147, +0.251) 유의함 | +0.203 (+0.152, +0.255) 유의함 |
+| multi_hop | +0.212 (+0.160, +0.269) 유의함 | +0.212 (+0.160, +0.269) 유의함 | +0.218 (+0.165, +0.275) 유의함 |
+| distractor_heavy | +0.179 (+0.106, +0.263) 유의함 | +0.179 (+0.106, +0.263) 유의함 | +0.179 (+0.107, +0.263) 유의함 |
+| long_context | +0.096 (+0.002, +0.223) 유의함 | +0.096 (+0.002, +0.223) 유의함 | +0.096 (+0.002, +0.223) 유의함 |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.156 (+0.001, +0.385) 유의함 | +0.156 (+0.001, +0.385) 유의함 | +0.154 (-0.001, +0.384) **유의하지 않음** |
 
 ## chunk_recall@10
 
@@ -60,13 +60,13 @@ Run: `20260520-1419-phase4-metadata-reaggregate` · commit `9af8d73a63` · index
 
 | 카테고리 | `soft_agency` | `prefilter_agency` | `prefilter_project` |
 |---|---|---|---|
-| overall | +0.213 (+0.162, +0.265) significant | +0.219 (+0.169, +0.271) significant | +0.223 (+0.174, +0.274) significant |
-| multi_hop | +0.225 (+0.167, +0.286) significant | +0.233 (+0.177, +0.293) significant | +0.238 (+0.183, +0.297) significant |
-| distractor_heavy | +0.188 (+0.109, +0.275) significant | +0.194 (+0.118, +0.279) significant | +0.192 (+0.121, +0.274) significant |
-| long_context | +0.127 (+0.012, +0.280) significant | +0.127 (+0.012, +0.280) significant | +0.127 (+0.012, +0.280) significant |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.158 (+0.003, +0.386) significant | +0.158 (+0.003, +0.386) significant | +0.157 (+0.000, +0.385) significant |
+| overall | +0.213 (+0.162, +0.265) 유의함 | +0.219 (+0.169, +0.271) 유의함 | +0.223 (+0.174, +0.274) 유의함 |
+| multi_hop | +0.225 (+0.167, +0.286) 유의함 | +0.233 (+0.177, +0.293) 유의함 | +0.238 (+0.183, +0.297) 유의함 |
+| distractor_heavy | +0.188 (+0.109, +0.275) 유의함 | +0.194 (+0.118, +0.279) 유의함 | +0.192 (+0.121, +0.274) 유의함 |
+| long_context | +0.127 (+0.012, +0.280) 유의함 | +0.127 (+0.012, +0.280) 유의함 | +0.127 (+0.012, +0.280) 유의함 |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.158 (+0.003, +0.386) 유의함 | +0.158 (+0.003, +0.386) 유의함 | +0.157 (+0.000, +0.385) 유의함 |
 
 ## mrr
 
@@ -84,13 +84,13 @@ Run: `20260520-1419-phase4-metadata-reaggregate` · commit `9af8d73a63` · index
 
 | 카테고리 | `soft_agency` | `prefilter_agency` | `prefilter_project` |
 |---|---|---|---|
-| overall | +0.402 (+0.329, +0.476) significant | +0.407 (+0.335, +0.481) significant | +0.435 (+0.362, +0.507) significant |
-| multi_hop | +0.443 (+0.359, +0.523) significant | +0.445 (+0.360, +0.525) significant | +0.477 (+0.396, +0.558) significant |
-| distractor_heavy | +0.416 (+0.302, +0.535) significant | +0.429 (+0.314, +0.546) significant | +0.464 (+0.350, +0.576) significant |
-| long_context | +0.197 (+0.016, +0.439) significant | +0.197 (+0.016, +0.439) significant | +0.197 (+0.016, +0.439) significant |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.500 (+0.500, +0.500) significant | +0.500 (+0.500, +0.500) significant | +0.500 (+0.500, +0.500) significant |
-| uncategorized | +0.121 (+0.007, +0.295) significant | +0.120 (+0.007, +0.295) significant | +0.133 (+0.018, +0.306) significant |
+| overall | +0.402 (+0.329, +0.476) 유의함 | +0.407 (+0.335, +0.481) 유의함 | +0.435 (+0.362, +0.507) 유의함 |
+| multi_hop | +0.443 (+0.359, +0.523) 유의함 | +0.445 (+0.360, +0.525) 유의함 | +0.477 (+0.396, +0.558) 유의함 |
+| distractor_heavy | +0.416 (+0.302, +0.535) 유의함 | +0.429 (+0.314, +0.546) 유의함 | +0.464 (+0.350, +0.576) 유의함 |
+| long_context | +0.197 (+0.016, +0.439) 유의함 | +0.197 (+0.016, +0.439) 유의함 | +0.197 (+0.016, +0.439) 유의함 |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.500 (+0.500, +0.500) 유의함 | +0.500 (+0.500, +0.500) 유의함 | +0.500 (+0.500, +0.500) 유의함 |
+| uncategorized | +0.121 (+0.007, +0.295) 유의함 | +0.120 (+0.007, +0.295) 유의함 | +0.133 (+0.018, +0.306) 유의함 |
 
 ## ndcg@10
 
@@ -108,27 +108,27 @@ Run: `20260520-1419-phase4-metadata-reaggregate` · commit `9af8d73a63` · index
 
 | 카테고리 | `soft_agency` | `prefilter_agency` | `prefilter_project` |
 |---|---|---|---|
-| overall | +0.300 (+0.248, +0.353) significant | +0.306 (+0.254, +0.359) significant | +0.324 (+0.270, +0.378) significant |
-| multi_hop | +0.324 (+0.266, +0.381) significant | +0.330 (+0.273, +0.387) significant | +0.352 (+0.296, +0.411) significant |
-| distractor_heavy | +0.276 (+0.197, +0.363) significant | +0.282 (+0.204, +0.366) significant | +0.290 (+0.216, +0.370) significant |
-| long_context | +0.213 (+0.051, +0.400) significant | +0.214 (+0.053, +0.401) significant | +0.214 (+0.053, +0.401) significant |
-| no_answer | -0.002 (-0.004, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.369 (+0.369, +0.369) significant | +0.369 (+0.369, +0.369) significant | +0.369 (+0.369, +0.369) significant |
-| uncategorized | +0.161 (+0.023, +0.354) significant | +0.161 (+0.023, +0.354) significant | +0.156 (+0.014, +0.347) significant |
+| overall | +0.300 (+0.248, +0.353) 유의함 | +0.306 (+0.254, +0.359) 유의함 | +0.324 (+0.270, +0.378) 유의함 |
+| multi_hop | +0.324 (+0.266, +0.381) 유의함 | +0.330 (+0.273, +0.387) 유의함 | +0.352 (+0.296, +0.411) 유의함 |
+| distractor_heavy | +0.276 (+0.197, +0.363) 유의함 | +0.282 (+0.204, +0.366) 유의함 | +0.290 (+0.216, +0.370) 유의함 |
+| long_context | +0.213 (+0.051, +0.400) 유의함 | +0.214 (+0.053, +0.401) 유의함 | +0.214 (+0.053, +0.401) 유의함 |
+| no_answer | -0.002 (-0.004, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.369 (+0.369, +0.369) 유의함 | +0.369 (+0.369, +0.369) 유의함 | +0.369 (+0.369, +0.369) 유의함 |
+| uncategorized | +0.161 (+0.023, +0.354) 유의함 | +0.161 (+0.023, +0.354) 유의함 | +0.156 (+0.014, +0.347) 유의함 |
 
 ## 카테고리별 winner
 
-winner = `chunk_recall@10` 평균이 가장 높으면서 `no_metadata` 대비 paired CI 가 완전히 0 위인 변형. "NOT SIGNIFICANT" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
+winner = `chunk_recall@10` 평균이 가장 높으면서 `no_metadata` 대비 paired CI 가 완전히 0 위인 변형. "유의하지 않음" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
 
 | 카테고리 | winner | 평균 recall@10 | `no_metadata` 대비 delta CI |
 |---|---|---|---|
-| overall | `prefilter_project` | 0.425 | +0.223 (+0.174, +0.274) significant |
-| multi_hop | `prefilter_project` | 0.427 | +0.238 (+0.183, +0.297) significant |
-| distractor_heavy | `prefilter_agency` | 0.453 | +0.194 (+0.118, +0.279) significant |
-| long_context | `soft_agency` | 0.429 | +0.127 (+0.012, +0.280) significant |
-| no_answer | `NOT SIGNIFICANT` | — | — |
-| ambiguous_query | `NOT SIGNIFICANT` | — | — |
-| uncategorized | `soft_agency` | 0.342 | +0.158 (+0.003, +0.386) significant |
+| overall | `prefilter_project` | 0.425 | +0.223 (+0.174, +0.274) 유의함 |
+| multi_hop | `prefilter_project` | 0.427 | +0.238 (+0.183, +0.297) 유의함 |
+| distractor_heavy | `prefilter_agency` | 0.453 | +0.194 (+0.118, +0.279) 유의함 |
+| long_context | `soft_agency` | 0.429 | +0.127 (+0.012, +0.280) 유의함 |
+| no_answer | `유의하지 않음` | — | — |
+| ambiguous_query | `유의하지 않음` | — | — |
+| uncategorized | `soft_agency` | 0.342 | +0.158 (+0.003, +0.386) 유의함 |
 
 ## 비고(notes)
 

--- a/reports/retrieval/phase4_realistic_metadata_20260521T013224Z_kordoc/REPORT.md
+++ b/reports/retrieval/phase4_realistic_metadata_20260521T013224Z_kordoc/REPORT.md
@@ -1,6 +1,6 @@
 # Phase 4 retrieval-eval — 현실 query-time 메타데이터 라우팅(realistic routing) (real100 n=221)
 
-Run: `20260521-0257-phase4-realistic-reaggregate` · commit `f4600721a9` · index_dir=`data/index/real100_kordoc` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
+Run: `20260521-0334-phase4-realistic-reaggregate` · commit `5e5f07bc96` · index_dir=`data/index/real100_kordoc` · eval_config=`eval/real_config.local.yaml` · seeds=[17, 23, 29] · top_k=20 · ks=[5, 10]
 
 ## 변형(variants)
 
@@ -50,16 +50,16 @@ follow_up cohort: n=4, agency 정확 추출 1 (단일 query 만 보므로 contex
 
 | 카테고리 | `extractor_soft_agency` | `extractor_prefilter_agency` | `extractor_prefilter_project` |
 |---|---|---|---|
-| overall | +0.000 (-0.000, +0.002) **NOT SIGNIFICANT** | +0.001 (+0.000, +0.002) **NOT SIGNIFICANT** | -0.006 (-0.017, +0.004) **NOT SIGNIFICANT** |
-| extractor_hit_agency | +0.007 (+0.000, +0.017) **NOT SIGNIFICANT** | +0.007 (+0.000, +0.017) **NOT SIGNIFICANT** | +0.005 (+0.000, +0.015) **NOT SIGNIFICANT** |
-| extractor_miss_agency | -0.000 (-0.001, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | -0.007 (-0.019, +0.003) **NOT SIGNIFICANT** |
-| multi_hop | +0.000 (-0.001, +0.002) **NOT SIGNIFICANT** | +0.001 (+0.000, +0.002) **NOT SIGNIFICANT** | -0.008 (-0.022, +0.004) **NOT SIGNIFICANT** |
-| distractor_heavy | +0.001 (+0.000, +0.004) **NOT SIGNIFICANT** | +0.001 (+0.000, +0.004) **NOT SIGNIFICANT** | -0.015 (-0.041, +0.004) **NOT SIGNIFICANT** |
-| long_context | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | -0.004 (-0.011, +0.000) **NOT SIGNIFICANT** |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| follow_up | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.002 (+0.000, +0.005) **NOT SIGNIFICANT** | +0.002 (+0.000, +0.005) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.000 (-0.000, +0.002) **유의하지 않음** | +0.001 (+0.000, +0.002) **유의하지 않음** | -0.006 (-0.017, +0.004) **유의하지 않음** |
+| extractor_hit_agency | +0.007 (+0.000, +0.017) **유의하지 않음** | +0.007 (+0.000, +0.017) **유의하지 않음** | +0.005 (+0.000, +0.015) **유의하지 않음** |
+| extractor_miss_agency | -0.000 (-0.001, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | -0.007 (-0.019, +0.003) **유의하지 않음** |
+| multi_hop | +0.000 (-0.001, +0.002) **유의하지 않음** | +0.001 (+0.000, +0.002) **유의하지 않음** | -0.008 (-0.022, +0.004) **유의하지 않음** |
+| distractor_heavy | +0.001 (+0.000, +0.004) **유의하지 않음** | +0.001 (+0.000, +0.004) **유의하지 않음** | -0.015 (-0.041, +0.004) **유의하지 않음** |
+| long_context | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | -0.004 (-0.011, +0.000) **유의하지 않음** |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| follow_up | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.002 (+0.000, +0.005) **유의하지 않음** | +0.002 (+0.000, +0.005) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
 
 ## chunk_recall@10
 
@@ -80,16 +80,16 @@ follow_up cohort: n=4, agency 정확 추출 1 (단일 query 만 보므로 contex
 
 | 카테고리 | `extractor_soft_agency` | `extractor_prefilter_agency` | `extractor_prefilter_project` |
 |---|---|---|---|
-| overall | -0.001 (-0.005, +0.002) **NOT SIGNIFICANT** | +0.001 (+0.000, +0.003) **NOT SIGNIFICANT** | -0.007 (-0.019, +0.004) **NOT SIGNIFICANT** |
-| extractor_hit_agency | +0.010 (+0.000, +0.024) **NOT SIGNIFICANT** | +0.010 (+0.000, +0.024) **NOT SIGNIFICANT** | +0.005 (+0.000, +0.015) **NOT SIGNIFICANT** |
-| extractor_miss_agency | -0.002 (-0.007, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | -0.008 (-0.022, +0.004) **NOT SIGNIFICANT** |
-| multi_hop | -0.002 (-0.007, +0.001) **NOT SIGNIFICANT** | +0.001 (+0.000, +0.002) **NOT SIGNIFICANT** | -0.008 (-0.025, +0.005) **NOT SIGNIFICANT** |
-| distractor_heavy | -0.003 (-0.014, +0.004) **NOT SIGNIFICANT** | +0.001 (+0.000, +0.004) **NOT SIGNIFICANT** | -0.018 (-0.050, +0.004) **NOT SIGNIFICANT** |
-| long_context | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | -0.004 (-0.011, +0.000) **NOT SIGNIFICANT** |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| follow_up | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.004 (+0.000, +0.013) **NOT SIGNIFICANT** | +0.004 (+0.000, +0.013) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| overall | -0.001 (-0.005, +0.002) **유의하지 않음** | +0.001 (+0.000, +0.003) **유의하지 않음** | -0.007 (-0.019, +0.004) **유의하지 않음** |
+| extractor_hit_agency | +0.010 (+0.000, +0.024) **유의하지 않음** | +0.010 (+0.000, +0.024) **유의하지 않음** | +0.005 (+0.000, +0.015) **유의하지 않음** |
+| extractor_miss_agency | -0.002 (-0.007, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | -0.008 (-0.022, +0.004) **유의하지 않음** |
+| multi_hop | -0.002 (-0.007, +0.001) **유의하지 않음** | +0.001 (+0.000, +0.002) **유의하지 않음** | -0.008 (-0.025, +0.005) **유의하지 않음** |
+| distractor_heavy | -0.003 (-0.014, +0.004) **유의하지 않음** | +0.001 (+0.000, +0.004) **유의하지 않음** | -0.018 (-0.050, +0.004) **유의하지 않음** |
+| long_context | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | -0.004 (-0.011, +0.000) **유의하지 않음** |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| follow_up | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.004 (+0.000, +0.013) **유의하지 않음** | +0.004 (+0.000, +0.013) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
 
 ## mrr
 
@@ -110,16 +110,16 @@ follow_up cohort: n=4, agency 정확 추출 1 (단일 query 만 보므로 contex
 
 | 카테고리 | `extractor_soft_agency` | `extractor_prefilter_agency` | `extractor_prefilter_project` |
 |---|---|---|---|
-| overall | -0.002 (-0.004, +0.001) **NOT SIGNIFICANT** | +0.002 (+0.000, +0.004) **NOT SIGNIFICANT** | -0.021 (-0.057, +0.013) **NOT SIGNIFICANT** |
-| extractor_hit_agency | +0.011 (+0.000, +0.026) **NOT SIGNIFICANT** | +0.015 (+0.000, +0.037) **NOT SIGNIFICANT** | +0.010 (+0.000, +0.031) **NOT SIGNIFICANT** |
-| extractor_miss_agency | -0.003 (-0.006, -0.001) significant | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | -0.025 (-0.063, +0.013) **NOT SIGNIFICANT** |
-| multi_hop | -0.002 (-0.004, +0.001) **NOT SIGNIFICANT** | +0.001 (+0.000, +0.004) **NOT SIGNIFICANT** | -0.033 (-0.075, +0.005) **NOT SIGNIFICANT** |
-| distractor_heavy | -0.003 (-0.009, +0.003) **NOT SIGNIFICANT** | +0.003 (+0.000, +0.009) **NOT SIGNIFICANT** | -0.016 (-0.081, +0.042) **NOT SIGNIFICANT** |
-| long_context | -0.006 (-0.017, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | -0.018 (-0.083, +0.030) **NOT SIGNIFICANT** |
-| no_answer | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| follow_up | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.004 (-0.001, +0.012) **NOT SIGNIFICANT** | +0.004 (+0.000, +0.012) **NOT SIGNIFICANT** | -0.006 (-0.018, +0.000) **NOT SIGNIFICANT** |
+| overall | -0.002 (-0.004, +0.001) **유의하지 않음** | +0.002 (+0.000, +0.004) **유의하지 않음** | -0.021 (-0.057, +0.013) **유의하지 않음** |
+| extractor_hit_agency | +0.011 (+0.000, +0.026) **유의하지 않음** | +0.015 (+0.000, +0.037) **유의하지 않음** | +0.010 (+0.000, +0.031) **유의하지 않음** |
+| extractor_miss_agency | -0.003 (-0.006, -0.001) 유의함 | +0.000 (+0.000, +0.000) **유의하지 않음** | -0.025 (-0.063, +0.013) **유의하지 않음** |
+| multi_hop | -0.002 (-0.004, +0.001) **유의하지 않음** | +0.001 (+0.000, +0.004) **유의하지 않음** | -0.033 (-0.075, +0.005) **유의하지 않음** |
+| distractor_heavy | -0.003 (-0.009, +0.003) **유의하지 않음** | +0.003 (+0.000, +0.009) **유의하지 않음** | -0.016 (-0.081, +0.042) **유의하지 않음** |
+| long_context | -0.006 (-0.017, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | -0.018 (-0.083, +0.030) **유의하지 않음** |
+| no_answer | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| follow_up | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.004 (-0.001, +0.012) **유의하지 않음** | +0.004 (+0.000, +0.012) **유의하지 않음** | -0.006 (-0.018, +0.000) **유의하지 않음** |
 
 ## ndcg@10
 
@@ -140,37 +140,37 @@ follow_up cohort: n=4, agency 정확 추출 1 (단일 query 만 보므로 contex
 
 | 카테고리 | `extractor_soft_agency` | `extractor_prefilter_agency` | `extractor_prefilter_project` |
 |---|---|---|---|
-| overall | +0.002 (-0.004, +0.012) **NOT SIGNIFICANT** | +0.005 (+0.000, +0.014) **NOT SIGNIFICANT** | -0.010 (-0.027, +0.007) **NOT SIGNIFICANT** |
-| extractor_hit_agency | +0.045 (+0.000, +0.126) **NOT SIGNIFICANT** | +0.046 (+0.000, +0.128) **NOT SIGNIFICANT** | +0.008 (+0.000, +0.025) **NOT SIGNIFICANT** |
-| extractor_miss_agency | -0.003 (-0.005, -0.001) significant | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | -0.012 (-0.031, +0.006) **NOT SIGNIFICANT** |
-| multi_hop | -0.002 (-0.005, +0.001) **NOT SIGNIFICANT** | +0.001 (+0.000, +0.003) **NOT SIGNIFICANT** | -0.014 (-0.036, +0.005) **NOT SIGNIFICANT** |
-| distractor_heavy | -0.001 (-0.008, +0.005) **NOT SIGNIFICANT** | +0.002 (+0.000, +0.007) **NOT SIGNIFICANT** | -0.014 (-0.051, +0.013) **NOT SIGNIFICANT** |
-| long_context | -0.006 (-0.012, -0.001) significant | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | -0.011 (-0.032, +0.000) **NOT SIGNIFICANT** |
-| no_answer | -0.002 (-0.004, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| ambiguous_query | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| follow_up | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
-| uncategorized | +0.035 (+0.000, +0.106) **NOT SIGNIFICANT** | +0.035 (+0.000, +0.106) **NOT SIGNIFICANT** | +0.000 (+0.000, +0.000) **NOT SIGNIFICANT** |
+| overall | +0.002 (-0.004, +0.012) **유의하지 않음** | +0.005 (+0.000, +0.014) **유의하지 않음** | -0.010 (-0.027, +0.007) **유의하지 않음** |
+| extractor_hit_agency | +0.045 (+0.000, +0.126) **유의하지 않음** | +0.046 (+0.000, +0.128) **유의하지 않음** | +0.008 (+0.000, +0.025) **유의하지 않음** |
+| extractor_miss_agency | -0.003 (-0.005, -0.001) 유의함 | +0.000 (+0.000, +0.000) **유의하지 않음** | -0.012 (-0.031, +0.006) **유의하지 않음** |
+| multi_hop | -0.002 (-0.005, +0.001) **유의하지 않음** | +0.001 (+0.000, +0.003) **유의하지 않음** | -0.014 (-0.036, +0.005) **유의하지 않음** |
+| distractor_heavy | -0.001 (-0.008, +0.005) **유의하지 않음** | +0.002 (+0.000, +0.007) **유의하지 않음** | -0.014 (-0.051, +0.013) **유의하지 않음** |
+| long_context | -0.006 (-0.012, -0.001) 유의함 | +0.000 (+0.000, +0.000) **유의하지 않음** | -0.011 (-0.032, +0.000) **유의하지 않음** |
+| no_answer | -0.002 (-0.004, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| ambiguous_query | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| follow_up | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
+| uncategorized | +0.035 (+0.000, +0.106) **유의하지 않음** | +0.035 (+0.000, +0.106) **유의하지 않음** | +0.000 (+0.000, +0.000) **유의하지 않음** |
 
 ## 카테고리별 winner
 
-winner = `chunk_recall@10` 평균이 가장 높으면서 `no_metadata` 대비 paired CI 가 완전히 0 위인 변형. "NOT SIGNIFICANT" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
+winner = `chunk_recall@10` 평균이 가장 높으면서 `no_metadata` 대비 paired CI 가 완전히 0 위인 변형. "유의하지 않음" = 어떤 변형의 CI 도 0 을 넘지 못함 (절대 규칙 #5).
 
 | 카테고리 | winner | 평균 recall@10 | `no_metadata` 대비 delta CI |
 |---|---|---|---|
-| overall | `NOT SIGNIFICANT` | — | — |
-| extractor_hit_agency | `NOT SIGNIFICANT` | — | — |
-| extractor_miss_agency | `NOT SIGNIFICANT` | — | — |
-| multi_hop | `NOT SIGNIFICANT` | — | — |
-| distractor_heavy | `NOT SIGNIFICANT` | — | — |
-| long_context | `NOT SIGNIFICANT` | — | — |
-| no_answer | `NOT SIGNIFICANT` | — | — |
-| ambiguous_query | `NOT SIGNIFICANT` | — | — |
-| follow_up | `NOT SIGNIFICANT` | — | — |
-| uncategorized | `NOT SIGNIFICANT` | — | — |
+| overall | `유의하지 않음` | — | — |
+| extractor_hit_agency | `유의하지 않음` | — | — |
+| extractor_miss_agency | `유의하지 않음` | — | — |
+| multi_hop | `유의하지 않음` | — | — |
+| distractor_heavy | `유의하지 않음` | — | — |
+| long_context | `유의하지 않음` | — | — |
+| no_answer | `유의하지 않음` | — | — |
+| ambiguous_query | `유의하지 않음` | — | — |
+| follow_up | `유의하지 않음` | — | — |
+| uncategorized | `유의하지 않음` | — | — |
 
 ## 비고(notes)
 
-* **결론 (NULL-WINNER)**: 위 추출 품질 표의 agency recall 과 카테고리별 winner 표가 보여주듯, 현실 추출기는 answerable cohort 의 소수에서만 정답 agency 를 회수하며(coverage 분석의 char-4gram proxy ~34% 보다 낮다 — 운영 matcher 는 compact-contains / 강한 토큰 중첩을 요구), 회수에 성공한 cohort(`extractor_hit_agency`)에서도 oracle ceiling(PR #1108, recall@10 +0.22)을 통계적으로 회복하지 못한다(모든 카테고리 NOT SIGNIFICANT). 이는 ADR 0065 의 "메타데이터 라우팅 = 좁은 opt-in 부가 기능, 운영 기본값 변경 아님" 결정을 측정으로 지지한다. 또한 `extractor_prefilter_project` 는 oracle 의 ~15배 지연시간 Pareto 와 달리 부정확한 project 매칭으로 p95 지연시간이 오히려 악화된다 — hard project 필터의 이득은 현실 추출 정밀도에 종속된다.
+* **결론 (NULL-WINNER)**: 위 추출 품질 표의 agency recall 과 카테고리별 winner 표가 보여주듯, 현실 추출기는 answerable cohort 의 소수에서만 정답 agency 를 회수하며(coverage 분석의 char-4gram proxy ~34% 보다 낮다 — 운영 matcher 는 compact-contains / 강한 토큰 중첩을 요구), 회수에 성공한 cohort(`extractor_hit_agency`)에서도 oracle ceiling(PR #1108, recall@10 +0.22)을 통계적으로 회복하지 못한다(모든 카테고리 유의하지 않음). 이는 ADR 0065 의 "메타데이터 라우팅 = 좁은 opt-in 부가 기능, 운영 기본값 변경 아님" 결정을 측정으로 지지한다. 또한 `extractor_prefilter_project` 는 oracle 의 ~15배 지연시간 Pareto 와 달리 부정확한 project 매칭으로 p95 지연시간이 오히려 악화된다 — hard project 필터의 이득은 현실 추출 정밀도에 종속된다.
 * **현실 추출기, oracle 아님**: agency / project 는 `match_metadata_targets` 가 query 텍스트만으로 corpus catalog(`metadata_targets`)에 매칭해 도출한다 (gold 미사용, 결정적, 새 의존성 0). gold 는 추출 품질 채점에만 쓰고 retrieval 에 주입하지 않는다. 이 측정의 delta 는 oracle ceiling(PR #1108, recall@10 +0.21~0.22) 대비 **실제 회수율**이다 — ADR 0065 decision #3.
 * **`extractor_hit_agency` cohort**: 추출기가 정답 agency 를 맞춘 케이스. oracle 의 ~34% metadata-identifiable cohort 의 현실 대응물 — 추출이 성공한 곳에서의 retrieval lift 를 보여준다. `extractor_miss_agency` = gold 는 있으나 추출 실패(라우팅 신호 없음 → baseline 으로 수렴).
 * **False-positive 라우팅 위험**: 잘못 추출된 agency 로 hard pre-filter 시 정답 doc 이 후보 풀에서 제거될 수 있다 → overall delta 가 음수일 수 있어 `extractor_hit_agency` / `extractor_miss_agency` cohort 를 분리 보고한다.

--- a/scripts/_ablation_common.py
+++ b/scripts/_ablation_common.py
@@ -125,7 +125,7 @@ def _fmt_ci(ci: dict[str, Any] | None, digits: int = 3) -> str:
     md = ci["mean_diff"]
     lo = ci["ci_lo"]
     hi = ci["ci_hi"]
-    significance = "**NOT SIGNIFICANT**" if lo <= 0 <= hi else "significant"
+    significance = "**유의하지 않음**" if lo <= 0 <= hi else "유의함"
     return f"{md:+.{digits}f} ({lo:+.{digits}f}, {hi:+.{digits}f}) {significance}"
 
 

--- a/scripts/phase2_chunking_ablation.py
+++ b/scripts/phase2_chunking_ablation.py
@@ -11,7 +11,7 @@ category. Output lives under
 * ``chunking_specs.json``  — variant metadata + section_detection_rate
 * ``raw_results.json``     — per-case scores for all 4 variants
 * ``REPORT.md``            — <=200 line markdown with per-category
-  winner or "NOT SIGNIFICANT" (CI crosses 0)
+  winner or "유의하지 않음" (CI crosses 0)
 
 Reuses (no new abstraction):
 
@@ -370,7 +370,7 @@ def render_report(
     ``{other_name: {metric: {category: ci}}}``.
     """
     lines: list[str] = []
-    lines.append(f"# Phase 2 retrieval-eval — chunking ablation (real100 n={config['num_cases']})")
+    lines.append(f"# Phase 2 retrieval-eval — 청킹(chunking) ablation (real100 n={config['num_cases']})")
     lines.append("")
     lines.append(
         f"Run: `{config['run_id']}` · commit `{config['git_commit'][:10]}` · "
@@ -379,9 +379,9 @@ def render_report(
         f"seeds={config['seeds']} · top_k={config['top_k']} · ks={config['ks']}"
     )
     lines.append("")
-    lines.append("## Variants")
+    lines.append("## 변형(variants)")
     lines.append("")
-    lines.append("| Variant | Strategy | Max chars | Overlap | Docs | Chunks | Section detect | Heuristic engaged |")
+    lines.append("| 변형 | 전략(strategy) | max chars | overlap | 문서 | 청크 | 섹션 감지 | heuristic 발화 |")
     lines.append("|---|---|---|---|---|---|---|---|")
     for spec in specs:
         sd = spec.get("section_detection_rate")
@@ -395,9 +395,9 @@ def render_report(
             f"{sd_str} | {he_str} |"
         )
     lines.append("")
-    lines.append("## Latency (ms)")
+    lines.append("## 지연시간(latency, ms)")
     lines.append("")
-    lines.append("| Variant | p50 | p95 | mean | n |")
+    lines.append("| 변형 | p50 | p95 | mean | n |")
     lines.append("|---|---|---|---|---|")
     for variant_name in [s["name"] for s in specs]:
         lat = measurements[variant_name]["latency_ms"]
@@ -420,7 +420,7 @@ def render_report(
     for metric in metrics_to_report:
         lines.append(f"## {metric}")
         lines.append("")
-        header_cols = ["Category"] + [f"`{s['name']}`" for s in specs]
+        header_cols = ["카테고리"] + [f"`{s['name']}`" for s in specs]
         lines.append("| " + " | ".join(header_cols) + " |")
         lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
         for category in categories:
@@ -432,9 +432,9 @@ def render_report(
                 )
             lines.append("| " + " | ".join(cells) + " |")
         lines.append("")
-        lines.append(f"### {metric} — paired CI delta vs `current` (seed-averaged)")
+        lines.append(f"### {metric} — `current` 대비 paired CI delta (seed 평균)")
         lines.append("")
-        header_cols = ["Category"] + [
+        header_cols = ["카테고리"] + [
             f"`{s['name']}`" for s in specs if s["name"] != "current"
         ]
         lines.append("| " + " | ".join(header_cols) + " |")
@@ -449,17 +449,18 @@ def render_report(
             lines.append("| " + " | ".join(cells) + " |")
         lines.append("")
 
-    lines.append("## Per-category winner")
+    lines.append("## 카테고리별 winner")
     lines.append("")
     lines.append(
-        "Winner = variant with highest `chunk_recall@10` mean AND paired CI vs `current` "
-        "fully above 0. \"NOT SIGNIFICANT\" = no variant's CI clears 0 (absolute rule #5)."
+        "winner = `chunk_recall@10` 평균이 가장 높으면서 `current` 대비 paired CI 가 "
+        "완전히 0 위인 변형. \"유의하지 않음\" = 어떤 변형의 CI 도 0 을 넘지 못함 "
+        "(절대 규칙 #5)."
     )
     lines.append("")
-    lines.append("| Category | Winner | Mean recall@10 | Delta CI vs current |")
+    lines.append("| 카테고리 | winner | 평균 recall@10 | `current` 대비 delta CI |")
     lines.append("|---|---|---|---|")
     for category in categories:
-        winner = "NOT SIGNIFICANT"
+        winner = "유의하지 않음"
         winner_mean: float | None = None
         winner_ci: dict[str, Any] | None = None
         for spec in specs:
@@ -476,49 +477,45 @@ def render_report(
         ci_str = _fmt_ci(winner_ci) if winner_ci is not None else "—"
         lines.append(f"| {category} | `{winner}` | {mean_str} | {ci_str} |")
     lines.append("")
-    lines.append("## Notes")
+    lines.append("## 비고(notes)")
     lines.append("")
     lines.append(
-        "* Planner-bypass: full query as the only sub-query, identity expansion, "
-        "no rerank — isolates chunking impact from query expansion / rerank effects."
+        "* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, "
+        "rerank 없음 — 청킹 효과를 query expansion / rerank 효과로부터 격리한다."
     )
     lines.append(
-        "* `chunk_recall@k` is None for cases without `expected_terms` / "
-        "`expected_doc_ids` (e.g. abstention) — those are dropped pairwise to "
-        "preserve case alignment between current and the variant."
+        "* `chunk_recall@k` 는 `expected_terms` / `expected_doc_ids` 가 없는 케이스"
+        "(예: abstention(보류))에서 None 이다 — current 와 변형 간 케이스 정렬을 "
+        "보존하기 위해 pairwise 에서 제외된다."
     )
     lines.append(
-        "* Seeds drive only the bootstrap RNG; retrieval itself is deterministic "
-        "for the same query+index (hashing-backend / dense backend both)."
+        "* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 query+index 에 "
+        "대해 결정적(deterministic)이다 (hashing-backend / dense backend 모두)."
     )
-    lines.append("* Index storage: `data/index/phase2_smaller`, `phase2_larger`, `phase2_structure_aware`.")
+    lines.append("* 인덱스 저장 위치: `data/index/phase2_smaller`, `phase2_larger`, `phase2_structure_aware`.")
     lines.append(
-        "* Category bucketing uses `hardcase_categories` (semantic difficulty tags) "
-        "from the eval config. The legacy `query_type` field "
-        "(single_doc / multi_doc / follow_up / abstention) is **not** used here. "
-        "A case tagged with N categories appears in N buckets, so per-category "
-        "counts overlap and per-category paired CIs share cases — combining "
-        "multiple categories via OR inflates family-wise error rate."
-    )
-    lines.append(
-        "* `uncategorized` covers cases without `hardcase_categories` tags "
-        "(typically the initial seed + probe cases authored before the tag "
-        "schema). They still contribute to `overall`."
+        "* 카테고리 버킷팅은 eval config 의 `hardcase_categories`(의미 난이도 태그)를 "
+        "쓴다. 레거시 `query_type` 필드(single_doc / multi_doc / follow_up / "
+        "abstention)는 여기서 **쓰지 않는다**. N 개 카테고리로 태깅된 케이스는 N 개 "
+        "버킷에 나타나므로 카테고리별 카운트는 겹치고 paired CI 가 케이스를 공유한다 "
+        "— 여러 카테고리를 OR 로 합치면 family-wise 오류율이 부풀려진다."
     )
     lines.append(
-        "* Phase 1 baseline (`UNIFIED_PHASE1_REPORT.md`) categorized by "
-        "`query_type` (e.g. `multi_doc → multi_hop` with n=1); direct "
-        "cross-phase category-by-category trend comparison is not meaningful "
-        "until Phase 1 is re-aggregated against the same `hardcase_categories` "
-        "field."
+        "* `uncategorized` 는 `hardcase_categories` 태그가 없는 케이스(보통 태그 "
+        "스키마 이전에 작성된 초기 seed + probe 케이스)를 포함한다. 이들도 `overall` "
+        "에는 기여한다."
+    )
+    lines.append(
+        "* Phase 1 baseline(`UNIFIED_PHASE1_REPORT.md`)은 `query_type` 으로 분류했다 "
+        "(예: `multi_doc → multi_hop` n=1); Phase 1 을 동일 `hardcase_categories` "
+        "필드로 재집계하기 전에는 phase 간 카테고리별 추세 직접 비교는 의미가 없다."
     )
     if config.get("reaggregate_source"):
         lines.append(
-            "* This report was regenerated via `--reaggregate` from "
-            f"`{config['reaggregate_source']}` — categorization re-derived "
-            "from `hardcase_categories`; retrieval scores in "
-            "`raw_results.json` are unchanged byte-for-byte modulo the "
-            "injected `categories` field."
+            "* 이 리포트는 `--reaggregate` 로 "
+            f"`{config['reaggregate_source']}` 로부터 재생성됨 — 카테고리는 "
+            "`hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval "
+            "점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변."
         )
 
     report_path = out_dir / "REPORT.md"

--- a/scripts/phase35_m3_ablation.py
+++ b/scripts/phase35_m3_ablation.py
@@ -20,7 +20,7 @@ Output lives under ``reports/retrieval/phase35_m3_<TIMESTAMP>/``:
 * ``raw_results.json`` — per-case scores for all 3 variants
 * ``deltas.json``      — paired CI vs dense_m3 per (variant, metric, category)
 * ``REPORT.md``        — <=200 line markdown with per-category winner or
-  ``NOT SIGNIFICANT`` (CI crosses 0) per absolute rule #5
+  ``유의하지 않음`` (CI crosses 0) per absolute rule #5
 
 Reuses (no new abstraction — absolute rule #3):
 
@@ -361,8 +361,8 @@ def render_report(
     baseline = config["baseline"]
     lines: list[str] = []
     lines.append(
-        f"# Phase 3.5 retrieval-eval — m3 mode ablation "
-        f"(real100 n={config['num_cases']}, semantic embeddings)"
+        f"# Phase 3.5 retrieval-eval — m3 검색 모드(mode) ablation "
+        f"(real100 n={config['num_cases']}, 의미 임베딩(semantic embeddings))"
     )
     lines.append("")
     lines.append(
@@ -372,9 +372,9 @@ def render_report(
         f"seeds={config['seeds']} · top_k={config['top_k']} · ks={config['ks']}"
     )
     lines.append("")
-    lines.append("## Variants")
+    lines.append("## 변형(variants)")
     lines.append("")
-    lines.append("| Variant | Backend | RRF k | Docs | Chunks |")
+    lines.append("| 변형 | backend | RRF k | 문서 | 청크 |")
     lines.append("|---|---|---|---|---|")
     for spec in specs:
         rrf = spec.get("rrf_k")
@@ -384,9 +384,9 @@ def render_report(
             f"{spec['num_documents']} | {spec['num_chunks']} |"
         )
     lines.append("")
-    lines.append("## Latency (ms)")
+    lines.append("## 지연시간(latency, ms)")
     lines.append("")
-    lines.append("| Variant | p50 | p95 | mean | n |")
+    lines.append("| 변형 | p50 | p95 | mean | n |")
     lines.append("|---|---|---|---|---|")
     for variant_name in [s["name"] for s in specs]:
         lat = measurements[variant_name]["latency_ms"]
@@ -409,7 +409,7 @@ def render_report(
     for metric in metrics_to_report:
         lines.append(f"## {metric}")
         lines.append("")
-        header_cols = ["Category"] + [f"`{s['name']}`" for s in specs]
+        header_cols = ["카테고리"] + [f"`{s['name']}`" for s in specs]
         lines.append("| " + " | ".join(header_cols) + " |")
         lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
         for category in categories:
@@ -421,9 +421,9 @@ def render_report(
                 )
             lines.append("| " + " | ".join(cells) + " |")
         lines.append("")
-        lines.append(f"### {metric} — paired CI delta vs `{baseline}` (seed-averaged)")
+        lines.append(f"### {metric} — `{baseline}` 대비 paired CI delta (seed 평균)")
         lines.append("")
-        header_cols = ["Category"] + [
+        header_cols = ["카테고리"] + [
             f"`{s['name']}`" for s in specs if s["name"] != baseline
         ]
         lines.append("| " + " | ".join(header_cols) + " |")
@@ -438,18 +438,18 @@ def render_report(
             lines.append("| " + " | ".join(cells) + " |")
         lines.append("")
 
-    lines.append("## Per-category winner")
+    lines.append("## 카테고리별 winner")
     lines.append("")
     lines.append(
-        f"Winner = variant with highest `chunk_recall@10` mean AND paired CI vs "
-        f"`{baseline}` fully above 0. \"NOT SIGNIFICANT\" = no variant's CI clears 0 "
-        f"(absolute rule #5)."
+        f"winner = `chunk_recall@10` 평균이 가장 높으면서 `{baseline}` 대비 paired CI "
+        f"가 완전히 0 위인 변형. \"유의하지 않음\" = 어떤 변형의 CI 도 0 을 넘지 못함 "
+        f"(절대 규칙 #5)."
     )
     lines.append("")
-    lines.append("| Category | Winner | Mean recall@10 | Delta CI vs " + f"`{baseline}` |")
+    lines.append("| 카테고리 | winner | 평균 recall@10 | " + f"`{baseline}` 대비 delta CI |")
     lines.append("|---|---|---|---|")
     for category in categories:
-        winner = "NOT SIGNIFICANT"
+        winner = "유의하지 않음"
         winner_mean: float | None = None
         winner_ci: dict[str, Any] | None = None
         for spec in specs:
@@ -466,98 +466,96 @@ def render_report(
         ci_str = _fmt_ci(winner_ci) if winner_ci is not None else "—"
         lines.append(f"| {category} | `{winner}` | {mean_str} | {ci_str} |")
     lines.append("")
-    lines.append("## Notes")
+    lines.append("## 비고(notes)")
     lines.append("")
     lines.append(
-        "* Planner-bypass: full query as the only sub-query, identity expansion, "
-        "no rerank, `metadata_first=False` — isolates retrieval-mode impact from "
-        "expansion / rerank / metadata-filter effects (same discipline as Phase 3)."
+        "* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, "
+        "rerank 없음, `metadata_first=False` — 검색 모드 효과를 expansion / rerank / "
+        "metadata-filter 효과로부터 격리한다 (Phase 3 과 동일 규율)."
     )
     lines.append(
-        "* All 3 variants share `data/index/real100_m3` (BGE-M3 1024-dim dense). "
-        "`hybrid_bm25_k60_m3` uses BM25 lazy-built on the index dict; `m3` populates "
-        "`index['_m3_cache']` (sparse + colbert per chunk, in-memory only per ADR 0025 "
-        "spike-mode, no disk persist) on its first call. `--warmup` absorbs the "
-        "~2 min cache cold-start so per-case latency reflects cache-hit cost."
+        "* 3 변형 모두 `data/index/real100_m3`(BGE-M3 1024-dim dense)를 공유한다. "
+        "`hybrid_bm25_k60_m3` 는 index dict 에 lazy-build 된 BM25 를 쓰고; `m3` 는 첫 "
+        "호출 시 `index['_m3_cache']`(청크별 sparse + colbert, ADR 0025 spike-mode 라 "
+        "in-memory only, 디스크 미persist)를 채운다. `--warmup` 이 ~2 분 캐시 "
+        "cold-start 를 흡수하므로 케이스별 지연시간은 캐시 hit 비용을 반영한다."
     )
     lines.append(
-        "* m3's RRF dense channel reuses the index's existing dense channel "
-        "(`rag_retrieval.py:449-454`) — for this run it IS the BGE-M3 dense (the "
-        "index was built with `--model BAAI/bge-m3`), so the 3 channels are all "
-        "BGE-M3 (dense + sparse + colbert). On hashing-built indexes the dense "
-        "channel would be hashing, mixing embedding families."
+        "* m3 의 RRF dense 채널은 인덱스의 기존 dense 채널을 재사용한다"
+        "(`rag_retrieval.py:449-454`) — 이 run 에서는 그것이 BGE-M3 dense 다(인덱스가 "
+        "`--model BAAI/bge-m3` 로 빌드됨), 따라서 3 채널 모두 BGE-M3(dense + sparse + "
+        "colbert)다. hashing 으로 빌드된 인덱스에서는 dense 채널이 hashing 이라 임베딩 "
+        "패밀리가 섞이게 된다."
     )
     lines.append(
-        "* `chunk_recall@k` is None for cases without `expected_terms` / "
-        "`expected_doc_ids` (e.g. abstention) — those are dropped pairwise to "
-        "preserve case alignment between variants."
+        "* `chunk_recall@k` 는 `expected_terms` / `expected_doc_ids` 가 없는 케이스"
+        "(예: abstention(보류))에서 None 이다 — 변형 간 케이스 정렬을 보존하기 위해 "
+        "pairwise 에서 제외된다."
     )
     lines.append(
-        "* Seeds drive only the bootstrap RNG; retrieval itself is deterministic "
-        "for the same query+index+backend+rrf_k (dense + BM25 + m3 sparse/colbert)."
+        "* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 "
+        "query+index+backend+rrf_k 에 대해 결정적(deterministic)이다 "
+        "(dense + BM25 + m3 sparse/colbert)."
     )
     lines.append(
-        "* Category bucketing uses `hardcase_categories` (semantic difficulty tags). "
-        "Multi-tag cases appear in multiple buckets, so per-category counts overlap "
-        "and per-category paired CIs share cases."
+        "* 카테고리 버킷팅은 `hardcase_categories`(의미 난이도 태그)를 쓴다. 멀티태그 "
+        "케이스는 여러 버킷에 나타나므로 카테고리별 카운트는 겹치고 paired CI 가 "
+        "케이스를 공유한다."
     )
     lines.append(
-        f"* `{baseline}` is the delta baseline because Phase 3.5 isolates "
-        "**multi-channel vs single-channel under semantic embeddings**. Deltas above "
-        "0 favor the multi-channel variant (hybrid or m3); below 0 favor dense alone."
+        f"* `{baseline}` 이 delta baseline 인 이유: Phase 3.5 는 **의미 임베딩 위에서 "
+        "multi-channel vs single-channel** 을 격리하기 때문이다. 0 위 delta 는 "
+        "multi-channel 변형(hybrid 또는 m3)에, 0 아래는 dense 단독에 유리하다."
     )
     lines.append(
-        "* **Phase 3 cross-ref + runner bug retraction**: "
-        "`reports/retrieval/phase3_mode_20260518T032404Z/` reported all 3 "
-        "`hybrid_bm25_k{30,60,100}` variants byte-identical and attributed it to "
-        "BM25 channel dominance. **That conclusion was wrong**: the Phase 3 "
-        "runner called `retrieve_candidates` (candidate generation only) without "
-        "the second-stage `apply_fusion_and_reranking` (RRF fusion + final top-k). "
-        "For hybrid + m3 backends `retrieve_candidates` returns `score=0.0` "
-        "placeholders, so the per-case ranking collapsed to chunk_id insertion "
-        "order — making every k value byte-identical. Phase 3.5 fixes the wire-up "
-        "(both calls in `run_single_case`); the hashing-index re-run is a "
-        "follow-up. Cross-backend delta math (hashing `dense` vs `dense_m3`) "
-        "remains confounded by the embedding family swap and is NOT computed."
+        "* **Phase 3 cross-ref + runner 버그 retraction(철회)**: "
+        "`reports/retrieval/phase3_mode_20260518T032404Z/` 는 3 개 "
+        "`hybrid_bm25_k{30,60,100}` 변형이 byte-identical 이라 보고하고 이를 BM25 채널 "
+        "dominance 로 귀인했다. **그 결론은 틀렸다**: Phase 3 runner 가 "
+        "`retrieve_candidates`(후보 생성만)를 호출하고 2단계 "
+        "`apply_fusion_and_reranking`(RRF fusion + 최종 top-k)를 누락했다. hybrid + m3 "
+        "backend 에서 `retrieve_candidates` 는 `score=0.0` placeholder 를 반환하므로 "
+        "케이스별 순위가 chunk_id 삽입 순서로 붕괴해 모든 k 값이 byte-identical 이 됐다. "
+        "Phase 3.5 는 wire-up 을 고친다(`run_single_case` 에 두 호출 모두); hashing "
+        "인덱스 재측정은 후속이다. Cross-backend delta(hashing `dense` vs `dense_m3`)는 "
+        "임베딩 패밀리 교체로 confounded 되어 산출하지 않는다."
     )
     lines.append(
-        "* **Chunk count caveat**: the BGE-M3 index used the `data_list_csv_text` "
-        "loader for both HWP and PDF (per ADR 0049 graceful fallback), yielding "
-        "~9 chunks/doc vs real100's ~264 chunks/doc with `kordoc` full extraction. "
-        "Re-embedding 26k kordoc chunks with BGE-M3 on MPS would take >2h (per-batch "
-        "GPU dispatch overhead); the csv_text fallback keeps the build under 20 min "
-        "while preserving the within-Phase-3.5 paired CI claim. Absolute "
-        "`chunk_recall@k` on this index is NOT directly comparable to Phase 3's "
-        "kordoc-built numbers — only Phase 3.5 internal deltas are."
+        "* **청크 수 caveat**: BGE-M3 인덱스가 HWP/PDF 모두에 `data_list_csv_text` "
+        "loader 를 썼고(ADR 0049 graceful fallback), doc 당 ~9 청크였다(`kordoc` 전체 "
+        "추출의 real100 ~264 청크/doc 대비). 26k kordoc 청크를 BGE-M3 로 MPS 에서 "
+        "재임베딩하면 >2h 걸린다(배치별 GPU dispatch overhead); csv_text fallback 은 "
+        "build 를 20 분 미만으로 유지하면서 Phase 3.5 내부 paired CI 주장을 보존한다. "
+        "이 인덱스의 절대 `chunk_recall@k` 는 Phase 3 의 kordoc 빌드 수치와 직접 비교 "
+        "불가 — Phase 3.5 내부 delta 만 비교 가능하다."
     )
     lines.append(
-        "* **Runner-side m3 batching (measurement-only optimization)**: per-query "
-        "colbert max-sim is the dominant cost on this index (per-chunk Python-loop "
-        "matmul × ~900 chunks × ~50s/query observed on the unoptimized path). The "
-        "runner concatenates all chunk colbert vectors into one `(Σ T_d, 1024)` "
-        "matrix and does **one** matmul per unique query, then splits the columns "
-        "back per chunk for the row-wise max+sum. Mathematically identical to the "
-        "per-chunk path (each chunk's column slice is independent), but ~100× faster. "
-        "The patch lives in the runner (`_prime_m3_index_cache_and_colbert`); "
-        "`rag_m3.py` / `rag_retrieval.py` unchanged."
+        "* **Runner 측 m3 batching (측정 전용 최적화)**: 이 인덱스에서 query 별 colbert "
+        "max-sim 이 지배적 비용이다(청크별 Python-loop matmul × ~900 청크 × 최적화 전 "
+        "경로에서 관측된 ~50s/query). runner 는 모든 청크 colbert 벡터를 하나의 "
+        "`(Σ T_d, 1024)` 행렬로 concat 해 unique query 당 **1회** matmul 후 행별 "
+        "max+sum 을 위해 컬럼을 청크별로 다시 split 한다. 청크별 경로와 수학적으로 "
+        "동일하나(각 청크의 컬럼 슬라이스는 독립) ~100× 빠르다. 패치는 runner 에 "
+        "있다(`_prime_m3_index_cache_and_colbert`); `rag_m3.py` / `rag_retrieval.py` "
+        "는 미변경."
     )
     lines.append(
-        "* **Out of scope**: per-channel m3 ablation (sparse-only, colbert-only — "
-        "see ADR 0010 'Alternatives considered'); RRF-k sweep on hybrid_bm25 (Phase 3 "
-        "already showed k=30/60/100 byte-identical on hashing); cross-encoder rerank "
-        "stacked on top (Phase 4)."
+        "* **범위 외**: 채널별 m3 ablation(sparse-only, colbert-only — ADR 0010 "
+        "'Alternatives considered' 참조); hybrid_bm25 의 RRF-k sweep(Phase 3 이 이미 "
+        "hashing 에서 k=30/60/100 byte-identical 을 보임); 위에 stack 된 cross-encoder "
+        "rerank(Phase 4)."
     )
     lines.append(
-        "* ADR cross-refs: ADR 0010 (BGE-M3 multi-channel deferred), ADR 0021 "
-        "(m3_full analysis row), ADR 0032 (torch>=2.6 unblock — closes the install "
-        "blocker that originally deferred this measurement)."
+        "* ADR cross-ref: ADR 0010(BGE-M3 multi-channel deferred), ADR 0021"
+        "(m3_full 분석 행), ADR 0032(torch>=2.6 unblock — 본 측정을 원래 미뤘던 install "
+        "blocker 를 해소)."
     )
     if config.get("reaggregate_source"):
         lines.append(
-            "* This report was regenerated via `--reaggregate` from "
-            f"`{config['reaggregate_source']}` — categorization re-derived from "
-            "`hardcase_categories`; retrieval scores in `raw_results.json` are "
-            "unchanged byte-for-byte modulo the injected `categories` field."
+            "* 이 리포트는 `--reaggregate` 로 "
+            f"`{config['reaggregate_source']}` 로부터 재생성됨 — 카테고리는 "
+            "`hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval "
+            "점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변."
         )
 
     report_path = out_dir / "REPORT.md"

--- a/scripts/phase3_mode_ablation.py
+++ b/scripts/phase3_mode_ablation.py
@@ -19,7 +19,7 @@ Output lives under ``reports/retrieval/phase3_mode_<TIMESTAMP>/``:
 * ``raw_results.json`` — per-case scores for all 4 variants
 * ``deltas.json``      — paired CI vs dense per (variant, metric, category)
 * ``REPORT.md``        — <=200 line markdown with per-category winner or
-  ``NOT SIGNIFICANT`` (CI crosses 0) per absolute rule #5
+  ``유의하지 않음`` (CI crosses 0) per absolute rule #5
 
 Reuses (no new abstraction — absolute rule #3):
 
@@ -206,7 +206,7 @@ def render_report(
     baseline = config["baseline"]
     lines: list[str] = []
     lines.append(
-        f"# Phase 3 retrieval-eval — mode ablation (real100 n={config['num_cases']})"
+        f"# Phase 3 retrieval-eval — 검색 모드(mode) ablation (real100 n={config['num_cases']})"
     )
     lines.append("")
     lines.append(
@@ -216,9 +216,9 @@ def render_report(
         f"seeds={config['seeds']} · top_k={config['top_k']} · ks={config['ks']}"
     )
     lines.append("")
-    lines.append("## Variants")
+    lines.append("## 변형(variants)")
     lines.append("")
-    lines.append("| Variant | Backend | RRF k | Docs | Chunks |")
+    lines.append("| 변형 | backend | RRF k | 문서 | 청크 |")
     lines.append("|---|---|---|---|---|")
     for spec in specs:
         rrf = spec.get("rrf_k")
@@ -228,9 +228,9 @@ def render_report(
             f"{spec['num_documents']} | {spec['num_chunks']} |"
         )
     lines.append("")
-    lines.append("## Latency (ms)")
+    lines.append("## 지연시간(latency, ms)")
     lines.append("")
-    lines.append("| Variant | p50 | p95 | mean | n |")
+    lines.append("| 변형 | p50 | p95 | mean | n |")
     lines.append("|---|---|---|---|---|")
     for variant_name in [s["name"] for s in specs]:
         lat = measurements[variant_name]["latency_ms"]
@@ -253,7 +253,7 @@ def render_report(
     for metric in metrics_to_report:
         lines.append(f"## {metric}")
         lines.append("")
-        header_cols = ["Category"] + [f"`{s['name']}`" for s in specs]
+        header_cols = ["카테고리"] + [f"`{s['name']}`" for s in specs]
         lines.append("| " + " | ".join(header_cols) + " |")
         lines.append("|" + "|".join(["---"] * len(header_cols)) + "|")
         for category in categories:
@@ -265,9 +265,9 @@ def render_report(
                 )
             lines.append("| " + " | ".join(cells) + " |")
         lines.append("")
-        lines.append(f"### {metric} — paired CI delta vs `{baseline}` (seed-averaged)")
+        lines.append(f"### {metric} — `{baseline}` 대비 paired CI delta (seed 평균)")
         lines.append("")
-        header_cols = ["Category"] + [
+        header_cols = ["카테고리"] + [
             f"`{s['name']}`" for s in specs if s["name"] != baseline
         ]
         lines.append("| " + " | ".join(header_cols) + " |")
@@ -282,18 +282,18 @@ def render_report(
             lines.append("| " + " | ".join(cells) + " |")
         lines.append("")
 
-    lines.append("## Per-category winner")
+    lines.append("## 카테고리별 winner")
     lines.append("")
     lines.append(
-        f"Winner = variant with highest `chunk_recall@10` mean AND paired CI vs "
-        f"`{baseline}` fully above 0. \"NOT SIGNIFICANT\" = no variant's CI clears 0 "
-        f"(absolute rule #5)."
+        f"winner = `chunk_recall@10` 평균이 가장 높으면서 `{baseline}` 대비 paired CI "
+        f"가 완전히 0 위인 변형. \"유의하지 않음\" = 어떤 변형의 CI 도 0 을 넘지 못함 "
+        f"(절대 규칙 #5)."
     )
     lines.append("")
-    lines.append("| Category | Winner | Mean recall@10 | Delta CI vs " + f"`{baseline}` |")
+    lines.append("| 카테고리 | winner | 평균 recall@10 | " + f"`{baseline}` 대비 delta CI |")
     lines.append("|---|---|---|---|")
     for category in categories:
-        winner = "NOT SIGNIFICANT"
+        winner = "유의하지 않음"
         winner_mean: float | None = None
         winner_ci: dict[str, Any] | None = None
         for spec in specs:
@@ -310,54 +310,54 @@ def render_report(
         ci_str = _fmt_ci(winner_ci) if winner_ci is not None else "—"
         lines.append(f"| {category} | `{winner}` | {mean_str} | {ci_str} |")
     lines.append("")
-    lines.append("## Notes")
+    lines.append("## 비고(notes)")
     lines.append("")
     lines.append(
-        "* Planner-bypass: full query as the only sub-query, identity expansion, "
-        "no rerank, `metadata_first=False` — isolates retrieval-mode impact from "
-        "expansion / rerank / metadata-filter effects."
+        "* Planner-bypass: 전체 query 를 유일한 sub-query 로, identity expansion, "
+        "rerank 없음, `metadata_first=False` — 검색 모드 효과를 expansion / rerank / "
+        "metadata-filter 효과로부터 격리한다."
     )
     lines.append(
-        "* All 4 variants share `data/index/real100`; only `plan['retrieval_backend']` "
-        "and `plan['rrf_k']` differ. BM25 lazy-builds on the first hybrid call via "
-        "`rag_retrieval.get_or_build_bm25` and is cached on the index dict, so "
-        "`hybrid_bm25_k30` pays the BM25 build cost once and `k60`/`k100` are cache hits."
+        "* 4 변형 모두 `data/index/real100` 을 공유한다; `plan['retrieval_backend']` "
+        "와 `plan['rrf_k']` 만 다르다. BM25 는 첫 hybrid 호출 시 "
+        "`rag_retrieval.get_or_build_bm25` 로 lazy-build 되어 index dict 에 캐시되므로 "
+        "`hybrid_bm25_k30` 가 BM25 build 비용을 1회 지불하고 `k60`/`k100` 은 캐시 hit 이다."
     )
     lines.append(
-        "* `chunk_recall@k` is None for cases without `expected_terms` / "
-        "`expected_doc_ids` (e.g. abstention) — those are dropped pairwise to "
-        "preserve case alignment between variants."
+        "* `chunk_recall@k` 는 `expected_terms` / `expected_doc_ids` 가 없는 케이스"
+        "(예: abstention(보류))에서 None 이다 — 변형 간 케이스 정렬을 보존하기 위해 "
+        "pairwise 에서 제외된다."
     )
     lines.append(
-        "* Seeds drive only the bootstrap RNG; retrieval itself is deterministic "
-        "for the same query+index+backend+rrf_k (dense + BM25 both)."
+        "* Seed 는 bootstrap RNG 만 구동한다; retrieval 자체는 동일 "
+        "query+index+backend+rrf_k 에 대해 결정적(deterministic)이다 (dense + BM25 모두)."
     )
     lines.append(
-        "* Category bucketing uses `hardcase_categories` (semantic difficulty tags). "
-        "Multi-tag cases appear in multiple buckets, so per-category counts overlap "
-        "and per-category paired CIs share cases."
+        "* 카테고리 버킷팅은 `hardcase_categories`(의미 난이도 태그)를 쓴다. 멀티태그 "
+        "케이스는 여러 버킷에 나타나므로 카테고리별 카운트는 겹치고 paired CI 가 "
+        "케이스를 공유한다."
     )
     lines.append(
-        f"* `{baseline}` is the delta baseline because ADR 0010's accept rationale "
-        "for `hybrid` framed the question as \"is hybrid actually better than dense?\". "
-        "Deltas above 0 favor the hybrid variant; below 0 favor dense."
+        f"* `{baseline}` 이 delta baseline 인 이유: ADR 0010 의 `hybrid` 채택 근거가 "
+        "질문을 \"hybrid 가 실제로 dense 보다 나은가?\" 로 프레이밍했기 때문이다. "
+        "0 위 delta 는 hybrid 변형에, 0 아래는 dense 에 유리하다."
     )
     lines.append(
-        "* m3 (FlagEmbedding 3-channel RRF) is **out of scope** for Phase 3 — it "
-        "requires a separate index build (`build_m3_index`), so deferring to "
-        "Phase 3.5 keeps Phase 3 measurement narrow (mode ↔ index decoupled)."
+        "* m3 (FlagEmbedding 3-channel RRF)는 Phase 3 **범위 외**다 — 별도 인덱스 "
+        "빌드(`build_m3_index`)가 필요하므로 Phase 3.5 로 미뤄 Phase 3 측정을 좁게 "
+        "유지한다 (mode ↔ index 분리)."
     )
     lines.append(
-        "* k=10 / k=200 are **out of scope** for Phase 3 — k∈{30,60,100} brackets "
-        "ADR 0010's k=60 default without inflating the variant count. Tighter/looser "
-        "k swings can be added in a follow-up if k=30 vs k=100 shows a clean gradient."
+        "* k=10 / k=200 은 Phase 3 **범위 외**다 — k∈{30,60,100} 이 변형 수를 부풀리지 "
+        "않으면서 ADR 0010 의 k=60 default 를 감싼다. k=30 vs k=100 이 깔끔한 gradient "
+        "를 보이면 후속에서 더 좁은/넓은 k 를 추가할 수 있다."
     )
     if config.get("reaggregate_source"):
         lines.append(
-            "* This report was regenerated via `--reaggregate` from "
-            f"`{config['reaggregate_source']}` — categorization re-derived from "
-            "`hardcase_categories`; retrieval scores in `raw_results.json` are "
-            "unchanged byte-for-byte modulo the injected `categories` field."
+            "* 이 리포트는 `--reaggregate` 로 "
+            f"`{config['reaggregate_source']}` 로부터 재생성됨 — 카테고리는 "
+            "`hardcase_categories` 에서 재유도; `raw_results.json` 의 retrieval "
+            "점수는 주입된 `categories` 필드를 제외하면 byte-for-byte 불변."
         )
 
     report_path = out_dir / "REPORT.md"

--- a/scripts/phase4_metadata_ablation.py
+++ b/scripts/phase4_metadata_ablation.py
@@ -40,7 +40,7 @@ Output lives under ``reports/retrieval/phase4_metadata_<TIMESTAMP>/``:
 * ``raw_results.json``    — per-case scores for all 4 variants
 * ``deltas.json``         — paired CI vs no_metadata per (variant, metric, category)
 * ``REPORT.md``           — <=200 line markdown with per-category winner or
-  ``NOT SIGNIFICANT`` (CI crosses 0) per absolute rule #5
+  ``유의하지 않음`` (CI crosses 0) per absolute rule #5
 
 Reuses (no new abstraction — absolute rule #3):
 
@@ -328,14 +328,14 @@ def render_report(
     lines.append("")
     lines.append(
         f"winner = `chunk_recall@10` 평균이 가장 높으면서 `{baseline}` 대비 paired CI "
-        f"가 완전히 0 위인 변형. \"NOT SIGNIFICANT\" = 어떤 변형의 CI 도 0 을 넘지 "
+        f"가 완전히 0 위인 변형. \"유의하지 않음\" = 어떤 변형의 CI 도 0 을 넘지 "
         f"못함 (절대 규칙 #5)."
     )
     lines.append("")
     lines.append("| 카테고리 | winner | 평균 recall@10 | " + f"`{baseline}` 대비 delta CI |")
     lines.append("|---|---|---|---|")
     for category in categories:
-        winner = "NOT SIGNIFICANT"
+        winner = "유의하지 않음"
         winner_mean: float | None = None
         winner_ci: dict[str, Any] | None = None
         for spec in specs:

--- a/scripts/phase4_realistic_metadata_ablation.py
+++ b/scripts/phase4_realistic_metadata_ablation.py
@@ -451,14 +451,14 @@ def render_report(
     lines.append("")
     lines.append(
         f"winner = `chunk_recall@10` 평균이 가장 높으면서 `{baseline}` 대비 paired CI "
-        f"가 완전히 0 위인 변형. \"NOT SIGNIFICANT\" = 어떤 변형의 CI 도 0 을 넘지 "
+        f"가 완전히 0 위인 변형. \"유의하지 않음\" = 어떤 변형의 CI 도 0 을 넘지 "
         f"못함 (절대 규칙 #5)."
     )
     lines.append("")
     lines.append("| 카테고리 | winner | 평균 recall@10 | " + f"`{baseline}` 대비 delta CI |")
     lines.append("|---|---|---|---|")
     for category in categories:
-        winner = "NOT SIGNIFICANT"
+        winner = "유의하지 않음"
         winner_mean: float | None = None
         winner_ci: dict[str, Any] | None = None
         for spec in specs:
@@ -483,7 +483,7 @@ def render_report(
         "회수하며(coverage 분석의 char-4gram proxy ~34% 보다 낮다 — 운영 matcher 는 "
         "compact-contains / 강한 토큰 중첩을 요구), 회수에 성공한 cohort"
         "(`extractor_hit_agency`)에서도 oracle ceiling(PR #1108, recall@10 +0.22)을 "
-        "통계적으로 회복하지 못한다(모든 카테고리 NOT SIGNIFICANT). 이는 ADR 0065 의 "
+        "통계적으로 회복하지 못한다(모든 카테고리 유의하지 않음). 이는 ADR 0065 의 "
         "\"메타데이터 라우팅 = 좁은 opt-in 부가 기능, 운영 기본값 변경 아님\" 결정을 "
         "측정으로 지지한다. 또한 `extractor_prefilter_project` 는 oracle 의 ~15배 "
         "지연시간 Pareto 와 달리 부정확한 project 매칭으로 p95 지연시간이 오히려 "

--- a/tests/test_ablation_common.py
+++ b/tests/test_ablation_common.py
@@ -117,19 +117,20 @@ class SeedAveragedPairedCITest(unittest.TestCase):
 
 class FmtCiTest(unittest.TestCase):
     def test_fmt_ci_significance_boundary(self) -> None:
-        # CI that straddles 0 → NOT SIGNIFICANT.
+        # CI that straddles 0 → 유의하지 않음 (not significant).
         ci_straddle = {"mean_diff": 0.0, "ci_lo": -0.001, "ci_hi": 0.001}
-        self.assertIn("NOT SIGNIFICANT", _fmt_ci(ci_straddle))
-        # CI strictly above 0 → significant.
+        self.assertIn("유의하지 않음", _fmt_ci(ci_straddle))
+        # CI strictly above 0 → 유의함 (significant). The token "유의함" is
+        # not a substring of "유의하지 않음", so the assertions stay disjoint.
         ci_above = {"mean_diff": 0.003, "ci_lo": 0.001, "ci_hi": 0.005}
         out_above = _fmt_ci(ci_above)
-        self.assertIn("significant", out_above)
-        self.assertNotIn("NOT SIGNIFICANT", out_above)
-        # CI strictly below 0 → significant.
+        self.assertIn("유의함", out_above)
+        self.assertNotIn("유의하지 않음", out_above)
+        # CI strictly below 0 → 유의함 (significant).
         ci_below = {"mean_diff": -0.003, "ci_lo": -0.005, "ci_hi": -0.001}
         out_below = _fmt_ci(ci_below)
-        self.assertIn("significant", out_below)
-        self.assertNotIn("NOT SIGNIFICANT", out_below)
+        self.assertIn("유의함", out_below)
+        self.assertNotIn("유의하지 않음", out_below)
         # None → "N/A" so caller never sees a fabricated band.
         self.assertEqual(_fmt_ci(None), "N/A")
 

--- a/tests/test_phase35_m3_ablation.py
+++ b/tests/test_phase35_m3_ablation.py
@@ -156,12 +156,12 @@ class ReaggregateMainTest(unittest.TestCase):
             for metric in ["chunk_recall@5", "chunk_recall@10", "mrr", "ndcg@10"]:
                 self.assertIn(f"## {metric}", report)
                 self.assertIn(
-                    f"### {metric} — paired CI delta vs `dense_m3`", report
+                    f"### {metric} — `dense_m3` 대비 paired CI delta", report
                 )
-            # Variant header + per-category winner + Notes section.
-            self.assertIn("## Variants", report)
-            self.assertIn("## Per-category winner", report)
-            self.assertIn("## Notes", report)
+            # Variant header + per-category winner + Notes section (Korean).
+            self.assertIn("## 변형(variants)", report)
+            self.assertIn("## 카테고리별 winner", report)
+            self.assertIn("## 비고(notes)", report)
             # 3-variant grid must be in the variants table (m3 is the
             # one that distinguishes Phase 3.5 from Phase 3).
             self.assertIn("`dense_m3`", report)

--- a/tests/test_phase3_mode_ablation.py
+++ b/tests/test_phase3_mode_ablation.py
@@ -134,12 +134,12 @@ class ReaggregateMainTest(unittest.TestCase):
             for metric in ["chunk_recall@5", "chunk_recall@10", "mrr", "ndcg@10"]:
                 self.assertIn(f"## {metric}", report)
                 self.assertIn(
-                    f"### {metric} — paired CI delta vs `dense`", report
+                    f"### {metric} — `dense` 대비 paired CI delta", report
                 )
-            # Variant header + per-category winner + Notes section.
-            self.assertIn("## Variants", report)
-            self.assertIn("## Per-category winner", report)
-            self.assertIn("## Notes", report)
+            # Variant header + per-category winner + Notes section (Korean).
+            self.assertIn("## 변형(variants)", report)
+            self.assertIn("## 카테고리별 winner", report)
+            self.assertIn("## 비고(notes)", report)
             # Line budget: REPORT.md must stay <=200 lines per skill spec.
             self.assertLessEqual(report.count("\n"), 200)
             # Sidecar artifacts written.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

retrieval-eval Phase 4 보고서는 사용자 결정으로 한국어로 작성됐으나(PR #1108/#1123) Phase 2/3/3.5 보고서와 render_report 템플릿은 영어였고, 유의성 토큰(`NOT SIGNIFICANT`/`significant`)이 공유 헬퍼 `_fmt_ci` 에서 영어로 생성돼 **모든 phase 보고서**에 영어로 박혀 있었다. 본 PR 은 전 retrieval 보고서를 한국어(한영 병기)로 통일한다.

Closes #1124

## 2. 영향 파일

- `scripts/_ablation_common.py` — `_fmt_ci` 유의성 토큰 → `유의하지 않음` / `유의함` (전 phase 공유)
- `scripts/phase2_chunking_ablation.py` / `phase3_mode_ablation.py` / `phase35_m3_ablation.py` — render_report prose 한국어화
- `scripts/phase4_metadata_ablation.py` / `phase4_realistic_metadata_ablation.py` — 리터럴 토큰 prose 참조 동기화
- `tests/test_ablation_common.py` / `test_phase3_mode_ablation.py` / `test_phase35_m3_ablation.py` — 토큰/헤더 assertion 갱신
- 6 × `reports/retrieval/**/REPORT.md` — `--reaggregate` 재생성 (한국어)

`scripts/` 는 `LOAD_BEARING_PATHS` 미포함; runtime 모듈(rag_*) edit 0.

## 3. 리스크

가장 가능성 높은 깨짐: reaggregate 가 retrieval 점수를 변조 → 측정 결과 변경. 배제 검증: 6개 보고서의 per-variant `chunk_recall@10` / `mrr` 합을 HEAD 와 비교해 byte-identical 확인(카테고리/헤더/prose 만 변경). `phase2_-0740`(구 `single_hop` 스키마 historical 원본)은 reaggregate 가 현재 `hardcase_categories` 로 재분류를 유발 → provenance 보존 위해 **의도적 제외**.

## 4. 테스트

토큰/헤더를 assert 하던 기존 테스트를 한국어 토큰/헤더로 갱신: `test_ablation_common.test_fmt_ci_significance_boundary`(유의함/유의하지 않음 disjoint 검증), `test_phase3_mode_ablation` / `test_phase35_m3_ablation`(`## 변형(variants)` / `## 카테고리별 winner` / `## 비고(notes)`). 영향 테스트 27개 green. 동작 변경이 아닌 표현(prose) 변경이라 신규 behavior 테스트 없음 — 변경 전 fail / 후 pass 하는 토큰 boundary 테스트가 핀.

## 5. Eval 영향

CI 합성 eval delta: **All `·`** — RAG 런타임 경로 미변경. 보고서 prose + 측정 스크립트의 출력 문자열만 변경.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 — `scripts/` 측정 스크립트의 보고서 prose / 유의성 토큰만 한국어화, runtime 모듈(`rag_core`/`rag_retrieval`/`rag_verifier`/`rag_answer`/`rag_query`) edit 0. 재생성된 6개 REPORT.md 의 retrieval 점수는 byte-identical (per-variant recall@10/mrr 합 HEAD 대비 동일 확인).

## 6. 하위 호환

`_fmt_ci` 의 반환 문자열이 영어→한국어로 바뀐다. 이 헬퍼는 보고서 렌더링 전용(reviewer-facing prose)이며 기계 판독 계약/스키마가 아니다. deltas.json 의 CI 수치(mean_diff/ci_lo/ci_hi)는 불변 — 유의성 판정은 렌더 시점 파생.

## 7. 범위 외

- `phase2_chunking_20260518-0740` historical 원본 (위 §3 사유)
- Phase 1 (`UNIFIED_PHASE1_REPORT.md`) — 별도 포맷, 본 ablation runner 미사용