### PR TITLE
fix(security): extend external-payload guard to remaining production egress (#1195)

### DIFF
--- a/docs/adr/0061-external-and-paid-api-dependencies-allowed.md
+++ b/docs/adr/0061-external-and-paid-api-dependencies-allowed.md
@@ -62,10 +62,20 @@ Cohere Rerank 3.5 multilingual (`rag_rerank.py:_cohere_backend` 는 이미 배�
   는 surface attestation 없이는 못 켜진다 (조건 ① opt-in 위에 데이터 경계 attestation
   한 겹 추가). 공개 synthetic 외부 비교(`scripts/compare_external_baselines.py`)는
   `public_synthetic` 를 setdefault 로 선언해 동작 유지.
-- **잔여 egress (follow-up)**: `rag_rerank._cohere_backend`, `rag_embedding` 외부
-  백엔드, `rag_query_expansion` HyDE, `rag_planner` 외부 경로, eval judges 는 동일
-  guard 미적용 — 같은 데이터 경계 위험이 있으므로 별도 PR 로 확장 필요. 중앙 guard 는
-  한 줄 호출로 재사용 가능.
+- **잔여 egress (follow-up, issue #1195 완료)**: metadata/synthesis 외 production
+  파이프라인 외부 진입점 4곳에 동일 guard 확장 — `rag_rerank._cohere_backend`
+  (`rerank:cohere`), `rag_embedding._embed_with_openai` (`embedding:openai`),
+  `rag_query_expansion._call_anthropic_hyde` (`query_expansion:hyde_anthropic`),
+  `rag_planner.LLMPlanner.plan_next` (`planner:anthropic`). 앞 셋 + planner 는
+  never-raise 폴백이 ExternalPayloadBlocked 를 잡아 오프라인으로 복귀(rerank=원순서
+  유지·hyde=원쿼리·planner=StaticPlanner)하고, openai 임베딩만 (폴백 없는 백엔드라)
+  raise 로 fail-closed. **eval judges 는 의도적 제외**: ADR 0006 이 real-data judge
+  egress 를 명시 허용하고 그 경계는 commit 레이어(aggregate-only, ADR 0005)가
+  강제하므로, public/synthetic-only egress guard 를 공유 `call_openai_json` 에 걸면
+  ADR 0006 과 충돌하고 `pr-judge.yml` 라이브 게이트(ADR 0043)를 깬다 — 비공개
+  real-eval egress 는 본 ADR 범위 밖(위 ③)이며 ADR 0005/0012 가 계속 관할. 오프라인
+  데이터 생성 스크립트(`scripts/generate_real_cases.py` 등)도 파이프라인 egress 가
+  아니라 범위 밖.
 - **비용**: 외부 백엔드 활성화 시 latency·과금·가용성 의존이 생긴다. p95 budget
   (ADR 0041) 과 cost telemetry (`rag_synthesis.compute_cost_usd`) 로 관측.
 - **남는 결정**: 비공개 데이터의 외부 전송을 허용할지는 미해결 — 필요 시 ADR 0005/

--- a/rag_embedding.py
+++ b/rag_embedding.py
@@ -39,6 +39,7 @@ from typing import Any
 
 import numpy as np
 
+from bidmate_data_boundary import assert_external_payload_allowed
 from rag_text_processing import tokenize
 
 
@@ -191,6 +192,14 @@ def embed_texts(
 
 
 def _embed_with_openai(texts: list[str], *, model_name: str) -> EmbeddingResult:
+    # Fail closed before any SDK import / network call: the corpus text
+    # batched below leaves the process, so the data-surface attestation must
+    # pass first (ADR 0061 ③ / ADR 0005). Unlike the never-raise backends,
+    # this path raises on failure rather than degrading silently, so a blocked
+    # surface surfaces as ExternalPayloadBlocked; the default offline path
+    # (hashing / sentence-transformers) never reaches this function and so
+    # stays byte-identical (ADR 0001).
+    assert_external_payload_allowed(channel="embedding:openai")
     try:
         from openai import OpenAI  # type: ignore[import-not-found]
     except Exception as exc:

--- a/rag_planner.py
+++ b/rag_planner.py
@@ -34,6 +34,8 @@ import os
 import time
 from typing import Any, Protocol, runtime_checkable
 
+from bidmate_data_boundary import assert_external_payload_allowed
+
 # Env-var contract (mirrors rag_query_expansion.py / rag_synthesis.py).
 ENV_PLANNER_BACKEND = "BIDMATE_PLANNER_BACKEND"
 ENV_PLANNER_MODEL = "BIDMATE_PLANNER_MODEL"
@@ -190,6 +192,12 @@ class LLMPlanner:
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         t0 = time.perf_counter()
         try:
+            # Fail closed before any SDK import / network call: the analysis +
+            # history JSON in the prompt below leaves the process, so the
+            # data-surface attestation must pass first (ADR 0061 ③ / ADR 0005).
+            # The except clause below catches the resulting
+            # ExternalPayloadBlocked and falls back to StaticPlanner.
+            assert_external_payload_allowed(channel="planner:anthropic")
             import anthropic  # type: ignore[import-not-found]
             from rag_agent_tools import AGENT_REACT_SYSTEM_PROMPT, AGENT_REACT_TOOLS
 

--- a/rag_query_expansion.py
+++ b/rag_query_expansion.py
@@ -30,6 +30,8 @@ import os
 import time
 from typing import Any, Protocol, runtime_checkable
 
+from bidmate_data_boundary import assert_external_payload_allowed
+
 # Env-var contract (mirrors rag_synthesis.py / rag_rerank.py idioms).
 ENV_MODEL = "BIDMATE_QUERY_EXPANSION_MODEL"
 ENV_ANTHROPIC_KEY = "ANTHROPIC_API_KEY"
@@ -190,6 +192,11 @@ def _call_anthropic_hyde(
     function without instantiating the SDK. Raises on any error — the
     caller is responsible for never-raise wrapping.
     """
+    # Fail closed before any SDK import / network call: the query text in the
+    # message below leaves the process, so the data-surface attestation must
+    # pass first (ADR 0061 ③ / ADR 0005). HyDEExpander.expand catches the
+    # resulting ExternalPayloadBlocked and falls back to the raw query.
+    assert_external_payload_allowed(channel="query_expansion:hyde_anthropic")
     try:
         import anthropic  # type: ignore[import-not-found]
     except Exception as exc:

--- a/rag_rerank.py
+++ b/rag_rerank.py
@@ -37,6 +37,8 @@ import os
 import time
 from typing import Any
 
+from bidmate_data_boundary import assert_external_payload_allowed
+
 RERANK_SCHEMA_VERSION = 1
 ENV_BACKEND = "BIDMATE_RERANK_BACKEND"
 ENV_MODEL = "BIDMATE_RERANK_MODEL"
@@ -159,6 +161,11 @@ def _cohere_backend(  # pragma: no cover - network
     candidates: list[dict[str, Any]],
     model: str | None,
 ) -> tuple[list[dict[str, Any]], str]:
+    # Fail closed before any SDK import / network call: the candidate chunk
+    # text sent as ``documents`` below leaves the process, so the data-surface
+    # attestation must pass first (ADR 0061 ③ / ADR 0005). ``rerank()`` catches
+    # the resulting ExternalPayloadBlocked and returns candidates unchanged.
+    assert_external_payload_allowed(channel="rerank:cohere")
     try:
         import cohere  # type: ignore[import-not-found]
     except Exception as exc:

--- a/tests/test_cross_encoder_rerank.py
+++ b/tests/test_cross_encoder_rerank.py
@@ -106,8 +106,12 @@ class RerankCohereMissingDepsTest(unittest.TestCase):
         candidates = [_make_candidate("a::001")]
         # The rerank() wrapper catches RuntimeError from backends and converts
         # to fell_back=True. With cohere SDK missing, the backend raises and
-        # the caller gets a clean fallback to input order.
-        with mock.patch.dict(sys.modules, {"cohere": None}):
+        # the caller gets a clean fallback to input order. The public-surface
+        # attestation passes the ADR 0061 ③ guard so this exercises the
+        # missing-SDK path rather than the data-boundary block (issue #1195).
+        with mock.patch.dict(
+            os.environ, {"BIDMATE_DATA_SURFACE": "public_synthetic"}
+        ), mock.patch.dict(sys.modules, {"cohere": None}):
             out, meta = rag_rerank.rerank("q", candidates, backend="cohere")
         self.assertEqual([c["chunk_id"] for c in out], ["a::001"])
         self.assertTrue(meta["fell_back"])

--- a/tests/test_embedding_backends.py
+++ b/tests/test_embedding_backends.py
@@ -38,7 +38,11 @@ class OpenAIBackendErrorPathTest(unittest.TestCase):
     def test_missing_api_key_raises(self) -> None:
         import rag_core
 
-        with mock.patch.dict(os.environ, {}, clear=False):
+        # Attest a public surface so the ADR 0061 ③ guard passes and the
+        # missing-key path (not the data-boundary block) is exercised (#1195).
+        with mock.patch.dict(
+            os.environ, {"BIDMATE_DATA_SURFACE": "public_synthetic"}, clear=False
+        ):
             os.environ.pop("BIDMATE_OPENAI_API_KEY", None)
             os.environ.pop("OPENAI_API_KEY", None)
             with mock.patch.dict(sys.modules, {"openai": mock.MagicMock()}):
@@ -49,7 +53,11 @@ class OpenAIBackendErrorPathTest(unittest.TestCase):
     def test_missing_sdk_raises_with_install_hint(self) -> None:
         import rag_core
 
-        with mock.patch.dict(sys.modules, {"openai": None}):
+        # Public-surface attestation passes the ADR 0061 ③ guard so the
+        # missing-SDK install hint (not the boundary block) is asserted (#1195).
+        with mock.patch.dict(
+            os.environ, {"BIDMATE_DATA_SURFACE": "public_synthetic"}, clear=False
+        ), mock.patch.dict(sys.modules, {"openai": None}):
             with self.assertRaises(RuntimeError) as ctx:
                 rag_core.embed_texts(["x"], backend="openai")
             self.assertIn("pip install openai", str(ctx.exception))
@@ -105,7 +113,15 @@ class OpenAIVectorNormalizationTest(unittest.TestCase):
         fake_openai.OpenAI = _FakeOpenAIClient
 
         with mock.patch.dict(sys.modules, {"openai": fake_openai}):
-            with mock.patch.dict(os.environ, {"BIDMATE_OPENAI_API_KEY": "test-key"}):
+            # BIDMATE_DATA_SURFACE attests public so the ADR 0061 ③ guard
+            # passes and the fake client (not the boundary block) runs (#1195).
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "BIDMATE_OPENAI_API_KEY": "test-key",
+                    "BIDMATE_DATA_SURFACE": "public_synthetic",
+                },
+            ):
                 result = rag_core.embed_texts(
                     ["hello", "world", "again"],
                     model_name="text-embedding-3-large",
@@ -128,7 +144,15 @@ class EmbedQueryForIndexOpenAITest(unittest.TestCase):
         fake_openai.OpenAI = _FakeOpenAIClient
 
         with mock.patch.dict(sys.modules, {"openai": fake_openai}):
-            with mock.patch.dict(os.environ, {"BIDMATE_OPENAI_API_KEY": "test-key"}):
+            # Public-surface attestation passes the ADR 0061 ③ guard so this
+            # genuinely routes through the openai backend, not hashing (#1195).
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "BIDMATE_OPENAI_API_KEY": "test-key",
+                    "BIDMATE_DATA_SURFACE": "public_synthetic",
+                },
+            ):
                 vec = rag_core.embed_query_for_index(
                     "안녕",
                     {"backend": "openai", "model": "text-embedding-3-large", "dimension": 4},
@@ -138,7 +162,12 @@ class EmbedQueryForIndexOpenAITest(unittest.TestCase):
     def test_openai_falls_back_to_hashing_when_sdk_missing(self) -> None:
         import rag_core
 
-        with mock.patch.dict(sys.modules, {"openai": None}):
+        # Public-surface attestation passes the ADR 0061 ③ guard so the
+        # SDK-missing branch (not the boundary block) drives the graceful
+        # hashing fallback this test asserts (#1195).
+        with mock.patch.dict(
+            os.environ, {"BIDMATE_DATA_SURFACE": "public_synthetic"}, clear=False
+        ), mock.patch.dict(sys.modules, {"openai": None}):
             vec = rag_core.embed_query_for_index(
                 "안녕",
                 {"backend": "openai", "model": "text-embedding-3-large", "dimension": 8},

--- a/tests/test_external_payload_boundary_regression.py
+++ b/tests/test_external_payload_boundary_regression.py
@@ -28,6 +28,9 @@ import os
 import unittest
 from typing import Any
 
+import rag_embedding
+import rag_query_expansion
+import rag_rerank
 import rag_synthesis
 from bidmate_data_boundary import (
     DATA_SURFACE_ENV,
@@ -42,6 +45,7 @@ from rag_metadata_extraction import (
     _regex_backend,
     extract_rfp_metadata,
 )
+from rag_planner import LLMPlanner, StaticPlanner
 
 
 @contextlib.contextmanager
@@ -63,6 +67,27 @@ def _surface(value: str | None):
             os.environ.pop(DATA_SURFACE_ENV, None)
         else:
             os.environ[DATA_SURFACE_ENV] = saved
+
+
+@contextlib.contextmanager
+def _cleared(*names: str):
+    """Temporarily clear env vars (restore on exit).
+
+    Used by the over-block tests to force the backend's own API-key check
+    to fail *without* a network round-trip, so the test proves the guard
+    is not the blocker regardless of whether the SDK is installed.
+    """
+    saved = {name: os.environ.get(name) for name in names}
+    for name in names:
+        os.environ.pop(name, None)
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 SAMPLE_DOCUMENT: dict[str, Any] = {
@@ -233,6 +258,203 @@ class GuardDoesNotOverBlockTest(unittest.TestCase):
             "ANTHROPIC_API_KEY" in message or "anthropic SDK" in message,
             f"unexpected error after guard: {message!r}",
         )
+
+
+_CANDIDATES: list[dict[str, Any]] = [
+    {
+        "chunk_id": "rfp-a::chunk-001",
+        "doc_id": "rfp-a",
+        "text": "제안사는 보안 통제 매뉴얼을 구축해야 한다.",
+    },
+    {
+        "chunk_id": "rfp-a::chunk-002",
+        "doc_id": "rfp-a",
+        "text": "사업비는 1억 5천만원으로 한다.",
+    },
+]
+
+
+class RerankBackendFailClosedTest(unittest.TestCase):
+    """rag_rerank cohere backend fails closed; rerank() keeps input order.
+
+    issue #1195 — extends the ADR 0061 ③ guard to the candidate-text
+    egress in ``rag_rerank._cohere_backend``.
+    """
+
+    def test_cohere_backend_entry_fail_closed(self) -> None:
+        for value in (None, "private", "local"):
+            with self.subTest(value=value), _surface(value):
+                with self.assertRaises(ExternalPayloadBlocked):
+                    rag_rerank._cohere_backend(
+                        query="q", candidates=list(_CANDIDATES), model=None
+                    )
+
+    def test_rerank_dispatch_falls_back_unchanged(self) -> None:
+        # never-raise wrapper: blocked surface returns the input candidates
+        # in their original order with fell_back set.
+        with _surface(None):
+            reordered, meta = rag_rerank.rerank(
+                "q", list(_CANDIDATES), backend="cohere"
+            )
+        self.assertEqual(
+            [c["chunk_id"] for c in reordered],
+            [c["chunk_id"] for c in _CANDIDATES],
+        )
+        self.assertTrue(meta["fell_back"])
+        self.assertIn("ExternalPayloadBlocked", meta["fallback_reason"])
+
+    def test_stub_backend_never_invokes_guard(self) -> None:
+        # ADR 0001 invariant: the default stub backend is guard-free and
+        # passes through even on an unset (blocked) surface.
+        with _surface(None):
+            reordered, meta = rag_rerank.rerank(
+                "q", list(_CANDIDATES), backend="stub"
+            )
+        self.assertFalse(meta["fell_back"])
+        self.assertEqual(
+            [c["chunk_id"] for c in reordered],
+            [c["chunk_id"] for c in _CANDIDATES],
+        )
+
+    def test_public_surface_passes_guard_then_sdk_or_key_check(self) -> None:
+        with _surface("public_synthetic"), _cleared(
+            "BIDMATE_COHERE_API_KEY", "COHERE_API_KEY"
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                rag_rerank._cohere_backend(
+                    query="q", candidates=list(_CANDIDATES), model=None
+                )
+        # Guard passed — the failure is the backend's own SDK/key check.
+        self.assertNotIsInstance(ctx.exception, ExternalPayloadBlocked)
+
+
+class EmbeddingBackendFailClosedTest(unittest.TestCase):
+    """rag_embedding openai backend fails closed by RAISING.
+
+    issue #1195 — unlike the never-raise backends, the openai embedding
+    path has no offline wrapper, so a blocked surface fails closed by
+    raising ExternalPayloadBlocked rather than degrading to hashing.
+    """
+
+    def test_embed_with_openai_entry_fail_closed(self) -> None:
+        for value in (None, "private", "local"):
+            with self.subTest(value=value), _surface(value):
+                with self.assertRaises(ExternalPayloadBlocked):
+                    rag_embedding._embed_with_openai(
+                        ["문서 본문 텍스트"], model_name="text-embedding-3-small"
+                    )
+
+    def test_embed_texts_openai_raises_not_silent(self) -> None:
+        # Asymmetry vs rerank / hyde / planner: no never-raise wrapper, so
+        # the block surfaces as an exception out of the public entry point.
+        with _surface(None):
+            with self.assertRaises(ExternalPayloadBlocked):
+                rag_embedding.embed_texts(["문서 본문 텍스트"], backend="openai")
+
+    def test_default_backend_never_invokes_guard(self) -> None:
+        # ADR 0001 invariant: the default offline path is not gated. The
+        # hashing backend produces vectors even on an unset (blocked) surface.
+        with _surface(None):
+            result = rag_embedding.embed_texts(["문서 본문 텍스트"], backend="hashing")
+        self.assertEqual(result.backend, "hashing")
+        self.assertEqual(result.vectors.shape[0], 1)
+
+    def test_public_surface_passes_guard_then_sdk_or_key_check(self) -> None:
+        with _surface("public_synthetic"), _cleared(
+            "BIDMATE_OPENAI_API_KEY", "OPENAI_API_KEY"
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                rag_embedding._embed_with_openai(
+                    ["문서 본문 텍스트"], model_name="text-embedding-3-small"
+                )
+        self.assertNotIsInstance(ctx.exception, ExternalPayloadBlocked)
+
+
+class QueryExpansionBackendFailClosedTest(unittest.TestCase):
+    """rag_query_expansion HyDE backend fails closed; expand() keeps raw query.
+
+    issue #1195 — extends the ADR 0061 ③ guard to the query-text egress in
+    ``rag_query_expansion._call_anthropic_hyde``.
+    """
+
+    QUERY = "기관 A의 보안 통제 요구사항은?"
+
+    def test_call_anthropic_hyde_entry_fail_closed(self) -> None:
+        for value in (None, "private", "local"):
+            with self.subTest(value=value), _surface(value):
+                with self.assertRaises(ExternalPayloadBlocked):
+                    rag_query_expansion._call_anthropic_hyde(
+                        query=self.QUERY,
+                        model="claude-haiku-4-5-20251001",
+                        max_tokens=256,
+                    )
+
+    def test_hyde_expander_falls_back_to_raw_query(self) -> None:
+        with _surface("private_local"):
+            expanded, meta = rag_query_expansion.HyDEExpander().expand(
+                self.QUERY, plan={}
+            )
+        self.assertEqual(expanded, self.QUERY)
+        self.assertTrue(meta["fell_back"])
+        self.assertIn("ExternalPayloadBlocked", meta["fallback_reason"])
+
+    def test_identity_expander_never_invokes_guard(self) -> None:
+        # ADR 0001 invariant: the default identity expander is guard-free.
+        with _surface(None):
+            expanded, meta = rag_query_expansion.IdentityExpander().expand(
+                self.QUERY, plan={}
+            )
+        self.assertEqual(expanded, self.QUERY)
+        self.assertFalse(meta["fell_back"])
+
+    def test_public_surface_passes_guard_then_sdk_or_key_check(self) -> None:
+        with _surface("public_synthetic"), _cleared("ANTHROPIC_API_KEY"):
+            with self.assertRaises(RuntimeError) as ctx:
+                rag_query_expansion._call_anthropic_hyde(
+                    query=self.QUERY,
+                    model="claude-haiku-4-5-20251001",
+                    max_tokens=256,
+                )
+        self.assertNotIsInstance(ctx.exception, ExternalPayloadBlocked)
+
+
+class PlannerBackendFailClosedTest(unittest.TestCase):
+    """rag_planner LLMPlanner falls back to StaticPlanner when blocked.
+
+    issue #1195 — the guard sits inside plan_next's try block, so a blocked
+    surface is caught by the existing except and routed to StaticPlanner;
+    the never-raise contract (always a valid action) is preserved.
+    """
+
+    @staticmethod
+    def _analysis() -> dict[str, Any]:
+        return {"query_type": "single_doc", "entities": ["기관 A"]}
+
+    def test_llm_planner_falls_back_to_static(self) -> None:
+        with _surface("private_local"):
+            action, meta = LLMPlanner().plan_next(
+                analysis=self._analysis(), history=[], budget={}
+            )
+        self.assertTrue(meta["fell_back"])
+        self.assertEqual(meta["backend"], "anthropic_fallback")
+        self.assertIn("ExternalPayloadBlocked", meta["fallback_reason"])
+        self.assertIn(action["tool"], {"retrieve_evidence", "abstain"})
+
+    def test_static_planner_never_invokes_guard(self) -> None:
+        # ADR 0001 invariant: the default static planner is guard-free.
+        with _surface(None):
+            _, meta = StaticPlanner().plan_next(
+                analysis=self._analysis(), history=[], budget={}
+            )
+        self.assertFalse(meta["fell_back"])
+        self.assertEqual(meta["backend"], "static")
+
+    def test_public_surface_does_not_block_planner_channel(self) -> None:
+        # The guard's allow/block decision is channel-independent, so an
+        # attested public surface must not block the planner channel. Asserted
+        # directly (network-free) since plan_next swallows backend errors.
+        with _surface("public_synthetic"):
+            assert_external_payload_allowed(channel="planner:anthropic")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0061 ③ (외부 egress 데이터 경계) 강제를 완성한다. PR #1190 이 도입한 중앙 fail-closed guard `bidmate_data_boundary.assert_external_payload_allowed` 는 지금까지 metadata + synthesis 진입점에만 적용돼 있었고, ADR 0061 Consequences 의 '잔여 egress (follow-up)' 항목이 나머지 production 파이프라인 외부 진입점을 가리켰다. 그 4곳에 동일 guard 를 SDK import·네트워크 호출 **전에** 한 줄씩 추가한다.

Closes #1195

## 2. 영향 파일

- `rag_rerank.py` — `_cohere_backend` 에 `channel="rerank:cohere"` guard (후보 chunk 텍스트 egress)
- `rag_embedding.py` — `_embed_with_openai` 에 `channel="embedding:openai"` guard (코퍼스 텍스트 egress)
- `rag_query_expansion.py` — `_call_anthropic_hyde` 에 `channel="query_expansion:hyde_anthropic"` guard (쿼리 텍스트 egress)
- `rag_planner.py` — `LLMPlanner.plan_next` 에 `channel="planner:anthropic"` guard (analysis/history JSON egress)
- `docs/adr/0061-external-and-paid-api-dependencies-allowed.md` *(load-bearing)* — '잔여 egress' follow-up 항목을 완료 기록 + judges 제외 사유로 갱신
- `tests/test_external_payload_boundary_regression.py` — 4개 백엔드 회귀 테스트 +222줄
- `tests/test_cross_encoder_rerank.py`, `tests/test_embedding_backends.py` — 기존 cohere/openai 백엔드 테스트가 public surface 를 attest 하도록 수정 (guard 통과 후 의도한 SDK/key/정규화 경로 도달)

## 3. 리스크

가장 가능성 높은 깨짐: guard 가 SDK/key 체크 **앞**에 들어가, 외부 백엔드를 surface 미설정으로 호출하던 기존 테스트가 예기치 않게 fail-closed 됨. → 전체 `tests/` 트리를 grep 해 이 4개 백엔드를 건드리는 **모든** 테스트(5개 파일)를 찾아, cohere/openai 를 success/SDK-error 경로로 호출하던 6개 테스트에 `BIDMATE_DATA_SURFACE=public_synthetic` attestation 을 추가했다. query_expansion·planner 테스트는 폴백을 캐치하거나 `_call_anthropic_hyde` 를 직접 monkeypatch 해 guard 를 우회하므로 무변경(직렬 재실행으로 확인).

두 번째 위험: 기본 오프라인 경로 회귀. → guard 는 opt-in 외부 분기(`backend=cohere/openai`, `hyde`, `planner=anthropic`)에만 존재하고 기본 경로(hashing/identity/stub/regex)는 도달하지 않는다. ADR 0001 baseline byte-identical 보존.

## 4. 테스트

`tests/test_external_payload_boundary_regression.py` 확장 (29개 통과). 백엔드별로:
- **guard-entry fail-closed**: private/local/unset surface 에서 `_cohere_backend`/`_embed_with_openai`/`_call_anthropic_hyde` 가 SDK import 전에 `ExternalPayloadBlocked` raise.
- **integration fallback**: `rerank(backend=cohere)` → 원순서 유지·fell_back, `HyDEExpander.expand` → 원쿼리·fell_back, `LLMPlanner.plan_next` → StaticPlanner 폴백·fell_back (fallback_reason 에 `ExternalPayloadBlocked`). embedding 은 폴백 없는 백엔드라 raise 로 fail-closed (비대칭, 명시 테스트).
- **over-block 방지**: public surface + 키 비움 → 각 백엔드가 자기 SDK/key 에러(≠ ExternalPayloadBlocked)에 도달.
- **ADR 0001 기본경로 무게이트**: stub rerank / hashing embed / identity expander / static planner 는 unset surface 에서도 정상 동작.

검증: 영향 모듈·importer 직렬 테스트 **146개 통과**, `ruff check` 통과. (전체 suite 는 로컬 `-n auto` OOM — CI 의 sharded 실행이 권위 게이트.)

## 5. Eval 영향

All `·` (no delta). 기본 CI eval 경로(hashing/stub/identity/static)는 guard 분기에 도달하지 않으므로 합성 eval 수치 무변화.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. guard 는 opt-in 외부 백엔드 분기(cohere rerank / openai embedding / HyDE / anthropic planner)에만 추가됐고, real-eval 이 도는 기본 오프라인 경로는 도달하지 않는다 — ADR 0001 baseline byte-identical 보존. ADR 파일 변경은 문서이며 파이프라인 동작 무관.

## 6. 하위 호환

깨짐 없음. 답변 계약(ADR 0003)·스키마·CLI flag 무변경. 외부 백엔드를 이미 쓰던 운영자는 ADR 0061 ③ 의도대로 `BIDMATE_DATA_SURFACE=public_synthetic` attestation 이 추가로 필요해진다(opt-in 위 데이터 경계 한 겹) — PR #1190 이 metadata/synthesis 에 세운 계약과 동일.

## 7. 범위 외

- **eval judges 의도적 제외**: ADR 0006 이 real-data judge egress 를 명시 허용하고 그 경계는 commit 레이어(aggregate-only, ADR 0005)가 강제한다. 공유 `call_openai_json` 에 public/synthetic-only egress guard 를 걸면 ADR 0006 과 충돌하고 `pr-judge.yml` 라이브 게이트(ADR 0043)를 깬다 — 비공개 real-eval egress 는 ADR 0061 범위 밖(ADR 0005/0012 관할). ADR 0061 follow-up 항목에 사유 기록.
- **오프라인 데이터 생성 스크립트**(`scripts/generate_real_cases.py`, `generate_finetune_pairs.py`, `synthesize_multihop_queries.py`): 파이프라인 egress 가 아닌 dev 툴이라 ADR 0061 follow-up 목록에 없음 — 별도 판단 필요 시 follow-up.

<!-- 참고: commit 은 미머지 #1181 pre-commit 훅 ↔ 구버전 worktree _governance.py 버전 스큐로 --no-verify 사용(사용자 승인). status-parity 는 메인 repo 스크립트로 독립 검증 exit 0 — 실제 위반 아님. #1181 테스트는 origin/main 미머지라 이 PR CI 무관. -->