### PR TITLE
feat(provenance): auto-print effective-config banner at run entrypoints

### DIFF
--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -102,6 +102,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--query", default=None, help="Unused in this command; accepted for CLI consistency.")
     parser.add_argument("--config", required=True, help="Path to eval config YAML file.")
     parser.add_argument(
+        "--no-config-banner",
+        dest="no_config_banner",
+        action="store_true",
+        help="Suppress the effective-config provenance banner (#1212). Also via BIDMATE_NO_CONFIG_BANNER=1.",
+    )
+    parser.add_argument(
         "--trace_dir",
         default=None,
         help="Directory for local planner/rewrite trace JSON files. Defaults to <output_dir>/traces.",
@@ -1091,6 +1097,12 @@ def main() -> int:
     except Exception as exc:
         print(f"[ERROR] Eval setup failed: {exc}", file=sys.stderr)
         return 2
+
+    # #1212: effective-config provenance banner. Surfaces the two artifact
+    # classes (hashing-embedding index, CSV-fallback ingestion) at run start.
+    from rag_provenance import emit_eval_banner
+
+    emit_eval_banner(index, config, args.index_dir, cli_flag=args.no_config_banner)
 
     run_summaries = []
     primary_summary = None

--- a/rag_provenance.py
+++ b/rag_provenance.py
@@ -1,0 +1,246 @@
+"""Effective-config provenance banner (issue #1212).
+
+실행 시점에 "지금 이 run 이 실제로 어떤 backend/모드로 도는가" 를 한 눈에
+보여준다. 최근 두 measurement artifact 가 모두 *실행 시점에 설정이 안 보임*
+갭에서 나왔다:
+
+1. CSV-fallback ingestion (#1129/#1133) — ``ingestion_report`` 를 사후에
+   까봐야 폴백 여부를 알 수 있었다.
+2. hashing 임베딩 — ``make real-eval`` 기본 ``EMBEDDING_BACKEND=hashing``
+   (= feature-hashing BoW, 의미 0) 인데 실행 시점에 드러나지 않아 retrieval
+   수치가 silently 오염됐다.
+
+이 모듈은 두 진입점 (``scripts/build_index.py``, ``eval/run_eval.py``) 이
+공유하는 단일 출처다. **READ-ONLY**: 어떤 retrieval/answer surface 도 바꾸지
+않는다 — 순수 관측 출력. degraded(의미-맹목/폴백) 경로는 ``[WARN: ...]`` 로
+강조한다.
+
+opt-out: ``--no-config-banner`` CLI flag 또는 ``BIDMATE_NO_CONFIG_BANNER=1``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+OPT_OUT_ENV = "BIDMATE_NO_CONFIG_BANNER"
+
+OK = "ok"
+WARN = "warn"
+INFO = "info"
+
+# (label, value, status, note|None)
+Row = tuple[str, str, str, "str | None"]
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def banner_disabled(cli_flag: bool = False) -> bool:
+    """True 면 banner 를 출력하지 않는다 (CLI flag 또는 env opt-out)."""
+    if cli_flag:
+        return True
+    return os.environ.get(OPT_OUT_ENV, "").strip().lower() in _TRUTHY
+
+
+def _env(name: str, default: str = "") -> str:
+    val = os.environ.get(name, "").strip()
+    return val or default
+
+
+def render(title: str, rows: Iterable[Row], stream: Any = None) -> None:
+    """``[CONFIG]`` banner 를 ``stream`` (기본 stderr) 에 출력한다.
+
+    레포 관례 (``[OK]``/``[INFO]``/``[WARN]`` 접두사) 와 align. degraded row 는
+    ``[WARN: ...]``, info row 는 ``[note]`` suffix 를 단다. stdout 을 오염시키지
+    않도록 기본 stream 은 stderr.
+    """
+    if stream is None:
+        stream = sys.stderr
+    rows = list(rows)
+    label_w = max((len(r[0]) for r in rows), default=0)
+    print(f"[CONFIG] effective config · {title}", file=stream)
+    for label, value, status, note in rows:
+        line = f"  {label.ljust(label_w)} : {value}"
+        if status == WARN:
+            line += f"   [WARN: {note}]" if note else "   [WARN]"
+        elif status == INFO and note:
+            line += f"   [{note}]"
+        print(line, file=stream)
+    stream.flush()
+
+
+def _embedding_row_from_backend(backend: str, model: str) -> Row:
+    backend = (backend or "?").strip()
+    model = (model or "?").strip()
+    value = f"{backend} ({model})"
+    if backend == "hashing":
+        return ("embedding", value, WARN,
+                "feature-hashing BoW — 의미 검색 무력, term-overlap only")
+    if backend in {"openai"}:
+        return ("embedding", value, INFO, "외부 API (BIDMATE_OPENAI_API_KEY)")
+    return ("embedding", value, OK, None)
+
+
+def _resolve_kordoc_cache(files_dir: str | None) -> str:
+    """``ingestion._resolve_kordoc_cache_dir`` 와 같은 규칙을 관측용으로 재현.
+
+    env (``BIDMATE_KORDOC_CACHE_DIR``) 우선, 없으면 sibling
+    ``<files_dir>_kordoc`` 자동탐지 (#1133). import 부작용을 피하려고 여기서
+    독립 구현 — 어차피 출력 전용.
+    """
+    env = _env("BIDMATE_KORDOC_CACHE_DIR")
+    if env:
+        return f"{env} (env)" if Path(env).is_dir() else f"{env} (env, MISSING)"
+    if files_dir:
+        parent = Path(files_dir)
+        sibling = parent.with_name(parent.name + "_kordoc")
+        if sibling.is_dir():
+            return f"{sibling} (sibling)"
+    return "(none — npx 변환 또는 csv_text 폴백)"
+
+
+def build_index_rows(args: Any) -> list[Row]:
+    """``scripts/build_index.py`` 문맥의 effective-config rows.
+
+    ingestion (loader/mode/kordoc cache) + embedding + chunking 축.
+    """
+    rows: list[Row] = [_embedding_row_from_backend(
+        getattr(args, "embedding_backend", "?"), getattr(args, "model", "?"))]
+
+    using_csv = bool(getattr(args, "metadata_csv", None))
+    if using_csv:
+        # loader 우선순위: build_index 가 args 를 env 로 승격하므로 env 가 진실.
+        hwp = _env("BIDMATE_HWP_LOADER") or getattr(args, "hwp_loader", None) or "(auto kordoc→csv_text)"
+        pdf = _env("BIDMATE_PDF_LOADER") or getattr(args, "pdf_loader", None) or "(auto kordoc→csv_text)"
+        if hwp == "csv_text":
+            rows.append(("hwp_loader", hwp, WARN, "CSV-text 폴백 — 본문 아닌 메타/표지만"))
+        else:
+            rows.append(("hwp_loader", hwp, OK, None))
+        if pdf == "csv_text":
+            rows.append(("pdf_loader", pdf, WARN, "CSV-text 폴백 — 본문 아닌 표지/TOC만"))
+        else:
+            rows.append(("pdf_loader", pdf, OK, None))
+        rows.append(("kordoc_cache", _resolve_kordoc_cache(getattr(args, "files_dir", None)), INFO, None))
+        rows.append(("ingestion_mode", str(getattr(args, "ingestion_mode", "csv-text")), OK, None))
+
+    rows.append(("chunking", str(getattr(args, "chunking_strategy", "fixed")), OK, None))
+    if _env("BIDMATE_INGEST_REDACT_PII").lower() in _TRUTHY:
+        rows.append(("pii_redaction", "on", INFO, "BIDMATE_INGEST_REDACT_PII"))
+    return rows
+
+
+def _text_source_summary(index_dir: str | Path | None) -> str | None:
+    """``<index_dir>/ingestion_report.json`` 의 text_source_counts 요약.
+
+    구조는 ``{filetype: {source: count}}`` (예 ``{"hwp": {"kordoc": 96}}``).
+    flatten 해서 ``hwp.kordoc:96, pdf.kordoc:4`` 형태로 돌려준다. 파일/필드
+    없으면 None.
+    """
+    if index_dir is None:
+        return None
+    report = Path(index_dir) / "ingestion_report.json"
+    try:
+        data = json.loads(report.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    counts = (((data.get("summary") or {}).get("text_source_counts")) or {})
+    if not isinstance(counts, dict) or not counts:
+        return None
+    pairs: list[tuple[str, int]] = []
+    for ftype, sources in counts.items():
+        if isinstance(sources, dict):
+            for source, n in sources.items():
+                pairs.append((f"{ftype}.{source}", int(n)))
+        else:  # flat {source: count} fallback shape
+            pairs.append((str(ftype), int(sources)))
+    if not pairs:
+        return None
+    return ", ".join(f"{k}:{v}" for k, v in sorted(pairs, key=lambda kv: -kv[1]))
+
+
+def eval_rows(index: Any, config: dict[str, Any], index_dir: str | Path | None) -> list[Row]:
+    """``eval/run_eval.py`` 문맥의 effective-config rows.
+
+    index 의 embedding/text_source (artifact 두 건 직격) + retrieval/synthesis/
+    planner/vector_store 축.
+    """
+    rows: list[Row] = []
+
+    emb = (index.get("embedding") or {}) if isinstance(index, dict) else {}
+    rows.append(_label_as(
+        _embedding_row_from_backend(str(emb.get("backend", "?")), str(emb.get("model", "?"))),
+        "index.embedding"))
+
+    text_src = _text_source_summary(index_dir)
+    if text_src is not None:
+        if "csv" in text_src.lower():
+            rows.append(("index.text_source", text_src, WARN,
+                         "CSV 폴백 본문 — chunk/term-level 수치 무효"))
+        else:
+            rows.append(("index.text_source", text_src, OK, None))
+
+    rows.append(("vector_store", _env("BIDMATE_INDEX_BACKEND", "memory"), OK, None))
+
+    backends = sorted({
+        str(r.get("retrieval_backend", "dense"))
+        for r in _iter_run_configs(config)
+    })
+    rows.append(("retrieval", ", ".join(backends) or "dense", OK, None))
+
+    synth = _env("BIDMATE_SYNTHESIS_BACKEND", "stub")
+    if synth == "stub":
+        rows.append(("synthesis", synth, INFO, "deterministic, LLM 0"))
+    else:
+        model = _env("BIDMATE_SYNTHESIS_MODEL")
+        rows.append(("synthesis", f"{synth} ({model})" if model else synth, INFO, "외부 LLM"))
+
+    rows.append(("rerank", _env("BIDMATE_RERANK_BACKEND", "stub"), OK, None))
+    rows.append(("planner", _env("BIDMATE_PLANNER_BACKEND", "static"), OK, None))
+    rows.append(("query_expansion", _env("BIDMATE_QUERY_EXPANSION_BACKEND", "identity"), OK, None))
+    if _env("BIDMATE_TRACE_FULL").lower() in _TRUTHY:
+        rows.append(("trace", "full", INFO, "BIDMATE_TRACE_FULL — synthesis prompt 캡처"))
+    return rows
+
+
+def _label_as(row: Row, label: str) -> Row:
+    _, value, status, note = row
+    return (label, value, status, note)
+
+
+def _iter_run_configs(config: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    runs = config.get("ablation_runs")
+    if isinstance(runs, list) and runs:
+        for r in runs:
+            if isinstance(r, dict):
+                yield r
+        return
+    yield config
+
+
+def emit_build_banner(args: Any, stream: Any = None) -> None:
+    """build_index.py 진입점용 — opt-out 체크 후 banner 출력."""
+    if banner_disabled(getattr(args, "no_config_banner", False)):
+        return
+    render("build (build_index.py)", build_index_rows(args), stream=stream)
+
+
+def emit_eval_banner(index: Any, config: dict[str, Any], index_dir: str | Path | None,
+                     cli_flag: bool = False, stream: Any = None) -> None:
+    """run_eval.py 진입점용 — opt-out 체크 후 banner 출력."""
+    if banner_disabled(cli_flag):
+        return
+    render("eval (run_eval.py)", eval_rows(index, config, index_dir), stream=stream)
+
+
+__all__ = [
+    "OPT_OUT_ENV",
+    "banner_disabled",
+    "render",
+    "build_index_rows",
+    "eval_rows",
+    "emit_build_banner",
+    "emit_eval_banner",
+]

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -64,6 +64,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--query", default=None, help="Unused in this command; accepted for CLI consistency.")
     parser.add_argument("--config", default=None, help="Unused in this command; accepted for CLI consistency.")
     parser.add_argument(
+        "--no-config-banner",
+        dest="no_config_banner",
+        action="store_true",
+        help="Suppress the effective-config provenance banner (#1212). Also via BIDMATE_NO_CONFIG_BANNER=1.",
+    )
+    parser.add_argument(
         "--model",
         default=DEFAULT_EMBEDDING_MODEL,
         help="Embedding model name (sentence-transformers ID, or OpenAI model name when --embedding_backend=openai).",
@@ -182,6 +188,11 @@ def main() -> int:
             os.environ["BIDMATE_HWP_LOADER"] = args.hwp_loader
         if args.pdf_loader is not None:
             os.environ["BIDMATE_PDF_LOADER"] = args.pdf_loader
+        # #1212: effective-config provenance banner BEFORE the long ingestion
+        # so operators see "what backends am I actually running" up front.
+        from rag_provenance import emit_build_banner
+
+        emit_build_banner(args)
         output_dir = Path(args.output_dir)
         visual_artifact_dir = (
             Path(args.visual_artifact_dir)

--- a/tests/test_provenance_banner.py
+++ b/tests/test_provenance_banner.py
@@ -1,0 +1,187 @@
+"""Effective-config provenance banner regression suite (issue #1212).
+
+Pins the observation surface shared by ``scripts/build_index.py`` and
+``eval/run_eval.py``:
+
+* hashing embedding → ``[WARN]`` row (the 의미-맹목 artifact class).
+* CSV-fallback ingestion text_source → ``[WARN]`` row (the #1129 artifact).
+* kordoc text_source → no WARN (post-#1133 healthy path).
+* opt-out honored via ``--no-config-banner`` flag AND
+  ``BIDMATE_NO_CONFIG_BANNER`` env.
+* banner writes to the chosen stream (default stderr) and never raises on
+  missing ingestion_report.json.
+
+READ-ONLY module — these tests assert formatting/classification only; no
+retrieval/answer surface is exercised.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import rag_provenance as p
+
+
+class _Args:
+    """Minimal argparse.Namespace stand-in for build_index_rows."""
+
+    def __init__(self, **kw):
+        self.embedding_backend = kw.get("embedding_backend", "sentence-transformers")
+        self.model = kw.get("model", "BAAI/bge-m3")
+        self.metadata_csv = kw.get("metadata_csv", "data/data_list.csv")
+        self.files_dir = kw.get("files_dir", "data/files")
+        self.hwp_loader = kw.get("hwp_loader", None)
+        self.pdf_loader = kw.get("pdf_loader", None)
+        self.ingestion_mode = kw.get("ingestion_mode", "csv-text")
+        self.chunking_strategy = kw.get("chunking_strategy", "fixed")
+        self.no_config_banner = kw.get("no_config_banner", False)
+
+
+class BannerOptOutTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.pop(p.OPT_OUT_ENV, None)
+
+    def tearDown(self):
+        os.environ.pop(p.OPT_OUT_ENV, None)
+        if self._saved is not None:
+            os.environ[p.OPT_OUT_ENV] = self._saved
+
+    def test_disabled_via_cli_flag(self):
+        self.assertTrue(p.banner_disabled(cli_flag=True))
+
+    def test_disabled_via_env(self):
+        os.environ[p.OPT_OUT_ENV] = "1"
+        self.assertTrue(p.banner_disabled())
+
+    def test_enabled_by_default(self):
+        self.assertFalse(p.banner_disabled())
+
+    def test_emit_build_suppressed_by_flag(self):
+        stream = io.StringIO()
+        p.emit_build_banner(_Args(no_config_banner=True), stream=stream)
+        self.assertEqual(stream.getvalue(), "")
+
+    def test_emit_eval_suppressed_by_env(self):
+        os.environ[p.OPT_OUT_ENV] = "true"
+        stream = io.StringIO()
+        p.emit_eval_banner({"embedding": {"backend": "hashing"}}, {}, None, stream=stream)
+        self.assertEqual(stream.getvalue(), "")
+
+
+class EmbeddingClassificationTest(unittest.TestCase):
+    def test_hashing_backend_warns(self):
+        rows = p.build_index_rows(_Args(embedding_backend="hashing", model="local-hashing-bow"))
+        emb = [r for r in rows if r[0] == "embedding"][0]
+        self.assertEqual(emb[2], p.WARN)
+        self.assertIn("feature-hashing", emb[3] or "")
+
+    def test_sentence_transformers_ok(self):
+        rows = p.build_index_rows(_Args(embedding_backend="sentence-transformers"))
+        emb = [r for r in rows if r[0] == "embedding"][0]
+        self.assertEqual(emb[2], p.OK)
+
+    def test_openai_backend_info(self):
+        rows = p.build_index_rows(_Args(embedding_backend="openai", model="text-embedding-3-small"))
+        emb = [r for r in rows if r[0] == "embedding"][0]
+        self.assertEqual(emb[2], p.INFO)
+
+
+class IngestionLoaderTest(unittest.TestCase):
+    def test_csv_text_hwp_loader_warns(self):
+        rows = p.build_index_rows(_Args(hwp_loader="csv_text"))
+        hwp = [r for r in rows if r[0] == "hwp_loader"][0]
+        self.assertEqual(hwp[2], p.WARN)
+
+    def test_kordoc_hwp_loader_ok(self):
+        rows = p.build_index_rows(_Args(hwp_loader="kordoc"))
+        hwp = [r for r in rows if r[0] == "hwp_loader"][0]
+        self.assertEqual(hwp[2], p.OK)
+
+    def test_no_metadata_csv_skips_loader_rows(self):
+        rows = p.build_index_rows(_Args(metadata_csv=None))
+        labels = {r[0] for r in rows}
+        self.assertNotIn("hwp_loader", labels)
+        self.assertIn("embedding", labels)
+
+
+class EvalTextSourceTest(unittest.TestCase):
+    def _write_report(self, tmp: Path, counts: dict) -> None:
+        (tmp / "ingestion_report.json").write_text(
+            json.dumps({"summary": {"text_source_counts": counts}}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    def test_kordoc_text_source_no_warn(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._write_report(tmp, {"hwp": {"kordoc": 96}, "pdf": {"kordoc": 4}})
+            rows = p.eval_rows({"embedding": {"backend": "hashing"}}, {}, tmp)
+            ts = [r for r in rows if r[0] == "index.text_source"][0]
+            self.assertEqual(ts[2], p.OK)
+            self.assertIn("kordoc", ts[1])
+
+    def test_csv_fallback_text_source_warns(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._write_report(tmp, {"hwp": {"data_list_csv_text": 100}})
+            rows = p.eval_rows({"embedding": {"backend": "sentence-transformers"}}, {}, tmp)
+            ts = [r for r in rows if r[0] == "index.text_source"][0]
+            self.assertEqual(ts[2], p.WARN)
+
+    def test_missing_report_omits_text_source_row(self):
+        with tempfile.TemporaryDirectory() as d:
+            rows = p.eval_rows({"embedding": {"backend": "hashing"}}, {}, Path(d))
+            labels = {r[0] for r in rows}
+            self.assertNotIn("index.text_source", labels)
+            # core rows still present
+            self.assertIn("index.embedding", labels)
+            self.assertIn("retrieval", labels)
+
+
+class EvalRetrievalBackendTest(unittest.TestCase):
+    def test_distinct_ablation_backends_listed(self):
+        config = {
+            "ablation_runs": [
+                {"name": "full", "retrieval_backend": "hybrid"},
+                {"name": "nb", "retrieval_backend": "dense"},
+                {"name": "dup", "retrieval_backend": "hybrid"},
+            ]
+        }
+        rows = p.eval_rows({"embedding": {"backend": "hashing"}}, config, None)
+        retr = [r for r in rows if r[0] == "retrieval"][0]
+        self.assertEqual(retr[1], "dense, hybrid")
+
+    def test_flat_config_defaults_to_dense(self):
+        rows = p.eval_rows({"embedding": {"backend": "hashing"}}, {}, None)
+        retr = [r for r in rows if r[0] == "retrieval"][0]
+        self.assertEqual(retr[1], "dense")
+
+
+class RenderFormatTest(unittest.TestCase):
+    def test_warn_row_renders_warn_marker(self):
+        stream = io.StringIO()
+        p.render("test", [("embedding", "hashing", p.WARN, "보류")], stream=stream)
+        out = stream.getvalue()
+        self.assertIn("[CONFIG]", out)
+        self.assertIn("[WARN: 보류]", out)
+
+    def test_info_note_renders_in_brackets(self):
+        stream = io.StringIO()
+        p.render("test", [("synthesis", "stub", p.INFO, "LLM 0")], stream=stream)
+        self.assertIn("[LLM 0]", stream.getvalue())
+
+    def test_ok_row_has_no_marker(self):
+        stream = io.StringIO()
+        p.render("test", [("vector_store", "memory", p.OK, None)], stream=stream)
+        out = stream.getvalue()
+        self.assertNotIn("[WARN", out)
+        self.assertIn("memory", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `build_index.py` / `run_eval.py` 가 실행 시점에 **effective-config provenance banner** 를 stderr 로 자동 출력한다. 최근 두 measurement artifact — CSV-fallback ingestion (#1129/#1133) + hashing 임베딩 semantic-blindness — 가 모두 *실행 시점에 설정이 안 보임* 갭에서 나왔다. 이 banner 가 그 갭을 닫는다.
- 신규 `rag_provenance.py` (단일 출처): context-aware rows + degraded 경로 `[WARN]` 강조. opt-out `--no-config-banner` / `BIDMATE_NO_CONFIG_BANNER=1`.

## 출력 예시 (run_eval, hashing 인덱스 + kordoc 본문)

```
[CONFIG] effective config · eval (run_eval.py)
  index.embedding   : hashing (local-hashing-bow)   [WARN: feature-hashing BoW — 의미 검색 무력, term-overlap only]
  index.text_source : hwp.kordoc:96, pdf.kordoc:4
  vector_store      : memory
  retrieval         : dense, hybrid
  synthesis         : stub   [deterministic, LLM 0]
  rerank            : stub
  planner           : static
  query_expansion   : identity
```

build_index 문맥은 ingestion(hwp/pdf loader · kordoc cache · mode) + embedding + chunking 축을, csv_text 폴백 loader 에 `[WARN]` 을 단다.

## Why

- **#2 artifact (hashing)**: `index.embedding == hashing` 이면 retrieval recall 수치가 의미-맹목 → `[WARN]`.
- **#1 artifact (CSV 폴백)**: `ingestion_report.text_source_counts` 에 `*csv*` 가 보이면 chunk/term-level 수치 무효 → `[WARN]`.
- 두 경우 모두 그동안 사후에 JSON 을 까봐야 알 수 있었다.

## ADR

불필요 — 이 banner 는 **측정 표면(eval 슬라이스/리더보드 신호/self-review 축)이 아니다**. 어떤 metric 도 생산하지 않는 순수 stderr 관측 출력. ADR 0001 baseline / ADR 0003 답변 계약 / eval 표면 모두 그대로 유지된다.

## Test plan

- [x] `tests/test_provenance_banner.py` 19 케이스 (hashing/csv-fallback `[WARN]` 분류, kordoc no-WARN, opt-out flag+env, render 포맷, ablation backend 집계)
- [x] `python3 -m pytest tests/test_provenance_banner.py tests/test_ingestion_kordoc_regression.py` → 41 passed
- [x] `build_index.py --help` / `run_eval.py --help` 에 `--no-config-banner` 노출 확인

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. (No behavior change in retrieval / verifier / eval path.) 이 banner 는 stderr 전용 관측 출력이다 — load-bearing 파일(`build_index.py`/`run_eval.py`)에 추가된 것은 argparse flag 와 `main()` 초입 banner 호출뿐이고, 어떤 retrieval/answer/summary 수치도 계산·기록되지 않는다. 따라서 `eval_summary.json` 산출은 byte-identical 이고 real-eval delta 는 정의상 0.

Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)