### PR TITLE
fix(docs): validate markdown #fragment anchors; repair i18n-broken links

### DIFF
--- a/docs/agentic/agentic-definition.md
+++ b/docs/agentic/agentic-definition.md
@@ -83,4 +83,4 @@ BidMate-DocAgent의 "agentic"은 **metadata filter를 단계적으로 완화하�
 
 - 파이프라인 실행 흐름: [`rag_core.py`](../../rag_core.py) `run_rag_query` → `_phase_retrieve_loop`
 - LangGraph Stage 1 case study: [`docs/agentic/agent-system-design-case-study.md`](./agent-system-design-case-study.md)
-- 아키텍처 다이어그램: [`README.md § 아키텍처`](../README.md#아키텍처-요약)
+- 아키텍처 다이어그램: [`README.md § 아키텍처`](../../README.md#아키텍처-요약)

--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -132,6 +132,8 @@ Stage 5 는 disarm 후 `git worktree remove --force <path>` 를 호출한다.
 방지한다. 실패는 non-blocking — 경고가 로깅되고 호출자가 수동으로
 정리해야 한다(`git worktree prune`).
 
+<a id="stacked-pr-discipline-tier-7"></a>
+
 ## Stacked-PR 규율 (tier 7)
 
 [`CLAUDE.md`](../../CLAUDE.md) 의 "one PR, one concern" 규칙은 브랜치의

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -184,6 +184,8 @@ Railway 의 도메인 생성기는
 `bidmate-docagent-demo.up.railway.app` 같은 URL 을 만든다. 포트폴리오
 링크용으로 커스텀 서브도메인을 고정하라.
 
+<a id="recording-the-demo-video"></a>
+
 ## 데모 비디오 녹화
 
 *코드 리뷰* 와 *제품 현실* 사이의 간극을 메우는 2–3분

--- a/docs/rag-challenges-solved.md
+++ b/docs/rag-challenges-solved.md
@@ -142,6 +142,6 @@ Public synthetic eval (n=100): Abstention Accuracy **1.000** (naive_baseline 0.2
 | Groundedness | 0.714 ± 0.14 | 0.929 ± 0.07 | +21.5pp |
 | Latency p95 | 7.5ms | 4.4ms | −3.1ms (−41%) |
 
-각 개선은 독립 ablation row 로 검증되어 어느 컴포넌트가 무슨 효과를 냈는지 추적 가능하다 ([ablation 상세](../README.md#ablation-breakdown)).
+각 개선은 독립 ablation row 로 검증되어 어느 컴포넌트가 무슨 효과를 냈는지 추적 가능하다 ([ablation 상세](../README.md#ablation-comparison)).
 
 > **주**: 상세 ablation breakdown 과 n=42→n=100 CI 수축 히스토리는 [docs/performance-evolution.md](performance-evolution.md) 를 참조.

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -20,13 +20,19 @@ Scope (deliberately narrow to keep false positives near zero):
   - Sources: all tracked `*.md` EXCEPT under `.claude/` (agent/skill
     definitions legitimately carry placeholder/example links).
   - Targets: any repo path, resolved relative to the SOURCE file's dir.
-  - Checked: inline `[text](path)` links to a real file, and prose
-    `ADR NNNN` references to a real `docs/adr/NNNN-*.md`.
-  - NOT checked: external URLs (network dependency), same-file `#anchor`
-    fragments (anchor validation deferred — the recurrence is file-level),
-    site-absolute `/...` and directory-style Jekyll permalinks (the docs
-    render via `permalink: pretty`, so `[x](../foo/)` is a valid page link
-    that has no filesystem target).
+  - Checked: inline `[text](path)` links to a real file; prose
+    `ADR NNNN` references to a real `docs/adr/NNNN-*.md`; and `#fragment`
+    anchors — both same-file `[x](#frag)` and cross-file `[x](other.md#frag)`
+    — against the target `.md`'s heading slugs (GitHub `github-slugger`
+    rules) plus explicit `<a id=…>`/`<a name=…>`/`{#id}` anchors. Fragment
+    validation was added after issue #1152: Korean-izing a heading changes
+    its auto-generated slug, silently breaking inbound `#old-english-anchor`
+    links that a file-existence-only check cannot see.
+  - NOT checked: external URLs (network dependency), site-absolute `/...`
+    and directory-style Jekyll permalinks (the docs render via
+    `permalink: pretty`, so `[x](../foo/)` is a valid page link that has no
+    filesystem target), and `#fragment`s on non-`.md` targets (e.g. a
+    `foo.py#L10` GitHub line anchor — we only enumerate markdown anchors).
 
 Zero runtime dependencies (Python stdlib + `git ls-files`).
 
@@ -76,6 +82,202 @@ _KNOWN_EXT_RE = re.compile(
 
 # Tracked-file source set excludes these prefixes (see module docstring).
 _EXCLUDED_SOURCE_PREFIXES = (".claude/",)
+
+
+# ---------------------------------------------------------------------------
+# Fragment-anchor validation (issue #1152)
+# ---------------------------------------------------------------------------
+
+# GitHub's heading→anchor algorithm (the `github-slugger` package its markdown
+# renderer uses): lowercase, drop this fixed punctuation set, then turn every
+# whitespace char into a hyphen. The two unicode ranges (general + supplemental
+# punctuation) drop the em-/en-dash etc. Hyphen `-` and underscore `_` are
+# DELIBERATELY absent from the set — GitHub keeps them in slugs.
+_SLUG_STRIP_RE = re.compile(
+    "[\\u2000-\\u206f\\u2e00-\\u2e7f"          # general + supplemental punctuation
+    "\\\\'!\"#$%&()*+,./:;<=>?@\\[\\]^`{|}~]"  # ASCII punctuation (keeps - and _)
+)
+
+# ATX heading line: 1–6 leading `#` then a space. Captures the text, dropping
+# an optional trailing run of `#`. Setext (`===`/`---` underline) headings are
+# not handled — the repo uses ATX exclusively and `---` collides with both the
+# YAML front-matter delimiter and a thematic break.
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.*?)\s*#*\s*$")
+
+# Inline link inside a heading, reduced to its visible text for slugging:
+# `## see [foo](x.md)` → GitHub slugs the rendered text "see foo".
+_HEADING_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+
+# Explicit anchors that GitHub/Jekyll honor in addition to heading slugs.
+# `{#id}` is kramdown-only (GitHub ignores it) but is treated as VALID anyway:
+# an extra anchor can only suppress a false positive, never create one.
+_HTML_ANCHOR_RE = re.compile(
+    r"""<a\s+(?:id|name)\s*=\s*["']([^"']+)["']""", re.IGNORECASE
+)
+_KRAMDOWN_ANCHOR_RE = re.compile(r"\{#([\w-]+)\}")
+
+# Only markdown targets have an enumerable anchor set.
+_MD_TARGET_RE = re.compile(r"\.(?:md|markdown)$", re.IGNORECASE)
+
+
+def slugify_heading(text: str) -> str:
+    """Return the GitHub anchor slug for a heading.
+
+    Mirrors `github-slugger`. Accepts either a raw heading line (`## Title`)
+    or already-extracted heading text (`Title`); a leading `#{1,6} ` run is
+    stripped when present. Inline links are reduced to their visible text
+    before slugging.
+    """
+    m = _HEADING_RE.match(text)
+    if m:
+        text = m.group(1)
+    text = _HEADING_LINK_RE.sub(r"\1", text)
+    s = _SLUG_STRIP_RE.sub("", text.strip().lower())
+    return re.sub(r"\s", "-", s)
+
+
+def _iter_heading_lines(text: str):
+    """Yield ATX heading lines, skipping regions that produce no GitHub anchor:
+    leading YAML front-matter, fenced code blocks, and HTML comment blocks.
+    """
+    lines = text.splitlines()
+    n = len(lines)
+    i = 0
+    # Leading YAML front-matter: only when the very first line is exactly `---`.
+    if n and lines[0].strip() == "---":
+        i = 1
+        while i < n and lines[i].strip() != "---":
+            i += 1
+        i += 1  # consume the closing `---`
+    in_fence = False
+    fence_char = ""
+    in_comment = False
+    while i < n:
+        line = lines[i]
+        i += 1
+        if in_comment:
+            if "-->" in line:
+                in_comment = False
+            continue
+        fence = re.match(r"\s*(`{3,}|~{3,})", line)
+        if not in_fence and fence:
+            in_fence = True
+            fence_char = fence.group(1)[0]
+            continue
+        if in_fence:
+            if fence and fence.group(1)[0] == fence_char:
+                in_fence = False
+            continue
+        stripped = line.strip()
+        if stripped.startswith("<!--"):
+            if "-->" not in stripped:
+                in_comment = True
+            continue
+        if _HEADING_RE.match(line):
+            yield line
+
+
+def collect_anchors(text: str) -> set[str]:
+    """Return the set of valid lowercase fragment targets in a markdown doc:
+    every heading's slug (with GitHub's per-document `-1`/`-2`… duplicate
+    suffixing) plus explicit `<a id=…>`/`<a name=…>`/`{#id}` anchors.
+    """
+    anchors: set[str] = set()
+    for m in _HTML_ANCHOR_RE.finditer(text):
+        anchors.add(m.group(1).strip().lower())
+    for m in _KRAMDOWN_ANCHOR_RE.finditer(text):
+        anchors.add(m.group(1).strip().lower())
+    counts: dict[str, int] = {}
+    for line in _iter_heading_lines(text):
+        slug = slugify_heading(line)
+        seen = counts.get(slug, 0)
+        anchors.add(slug if seen == 0 else f"{slug}-{seen}")
+        counts[slug] = seen + 1
+    return anchors
+
+
+def split_fragment(raw: str) -> tuple[str, str] | None:
+    """Parse an inline href into ``(path_without_fragment, fragment)`` when the
+    link carries a checkable `#fragment`, else None.
+
+    Returns ``("", frag)`` for a same-file `#frag` link. Returns None for:
+    links with no `#`, external/protocol-relative/site-absolute links, an
+    empty fragment, and cross-file links whose target is not a `.md`/`.markdown`
+    file (only markdown anchors are enumerable). Mirrors `normalize_target`'s
+    angle-bracket and trailing-``"title"`` stripping, but — unlike it — KEEPS
+    the fragment, which is the whole point.
+    """
+    t = raw.strip()
+    if t.startswith("<") and t.endswith(">"):
+        t = t[1:-1].strip()
+    t = re.sub(r"""\s+["'].*$""", "", t).strip()
+    if "#" not in t:
+        return None
+    if _EXTERNAL_RE.match(t) or t.startswith("//") or t.startswith("/"):
+        return None
+    path_part, frag = t.split("#", 1)
+    frag = frag.strip()
+    if not frag:
+        return None
+    if path_part == "":
+        return ("", frag)
+    path_part = re.sub(r":\d+(?:-\d+)?$", "", path_part)  # drop `path:line`
+    final_segment = path_part.rstrip("/").rsplit("/", 1)[-1]
+    if not _MD_TARGET_RE.search(final_segment):
+        return None
+    return (path_part, frag)
+
+
+def find_broken_fragments(
+    md_files: list[str],
+    repo_root: str | Path = ".",
+) -> list[tuple[str, str, str]]:
+    """Return ``[(source, raw_href, fragment), ...]`` for links whose `#anchor`
+    has no matching heading slug / explicit anchor in the target markdown file.
+
+    A missing TARGET FILE is intentionally NOT reported here — that is
+    `find_broken_links`' job; this check stays silent so a single broken link
+    does not double-report. Anchor sets are computed once per target file.
+    """
+    root = Path(repo_root)
+    anchor_cache: dict[str, set[str] | None] = {}
+
+    def anchors_for(relpath: str) -> set[str] | None:
+        if relpath not in anchor_cache:
+            try:
+                body = (root / relpath).read_text(
+                    encoding="utf-8", errors="replace"
+                )
+            except OSError:
+                anchor_cache[relpath] = None
+            else:
+                anchor_cache[relpath] = collect_anchors(body)
+        return anchor_cache[relpath]
+
+    broken: list[tuple[str, str, str]] = []
+    for src in md_files:
+        try:
+            text = (root / src).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        src_dir = os.path.dirname(src)
+        for href in extract_links(strip_code_spans(text)):
+            parsed = split_fragment(href)
+            if parsed is None:
+                continue
+            path_part, frag = parsed
+            if path_part == "":
+                target = src
+            else:
+                target = os.path.normpath(os.path.join(src_dir, path_part))
+                if not (root / target).exists():
+                    continue  # missing file → reported by find_broken_links
+            anchors = anchors_for(target)
+            if anchors is None:
+                continue
+            if frag.lower() not in anchors:
+                broken.append((src, href, frag))
+    return broken
 
 
 def _err(msg: str) -> None:
@@ -284,9 +486,29 @@ def _report_broken_adr_refs(broken: list[tuple[str, str]]) -> None:
     )
 
 
+def _report_broken_fragments(broken: list[tuple[str, str, str]]) -> None:
+    _err(
+        f"\n❌ Markdown fragment-anchor check failed (issue #1152): "
+        f"{len(broken)} link(s) point to a #anchor that does not exist.\n"
+    )
+    for src, href, frag in broken:
+        _err(f"     {src}\n         [{href}]  →  no heading/anchor '#{frag}'\n")
+    _err(
+        "\n   The target file exists but has no heading whose GitHub slug is\n"
+        "   this #fragment (and no explicit <a id=…>/<a name=…>/{#id} anchor).\n"
+        "   The usual cause is a renamed/translated heading whose old\n"
+        "   #english-anchor is still linked (issue #1152). Fix: point the\n"
+        "   #fragment at the new slug, or add a stable `<a id=\"old-anchor\">"
+        "</a>`\n"
+        "   on its own line before the heading to keep external links alive.\n"
+        "   Run locally: make check-doc-links\n\n"
+    )
+
+
 def _run(
     check_links: bool,
     check_adr: bool,
+    check_fragments: bool,
     paths: list[str] | None,
     repo_root: str | Path,
     allow_forward: bool,
@@ -303,9 +525,25 @@ def _run(
         if dead:
             _report_broken_adr_refs(dead)
             rc = 1
+    if check_fragments:
+        bad_frags = find_broken_fragments(md_files, repo_root)
+        if bad_frags:
+            _report_broken_fragments(bad_frags)
+            rc = 1
     if rc == 0:
-        scope = "links + ADR refs" if (check_links and check_adr) else (
-            "links" if check_links else "ADR refs"
+        scopes = [
+            name
+            for name, on in (
+                ("links", check_links),
+                ("ADR refs", check_adr),
+                ("fragments", check_fragments),
+            )
+            if on
+        ]
+        scope = (
+            " + ".join(scopes[:-1]) + " + " + scopes[-1]
+            if len(scopes) > 1
+            else scopes[0]
         )
         sys.stdout.write(
             f"OK: {len(md_files)} markdown file(s) scanned; no broken {scope}.\n"
@@ -327,8 +565,13 @@ def main() -> int:
         help="Check prose `ADR NNNN` references resolve to a real ADR file.",
     )
     g.add_argument(
+        "--check-fragments", action="store_true",
+        help="Check `#anchor` fragments resolve to a heading slug / explicit "
+             "anchor in the target `.md` (issue #1152).",
+    )
+    g.add_argument(
         "--check-all", action="store_true",
-        help="Run both checks (used by the pre-commit hook + Makefile).",
+        help="Run all checks (used by the pre-commit hook + Makefile).",
     )
     p.add_argument(
         "--paths", nargs="*", default=None, metavar="MD_FILE",
@@ -348,9 +591,11 @@ def main() -> int:
 
     check_links = args.check_links or args.check_all
     check_adr = args.check_adr_refs or args.check_all
+    check_fragments = args.check_fragments or args.check_all
     return _run(
         check_links,
         check_adr,
+        check_fragments,
         args.paths,
         args.repo_root,
         allow_forward=not args.no_allow_forward_adr,

--- a/tests/test_doc_links.py
+++ b/tests/test_doc_links.py
@@ -157,6 +157,159 @@ def test_adr_refs_forward_reference_tolerated_by_default(tmp_path: Path) -> None
     assert strict == [("docs/note.md", "0060")]
 
 
+# ---- fragment anchors: slugify_heading (GitHub github-slugger rules) --------
+
+
+@pytest.mark.parametrize(
+    "heading,slug",
+    [
+        # The incident: a Korean-ized heading produces a Korean slug, so the
+        # old English #anchor no longer resolves (issue #1152).
+        ("## 데모 비디오 녹화", "데모-비디오-녹화"),
+        # em-dash (U+2014) is dropped; the spaces around it survive → "--".
+        (
+            "## 핵심 기술 기여 — comparison-aware balanced top-k",
+            "핵심-기술-기여--comparison-aware-balanced-top-k",
+        ),
+        # "&" dropped, surrounding spaces survive → double hyphen.
+        ("Milestones & 이슈 lifecycle", "milestones--이슈-lifecycle"),
+        # parentheses + the period in "4.12" are dropped.
+        ("### C5 인용 불일치(약한 근거) 빈도 4.12", "c5-인용-불일치약한-근거-빈도-412"),
+        # backticks dropped; underscore is KEPT (not in the strip set).
+        ("## Hard caps (`react_loop` 강제)", "hard-caps-react_loop-강제"),
+        # a trailing run of `#` (closed ATX heading) is stripped.
+        ("## Title ##", "title"),
+        # already-extracted text (no leading `#`) is accepted too.
+        ("already text only", "already-text-only"),
+    ],
+)
+def test_slugify_heading_matches_github(heading: str, slug: str) -> None:
+    assert cdl.slugify_heading(heading) == slug
+
+
+# ---- fragment anchors: collect_anchors -------------------------------------
+
+
+def test_collect_anchors_dedup_explicit_and_skips() -> None:
+    text = (
+        "---\n"
+        "title: front matter\n"
+        "## Heading in front matter is ignored\n"
+        "---\n"
+        "# Top\n"
+        '<a id="Stable-Anchor"></a>\n'
+        "## Result\n"
+        "## Result\n"  # duplicate → result, result-1 (GitHub -N suffixing)
+        '<a name="named"></a>\n'
+        "Custom heading {#custom-id}\n"
+        "```\n"
+        "## fenced heading ignored\n"
+        "```\n"
+        "<!--\n"
+        "## commented heading ignored\n"
+        "-->\n"
+    )
+    anchors = cdl.collect_anchors(text)
+    assert "top" in anchors
+    assert "result" in anchors and "result-1" in anchors  # duplicate suffix
+    assert "stable-anchor" in anchors  # <a id> harvested + lowercased
+    assert "named" in anchors  # <a name> harvested
+    assert "custom-id" in anchors  # kramdown {#id} harvested
+    # Headings in front matter / fenced code / HTML comments emit no anchor.
+    assert "heading-in-front-matter-is-ignored" not in anchors
+    assert "fenced-heading-ignored" not in anchors
+    assert "commented-heading-ignored" not in anchors
+
+
+# ---- fragment anchors: split_fragment --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "href",
+    [
+        "../foo.md",  # no fragment at all
+        "https://x.com#frag",  # external
+        "/site/abs.md#frag",  # site-absolute
+        "../code.py#L10",  # non-markdown target (anchors not enumerable)
+        "../dir/#frag",  # directory-style permalink
+        "../foo.md#",  # empty fragment
+    ],
+)
+def test_split_fragment_skips(href: str) -> None:
+    assert cdl.split_fragment(href) is None
+
+
+@pytest.mark.parametrize(
+    "href,expected",
+    [
+        ("#same-file", ("", "same-file")),
+        ("../foo.md#section", ("../foo.md", "section")),
+        ("../foo.md:120#section", ("../foo.md", "section")),  # path:line dropped
+        ("<../foo.md#section>", ("../foo.md", "section")),  # angle brackets
+        ('../foo.md#section "Title"', ("../foo.md", "section")),  # link title
+    ],
+)
+def test_split_fragment_parses(href: str, expected: tuple[str, str]) -> None:
+    assert cdl.split_fragment(href) == expected
+
+
+# ---- fragment anchors: find_broken_fragments (tmp tree) --------------------
+
+
+def test_find_broken_fragments_incident_korean_heading(tmp_path: Path) -> None:
+    # Exactly the #1152 regression: heading translated, inbound link still
+    # points at the dropped English slug.
+    _write(tmp_path / "target.md", "# 데모 비디오 녹화\n")
+    _write(
+        tmp_path / "docs" / "src.md",
+        "[walkthrough](../target.md#recording-the-demo-video)\n",
+    )
+    broken = cdl.find_broken_fragments(["docs/src.md", "target.md"], tmp_path)
+    assert broken == [
+        (
+            "docs/src.md",
+            "../target.md#recording-the-demo-video",
+            "recording-the-demo-video",
+        )
+    ]
+
+
+def test_find_broken_fragments_stable_anchor_fixes_it(tmp_path: Path) -> None:
+    # The recommended fix: a stable <a id> before the heading keeps the old
+    # English anchor alive alongside the Korean title.
+    _write(
+        tmp_path / "target.md",
+        '<a id="recording-the-demo-video"></a>\n\n# 데모 비디오 녹화\n',
+    )
+    _write(
+        tmp_path / "docs" / "src.md",
+        "[walkthrough](../target.md#recording-the-demo-video)\n",
+    )
+    assert cdl.find_broken_fragments(["docs/src.md", "target.md"], tmp_path) == []
+
+
+def test_find_broken_fragments_same_file(tmp_path: Path) -> None:
+    _write(tmp_path / "doc.md", "[up](#stable) and [bad](#missing)\n\n## Stable\n")
+    broken = cdl.find_broken_fragments(["doc.md"], tmp_path)
+    assert broken == [("doc.md", "#missing", "missing")]
+
+
+def test_find_broken_fragments_valid_anchor_and_no_false_positives(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "target.md", "# 아키텍처 요약\n")
+    _write(tmp_path / "code.py", "x = 1\n")
+    _write(
+        tmp_path / "docs" / "src.md",
+        "[ok](../target.md#아키텍처-요약)\n"  # valid Korean anchor
+        "[ext](https://x.com#frag)\n"  # external — skipped
+        "[code](../code.py#L1)\n"  # non-md target — skipped
+        "[gone](../nope.md#frag)\n"  # missing FILE — find_broken_links' job
+        "[dir](../somedir/#frag)\n",  # directory permalink — skipped
+    )
+    assert cdl.find_broken_fragments(["docs/src.md"], tmp_path) == []
+
+
 # ---- CLI wrapper -----------------------------------------------------------
 
 
@@ -190,6 +343,35 @@ def test_cli_fails_with_actionable_message(tmp_path: Path) -> None:
     assert "missing.md" in result.stderr
 
 
+def test_cli_check_fragments_reds_on_broken_anchor(tmp_path: Path) -> None:
+    _write(tmp_path / "target.md", "# 데모 비디오 녹화\n")
+    _write(
+        tmp_path / "docs" / "src.md",
+        "[x](../target.md#recording-the-demo-video)\n",
+    )
+    result = _run_cli(
+        "--check-fragments", "--repo-root", str(tmp_path),
+        "--paths", "docs/src.md", "target.md",
+    )
+    assert result.returncode == 1
+    # Losing the issue ref or the offending fragment is a regression.
+    assert "issue #1152" in result.stderr
+    assert "recording-the-demo-video" in result.stderr
+
+
+def test_cli_check_all_includes_fragment_check(tmp_path: Path) -> None:
+    # --check-all must run fragments too, else the pre-commit hook + Makefile
+    # silently stop catching #1152-style breakage.
+    _write(tmp_path / "target.md", "# 한국어 제목\n")
+    _write(tmp_path / "docs" / "src.md", "[x](../target.md#english-anchor)\n")
+    result = _run_cli(
+        "--check-all", "--repo-root", str(tmp_path),
+        "--paths", "docs/src.md", "target.md",
+    )
+    assert result.returncode == 1
+    assert "fragment" in result.stderr.lower()
+
+
 # ---- real-repo sentinels (the canonical CI gate) ---------------------------
 
 
@@ -206,6 +388,19 @@ def test_repo_has_no_dead_adr_refs_today() -> None:
     dead = cdl.find_broken_adr_refs(files, ROOT_DIR)
     assert dead == [], "Dead prose ADR references on this tree:\n  - " + "\n  - ".join(
         f"{src}: ADR {num}" for src, num in dead
+    )
+
+
+def test_repo_has_no_broken_fragments_today() -> None:
+    """The sentinel that would have caught #1112's Korean-ization regression:
+    every inbound `#anchor` must resolve to a heading slug / explicit anchor in
+    its target `.md`. Near-zero-false-positive by construction — only `.md`
+    targets that exist are checked; missing files are find_broken_links' job.
+    """
+    files = cdl.tracked_markdown_files(ROOT_DIR)
+    broken = cdl.find_broken_fragments(files, ROOT_DIR)
+    assert broken == [], "Broken #fragment anchors on this tree:\n  - " + "\n  - ".join(
+        f"{src}: [{href}] -> #{frag}" for src, href, frag in broken
     )
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

한국어화 PR #1112 가 헤딩을 영어→한국어로 번역하면서 GitHub 자동 생성 anchor slug 가 바뀌어, 옛 영어 `#anchor` 를 가리키던 inbound 링크가 조용히 죽었다. `scripts/check_doc_links.py` 는 링크 대상 **파일 존재**만 검사하고 `#fragment` 는 버려서(`normalize_target` 의 `t.split("#",1)[0]`) 이 회귀가 CI 게이트를 통과했다. 전수 audit 으로 찾은 깨진 inbound 링크 4건을 고치고, 재발 방지로 fragment 검증을 추가한다.

Closes #1152

## 2. 영향 파일

- `scripts/check_doc_links.py` — fragment 검증 추가 (`--check-fragments` 모드 + `--check-all` 포함). github-slugger 규칙 slug + 명시 `<a id>`/`<a name>`/`{#id}` 앵커. **load-bearing 아님**
- `tests/test_doc_links.py` — slug/anchor/split/find 단위 + CLI + real-repo sentinel 회귀 테스트 (+28)
- `docs/operations/deployment.md` — `## 데모 비디오 녹화` 앞 `<a id="recording-the-demo-video">` 안정 앵커
- `docs/operations/auto-ship.md` — `## Stacked-PR 규율 (tier 7)` 앞 `<a id="stacked-pr-discipline-tier-7">` 안정 앵커
- `docs/agentic/agentic-definition.md` — `../README.md` → `../../README.md` (depth 버그; docs/ stub 가 아닌 root README §아키텍처)
- `docs/rag-challenges-solved.md` — `#ablation-breakdown` → `#ablation-comparison`

위 모든 파일은 load-bearing path 아님 (`scripts/_governance.py` `LOAD_BEARING_PATHS` 기준; `docs/adr/` 미포함).

## 3. 리스크

가장 가능성 높은 깨짐 = slug 알고리즘이 GitHub 과 어긋나 **false positive** (멀쩡한 링크를 깨졌다고 막음). 배제 확인:
- github-slugger 정확 사양으로 구현 (strip set ` -⁯⸀-⹿` + ASCII 구두점, `-`/`_` 보존; space→hyphen). 명시적 `\uXXXX` escape 로 invisible-char fragility 제거.
- 전체 트리 159 파일 audit → em-dash 이중하이픈, `&`, 괄호/마침표, underscore 보존, 중복 헤딩 `-N` suffix, 한국어 slug 모든 working anchor 에서 false positive 0, 알려진 깨짐만 정확히 탐지.
- 대상 파일이 없으면(missing FILE) fragment 검증은 침묵 — 기존 link 검사 책임(이중 보고 방지). `.md` 대상만 검사. fenced code/HTML 주석/YAML front-matter 헤딩은 phantom 앵커로 안 셈.

## 4. 테스트

Behavior change → 변경 전 fail / 후 pass 회귀 테스트 추가:
- `test_find_broken_fragments_incident_korean_heading` — 이번 인시던트 정확 재현(한국어 헤딩이 영어 slug 드롭 → 깨짐 탐지)
- `test_find_broken_fragments_stable_anchor_fixes_it` — `<a id>` 수정이 살리는지
- `test_repo_has_no_broken_fragments_today` — **#1112 를 잡았을 새 real-repo sentinel** (pr-eval.yml 전체 pytest 에서 hard-fail)
- slug(7 케이스)/collect_anchors(중복·명시·skip)/split_fragment(skip vs keep)/same-file/CLI(`--check-fragments` reds, `--check-all` 포함) 단위
- `pytest tests/test_doc_links.py` = **53 passed**. ruff clean. `--check-all` 159 파일 0 broken.

## 5. Eval 영향

All `·` — RAG 검색/검증/답변 path 미변경, doc-link lint + 문서만.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 — 변경 파일 중 load-bearing path 없음 (lint 스크립트 + 테스트 + 문서). real-eval delta N/A.

## 6. 하위 호환

깨짐 없음. `--check-fragments` 는 신규 additive 플래그. `--check-all` 이 이제 fragment 도 검사(더 엄격해지지만 기존 계약 불변 — 트리는 이미 통과). `normalize_target` 계약·기존 `--check-links`/`--check-adr-refs` 동작 불변(테스트 line 57 그대로). 답변 계약(ADR 0003) 무관 → `schema_version` bump 불필요.

## 7. 범위 외

같은 i18n 회귀 계열의 **'ADR 0058 verifies-key broken'** 은 별도 surface(governance `## Verifies` 메타데이터 vs markdown 링크 fragment)라 분리 — `_governance.py` 관할이며 이 PR 의 fragment 게이트와 코드 겹침 없음. 별도 PR 로 처리. (CLAUDE.md "one PR, one concern")