### PR TITLE
fix(eval): anonymize private names in committed eval artifacts + structural privacy gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -231,6 +231,27 @@ if [[ -n "$phase4_staged" ]]; then
   fi
 fi
 
+# Guard: structural eval-artifact privacy (CONTENT scan, #1204).
+# Broader than the phase4 key-name gate above: any committable JSON under
+# reports/retrieval/ or reports/real100/ must carry zero Hangul (anonymized
+# qids are real_<hex>; categories/metrics are ASCII/numeric) and zero
+# colon-bearing dict keys (retry-reason payloads embed agency names / 공고번호
+# doc-ids). The check uses NO name list — listing the real agency names in
+# committed source would itself re-leak them. Fires whenever such a JSON OR
+# one of the sanitizing generators is staged. tests/
+# test_eval_artifact_privacy_regression.py is the CI backstop.
+eval_priv_staged=$(git diff --cached --name-only --diff-filter=ACMR -- \
+  'reports/retrieval/*.json' 'reports/real100/*.json' \
+  'scripts/_ablation_common.py' 'scripts/run_real_eval_delta.py' \
+  'scripts/eda_real100.py' 'scripts/phase*_ablation.py' 2>/dev/null || true)
+if [[ -n "$eval_priv_staged" ]]; then
+  eval_priv_out=$(python3 scripts/_governance.py --check-eval-privacy 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$eval_priv_out" >&2
+    exit 1
+  fi
+fi
+
 staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
 
 if [[ -z "$staged" ]]; then

--- a/reports/real100/baseline.aggregate.json
+++ b/reports/real100/baseline.aggregate.json
@@ -288,17 +288,9 @@
         "retry_resolution_rate": 0.7701149425287356
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240615212-0.0": 1,
-        "missing_comparison_doc:20241139040-0.0": 1,
-        "missing_comparison_doc:국민연금공단_2024년-이러닝시스템-운영-용역,20240327871-0.0,20240330003-0.0,20240404154-0.0,20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_entity:국민연금공단,재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_entity:대전대학교": 1,
-        "missing_comparison_entity:서울특별시교육청": 1,
-        "missing_comparison_entity:재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_topic:고양도시관리공사": 2,
-        "missing_comparison_topic:재단법인충북연구원": 2,
-        "missing_comparison_topic:한국수자원공사": 2,
+        "missing_comparison_doc": 4,
+        "missing_comparison_entity": 4,
+        "missing_comparison_topic": 6,
         "partial_topic_grounding": 2,
         "topic_not_grounded": 203
       },
@@ -678,7 +670,7 @@
         "retry_resolution_rate": 0.8333333333333334
       },
       "retry_reason_counts": {
-        "missing_comparison_topic:재단법인충북연구원": 2,
+        "missing_comparison_topic": 2,
         "partial_topic_grounding": 1,
         "topic_not_grounded": 47
       },
@@ -1066,14 +1058,9 @@
         "retry_resolution_rate": 0.7733333333333333
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240615212-0.0": 1,
-        "missing_comparison_doc:국민연금공단_2024년-이러닝시스템-운영-용역,20240327871-0.0,20240330003-0.0,20240404154-0.0,20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_entity:국민연금공단,재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_entity:서울특별시교육청": 1,
-        "missing_comparison_entity:재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_topic:재단법인충북연구원": 2,
-        "missing_comparison_topic:한국수자원공사": 2,
+        "missing_comparison_doc": 3,
+        "missing_comparison_entity": 3,
+        "missing_comparison_topic": 4,
         "partial_topic_grounding": 2,
         "topic_not_grounded": 91
       },
@@ -1254,9 +1241,9 @@
         "retry_resolution_rate": null
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20241139040-0.0": 1,
-        "missing_comparison_entity:대전대학교": 1,
-        "missing_comparison_topic:고양도시관리공사": 2,
+        "missing_comparison_doc": 1,
+        "missing_comparison_entity": 1,
+        "missing_comparison_topic": 2,
         "topic_not_grounded": 99
       },
       "stage_latency": {
@@ -1469,17 +1456,9 @@
     "retry_resolution_rate": 0.7701149425287356
   },
   "retry_reason_counts": {
-    "missing_comparison_doc:20240419765-0.0,20240611774-0.0": 1,
-    "missing_comparison_doc:20240615212-0.0": 1,
-    "missing_comparison_doc:20241139040-0.0": 1,
-    "missing_comparison_doc:국민연금공단_2024년-이러닝시스템-운영-용역,20240327871-0.0,20240330003-0.0,20240404154-0.0,20240419765-0.0,20240611774-0.0": 1,
-    "missing_comparison_entity:국민연금공단,재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-    "missing_comparison_entity:대전대학교": 1,
-    "missing_comparison_entity:서울특별시교육청": 1,
-    "missing_comparison_entity:재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-    "missing_comparison_topic:고양도시관리공사": 2,
-    "missing_comparison_topic:재단법인충북연구원": 2,
-    "missing_comparison_topic:한국수자원공사": 2,
+    "missing_comparison_doc": 4,
+    "missing_comparison_entity": 4,
+    "missing_comparison_topic": 6,
     "partial_topic_grounding": 2,
     "topic_not_grounded": 208
   },

--- a/reports/real100/eda.aggregate.json
+++ b/reports/real100/eda.aggregate.json
@@ -392,52 +392,52 @@
       "top": [
         {
           "count": 3,
-          "name": "한국수자원공사",
+          "name": "agency_01",
           "rank": 1
         },
         {
           "count": 3,
-          "name": "한국철도공사 (용역)",
+          "name": "agency_02",
           "rank": 2
         },
         {
           "count": 2,
-          "name": "한국연구재단",
+          "name": "agency_03",
           "rank": 3
         },
         {
           "count": 2,
-          "name": "한국생산기술연구원",
+          "name": "agency_04",
           "rank": 4
         },
         {
           "count": 2,
-          "name": "인천광역시",
+          "name": "agency_05",
           "rank": 5
         },
         {
           "count": 2,
-          "name": "국방과학연구소",
+          "name": "agency_06",
           "rank": 6
         },
         {
           "count": 2,
-          "name": "수협중앙회",
+          "name": "agency_07",
           "rank": 7
         },
         {
           "count": 2,
-          "name": "한국농어촌공사",
+          "name": "agency_08",
           "rank": 8
         },
         {
           "count": 2,
-          "name": "축산물품질평가원",
+          "name": "agency_09",
           "rank": 9
         },
         {
           "count": 2,
-          "name": "광주과학기술원",
+          "name": "agency_10",
           "rank": 10
         }
       ],

--- a/reports/real100/history/20260517T130501Z_c39360a353ba.aggregate.json
+++ b/reports/real100/history/20260517T130501Z_c39360a353ba.aggregate.json
@@ -279,16 +279,9 @@
         "retry_resolution_rate": 0.8831168831168831
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20240327871-0.0,20240330003-0.0,20240404154-0.0,한국발명진흥회-입찰공고_2024년-건설기술에-관한-특허·실용신안-활용실,20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240327871-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240615212-0.0": 1,
-        "missing_comparison_doc:20241139040-0.0": 1,
-        "missing_comparison_entity:대전대학교": 1,
-        "missing_comparison_entity:서울특별시교육청": 1,
-        "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,한국발명진흥회 입찰공고,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)부산국제영화제": 1,
-        "missing_comparison_topic:재단법인충북연구원": 2,
-        "missing_comparison_topic:한국수자원공사": 2,
+        "missing_comparison_doc": 4,
+        "missing_comparison_entity": 4,
+        "missing_comparison_topic": 4,
         "partial_topic_grounding": 2,
         "topic_not_grounded": 167
       },
@@ -650,7 +643,7 @@
         "retry_resolution_rate": 0.90625
       },
       "retry_reason_counts": {
-        "missing_comparison_topic:재단법인충북연구원": 2,
+        "missing_comparison_topic": 2,
         "partial_topic_grounding": 1,
         "topic_not_grounded": 39
       },
@@ -1018,14 +1011,9 @@
         "retry_resolution_rate": 0.8656716417910447
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20240327871-0.0,20240330003-0.0,20240404154-0.0,한국발명진흥회-입찰공고_2024년-건설기술에-관한-특허·실용신안-활용실,20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240327871-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240615212-0.0": 1,
-        "missing_comparison_entity:서울특별시교육청": 1,
-        "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,한국발명진흥회 입찰공고,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)부산국제영화제": 1,
-        "missing_comparison_topic:재단법인충북연구원": 2,
-        "missing_comparison_topic:한국수자원공사": 2,
+        "missing_comparison_doc": 3,
+        "missing_comparison_entity": 3,
+        "missing_comparison_topic": 4,
         "partial_topic_grounding": 2,
         "topic_not_grounded": 75
       },
@@ -1197,8 +1185,8 @@
         "retry_resolution_rate": null
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20241139040-0.0": 1,
-        "missing_comparison_entity:대전대학교": 1,
+        "missing_comparison_doc": 1,
+        "missing_comparison_entity": 1,
         "topic_not_grounded": 84
       },
       "stage_latency": {
@@ -1402,16 +1390,9 @@
     "retry_resolution_rate": 0.8831168831168831
   },
   "retry_reason_counts": {
-    "missing_comparison_doc:20240327871-0.0,20240330003-0.0,20240404154-0.0,한국발명진흥회-입찰공고_2024년-건설기술에-관한-특허·실용신안-활용실,20240419765-0.0,20240611774-0.0": 1,
-    "missing_comparison_doc:20240327871-0.0,20240611774-0.0": 1,
-    "missing_comparison_doc:20240615212-0.0": 1,
-    "missing_comparison_doc:20241139040-0.0": 1,
-    "missing_comparison_entity:대전대학교": 1,
-    "missing_comparison_entity:서울특별시교육청": 1,
-    "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,한국발명진흥회 입찰공고,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-    "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)부산국제영화제": 1,
-    "missing_comparison_topic:재단법인충북연구원": 2,
-    "missing_comparison_topic:한국수자원공사": 2,
+    "missing_comparison_doc": 4,
+    "missing_comparison_entity": 4,
+    "missing_comparison_topic": 4,
     "partial_topic_grounding": 2,
     "topic_not_grounded": 171
   },

--- a/reports/real100/history/20260518T045934Z_af461b1a90f0.aggregate.json
+++ b/reports/real100/history/20260518T045934Z_af461b1a90f0.aggregate.json
@@ -279,16 +279,9 @@
         "retry_resolution_rate": 0.8831168831168831
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20240327871-0.0,20240330003-0.0,20240404154-0.0,한국발명진흥회-입찰공고_2024년-건설기술에-관한-특허·실용신안-활용실,20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240327871-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240615212-0.0": 1,
-        "missing_comparison_doc:20241139040-0.0": 1,
-        "missing_comparison_entity:대전대학교": 1,
-        "missing_comparison_entity:서울특별시교육청": 1,
-        "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,한국발명진흥회 입찰공고,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)부산국제영화제": 1,
-        "missing_comparison_topic:재단법인충북연구원": 2,
-        "missing_comparison_topic:한국수자원공사": 2,
+        "missing_comparison_doc": 4,
+        "missing_comparison_entity": 4,
+        "missing_comparison_topic": 4,
         "partial_topic_grounding": 2,
         "topic_not_grounded": 167
       },
@@ -650,7 +643,7 @@
         "retry_resolution_rate": 0.90625
       },
       "retry_reason_counts": {
-        "missing_comparison_topic:재단법인충북연구원": 2,
+        "missing_comparison_topic": 2,
         "partial_topic_grounding": 1,
         "topic_not_grounded": 39
       },
@@ -1018,14 +1011,9 @@
         "retry_resolution_rate": 0.8656716417910447
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20240327871-0.0,20240330003-0.0,20240404154-0.0,한국발명진흥회-입찰공고_2024년-건설기술에-관한-특허·실용신안-활용실,20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240327871-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240615212-0.0": 1,
-        "missing_comparison_entity:서울특별시교육청": 1,
-        "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,한국발명진흥회 입찰공고,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)부산국제영화제": 1,
-        "missing_comparison_topic:재단법인충북연구원": 2,
-        "missing_comparison_topic:한국수자원공사": 2,
+        "missing_comparison_doc": 3,
+        "missing_comparison_entity": 3,
+        "missing_comparison_topic": 4,
         "partial_topic_grounding": 2,
         "topic_not_grounded": 75
       },
@@ -1197,8 +1185,8 @@
         "retry_resolution_rate": null
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20241139040-0.0": 1,
-        "missing_comparison_entity:대전대학교": 1,
+        "missing_comparison_doc": 1,
+        "missing_comparison_entity": 1,
         "topic_not_grounded": 84
       },
       "stage_latency": {
@@ -1402,16 +1390,9 @@
     "retry_resolution_rate": 0.8831168831168831
   },
   "retry_reason_counts": {
-    "missing_comparison_doc:20240327871-0.0,20240330003-0.0,20240404154-0.0,한국발명진흥회-입찰공고_2024년-건설기술에-관한-특허·실용신안-활용실,20240419765-0.0,20240611774-0.0": 1,
-    "missing_comparison_doc:20240327871-0.0,20240611774-0.0": 1,
-    "missing_comparison_doc:20240615212-0.0": 1,
-    "missing_comparison_doc:20241139040-0.0": 1,
-    "missing_comparison_entity:대전대학교": 1,
-    "missing_comparison_entity:서울특별시교육청": 1,
-    "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,한국발명진흥회 입찰공고,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-    "missing_comparison_entity:재단법인 한국장애인문화예술원,(사)부산국제영화제": 1,
-    "missing_comparison_topic:재단법인충북연구원": 2,
-    "missing_comparison_topic:한국수자원공사": 2,
+    "missing_comparison_doc": 4,
+    "missing_comparison_entity": 4,
+    "missing_comparison_topic": 4,
     "partial_topic_grounding": 2,
     "topic_not_grounded": 171
   },

--- a/reports/real100/history/20260519T030310Z_a7fd711d0573.aggregate.json
+++ b/reports/real100/history/20260519T030310Z_a7fd711d0573.aggregate.json
@@ -288,17 +288,9 @@
         "retry_resolution_rate": 0.7701149425287356
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240615212-0.0": 1,
-        "missing_comparison_doc:20241139040-0.0": 1,
-        "missing_comparison_doc:국민연금공단_2024년-이러닝시스템-운영-용역,20240327871-0.0,20240330003-0.0,20240404154-0.0,20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_entity:국민연금공단,재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_entity:대전대학교": 1,
-        "missing_comparison_entity:서울특별시교육청": 1,
-        "missing_comparison_entity:재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_topic:고양도시관리공사": 2,
-        "missing_comparison_topic:재단법인충북연구원": 2,
-        "missing_comparison_topic:한국수자원공사": 2,
+        "missing_comparison_doc": 4,
+        "missing_comparison_entity": 4,
+        "missing_comparison_topic": 6,
         "partial_topic_grounding": 2,
         "topic_not_grounded": 203
       },
@@ -678,7 +670,7 @@
         "retry_resolution_rate": 0.8333333333333334
       },
       "retry_reason_counts": {
-        "missing_comparison_topic:재단법인충북연구원": 2,
+        "missing_comparison_topic": 2,
         "partial_topic_grounding": 1,
         "topic_not_grounded": 47
       },
@@ -1066,14 +1058,9 @@
         "retry_resolution_rate": 0.7733333333333333
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_doc:20240615212-0.0": 1,
-        "missing_comparison_doc:국민연금공단_2024년-이러닝시스템-운영-용역,20240327871-0.0,20240330003-0.0,20240404154-0.0,20240419765-0.0,20240611774-0.0": 1,
-        "missing_comparison_entity:국민연금공단,재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_entity:서울특별시교육청": 1,
-        "missing_comparison_entity:재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-        "missing_comparison_topic:재단법인충북연구원": 2,
-        "missing_comparison_topic:한국수자원공사": 2,
+        "missing_comparison_doc": 3,
+        "missing_comparison_entity": 3,
+        "missing_comparison_topic": 4,
         "partial_topic_grounding": 2,
         "topic_not_grounded": 91
       },
@@ -1254,9 +1241,9 @@
         "retry_resolution_rate": null
       },
       "retry_reason_counts": {
-        "missing_comparison_doc:20241139040-0.0": 1,
-        "missing_comparison_entity:대전대학교": 1,
-        "missing_comparison_topic:고양도시관리공사": 2,
+        "missing_comparison_doc": 1,
+        "missing_comparison_entity": 1,
+        "missing_comparison_topic": 2,
         "topic_not_grounded": 99
       },
       "stage_latency": {
@@ -1469,17 +1456,9 @@
     "retry_resolution_rate": 0.7701149425287356
   },
   "retry_reason_counts": {
-    "missing_comparison_doc:20240419765-0.0,20240611774-0.0": 1,
-    "missing_comparison_doc:20240615212-0.0": 1,
-    "missing_comparison_doc:20241139040-0.0": 1,
-    "missing_comparison_doc:국민연금공단_2024년-이러닝시스템-운영-용역,20240327871-0.0,20240330003-0.0,20240404154-0.0,20240419765-0.0,20240611774-0.0": 1,
-    "missing_comparison_entity:국민연금공단,재단법인 한국장애인문화예술원,(사)벤처기업협회,서울특별시,재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-    "missing_comparison_entity:대전대학교": 1,
-    "missing_comparison_entity:서울특별시교육청": 1,
-    "missing_comparison_entity:재단법인 광주광역시 광주문화재단,(사)부산국제영화제": 1,
-    "missing_comparison_topic:고양도시관리공사": 2,
-    "missing_comparison_topic:재단법인충북연구원": 2,
-    "missing_comparison_topic:한국수자원공사": 2,
+    "missing_comparison_doc": 4,
+    "missing_comparison_entity": 4,
+    "missing_comparison_topic": 6,
     "partial_topic_grounding": 2,
     "topic_not_grounded": 208
   },

--- a/reports/retrieval/phase2_chunking_20260518-0202-reaggregate/raw_results.json
+++ b/reports/retrieval/phase2_chunking_20260518-0202-reaggregate/raw_results.json
@@ -297,7 +297,7 @@
         ]
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -312,7 +312,7 @@
         ]
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -383,7 +383,7 @@
         ]
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 20,
@@ -398,7 +398,7 @@
         ]
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -530,7 +530,7 @@
         ]
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -544,7 +544,7 @@
         ]
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -614,7 +614,7 @@
         ]
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -628,7 +628,7 @@
         ]
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -701,7 +701,7 @@
         ]
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 92,
@@ -716,7 +716,7 @@
         ]
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -744,7 +744,7 @@
         ]
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -816,7 +816,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -830,7 +830,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -844,7 +844,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -858,7 +858,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -901,7 +901,7 @@
         ]
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -916,7 +916,7 @@
         ]
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -930,7 +930,7 @@
         ]
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 90,
@@ -944,7 +944,7 @@
         ]
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1046,7 +1046,7 @@
         ]
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 210,
@@ -1061,7 +1061,7 @@
         ]
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1132,7 +1132,7 @@
         ]
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -1147,7 +1147,7 @@
         ]
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1162,7 +1162,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -1176,7 +1176,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1246,7 +1246,7 @@
         ]
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -1260,7 +1260,7 @@
         ]
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1330,7 +1330,7 @@
         ]
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -1344,7 +1344,7 @@
         ]
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1386,7 +1386,7 @@
         ]
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -1571,7 +1571,7 @@
         ]
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -1585,7 +1585,7 @@
         ]
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1599,7 +1599,7 @@
         ]
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -1614,7 +1614,7 @@
         ]
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 2,
@@ -1686,7 +1686,7 @@
         ]
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -1701,7 +1701,7 @@
         ]
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1830,7 +1830,7 @@
         ]
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -1844,7 +1844,7 @@
         ]
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1858,7 +1858,7 @@
         ]
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -1873,7 +1873,7 @@
         ]
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1916,7 +1916,7 @@
         ]
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -1930,7 +1930,7 @@
         ]
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1944,7 +1944,7 @@
         ]
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -1958,7 +1958,7 @@
         ]
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1972,7 +1972,7 @@
         ]
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -1986,7 +1986,7 @@
         ]
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2057,7 +2057,7 @@
         ]
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -2072,7 +2072,7 @@
         ]
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2144,7 +2144,7 @@
         ]
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -2159,7 +2159,7 @@
         ]
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2202,7 +2202,7 @@
         ]
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -2216,7 +2216,7 @@
         ]
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2231,7 +2231,7 @@
         ]
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -2245,7 +2245,7 @@
         ]
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2344,7 +2344,7 @@
         ]
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 35,
@@ -2358,7 +2358,7 @@
         ]
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2429,7 +2429,7 @@
         ]
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 22,
@@ -2443,7 +2443,7 @@
         ]
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2457,7 +2457,7 @@
         ]
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -2471,7 +2471,7 @@
         ]
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2570,7 +2570,7 @@
         ]
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -2584,7 +2584,7 @@
         ]
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2654,7 +2654,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 14,
@@ -2668,7 +2668,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2682,7 +2682,7 @@
         ]
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -2697,7 +2697,7 @@
         ]
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2711,7 +2711,7 @@
         ]
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -2725,7 +2725,7 @@
         ]
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2768,7 +2768,7 @@
         ]
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -2782,7 +2782,7 @@
         ]
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2796,7 +2796,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -2811,7 +2811,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2825,7 +2825,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 16,
@@ -2839,7 +2839,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2853,7 +2853,7 @@
         ]
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 13,
@@ -2867,7 +2867,7 @@
         ]
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2881,7 +2881,7 @@
         ]
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -2895,7 +2895,7 @@
         ]
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2938,7 +2938,7 @@
         ]
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -2952,7 +2952,7 @@
         ]
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3027,7 +3027,7 @@
         ]
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -3042,7 +3042,7 @@
         ]
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3114,7 +3114,7 @@
         ]
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -3129,7 +3129,7 @@
         ]
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3143,7 +3143,7 @@
         ]
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3463,7 +3463,7 @@
         ]
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -3478,7 +3478,7 @@
         ]
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3549,7 +3549,7 @@
         ]
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 20,
@@ -3564,7 +3564,7 @@
         ]
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3696,7 +3696,7 @@
         ]
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -3710,7 +3710,7 @@
         ]
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3780,7 +3780,7 @@
         ]
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3794,7 +3794,7 @@
         ]
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -3867,7 +3867,7 @@
         ]
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 122,
@@ -3882,7 +3882,7 @@
         ]
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3910,7 +3910,7 @@
         ]
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3982,7 +3982,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -3996,7 +3996,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4010,7 +4010,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -4024,7 +4024,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4067,7 +4067,7 @@
         ]
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -4082,7 +4082,7 @@
         ]
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4096,7 +4096,7 @@
         ]
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 104,
@@ -4110,7 +4110,7 @@
         ]
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4212,7 +4212,7 @@
         ]
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 360,
@@ -4227,7 +4227,7 @@
         ]
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4298,7 +4298,7 @@
         ]
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -4313,7 +4313,7 @@
         ]
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4328,7 +4328,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 13,
@@ -4342,7 +4342,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4412,7 +4412,7 @@
         ]
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -4426,7 +4426,7 @@
         ]
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4496,7 +4496,7 @@
         ]
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -4510,7 +4510,7 @@
         ]
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4552,7 +4552,7 @@
         ]
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -4737,7 +4737,7 @@
         ]
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -4751,7 +4751,7 @@
         ]
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4765,7 +4765,7 @@
         ]
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -4780,7 +4780,7 @@
         ]
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 1,
@@ -4852,7 +4852,7 @@
         ]
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -4867,7 +4867,7 @@
         ]
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4996,7 +4996,7 @@
         ]
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -5010,7 +5010,7 @@
         ]
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5024,7 +5024,7 @@
         ]
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -5039,7 +5039,7 @@
         ]
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5082,7 +5082,7 @@
         ]
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -5096,7 +5096,7 @@
         ]
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5110,7 +5110,7 @@
         ]
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -5124,7 +5124,7 @@
         ]
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5138,7 +5138,7 @@
         ]
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -5152,7 +5152,7 @@
         ]
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5223,7 +5223,7 @@
         ]
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -5238,7 +5238,7 @@
         ]
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5310,7 +5310,7 @@
         ]
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -5325,7 +5325,7 @@
         ]
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5368,7 +5368,7 @@
         ]
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -5382,7 +5382,7 @@
         ]
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5397,7 +5397,7 @@
         ]
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -5411,7 +5411,7 @@
         ]
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5510,7 +5510,7 @@
         ]
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 38,
@@ -5524,7 +5524,7 @@
         ]
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5595,7 +5595,7 @@
         ]
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 25,
@@ -5609,7 +5609,7 @@
         ]
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5623,7 +5623,7 @@
         ]
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -5637,7 +5637,7 @@
         ]
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5736,7 +5736,7 @@
         ]
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -5750,7 +5750,7 @@
         ]
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5820,7 +5820,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 19,
@@ -5834,7 +5834,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5848,7 +5848,7 @@
         ]
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -5863,7 +5863,7 @@
         ]
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5877,7 +5877,7 @@
         ]
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -5891,7 +5891,7 @@
         ]
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5934,7 +5934,7 @@
         ]
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -5948,7 +5948,7 @@
         ]
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5962,7 +5962,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -5977,7 +5977,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5991,7 +5991,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 16,
@@ -6005,7 +6005,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6019,7 +6019,7 @@
         ]
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -6033,7 +6033,7 @@
         ]
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6047,7 +6047,7 @@
         ]
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -6061,7 +6061,7 @@
         ]
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6104,7 +6104,7 @@
         ]
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -6118,7 +6118,7 @@
         ]
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6193,7 +6193,7 @@
         ]
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -6208,7 +6208,7 @@
         ]
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6280,7 +6280,7 @@
         ]
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -6295,7 +6295,7 @@
         ]
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6309,7 +6309,7 @@
         ]
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6629,7 +6629,7 @@
         ]
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -6644,7 +6644,7 @@
         ]
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6715,7 +6715,7 @@
         ]
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 19,
@@ -6730,7 +6730,7 @@
         ]
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6862,7 +6862,7 @@
         ]
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -6876,7 +6876,7 @@
         ]
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6946,7 +6946,7 @@
         ]
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6960,7 +6960,7 @@
         ]
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -7033,7 +7033,7 @@
         ]
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 67,
@@ -7048,7 +7048,7 @@
         ]
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7076,7 +7076,7 @@
         ]
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7148,7 +7148,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -7162,7 +7162,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7176,7 +7176,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -7190,7 +7190,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7233,7 +7233,7 @@
         ]
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -7248,7 +7248,7 @@
         ]
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7262,7 +7262,7 @@
         ]
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 73,
@@ -7276,7 +7276,7 @@
         ]
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7378,7 +7378,7 @@
         ]
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 128,
@@ -7393,7 +7393,7 @@
         ]
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7464,7 +7464,7 @@
         ]
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -7479,7 +7479,7 @@
         ]
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7494,7 +7494,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -7508,7 +7508,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7578,7 +7578,7 @@
         ]
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -7592,7 +7592,7 @@
         ]
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7662,7 +7662,7 @@
         ]
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -7676,7 +7676,7 @@
         ]
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7718,7 +7718,7 @@
         ]
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -7903,7 +7903,7 @@
         ]
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -7917,7 +7917,7 @@
         ]
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7931,7 +7931,7 @@
         ]
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -7946,7 +7946,7 @@
         ]
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 1,
@@ -8018,7 +8018,7 @@
         ]
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -8033,7 +8033,7 @@
         ]
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8162,7 +8162,7 @@
         ]
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -8176,7 +8176,7 @@
         ]
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8190,7 +8190,7 @@
         ]
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -8205,7 +8205,7 @@
         ]
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8248,7 +8248,7 @@
         ]
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -8262,7 +8262,7 @@
         ]
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8276,7 +8276,7 @@
         ]
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -8290,7 +8290,7 @@
         ]
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8304,7 +8304,7 @@
         ]
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -8318,7 +8318,7 @@
         ]
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8389,7 +8389,7 @@
         ]
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -8404,7 +8404,7 @@
         ]
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8476,7 +8476,7 @@
         ]
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -8491,7 +8491,7 @@
         ]
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8534,7 +8534,7 @@
         ]
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -8548,7 +8548,7 @@
         ]
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8563,7 +8563,7 @@
         ]
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -8577,7 +8577,7 @@
         ]
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8676,7 +8676,7 @@
         ]
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 31,
@@ -8690,7 +8690,7 @@
         ]
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8761,7 +8761,7 @@
         ]
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 16,
@@ -8775,7 +8775,7 @@
         ]
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8789,7 +8789,7 @@
         ]
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -8803,7 +8803,7 @@
         ]
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8902,7 +8902,7 @@
         ]
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -8916,7 +8916,7 @@
         ]
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8986,7 +8986,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -9000,7 +9000,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9014,7 +9014,7 @@
         ]
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -9029,7 +9029,7 @@
         ]
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9043,7 +9043,7 @@
         ]
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -9057,7 +9057,7 @@
         ]
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9100,7 +9100,7 @@
         ]
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -9114,7 +9114,7 @@
         ]
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9128,7 +9128,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -9143,7 +9143,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9157,7 +9157,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 14,
@@ -9171,7 +9171,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9185,7 +9185,7 @@
         ]
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -9199,7 +9199,7 @@
         ]
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9213,7 +9213,7 @@
         ]
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -9227,7 +9227,7 @@
         ]
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9270,7 +9270,7 @@
         ]
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -9284,7 +9284,7 @@
         ]
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9359,7 +9359,7 @@
         ]
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -9374,7 +9374,7 @@
         ]
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9446,7 +9446,7 @@
         ]
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -9461,7 +9461,7 @@
         ]
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9475,7 +9475,7 @@
         ]
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9795,7 +9795,7 @@
         ]
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -9810,7 +9810,7 @@
         ]
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9881,7 +9881,7 @@
         ]
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 18,
@@ -9896,7 +9896,7 @@
         ]
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10028,7 +10028,7 @@
         ]
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -10042,7 +10042,7 @@
         ]
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10112,7 +10112,7 @@
         ]
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10126,7 +10126,7 @@
         ]
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -10199,7 +10199,7 @@
         ]
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 93,
@@ -10214,7 +10214,7 @@
         ]
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10242,7 +10242,7 @@
         ]
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10314,7 +10314,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -10328,7 +10328,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10342,7 +10342,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -10356,7 +10356,7 @@
         ]
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10399,7 +10399,7 @@
         ]
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -10414,7 +10414,7 @@
         ]
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10428,7 +10428,7 @@
         ]
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 88,
@@ -10442,7 +10442,7 @@
         ]
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10544,7 +10544,7 @@
         ]
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 216,
@@ -10559,7 +10559,7 @@
         ]
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10630,7 +10630,7 @@
         ]
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -10645,7 +10645,7 @@
         ]
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10660,7 +10660,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -10674,7 +10674,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10744,7 +10744,7 @@
         ]
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -10758,7 +10758,7 @@
         ]
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10828,7 +10828,7 @@
         ]
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -10842,7 +10842,7 @@
         ]
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -10884,7 +10884,7 @@
         ]
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -11069,7 +11069,7 @@
         ]
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -11083,7 +11083,7 @@
         ]
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11097,7 +11097,7 @@
         ]
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -11112,7 +11112,7 @@
         ]
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 2,
@@ -11184,7 +11184,7 @@
         ]
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -11199,7 +11199,7 @@
         ]
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11328,7 +11328,7 @@
         ]
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -11342,7 +11342,7 @@
         ]
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11356,7 +11356,7 @@
         ]
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -11371,7 +11371,7 @@
         ]
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11414,7 +11414,7 @@
         ]
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -11428,7 +11428,7 @@
         ]
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11442,7 +11442,7 @@
         ]
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -11456,7 +11456,7 @@
         ]
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11470,7 +11470,7 @@
         ]
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -11484,7 +11484,7 @@
         ]
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11555,7 +11555,7 @@
         ]
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -11570,7 +11570,7 @@
         ]
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11642,7 +11642,7 @@
         ]
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -11657,7 +11657,7 @@
         ]
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11700,7 +11700,7 @@
         ]
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -11714,7 +11714,7 @@
         ]
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11729,7 +11729,7 @@
         ]
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -11743,7 +11743,7 @@
         ]
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11842,7 +11842,7 @@
         ]
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 33,
@@ -11856,7 +11856,7 @@
         ]
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11927,7 +11927,7 @@
         ]
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 21,
@@ -11941,7 +11941,7 @@
         ]
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -11955,7 +11955,7 @@
         ]
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -11969,7 +11969,7 @@
         ]
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12068,7 +12068,7 @@
         ]
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -12082,7 +12082,7 @@
         ]
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12152,7 +12152,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 14,
@@ -12166,7 +12166,7 @@
         ]
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12180,7 +12180,7 @@
         ]
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -12195,7 +12195,7 @@
         ]
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12209,7 +12209,7 @@
         ]
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -12223,7 +12223,7 @@
         ]
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12266,7 +12266,7 @@
         ]
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -12280,7 +12280,7 @@
         ]
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12294,7 +12294,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -12309,7 +12309,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12323,7 +12323,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 16,
@@ -12337,7 +12337,7 @@
         ]
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12351,7 +12351,7 @@
         ]
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -12365,7 +12365,7 @@
         ]
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12379,7 +12379,7 @@
         ]
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -12393,7 +12393,7 @@
         ]
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12436,7 +12436,7 @@
         ]
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -12450,7 +12450,7 @@
         ]
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12525,7 +12525,7 @@
         ]
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -12540,7 +12540,7 @@
         ]
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12612,7 +12612,7 @@
         ]
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -12627,7 +12627,7 @@
         ]
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -12641,7 +12641,7 @@
         ]
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,

--- a/reports/retrieval/phase2_chunking_20260518-0740/raw_results.json
+++ b/reports/retrieval/phase2_chunking_20260518-0740/raw_results.json
@@ -234,7 +234,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -245,7 +245,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -300,7 +300,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 20,
@@ -311,7 +311,7 @@
         "ndcg@10": 0.07839826897867533
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -410,7 +410,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -421,7 +421,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -476,7 +476,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -487,7 +487,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -542,7 +542,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 92,
@@ -553,7 +553,7 @@
         "ndcg@10": 0.09478836436955078
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -575,7 +575,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -630,7 +630,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -641,7 +641,7 @@
         "ndcg@10": 0.1681522864689108
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -652,7 +652,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -663,7 +663,7 @@
         "ndcg@10": 0.22009176629808017
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -696,7 +696,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -707,7 +707,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -718,7 +718,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 90,
@@ -729,7 +729,7 @@
         "ndcg@10": 0.06362078819895171
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -806,7 +806,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 210,
@@ -817,7 +817,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -872,7 +872,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -883,7 +883,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -894,7 +894,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -905,7 +905,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -960,7 +960,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -971,7 +971,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1026,7 +1026,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -1037,7 +1037,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1070,7 +1070,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -1213,7 +1213,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -1224,7 +1224,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1235,7 +1235,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -1246,7 +1246,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 2,
@@ -1301,7 +1301,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -1312,7 +1312,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1411,7 +1411,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -1422,7 +1422,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1433,7 +1433,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -1444,7 +1444,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1477,7 +1477,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -1488,7 +1488,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1499,7 +1499,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -1510,7 +1510,7 @@
         "ndcg@10": 0.10633668103022985
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1521,7 +1521,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -1532,7 +1532,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1587,7 +1587,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -1598,7 +1598,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1653,7 +1653,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -1664,7 +1664,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1697,7 +1697,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -1708,7 +1708,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1719,7 +1719,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -1730,7 +1730,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1807,7 +1807,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 35,
@@ -1818,7 +1818,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1873,7 +1873,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 22,
@@ -1884,7 +1884,7 @@
         "ndcg@10": 0.13886244387355454
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1895,7 +1895,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -1906,7 +1906,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -1983,7 +1983,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -1994,7 +1994,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2049,7 +2049,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 14,
@@ -2060,7 +2060,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2071,7 +2071,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -2082,7 +2082,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2093,7 +2093,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -2104,7 +2104,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2137,7 +2137,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -2148,7 +2148,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2159,7 +2159,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -2170,7 +2170,7 @@
         "ndcg@10": 0.6309297535714575
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2181,7 +2181,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 16,
@@ -2192,7 +2192,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2203,7 +2203,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 13,
@@ -2214,7 +2214,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2225,7 +2225,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -2236,7 +2236,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2269,7 +2269,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -2280,7 +2280,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2335,7 +2335,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -2346,7 +2346,7 @@
         "ndcg@10": 0.06943122193677727
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2401,7 +2401,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -2412,7 +2412,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2423,7 +2423,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2676,7 +2676,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -2687,7 +2687,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2742,7 +2742,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 20,
@@ -2753,7 +2753,7 @@
         "ndcg@10": 0.13886244387355454
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2852,7 +2852,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -2863,7 +2863,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2918,7 +2918,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -2929,7 +2929,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -2984,7 +2984,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 122,
@@ -2995,7 +2995,7 @@
         "ndcg@10": 0.08514311764162098
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3017,7 +3017,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3072,7 +3072,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -3083,7 +3083,7 @@
         "ndcg@10": 0.22009176629808017
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3094,7 +3094,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -3105,7 +3105,7 @@
         "ndcg@10": 0.06943122193677727
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3138,7 +3138,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -3149,7 +3149,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3160,7 +3160,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 104,
@@ -3171,7 +3171,7 @@
         "ndcg@10": 0.13886244387355454
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3248,7 +3248,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 360,
@@ -3259,7 +3259,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3314,7 +3314,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -3325,7 +3325,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3336,7 +3336,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 13,
@@ -3347,7 +3347,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3402,7 +3402,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -3413,7 +3413,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3468,7 +3468,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -3479,7 +3479,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3512,7 +3512,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -3655,7 +3655,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -3666,7 +3666,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3677,7 +3677,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -3688,7 +3688,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 1,
@@ -3743,7 +3743,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -3754,7 +3754,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3853,7 +3853,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -3864,7 +3864,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3875,7 +3875,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -3886,7 +3886,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3919,7 +3919,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -3930,7 +3930,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3941,7 +3941,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -3952,7 +3952,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -3963,7 +3963,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -3974,7 +3974,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4029,7 +4029,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -4040,7 +4040,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4095,7 +4095,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -4106,7 +4106,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4139,7 +4139,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -4150,7 +4150,7 @@
         "ndcg@10": 0.27487633291429087
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4161,7 +4161,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -4172,7 +4172,7 @@
         "ndcg@10": 0.3903800499921017
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4249,7 +4249,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 38,
@@ -4260,7 +4260,7 @@
         "ndcg@10": 0.06625422345438903
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4315,7 +4315,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 25,
@@ -4326,7 +4326,7 @@
         "ndcg@10": 0.13886244387355454
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4337,7 +4337,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -4348,7 +4348,7 @@
         "ndcg@10": 0.1208113026994942
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4425,7 +4425,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -4436,7 +4436,7 @@
         "ndcg@10": 0.10122860821230018
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4491,7 +4491,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 19,
@@ -4502,7 +4502,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4513,7 +4513,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -4524,7 +4524,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4535,7 +4535,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -4546,7 +4546,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4579,7 +4579,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -4590,7 +4590,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4601,7 +4601,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -4612,7 +4612,7 @@
         "ndcg@10": 0.43067655807339306
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4623,7 +4623,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 16,
@@ -4634,7 +4634,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4645,7 +4645,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -4656,7 +4656,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4667,7 +4667,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -4678,7 +4678,7 @@
         "ndcg@10": 0.15642624200758548
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4711,7 +4711,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -4722,7 +4722,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4777,7 +4777,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -4788,7 +4788,7 @@
         "ndcg@10": 0.28371255449703187
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4843,7 +4843,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -4854,7 +4854,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -4865,7 +4865,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5118,7 +5118,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -5129,7 +5129,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5184,7 +5184,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 19,
@@ -5195,7 +5195,7 @@
         "ndcg@10": 0.06362078819895171
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5294,7 +5294,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -5305,7 +5305,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5360,7 +5360,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5371,7 +5371,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -5426,7 +5426,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 67,
@@ -5437,7 +5437,7 @@
         "ndcg@10": 0.06625422345438903
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5459,7 +5459,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5514,7 +5514,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -5525,7 +5525,7 @@
         "ndcg@10": 0.09010000865236768
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5536,7 +5536,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -5547,7 +5547,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5580,7 +5580,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -5591,7 +5591,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5602,7 +5602,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 73,
@@ -5613,7 +5613,7 @@
         "ndcg@10": 0.11004588314904008
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5690,7 +5690,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 128,
@@ -5701,7 +5701,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5756,7 +5756,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -5767,7 +5767,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5778,7 +5778,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -5789,7 +5789,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5844,7 +5844,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -5855,7 +5855,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5910,7 +5910,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -5921,7 +5921,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -5954,7 +5954,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -6097,7 +6097,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -6108,7 +6108,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6119,7 +6119,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -6130,7 +6130,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 1,
@@ -6185,7 +6185,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -6196,7 +6196,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6295,7 +6295,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -6306,7 +6306,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6317,7 +6317,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -6328,7 +6328,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6361,7 +6361,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -6372,7 +6372,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6383,7 +6383,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -6394,7 +6394,7 @@
         "ndcg@10": 0.17342765698823945
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6405,7 +6405,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -6416,7 +6416,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6471,7 +6471,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -6482,7 +6482,7 @@
         "ndcg@10": 0.43067655807339306
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6537,7 +6537,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -6548,7 +6548,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6581,7 +6581,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -6592,7 +6592,7 @@
         "ndcg@10": 0.09803928583135704
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6603,7 +6603,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -6614,7 +6614,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6691,7 +6691,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 31,
@@ -6702,7 +6702,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6757,7 +6757,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 16,
@@ -6768,7 +6768,7 @@
         "ndcg@10": 0.09478836436955078
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6779,7 +6779,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -6790,7 +6790,7 @@
         "ndcg@10": 0.2638647595767405
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6867,7 +6867,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -6878,7 +6878,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6933,7 +6933,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -6944,7 +6944,7 @@
         "ndcg@10": 0.22009176629808017
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6955,7 +6955,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -6966,7 +6966,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -6977,7 +6977,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -6988,7 +6988,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7021,7 +7021,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -7032,7 +7032,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7043,7 +7043,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -7054,7 +7054,7 @@
         "ndcg@10": 0.3562071871080222
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7065,7 +7065,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 14,
@@ -7076,7 +7076,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7087,7 +7087,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -7098,7 +7098,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7109,7 +7109,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -7120,7 +7120,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7153,7 +7153,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -7164,7 +7164,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7219,7 +7219,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -7230,7 +7230,7 @@
         "ndcg@10": 0.28293142797029985
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7285,7 +7285,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -7296,7 +7296,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7307,7 +7307,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7560,7 +7560,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -7571,7 +7571,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7626,7 +7626,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 18,
@@ -7637,7 +7637,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7736,7 +7736,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -7747,7 +7747,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7802,7 +7802,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7813,7 +7813,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -7868,7 +7868,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 93,
@@ -7879,7 +7879,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7901,7 +7901,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7956,7 +7956,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -7967,7 +7967,7 @@
         "ndcg@10": 0.305801310135566
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -7978,7 +7978,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 11,
@@ -7989,7 +7989,7 @@
         "ndcg@10": 0.06943122193677727
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8022,7 +8022,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -8033,7 +8033,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8044,7 +8044,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 88,
@@ -8055,7 +8055,7 @@
         "ndcg@10": 0.08514311764162098
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8132,7 +8132,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 216,
@@ -8143,7 +8143,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8198,7 +8198,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -8209,7 +8209,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8220,7 +8220,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -8231,7 +8231,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8286,7 +8286,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -8297,7 +8297,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8352,7 +8352,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -8363,7 +8363,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8396,7 +8396,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -8539,7 +8539,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -8550,7 +8550,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8561,7 +8561,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -8572,7 +8572,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 2,
@@ -8627,7 +8627,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -8638,7 +8638,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8737,7 +8737,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -8748,7 +8748,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8759,7 +8759,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -8770,7 +8770,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8803,7 +8803,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -8814,7 +8814,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8825,7 +8825,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -8836,7 +8836,7 @@
         "ndcg@10": 0.10633668103022985
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8847,7 +8847,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -8858,7 +8858,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8913,7 +8913,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -8924,7 +8924,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -8979,7 +8979,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 6,
@@ -8990,7 +8990,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9023,7 +9023,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 7,
@@ -9034,7 +9034,7 @@
         "ndcg@10": 0.27487633291429087
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9045,7 +9045,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -9056,7 +9056,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9133,7 +9133,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 33,
@@ -9144,7 +9144,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9199,7 +9199,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 21,
@@ -9210,7 +9210,7 @@
         "ndcg@10": 0.08514311764162098
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9221,7 +9221,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 5,
@@ -9232,7 +9232,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9309,7 +9309,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 8,
@@ -9320,7 +9320,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9375,7 +9375,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 14,
@@ -9386,7 +9386,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9397,7 +9397,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -9408,7 +9408,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9419,7 +9419,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 2,
@@ -9430,7 +9430,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9463,7 +9463,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -9474,7 +9474,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9485,7 +9485,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 1,
@@ -9496,7 +9496,7 @@
         "ndcg@10": 0.5
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9507,7 +9507,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 16,
@@ -9518,7 +9518,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9529,7 +9529,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 12,
@@ -9540,7 +9540,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9551,7 +9551,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 3,
@@ -9562,7 +9562,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9595,7 +9595,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 4,
@@ -9606,7 +9606,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9661,7 +9661,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 9,
@@ -9672,7 +9672,7 @@
         "ndcg@10": 0.4880470105041527
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9727,7 +9727,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "category": "single_hop",
         "gold_chunk_n": 10,
@@ -9738,7 +9738,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,
@@ -9749,7 +9749,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "category": "no_answer",
         "gold_chunk_n": 0,

--- a/reports/retrieval/phase35_m3_20260518T090328Z/raw_results.json
+++ b/reports/retrieval/phase35_m3_20260518T090328Z/raw_results.json
@@ -276,7 +276,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -290,7 +290,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -356,7 +356,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -370,7 +370,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -493,7 +493,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -506,7 +506,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -571,7 +571,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -584,7 +584,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -652,7 +652,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -666,7 +666,7 @@
         "ndcg@10": 0.10778915452451093
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -692,7 +692,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -759,7 +759,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -772,7 +772,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -785,7 +785,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -798,7 +798,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -838,7 +838,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -852,7 +852,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -865,7 +865,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -878,7 +878,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -973,7 +973,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -987,7 +987,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1053,7 +1053,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1067,7 +1067,7 @@
         "ndcg@10": 0.5
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1081,7 +1081,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1094,7 +1094,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1159,7 +1159,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1172,7 +1172,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1237,7 +1237,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1250,7 +1250,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1289,7 +1289,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -1461,7 +1461,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1474,7 +1474,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1487,7 +1487,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -1501,7 +1501,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -1568,7 +1568,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1582,7 +1582,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1702,7 +1702,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1715,7 +1715,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1728,7 +1728,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1742,7 +1742,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1782,7 +1782,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1795,7 +1795,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1808,7 +1808,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1821,7 +1821,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1834,7 +1834,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1847,7 +1847,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1913,7 +1913,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -1927,7 +1927,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1994,7 +1994,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -2008,7 +2008,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2048,7 +2048,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2061,7 +2061,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2075,7 +2075,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -2088,7 +2088,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2180,7 +2180,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2193,7 +2193,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2259,7 +2259,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2272,7 +2272,7 @@
         "ndcg@10": 0.6309297535714575
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2285,7 +2285,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2298,7 +2298,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2390,7 +2390,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2403,7 +2403,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2468,7 +2468,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2481,7 +2481,7 @@
         "ndcg@10": 0.9267582364714126
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2494,7 +2494,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2508,7 +2508,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2521,7 +2521,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2534,7 +2534,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2574,7 +2574,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2587,7 +2587,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2600,7 +2600,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2614,7 +2614,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2627,7 +2627,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2640,7 +2640,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2653,7 +2653,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2666,7 +2666,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2679,7 +2679,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2692,7 +2692,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2732,7 +2732,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2745,7 +2745,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2815,7 +2815,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2829,7 +2829,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2896,7 +2896,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2910,7 +2910,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2923,7 +2923,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -3221,7 +3221,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -3235,7 +3235,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3301,7 +3301,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3315,7 +3315,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -3438,7 +3438,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3451,7 +3451,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3516,7 +3516,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3529,7 +3529,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3597,7 +3597,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3611,7 +3611,7 @@
         "ndcg@10": 0.30260241349881345
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3637,7 +3637,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3704,7 +3704,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3717,7 +3717,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3730,7 +3730,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3743,7 +3743,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3783,7 +3783,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3797,7 +3797,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3810,7 +3810,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3823,7 +3823,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3918,7 +3918,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3932,7 +3932,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3998,7 +3998,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4012,7 +4012,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4026,7 +4026,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4039,7 +4039,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4104,7 +4104,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4117,7 +4117,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4182,7 +4182,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4195,7 +4195,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4234,7 +4234,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -4406,7 +4406,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4419,7 +4419,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4432,7 +4432,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -4446,7 +4446,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -4513,7 +4513,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4527,7 +4527,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4647,7 +4647,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4660,7 +4660,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4673,7 +4673,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4687,7 +4687,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4727,7 +4727,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4740,7 +4740,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4753,7 +4753,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4766,7 +4766,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4779,7 +4779,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4792,7 +4792,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4858,7 +4858,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -4872,7 +4872,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4939,7 +4939,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -4953,7 +4953,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4993,7 +4993,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5006,7 +5006,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5020,7 +5020,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -5033,7 +5033,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5125,7 +5125,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5138,7 +5138,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5204,7 +5204,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5217,7 +5217,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5230,7 +5230,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5243,7 +5243,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5335,7 +5335,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5348,7 +5348,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5413,7 +5413,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5426,7 +5426,7 @@
         "ndcg@10": 0.6366824387328317
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5439,7 +5439,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5453,7 +5453,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5466,7 +5466,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5479,7 +5479,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5519,7 +5519,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5532,7 +5532,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5545,7 +5545,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5559,7 +5559,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5572,7 +5572,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5585,7 +5585,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5598,7 +5598,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5611,7 +5611,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5624,7 +5624,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5637,7 +5637,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5677,7 +5677,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5690,7 +5690,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5760,7 +5760,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5774,7 +5774,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5841,7 +5841,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5855,7 +5855,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5868,7 +5868,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -6166,7 +6166,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -6180,7 +6180,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6246,7 +6246,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6260,7 +6260,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -6383,7 +6383,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6396,7 +6396,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6461,7 +6461,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6474,7 +6474,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6542,7 +6542,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6556,7 +6556,7 @@
         "ndcg@10": 0.30260241349881345
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6582,7 +6582,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6649,7 +6649,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6662,7 +6662,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6675,7 +6675,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6688,7 +6688,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6728,7 +6728,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6742,7 +6742,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6755,7 +6755,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6768,7 +6768,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6863,7 +6863,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6877,7 +6877,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6943,7 +6943,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6957,7 +6957,7 @@
         "ndcg@10": 0.3010299956639812
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -6971,7 +6971,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6984,7 +6984,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7049,7 +7049,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7062,7 +7062,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7127,7 +7127,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7140,7 +7140,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7179,7 +7179,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -7351,7 +7351,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7364,7 +7364,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7377,7 +7377,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -7391,7 +7391,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -7458,7 +7458,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -7472,7 +7472,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7592,7 +7592,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7605,7 +7605,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7618,7 +7618,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -7632,7 +7632,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7672,7 +7672,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7685,7 +7685,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7698,7 +7698,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7711,7 +7711,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7724,7 +7724,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7737,7 +7737,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7803,7 +7803,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -7817,7 +7817,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7884,7 +7884,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -7898,7 +7898,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7938,7 +7938,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7951,7 +7951,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7965,7 +7965,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -7978,7 +7978,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8070,7 +8070,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8083,7 +8083,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8149,7 +8149,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8162,7 +8162,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8175,7 +8175,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8188,7 +8188,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8280,7 +8280,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8293,7 +8293,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8358,7 +8358,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8371,7 +8371,7 @@
         "ndcg@10": 0.7495275800817669
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8384,7 +8384,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8398,7 +8398,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8411,7 +8411,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8424,7 +8424,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8464,7 +8464,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8477,7 +8477,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8490,7 +8490,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8504,7 +8504,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8517,7 +8517,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8530,7 +8530,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8543,7 +8543,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8556,7 +8556,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8569,7 +8569,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8582,7 +8582,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8622,7 +8622,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8635,7 +8635,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8705,7 +8705,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8719,7 +8719,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8786,7 +8786,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8800,7 +8800,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8813,7 +8813,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",

--- a/reports/retrieval/phase35_m3_20260518T214937Z_kordoc_no_m3/raw_results.json
+++ b/reports/retrieval/phase35_m3_20260518T214937Z_kordoc_no_m3/raw_results.json
@@ -276,7 +276,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -290,7 +290,7 @@
         "ndcg@10": 0.6131471927654584
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -356,7 +356,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -370,7 +370,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -493,7 +493,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -506,7 +506,7 @@
         "ndcg@10": 0.38685280723454163
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -571,7 +571,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -584,7 +584,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -652,7 +652,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -666,7 +666,7 @@
         "ndcg@10": 0.7529694065526482
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -692,7 +692,7 @@
         "ndcg@10": 0.07336392209936005
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -759,7 +759,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -772,7 +772,7 @@
         "ndcg@10": 0.22009176629808017
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -785,7 +785,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -798,7 +798,7 @@
         "ndcg@10": 0.13886244387355454
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -838,7 +838,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -852,7 +852,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -865,7 +865,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -878,7 +878,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -973,7 +973,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -987,7 +987,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1053,7 +1053,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1067,7 +1067,7 @@
         "ndcg@10": 0.3903800499921017
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1081,7 +1081,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1094,7 +1094,7 @@
         "ndcg@10": 0.3436966913921454
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1159,7 +1159,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1172,7 +1172,7 @@
         "ndcg@10": 0.3391602052736161
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1237,7 +1237,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1250,7 +1250,7 @@
         "ndcg@10": 0.13905617951077562
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1289,7 +1289,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -1461,7 +1461,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1474,7 +1474,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1487,7 +1487,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -1501,7 +1501,7 @@
         "ndcg@10": 0.6309297535714575
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -1568,7 +1568,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1582,7 +1582,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1702,7 +1702,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1715,7 +1715,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1728,7 +1728,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1742,7 +1742,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1782,7 +1782,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1795,7 +1795,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1808,7 +1808,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1821,7 +1821,7 @@
         "ndcg@10": 0.09162544430476362
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1834,7 +1834,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1847,7 +1847,7 @@
         "ndcg@10": 0.22009176629808017
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1913,7 +1913,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -1927,7 +1927,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1994,7 +1994,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -2008,7 +2008,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2048,7 +2048,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2061,7 +2061,7 @@
         "ndcg@10": 0.18908270233554988
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2075,7 +2075,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -2088,7 +2088,7 @@
         "ndcg@10": 0.5585075862632192
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2180,7 +2180,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2193,7 +2193,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2259,7 +2259,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2272,7 +2272,7 @@
         "ndcg@10": 0.7846170207230129
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2285,7 +2285,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2298,7 +2298,7 @@
         "ndcg@10": 0.19519002499605084
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2390,7 +2390,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2403,7 +2403,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2468,7 +2468,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2481,7 +2481,7 @@
         "ndcg@10": 0.43231813227099475
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2494,7 +2494,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2508,7 +2508,7 @@
         "ndcg@10": 0.07336392209936005
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2521,7 +2521,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2534,7 +2534,7 @@
         "ndcg@10": 0.6131471927654584
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2574,7 +2574,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2587,7 +2587,7 @@
         "ndcg@10": 0.6309297535714575
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2600,7 +2600,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2614,7 +2614,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2627,7 +2627,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2640,7 +2640,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2653,7 +2653,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2666,7 +2666,7 @@
         "ndcg@10": 0.14279514403613733
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2679,7 +2679,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2692,7 +2692,7 @@
         "ndcg@10": 0.6257049680303419
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2732,7 +2732,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2745,7 +2745,7 @@
         "ndcg@10": 0.3903800499921017
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2815,7 +2815,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2829,7 +2829,7 @@
         "ndcg@10": 0.31488013066763093
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2896,7 +2896,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2910,7 +2910,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2923,7 +2923,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -3221,7 +3221,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -3235,7 +3235,7 @@
         "ndcg@10": 0.6131471927654584
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3301,7 +3301,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3315,7 +3315,7 @@
         "ndcg@10": 0.09478836436955078
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -3438,7 +3438,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3451,7 +3451,7 @@
         "ndcg@10": 0.38685280723454163
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3516,7 +3516,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3529,7 +3529,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3597,7 +3597,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3611,7 +3611,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3637,7 +3637,7 @@
         "ndcg@10": 0.18340980524840012
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3704,7 +3704,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3717,7 +3717,7 @@
         "ndcg@10": 0.22009176629808017
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3730,7 +3730,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3743,7 +3743,7 @@
         "ndcg@10": 0.20248323207250624
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3783,7 +3783,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3797,7 +3797,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3810,7 +3810,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3823,7 +3823,7 @@
         "ndcg@10": 0.06943122193677727
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3918,7 +3918,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3932,7 +3932,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3998,7 +3998,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4012,7 +4012,7 @@
         "ndcg@10": 0.5294362295028773
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4026,7 +4026,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4039,7 +4039,7 @@
         "ndcg@10": 0.6136525857537393
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4104,7 +4104,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4117,7 +4117,7 @@
         "ndcg@10": 0.3391602052736161
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4182,7 +4182,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4195,7 +4195,7 @@
         "ndcg@10": 0.24630238874073
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4234,7 +4234,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -4406,7 +4406,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4419,7 +4419,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4432,7 +4432,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -4446,7 +4446,7 @@
         "ndcg@10": 0.6309297535714575
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -4513,7 +4513,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4527,7 +4527,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4647,7 +4647,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4660,7 +4660,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4673,7 +4673,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4687,7 +4687,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4727,7 +4727,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4740,7 +4740,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4753,7 +4753,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4766,7 +4766,7 @@
         "ndcg@10": 0.11838279295536291
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4779,7 +4779,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4792,7 +4792,7 @@
         "ndcg@10": 0.28371255449703187
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4858,7 +4858,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -4872,7 +4872,7 @@
         "ndcg@10": 0.9197207891481876
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4939,7 +4939,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -4953,7 +4953,7 @@
         "ndcg@10": 0.10086747116627115
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4993,7 +4993,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5006,7 +5006,7 @@
         "ndcg@10": 0.3615901614084106
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5020,7 +5020,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -5033,7 +5033,7 @@
         "ndcg@10": 0.5855700749881525
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5125,7 +5125,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5138,7 +5138,7 @@
         "ndcg@10": 0.33013764944712026
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5204,7 +5204,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5217,7 +5217,7 @@
         "ndcg@10": 0.8643145546088337
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5230,7 +5230,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5243,7 +5243,7 @@
         "ndcg@10": 0.11751610475642714
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5335,7 +5335,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5348,7 +5348,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5413,7 +5413,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5426,7 +5426,7 @@
         "ndcg@10": 0.652370608445272
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5439,7 +5439,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5453,7 +5453,7 @@
         "ndcg@10": 0.17947710508581735
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5466,7 +5466,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5479,7 +5479,7 @@
         "ndcg@10": 0.6131471927654584
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5519,7 +5519,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5532,7 +5532,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5545,7 +5545,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5559,7 +5559,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5572,7 +5572,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5585,7 +5585,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5598,7 +5598,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5611,7 +5611,7 @@
         "ndcg@10": 0.13886244387355454
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5624,7 +5624,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5637,7 +5637,7 @@
         "ndcg@10": 0.6508205185601091
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5677,7 +5677,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5690,7 +5690,7 @@
         "ndcg@10": 0.19519002499605084
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5760,7 +5760,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5774,7 +5774,7 @@
         "ndcg@10": 0.30523488393970116
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5841,7 +5841,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5855,7 +5855,7 @@
         "ndcg@10": 0.08514311764162098
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5868,7 +5868,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",

--- a/reports/retrieval/phase3_mode_20260518T032404Z/raw_results.json
+++ b/reports/retrieval/phase3_mode_20260518T032404Z/raw_results.json
@@ -276,7 +276,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -290,7 +290,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -356,7 +356,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -370,7 +370,7 @@
         "ndcg@10": 0.07839826897867533
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -493,7 +493,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -506,7 +506,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -571,7 +571,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -584,7 +584,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -652,7 +652,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -666,7 +666,7 @@
         "ndcg@10": 0.09478836436955078
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -692,7 +692,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -759,7 +759,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -772,7 +772,7 @@
         "ndcg@10": 0.1681522864689108
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -785,7 +785,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -798,7 +798,7 @@
         "ndcg@10": 0.22009176629808017
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -838,7 +838,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -852,7 +852,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -865,7 +865,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -878,7 +878,7 @@
         "ndcg@10": 0.06362078819895171
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -973,7 +973,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -987,7 +987,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1053,7 +1053,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1067,7 +1067,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1081,7 +1081,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1094,7 +1094,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1159,7 +1159,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1172,7 +1172,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1237,7 +1237,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1250,7 +1250,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1289,7 +1289,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -1461,7 +1461,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1474,7 +1474,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1487,7 +1487,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -1501,7 +1501,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -1568,7 +1568,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1582,7 +1582,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1702,7 +1702,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1715,7 +1715,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1728,7 +1728,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1742,7 +1742,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1782,7 +1782,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1795,7 +1795,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1808,7 +1808,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1821,7 +1821,7 @@
         "ndcg@10": 0.10633668103022985
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1834,7 +1834,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1847,7 +1847,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1913,7 +1913,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -1927,7 +1927,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1994,7 +1994,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -2008,7 +2008,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2048,7 +2048,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2061,7 +2061,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2075,7 +2075,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -2088,7 +2088,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2180,7 +2180,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2193,7 +2193,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2259,7 +2259,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2272,7 +2272,7 @@
         "ndcg@10": 0.13886244387355454
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2285,7 +2285,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2298,7 +2298,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2390,7 +2390,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2403,7 +2403,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2468,7 +2468,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2481,7 +2481,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2494,7 +2494,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2508,7 +2508,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2521,7 +2521,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2534,7 +2534,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2574,7 +2574,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2587,7 +2587,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2600,7 +2600,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2614,7 +2614,7 @@
         "ndcg@10": 0.6309297535714575
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2627,7 +2627,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2640,7 +2640,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2653,7 +2653,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2666,7 +2666,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2679,7 +2679,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2692,7 +2692,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2732,7 +2732,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2745,7 +2745,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2815,7 +2815,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2829,7 +2829,7 @@
         "ndcg@10": 0.06943122193677727
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2896,7 +2896,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2910,7 +2910,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2923,7 +2923,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -3221,7 +3221,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -3235,7 +3235,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3301,7 +3301,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3315,7 +3315,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -3438,7 +3438,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3451,7 +3451,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3516,7 +3516,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3529,7 +3529,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3597,7 +3597,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3611,7 +3611,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3637,7 +3637,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3704,7 +3704,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3717,7 +3717,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3730,7 +3730,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3743,7 +3743,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3783,7 +3783,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3797,7 +3797,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3810,7 +3810,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3823,7 +3823,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3918,7 +3918,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3932,7 +3932,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3998,7 +3998,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4012,7 +4012,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4026,7 +4026,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4039,7 +4039,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4104,7 +4104,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4117,7 +4117,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4182,7 +4182,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4195,7 +4195,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4234,7 +4234,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -4406,7 +4406,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4419,7 +4419,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4432,7 +4432,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -4446,7 +4446,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -4513,7 +4513,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4527,7 +4527,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4647,7 +4647,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4660,7 +4660,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4673,7 +4673,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4687,7 +4687,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4727,7 +4727,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4740,7 +4740,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4753,7 +4753,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4766,7 +4766,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4779,7 +4779,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4792,7 +4792,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4858,7 +4858,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -4872,7 +4872,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4939,7 +4939,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -4953,7 +4953,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4993,7 +4993,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5006,7 +5006,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5020,7 +5020,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -5033,7 +5033,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5125,7 +5125,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5138,7 +5138,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5204,7 +5204,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5217,7 +5217,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5230,7 +5230,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5243,7 +5243,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5335,7 +5335,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5348,7 +5348,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5413,7 +5413,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5426,7 +5426,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5439,7 +5439,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5453,7 +5453,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5466,7 +5466,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5479,7 +5479,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5519,7 +5519,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5532,7 +5532,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5545,7 +5545,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5559,7 +5559,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5572,7 +5572,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5585,7 +5585,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5598,7 +5598,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5611,7 +5611,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5624,7 +5624,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5637,7 +5637,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5677,7 +5677,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5690,7 +5690,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5760,7 +5760,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5774,7 +5774,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5841,7 +5841,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5855,7 +5855,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5868,7 +5868,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -6166,7 +6166,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -6180,7 +6180,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6246,7 +6246,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6260,7 +6260,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -6383,7 +6383,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6396,7 +6396,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6461,7 +6461,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6474,7 +6474,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6542,7 +6542,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6556,7 +6556,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6582,7 +6582,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6649,7 +6649,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6662,7 +6662,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6675,7 +6675,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6688,7 +6688,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6728,7 +6728,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6742,7 +6742,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6755,7 +6755,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6768,7 +6768,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6863,7 +6863,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6877,7 +6877,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6943,7 +6943,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6957,7 +6957,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -6971,7 +6971,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6984,7 +6984,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7049,7 +7049,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7062,7 +7062,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7127,7 +7127,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7140,7 +7140,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7179,7 +7179,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -7351,7 +7351,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7364,7 +7364,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7377,7 +7377,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -7391,7 +7391,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -7458,7 +7458,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -7472,7 +7472,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7592,7 +7592,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7605,7 +7605,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7618,7 +7618,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -7632,7 +7632,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7672,7 +7672,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7685,7 +7685,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7698,7 +7698,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7711,7 +7711,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7724,7 +7724,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7737,7 +7737,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7803,7 +7803,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -7817,7 +7817,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7884,7 +7884,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -7898,7 +7898,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7938,7 +7938,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7951,7 +7951,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7965,7 +7965,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -7978,7 +7978,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8070,7 +8070,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8083,7 +8083,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8149,7 +8149,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8162,7 +8162,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8175,7 +8175,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8188,7 +8188,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8280,7 +8280,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8293,7 +8293,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8358,7 +8358,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8371,7 +8371,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8384,7 +8384,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8398,7 +8398,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8411,7 +8411,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8424,7 +8424,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8464,7 +8464,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8477,7 +8477,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8490,7 +8490,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8504,7 +8504,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8517,7 +8517,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8530,7 +8530,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8543,7 +8543,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8556,7 +8556,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8569,7 +8569,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8582,7 +8582,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8622,7 +8622,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8635,7 +8635,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8705,7 +8705,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8719,7 +8719,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8786,7 +8786,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8800,7 +8800,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8813,7 +8813,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -9111,7 +9111,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -9125,7 +9125,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9191,7 +9191,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9205,7 +9205,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -9328,7 +9328,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9341,7 +9341,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9406,7 +9406,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9419,7 +9419,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9487,7 +9487,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9501,7 +9501,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9527,7 +9527,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9594,7 +9594,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9607,7 +9607,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9620,7 +9620,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9633,7 +9633,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9673,7 +9673,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9687,7 +9687,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9700,7 +9700,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9713,7 +9713,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9808,7 +9808,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9822,7 +9822,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9888,7 +9888,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9902,7 +9902,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -9916,7 +9916,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9929,7 +9929,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9994,7 +9994,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10007,7 +10007,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10072,7 +10072,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10085,7 +10085,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10124,7 +10124,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -10296,7 +10296,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10309,7 +10309,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10322,7 +10322,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -10336,7 +10336,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -10403,7 +10403,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -10417,7 +10417,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -10537,7 +10537,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10550,7 +10550,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10563,7 +10563,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -10577,7 +10577,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10617,7 +10617,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10630,7 +10630,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10643,7 +10643,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10656,7 +10656,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10669,7 +10669,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10682,7 +10682,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10748,7 +10748,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -10762,7 +10762,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -10829,7 +10829,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -10843,7 +10843,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10883,7 +10883,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10896,7 +10896,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -10910,7 +10910,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -10923,7 +10923,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11015,7 +11015,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11028,7 +11028,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11094,7 +11094,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11107,7 +11107,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11120,7 +11120,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11133,7 +11133,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -11225,7 +11225,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11238,7 +11238,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11303,7 +11303,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11316,7 +11316,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11329,7 +11329,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -11343,7 +11343,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11356,7 +11356,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11369,7 +11369,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11409,7 +11409,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11422,7 +11422,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11435,7 +11435,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -11449,7 +11449,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11462,7 +11462,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11475,7 +11475,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11488,7 +11488,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11501,7 +11501,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11514,7 +11514,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11527,7 +11527,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11567,7 +11567,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11580,7 +11580,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -11650,7 +11650,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -11664,7 +11664,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -11731,7 +11731,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -11745,7 +11745,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11758,7 +11758,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",

--- a/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/raw_results.json
+++ b/reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/raw_results.json
@@ -276,7 +276,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -290,7 +290,7 @@
         "ndcg@10": 0.3065735963827292
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -356,7 +356,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -370,7 +370,7 @@
         "ndcg@10": 0.1635413866202963
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -493,7 +493,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -506,7 +506,7 @@
         "ndcg@10": 0.5706417189553201
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -571,7 +571,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -584,7 +584,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -652,7 +652,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -666,7 +666,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -692,7 +692,7 @@
         "ndcg@10": 0.08514311764162098
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -759,7 +759,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -772,7 +772,7 @@
         "ndcg@10": 0.2934556883974402
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -785,7 +785,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -798,7 +798,7 @@
         "ndcg@10": 0.22009176629808017
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -838,7 +838,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -852,7 +852,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -865,7 +865,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -878,7 +878,7 @@
         "ndcg@10": 0.1736666713479918
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -973,7 +973,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -987,7 +987,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1053,7 +1053,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1067,7 +1067,7 @@
         "ndcg@10": 0.3903800499921017
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1081,7 +1081,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1094,7 +1094,7 @@
         "ndcg@10": 0.07839826897867533
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1159,7 +1159,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1172,7 +1172,7 @@
         "ndcg@10": 0.3391602052736161
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1237,7 +1237,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1250,7 +1250,7 @@
         "ndcg@10": 0.13012668333070054
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1289,7 +1289,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -1461,7 +1461,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1474,7 +1474,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1487,7 +1487,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -1501,7 +1501,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -1568,7 +1568,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1582,7 +1582,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1702,7 +1702,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1715,7 +1715,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1728,7 +1728,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -1742,7 +1742,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1782,7 +1782,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1795,7 +1795,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1808,7 +1808,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1821,7 +1821,7 @@
         "ndcg@10": 0.13743816645714543
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1834,7 +1834,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -1847,7 +1847,7 @@
         "ndcg@10": 0.07839826897867533
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -1913,7 +1913,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -1927,7 +1927,7 @@
         "ndcg@10": 0.2640681225725909
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -1994,7 +1994,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -2008,7 +2008,7 @@
         "ndcg@10": 0.15130120674940672
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2048,7 +2048,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2061,7 +2061,7 @@
         "ndcg@10": 0.17342765698823945
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2075,7 +2075,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -2088,7 +2088,7 @@
         "ndcg@10": 0.19519002499605084
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2180,7 +2180,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2193,7 +2193,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2259,7 +2259,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2272,7 +2272,7 @@
         "ndcg@10": 0.2863459897524692
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2285,7 +2285,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2298,7 +2298,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2390,7 +2390,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2403,7 +2403,7 @@
         "ndcg@10": 0.11706259313796354
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2468,7 +2468,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2481,7 +2481,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2494,7 +2494,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2508,7 +2508,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2521,7 +2521,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2534,7 +2534,7 @@
         "ndcg@10": 0.20438239758848611
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2574,7 +2574,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2587,7 +2587,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2600,7 +2600,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2614,7 +2614,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2627,7 +2627,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2640,7 +2640,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2653,7 +2653,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2666,7 +2666,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2679,7 +2679,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2692,7 +2692,7 @@
         "ndcg@10": 0.46927872602275644
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2732,7 +2732,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -2745,7 +2745,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2815,7 +2815,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2829,7 +2829,7 @@
         "ndcg@10": 0.42333070005078094
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -2896,7 +2896,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -2910,7 +2910,7 @@
         "ndcg@10": 0.07336392209936005
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -2923,7 +2923,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -3221,7 +3221,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -3235,7 +3235,7 @@
         "ndcg@10": 0.3065735963827292
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3301,7 +3301,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3315,7 +3315,7 @@
         "ndcg@10": 0.4920062203073637
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -3438,7 +3438,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3451,7 +3451,7 @@
         "ndcg@10": 0.6934264036172708
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3516,7 +3516,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3529,7 +3529,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3597,7 +3597,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3611,7 +3611,7 @@
         "ndcg@10": 0.9266360779006401
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3637,7 +3637,7 @@
         "ndcg@10": 0.6758704024811183
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3704,7 +3704,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3717,7 +3717,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3730,7 +3730,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3743,7 +3743,7 @@
         "ndcg@10": 0.33013764944712026
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3783,7 +3783,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3797,7 +3797,7 @@
         "ndcg@10": 0.1480409554829326
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3810,7 +3810,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -3823,7 +3823,7 @@
         "ndcg@10": 0.8512360941594274
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3918,7 +3918,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -3932,7 +3932,7 @@
         "ndcg@10": 0.84860265890399
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -3998,7 +3998,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4012,7 +4012,7 @@
         "ndcg@10": 0.3903800499921017
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4026,7 +4026,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4039,7 +4039,7 @@
         "ndcg@10": 0.1681522864689108
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4104,7 +4104,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4117,7 +4117,7 @@
         "ndcg@10": 0.3391602052736161
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4182,7 +4182,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4195,7 +4195,7 @@
         "ndcg@10": 0.5205067333228022
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4234,7 +4234,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -4406,7 +4406,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4419,7 +4419,7 @@
         "ndcg@10": 0.38685280723454163
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4432,7 +4432,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -4446,7 +4446,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -4513,7 +4513,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4527,7 +4527,7 @@
         "ndcg@10": 0.34337431936037655
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4647,7 +4647,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4660,7 +4660,7 @@
         "ndcg@10": 0.13120507751234178
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4673,7 +4673,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -4687,7 +4687,7 @@
         "ndcg@10": 0.591793585310856
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4727,7 +4727,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4740,7 +4740,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4753,7 +4753,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4766,7 +4766,7 @@
         "ndcg@10": 0.27487633291429087
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4779,7 +4779,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -4792,7 +4792,7 @@
         "ndcg@10": 0.38363315291837646
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4858,7 +4858,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -4872,7 +4872,7 @@
         "ndcg@10": 0.6934264036172708
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -4939,7 +4939,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -4953,7 +4953,7 @@
         "ndcg@10": 0.7456919575934261
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -4993,7 +4993,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5006,7 +5006,7 @@
         "ndcg@10": 0.5087056958335152
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5020,7 +5020,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -5033,7 +5033,7 @@
         "ndcg@10": 0.5205067333228022
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5125,7 +5125,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5138,7 +5138,7 @@
         "ndcg@10": 0.4959389204699464
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5204,7 +5204,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5217,7 +5217,7 @@
         "ndcg@10": 0.3963918729015093
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5230,7 +5230,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5243,7 +5243,7 @@
         "ndcg@10": 0.8318724637288826
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5335,7 +5335,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5348,7 +5348,7 @@
         "ndcg@10": 0.644824486427155
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5413,7 +5413,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5426,7 +5426,7 @@
         "ndcg@10": 0.5271064966405455
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5439,7 +5439,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5453,7 +5453,7 @@
         "ndcg@10": 0.3845937724137609
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5466,7 +5466,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5479,7 +5479,7 @@
         "ndcg@10": 0.6131471927654584
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5519,7 +5519,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5532,7 +5532,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5545,7 +5545,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5559,7 +5559,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5572,7 +5572,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5585,7 +5585,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5598,7 +5598,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5611,7 +5611,7 @@
         "ndcg@10": 0.2781981696179509
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5624,7 +5624,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5637,7 +5637,7 @@
         "ndcg@10": 0.46927872602275644
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5677,7 +5677,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -5690,7 +5690,7 @@
         "ndcg@10": 0.5294362295028773
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5760,7 +5760,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5774,7 +5774,7 @@
         "ndcg@10": 0.4193979998881982
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -5841,7 +5841,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -5855,7 +5855,7 @@
         "ndcg@10": 0.11004588314904008
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -5868,7 +5868,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -6166,7 +6166,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -6180,7 +6180,7 @@
         "ndcg@10": 0.3065735963827292
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6246,7 +6246,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6260,7 +6260,7 @@
         "ndcg@10": 0.4920062203073637
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -6383,7 +6383,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6396,7 +6396,7 @@
         "ndcg@10": 0.6934264036172708
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6461,7 +6461,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6474,7 +6474,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6542,7 +6542,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6556,7 +6556,7 @@
         "ndcg@10": 0.9266360779006401
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6582,7 +6582,7 @@
         "ndcg@10": 0.6758704024811183
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6649,7 +6649,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6662,7 +6662,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6675,7 +6675,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6688,7 +6688,7 @@
         "ndcg@10": 0.33013764944712026
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6728,7 +6728,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6742,7 +6742,7 @@
         "ndcg@10": 0.1480409554829326
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6755,7 +6755,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6768,7 +6768,7 @@
         "ndcg@10": 0.8512360941594274
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6863,7 +6863,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6877,7 +6877,7 @@
         "ndcg@10": 0.84860265890399
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -6943,7 +6943,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -6957,7 +6957,7 @@
         "ndcg@10": 0.3903800499921017
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -6971,7 +6971,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -6984,7 +6984,7 @@
         "ndcg@10": 0.1681522864689108
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7049,7 +7049,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7062,7 +7062,7 @@
         "ndcg@10": 0.3391602052736161
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7127,7 +7127,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7140,7 +7140,7 @@
         "ndcg@10": 0.5205067333228022
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7179,7 +7179,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -7351,7 +7351,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7364,7 +7364,7 @@
         "ndcg@10": 0.38685280723454163
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7377,7 +7377,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -7391,7 +7391,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -7458,7 +7458,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -7472,7 +7472,7 @@
         "ndcg@10": 0.34337431936037655
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7592,7 +7592,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7605,7 +7605,7 @@
         "ndcg@10": 0.13120507751234178
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7618,7 +7618,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -7632,7 +7632,7 @@
         "ndcg@10": 0.591793585310856
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7672,7 +7672,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7685,7 +7685,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7698,7 +7698,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7711,7 +7711,7 @@
         "ndcg@10": 0.27487633291429087
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7724,7 +7724,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7737,7 +7737,7 @@
         "ndcg@10": 0.40350157154648025
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7803,7 +7803,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -7817,7 +7817,7 @@
         "ndcg@10": 0.6934264036172708
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7884,7 +7884,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -7898,7 +7898,7 @@
         "ndcg@10": 0.7456919575934261
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -7938,7 +7938,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -7951,7 +7951,7 @@
         "ndcg@10": 0.5087056958335152
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -7965,7 +7965,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -7978,7 +7978,7 @@
         "ndcg@10": 0.5205067333228022
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8070,7 +8070,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8083,7 +8083,7 @@
         "ndcg@10": 0.4959389204699464
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8149,7 +8149,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8162,7 +8162,7 @@
         "ndcg@10": 0.3995688713838975
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8175,7 +8175,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8188,7 +8188,7 @@
         "ndcg@10": 0.8318724637288826
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8280,7 +8280,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8293,7 +8293,7 @@
         "ndcg@10": 0.644824486427155
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8358,7 +8358,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8371,7 +8371,7 @@
         "ndcg@10": 0.5271064966405455
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8384,7 +8384,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8398,7 +8398,7 @@
         "ndcg@10": 0.3845937724137609
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8411,7 +8411,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8424,7 +8424,7 @@
         "ndcg@10": 0.6131471927654584
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8464,7 +8464,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8477,7 +8477,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8490,7 +8490,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8504,7 +8504,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8517,7 +8517,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8530,7 +8530,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8543,7 +8543,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8556,7 +8556,7 @@
         "ndcg@10": 0.2781981696179509
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8569,7 +8569,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8582,7 +8582,7 @@
         "ndcg@10": 0.6049306994552042
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8622,7 +8622,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -8635,7 +8635,7 @@
         "ndcg@10": 0.5294362295028773
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8705,7 +8705,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8719,7 +8719,7 @@
         "ndcg@10": 0.42333070005078094
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -8786,7 +8786,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -8800,7 +8800,7 @@
         "ndcg@10": 0.11004588314904008
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -8813,7 +8813,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",
@@ -9111,7 +9111,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_보험개발원_요양기관_연계_DB_지원범위",
+        "qid": "real_da14ea693a",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -9125,7 +9125,7 @@
         "ndcg@10": 0.3065735963827292
       },
       {
-        "qid": "real_보험개발원_청구내역_보관기간_변경주체",
+        "qid": "real_b9dca4f1fe",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9191,7 +9191,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도사회서비스원_security_penalty_cross_ref",
+        "qid": "real_0da3616c0d",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9205,7 +9205,7 @@
         "ndcg@10": 0.4920062203073637
       },
       {
-        "qid": "real_경기도사회서비스원_next_vendor_obligation_scope",
+        "qid": "real_b8c7cd2769",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -9328,7 +9328,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_적십자사의료원_DR서버설치시간_vs_DBMS설치시간",
+        "qid": "real_3a91d46f90",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9341,7 +9341,7 @@
         "ndcg@10": 0.6934264036172708
       },
       {
-        "qid": "real_적십자사의료원_유사실적_하한기준",
+        "qid": "real_7433abf473",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9406,7 +9406,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_security_violation_abstention",
+        "qid": "real_a15eea6628",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9419,7 +9419,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_부산관광공사_credit_eval_crossref",
+        "qid": "real_9df0b06536",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9487,7 +9487,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_나노종합기술원_secs_equipment_count_multihop",
+        "qid": "real_40e625127f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9501,7 +9501,7 @@
         "ndcg@10": 0.9266360779006401
       },
       {
-        "qid": "real_나노종합기술원_copyright_ownership_noanswer",
+        "qid": "real_5460067ab5",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9527,7 +9527,7 @@
         "ndcg@10": 0.6758704024811183
       },
       {
-        "qid": "real_kochildcare_업무인계_deadline_basis",
+        "qid": "real_5e99249f57",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9594,7 +9594,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하도급_인건비_기준_multihop",
+        "qid": "real_5ee1457642",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9607,7 +9607,7 @@
         "ndcg@10": 0.3589542101716347
       },
       {
-        "qid": "real_축산물품질평가원_PM_재직요건_처벌규정_noanswer",
+        "qid": "real_f1fdacb3e6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9620,7 +9620,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_축산물품질평가원_하자담보_vs_웹접근성_인증시점",
+        "qid": "real_5d6b723969",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9633,7 +9633,7 @@
         "ndcg@10": 0.43231813227099475
       },
       {
-        "qid": "real_축산물품질평가원_소프트웨어보안_진단인력_자격기준",
+        "qid": "real_3fcb400994",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9673,7 +9673,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대검찰청_TTS_scope_vs_security_crossref",
+        "qid": "real_d7ae694314",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9687,7 +9687,7 @@
         "ndcg@10": 0.1480409554829326
       },
       {
-        "qid": "real_대검찰청_3D_SLA_penalty_no_answer",
+        "qid": "real_cf07ab02f3",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9700,7 +9700,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울여성가족재단_삭제지원시스템_하도급비율_평가점수_연계",
+        "qid": "real_b455935dd2",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9713,7 +9713,7 @@
         "ndcg@10": 0.8512360941594274
       },
       {
-        "qid": "real_서울여성가족재단_AI삭제지원_모델정확도기준",
+        "qid": "real_74e7549be6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9808,7 +9808,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_어촌어항공단_security_violation_penalty_multihop",
+        "qid": "real_ac763e8792",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9822,7 +9822,7 @@
         "ndcg@10": 0.84860265890399
       },
       {
-        "qid": "real_어촌어항공단_sw_output_ownership_supplier_rights",
+        "qid": "real_debc70b8f4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9888,7 +9888,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_파주도시관광공사_system_access_method_multihop",
+        "qid": "real_77d8bc3697",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -9902,7 +9902,7 @@
         "ndcg@10": 0.3903800499921017
       },
       {
-        "qid": "real_파주도시관광공사_password_change_cycle_noans",
+        "qid": "real_8faf7276f4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -9916,7 +9916,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_ismp_rfp_작성주체_및_단계별책임",
+        "qid": "real_766df2fa69",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -9929,7 +9929,7 @@
         "ndcg@10": 0.1681522864689108
       },
       {
-        "qid": "real_수협중앙회_ismp_보안등급_산출물폐기기준",
+        "qid": "real_87430ee98c",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -9994,7 +9994,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서민금융진흥원_license_and_encryption_multihop",
+        "qid": "real_9422270574",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10007,7 +10007,7 @@
         "ndcg@10": 0.3391602052736161
       },
       {
-        "qid": "real_서민금융진흥원_subcontract_penalty_noanswer",
+        "qid": "real_b251e3bb22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10072,7 +10072,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울특별시교육청_PM자격요건과참여인력평가기준교차",
+        "qid": "real_fc57e44300",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10085,7 +10085,7 @@
         "ndcg@10": 0.5205067333228022
       },
       {
-        "qid": "real_서울특별시교육청_ISP수립기간산출근거없음",
+        "qid": "real_e780fb0f07",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10124,7 +10124,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_수행실적_창업기업기준",
+        "qid": "real_b4c5fd7c35",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -10296,7 +10296,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국사학진흥재단_dbms_migration_hop",
+        "qid": "real_dcf8cf5e93",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10309,7 +10309,7 @@
         "ndcg@10": 0.38685280723454163
       },
       {
-        "qid": "real_한국사학진흥재단_penalty_no_answer",
+        "qid": "real_f060bffb35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10322,7 +10322,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_스포츠윤리센터_lms_personal_info_retention_multihop",
+        "qid": "real_887bed8513",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -10336,7 +10336,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_스포츠윤리센터_lms_presenter_change_deadline",
+        "qid": "real_4711117c96",
         "query_type": "abstention",
         "categories": [
           "distractor_heavy",
@@ -10403,7 +10403,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고양도시관리공사_접속기록보관기간_vs_보안점검기준",
+        "qid": "real_8d59418010",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -10417,7 +10417,7 @@
         "ndcg@10": 0.34337431936037655
       },
       {
-        "qid": "real_고양도시관리공사_응답속도_모바일앱기준",
+        "qid": "real_ad42ac38e4",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -10537,7 +10537,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_hanyeong_multihop_障害복구기준_vs_보안요건",
+        "qid": "real_873345dc76",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10550,7 +10550,7 @@
         "ndcg@10": 0.13120507751234178
       },
       {
-        "qid": "real_hanyeong_noanswer_트랙시스템_예산규모",
+        "qid": "real_2766a807ff",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10563,7 +10563,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국립민속박물관_security_contract_scope",
+        "qid": "real_0e128b5d53",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -10577,7 +10577,7 @@
         "ndcg@10": 0.591793585310856
       },
       {
-        "qid": "real_국립민속박물관_ip_commercial_use_penalty",
+        "qid": "real_18b20268a9",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10617,7 +10617,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_아시아물위원회_multi_hop_pm_실적_건수_환산",
+        "qid": "real_a5d0a6643a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10630,7 +10630,7 @@
         "ndcg@10": 0.0
       },
       {
-        "qid": "real_아시아물위원회_no_answer_현지전문가_체재비_일단가",
+        "qid": "real_b53e739980",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10643,7 +10643,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_남서울대학교_encryption_scope_multihop",
+        "qid": "real_9c8c910c3a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10656,7 +10656,7 @@
         "ndcg@10": 0.27487633291429087
       },
       {
-        "qid": "real_남서울대학교_warranty_penalty_noans",
+        "qid": "real_89d8248789",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10669,7 +10669,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_광주연구원_security_password_vs_access_control",
+        "qid": "real_009fddd972",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10682,7 +10682,7 @@
         "ndcg@10": 0.40350157154648025
       },
       {
-        "qid": "real_광주연구원_no_answer_penalty_rate",
+        "qid": "real_00a0057ac6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10748,7 +10748,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_중앙선거관리위원회_security_device_provider",
+        "qid": "real_c3fd414b11",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy",
@@ -10762,7 +10762,7 @@
         "ndcg@10": 0.6934264036172708
       },
       {
-        "qid": "real_중앙선거관리위원회_penalty_criteria_detail",
+        "qid": "real_80d8376ffd",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -10829,7 +10829,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경기도일자리재단_security_penalty_grade_threshold",
+        "qid": "real_acb8820a60",
         "query_type": "single_doc",
         "categories": [
           "long_context",
@@ -10843,7 +10843,7 @@
         "ndcg@10": 0.7456919575934261
       },
       {
-        "qid": "real_경기도일자리재단_worker_dispatch_legal_basis",
+        "qid": "real_3896276cef",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -10883,7 +10883,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대전대학교_개인정보파기기한_vs_위탁기간종료",
+        "qid": "real_ee979f6734",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -10896,7 +10896,7 @@
         "ndcg@10": 0.5087056958335152
       },
       {
-        "qid": "real_대전대학교_수행실적평가_사업예산비율_노답",
+        "qid": "real_8d9f31a4e8",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -10910,7 +10910,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천해양박물관_보안약점진단도구요건",
+        "qid": "real_4216b4d979",
         "query_type": "single_doc",
         "categories": [
           "distractor_heavy"
@@ -10923,7 +10923,7 @@
         "ndcg@10": 0.5205067333228022
       },
       {
-        "qid": "real_인천해양박물관_동점처리낙찰기준",
+        "qid": "real_64a1993e22",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11015,7 +11015,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국건강가정진흥원_backup_policy_vs_security_incident",
+        "qid": "real_149a09b54f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11028,7 +11028,7 @@
         "ndcg@10": 0.4959389204699464
       },
       {
-        "qid": "real_한국건강가정진흥원_pm_work_location_penalty",
+        "qid": "real_749568f4a6",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11094,7 +11094,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_KESCO_KCMVP_bo안적합성_절차",
+        "qid": "real_0480983d45",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11107,7 +11107,7 @@
         "ndcg@10": 0.3995688713838975
       },
       {
-        "qid": "real_KESCO_통신서버_SLA기준",
+        "qid": "real_352cf83c93",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11120,7 +11120,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_충북연구원_evaluation_score_breakdown",
+        "qid": "real_9661c17062",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11133,7 +11133,7 @@
         "ndcg@10": 0.8318724637288826
       },
       {
-        "qid": "real_충북연구원_penalty_grade_threshold",
+        "qid": "real_27e6510685",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -11225,7 +11225,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_대한장애인체육회_multi_hop_evaluation_ratio",
+        "qid": "real_c795f7741a",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11238,7 +11238,7 @@
         "ndcg@10": 0.644824486427155
       },
       {
-        "qid": "real_대한장애인체육회_no_answer_security_penalty",
+        "qid": "real_1d9381ae61",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11303,7 +11303,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_수협중앙회_videowallcontroller_connected_devices_multihop",
+        "qid": "real_e667537648",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11316,7 +11316,7 @@
         "ndcg@10": 0.5983950669742499
       },
       {
-        "qid": "real_수협중앙회_wireless_mic_install_location_no_answer",
+        "qid": "real_4e24947cb4",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11329,7 +11329,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_경희대학교_multihop_contract_deadline_and_penalty",
+        "qid": "real_f647485aa0",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -11343,7 +11343,7 @@
         "ndcg@10": 0.3845937724137609
       },
       {
-        "qid": "real_경희대학교_noanswer_penalty_rate",
+        "qid": "real_31e1124b35",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11356,7 +11356,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_고려대학교_budget_payment_vs_maintenance_crossref",
+        "qid": "real_44122848fa",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11369,7 +11369,7 @@
         "ndcg@10": 0.6131471927654584
       },
       {
-        "qid": "real_고려대학교_SFR_graduation_vs_transfer_quota_no_answer",
+        "qid": "real_4d304c4f9e",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11409,7 +11409,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국가철도공단_security_education_timing_multihop",
+        "qid": "real_8fe0bbf4b3",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11422,7 +11422,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국가철도공단_penalty_legal_basis_no_answer",
+        "qid": "real_368fcb2475",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11435,7 +11435,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_수료기준_과정유형별_교차",
+        "qid": "real_333040630f",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -11449,7 +11449,7 @@
         "ndcg@10": 1.0
       },
       {
-        "qid": "real_국민연금공단_콘텐츠단가_모바일연동비용",
+        "qid": "real_b0967094fc",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11462,7 +11462,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_국민연금공단_SFR006_환수금_산출물_cross",
+        "qid": "real_a006765b48",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11475,7 +11475,7 @@
         "ndcg@10": 0.13698471029831175
       },
       {
-        "qid": "real_국민연금공단_보안USB_암호모듈_인증기관",
+        "qid": "real_eddd69f30d",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11488,7 +11488,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_서울시립대학교_하도급비율_담합제한_교차",
+        "qid": "real_b67696f813",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11501,7 +11501,7 @@
         "ndcg@10": 0.2781981696179509
       },
       {
-        "qid": "real_서울시립대학교_여성고용우수기업_가점기준_abstention",
+        "qid": "real_57a6caff4b",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11514,7 +11514,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_세종테크노파크_유연근무유형별설정기능_multihop",
+        "qid": "real_cc672a3d14",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11527,7 +11527,7 @@
         "ndcg@10": 0.6049306994552042
       },
       {
-        "qid": "real_세종테크노파크_보안서약서제출기한_noanswer",
+        "qid": "real_68f7975488",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11567,7 +11567,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국발명진흥회_무상하자보수_PM교체_연계",
+        "qid": "real_09ab802e5b",
         "query_type": "single_doc",
         "categories": [
           "multi_hop"
@@ -11580,7 +11580,7 @@
         "ndcg@10": 0.5294362295028773
       },
       {
-        "qid": "real_한국발명진흥회_CPU사용률_야간시간대_보장여부",
+        "qid": "real_0625012a54",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -11650,7 +11650,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_한국수자원공사_supply-volume-multihop",
+        "qid": "real_aa7b5fa892",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -11664,7 +11664,7 @@
         "ndcg@10": 0.42333070005078094
       },
       {
-        "qid": "real_한국수자원공사_yongji-abstention",
+        "qid": "real_af41d88a64",
         "query_type": "abstention",
         "categories": [
           "no_answer",
@@ -11731,7 +11731,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_korail_산출물_보안준수_crossref",
+        "qid": "real_4b7b934fee",
         "query_type": "single_doc",
         "categories": [
           "multi_hop",
@@ -11745,7 +11745,7 @@
         "ndcg@10": 0.30523488393970116
       },
       {
-        "qid": "real_korail_ISMP_구축예산산정기준_nonanswer",
+        "qid": "real_0681bac3d0",
         "query_type": "abstention",
         "categories": [
           "no_answer"
@@ -11758,7 +11758,7 @@
         "ndcg@10": null
       },
       {
-        "qid": "real_인천공항운영서비스_평가비율_기술가격분리",
+        "qid": "real_88b2c950ea",
         "query_type": "abstention",
         "categories": [
           "multi_hop",

--- a/scripts/_ablation_common.py
+++ b/scripts/_ablation_common.py
@@ -14,11 +14,40 @@ only repo-internal dependency.
 """
 from __future__ import annotations
 
+import hashlib
+import re
 import statistics
 from collections import defaultdict
 from typing import Any
 
 from eval.bootstrap import paired_bootstrap_ci
+
+# Hangul (가-힣) + Jamo blocks. Real-eval case ids embed agency / project /
+# topic names in Korean; synthetic CI ids are opaque ASCII ("q1", "a"). Any
+# Hangul in a committable eval artifact is, by the ADR 0005 private-local +
+# ADR 0065 boundary ("qid + categories + metric values only"), a private leak.
+_HANGUL_RE = re.compile(r"[가-힣ᄀ-ᇿ㄰-㆏ꥠ-꥿]")
+
+
+def contains_hangul(text: str) -> bool:
+    """True when ``text`` carries any Korean syllable/Jamo codepoint."""
+    return bool(_HANGUL_RE.search(text))
+
+
+def anon_qid(qid: str) -> str:
+    """Map a possibly-identifying case id to an opaque, deterministic token.
+
+    Real-eval qids embed agency/topic names (Korean), so emitting them into a
+    committable ``raw_results.json`` leaks private RFP metadata. Synthetic CI
+    qids are already opaque ASCII and stay readable. Only Hangul-bearing ids
+    are hashed (``real_<sha1(qid)[:10]>``), so the transform is a pure,
+    index-free function that can re-derive the same token from the private
+    eval config at re-aggregation time (see the runners' ``cases_by_qid``).
+    """
+    s = str(qid)
+    if not contains_hangul(s):
+        return s
+    return "real_" + hashlib.sha1(s.encode("utf-8")).hexdigest()[:10]
 
 
 def categories_from_case(case: dict[str, Any]) -> list[str]:
@@ -147,6 +176,8 @@ def _fmt_mean(rows: list[dict[str, Any]], metric: str, category: str | None) -> 
 
 
 __all__ = [
+    "contains_hangul",
+    "anon_qid",
     "categories_from_case",
     "_drop_paired_nones",
     "_seed_averaged_paired_ci",

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -211,6 +211,22 @@ PHASE4_PRIVATE_KEYS: frozenset[str] = frozenset(
 )
 PHASE4_ARTIFACT_GLOB = "reports/retrieval/phase4*"
 
+# Issue #1204: a structural (no-name-list) privacy gate for committable
+# eval-data JSON. The Phase 4 key-name gate above only catches a fixed set of
+# forbidden KEYS; it misses private VALUES that hide elsewhere — qids that
+# embed 발주기관/사업명 (`real_<agency>_<topic>`), retry-reason map KEYS that
+# embed agency names or 공고번호 doc-ids after a colon
+# (`missing_comparison_entity:<agency>`), and eda agency labels. Listing the
+# 73 real agency names in this committed source would itself re-leak them, so
+# the gate is purely STRUCTURAL: under the eval-data globs, a committable JSON
+# artifact must contain (a) zero Hangul codepoints anywhere (anonymized qids
+# are `real_<hex>`; categories/query_type are ASCII; metrics are numeric) and
+# (b) zero dict KEYS containing a colon (retry-reason payloads are stripped to
+# their enum prefix). reports/self_review_agreement/ is intentionally NOT in
+# scope — its axis labels are public Korean prose, not private RFP data.
+EVAL_PRIVACY_ARTIFACT_GLOBS = ("reports/retrieval", "reports/real100")
+_EVAL_PRIVACY_HANGUL_RE = re.compile(r"[가-힣ᄀ-ᇿ㄰-㆏ꥠ-꥿]")
+
 # Issue #818: detection-only relaxation. The kebab-lowercase slug remains the
 # *convention* (see ``docs/adr/README.md`` File layout), but the live bug
 # discovery on ``0044-realN-eval-case-expansion.md`` showed that a strict
@@ -1034,6 +1050,108 @@ def _cmd_check_phase4_privacy(repo_root: str) -> int:
     return 1
 
 
+def find_eval_private_text(obj: object) -> dict[str, int]:
+    """Structurally scan a parsed JSON value for the two private-text
+    signatures a committable eval artifact must never carry:
+
+    * ``hangul`` — count of Korean codepoints in any string key OR value.
+    * ``colon_keys`` — count of dict keys containing ``:`` (un-stripped
+      retry-reason payloads embed agency names / 공고번호 doc-ids there).
+
+    Returns ``{signature: count}`` for signatures actually present (empty
+    dict when clean). No name list is consulted — the check is purely
+    structural, so it can live in committed source without re-leaking.
+    """
+    found: dict[str, int] = {}
+
+    def _bump(sig: str, n: int = 1) -> None:
+        if n:
+            found[sig] = found.get(sig, 0) + n
+
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if isinstance(key, str):
+                    _bump("hangul", len(_EVAL_PRIVACY_HANGUL_RE.findall(key)))
+                    if ":" in key:
+                        _bump("colon_keys")
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+        elif isinstance(node, str):
+            _bump("hangul", len(_EVAL_PRIVACY_HANGUL_RE.findall(node)))
+
+    _walk(obj)
+    return found
+
+
+def eval_privacy_artifact_paths(repo_root: str = ".") -> list[str]:
+    """git-tracked ``*.json`` under the EVAL_PRIVACY_ARTIFACT_GLOBS prefixes
+    (committable eval-data artifacts). Empty when none tracked / git absent.
+    """
+    import subprocess
+
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", repo_root, "ls-files", *EVAL_PRIVACY_ARTIFACT_GLOBS],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    return [p for p in out.splitlines() if p.endswith(".json")]
+
+
+def scan_eval_artifacts_for_private_text(
+    repo_root: str = ".",
+) -> list[tuple[str, dict[str, int]]]:
+    """Scan every git-tracked eval-data JSON for private-text signatures.
+    Returns ``[(relpath, {signature: count}), ...]`` for offending files; a
+    clean repo returns ``[]``.
+    """
+    import json
+
+    violations: list[tuple[str, dict[str, int]]] = []
+    for rel in eval_privacy_artifact_paths(repo_root):
+        try:
+            data = json.loads((Path(repo_root) / rel).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        found = find_eval_private_text(data)
+        if found:
+            violations.append((rel, found))
+    return violations
+
+
+def _cmd_check_eval_privacy(repo_root: str) -> int:
+    violations = scan_eval_artifacts_for_private_text(repo_root)
+    if not violations:
+        return 0
+    # Print signature names + counts only — never the offending text itself.
+    sys.stderr.write(
+        "\n❌ Eval artifact privacy gate: committed eval-data JSON carries "
+        "private text.\n\n"
+        "   Committable eval artifacts must hold qid + categories + metric "
+        "values only (ADR 0005 private-local + ADR 0065). These git-tracked "
+        "files break that boundary:\n\n"
+    )
+    for rel, found in violations:
+        detail = ", ".join(f"{k}×{n}" for k, n in sorted(found.items()))
+        sys.stderr.write(f"     - {rel}: {detail}\n")
+    sys.stderr.write(
+        "\n   `hangul` = Korean text (agency/사업명) in a qid or value; "
+        "`colon_keys` = un-stripped retry-reason payload "
+        "(`missing_comparison_*:<agency-or-docid>`).\n"
+        "   Fix: regenerate with the sanitized generators — ablation runners "
+        "write `anon_qid(qid)`, run_real_eval_delta strips retry-reason "
+        "payloads, eda_real100 anonymizes every agency rank — or migrate the "
+        "tracked file in place. Raw labels / query text stay local "
+        "(gitignored).\n\n"
+    )
+    return 1
+
+
 def _cmd_is_load_bearing(path: str) -> int:
     return 0 if is_load_bearing(path) else 1
 
@@ -1150,6 +1268,14 @@ def main() -> int:
              "the offending files + forbidden keys if any are found.",
     )
     g.add_argument(
+        "--check-eval-privacy", action="store_true",
+        help="Structurally scan git-tracked reports/retrieval/ + "
+             "reports/real100/ JSON for private text (Hangul anywhere, or "
+             "colon-bearing dict keys) that breaks the ADR 0005 / ADR 0065 "
+             "committable boundary; exit 1 with offending files + signature "
+             "counts (never the text) if any are found. Uses no name list.",
+    )
+    g.add_argument(
         "--proposed-adr-age", action="store_true",
         help="Report each proposed-status ADR's age + 30-day SLA flag "
              "(ADR 0047). Tab-separated columns: NNNN, age_days, flag "
@@ -1207,7 +1333,8 @@ def main() -> int:
         "--repo-root", default=".",
         help="Repo root for verifies-key marker resolution + the Phase 4 "
              "artifact scan (default: current directory). Used by "
-             "--lint-adr-consequences and --check-phase4-privacy.",
+             "--lint-adr-consequences, --check-phase4-privacy, and "
+             "--check-eval-privacy.",
     )
     args = p.parse_args()
 
@@ -1245,6 +1372,8 @@ def main() -> int:
         return _cmd_proposed_adr_age(args.adr_dir)
     if args.check_phase4_privacy:
         return _cmd_check_phase4_privacy(args.repo_root)
+    if args.check_eval_privacy:
+        return _cmd_check_eval_privacy(args.repo_root)
     return 2
 
 

--- a/scripts/eda_real100.py
+++ b/scripts/eda_real100.py
@@ -13,10 +13,12 @@ Writes:
   - reports/figures/real100_*.png|.svg         (matplotlib optional, 5-7 figures)
 
 ADR 0005 boundary: raw RFP body / 사업명 / 사업 요약 / 파일명 are read only for
-length statistics — never rendered to md/json. Agency names beyond top-10
-are anonymized to ``agency_NN`` rank labels. The only public-facing string
-fields that survive into output are 공고 번호 (procurement notice ID, public)
-and 파일형식 (hwp/pdf).
+length statistics — never rendered to md/json. ALL agency names (top-N and
+tail alike) are anonymized to ``agency_NN`` rank labels — the eda.aggregate.json
+and eda.md are committed, so raw 발주기관 names must not survive into either
+(#1204; the earlier "raw top-N in md" carve-out leaked them). The only
+public-facing string fields that survive into output are 공고 번호 (procurement
+notice ID, public) and 파일형식 (hwp/pdf).
 
 Usage:
     python scripts/eda_real100.py [--data-list ...] [--index ...] [--baseline ...]
@@ -135,7 +137,8 @@ def safe_mean(values: Iterable[float]) -> float:
 
 
 def anonymize_agency(rank: int) -> str:
-    """rank is 1-based; only called for rank > OUTPUT_TOP_N_AGENCIES."""
+    """rank is 1-based; called for every agency rank (top-N and tail) so no
+    raw 발주기관 name reaches the committed eda artifacts (#1204)."""
     return f"agency_{rank:02d}"
 
 
@@ -194,8 +197,12 @@ def axis1_metadata(rows: list[dict[str, str]]) -> dict[str, Any]:
         "agency": {
             "unique_count": len(agency_counts),
             "top": [
-                {"rank": i + 1, "name": name, "count": cnt}
-                for i, (name, cnt) in enumerate(top)
+                # Anonymize top-N too: raw 발주기관 names must not reach the
+                # committed eda.aggregate.json / eda.md (#1204). Ranks stay
+                # 1..N so the distribution shape is preserved; only the
+                # identifying label is replaced.
+                {"rank": i + 1, "name": anonymize_agency(i + 1), "count": cnt}
+                for i, (_name, cnt) in enumerate(top)
             ],
             "tail_anonymized": [
                 {"rank": OUTPUT_TOP_N_AGENCIES + i + 1, "label": anonymize_agency(OUTPUT_TOP_N_AGENCIES + i + 1), "count": cnt}
@@ -472,8 +479,8 @@ def render_markdown(stats: dict[str, Any]) -> str:
     lines.append(
         "Aggregate-only profile of the private 100-document RFP dataset. "
         "ADR 0005 boundary: 사업명 / 사업 요약 / 텍스트 / 파일명 are read for "
-        "length statistics only; never rendered. Agency names beyond rank "
-        f"{OUTPUT_TOP_N_AGENCIES} are anonymized to `agency_NN` labels."
+        "length statistics only; never rendered. All agency names are "
+        "anonymized to `agency_NN` rank labels."
     )
     lines.append("")
     lines.append(f"Sources: `{stats['_sources']['data_list']}`, `{stats['_sources']['index']}`, "
@@ -684,7 +691,8 @@ def render_figures(stats: dict[str, Any], out_dir: Path) -> list[str]:
     a3 = stats["axis3_text_source"]
 
     # Figure 1: agency top-N bar (rank labels only — keeps figure ascii-safe
-    # and reinforces ADR 0005 anonymization). Raw agency names live in the md.
+    # and reinforces ADR 0005 anonymization). No raw agency name appears in
+    # the figure, the md, or the aggregate json (#1204).
     top = a1["agency"]["top"]
     if top:
         fig, ax = plt.subplots(figsize=(9, 5))

--- a/scripts/phase2_chunking_ablation.py
+++ b/scripts/phase2_chunking_ablation.py
@@ -68,6 +68,7 @@ from scripts._ablation_common import (  # noqa: E402
     _fmt_ci,
     _fmt_mean,
     _seed_averaged_paired_ci,
+    anon_qid,
     categories_from_case,
     compute_deltas,
 )
@@ -321,7 +322,7 @@ def measure_variant(
         retrieved_chunk_ids, latency_ms = run_single_case(index, case, top_k)
         latency_vals.append(latency_ms)
         row: dict[str, Any] = {
-            "qid": qid,
+            "qid": anon_qid(qid),
             "query_type": qt,
             "category": category,
             "categories": categories_from_case(case),
@@ -599,7 +600,15 @@ def _run_reaggregate(
 
     cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
     cases = cfg.get("cases", []) or []
-    cases_by_qid = {str(c.get("id")): c for c in cases}
+    cases_by_qid = {}
+    for _c in cases:
+        _cid = str(_c.get("id"))
+        # Tolerant join: committed real-eval artifacts carry anonymized
+        # qids (anon_qid maps Hangul ids -> real_<hash>); synthetic /
+        # legacy files carry the raw id. Map both so re-aggregation
+        # works regardless of which the persisted row used.
+        cases_by_qid[_cid] = _c
+        cases_by_qid[anon_qid(_cid)] = _c
 
     untagged_per_variant: int | None = None
     for variant_name, m in measurements.items():

--- a/scripts/phase35_m3_ablation.py
+++ b/scripts/phase35_m3_ablation.py
@@ -76,6 +76,7 @@ from rag_text_processing import tokenize  # noqa: E402
 from scripts._ablation_common import (  # noqa: E402
     _fmt_ci,
     _fmt_mean,
+    anon_qid,
     categories_from_case,
     compute_deltas,
 )
@@ -316,7 +317,7 @@ def measure_variant(
         retrieved_chunk_ids, latency_ms = run_single_case(index, case, spec, top_k)
         latency_vals.append(latency_ms)
         row: dict[str, Any] = {
-            "qid": qid,
+            "qid": anon_qid(qid),
             "query_type": qt,
             "categories": categories_from_case(case),
             "gold_chunk_n": len(gold_chunk_ids),
@@ -630,7 +631,15 @@ def _run_reaggregate(
 
     cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
     cases = cfg.get("cases", []) or []
-    cases_by_qid = {str(c.get("id")): c for c in cases}
+    cases_by_qid = {}
+    for _c in cases:
+        _cid = str(_c.get("id"))
+        # Tolerant join: committed real-eval artifacts carry anonymized
+        # qids (anon_qid maps Hangul ids -> real_<hash>); synthetic /
+        # legacy files carry the raw id. Map both so re-aggregation
+        # works regardless of which the persisted row used.
+        cases_by_qid[_cid] = _c
+        cases_by_qid[anon_qid(_cid)] = _c
 
     for variant_name, m in measurements.items():
         rows = m.get("per_case", []) or []

--- a/scripts/phase3_mode_ablation.py
+++ b/scripts/phase3_mode_ablation.py
@@ -68,6 +68,7 @@ from rag_text_processing import tokenize  # noqa: E402
 from scripts._ablation_common import (  # noqa: E402
     _fmt_ci,
     _fmt_mean,
+    anon_qid,
     categories_from_case,
     compute_deltas,
 )
@@ -161,7 +162,7 @@ def measure_variant(
         retrieved_chunk_ids, latency_ms = run_single_case(index, case, spec, top_k)
         latency_vals.append(latency_ms)
         row: dict[str, Any] = {
-            "qid": qid,
+            "qid": anon_qid(qid),
             "query_type": qt,
             "categories": categories_from_case(case),
             "gold_chunk_n": len(gold_chunk_ids),
@@ -419,7 +420,15 @@ def _run_reaggregate(
 
     cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
     cases = cfg.get("cases", []) or []
-    cases_by_qid = {str(c.get("id")): c for c in cases}
+    cases_by_qid = {}
+    for _c in cases:
+        _cid = str(_c.get("id"))
+        # Tolerant join: committed real-eval artifacts carry anonymized
+        # qids (anon_qid maps Hangul ids -> real_<hash>); synthetic /
+        # legacy files carry the raw id. Map both so re-aggregation
+        # works regardless of which the persisted row used.
+        cases_by_qid[_cid] = _c
+        cases_by_qid[anon_qid(_cid)] = _c
 
     for variant_name, m in measurements.items():
         rows = m.get("per_case", []) or []

--- a/scripts/phase4_metadata_ablation.py
+++ b/scripts/phase4_metadata_ablation.py
@@ -81,6 +81,7 @@ from rag_text_processing import tokenize  # noqa: E402
 from scripts._ablation_common import (  # noqa: E402
     _fmt_ci,
     _fmt_mean,
+    anon_qid,
     categories_from_case,
     compute_deltas,
 )
@@ -204,7 +205,7 @@ def measure_variant(
         )
         latency_vals.append(latency_ms)
         row: dict[str, Any] = {
-            "qid": qid,
+            "qid": anon_qid(qid),
             "query_type": qt,
             "categories": categories_from_case(case),
             "gold_chunk_n": len(gold_chunk_ids),
@@ -503,7 +504,15 @@ def _run_reaggregate(
 
     cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
     cases = cfg.get("cases", []) or []
-    cases_by_qid = {str(c.get("id")): c for c in cases}
+    cases_by_qid = {}
+    for _c in cases:
+        _cid = str(_c.get("id"))
+        # Tolerant join: committed real-eval artifacts carry anonymized
+        # qids (anon_qid maps Hangul ids -> real_<hash>); synthetic /
+        # legacy files carry the raw id. Map both so re-aggregation
+        # works regardless of which the persisted row used.
+        cases_by_qid[_cid] = _c
+        cases_by_qid[anon_qid(_cid)] = _c
 
     for variant_name, m in measurements.items():
         rows = m.get("per_case", []) or []

--- a/scripts/phase4_realistic_metadata_ablation.py
+++ b/scripts/phase4_realistic_metadata_ablation.py
@@ -88,6 +88,7 @@ from rag_text_processing import tokenize  # noqa: E402
 from scripts._ablation_common import (  # noqa: E402
     _fmt_ci,
     _fmt_mean,
+    anon_qid,
     categories_from_case,
     compute_deltas,
 )
@@ -266,7 +267,7 @@ def measure_variant(
         retrieved_chunk_ids, latency_ms = run_single_case(index, case, spec, top_k)
         latency_vals.append(latency_ms)
         row: dict[str, Any] = {
-            "qid": qid,
+            "qid": anon_qid(qid),
             "query_type": qt,
             "categories": list(case["_categories"]),
             "gold_chunk_n": len(gold_chunk_ids),
@@ -630,7 +631,15 @@ def _run_reaggregate(
 
     cfg = yaml.safe_load(Path(args.eval_config).read_text(encoding="utf-8"))
     cases = cfg.get("cases", []) or []
-    cases_by_qid = {str(c.get("id")): c for c in cases}
+    cases_by_qid = {}
+    for _c in cases:
+        _cid = str(_c.get("id"))
+        # Tolerant join: committed real-eval artifacts carry anonymized
+        # qids (anon_qid maps Hangul ids -> real_<hash>); synthetic /
+        # legacy files carry the raw id. Map both so re-aggregation
+        # works regardless of which the persisted row used.
+        cases_by_qid[_cid] = _c
+        cases_by_qid[anon_qid(_cid)] = _c
 
     for variant_name, m in measurements.items():
         rows = m.get("per_case", []) or []

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -75,7 +75,7 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         "retry",
         "latency",  # only sub-keys "p50", "p95", "mean" extracted below
         "stage_latency",  # aggregated p50/p95/mean per stage
-        "retry_reason_counts",  # reason strings are non-identifying
+        "retry_reason_counts",  # enum prefix kept; colon payload stripped (#1204)
         # Issue #120: retry effectiveness aggregates. All sub-fields are
         # counts/rates over the case set with no per-case payload; the
         # extractor below whitelists the exact sub-keys.
@@ -402,9 +402,19 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                 if isinstance(v, dict)
             }
         elif key == "retry_reason_counts" and isinstance(value, dict):
-            # Reason strings are taxonomy codes ("topic_not_grounded"), not
-            # identifying. Counts are integers. Safe.
-            out[key] = {str(k): int(v) for k, v in value.items()}
+            # Reason keys are MOSTLY taxonomy codes ("topic_not_grounded"),
+            # but comparison reasons embed private payloads after a colon —
+            # e.g. ``missing_comparison_entity:<agency>`` (Korean agency
+            # names) or ``missing_comparison_doc:<공고번호>`` (real doc ids).
+            # Persisting them verbatim leaked private real-eval metadata
+            # (#1204). Keep only the enum prefix before the first ``:`` and
+            # sum the counts of any keys that collapse together. The taxonomy
+            # totals are preserved; only the identifying payload is dropped.
+            collapsed: dict[str, int] = {}
+            for k, v in value.items():
+                prefix = str(k).split(":", 1)[0]
+                collapsed[prefix] = collapsed.get(prefix, 0) + int(v)
+            out[key] = collapsed
         elif key == "retry_effectiveness" and isinstance(value, dict):
             extracted: dict[str, Any] = {
                 sub: value.get(sub)

--- a/tests/test_eval_artifact_privacy_regression.py
+++ b/tests/test_eval_artifact_privacy_regression.py
@@ -1,0 +1,114 @@
+"""Regression guard for the structural eval-artifact privacy gate (#1204).
+
+``scripts/_governance.py --check-eval-privacy`` enforces that committable
+eval-data JSON under ``reports/retrieval/`` and ``reports/real100/`` carries
+only the ADR 0005 / ADR 0065 boundary fields (qid + categories + metric
+values). The check is purely STRUCTURAL — it consults no list of real agency
+names (that would re-leak them in committed source) — and flags two private
+signatures:
+
+* ``hangul`` — Korean text anywhere in a key or value. Real-eval qids used to
+  embed 발주기관/사업명 (``real_<agency>_<topic>``); the ablation runners now
+  write ``anon_qid(qid)`` (``real_<hex>``), eda_real100 anonymizes every
+  agency rank, so no Hangul should survive.
+* ``colon_keys`` — dict keys containing ``:``. ``retry_reason_counts`` maps
+  embedded private payloads after a colon (``missing_comparison_entity:<agency>``
+  / ``missing_comparison_doc:<공고번호>``); run_real_eval_delta now strips them
+  to the enum prefix.
+
+This complements the key-name ``--check-phase4-privacy`` gate, which only
+covers a fixed forbidden-key set under ``reports/retrieval/phase4*``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts._governance import (
+    EVAL_PRIVACY_ARTIFACT_GLOBS,
+    eval_privacy_artifact_paths,
+    find_eval_private_text,
+    scan_eval_artifacts_for_private_text,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_globs_cover_both_eval_data_surfaces() -> None:
+    # Retrieval ablations + real100 aggregates both leaked private text and
+    # both sit outside the pre-commit ^reports/real[^/]*/ path block.
+    assert "reports/retrieval" in EVAL_PRIVACY_ARTIFACT_GLOBS
+    assert "reports/real100" in EVAL_PRIVACY_ARTIFACT_GLOBS
+    # Self-review agreement holds public Korean axis labels — intentionally
+    # NOT in scope, or the gate would false-positive on legitimate prose.
+    assert "reports/self_review_agreement" not in EVAL_PRIVACY_ARTIFACT_GLOBS
+
+
+def test_find_eval_private_text_flags_hangul_in_qid_and_value() -> None:
+    payload = {
+        "no_metadata": {
+            "per_case": [
+                {"qid": "real_한국전자통신연구원_예산", "chunk_recall@10": 0.5},
+                {"qid": "real_abc1234567", "chunk_recall@10": 0.0},
+            ]
+        },
+        "axis1": {"agency": {"top": [{"rank": 1, "name": "고양도시관리공사"}]}},
+    }
+    found = find_eval_private_text(payload)
+    # 한국전자통신연구원(9)+예산(2) in the qid (11) + 고양도시관리공사(8) in the
+    # agency name = 19 Hangul codepoints.
+    assert found["hangul"] == 19
+    assert "colon_keys" not in found
+
+
+def test_find_eval_private_text_flags_colon_keys() -> None:
+    payload = {
+        "retry_reason_counts": {
+            "topic_not_grounded": 3,
+            "missing_comparison_doc:20240419765-0.0": 1,
+        }
+    }
+    found = find_eval_private_text(payload)
+    assert found["colon_keys"] == 1
+    # The ASCII doc-id payload carries no Hangul, so colon_keys is the only
+    # signature — proving the structural check catches non-Hangul leaks too.
+    assert "hangul" not in found
+
+
+def test_find_eval_private_text_ignores_clean_artifact() -> None:
+    clean = {
+        "no_metadata": {
+            "per_case": [
+                {
+                    "qid": "real_abc1234567",
+                    "query_type": "single_doc",
+                    "categories": ["multi_hop"],
+                    "chunk_recall@10": 0.5,
+                    "mrr": 0.25,
+                },
+            ],
+            "retry_reason_counts": {
+                "topic_not_grounded": 2,
+                "missing_comparison_entity": 1,
+            },
+        },
+        "agency": {"top": [{"rank": 1, "name": "agency_01", "count": 9}]},
+    }
+    assert find_eval_private_text(clean) == {}
+
+
+def test_tracked_eval_artifacts_are_clean() -> None:
+    # The real regression guard: no committed eval-data JSON may carry private
+    # text. Fails on the pre-fix tree (qids with agency names, colon-payload
+    # retry keys, raw eda top names).
+    violations = scan_eval_artifacts_for_private_text(str(REPO_ROOT))
+    assert violations == [], "eval artifacts leak private text: " + "; ".join(
+        f"{rel}: {sorted(found)}" for rel, found in violations
+    )
+
+
+def test_tracked_artifacts_parse_as_json() -> None:
+    # The scanner silently skips unparseable files; assert the tracked set is
+    # actually valid JSON so a corrupt artifact can't hide a leak.
+    for rel in eval_privacy_artifact_paths(str(REPO_ROOT)):
+        json.loads((REPO_ROOT / rel).read_text(encoding="utf-8"))


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

커밋된 real-eval 산출물이 비공개 RFP 메타데이터를 세 경로로 누출하고 있었음:
ablation `qid` 가 발주기관/사업명을 임베드(`real_<agency>_<topic>`),
`retry_reason_counts` 키가 `:` 뒤에 기관명/공고번호 doc-id 를 임베드
(`missing_comparison_entity:<agency>`), eda top-N 이 실 기관명을 그대로 커밋.
모두 ADR 0005 private-local + ADR 0065 경계("qid + categories + metric values only") 위반.
이를 익명화하고, **이름 목록 없는 구조적 게이트**로 회귀를 강제함.

Closes #1204

## 2. 영향 파일

- `scripts/_ablation_common.py` — `anon_qid` (Hangul 조건부 `real_<sha1[:10]>`) + `contains_hangul` (supporting)
- `scripts/{phase2_chunking,phase3_mode,phase35_m3,phase4_metadata,phase4_realistic_metadata}_ablation.py` — `anon_qid(qid)` 기록 + reaggregate join raw/anon 양쪽 매핑 (supporting)
- `scripts/run_real_eval_delta.py` — `retry_reason_counts` 키를 enum prefix 로 strip + 충돌 count 합산 (supporting; `write_real_eval_baseline` 도 이 chokepoint 재사용)
- `scripts/eda_real100.py` — 모든 agency rank 익명화(top-N 포함) (supporting)
- `scripts/_governance.py` — 구조적 `--check-eval-privacy` 게이트 (supporting)
- `.githooks/pre-commit` — 게이트 배선
- `tests/test_eval_artifact_privacy_regression.py` — 신규 회귀 테스트
- `reports/real100/*.aggregate.json` (5) + `reports/retrieval/**/raw_results.json` (6) — in-place 마이그레이션

**Load-bearing 변경 없음** (`scripts/_governance.py --is-load-bearing` 전부 supporting).

## 3. 리스크

- **Reaggregate join 깨짐**: 마이그레이션으로 커밋 산출물의 qid 는 익명화됐는데 비공개 eval config 의 case.id 는 원본(Korean) → join 실패 가능. → 방어: reaggregate join 이 `cases_by_qid` 에 raw id 와 `anon_qid(id)` 를 **둘 다** 매핑(하위호환). 합성 qid("a","q1")는 Hangul 없어 `anon_qid` 가 항등 → 기존 runner 테스트 무수정 통과.
- **ADR 0001 baseline byte-identity**: `baseline.aggregate.json` 의 `retry_reason_counts` 키가 바뀜. → 충돌 count 를 합산해 **taxonomy 총계 보존**, metric rate 는 불변. baseline-provenance/failure-rate/write-baseline 테스트 통과로 확인.
- **eda 스키마 변경**: top `name` 값만 `agency_NN` 으로 교체(키명 유지) → md/figure consumer 무영향. `test_eda_real100` 통과.
- **게이트 false-positive**: `reports/self_review_agreement/` 의 공개 한국어 axis 라벨은 의도적으로 scope 제외(globs = retrieval + real100 한정).

## 4. 테스트

- 신규 `tests/test_eval_artifact_privacy_regression.py`: 구조적 signature(hangul/colon_keys) 탐지 + 안전 sibling 무시 + `test_tracked_eval_artifacts_are_clean` (마이그레이션 전 tree 에서 fail → 후 pass = 회귀 가드).
- 검증 배치: privacy/eda/ablation 35 passed + delta/baseline/provenance/failure-rate 89 passed (양쪽 green).
- 두 게이트 모두 exit 0 (`--check-eval-privacy`, `--check-phase4-privacy`).

## 5. Eval 영향

검색/검증/답변 path 동작 변화 없음 — 변경은 (a) 산출물 라벨 익명화(metric rate 불변), (b) 거버넌스 게이트 추가뿐. CI eval delta: all `·` 예상.

### 5b. Real-data delta

**검색/검증 path 동작 변화 없음.** Load-bearing path 미변경(전 supporting). 마이그레이션은 커밋된 산출물의 *라벨* 만 정리하며 retrieval/verifier metric rate 는 byte-동일(round-trip 검증 + retry count 총계 보존). `make real-eval-delta` 재실행 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)