### PR TITLE
fix(self-review): parse v2 5-field hook-fires.log via analyze_hook_outcomes

### DIFF
--- a/scripts/claude-hooks/_self_review.py
+++ b/scripts/claude-hooks/_self_review.py
@@ -411,24 +411,58 @@ def _compute_adr_lags(repo: str, start: str, end: str) -> list[dict[str, Any]]:
     return results
 
 
-def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
-    """Parse `.claude/.hook-fires.log` for PreToolUse load-bearing fires.
+def _load_parse_log_line():
+    """Import the validated fire-log line parser from analyze_hook_outcomes.
 
-    Log line formats (both accepted):
-    - legacy 2-field: ``<ISO8601 UTC>|<file_path>``
-    - current 4-field: ``<ISO8601 UTC>|<action>|<context>|<detail>``
-      loadbearing fires use ``aware|load-bearing|<file_path>``
-      bash-guard blocks use ``blocked|gh-merge-delete-branch|<branch>``
+    ``scripts/analyze_hook_outcomes.py::parse_log_line`` is the single
+    validated parser for the 3/4/5-field hook-fires.log shapes (ADR 0060):
+    reuse it instead of re-deriving the field split here. A prior ad-hoc
+    ``line.split("|", 3)`` mis-parsed v2 5-field lines, fusing
+    ``<category>|<path>`` into one path token. Fail-soft to ``None``
+    (mirrors `load_load_bearing_paths`): the collector then reports fires
+    as unmeasured rather than crashing if the sibling script is absent.
+    """
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from analyze_hook_outcomes import parse_log_line  # type: ignore
+        return parse_log_line
+    except Exception:
+        return None
+
+
+def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
+    """Parse `.claude/.hook-fires.log` for governance hook fires.
+
+    Field extraction is delegated to
+    ``analyze_hook_outcomes.parse_log_line`` — the single validated parser
+    for every historical line shape, with parse provenance:
+
+    - v1 3-field: ``<ts>|<category>|<path>``
+    - v1 4-field: ``<ts>|<action>|<reason>|<path>``
+    - v2 5-field: ``<ts>|<outcome>|<hook>|<category>|<path>[|<extra>]`` (ADR 0060)
+
+    The pre-ADR-0060 2-field loadbearing shape (``<ts>|<path>``) predates
+    that parser, so it is reconstructed here as a compat shim. The old
+    ad-hoc ``split("|", 3)`` mis-parsed v2 lines: the 4-way split fused
+    ``<category>|<path>`` into one token, so ``fires_by_path`` keys came out
+    as ``"file-edit|rag_core.py"`` instead of ``"rag_core.py"``.
     """
     log_path = Path(repo) / ".claude" / ".hook-fires.log"
-    if not log_path.is_file():
+    parse_log_line = _load_parse_log_line()
+    if not log_path.is_file() or parse_log_line is None:
+        note = (
+            "Hook fire log absent at .claude/.hook-fires.log; emit 0."
+            if not log_path.is_file()
+            else "fire-log parser unavailable "
+            "(scripts/analyze_hook_outcomes.py); fires unmeasured."
+        )
         return {
             "pretooluse_loadbearing_fires": 0,
             "fires_by_path": {},
             "fires_by_action": {},
             "memory_lines": {"aware": 0, "blocked": 0},
             "rule_to_automation_lag_days": _compute_adr_lags(repo, start, end),
-            "note": "Hook fire log absent at .claude/.hook-fires.log; emit 0.",
+            "note": note,
         }
     start_dt = datetime.fromisoformat(start).replace(tzinfo=timezone.utc)
     end_dt = datetime.fromisoformat(end).replace(
@@ -437,39 +471,44 @@ def collect_governance_hooks(repo: str, start: str, end: str) -> dict[str, Any]:
     fires = 0
     by_path: Counter[str] = Counter()
     by_action: Counter[str] = Counter()
-    # axis #5-A index hygiene: count `memory-lines` category fires split by
-    # action so the rubric can separate aware (soft-warn) from blocked
-    # (edit refused = index exploded). The category lives in parts[2]; the
-    # historical aggregation above only kept action + path, dropping it.
+    # axis #5-A index hygiene: count `memory-lines` hook fires split by
+    # outcome so the rubric can separate aware (soft-warn) from blocked
+    # (edit refused = index exploded). Keyed on the parsed `hook` field —
+    # works for both v2 5-field (hook="memory-lines") and v1 4-field legacy
+    # (LEGACY_CATEGORY_TO_HOOK maps the reason field to "memory-lines"). The
+    # old code matched parts[2] == "memory-lines", which only worked by
+    # luck: in a v2 line parts[2] is the hook, not the category.
     memory_lines: Counter[str] = Counter()
     try:
         for line in log_path.read_text().splitlines():
             line = line.strip()
-            if not line or "|" not in line:
-                continue
-            parts = line.split("|", 3)
-            ts = parts[0]
+            ev = parse_log_line(line)
+            if ev is None:
+                # parse_log_line requires >=3 fields. Reconstruct the
+                # pre-ADR-0060 2-field loadbearing shape `<ts>|<path>` so
+                # historical logs (issue #502) still count; an invalid ts is
+                # dropped by the window parse below, everything else skips.
+                parts = line.split("|")
+                if len(parts) != 2:
+                    continue
+                ev = {
+                    "ts": parts[0], "outcome": "aware",
+                    "hook": "loadbearing", "category": "", "path": parts[1],
+                }
             try:
-                fire_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                fire_dt = datetime.fromisoformat(ev["ts"].replace("Z", "+00:00"))
             except ValueError:
                 continue
             if fire_dt < start_dt or fire_dt > end_dt:
                 continue
-            if len(parts) >= 4:
-                action, category, path = parts[1], parts[2], parts[3]
-            else:
-                action, category, path = (
-                    "aware",
-                    "",
-                    parts[1] if len(parts) > 1 else "",
-                )
+            outcome, hook, path = ev["outcome"], ev["hook"], ev["path"]
             fires += 1
             if path:
                 by_path[path] += 1
-            if action:
-                by_action[action] += 1
-            if category == "memory-lines" and action:
-                memory_lines[action] += 1
+            if outcome:
+                by_action[outcome] += 1
+            if hook == "memory-lines" and outcome:
+                memory_lines[outcome] += 1
     except OSError:
         pass
     lags = _compute_adr_lags(repo, start, end)

--- a/tests/test_self_review_regression.py
+++ b/tests/test_self_review_regression.py
@@ -64,6 +64,85 @@ class TestHookFiresQuarterWindowFilter(unittest.TestCase):
         self.assertEqual(result["pretooluse_loadbearing_fires"], 0)
 
 
+class TestHookFiresV2FiveField(unittest.TestCase):
+    """Issue #1196: v2 5-field lines (ADR 0060) must parse with clean
+    fires_by_path keys. The old ad-hoc ``split("|", 3)`` fused
+    ``<category>|<path>`` into the path token, so every v2 fire produced a
+    corrupted key (e.g. ``"file-edit|rag_core.py"``)."""
+
+    def test_v2_5field_fires_by_path_is_clean(self):
+        lines = (
+            "2026-04-01T10:00:00Z|aware|loadbearing|file-edit|rag_core.py\n"
+            "2026-04-02T10:00:00Z|nudged|delegation-gate|agent-delegation|<user-prompt>\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(lines)
+            result = sr.collect_governance_hooks(str(repo), "2026-04-01", "2026-06-30")
+        # path is the 5th field only — NOT "<category>|<path>".
+        self.assertEqual(
+            result["fires_by_path"], {"rag_core.py": 1, "<user-prompt>": 1}
+        )
+        self.assertNotIn("file-edit|rag_core.py", result["fires_by_path"])
+        # outcome (field 2), not the buggy hook field, drives the action split.
+        self.assertEqual(result["fires_by_action"].get("aware"), 1)
+        self.assertEqual(result["fires_by_action"].get("nudged"), 1)
+        self.assertEqual(result["pretooluse_loadbearing_fires"], 2)
+
+    def test_v2_5field_memory_lines_matched_by_hook(self):
+        # memory-lines fires are matched on the parsed hook field, not on a
+        # category that happens to equal "memory-lines". In v2 the real
+        # category is "line-count"; the hook field carries "memory-lines".
+        lines = (
+            "2026-04-01T10:00:00Z|aware|memory-lines|line-count|MEMORY.md\n"
+            "2026-04-01T11:00:00Z|aware|memory-lines|line-count|MEMORY.md\n"
+            "2026-04-01T12:00:00Z|blocked|memory-lines|line-count|MEMORY.md\n"
+            "2026-04-01T13:00:00Z|aware|loadbearing|file-edit|rag_core.py\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(lines)
+            result = sr.collect_governance_hooks(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(result["memory_lines"], {"aware": 2, "blocked": 1})
+        # the v2 memory-lines path key is clean (MEMORY.md, not line-count|MEMORY.md).
+        self.assertIn("MEMORY.md", result["fires_by_path"])
+        self.assertNotIn("line-count|MEMORY.md", result["fires_by_path"])
+
+    def test_mixed_2field_4field_5field_all_parse(self):
+        # 2-field (pre-0060 shim) + 4-field (legacy) + 5-field (v2) all count,
+        # each with a clean path key.
+        lines = (
+            "2026-04-01T10:00:00Z|legacy2.py\n"
+            "2026-04-01T11:00:00Z|aware|load-bearing|legacy4.py\n"
+            "2026-04-01T12:00:00Z|aware|loadbearing|file-edit|v2.py\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(lines)
+            result = sr.collect_governance_hooks(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(result["pretooluse_loadbearing_fires"], 3)
+        self.assertEqual(
+            set(result["fires_by_path"]), {"legacy2.py", "legacy4.py", "v2.py"}
+        )
+
+    def test_v2_5field_with_trailing_extra_field(self):
+        # bash-guard emits a 6th `extra` field; path must still be field 5.
+        lines = (
+            "2026-04-01T10:00:00Z|blocked|bash-guard|gh-pr-create-stacked|"
+            "feat/issue-99-foo|on=feat/issue-88-bar\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            (repo / ".claude").mkdir()
+            (repo / ".claude" / ".hook-fires.log").write_text(lines)
+            result = sr.collect_governance_hooks(str(repo), "2026-04-01", "2026-06-30")
+        self.assertEqual(result["fires_by_path"], {"feat/issue-99-foo": 1})
+        self.assertEqual(result["fires_by_action"].get("blocked"), 1)
+
+
 def _git(*args, cwd, **kwargs):
     return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, **kwargs)
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`collect_governance_hooks` (`scripts/claude-hooks/_self_review.py`) 가 ADR 0060 (#1040) 의 canonical 5-field hook-fires.log 포맷을 잘못 파싱했다. ad-hoc `line.split("|", 3)` (maxsplit=3 → 최대 4필드) 후 `path = parts[3]` 로 읽는데, 5-field 행 `<ts>|<outcome>|<hook>|<category>|<path>` 에서 `parts[3]` 은 `<category>|<path>` 가 되어 path 가 오염된다. 결과로 `/self-review-quarterly` axis #3 (자동화 ROI) 이 소비하는 `fires_by_path` 키가 모든 v2 발화에서 `"file-edit|rag_core.py"` 처럼 깨졌다. 필드 추출을 검증된 `analyze_hook_outcomes.parse_log_line` (3/4/5-field + provenance) 재사용으로 교체했다.

Closes #1196

## 2. 영향 파일

- `scripts/claude-hooks/_self_review.py` — `collect_governance_hooks` 파서 교체 (parse_log_line 재사용), `_load_parse_log_line` fail-soft import 헬퍼 추가. **load-bearing 아님** (`scripts/_governance.py --is-load-bearing` exit=1).
- `tests/test_self_review_regression.py` — v2 5-field 회귀 테스트 클래스 추가.

(둘 다 load-bearing 경로 아님.)

## 3. 리스크

- **memory_lines 회귀**: 기존 코드는 `category == "memory-lines"` (parts[2]) 매칭으로 우연히 동작 — 5-field 에서 parts[2] 는 실제 hook 필드. 수정 후 `hook == "memory-lines"` 기준 명시 매칭. 4-field legacy (LEGACY_CATEGORY_TO_HOOK 가 reason→"memory-lines" 매핑) + 5-field 모두 커버 확인.
- **2-field 하위호환**: `parse_log_line` 은 ≥3 필드 요구(2-field → None). 기존 `test_legacy_2field_and_4field_both_counted` 핀을 깨지 않도록 pre-0060 2-field shape `<ts>|<path>` 를 compat shim 으로 보존.
- 출력 dict shape 불변 (키/구조 동일) → `--quarter`/`--window-days` 소비자 영향 없음.
- analyze_hook_outcomes 는 재사용만, 리팩터 안 함 (one concern).

## 4. 테스트

`tests/test_self_review_regression.py::TestHookFiresV2FiveField` 추가 (수정 전 fail / 후 pass):

- `test_v2_5field_fires_by_path_is_clean` — 5-field 행이 clean path 키 (`rag_core.py`, NOT `file-edit|rag_core.py`) + outcome 기반 action 분포.
- `test_v2_5field_memory_lines_matched_by_hook` — hook 기준 memory-lines 매칭, path 키 clean.
- `test_mixed_2field_4field_5field_all_parse` — 세 포맷 혼합 모두 카운트.
- `test_v2_5field_with_trailing_extra_field` — 6-field(extra) 행도 path=field5.

회귀 명령: `python3 -m unittest tests.test_hook_telemetry tests.test_self_review_regression tests.test_self_review_window_regression`

검증: self-review/hook/governance 전체 표면 **121 passed** (`pytest -p no:xdist`, 9개 파일). 전체 스위트(`scripts/test.sh`)는 로컬 머신 포화(동시 워크트리 18개 pytest, mem 24% free)로 워커 OOM — 클린 전체 그린은 CI(pr-eval.yml 샤딩)에 위임. 본 변경은 어떤 production import 경로도 타지 않아 무거운 retrieval/eval 테스트와 무관.

## 5. Eval 영향

All `·`. RAG 파이프라인 (retrieval/answer/verifier/eval) 미변경 — self-review 측정 collector 의 로그 파서만 수정.

### 5b. Real-data delta

N/A — `scripts/claude-hooks/_self_review.py` 는 load-bearing 경로 아님 (`scripts/_governance.py` `LOAD_BEARING_PATHS` 미포함). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

- 출력 dict shape 불변. answer-contract (ADR 0003) 무관 → schema_version bump 불필요.
- 3/4/5-field + pre-0060 2-field 전부 계속 파싱 (compat shim).

## 7. 범위 외

- `pretooluse_loadbearing_fires` 필드명이 모든 fire 를 카운트하는 기존 misnomer 는 그대로 둠 (별도 concern).
- `analyze_hook_outcomes.parse_log_line` 의 strict ts 정규식(fractional/offset 미허용)은 현 실데이터(전부 strict `Z`)와 일치하므로 손대지 않음.

출처: codex adversarial-review 역순 루프 idx35 (#1040 commit b5ae179) finding 1; idx0 (#1138) 재확인 중 독립 확인.