### PR TITLE
fix(governance): parse table-form ADR Status in proposed-ADR SLA collector

### DIFF
--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -437,10 +437,19 @@ def lint_adr_verification(
 # grandfathered: reported, but never flagged OVER_SLA.
 ADR_SLA_GRANDFATHER_DATE = date(2026, 5, 15)
 
-# Tolerant of the two formats live in docs/adr/ — `- **Status**: proposed`
-# and `- Status: Proposed`. First match on the file wins.
+# Tolerant of the three Status metablock forms live in docs/adr/:
+#   - **Status**: proposed       (bold list item)
+#   - Status: Proposed           (plain list item)
+#   | **Status** | Proposed |    (2-column table — value in the next cell,
+#                                  no colon; e.g. ADR 0052/0044/0034)
+# First match on the file wins. The table branch must open with a pipe and
+# terminate the value with one, since it lives between cells not after a colon.
 ADR_STATUS_RE = re.compile(
-    r"^\s*[-*]?\s*(?:\*\*)?status(?:\*\*)?\s*:\s*(.+?)\s*$",
+    r"^\s*(?:"
+    r"[-*]?\s*(?:\*\*)?status(?:\*\*)?\s*:\s*(?P<colon>.+?)"
+    r"|"
+    r"\|\s*(?:\*\*)?status(?:\*\*)?\s*\|\s*(?P<table>.+?)\s*\|"
+    r")\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -456,18 +465,25 @@ class ProposedADR(NamedTuple):
 
 
 def parse_adr_status(adr_path: str | Path) -> str | None:
-    """Return the first `Status:` meta-line value (lowercased), or None.
+    """Return the first Status meta-value (lowercased), or None.
 
-    None if the file is missing or has no Status meta-line. Tolerant of
-    the bold (`- **Status**: proposed`) and plain (`- Status: Proposed`)
-    variants both present in docs/adr/.
+    None if the file is missing or has no Status meta-line. Tolerant of the
+    three variants present in docs/adr/: the bold (`- **Status**: proposed`)
+    and plain (`- Status: Proposed`) list forms, and the 2-column metablock
+    table form (`| **Status** | Proposed |`, e.g. ADR 0052) where the value
+    lives in the next cell with no colon.
     """
     p = Path(adr_path)
     if not p.is_file():
         return None
     text = p.read_text(encoding="utf-8", errors="replace")
     m = ADR_STATUS_RE.search(text)
-    return m.group(1).strip().lower() if m else None
+    if not m:
+        return None
+    value = m.group("colon")
+    if value is None:
+        value = m.group("table")
+    return value.strip().lower()
 
 
 def _git_first_commit_date(path: str | Path) -> date | None:

--- a/tests/test_governance_proposed_adr_age.py
+++ b/tests/test_governance_proposed_adr_age.py
@@ -8,6 +8,7 @@ injected date resolver so they run without a git repo.
 
 from __future__ import annotations
 
+import re
 from datetime import date
 from pathlib import Path
 
@@ -50,6 +51,32 @@ def test_parse_status_no_status_line_returns_none(tmp_path: Path) -> None:
     assert parse_adr_status(tmp_path / "0003-c.md") is None
 
 
+def test_parse_status_table_metablock_form(tmp_path: Path) -> None:
+    # ADR 0052 shape: 2-column metablock table, value in the next cell with
+    # no colon. The pre-#1151 colon-only regex returned None here (fail-open).
+    (tmp_path / "0052-t.md").write_text(
+        "# 0052: x\n\n"
+        "| Field       | Value                                    |\n"
+        "|-------------|------------------------------------------|\n"
+        "| **Status**  | Proposed                                 |\n"
+        "| **Date**    | 2026-05-17                               |\n",
+        encoding="utf-8",
+    )
+    assert parse_adr_status(tmp_path / "0052-t.md") == "proposed"
+
+
+def test_parse_status_table_form_with_annotation(tmp_path: Path) -> None:
+    # ADR 0044 shape: table value carries a trailing annotation; not proposed.
+    (tmp_path / "0044-t.md").write_text(
+        "# 0044: x\n\n"
+        "| Field       | Value                              |\n"
+        "|-------------|------------------------------------|\n"
+        "| **Status**  | Accepted (Superseded by ADR 0052)  |\n",
+        encoding="utf-8",
+    )
+    assert parse_adr_status(tmp_path / "0044-t.md") == "accepted (superseded by adr 0052)"
+
+
 # ---- proposed_adr_age: status filtering ----------------------------------
 
 
@@ -64,6 +91,22 @@ def test_only_proposed_status_returned(tmp_path: Path) -> None:
         now=date(2026, 6, 2),
     )
     assert [r.number for r in recs] == [1]
+
+
+def test_table_form_proposed_included_in_collector(tmp_path: Path) -> None:
+    # Regression for #1151: a table-form proposed ADR must reach the collector
+    # (and be SLA-flaggable), not be silently exempted.
+    (tmp_path / "0052-t.md").write_text(
+        "# 0052: x\n\n| Field | Value |\n|---|---|\n| **Status** | Proposed |\n",
+        encoding="utf-8",
+    )
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 16),  # after grandfather
+        now=date(2026, 6, 25),  # 40 days > 30
+    )
+    assert [r.number for r in recs] == [52]
+    assert recs[0].over_sla is True
 
 
 def test_non_adr_files_ignored(tmp_path: Path) -> None:
@@ -191,3 +234,41 @@ def test_repo_proposed_adr_age_runs() -> None:
         assert r.status.startswith("proposed")
         assert r.number > 0
         assert (r.age_days is None) or (r.age_days >= 0)
+
+
+# ---- README ↔ collector parity (anti-fail-open) --------------------------
+
+
+def test_readme_proposed_rows_all_in_collector() -> None:
+    """Every ADR the README main index marks `proposed` must be returned by
+    the collector. This is the format-agnostic guard: it fails whenever a live
+    ADR uses a Status form `parse_adr_status` cannot read — the table-form
+    fail-open (#1151, ADR 0052) was the original instance.
+
+    Forward direction only. The `## Roadmap (proposed, not yet committed)`
+    section is excluded: its rows carry a *title* in column 2, not a status,
+    so the collector legitimately reports more than the main index. An injected
+    date_resolver keeps this a pure status-parity check (no git, no ages).
+    """
+    readme = Path("docs/adr/README.md").read_text(encoding="utf-8")
+    main_index = readme.split("## Roadmap", 1)[0]
+    row_re = re.compile(
+        r"^\|\s*\[(\d{4})\]\([^)]+\)\s*\|\s*([^|]+?)\s*\|", re.MULTILINE
+    )
+    readme_proposed = {
+        int(num)
+        for num, status in row_re.findall(main_index)
+        if status.strip().lower().startswith("proposed")
+    }
+    # Guard against a silently-empty README parse making this vacuously pass.
+    assert readme_proposed, "README main index parsed zero proposed rows"
+
+    collector = {
+        r.number
+        for r in proposed_adr_age("docs/adr", date_resolver=lambda p: date(2026, 1, 1))
+    }
+    missing = readme_proposed - collector
+    assert not missing, (
+        "README marks these ADRs proposed but the collector missed them "
+        f"(Status-format fail-open): {sorted(missing)}"
+    )


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1151

`scripts/_governance.py` 의 `ADR_STATUS_RE` 가 status 라벨 뒤 **콜론(`:`)** 을 요구해, 2-열 메타블록 테이블 형식 `| **Status** | Proposed |` (ADR 0034/0044/0052) 을 못 잡고 `parse_adr_status` 가 `None` 을 반환했다. 그 결과 ADR 0047 30일 SLA collector (`proposed_adr_age`, #1094) 가 table-form proposed ADR 인 **0052** 를 silently 제외 — `docs/adr/README.md:128` 메인 인덱스가 0052 를 `proposed` 로 등록함에도 over-SLA 표면화에서 빠지는 **governance SLA 기반의 fail-open**. 단일 파서가 table 형식(값이 다음 파이프 셀)도 읽도록 확장하고 first-match-wins 를 보존한다.

## 2. 영향 파일

- `scripts/_governance.py` — `ADR_STATUS_RE` 에 table-form 분기(named group `colon`/`table`) 추가, `parse_adr_status` 가 매칭된 그룹에서 값 추출. (이 파일은 `LOAD_BEARING_PATHS` 의 **정의처**지만 목록 멤버는 아님 — §5b CI gate 비대상)
- `tests/test_governance_proposed_adr_age.py` — 회귀 + parity 테스트 4종 추가

## 3. 리스크

가장 가능성 높은 깨짐 = colon-form ADR 회귀(기존 동작 변경). 확인: 전체 66개 ADR 파일에 대해 before/after `parse_adr_status` 비교 — parse==None 파일 `{0034,0044,0052}` → `{}` (전부 파싱), proposed 집합은 정확히 `+{52}` 만 증가, colon-form ADR 의 파싱 값은 하나도 안 변함. table 헤더/구분 행(`| Field | Value |`, `|---|---|`)은 "status" 부재로 미매칭. ruff check 통과.

## 4. 테스트

- `test_parse_status_table_metablock_form` — 0052 table shape → `"proposed"`
- `test_parse_status_table_form_with_annotation` — 0044 shape(주석 포함 값) 파싱
- `test_table_form_proposed_included_in_collector` — table-form proposed 가 collector 도달 + `over_sla` 플래그
- `test_readme_proposed_rows_all_in_collector` — **불변(anti-fail-open)**: README 메인 인덱스가 `proposed` 로 표기한 모든 ADR 이 collector 에 포함. Roadmap 섹션(컬럼2=title)은 제외. pre-#1151 코드에서 `missing={52}` 로 실제 fail 함을 확인 (vacuous 아님).

`78 passed, 3 skipped` (`tests/test_governance_proposed_adr_age.py tests/test_governance.py`).

## 5. Eval 영향

All `·` — RAG 파이프라인(검색/검증/답변/eval) 코드 경로 미변경. governance 메타데이터 파서만 손봄.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. 변경 대상은 governance 리포팅 collector (`proposed_adr_age`, exit 0 reporting-only) 의 ADR Status 파서로, retrieval/answer/eval/ingestion 어느 경로도 타지 않는다. `scripts/_governance.py` 는 `LOAD_BEARING_PATHS` 멤버가 아니므로 `--check-5b` gate 비대상이나 명시.

## 6. 하위 호환

깨짐 없음. `parse_adr_status` 는 기존에 `None` 을 반환하던 table-form 파일(0034/0044/0052)에 대해 이제 실제 status 문자열을 반환한다 — 더 정확한 동작이며, `None` 에 의존하던 호출자는 없음(collector 는 `None`/`not proposed` 를 동일하게 skip). 반환 계약(타입·lowercase) 불변.

## 7. 범위 외

- idx19 follow-up ("adr-lifecycle-manager skill ↔ governance mismatch" Finding 3 — `proposed_adr_age` 가 resolution marker 를 인식해 append-only-resolved ADR 보고 중단). 동일 collector 를 건드리나 **별도 동작 정책 변경**이라 분리. 이 parsing fail-open 은 독립적으로 high-severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)