### PR TITLE
fix(adr): sync ADR 0058 verifies-key to Korean report anchor

### DIFF
--- a/docs/adr/0058-phase35-mode-winner.md
+++ b/docs/adr/0058-phase35-mode-winner.md
@@ -68,8 +68,8 @@ ADR 0010 (2026-05-11) 은 `retrieval_backend ∈ {dense, hybrid}` 를 default `d
 
 ## Verification
 
-<!-- verifies-key: reports/retrieval/phase35_m3_20260518T214937Z_kordoc_no_m3/REPORT.md:Per-category winner -->
+<!-- verifies-key: reports/retrieval/phase35_m3_20260518T214937Z_kordoc_no_m3/REPORT.md:카테고리별 winner -->
 <!-- verifies-key: docs/adr/0010-hybrid-bm25-dense-retrieval-rrf.md:BGE-M3 ablation closeout -->
 <!-- verifies-key: eval/config.yaml:retrieval_backend -->
 
-kordoc-corpus REPORT.md 의 Per-category winner 섹션이 본 결정의 load-bearing 근거다. ADR 0010 은 여기로 되짚는 closeout 섹션을 획득해야 함 (PR-G). `eval/config.yaml` 은 scenario A 또는 B default 를 명시 반영해야 함 (annotation 또는 value 변경). 참조 파일이 keyed 섹션을 잃으면 `scripts/_governance.py --lint-adr-consequences` linter 가 본 ADR 을 flag 한다.
+kordoc-corpus REPORT.md 의 카테고리별 winner 섹션이 본 결정의 load-bearing 근거다. ADR 0010 은 여기로 되짚는 closeout 섹션을 획득해야 함 (PR-G). `eval/config.yaml` 은 scenario A 또는 B default 를 명시 반영해야 함 (annotation 또는 value 변경). 참조 파일이 keyed 섹션을 잃으면 `scripts/_governance.py --lint-adr-consequences` linter 가 본 ADR 을 flag 한다.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1141

PR #1125 ("Korean-ize Phase 2/3/3.5/4 retrieval reports", commit 1484a86) 가 리포트 섹션 제목을 `## Per-category winner` → `## 카테고리별 winner` 로 한국어화하면서, ADR 0058 의 `verifies-key` machine-checkable 앵커가 끊겨 `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0058-phase35-mode-winner.md` 가 exit 1 로 실패했다. docs 한국어화 정책상 ADR governance 토큰 보존이 원칙이고, sibling ADR 0065 가 이미 동일 패턴의 리포트를 한국어 앵커 `카테고리별 winner` 로 참조하며 통과하므로 — 일관성을 위해 ADR 0058 의 `verifies-key` + 설명문을 한국어 섹션명으로 동기화한다(수정 방향 a).

## 2. 영향 파일

- `docs/adr/0058-phase35-mode-winner.md` (**load-bearing**) — `verifies-key` 마커 1줄 + 설명문 1줄에서 `Per-category winner` → `카테고리별 winner`

## 3. 리스크

- 잘못된 substring 선택 시 앵커가 여전히 끊김. 배제: 리포트 실제 헤더가 `## 카테고리별 winner` (REPORT.md:115) 임을 grep 확인 + sibling ADR 0065 가 동일 substring `카테고리별 winner` 로 통과함을 확인.
- 다른 ADR 의 verifies-key 회귀 가능성. 배제: `rg "verifies-key:" docs/adr` 전수 후 모든 마커를 lint — broken-key 는 선존재 0045/0046 뿐(이 PR 무관, §7 참조), 신규 회귀 0.

## 4. 테스트

- **신규 동작 = lint exit 0.** `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0058-phase35-mode-winner.md`: 변경 전 exit 1 (`key 'Per-category winner' not found`) → 변경 후 **exit 0**.
- `pytest tests/test_governance.py tests/test_doc_links.py` → **84 passed, 3 skipped**.
- 별도 회귀 테스트 미추가 사유: `lint_adr_verification` 동작은 `tests/test_governance.py` 가 이미 커버. 본 변경은 깨진 앵커 문자열을 타깃 섹션명에 맞춘 docs-only 동기화로, 새 코드 경로 없음.

## 5. Eval 영향

All `·` — docs/adr 앵커 동기화. RAG/eval surface 미변경.

### 5b. Real-data delta

검색·검증·평가 동작 변화 없음. ADR 0058 의 `verifies-key` 앵커 문자열(+설명문) 2줄을 PR #1125 가 한국어화한 리포트 섹션명(`카테고리별 winner`)에 맞춘 docs-only 변경 — RAG 파이프라인·메트릭·`eval/config.yaml` 무관.

## 6. 하위 호환

깨짐 없음. answer-contract (ADR 0003)·schema·CLI flag·doc link 무관. ADR governance 토큰(`## Verification` 헤더, `verifies-key` 마커 형식)은 보존.

## 7. 범위 외

전수 audit 중 발견한 별개의 **선존재** broken-key (main 에 이미 존재, 이 PR 과 무관 — 별도 issue/follow-up):
- **ADR 0046**: `Korean public` 앵커가 한국어화된 ADR 0018 에 부재 (#1120/#925 유래, 리포트 아닌 ADR 상호참조).
- **ADR 0045**: `from rag_core import` 마커가 의미상 역전 (ADR 본문이 "`from rag_core` ... returns no lines" 라고 명시 — 마커가 검증하려는 문자열이 부재해야 정상).

근본 갭: `--lint-adr-consequences` 가 pre-commit 훅에서 **새로 추가된 ADR 에만** 강제되어(`.githooks/pre-commit:146`), 타깃 파일이 나중에 편집되면 source ADR 의 앵커가 조용히 깨진다. 전수 lint 게이트 도입은 새 측정 표면이므로 별도 concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)