### PR TITLE
feat(eval): paired-bootstrap CI in local arm-vs-arm comparator

### DIFF
--- a/scripts/compare_eval.py
+++ b/scripts/compare_eval.py
@@ -64,6 +64,21 @@ def parse_args() -> argparse.Namespace:
             f"surfaces the regression; the script exits 0. Env: {ENV_ALLOW_REGRESSION}."
         ),
     )
+    ap.add_argument(
+        "--paired-ci",
+        action="store_true",
+        help=(
+            "Append a paired-bootstrap 95%% CI block computed from per-case "
+            "`case_results` (local runs only; the aggregate baseline carries "
+            "no per-case data per ADR 0005). Display-only — the regression "
+            "gate is unchanged."
+        ),
+    )
+    ap.add_argument(
+        "--paired-ci-seeds",
+        default="17,19,23",
+        help="Comma-separated bootstrap seeds for seed-averaged paired CI (default 17,19,23).",
+    )
     return ap.parse_args()
 
 
@@ -95,6 +110,77 @@ def _render_gate_block(regressions: list[dict], *, allow: bool) -> list[str]:
             "to acknowledge an intentional trade-off."
         )
     return [header, *bullets]
+
+
+def _render_paired_ci_block(base, head, *, seeds) -> list[str]:
+    """Per-metric paired-bootstrap CI of (head − base) from ``case_results``.
+
+    Reuses the tested estimators in ``scripts/_ablation_common`` (which the
+    retrieval-eval ablation runners already share): cases are paired by
+    ``id`` (intersection), ``None`` scores are dropped per ADR 0054
+    conditional-metric semantics, and the paired delta CI is seed-averaged.
+    Display-only: the regression gate above is unchanged, and a committed
+    aggregate baseline (no ``case_results``) degrades to an explanatory note
+    rather than a crash.
+    """
+    # Lazy import: keeps the default compare path free of the eval.bootstrap
+    # dependency (imported transitively by _ablation_common). Repo root must
+    # be importable for `eval.bootstrap`.
+    root = str(Path(__file__).resolve().parent.parent)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    try:
+        from _ablation_common import (  # noqa: E402
+            _drop_paired_nones,
+            _fmt_ci,
+            _seed_averaged_paired_ci,
+        )
+    except Exception as exc:  # pragma: no cover - import guard
+        return [f"_Paired CI unavailable: {exc}_"]
+
+    base_cases = base.get("case_results") if isinstance(base, dict) else None
+    head_cases = head.get("case_results") if isinstance(head, dict) else None
+    if not isinstance(base_cases, list) or not isinstance(head_cases, list):
+        return [
+            "_Paired CI: requires `case_results` in both runs (local "
+            "`eval_summary.json`, not the aggregate baseline — ADR 0005)._"
+        ]
+
+    base_by_id = {c["id"]: c for c in base_cases if isinstance(c, dict) and "id" in c}
+    common_ids = [
+        c["id"]
+        for c in head_cases
+        if isinstance(c, dict) and c.get("id") in base_by_id
+    ]
+    head_by_id = {c["id"]: c for c in head_cases if isinstance(c, dict) and "id" in c}
+    if not common_ids:
+        return ["_Paired CI: no shared case ids between the two runs._"]
+
+    lines = [
+        "#### Paired bootstrap 95% CI — head − base (per-case, seed-averaged)",
+        "",
+        f"- paired cases: {len(common_ids)} · seeds: {list(seeds)}",
+        "",
+        "| metric | Δ (95% CI) |",
+        "|---|---|",
+    ]
+    for path, label, _higher, gated in METRICS:
+        if not gated or "." in path:
+            continue
+        a = [head_by_id[i].get(path) for i in common_ids]  # other = head
+        b = [base_by_id[i].get(path) for i in common_ids]  # current = base
+        a_clean, b_clean = _drop_paired_nones(a, b)
+        if len(a_clean) < 2:
+            lines.append(f"| {label} | N/A (n<2) |")
+            continue
+        ci = _seed_averaged_paired_ci(a_clean, b_clean, list(seeds))
+        lines.append(f"| {label} | {_fmt_ci(ci)} |")
+    lines.append("")
+    lines.append(
+        "_Significance = 95% CI excludes 0 (seed-averaged paired bootstrap). "
+        "Display-only; the regression gate above is unchanged._"
+    )
+    return lines
 
 
 def main() -> int:
@@ -131,6 +217,11 @@ def main() -> int:
         regressions = detect_regressions(base, head, threshold=args.regression_threshold)
         regressions += detect_abstention_outcome_regressions(base, head)
     lines.extend(_render_gate_block(regressions, allow=args.allow_regression))
+
+    if args.paired_ci:
+        seeds = [int(s) for s in str(args.paired_ci_seeds).split(",") if s.strip()]
+        lines.append("")
+        lines.extend(_render_paired_ci_block(base, head, seeds=seeds))
 
     print("\n".join(lines))
 

--- a/tests/test_compare_eval_paired_ci.py
+++ b/tests/test_compare_eval_paired_ci.py
@@ -1,0 +1,142 @@
+"""Paired-bootstrap CI block in the local eval comparator (issue #1205).
+
+Locks the additive ``--paired-ci`` surface of ``scripts/compare_eval.py``:
+
+* A clear per-case improvement reports a CI excluding 0 (유의함).
+* An identical pair reports a CI bracketing 0 (유의하지 않음).
+* A committed aggregate baseline (no ``case_results``) degrades to an
+  explanatory note rather than crashing — the ADR 0005 boundary case.
+* An all-``None`` conditional metric (ADR 0054) is skipped, not fatal.
+* The block is OFF by default so existing PR-eval output is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))  # for eval.bootstrap via _ablation_common
+
+from compare_eval import _render_paired_ci_block  # noqa: E402
+
+
+def _summary(case_scores: Sequence[tuple[str, float | None]]) -> dict:
+    """Minimal eval_summary.json with per-case ``accuracy``/``abstention``."""
+    return {
+        "pipeline": "agentic_full",
+        "primary_run": "full",
+        "num_predictions": len(case_scores),
+        "accuracy": (
+            sum(a for _, a in case_scores if a is not None)
+            / max(1, sum(1 for _, a in case_scores if a is not None))
+        ),
+        "case_results": [
+            {"id": cid, "accuracy": acc, "groundedness": acc, "abstention": None}
+            for cid, acc in case_scores
+        ],
+    }
+
+
+class PairedCIBlockTest(unittest.TestCase):
+    def test_clear_improvement_excludes_zero(self) -> None:
+        base = _summary([(f"c{i}", 0.0) for i in range(30)])
+        head = _summary([(f"c{i}", 1.0) for i in range(30)])
+        block = "\n".join(_render_paired_ci_block(base, head, seeds=[17, 19, 23]))
+        self.assertIn("accuracy", block)
+        self.assertIn("+1.000", block)
+        self.assertIn("유의함", block)
+        self.assertIn("paired cases: 30", block)
+
+    def test_identical_pair_brackets_zero(self) -> None:
+        rows = [(f"c{i}", float(i % 2)) for i in range(30)]
+        block = "\n".join(
+            _render_paired_ci_block(_summary(rows), _summary(rows), seeds=[17, 19, 23])
+        )
+        self.assertIn("유의하지 않음", block)
+
+    def test_missing_case_results_degrades_gracefully(self) -> None:
+        base = {"accuracy": 0.5}  # aggregate-only baseline, no case_results
+        head = {"accuracy": 0.6}
+        block = "\n".join(_render_paired_ci_block(base, head, seeds=[17]))
+        self.assertIn("case_results", block)
+
+    def test_all_none_metric_is_skipped_not_fatal(self) -> None:
+        # abstention is None for every case -> N/A row, no exception.
+        rows = [(f"c{i}", 1.0) for i in range(10)]
+        block = "\n".join(_render_paired_ci_block(_summary(rows), _summary(rows), seeds=[17]))
+        self.assertIn("abstention", block)
+        self.assertIn("N/A", block)
+
+    def test_no_shared_ids(self) -> None:
+        base = _summary([(f"a{i}", 1.0) for i in range(5)])
+        head = _summary([(f"b{i}", 1.0) for i in range(5)])
+        block = "\n".join(_render_paired_ci_block(base, head, seeds=[17]))
+        self.assertIn("no shared case ids", block)
+
+    def test_flag_off_by_default_via_cli(self) -> None:
+        """Default invocation must not emit the paired-CI block."""
+        with _tmp_summaries() as (base_path, head_path):
+            out = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "compare_eval.py"),
+                    "--base",
+                    base_path,
+                    "--head",
+                    head_path,
+                    "--regression-threshold",
+                    "0",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(REPO_ROOT),
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertNotIn("Paired bootstrap", out.stdout)
+
+    def test_flag_on_emits_block_via_cli(self) -> None:
+        with _tmp_summaries() as (base_path, head_path):
+            out = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "compare_eval.py"),
+                    "--base",
+                    base_path,
+                    "--head",
+                    head_path,
+                    "--regression-threshold",
+                    "0",
+                    "--paired-ci",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(REPO_ROOT),
+            )
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertIn("Paired bootstrap", out.stdout)
+
+
+import contextlib  # noqa: E402
+import tempfile  # noqa: E402
+
+
+@contextlib.contextmanager
+def _tmp_summaries():
+    base = _summary([(f"c{i}", 0.0) for i in range(20)])
+    head = _summary([(f"c{i}", 1.0) for i in range(20)])
+    with tempfile.TemporaryDirectory() as d:
+        bp = Path(d) / "base.json"
+        hp = Path(d) / "head.json"
+        bp.write_text(json.dumps(base), encoding="utf-8")
+        hp.write_text(json.dumps(head), encoding="utf-8")
+        yield str(bp), str(hp)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

real-100 실험 프로그램은 두 로컬 eval 런(arm A vs arm B)을 같은 n=221 케이스로 비교한다. 기존 로컬 비교기(`compare_eval.py` + `_eval_delta.py`)는 aggregate point-delta + N-aware silence-band 휴리스틱(`0.5/n`)만 제공 — 진짜 유의성 검정이 아니다. 이미 구현돼 있던 `eval.bootstrap.paired_bootstrap_ci` 와 `_ablation_common` 의 seed-averaged paired 헬퍼를 opt-in `--paired-ci` 플래그로 wiring해 per-metric Δ 95% CI 를 표시한다. 신규 통계 로직 0줄(전부 재사용).

Closes #1205

## 2. 영향 파일

- `scripts/compare_eval.py` — `--paired-ci`/`--paired-ci-seeds` 플래그 + `_render_paired_ci_block`(case_results를 `id`로 페어링, ADR 0054 None-skip, `_ablation_common` 재사용). **load-bearing 아님**(단일 출처 `scripts/_governance.py` 목록엔 `scripts/build_index.py`만 포함).
- `tests/test_compare_eval_paired_ci.py` — 신규 회귀 테스트 7개.

## 3. 리스크

가장 가능성 높은 깨짐 = 기존 PR-eval 코멘트 출력 변형. → `--paired-ci` 기본 OFF 라 기존 출력 byte-identical(`test_flag_off_by_default_via_cli` CLI smoke로 확인). 통계 로직 신규 0줄 — 테스트된 `_ablation_common`/`_eval_delta` 재사용.

## 4. 테스트

신규 `tests/test_compare_eval_paired_ci.py` 7개: 명확한 개선→CI 0 제외(유의함), 동일쌍→CI 0 포함(유의하지 않음), case_results 부재(aggregate baseline)→graceful note, all-None 지표(ADR 0054)→skip, 공유 id 없음, 플래그 off/on CLI. 기존 `test_compare_eval_regression_gate.py` 포함 **33 passed**.

## 5. Eval 영향

RAG 파이프라인 미변경 → 합성 CI delta **All `·`**. 비교기 표시 레이어만 추가.

### 5b. Real-data delta

N/A — `scripts/compare_eval.py` 는 load-bearing path 아님(검색/검증/답변/ingestion/eval/ 어디에도 해당 없음, additive display-only 플래그·기본 off). 파이프라인 동작 변화 없음.

## 6. 하위 호환

호환 유지. 신규 플래그는 opt-in·기본 off → 기존 CLI/CI 동작 불변. answer-contract(ADR 0003) 무관, schema 변경 없음.

## 7. 범위 외

- per-category(`hardcase_categories`) paired CI 분해는 후속(`compute_deltas` 재사용 가능하나 `hardcase_categories`↔`categories` 필드 매핑 필요). 이번엔 overall만.
- `run_real_eval_delta.py`(committed aggregate-baseline 경로) 미변경 — baseline엔 per-case 데이터 없음(ADR 0005).