### PR TITLE
feat(self-review): implement axis_5 5-A memory-index hygiene

### DIFF
--- a/eval/judges/self_review_judge.py
+++ b/eval/judges/self_review_judge.py
@@ -116,7 +116,13 @@ def extract_signals(stats: dict[str, Any]) -> dict[str, Any]:
                 axis_4.get("pr_turnaround_hours", {}) or {}
             ).get("mean"),
         },
-        "axis_5": {"content_fresh_rate": axis_5.get("fresh_rate")},
+        "axis_5": {
+            "content_fresh_rate": axis_5.get("fresh_rate"),
+            # 5-A index hygiene. ``None`` when the collector did not emit the
+            # field (old data) → grade on 5-B alone; a dict (even all-zero)
+            # means the collector measured it → SKILL.md count=0 → △ applies.
+            "memory_lines": gov.get("memory_lines"),
+        },
         "evidence_age_days": stats.get("evidence_age_days"),
     }
 
@@ -202,20 +208,48 @@ def stub_verdicts(stats: dict[str, Any]) -> dict[str, str]:
         else ("✗" if ("✗" in (v4a, v4b)) else "△")
     )
 
-    # axis #5 — memory hygiene (5-B content freshness only). 5-A index
-    # hygiene needs fires_by_reason["memory-lines"], but the collector emits
-    # fires_by_action (action key, not reason) — a known SKILL.md↔collector
-    # mismatch documented in ADR 0064 Context. 5-A is deferred until the
-    # collector emits fires_by_action_reason; axis_5 grades on 5-B alone.
-    fr = sig["axis_5"]["content_fresh_rate"]
+    # axis #5 — memory hygiene = 5-A index hygiene + 5-B content freshness,
+    # combined by the SKILL.md dual-sub-signal rule (both ✓ → ✓; any ✗ → ✗;
+    # else △). 5-A reads governance_hooks.memory_lines, emitted by the
+    # collector as the count of `memory-lines` category fires split by action.
+    a5 = sig["axis_5"]
+
+    # 5-B content freshness band.
+    fr = a5["content_fresh_rate"]
     if fr is None:
-        out["axis_5_memory_hygiene"] = "✗"
+        v5b = "✗"
     elif fr >= 0.5:
-        out["axis_5_memory_hygiene"] = "✓"
+        v5b = "✓"
     elif fr >= 0.2:
-        out["axis_5_memory_hygiene"] = "△"
+        v5b = "△"
     else:
-        out["axis_5_memory_hygiene"] = "✗"
+        v5b = "✗"
+
+    # 5-A index hygiene. ``None`` = collector did not emit the field (old
+    # data) → fall back to 5-B alone (backward-compatible). Otherwise grade:
+    # count=0 → △ (측정 부재); blocked≥1 → ✗ (edit refused = index exploded);
+    # blocked=0 + aware≤2 → ✓; blocked=0 + aware≥3 → △.
+    ml = a5["memory_lines"]
+    if ml is None:
+        out["axis_5_memory_hygiene"] = v5b
+    else:
+        aware = int(ml.get("aware", 0) or 0)
+        blocked = int(ml.get("blocked", 0) or 0)
+        if aware + blocked == 0:
+            v5a = "△"
+        elif blocked >= 1:
+            v5a = "✗"
+        elif aware <= 2:
+            v5a = "✓"
+        else:
+            v5a = "△"
+        # dual-sub-signal combine
+        if v5a == "✓" and v5b == "✓":
+            out["axis_5_memory_hygiene"] = "✓"
+        elif "✗" in (v5a, v5b):
+            out["axis_5_memory_hygiene"] = "✗"
+        else:
+            out["axis_5_memory_hygiene"] = "△"
 
     return {k: _guard_downgrade(v, ev_age) for k, v in out.items()}
 
@@ -236,8 +270,13 @@ def _build_prompt(stats: dict[str, Any]) -> str:
         "fires >0 with 1 action; ✗ if fires=0.\n"
         "4. cycle_time: ✓ if adr_lag_days_mean ≤5 AND pr_turnaround_hours_mean "
         "≤48; ✗ if adr_lag >10 or pr_turnaround >120; △ otherwise (null=△).\n"
-        "5. memory_hygiene: ✓ if content_fresh_rate ≥0.5; △ if 0.2–0.5; ✗ if "
-        "<0.2 or null.\n\n"
+        "5. memory_hygiene = 5-A index hygiene + 5-B content freshness, "
+        "combined (both ✓ → ✓; any ✗ → ✗; else △). "
+        "5-B: ✓ if content_fresh_rate ≥0.5; △ if 0.2–0.5; ✗ if <0.2 or null. "
+        "5-A from memory_lines {aware, blocked}: if the field is null grade on "
+        "5-B alone; else count=aware+blocked=0 → △ (not measured), blocked ≥1 "
+        "→ ✗ (index-edit refused), blocked=0 and aware ≤2 → ✓, blocked=0 and "
+        "aware ≥3 → △.\n\n"
         "If evidence_age_days <1.0, downgrade any ✓ to △ (evidence and review "
         "produced the same day — cannot be independently confirmed).\n\n"
         f"Raw signals:\n{json.dumps(signals, indent=2, ensure_ascii=False)}\n\n"

--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -414,6 +414,7 @@ def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
             "pretooluse_loadbearing_fires": 0,
             "fires_by_path": {},
             "fires_by_action": {},
+            "memory_lines": {"aware": 0, "blocked": 0},
             "rule_to_automation_lag_days": _compute_adr_lags(repo, start, end),
             "note": "Hook fire log absent at .claude/.hook-fires.log; emit 0.",
         }
@@ -424,6 +425,11 @@ def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
     fires = 0
     by_path: Counter[str] = Counter()
     by_action: Counter[str] = Counter()
+    # axis #5-A index hygiene: count `memory-lines` category fires split by
+    # action so the rubric can separate aware (soft-warn) from blocked
+    # (edit refused = index exploded). The category lives in parts[2]; the
+    # historical aggregation above only kept action + path, dropping it.
+    memory_lines: Counter[str] = Counter()
     try:
         for line in log_path.read_text().splitlines():
             line = line.strip()
@@ -438,14 +444,20 @@ def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
             if fire_dt < start_dt or fire_dt > end_dt:
                 continue
             if len(parts) >= 4:
-                action, path = parts[1], parts[3]
+                action, category, path = parts[1], parts[2], parts[3]
             else:
-                action, path = "aware", parts[1] if len(parts) > 1 else ""
+                action, category, path = (
+                    "aware",
+                    "",
+                    parts[1] if len(parts) > 1 else "",
+                )
             fires += 1
             if path:
                 by_path[path] += 1
             if action:
                 by_action[action] += 1
+            if category == "memory-lines" and action:
+                memory_lines[action] += 1
     except OSError:
         pass
     lags = _compute_adr_lags(repo, start, end)
@@ -454,6 +466,10 @@ def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
         "pretooluse_loadbearing_fires": fires,
         "fires_by_path": dict(by_path.most_common(10)),
         "fires_by_action": dict(by_action),
+        "memory_lines": {
+            "aware": memory_lines.get("aware", 0),
+            "blocked": memory_lines.get("blocked", 0),
+        },
         "rule_to_automation_lag_days": lags,
         "note": note,
     }
@@ -719,6 +735,11 @@ def emit_report(stats: dict[str, Any]) -> str:
             f"{stats['axis_4_cycle_time']['pr_turnaround_hours'].get('mean')} / "
             f"{stats['axis_4_cycle_time']['pr_turnaround_hours'].get('p90')} "
             f"(n={stats['axis_4_cycle_time']['pr_turnaround_hours'].get('count')})"
+        ),
+        (
+            f"- Axis #5-A Memory index hygiene (memory-lines fires): "
+            f"aware={stats['governance_hooks'].get('memory_lines', {}).get('aware', 0)}"
+            f" / blocked={stats['governance_hooks'].get('memory_lines', {}).get('blocked', 0)}"
         ),
         (
             f"- Axis #5-B Memory freshness (fresh/total): "

--- a/tests/test_self_review_judge.py
+++ b/tests/test_self_review_judge.py
@@ -173,6 +173,45 @@ def test_axis_5_null_freshness_is_fail():
     assert stub_verdicts(stats)["axis_5_memory_hygiene"] == "✗"
 
 
+def _gov_with_memory_lines(aware: int, blocked: int) -> dict:
+    """governance_hooks block keeping axis #3 ✓ + a 5-A memory_lines signal."""
+    return {
+        "pretooluse_loadbearing_fires": 20,
+        "fires_by_action": {"aware": 18, "ok": 2},
+        "memory_lines": {"aware": aware, "blocked": blocked},
+    }
+
+
+def test_axis_5_absent_memory_lines_falls_back_to_5b():
+    """5-A field absent (old collector) → grade on 5-B alone (✓ here)."""
+    # _base_stats has no governance_hooks.memory_lines key.
+    assert stub_verdicts(_base_stats())["axis_5_memory_hygiene"] == "✓"
+
+
+def test_axis_5_blocked_forces_fail():
+    """5-A: blocked ≥1 (index edit refused) → ✗, dominates a ✓ 5-B."""
+    stats = _base_stats(governance_hooks=_gov_with_memory_lines(aware=0, blocked=1))
+    assert stub_verdicts(stats)["axis_5_memory_hygiene"] == "✗"
+
+
+def test_axis_5_zero_count_is_partial():
+    """5-A: present but count=0 → △ (측정 부재), combined with ✓ 5-B → △."""
+    stats = _base_stats(governance_hooks=_gov_with_memory_lines(aware=0, blocked=0))
+    assert stub_verdicts(stats)["axis_5_memory_hygiene"] == "△"
+
+
+def test_axis_5_high_aware_is_partial():
+    """5-A: blocked=0 + aware≥3 → △, combined with ✓ 5-B → △."""
+    stats = _base_stats(governance_hooks=_gov_with_memory_lines(aware=3, blocked=0))
+    assert stub_verdicts(stats)["axis_5_memory_hygiene"] == "△"
+
+
+def test_axis_5_both_subsignals_pass():
+    """5-A ✓ (blocked=0 + aware≤2) AND 5-B ✓ → combined ✓."""
+    stats = _base_stats(governance_hooks=_gov_with_memory_lines(aware=2, blocked=0))
+    assert stub_verdicts(stats)["axis_5_memory_hygiene"] == "✓"
+
+
 def test_unknown_backend_raises():
     """Unknown backend → ValueError."""
     with pytest.raises(ValueError):

--- a/tests/test_self_review_window_regression.py
+++ b/tests/test_self_review_window_regression.py
@@ -58,6 +58,32 @@ class TestWindowDaysMode(unittest.TestCase):
             data["governance_hooks"]["pretooluse_loadbearing_fires"], 0
         )
 
+    def test_memory_lines_category_split_by_action(self):
+        """axis #5-A: `memory-lines` category fires cross-tabbed by action."""
+        today = datetime.now(timezone.utc).date()
+        ts = (today - timedelta(days=1)).isoformat()
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(
+                f"{ts}T10:00:00Z|aware|load-bearing|rag_core.py\n"
+                f"{ts}T10:01:00Z|aware|memory-lines|MEMORY.md\n"
+                f"{ts}T10:02:00Z|aware|memory-lines|MEMORY.md\n"
+                f"{ts}T10:03:00Z|blocked|memory-lines|MEMORY.md\n"
+            )
+            result = _run("--window-days", "7", "--repo", str(repo))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        gov = json.loads(result.stdout)["governance_hooks"]
+        # 2 aware + 1 blocked memory-lines fires; load-bearing excluded.
+        self.assertEqual(gov["memory_lines"], {"aware": 2, "blocked": 1})
+
+    def test_absent_log_emits_zero_memory_lines(self):
+        """No log → memory_lines present as all-zero (measured, not absent)."""
+        with tempfile.TemporaryDirectory() as td:
+            result = _run("--window-days", "7", "--repo", td)
+        gov = json.loads(result.stdout)["governance_hooks"]
+        self.assertEqual(gov["memory_lines"], {"aware": 0, "blocked": 0})
+
     def test_quarter_and_window_mutually_exclusive(self):
         result = _run("--quarter", "Q2-2026", "--window-days", "7")
         self.assertNotEqual(result.returncode, 0)


### PR DESCRIPTION
## Summary
ADR 0064 Outcome B 가 드러낸 **실제 spec/구현 gap** 을 닫는다: SKILL.md 의 axis #5-A signal path 는 `memory-lines` 카테고리 hook fire 카운트인데, collector 가 hook-fires.log 의 category(`parts[2]`) 를 버리고 action+path 만 집계해 stub judge 가 5-A 를 채점 못 하고 5-B 단독으로 axis_5 를 평가해 왔다.

- **collector** (`scripts/claude-hooks/_self_review.py`): `memory-lines` 카테고리 발화를 action 별 cross-tab → `governance_hooks.memory_lines = {"aware": N, "blocked": M}` 신규 emit. 마크다운 리포트에 5-A 라인 추가.
- **judge** (`eval/judges/self_review_judge.py`): `stub_verdicts` 가 5-A 밴드(blocked≥1→✗ / blocked=0+aware≤2→✓ / aware≥3→△ / count=0→△ 측정부재)를 계산하고 5-B 와 dual-sub-signal 규칙(둘 다 ✓→✓ / 하나라도 ✗→✗ / else △)으로 결합. `memory_lines` 키 부재(구 collector 데이터)면 5-B 단독 폴백 → 하위 호환.
- 외부 LLM 프롬프트도 full 5-A+5-B 룰로 갱신 — Outcome B caveat #2(프롬프트가 stub 의 *축소* rubric 만 줘서 κ=1.0 이 구조적으로 보장된 부분)를 해소.

## Test plan
- [x] judge 5-A 5종 (absent→5-B 폴백 / blocked→✗ / count=0→△ / aware≥3→△ / both✓→✓).
- [x] collector cross-tab 2종 (aware+blocked split, log 부재→all-zero).
- [x] `pytest tests/test_self_review_judge.py tests/test_self_review_window_regression.py` → 23 passed.
- [x] 사전 회귀 (axis_5_regression / no_body_leak / telemetry / self_review_regression) 56 passed.

## Risk / 5b real-data 델타
- load-bearing 아님 (self-review 측정 표면, ADR 0001 baseline 경로 무관). collector 가 신규 필드를 추가 emit 할 뿐 기존 필드 불변 → 하위 호환. 신규 ADR 불필요 (ADR 0064 에 문서화된 deferred 5-A 완성, SKILL.md signal path 변경 없음).
- 효과: 새로 수집된 스냅샷은 이제 axis_5 를 full rubric 로 채점 → Outcome B 의 blind operator(△)와 정합. 구 스냅샷은 5-B 단독 폴백으로 기존 동작 보존.

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)