### PR TITLE
fix(ingestion): auto-detect sibling files_kordoc cache dir

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -270,6 +270,28 @@ def _kordoc_output_stem(source_path: Path) -> str:
     return unicodedata.normalize("NFC", source_path.stem)
 
 
+def _resolve_kordoc_cache_dir(source_paths: list[Path]) -> Path | None:
+    """Resolve the pre-extracted kordoc ``.md`` cache dir, or None.
+
+    ``BIDMATE_KORDOC_CACHE_DIR`` overrides; otherwise the sibling
+    ``<files_dir>_kordoc`` convention (``data/files`` → ``data/files_kordoc``)
+    is used automatically. The sibling default means a committed kordoc cache
+    is consumed without any env setup — so the default build path stops
+    silently falling back to CSV text when ``npx`` is unavailable / times out.
+    Returns None when the resolved directory does not exist, leaving the live
+    ``npx`` + CSV-fallback path unchanged.
+    """
+    env = os.environ.get("BIDMATE_KORDOC_CACHE_DIR", "").strip()
+    if env:
+        chosen = Path(env)
+        return chosen if chosen.is_dir() else None
+    if not source_paths:
+        return None
+    parent = source_paths[0].parent
+    sibling = parent.with_name(parent.name + "_kordoc")
+    return sibling if sibling.is_dir() else None
+
+
 def _kordoc_convert_batch(source_paths: list[Path]) -> dict[str, str]:
     """Invoke ``npx kordoc`` on the file list, return ``{stem: markdown}``.
 
@@ -283,48 +305,47 @@ def _kordoc_convert_batch(source_paths: list[Path]) -> dict[str, str]:
     On success returns a dict mapping ``Path.stem`` (NFC-normalized) to
     the Markdown text content of the corresponding output file.
 
-    ``BIDMATE_KORDOC_CACHE_DIR`` env var enables a pre-extracted markdown
-    cache bypass: if every ``source_paths`` stem has a matching
-    ``<stem>.md`` file in the cache dir, the subprocess is skipped and
-    the cached content is returned directly. Partial cache hits fall
-    through to the subprocess (which extracts ALL files; partial-miss
-    merging is not worth the complexity). The cached files are
-    expected to be the output of an earlier kordoc run on the same
-    source files — same demote/scrub/normalize pipeline applies so
-    downstream readers see identical text. Enables ~30x ingestion
-    speed-up for reproducible builds against a vendored kordoc cache
-    (Phase 3.5 closeout, real100 corpus).
+    Pre-extracted markdown cache (``_resolve_kordoc_cache_dir``:
+    ``BIDMATE_KORDOC_CACHE_DIR`` env, else sibling ``<files_dir>_kordoc``)
+    is consulted first: if every ``source_paths`` stem has a matching
+    ``<stem>.md`` file in the cache dir, the subprocess is skipped and the
+    cached content is returned directly. Partial cache hits fall through to
+    the subprocess (which extracts ALL files; partial-miss merging is not
+    worth the complexity). The cached files are the output of an earlier
+    kordoc run on the same source files — the same demote/scrub/normalize
+    pipeline applies so downstream readers see identical text. The sibling
+    default means committed kordoc output (``data/files_kordoc``) is used
+    automatically, so the build no longer silently falls back to CSV text
+    when ``npx`` is missing / times out (Phase 3.5 closeout, real100 corpus).
     """
     import subprocess  # noqa: PLC0415 — local import keeps module load fast for non-HWP paths
     import shutil  # noqa: PLC0415
     import tempfile  # noqa: PLC0415
 
-    cache_dir_env = os.environ.get("BIDMATE_KORDOC_CACHE_DIR", "").strip()
-    if cache_dir_env:
-        cache_dir = Path(cache_dir_env)
-        if cache_dir.is_dir():
-            markdown_by_stem: dict[str, str] = {}
-            for src in source_paths:
-                stem = unicodedata.normalize("NFC", src.stem)
-                md_path = cache_dir / f"{stem}.md"
-                if not md_path.exists():
-                    continue
-                try:
-                    content = md_path.read_text(encoding="utf-8")
-                except OSError:
-                    continue
-                # Same post-processing pipeline as the subprocess path
-                # (issue #904 demote + issue #906 ToC scrub + body normalize)
-                # so the cached output is byte-identical to a fresh kordoc run.
-                demoted = _demote_over_promoted_bullet_headings(content)
-                scrubbed = _strip_kordoc_toc_noise(demoted)
-                normalized = normalize_body_text(scrubbed)
-                if normalized:
-                    markdown_by_stem[stem] = normalized
-            if markdown_by_stem and len(markdown_by_stem) == len(source_paths):
-                return markdown_by_stem
-            # partial hit → fall through to npx subprocess (which extracts
-            # ALL files; partial-miss merging is not worth the complexity).
+    cache_dir = _resolve_kordoc_cache_dir(source_paths)
+    if cache_dir is not None:
+        markdown_by_stem: dict[str, str] = {}
+        for src in source_paths:
+            stem = unicodedata.normalize("NFC", src.stem)
+            md_path = cache_dir / f"{stem}.md"
+            if not md_path.exists():
+                continue
+            try:
+                content = md_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            # Same post-processing pipeline as the subprocess path
+            # (issue #904 demote + issue #906 ToC scrub + body normalize)
+            # so the cached output is byte-identical to a fresh kordoc run.
+            demoted = _demote_over_promoted_bullet_headings(content)
+            scrubbed = _strip_kordoc_toc_noise(demoted)
+            normalized = normalize_body_text(scrubbed)
+            if normalized:
+                markdown_by_stem[stem] = normalized
+        if markdown_by_stem and len(markdown_by_stem) == len(source_paths):
+            return markdown_by_stem
+        # partial hit → fall through to npx subprocess (which extracts
+        # ALL files; partial-miss merging is not worth the complexity).
 
     if shutil.which("node") is None or shutil.which("npx") is None:
         raise _KordocFallback("node/npx not on PATH") from FileNotFoundError(

--- a/tests/test_ingestion_kordoc_regression.py
+++ b/tests/test_ingestion_kordoc_regression.py
@@ -445,6 +445,62 @@ class KordocCacheDirBypassTest(unittest.TestCase):
             self.assertEqual(len(captured), 1)
             self.assertIn("subprocess body", result["doc"])
 
+    def test_sibling_default_cache_dir_bypasses_npx(self) -> None:
+        # env var UNSET but a sibling ``<files_dir>_kordoc`` exists → the cache
+        # is used automatically (no manual env needed), so the default build
+        # stops silently falling back to CSV text when npx is unavailable.
+        from ingestion import _kordoc_convert_batch
+
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            files_dir = tmp_path / "files"
+            cache_dir = tmp_path / "files_kordoc"  # sibling convention
+            files_dir.mkdir()
+            cache_dir.mkdir()
+            src = files_dir / "doc.hwp"
+            src.touch()
+            (cache_dir / "doc.md").write_text(
+                "# 2024. 8.\n\n사업 개요·········· 3\n\n소요예산: 1억 5천만 원\n",
+                encoding="utf-8",
+            )
+            self.assertNotIn("BIDMATE_KORDOC_CACHE_DIR", os.environ)
+
+            def must_not_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+                raise AssertionError(
+                    "subprocess.run must not be invoked on sibling-default cache hit"
+                )
+
+            # node "present" so a regression would actually call npx and trip the sentinel.
+            with mock.patch.object(shutil, "which", return_value="/usr/bin/npx"):
+                with mock.patch.object(subprocess, "run", side_effect=must_not_run):
+                    result = _kordoc_convert_batch([src])
+
+            self.assertEqual(set(result.keys()), {"doc"})
+            self.assertIn("소요예산", result["doc"])
+            self.assertIn("1억 5천만 원", result["doc"])
+            self.assertNotIn("··········", result["doc"])  # ToC leader dots scrubbed (#906)
+
+    def test_sibling_default_works_when_node_missing(self) -> None:
+        # Sibling cache covers the source AND node/npx is absent → still
+        # returns kordoc text (no CSV fallback). This is the real-eval-on-CI
+        # case the fix targets.
+        from ingestion import _kordoc_convert_batch
+
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            files_dir = tmp_path / "files"
+            cache_dir = tmp_path / "files_kordoc"
+            files_dir.mkdir()
+            cache_dir.mkdir()
+            src = files_dir / "doc.hwp"
+            src.touch()
+            (cache_dir / "doc.md").write_text("# H\n\nkordoc body\n", encoding="utf-8")
+
+            with mock.patch.object(shutil, "which", return_value=None):
+                result = _kordoc_convert_batch([src])
+
+            self.assertIn("kordoc body", result["doc"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1129

`ingestion.py::_kordoc_convert_batch` 의 pre-extracted 캐시 조회가 `BIDMATE_KORDOC_CACHE_DIR` env 를 **수동 set 해야만** 작동했다. 기본 빌드 경로(`make real-eval` → `smoke_real.sh`, `build_index`)는 env 를 set 하지 않아 → `npx kordoc` 600s 타임아웃 → CSV 메타(`data_list.csv::텍스트`) 폴백으로 **조용히** 빠졌고, `data/index/real100` 이 문서 본문 없이 빌드됐다 (single_doc expected_term substring coverage clean = 9%). 진짜 본문(kordoc `.md`, 106–518KB)은 `data/files_kordoc/` 에 이미 있었으나 미사용.

`_resolve_kordoc_cache_dir` 추출: `BIDMATE_KORDOC_CACHE_DIR` override 우선, 없으면 sibling `<files_dir>_kordoc` (`data/files` → `data/files_kordoc`) 자동 사용. 기본 빌드가 더는 CSV 로 silent fallback 하지 않는다.

## 2. 영향 파일

- `ingestion.py` (**load-bearing**) — `_resolve_kordoc_cache_dir` 헬퍼 추가 + `_kordoc_convert_batch` 캐시 dir 해석을 env-only → env-or-sibling 으로
- `tests/test_ingestion_kordoc_regression.py` — sibling-default bypass 테스트 2종

## 3. 리스크

- 가장 가능성 높은 깨짐: sibling `<files_dir>_kordoc` 가 stale/부분이면 잘못된 본문 사용. → full-hit 일 때만 bypass(기존 의미 유지), partial → npx 로 fall-through. 캐시 dir 부재 시 기존 npx + CSV 폴백 경로 무변경(역호환). 기존 env-override 경로 의미 불변.

## 4. 테스트

- `test_sibling_default_cache_dir_bypasses_npx` — env 미설정 + sibling 존재 → npx 호출 안 됨(sentinel) + 후처리(ToC scrub) 적용 확인
- `test_sibling_default_works_when_node_missing` — sibling 캐시 + node 부재 → CSV 폴백 없이 kordoc 텍스트 반환
- 기존 `BIDMATE_KORDOC_CACHE_DIR` 경로(이전까지 **테스트 부재**)도 같은 클래스에서 함께 커버됨. 전체 `tests/test_ingestion_kordoc_regression.py` 22 passed, ruff clean.

## 5. Eval 영향

합성 CI eval delta 없음 — ingestion 빌드-타임 경로 변경이며 retrieval/answer 런타임 로직 무변경. 실제 영향은 §5b (index 재빌드 시 본문 인덱싱).

### 5b. Real-data delta

검색/검증 런타임 path 동작 변화 없음 — 빌드 경로 변경. patched 코드로 `data/index/real100` 재빌드 결과 (hashing embeddings 고정, 텍스트 source 만 변경):

| 항목 | OLD (CSV 폴백) | NEW (kordoc sibling) |
|---|---|---|
| `ingestion_report.text_source_counts` | data_list_csv_text 100 | kordoc 100 |
| `fallback_reasons` | TimeoutExpired 100 | (없음) |
| index chunks | 898 | 26376 |
| single_doc expected_term coverage clean | 9% (10/112) | 86% (96/112) |

(term-coverage 는 substring-on-text 측정이라 embedding backend 무관. answer-quality real-eval-delta 는 별도 — embedding backend(현 hashing, bge-m3 권장)는 별개 concern 으로 후속 issue.)

## 6. 하위 호환

계약/스키마/CLI flag 변경 없음. `BIDMATE_KORDOC_CACHE_DIR` env 동작 불변(override 로 유지). sibling 자동탐지는 순수 additive. ADR 0049 kordoc 계약 내 개선, ADR 0001 offline CSV 폴백 invariant 보존.

## 7. 범위 외

- real-eval 기본 embedding backend 가 `hashing`(feature-hashing BoW, 의미-맹목)인 문제 — 별도 issue 로 분리 예정.
- 캐노니컬 `data/index/real100` 의 bge-m3 재빌드 — 별도.