### PR TITLE
test: enforce PR-template parity per-section, not substring-anywhere

### DIFF
--- a/tests/test_pr_template_loadbearing_parity.py
+++ b/tests/test_pr_template_loadbearing_parity.py
@@ -17,10 +17,16 @@ drift 발생 시 fail message 가 어디를 update 할지 명시.
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PR_TEMPLATE = REPO_ROOT / ".github" / "pull_request_template.md"
+
+# The two textual mirror sites the parity check must enforce. Substrings matched
+# against each section's header line (markdown ``##``/``###``).
+SECTION_2 = "2. 영향 파일"
+SECTION_5B = "5b"
 
 
 def _load_governance():
@@ -33,30 +39,100 @@ def _load_governance():
     return mod
 
 
-def test_pr_template_mentions_all_loadbearing_paths():
-    """Each LOAD_BEARING_PATHS entry must appear at least once in PR template.
+def _split_into_blocks(text: str) -> dict[str, str]:
+    """Split markdown into header→block text, keyed by the header line.
 
-    Two textual mirror sites currently exist (§2 영향 파일 안내 + §5b 강제
-    안내). If LOAD_BEARING_PATHS grows, both sites must be updated.
+    A block runs from its ``##``/``###`` header until the next header. Text
+    before the first header is dropped (front-matter comment).
+    """
+    blocks: dict[str, str] = {}
+    header: str | None = None
+    buf: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if re.match(r"^#{2,4}\s", line):
+            if header is not None:
+                blocks[header] = "".join(buf)
+            header = line.strip()
+            buf = [line]
+        else:
+            buf.append(line)
+    if header is not None:
+        blocks[header] = "".join(buf)
+    return blocks
+
+
+def _find_block(blocks: dict[str, str], header_substr: str) -> str:
+    """Return the block whose header contains ``header_substr`` (exactly one)."""
+    matches = [body for hdr, body in blocks.items() if header_substr in hdr]
+    assert len(matches) == 1, (
+        f"expected exactly one section header containing {header_substr!r}, "
+        f"found {len(matches)}: {[h for h in blocks if header_substr in h]}"
+    )
+    return matches[0]
+
+
+def _missing_per_section(template_text: str, paths) -> list[tuple[str, str]]:
+    """Return (path, section_label) for each path absent from §2 or §5b.
+
+    Per-block — a path present in §2 but not §5b (or vice versa) is reported,
+    which a substring-anywhere check over the whole template would miss.
+    """
+    blocks = _split_into_blocks(template_text)
+    sec2 = _find_block(blocks, SECTION_2)
+    sec5b = _find_block(blocks, SECTION_5B)
+    problems: list[tuple[str, str]] = []
+    for path in paths:
+        # Strip trailing "/" so "eval/" matches "eval/" or "eval" in prose.
+        needle = path.rstrip("/")
+        if needle not in sec2:
+            problems.append((path, "§2 영향 파일"))
+        if needle not in sec5b:
+            problems.append((path, "§5b Real-data delta"))
+    return problems
+
+
+def test_pr_template_mentions_all_loadbearing_paths():
+    """Each LOAD_BEARING_PATHS entry must appear in BOTH mirror sites.
+
+    Two textual mirror sites exist (§2 영향 파일 안내 + §5b 강제 안내). The
+    check is per-section: a path present in only one site is drift, since the
+    other site silently under-promises 5b enforcement.
     """
     gov = _load_governance()
     template_text = PR_TEMPLATE.read_text(encoding="utf-8")
 
-    missing: list[str] = []
-    for path in gov.LOAD_BEARING_PATHS:
-        # Strip trailing "/" so "eval/" and "docs/adr/" match e.g. "eval/" or "docs/adr/" in prose.
-        needle = path.rstrip("/")
-        if needle not in template_text:
-            missing.append(path)
+    problems = _missing_per_section(template_text, gov.LOAD_BEARING_PATHS)
 
-    assert not missing, (
-        "PR template (.github/pull_request_template.md) is missing the following "
-        "LOAD_BEARING_PATHS entries:\n"
-        + "\n".join(f"  - {p}" for p in missing)
-        + "\n\nDrift detected — update the two textual mirror sites in PR template "
-        "(§2 영향 파일 안내 + §5b 강제 안내) to include these paths. "
+    assert not problems, (
+        "PR template (.github/pull_request_template.md) is missing "
+        "LOAD_BEARING_PATHS entries from a mirror section:\n"
+        + "\n".join(f"  - {p}  (missing from {sec})" for p, sec in problems)
+        + "\n\nDrift detected — each load-bearing path must appear in BOTH "
+        "§2 영향 파일 안내 AND §5b 강제 안내. "
         "Single source of truth: scripts/_governance.py:LOAD_BEARING_PATHS."
     )
+
+
+def test_per_section_check_catches_misplaced_path():
+    """Regression for the substring-anywhere bug: a path present only in §2
+    (or only in §5b) must be reported as drift.
+
+    The old check used ``needle not in template_text`` and would pass when a
+    path lived in either mirror site. This doctored template has ``api`` in §2
+    only and ``rag_core.py`` in §5b only — both must be flagged.
+    """
+    doctored = (
+        "## 2. 영향 파일\n"
+        "<!-- api/ -->\n"
+        "## 3. 리스크\n"
+        "<!-- x -->\n"
+        "### 5b. Real-data delta\n"
+        "<!-- rag_core.py -->\n"
+        "## 6. 하위 호환\n"
+    )
+    problems = _missing_per_section(doctored, ["api/", "rag_core.py"])
+    assert ("api/", "§5b Real-data delta") in problems
+    assert ("rag_core.py", "§2 영향 파일") in problems
 
 
 def test_pr_template_does_not_silently_remove_paths():


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`tests/test_pr_template_loadbearing_parity.py::test_pr_template_mentions_all_loadbearing_paths` 가 `needle not in template_text` 로 PR 템플릿 **전체 텍스트**에서 substring-anywhere 검사를 했다. docstring 은 "Two textual mirror sites (§2 영향 파일 + §5b 강제 안내) ... both sites must be updated" 라고 주장하지만, 실제로는 두 mirror site 중 어느 한 곳에만 경로가 있어도 통과 — 즉 섹션 배치가 틀려도 그린이었다. governance-guard-doesn't-enforce-claim 테마.

수정: PR 템플릿을 markdown 헤더(`##`/`###`)로 블록 분할 후, 각 `LOAD_BEARING_PATHS` 엔트리가 **§2 블록과 §5b 블록 양쪽**에 존재하는지 per-block 검사. 잘못된 블록에 needle 을 두면 fail 하는 회귀(`test_per_section_check_catches_misplaced_path`) 추가.

Closes #1232

## 2. 영향 파일

- `tests/test_pr_template_loadbearing_parity.py` — 헬퍼(`_split_into_blocks`/`_find_block`/`_missing_per_section`) + per-section 검사 + 회귀 1건

load-bearing 파일 변경 없음.

## 3. 리스크

가장 가능성 높은 깨짐: PR 템플릿 섹션 헤더 텍스트(`2. 영향 파일`, `5b`)가 바뀌면 `_find_block` 의 assert(정확히 1개 매칭)가 실패. 현재 템플릿에 두 섹션이 각 1개씩 존재함을 확인.

## 4. 테스트

`tests/test_pr_template_loadbearing_parity.py` 4건 로컬 통과. 신규 회귀는 doctored 템플릿에서 §2-only / §5b-only 배치를 drift 로 검출(구 substring-anywhere 검사는 통과시켰을 케이스).

## 5. Eval 영향

All `·` — 테스트 전용 변경, RAG 파이프라인 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. (load-bearing 파일 미변경)

## 6. 하위 호환

기존 테스트 함수 2건(`test_pr_template_does_not_silently_remove_paths`, `test_loadbearing_paths_has_minimum_invariants`) 시그니처·동작 유지. 계약 변경 없음.

## 7. 범위 외

`_load_governance` 의 기존 Pyright 진단(ModuleSpec None) — 이번 변경과 무관, 별도 정리 대상.