### PR TITLE
fix(adr): repoint ADR 0045 verifies-key to leaf-invariant regression test

### DIFF
--- a/docs/adr/0045-rag-core-leaf-migration-plan.md
+++ b/docs/adr/0045-rag-core-leaf-migration-plan.md
@@ -132,9 +132,9 @@ $ grep -nE "^from rag_|^import rag_" rag_query.py
 
 ## Verification
 
-본 ADR 은 plan-only. PR 시점 워킹 트리에 존재해야 할 두 전제조건 (G2 가 코드 이동 후 *제거* 검증):
+본 ADR 은 plan-only. G2 (#459/#461) 마이그레이션 완료 후 검증 앵커 — rag_retrieval 의 rag_core back-edge 0 불변량은 회귀 테스트가 강제하고, rag_query 로 재배치된 함수는 존재로 확인:
 
-<!-- verifies-key: rag_retrieval.py:from rag_core import -->
+<!-- verifies-key: tests/test_dependency_graph_invariance.py:test_leaf_module_has_zero_rag_core_back_edges -->
 <!-- verifies-key: rag_query.py:def comparison_targets_for_analysis -->
 
 G2 구현 PR 은 다음을 보여야 함:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1161

ADR 0045 line 137 의 `verifies-key` 마커 `<!-- verifies-key: rag_retrieval.py:from rag_core import -->` 는 의미가 **역전**돼 있었다. ADR 0045 의 load-bearing invariant 는 "rag_retrieval → rag_core back-edge 0" (ADR 본문 §Verification item 4: `git grep -nE "^\s+from rag_core" rag_retrieval.py` 가 **0** 라인 반환)인데, 마커는 부재해야 하는 그 문자열(`from rag_core import`)의 존재를 rag_retrieval.py 에 요구한다. G2 마이그레이션(#459/#461)이 그 문자열을 제거하며 `python3 scripts/_governance.py --lint-adr-consequences docs/adr/0045-rag-core-leaf-migration-plan.md` 가 exit 1 로 실패.

부재(absence) 불변량은 presence-substring 마커로 직접 검증할 수 없으므로, 그 불변량을 실제로 강제하는 AST 회귀 테스트 `tests/test_dependency_graph_invariance.py` (`test_leaf_module_has_zero_rag_core_back_edges`)로 마커를 re-point 한다. ADR 0051 이 이미 같은 테스트 파일을 동일 패턴(`tests/test_dependency_graph_invariance.py:rag_core`)으로 참조한다. 인접 설명문도 마이그레이션-완료 상태로 정렬. (#1142 가 ADR 0058 을 "마커 1줄 + 설명문 1줄" 로 복구한 것과 동일 패턴.)

## 2. 영향 파일

- `docs/adr/0045-rag-core-leaf-migration-plan.md` (**load-bearing**) — `verifies-key` 마커 1줄(`rag_retrieval.py:from rag_core import` → `tests/test_dependency_graph_invariance.py:test_leaf_module_has_zero_rag_core_back_edges`) + 인접 설명문 1줄

## 3. 리스크

- 마커가 검증하는 invariant 가 ADR 의도와 어긋날 위험. 배제: re-point 대상이 ADR 본문이 직접 언급하는 회귀 테스트(item 4 의 grep 을 AST 로 강제) — invariant 와 정합. line 138 (`rag_query.py:def comparison_targets_for_analysis`)는 정상 통과라 유지.
- 다른 ADR verifies-key 회귀. 배제: 0045 단일 파일 2줄만 수정, `pytest tests/test_governance.py tests/test_dependency_graph_invariance.py` green.

## 4. 테스트

- **신규 동작 = lint exit 0.** `--lint-adr-consequences docs/adr/0045-...md`: 변경 전 exit 1 (`key 'from rag_core import' not found in rag_retrieval.py`) → 변경 후 **exit 0**.
- `pytest tests/test_governance.py tests/test_dependency_graph_invariance.py` → **64 passed, 3 skipped** (zero-back-edge 회귀 포함).
- 별도 회귀 테스트 미추가 사유: 마커가 가리키는 불변량은 `tests/test_dependency_graph_invariance.py` (ADR 0045 가 명명한 AST 회귀)가 이미 강제. 본 변경은 깨진/역전된 앵커를 그 테스트로 맞춘 docs-only 동기화로 새 코드 경로 없음.

## 5. Eval 영향

All `·` — docs/adr 앵커 동기화. RAG/eval surface 미변경.

### 5b. Real-data delta

검색·검증·평가 동작 변화 없음. ADR 0045 의 `verifies-key` 마커 + 설명문 2줄을 leaf-invariant 회귀 테스트로 re-point 한 docs-only 변경 — rag_retrieval.py·rag_core·RAG 파이프라인·메트릭·`eval/config.yaml` 무관. (코드 동작은 G2 #459/#461 에서 이미 land, 본 PR 은 ADR 의 검증 앵커만 정정.)

## 6. 하위 호환

깨짐 없음. answer-contract (ADR 0003)·schema·CLI flag·doc link 무관. ADR governance 토큰(`## Verification` 헤더, `verifies-key` 마커 형식) 보존. ADR 0051 의 dependency-graph 참조와도 정합.

## 7. 범위 외

- ADR 0046 의 한국어화 앵커 끊김 (#1142 §7 의 다른 항목) — 별도 PR #1158.
- 근본 갭: `--lint-adr-consequences` 가 pre-commit 훅에서 새로 추가된 ADR 에만 강제되어(`.githooks/pre-commit:146`), 타깃 파일이 나중에 편집되면 source ADR 앵커가 조용히 깨진다(0045 는 G2 코드 이동, 0046 은 0018 한국어화로 깨짐). 전수 lint 게이트 도입은 새 측정 표면이므로 별도 concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)