### PR TITLE
fix(rag_core): narrow Optional ctx fields at build-answer call sites

### DIFF
--- a/rag_core.py
+++ b/rag_core.py
@@ -1045,7 +1045,7 @@ def _phase_build_answer(ctx: _RunContext) -> dict[str, Any]:
         ctx.retrieval_query,
         analysis,
         evidence,
-        ctx.context_resolution,
+        ctx.context_resolution or {},
     )
     latency_ms = (time.perf_counter() - ctx.started) * 1000
     stage_latency = {
@@ -1066,8 +1066,8 @@ def _phase_build_answer(ctx: _RunContext) -> dict[str, Any]:
         analysis,
         plan,
         metadata_resolution,
-        ctx.context_resolution,
-        ctx.stage_sequence,
+        ctx.context_resolution or {},
+        ctx.stage_sequence or [],
         stage_attempts,
         answer,
         stage_latencies_ms=stage_latency,


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Pyright(local pyrightconfig.json, basic 모드)가 `_phase_build_answer` 안에서 `reportArgumentType` 3건을 표면화했다 — `update_conversation_state`(1048) + `build_result_trace`(1069/1070)가 `ctx.context_resolution` / `ctx.stage_sequence`를 받는데, `_RunContext`에서 두 필드가 `dict|None` / `list|None`로 선언돼 있다. triage 결과 **case (b) 과한 타입**: 두 필드는 `_phase_analyze`(892/894)에서 채워지고, `_phase_build_answer`는 analyze 완주(`None` 반환) 시에만 호출(오케스트레이터 가드 1260-1262)되므로 호출 시점엔 항상 non-None. 함수 간 제어흐름 불변식을 Pyright가 못 봐서 나는 경보이지 런타임 버그가 아니다. 이미 `_phase_retrieve_loop`(923)에서 쓰는 `ctx.stage_sequence or []` idiom을 3개 호출부에 동일 적용.

Closes #1197

## 2. 영향 파일

- `rag_core.py` (**load-bearing**) — `_phase_build_answer` 3개 호출부 타입 좁히기 (`or {}` / `or []`, 3줄)

## 3. 리스크

가장 가능성 높은 깨짐 경로: `or {}`/`or []`가 의도치 않게 동작을 바꾸는 경우. 배제 근거 — `or` 우변은 좌변이 falsy(None/빈 컬렉션)일 때만 도달하는데, ① 호출 시점 두 필드는 non-None 보장(가드 1260-1262), ② `resolve_conversation_context`/`metadata_stage_sequence` 반환값은 빈 dict/list가 아님. 따라서 우변 도달 불가. 동일 idiom이 923줄에 선례로 존재.

## 4. 테스트

신규 테스트 없음 — **동작 변경이 아니기 때문**. `or {}`/`or []`는 도달 불가한 None 분기에만 영향하므로 변경 전후 동작 동일. 검증: `_phase_build_answer` 경로 커버 테스트 직렬 실행(`test_phase_mutation_contract` / `test_langgraph_orchestrator_regression` / `test_observability_tracing`) **28 passed**. (전체 `scripts/test.sh`는 로컬에서 xdist OOM(SIGKILL)으로 미완주 — 인프라 제약, 본 변경 무관; CI에서 재확인.)

## 5. Eval 영향

없음 — no-op 타입 좁히기, RAG 동작 경로 미변경.

### 5b. Real-data delta

No behavior change in retrieval, verifier, eval, api, or ingestion — 검색/검증/평가 path 동작 변화 없음. 순수 타입 좁히기(`or {}`/`or []`)이고 None 분기가 도달 불가(오케스트레이터 가드 1260-1262)라 real-data delta는 증명상 0. `make real-eval-delta` 미실행(no-op attestation 대체), 로컬 targeted 게이트 통과.

## 6. 하위 호환

깨짐 없음. answer-contract(ADR 0003) 미변경 — 반환 dict 구조·`schema_version` 불변. CLI flag·doc link 영향 없음.

## 7. 범위 외

- `_phase_build_answer`의 타입 제약 없는 `ctx.context_resolution` 참조(예: 1088줄)는 에러 미발생 — 미변경.
- IDE가 띄운 unused-import hint(`json`/`Path`/`re` 등, re-export 추정)는 본 PR 범위 밖.
- `pyrightconfig.json`은 로컬 전용(.git/info/exclude)이라 PR 미포함.