### PR TITLE
fix(self-review): feed axis-4 zero-lag telemetry into #4-A grade + rename is_retrofit→zero_lag

### DIFF
--- a/.claude/skills/self-review-quarterly/SKILL.md
+++ b/.claude/skills/self-review-quarterly/SKILL.md
@@ -109,7 +109,7 @@ This skill writes to a **committed git file**. Privacy violations cannot be retr
 | 1 | 컨텍스트 효율 | ... | `sessions.tool_call_distribution`, `sessions.agent_delegations` | ... |
 | 2 | Agent 위임 패턴 | ... | `axis_2_plan_subagent_skip_rate.skip_rate` (PR #745) | ... |
 | 3 | 거버넌스 자동화 ROI | ... | `governance_hooks.pretooluse_loadbearing_fires`, `governance_hooks.fires_by_action` | ... |
-| 4 | 사이클 타임 | ... | `axis_4_cycle_time.adr_lag_days`, `axis_4_cycle_time.pr_turnaround_hours` (PR #748) | ... |
+| 4 | 사이클 타임 | ... | `axis_4_cycle_time.adr_lag_days.non_zero_lag`, `…adr_lag_days.zero_lag_count`, `axis_4_cycle_time.pr_turnaround_hours` (PR #748) | ... |
 | 5 | 메모리 위생 | ... | #5-A `governance_hooks.fires_by_action["memory-lines"]` (PR #747) + #5-B `axis_5_memory_hygiene.content_freshness.fresh_rate` (issue #877) | ... |
 
 ## 5축 채점 임계값 (Q3-2026~)
@@ -129,7 +129,7 @@ SoT — 두 SoT는 직교한다 (값 vs 채점 등급).
 | #1 컨텍스트 효율 | `sessions.agent_delegations["Explore"]` 호출 / 분기 | ≥ 2 + Read 평균 ≤ 메인 대화당 10회 | 둘 중 하나 미달 | 둘 다 미달 |
 | #2 Agent 위임 | `axis_2_plan_subagent_skip_rate.skip_rate` | ≤ 0.2 | 0.2–0.5 | > 0.5 |
 | #3 자동화 ROI | `governance_hooks.pretooluse_loadbearing_fires` + `fires_by_action` 다양성 | fires > 0 **그리고** ≥ 2개 reason 발화 (e.g. `load-bearing` + `memory-lines`) | fires > 0 그러나 1개 reason만 | fires = 0 |
-| #4-A 사이클 타임 (ADR) | `axis_4_cycle_time.adr_lag_days.mean` (days) | ≤ 5 | 5–10 | > 10 |
+| #4-A 사이클 타임 (ADR) | `axis_4_cycle_time.adr_lag_days.non_zero_lag.mean` (zero-lag 제외 days) | ≤ 5 | 5–10 | > 10 |
 | #4-B 사이클 타임 (PR) | `axis_4_cycle_time.pr_turnaround_hours.mean` (hours) | ≤ 48 | 48–120 | > 120 |
 | #5-A 메모리 인덱스 위생 | `governance_hooks.fires_by_action["memory-lines"]` 카운트 (action="aware" / "blocked") | blocked=0 + aware ≤ 2 | aware ≥ 3 + blocked=0 | blocked ≥ 1 (편집 차단 = 인덱스 폭발) |
 | #5-B 메모리 콘텐츠 신선도 | `axis_5_memory_hygiene.content_freshness.fresh_rate` (분기 내 수정된 메모리 파일 비율) | ≥ 0.5 | 0.2–0.5 | < 0.2 또는 `null` |
@@ -137,6 +137,8 @@ SoT — 두 SoT는 직교한다 (값 vs 채점 등급).
 **판정 규칙:**
 - 동일 축이 sub-signal 두 개를 가질 때(예: #4-A + #4-B), **둘 다 ✓** 이어야 ✓; 하나라도 ✗면 ✗; 그 외 △.
 - raw signal 이 `null` / `count=0` 이면 측정 부재 — △ 표기 + "측정 인프라 미작동" 한 줄.
+- **#4-A 는 반드시 `non_zero_lag.mean` 으로 채점** (`adr_lag_days.mean` 아님). zero-lag ADR (same-day proposed→accepted) 은 진짜 빠른 결정인지 retrofit 인지 날짜만으로 구분 불가 → 전체 mean 을 0 쪽으로 끌어내려 ✓ 를 부풀린다. `zero_lag_count` 가 전체 `count` 의 ≥ 1/3 이면 코멘트에 "zero-lag N/총M, 수동 retrofit 검토 필요" 한 줄 명시.
+- `non_zero_lag.count == 0` (모든 ADR 이 zero-lag) → lag 측정 불가 → △ + "전체 N개 ADR zero-lag, lag 측정 불가, 수동 retrofit 검토" 한 줄. ✓ 금지 (mean=0 을 빠른 사이클로 오독 방지).
 - `p90` 이 `mean` 보다 현저히 크면 (> 2×) outlier 가능성 — `pr_turnaround_hours.max` 확인 후 reopened-PR 영향 한 줄 명시.
 
 ## 최우선 개선점 (ROI)

--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -388,13 +388,15 @@ def _compute_adr_lags(repo: str, start: str, end: str) -> list[dict[str, Any]]:
             "proposed_date": proposed_dt.date().isoformat(),
             "accepted_date": accepted_dt.date().isoformat(),
             "lag_days": lag_days,
-            # lag_days == 0 means proposed and accepted commits land the same
-            # day. That is either a genuine same-day decision or a *retrofit*
-            # (the `-S "**Status**: accepted"` search finds the original
-            # acceptance commit, so a later Verification-surface add looks
-            # zero-lag). Flag it so the LLM rubric layer can separate the two
-            # instead of silently averaging retrofits into the lag p50/p90.
-            "is_retrofit": lag_days == 0,
+            # lag_days == 0 means the proposed and accepted commits land on the
+            # same calendar day. By date alone we cannot tell a genuine same-day
+            # decision from a retrofit (the `-S "**Status**: accepted"` search
+            # finds the original acceptance commit, so a later Verification-surface
+            # add also reads zero-lag). So the flag is named for what it actually
+            # measures — zero lag — not for the retrofit it might be. The rubric
+            # layer treats zero-lag ADRs as needing manual review and grades axis
+            # #4-A on the zero-lag-excluded mean (see compute_adr_lag_summary).
+            "zero_lag": lag_days == 0,
         })
     return results
 
@@ -598,12 +600,14 @@ def compute_adr_lag_summary(adr_lags: list[dict[str, Any]]) -> dict[str, Any]:
         if isinstance(v, (int, float)):
             days.append(float(v))
     summary = _summary_p50_p90(days)
-    # Axis #4 honesty: a lag p50 near 0 can be inflated by retrofits (see
-    # `_compute_adr_lags`). Surface the count so the rubric can subtract
-    # them rather than read a flattering near-zero median at face value.
-    summary["retrofit_count"] = sum(
-        1 for e in adr_lags if e.get("is_retrofit")
-    )
+    # Axis #4 honesty: zero-lag ADRs (same-day proposed→accepted; see
+    # `_compute_adr_lags`) pull the lag mean toward 0 whether they are genuine
+    # fast decisions or retrofits. Surface their count AND a zero-lag-excluded
+    # summary so the rubric grades #4-A on decisions that actually had a lag
+    # instead of reading a flattering near-zero mean at face value.
+    summary["zero_lag_count"] = sum(1 for e in adr_lags if e.get("zero_lag"))
+    non_zero_days = [d for d in days if d != 0.0]
+    summary["non_zero_lag"] = _summary_p50_p90(non_zero_days)
     return summary
 
 
@@ -709,6 +713,8 @@ def assemble_stats(
 def emit_report(stats: dict[str, Any]) -> str:
     """Render Markdown skeleton from stats. LLM (SKILL.md) fills verdicts."""
     quarter = stats["quarter"]
+    adr_lag = stats["axis_4_cycle_time"]["adr_lag_days"]
+    adr_non_zero = adr_lag.get("non_zero_lag", {})
     lines: list[str] = [
         f"# Self-Review {quarter}",
         "",
@@ -726,9 +732,11 @@ def emit_report(stats: dict[str, Any]) -> str:
         ),
         (
             f"- Axis #4 ADR lag (days) mean/p90: "
-            f"{stats['axis_4_cycle_time']['adr_lag_days'].get('mean')} / "
-            f"{stats['axis_4_cycle_time']['adr_lag_days'].get('p90')} "
-            f"(n={stats['axis_4_cycle_time']['adr_lag_days'].get('count')})"
+            f"{adr_lag.get('mean')} / {adr_lag.get('p90')} "
+            f"(n={adr_lag.get('count')}; "
+            f"zero-lag={adr_lag.get('zero_lag_count')}, "
+            f"non-zero mean={adr_non_zero.get('mean')} "
+            f"n={adr_non_zero.get('count')})"
         ),
         (
             f"- Axis #4 PR turnaround (hours) mean/p90: "

--- a/tests/test_self_review_axis_4_regression.py
+++ b/tests/test_self_review_axis_4_regression.py
@@ -100,23 +100,101 @@ class TestComputeAdrLagSummary(unittest.TestCase):
         result = sr.compute_adr_lag_summary(lags)
         self.assertEqual(result["count"], 0)
 
-    def test_retrofit_count_from_is_retrofit_flag(self) -> None:
+    def test_zero_lag_count_from_zero_lag_flag(self) -> None:
         lags = [
-            {"adr_id": "0040", "lag_days": 0, "is_retrofit": True},
-            {"adr_id": "0041", "lag_days": 0, "is_retrofit": True},
-            {"adr_id": "0042", "lag_days": 5, "is_retrofit": False},
+            {"adr_id": "0040", "lag_days": 0, "zero_lag": True},
+            {"adr_id": "0041", "lag_days": 0, "zero_lag": True},
+            {"adr_id": "0042", "lag_days": 5, "zero_lag": False},
         ]
         result = sr.compute_adr_lag_summary(lags)
-        self.assertEqual(result["retrofit_count"], 2)
-        # retrofit flag must not perturb the existing lag aggregation
+        self.assertEqual(result["zero_lag_count"], 2)
+        # zero_lag flag must not perturb the existing lag aggregation
         self.assertEqual(result["count"], 3)
+        # the misleading is_retrofit name (#1067) is gone (#1147)
+        self.assertNotIn("retrofit_count", result)
 
-    def test_retrofit_count_absent_flag_counts_zero(self) -> None:
-        # Defensive: entries without is_retrofit (e.g. older callers) must
-        # not raise and contribute 0 to the retrofit count.
+    def test_zero_lag_count_absent_flag_counts_zero(self) -> None:
+        # Defensive: entries without zero_lag (e.g. older callers) must
+        # not raise and contribute 0 to the zero-lag count.
         lags = [{"adr_id": "0040", "lag_days": 3}]
         result = sr.compute_adr_lag_summary(lags)
-        self.assertEqual(result["retrofit_count"], 0)
+        self.assertEqual(result["zero_lag_count"], 0)
+
+    def test_non_zero_lag_excludes_zero_lag_entries(self) -> None:
+        # Issue #1147: #4-A must grade on a zero-lag-excluded mean so a
+        # quarter padded with same-day ADRs cannot flatten the lag toward 0.
+        lags = [
+            {"adr_id": "0040", "lag_days": 0, "zero_lag": True},
+            {"adr_id": "0041", "lag_days": 0, "zero_lag": True},
+            {"adr_id": "0042", "lag_days": 6, "zero_lag": False},
+            {"adr_id": "0043", "lag_days": 12, "zero_lag": False},
+        ]
+        result = sr.compute_adr_lag_summary(lags)
+        # full mean is dragged down by the two zero-lag ADRs ...
+        self.assertAlmostEqual(result["mean"], 4.5)
+        # ... but the grading input excludes them.
+        self.assertEqual(result["non_zero_lag"]["count"], 2)
+        self.assertAlmostEqual(result["non_zero_lag"]["mean"], 9.0)
+        self.assertEqual(result["zero_lag_count"], 2)
+
+    def test_all_zero_lag_non_zero_summary_is_empty_skeleton(self) -> None:
+        # When every ADR is zero-lag the lag signal is unmeasurable; the
+        # non_zero_lag summary must be an empty skeleton (mean=None) so the
+        # rubric flags 측정 부재 rather than reading a flattering mean=0.
+        lags = [
+            {"adr_id": "0040", "lag_days": 0, "zero_lag": True},
+            {"adr_id": "0041", "lag_days": 0, "zero_lag": True},
+        ]
+        result = sr.compute_adr_lag_summary(lags)
+        self.assertEqual(result["zero_lag_count"], 2)
+        self.assertEqual(result["non_zero_lag"]["count"], 0)
+        self.assertIsNone(result["non_zero_lag"]["mean"])
+
+
+class TestEmitReportSurfacesZeroLag(unittest.TestCase):
+    """Issue #1147: the zero-lag count + non-zero mean must reach the
+    Markdown summary the LLM grader reads — not stay buried in raw JSON."""
+
+    def _minimal_stats(self, adr_lags: list[dict]) -> dict:
+        return {
+            "quarter": "Q2-2026",
+            "date_range": ["2026-04-01", "2026-06-30"],
+            "sessions": {"count": 0},
+            "memory": {},
+            "git": {
+                "commits": 0, "load_bearing_touches": 0,
+                "adr_changes": [], "prs_merged": [],
+            },
+            "governance_hooks": {"memory_lines": {"aware": 0, "blocked": 0}},
+            "pr_diff_stats": [],
+            "axis_2_plan_subagent_skip_rate": {
+                "skip_rate": None, "prs_with_zero_plan_calls": 0,
+                "prs_evaluated": 0,
+            },
+            "axis_4_cycle_time": {
+                "adr_lag_days": sr.compute_adr_lag_summary(adr_lags),
+                "pr_turnaround_hours": sr.compute_pr_turnaround_summary([]),
+            },
+            "axis_5_memory_hygiene": {
+                "content_freshness": {
+                    "fresh_rate": None, "fresh_in_quarter": 0, "total": 0,
+                },
+            },
+        }
+
+    def test_zero_lag_and_non_zero_mean_in_markdown(self) -> None:
+        lags = [
+            {"adr_id": "0040", "lag_days": 0, "zero_lag": True},
+            {"adr_id": "0041", "lag_days": 0, "zero_lag": True},
+            {"adr_id": "0042", "lag_days": 6, "zero_lag": False},
+        ]
+        report = sr.emit_report(self._minimal_stats(lags))
+        adr_line = next(
+            ln for ln in report.splitlines() if "Axis #4 ADR lag" in ln
+        )
+        # the grader-visible summary line carries both new signals
+        self.assertIn("zero-lag=2", adr_line)
+        self.assertIn("non-zero mean=6.0", adr_line)
 
 
 if __name__ == "__main__":

--- a/tests/test_self_review_regression.py
+++ b/tests/test_self_review_regression.py
@@ -109,9 +109,38 @@ class TestRuleToAutomationLagBasic(unittest.TestCase):
         self.assertEqual(len(lags), 1)
         self.assertEqual(lags[0]["adr_id"], "0001")
         self.assertEqual(lags[0]["lag_days"], 10)
-        # is_retrofit must be present and False for a genuine multi-day lag.
-        self.assertIn("is_retrofit", lags[0])
-        self.assertFalse(lags[0]["is_retrofit"])
+        # zero_lag must be present and False for a genuine multi-day lag.
+        self.assertIn("zero_lag", lags[0])
+        self.assertFalse(lags[0]["zero_lag"])
+        # the misleading is_retrofit name (#1067) is gone (#1147).
+        self.assertNotIn("is_retrofit", lags[0])
+
+
+class TestSameDayAdrIsZeroLagNotRetrofit(unittest.TestCase):
+    def test_genuine_same_day_decision_is_zero_lag_not_retrofit(self):
+        # Issue #1147: a real same-day proposed→accepted decision yields
+        # lag_days == 0. It must be labeled honestly as zero_lag (a fact),
+        # NOT silently asserted to be a retrofit. The is_retrofit field from
+        # #1067 is gone; grading runs on non_zero_lag so this fast decision
+        # is neither mislabeled nor penalized.
+        with tempfile.TemporaryDirectory() as td:
+            repo = _make_repo_with_adr(
+                td,
+                "0003-same-day.md",
+                content_at_add="- **Status**: proposed\n",
+                content_at_accept="- **Status**: accepted\n",
+                add_date="2026-04-05T09:00:00+00:00",
+                accept_date="2026-04-05T15:00:00+00:00",
+            )
+            lags = sr._compute_adr_lags(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(len(lags), 1)
+        self.assertEqual(lags[0]["lag_days"], 0)
+        self.assertTrue(lags[0]["zero_lag"])
+        self.assertNotIn("is_retrofit", lags[0])
+        # excluded from the grading mean rather than dragging it toward 0
+        summary = sr.compute_adr_lag_summary(lags)
+        self.assertEqual(summary["zero_lag_count"], 1)
+        self.assertEqual(summary["non_zero_lag"]["count"], 0)
 
 
 class TestRuleToAutomationLagSkipsUnaccepted(unittest.TestCase):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1147

`#1067` (commit `6c33153`) 이 axis-4 cycle-time 에 추가한 retrofit telemetry 가 **inert** 했고 **정의가 부정확**했다. (1) `retrofit_count` 가 채점에서 고아 — `SKILL.md` 가 그 값을 한 번도 읽지 않고 #4-A 는 여전히 `adr_lag_days.mean` 으로 채점. `compute_adr_lag_summary` 가 zero-lag(retrofit) ADR 을 mean 에 그대로 접어넣어, same-day retrofit 으로 가득 찬 분기가 mean 을 **아래로** 끌어내려 #4-A 에서 ✓ 를 받는다 — 이 flag 가 폭로하려던 바로 그 over-good verdict. (2) `is_retrofit = (lag_days == 0)` 이 진짜 빠른 same-day 결정과 retrofit 을 날짜만으로 혼동.

이 PR 은 telemetry 를 grade 에 실제로 feed 하고, 측정 실체에 맞게 정직하게 정의한다:
- `compute_adr_lag_summary`: `non_zero_lag` sub-summary 추가 (zero-lag 제외 mean/p50/p90)
- `emit_report`: Axis #4 ADR 라인에 `zero_lag_count` + non-zero mean 노출 — grader 가 raw JSON 이 아니라 markdown 요약에서 본다
- `SKILL.md` #4-A: `non_zero_lag.mean` 으로 채점하도록 repoint + zero_lag_count 회계 판정 규칙 + all-zero-lag 측정부재 △ 규칙
- `is_retrofit`→`zero_lag`, `retrofit_count`→`zero_lag_count` rename (날짜만으로 retrofit↔빠른 결정 구분 불가하므로 측정하는 실체 = "zero lag" 로 명명)

## 2. 영향 파일

- `scripts/claude-hooks/_self_review.py` — `_compute_adr_lags` 필드 rename + `compute_adr_lag_summary` non_zero_lag + `emit_report` 라인 (load-bearing 아님)
- `.claude/skills/self-review-quarterly/SKILL.md` — #4-A 채점 신호 path + 판정 규칙 (load-bearing 아님)
- `tests/test_self_review_axis_4_regression.py` — 회귀 테스트 (rename + non_zero_lag + emit_report e2e)
- `tests/test_self_review_regression.py` — rename + same-day genuine ADR 회귀

LOAD_BEARING_PATHS (`scripts/_governance.py`) 해당 없음.

## 3. 리스크

가장 가능성 높은 깨짐: (a) 다른 소비자가 `is_retrofit`/`retrofit_count` 를 읽고 있었다면 rename 으로 깨짐 — repo-wide grep 결과 소비자는 이 PR 의 3개 파일뿐 (`#1067` 어제 머지, orphaned). (b) `emit_report` 가 `non_zero_lag` 누락 시 KeyError — `.get("non_zero_lag", {})` 로 방어. (c) 채점 신호 path 변경이 과거 보고서에 영향 — `docs/self-review/Q2-2026.md` 는 frozen artifact, 미래 보고서만 적용.

## 4. 테스트

신규/갱신 회귀 테스트 (변경 전엔 `is_retrofit`/`retrofit_count` 기준, 변경 후 `zero_lag` 기준 pass):
- `test_non_zero_lag_excludes_zero_lag_entries` — full mean=4.5 인데 grading mean(non_zero)=9.0 으로 zero-lag 제외 검증
- `test_all_zero_lag_non_zero_summary_is_empty_skeleton` — 전부 zero-lag → non_zero count=0, mean=None (측정부재)
- `test_zero_lag_and_non_zero_mean_in_markdown` — `emit_report` markdown 에 `zero-lag=2` + `non-zero mean=6.0` 노출 (end-to-end)
- `test_genuine_same_day_decision_is_zero_lag_not_retrofit` — same-day 진짜 결정이 `zero_lag=True`(fact) 로만 라벨, `is_retrofit` 키 부재, grading 은 non_zero 로 페널티 없음

검증: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_self_review_axis_4_regression tests.test_self_review_regression`. **CI(Python 3.11) green.** 로컬 stock 3.9.6(`/usr/bin/python3`)에서도 git-fixture 테스트 정상 통과 확인 — git `%aI` 는 `+00:00`(콜론 오프셋)을 emit 하므로 `_compute_adr_lags` 의 `fromisoformat` 가 3.9 에서도 정상 파싱(같은-날 시나리오 직접 재현: `len(lags)==1, lag_days==0`).

> 정정: 이 PR 초안은 "git-fixture 2개가 raw `datetime.fromisoformat(...Z)` 때문에 3.9 에서 fail" 이라고 적었으나 이는 **오진**이다 — git 의 strict ISO 8601 `%aI` 는 `Z` 가 아니라 `+00:00`(콜론) 오프셋을 emit 하고, stock 3.9.6 은 이를 정상 파싱하므로 해당 코드 경로에 `Z` 가 유입될 일이 없다. 작성 당시 본 실패가 있었다면 코드 버그가 아니라 환경 비결정성(homebrew `python3`=3.11.4 가 `/usr/bin/python3`=3.9.6 을 셸에 따라 가림, 또는 stale `.pyc`)일 가능성이 높다. ("git 이 `Z` 를 emit" 이라는 모델은 `_parse_gh_iso` docstring — 이건 **gh CLI** 타임스탬프 얘기 — 을 git 경로에 잘못 적용한 것으로 보인다.)

## 5. Eval 영향

All `·` — RAG 검색/검증/답변 path 무변경 (self-review 측정 표면 한정).

### 5b. Real-data delta

N/A — 변경 파일(`.claude/skills/`, `scripts/claude-hooks/`, `tests/`) 모두 `LOAD_BEARING_PATHS` 비해당. 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

`is_retrofit`/`retrofit_count` 는 `#1067`(어제) 도입 후 어떤 소비자도 없는 orphaned 필드 → rename 에 마이그레이션 경로 불필요 (back-compat shim 미추가). 답변 계약(ADR 0003) 무관, `schema_version` bump 불필요. `SKILL.md` #4-A 신호 path 변경은 미래 보고서에만 적용.

## 7. 범위 외

N/A — 범위 외 항목 없음.

> (초안에는 `_compute_adr_lags` 의 `datetime.fromisoformat(...Z)` 가 Python ≤3.10 에서 `ValueError`→`[]` 를 낸다며 date-parse 이식성 버그를 follow-up issue 로 분리한다고 적었으나, stock 3.9.6 직접 재현 결과 **오진**으로 확인 — git `%aI` 는 `+00:00` 콜론 오프셋을 emit 하고 3.9 가 정상 파싱하므로 해당 경로에 `Z` 유입이 없고 `[]` 도 반환되지 않는다. follow-up issue 미생성. §4 정정 참조.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
