### PR TITLE
fix(governance): derive README ADR count from file SoT + parity gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > 한국 공공·B2B 입찰 RFP 에서 비교·요건 추출 질의를 **근거 기반 답변**으로 돌려주는 한국어 도메인 특화 RAG. 외부 LLM 호출 없이 추출형(extractive) grounding 으로 hallucination 을 구조적으로 차단.
 > **차별점**: 비교 질의에서 두 기관 문서를 균등 인용하는 [comparison-aware balanced retrieval](#핵심-기술-기여--comparison-aware-balanced-top-k), 메타데이터 우선 검색 ([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), 근거 불충분 시 보류(abstention) 명시 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
-> **측정**: 공개 합성 (`agentic_full`, n=100): accuracy 0.718 ± 0.10, citation_precision 0.705 ± 0.08 (95% CI). 비공개 real-eval (100-doc RFP, n=221 hardcase, [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md)): accuracy 29.66%, **distinguishing-power gauge 4/5 signal alive** (groundedness +31.36pp · citation_precision +22.06pp · accuracy +27.12pp · claim_citation_alignment +8.04pp vs random_retrieval; answer_format_compliance −0.64pp 남은 false-negative) — Goodhart 함정 ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) 첫 측정에서 발견 → [ADR 0054](docs/adr/0054-conditional-on-answer-scorer-semantics.md) 에서 scorer 정정) 폐루프 ([reports/real100/distinguishing_power.md](reports/real100/distinguishing_power.md)). 공개 합성 + 비공개 real-data 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 59개 설계 결정 (ADR).
+> **측정**: 공개 합성 (`agentic_full`, n=100): accuracy 0.718 ± 0.10, citation_precision 0.705 ± 0.08 (95% CI). 비공개 real-eval (100-doc RFP, n=221 hardcase, [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md)): accuracy 29.66%, **distinguishing-power gauge 4/5 signal alive** (groundedness +31.36pp · citation_precision +22.06pp · accuracy +27.12pp · claim_citation_alignment +8.04pp vs random_retrieval; answer_format_compliance −0.64pp 남은 false-negative) — Goodhart 함정 ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) 첫 측정에서 발견 → [ADR 0054](docs/adr/0054-conditional-on-answer-scorer-semantics.md) 에서 scorer 정정) 폐루프 ([reports/real100/distinguishing_power.md](reports/real100/distinguishing_power.md)). 공개 합성 + 비공개 real-data 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 65개 설계 결정 (ADR).
 
 ### 5초 비주얼 훅 — 실제 `comparison` 질의 한 건 (extractive, no LLM)
 
@@ -222,7 +222,7 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 
 | 목적 | 링크 |
 |---|---|
-| ADR 인덱스 (59개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |
+| ADR 인덱스 (65개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |
 | 분석 변형 결과 + benchmarking + latency 비교 | [`docs/benchmarking.md`](docs/benchmarking.md) / [`docs/eval/ablation-results.md`](docs/eval/ablation-results.md) |
 | 설계 배경 (한국 RFP 적응 5가지) | [`docs/design-background.md`](docs/design-background.md) |
 | 답변 출력 정책 + Evidence boundary + Baseline policy | [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md) |

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -331,6 +331,69 @@ def adr_readme_parity_violations(
     return missing
 
 
+# ---------------------------------------------------------------------------
+# Top-level README ADR-count parity (issue #1156).
+#
+# README.md states the ADR count in two human-facing spots — the prose
+# headline ("… 59개 설계 결정 (ADR).") and the 주요 링크 table row
+# ("| ADR 인덱스 (59개 결정) | … |"). Both were hand-edited and re-staled
+# every time an ADR landed in a concurrent worktree (#1059 corrected the
+# number but not the mechanism — it was off-by-one the moment it merged).
+#
+# Source of truth for the count is the number of NNNN-slug.md ADR *files*,
+# i.e. `len(existing_adr_numbers())` — the same canonical introspection
+# `--next-adr-number` and the collision scanner already use. The
+# docs/adr/README.md index is deliberately NOT the count SoT: its
+# reopen-condition tables re-list ADRs (e.g. one row for `0019 + 0021`), so
+# its row count exceeds the file count. File ↔ index-row parity is held by
+# `test_repo_adr_dir_parity_today`, so the headline count and the ADR index
+# cannot disagree once both are pinned to the file set.
+#
+# `rewrite_readme_adr_count` regenerates both spots (scripts/update_readme_
+# metrics.py calls it on every metrics refresh); `readme_adr_count_violations`
+# is the read-only check the pytest gate uses so drift cannot merge silently.
+# Each pattern's *full match* is only the digit run (the surrounding Korean
+# is a zero-width look-around), so a sub replaces just the number and a
+# rewrite is idempotent.
+# ---------------------------------------------------------------------------
+
+_README_ADR_COUNT_PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    ("prose headline", re.compile(r"\d+(?=개 설계 결정)")),
+    ("주요 링크 table", re.compile(r"(?<=ADR 인덱스 \()\d+(?=개 결정\))")),
+)
+
+
+def rewrite_readme_adr_count(readme_text: str, count: int) -> str:
+    """Return ``readme_text`` with every ADR-count claim set to ``count``.
+
+    Idempotent — re-running with the already-correct count is a no-op. Only
+    the digit run is rewritten; the surrounding text is preserved verbatim.
+    """
+    out = readme_text
+    for _, pattern in _README_ADR_COUNT_PATTERNS:
+        out = pattern.sub(str(count), out)
+    return out
+
+
+def readme_adr_count_violations(readme_text: str, expected_count: int) -> list[str]:
+    """Return human-readable messages for ADR-count claims that disagree
+    with ``expected_count`` (the SoT = number of NNNN-slug.md files).
+
+    A claim already equal to ``expected_count`` is clean. Absence of any
+    claim is NOT a violation — dropping the count (e.g. switching the
+    headline to a bare ``docs/adr/README.md`` pointer) is an intentional act.
+    """
+    violations: list[str] = []
+    for label, pattern in _README_ADR_COUNT_PATTERNS:
+        for m in pattern.finditer(readme_text):
+            stated = int(m.group(0))
+            if stated != expected_count:
+                violations.append(
+                    f"README {label}: states {stated} ADRs, actual is {expected_count}"
+                )
+    return violations
+
+
 def adr_has_verification_section(adr_path: str | Path) -> bool:
     """Return True if the ADR file contains a `## Verification` H2 header."""
     p = Path(adr_path)

--- a/scripts/update_readme_metrics.py
+++ b/scripts/update_readme_metrics.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from eval.bootstrap import format_ci_band  # noqa: E402
 from _utils import fmt_rate  # noqa: E402
+from _governance import existing_adr_numbers, rewrite_readme_adr_count  # noqa: E402
 
 START_MARKER = "<!-- METRICS_TABLE:START -->"
 END_MARKER = "<!-- METRICS_TABLE:END -->"
@@ -440,21 +441,33 @@ def main() -> int:
 
     summary = load_summary(report_path)
     original = readme_path.read_text(encoding="utf-8")
-    updated = replace_section(original, render_table(summary))
+    adr_count = len(existing_adr_numbers(ROOT_DIR / "docs" / "adr"))
+    updated = rewrite_readme_adr_count(
+        replace_section(original, render_table(summary)), adr_count
+    )
 
-    if normalize_outside_markers(original) != normalize_outside_markers(updated):
+    # Guard: outside the metrics marker block, the ONLY sanctioned rewrite is
+    # the ADR count (issue #1156). Apply that same rewrite to the original
+    # before comparing, so the count delta cancels while any *other*
+    # outside-marker drift — e.g. a render_table/replace_section regression —
+    # still trips the guard.
+    baseline = rewrite_readme_adr_count(original, adr_count)
+    if normalize_outside_markers(baseline) != normalize_outside_markers(updated):
         print("[ERROR] Guard failed: changes detected outside metrics marker block", file=sys.stderr)
         return 3
 
     if args.check:
         if original != updated:
-            print("[FAIL] README metrics table is out of date. Run scripts/update_readme_metrics.py")
+            print(
+                "[FAIL] README metrics table or ADR count is out of date. "
+                "Run scripts/update_readme_metrics.py"
+            )
             return 1
-        print("[OK] README metrics table is up-to-date")
+        print("[OK] README metrics table + ADR count up-to-date")
         return 0
 
     readme_path.write_text(updated, encoding="utf-8")
-    print(f"[OK] Updated metrics table in {readme_path}")
+    print(f"[OK] Updated metrics table + ADR count ({adr_count}) in {readme_path}")
     return 0
 
 

--- a/tests/test_governance_readme_adr_count.py
+++ b/tests/test_governance_readme_adr_count.py
@@ -1,0 +1,136 @@
+"""Regression tests for top-level README ADR-count parity (issue #1156).
+
+``README.md`` states the ADR count in two human-facing spots — the prose
+headline ("… 59개 설계 결정 (ADR).") and the 주요 링크 table row
+("| ADR 인덱스 (59개 결정) | … |"). Both were hand-edited and re-staled every
+time an ADR landed in a concurrent worktree; #1059 corrected the number but
+not the mechanism, so it was off-by-one the moment it merged.
+
+The count's source of truth is the number of ``NNNN-slug.md`` ADR *files*
+(``existing_adr_numbers()``), NOT the ``docs/adr/README.md`` index — whose
+reopen-condition tables re-list ADRs and so over-count. ``rewrite_readme_adr_count``
+regenerates both spots (called by ``scripts/update_readme_metrics.py``);
+``readme_adr_count_violations`` is the read-only gate so drift cannot merge
+silently. These tests pin both helpers + a real-repo sentinel.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts._governance import (
+    existing_adr_numbers,
+    readme_adr_count_violations,
+    rewrite_readme_adr_count,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---- helpers --------------------------------------------------------------
+
+
+def _readme_with(count: int) -> str:
+    """Minimal README fragment carrying both canonical ADR-count spots."""
+    return (
+        f"> 분리 평가 ([ADR 0005](docs/adr/0005-x.md)), {count}개 설계 결정 (ADR).\n\n"
+        "## 주요 링크\n\n"
+        "| 목적 | 링크 |\n|---|---|\n"
+        f"| ADR 인덱스 ({count}개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |\n"
+    )
+
+
+# ---- rewrite_readme_adr_count --------------------------------------------
+
+
+def test_rewrite_sets_both_spots() -> None:
+    out = rewrite_readme_adr_count(_readme_with(59), 65)
+    assert "65개 설계 결정 (ADR)." in out
+    assert "ADR 인덱스 (65개 결정)" in out
+    assert "59" not in out
+
+
+def test_rewrite_is_idempotent() -> None:
+    fixed = _readme_with(65)
+    assert rewrite_readme_adr_count(fixed, 65) == fixed
+
+
+def test_rewrite_preserves_surrounding_text() -> None:
+    src = _readme_with(59)
+    out = rewrite_readme_adr_count(src, 65)
+    # Only the digit runs change (59 and 65 are both 2-digit → equal length).
+    assert len(out) == len(src)
+    assert "분리 평가 ([ADR 0005](docs/adr/0005-x.md))" in out
+    assert "[`docs/adr/README.md`](docs/adr/README.md)" in out
+
+
+def test_rewrite_handles_multi_digit_growth() -> None:
+    # 9 -> 123: replacement must be digit-length agnostic.
+    out = rewrite_readme_adr_count(_readme_with(9), 123)
+    assert "123개 설계 결정 (ADR)." in out
+    assert "ADR 인덱스 (123개 결정)" in out
+
+
+# ---- readme_adr_count_violations -----------------------------------------
+
+
+def test_violations_empty_when_matching() -> None:
+    assert readme_adr_count_violations(_readme_with(65), 65) == []
+
+
+def test_violations_flag_both_stale_spots() -> None:
+    out = readme_adr_count_violations(_readme_with(59), 65)
+    assert len(out) == 2
+    assert any("prose headline" in v for v in out)
+    assert any("주요 링크 table" in v for v in out)
+    assert all("states 59 ADRs" in v and "actual is 65" in v for v in out)
+
+
+def test_violations_absence_is_not_a_violation() -> None:
+    # Dropping the count entirely (the "bare pointer" option) is an
+    # intentional act, not drift — so absence must not flag.
+    assert readme_adr_count_violations("no ADR count anywhere here", 65) == []
+
+
+def test_violations_flag_only_the_stale_spot() -> None:
+    # Prose correct, table stale → exactly one violation, naming the table.
+    mixed = "65개 설계 결정 (ADR).\n| ADR 인덱스 (59개 결정) | x |\n"
+    out = readme_adr_count_violations(mixed, 65)
+    assert len(out) == 1
+    assert "주요 링크 table" in out[0]
+
+
+# ---- real-repo sentinel ---------------------------------------------------
+
+
+def test_repo_readme_adr_count_today() -> None:
+    """Sentinel: the live README ADR count equals the ADR file count right
+    now. This is the always-on gate — when an ADR lands in a concurrent
+    worktree and the README is not regenerated, this fails fast (CI red) so
+    the drift cannot merge silently. Regenerate with
+    ``python scripts/update_readme_metrics.py``.
+    """
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    expected = len(existing_adr_numbers(REPO_ROOT / "docs" / "adr"))
+    violations = readme_adr_count_violations(readme, expected)
+    assert violations == [], (
+        "README ADR-count drift on main:\n  - " + "\n  - ".join(violations)
+    )
+
+
+def test_repo_readme_still_states_a_count() -> None:
+    """Guard against silent deletion: the live README must carry both
+    canonical ADR-count spots. If a future change intentionally drops the
+    count (switching to a bare ``docs/adr/README.md`` pointer), update this
+    test deliberately — otherwise a vacuous-pass sentinel would hide the
+    removal and re-open the drift hole from the other side.
+    """
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "개 설계 결정" in readme
+    assert "ADR 인덱스 (" in readme
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

최상위 `README.md` 의 ADR 개수가 두 곳(prose headline + 주요 링크 table)에 **하드코딩**되어 있었고, 도출 로직도 parity 게이트도 없어 ADR 이 추가될 때마다 재차 stale 했다. #1059 (commit `0c3d978`)가 숫자를 59 로 동기화했지만 메커니즘은 고치지 않아 머지 시점에 이미 off-by-one(60) 이었고, 동시 worktree 에서 ADR 이 떨어지며 `main` 은 59, 실제 `docs/adr/` 는 65 로 6 만큼 벌어졌다. 숫자를 **도출되게** 만들고(파일 수 SoT) drift 를 CI 에서 막는다.

Closes #1156

## 2. 영향 파일

- `scripts/_governance.py` — `rewrite_readme_adr_count` + `readme_adr_count_violations` 추가 (digit-only look-around 패턴, 재작성 idempotent). ADR 도입부(`existing_adr_numbers`)와 같은 모듈.
- `scripts/update_readme_metrics.py` — 매 metrics 갱신 시 두 곳 재생성; outside-marker 가드를 재구성해 ADR 개수만 허용되는 외부 편집이 되도록 + `--check` 가 개수 drift 도 잡도록.
- `tests/test_governance_readme_adr_count.py` — 신규. 단위 테스트 + 실저장소 sentinel(`test_repo_readme_adr_count_today`) = always-on CI 게이트.
- `README.md` — 두 곳 59 → 65 **재생성** (손편집 아님; `rewrite_readme_adr_count` 출력).

load-bearing 파일 없음.

## 3. 리스크

- **가장 가능성 높은 깨짐**: 재작성 정규식이 의도치 않은 곳을 건드림. → README 에서 `개 설계 결정`(1회) / `ADR 인덱스 (`(1회) 유일성 확인. 패턴의 full-match 는 숫자 run 뿐(주변 한국어는 zero-width look-around)이라 숫자만 치환되고 surrounding text 보존. 단위 테스트로 idempotency + 길이 보존 + multi-digit 성장(9→123) 고정.
- **가드 약화 우려**: 외부-마커 편집을 허용하면 `render_table`/`replace_section` 회귀를 못 잡을 수 있음. → 가드는 `rewrite(original)` 과 `rewrite(replace_section(original))` 의 outside-marker 정규화 결과를 비교하므로, 개수 delta 만 상쇄되고 *다른* 외부-마커 drift 는 여전히 trip. 합성 report+README 통합 테스트로 write(rc=0)/`--check`(idempotent) 확인.
- SoT 불일치 우려: 파일 수 vs `docs/adr/README.md` 인덱스 행. → 인덱스는 reopen-condition 표에서 ADR 재나열(68 ≠ 65)이라 count SoT 부적합. 파일 수를 SoT 로 명시; 파일 ↔ 인덱스행 parity 는 기존 `test_repo_adr_dir_parity_today` 가 보장 → headline 과 인덱스가 어긋날 수 없음.

## 4. 테스트

`tests/test_governance_readme_adr_count.py` 신규 10개. 변경 전 `readme_adr_count_violations(README, 65)` 는 2개 위반(59 vs 65) → 변경 후 README 재생성으로 0개(=sentinel pass). 즉 sentinel 이 변경 전 fail / 후 pass.

- `pytest tests/test_governance_readme_adr_count.py -v` → 10 passed
- 회귀 안전: `tests/test_governance*.py` 합산 91 passed, 3 skipped
- 통합: 합성 report+README 로 `update_readme_metrics.py` write(rc=0, 59→65) + `--check`(rc=0) 확인
- `ruff check` 통과

## 5. Eval 영향

All `·` — RAG 검색/검증/답변 path 무변경. governance 도구 + README 텍스트 한정.

### 5b. Real-data delta

N/A — load-bearing path(`rag_core.py`/`rag_retrieval.py`/`rag_verifier.py`/`rag_answer.py`/`rag_query.py`/`ingestion.py`/`visual_ingestion.py`/`eval/`/`api/`/`docs/adr/`/`scripts/build_index.py`) 미변경. 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

깨짐 없음. 답변 계약(ADR 0003) 무관 → `schema_version` bump 불필요. `update_readme_metrics.py` 의 `--report`/`--readme`/`--check` CLI flag 보존. `--check` 의 FAIL 메시지 문구만 metrics+count 포함하도록 확장(동작 호환).

## 7. 범위 외

- `_governance.py` 에 standalone `--check-readme-adr-count` / `--fix-readme-adr-count` CLI flag 미추가 (pre-commit shift-left 용). 현재 게이트 = pytest sentinel(always-on), 수정 경로 = `update_readme_metrics.py`(eval report 필요). report 없이 개수만 고치는 CLI 는 follow-up 후보.
- `docs/adr/README.md` 인덱스 행 정합성 자체는 기존 parity 테스트 관할 — 본 PR 범위 밖.