### PR TITLE
fix(self-review): revive both dead ADR-0064 judge guards on the real input path

### DIFF
--- a/docs/adr/0064-self-review-external-judge.md
+++ b/docs/adr/0064-self-review-external-judge.md
@@ -61,10 +61,15 @@
 ## Verification
 
 <!-- verifies-key: eval/judges/self_review_judge.py:judge_self_review -->
+<!-- verifies-key: eval/judges/self_review_judge.py:_validate_operator_verdicts -->
+<!-- verifies-key: scripts/claude-hooks/_self_review.py:compute_evidence_age_days -->
 <!-- verifies-key: tests/test_self_review_judge.py:test_stub_backend_deterministic -->
 <!-- verifies-key: tests/test_self_review_judge.py:test_verdict_status_mapping -->
 <!-- verifies-key: tests/test_self_review_judge.py:test_agreement_against_operator -->
 <!-- verifies-key: tests/test_self_review_judge.py:test_weighted_kappa_ordinal_distance -->
+<!-- verifies-key: tests/test_self_review_judge.py:test_partial_operator_raises -->
+<!-- verifies-key: tests/test_self_review_judge.py:test_missing_evidence_age_downgrades_all_passes -->
+<!-- verifies-key: tests/test_self_review_judge.py:test_assemble_stats_emits_evidence_age_and_judge_consumes_it -->
 
 ### 첫 실행 결과 (Q2-2026, stub backend)
 
@@ -90,7 +95,7 @@
 후속:
 
 - 사용자 key 설정 시 `--backend openai_compatible` 1회 실행 → 외부 LLM verdict 와의 agreement (same-family 편향은 다른 vendor 모델로 완화).
-- collector 가 `evidence_age_days` 를 emit 하면 시간분리 가드가 실제 발화 (현재 null → 미발화) — axis_3 시점 드리프트의 근본 해결 경로.
+- **[완료 #1166]** collector 가 `evidence_age_days` 를 emit → 시간분리 가드 실제 발화. `_self_review.compute_evidence_age_days` 가 freshest 근거 timestamp (PR merge·ADR accepted·memory mtime·gh `merged_at`) 대비 나이를 산출하고, 가드는 `None`(미측정)도 보수적으로 ✓→△ 처리. **재실행 델타** (Q2-2026, 2026-05-21, `evidence_age_days≈0.014 < 1.0`): 가드 발화로 stub axis_3/4/5 가 ✓→△ → operator (axis_1=✓, 나머지 △) 대비 raw 일치 **0/5 → 3/5**, κ **−0.389 → −0.111** (여전히 `passes=False`). 첫 실행 결과(위 표, 2026-05-19 스냅샷)가 진단한 "axis_3 시점 드리프트"의 근본 해결 경로가 실제로 작동함을 확인. 합쳐서, operator JSON 이 5축 전체·유효 verdict 가 아니면 `_validate_operator_verdicts` 가 `ValueError` (이전엔 누락 축이 조용히 drop → n=1 → κ=1.0 통과).
 
 ## Alternatives considered
 

--- a/eval/judges/self_review_judge.py
+++ b/eval/judges/self_review_judge.py
@@ -139,16 +139,16 @@ def _band(value: float | None, good: float, bad: float) -> str:
 
 
 def _guard_downgrade(verdict: str, evidence_age_days: float | None) -> str:
-    """ADR 0064 time-separation guard: evidence_age < 1.0 day downgrades ✓→△.
+    """ADR 0064 time-separation guard: same-day/unknown evidence downgrades ✓→△.
 
     Q2-2026's evidence (ADR 0038, hook-fires.log) was produced the *same
     day* the review was written. A ✓ that rests on same-day evidence cannot
-    be confirmed, so it is forced to △.
+    be confirmed, so it is forced to △. ``None`` — the collector emitted no
+    datable evidence age — is treated the same way (conservative): a missing
+    freshness signal can only ever lower a verdict, never falsely promote one.
     """
-    if (
-        evidence_age_days is not None
-        and evidence_age_days < 1.0
-        and verdict == "✓"
+    if verdict == "✓" and (
+        evidence_age_days is None or evidence_age_days < 1.0
     ):
         return "△"
     return verdict
@@ -160,7 +160,7 @@ def stub_verdicts(stats: dict[str, Any]) -> dict[str, str]:
     This is the stub backend — it absorbs what was the standalone
     "deterministic scorer". Three self-pass guards are baked in:
 
-    - ``evidence_age_days < 1.0`` → any ✓ downgraded to △ (time separation)
+    - ``evidence_age_days < 1.0`` (or ``None``/unmeasured) → ✓ downgraded to △
     - axis #3 ``fires == 0`` → ✗ (silence is infra-dead, not a pass)
     - axis #2 ``prs_evaluated < 10`` → △ (sample too small to grade)
     """
@@ -346,6 +346,39 @@ def _weighted_kappa(
     return 1.0 - num / den
 
 
+def _validate_operator_verdicts(operator_verdicts: object) -> None:
+    """Reject an operator verdict file that isn't exactly the 5 valid axes.
+
+    ADR 0064's agreement gate is only meaningful when every axis is rated by
+    *both* raters. A file missing an axis (or with a typo'd / out-of-vocab
+    value) used to silently shrink the row set; a single surviving diagonal
+    row (n=1) then hit ``compute_agreement``'s perfect-agreement special case
+    (κ=1.0, passes=True) — defeating the external-anchor purpose. Validate at
+    this boundary (the operator JSON is an external input) so one parse
+    mistake fails loudly instead of passing the gate with axes unverified.
+    """
+    if not isinstance(operator_verdicts, dict):
+        raise ValueError(
+            "operator verdicts must be a JSON object, got "
+            f"{type(operator_verdicts).__name__}"
+        )
+    keys = set(operator_verdicts)
+    expected = set(AXIS_KEYS)
+    if keys != expected:
+        raise ValueError(
+            "operator verdicts must cover exactly the 5 axes "
+            f"(missing={sorted(expected - keys)}, extra={sorted(keys - expected)})"
+        )
+    bad = {
+        k: v for k, v in operator_verdicts.items() if v not in VERDICT_TO_STATUS
+    }
+    if bad:
+        raise ValueError(
+            "operator verdicts have invalid values (must be one of "
+            f"{VALID_VERDICTS}): {bad}"
+        )
+
+
 def judge_self_review(
     stats: dict[str, Any],
     operator_verdicts: dict[str, str] | None = None,
@@ -361,6 +394,12 @@ def judge_self_review(
         cohens_kappa, spearman_rho, confusion, passes) augmented with
         weighted_kappa_linear / weighted_kappa_quadratic (ordinal).
     """
+    # Validate the operator JSON *before* dispatching the backend so an
+    # invalid file fails fast (no wasted openai call) — and so a parse
+    # mistake can never reach the agreement gate (see _validate_operator_verdicts).
+    if operator_verdicts is not None:
+        _validate_operator_verdicts(operator_verdicts)
+
     if backend == "stub":
         judge = stub_verdicts(stats)
     elif backend == "openai_compatible":
@@ -379,7 +418,10 @@ def judge_self_review(
         for key, label in AXES
     }
     aggregate: dict[str, Any] = {"backend": backend, "judge_verdicts": judge}
-    if operator_verdicts:
+    if operator_verdicts is not None:
+        # operator_verdicts is validated to span exactly AXIS_KEYS with
+        # in-vocab values, and the backend always emits all 5 axes, so rows
+        # span all 5 — n == len(AXIS_KEYS), never a silently truncated set.
         rows = [
             (
                 key,
@@ -387,7 +429,6 @@ def judge_self_review(
                 VERDICT_TO_STATUS[operator_verdicts[key]],
             )
             for key in AXIS_KEYS
-            if key in judge and operator_verdicts.get(key) in VERDICT_TO_STATUS
         ]
         agreement = compute_agreement(rows)
         # Augment the (unweighted) compute_agreement output with ordinal

--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -672,6 +672,66 @@ def compute_axis_5_memory_hygiene(
     }
 
 
+def compute_evidence_age_days(
+    stats: dict[str, Any], now: datetime | None = None
+) -> float | None:
+    """Days between the freshest datable evidence and ``now`` (ADR 0064).
+
+    The time-separation guard in ``eval/judges/self_review_judge.py``
+    downgrades a ✓ to △ when this is < 1.0 — evidence produced the same day
+    as the review cannot be independently confirmed. Derived purely from the
+    datable timestamps already in the assembled stats (PR merge dates, ADR
+    accepted dates, memory mtimes, gh ``merged_at``), so it is recomputable
+    and verifiable with no extra collection pass. Returns ``None`` when no
+    datable evidence exists; the judge treats that conservatively (downgrade),
+    never as a pass.
+
+    ``now`` is injectable so callers can compute a deterministic age in tests;
+    production passes the current UTC time.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    def _ts(value: Any) -> datetime | None:
+        # Reuse the gh-ISO parser (handles the trailing `Z`); it returns a
+        # naive datetime for date-only `YYYY-MM-DD` strings, so normalise to
+        # UTC before comparing across the mixed-format candidates.
+        dt = _parse_gh_iso(value if isinstance(value, str) else None)
+        if dt is not None and dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+
+    candidates: list[datetime] = []
+    git = stats.get("git") or {}
+    for pr in git.get("prs_merged") or []:
+        if isinstance(pr, dict):
+            dt = _ts(pr.get("date"))
+            if dt is not None:
+                candidates.append(dt)
+    for pr in stats.get("pr_diff_stats") or []:
+        if isinstance(pr, dict):
+            dt = _ts(pr.get("merged_at"))
+            if dt is not None:
+                candidates.append(dt)
+    gov = stats.get("governance_hooks") or {}
+    for lag in gov.get("rule_to_automation_lag_days") or []:
+        if isinstance(lag, dict):
+            dt = _ts(lag.get("accepted_date"))
+            if dt is not None:
+                candidates.append(dt)
+    memory = stats.get("memory") or {}
+    for f in memory.get("files") or []:
+        if isinstance(f, dict):
+            dt = _ts(f.get("mtime"))
+            if dt is not None:
+                candidates.append(dt)
+
+    if not candidates:
+        return None
+    newest = max(candidates)
+    return max((now - newest).total_seconds() / 86400.0, 0.0)
+
+
 def assemble_stats(
     quarter: str, transcripts_glob: str, memory_dir: str, repo: str
 ) -> dict[str, Any]:
@@ -692,18 +752,21 @@ def assemble_stats(
     axis_5 = {
         "content_freshness": compute_axis_5_memory_hygiene(memory_data, start),
     }
-    return {
+    git_data = collect_git(repo, start, end)
+    stats: dict[str, Any] = {
         "quarter": quarter,
         "date_range": [start, end],
         "sessions": sessions,
         "memory": memory_data,
-        "git": collect_git(repo, start, end),
+        "git": git_data,
         "governance_hooks": governance,
         "pr_diff_stats": pr_diff_stats,
         "axis_2_plan_subagent_skip_rate": axis_2,
         "axis_4_cycle_time": axis_4,
         "axis_5_memory_hygiene": axis_5,
     }
+    stats["evidence_age_days"] = compute_evidence_age_days(stats)
+    return stats
 
 
 def emit_report(stats: dict[str, Any]) -> str:

--- a/tests/test_self_review_judge.py
+++ b/tests/test_self_review_judge.py
@@ -9,6 +9,7 @@ guards (time separation, hook-fire silence, low sample).
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -16,12 +17,20 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+SCRIPTS_HOOKS = ROOT / "scripts" / "claude-hooks"
+if str(SCRIPTS_HOOKS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_HOOKS))
 
 from eval.judges.self_review_judge import (  # noqa: E402
+    AXIS_KEYS,
     VERDICT_TO_STATUS,
     _weighted_kappa,
     judge_self_review,
     stub_verdicts,
+)
+from _self_review import (  # noqa: E402
+    assemble_stats,
+    compute_evidence_age_days,
 )
 
 
@@ -46,6 +55,10 @@ def _base_stats(**overrides):
             "pr_turnaround_hours": {"mean": 24.0},
         },
         "axis_5_memory_hygiene": {"content_freshness": {"fresh_rate": 0.8}},
+        # Time-separated evidence by default (≥1 day) so the baseline grades
+        # to ✓; guard tests override this. A missing key is exercised
+        # separately (test_missing_evidence_age_downgrades_all_passes).
+        "evidence_age_days": 2.0,
     }
     stats.update(overrides)
     return stats
@@ -216,3 +229,145 @@ def test_unknown_backend_raises():
     """Unknown backend → ValueError."""
     with pytest.raises(ValueError):
         judge_self_review(_base_stats(), backend="bogus")
+
+
+# --- Bug 1: incomplete/invalid operator verdicts no longer pass the gate ---
+
+_OPERATOR_FULL = {key: "✓" for key in AXIS_KEYS}
+
+
+def test_agreement_spans_all_axes():
+    """A complete operator file → agreement over all 5 axes (n == len(AXIS_KEYS))."""
+    _, aggregate = judge_self_review(
+        _base_stats(), dict(_OPERATOR_FULL), backend="stub"
+    )
+    assert aggregate["agreement"]["n"] == len(AXIS_KEYS)
+
+
+def test_partial_operator_raises():
+    """1-of-5 operator file raises, not a silent n=1 / κ=1.0 / passes=True.
+
+    This is the core Bug-1 regression: before the fix, a single valid axis
+    survived the filter and hit compute_agreement's perfect-agreement special
+    case, passing the gate with 4 axes unverified.
+    """
+    partial = {"axis_1_context_efficiency": "✓"}
+    with pytest.raises(ValueError):
+        judge_self_review(_base_stats(), partial, backend="stub")
+
+
+def test_typoed_operator_value_raises():
+    """An out-of-vocabulary verdict raises rather than being silently dropped."""
+    bad = dict(_OPERATOR_FULL)
+    bad["axis_3_governance_roi"] = "yes"  # not one of ✓/△/✗
+    with pytest.raises(ValueError):
+        judge_self_review(_base_stats(), bad, backend="stub")
+
+
+def test_extra_key_operator_raises():
+    """An unexpected extra axis key raises (strict exactly-5-axes contract)."""
+    extra = dict(_OPERATOR_FULL)
+    extra["axis_6_made_up"] = "✓"
+    with pytest.raises(ValueError):
+        judge_self_review(_base_stats(), extra, backend="stub")
+
+
+def test_empty_operator_dict_raises():
+    """An explicit empty operator object raises (missing all axes), not a skip.
+
+    None still means 'no operator provided' (no agreement block); {} is a
+    parse mistake and must fail loudly.
+    """
+    with pytest.raises(ValueError):
+        judge_self_review(_base_stats(), {}, backend="stub")
+
+
+# --- Bug 2: missing evidence_age_days is treated conservatively (downgrade) ---
+
+
+def test_missing_evidence_age_downgrades_all_passes():
+    """A stats dict with no evidence_age_days downgrades every ✓ → △.
+
+    Regression for the dead-guard path: when the producer emits no datable
+    evidence age, the guard must default to the conservative (cannot-confirm)
+    branch rather than no-op and let same-day evidence promote to ✓.
+    """
+    stats = _base_stats()
+    del stats["evidence_age_days"]
+    verdicts = stub_verdicts(stats)
+    assert all(v == "△" for v in verdicts.values()), verdicts
+
+
+def test_compute_evidence_age_days_uses_freshest_timestamp():
+    """Age is measured from the newest datable evidence across all sources."""
+    now = datetime(2026, 5, 21, tzinfo=timezone.utc)
+    stats = {
+        "git": {"prs_merged": [{"date": "2026-05-01"}, {"date": "2026-05-20"}]},
+        "memory": {"files": [{"mtime": "2026-05-10"}]},
+        "governance_hooks": {
+            "rule_to_automation_lag_days": [{"accepted_date": "2026-04-15"}]
+        },
+        "pr_diff_stats": [],
+    }
+    # freshest = 2026-05-20 → exactly 1 day before now
+    assert compute_evidence_age_days(stats, now=now) == pytest.approx(1.0)
+
+
+def test_compute_evidence_age_days_handles_iso_merged_at():
+    """gh merged_at (full ISO with Z) is parsed alongside date-only fields."""
+    now = datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc)
+    stats = {
+        "git": {"prs_merged": [{"date": "2026-05-01"}]},
+        "pr_diff_stats": [{"merged_at": "2026-05-21T00:00:00Z"}],
+    }
+    # freshest = 2026-05-21T00:00Z, now = +12h → 0.5 day
+    assert compute_evidence_age_days(stats, now=now) == pytest.approx(0.5)
+
+
+def test_compute_evidence_age_days_none_when_no_dates():
+    """No datable evidence → None (the judge then downgrades conservatively)."""
+    now = datetime(2026, 5, 21, tzinfo=timezone.utc)
+    assert compute_evidence_age_days({}, now=now) is None
+    assert (
+        compute_evidence_age_days(
+            {"git": {"prs_merged": []}, "memory": {"files": []}}, now=now
+        )
+        is None
+    )
+
+
+def test_compute_evidence_age_days_floors_at_zero():
+    """A future timestamp (clock skew) floors to 0.0, never negative."""
+    now = datetime(2026, 5, 21, tzinfo=timezone.utc)
+    stats = {"git": {"prs_merged": [{"date": "2026-05-25"}]}}
+    assert compute_evidence_age_days(stats, now=now) == 0.0
+
+
+def test_compute_evidence_age_days_same_day_under_one():
+    """Same-day evidence → age < 1.0 so the time-separation guard fires."""
+    now = datetime(2026, 5, 21, 18, 0, tzinfo=timezone.utc)
+    stats = {"git": {"prs_merged": [{"date": "2026-05-21"}]}}
+    assert compute_evidence_age_days(stats, now=now) < 1.0
+
+
+def test_assemble_stats_emits_evidence_age_and_judge_consumes_it(tmp_path):
+    """Real assemble_stats() shape carries evidence_age_days through the judge.
+
+    Integration regression for the missing producer (Bug 2): before the fix,
+    assemble_stats never emitted the key, so ``"evidence_age_days" in stats``
+    would have been False and this test would have failed. Empty
+    transcripts/memory globs isolate the git-only path (gh fails soft to []).
+    """
+    stats = assemble_stats(
+        quarter="Q2-2026",
+        transcripts_glob=str(tmp_path / "none" / "*.jsonl"),
+        memory_dir=str(tmp_path / "no-memory"),
+        repo=str(ROOT),
+    )
+    assert "evidence_age_days" in stats
+    assert stats["evidence_age_days"] is None or isinstance(
+        stats["evidence_age_days"], float
+    )
+    operator = {key: "△" for key in AXIS_KEYS}
+    _, aggregate = judge_self_review(stats, operator, backend="stub")
+    assert aggregate["agreement"]["n"] == len(AXIS_KEYS)

--- a/tests/test_self_review_no_body_leak_regression.py
+++ b/tests/test_self_review_no_body_leak_regression.py
@@ -192,6 +192,7 @@ class AssembleStatsStructuralTest(unittest.TestCase):
             "axis_2_plan_subagent_skip_rate",
             "axis_4_cycle_time",
             "axis_5_memory_hygiene",
+            "evidence_age_days",
         }
         self.assertEqual(set(stats.keys()), expected_keys)
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1166

커밋 e61dcb0 (#1087, ADR 0064) 가 추가한 self-review 외부 judge 의 **두 안전장치가 실제 입력 경로에서 모두 죽어 있었다** — 외부 anchor 로 자기참조 cycle 을 깬다는 ADR 0064 의 목적 자체를 무력화. (1) 시간분리 가드(`evidence_age_days < 1.0 → ✓→△`)는 producer 가 없어 항상 `None` → no-op. (2) operator verdict agreement gate 는 누락/오타 축을 조용히 drop → n=1 → `compute_agreement` 의 완전일치 특수케이스(κ=1.0, passes)에 걸려 4축 미검증으로 통과. 한 파일의 두 가드가 한 concern → 단일 PR.

## 2. 영향 파일

- `eval/judges/self_review_judge.py` **(load-bearing: eval/)** — `_validate_operator_verdicts` 추가(누락/추가/무효 verdict 시 ValueError), agreement 행을 5축 전체로 구성(n==len(AXIS_KEYS)), `_guard_downgrade` 가 `None`(미측정)도 보수적으로 ✓→△ 처리.
- `scripts/claude-hooks/_self_review.py` — `compute_evidence_age_days(stats, now=None)` 추가(freshest 근거 timestamp 대비 나이, `_parse_gh_iso` 재사용)하고 `assemble_stats` 출력에 `evidence_age_days` emit.
- `tests/test_self_review_judge.py` — 12 신규 테스트(validation raise 4종, None-downgrade, compute_evidence_age_days 단위 5종, producer→judge 통합 1종).
- `tests/test_self_review_no_body_leak_regression.py` — top-level key-set 단언에 `evidence_age_days` 추가.
- `docs/adr/0064-self-review-external-judge.md` **(load-bearing: docs/adr/)** — dead-guard 후속 bullet 을 "완료 #1166" 으로 갱신 + 신규 verifies-key 마커 5개.

## 3. 리스크

- **가장 가능성 높은 깨짐**: `assemble_stats` 출력에 키 추가 → 정확-일치 key-set 단언 테스트 깨짐. → `test_top_level_keys_present` 의 `expected_keys` 에 `evidence_age_days` 추가로 배제. 다른 stats-key 정확일치 단언은 grep 으로 없음을 확인(나머지 `expected_keys` 는 무관 함수).
- **operator 검증 strict 화**(`{}` / 부분 / extra-key → raise): `judge_self_review`/`assemble_stats` 호출자는 테스트 외 production 코드에 없음을 확인. CLI `main` 은 `--operator-verdicts` 없으면 `operator=None`(검증 skip), 있으면 `ValueError`→exit 2 로 정상 degrade.
- **None→downgrade**(boundary 가 아닌 내부 producer 출력): 미측정 신호는 verdict 를 낮추기만 함(거짓 승급 불가) → 안전 방향.

## 4. 테스트

Behavior change 전-fail/후-pass 충족:
- `test_partial_operator_raises` — 변경 전: 1축 operator → n=1, κ=1.0, passes(통과). 변경 후: ValueError.
- `test_missing_evidence_age_downgrades_all_passes` — 변경 전: `evidence_age_days` 부재 → 가드 no-op → 전축 ✓. 변경 후: 전축 △.
- `test_assemble_stats_emits_evidence_age_and_judge_consumes_it` — 실제 `assemble_stats()` → `judge_self_review` 통합. 변경 전: producer 부재로 `"evidence_age_days" in stats` False(fail). 변경 후 pass — **누락 producer 를 잡았을 테스트**.
- 추가: typo/extra-key/empty operator raise, `compute_evidence_age_days` 단위(freshest 선택·mixed date/ISO·None·floor-0·same-day<1.0).

로컬: `pytest tests/test_self_review_judge.py` 28 passed. self-review 7개 테스트 파일 풀런 exit 0. 전체 스위트 진행 중(다중 worktree 경합으로 느림; CI 가 게이트).

## 5. Eval 영향

RAG 파이프라인(retrieval/answer/verifier) 미변경 → CI eval delta **All `·`**. 변경 표면은 self-review collaboration judge 로 `make real-eval` 경로와 무관.

### 5b. Real-data delta

`make real-eval-delta` 는 RAG 전용이라 해당 없음. 대신 **self-review judge 를 실제 Q2-2026 stats 로 재실행**한 델타 (재현: `_self_review.py --quarter Q2-2026 --emit-stats` → `self_review_judge.py --stats <q2> --operator-verdicts <q2-ops> --backend stub`):

| 축 | operator | judge BEFORE (committed `Q2-2026.json`) | judge AFTER (가드 발화) |
|---|---|---|---|
| axis_1 context | ✓ | △ | △ |
| axis_2 delegation | △ | ✗ | ✗ |
| axis_3 governance | △ | **✓** | **△** ← 가드 |
| axis_4 cycle | △ | **✓** | **△** ← 가드 |
| axis_5 memory | △ | **✓** | **△** ← 가드 |
| raw 일치 | | 0/5 | **3/5** |
| Cohen's κ | | −0.389 | **−0.111** |
| passes (κ≥0.6) | | False | False |

실측 `evidence_age_days ≈ 0.014 (<1.0)` → 같은 날 근거라 가드가 stub axis_3/4/5 의 ✓ 를 △ 로 강등 → operator(전축 △ 중심) 와 일치가 0/5→3/5 로 상승, κ −0.389→−0.111. ADR 0064 첫 실행이 진단한 "axis_3 시점 드리프트"의 근본 해결이 실제 작동함을 확인. (committed `reports/self_review_agreement/Q2-2026.json` 은 2026-05-19 BEFORE 스냅샷으로 보존, now-의존이라 덮어쓰지 않음.)

## 6. 하위 호환

- `assemble_stats` 출력 키 추가 = **순증(additive)**. answer-contract(ADR 0003) 무관 → `schema_version` bump 불필요.
- operator 검증 strict 화는 잘못된 입력을 통과시키던 버그 수정 — 정상 5축 파일은 영향 없음.
- CLI flag / doc link 변경 없음.

## 7. 범위 외

- **openai 백엔드 가드 비대칭**: `_guard_downgrade` 는 `stub_verdicts` 에만 적용되고 `openai_verdicts` 에는 미적용(프롬프트로만 안내). 즉 `--backend openai_compatible` 는 시간분리 가드를 코드로 강제하지 않음. 본 PR 범위(stub 실입력 경로의 죽은 가드) 밖 — 별도 follow-up 후보. committed `Q2-openai-vs-stub.json` 은 본 변경에 영향 없음(가드가 stub 안에만 있어서).