### PR TITLE
docs(adr): label dependency graph as foundation-ADR excerpt

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -293,7 +293,13 @@ on n=221, csv_text-fallback 898 chunks); `naive_baseline` stays `dense` per 0001
 adds a 7-category rule-based failure classifier so error attribution
 is auditable rather than folkloric.
 
-### Dependency graph
+### Dependency graph — Foundation ADRs (0001–0016) excerpt
+
+This is a **curated excerpt**, not the full dependency graph: it shows how the
+foundation-era ADRs (0001–0016) build on each other. Newer ADRs (0017+) are
+not drawn here — each ADR's `Related` field is the authoritative per-ADR
+dependency record (the table above lists all 65). The graph is kept small on
+purpose so the foundational invariants stay legible.
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## Summary

- `docs/adr/README.md` 의 mermaid Dependency graph 는 foundation-era ADR 0001–0016 의 일부 노드만 그리는데, 실제 ADR 파일은 65개. 49개 ADR(예: 0058 hybrid default flip)이 그래프에 silently absent → reviewer 가 이를 완전한 의존도 그래프로 오인할 수 있음.
- 헤더를 "Dependency graph — Foundation ADRs (0001–0016) excerpt" 로 relabel + "Newer ADRs (0017+) not shown, 각 ADR `Related` 필드가 authoritative, 표가 전체 65개 링크" 노트 추가.
- 65-node 전체 그래프로 키우는 트레드밀이 아닌 **범위 라벨링** (idx34/43 doc-accuracy 패턴과 동일).

## Test plan

- [ ] 문서 변경만 — mermaid 노드/edge 내용 무변경, 코드/governance 토큰 무영향
- [ ] ADR↔README Status-column parity check 무관 (표/Status 미변경)

### 5b. Real-data delta

N/A — 검색/검증 path 동작 변화 없음. 변경 파일은 `docs/adr/README.md` 한 곳뿐이고, mermaid 그래프 헤더/캡션 산문(prose)만 수정. 코드·config·eval 표면·answer contract 무변경이라 real-data eval 델타가 발생할 수 없음. (`docs/adr/README.md` 는 governance SSoT 의 LOAD_BEARING_PATHS 에 포함되어 §5b 게이트가 트리거되나, 이번 변경은 순수 문서.)

Closes #1229

🤖 Generated with [Claude Code](https://claude.com/claude-code)