### PR TITLE
chore(ci): cut runner-minutes (pytest shard 8→4 + conditional eval-delta skip)

### DIFF
--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -25,11 +25,18 @@ env:
 
 jobs:
   test:
-    # Issue #931: matrix shard pytest x8 fans the suite across 8 parallel
+    # Issue #931: matrix shard pytest x4 fans the suite across 4 parallel
     # ubuntu-latest runners. `scripts/test.sh` honors `BIDMATE_PYTEST_SPLITS`
     # + `BIDMATE_PYTEST_SHARD` env vars (passes `--splits N --group K` to
     # pytest-split). `fail-fast: false` so we see every failing shard, not
-    # just the first. ~25min serial wall-clock → ~3-4min per-shard.
+    # just the first. ~25min serial wall-clock → ~6-8min per-shard.
+    # Shard count was 8; halved to 4 to cut runner-minutes (each shard
+    # re-installs the heavy torch/sentence-transformers stack, so fewer
+    # shards = proportionally fewer redundant installs). CI runs on the
+    # `hashing` backend (no real model load), so the per-shard memory
+    # headroom that motivated 8 shards locally does not bind here.
+    # `BIDMATE_PYTEST_SPLITS` MUST equal the matrix length, else pytest-split
+    # leaves orphaned groups uncovered.
     # Per-shard coverage.xml uploads to Codecov with `shard-N` flags;
     # Codecov merges them server-side. Leaderboard --check runs only on
     # shard 1 (single-runner invariant; not test-suite-dependent).
@@ -37,10 +44,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4]
     runs-on: ubuntu-latest
     env:
-      BIDMATE_PYTEST_SPLITS: "8"
+      BIDMATE_PYTEST_SPLITS: "4"
       BIDMATE_PYTEST_SHARD: ${{ matrix.shard }}
     steps:
       - uses: actions/checkout@v6
@@ -133,8 +140,43 @@ jobs:
             python scripts/check_baseline_provenance.py --ref "$BASE_REF"
           fi
 
+  changes:
+    # Decide whether this PR touches any path that can move the eval delta.
+    # docs/governance-only PRs (no runtime code) get eval-delta skipped to
+    # save runner-minutes. No checkout — the PR file list comes from the
+    # GitHub API (gh is preinstalled), so this job is seconds-cheap.
+    # `main` carries no required status checks, so a skipped eval-delta does
+    # not leave the PR pending. pytest + baseline-provenance still always run.
+    name: Detect runtime-affecting changes
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.filter.outputs.runtime }}
+    steps:
+      - name: Classify changed files
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(gh api --paginate \
+            "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          echo "Changed files:"; echo "$files"
+          # Any of: a .py module, the eval/ tree, raw corpus, requirements,
+          # the run-eval composite action, or this workflow → run eval-delta.
+          if echo "$files" | grep -qE \
+            '\.py$|^eval/|^data/raw/|^requirements.*\.txt$|^\.github/actions/run-eval/|^\.github/workflows/pr-eval\.yml$'; then
+            echo "runtime=true" >> "$GITHUB_OUTPUT"
+            echo "→ runtime-affecting; eval-delta will run."
+          else
+            echo "runtime=false" >> "$GITHUB_OUTPUT"
+            echo "→ docs/governance-only; eval-delta skipped."
+          fi
+
   eval-delta:
     name: Eval delta vs base
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR 게이트 러너-분 대부분이 `pr-eval.yml`의 8-shard pytest 매트릭스에 몰려 있다. 각 shard가 `torch>=2.6` + sentence-transformers + transformers 스택을 매번 install → 8 러너 = 8회 중복 install. shard를 4로 줄여 install 횟수·러너 수를 절반으로 낮추고(러너-분 ~50% 절감), 가장 무거운 eval-delta job은 docs/governance-only PR에서 조건부 스킵한다. `main`에 `required_status_checks`가 없어 스킵해도 PR이 pending으로 막히지 않는다.

Closes #1259

## 2. 영향 파일

- `.github/workflows/pr-eval.yml` — shard 매트릭스 8→4, `BIDMATE_PYTEST_SPLITS` 8→4, `changes` 판정 job 신규 + eval-delta `needs`/`if` 조건부 스킵

(load-bearing 파일 변경 없음 — `.github/workflows/`는 `LOAD_BEARING_PATHS` 비포함)

## 3. 리스크

- **shard 균형 붕괴**: `BIDMATE_PYTEST_SPLITS`가 매트릭스 길이와 어긋나면 pytest-split이 일부 그룹을 빠뜨림 → 둘 다 4로 동기화, yaml 파싱으로 `len(matrix)==SPLITS` 확인.
- **shard당 메모리 2배 → OOM**: 기록상 OOM은 로컬 full 환경(torch+xdist) 한정. CI는 `hashing` 백엔드라 실모델 미로드 → 8-shard에서도 OOM 이력 없음, 4-shard 안전 범위.
- **eval-delta 오스킵**: 런타임 코드가 바뀌었는데 스킵되면 회귀 누락. 판정 regex가 `\.py$`/`eval/`/`data/raw/`/`requirements*.txt`/run-eval 액션/이 워크플로를 모두 포함 → 런타임 영향 경로는 항상 run.
- 트리거 불변 regression(`tests/test_pr_gate_workflow_triggers_regression.py`)은 `branches:` 필터만 금지, `paths`/job-level `if`는 무관 → 통과 확인.

## 4. 테스트

CI workflow YAML 설정 변경으로 신규 코드 동작 없음 — 단위 테스트 대상 아님. 기존 트리거 불변 regression 3건 통과(`branches:` 필터 부재 + §5b step 유지 pin)로 게이트 구조 무결성 확인. 로컬 게이트 `make test-fast` 2137 passed / 16 skipped (real-model `slow` 테스트는 로컬 FlagEmbedding 설치로 제외, CI가 커버).

## 5. Eval 영향

All `·` — eval 파이프라인/스코어러 무변경. 이 PR은 CI 실행 비용만 조정하며 eval 결과 산출 로직을 건드리지 않는다.

### 5b. Real-data delta

N/A — 검색/검증 path 동작 변화 없음. 변경 파일 `.github/workflows/pr-eval.yml`은 load-bearing 비포함이라 §5b CI gate가 트리거되지 않으며, RAG 런타임 코드 무변경.