### PR TITLE
fix(ship): fail-closed ship-pr mutex on stat error + symmetric code guard

### DIFF
--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -20,7 +20,12 @@ ADR-aware, approval-gated single-PR shipping. The skill replaces an ad-hoc seque
 
 ## Workflow
 
-0. **Mutex guard (issue #1043).** Before any other step, check that `.claude/.ship-armed` does NOT exist. If it does, refuse and tell the user to run `make ship-disarm` first — the two ship surfaces are mutually exclusive and `make ship-arm` is currently active. Then `touch .claude/.ship-pr-active` so `make ship-arm` will refuse if invoked while this skill is running. The cleanup (step 13) removes the marker; if the skill aborts, the marker auto-expires after 6h (`_ship_arm.py` stale-marker safety).
+0. **Mutex guard (issue #1043).** Before any other step, run:
+   `python3 scripts/claude-hooks/_ship_arm.py --enter-ship-pr`
+   Code-enforced (symmetric with the ship-arm side): non-zero exit if
+   `.claude/.ship-armed` exists (run `make ship-disarm` first) — otherwise it
+   creates `.claude/.ship-pr-active`. If it exits non-zero, STOP. Step 13
+   releases it; aborts auto-expire after 6h.
 
 1. **Scope confirmation.** Ask the user (inline or via `AskUserQuestion`): "Which issue does this PR close, and what's the one-line summary?" If no issue exists yet, propose a title + body and require **explicit approval** before `gh issue create`.
 
@@ -75,7 +80,7 @@ ADR-aware, approval-gated single-PR shipping. The skill replaces an ad-hoc seque
     ```
     **If the step-6 real-model fallback (`make test-fast`) was used, local coverage was partial — this merge is hard-gated on CI green: confirm `gh pr checks <N>` reports all-green before displaying the merge command.** Wait for explicit go-ahead. Then execute.
 
-13. **Aftermath.** `git checkout main` (if the worktree owns main) or `git fetch origin main` + branch advance (worktree case). **Remove the mutex marker** (`rm -f .claude/.ship-pr-active`) so `make ship-arm` is unblocked. If the user has another PR stacked on top, prompt them to re-invoke the skill for the next layer (which re-touches the marker at step 0).
+   **Release the mutex marker** (`python3 scripts/claude-hooks/_ship_arm.py --exit-ship-pr`) so `make ship-arm` is unblocked.
 
 ## Approval-gate language
 

--- a/scripts/claude-hooks/_ship_arm.py
+++ b/scripts/claude-hooks/_ship_arm.py
@@ -2,11 +2,15 @@
 """Write `.claude/.ship-armed` from `make ship-arm`.
 
 Centralises TTL parsing, branch capture, and JSON write in Python so the
-Makefile target stays declarative.
+Makefile target stays declarative. Also owns both sides of the ship-arm ↔
+ship-pr mutex (issue #1043): `check_ship_pr_mutex` guards the ship-arm side,
+and `--enter-ship-pr` / `--exit-ship-pr` give the ship-pr skill a code-level
+guard symmetric with it (SKILL.md steps 0 and 13).
 
 Exit codes:
-    0  armed file written
-    1  refused (e.g. on main, branch violates ADR 0007)
+    0  armed file written / mutex acquired / mutex released
+    1  refused (on main, branch violates ADR 0007, or mutex held by the
+       other ship surface)
     2  internal / usage error
 """
 
@@ -65,8 +69,18 @@ def check_ship_pr_mutex() -> int:
         return 0
     try:
         mtime = os.path.getmtime(SHIP_PR_ACTIVE_FILE)
-    except OSError:
-        return 0  # cannot stat — fail open
+    except OSError as e:
+        # Marker exists but cannot be stat'd — we cannot prove it is stale,
+        # so a concurrent ship-pr workflow may be active. Fail closed: refuse
+        # to arm rather than risk activating both ship surfaces at once.
+        sys.stderr.write(
+            f"ship-arm: refuse — ship-pr marker {SHIP_PR_ACTIVE_FILE} exists "
+            f"but cannot be stat'd ({e}); cannot prove it is stale.\n"
+            f"   Two ship surfaces are mutually exclusive (CLAUDE.md).\n"
+            f"   Investigate, or remove it manually if genuinely stale: "
+            f"rm {SHIP_PR_ACTIVE_FILE}\n"
+        )
+        return 1  # fail closed
     age = (datetime.now(timezone.utc).timestamp() - mtime)
     if age >= SHIP_PR_ACTIVE_STALE_SECONDS:
         try:
@@ -90,8 +104,53 @@ def check_ship_pr_mutex() -> int:
     return 1
 
 
+def enter_ship_pr() -> int:
+    """ship-pr skill entry guard — symmetric with ``check_ship_pr_mutex``.
+
+    Refuse to start the ship-pr workflow while ``make ship-arm`` holds the
+    armed file; otherwise create the ship-pr-active marker so a later
+    ``make ship-arm`` will refuse. Code-level enforcement of SKILL.md step 0
+    so the mutex no longer relies on the LLM following a markdown bullet
+    (the ship-arm side was already enforced; this closes the asymmetry).
+    """
+    if os.path.exists(ARMED_FILE):
+        sys.stderr.write(
+            f"ship-pr: refuse — ship-arm is active ({ARMED_FILE}).\n"
+            f"   Two ship surfaces are mutually exclusive (CLAUDE.md).\n"
+            f"   Run `make ship-disarm` (or rm {ARMED_FILE}) first.\n"
+        )
+        return 1
+    os.makedirs(os.path.dirname(SHIP_PR_ACTIVE_FILE), exist_ok=True)
+    with open(SHIP_PR_ACTIVE_FILE, "w") as f:
+        f.write(
+            datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ") + "\n"
+        )
+    sys.stdout.write(f"ship-pr: mutex acquired ({SHIP_PR_ACTIVE_FILE}).\n")
+    return 0
+
+
+def exit_ship_pr() -> int:
+    """Release the ship-pr mutex marker (SKILL.md step 13)."""
+    try:
+        os.unlink(SHIP_PR_ACTIVE_FILE)
+    except FileNotFoundError:
+        pass  # already gone — idempotent
+    except OSError as e:
+        sys.stderr.write(
+            f"ship-pr: warning — could not remove {SHIP_PR_ACTIVE_FILE} ({e}); "
+            f"remove it manually so make ship-arm is unblocked.\n"
+        )
+        return 1
+    sys.stdout.write(f"ship-pr: mutex released ({SHIP_PR_ACTIVE_FILE}).\n")
+    return 0
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--enter-ship-pr", action="store_true",
+                   help="acquire the ship-pr mutex (refuse if ship-arm active)")
+    p.add_argument("--exit-ship-pr", action="store_true",
+                   help="release the ship-pr mutex marker")
     p.add_argument("--ttl", default="2h")
     p.add_argument("--real-eval", default="auto",
                    choices=["auto", "skip", "async"])
@@ -100,6 +159,11 @@ def main() -> int:
     p.add_argument("--cross-owner", default="")
     p.add_argument("--stacked", default="")
     args = p.parse_args()
+
+    if args.enter_ship_pr:
+        return enter_ship_pr()
+    if args.exit_ship_pr:
+        return exit_ship_pr()
 
     try:
         ttl = parse_ttl(args.ttl)

--- a/tests/test_ship_arm_mutex.py
+++ b/tests/test_ship_arm_mutex.py
@@ -9,7 +9,9 @@
 - ship-pr-active marker 없을 때 → 0 반환 (정상 진행)
 - 신선한 marker 존재 시 → 1 반환 + stderr 메시지 (refuse)
 - 6h 이상 stale marker → marker 자동 삭제 + 0 반환 (stale 우회)
-- marker 가 stat 불가 (perm error 등) → 0 반환 (fail open)
+- marker 가 stat 불가 (perm error 등) → 1 반환 (fail closed: staleness 증명 불가)
+- ship-pr 진입 가드 (`enter_ship_pr`) — ship-arm 활성 시 refuse, 아니면 marker 생성
+- ship-pr 종료 가드 (`exit_ship_pr`) — marker 제거 (idempotent)
 """
 
 from __future__ import annotations
@@ -86,8 +88,12 @@ def test_marker_at_boundary_still_refuses(ship_arm, capsys):
     assert marker.exists()
 
 
-def test_marker_stat_failure_fails_open(ship_arm, monkeypatch):
-    """os.path.getmtime() raises → check returns 0 (fail open)."""
+def test_marker_stat_failure_fails_closed(ship_arm, monkeypatch, capsys):
+    """os.path.getmtime() raises while marker exists → 1 (fail closed).
+
+    Cannot prove the marker is stale, so refuse rather than risk activating
+    both ship surfaces at once.
+    """
     Path(ship_arm.SHIP_PR_ACTIVE_FILE).write_text("")
 
     def _raise(_path):
@@ -95,4 +101,46 @@ def test_marker_stat_failure_fails_open(ship_arm, monkeypatch):
 
     monkeypatch.setattr(os.path, "getmtime", _raise)
     result = ship_arm.check_ship_pr_mutex()
-    assert result == 0  # fail open
+    assert result == 1  # fail closed
+    captured = capsys.readouterr()
+    assert "cannot be stat" in captured.err
+    assert "refuse" in captured.err
+
+
+def test_enter_ship_pr_refuses_when_armed(ship_arm, tmp_path, monkeypatch, capsys):
+    """ship-arm active (.ship-armed exists) → enter_ship_pr refuses (1)."""
+    armed = tmp_path / ".ship-armed"
+    armed.write_text("{}")
+    monkeypatch.setattr(ship_arm, "ARMED_FILE", str(armed))
+    result = ship_arm.enter_ship_pr()
+    assert result == 1
+    assert not Path(ship_arm.SHIP_PR_ACTIVE_FILE).exists()
+    captured = capsys.readouterr()
+    assert "ship-arm is active" in captured.err
+
+
+def test_enter_ship_pr_creates_marker_when_clear(ship_arm, tmp_path, monkeypatch):
+    """No .ship-armed → enter_ship_pr acquires marker (0)."""
+    monkeypatch.setattr(ship_arm, "ARMED_FILE", str(tmp_path / ".ship-armed"))
+    result = ship_arm.enter_ship_pr()
+    assert result == 0
+    marker = Path(ship_arm.SHIP_PR_ACTIVE_FILE)
+    assert marker.exists()
+    # Marker carries a timestamp so check_ship_pr_mutex staleness still works.
+    assert marker.read_text().strip()
+
+
+def test_enter_then_arm_mutex_refuses(ship_arm, tmp_path, monkeypatch):
+    """End-to-end: enter_ship_pr then check_ship_pr_mutex refuses (1)."""
+    monkeypatch.setattr(ship_arm, "ARMED_FILE", str(tmp_path / ".ship-armed"))
+    assert ship_arm.enter_ship_pr() == 0
+    assert ship_arm.check_ship_pr_mutex() == 1
+
+
+def test_exit_ship_pr_removes_marker(ship_arm):
+    """exit_ship_pr removes the marker and is idempotent."""
+    Path(ship_arm.SHIP_PR_ACTIVE_FILE).write_text("ts\n")
+    assert ship_arm.exit_ship_pr() == 0
+    assert not Path(ship_arm.SHIP_PR_ACTIVE_FILE).exists()
+    # Idempotent: second call on missing marker still succeeds.
+    assert ship_arm.exit_ship_pr() == 0


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ship-arm ↔ ship-pr 상호배제(mutex) 가드의 두 결함을 닫는다 (codex adversarial-review idx40, #1044 재발행). **F2**: `check_ship_pr_mutex` 가 active marker 존재 시 `getmtime()` 실패하면 `return 0`(fail open) — stat 불가 시 뮤텍스가 통과되어 `make ship-arm` 과 `ship-pr` skill 이 동시에 활성화될 수 있었다. 이제 staleness 증명 불가 시 refuse(`return 1`). **F1**: ship-arm 측은 `check_ship_pr_mutex()` 로 코드 강제됐지만 ship-pr skill 측 step 0/13 가드는 SKILL.md 마크다운 지시뿐이라 LLM 이 step 을 건너뛰면 무력했다 — ship-arm 측과 대칭인 `enter_ship_pr()`/`exit_ship_pr()` + CLI 플래그를 추가하고 SKILL.md 를 명령 호출로 wiring.

Closes #1244

## 2. 영향 파일

- `scripts/claude-hooks/_ship_arm.py` — `check_ship_pr_mutex` fail-closed + `enter_ship_pr`/`exit_ship_pr` + `--enter-ship-pr`/`--exit-ship-pr` 플래그 (load-bearing 아님)
- `.claude/skills/ship-pr/SKILL.md` — step 0/13 을 코드 가드 명령 호출로 wiring
- `tests/test_ship_arm_mutex.py` — fail-closed + enter/exit/end-to-end 회귀 테스트

## 3. 리스크

- 가장 가능성 높은 깨짐: `make ship-arm` arming 경로가 새 플래그 분기 영향 받음 → `--enter/--exit-ship-pr` 미전달 시 short-circuit 안 함을 수동 확인, Makefile 호출 무영향.
- enter 가 타임스탬프 marker 를 쓰므로 기존 `check_ship_pr_mutex` 의 mtime 기반 staleness 판정 그대로 동작 (end-to-end 테스트로 확인).

## 4. 테스트

`tests/test_ship_arm_mutex.py` — fail-closed 전환은 변경 전 `assert == 0`(fail open) → 변경 후 `assert == 1`(refuse) 로 동작 반전을 검증. 신규: `enter_ship_pr` armed 시 refuse / clear 시 marker 생성, enter→`check_ship_pr_mutex` end-to-end refuse, `exit_ship_pr` idempotent 제거. 9개 통과, ruff 클린.

## 5. Eval 영향

All `·` — RAG 파이프라인(검색/검증/답변) 무관, governance 자동화 표면만 변경.

### 5b. Real-data delta

N/A — load-bearing path 변경 없음 (`_ship_arm.py`/SKILL.md/test 모두 비-load-bearing). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

깨짐 없음. 신규 CLI 플래그는 additive (기존 arming 인터페이스 무변경). 답변 계약(ADR 0003) 무관.

## 7. 범위 외

- `tests/test_ship_dispatcher_gates.py` 3개(`test_no_arm_under_100ms` / `test_live_pid_blocks_re_entry` / `test_stale_pid_cleared`)가 로컬에서 `stop-ship.sh` 10초 timeout 으로 실패 — 본 변경과 무관(stop-ship.sh 는 `_ship_arm.py` 미참조, main 기준 unchanged), 느린 로컬 환경의 timing/timeout flakiness. 별도 follow-up 대상.