### PR TITLE
fix(eval): repoint baseline provenance to rewritten SHA

### DIFF
--- a/reports/real100/baseline.aggregate.json
+++ b/reports/real100/baseline.aggregate.json
@@ -1438,7 +1438,7 @@
   "prompt_profile": "structured_grounded_claims",
   "provenance": {
     "generated_at": "2026-05-19T03:03:10.940691Z",
-    "git_commit": "a7fd711d0573",
+    "git_commit": "de69c5c2d456",
     "git_dirty": true
   },
   "retry": 0.7647058823529411,
@@ -1486,7 +1486,7 @@
   "run_manifest": {
     "config_sha256": "cfb1fc68d994a4b7",
     "generated_at": "2026-05-19T03:01:21.745364Z",
-    "git_commit": "a7fd711d0573",
+    "git_commit": "de69c5c2d456",
     "git_dirty": true
   },
   "stage_latency": {


### PR DESCRIPTION
## Summary
- `reports/real100/baseline.aggregate.json` 의 `provenance.git_commit`/`run_manifest.git_commit` 를 orphaned `a7fd711d0573` → reachable `de69c5c2d456` 로 갱신
- 2026-05-21 filter-repo history rewrite(#1144) 가 동일 커밋을 re-SHA 하면서 baseline 포인터가 dangling → `Baseline provenance reachability` 게이트가 rewrite 이후 모든 PR 에서 실패하던 것을 해소

## Why
두 SHA 의 tree 는 byte-identical (`a7fd711^{tree}` == `de69c5c^{tree}`) — eval 코드 상태 불변. eval 재실행 불필요, 순수 포인터 정정.

`history/*.aggregate.json` 도 orphan SHA 를 참조하나 CI 게이트(`check_baseline_provenance.py`)는 `baseline.aggregate.json` 만 읽으므로 비차단. 과거 스냅샷은 파일명에 SHA 가 박혀 보존.

Closes #1218

## Test plan
- [x] `python3 scripts/check_baseline_provenance.py --ref origin/main` → `[OK] ... reachable`
- [x] JSON 유효성 확인