### PR TITLE
fix(eval): dirty-state gate + squash-aware post-#N in eval-baseline-regen

### DIFF
--- a/.claude/skills/eval-baseline-regen/SKILL.md
+++ b/.claude/skills/eval-baseline-regen/SKILL.md
@@ -24,16 +24,21 @@ private real-100 eval 베이스라인(`reports/real100/baseline.aggregate.json` 
 각 단계는 (gate) 통과 후 다음으로. STOP gate(1·4)는 사용자 명시 승인 전 진행 금지.
 
 1. **Prerequisite gate — provenance 자기일관성 (가장 중요한 guard, 절대 우회 금지)**
-   - `reports/real100/eval_summary.json` 존재 확인. 없으면 **STOP**: "private 100-doc 데이터라 skill 이 생성 못 함. `make real-eval` 를 HEAD 에서 먼저 실행" 안내 ([`write_real_eval_baseline.py:127`](../../../scripts/write_real_eval_baseline.py) — 부재 시 exit 2).
-   - eval_summary 의 `provenance.git_commit` 와 `git rev-parse HEAD` 비교. **skew 시 STOP** = 이것이 #160 실패모드(eval 은 commit X, baseline 작성은 commit Y → metric/provenance 불일치). 권고: `make real-eval` 를 HEAD 에서 재실행. 그대로 진행해야 하면 **`make real-eval-baseline-update STRICT=1`** 사용 — 스크립트가 skew 에 hard-fail(exit 2)하여 침묵 오염을 차단([`write_real_eval_baseline.py:80-106`](../../../scripts/write_real_eval_baseline.py)).
+   - `reports/real100/eval_summary.json` 존재 확인. 없으면 **STOP**: "private 100-doc 데이터라 skill 이 생성 못 함. `make real-eval` 를 HEAD 에서 먼저 실행" 안내 ([`write_real_eval_baseline.py`](../../../scripts/write_real_eval_baseline.py) `main` — 부재 시 exit 2).
+   - eval_summary 의 `provenance.git_commit` 와 `git rev-parse HEAD` 비교. **skew 시 STOP** = 이것이 #160 실패모드(eval 은 commit X, baseline 작성은 commit Y → metric/provenance 불일치). 권고: `make real-eval` 를 HEAD 에서 재실행. 그대로 진행해야 하면 **`make real-eval-baseline-update STRICT=1`** 사용 — 스크립트가 skew 에 hard-fail(exit 2)하여 침묵 오염을 차단([`write_real_eval_baseline.py`](../../../scripts/write_real_eval_baseline.py) `_warn_if_stale`).
+   - **dirty-state gate (#1148, SHA 일치만으로 부족)**: `provenance.git_dirty` 또는 `run_manifest.git_dirty` 중 하나라도 `true` 면 **STOP**. eval 을 dirty worktree(uncommitted scorer/config/code)에서 돌리면 SHA 가 HEAD 와 같아도 baseline 이 재현 불가능한 metric 을 박제한다 — skew check 가 못 잡는 #160 잔여 구멍. `make real-eval` 와 baseline-update **둘 다 clean worktree 에서** 실행. `STRICT=1` 이 dirty 에도 hard-fail(exit 2). 의도된 dirty baseline 만 `make real-eval-baseline-update STRICT=1 ALLOW_DIRTY=1`(또는 스크립트 `--allow-dirty` / `BIDMATE_BASELINE_ALLOW_DIRTY=1`)로 명시 override([`write_real_eval_baseline.py`](../../../scripts/write_real_eval_baseline.py) `_warn_if_dirty`).
 
 2. **`post-#N` 산출 (intervening PR provenance)**
-   - 현재 *committed* baseline 의 anchor commit 추출:
+   - 현재 *committed* baseline 의 anchor commit 추출 후 squash-aware 로 PR 번호 열거:
      ```
      ANCHOR=$(python3 -c "import json;print(json.load(open('reports/real100/baseline.aggregate.json'))['provenance']['git_commit'])")
-     git log ${ANCHOR}..HEAD --merges --oneline
+     # 이 repo 는 squash merge(gh pr merge --squash, docs/operations/auto-ship.md) →
+     # true merge commit 이 없다. --merges 는 0건을 반환하므로 절대 사용 금지(#1148).
+     # first-parent 스캔으로 squash commit subject 의 (#N) 을 추출:
+     git log ${ANCHOR}..HEAD --first-parent --oneline | grep -oE '\(#[0-9]+\)'
      ```
-   - 열거된 머지 PR 을 분류: **(a) eval-surface 변경**(scorer / `eval/config.yaml` / preset / load-bearing 경로 — regen 을 *필요로* 한 PR) vs **(b) intervening variance**(infra / orthogonal 머지지만 metric 을 흔든 PR). 커밋 subject 의 `post-#X/#Y` 는 주로 (a), 본문에 (b) 를 변동 사유로 기록.
+   - **복구된 PR 번호가 0건이면 STOP** — anchor..HEAD 사이 PR 식별 실패(anchor SHA 가 origin/main 에 reachable 하지 않거나, ANCHOR==HEAD). `make real-eval-delta` / [`scripts/check_baseline_provenance.py`](../../../scripts/check_baseline_provenance.py) 로 anchor reachability 재확인 후 진행. post-#N 을 빈 채로 커밋하면 regen 을 정당화한 바로 그 eval-surface PR 을 누락한다.
+   - 열거된 PR 을 분류: **(a) eval-surface 변경**(scorer / `eval/config.yaml` / preset / load-bearing 경로 — regen 을 *필요로* 한 PR) vs **(b) intervening variance**(infra / orthogonal 머지지만 metric 을 흔든 PR). 커밋 subject 의 `post-#X/#Y` 는 주로 (a), 본문에 (b) 를 변동 사유로 기록.
 
 3. **기계적 regen 실행**
    - `make real-eval-baseline-update`(skew 우려 시 `STRICT=1`) → baseline + `history/<ts>_<sha>.aggregate.json` 작성.
@@ -62,17 +67,18 @@ go-ahead(진행): "진행" / "ㄱㄱ" / "ㅇㅋ" / "ok" / "go". 질문(답변만
 ## When the user pushes back
 
 - **"regression 그냥 통과시켜"** → 비용 명시: 잘못된 `[ALLOW_REGRESSION]` 은 변별력(distinguishing power) 측정을 오염시켜 이후 모든 델타 비교의 기준선을 흐린다. 1회만 명시 확인 후 진행.
-- **"real-eval 생략하고 베이스라인만 갱신"** → 거부. `eval_summary.json` 없이는 baseline 작성 불가([`write_real_eval_baseline.py:127`](../../../scripts/write_real_eval_baseline.py)), private 데이터(ADR 0005)라 skill 이 대신 생성 못 함.
+- **"real-eval 생략하고 베이스라인만 갱신"** → 거부. `eval_summary.json` 없이는 baseline 작성 불가([`write_real_eval_baseline.py`](../../../scripts/write_real_eval_baseline.py) `main`), private 데이터(ADR 0005)라 skill 이 대신 생성 못 함.
 - **"provenance skew 무시"** → `STRICT` 끄면 가능하나 #160 사유(metric/provenance 불일치 침묵 오염) 경고 후 사용자 선택. 기본은 `STRICT=1` 권장.
+- **"dirty 인데 그냥 baseline 떠"** → 비용 명시: dirty eval 은 SHA 가 HEAD 와 같아도 uncommitted 변경의 metric 을 박제 → 재현 불가, 이후 모든 델타 비교의 기준선 오염(#1148, skew check 가 못 잡는 #160 잔여 구멍). 권고는 commit/stash 후 clean 재실행. 의도적이면 1회 명시 확인 후 `ALLOW_DIRTY=1`.
 - **"synthetic leaderboard 도 같이 갱신"** → out of scope. `make leaderboard` / `make cost-frontier` 는 별도, leaderboard freshness 는 이미 `make leaderboard-check` CI 가 강제. 묶지 않음.
 
 ## References
 
 - [Makefile](../../../Makefile) `real-eval-baseline-update` (`STRICT` 지원), `real-eval-delta`, `leaderboard-check`.
-- [scripts/write_real_eval_baseline.py](../../../scripts/write_real_eval_baseline.py) — baseline + history 작성, provenance skew 가드(80-106), eval_summary 부재 처리(127), `provenance` 기록(137-139).
+- [scripts/write_real_eval_baseline.py](../../../scripts/write_real_eval_baseline.py) — baseline + history 작성, provenance skew 가드(`_warn_if_stale`) + dirty-state 가드(`_warn_if_dirty`, #1148), `STRICT`/`--allow-dirty` 해석, eval_summary 부재 처리(`main`), `provenance` 기록.
 - [scripts/check_baseline_provenance.py](../../../scripts/check_baseline_provenance.py) — committed baseline 의 `provenance.git_commit` reachability(origin/main).
 - [.githooks/pre-commit](../../../.githooks/pre-commit) — ADR 0005 allowlist(real100 baseline / history 만 통과).
-- ADR 0005(eval public/private 분리), #160 / #414(provenance 자기일관성), ADR 0054(aggregate semantics).
+- ADR 0005(eval public/private 분리), #160 / #414 / #1148(provenance 자기일관성 + dirty 가드), ADR 0054(aggregate semantics).
 - [.claude/skills/ship-pr/SKILL.md](../ship-pr/SKILL.md) — push/PR/merge + stacked-audit + approval-gate 컨벤션(핸드오프 대상).
 - [.claude/skills/retrieval-eval/SKILL.md](../retrieval-eval/SKILL.md) — "no helper code" + STOP gate 패턴.
 
@@ -84,4 +90,4 @@ go-ahead(진행): "진행" / "ㄱㄱ" / "ㅇㅋ" / "ok" / "go". 질문(답변만
 - Does NOT draft an ADR — `eval-to-adr-bridge` agent 담당.
 - Does NOT push / open PR / merge — `ship-pr` 담당.
 - Does NOT auto-tag `[ALLOW_REGRESSION]` — 항상 사용자 명시 확인.
-- Does NOT bypass the provenance skew gate silently — skew 시 STOP 또는 `STRICT=1` hard-fail.
+- Does NOT bypass the provenance skew/dirty gate silently — skew·dirty 시 STOP 또는 `STRICT=1` hard-fail. dirty override 는 명시 `ALLOW_DIRTY=1` / `--allow-dirty` 만(#1148).

--- a/Makefile
+++ b/Makefile
@@ -339,11 +339,13 @@ real-eval-delta:
 # not on every eval. Diff the result with `git diff` before committing.
 #
 # Pass STRICT=1 (or set BIDMATE_BASELINE_STRICT=1, issue #414) to escalate
-# the two existing provenance warnings (no eval-side provenance; eval/
-# baseline SHA skew per issue #160) to hard failures — for CI/pre-push
-# or any gate that requires a self-consistent baseline.
+# the provenance warnings (no eval-side provenance; eval/baseline SHA skew
+# per issue #160; dirty worktree per issue #1148) to hard failures — for
+# CI/pre-push or any gate that requires a self-consistent baseline.
+# Pass ALLOW_DIRTY=1 (or BIDMATE_BASELINE_ALLOW_DIRTY=1) to override the
+# dirty-worktree gate for a deliberate dirty baseline (#1148).
 real-eval-baseline-update:
-	$(PYTHON) scripts/write_real_eval_baseline.py $(if $(STRICT),--strict,)
+	$(PYTHON) scripts/write_real_eval_baseline.py $(if $(STRICT),--strict,) $(if $(ALLOW_DIRTY),--allow-dirty,)
 
 # Render the chronological real-data history table into
 # docs/real-data/private-100-doc-experiments.md (between the

--- a/scripts/write_real_eval_baseline.py
+++ b/scripts/write_real_eval_baseline.py
@@ -18,10 +18,20 @@ Intended cadence: deliberate, after a decision lands (PR merged,
 threshold tightened). Not every run.
 
 Strict mode (issue #414): pass ``--strict`` or set
-``BIDMATE_BASELINE_STRICT=1`` to escalate the two existing provenance
+``BIDMATE_BASELINE_STRICT=1`` to escalate the existing provenance
 warnings (no eval-side provenance block; eval/baseline SHA skew per
-issue #160) from stderr-only to hard failures (exit 2, no baseline
-written). Default behavior is unchanged.
+issue #160; dirty worktree per issue #1148) from stderr-only to hard
+failures (exit 2, no baseline written). Default behavior is unchanged.
+
+Dirty gate (issue #1148): the SHA-only skew check passes whenever the
+eval and the baseline share a commit, but says nothing about
+*uncommitted* changes at that commit. An eval run from a dirty worktree
+(uncommitted scorer/config/code) therefore bakes unreproducible metrics
+into the committed baseline even under ``--strict``. The dirty gate
+inspects the eval-side ``provenance``/``run_manifest`` dirty flags and
+the write-time worktree; ``--allow-dirty`` /
+``BIDMATE_BASELINE_ALLOW_DIRTY=1`` is the documented escape hatch for a
+deliberate dirty baseline.
 """
 from __future__ import annotations
 
@@ -39,6 +49,7 @@ from scripts._utils import build_provenance, make_run_id
 from scripts.run_real_eval_delta import extract_aggregate
 
 STRICT_ENV_VAR = "BIDMATE_BASELINE_STRICT"
+ALLOW_DIRTY_ENV_VAR = "BIDMATE_BASELINE_ALLOW_DIRTY"
 _TRUTHY = {"1", "true", "yes"}
 
 EVAL_SUMMARY = ROOT / "reports" / "real100" / "eval_summary.json"
@@ -57,6 +68,19 @@ def _resolve_strict(flag: bool) -> bool:
     if flag:
         return True
     raw = os.environ.get(STRICT_ENV_VAR, "").strip().lower()
+    return raw in _TRUTHY
+
+
+def _resolve_allow_dirty(flag: bool) -> bool:
+    """Effective allow-dirty = ``--allow-dirty`` flag OR
+    ``BIDMATE_BASELINE_ALLOW_DIRTY`` truthy.
+
+    Uses the same truthy set as :func:`_resolve_strict` (``1``/``true``/
+    ``yes``, case-insensitive); any other value is falsy.
+    """
+    if flag:
+        return True
+    raw = os.environ.get(ALLOW_DIRTY_ENV_VAR, "").strip().lower()
     return raw in _TRUTHY
 
 
@@ -106,6 +130,60 @@ def _warn_if_stale(
         raise SystemExit(2)
 
 
+def _warn_if_dirty(
+    eval_prov: dict[str, object] | None,
+    run_manifest: dict[str, object] | None,
+    baseline_prov: dict[str, object],
+    *,
+    strict: bool = False,
+    allow_dirty: bool = False,
+) -> None:
+    """Warn — or, in strict mode, hard-fail — when the baseline would
+    capture an unreproducible *dirty* code state.
+
+    The SHA-only skew check (:func:`_warn_if_stale`) passes whenever the
+    eval and the baseline share a commit, but says nothing about
+    uncommitted changes *at* that commit. An eval run from a dirty
+    worktree (uncommitted scorer/config/code) therefore bakes
+    unreproducible metrics into the committed baseline even under
+    ``--strict`` — the residual #160-class hole reported in issue #1148.
+
+    Three dirty signals are inspected: the eval-side ``provenance`` and
+    ``run_manifest`` blocks from ``eval_summary.json`` (the eval was run
+    dirty) and ``baseline_prov`` (the baseline is being written from a
+    dirty worktree). Any true flag warns; under ``strict`` it is a hard
+    failure (exit 2, no baseline written). ``allow_dirty``
+    (``--allow-dirty`` / ``BIDMATE_BASELINE_ALLOW_DIRTY=1``) is the
+    documented override for a deliberate dirty baseline.
+    """
+    if allow_dirty:
+        return
+    dirty_sources: list[str] = []
+    if isinstance(eval_prov, dict) and eval_prov.get("git_dirty"):
+        dirty_sources.append("eval_summary.json `provenance` (git_dirty=true)")
+    if isinstance(run_manifest, dict) and run_manifest.get("git_dirty"):
+        dirty_sources.append("eval_summary.json `run_manifest` (git_dirty=true)")
+    if isinstance(baseline_prov, dict) and baseline_prov.get("git_dirty"):
+        dirty_sources.append("baseline write-time worktree (git_dirty=true)")
+    if not dirty_sources:
+        return
+    level = "ERROR" if strict else "WARN"
+    detail = "".join(f"        - {src}\n" for src in dirty_sources)
+    print(
+        f"[{level}] Dirty worktree detected — the baseline would capture an\n"
+        f"        unreproducible code state:\n"
+        f"{detail}"
+        f"        Re-run `make real-eval` and the baseline update from a clean\n"
+        f"        worktree (commit or stash first). This is the residual #160\n"
+        f"        failure mode the SHA-only skew check does not catch (#1148).\n"
+        f"        Override with --allow-dirty / {ALLOW_DIRTY_ENV_VAR}=1 only for\n"
+        f"        a deliberate dirty baseline.",
+        file=sys.stderr,
+    )
+    if strict:
+        raise SystemExit(2)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -117,12 +195,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             f"baseline NOT written. Equivalent to {STRICT_ENV_VAR}=1."
         ),
     )
+    ap.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help=(
+            "Override the dirty-worktree gate (issue #1148): write the "
+            "baseline even when the eval provenance/run_manifest or the "
+            "write-time worktree is dirty. For a deliberate dirty baseline "
+            f"only. Equivalent to {ALLOW_DIRTY_ENV_VAR}=1."
+        ),
+    )
     return ap.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     strict = _resolve_strict(args.strict)
+    allow_dirty = _resolve_allow_dirty(args.allow_dirty)
 
     if not EVAL_SUMMARY.exists():
         print(
@@ -134,8 +223,12 @@ def main(argv: list[str] | None = None) -> int:
     raw = json.loads(EVAL_SUMMARY.read_text(encoding="utf-8"))
     agg = extract_aggregate(raw)
     eval_prov = raw.get("provenance") if isinstance(raw, dict) else None
+    run_manifest = raw.get("run_manifest") if isinstance(raw, dict) else None
     baseline_prov = build_provenance()
     _warn_if_stale(eval_prov, baseline_prov, strict=strict)
+    _warn_if_dirty(
+        eval_prov, run_manifest, baseline_prov, strict=strict, allow_dirty=allow_dirty
+    )
     agg["provenance"] = baseline_prov
 
     # If a judge run is present (ADR 0006), fold its aggregate into the

--- a/tests/test_write_real_eval_baseline.py
+++ b/tests/test_write_real_eval_baseline.py
@@ -1,9 +1,14 @@
-"""Contract test for strict mode in scripts/write_real_eval_baseline.py (#414).
+"""Contract test for strict mode in scripts/write_real_eval_baseline.py (#414, #1148).
 
 Locks (a) the default warn-only behavior preserved for back-compat and
 (b) the strict-mode escalation: ``--strict`` and
-``BIDMATE_BASELINE_STRICT=1`` must both flip the two existing
-provenance warnings to hard failures (exit 2, no baseline written).
+``BIDMATE_BASELINE_STRICT=1`` must both flip the provenance warnings to
+hard failures (exit 2, no baseline written).
+
+Also locks the dirty-worktree gate (#1148): a SHA-matched but *dirty*
+eval run must hard-fail under ``--strict`` (the residual #160 hole the
+skew check does not catch), and ``--allow-dirty`` /
+``BIDMATE_BASELINE_ALLOW_DIRTY=1`` must be the only way to override it.
 """
 
 from __future__ import annotations
@@ -100,6 +105,93 @@ class WarnIfStaleUnit(unittest.TestCase):
             self.fail("matching SHAs must not raise in either mode")
 
 
+# ---- _resolve_allow_dirty unit (#1148) ------------------------------------
+
+
+class ResolveAllowDirtyUnit(unittest.TestCase):
+    def test_flag_true_returns_true(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(writer.ALLOW_DIRTY_ENV_VAR, None)
+            self.assertTrue(writer._resolve_allow_dirty(True))
+
+    def test_flag_false_env_unset_returns_false(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(writer.ALLOW_DIRTY_ENV_VAR, None)
+            self.assertFalse(writer._resolve_allow_dirty(False))
+
+    def test_env_truthy_values(self) -> None:
+        for value in ("1", "true", "TRUE", "yes", "Yes"):
+            with mock.patch.dict(os.environ, {writer.ALLOW_DIRTY_ENV_VAR: value}):
+                self.assertTrue(
+                    writer._resolve_allow_dirty(False),
+                    f"expected {value!r} to be truthy",
+                )
+
+    def test_env_falsy_values(self) -> None:
+        for value in ("0", "false", "no", "", "off", "garbage"):
+            with mock.patch.dict(os.environ, {writer.ALLOW_DIRTY_ENV_VAR: value}):
+                self.assertFalse(
+                    writer._resolve_allow_dirty(False),
+                    f"expected {value!r} to be falsy",
+                )
+
+    def test_flag_overrides_falsy_env(self) -> None:
+        with mock.patch.dict(os.environ, {writer.ALLOW_DIRTY_ENV_VAR: "0"}):
+            self.assertTrue(writer._resolve_allow_dirty(True))
+
+
+# ---- _warn_if_dirty unit (#1148) ------------------------------------------
+
+
+class WarnIfDirtyUnit(unittest.TestCase):
+    CLEAN = {"git_commit": "abc123", "git_dirty": False}
+    DIRTY = {"git_commit": "abc123", "git_dirty": True}
+
+    def test_all_clean_silent_in_both_modes(self) -> None:
+        try:
+            writer._warn_if_dirty(self.CLEAN, self.CLEAN, self.CLEAN)
+            writer._warn_if_dirty(self.CLEAN, self.CLEAN, self.CLEAN, strict=True)
+        except SystemExit:
+            self.fail("clean provenance must not raise in either mode")
+
+    def test_absent_eval_blocks_treated_as_clean(self) -> None:
+        # eval_summary may legitimately lack provenance/run_manifest; absence
+        # is not dirtiness, so a clean write-time worktree must still pass.
+        try:
+            writer._warn_if_dirty(None, None, self.CLEAN, strict=True)
+        except SystemExit:
+            self.fail("absent eval blocks must not raise when write-time is clean")
+
+    def test_default_warns_on_dirty_eval_and_returns(self) -> None:
+        try:
+            writer._warn_if_dirty(self.DIRTY, None, self.CLEAN)
+        except SystemExit:
+            self.fail("default mode must not raise on dirty eval")
+
+    def test_strict_raises_on_dirty_eval_provenance(self) -> None:
+        with self.assertRaises(SystemExit) as cm:
+            writer._warn_if_dirty(self.DIRTY, None, self.CLEAN, strict=True)
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_strict_raises_on_dirty_run_manifest(self) -> None:
+        with self.assertRaises(SystemExit) as cm:
+            writer._warn_if_dirty(self.CLEAN, self.DIRTY, self.CLEAN, strict=True)
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_strict_raises_on_dirty_baseline_writetime(self) -> None:
+        with self.assertRaises(SystemExit) as cm:
+            writer._warn_if_dirty(self.CLEAN, None, self.DIRTY, strict=True)
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_allow_dirty_overrides_strict(self) -> None:
+        try:
+            writer._warn_if_dirty(
+                self.DIRTY, self.DIRTY, self.DIRTY, strict=True, allow_dirty=True
+            )
+        except SystemExit:
+            self.fail("allow_dirty must suppress the strict dirty failure")
+
+
 # ---- CLI integration ------------------------------------------------------
 
 
@@ -116,7 +208,9 @@ class WriterCli(unittest.TestCase):
         self._baseline = self._reports / "baseline.aggregate.json"
         self._history = self._reports / "history"
 
-    def _write_eval_summary(self, eval_sha: str | None) -> None:
+    def _write_eval_summary(
+        self, eval_sha: str | None, *, eval_dirty: bool = False
+    ) -> None:
         body: dict[str, object] = {
             "num_predictions": 21,
             "accuracy": 0.47,
@@ -127,11 +221,20 @@ class WriterCli(unittest.TestCase):
             body["provenance"] = {
                 "generated_at": "2026-05-12T00:00:00.000000Z",
                 "git_commit": eval_sha,
-                "git_dirty": False,
+                "git_dirty": eval_dirty,
             }
         self._eval_summary.write_text(
             json.dumps(body, ensure_ascii=False), encoding="utf-8"
         )
+
+    def _head_sha(self) -> str:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()[:12]
 
     def _invoke(
         self,
@@ -216,6 +319,41 @@ class WriterCli(unittest.TestCase):
             "[ERROR] eval_summary.json has no `provenance` block", result.stderr
         )
         self.assertFalse(self._baseline.exists())
+
+    # ---- dirty-worktree gate (#1148) --------------------------------------
+    # SHA matches HEAD (no skew) but the eval ran dirty — the residual #160
+    # hole the skew check does not catch.
+
+    def test_warn_mode_dirty_eval_still_writes_baseline(self) -> None:
+        self._write_eval_summary(eval_sha=self._head_sha(), eval_dirty=True)
+        result = self._invoke()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[WARN] Dirty worktree detected", result.stderr)
+        self.assertTrue(self._baseline.exists(), "warn mode must still write")
+
+    def test_strict_flag_blocks_on_dirty_eval(self) -> None:
+        self._write_eval_summary(eval_sha=self._head_sha(), eval_dirty=True)
+        result = self._invoke("--strict")
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("[ERROR] Dirty worktree detected", result.stderr)
+        self.assertFalse(
+            self._baseline.exists(), "baseline must NOT be written on strict-dirty"
+        )
+
+    def test_strict_env_blocks_on_dirty_eval(self) -> None:
+        self._write_eval_summary(eval_sha=self._head_sha(), eval_dirty=True)
+        result = self._invoke(env_strict="1")
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("[ERROR] Dirty worktree detected", result.stderr)
+        self.assertFalse(self._baseline.exists())
+
+    def test_allow_dirty_lets_strict_pass_on_dirty_eval(self) -> None:
+        self._write_eval_summary(eval_sha=self._head_sha(), eval_dirty=True)
+        result = self._invoke("--strict", "--allow-dirty")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(
+            self._baseline.exists(), "baseline must be written with --allow-dirty"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1148

commit 9e0184c (#1089) 의 `eval-baseline-regen` skill provenance guard 에 adversarial review 로 발견한 HIGH 2건을 닫는다. 둘 다 현재 main 에서 검증됨 (실증: 현재 committed `reports/real100/baseline.aggregate.json` 의 provenance 가 이미 `git_dirty: True`, 그리고 현재 anchor 기준 `--merges`=0건 vs `--first-parent`=57 PR).

- **Finding 1 — STRICT 가 `git_dirty` 무시.** skew gate 는 `eval_sha == baseline_sha` 만 비교 → dirty worktree(uncommitted scorer/config/code)에서 돌린 eval 은 SHA 가 HEAD 와 같아도 재현 불가능한 metric 을 committed baseline 에 박제. STRICT=1 도 못 막던 #160 잔여 구멍. `_warn_if_dirty` 게이트(eval `provenance` / `run_manifest` / write-time worktree 의 `git_dirty` 검사) + `--allow-dirty` / `BIDMATE_BASELINE_ALLOW_DIRTY` override 추가.
- **Finding 2 — post-#N 이 squash-merge 에서 침묵 empty.** repo 는 `gh pr merge --squash` (single-parent, subject 에 `(#N)`) → `git log --merges` 는 0건 반환 → regen 을 정당화한 eval-surface PR 을 commit 에서 누락. SKILL.md step 2 를 `--first-parent` + `(#N)` 파싱 + fail-if-empty STOP 으로 교체.

## 2. 영향 파일

- `scripts/write_real_eval_baseline.py` — `_warn_if_dirty` 게이트 + `_resolve_allow_dirty` + `--allow-dirty` 플래그 + `main` 에서 `run_manifest` 읽어 게이트 호출. (**non-load-bearing** — `LOAD_BEARING_PATHS` 비포함)
- `tests/test_write_real_eval_baseline.py` — 회귀 테스트: `_warn_if_dirty` unit 7개 + `_resolve_allow_dirty` unit 5개 + CLI 4개 (총 +19).
- `.claude/skills/eval-baseline-regen/SKILL.md` — step 1 dirty 게이트 명시, step 2 `--first-parent` 교체 + fail-if-empty, references/pushback/does-NOT 갱신, brittle `:127` 라인참조 → 함수명.
- `Makefile` — `real-eval-baseline-update` 에 `ALLOW_DIRTY` 와이어링(`STRICT` 와 대칭). (**non-load-bearing**)

load-bearing 파일 변경 없음.

## 3. 리스크

가장 가능성 높은 깨짐 경로: (a) dirty 게이트가 정상 clean 워크플로를 막음 — non-strict 기본은 warn-only(write 진행)로 유지, hard-fail 은 `STRICT=1` 한정, override 는 `--allow-dirty`. (b) 기존 STRICT skew 테스트 회귀 — `_warn_if_stale` 가 `_warn_if_dirty` 보다 먼저 호출되어 skew/missing 케이스는 종전대로 raise. 전체 32개 테스트 통과로 배제. (c) step 2 grep 오탐 — `\(#[0-9]+\)` 로 squash subject 의 괄호 PR-번호만 추출, `closes #5` 류 비괄호 ref 미포함. 실제 anchor 로 57 PR 정확 추출 확인.

## 4. 테스트

`tests/test_write_real_eval_baseline.py` 에 #1148 회귀 추가 (변경 전 fail / 변경 후 pass):
- `WarnIfDirtyUnit` — eval/run_manifest/write-time 각 dirty 소스가 STRICT 에서 `SystemExit(2)`, warn 모드는 미raise, `allow_dirty` 가 STRICT 억제, all-clean·absent-block 침묵.
- `ResolveAllowDirtyUnit` — flag/env truthy·falsy·override (`_resolve_strict` 미러).
- CLI: `git_dirty=true` provenance(SHA=HEAD, skew 없음) 를 먹여 `--strict`/`STRICT=1` → exit 2 + baseline 미작성; `--allow-dirty` → exit 0 + 작성; warn 모드 → write + `[WARN]`.

`pytest -q tests/test_write_real_eval_baseline.py` → **32 passed**. `ruff check .` clean. step 2 명령은 실제 baseline anchor 로 e2e 검증.

## 5. Eval 영향

All `·` (no RAG-path change). retrieval/verifier/answer/planner 미변경 — baseline writer 의 strict-mode 가드 + skill 문서 + Makefile 와이어링뿐. eval metric 산출 로직 불변.

### 5b. Real-data delta

**N/A.** `scripts/write_real_eval_baseline.py` 는 `LOAD_BEARING_PATHS` 비포함이고, 변경은 strict-mode dirty 가드 추가 + 신규 opt-in 플래그뿐 — baseline metric **content** 나 default(warn) write 경로를 바꾸지 않는다. 검색/검증 path 동작 변화 없음. (`--check-5b` gate 도 load-bearing 미변경이라 §5b 미요구.)

## 6. 하위 호환

깨짐 없음 — 전부 additive·opt-in. `_warn_if_stale` 시그니처 불변, default(non-strict) 동작 불변(dirty 는 warn-only), 신규 `--allow-dirty` / `ALLOW_DIRTY` 는 미지정 시 no-op. answer-contract(ADR 0003) 무관 → `schema_version` bump 불필요.

## 7. 범위 외

- **Cross-cutting squash-merge-blindness sweep.** `.githooks/_pre-push-worktree-hygiene.sh` 의 `git branch --merged` 도 같은 squash-merge 가정(merged 브랜치 미탐지) — 이미 idx21 follow-up chip 으로 추적 중이라 본 PR(one concern: regen skill provenance)에서 제외. 다른 `--merges`/`--merged`/ancestry 가정도 별도 sweep 가치.
- `reports/real100/baseline.aggregate.json` 자체의 stale(57 PR) + `git_dirty:True` 재생성은 별건(eval-baseline-regen skill 호출로 처리할 chore).