### PR TITLE
fix(governance): normalize proposed-ADR first-commit date to UTC

### DIFF
--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -26,7 +26,7 @@ import argparse
 import ast
 import re
 import sys
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Callable, NamedTuple
 
@@ -605,7 +605,12 @@ def adr_has_resolution_section(adr_path: str | Path) -> bool:
 
 
 def _git_first_commit_date(path: str | Path) -> date | None:
-    """First-add author date of `path` via git, or None if untracked/unknown."""
+    """First-add author date of `path` as a UTC calendar date, or None.
+
+    `%aI` carries the commit's local tz (+09:00 KST in this repo); normalizing
+    to UTC keeps the date on the same frame as the UTC `today` — else an ADR
+    committed just after KST midnight ages to -1 until UTC rolls over.
+    """
     import subprocess
 
     try:
@@ -621,9 +626,12 @@ def _git_first_commit_date(path: str | Path) -> date | None:
     if not lines:
         return None
     try:
-        return date.fromisoformat(lines[0][:10])
+        dt = datetime.fromisoformat(lines[0].strip())
     except ValueError:
         return None
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc)
+    return dt.date()
 
 
 def proposed_adr_age(
@@ -651,7 +659,7 @@ def proposed_adr_age(
     ``sla_days`` defaults to ``THRESHOLDS["ADR_PROPOSED_SLA_DAYS"]``.
     """
     resolver = date_resolver or _git_first_commit_date
-    today = now or date.today()
+    today = now or datetime.now(timezone.utc).date()
     sla = THRESHOLDS["ADR_PROPOSED_SLA_DAYS"] if sla_days is None else sla_days
 
     records: list[ProposedADR] = []

--- a/tests/test_governance_proposed_adr_age.py
+++ b/tests/test_governance_proposed_adr_age.py
@@ -16,6 +16,7 @@ from scripts._governance import (
     ADR_SLA_GRANDFATHER_DATE,
     THRESHOLDS,
     _cmd_proposed_adr_age,
+    _git_first_commit_date,
     adr_has_resolution_section,
     parse_adr_status,
     proposed_adr_age,
@@ -346,6 +347,39 @@ def test_cmd_output_shows_resolved_in_place_flag(tmp_path, capsys) -> None:
     assert "OVER_SLA" not in captured.out
     # Summary (stderr) reports the in-place count.
     assert "resolved in place" in captured.err
+
+
+# ---- proposed_adr_age: timezone boundary (#1192) -------------------------
+
+
+def test_first_commit_date_normalizes_local_tz_to_utc(monkeypatch) -> None:
+    """`%aI` is the author date in the commit's local tz; the resolver must
+    return the UTC calendar date. 2026-05-22T00:14:01+09:00 == 2026-05-21T15:14
+    UTC, so the first-commit date is 2026-05-21, not the KST 2026-05-22. Pre-fix
+    `%aI[:10]` kept the KST date."""
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *a, **k: "2026-05-22T00:14:01+09:00\n",
+    )
+    assert _git_first_commit_date("docs/adr/0099-x.md") == date(2026, 5, 21)
+
+
+def test_kst_midnight_commit_not_negative_age(tmp_path: Path, monkeypatch) -> None:
+    """Boundary regression for #1192: a proposed ADR committed just after KST
+    midnight (2026-05-22T00:14:01+09:00 == 2026-05-21T15:14 UTC) must not age to
+    -1 when the UTC `today` is still 2026-05-21. Pre-fix the KST date 05-22 minus
+    the UTC today 05-21 gave age_days == -1, tripping the `assert age_days >= 0`
+    sentinel in test_repo_proposed_adr_age_runs. Uses the default git resolver
+    (no date_resolver injection) so the normalization path is exercised."""
+    _adr(tmp_path, "0099-new.md", "proposed")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *a, **k: "2026-05-22T00:14:01+09:00\n",
+    )
+    recs = proposed_adr_age(tmp_path, now=date(2026, 5, 21))
+    assert recs[0].first_commit == date(2026, 5, 21)
+    assert recs[0].age_days == 0
+    assert recs[0].age_days >= 0
 
 
 # ---- constants -----------------------------------------------------------


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1192

`scripts/_governance.py` 의 proposed-ADR age collector 가 타임존 경계에서 `age_days == -1` 을 내어, KST-자정 ~ UTC-롤오버 창에서 main 으로 가는 모든 PR 의 `tests/test_governance_proposed_adr_age.py::test_repo_proposed_adr_age_runs` (`assert age_days >= 0`) 를 flake 시켰다 (#1190 머지 시 표면화). 근본 원인: `_git_first_commit_date` 가 `git log --format=%aI`(커밋 **로컬 tz**, 본 저장소 `+09:00` KST)를 `[:10]` 로 잘라 KST 캘린더 날짜를 반환하는데, `proposed_adr_age` 는 이를 `date.today()`(CI 러너 = **UTC**)와 비교 → 경계에서 off-by-one.

수정 (이슈 #1192 옵션 B — tz 일관 비교): `%aI` 를 tz-aware datetime 으로 파싱 후 `.astimezone(timezone.utc).date()` 로 UTC 정규화하고, `proposed_adr_age` 의 default `today` 도 `datetime.now(timezone.utc).date()` 로 통일해 양변이 동일 UTC 프레임을 공유하게 했다.

## 2. 영향 파일

- `scripts/_governance.py` — `_git_first_commit_date` UTC 정규화 + `proposed_adr_age` default `today` UTC (둘 다 **load-bearing 아님** — `LOAD_BEARING_PATHS` 미포함)
- `tests/test_governance_proposed_adr_age.py` — 경계 회귀 테스트 2개 추가

## 3. 리스크

가장 가능성 높은 깨짐: (a) `datetime.fromisoformat` 가 `%aI` offset 형식(`+09:00`)을 파싱 못 함 → 본 저장소 Python 3.11 + 모든 3.7+ 에서 `±HH:MM` offset 파싱 지원 확인. git `%aI` 는 `Z` 가 아닌 numeric offset 만 방출하므로 #1185 의 Z-suffix 이슈와 무관. (b) default `today` UTC 전환이 다른 호출처를 깸 → `proposed_adr_age` 호출처는 `scripts/_governance.py` 내부뿐(CLI `_cmd_proposed_adr_age`), 모든 테스트는 `now=`/`date_resolver=` 주입. blast-radius 거버넌스/hook/self-review 테스트 324개 + 전체 스위트 collection 무결성 통과로 배제.

## 4. 테스트

`tests/test_governance_proposed_adr_age.py` 에 경계 회귀 2개 추가:
- `test_first_commit_date_normalizes_local_tz_to_utc` — git subprocess 를 monkeypatch 해 `2026-05-22T00:14:01+09:00` 입력 시 resolver 가 UTC 날짜 `2026-05-21` 반환 검증.
- `test_kst_midnight_commit_not_negative_age` — default git resolver 경로로 KST 자정 직후 커밋이 `now=2026-05-21` 에 대해 `age_days == 0`(음수 아님) 검증.

둘 다 **수정 전 fail (구 `%aI[:10]` → `2026-05-22`, age `-1`) / 수정 후 pass** (검증 완료). 23개 통과.

## 5. Eval 영향

All `·` — 거버넌스 날짜 산술 변경, RAG 검색/검증/답변 path 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. `scripts/_governance.py` 는 load-bearing path 가 아니며(`LOAD_BEARING_PATHS` 미포함) RAG 파이프라인에 진입하지 않음.

## 6. 하위 호환

계약/스키마/CLI flag 변경 없음. `_git_first_commit_date` 반환 타입(`date | None`) 유지 — 값이 KST 캘린더 날짜에서 UTC 캘린더 날짜로 정규화될 뿐(버그 수정). `proposed_adr_age` 시그니처 불변.

## 7. 범위 외

- shallow-clone first-add 오분류 (이슈 #1192 옵션 C — `pr-eval.yml` `fetch-depth: 0`). 별도 표면(워크플로)이라 follow-up PR 로 분리. tz 정규화(B) 만으로 `-1` 증상은 제거되며, shallow 오분류는 age 를 *과소*보고할 뿐 음수를 내지 않음.
- 음수 age clamp (옵션 A) — B 적용 후 정상 경로에서 음수 age 가 발생 불가하므로 미적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)