### PR TITLE
feat(judges): configurable call_openai_json temperature (unblock gpt-5.x)

### DIFF
--- a/eval/judges/judge_common.py
+++ b/eval/judges/judge_common.py
@@ -184,6 +184,32 @@ def get_judge_model() -> str:
     return model
 
 
+def get_judge_temperature() -> float:
+    """Read the sampling temperature for judge calls from the environment.
+
+    Returns ``BIDMATE_JUDGE_TEMPERATURE`` parsed as a float, defaulting to
+    ``0.0`` when unset — the deterministic path that keeps existing judge
+    behaviour byte-identical (ADR 0012 stub-default reproducibility).
+
+    The override exists because some reasoning models (e.g. the gpt-5.x
+    family) reject ``temperature=0`` outright ("only the default (1) value
+    is supported"); setting ``BIDMATE_JUDGE_TEMPERATURE=1`` unblocks them
+    without changing the default for every other backend.
+
+    Raises:
+        ValueError: when the env var is set but not parseable as a float.
+    """
+    raw = os.environ.get("BIDMATE_JUDGE_TEMPERATURE")
+    if raw is None or raw.strip() == "":
+        return 0.0
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"BIDMATE_JUDGE_TEMPERATURE is not a valid float: {raw!r}"
+        ) from exc
+
+
 def call_openai_json(
     client: Any,
     model: str,
@@ -191,8 +217,10 @@ def call_openai_json(
 ) -> dict[str, Any] | None:
     """Call an OpenAI-compatible endpoint and return a parsed JSON dict.
 
-    Uses ``temperature=0.0`` and ``response_format={"type": "json_object"}``
-    for deterministic, structured output.
+    Uses ``response_format={"type": "json_object"}`` for structured output.
+    Temperature defaults to ``0.0`` (deterministic) but is overridable via
+    ``BIDMATE_JUDGE_TEMPERATURE`` (see :func:`get_judge_temperature`) so that
+    reasoning models which reject ``temperature=0`` can still be called.
 
     Args:
         client: An ``openai.OpenAI`` instance (from :func:`build_openai_client`).
@@ -211,7 +239,7 @@ def call_openai_json(
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],
-        temperature=0.0,
+        temperature=get_judge_temperature(),
         response_format={"type": "json_object"},
     )
     content = response.choices[0].message.content or "{}"

--- a/tests/test_judge_common_regression.py
+++ b/tests/test_judge_common_regression.py
@@ -9,6 +9,7 @@ All tests use no network access and no external API keys.
 """
 from __future__ import annotations
 
+import os
 import unittest
 
 from eval.judges.judge_common import (
@@ -16,6 +17,7 @@ from eval.judges.judge_common import (
     build_evidence_block,
     clamp_score,
     extract_summary,
+    get_judge_temperature,
     normalize_status_verdict,
 )
 
@@ -232,6 +234,39 @@ class JudgeStatusesConstantTest(unittest.TestCase):
         self.assertIn("supported", JUDGE_STATUSES)
         self.assertIn("partial", JUDGE_STATUSES)
         self.assertIn("insufficient", JUDGE_STATUSES)
+
+
+class GetJudgeTemperatureTest(unittest.TestCase):
+    """get_judge_temperature: env override with deterministic 0.0 default."""
+
+    def setUp(self) -> None:
+        self._saved = os.environ.pop("BIDMATE_JUDGE_TEMPERATURE", None)
+
+    def tearDown(self) -> None:
+        if self._saved is None:
+            os.environ.pop("BIDMATE_JUDGE_TEMPERATURE", None)
+        else:
+            os.environ["BIDMATE_JUDGE_TEMPERATURE"] = self._saved
+
+    def test_unset_defaults_to_zero(self) -> None:
+        self.assertEqual(0.0, get_judge_temperature())
+
+    def test_empty_string_defaults_to_zero(self) -> None:
+        os.environ["BIDMATE_JUDGE_TEMPERATURE"] = "   "
+        self.assertEqual(0.0, get_judge_temperature())
+
+    def test_explicit_one_parsed(self) -> None:
+        os.environ["BIDMATE_JUDGE_TEMPERATURE"] = "1"
+        self.assertAlmostEqual(1.0, get_judge_temperature())
+
+    def test_fractional_value_parsed(self) -> None:
+        os.environ["BIDMATE_JUDGE_TEMPERATURE"] = "0.7"
+        self.assertAlmostEqual(0.7, get_judge_temperature())
+
+    def test_invalid_value_raises(self) -> None:
+        os.environ["BIDMATE_JUDGE_TEMPERATURE"] = "hot"
+        with self.assertRaises(ValueError):
+            get_judge_temperature()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `eval/judges/judge_common.py`: add `get_judge_temperature()` (mirrors `get_judge_model()`), reading `BIDMATE_JUDGE_TEMPERATURE` with default `0.0`; `call_openai_json` now uses it instead of a hardcoded `temperature=0.0`.
- gpt-5.x reasoning 모델은 `temperature=0` 을 거부하므로 ADR 0064 첫 openai_compatible 실행이 gpt-4.1 로 폴백해야 했음. `BIDMATE_JUDGE_TEMPERATURE=1` 로 해금.
- 기본값 `0.0` 보존 → 기존 모든 judge 경로 동작 byte 동일 (하위 호환).

## Test plan
- [x] `tests/test_judge_common_regression.py`: 5 new tests for `get_judge_temperature` (unset→0.0, empty→0.0, "1"→1.0, "0.7"→0.7, invalid→ValueError). 네트워크 없음.
- [x] `pytest tests/test_judge_common_regression.py` → 43 passed.

## Risk / 5b real-data 델타
- N/A — load-bearing 아님 (eval judge helper, ADR 0001 baseline 경로 무관). 기본값 보존으로 동작 변경 0 → real-data 델타 없음.

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)