### PR TITLE
docs(skill): correct adr-lifecycle-manager governance overclaims

### DIFF
--- a/.claude/skills/adr-lifecycle-manager/SKILL.md
+++ b/.claude/skills/adr-lifecycle-manager/SKILL.md
@@ -21,16 +21,16 @@ ADR 0047이 선언한 30일 proposed-status SLA를 해소하는 skill. **기계�
 
 ## Workflow
 
-1. **탐지** — `python3 scripts/_governance.py --proposed-adr-age` 실행. 출력 컬럼: `NNNN<TAB>age_days<TAB>flag(OVER_SLA/grandfathered/ok)<TAB>first_commit<TAB>filename`. OVER_SLA 우선, 그다음 approaching(age ≥ 23일 = SLA−7) 표면화. grandfathered/ok 는 정보용.
+1. **탐지** — `python3 scripts/_governance.py --proposed-adr-age` 실행. 출력 컬럼: `NNNN<TAB>age_days<TAB>flag(OVER_SLA/grandfathered/ok)<TAB>first_commit<TAB>filename`. OVER_SLA 우선, 그다음 approaching(age ≥ 23일 = SLA−7) 표면화. grandfathered/ok 는 정보용. **탐지는 `Status:` 값만 본다**(`proposed_adr_age` 가 `status.startswith("proposed")` 로 필터) — `## Resolution` 만 append 하고 Status 를 proposed 로 둔 ADR 은 0047 상 해소돼도 collector 가 계속 표면화함(step 3 resolve-in-place 참조).
 2. **대상 선정 (gate)** — 해소할 ADR을 사용자와 확정. OVER_SLA 0건이면 "해소 대상 없음" 보고 후 종료. 다건이면 한 lifecycle PR로 묶을지(one concern) 확인.
 3. **per-ADR 판단 (각 건 명시 확인)** — 해당 ADR 본문을 읽고 5개 중 택1 제시:
    - **promote** → `Status: accepted` (결정 유효·검증됨). post-2026-05-15 ADR이면 먼저 `--lint-adr-consequences docs/adr/<file>` 로 Verification 마커가 실제 wired 인지 확인.
-   - **supersede** → `Status: superseded by NNNN`. 대체 ADR이 있으면 그 번호, 없으면 `--next-adr-number` 로 예약 번호만 안내 — 새 ADR **작성은 ship-pr/author 몫**, 이 skill은 status 포인터만 설정.
+   - **supersede** → `Status: superseded by NNNN`. **대체 ADR 파일이 이미 존재할 때만 사용** — 그 실재 번호로 포인터 설정(가능하면 대체 ADR 이 본 ADR 을 backlink). 대체가 아직 없으면 `superseded by NNNN` **설정 금지**: `--next-adr-number` 는 filesystem max+1 **힌트일 뿐 예약 아님**(`next_adr_number` docstring) — 동시 worktree 가 같은 번호를 무관 ADR 로 가져가거나 포인터가 영영 작성 안 될 수 있음(CLAUDE.md 충돌 이력 0022→0023 / 0029→0030). 대체 없이 폐기면 **deprecate**, 대체가 필요하면 ADR 작성(ship-pr / eval-to-adr-bridge)으로 **파일을 먼저 만든 뒤** 돌아와 포인터 설정.
    - **deprecate** → `Status: deprecated` (대체 없이 폐기).
-   - **resolve-in-place** → `## Resolution` 단락 append(0047: 해소 = status mutation 또는 Resolution append). 결과·근거 1문단.
-   - **keep-open + justify** → 아직 열려있으면 거부가 아니라 본문에 **명시 사유** append(방치 아닌 의식적 연장).
+   - **resolve-in-place** → `## Resolution` 단락 append(0047 결정 #2 는 해소 = status mutation **또는** `## Resolution` append 로 명시). 결과·근거 1문단. **단 collector 한계 명시: `--proposed-adr-age` 는 `Status:` 만 키로 보므로**, Status 를 `proposed` 로 둔 채 append 만 하면 30일 초과 시 **계속 OVER_SLA 로 재표면**된다(0047 상 해소여도). 그러므로 (a) resolution 이 accepted/deprecated 를 함의하면 Status 도 같이 바꿔 신호를 지우거나, (b) 의도적으로 proposed 유지 시 collector 가 계속 list 함을 받아들이고 — 해소 여부는 collector 재실행이 아니라 파일의 `## Resolution` 을 읽어 확인. (collector 가 `## Resolution` 을 해소 마커로 인식하게 만드는 것은 별도 `_governance.py` follow-up.)
+   - **keep-open + justify** → 아직 열려있으면 거부가 아니라 본문에 **명시 사유** append(방치 아닌 의식적 연장). 이는 해소가 아니므로 `--proposed-adr-age` 가 **계속 flag 하는 게 정상** — 다음 run 에서 사라질 거라 기대하지 말 것.
    - **자동 promote/supersede 절대 금지** — 항상 사용자 확인.
-4. **편집 + 동기화** — 선택된 해소를 ADR Status 블록에 적용. Status 문자열이 바뀌면 [docs/adr/README.md](../../../docs/adr/README.md) 인덱스 row의 status 컬럼도 **같은 커밋**에서 갱신 → `python3 scripts/_governance.py --check-adr-readme-parity docs/adr/<file>` 로 parity 확인.
+4. **편집 + 동기화** — 선택된 해소를 ADR Status 블록에 적용. Status 문자열이 바뀌면 [docs/adr/README.md](../../../docs/adr/README.md) 인덱스 row의 status 컬럼도 **같은 커밋**에서 갱신. **주의: `--check-adr-readme-parity` 와 CI `test_no_unlinked_adr_files_on_disk` 는 row 가 파일명으로 linked 되어 있는지만 검증 — status 컬럼 값은 비교하지 않는다**(`_ADR_INDEX_ROW_RE` 가 number+filename 만 캡처). 따라서 status cell 일치는 자동 검증되지 않으므로 **편집 후 README row 를 직접 열어 status 를 눈으로 readback**(promote 시 README 의 "Proposed / Promote 조건" 표에서 빼는 것도 수동 확인). `--check-adr-readme-parity docs/adr/<file>` 는 row **누락** 검출용으로만 실행.
 5. **로컬 검증 (gate)** — `bash scripts/test.sh`(특히 `test_no_unlinked_adr_files_on_disk` + collector 테스트). post-2026-05-15 ADR 편집 시 `--lint-adr-consequences` 통과 확인. commit `chore(adr): resolve proposed SLA — <NNNN> <action> (closes #N)`(다건이면 요약).
 6. **ship-pr 핸드오프** — "로컬 lifecycle 편집 완료. `/ship-pr` 로 push+PR" 안내. **주의: `docs/adr/` 는 load-bearing** 이므로 resolution PR 은 §5b 필수 — 단 Status 변경은 검색/검증/답변 path 무영향이라 "동작 변화 없음" 명시로 충족.
 
@@ -42,13 +42,13 @@ go-ahead(진행): "진행" / "ㄱㄱ" / "ㅇㅋ" / "ok" / "go". 질문(답변만
 
 - **"전부 그냥 accepted 로 promote 해"** → 강한 경고. promote는 "결정이 검증됐다"는 신호 — 무검증 일괄 promote는 ADR을 Decision Theatre로 되돌림(0047이 막으려던 바). 각 건 최소 1줄 근거 요구.
 - **"grandfathered 도 정리해"** → 가능하나 0047 면제 대상임을 명시 후 진행(면제는 normative 결정).
-- **"supersede 할 새 ADR 도 여기서 써줘"** → 거부. ADR 작성·번호예약은 ship-pr / author 몫(조기 범위 확장 금지). 이 skill은 `superseded by NNNN` 포인터만.
-- **"README parity 무시"** → 거부. status 불일치는 `test_no_unlinked_adr_files_on_disk` CI를 머지 시 red로 만들어 모든 open PR에 cascade(이슈 #730/#732/#750 전례).
+- **"supersede 할 새 ADR 도 여기서 써줘"** → 거부. ADR 작성·번호예약은 ship-pr / eval-to-adr-bridge 몫(조기 범위 확장 금지). 이 skill 의 `superseded by NNNN` 포인터는 **대상 파일이 이미 존재할 때만** — 미존재 번호 포인터는 dangling 이라 금지(step 3 supersede 항목). 대체가 없으면 deprecate 하거나, 대체부터 author 후 재방문.
+- **"README parity 무시"** → 거부, 단 정확히. row **누락**(파일명 미링크)은 `test_no_unlinked_adr_files_on_disk` CI를 머지 시 red로 만들어 모든 open PR에 cascade(이슈 #730/#732/#750 전례) — 그러므로 row 자체는 반드시 추가. 반면 **status 컬럼 불일치는 어떤 CI도 잡지 못함**(테스트·parity 헬퍼 모두 파일명 존재만 확인) — 그래서 step 4 의 수동 readback 이 status drift 의 유일한 방어선.
 
 ## References
 
 - ADR 0047 — 1인 저자 ADR governance: 30일 proposed SLA + Verification 계약 + 번호예약.
-- [scripts/_governance.py](../../../scripts/_governance.py) — `--proposed-adr-age`(PR #1094, 탐지), `--lint-adr-consequences`(#793), `--check-adr-readme-parity`(#803), `--next-adr-number`(supersede 대상 번호).
+- [scripts/_governance.py](../../../scripts/_governance.py) — `--proposed-adr-age`(PR #1094, 탐지; `Status:` 만 키 → `## Resolution`-only append 미인식), `--lint-adr-consequences`(#793), `--check-adr-readme-parity`(#803, **row 파일명 존재만 검증 — status 컬럼 아님**), `--next-adr-number`(다음 번호 **힌트, 예약 아님**; 동시 worktree 미감지).
 - [docs/adr/README.md](../../../docs/adr/README.md) — 인덱스 row(status 컬럼 동기화 대상).
 - [docs/adr/_template.md](../../../docs/adr/_template.md) — Status 블록 + Verification 형식.
 - [.claude/skills/ship-pr/SKILL.md](../ship-pr/SKILL.md) — push/PR/merge 핸드오프 + approval-gate 컨벤션.
@@ -57,7 +57,7 @@ go-ahead(진행): "진행" / "ㄱㄱ" / "ㅇㅋ" / "ok" / "go". 질문(답변만
 ## What this skill does NOT do
 
 - Does NOT write helper code — 기존 `_governance.py` 플래그만 오케스트레이션.
-- Does NOT author new ADRs or reserve numbers — ship-pr / eval-to-adr-bridge 담당. supersede 시 `superseded by NNNN` 포인터만.
+- Does NOT author new ADRs or reserve numbers — ship-pr / eval-to-adr-bridge 담당. supersede 포인터는 **대체 ADR 파일이 이미 존재할 때만** 설정(미존재 번호 = dangling, 금지).
 - Does NOT auto-promote/supersede — 항상 사용자 per-ADR 확인.
 - Does NOT touch grandfathered ADRs by default — 0047 면제, 명시 요청 시만.
 - Does NOT push / open PR / merge — ship-pr 담당.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`adr-lifecycle-manager` skill (#1099, commit 233c6d8) 이 `scripts/_governance.py` 가 실제로 제공하지 않는 거버넌스 보장 3건을 주장했다. commit 233c6d8 의 adversarial review 에서 발견. skill 텍스트를 도구의 실제 동작에 맞춰 정정 — 코드/도구는 그대로, skill 의 false guarantee 만 제거.

- **README status-sync (high):** `--check-adr-readme-parity` 와 CI `test_no_unlinked_adr_files_on_disk` 는 인덱스 row 가 **파일명으로 존재**하는지만 검증(`_ADR_INDEX_ROW_RE` 가 number+filename 만 캡처) — status 컬럼은 비교 안 함. 그래서 status 변경 후 **수동 readback** 을 요구하고, CI-red cascade 경고를 row 누락 한정으로 scope 축소.
- **supersede (high):** `--next-adr-number` 는 filesystem max+1 **힌트**(예약 아님). 대체 ADR 파일이 **이미 존재할 때만** `superseded by NNNN` 설정하도록 제한 — 미존재 번호 포인터는 dangling(동시 worktree 충돌 이력). 없으면 deprecate 또는 대체부터 author.
- **resolve-in-place (medium):** ADR 0047 결정 #2 는 `## Resolution` append 를 정당한 해소로 명시하나, `proposed_adr_age` 는 `Status:` 만 키로 봐서 append-without-status-change 는 계속 OVER_SLA flag. 이 한계를 명시(0047 오독 아님 — collector 미구현). collector 강화는 별도 `_governance.py` follow-up 으로 표기.

Closes #1149

## 2. 영향 파일

- `.claude/skills/adr-lifecycle-manager/SKILL.md` — **non-load-bearing** (`.claude/skills/`, `LOAD_BEARING_PATHS` 에 없음). 9 line 교체.

## 3. 리스크

docs-only(markdown). frontmatter·structured field 미변경 → skill 트리거/description lint 무영향. 가장 가능성 높은 깨짐: skill 텍스트가 0047 또는 도구와 또 어긋남 — 배제 위해 3건 모두 현재 main 의 `scripts/_governance.py`(`adr_readme_parity_violations` :310, `next_adr_number` :219, `proposed_adr_age` :495), `tests/test_governance.py:286`, `docs/adr/0047-solo-author-adr-governance.md` 결정 #2 대조 확인.

## 4. 테스트

테스트 미추가 — 동작 변경 없음(skill 가이드 텍스트만). 3개 주장은 소스 코드 직접 대조로 검증(섹션 3). skill 콘텐츠 검증 CI 게이트 없음(skill = 판단 가이드, 코드 아님).

## 5. Eval 영향

All `·` — RAG 파이프라인(검색/검증/답변/eval) 무관, docs-only.

### 5b. Real-data delta

N/A — 비-load-bearing(`.claude/skills/` 만 변경, `LOAD_BEARING_PATHS` 미해당). 검색/검증/답변·eval path 동작 변화 없음. §5b CI gate(`--check-5b`)는 load-bearing 변경에만 발화하므로 본 PR 미트리거.

## 6. 하위 호환

깨짐 없음. answer-contract(ADR 0003)·schema·CLI flag·doc link 무변경. skill 가이드만 더 정확·보수적으로(supersede 조건 강화, status readback 추가). `_governance.py` 의 어떤 flag 동작도 안 바뀜.

## 7. 범위 외

의도적으로 코드는 안 고침 — 별도 surface(코드+테스트+ADR 임계값 검토) follow-up 후보:

- **실제 README status-parity 체크**: `_governance.py` 가 각 ADR Status 블록 ↔ README row status 컬럼을 비교하는 게이트 추가(현재 issue #317 의 `senior-positioning.md` narrative 버전만 존재, `docs/adr/README.md` 는 미검증).
- **collector 의 `## Resolution` 인식**: `proposed_adr_age` 가 `## Resolution` H2 또는 extension metadata 를 해소 마커로 인식해 append-resolved ADR 을 flag 중단 — 0047 결정 #2 정의에 collector 를 정렬.

둘 다 load-bearing 아닌 `_governance.py` 이나 새 측정 표면 거동 변경이라 별도 PR + 측정(`--proposed-adr-age` 재실행 증빙)이 적절.