### PR TITLE
fix(eval): include judge sampling temperature in RAGAS verdict cache key

### DIFF
--- a/eval/judges/llm_judge.py
+++ b/eval/judges/llm_judge.py
@@ -57,6 +57,7 @@ from eval.judges.judge_common import (  # noqa: E402
     clamp_score as clamp_score_common,
     extract_summary,
     get_judge_model,
+    get_judge_temperature,
 )
 from rag_core import neutralize_instruction_patterns  # noqa: E402
 
@@ -164,8 +165,12 @@ def _build_prompt(case: dict[str, Any]) -> str:
 def _cache_key(case: dict[str, Any], backend: str, model: str) -> str:
     """SHA256 over the inputs that determine the verdict.
 
-    Includes backend + model so switching the backend invalidates the
-    cache (we want fresh judgments when changing the underlying judge).
+    Includes backend + model + sampling temperature so switching any of
+    them invalidates the cache (we want fresh judgments when changing the
+    underlying judge or how it samples). Temperature is part of the judge
+    configuration that changes the verdict, so a verdict produced at one
+    temperature must not be served as a cache hit for a re-run at another
+    (ADR 0012 judge reproducibility; temperature added via #1132).
     """
     query = str(case.get("query") or "")
     summary = extract_summary(case)
@@ -181,7 +186,9 @@ def _cache_key(case: dict[str, Any], backend: str, model: str) -> str:
         ensure_ascii=False,
         sort_keys=True,
     )
-    payload = "|".join([backend, model, query, summary, ev_repr])
+    payload = "|".join(
+        [backend, model, f"{get_judge_temperature():.4f}", query, summary, ev_repr]
+    )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -13,15 +13,18 @@ a network / API key. Tests pin:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 from eval.judges.llm_judge import (
     DEFAULT_TOKEN_BUDGET,
     RAGAS_METRICS,
+    _cache_key,
     judge_ragas,
 )
 from scripts.llm_judge import judge_summary
@@ -218,6 +221,46 @@ class JudgeRagasStubTest(unittest.TestCase):
         self.assertEqual(0, agg["n"])
         for metric in RAGAS_METRICS:
             self.assertIsNone(agg[metric])
+
+
+class JudgeCacheKeyTemperatureRegressionTest(unittest.TestCase):
+    """Sampling temperature must participate in the verdict cache key.
+
+    Regression for a measurement-integrity bug: ``BIDMATE_JUDGE_TEMPERATURE``
+    became configurable in #1132, but ``_cache_key`` keyed only on
+    backend+model+inputs. A verdict produced at one temperature was served
+    as a cache hit for a re-run at another, silently returning a stale
+    judgment (ADR 0012 judge reproducibility).
+    """
+
+    @staticmethod
+    def _key() -> str:
+        case = {
+            "query": "q",
+            "answer": {"summary": "s"},
+            "evidence": [{"doc_id": "d1", "text": "e"}],
+        }
+        return _cache_key(case, "stub", "stub")
+
+    def test_distinct_temperatures_produce_distinct_keys(self) -> None:
+        """The core fix: temperature 0.0 (default) vs 1 must not collide."""
+        with mock.patch.dict(os.environ, clear=False):
+            os.environ.pop("BIDMATE_JUDGE_TEMPERATURE", None)
+            default_key = self._key()
+        with mock.patch.dict(os.environ, {"BIDMATE_JUDGE_TEMPERATURE": "1"}):
+            hot_key = self._key()
+        self.assertNotEqual(default_key, hot_key)
+
+    def test_unset_temperature_matches_explicit_zero(self) -> None:
+        """Unset resolves to 0.0, so its key equals an explicit 0.0 — the
+        default deterministic path stays stable and self-consistent across
+        runs (ADR 0001: default offline behaviour byte-identical)."""
+        with mock.patch.dict(os.environ, clear=False):
+            os.environ.pop("BIDMATE_JUDGE_TEMPERATURE", None)
+            unset_key = self._key()
+        with mock.patch.dict(os.environ, {"BIDMATE_JUDGE_TEMPERATURE": "0.0"}):
+            zero_key = self._key()
+        self.assertEqual(unset_key, zero_key)
 
 
 class JudgeRagasCLITest(unittest.TestCase):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1198

`eval/judges/llm_judge.py` 의 `_cache_key` 가 per-case RAGAS verdict 캐시 키를 `backend + model + inputs` 로만 만들어 sampling **temperature 를 누락**했다. PR #1132 이후 `BIDMATE_JUDGE_TEMPERATURE` (env, `judge_common.get_judge_temperature()`, 기본 0.0) 로 temperature 를 바꿀 수 있는데, 키에 temperature 가 없어 **같은 model 에서 temperature 만 바꿔 재실행하면 옛 temperature 로 생성된 verdict 가 그대로 cache hit 으로 조용히 반환**된다 (측정 무결성 버그). `_cache_key` docstring 이 명시한 "fresh judgments when changing the underlying judge" 불변식을 temperature 도 따라야 하므로, resolved temperature (`f"{get_judge_temperature():.4f}"`) 를 키 payload 에 포함하도록 수정했다.

## 2. 영향 파일

- `eval/judges/llm_judge.py` — **load-bearing** (`eval/`). `_cache_key` payload 에 temperature 추가 + docstring 갱신 + `get_judge_temperature` import
- `tests/test_llm_judge.py` — 회귀 테스트 1클래스 2메서드 추가

## 3. 리스크

- **가장 가능성 높은 깨짐**: 키 문자열 변경으로 기존 `reports/judge_cache/` 엔트리가 1회 무효화 → 첫 재실행이 cache miss. 이는 **의도된 동작**(옛 엔트리는 temperature 미기록이라 안전 폐기). 재계산 verdict 는 동일 (backend+model+temperature+inputs 가 같으면 결정론적), 따라서 측정값 변화 없음
- **배제 확인**: 기본 오프라인 경로(temperature 미설정 → 0.0)는 키 표현만 바뀌고 verdict 값/aggregate 는 byte-identical. `judge_ragas` stub 경로 전체 테스트 통과로 확인

## 4. 테스트

`tests/test_llm_judge.py::JudgeCacheKeyTemperatureRegressionTest` (2):
- `test_distinct_temperatures_produce_distinct_keys` — temperature 0.0(기본) vs `"1"` 에서 `_cache_key` 가 **다른** 키. **수정 전 fail / 수정 후 pass** (옛 코드는 두 키가 동일 → assertNotEqual 실패)
- `test_unset_temperature_matches_explicit_zero` — 미설정 == 명시적 `"0.0"` → 같은 키 (기본 결정론 경로 자기일관성, ADR 0001)

`pytest tests/test_llm_judge.py` → 15 passed. `ruff check` → clean.

## 5. Eval 영향

CI 합성 eval delta: **All `·`** — 캐시 키 표현만 바뀌고 retrieval/verifier/answer path 동작 변화 없음. judge_ragas verdict 값/aggregate 불변.

### 5b. Real-data delta

**검색/검증/답변 path 동작 변화 없음.** 변경은 `_cache_key` 의 SHA256 payload 문자열 표현 한정이다. `make real-eval-delta` 가 집계하는 `judge_ragas` aggregate 는 verdict 값의 함수이고, verdict 는 `(backend, model, temperature, inputs)` 의 결정론적 함수다 — 동일 설정 재실행 시 byte-identical. 키에 temperature 가 새로 기록되어 **최초 1회만 cache miss → 동일 verdict 재생성**하므로 real-data 델타 = **0**. (ADR 0005 / ADR 0012)

## 6. 하위 호환

답변 계약(ADR 0003) `schema_version` 무관 — judge 캐시 키 내부 표현 변경. CLI flag / doc link 변화 없음. 유일한 가시 효과는 `reports/judge_cache/` 1회 무효화(gitignored, 재생성으로 자동 복구).

## 7. 범위 외 (의도적 미수정)

- `rag_verifier`/`rationality_judge.py` 의 미사용 `cache_dir` — 별개 정리 대상
- `self_review_judge` / `synthetic_judge` 는 per-case 캐시를 안 하므로 무관 (one PR one concern)
- `eval/judges/llm_judge.py` 의 기존 pyright 경고(line 107/133/145/182/287, reportOptionalSubscript 등) — 이 변경과 무관한 선재 이슈, 건드리지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)