### PR TITLE
test: gate heavy suites behind slow marker, add make test-fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,15 @@ harness-compare:
 test:
 	bash scripts/test.sh
 
+# Fast local edit loop: the full suite minus `slow`-marked files (full
+# data/raw corpus or real embedding-model tests — see pyproject.toml
+# markers). Those few files dominate wall-clock under `--dist loadfile`
+# tail latency; deselecting them keeps the local loop snappy. The CI gate
+# (`make test` / scripts/test.sh) still runs EVERYTHING — never rely on
+# test-fast for a merge decision.
+test-fast:
+	$(PYTHON) -m pytest -m "not slow" -n auto --dist loadfile -q
+
 # Fast P0 regression guards for the retrieval loop and answerable smoke path.
 # Run before any change to rag_core retrieval/verification or the eval pipeline.
 test-regression:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,14 @@ testpaths = ["tests"]
 # Marker registry. Tests under unregistered markers warn under
 # pytest-strict-markers. ``qdrant_integration`` flags suites that
 # need a live Qdrant HTTP server (see Makefile `qdrant-up`, issue #853).
+# ``slow`` flags suites that process the full data/raw corpus (383 chunks,
+# ADR 0050) or load a real embedding model — each runs tens of seconds and
+# dominates the wall-clock under ``--dist loadfile`` tail latency. The CI
+# gate (scripts/test.sh) still runs them; ``make test-fast`` deselects them
+# via ``-m "not slow"`` for the local edit loop.
 markers = [
     "qdrant_integration: requires a live Qdrant HTTP server on BIDMATE_QDRANT_URL (default http://localhost:6333); not run in CI",
+    "slow: full-corpus or real-model suite (tens of seconds); deselected by `make test-fast`, still run in CI",
 ]
 
 # Issue #334 (G8 of #284): opt-in ruff lint gate from scripts/test.sh.

--- a/scripts/generate_finetune_pairs.py
+++ b/scripts/generate_finetune_pairs.py
@@ -292,7 +292,7 @@ def build_subchunks(input_dir: Path, max_chars: int) -> list[dict[str, Any]]:
 def mine_hard_negatives(
     positive: dict[str, Any],
     query: str,
-    subchunks: list[dict[str, Any]],
+    by_id: dict[str, dict[str, Any]],
     bm25_index: dict[str, Any],
     rank_window: tuple[int, int],
     neg_per_pos: int,
@@ -303,6 +303,10 @@ def mine_hard_negatives(
     Drops same-``doc_id`` chunks (likely false negatives) then samples
     from the configured rank window. Window is clamped to the
     available corpus so this stays robust on small fixtures.
+
+    ``by_id`` is the ``chunk_id -> chunk`` lookup, built once by the
+    caller and reused across every query — rebuilding it per call made
+    this O(queries x corpus) and dominated the suite's wall-clock.
     """
     bm25, chunk_ids = get_or_build_bm25(bm25_index)
     query_tokens = tokenize(query)
@@ -311,7 +315,6 @@ def mine_hard_negatives(
     scores = bm25.get_scores(query_tokens)
     ranked = sorted(zip(chunk_ids, scores), key=lambda kv: kv[1], reverse=True)
 
-    by_id = {c["chunk_id"]: c for c in subchunks}
     positive_doc_id = positive["doc_id"]
     candidates: list[tuple[str, float, int]] = []
     for rank, (cid, score) in enumerate(ranked):
@@ -378,6 +381,7 @@ def generate_pairs(
         raise RuntimeError(f"No sub-chunks produced from {input_dir}.")
 
     bm25_index: dict[str, Any] = {"chunks": subchunks}
+    by_id = {c["chunk_id"]: c for c in subchunks}
     guard = ContaminationGuard.from_eval_queries(load_eval_queries())
 
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -400,7 +404,7 @@ def generate_pairs(
                 negs = mine_hard_negatives(
                     chunk,
                     q,
-                    subchunks,
+                    by_id,
                     bm25_index,
                     hard_neg_rank_window,
                     neg_per_pos,

--- a/tests/test_chunking_ablation.py
+++ b/tests/test_chunking_ablation.py
@@ -11,6 +11,8 @@ import unittest
 from pathlib import Path
 import sys
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
@@ -19,6 +21,10 @@ from run_chunking_ablation import (  # noqa: E402
     STRATEGIES,
     run_for_strategy,
 )
+
+# Runs every chunking strategy over the full data/raw corpus — ~9s.
+# Marked slow so `make test-fast` deselects it; CI still runs.
+pytestmark = pytest.mark.slow
 
 
 class ChunkingAblationRunnerTest(unittest.TestCase):

--- a/tests/test_data_list_validation.py
+++ b/tests/test_data_list_validation.py
@@ -5,6 +5,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pytest
+
 from ingestion import (
     FAILURE_TAXONOMY,
     canonical_doc_id,
@@ -78,6 +80,10 @@ class CanonicalDocIdTest(unittest.TestCase):
         )
 
 
+# Several cases here ingest real pdf/hwp rows via the npx kordoc subprocess
+# (~136s); CanonicalDocIdTest above stays fast. Slow → deselected by
+# `make test-fast`, still run in CI.
+@pytest.mark.slow
 class ValidateDataListCsvTest(unittest.TestCase):
     """Issue #51 — schema audit + #53 grouped diagnostics."""
 
@@ -326,6 +332,7 @@ class ValidateDataListCsvTest(unittest.TestCase):
             )
 
 
+@pytest.mark.slow  # real pdf/hwp ingestion (~137s) — see ValidateDataListCsvTest note
 class IngestionDuplicateResolutionTest(unittest.TestCase):
     """Issue #52 — auto-suffix policy keeps the second row indexable."""
 

--- a/tests/test_eda_real100.py
+++ b/tests/test_eda_real100.py
@@ -20,6 +20,10 @@ from pathlib import Path
 
 import pytest
 
+# Drives the eda_real100 script over the full data/raw corpus via subprocess
+# — tens of seconds. Marked slow so `make test-fast` deselects it; CI still runs.
+pytestmark = pytest.mark.slow
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "eda_real100.py"
 

--- a/tests/test_eval_reproducibility_regression.py
+++ b/tests/test_eval_reproducibility_regression.py
@@ -35,6 +35,11 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
+
+# The shared setUp runs two full eval passes (~66s) before any assertion —
+# the whole class is heavy. Marked slow so `make test-fast` deselects it; CI runs it.
+pytestmark = pytest.mark.slow
 
 ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_finetuned_ablation_baseline_invariant.py
+++ b/tests/test_finetuned_ablation_baseline_invariant.py
@@ -36,6 +36,7 @@ import sys
 import unittest
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -264,6 +265,10 @@ class EmbedTextsAdapterGatingTest(unittest.TestCase):
         )
 
 
+# Runs eval/run_eval.py end-to-end in setUp (~30s); the YamlRowsLanded /
+# NormalizedConfigEquality / EmbedTextsAdapterGating classes above stay fast.
+# Slow → deselected by `make test-fast`, still run in CI.
+@pytest.mark.slow
 class EvalSummaryMetricEqualityTest(unittest.TestCase):
     """End-to-end invariance: run ``eval/run_eval.py`` once and assert
     that the finetuned rows produce byte-equal correctness metrics to

--- a/tests/test_generate_finetune_pairs.py
+++ b/tests/test_generate_finetune_pairs.py
@@ -20,6 +20,8 @@ from tempfile import TemporaryDirectory
 
 import sys
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -32,6 +34,11 @@ from scripts.generate_finetune_pairs import (  # noqa: E402
     generate_pairs,
     load_eval_queries,
 )
+
+# Most cases here mine BM25 hard negatives over the full data/raw corpus
+# (383 chunks, ADR 0050) — query-by-query get_scores/sort dominates, tens
+# of seconds. Marked slow so `make test-fast` deselects them; CI still runs.
+pytestmark = pytest.mark.slow
 
 
 def _run(tmpdir: Path, **overrides) -> tuple[Path, dict]:

--- a/tests/test_harness_observability.py
+++ b/tests/test_harness_observability.py
@@ -29,6 +29,11 @@ import sys
 import unittest
 from pathlib import Path
 
+import pytest
+
+# Every case here runs the harness end-to-end (subprocess + index build) —
+# tens of seconds each. Marked slow so `make test-fast` deselects it; CI runs it.
+pytestmark = pytest.mark.slow
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -3,6 +3,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pytest
+
 from ingestion import load_documents_from_metadata_csv
 from rag_core import build_index_payload_from_documents
 
@@ -23,6 +25,10 @@ FIELDNAMES = [
 ]
 
 
+# Real pdf/hwp ingestion via the npx kordoc subprocess (~155s); the sibling
+# RowValidationParityRegression stays fast and unmarked. Slow → deselected by
+# `make test-fast`, still run in CI.
+@pytest.mark.slow
 class MetadataCsvIngestionTest(unittest.TestCase):
     def test_ingests_pdf_hwp_rows_and_reports_missing_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_m3_backend_regression.py
+++ b/tests/test_m3_backend_regression.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
+import pytest
 
 from rag_core import (
     VALID_RETRIEVAL_BACKENDS,
@@ -156,6 +157,7 @@ class NaiveBaselineInvariantTest(unittest.TestCase):
         self.assertNotIn("m3", str(plan["strategy"]).lower())
 
 
+@pytest.mark.slow
 @unittest.skipUnless(
     _flag_embedding_available(), "FlagEmbedding not installed — m3 spike test skipped"
 )
@@ -201,6 +203,7 @@ class M3EndToEndTest(unittest.TestCase):  # pragma: no cover — opt-in, gated o
             self.assertLessEqual(item["score"], 1.0)
 
 
+@pytest.mark.slow
 @unittest.skipUnless(
     _flag_embedding_available(), "FlagEmbedding not installed — m3 spike test skipped"
 )
@@ -268,6 +271,7 @@ class M3Fp16CacheRegressionTest(unittest.TestCase):  # pragma: no cover — opt-
         np.testing.assert_allclose(s_fp32, s_fp16, rtol=1e-2)
 
 
+@pytest.mark.slow
 @unittest.skipUnless(
     _flag_embedding_available(), "FlagEmbedding not installed — m3 spike test skipped"
 )
@@ -367,6 +371,7 @@ class M3Int8CacheRegressionTest(unittest.TestCase):  # pragma: no cover — opt-
         self.assertEqual(s_no_scale, s_explicit_1)
 
 
+@pytest.mark.slow
 @unittest.skipUnless(
     _flag_embedding_available(), "FlagEmbedding not installed — m3 spike test skipped"
 )

--- a/tests/test_rag_pipeline_eda.py
+++ b/tests/test_rag_pipeline_eda.py
@@ -18,6 +18,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+# Every case builds a fixture and runs the eda script via subprocess —
+# tens of seconds each. Marked slow so `make test-fast` deselects it; CI runs it.
+pytestmark = pytest.mark.slow
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "rag_pipeline_eda.py"
 

--- a/tests/test_run_harness.py
+++ b/tests/test_run_harness.py
@@ -20,6 +20,7 @@ import sys
 import unittest
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -240,6 +241,10 @@ class CompareCliTest(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+# E2E: full harness run via subprocess + index build (~100s); the pure unit
+# tests above (DeepMerge / MatrixValidation / CompareRendering / ...) stay fast.
+# Slow → deselected by `make test-fast`, still run in CI.
+@pytest.mark.slow
 class HarnessE2ETest(unittest.TestCase):
     """E2E: invoke run_harness.py as a subprocess against committed synthetic data.
 
@@ -529,6 +534,7 @@ class IndexCacheHelperTest(unittest.TestCase):
             self.assertEqual(run_harness.resolve_cached_index(root, "unknown"), (None, None))
 
 
+@pytest.mark.slow  # E2E index-cache roundtrip (~57s) — see HarnessE2ETest note
 class IndexCacheE2ETest(unittest.TestCase):
     """E2E: same dataset+index config across two runs hits the cache.
 

--- a/tests/test_self_review_judge.py
+++ b/tests/test_self_review_judge.py
@@ -385,6 +385,9 @@ def test_compute_evidence_age_days_same_day_under_one():
     assert compute_evidence_age_days(stats, now=now) < 1.0
 
 
+# Real assemble_stats() over the live repo (~84s); the rest of this file is
+# fast stub-based unit tests. Slow → deselected by `make test-fast`, run in CI.
+@pytest.mark.slow
 def test_assemble_stats_emits_evidence_age_and_judge_consumes_it(tmp_path):
     """Real assemble_stats() shape carries evidence_age_days through the judge.
 

--- a/tests/test_self_review_no_body_leak_regression.py
+++ b/tests/test_self_review_no_body_leak_regression.py
@@ -25,6 +25,8 @@ import textwrap
 import unittest
 from pathlib import Path
 
+import pytest
+
 
 # ---------------------------------------------------------------------------
 # Import helpers
@@ -170,6 +172,10 @@ class CollectMemoryNoBodyLeakTest(unittest.TestCase):
             self.assertIn("user", combined)  # type field
 
 
+# Runs real assemble_stats() over the live repo (~92s); the CollectSessions /
+# CollectMemory tests above use small fixtures and stay fast. Slow →
+# deselected by `make test-fast`, still run in CI.
+@pytest.mark.slow
 class AssembleStatsStructuralTest(unittest.TestCase):
     """assemble_stats output has correct top-level keys, all metadata."""
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

로컬 전체 pytest 스위트의 wall-clock을 극소수의 무거운 통합/E2E/실모델 테스트가 지배한다 (`--dist loadfile` tail latency). 특히 `test_m3_backend_regression`의 실모델(FlagEmbedding) 테스트는 FlagEmbedding이 설치된 환경에서 hang에 가깝다. `slow` marker로 이들을 게이트해 `make test-fast`(`-m "not slow"`)가 빠른 로컬 편집 루프를 제공한다. **CI gate(`scripts/test.sh`)는 불변** — `slow` 포함 전체를 계속 실행한다.

Closes #1215

## 2. 영향 파일

- `pyproject.toml` — `slow` marker 등록
- `Makefile` — `make test-fast` 타깃 (`-m "not slow" -n auto --dist loadfile`)
- `scripts/generate_finetune_pairs.py` — `by_id` 룩업 1회 빌드 리팩터 (load-bearing 아님)
- `tests/` 13개 파일 — `@pytest.mark.slow` (전체 무거운 건 모듈, 일부만 무거운 건 클래스/함수 단위)
- load-bearing 파일 변경 **없음** (`scripts/_governance.py --is-load-bearing` 전부 exit 1)

## 3. 리스크

- 가장 가능성 높은 깨짐: marker 오부착으로 빠른 단위 테스트가 로컬에서 누락되거나, 무거운 테스트가 CI에서 빠지는 것. → collect-only로 검증: `HarnessE2ETest`/`IndexCacheE2ETest`는 `-m "not slow"`에서 0개 수집, `DeepMergeTest` 등 빠른 단위 클래스는 유지(10개). `slow` 68개 / not-slow 2102개, 정확히 의도한 13개 파일만 기여.
- CI 영향 없음: `scripts/test.sh`는 marker 필터를 추가하지 않으므로 전체를 계속 실행.

## 4. 테스트

동작 변경 없음(테스트 게이트 메타데이터 추가 + byte-identical 리팩터)이라 신규 테스트 불필요. `generate_finetune_pairs`의 `by_id` 리팩터는 기존 `DeterminismTest`(byte-equal 출력)가 회귀 가드. 로컬 검증: `ruff check .` 통과, `make test-fast` 2086 passed / 16 skipped / EXIT 0.

## 5. Eval 영향

All `·` — eval 파이프라인 동작 변경 없음. 테스트 marker + Makefile 타깃 + LoRA 보조 스크립트의 byte-identical 리팩터일 뿐.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Load-bearing path 미변경 (`--is-load-bearing` 전부 exit 1) → §5b 비해당.

## 6. 하위 호환

깨짐 없음. `make test`/`scripts/test.sh`(CI gate)는 동일하게 전체 실행. `make test-fast`는 신규 추가 타깃. answer-contract/스키마/CLI 변경 없음.

## 7. 범위 외

- not-slow suite의 새 tail(28초대: git-subprocess hook 테스트, kiwi 형태소 분석)은 단위에 가까워 추가 마킹하지 않음 — 더 빼면 로컬 단위 커버리지 손실.
- wall-clock 절대 시간 벤치마크는 측정 환경(이 머신 load 92/8core) 부하로 신뢰 불가해 본문에 포함하지 않음. 효과는 durations 상대 순위(tail 155s→28s)로 근거.