### PR TITLE
chore(eval): add real-eval-semantic target + document hashing semantic-blindness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 .PHONY: eval smoke smoke-with-judge reproduce benchmark synthetic-judge judge-disagreements leaderboard pareto cost-frontier korean-public-fetch korean-public-eval external-baselines-stub external-baselines-langchain external-baselines-llamaindex external-baselines-ollama harness-smoke harness-ablation harness-compare synthesize-multihop eval-multihop
 
 # Real-data eval cycle (private; ADR 0005 commit boundary).
-.PHONY: real-eval real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
+.PHONY: real-eval real-eval-semantic real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
 
 # Real-data case proposer cycle (ADR 0029; gitignored I/O).
 .PHONY: case-propose case-propose-metadata case-review case-promote
@@ -338,8 +338,23 @@ demo-docker:
 
 # Run the private real-data eval end-to-end (build index, sample query,
 # eval). Writes reports/real100/eval_summary.json locally (gitignored).
+# NOTE: builds a `hashing` (feature-hashing BoW) index — deterministic +
+# offline, but semantic-blind, so dense/hybrid retrieval recall is NOT
+# meaningful here (issue #1295). Use `real-eval-semantic` for that.
 real-eval:
 	bash scripts/smoke_real.sh
+
+# Semantic variant of real-eval (issue #1295): builds a sentence-transformers
+# BGE-M3 index into a SEPARATE dir (real100_m3) so the canonical hashing
+# real100 index is untouched. Requires the model to be downloadable/cached
+# (not offline/CI-safe). Use this — not `real-eval` — when measuring dense or
+# hybrid retrieval recall, since hashing embeddings carry no semantic signal.
+real-eval-semantic:
+	EMBEDDING_BACKEND=sentence-transformers MODEL=BAAI/bge-m3 \
+	  INDEX_DIR=data/index/real100_m3 \
+	  OUTPUT_DIR=outputs/real100_m3 \
+	  REPORT_DIR=reports/real100_m3 \
+	  bash scripts/smoke_real.sh
 
 # Render an aggregate-only markdown delta between the current
 # real-data run and the committed baseline. Aggregate-only by

--- a/scripts/smoke_real.sh
+++ b/scripts/smoke_real.sh
@@ -14,7 +14,18 @@ OUTPUT_DIR="${OUTPUT_DIR:-outputs/real100}"
 REPORT_DIR="${REPORT_DIR:-reports/real100}"
 QUERY="${QUERY:-한영대학교 특성화 맞춤형 교육환경 구축 사업의 사업기간과 사업예산 알려줘}"
 EVAL_CONFIG="${EVAL_CONFIG:-eval/real_config.local.yaml}"
+# EMBEDDING_BACKEND default `hashing` = feature-hashing BoW (rag_embedding.py::
+# hashing_embeddings) — deterministic + offline + no model download, so it is
+# the CI-safe SSoT baseline (ADR 0061). BUT it is *semantic-blind*: dense/hybrid
+# retrieval recall measured on a hashing index is meaningless (issue #1295).
+# For semantic retrieval measurement build with sentence-transformers + a real
+# model, e.g. `make real-eval-semantic` (EMBEDDING_BACKEND=sentence-transformers
+# MODEL=BAAI/bge-m3). The #1212 provenance banner WARNs at run start when an
+# index is hashing-backed.
 EMBEDDING_BACKEND="${EMBEDDING_BACKEND:-hashing}"
+# MODEL empty → build_index.py uses its DEFAULT_EMBEDDING_MODEL; pass-through
+# only when set so the default `make real-eval` invocation stays byte-identical.
+MODEL="${MODEL:-}"
 INGESTION_MODE="${INGESTION_MODE:-csv-text}"
 HWP_LOADER="${HWP_LOADER:-kordoc}"
 PDF_LOADER="${PDF_LOADER:-kordoc}"
@@ -57,6 +68,10 @@ if ! python3 scripts/validate_data_list.py \
 fi
 
 log "Building real-data index"
+MODEL_ARGS=()
+if [[ -n "$MODEL" ]]; then
+  MODEL_ARGS=(--model "$MODEL")
+fi
 python3 scripts/build_index.py \
   --metadata_csv "$METADATA_CSV" \
   --files_dir "$FILES_DIR" \
@@ -64,7 +79,8 @@ python3 scripts/build_index.py \
   --hwp_loader "$HWP_LOADER" \
   --pdf_loader "$PDF_LOADER" \
   --output_dir "$INDEX_DIR" \
-  --embedding_backend "$EMBEDDING_BACKEND"
+  --embedding_backend "$EMBEDDING_BACKEND" \
+  "${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"}"
 
 log "Running real-data sample query"
 python3 app.py --input_dir "$INDEX_DIR" --output_dir "$OUTPUT_DIR" --query "$QUERY"


### PR DESCRIPTION
## Summary

- `make real-eval` 는 deterministic/offline 을 위해 **hashing** (feature-hashing BoW) 인덱스를 빌드한다 — CI-safe SSoT(ADR 0061) 지만 *의미-맹목* 이라 dense/hybrid retrieval recall 측정엔 무의미하다 (#1295). 이 사실이 명령·문서에 드러나지 않아 그동안 오염된 retrieval 수치가 나왔다.
- **`scripts/smoke_real.sh`**: `MODEL` env passthrough(`--model`) + hashing 의미-맹목 주석. `MODEL` 비었으면 `--model` 미전달 → **기본 `make real-eval` invocation byte-identical**.
- **`Makefile`**: `real-eval-semantic` 타깃 추가 — sentence-transformers + `BAAI/bge-m3` 를 **별도** `data/index/real100_m3` (+ `outputs/`·`reports/` 분리) 로 빌드해 canonical hashing `real100` 인덱스를 건드리지 않는다.

## Why

`make real-eval` → hashing index 위 dense/hybrid recall = 무의미. 기본값 자체는 **의도적으로 유지**(오프라인·deterministic·모델 다운로드 불필요 = ADR 0061 SSoT). 바꾸면 CI determinism 깨지고 ~2GB 모델 강제. 대신 의미 측정 경로를 first-class + 문서화 했다. #1212 provenance banner 가 이미 hashing index 를 실행 시점에 `[WARN]`.

## ADR

불필요 — 새 측정 슬라이스/리더보드 신호/self-review 축 아님. 같은 eval 을 다른 embedding 으로 돌리는 편의 타깃 + 문서. retrieval 측정 protocol 계약은 `retrieval-eval` skill 이 이미 관할.

## Test plan

- [x] `bash -n scripts/smoke_real.sh` — 구문 OK
- [x] bash 3.2-safe 빈 배열 idiom `"${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"}"` 검증 (empty → 인자 0개, set → `--model BAAI/bge-m3`) — `set -u` 하에서 unbound 에러 없음 (cf. #1202)
- [x] `make -n real-eval` → `bash scripts/smoke_real.sh` (변경 없음, byte-identical)
- [x] `make -n real-eval-semantic` → `EMBEDDING_BACKEND=sentence-transformers MODEL=BAAI/bge-m3 INDEX_DIR=data/index/real100_m3 ... bash scripts/smoke_real.sh`

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. (No behavior change in retrieval / verifier / eval path.) 기본 `make real-eval` 은 `MODEL` 미설정 → `--model` 미전달 → build_index 호출이 변경 전과 동일하므로 `eval_summary.json` 산출 byte-identical. `real-eval-semantic` 은 신규 opt-in 타깃으로 별도 인덱스/리포트 디렉터리에만 쓴다. (smoke_real.sh·Makefile 은 load-bearing 경로 아님 — `_governance.py --is-load-bearing` exit 1.)

Closes #1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)