### PR TITLE
fix(governance): enforce ADR 0062 monotone ceiling ratchet

### DIFF
--- a/.github/workflows/branch-and-issue-check.yml
+++ b/.github/workflows/branch-and-issue-check.yml
@@ -53,6 +53,18 @@ jobs:
         run: |
           python scripts/check_branch_and_issue.py --check-5b ${{ github.event.pull_request.number }}
 
+      - name: Enforce failure-rate ceiling ratchet (ADR 0062)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          # Fail when a PR raises/removes a ceiling in
+          # tests/test_failure_rate_regression.py without an explicit
+          # [ALLOW_REGRESSION: <category> ...] token in the body. Fetches the
+          # base + head versions of the test file via the contents API, so no
+          # extra checkout is needed. Skips when the file isn't in the diff.
+          python scripts/check_branch_and_issue.py --check-ceiling-ratchet ${{ github.event.pull_request.number }}
+
       - name: Guard ADR file deletion/rename (CLAUDE.md Prohibited)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/adr/0062-failure-rate-regression-contract.md
+++ b/docs/adr/0062-failure-rate-regression-contract.md
@@ -25,7 +25,7 @@ variance audit (#1025) 는 또한 절대 failure count 가
 
 ## Decision
 
-두 부분으로 구성된 **failure-rate regression contract** 를 도입한다:
+세 부분으로 구성된 **failure-rate regression contract** 를 도입한다:
 
 1. `tests/test_failure_rate_regression.py` 가 커밋된
    `reports/real100/baseline.aggregate.json` (aggregate-only, ADR 0005
@@ -45,13 +45,37 @@ variance audit (#1025) 는 또한 절대 failure count 가
    (b) real-eval set 에 대표 예시 ≥5 추가, (c) `test_failure_rate_regression.py` 에서
    그 ceiling 설정 또는 tighten, (d) supply 2 dashboard 가 렌더링. 이것이 closed loop 다.
 
+3. `scripts/check_branch_and_issue.py --check-ceiling-ratchet` (CI 의
+   `branch-and-issue-check.yml` 에 wired) 가 커밋된 ceiling 을 base 브랜치와
+   diff 하여, gate 대상 ceiling 을 **상향**하거나 gated 카테고리를 **제거**하는
+   PR 을 PR 본문에 명시적 `[ALLOW_REGRESSION: <category> ...]` 토큰이 없으면
+   실패시킨다. 이것이 "정당화 없이는 절대 올라가지 않는다" 를 운영자 규율이
+   아닌 실제 gate 로 만든다. in-test `test_ceilings_are_monotone_sane` 은
+   ceiling 을 현재 rate *아래로* 두는 역전(inversion)만 가드하며 상향 자체는
+   잡지 못하므로, 이 CI gate 가 그 갭을 닫는다 (issue #1150).
+
 테스트는 또한 ADR 0059 first-match 계약
 (`verifier_false_negative == abstention_outcomes.incorrect_answer`) 을 재단언하여
 이를 깨뜨리는 향후 ordering 변경도 regression gate 를 실패시키도록 한다.
 
+**CI 강제 vs 운영자(operator) 실행 (정직한 경계).** CI 가 강제하는 것:
+(i) 커밋된 baseline 의 rate ≤ ceiling (위 pytest gate — 커밋된 aggregate 를
+읽으므로 private 데이터 없이 CI 에서 실행), (ii) ceiling ratchet (위 #3 CI gate
+— 정당화 없는 ceiling 상향/제거 차단). CI 가 강제하지 **못하는** 것:
+head-vs-baseline 회귀 탐지 — "이 코드 변경이 *실제로* failure mode 를
+악화시켰는가". real-eval 은 private-local (ADR 0005) 이라 CI 에 head eval 을
+실행할 수 없다. 그 탐지는 운영자가 `make real-eval` + `make real-eval-delta` 를
+돌리는 단계이며, delta 는 `failure_category_counts` 도 표면화한다
+(`scripts/run_real_eval_delta.py`). load-bearing 변경의 §5b 요구가 운영자에게
+그 실행을 촉구하는 discipline hook 이다. **잔여 갭(residual gap)**: failure mode 를
+악화시키지만 baseline 을 regen 하지 않는 코드 변경은 CI 에 보이지 않는다 —
+폐루프는 운영자가 real-eval 을 돌려 회귀가 커밋된 baseline 에 반영될 때 비로소
+ceiling 테스트가 발화하는 것에 의존한다.
+
 production code path 변경 없음 (`rag_*.py`, `api/`, `eval/config.yaml`
 미터치). 테스트는 커밋된 baseline 의 read-only consumer 이며, private 데이터
-없이 CI 에서 실행된다.
+없이 CI 에서 실행된다. ceiling-ratchet gate 도 커밋된 ceiling 소스만 비교하므로
+마찬가지로 private 데이터 없이 동작한다.
 
 ## Consequences
 
@@ -66,8 +90,9 @@ production code path 변경 없음 (`rag_*.py`, `api/`, `eval/config.yaml`
   Issue G multi-doc topic spread) 은 구체적 ratchet 목표를 가진다: 커밋된
   rate 를 낮추고, 같은 PR 에서 ceiling 을 tighten.
 - 비용: gate 대상 rate 를 악화시키는 baseline regen 은 이제 수정이나
-  명시적 `[ALLOW_REGRESSION]` ceiling bump 중 하나가 필요 — 설계상 regen PR 에
-  약간 더 많은 마찰.
+  명시적 `[ALLOW_REGRESSION]` ceiling bump 중 하나가 필요하고, ceiling 상향/제거는
+  PR 본문의 `[ALLOW_REGRESSION: <category> ...]` 토큰을 CI 가 확인한다
+  (issue #1150) — 설계상 regen PR 에 약간 더 많은 마찰.
 - ADR 0001 (naive_baseline byte-identical) / 0003 (answer dict) / 0005
   (eval-split aggregate-only) / 0059 (classifier additive) 불변식 모두
   보존.
@@ -90,3 +115,6 @@ production code path 변경 없음 (`rag_*.py`, `api/`, `eval/config.yaml`
 <!-- verifies-key: tests/test_failure_rate_regression.py:def test_gated_category_rates_under_ceiling -->
 <!-- verifies-key: tests/test_failure_rate_regression.py:def test_adr_0059_first_match_contract -->
 <!-- verifies-key: docs/operations/failure-mode-harden-process.md:monotone-harden -->
+<!-- verifies-key: scripts/_governance.py:def ceiling_ratchet_violations -->
+<!-- verifies-key: scripts/check_branch_and_issue.py:def check_ceiling_ratchet_mode -->
+<!-- verifies-key: .github/workflows/branch-and-issue-check.yml:check-ceiling-ratchet -->

--- a/docs/operations/failure-mode-harden-process.md
+++ b/docs/operations/failure-mode-harden-process.md
@@ -31,6 +31,13 @@ fix lands ──▶ lower committed rate ──▶ TIGHTEN ceiling in same PR �
 래칫은 **한 방향**으로만 돌아간다: 천장은 fix 가 landing 되면 내려가며,
 명시적 `[ALLOW_REGRESSION]` 정당화 없이는 절대 올라가지 않는다.
 
+이 방향성은 이제 CI 가 강제한다 — `branch-and-issue-check.yml` 의
+ceiling-ratchet gate (`scripts/check_branch_and_issue.py
+--check-ceiling-ratchet`) 가 base 브랜치 대비 ceiling 상향/제거를 PR 본문의
+`[ALLOW_REGRESSION: <category> ...]` 토큰 없이는 차단한다 (issue #1150).
+in-test `test_ceilings_are_monotone_sane` 은 역전(천장 < 현재 rate)만 가드하므로,
+상향 차단은 이 CI gate 가 담당한다.
+
 ## 각 표면의 역할
 
 | surface | file | role |
@@ -39,6 +46,7 @@ fix lands ──▶ lower committed rate ──▶ TIGHTEN ceiling in same PR �
 | classifier lock | `tests/test_failure_classifier.py` | ordering 을 고정해 Finding #1 이 `verifier_false_negative` 로 유지되게 함 |
 | dashboard | `scripts/render_failure_distribution.py` | distribution + ADR 0059 계약 ✓ 렌더 (supply 2) |
 | **regression gate** | `tests/test_failure_rate_regression.py` | **커밋된 baseline 의 래칫 천장 (ADR 0062)** |
+| **ratchet gate** | `scripts/check_branch_and_issue.py --check-ceiling-ratchet` | **base 대비 ceiling 상향/제거를 `[ALLOW_REGRESSION]` 없이 차단 (CI, issue #1150)** |
 | baseline | `reports/real100/baseline.aggregate.json` | 게이트가 읽는 커밋된 aggregate (ADR 0005 경계) |
 
 ## 새로 표면화된 실패 모드 추가하기
@@ -74,6 +82,11 @@ fix PR 이 게이트된 rate 를 낮출 때:
    `current_rate + small_margin` 으로 **같은 PR 에서** 낮춘다.
 3. `test_ceilings_are_monotone_sane` 은 천장을 현재 rate
    *아래로* 설정하는 것(역전된 래칫)을 가드한다.
+
+의도적으로 천장을 **상향**해야 한다면 (예: ADR 0058 같은 cross-HEAD 변경으로
+variance 가 커진 경우), PR 본문에 `[ALLOW_REGRESSION: <category> 0.X→0.Y 사유]`
+토큰을 추가한다 — CI ceiling-ratchet gate 가 이를 확인하고, 없으면 PR 을
+차단한다.
 
 ## 절대 카운트가 아닌 rate 인 이유
 

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -23,6 +23,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import sys
 from datetime import date
@@ -551,6 +552,119 @@ def proposed_adr_age(
     # Oldest first; uncommitted (age None) sort last.
     records.sort(key=lambda r: (r.age_days is None, -(r.age_days or 0)))
     return records
+
+
+# ---------------------------------------------------------------------------
+# Failure-rate ceiling ratchet enforcement (ADR 0062, issue #1150).
+#
+# ADR 0062 documents a "monotone-ratchet" contract: the failure-rate ceilings
+# in tests/test_failure_rate_regression.py may only ratchet DOWN as fixes land
+# — never up without an explicit [ALLOW_REGRESSION] justification in the PR
+# body. But the in-test guard (test_ceilings_are_monotone_sane) only asserts
+# ceiling >= the *current committed rate*; it never compares against the base
+# branch, so a PR could RAISE a ceiling (loosening the gate) with every test
+# still green. The ratchet was operator-discipline-only.
+#
+# These pure helpers + the check_branch_and_issue.py --check-ceiling-ratchet CI
+# mode close that hole: diff the committed ceilings against the base branch and
+# FAIL when any ceiling loosened (raised, or a gated category removed) unless
+# the PR body carries [ALLOW_REGRESSION: <category> ...]. Parsing is AST-based
+# (no import) so it works on a base-branch source string fetched via the GitHub
+# contents API — importing it would pull in eval.scorers.failure_classifier.
+# ---------------------------------------------------------------------------
+
+# Flat-dict key for the scalar CEILING_TOTAL_FAILURE_RATE. Not one of the 7
+# ADR 0059 FAILURE_CATEGORIES, so it cannot collide with a real category key.
+TOTAL_FAILURE_RATE_KEY = "total_failure_rate"
+
+_CEILING_DICT_NAME = "CEILING_RATE_BY_CATEGORY"
+_CEILING_TOTAL_NAME = "CEILING_TOTAL_FAILURE_RATE"
+
+# An [ALLOW_REGRESSION: <category> <old>→<new> reason] token. Only the leading
+# category name is captured; old→new/reason are free-form (the token's job is
+# to force acknowledgment, per ADR 0062, not to be machine-validated).
+ALLOW_REGRESSION_RE = re.compile(r"\[ALLOW_REGRESSION:\s*([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def parse_failure_rate_ceilings(source: str) -> dict[str, float]:
+    """Extract the ratchet ceilings from a test_failure_rate_regression.py source.
+
+    Returns a flat ``{category: ceiling}`` dict with the scalar
+    ``CEILING_TOTAL_FAILURE_RATE`` stored under ``TOTAL_FAILURE_RATE_KEY``.
+    AST-based (``ast.literal_eval`` on the assignment values) so it parses a
+    base-branch string fetched via ``git show`` / the GitHub contents API,
+    which would fail to *import* (it pulls in eval.scorers.failure_classifier).
+
+    Raises ``ValueError`` if either expected assignment is absent or is not a
+    plain literal — a refactor that hides the ceilings from this parser must
+    fail loudly rather than silently disable the ratchet gate.
+    """
+    tree = ast.parse(source)
+    ceilings: dict[str, float] = {}
+    found_dict = False
+    found_total = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+        if _CEILING_DICT_NAME in names:
+            value = ast.literal_eval(node.value)
+            if not isinstance(value, dict):
+                raise ValueError(f"{_CEILING_DICT_NAME} is not a dict literal")
+            for k, v in value.items():
+                ceilings[str(k)] = float(v)
+            found_dict = True
+        elif _CEILING_TOTAL_NAME in names:
+            ceilings[TOTAL_FAILURE_RATE_KEY] = float(ast.literal_eval(node.value))
+            found_total = True
+    if not found_dict:
+        raise ValueError(f"{_CEILING_DICT_NAME} assignment not found")
+    if not found_total:
+        raise ValueError(f"{_CEILING_TOTAL_NAME} assignment not found")
+    return ceilings
+
+
+def parse_allow_regression_categories(pr_body: str) -> set[str]:
+    """Return the category names named in ``[ALLOW_REGRESSION: <category> ...]``.
+
+    Empty set for an empty/None body or no tokens.
+    """
+    if not pr_body:
+        return set()
+    return {m.group(1) for m in ALLOW_REGRESSION_RE.finditer(pr_body)}
+
+
+def ceiling_ratchet_violations(
+    base: dict[str, float],
+    head: dict[str, float],
+    allowed: set[str],
+    *,
+    epsilon: float = 1e-9,
+) -> list[str]:
+    """Return one message per unjustified ceiling *loosening*; empty = clean.
+
+    A loosening is either a RAISED ceiling (``head > base``) or a REMOVED gated
+    category (present in ``base``, absent in ``head`` — drops the gate, strictly
+    more permissive than any value). Each must be justified by an
+    ``[ALLOW_REGRESSION: <category> ...]`` token (i.e. ``category in allowed``);
+    otherwise it is a violation. New categories (absent in ``base``) and
+    lowered/equal ceilings never violate — that is the monotone ratchet.
+    """
+    violations: list[str] = []
+    for category, base_ceiling in sorted(base.items()):
+        if category in head:
+            head_ceiling = head[category]
+            if head_ceiling > base_ceiling + epsilon and category not in allowed:
+                violations.append(
+                    f"{category}: ceiling raised {base_ceiling} → {head_ceiling} "
+                    f"without [ALLOW_REGRESSION: {category} ...] in the PR body"
+                )
+        elif category not in allowed:
+            violations.append(
+                f"{category}: gated ceiling removed ({base_ceiling} → absent) "
+                f"without [ALLOW_REGRESSION: {category} ...] in the PR body"
+            )
+    return violations
 
 
 def _cmd_next_adr_number(adr_dir: str) -> int:

--- a/scripts/check_branch_and_issue.py
+++ b/scripts/check_branch_and_issue.py
@@ -24,7 +24,12 @@ import subprocess
 import sys
 from typing import Optional
 
-from _governance import is_load_bearing
+from _governance import (
+    ceiling_ratchet_violations,
+    is_load_bearing,
+    parse_allow_regression_categories,
+    parse_failure_rate_ceilings,
+)
 
 
 BRANCH_REGEX = re.compile(
@@ -315,6 +320,134 @@ def check_5b_mode(pr_number: int) -> int:
     return 0
 
 
+CEILING_TEST_PATH = "tests/test_failure_rate_regression.py"
+
+
+def _fetch_file_at_ref(repo: str, path: str, ref: str) -> Optional[str]:
+    """Return `path` content at `ref` via the GitHub contents API, or None.
+
+    Uses the `raw` media type so no base64 decode is needed. Returns None on
+    any failure (404 = file absent at that ref, network error, etc.) so the
+    caller decides whether absence is fatal or a skip.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/contents/{path}?ref={ref}",
+             "-H", "Accept: application/vnd.github.raw"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return result.stdout
+
+
+def check_ceiling_ratchet_mode(pr_number: int) -> int:
+    """Enforce the ADR 0062 monotone ceiling ratchet for a PR.
+
+    The failure-rate ceilings in ``tests/test_failure_rate_regression.py`` may
+    only ratchet DOWN as fixes land. The in-test guard only checks each ceiling
+    against the *current committed rate*, never the base branch — so a PR could
+    RAISE a ceiling (loosening the gate) with every test green. This closes that
+    hole.
+
+    Logic:
+      1. `gh pr view --json files,body,baseRefName,headRefOid`.
+      2. If the ceiling test file isn't in the diff → exit 0 (ceilings unchanged).
+      3. Fetch the base + head versions of the file via the contents API.
+      4. Diff the parsed ceilings; FAIL on any loosening (raised, or a gated
+         category removed) not justified by an `[ALLOW_REGRESSION: <category>
+         ...]` token in the PR body.
+    """
+    if not gh_available():
+        _err("❌ `gh` CLI is required in --check-ceiling-ratchet mode but is not available.\n")
+        return 2
+    repo = get_repo_slug()
+    if not repo:
+        _err("❌ Could not determine repo slug (set GITHUB_REPOSITORY).\n")
+        return 2
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--repo", repo,
+             "--json", "files,body,baseRefName,headRefOid"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        _err(f"❌ Could not fetch PR #{pr_number}: {e.stderr}\n")
+        return 2
+
+    pr = json.loads(result.stdout)
+    files = pr.get("files") or []
+    body = pr.get("body") or ""
+    base_ref = pr.get("baseRefName") or ""
+    head_ref = pr.get("headRefOid") or ""
+
+    changed = {f.get("path", "") for f in files}
+    if CEILING_TEST_PATH not in changed:
+        sys.stdout.write(
+            f"OK: PR #{pr_number} does not touch {CEILING_TEST_PATH}; "
+            "ceiling ratchet not applicable.\n"
+        )
+        return 0
+
+    base_src = _fetch_file_at_ref(repo, CEILING_TEST_PATH, base_ref) if base_ref else None
+    if base_src is None:
+        sys.stdout.write(
+            f"OK: {CEILING_TEST_PATH} not present on base '{base_ref}' "
+            "(first introduction); no ratchet baseline to compare against.\n"
+        )
+        return 0
+    head_src = _fetch_file_at_ref(repo, CEILING_TEST_PATH, head_ref) if head_ref else None
+    if head_src is None:
+        _err(f"❌ Could not fetch {CEILING_TEST_PATH} at head '{head_ref}'.\n")
+        return 2
+
+    try:
+        base_ceilings = parse_failure_rate_ceilings(base_src)
+    except (ValueError, SyntaxError) as exc:
+        # Base unparseable → don't block the PR on an upstream issue.
+        sys.stdout.write(
+            f"OK: could not parse ceilings on base '{base_ref}' ({exc}); "
+            "skipping ratchet check.\n"
+        )
+        return 0
+    try:
+        head_ceilings = parse_failure_rate_ceilings(head_src)
+    except (ValueError, SyntaxError) as exc:
+        _err(
+            f"\n❌ Could not parse the ratchet ceilings in {CEILING_TEST_PATH} "
+            f"at this PR's head: {exc}\n"
+            "   CEILING_RATE_BY_CATEGORY (dict) and CEILING_TOTAL_FAILURE_RATE\n"
+            "   (float) must stay plain literals so the ADR 0062 ratchet gate can\n"
+            "   read them. Keep them parseable (and update the ADR 0062\n"
+            "   Verification markers if you move them).\n"
+        )
+        return 1
+
+    allowed = parse_allow_regression_categories(body)
+    violations = ceiling_ratchet_violations(base_ceilings, head_ceilings, allowed)
+    if violations:
+        _err(
+            f"\n❌ ADR 0062 monotone ceiling ratchet violated by PR #{pr_number}:\n\n"
+        )
+        for v in violations:
+            _err(f"     - {v}\n")
+        _err(
+            "\n   The failure-rate ceilings in tests/test_failure_rate_regression.py\n"
+            "   may only ratchet DOWN as fixes land. To LOOSEN one deliberately,\n"
+            "   add an explicit token to the PR body, e.g.:\n"
+            "       [ALLOW_REGRESSION: retrieval_miss 0.34→0.40 reason here]\n"
+            "   See docs/adr/0062-failure-rate-regression-contract.md and\n"
+            "   docs/operations/failure-mode-harden-process.md.\n"
+        )
+        return 1
+
+    sys.stdout.write(
+        f"OK: PR #{pr_number} touches {CEILING_TEST_PATH}; "
+        "no unjustified ceiling loosening.\n"
+    )
+    return 0
+
+
 def main() -> int:
     p = argparse.ArgumentParser(
         description="Validate branch + issue convention + §5b (ADR 0007, CLAUDE.md).",
@@ -326,6 +459,13 @@ def main() -> int:
         "--check-5b", type=int, dest="check_5b", metavar="PR_NUMBER",
         help="Verify PR body §5b for load-bearing changes (CI mode).",
     )
+    g.add_argument(
+        "--check-ceiling-ratchet", type=int, dest="check_ceiling_ratchet",
+        metavar="PR_NUMBER",
+        help="Enforce the ADR 0062 monotone failure-rate ceiling ratchet: a PR "
+             "that raises/removes a ceiling in tests/test_failure_rate_regression.py "
+             "without an [ALLOW_REGRESSION: <category> ...] token fails (CI mode).",
+    )
     p.add_argument(
         "--check-issue", action="store_true",
         help="In --branch mode, also verify the referenced issue exists via gh.",
@@ -336,6 +476,8 @@ def main() -> int:
         return check_branch_mode(args.branch, args.check_issue)
     if args.pr is not None:
         return check_pr_mode(args.pr)
+    if args.check_ceiling_ratchet is not None:
+        return check_ceiling_ratchet_mode(args.check_ceiling_ratchet)
     return check_5b_mode(args.check_5b)
 
 

--- a/tests/test_governance_ceiling_ratchet.py
+++ b/tests/test_governance_ceiling_ratchet.py
@@ -1,0 +1,237 @@
+"""Regression tests for the ADR 0062 monotone ceiling ratchet enforcement
+(issue #1150).
+
+ADR 0062 documents a ratchet contract — the failure-rate ceilings in
+``tests/test_failure_rate_regression.py`` may only go DOWN, never up without an
+explicit ``[ALLOW_REGRESSION]`` justification. Before #1150 nothing enforced
+it: ``test_ceilings_are_monotone_sane`` only checks each ceiling against the
+*current committed rate*, never the base branch, so a PR could RAISE a ceiling
+(loosening the gate) with every test green.
+
+These tests pin the pure helpers that the
+``check_branch_and_issue.py --check-ceiling-ratchet`` CI gate is built on:
+parsing ceilings out of source (AST, no import), parsing the
+``[ALLOW_REGRESSION]`` tokens out of a PR body, and the loosening-detection
+itself. The (a)/(b)/(c) cases from the issue map to
+``test_raise_without_token_*`` / ``test_raise_with_token_passes`` /
+``test_lowered_or_equal_passes``.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from eval.scorers.failure_classifier import FAILURE_CATEGORIES
+
+REPO = Path(__file__).resolve().parents[1]
+CEILING_TEST = REPO / "tests" / "test_failure_rate_regression.py"
+CHECK_SCRIPT = REPO / "scripts" / "check_branch_and_issue.py"
+
+sys.path.insert(0, str(REPO / "scripts"))
+import _governance as gov  # type: ignore  # noqa: E402
+
+
+SAMPLE_SOURCE = """
+CEILING_TOTAL_FAILURE_RATE = 0.86
+CEILING_RATE_BY_CATEGORY = {
+    "verifier_false_negative": 0.40,
+    "retrieval_miss": 0.34,
+}
+"""
+
+
+class TestParseFailureRateCeilings(unittest.TestCase):
+    def test_parses_sample_with_total_under_sentinel(self) -> None:
+        c = gov.parse_failure_rate_ceilings(SAMPLE_SOURCE)
+        self.assertEqual(
+            c,
+            {
+                gov.TOTAL_FAILURE_RATE_KEY: 0.86,
+                "verifier_false_negative": 0.40,
+                "retrieval_miss": 0.34,
+            },
+        )
+
+    def test_parses_the_real_committed_file(self) -> None:
+        c = gov.parse_failure_rate_ceilings(CEILING_TEST.read_text(encoding="utf-8"))
+        # Total present under the sentinel key; gated categories present.
+        self.assertIn(gov.TOTAL_FAILURE_RATE_KEY, c)
+        self.assertIn("verifier_false_negative", c)
+        self.assertIn("retrieval_miss", c)
+        for v in c.values():
+            self.assertIsInstance(v, float)
+            self.assertGreaterEqual(v, 0.0)
+
+    def test_real_file_gated_keys_are_known_categories(self) -> None:
+        """Integrity: every gated key is an ADR 0059 category or the total
+        sentinel. Catches a constant rename that would silently blind the gate.
+        """
+        c = gov.parse_failure_rate_ceilings(CEILING_TEST.read_text(encoding="utf-8"))
+        allowed_keys = set(FAILURE_CATEGORIES) | {gov.TOTAL_FAILURE_RATE_KEY}
+        self.assertTrue(set(c).issubset(allowed_keys), set(c) - allowed_keys)
+
+    def test_total_sentinel_does_not_collide_with_a_category(self) -> None:
+        self.assertNotIn(gov.TOTAL_FAILURE_RATE_KEY, set(FAILURE_CATEGORIES))
+
+    def test_missing_dict_assignment_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            gov.parse_failure_rate_ceilings("CEILING_TOTAL_FAILURE_RATE = 0.86\n")
+
+    def test_missing_total_assignment_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            gov.parse_failure_rate_ceilings(
+                'CEILING_RATE_BY_CATEGORY = {"retrieval_miss": 0.34}\n'
+            )
+
+    def test_non_dict_value_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            gov.parse_failure_rate_ceilings(
+                "CEILING_TOTAL_FAILURE_RATE = 0.86\n"
+                "CEILING_RATE_BY_CATEGORY = 0.5\n"
+            )
+
+
+class TestParseAllowRegressionCategories(unittest.TestCase):
+    def test_empty_body(self) -> None:
+        self.assertEqual(gov.parse_allow_regression_categories(""), set())
+        self.assertEqual(gov.parse_allow_regression_categories(None), set())  # type: ignore[arg-type]
+
+    def test_no_token(self) -> None:
+        self.assertEqual(
+            gov.parse_allow_regression_categories("just a normal PR body"), set()
+        )
+
+    def test_single_token(self) -> None:
+        body = "We loosen [ALLOW_REGRESSION: retrieval_miss 0.34→0.40 cross-HEAD variance]."
+        self.assertEqual(
+            gov.parse_allow_regression_categories(body), {"retrieval_miss"}
+        )
+
+    def test_multiple_tokens(self) -> None:
+        body = (
+            "[ALLOW_REGRESSION: retrieval_miss 0.34->0.40 x]\n"
+            "[ALLOW_REGRESSION: total_failure_rate 0.86->0.90 y]"
+        )
+        self.assertEqual(
+            gov.parse_allow_regression_categories(body),
+            {"retrieval_miss", "total_failure_rate"},
+        )
+
+    def test_arrow_variants_irrelevant_to_capture(self) -> None:
+        # Both the unicode arrow and ASCII '->' work — we only capture the
+        # leading category name, so the arrow form never matters.
+        for arrow in ("→", "->", " "):
+            with self.subTest(arrow=arrow):
+                body = f"[ALLOW_REGRESSION: verifier_false_negative 0.40{arrow}0.45 r]"
+                self.assertEqual(
+                    gov.parse_allow_regression_categories(body),
+                    {"verifier_false_negative"},
+                )
+
+    def test_lowercase_keyword_does_not_match(self) -> None:
+        # The token keyword is a deliberate, visible marker; a lowercase
+        # mention in prose must not silently satisfy the gate.
+        body = "we should allow_regression: retrieval_miss someday"
+        self.assertEqual(gov.parse_allow_regression_categories(body), set())
+
+
+class TestCeilingRatchetViolations(unittest.TestCase):
+    # --- (a) raised without token → violation -----------------------------
+    def test_raise_without_token_violates(self) -> None:
+        v = gov.ceiling_ratchet_violations(
+            {"retrieval_miss": 0.34}, {"retrieval_miss": 0.40}, set()
+        )
+        self.assertEqual(len(v), 1)
+        self.assertIn("retrieval_miss", v[0])
+        self.assertIn("ALLOW_REGRESSION", v[0])
+
+    def test_total_raise_without_token_violates(self) -> None:
+        v = gov.ceiling_ratchet_violations(
+            {gov.TOTAL_FAILURE_RATE_KEY: 0.86},
+            {gov.TOTAL_FAILURE_RATE_KEY: 0.90},
+            set(),
+        )
+        self.assertEqual(len(v), 1)
+        self.assertIn(gov.TOTAL_FAILURE_RATE_KEY, v[0])
+
+    # --- (b) raised with token → passes -----------------------------------
+    def test_raise_with_token_passes(self) -> None:
+        v = gov.ceiling_ratchet_violations(
+            {"retrieval_miss": 0.34}, {"retrieval_miss": 0.40}, {"retrieval_miss"}
+        )
+        self.assertEqual(v, [])
+
+    def test_total_raise_with_token_passes(self) -> None:
+        v = gov.ceiling_ratchet_violations(
+            {gov.TOTAL_FAILURE_RATE_KEY: 0.86},
+            {gov.TOTAL_FAILURE_RATE_KEY: 0.90},
+            {gov.TOTAL_FAILURE_RATE_KEY},
+        )
+        self.assertEqual(v, [])
+
+    # --- (c) lowered / equal → passes -------------------------------------
+    def test_lowered_or_equal_passes(self) -> None:
+        self.assertEqual(
+            gov.ceiling_ratchet_violations(
+                {"retrieval_miss": 0.34}, {"retrieval_miss": 0.30}, set()
+            ),
+            [],
+        )
+        self.assertEqual(
+            gov.ceiling_ratchet_violations(
+                {"retrieval_miss": 0.34}, {"retrieval_miss": 0.34}, set()
+            ),
+            [],
+        )
+
+    # --- removal (the deletion bypass hole) -------------------------------
+    def test_removed_category_without_token_violates(self) -> None:
+        v = gov.ceiling_ratchet_violations({"retrieval_miss": 0.34}, {}, set())
+        self.assertEqual(len(v), 1)
+        self.assertIn("removed", v[0])
+
+    def test_removed_category_with_token_passes(self) -> None:
+        v = gov.ceiling_ratchet_violations(
+            {"retrieval_miss": 0.34}, {}, {"retrieval_miss"}
+        )
+        self.assertEqual(v, [])
+
+    # --- new category is fine (tightening the net) ------------------------
+    def test_new_category_passes(self) -> None:
+        v = gov.ceiling_ratchet_violations(
+            {}, {"verifier_false_negative": 0.40}, set()
+        )
+        self.assertEqual(v, [])
+
+    # --- mixed: one justified raise + one unjustified ---------------------
+    def test_mixed_only_unjustified_violates(self) -> None:
+        base = {"retrieval_miss": 0.34, "verifier_false_negative": 0.40}
+        head = {"retrieval_miss": 0.40, "verifier_false_negative": 0.45}
+        v = gov.ceiling_ratchet_violations(base, head, {"retrieval_miss"})
+        self.assertEqual(len(v), 1)
+        self.assertIn("verifier_false_negative", v[0])
+
+    def test_float_noise_not_flagged(self) -> None:
+        # Reparsed-but-equal values must not register as a raise.
+        v = gov.ceiling_ratchet_violations(
+            {"retrieval_miss": 0.1 + 0.2}, {"retrieval_miss": 0.3}, set()
+        )
+        self.assertEqual(v, [])
+
+
+class TestCliWiring(unittest.TestCase):
+    def test_check_ceiling_ratchet_flag_is_registered(self) -> None:
+        """Smoke: the CI flag is wired into the argparser (catches a wiring
+        regression without needing gh / network)."""
+        r = subprocess.run(
+            ["python3", str(CHECK_SCRIPT), "--help"],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("--check-ceiling-ratchet", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0062 (#1073) 는 failure-rate ceiling 이 **monotone ratchet** — 정당화 없이는 절대 올라가지 않음 — 이라고 문서화했지만, 그걸 강제하는 게 아무것도 없었다. `test_ceilings_are_monotone_sane` 은 "ceiling ≥ 현재 커밋된 rate"만 보지 base 브랜치와 비교를 안 한다. 그래서 PR 이 `CEILING_RATE_BY_CATEGORY` / `CEILING_TOTAL_FAILURE_RATE` 를 **올려도**(게이트 느슨하게) 모든 테스트가 통과한다 — ratchet 이 운영자 규율일 뿐이었다.

이 PR 은 base 브랜치 대비 ceiling 을 diff 해서 정당화 없는 상향/제거를 차단하는 CI 게이트를 추가하고(PRIMARY), ADR 0062 의 문구를 CI-vs-운영자 강제 경계에 대해 정직하게 다듬는다(SECONDARY).

Closes #1150

## 2. 영향 파일

- `scripts/_governance.py` — 순수 helper 3개: `parse_failure_rate_ceilings`(AST), `parse_allow_regression_categories`, `ceiling_ratchet_violations`
- `scripts/check_branch_and_issue.py` — `--check-ceiling-ratchet` CI 모드 (base/head 테스트파일을 contents API 로 가져와 비교)
- `.github/workflows/branch-and-issue-check.yml` — §5b 옆에 ceiling-ratchet 게이트 step 추가
- `tests/test_governance_ceiling_ratchet.py` — 회귀 테스트 24개 (신규)
- `docs/adr/0062-failure-rate-regression-contract.md` — **load-bearing (docs/adr/)**; 정직한 CI-vs-운영자 경계 문구 + Verification 마커
- `docs/operations/failure-mode-harden-process.md` — ratchet 이 이제 CI 강제됨 + surface 표 행 + 토큰 사용법

## 3. 리스크

가장 가능성 높은 깨짐: CI 게이트의 gh 통합 (필드명/contents API). `headRefOid`/`baseRefName`/`files`/`body` 필드 유효성 + raw contents fetch 를 live repo 로 검증함. parse 가 ceiling 상수를 못 읽으면 → head unparseable 시 fail(의도적 — 상수는 ADR 0062 계약이므로 parseable 유지 강제), base unparseable/absent 시 skip(upstream 이슈로 PR 차단 안 함). **이 PR 은 `tests/test_failure_rate_regression.py` 를 수정하지 않으므로 자기 PR 에서는 게이트가 skip(exit 0)** — 올바른 동작.

## 4. 테스트

`tests/test_governance_ceiling_ratchet.py` 신규 24개:
- **(a)** raised-without-token → violation / **(b)** raised-with-token → pass / **(c)** lowered·equal → pass
- removal(삭제 우회 구멍) without/with token, new category, mixed, float-noise, `total_failure_rate`
- 실제 커밋된 테스트파일 parse + 키 ⊆ `FAILURE_CATEGORIES ∪ {total sentinel}` (상수 rename 가드)
- CLI `--help` smoke (플래그 등록 확인)

이 enforcement 자체가 신규 동작이므로 위 테스트가 "변경 후 pass" 를 검증. 로컬 전체 스위트 green (ruff + pytest exit 0 + ADR lint).

## 5. Eval 영향

All `·` — RAG 파이프라인 / eval 산출물 변경 없음. governance 스크립트 + 테스트 + 문서만.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 (pipeline 코드 미터치 — governance/test/docs only). `docs/adr/` 변경으로 load-bearing 분류되나 production code path(`rag_*.py`, `api/`, `eval/config.yaml`) 무변경. ADR 0005 참조.

## 6. 하위 호환

기존 계약/스키마/CLI flag 깨짐 없음. `check_branch_and_issue.py` 에 `--check-ceiling-ratchet` 추가(기존 모드 유지), `_governance.py` 에 함수 추가(기존 함수 무변경). ADR 0003 answer-contract 무관, `schema_version` 변경 없음.

## 7. 범위 외

- ADR 0062 Status `proposed`→`accepted` 승격 — lifecycle 결정이라 `adr-lifecycle-manager` 관할로 분리
- SECONDARY option (a) (§5b 게이트가 baseline regen 강제) 는 비실용적이라 기각: behavior-preserving load-bearing 변경에 false friction + private 데이터 CI 불가 + §5b escape 경로 충돌. option (b)(정직한 문서화) 채택

🤖 Generated with [Claude Code](https://claude.com/claude-code)