### PR TITLE
fix(self-review): enforce ADR-0064 time-separation guard on openai backend

### DIFF
--- a/docs/adr/0064-self-review-external-judge.md
+++ b/docs/adr/0064-self-review-external-judge.md
@@ -70,6 +70,7 @@
 <!-- verifies-key: tests/test_self_review_judge.py:test_partial_operator_raises -->
 <!-- verifies-key: tests/test_self_review_judge.py:test_missing_evidence_age_downgrades_all_passes -->
 <!-- verifies-key: tests/test_self_review_judge.py:test_assemble_stats_emits_evidence_age_and_judge_consumes_it -->
+<!-- verifies-key: tests/test_self_review_judge.py:test_openai_backend_applies_time_separation_guard -->
 
 ### 첫 실행 결과 (Q2-2026, stub backend)
 

--- a/eval/judges/self_review_judge.py
+++ b/eval/judges/self_review_judge.py
@@ -409,6 +409,15 @@ def judge_self_review(
             f"unknown backend: {backend!r} (expected stub|openai_compatible)"
         )
 
+    # ADR 0064 time-separation guard, enforced post-dispatch so every backend
+    # is symmetric. stub_verdicts already self-guards, but openai_verdicts
+    # returns the LLM's raw verdicts — the guard is only *described* in
+    # _build_prompt, never enforced — so same-day or unmeasured evidence
+    # (evidence_age_days < 1.0 or None) could promote a ✓ on the openai path
+    # that the stub path forbids. Re-application on the stub path is idempotent.
+    ev_age = extract_signals(stats)["evidence_age_days"]
+    judge = {k: _guard_downgrade(v, ev_age) for k, v in judge.items()}
+
     local = {
         key: {
             "axis": label,

--- a/tests/test_self_review_judge.py
+++ b/tests/test_self_review_judge.py
@@ -225,6 +225,41 @@ def test_axis_5_both_subsignals_pass():
     assert stub_verdicts(stats)["axis_5_memory_hygiene"] == "✓"
 
 
+def test_openai_backend_applies_time_separation_guard(monkeypatch):
+    """ADR 0064 backend symmetry: the openai backend's raw verdicts pass
+    through _guard_downgrade too (evidence_age_days < 1.0 → ✓→△), matching
+    the stub path.
+
+    Regression for the asymmetry deferred out of PR #1187: _guard_downgrade
+    was applied only inside stub_verdicts, so an all-✓ openai verdict on
+    same-day evidence stayed ✓ while stub forced it to △. We monkeypatch
+    openai_verdicts to a fixed all-✓ dict so the assertion isolates the
+    guard, not the (unmocked) LLM call.
+    """
+    all_pass = {
+        "axis_1_context_efficiency": "✓",
+        "axis_2_agent_delegation": "✓",
+        "axis_3_governance_roi": "✓",
+        "axis_4_cycle_time": "✓",
+        "axis_5_memory_hygiene": "✓",
+    }
+    monkeypatch.setattr(
+        "eval.judges.self_review_judge.openai_verdicts",
+        lambda *_: dict(all_pass),
+    )
+    # same-day evidence (< 1.0 day) → the guard must fire on the openai path.
+    _, agg = judge_self_review(
+        _base_stats(evidence_age_days=0.5), backend="openai_compatible"
+    )
+    assert agg["judge_verdicts"] == {k: "△" for k in all_pass}, agg
+    # control: age ≥ 1.0 leaves the verdicts untouched, proving the downgrade
+    # is the time-separation guard and not an unconditional rewrite.
+    _, agg_old = judge_self_review(
+        _base_stats(evidence_age_days=2.0), backend="openai_compatible"
+    )
+    assert agg_old["judge_verdicts"] == all_pass, agg_old
+
+
 def test_unknown_backend_raises():
     """Unknown backend → ValueError."""
     with pytest.raises(ValueError):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1189

ADR-0064 의 시간분리 가드 `_guard_downgrade` (`evidence_age_days < 1.0` 일 때 ✓ → △) 가 **stub backend 에만** 적용됐다 — `stub_verdicts` 의 마지막 `return {k: _guard_downgrade(v, ev_age) ...}`. `openai_verdicts` 는 LLM 의 raw verdict 를 가드 없이 반환했고, 가드는 `_build_prompt` 에서 모델에게 *설명*만 됐을 뿐 코드로 강제되지 않았다. 결과적으로 `--backend openai_compatible` 은 same-day 근거를 ✓ 로 승급할 수 있지만 `--backend stub` 은 불가능 — backend 간 비대칭. ADR 0064 의 외부-anchor 목적상 시간분리 가드는 backend 무관 불변식이어야 한다. (PR #1187 이 stub 경로를 고치며 이 비대칭을 범위 외로 명시 보류함.)

`judge_self_review` 의 backend dispatch 직후 `_guard_downgrade` 를 dispatch 된 verdict dict 에 uniform 하게 적용 → 두 backend 모두 time-separation-safe. stub 경로 재적용은 idempotent (✓→△ 후 △→△).

## 2. 영향 파일

- `eval/judges/self_review_judge.py` **(load-bearing: eval/)** — `judge_self_review` 에 backend dispatch 직후 `_guard_downgrade` uniform 적용 (+9 LOC). `_guard_downgrade` 시맨틱·`stub_verdicts`·`openai_verdicts` 시그니처 무변경.
- `tests/test_self_review_judge.py` — `test_openai_backend_applies_time_separation_guard` 1개 추가 (monkeypatch `openai_verdicts` → all-✓, age=0.5 → 전축 △, age=2.0 control → 전축 ✓).
- `docs/adr/0064-self-review-external-judge.md` **(load-bearing: docs/adr/)** — 신규 테스트용 `verifies-key` 마커 1줄 추가.

## 3. 리스크

- **가장 가능성 높은 깨짐**: `judge_self_review` 가 stub 경로에서 가드를 두 번 적용 → 중복. 그러나 `_guard_downgrade` 는 idempotent (✓→△, 그 후 △/✗ 무변경) 이므로 기존 stub 테스트 16개 전부 그대로 통과 확인.
- **다른 호출자 영향**: `judge_self_review` 호출자는 CLI `main` + 테스트뿐 (production 코드 없음, PR #1187 에서도 동일 확인). CLI 동작 변화 없음.
- **실제 발화 시점**: collector 가 현재 `evidence_age_days = null` 을 emit (ADR 0064 line 93) → 가드는 실 CI/leaderboard 에서 여전히 no-op. age<1.0 producer 가 들어와야 (PR #1187 의 `compute_evidence_age_days`) 발화 → 그 시점에 양 backend 가 대칭 발화. 즉 이 PR 은 dormant safety 추가.

## 4. 테스트

Behavior change 전-fail / 후-pass 충족 (소스만 stash 후 검증):
- `test_openai_backend_applies_time_separation_guard` — **변경 전**: openai 경로 가드 미적용 → monkeypatched all-✓ 가 그대로 통과, `judge_verdicts` 전축 ✓ → assert `△` fail. **변경 후**: 전축 △ pass. control (age=2.0) 은 전후 모두 전축 ✓ — 강등이 시간분리 가드임을 격리 입증.
- 기존 stub 가드 테스트 (`test_evidence_age_under_24h_forces_partial` 등) 영향 없음 (stub 자체 가드 유지).
- 로컬: `python3.11 -m pytest tests/test_self_review_judge.py` → 17 passed. self-review 7개 테스트 파일 풀런 → 60 passed, 2 subtests, exit 0. ADR 0064 verifies-key lint (`_governance.py --lint-adr-consequences`) exit 0.

## 5. Eval 영향

RAG 외 변경 (self-review 협업 메타-judge). CI RAG eval delta = All `·`.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 — 이 PR 은 `eval/judges/self_review_judge.py` (협업 5축 메타-judge) 만 손대며 RAG ingestion/retrieval/verifier/answer 파이프라인을 일절 건드리지 않는다. `make real-eval` (RAG 답변 채점) 산물 무관 → real-data delta 없음. 변경된 동작은 self-review judge 의 `openai_compatible` backend 가 이제 stub 과 동일하게 시간분리 가드를 강제한다는 점뿐 (현재 collector `evidence_age_days=null` 로 dormant).

## 6. 하위 호환

답변 계약 (ADR 0003) / `schema_version` 무관 — 무변경. `judge_self_review` / `_guard_downgrade` / CLI 시그니처 전부 보존. 가드는 ✓→△ 강등만 (거짓 승급 불가) → 안전 방향, 기존 verdict 를 더 보수적으로만 만든다.

## 7. 범위 외

- **`reports/self_review_agreement/Q2-openai-vs-stub.json` 스냅샷 미갱신 (의도적)**: 이 historical 스냅샷은 `evidence_age_days=null` 입력으로 생성돼 가드가 no-op 였고 judge==operator (강등 0) 를 보인다. 이 PR 의 가드는 age<1.0 일 때만 발화하므로 동일 null-age stats 로 재생성해도 스냅샷은 불변 — 따라서 historical 기록을 덮어쓰지 않았다. same-day(age<1.0) 근거로 재생성하면 axis_3/4/5 의 ✓ 가 △ 로 강등될 것이며, 이는 정상 동작 (별도 시점정합 재채점 follow-up 시 갱신).
- **`_guard_downgrade` 의 None(미측정) 처리**: 현재 main 에서 None 은 no-op (✓ 유지). None 도 보수적 강등하는 변경은 PR #1187 관할 — 본 PR 은 backend *대칭* 만 다루며 가드 시맨틱은 불변.
- **PR #1187 과의 관계**: 둘 다 `judge_self_review` 를 건드리나 영역이 다르다 (#1187 = operator 검증 + agreement 행 구성 / 본 PR = dispatch 직후 가드). 나중에 머지되는 쪽이 사소한 충돌 해소.