### PR TITLE
fix(test): bash 3.2-safe empty-array flag expansion in scripts/test.sh

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -68,7 +68,20 @@ if command -v pytest >/dev/null 2>&1; then
       echo "pytest-split not importable; ignoring BIDMATE_PYTEST_STORE_DURATIONS." >&2
     fi
   fi
-  pytest -q "${XDIST_FLAGS[@]}" "${COV_FLAGS[@]}" "${SPLIT_FLAGS[@]}" "${STORE_DURATIONS_FLAGS[@]}"
+  # macOS system bash (3.2.57) treats an empty array expanded as "${ARR[@]}"
+  # under `set -u` as an unbound-variable error and aborts. All four flag groups
+  # can legitimately reach this line empty (xdist/cov/split not installed, or
+  # BIDMATE_PYTEST_SPLITS/SHARD/STORE_DURATIONS unset on a normal local run), so
+  # the plain "${ARR[@]}" form crashes before pytest ever runs (#1179). The
+  # "${ARR[@]+"${ARR[@]}"}" form expands to nothing for an empty array and to the
+  # quoted elements otherwise — safe on bash 3.2 AND 4.4+. Do NOT simplify back
+  # to "${ARR[@]}"; that reintroduces the macOS-bash-3.2 crash. (bash 4.4+ /
+  # Linux CI never hit this, which is why it slipped past the sharded CI gate.)
+  pytest -q \
+    "${XDIST_FLAGS[@]+"${XDIST_FLAGS[@]}"}" \
+    "${COV_FLAGS[@]+"${COV_FLAGS[@]}"}" \
+    "${SPLIT_FLAGS[@]+"${SPLIT_FLAGS[@]}"}" \
+    "${STORE_DURATIONS_FLAGS[@]+"${STORE_DURATIONS_FLAGS[@]}"}"
 else
   echo "pytest not found. Install dev dependencies or add pytest to requirements." >&2
   exit 1


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/test.sh` 가 `set -euo pipefail` 하에서 line 71 의 네 optional 플래그 배열을 펼칠 때, macOS 시스템 bash(3.2.57)가 **빈 배열**(`"${ARR[@]}"`)을 unbound-variable 에러로 취급해 pytest 가 돌기도 전에 즉시 죽었다. 일반 로컬 실행에서는 `XDIST_FLAGS`/`COV_FLAGS`/`SPLIT_FLAGS`/`STORE_DURATIONS_FLAGS` 가 모두 비어 도달할 수 있어(미설치 + env unset) → `bash scripts/test.sh` / `make smoke` 가 통째로 막혔다. bash 3.2 안전한 빈-배열 펼침 관용구 `"${ARR[@]+"${ARR[@]}"}"` (빈 배열 → 무기여, non-empty → 따옴표 보존 펼침)로 교체.

Linux CI 는 bash 4+/5 라 빈 배열 펼침이 정상이고 pytest-split 샤딩으로 `SPLIT_FLAGS` 가 항상 채워져 → 이 버그는 sharded CI gate 를 통과했다 (homebrew bash 없는 로컬 macOS 개발자만 물림).

Closes #1179

## 2. 영향 파일

- `scripts/test.sh` — line 71 플래그 펼침만. **load-bearing 아님** (`scripts/_governance.py` `LOAD_BEARING_PATHS` 미포함), CI 강제 동작 변경 아님

## 3. 리스크

- 가장 가능성 높은 깨짐: 관용구가 인자 경계(공백 포함)를 깨거나, non-empty 일 때 플래그를 빠뜨림. → bash 3.2 + 5.2 양쪽에서 (a) 빈 배열, (b) `-n auto --dist loadfile`, (c) 공백 포함 인자 `--foo="x y"` 펼침을 확인 — 전부 경계 보존 (`<-n> <auto> <--foo=x y>`)
- 미래 회귀: 누군가 `"${ARR[@]}"` 로 "단순화" → line 71 위에 do-NOT-simplify 주석 + 사유 명시

## 4. 테스트

bash 셸 스크립트 분기라 pytest 단위테스트 부적합. `pytest`/`ruff`/`python`(optional dep 부재 모사) stub + PATH 우회로 **사용자 정확 호출 경로**를 양쪽 bash 에서 end-to-end 재현·검증:

| 시나리오 | bash 3.2 (`/bin/bash`) | bash 5.2 (PATH) |
|---|---|---|
| 수정 전, xdist 부재 | `line 71: XDIST_FLAGS[@]: unbound variable` exit 1 | `args:-q` exit 0 |
| 수정 후, xdist 부재 | `args:-q` exit 0 ✅ | `args:-q` exit 0 |
| 수정 후, xdist+cov 존재 | `-q -n auto --dist loadfile --cov ...` 전달 ✅ | 동일 |
| `bash -n` parse | OK | OK |

graceful serial fallback 보존 + 플래그 전달 정상 + bash 5.2 무회귀 확인.

## 5. Eval 영향

All `·` — 테스트 게이트 셸 스크립트 변경, RAG 검색/검증/답변 path 무관.

### 5b. Real-data delta

N/A — `scripts/test.sh` 는 load-bearing path 아님 (`LOAD_BEARING_PATHS` 미포함). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

깨짐 없음. 동일 인자로 pytest 호출 (빈 그룹은 펼치지 않음 = 기존 bash 4.4+ 동작과 동일). 답변 계약(ADR 0003) 무관.

## 7. 범위 외

- 셸 portability 정적 분석(shellcheck) 게이트 도입 — 별도 issue 후보
- `scripts/` 내 다른 스크립트의 동일 패턴 audit — 본 PR 은 #1179 의 line 71 한정

🤖 Generated with [Claude Code](https://claude.com/claude-code)