### PR TITLE
fix(governance): recognize ADR 0047 `## Resolution` append in proposed-ADR SLA collector

### DIFF
--- a/.claude/skills/adr-lifecycle-manager/SKILL.md
+++ b/.claude/skills/adr-lifecycle-manager/SKILL.md
@@ -21,14 +21,14 @@ ADR 0047이 선언한 30일 proposed-status SLA를 해소하는 skill. **기계�
 
 ## Workflow
 
-1. **탐지** — `python3 scripts/_governance.py --proposed-adr-age` 실행. 출력 컬럼: `NNNN<TAB>age_days<TAB>flag(OVER_SLA/grandfathered/ok)<TAB>first_commit<TAB>filename`. OVER_SLA 우선, 그다음 approaching(age ≥ 23일 = SLA−7) 표면화. grandfathered/ok 는 정보용. **탐지는 `Status:` 값만 본다**(`proposed_adr_age` 가 `status.startswith("proposed")` 로 필터) — `## Resolution` 만 append 하고 Status 를 proposed 로 둔 ADR 은 0047 상 해소돼도 collector 가 계속 표면화함(step 3 resolve-in-place 참조).
+1. **탐지** — `python3 scripts/_governance.py --proposed-adr-age` 실행. 출력 컬럼: `NNNN<TAB>age_days<TAB>flag(resolved_in_place/OVER_SLA/grandfathered/ok)<TAB>first_commit<TAB>filename`. OVER_SLA 우선, 그다음 approaching(age ≥ 23일 = SLA−7) 표면화. resolved_in_place/grandfathered/ok 는 정보용. **collector 는 0047 결정 #2 의 두 해소 경로를 모두 인식한다**(#1178): Status mutation 은 `status.startswith("proposed")` 필터에서 빠져 아예 안 나오고, `## Resolution` H2 만 append 하고 Status 를 proposed 로 둔 ADR 은 `resolved_in_place` 로 표면화돼 OVER_SLA flag 가 걸리지 않는다 — 따라서 append 로 해소한 ADR 은 더는 false OVER_SLA 신호가 아니다(step 3 resolve-in-place 참조).
 2. **대상 선정 (gate)** — 해소할 ADR을 사용자와 확정. OVER_SLA 0건이면 "해소 대상 없음" 보고 후 종료. 다건이면 한 lifecycle PR로 묶을지(one concern) 확인.
 3. **per-ADR 판단 (각 건 명시 확인)** — 해당 ADR 본문을 읽고 5개 중 택1 제시:
    - **promote** → `Status: accepted` (결정 유효·검증됨). post-2026-05-15 ADR이면 먼저 `--lint-adr-consequences docs/adr/<file>` 로 Verification 마커가 실제 wired 인지 확인.
    - **supersede** → `Status: superseded by NNNN`. **대체 ADR 파일이 이미 존재할 때만 사용** — 그 실재 번호로 포인터 설정(가능하면 대체 ADR 이 본 ADR 을 backlink). 대체가 아직 없으면 `superseded by NNNN` **설정 금지**: `--next-adr-number` 는 filesystem max+1 **힌트일 뿐 예약 아님**(`next_adr_number` docstring) — 동시 worktree 가 같은 번호를 무관 ADR 로 가져가거나 포인터가 영영 작성 안 될 수 있음(CLAUDE.md 충돌 이력 0022→0023 / 0029→0030). 대체 없이 폐기면 **deprecate**, 대체가 필요하면 ADR 작성(ship-pr / eval-to-adr-bridge)으로 **파일을 먼저 만든 뒤** 돌아와 포인터 설정.
    - **deprecate** → `Status: deprecated` (대체 없이 폐기).
-   - **resolve-in-place** → `## Resolution` 단락 append(0047 결정 #2 는 해소 = status mutation **또는** `## Resolution` append 로 명시). 결과·근거 1문단. **단 collector 한계 명시: `--proposed-adr-age` 는 `Status:` 만 키로 보므로**, Status 를 `proposed` 로 둔 채 append 만 하면 30일 초과 시 **계속 OVER_SLA 로 재표면**된다(0047 상 해소여도). 그러므로 (a) resolution 이 accepted/deprecated 를 함의하면 Status 도 같이 바꿔 신호를 지우거나, (b) 의도적으로 proposed 유지 시 collector 가 계속 list 함을 받아들이고 — 해소 여부는 collector 재실행이 아니라 파일의 `## Resolution` 을 읽어 확인. (collector 가 `## Resolution` 을 해소 마커로 인식하게 만드는 것은 별도 `_governance.py` follow-up.)
-   - **keep-open + justify** → 아직 열려있으면 거부가 아니라 본문에 **명시 사유** append(방치 아닌 의식적 연장). 이는 해소가 아니므로 `--proposed-adr-age` 가 **계속 flag 하는 게 정상** — 다음 run 에서 사라질 거라 기대하지 말 것.
+   - **resolve-in-place** → `## Resolution` 단락 append(0047 결정 #2 는 해소 = status mutation **또는** `## Resolution` append 로 명시). 결과·근거 1문단. collector(`--proposed-adr-age`, #1178)가 이 `## Resolution` H2 를 인식해 해당 ADR 을 `resolved_in_place` 로 표면화하고 OVER_SLA flag 를 걸지 않으므로, Status 를 `proposed` 로 두더라도 30일 초과 시 false OVER_SLA 로 재표면되지 않는다. **단 정확히 `## Resolution` H2 여야** 인식된다(`### Resolution` H3·`## Resolution notes` 는 미인식 — `ADR_RESOLUTION_HEADER_RE`). resolution 이 사실상 accepted/deprecated 를 함의하면 Status 도 함께 바꾸는 게 더 정확한 신호.
+   - **keep-open + justify** → 아직 열려있으면 거부가 아니라 본문에 **명시 사유** append(방치 아닌 의식적 연장). 이는 해소가 아니므로 `--proposed-adr-age` 가 **계속 flag 하는 게 정상** — 다음 run 에서 사라질 거라 기대하지 말 것. (사유는 `## Resolution` 이 **아닌** 다른 헤더/문단으로 작성 — `## Resolution` H2 를 쓰면 collector 가 `resolved_in_place` 로 인식해 의도와 달리 신호가 사라진다.)
    - **자동 promote/supersede 절대 금지** — 항상 사용자 확인.
 4. **편집 + 동기화** — 선택된 해소를 ADR Status 블록에 적용. Status 문자열이 바뀌면 [docs/adr/README.md](../../../docs/adr/README.md) 인덱스 row의 status 컬럼도 **같은 커밋**에서 갱신. **주의: `--check-adr-readme-parity` 와 CI `test_no_unlinked_adr_files_on_disk` 는 row 가 파일명으로 linked 되어 있는지만 검증 — status 컬럼 값은 비교하지 않는다**(`_ADR_INDEX_ROW_RE` 가 number+filename 만 캡처). 따라서 status cell 일치는 자동 검증되지 않으므로 **편집 후 README row 를 직접 열어 status 를 눈으로 readback**(promote 시 README 의 "Proposed / Promote 조건" 표에서 빼는 것도 수동 확인). `--check-adr-readme-parity docs/adr/<file>` 는 row **누락** 검출용으로만 실행.
 5. **로컬 검증 (gate)** — `bash scripts/test.sh`(특히 `test_no_unlinked_adr_files_on_disk` + collector 테스트). post-2026-05-15 ADR 편집 시 `--lint-adr-consequences` 통과 확인. commit `chore(adr): resolve proposed SLA — <NNNN> <action> (closes #N)`(다건이면 요약).
@@ -48,7 +48,7 @@ go-ahead(진행): "진행" / "ㄱㄱ" / "ㅇㅋ" / "ok" / "go". 질문(답변만
 ## References
 
 - ADR 0047 — 1인 저자 ADR governance: 30일 proposed SLA + Verification 계약 + 번호예약.
-- [scripts/_governance.py](../../../scripts/_governance.py) — `--proposed-adr-age`(PR #1094, 탐지; `Status:` 만 키 → `## Resolution`-only append 미인식), `--lint-adr-consequences`(#793), `--check-adr-readme-parity`(#803, **row 파일명 존재만 검증 — status 컬럼 아님**), `--next-adr-number`(다음 번호 **힌트, 예약 아님**; 동시 worktree 미감지).
+- [scripts/_governance.py](../../../scripts/_governance.py) — `--proposed-adr-age`(PR #1094 탐지 + #1178 `## Resolution` H2 인식 → `resolved_in_place`), `--lint-adr-consequences`(#793), `--check-adr-readme-parity`(#803, **row 파일명 존재만 검증 — status 컬럼 아님**), `--next-adr-number`(다음 번호 **힌트, 예약 아님**; 동시 worktree 미감지).
 - [docs/adr/README.md](../../../docs/adr/README.md) — 인덱스 row(status 컬럼 동기화 대상).
 - [docs/adr/_template.md](../../../docs/adr/_template.md) — Status 블록 + Verification 형식.
 - [.claude/skills/ship-pr/SKILL.md](../ship-pr/SKILL.md) — push/PR/merge 핸드오프 + approval-gate 컨벤션.

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -421,10 +421,16 @@ def lint_adr_verification(
 # Proposed-ADR lifecycle SLA collector (ADR 0047 — deferred follow-up).
 #
 # ADR 0047 declared a 30-day SLA: a `Status: proposed` ADR first committed
-# on/after 2026-05-15 must resolve (accepted / superseded by NNNN /
-# deprecated) within 30 days. 0047 fixed the contract but explicitly
-# deferred the measurement collector ("proposed_adr_age(); 측정 collector 는
-# 나중에"). This implements that collector — reporting only (exit 0). The
+# on/after 2026-05-15 must resolve within 30 days. 0047 decision #2 defines
+# resolution two ways: a git-history Status mutation (accepted / superseded
+# by NNNN / deprecated) — which drops the ADR out of the proposed filter
+# entirely — OR an in-place `## Resolution` H2 paragraph append that records
+# the outcome while Status legitimately stays `proposed`. The collector
+# honors both: the latter surfaces as `resolved_in_place` instead of
+# OVER_SLA (issue #1178), so an append-resolved ADR stops being a false
+# OVER_SLA signal. 0047 fixed the contract but explicitly deferred the
+# measurement collector ("proposed_adr_age(); 측정 collector 는 나중에").
+# This implements that collector — reporting only (exit 0). The
 # promote/supersede *decision* is a judgment layer (the adr-lifecycle-manager
 # skill); any hard CI gate is a separate later policy choice.
 #
@@ -453,6 +459,12 @@ ADR_STATUS_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# ADR 0047 decision #2 sanctions an in-place `## Resolution` H2 append as a
+# resolution even when Status stays `proposed`. Mirrors the
+# `ADR_VERIFICATION_HEADER_RE` `## Verification` detector — exact H2, so
+# `### Resolution` (H3) and `## Resolution notes` do NOT match.
+ADR_RESOLUTION_HEADER_RE = re.compile(r"^##\s+Resolution\s*$", re.MULTILINE)
+
 
 class ProposedADR(NamedTuple):
     number: int
@@ -462,6 +474,9 @@ class ProposedADR(NamedTuple):
     age_days: int | None
     grandfathered: bool
     over_sla: bool
+    # ADR 0047 in-place resolution: a `## Resolution` H2 was appended while
+    # Status legitimately stays `proposed`. True suppresses `over_sla`.
+    resolved_in_place: bool
 
 
 def parse_adr_status(adr_path: str | Path) -> str | None:
@@ -484,6 +499,21 @@ def parse_adr_status(adr_path: str | Path) -> str | None:
     if value is None:
         value = m.group("table")
     return value.strip().lower()
+
+
+def adr_has_resolution_section(adr_path: str | Path) -> bool:
+    """Return True if the ADR file contains a `## Resolution` H2 header.
+
+    This is the in-place resolution marker ADR 0047 decision #2 sanctions:
+    a proposed ADR that appends `## Resolution` is resolved even though its
+    Status stays `proposed`, so the SLA collector should stop flagging it
+    OVER_SLA. Missing file → False. Mirrors ``adr_has_verification_section``.
+    """
+    p = Path(adr_path)
+    if not p.is_file():
+        return False
+    text = p.read_text(encoding="utf-8", errors="replace")
+    return bool(ADR_RESOLUTION_HEADER_RE.search(text))
 
 
 def _git_first_commit_date(path: str | Path) -> date | None:
@@ -519,10 +549,15 @@ def proposed_adr_age(
     """Return one ``ProposedADR`` per `Status: proposed` ADR, oldest first.
 
     ``over_sla`` is True iff the ADR was first committed on/after
-    ``grandfather_date`` AND its age exceeds ``sla_days`` (ADR 0047). ADRs
-    first committed earlier carry ``grandfathered=True`` and are never
-    flagged. Uncommitted files (no first-commit date) get ``age_days=None``
-    and ``over_sla=False``.
+    ``grandfather_date`` AND its age exceeds ``sla_days`` (ADR 0047) AND it
+    carries no in-place resolution. ADRs first committed earlier carry
+    ``grandfathered=True`` and are never flagged. Uncommitted files (no
+    first-commit date) get ``age_days=None`` and ``over_sla=False``.
+
+    ``resolved_in_place`` is True when the ADR appended a `## Resolution` H2
+    section — ADR 0047 decision #2's sanctioned in-place resolution. Such an
+    ADR is reported (Status still `proposed`) but never flagged ``over_sla``,
+    so an append-resolved ADR is no longer a false OVER_SLA signal.
 
     ``date_resolver`` defaults to a git lookup; inject a stub for testing.
     ``sla_days`` defaults to ``THRESHOLDS["ADR_PROPOSED_SLA_DAYS"]``.
@@ -544,6 +579,7 @@ def proposed_adr_age(
         status = parse_adr_status(entry)
         if status is None or not status.startswith("proposed"):
             continue
+        resolved_in_place = adr_has_resolution_section(entry)
         first_commit = resolver(entry)
         if first_commit is None:
             age_days: int | None = None
@@ -552,7 +588,7 @@ def proposed_adr_age(
         else:
             age_days = (today - first_commit).days
             grandfathered = first_commit < grandfather_date
-            over_sla = (not grandfathered) and age_days > sla
+            over_sla = (not grandfathered) and (not resolved_in_place) and age_days > sla
         records.append(
             ProposedADR(
                 number=int(m.group(1)),
@@ -562,6 +598,7 @@ def proposed_adr_age(
                 age_days=age_days,
                 grandfathered=grandfathered,
                 over_sla=over_sla,
+                resolved_in_place=resolved_in_place,
             )
         )
     # Oldest first; uncommitted (age None) sort last.
@@ -687,16 +724,23 @@ def _cmd_proposed_adr_age(adr_dir: str) -> int:
         fc = r.first_commit.isoformat() if r.first_commit else "uncommitted"
         age = "?" if r.age_days is None else str(r.age_days)
         flag = (
-            "OVER_SLA" if r.over_sla
-            else ("grandfathered" if r.grandfathered else "ok")
+            "resolved_in_place" if r.resolved_in_place
+            else "OVER_SLA" if r.over_sla
+            else "grandfathered" if r.grandfathered
+            else "ok"
         )
         sys.stdout.write(f"{r.number:04d}\t{age}\t{flag}\t{fc}\t{r.filename}\n")
     n_over = sum(1 for r in records if r.over_sla)
+    n_resolved = sum(1 for r in records if r.resolved_in_place)
     sla = THRESHOLDS["ADR_PROPOSED_SLA_DAYS"]
+    resolved_note = (
+        f" {n_resolved} resolved in place (## Resolution appended, ADR 0047)."
+        if n_resolved else ""
+    )
     sys.stderr.write(
         f"\n{len(records)} proposed ADR(s); {n_over} over the {sla}-day SLA "
-        "(ADR 0047). Reporting only — resolve via the adr-lifecycle-manager "
-        "skill (promote / supersede / deprecate).\n"
+        f"(ADR 0047).{resolved_note} Reporting only — resolve via the "
+        "adr-lifecycle-manager skill (promote / supersede / deprecate).\n"
     )
     return 0
 
@@ -813,7 +857,9 @@ def main() -> int:
         "--proposed-adr-age", action="store_true",
         help="Report each proposed-status ADR's age + 30-day SLA flag "
              "(ADR 0047). Tab-separated columns: NNNN, age_days, flag "
-             "(OVER_SLA/grandfathered/ok), first_commit, filename. "
+             "(resolved_in_place/OVER_SLA/grandfathered/ok), first_commit, "
+             "filename. `resolved_in_place` = a `## Resolution` H2 was "
+             "appended (0047 in-place resolution) so it is not flagged. "
              "Reporting only; exit 0.",
     )
     p.add_argument(

--- a/tests/test_governance_proposed_adr_age.py
+++ b/tests/test_governance_proposed_adr_age.py
@@ -15,16 +15,20 @@ from pathlib import Path
 from scripts._governance import (
     ADR_SLA_GRANDFATHER_DATE,
     THRESHOLDS,
+    _cmd_proposed_adr_age,
+    adr_has_resolution_section,
     parse_adr_status,
     proposed_adr_age,
 )
 
 
-def _adr(dir_: Path, name: str, status: str) -> None:
-    (dir_ / name).write_text(
-        f"# {name}\n\n- **Status**: {status}\n\n## Context\nstub\n",
-        encoding="utf-8",
-    )
+def _adr(dir_: Path, name: str, status: str, *, resolution: bool = False) -> None:
+    body = f"# {name}\n\n- **Status**: {status}\n\n## Context\nstub\n"
+    if resolution:
+        # ADR 0047 decision #2 in-place resolution: a `## Resolution` H2 append
+        # while Status legitimately stays as-is.
+        body += "\n## Resolution\n\nResolved in place per ADR 0047 decision #2.\n"
+    (dir_ / name).write_text(body, encoding="utf-8")
 
 
 # ---- parse_adr_status ----------------------------------------------------
@@ -75,6 +79,41 @@ def test_parse_status_table_form_with_annotation(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert parse_adr_status(tmp_path / "0044-t.md") == "accepted (superseded by adr 0052)"
+
+
+# ---- adr_has_resolution_section (ADR 0047 in-place marker) ----------------
+
+
+def test_resolution_section_detected(tmp_path: Path) -> None:
+    _adr(tmp_path, "0050-x.md", "proposed", resolution=True)
+    assert adr_has_resolution_section(tmp_path / "0050-x.md") is True
+
+
+def test_resolution_section_absent(tmp_path: Path) -> None:
+    _adr(tmp_path, "0050-x.md", "proposed")  # only `## Context`, no Resolution
+    assert adr_has_resolution_section(tmp_path / "0050-x.md") is False
+
+
+def test_resolution_section_h3_not_detected(tmp_path: Path) -> None:
+    # H3 is not the sanctioned marker — exact `## Resolution` H2 only.
+    (tmp_path / "0050-x.md").write_text(
+        "# t\n\n- **Status**: proposed\n\n### Resolution\n\nnot an H2\n",
+        encoding="utf-8",
+    )
+    assert adr_has_resolution_section(tmp_path / "0050-x.md") is False
+
+
+def test_resolution_section_inline_suffix_not_detected(tmp_path: Path) -> None:
+    # `## Resolution notes` is a different heading; the detector is anchored.
+    (tmp_path / "0050-x.md").write_text(
+        "# t\n\n- **Status**: proposed\n\n## Resolution notes\n\ntext\n",
+        encoding="utf-8",
+    )
+    assert adr_has_resolution_section(tmp_path / "0050-x.md") is False
+
+
+def test_resolution_section_missing_file_returns_false(tmp_path: Path) -> None:
+    assert adr_has_resolution_section(tmp_path / "nope.md") is False
 
 
 # ---- proposed_adr_age: status filtering ----------------------------------
@@ -210,6 +249,91 @@ def test_missing_dir_returns_empty(tmp_path: Path) -> None:
     assert proposed_adr_age(tmp_path / "nope") == []
 
 
+# ---- proposed_adr_age: ## Resolution in-place resolution (#1178) ----------
+# ADR 0047 decision #2 sanctions a `## Resolution` append as a resolution even
+# when Status stays `proposed`. The collector must stop flagging such an ADR
+# OVER_SLA and surface `resolved_in_place` instead.
+
+
+def test_resolution_append_suppresses_over_sla(tmp_path: Path) -> None:
+    # The before/after pair: an otherwise-OVER_SLA ADR (40d > 30d, post-
+    # grandfather) flips to resolved_in_place once `## Resolution` is appended.
+    _adr(tmp_path, "0050-x.md", "proposed", resolution=True)
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 16),  # after grandfather
+        now=date(2026, 6, 25),  # 40 days > 30
+    )
+    assert recs[0].age_days == 40
+    assert recs[0].grandfathered is False
+    assert recs[0].resolved_in_place is True
+    assert recs[0].over_sla is False
+    assert recs[0].status == "proposed"  # Status legitimately unchanged
+
+
+def test_no_resolution_still_over_sla(tmp_path: Path) -> None:
+    # Control for the pair above: identical dates, no `## Resolution` → still
+    # OVER_SLA, resolved_in_place False.
+    _adr(tmp_path, "0050-x.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 16),
+        now=date(2026, 6, 25),
+    )
+    assert recs[0].over_sla is True
+    assert recs[0].resolved_in_place is False
+
+
+def test_resolution_independent_of_grandfather(tmp_path: Path) -> None:
+    # A grandfathered ADR with a `## Resolution` is marked resolved_in_place;
+    # over_sla stays False either way (grandfather already exempts it).
+    _adr(tmp_path, "0011-old.md", "proposed", resolution=True)
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 1),  # before grandfather
+        now=date(2026, 7, 1),  # 61 days
+    )
+    assert recs[0].grandfathered is True
+    assert recs[0].resolved_in_place is True
+    assert recs[0].over_sla is False
+
+
+def test_resolution_within_sla_still_marked_resolved(tmp_path: Path) -> None:
+    # resolved_in_place reflects file content, not age — a young ADR resolved
+    # early is still resolved_in_place (not merely "ok").
+    _adr(tmp_path, "0050-x.md", "proposed", resolution=True)
+    recs = proposed_adr_age(
+        tmp_path,
+        date_resolver=lambda p: date(2026, 5, 16),
+        now=date(2026, 6, 10),  # 25 days <= 30
+    )
+    assert recs[0].over_sla is False
+    assert recs[0].resolved_in_place is True
+
+
+def test_resolved_in_place_defaults_false_without_marker(tmp_path: Path) -> None:
+    # Every record carries the new field; absent the marker it is False.
+    _adr(tmp_path, "0050-x.md", "proposed")
+    recs = proposed_adr_age(
+        tmp_path, date_resolver=lambda p: date(2026, 5, 16), now=date(2026, 6, 1)
+    )
+    assert recs[0].resolved_in_place is False
+
+
+def test_cmd_output_shows_resolved_in_place_flag(tmp_path, capsys) -> None:
+    # CLI flag-string mapping: resolved_in_place outranks ok/OVER_SLA in the
+    # printed flag column, and the summary notes the resolved count.
+    _adr(tmp_path, "0099-x.md", "proposed", resolution=True)
+    rc = _cmd_proposed_adr_age(str(tmp_path))
+    captured = capsys.readouterr()
+    assert rc == 0
+    # Data row goes to stdout; the resolved ADR shows the resolved flag.
+    assert "\tresolved_in_place\t" in captured.out
+    assert "OVER_SLA" not in captured.out
+    # Summary (stderr) reports the in-place count.
+    assert "resolved in place" in captured.err
+
+
 # ---- constants -----------------------------------------------------------
 
 
@@ -234,6 +358,11 @@ def test_repo_proposed_adr_age_runs() -> None:
         assert r.status.startswith("proposed")
         assert r.number > 0
         assert (r.age_days is None) or (r.age_days >= 0)
+        # New field is populated for every live record (exercises
+        # adr_has_resolution_section against real ADR files).
+        assert isinstance(r.resolved_in_place, bool)
+        # A resolved-in-place ADR is never simultaneously OVER_SLA.
+        assert not (r.resolved_in_place and r.over_sla)
 
 
 # ---- README ↔ collector parity (anti-fail-open) --------------------------


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/_governance.py` 의 proposed-ADR SLA collector(`proposed_adr_age`)를 그 거버넌스 ADR(0047)의 해소 정의에 정렬했다. ADR 0047 결정 #2 는 해소를 **git history mutation 또는 `## Resolution` 단락 append** 두 가지로 정의하나, collector 는 `status.startswith("proposed")` 만 키로 봐서 `## Resolution` 을 append 하고 Status 를 `proposed` 로 둔 ADR(0047 상 이미 해소)을 30일 초과 시 계속 `OVER_SLA` 로 표면화했다 — 자신의 ADR과 모순되는 false signal. 이제 `## Resolution` H2 를 인식해 그런 ADR 을 `OVER_SLA` 대신 `resolved_in_place` 로 표면화한다. PR #1165 / issue #1149 "범위 외" 에서 명시 연기된 follow-up.

Closes #1178

## 2. 영향 파일

- `scripts/_governance.py` — **non-load-bearing** (`LOAD_BEARING_PATHS` 미해당). `ADR_RESOLUTION_HEADER_RE` + `adr_has_resolution_section()`(기존 `ADR_VERIFICATION_HEADER_RE`/`adr_has_verification_section` mirror), `ProposedADR.resolved_in_place` 필드, SLA 판정에 `(not resolved_in_place)` 결합, CLI flag 매핑·summary·argparse help·섹션 주석.
- `tests/test_governance_proposed_adr_age.py` — **non-load-bearing**. +10 단위 테스트(주입 date_resolver/now, git 불요).
- `.claude/skills/adr-lifecycle-manager/SKILL.md` — **non-load-bearing** (`.claude/skills/`). step 1·step 3·References 의 "collector 가 `## Resolution` 미인식" caveat 제거·정정 + keep-open 명확화.

## 3. 리스크

가장 가능성 높은 깨짐: (a) `## Resolution` 외 헤더 오탐/누락, (b) NamedTuple 필드 추가로 위치 기반 unpack 깨짐. 배제: regex 는 `## Verification` 탐지를 그대로 mirror(exact H2 — `### Resolution` H3·`## Resolution notes` 미매치, 테스트로 고정). 필드는 끝에 추가했고 모든 소비자(`_cmd_proposed_adr_age`, 테스트)가 속성 접근(위치 unpack 없음). live `--proposed-adr-age` 출력은 현재 proposed 14개 중 `## Resolution` 보유 ADR 0건이라 동일(safe). resolved-in-place ADR 은 `over_sla=False` 라 adr-lifecycle-manager skill(OVER_SLA 키 소비)이 자동 제외.

## 4. 테스트

Behavior change → 변경 전 fail / 후 pass 테스트 추가. `tests/test_governance_proposed_adr_age.py`:
- `test_resolution_append_suppresses_over_sla` — 40일(>30) post-grandfather proposed ADR 이 `## Resolution` 보유 시 `over_sla=False`, `resolved_in_place=True`, Status 여전히 `proposed` (핵심 before/after).
- `test_no_resolution_still_over_sla` — 대조군: 동일 날짜, `## Resolution` 없으면 여전히 `OVER_SLA`.
- `adr_has_resolution_section` 단위(H2 매치 / H3·`## Resolution notes` 미매치 / missing), grandfather 독립, SLA 내 resolved, 필드 기본값 False, CLI flag 문자열(`resolved_in_place` 우선 + summary note), live-repo smoke 에 필드 invariant.

로컬: `tests/test_governance.py` + `tests/test_governance_proposed_adr_age.py` **89 passed, 3 skipped**, `ruff check .` 통과. 전체 `bash scripts/test.sh`(xdist `-n auto` + coverage)는 로컬 머신에서 OOM(SIGKILL/137)으로 중단 — 테스트 실패 아닌 병렬 워커 메모리 한계. serial 전체 run + CI 샤딩 매트릭스(`pr-eval.yml`)가 authoritative 전체 게이트. 변경 표면이 governance collector(+테스트+skill md)로 한정돼 RAG/eval/answer import-graph 미도달이라 비-governance 테스트 영향 불가.

결정론적 fixture 증명(주입 날짜): BEFORE→`OVER_SLA`, AFTER(`## Resolution` append)→`resolved_in_place`. raw `--proposed-adr-age` CLI 는 날짜 주입 불가 + grandfather(2026-05-15)+30=2026-06-14 라 오늘(2026-05-22) 실제 OVER_SLA 가 0건이므로 OVER_SLA→resolved 전이는 함수 경유로 증명.

## 5. Eval 영향

All `·` — RAG 파이프라인(검색/검증/답변/eval) 무관. governance collector + skill 가이드 + 테스트만.

### 5b. Real-data delta

N/A — 비-load-bearing(`scripts/_governance.py`, `tests/`, `.claude/skills/` 만 변경; `LOAD_BEARING_PATHS` 미해당). 검색/검증/답변·eval path 동작 변화 없음. §5b CI gate(`--check-5b`)는 load-bearing 변경에만 발화하므로 본 PR 미트리거.

## 6. 하위 호환

깨짐 없음. answer-contract(ADR 0003)·schema 무관. `ProposedADR` 에 필드 1개 **추가**(끝, 속성 접근만) — 기존 flag 값(`OVER_SLA/grandfathered/ok`)은 그대로 emit, `resolved_in_place` 는 additive. CLI 출력은 새 flag 값만 추가(컬럼/탭 구조 동일). doc link 무변경.

**ADR 임계값 평가**: 신규 측정 표면 도입이 아니라 **기존 collector(PR #1094)를 이미 accepted 된 거버넌스 ADR(0047 결정 #2)에 정렬**하는 bug-fix. reviewer 가 의존할 새 계약 고정 아님(0047 이 이미 계약) → 새 ADR 불요, 0047 참조로 충분.

## 7. 범위 외

- **실제 README status-parity 체크** — PR #1165 "범위 외" 의 또 다른 항목(`docs/adr/README.md` row status 컬럼 ↔ ADR Status 블록 비교). 본 PR 미포함, 별도 surface.
- **`## Resolution` 외 extension metadata 인식** — issue #1178 은 "H2 and/or extension metadata" 를 언급하나, 0047 결정 #2 가 문자 그대로 sanctioned 한 것은 `## Resolution` H2 뿐이므로 그에 한정(YAGNI). 별도 metadata 형식이 정의되면 follow-up.
- **SLA hard-gate** — 여전히 reporting-only(exit 0). 강제는 별도 정책.
