### PR TITLE
fix(self-review): parse git %aI Z-suffix in _compute_adr_lags for Python ≤3.10

### DIFF
--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -363,7 +363,15 @@ def _compute_adr_lags(repo: str, start: str, end: str) -> list[dict[str, Any]]:
             ).stdout.strip().splitlines()
             if not proposed_lines:
                 continue
-            proposed_dt = datetime.fromisoformat(proposed_lines[-1])
+            # git's `%aI` emits a trailing `Z` for UTC, which
+            # `datetime.fromisoformat` only accepts on Python 3.11+. Route both
+            # timestamps through `_parse_gh_iso` (which normalizes `Z`) so the
+            # parse also works on 3.9/3.10 — otherwise the ValueError is
+            # swallowed by the `except` below and the entire ADR-lag signal
+            # silently empties on older interpreters.
+            proposed_dt = _parse_gh_iso(proposed_lines[-1])
+            if proposed_dt is None:
+                continue
             if proposed_dt.tzinfo is None:
                 proposed_dt = proposed_dt.replace(tzinfo=timezone.utc)
 
@@ -374,7 +382,9 @@ def _compute_adr_lags(repo: str, start: str, end: str) -> list[dict[str, Any]]:
             ).stdout.strip().splitlines()
             if not accepted_lines:
                 continue
-            accepted_dt = datetime.fromisoformat(accepted_lines[0])
+            accepted_dt = _parse_gh_iso(accepted_lines[0])
+            if accepted_dt is None:
+                continue
             if accepted_dt.tzinfo is None:
                 accepted_dt = accepted_dt.replace(tzinfo=timezone.utc)
         except (subprocess.TimeoutExpired, ValueError, OSError):

--- a/tests/test_self_review_regression.py
+++ b/tests/test_self_review_regression.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "claude-hooks"))
 import _self_review as sr
@@ -127,6 +128,33 @@ class TestRuleToAutomationLagSkipsUnaccepted(unittest.TestCase):
             )
             lags = sr._compute_adr_lags(str(repo), "2026-04-01", "2026-06-30")
         self.assertEqual(lags, [])
+
+
+class TestComputeAdrLagsHandlesZSuffix(unittest.TestCase):
+    def test_z_suffixed_git_timestamps_are_parsed(self):
+        # Issue #1185: git `%aI` emits a `Z` UTC suffix. `_compute_adr_lags`
+        # must parse it on every supported interpreter (3.9+), but raw
+        # `datetime.fromisoformat("...Z")` raises ValueError on Python ≤3.10 —
+        # which the function's `except` swallows, silently emptying the entire
+        # axis-4 ADR-lag signal. We mock the two `git log` subprocess calls so
+        # the test is deterministic regardless of the local git's actual
+        # timestamp format or the interpreter version: before the fix this
+        # asserted len 0 on ≤3.10; after the fix it parses on all Pythons.
+        with tempfile.TemporaryDirectory() as td:
+            adr_dir = Path(td) / "docs" / "adr"
+            adr_dir.mkdir(parents=True)
+            (adr_dir / "0001-z.md").write_text("- **Status**: accepted\n")
+
+            proposed = mock.Mock(stdout="2026-04-01T10:00:00Z\n")
+            accepted = mock.Mock(stdout="2026-04-09T10:00:00Z\n")
+            with mock.patch.object(
+                sr.subprocess, "run", side_effect=[proposed, accepted]
+            ):
+                lags = sr._compute_adr_lags(td, "2026-04-01", "2026-06-30")
+
+        self.assertEqual(len(lags), 1)
+        self.assertEqual(lags[0]["adr_id"], "0001")
+        self.assertEqual(lags[0]["lag_days"], 8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1185

`_compute_adr_lags` 가 git `%aI` 타임스탬프를 raw `datetime.fromisoformat()` 로 파싱했는데, git 이 UTC 에 emit 하는 `Z` 접미사(`2026-04-01T10:00:00Z`)는 `datetime.fromisoformat` 이 **Python 3.11+ 에서만** 받는다. 3.10 이하에서는 `ValueError` → 함수의 `except (TimeoutExpired, ValueError, OSError): continue` 가 삼켜서 axis-4 ADR-lag 신호 **전체가 silently `[]`** 가 된다 (CI 는 3.11 핀이라 #1067 머지 시 미검출; 로컬 `python3` 3.9.6 에서 표면화). 같은 모듈의 `collect_governance_hooks`(line ~164)와 `_parse_gh_iso` 는 이미 `.replace("Z","+00:00")` 로 정규화하고 있어 — `_compute_adr_lags` 만 누락이었다.

두 `fromisoformat` 호출을 기존 `_parse_gh_iso` 헬퍼 재사용으로 교체하고 `None` 반환 시 `continue`. fail-soft `except` 는 방어망으로 유지.

## 2. 영향 파일

- `scripts/claude-hooks/_self_review.py` — `_compute_adr_lags` 의 2개 timestamp 파싱을 `_parse_gh_iso` 로 (load-bearing 아님)
- `tests/test_self_review_regression.py` — deterministic Z-suffix 회귀 테스트 + mock import

`LOAD_BEARING_PATHS` (`scripts/_governance.py`) 해당 없음.

## 3. 리스크

가장 가능성 높은 깨짐: `_parse_gh_iso` 가 예상외 입력에 `None` 반환 → 해당 ADR skip. 기존 동작(ValueError→continue)과 동일한 fail-soft 라 회귀 아님. `_parse_gh_iso` 는 `TestGhIsoParser` 로 이미 커버. 3.11 에서는 입력/출력 byte-identical (Z 를 어차피 파싱했으므로 동작 무변화).

## 4. 테스트

- **신규** `TestComputeAdrLagsHandlesZSuffix.test_z_suffixed_git_timestamps_are_parsed` — `subprocess.run` 을 mock 해 `Z`-suffix `%aI` 출력을 강제, `_compute_adr_lags` 가 non-empty + `lag_days==8` 반환 검증. 로컬 git 의 Z emit 여부·인터프리터 버전에 무관한 deterministic 회귀 (수정 전 Python ≤3.10 에서 `len==0` 으로 fail / 수정 후 전 Python pass).
- 수정 전 Python 3.9 에서 fail 하던 기존 git-fixture 테스트 `TestRuleToAutomationLagBasic::test_lag_days_computed_correctly` 도 이제 통과 (직접 before/after 확인).

검증: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_self_review_regression` → 6/6 OK (Python 3.9.6 로컬).

## 5. Eval 영향

All `·` — RAG 검색/검증/답변 path 무변경 (self-review 측정 표면 한정).

### 5b. Real-data delta

N/A — 변경 파일(`scripts/claude-hooks/`, `tests/`) 모두 `LOAD_BEARING_PATHS` 비해당. 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

계약/스키마/CLI 무변경. 출력은 Python 3.11 에서 byte-identical, 3.9/3.10 에서는 silently-empty → 정상 산출로 **개선만** 된다. `schema_version` bump 불필요.

## 7. 범위 외

없음. 본 PR 은 PR #1176 (issue #1147, axis-4 retrofit telemetry) 작업 중 로컬 3.9 검증 갭으로 발견된 별도 root cause(date-parse 이식성)를 one-concern 원칙대로 분리한 것. #1176 와 같은 함수(`_compute_adr_lags`)를 건드리나 서로 다른 hunk(파싱 vs 결과 dict)라 머지 충돌 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)