### PR TITLE
fix(eval): refuse degraded naive_baseline golden rebuild (#1146)

### DIFF
--- a/scripts/regen_naive_baseline_golden.py
+++ b/scripts/regen_naive_baseline_golden.py
@@ -11,9 +11,13 @@ H/I/J/K corpus), and until now each drift was repaired by hand with tribal
 Write mode (default): rebuild and overwrite the golden in place, preserving the
 committed query set and each query's top-K length. To add/remove a query, edit
 the golden's keys first (a deliberate act), then regenerate to fill the values.
+A degraded/malformed rebuild (too few citations, blank chunk_id, non-numeric
+score) is refused — never serialized — so a real regression cannot be blessed
+into the baseline (see ``_validate_rebuild``).
 
-``--check`` mode: rebuild and exit 1 if the committed golden is stale (used by
-the pre-push reminder and ``make check-golden``).
+``--check`` mode: rebuild and exit 1 if the committed golden is stale or if the
+rebuild itself is degraded (used by the pre-push reminder and ``make
+check-golden``).
 
 This module is the single source of truth for *how* the golden is built;
 ``tests/test_naive_baseline_ranking_invariance.py`` imports ``build_golden`` so
@@ -45,6 +49,50 @@ EMBEDDING_BACKEND = "hashing"
 CHUNKING_STRATEGY = "fixed"
 
 
+class DegradedRebuildError(RuntimeError):
+    """Raised when a rebuilt golden is shorter, blank, or schema-malformed.
+
+    Closes the self-validating-golden trap (ADR 0001): the invariance test and
+    this regenerator share ``build_golden``, and the documented remedy for a
+    failing invariance test is ``make regen-golden`` (the write path). Without
+    this guard a real retrieval/schema regression would be written into the
+    committed golden, agree with itself on the next rebuild, and be blessed as
+    the baseline forever. We refuse to serialize a degraded rebuild instead.
+    """
+
+
+def _validate_rebuild(rebuilt: dict[str, list], reference: dict[str, list]) -> None:
+    """Reject a rebuild that is shorter/blank/malformed vs ``reference``.
+
+    ``build_golden`` only ever caps each query at the committed K, so the sole
+    degradation modes are too-few citations (incl. empty) or ``None``
+    chunk_id/score from a missing key — both surfaced here. Raises
+    ``DegradedRebuildError`` listing every offending query; never mutates.
+    """
+    problems: list[str] = []
+    for query, golden_top in reference.items():
+        rows = rebuilt.get(query, [])
+        if len(rows) < len(golden_top):
+            problems.append(
+                f"  {query!r}: rebuilt {len(rows)} citation(s) < golden K={len(golden_top)} "
+                f"(retrieval returned too few candidates)"
+            )
+            continue
+        for i, (chunk_id, score) in enumerate(rows):
+            if not chunk_id:
+                problems.append(f"  {query!r}[{i}]: empty/None chunk_id in {[chunk_id, score]!r}")
+            if not isinstance(score, (int, float)):
+                problems.append(f"  {query!r}[{i}]: non-numeric score in {[chunk_id, score]!r}")
+    if problems:
+        raise DegradedRebuildError(
+            "naive_baseline rebuild is degraded/malformed — refusing to bless it "
+            "into the golden (ADR 0001):\n"
+            + "\n".join(problems)
+            + "\n\nThis means retrieval or the answer schema regressed. Fix the "
+            "regression — do NOT regenerate the golden to make the invariance test pass."
+        )
+
+
 def build_golden(reference: dict[str, list]) -> dict[str, list]:
     """Rebuild the naive_baseline top-K snapshot for ``reference``'s query set.
 
@@ -52,6 +100,10 @@ def build_golden(reference: dict[str, list]) -> dict[str, list]:
     truncated to the same length the query has in ``reference``, so the curated
     query set + per-query K are preserved. Adding/removing a query is therefore
     a deliberate edit to the golden, never a side effect of regeneration.
+
+    A degraded/malformed rebuild (too few citations, blank chunk_id, non-numeric
+    score) raises ``DegradedRebuildError`` so it can never be blessed into the
+    golden — see ``_validate_rebuild`` (ADR 0001).
     """
     index = build_index_payload(
         CORPUS_DIR,
@@ -65,6 +117,7 @@ def build_golden(reference: dict[str, list]) -> dict[str, list]:
         rebuilt[query] = [
             [c.get("chunk_id"), c.get("score")] for c in citations[: len(golden_top)]
         ]
+    _validate_rebuild(rebuilt, reference)
     return rebuilt
 
 
@@ -76,7 +129,15 @@ def _serialize(golden: dict[str, list]) -> str:
 
 def run(check: bool, golden_path: Path = GOLDEN_PATH) -> int:
     committed = json.loads(golden_path.read_text(encoding="utf-8"))
-    rebuilt = build_golden(committed)
+    try:
+        rebuilt = build_golden(committed)
+    except DegradedRebuildError as exc:
+        # Validation runs inside build_golden, before the stale-compare/write
+        # branch below — so a degraded rebuild fails BOTH modes: --check returns
+        # non-zero (even if the degraded rebuild happens to equal a null-blessed
+        # committed golden) and write never overwrites the golden with it.
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        return 1
 
     if check:
         if rebuilt != committed:

--- a/tests/test_regen_naive_baseline_golden.py
+++ b/tests/test_regen_naive_baseline_golden.py
@@ -7,6 +7,12 @@ preservation, and the committed serialization style of
 index-build correctness is covered by
 ``tests/test_naive_baseline_ranking_invariance.py``, which imports the same
 ``build_golden``.
+
+``RegenGoldenDegradedGuardTest`` instead exercises the REAL ``build_golden`` +
+``_validate_rebuild`` (monkeypatching only its ``build_index_payload`` /
+``run_rag_query`` deps): a degraded/malformed rebuild must fail BOTH ``--check``
+and write, and write must never serialize it — the self-validating-golden trap
+(ADR 0001) that would otherwise bless a real regression into the baseline.
 """
 
 import json
@@ -83,6 +89,88 @@ class RegenGoldenCliTest(unittest.TestCase):
         with mock.patch.object(regen, "run", return_value=0) as run_mock:
             self.assertEqual(0, regen.main([]))
         run_mock.assert_called_once_with(check=False)
+
+
+class RegenGoldenDegradedGuardTest(unittest.TestCase):
+    """A degraded/malformed rebuild must fail BOTH modes without being written.
+
+    Exercises the real ``build_golden`` + ``_validate_rebuild`` by stubbing only
+    its deps, so a retrieval/schema regression cannot be blessed into the golden
+    (ADR 0001). Without the guard the write path would happily serialize a
+    short/null rebuild and ``--check`` would later agree with it.
+    """
+
+    _HEALTHY_GOLDEN = {"q1": [["c1", 0.9], ["c2", 0.8]]}  # K=2
+
+    def _run(self, results_by_query: dict, *, check: bool, golden_data: dict):
+        """Run regen with ``run_rag_query`` stubbed per query (no real index).
+
+        Returns ``(rc, before, after)`` where before/after are the on-disk golden
+        text, so callers can assert a failed write left the file untouched.
+        """
+
+        def fake_run_rag_query(_index, query, **_kwargs):
+            return results_by_query[query]
+
+        with TemporaryDirectory() as d, mock.patch.object(
+            regen, "build_index_payload", return_value={}
+        ), mock.patch.object(regen, "run_rag_query", side_effect=fake_run_rag_query):
+            golden = _write_golden(Path(d), golden_data)
+            before = golden.read_text(encoding="utf-8")
+            rc = regen.run(check=check, golden_path=golden)
+            after = golden.read_text(encoding="utf-8")
+        return rc, before, after
+
+    # (a) retrieval returns fewer citations than the committed K.
+    def test_fewer_citations_refuses_write(self) -> None:
+        results = {"q1": {"citations": [{"chunk_id": "c1", "score": 0.9}]}}  # 1 < K=2
+        rc, before, after = self._run(results, check=False, golden_data=self._HEALTHY_GOLDEN)
+        self.assertEqual(1, rc)
+        self.assertEqual(before, after)  # golden NOT overwritten with the short rebuild
+
+    def test_fewer_citations_fails_check(self) -> None:
+        results = {"q1": {"citations": [{"chunk_id": "c1", "score": 0.9}]}}
+        rc, _, _ = self._run(results, check=True, golden_data=self._HEALTHY_GOLDEN)
+        self.assertEqual(1, rc)
+
+    # (b) retrieval returns no citations at all.
+    def test_empty_citations_refuses_write(self) -> None:
+        results = {"q1": {"citations": []}}
+        rc, before, after = self._run(results, check=False, golden_data=self._HEALTHY_GOLDEN)
+        self.assertEqual(1, rc)
+        self.assertEqual(before, after)
+
+    def test_empty_citations_fails_check(self) -> None:
+        results = {"q1": {"citations": []}}
+        rc, _, _ = self._run(results, check=True, golden_data=self._HEALTHY_GOLDEN)
+        self.assertEqual(1, rc)
+
+    # (c) schema regression: citations missing chunk_id / score -> None entries.
+    def test_missing_chunk_id_or_score_refuses_write(self) -> None:
+        results = {"q1": {"citations": [{"score": 0.9}, {"chunk_id": "c2"}]}}
+        rc, before, after = self._run(results, check=False, golden_data=self._HEALTHY_GOLDEN)
+        self.assertEqual(1, rc)
+        self.assertEqual(before, after)
+
+    def test_missing_chunk_id_or_score_fails_check(self) -> None:
+        results = {"q1": {"citations": [{"score": 0.9}, {"chunk_id": "c2"}]}}
+        rc, _, _ = self._run(results, check=True, golden_data=self._HEALTHY_GOLDEN)
+        self.assertEqual(1, rc)
+
+    # Positive control: a full, well-formed rebuild still writes (no false positive).
+    def test_healthy_rebuild_still_writes(self) -> None:
+        results = {"q1": {"citations": [{"chunk_id": "n1", "score": 0.5}, {"chunk_id": "n2", "score": 0.4}]}}
+        stale = {"q1": [["old1", 0.1], ["old2", 0.0]]}
+        rc, _, after = self._run(results, check=False, golden_data=stale)
+        self.assertEqual(0, rc)
+        self.assertEqual({"q1": [["n1", 0.5], ["n2", 0.4]]}, json.loads(after))
+
+    def test_build_golden_raises_on_degraded_rebuild(self) -> None:
+        with mock.patch.object(regen, "build_index_payload", return_value={}), mock.patch.object(
+            regen, "run_rag_query", return_value={"citations": []}
+        ):
+            with self.assertRaises(regen.DegradedRebuildError):
+                regen.build_golden({"q1": [["c1", 0.9]]})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1146

`scripts/regen_naive_baseline_golden.py`의 `build_golden`(#1072, commit 8e6753a)이 **열화된(degraded) retrieval 결과를 committed golden에 영구히 bless**할 수 있어, 보호하려던 ADR 0001 baseline invariant를 스스로 무력화했다.

- `citations[: len(golden_top)]`는 길이를 CAP만 한다 — `len(citations) >= len(golden_top)`를 요구하지 않아 retrieval이 더 적게 반환하면 rebuilt가 조용히 짧아진다.
- `c.get("chunk_id")` / `c.get("score")`는 키 부재 시 `None` → schema 회귀가 `[null, null]`로 직렬화된다.
- citations 비면 → `rebuilt[query] = []`.

**self-validating-golden 함정:** invariance 테스트(`tests/test_naive_baseline_ranking_invariance.py`)와 regenerator가 동일한 `build_golden`을 공유하고, invariance 테스트 실패 시 문서화된 처방이 `make regen-golden`(write 경로)이다. 따라서 retrieval/schema가 실제로 회귀하면 → 테스트 실패 → operator가 `make regen-golden` → 열화 결과가 golden에 기록 → 다음 실행에서 동일 열화 결과를 재빌드해 자기 자신과 일치 → green. 실제 회귀가 baseline으로 영구 bless된다.

**수정:** `DegradedRebuildError` + `_validate_rebuild` 추가 — per query `len(citations) >= committed K`, non-empty `chunk_id`, numeric `score` 강제. `run()`이 이를 잡아 `--check`와 write 모드 **양쪽** 모두 non-zero 반환 + 직렬화 거부. `naive_baseline` 파이프라인 코드는 손대지 않음(snapshot 도구만).

## 2. 영향 파일

- `scripts/regen_naive_baseline_golden.py` — `DegradedRebuildError`, `_validate_rebuild`, `build_golden` 검증 호출, `run()` try/except. **load-bearing 아님** (load-bearing은 `scripts/build_index.py`; 이 regenerator는 목록 외)
- `tests/test_regen_naive_baseline_golden.py` — `RegenGoldenDegradedGuardTest` 추가 (8 케이스)

## 3. 리스크

- **False positive (healthy golden을 거부)**: golden은 쿼리별 K가 가변(K=1 쿼리 "공통 제출조건…" 포함). 검증을 하드코딩 K가 아닌 `len(golden_top)`(committed per-query K) 기준으로 해 배제. 실제 인덱스 빌드 invariance 테스트 + `--check` CLI 모두 healthy에서 통과(exit 0) 확인.
- 기존 CLI wiring 테스트는 `build_golden`을 직접 mock → 검증 경로 미통과로 그대로 green. 신규 테스트는 의존성(`build_index_payload`/`run_rag_query`)만 mock해 실제 `build_golden` 검증을 탄다.

## 4. 테스트

regression: `RegenGoldenDegradedGuardTest` — `run_rag_query`를 mock해 (a) committed K보다 적은 citations, (b) 빈 citations, (c) `chunk_id`/`score` 누락 케이스에서 **write와 check 모두 non-zero + 미직렬화(파일 unchanged)** 확인. positive control(healthy rebuild는 그대로 write) + `build_golden`이 직접 `DegradedRebuildError` raise 확인 포함.

```
python3 -m pytest tests/test_regen_naive_baseline_golden.py tests/test_naive_baseline_ranking_invariance.py
→ 15 passed (regen) + 1 passed/5 subtests (invariance, 실제 인덱스 빌드)
```

수정 전이라면 (a)/(b)/(c) 모두 degraded 결과를 직렬화하며 통과 → 회귀가 fail-before/pass-after를 만족.

## 5. Eval 영향

All `·` — eval 산출물/메트릭에 영향 없음. `naive_baseline` 파이프라인 코드 미변경, golden snapshot 파일도 미변경(검증 도구의 가드만 추가).

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. `scripts/regen_naive_baseline_golden.py`는 snapshot 재생성 도구로 load-bearing 경로가 아니며(`LOAD_BEARING_PATHS` 외), `naive_baseline` 파이프라인 코드를 호출만 하고 변경하지 않는다 (ADR 0001). 따라서 real-data delta 없음.

## 6. 하위 호환

기존 계약/CLI flag/스키마 변경 없음. `--check`/write 모드 동작은 healthy golden에 대해 동일(exit 0 / 재생성). 새로 추가된 동작은 degraded rebuild에 한해 non-zero로 거부하는 것뿐 — 정상 경로에 영향 없음.

## 7. 범위 외

- 이미 committed golden이 사전에 더 짧은 K로 오염된 경우(누군가 이전에 잘못 bless)는 검증이 committed K 기준이라 잡지 못한다. 현재 golden은 healthy이고 첫 bless를 차단하므로 이 상태는 발생 불가 — 별도 처리 안 함.
- `_index`/`_kwargs` 미사용 파라미터 Pyright hint는 stub 시그니처 관례(underscore prefix)로 의도적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)