### PR TITLE
docs(ship-pr): add real-model fallback to step 6 local gate

### DIFF
--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -36,7 +36,11 @@ ADR-aware, approval-gated single-PR shipping. The skill replaces an ad-hoc seque
 
 5. **Update SSoT if load-bearing path changes.** If the change touches files in `scripts/_governance.py` `LOAD_BEARING_PATHS`, update the list there first (single source of truth read by `.githooks/pre-push` + the §5b CI gate).
 
-6. **Local gate.** Run `bash scripts/test.sh` (pytest -q) and `ruff check .`. On failure, stop and report exactly which test / lint rule failed — ask the user whether to fix in this PR or open a follow-up.
+6. **Local gate.** Default: run full `bash scripts/test.sh` (pytest -q, all shards) + `ruff check .`. On failure, stop and report exactly which test / lint rule failed — ask the user whether to fix in this PR or open a follow-up.
+
+   **Real-model fallback.** In a worktree where a heavy real-model dependency is installed (e.g. FlagEmbedding → the `tests/test_m3_backend_regression.py` real-model classes run unconditionally, because `@unittest.skipUnless(_flag_embedding_available())` keys off *import availability*, not `EMBEDDING_BACKEND` — so `EMBEDDING_BACKEND=hashing` does not skip them), the full suite loads the real model and becomes minutes-long-to-hung; local completion is structurally impractical, not a one-off flake. **Only in that case**, and **only if the repo defines a `slow` pytest marker**, you may substitute `make test-fast` (`pytest -m "not slow" -n auto --dist loadfile`) + `ruff check .` as the local gate. This excludes *only* the real-model / heavy integration tests carrying the `slow` marker — it is NOT "skip the tests". The excluded `slow` coverage is carried by CI, where FlagEmbedding is not installed (those tests auto-skip, or run across 8 shards). In an ordinary environment (no real-model dep installed) the full `bash scripts/test.sh` completes normally, so this fallback is unnecessary — do not use it there.
+
+   If you use the fallback you MUST: (a) note it explicitly in the PR body — e.g. "Local gate: `make test-fast` — real-model `slow` tests excluded locally, covered by CI"; and (b) treat **step 12's merge gate as hard-conditional on CI green** — local did not verify full coverage, so the merge MUST NOT proceed until `gh pr checks <N>` is green.
 
 7. **Branch convention check.** Run `python3 scripts/check_branch_and_issue.py --branch "$(git rev-parse --abbrev-ref HEAD)" --check-issue`. If the branch name violates `<type>/issue-<N>[-<slug>]` (ADR 0007), propose a rename and apply `git branch -m` only with explicit approval.
 
@@ -69,7 +73,7 @@ ADR-aware, approval-gated single-PR shipping. The skill replaces an ad-hoc seque
     gh pr merge 493 --squash --admin                   # stacked dependents present
     gh pr merge 493 --squash --admin --delete-branch   # no dependents
     ```
-    Wait for explicit go-ahead. Then execute.
+    **If the step-6 real-model fallback (`make test-fast`) was used, local coverage was partial — this merge is hard-gated on CI green: confirm `gh pr checks <N>` reports all-green before displaying the merge command.** Wait for explicit go-ahead. Then execute.
 
 13. **Aftermath.** `git checkout main` (if the worktree owns main) or `git fetch origin main` + branch advance (worktree case). **Remove the mutex marker** (`rm -f .claude/.ship-pr-active`) so `make ship-arm` is unblocked. If the user has another PR stacked on top, prompt them to re-invoke the skill for the next layer (which re-touches the marker at step 0).
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`.claude/skills/ship-pr/SKILL.md` step 6의 로컬 게이트(full `bash scripts/test.sh` + `ruff check .`)가 **FlagEmbedding(실모델 dep)이 설치된 worktree**에서 구조적으로 비현실적이 되는 케이스를 보강한다. `tests/test_m3_backend_regression.py`의 실모델 클래스는 `@unittest.skipUnless(_flag_embedding_available())` 가드가 import 가능 여부를 키로 삼기 때문에 `EMBEDDING_BACKEND=hashing`으로도 skip되지 않아, 실모델 실험을 한 worktree에서 full 스위트가 수십 분~hang 수준이 된다. #1215/#1216이 도입한 `slow` marker + `make test-fast`를 step 6의 **명시적 fallback**으로 문서화하고, fallback 사용 시 step 12 merge gate를 CI green 전제로 강제하도록 양쪽에 명기했다.

Closes #1217

## 2. 영향 파일

- `.claude/skills/ship-pr/SKILL.md` — step 6 real-model fallback 절 추가, step 12 merge gate에 CI-green hard-condition 추가 (문서성, load-bearing 아님)

## 3. 리스크

문서(skill markdown) 단일 파일 변경 — 실행 표면 0. 가장 가능성 높은 깨짐은 fallback 문구가 "테스트 안 돌려도 됨"으로 오독되는 것 → (a) fallback을 "실모델 테스트만 로컬 제외 + CI가 커버"로 명시, (b) 일반 환경(dep 미설치)에선 full test.sh가 정상 완주하므로 fallback 불필요임을 명시, (c) fallback 사용 시 merge는 CI green 강제 — 3중으로 약화 방지.

## 4. 테스트

문서성 변경, 동작 변경 없음 — 테스트 미추가. `ruff check .` 통과.

## 5. Eval 영향

All `·` — RAG 파이프라인 외 skill 문서 변경.

### 5b. Real-data delta

N/A — load-bearing path 미변경 (skill markdown 문서). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

기존 계약/스키마/CLI flag 변경 없음. ship-pr 워크플로의 기본 게이트(full test.sh)는 그대로 유지되고 fallback은 조건부 추가일 뿐이라 하위 호환.

## 7. 범위 외

- `slow` marker / `make test-fast` 실 도입은 #1216 소관 (이 PR은 그 fallback을 ship-pr 문서에 반영만).

---

**Local gate 주석**: 이 PR을 작성한 worktree는 FlagEmbedding 설치 + `slow` marker 미존재(PR #1216 미머지) 상태라 full `bash scripts/test.sh`가 구조적으로 hang하고 `make test-fast` fallback도 아직 불가. 문서성 단일 파일 변경이라 `ruff check .` 통과로 게이트를 갈음하고, full 커버리지는 CI(FlagEmbedding 미설치)가 담당 — **merge는 CI green 전제**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)