### PR TITLE
fix(ci): run §5b + eval gates on every PR base, not just main

### DIFF
--- a/.github/workflows/branch-and-issue-check.yml
+++ b/.github/workflows/branch-and-issue-check.yml
@@ -14,7 +14,12 @@ name: Branch & Issue Convention
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [main]
+    # No `branches:` filter — these gates (esp. §5b `--check-5b`) must fire on
+    # EVERY PR base, not just main. A `branches: [main]` filter let a
+    # load-bearing change ride in via a stacked PR (base≠main) with §5b never
+    # checked, neutralizing the PR #69 hard-gate (issue #1159). pr-judge.yml
+    # (ADR 0043) is the in-repo precedent: PR gates are base-agnostic.
+    # Guarded by tests/test_pr_gate_workflow_triggers_regression.py.
 
 permissions:
   contents: read

--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -1,8 +1,12 @@
 name: PR Eval Delta
 
 on:
+  # No `branches:` filter — the eval-delta + pytest + provenance gates must
+  # fire on EVERY PR base, incl. stacked PRs (base≠main). A `branches: [main]`
+  # filter exempted stacked PRs from these gates, part of the §5b bypass in
+  # issue #1159; pr-judge.yml (ADR 0043) is the base-agnostic precedent.
+  # Guarded by tests/test_pr_gate_workflow_triggers_regression.py.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/scripts/claude-hooks/pretooluse-bash-guard.sh
+++ b/scripts/claude-hooks/pretooluse-bash-guard.sh
@@ -66,8 +66,9 @@ if [[ "$gh_subcommand" == "create" ]]; then
   # --- §5b soft-warn (issue #1097): load-bearing PR body must carry §5b ---
   # Runs for every `gh pr create` (independent of the --base / stacked guard
   # below): warns when a load-bearing-touching PR's body has no §5b
-  # (real-data delta) section. The CI `--check-5b` gate only runs post-create
-  # (gh pr view), so this is the pre-create early warning. Reuses the exact
+  # (real-data delta) section. The CI `--check-5b` gate runs post-create
+  # (gh pr view) on EVERY PR base incl. stacked (base≠main) since issue #1159,
+  # so this is purely the pre-create early warning. Reuses the exact
   # validate_5b + is_load_bearing logic via _ship_pr_body.py — no duplicated
   # regex. Warns only; never exits — control falls through to the stacked
   # guard which owns exit 0 / 2.
@@ -109,7 +110,8 @@ if [[ "$gh_subcommand" == "create" ]]; then
     또는 escape 문장: `No behavior change in retrieval / verifier path.`
 
     PR #69 교훈: 합성 CI 델타만으론 의도된 보류(abstention) 회귀를 놓침.
-    PR 생성은 그대로 진행됩니다(경고만). CI `--check-5b` 가 생성 후 hard-gate 합니다.
+    PR 생성은 그대로 진행됩니다(경고만). CI `--check-5b` 가 생성 후 hard-gate 합니다
+    — base 가 main 이든 stacked(base≠main) 든 모두 (branch-and-issue-check.yml).
 EOF
   fi
   # NB: do NOT exit here — fall through to the stacked guard below.

--- a/tests/test_hook_pretooluse_bash_guard.py
+++ b/tests/test_hook_pretooluse_bash_guard.py
@@ -333,6 +333,9 @@ class TestBashGuard5bSoftWarn(unittest.TestCase):
         r = self._run("gh pr create --title T --body 'no 5b section here'")
         self.assertEqual(r.returncode, 0, msg=r.stderr)  # not stacked
         self.assertIn("§5b", r.stderr)
+        # Message-alignment (issue #1159): the soft-warn must point at the CI
+        # hard-gate that now fires on every base, not imply main-only.
+        self.assertIn("hard-gate", r.stderr)
         self.assertTrue(self._fires_log.exists())
         self.assertIn("|aware|bash-guard|pr-body-5b-missing|", self._fires_log.read_text())
 

--- a/tests/test_pr_gate_workflow_triggers_regression.py
+++ b/tests/test_pr_gate_workflow_triggers_regression.py
@@ -1,0 +1,95 @@
+"""Regression: PR-gate workflows must fire on EVERY PR base, not just main.
+
+Issue #1159 — the §5b real-data-delta hard-gate (``--check-5b``) lives only in
+``branch-and-issue-check.yml``, which was triggered by
+``pull_request: branches: [main]``. A load-bearing change opened as a stacked
+PR (base≠main — a CLAUDE.md-blessed 1-day-decomposition pattern) therefore
+never ran ``--check-5b``: the PR #69 hard-gate was silently bypassable on the
+stacked path. ``pr-eval.yml`` carried the same ``branches: [main]`` filter, so
+its eval-delta / pytest gates were also exempt on stacked PRs.
+
+``pr-judge.yml`` (ADR 0043) was already correctly base-agnostic and is the
+in-repo precedent. These tests pin "PR-correctness gates fire on all bases" so
+that re-adding a ``branches:`` filter — which reintroduces the §5b bypass —
+fails CI before it can merge.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Workflows that gate PR correctness. Each MUST run on every PR base (no
+# ``branches:`` restriction) so stacked PRs (base≠main) are never exempt.
+PR_GATE_WORKFLOWS = (
+    "branch-and-issue-check.yml",
+    "pr-eval.yml",
+    "pr-judge.yml",
+)
+
+
+def _load(name: str) -> dict:
+    with (WORKFLOWS / name).open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _on_block(wf: dict) -> dict:
+    # PyYAML maps the bareword key ``on`` to the boolean True; accept either.
+    block = wf.get("on")
+    if block is None:
+        block = wf.get(True)
+    assert block is not None, "workflow has no `on:` trigger block"
+    return block
+
+
+class PrGateBaseAgnosticTest(unittest.TestCase):
+    def test_each_gate_has_pull_request_trigger(self) -> None:
+        for name in PR_GATE_WORKFLOWS:
+            with self.subTest(workflow=name):
+                on_block = _on_block(_load(name))
+                self.assertIsNotNone(on_block, f"{name}: `on:` block missing")
+                self.assertIn(
+                    "pull_request",
+                    on_block,
+                    f"{name}: must be pull_request-triggered to gate PRs",
+                )
+
+    def test_no_gate_restricts_branches_to_main(self) -> None:
+        for name in PR_GATE_WORKFLOWS:
+            with self.subTest(workflow=name):
+                pr = _on_block(_load(name))["pull_request"]
+                # ``pull_request:`` with no body parses to None (no filter);
+                # a dict carries a ``branches`` key only if a filter is set.
+                branches = (pr or {}).get("branches")
+                self.assertIsNone(
+                    branches,
+                    f"{name}: `pull_request.branches` is {branches!r}, but PR "
+                    f"gates must fire on EVERY base. A `branches: [main]` "
+                    f"filter exempts stacked PRs (base≠main) from the gate and "
+                    f"reintroduces the §5b bypass (issue #1159). pr-judge.yml "
+                    f"is the base-agnostic precedent.",
+                )
+
+
+class FiveBGateStillWiredTest(unittest.TestCase):
+    """The trigger fix is moot if the §5b step itself is dropped."""
+
+    def test_check_5b_step_present(self) -> None:
+        text = (WORKFLOWS / "branch-and-issue-check.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "--check-5b",
+            text,
+            "branch-and-issue-check.yml must still invoke "
+            "`check_branch_and_issue.py --check-5b` (PR #69 hard-gate).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`branch-and-issue-check.yml` + `pr-eval.yml` 의 트리거가 `pull_request: branches: [main]` 이라, load-bearing 변경을 **stacked PR (base≠main)** 로 올리면 `--check-5b` (PR #69 real-data-delta hard-gate) 가 **실행되지 않았다**. CLAUDE.md 가 stacked-PR(1-day decomposition)을 valid 패턴으로 권장하므로, §5b 게이트가 stacked 경로에서 조용히 우회 가능한 실질 갭이었다. 두 게이트의 `branches:` 필터를 제거해 **모든 base 의 PR 에서 게이트가 실행**되도록 한다 (이미 base-agnostic 인 `pr-judge.yml`(ADR 0043) 선례와 일치).

Closes #1159

## 2. 영향 파일

- `.github/workflows/branch-and-issue-check.yml` — `pull_request` 트리거에서 `branches: [main]` 제거 (`--check-5b` + ADR-deletion + embedding-spread 게이트가 모든 base 에서 실행)
- `.github/workflows/pr-eval.yml` — 동일하게 `branches: [main]` 제거 (pytest / baseline-provenance / eval-delta)
- `scripts/claude-hooks/pretooluse-bash-guard.sh` — §5b soft-warn 문구를 "base 무관 hard-gate" 로 정정 (PR #1101 설계대로 여전히 soft, exit 0)
- `tests/test_pr_gate_workflow_triggers_regression.py` — **신규** workflow-trigger 회귀 테스트
- `tests/test_hook_pretooluse_bash_guard.py` — 메시지 정렬 단언 1줄 추가

**load-bearing 경로 변경 없음** (단일 출처 `scripts/_governance.py` 기준 — `rag_*.py`/`ingestion`/`eval/`/`api/`/`docs/adr/`/`scripts/build_index.py` 미포함).

## 3. 리스크

- 가장 가능성 높은 깨짐: `pr-eval.yml` 의 checkout 기반 job(baseline-provenance / eval-delta)이 stacked base ref(`origin/<parent>`)를 못 풀 가능성. → `pr-judge.yml` 이 동일하게 `pull_request.head.sha` 를 checkout 해 eval 을 모든 base 에서 돌리는 선례로 검증됨. `eval-delta` 는 `ref: base.ref` 를 명시 fetch 하므로 임의 base 에서 동작. 실패 시 **loud red** 일 뿐 silent bypass 아님.
- branch protection(required status)은 main 에만 적용 → stacked PR(parent 머지 대상)은 branch protection 으로 머지 차단되진 않으나, auto-ship 이 `gh pr checks --watch`(`docs/operations/auto-ship.md`)로 게이팅하고 parent→main PR 이 누적 변경에 §5b 를 강제하므로 실효 enforcement 유지.
- 트리거 확장은 main-targeted PR 의 상위집합 → 기존 main PR 흐름 불변.

## 4. 테스트

- 신규 `tests/test_pr_gate_workflow_triggers_regression.py`: 세 PR-gate workflow(`branch-and-issue-check`/`pr-eval`/`pr-judge`)가 `branches:` 제한 없이 모든 base 에서 실행됨을 단언 + `--check-5b` 스텝 잔존 단언. `branches: [main]` 재도입 시 `assertIsNone(["main"])` 로 **fail** (non-vacuous).
- `tests/test_hook_pretooluse_bash_guard.py`: soft-warn 이 CI hard-gate 를 가리키는지(`"hard-gate" in stderr`) 단언 추가.
- 로컬 실행: `test_pr_gate_workflow_triggers_regression` + `test_hook_pretooluse_bash_guard` + `test_branch_convention` + `test_pr_judge_workflow_regression` → **85 passed + 6 subtests**.

## 5. Eval 영향

All `·` — CI/hook/test 설정 변경이며 RAG 파이프라인 동작 무변경.

### 5b. Real-data delta

검색/검증/eval/api/ingestion path 동작 변화 없음. (load-bearing 경로 미변경 — `--check-5b` 는 이 PR 에서 skip)

## 6. 하위 호환

계약/스키마/CLI flag/doc link 변경 없음. required status check **이름**(예: "Validate branch name + issue link", "Eval delta vs base") 불변 → main branch protection 설정 그대로 유효. 훅은 PR #1101 설계대로 soft 유지.

## 7. 범위 외

- parent feature 브랜치에 branch protection 적용(레포 설정 변경) — stacked PR 의 강제력을 자동 머지 게이팅(auto-ship)에 의존; 별도 판단 필요 시 follow-up.
- `pr-eval.yml` baseline-provenance job 의 stacked base-ref 해석 견고성 — 실제 stacked PR 에서 표면화되면 follow-up.