### PR TITLE
fix(githooks): flag squash-merged orphan worktrees

### DIFF
--- a/.githooks/_pre-push-worktree-hygiene.sh
+++ b/.githooks/_pre-push-worktree-hygiene.sh
@@ -12,28 +12,82 @@
 # for each orphan — never auto-removes (a worktree may hold un-pushed
 # work the merge check can't see). Soft-warn only: `exit 0` always.
 #
-# bash 3.2 compatible (macOS default): no associative arrays — merged
-# branch membership is tested with `grep -qxF` against a newline list.
+# "Merged" is decided per branch by three OFFLINE signals (no network — every
+# push stays fast, like the other pre-push sub-hooks) plus one OPT-IN online
+# signal:
+#
+#   (a) ancestor      branch tip is an ancestor of main — classic
+#                     fast-forward / merge-commit merge.
+#   (b) patch-equiv   `git cherry main <branch>` shows no '+' line: every
+#                     commit since the fork point is already applied on main
+#                     by patch-id. THIS catches the squash-merge
+#                     (`gh pr merge --squash`, this repo's documented default):
+#                     a squash lands a brand-new SHA, so the original tip is
+#                     NOT an ancestor and signal (a) — the old
+#                     `git branch --merged` test — silently missed it.
+#   (c) gone upstream the branch's remote-tracking ref is '[gone]', i.e. the
+#                     remote branch was deleted (`gh pr merge --delete-branch`).
+#                     Targets the documented incident where --delete-branch
+#                     fails locally ("'main' already used by worktree") and
+#                     leaves the stale worktree behind.
+#   (d) gh PR MERGED  OPT-IN via BIDMATE_WORKTREE_HYGIENE_GH=1 (requires gh).
+#                     Authoritative for a multi-commit branch squash-merged
+#                     while its upstream is still present — the only case
+#                     (a)-(c) miss. Off by default so pushes stay offline.
+#
+# bash 3.2 compatible (macOS default): no associative arrays.
 #
 # By design no `set -e`: a fresh clone without a local `main` should skip
 # the check, never block the push.
 
 set -u
 
-# Merged-branch set: local branches already merged into main (origin/main
-# fallback for checkouts without a local main ref). The `^[*+ ]` strip
-# removes the `* ` current marker and the `+ ` worktree marker.
-merged=$(git branch --merged main 2>/dev/null | sed 's/^[*+ ]*//' || true)
-if [[ -z "$merged" ]]; then
-  merged=$(git branch --merged origin/main 2>/dev/null | sed 's/^[*+ ]*//' || true)
+# Base ref, resolved once: prefer a local `main`, fall back to `origin/main`
+# for checkouts without a local main ref. No base → fresh clone → skip.
+if git rev-parse --verify -q refs/heads/main >/dev/null 2>&1; then
+  base_ref="main"
+elif git rev-parse --verify -q refs/remotes/origin/main >/dev/null 2>&1; then
+  base_ref="origin/main"
+else
+  exit 0
 fi
-[[ -z "$merged" ]] && exit 0
 
 # Current worktree root — never warn about the one we're pushing from.
 self_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
 
+# Opt-in online signal: only when explicitly enabled AND gh is installed.
+gh_enabled=""
+if [[ -n "${BIDMATE_WORKTREE_HYGIENE_GH:-}" ]] && command -v gh >/dev/null 2>&1; then
+  gh_enabled="1"
+fi
+
 _is_merged() {
-  printf '%s\n' "$merged" | grep -qxF "$1"
+  # Returns 0 (merged/stale) if any signal fires; 1 otherwise. Cheap local
+  # signals first; the opt-in network call only for branches still unflagged.
+  local branch="$1"
+
+  # (a) ancestor of base — fast-forward / merge-commit merge.
+  git merge-base --is-ancestor "$branch" "$base_ref" 2>/dev/null && return 0
+
+  # (b) patch-equivalent — no '+' line ⇒ every commit since the fork point is
+  # already applied on base by patch-id (catches single-commit squash-merge).
+  # Guarded on cherry succeeding so a bad ref never flags a branch.
+  local cherry
+  if cherry=$(git cherry "$base_ref" "$branch" 2>/dev/null); then
+    printf '%s\n' "$cherry" | grep -q '^+' || return 0
+  fi
+
+  # (c) remote-tracking branch deleted on the remote (--delete-branch merge).
+  local track
+  track=$(git for-each-ref --format='%(upstream:track)' "refs/heads/$branch" 2>/dev/null || true)
+  [[ "$track" == *"[gone]"* ]] && return 0
+
+  # (d) opt-in authoritative: the branch's PR is merged per gh.
+  if [[ -n "$gh_enabled" ]]; then
+    [[ "$(gh pr view "$branch" --json state -q .state 2>/dev/null || true)" == "MERGED" ]] && return 0
+  fi
+
+  return 1
 }
 
 orphans=""

--- a/tests/test_hook_pre_push_worktree_hygiene.py
+++ b/tests/test_hook_pre_push_worktree_hygiene.py
@@ -1,4 +1,4 @@
-"""Regression: pre-push orphan-worktree hygiene (issue #1052).
+"""Regression: pre-push orphan-worktree hygiene (issue #1052, #1163).
 
 Pins the soft-warn contract (always exit 0; warning only on stderr) for
 `.githooks/_pre-push-worktree-hygiene.sh`:
@@ -7,12 +7,20 @@ Pins the soft-warn contract (always exit 0; warning only on stderr) for
   2. worktree whose branch is NOT merged       → exit 0, stderr quiet
   3. detached-HEAD worktree                     → exit 0, stderr quiet
   4. run from the orphan worktree itself        → exit 0, not self-flagged
+  5. SQUASH-merged branch (new SHA on main)     → exit 0, stderr names it
+  6. branch with a '[gone]' upstream            → exit 0, stderr names it
+  7. gh PR MERGED + opt-in env                  → exit 0, stderr names it
+  8. gh PR MERGED but opt-in OFF (default)      → exit 0, stderr quiet
 
-Each scenario runs in an isolated temp git repo with real `git worktree`
-checkouts. The hook is pure git (no python dep), so nothing is copied in.
+Scenarios 5-8 are the #1163 fix: `git branch --merged` only lists ancestor
+tips, so squash-merges (this repo's default merge path) were a silent
+false-negative. Each scenario runs in an isolated temp git repo with real
+`git worktree` checkouts. The hook is pure git (no python dep), so nothing
+is copied in.
 """
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
@@ -63,14 +71,42 @@ class TestPrePushWorktreeHygiene(unittest.TestCase):
             self._git("commit", "-q", "-m", "ahead of main", cwd=wt)
         return wt
 
-    def _run_hook(self, *, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    def _run_hook(
+        self, *, cwd: Path | None = None, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess:
         return subprocess.run(
             ["bash", str(HOOK)],
             cwd=str(cwd or self.repo),
             capture_output=True,
             text=True,
             check=False,
+            env=env,
         )
+
+    def _squash_merge(self, branch: str) -> None:
+        # Mimic `gh pr merge --squash`: collapse the branch's commits into a
+        # single brand-new commit on main (a SHA the branch tip is NOT an
+        # ancestor of), from the primary worktree.
+        self._git("merge", "--squash", branch)
+        self._git("commit", "-q", "-m", f"squash-merge {branch}")
+
+    def _write_fake_gh(self, merged_branch: str) -> Path:
+        # A stub `gh` that reports MERGED only for `pr view <merged_branch>`,
+        # so the opt-in (d) signal can be exercised without the network.
+        bindir = Path(self._tmp) / "fakebin"
+        bindir.mkdir(exist_ok=True)
+        gh = bindir / "gh"
+        gh.write_text(
+            "#!/usr/bin/env bash\n"
+            f'if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = "{merged_branch}" ]; then\n'
+            "  echo MERGED\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+        return bindir
 
     def test_merged_worktree_is_flagged(self) -> None:
         # No extra commit → branch tip == main tip → merged → orphan.
@@ -100,6 +136,69 @@ class TestPrePushWorktreeHygiene(unittest.TestCase):
         self.assertEqual(0, r.returncode, r.stderr)
         # self_top == wt → excluded → its own branch is not reported.
         self.assertNotIn("feat-merged", r.stderr)
+
+    def test_squash_merged_worktree_is_flagged(self) -> None:
+        # #1163: gh pr merge --squash lands a NEW commit on main, so the
+        # feature tip is NOT an ancestor and `git branch --merged` missed it.
+        # Patch-equivalence (git cherry) must still flag the orphan worktree.
+        self._add_worktree("wt_squash", "feat-squash", extra_commit=True)
+        self._squash_merge("feat-squash")
+        # Guard the premise: the squash is genuinely non-ancestor (else this
+        # would silently degrade into the old ancestor-only case).
+        anc = self._git("merge-base", "--is-ancestor", "feat-squash", "main")
+        self.assertNotEqual(0, anc.returncode, "squash merge must not be an ancestor")
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("git worktree remove", r.stderr)
+        self.assertIn("feat-squash", r.stderr)
+        self.assertIn("wt_squash", r.stderr)
+
+    def test_gone_upstream_worktree_is_flagged(self) -> None:
+        # The documented incident: --delete-branch removes the remote branch
+        # after merge; once pruned, the local branch tracks a '[gone]'
+        # upstream — a stale signal offline can detect without the network.
+        remote = Path(self._tmp) / "remote.git"
+        self._git("init", "--bare", "-q", str(remote))
+        self._git("remote", "add", "origin", str(remote))
+        wt = self._add_worktree("wt_gone", "feat-gone", extra_commit=True)
+        push = self._git("push", "-u", "origin", "feat-gone", cwd=wt)
+        self.assertEqual(0, push.returncode, push.stderr)
+        self._git("push", "origin", "--delete", "feat-gone")
+        self._git("fetch", "--prune", "origin")
+        track = self._git(
+            "for-each-ref", "--format=%(upstream:track)", "refs/heads/feat-gone"
+        )
+        self.assertIn("[gone]", track.stdout, "setup: upstream should be gone")
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("feat-gone", r.stderr)
+        self.assertIn("wt_gone", r.stderr)
+
+    def test_gh_merged_pr_is_flagged_when_opted_in(self) -> None:
+        # Multi-commit squash with a live upstream is the one case (a)-(c)
+        # miss; the opt-in (d) gh signal catches it. The branch is genuinely
+        # active offline (1 commit ahead, no gone upstream), so only gh flags.
+        self._add_worktree("wt_gh", "feat-gh", extra_commit=True)
+        bindir = self._write_fake_gh("feat-gh")
+        env = {
+            **os.environ,
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "BIDMATE_WORKTREE_HYGIENE_GH": "1",
+        }
+        r = self._run_hook(env=env)
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("feat-gh", r.stderr)
+        self.assertIn("wt_gh", r.stderr)
+
+    def test_gh_signal_is_off_by_default(self) -> None:
+        # Same setup, fake gh on PATH reports MERGED — but without the opt-in
+        # env the offline-active branch stays quiet (pushes stay offline/fast).
+        self._add_worktree("wt_gh", "feat-gh", extra_commit=True)
+        bindir = self._write_fake_gh("feat-gh")
+        env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}"}
+        r = self._run_hook(env=env)
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertEqual("", r.stderr.strip(), r.stderr)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1163

`_pre-push-worktree-hygiene.sh` (#1096) decided "merged" via `git branch --merged main`, which lists only branches whose **tip is an ancestor** of `main`. A squash-merge (`gh pr merge --squash` — this repo's documented default in [`docs/operations/auto-ship.md`](../blob/main/docs/operations/auto-ship.md)) lands a brand-new single commit on `main`, so the original feature-branch tip is **not** an ancestor and the worktree was **never** flagged. The hook's stated purpose — surface "merged but never-removed" worktrees, the root cause of the recurring "동시 worktree → ADR 번호 충돌" failure mode it cites in its own header — was therefore defeated on the dominant workflow; it only caught rare non-squash true-merges. Found by adversarial review of commit 879eb7e (#1096).

The fix decides "merged" per branch with **offline-first** signals (every push stays offline/fast, like the sibling pre-push sub-hooks), soft-warn + never-auto-remove preserved:

- **(a) ancestor** of `main` — existing fast-forward / merge-commit case.
- **(b) patch-equivalence** via `git cherry main <branch>` (no `+` line ⇒ every commit since the fork point is already applied) — catches the single-commit squash-merge.
- **(c) `[gone]` upstream** (`git for-each-ref --format='%(upstream:track)'`) — catches the documented `--delete-branch` incident (`'main' already used by worktree`, PR state MERGED) after a prune.
- **(d) opt-in `gh pr view <branch> --json state` MERGED** — gated behind `BIDMATE_WORKTREE_HYGIENE_GH=1` (requires `gh`). Authoritative for a multi-commit branch squash-merged with a live upstream — the only case (a)–(c) miss. **Off by default** so pushes never make a per-worktree network call.

## 2. 영향 파일

- `.githooks/_pre-push-worktree-hygiene.sh` — detection rewrite (not load-bearing).
- `tests/test_hook_pre_push_worktree_hygiene.py` — +4 regression scenarios (not load-bearing).

Neither path is in `scripts/_governance.py` `LOAD_BEARING_PATHS`.

## 3. 리스크

Most likely break path: **false positives** (flagging an active worktree as orphan). Mitigations verified:
- Soft-warn only (`exit 0` always) + never auto-removes — a false positive costs the dev one ignorable line, never lost work. The header already documents un-pushed work as the reason it never removes.
- Signal (b) is guarded on `git cherry` *succeeding* (a bad ref never flags) and requires a non-`+` result; a branch with any un-applied commit shows `+` and stays quiet.
- Signal (d) is off unless explicitly opted in.
- Validated live in this 39-worktree repo: the hook now flags 26 genuinely squash-merged worktrees the old logic missed, while leaving active branches (`fix/issue-1146`, `fix/issue-1161`, `fix/issue-1129`, …) quiet and self-excluding the pushing worktree.

## 4. 테스트

`tests/test_hook_pre_push_worktree_hygiene.py` — 4 existing + 4 new scenarios, all green (8/8; the two-suite verification command runs 12/12):
- **squash-merged worktree is flagged** — the core regression. The previously-uncovered case; asserts the squash tip is genuinely non-ancestor (so it can't silently degrade to the old ancestor-only path), then asserts the hook warns. Fails against the old `git branch --merged` logic, passes now.
- **gone-upstream worktree is flagged** — bare-remote setup, push+delete+prune to produce a real `[gone]` upstream.
- **gh PR MERGED + opt-in** — stub `gh` on PATH, asserts an offline-active branch is flagged only via (d).
- **gh signal off by default** — same stub, no env var ⇒ stays quiet (pins the offline-default contract).

Verification: `python -m pytest tests/test_hook_pre_push_worktree_hygiene.py tests/test_hook_pre_push_test_coverage.py` → 12 passed.

## 5. Eval 영향

All `·` — `.githooks/` + `tests/` only, no RAG retrieval/verifier/answer/eval path touched.

### 5b. Real-data delta

N/A — `.githooks/` is not a load-bearing path (`scripts/_governance.py` `LOAD_BEARING_PATHS`). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

Soft-warn contract preserved: always `exit 0`, warning on stderr only, never auto-removes. New `BIDMATE_WORKTREE_HYGIENE_GH` env var is opt-in (unset ⇒ no network, no new behavior beyond the offline detections). No CLI flag, answer-schema (ADR 0003), or doc-link breakage. The standalone-runnable contract (`bash .githooks/_pre-push-worktree-hygiene.sh`) is unchanged.

## 7. 범위 외

- The 26 stale worktrees the hook now reveals are **not** removed here — soft-warn surfaces them; the operator decides (intentional, per the never-auto-remove invariant).
- `scripts/test.sh` has a pre-existing macOS bash 3.2 portability bug (`SPLIT_FLAGS[@]: unbound variable` under `set -u` on empty arrays) — out of scope for this PR; the suite was run directly via `pytest` to verify.