### PR TITLE
fix(adr): sync ADR 0046 verifies-key to Korean ADR 0018 anchor

### DIFF
--- a/docs/adr/0046-ood-evaluation-domain-selection.md
+++ b/docs/adr/0046-ood-evaluation-domain-selection.md
@@ -116,7 +116,7 @@ OOD 분석 변형은 `agentic_full` 이 OOD 에서 `≥ 0.6 × accuracy(RFP-full
 본 ADR 은 plan-only. 의존하는 두 전제조건은 PR 시점에 체크; E2 / E3 / E4 PR 이 바닥 불변량 lift.
 
 <!-- verifies-key: eval/config.yaml:naive_baseline -->
-<!-- verifies-key: docs/adr/0018-korean-public-rag-bench.md:Korean public -->
+<!-- verifies-key: docs/adr/0018-korean-public-rag-bench.md:한국어 공개 RAG bench -->
 
 E2 / E3 / E4 PR 은 다음을 보여야:
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1153

PR #1120 / #925 (docs/ADR 한국어화) 가 ADR 0018 을 한국어화하면서 H1 이 `# 0018: 한국어 공개 RAG bench 를 보조 out-of-domain 표면으로` 로 바뀌어, ADR 0046 의 `verifies-key` machine-checkable 앵커 `Korean public` 이 끊겨 `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0046-ood-evaluation-domain-selection.md` 가 exit 1 로 실패했다. 같은 클래스의 ADR 0058 깨짐을 복구한 #1142 와 동일 방향으로, ADR 0018 에 실재하는 안정적 한국어 substring `한국어 공개 RAG bench` (H1 타이틀)로 동기화한다.

## 2. 영향 파일

- `docs/adr/0046-ood-evaluation-domain-selection.md` (**load-bearing**) — `verifies-key` 마커 1줄에서 `Korean public` → `한국어 공개 RAG bench`

## 3. 리스크

- 잘못된 substring 선택 시 앵커가 여전히 끊김. 배제: ADR 0018 의 H1(line 1)에 `한국어 공개 RAG bench` 가 실재함을 `grep -c`(=1) 로 확인 + 변경 후 lint exit 0.
- 다른 ADR verifies-key 회귀. 배제: 본 PR 은 0046 의 단일 마커만 수정, 신규 회귀 0.

## 4. 테스트

- **신규 동작 = lint exit 0.** `--lint-adr-consequences docs/adr/0046-...md`: 변경 전 exit 1 (`key 'Korean public' not found`) → 변경 후 **exit 0**.
- `pytest tests/test_governance.py` → **57 passed, 3 skipped**.
- 별도 회귀 테스트 미추가 사유: `lint_adr_verification` 동작은 `tests/test_governance.py` 가 이미 커버. 본 변경은 깨진 앵커 문자열을 타깃 ADR 의 한국어 H1 에 맞춘 docs-only 동기화로 새 코드 경로 없음.

## 5. Eval 영향

All `·` — docs/adr 앵커 동기화. RAG/eval surface 미변경.

### 5b. Real-data delta

검색·검증·평가 동작 변화 없음. ADR 0046 의 `verifies-key` 앵커 문자열 1줄을 PR #1120/#925 가 한국어화한 ADR 0018 의 H1 타이틀(`한국어 공개 RAG bench`)에 맞춘 docs-only 변경 — RAG 파이프라인·메트릭·`eval/config.yaml` 무관.

## 6. 하위 호환

깨짐 없음. answer-contract (ADR 0003)·schema·CLI flag·doc link 무관. ADR governance 토큰(`## Verification` 헤더, `verifies-key` 마커 형식) 보존.

## 7. 범위 외

- ADR 0045 의 의미상 역전된 verifies-key 마커 (#1142 §7 의 다른 항목) — 별도 issue/PR.
- 근본 갭: `--lint-adr-consequences` 가 pre-commit 훅에서 새로 추가된 ADR 에만 강제되어(`.githooks/pre-commit:146`), 타깃 파일이 나중에 편집되면 source ADR 앵커가 조용히 깨진다. 전수 lint 게이트 도입은 새 측정 표면이므로 별도 concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)