### PR TITLE
fix(governance): clamp proposed-ADR age_days to 0 for future-dated commits

### DIFF
--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -638,7 +638,9 @@ def proposed_adr_age(
             grandfathered = False
             over_sla = False
         else:
-            age_days = (today - first_commit).days
+            # Floor at 0: a commit author-dated ahead of `today` (KST/+09:00
+            # vs the runner's UTC clock) would otherwise yield a negative age.
+            age_days = max(0, (today - first_commit).days)
             grandfathered = first_commit < grandfather_date
             over_sla = (not grandfathered) and age_days > sla
         records.append(

--- a/tests/test_governance_proposed_adr_age.py
+++ b/tests/test_governance_proposed_adr_age.py
@@ -178,6 +178,20 @@ def test_uncommitted_age_none_not_over(tmp_path: Path) -> None:
     assert recs[0].grandfathered is False
 
 
+def test_future_dated_commit_clamps_to_zero(tmp_path: Path) -> None:
+    # KST/+09:00 author date can resolve a calendar day ahead of the runner's
+    # UTC `now`; age must floor at 0 (not -1) and never flag over_sla.
+    _adr(tmp_path, "0011-x.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 22),  # one day ahead of `now`
+        now=date(2026, 5, 21),
+    )
+    assert recs[0].age_days == 0
+    assert recs[0].over_sla is False
+    assert recs[0].grandfathered is False
+
+
 def test_sorted_oldest_first_uncommitted_last(tmp_path: Path) -> None:
     _adr(tmp_path, "0001-a.md", "proposed")  # newer
     _adr(tmp_path, "0002-b.md", "proposed")  # older


### PR DESCRIPTION
## Summary
- `proposed_adr_age()` in `scripts/_governance.py` computed `age_days = (today - first_commit).days`, which goes negative when a commit's git author date resolves to a calendar day ahead of the CI runner's UTC `now` (commit authored in KST/+09:00 while the runner clock is still the previous UTC day).
- This red `tests/test_governance_proposed_adr_age.py::test_repo_proposed_adr_age_runs` (`assert -1 is None or -1 >= 0`) during the ~9h KST-morning window, self-resolving once UTC passes midnight — a recurring flake.
- Fix: floor `age_days` at 0. `grandfathered` (keys off `first_commit < grandfather_date`) and `over_sla` (with age 0 → `0 > sla` is False) are both unaffected.

Exists on main; surfaced by #1194's CI but unrelated to that PR (docs/assets only).

## Test plan
- [x] New unit test `test_future_dated_commit_clamps_to_zero` feeds `first_commit` one day ahead of `now`, asserts `age_days == 0`, `over_sla is False`, `grandfathered is False`.
- [x] Full `tests/test_governance_proposed_adr_age.py` — 22 passed (existing over_sla/grandfathered/sorting invariants intact).
- [x] `python3 scripts/_governance.py --proposed-adr-age` runs clean.
- [x] `ruff check` on both changed files passes.

## 5b (real-data 델타)
N/A — `scripts/_governance.py` is not a load-bearing pipeline path (governance lint collector only); no retrieval/answer/eval surface touched, no real-data behavior change.

closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)