### PR TITLE
fix(governance): make cross-worktree ADR-collision hook reliable

### DIFF
--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -95,6 +95,7 @@ KNOWN_HOOKS: set[str] = {
     "loadbearing",
     "memory-lines",
     "adr-template",
+    "adr-collision",
     "plan-slug-race",
     "delegation-gate",
     "stop-ship",

--- a/scripts/analyze_hook_outcomes.py
+++ b/scripts/analyze_hook_outcomes.py
@@ -212,7 +212,7 @@ def filter_window(events: list[dict], window: str) -> list[dict]:
 # Canonical hook inventory — matches scripts/claude-hooks/README.md table.
 ALL_HOOKS = [
     "bash-guard", "loadbearing", "memory-lines",
-    "adr-template", "plan-slug-race",
+    "adr-template", "adr-collision", "plan-slug-race",
     "delegation-gate", "stop-ship",
 ]
 

--- a/scripts/claude-hooks/README.md
+++ b/scripts/claude-hooks/README.md
@@ -22,6 +22,7 @@ Claude Code 의 PreToolUse / Stop / UserPromptSubmit 훅 모음. `.claude/settin
 |---|---|---|---|
 | [`plan-slug-race.sh`](./plan-slug-race.sh) | block | `Write` | `~/.claude/plans/<slug>.md` 5-min 내 cross-worktree race 차단 (issue #779) |
 | [`pretooluse-adr-template.sh`](./pretooluse-adr-template.sh) | block | `Edit\|MultiEdit\|Write` | 신규 ADR 의 Verification section + verifies-key marker 누락 차단 (issue #826/#866) |
+| [`pretooluse-adr-collision.sh`](./pretooluse-adr-collision.sh) | block | `Edit\|MultiEdit\|Write` | 신규 ADR 의 NNNN 번호가 다른 worktree 의 open PR (title **또는** head branch) 에 이미 예약돼 있으면 Write 차단 (cross-worktree collision; ADR 0063, issue #1069/#1155) |
 | [`pretooluse-bash-guard.sh`](./pretooluse-bash-guard.sh) | block | `Bash` | (1) stacked-dependent 있을 때 `gh pr merge --delete-branch` 차단, (2) `gh pr create` 시 stacked-base mismatch 차단 (PR #423→#431, #470 incident) |
 | [`pretooluse-loadbearing.sh`](./pretooluse-loadbearing.sh) | awareness | `Edit\|MultiEdit\|Write` | load-bearing 파일 편집 시 ADR / PR §5b 영향 환기 (CLAUDE.md) |
 | [`pretooluse-memory-lines.sh`](./pretooluse-memory-lines.sh) | graduated | `Edit\|MultiEdit\|Write` | MEMORY.md 라인 수 ≥AWARE 경고 / ≥BLOCK 차단 (issue #720) |

--- a/scripts/claude-hooks/pretooluse-adr-collision.sh
+++ b/scripts/claude-hooks/pretooluse-adr-collision.sh
@@ -2,6 +2,12 @@
 # Claude Code PreToolUse hook for BidMate-DocAgent — cross-worktree ADR
 # number collision guard.
 #
+# Enforcement: block — exit 2 refuses the Write when <NNNN> collides with a
+#   named open PR; exit 0 (fail-open) on every uncertainty (gh absent, network
+#   fail, empty list, parse/import failure).
+# Classification rationale: same family as pretooluse-adr-template (block) — it
+#   refuses a specific Write rather than merely warning.
+#
 # Registered in `.claude/settings.json` with matcher `Edit|MultiEdit|Write`.
 # Fires before Claude writes a *new* `docs/adr/<NNNN>-*.md` and refuses the
 # Write when <NNNN> is already reserved by an OPEN PR on another
@@ -56,16 +62,35 @@ tool_name=$(printf '%s' "$parsed" | sed -n '2p')
 # Gate 1: not a Write — Edit / MultiEdit on existing files are out of scope.
 [[ "$tool_name" != "Write" ]] && exit 0
 
-# Gate 2: not a new-ADR filename. The 4-digit prefix mirrors the established
-# numbering (docs/adr/_template.md is excluded by the [0-9]{4} requirement).
-[[ "$file_path" =~ docs/adr/[0-9]{4}-[a-z0-9-]+\.md$ ]] || exit 0
+# Gate 2a: must live directly under docs/adr/ (mirrors where _governance
+# scans). Cheap string check — the common non-ADR Write path stays
+# subprocess-free.
+adr_dir=$(dirname "$file_path")
+[[ "$adr_dir" == "docs/adr" || "$adr_dir" == */docs/adr ]] || exit 0
 
 # Gate 3: file already exists → edit/rewrite of an existing ADR, grandfathered.
+# Checked before the (heavier) Gate 2b so edits never pay the import.
 [[ -e "$file_path" ]] && exit 0
 
-# Extract the 4-digit number from the basename.
-adr_num=$(basename "$file_path" | grep -oE '^[0-9]{4}')
-[[ -z "$adr_num" ]] && exit 0
+# Gate 2b: basename must match the ADR-filename SSoT — scripts/_governance.py
+# ADR_FILENAME_RE. Reuse over a local copy (CLAUDE.md 새로 만들기보다 재사용):
+# a narrower lowercase-only regex silently skipped mixed-case realN ADRs
+# (e.g. 0048-realN-metrics-extension.md, issue #818). _template.md is excluded
+# by the regex's required 4-digit prefix. Import failure → exit 0 (fail-open;
+# pre-commit is the backstop). Only runs on the rare new-ADR Write path.
+adr_basename=$(basename "$file_path")
+BIDMATE_REPO_ROOT="$REPO_ROOT" ADR_BASENAME="$adr_basename" python3 -c '
+import os, sys
+sys.path.insert(0, os.path.join(os.environ.get("BIDMATE_REPO_ROOT", ""), "scripts"))
+try:
+    from _governance import ADR_FILENAME_RE
+except Exception:
+    sys.exit(1)  # cannot reach the SSoT → fail-open (pre-commit backstop)
+sys.exit(0 if ADR_FILENAME_RE.match(os.environ["ADR_BASENAME"]) else 1)
+' || exit 0
+
+# 4-digit number prefix (Gate 2b's regex guarantees a leading NNNN-).
+adr_num=${adr_basename:0:4}
 
 # Gate 4 (fail-open): gh absent → soft skip. pre-commit is the backstop.
 command -v gh >/dev/null 2>&1 || {
@@ -74,16 +99,20 @@ command -v gh >/dev/null 2>&1 || {
   exit 0
 }
 
-# Query open PRs whose title mentions an ADR. --search widens the net; we
-# re-filter locally by exact number so a loose match can never over-block.
-# `timeout` guards a hung network call when available (GNU coreutils); on
-# systems without it (stock macOS) we fall back to a bare call so the check
-# still runs rather than silently fail-open.
+# List open PRs and re-filter locally on BOTH title and headRefName. We do
+# NOT prefilter with `--search "ADR in:title"`: that drops PRs whose *title*
+# lacks "ADR" even when the head BRANCH reserves the number (e.g.
+# docs/issue-200-adr-0060-foo) — which is exactly the cross-worktree
+# branch-only reservation this hook exists to catch (issue #1155). `--limit`
+# raises gh's default 30-PR cap so a reservation past the 30th open PR is
+# still seen. `timeout` guards a hung network call when available (GNU
+# coreutils); stock macOS lacks it, so we fall back to a bare call rather
+# than silently fail-open.
 if command -v timeout >/dev/null 2>&1; then
-  prs=$(timeout 8 gh pr list --search "ADR in:title" --state open \
+  prs=$(timeout 8 gh pr list --state open --limit 200 \
           --json number,title,headRefName 2>/dev/null || true)
 else
-  prs=$(gh pr list --search "ADR in:title" --state open \
+  prs=$(gh pr list --state open --limit 200 \
           --json number,title,headRefName 2>/dev/null || true)
 fi
 
@@ -93,7 +122,7 @@ fi
 # Parse each PR's reserved ADR number from title + headRefName, zero-pad
 # insensitive. Body is intentionally ignored: bodies cite *other* ADRs
 # constantly ("supersedes 0012") → false positives. Re-filter by exact
-# integer so the loose --search cannot over-block.
+# integer so a loose substring match cannot over-block.
 hit=$(printf '%s' "$prs" | ADR_NUM="$adr_num" python3 -c '
 import json, os, re, sys
 target = int(os.environ["ADR_NUM"])
@@ -119,11 +148,14 @@ for p in prs:
 pr_number=$(printf '%s' "$hit" | cut -f1)
 pr_title=$(printf '%s' "$hit" | cut -f2)
 pr_branch=$(printf '%s' "$hit" | cut -f3)
-adr_basename=$(basename "$file_path")
 
-printf '%s|blocked|adr-collision|%s|open_pr=%s\n' \
-  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$adr_basename" "$pr_number" \
-  >> "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
+# v2-5field telemetry (ADR 0060) via the canonical --emit-fire path: routes
+# through the KNOWN_HOOKS / KNOWN_OUTCOMES typo guard and lands the basename
+# in the <path> slot + open_pr in <extra> — not the wrong-field raw printf.
+python3 "$REPO_ROOT/scripts/_governance.py" --emit-fire \
+  --outcome blocked --hook adr-collision --category cross-worktree-collision \
+  --path "$adr_basename" --extra "open_pr=$pr_number" \
+  --fire-log "$REPO_ROOT/.claude/.hook-fires.log" 2>/dev/null || true
 
 cat >&2 <<EOF
 ⛔ Refusing Write of new ADR \`$adr_basename\`: number $adr_num is already
@@ -138,7 +170,7 @@ cat >&2 <<EOF
    Pick the next free number, then cross-check the open-PR list it
    cannot see:
        python scripts/_governance.py --next-adr-number
-       gh pr list --search "ADR in:title" --state open
+       gh pr list --search "ADR" --state open
    and re-run Write with the renumbered filename + body heading.
 
    Policy: CLAUDE.md \`ADR 번호 사전 예약\` (issue #1069).

--- a/tests/test_hook_pretooluse_adr_collision.py
+++ b/tests/test_hook_pretooluse_adr_collision.py
@@ -11,7 +11,13 @@ Exercises ``scripts/claude-hooks/pretooluse-adr-collision.sh``:
 The hook shells out to ``gh pr list``, which is non-deterministic in CI, so
 a fake ``gh`` is written into a temp ``bin/`` and prepended to PATH. The
 stub touches a marker file so tests can assert the early-exit gates never
-reach the network. The hook is copied into a per-test temp REPO_ROOT so
+reach the network, records its argv so a test can assert the query shape,
+and *simulates GitHub's ``in:title`` search filter* — the load-bearing part
+of the issue #1155 regression: a stub that echoed unconditionally let the
+title-prefilter bug (defect #1) pass unnoticed, because a branch-only
+reservation with no "ADR" in its title was returned anyway. The hook +
+``scripts/_governance.py`` are copied into a per-test temp REPO_ROOT so the
+gate-2b regex import and the ``--emit-fire`` telemetry call resolve, and
 ``.hook-fires.log`` writes stay isolated from the developer's machine.
 """
 from __future__ import annotations
@@ -40,11 +46,16 @@ class TestPreToolUseAdrCollision(unittest.TestCase):
         (self._tmp_repo / "docs" / "adr").mkdir(parents=True)
         (self._tmp_repo / "src").mkdir(parents=True)
         shutil.copy(HOOK, self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name)
+        # Gate 2b imports ADR_FILENAME_RE and the block path calls --emit-fire;
+        # both need _governance.py resolvable under the temp REPO_ROOT.
+        shutil.copy(REPO / "scripts" / "_governance.py",
+                    self._tmp_repo / "scripts" / "_governance.py")
         self._hook = self._tmp_repo / "scripts" / "claude-hooks" / HOOK.name
         self._fires_log = self._tmp_repo / ".claude" / ".hook-fires.log"
         self._bin = self._tmp_repo / "bin"
         self._bin.mkdir()
         self._gh_marker = self._tmp_repo / "gh_called"
+        self._gh_args = self._tmp_repo / "gh_args"
 
     def tearDown(self) -> None:
         shutil.rmtree(self._tmp, ignore_errors=True)
@@ -54,18 +65,49 @@ class TestPreToolUseAdrCollision(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def _write_gh_stub(self, json_output: str, exit_code: int = 0) -> None:
-        """Fake `gh` that records invocation then echoes canned JSON."""
+        """Fake `gh` that records argv, simulates GitHub's `in:title` search
+        filter, then echoes the (possibly filtered) JSON.
+
+        The `in:title` simulation is the regression's teeth: real
+        `gh pr list --search "ADR in:title"` drops PRs whose *title* lacks
+        the term even when the head branch reserves the number, so a hook
+        that re-adds an `in:title` prefilter would see `[]` here and the
+        branch-only collision tests would fail (defect #1, issue #1155).
+        When the hook lists open PRs without `--search`, the stub returns
+        every canned PR unchanged.
+        """
         gh = self._bin / "gh"
         gh.write_text(
-            "#!/usr/bin/env bash\n"
-            f"touch '{self._gh_marker}'\n"
-            f"cat <<'JSON'\n{json_output}\nJSON\n"
-            f"exit {exit_code}\n"
+            "#!/usr/bin/env python3\n"
+            "import json, sys, pathlib\n"
+            f"pathlib.Path({str(self._gh_marker)!r}).touch()\n"
+            f"pathlib.Path({str(self._gh_args)!r}).write_text("
+            "' '.join(sys.argv[1:]))\n"
+            f"raw = {json_output!r}\n"
+            "argv = sys.argv[1:]\n"
+            "try:\n"
+            "    prs = json.loads(raw)\n"
+            "except Exception:\n"
+            "    sys.stdout.write(raw)\n"
+            f"    sys.exit({exit_code})\n"
+            "if '--search' in argv:\n"
+            "    i = argv.index('--search')\n"
+            "    val = argv[i + 1] if i + 1 < len(argv) else ''\n"
+            "    if 'in:title' in val:\n"
+            "        term = val.split('in:title')[0].strip().lower()\n"
+            "        prs = [p for p in prs\n"
+            "               if term in (p.get('title', '') or '').lower()]\n"
+            "print(json.dumps(prs))\n"
+            f"sys.exit({exit_code})\n"
         )
         gh.chmod(0o755)
 
     def _gh_was_called(self) -> bool:
         return self._gh_marker.exists()
+
+    def _gh_argv(self) -> str:
+        """Recorded argv of the last fake-`gh` invocation ('' if never run)."""
+        return self._gh_args.read_text() if self._gh_args.exists() else ""
 
     def _run(self, file_path: str, tool_name: str = "Write"):
         payload = {"tool_name": tool_name, "tool_input": {"file_path": file_path}}
@@ -141,7 +183,10 @@ class TestPreToolUseAdrCollision(unittest.TestCase):
         self.assertIn("open_pr=900", line)
 
     def test_collision_via_branch_name_blocks(self) -> None:
-        # title lacks the number; only the head branch reserves it.
+        # The title lacks BOTH the number AND "ADR"; only the head branch
+        # reserves it. With the stub's `in:title` simulation, a hook that
+        # prefilters by title (defect #1) would never see this PR and would
+        # pass — so this is now a genuine cross-worktree-branch regression.
         self._write_gh_stub(
             '[{"number":901,"title":"sync stuff","headRefName":"docs/issue-5-adr-0060-foo"}]'
         )
@@ -149,11 +194,39 @@ class TestPreToolUseAdrCollision(unittest.TestCase):
         self.assertEqual(r.returncode, 2, msg=r.stderr)
         self.assertIn("901", r.stderr)
 
+    def test_gh_query_does_not_prefilter_by_title(self) -> None:
+        # Defect #1 (issue #1155): `gh pr list --search "ADR in:title"` drops
+        # PRs whose title lacks "ADR" even when the head branch reserves the
+        # number. The hook must list open PRs (with a --limit above gh's
+        # default 30) and filter title+headRefName locally instead.
+        self._write_gh_stub(
+            '[{"number":910,"title":"sync stuff","headRefName":"docs/issue-5-adr-0060-foo"}]'
+        )
+        r = self._run(self._adr_path("0060-mine.md"))
+        self.assertEqual(r.returncode, 2, msg=r.stderr)
+        argv = self._gh_argv()
+        self.assertIn("--state open", argv)
+        self.assertIn("--limit", argv)
+        self.assertNotIn("in:title", argv)
+
     def test_zero_pad_insensitive_match_blocks(self) -> None:
         self._write_gh_stub('[{"number":902,"title":"ADR-60 thing","headRefName":"x"}]')
         r = self._run(self._adr_path("0060-mine.md"))
         self.assertEqual(r.returncode, 2, msg=r.stderr)
         self.assertIn("902", r.stderr)
+
+    def test_mixed_case_adr_filename_is_guarded(self) -> None:
+        # Defect #2 (issue #1155): governance ADR_FILENAME_RE accepts
+        # [a-zA-Z0-9] (widened for realN ADRs, #818). A lowercase-only gate
+        # regex silently skipped the collision check for a mixed-case slug;
+        # reusing the SSoT regex guards it.
+        self._write_gh_stub(
+            '[{"number":911,"title":"ADR 0060 realN","headRefName":"docs/issue-9-adr-0060"}]'
+        )
+        r = self._run(self._adr_path("0060-realN-metrics.md"))
+        self.assertEqual(r.returncode, 2, msg=r.stderr)
+        self.assertIn("911", r.stderr)
+        self.assertIn("0060", r.stderr)
 
     # ------------------------------------------------------------------
     # no collision / fail-open — pass (exit 0)

--- a/tests/test_hook_telemetry.py
+++ b/tests/test_hook_telemetry.py
@@ -133,7 +133,7 @@ def test_known_outcomes_includes_required_set(gov):
 def test_known_hooks_matches_inventory(gov):
     expected = {
         "bash-guard", "loadbearing", "memory-lines",
-        "adr-template", "plan-slug-race",
+        "adr-template", "adr-collision", "plan-slug-race",
         "delegation-gate", "stop-ship",
     }
     assert gov.KNOWN_HOOKS == expected
@@ -222,6 +222,8 @@ HOOK_EMIT_EXPECTATIONS = [
      "--hook delegation-gate", "--outcome nudged"),
     ("scripts/claude-hooks/pretooluse-adr-template.sh",
      "--hook adr-template", "--outcome blocked"),
+    ("scripts/claude-hooks/pretooluse-adr-collision.sh",
+     "--hook adr-collision", "--outcome blocked"),
     ("scripts/claude-hooks/plan-slug-race.sh",
      "--hook plan-slug-race", "--outcome blocked"),
     ("scripts/claude-hooks/pretooluse-bash-guard.sh",


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

#1074 의 cross-worktree ADR-collision PreToolUse hook (ADR 0063) 을 adversarial review 한 결과 3개 결함 발견 — 첫째는 hook 의 핵심 보장을 무력화했다. 모두 한 concern("새 ADR-collision hook 이 신뢰 불가")으로 hook 파일 + 그 테스트/레지스트리에서 수정.

- **[high] branch-only 예약이 검사 전에 필터링됨.** 쿼리가 `gh pr list --search "ADR in:title"` 라서 *title* 에 "ADR" 이 없는 PR 은 head **branch** 가 번호를 예약(`docs/issue-200-adr-0060-foo`)해도 결과에서 제외됐다. 이게 바로 hook 이 막으려던 cross-worktree branch-only 예약(0022→0023 / 0029→0030 재발 패턴)이다. → `--search` 프리필터 제거, open PR 을 `--limit 200` 으로 나열하고 title+headRefName 을 로컬 필터. 기존 fake gh 가 무조건 echo 라 필터를 한 번도 안 거쳐 false confidence 였음.
- **[medium] mixed-case ADR 파일명이 gate 우회.** gate regex `[a-z0-9-]+` 가 lowercase-only 라, `_governance.py` `ADR_FILENAME_RE`(`[a-zA-Z0-9]`, realN ADR 위해 #818 에서 확장)가 받는 mixed-case 슬러그를 놓쳐 collision 검사를 통째로 skip 했다. → 좁은 로컬 복제 대신 SSoT regex 재사용(CLAUDE.md "새로 만들기보다 재사용").
- **[medium] canonical telemetry 계약 우회.** raw `printf` 가 fire-log 를 잘못된 필드 의미(`<category>` 슬롯에 basename, `<path>` 슬롯에 `open_pr=N`)로 기록하고 `--emit-fire` enum/typo 가드를 우회했다. `adr-collision` 도 미등록. → `KNOWN_HOOKS` / `ALL_HOOKS` / hooks README / telemetry 테스트에 등록하고 canonical `--emit-fire`(ADR 0060) 로 emit.

Closes #1155

## 2. 영향 파일

- `scripts/claude-hooks/pretooluse-adr-collision.sh` — 결함 3개 수정 (query / gate regex / telemetry emit) + 헤더에 `# Enforcement: block` 라벨
- `scripts/_governance.py` — `KNOWN_HOOKS` 에 `adr-collision` 추가
- `scripts/analyze_hook_outcomes.py` — `ALL_HOOKS` 에 `adr-collision` 추가
- `scripts/claude-hooks/README.md` — hook 인벤토리 표에 row 추가
- `tests/test_hook_pretooluse_adr_collision.py` — fake gh 가 argv 기록 + `in:title` 필터 시뮬레이션하도록 재작성, `_governance.py` 를 temp REPO_ROOT 에 복사, defect 1/2 회귀 테스트 2개 추가
- `tests/test_hook_telemetry.py` — `test_known_hooks_matches_inventory` 기대셋 + `HOOK_EMIT_EXPECTATIONS` 에 `adr-collision` 추가

load-bearing 파일 없음 (전부 governance automation + 테스트).

## 3. 리스크

- **가장 가능성 높은 깨짐:** gate 2b 가 `_governance` import 실패 시 collision 검사를 skip. → import 실패는 fail-open(exit 0)으로 의도적 처리(pre-commit 이 backstop). `_governance.py` 는 stdlib-only import 라 항상 가능, 또 hook 은 이미 JSON 파싱에 python 을 쓰므로 python 부재면 그 전에 fail-open.
- **perf:** gate 2b 의 python(SSoT regex) 은 docs/adr/ 아래 **신규** Write 에만 실행(Gate 1 Write + Gate 2a dir + Gate 3 not-exists 통과 후). 일반 편집 경로는 subprocess 추가 없음 — Gate 3 를 Gate 2b 앞으로 옮겨 기존 ADR 편집은 import 비용 0.
- **over-block:** `--limit 200` open PR 전수 + 로컬 정확 정수 필터라 loose substring 매치가 over-block 못 함. body 는 무시(다른 ADR 인용 false positive 방지).

## 4. 테스트

`bash scripts/test.sh` 와 동일 게이트의 검증 대상 4파일 **68 passed**:
`pytest tests/test_hook_pretooluse_adr_collision.py tests/test_governance_adr_numbers.py tests/test_hook_telemetry.py tests/test_analyze_hook_outcomes.py`

Behavior change → 변경 전 fail / 변경 후 pass 검증 완료. HEAD(버그) 버전으로 되돌려 차별 테스트만 실행한 결과 **정확히 4개 fail**(각 결함당 teeth):
- `test_collision_via_branch_name_blocks` + `test_gh_query_does_not_prefilter_by_title` → 결함 1
- `test_mixed_case_adr_filename_is_guarded` → 결함 2
- `test_no_hook_uses_legacy_printf_fire_log` → 결함 3

## 5. Eval 영향

All `·` — RAG 파이프라인(검색/검증/답변/계획) 외 변경. governance hook + telemetry 레지스트리 + 테스트만 손댐.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. 변경 파일에 load-bearing path 없음(`scripts/claude-hooks`, `scripts/_governance.py`, `scripts/analyze_hook_outcomes.py`, 테스트는 모두 LOAD_BEARING_PATHS 밖) → §5b CI gate 미발동. RFP 문서 처리 경로 무영향.

## 6. 하위 호환

깨짐 없음. fire-log 포맷은 오히려 canonical 5-field(ADR 0060)로 **정정**(기존 raw printf 가 비표준이었음). 답변 계약(ADR 0003) 무관 → `schema_version` bump 불필요. hook 의 외부 동작(차단 시 exit 2 + stderr, 안전 시 exit 0)은 동일.

## 7. 범위 외

- `analyze_hook_outcomes.py` line 64/281 의 기존 Pyright 경고(`Iterable`/`window` unused) — 내 변경 영역 밖, 별도 정리.
- ADR 0063 본문 갱신은 불필요(결정 자체는 유효, 구현 버그만 수정).