### PR TITLE
fix(eval): anonymize nested retry_reason_counts in extract_aggregate slices

### DIFF
--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -319,6 +319,26 @@ METRICS: list[tuple[str, str, bool]] = [
 # -----------------------------------------------------------------------------
 
 
+def _collapse_retry_reason_counts(value: dict[str, Any]) -> dict[str, int]:
+    """Strip the private payload after the first ``:`` from retry-reason keys.
+
+    Reason keys are MOSTLY taxonomy codes (``topic_not_grounded``), but
+    comparison reasons embed private payloads after a colon — e.g.
+    ``missing_comparison_entity:<agency>`` (Korean agency names) or
+    ``missing_comparison_doc:<공고번호>`` (real doc ids). Persisting them
+    verbatim leaked private real-eval metadata (#1204). Keep only the enum
+    prefix before the first ``:`` and sum the counts of any keys that collapse
+    together. The taxonomy totals are preserved; only the identifying payload
+    is dropped. Shared by the top-level handler and the by_format /
+    by_hardcase_category / by_metadata_field slice passthrough (#1286).
+    """
+    collapsed: dict[str, int] = {}
+    for k, v in value.items():
+        prefix = str(k).split(":", 1)[0]
+        collapsed[prefix] = collapsed.get(prefix, 0) + int(v)
+    return collapsed
+
+
 def _extract_ablation_full(run_summary: dict[str, Any]) -> dict[str, Any] | None:
     """Return the ADR 0005-safe headline metrics for one ablation run.
 
@@ -402,19 +422,7 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                 if isinstance(v, dict)
             }
         elif key == "retry_reason_counts" and isinstance(value, dict):
-            # Reason keys are MOSTLY taxonomy codes ("topic_not_grounded"),
-            # but comparison reasons embed private payloads after a colon —
-            # e.g. ``missing_comparison_entity:<agency>`` (Korean agency
-            # names) or ``missing_comparison_doc:<공고번호>`` (real doc ids).
-            # Persisting them verbatim leaked private real-eval metadata
-            # (#1204). Keep only the enum prefix before the first ``:`` and
-            # sum the counts of any keys that collapse together. The taxonomy
-            # totals are preserved; only the identifying payload is dropped.
-            collapsed: dict[str, int] = {}
-            for k, v in value.items():
-                prefix = str(k).split(":", 1)[0]
-                collapsed[prefix] = collapsed.get(prefix, 0) + int(v)
-            out[key] = collapsed
+            out[key] = _collapse_retry_reason_counts(value)
         elif key == "retry_effectiveness" and isinstance(value, dict):
             extracted: dict[str, Any] = {
                 sub: value.get(sub)
@@ -654,6 +662,30 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                 metadata_out[str(bucket_name)] = extracted_bucket
         if metadata_out:
             out["by_metadata_field"] = metadata_out
+
+    # #1286: by_format / by_hardcase_category / by_metadata_field are
+    # whitelisted top-level keys, so the main loop raw-passes them through.
+    # The fail-closed bucket sanitizers above only *overwrite* that raw
+    # passthrough when a public bucket name (SAFE_*_BUCKET_KEYS) is present —
+    # real-eval bucket names (``private_pdf_hwp_csv_text`` / ``multi_hop`` …)
+    # never are, so the rich raw bucket is what reaches the committed
+    # aggregate. Its only nested key that embeds a private payload is
+    # ``retry_reason_counts``; collapse it to enum prefixes (same as the
+    # top-level handler) so the surviving raw passthrough cannot leak
+    # 발주기관/공고번호 after a colon. (Sibling by_query_type is not a
+    # top-level key — it is fully rebuilt from SAFE_SLICE_METRICS above and
+    # never carries retry_reason_counts, so it needs no collapse here.)
+    for slice_key in ("by_format", "by_hardcase_category", "by_metadata_field"):
+        slice_val = out.get(slice_key)
+        if not isinstance(slice_val, dict):
+            continue
+        for bucket in slice_val.values():
+            if isinstance(bucket, dict) and isinstance(
+                bucket.get("retry_reason_counts"), dict
+            ):
+                bucket["retry_reason_counts"] = _collapse_retry_reason_counts(
+                    bucket["retry_reason_counts"]
+                )
 
     _assert_no_forbidden(out)
     return out

--- a/tests/test_eval_by_format_aggregate_regression.py
+++ b/tests/test_eval_by_format_aggregate_regression.py
@@ -19,6 +19,7 @@ from eval.run_eval import (
     _case_source_format,
     summarize_run,
 )
+from scripts._governance import find_eval_private_text
 from scripts.run_real_eval_delta import (
     FORBIDDEN_KEYS,
     SAFE_FORMAT_BUCKET_KEYS,
@@ -234,6 +235,87 @@ class TestExtractAggregateByFormat(unittest.TestCase):
         self.assertIn("hwp", SAFE_FORMAT_BUCKET_KEYS)
         self.assertIn("pdf", SAFE_FORMAT_BUCKET_KEYS)
         self.assertIn("synthetic_public_sample", SAFE_FORMAT_BUCKET_KEYS)
+
+
+class TestSliceRetryReasonAnonymization(unittest.TestCase):
+    """#1286: by_format / by_hardcase_category / by_metadata_field are
+    whitelisted top-level keys, so the main loop raw-passes them through. When
+    the bucket name is not in the public SAFE_*_BUCKET_KEYS enum (every
+    real-eval bucket — ``private_pdf_hwp_csv_text`` / ``multi_hop`` …), the
+    fail-closed sanitizer produces an empty result and does not overwrite the
+    raw passthrough. The surviving raw bucket carries a nested
+    ``retry_reason_counts`` whose comparison keys embed 발주기관/공고번호 after a
+    colon; #1204's top-level collapse did not reach these slices, so a baseline
+    regen re-leaked the payload. The fix collapses the nested counts to enum
+    prefixes (identical to the top-level handler).
+    """
+
+    # missing_comparison_entity:<Korean agency> + missing_comparison_doc:<id>
+    # are the exact private signatures find_eval_private_text scans for.
+    PRIVATE_RETRY_REASON_COUNTS = {
+        "topic_not_grounded": 91,
+        "missing_comparison_entity:한국전자통신연구원": 3,
+        "missing_comparison_entity:고양도시관리공사": 1,
+        "missing_comparison_doc:20240419765-0.0": 2,
+        "partial_topic_grounding": 2,
+    }
+    # After collapse the four colon keys fold into two enum prefixes and sum.
+    EXPECTED_COLLAPSED = {
+        "topic_not_grounded": 91,
+        "missing_comparison_entity": 4,
+        "missing_comparison_doc": 2,
+        "partial_topic_grounding": 2,
+    }
+
+    def _summary(self, slice_key: str, bucket_name: str) -> dict[str, Any]:
+        return {
+            "num_predictions": 100,
+            "accuracy": 0.5,
+            slice_key: {
+                bucket_name: {
+                    "num_predictions": 100,
+                    "accuracy": 0.5,
+                    "retry_reason_counts": dict(self.PRIVATE_RETRY_REASON_COUNTS),
+                }
+            },
+        }
+
+    def _assert_clean_and_collapsed(self, out: dict[str, Any], slice_key: str, bucket_name: str) -> None:
+        # The rich raw bucket is preserved (not dropped) ...
+        self.assertIn(slice_key, out)
+        self.assertIn(bucket_name, out[slice_key])
+        rrc = out[slice_key][bucket_name]["retry_reason_counts"]
+        # ... but the colon payload is gone and counts collapsed to prefixes.
+        self.assertEqual(rrc, self.EXPECTED_COLLAPSED)
+        # And the structural privacy scanner finds no Hangul / colon keys.
+        found = find_eval_private_text(out)
+        self.assertNotIn("hangul", found, f"Hangul leaked in {slice_key}: {found}")
+        self.assertNotIn("colon_keys", found, f"colon key leaked in {slice_key}: {found}")
+
+    def test_by_format_private_bucket_retry_reason_collapsed(self) -> None:
+        out = extract_aggregate(self._summary("by_format", "private_pdf_hwp_csv_text"))
+        self._assert_clean_and_collapsed(out, "by_format", "private_pdf_hwp_csv_text")
+
+    def test_by_hardcase_category_private_bucket_retry_reason_collapsed(self) -> None:
+        out = extract_aggregate(self._summary("by_hardcase_category", "multi_hop"))
+        self._assert_clean_and_collapsed(out, "by_hardcase_category", "multi_hop")
+
+    def test_by_metadata_field_private_bucket_retry_reason_collapsed(self) -> None:
+        # by_metadata_field uses a different enum; a non-whitelisted bucket
+        # still exercises the raw passthrough path.
+        out = extract_aggregate(self._summary("by_metadata_field", "issuing_agency"))
+        self._assert_clean_and_collapsed(out, "by_metadata_field", "issuing_agency")
+
+    def test_collapse_matches_top_level_handler(self) -> None:
+        # The slice collapse must be byte-identical to the top-level
+        # retry_reason_counts handler so the two surfaces never diverge.
+        top = extract_aggregate(
+            {
+                "num_predictions": 100,
+                "retry_reason_counts": dict(self.PRIVATE_RETRY_REASON_COUNTS),
+            }
+        )["retry_reason_counts"]
+        self.assertEqual(top, self.EXPECTED_COLLAPSED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 무엇을 / 왜

`scripts/run_real_eval_delta.py` `extract_aggregate` 가 `by_format` / `by_hardcase_category` / `by_metadata_field` 슬라이스의 nested `retry_reason_counts` 를 익명화하지 못해, baseline regen 시 private 발주기관/공고번호가 재유입되는 ADR 0005 경계 누출을 닫는다 (#1286, #1204 후속).

근본 원인: 이 3개 키는 `SAFE_TOPLEVEL_KEYS` 멤버라 main loop 의 `else: out[key] = value` 로 **raw passthrough** 된다. 아래 fail-closed `SAFE_*_BUCKET_KEYS` sanitizer 는 **public 버킷명이 있을 때만** 그 raw 를 overwrite 하는데, real-eval 버킷명(`private_pdf_hwp_csv_text` / `multi_hop` 등)은 whitelist 에 하나도 없어 sanitizer 결과가 비고 → overwrite 가 건너뛰어 rich raw 버킷이 committed surface 로 살아남는다. 그 안의 `retry_reason_counts` 가 `missing_comparison_entity:<agency>` 처럼 colon 뒤 payload 를 담아 누출. #1211 은 committed 11개 아티팩트를 수동으로만 정리했어서 main 은 깨끗하나, `make real-eval-baseline-update` regen 이 누출을 재유입했다 (#1276 §5b 가 hangul=273 / colon_keys=23 로 포착, baseline 보류 사유).

## 어떻게

- colon-collapse 로직을 `_collapse_retry_reason_counts()` 헬퍼로 추출 → top-level 핸들러와 슬라이스가 **byte-identical** 로직 공유.
- `extract_aggregate` 말미에 3개 슬라이스의 각 버킷 nested `retry_reason_counts` 를 enum prefix 로 collapse 하는 post-pass 추가. **버킷을 drop 하지 않고** rich 메트릭(ci / latency / failure_category_counts …)은 보존 — #1211 수동 clean 의 자동 재현.
- 이미 clean 한 baseline 에 대해 **idempotent** (재추출 시 세 슬라이스 byte-identical, privacy scan `{}`).

## 테스트

`tests/test_eval_by_format_aggregate_regression.py` 에 `TestSliceRetryReasonAnonymization` 추가:
- by_format / by_hardcase_category / by_metadata_field 각각 non-whitelisted private 버킷 + colon+한글 payload fixture → collapse 후 버킷 보존 + enum prefix only + `find_eval_private_text` 가 hangul/colon_keys 미검출 확인.
- 슬라이스 collapse == top-level 핸들러 동일성 단언.

## 변경 범위 / 영향

- `scripts/run_real_eval_delta.py` (load-bearing 아님 — `--is-load-bearing` exit 1), `tests/`. 답변 계약(ADR 0003) / baseline(ADR 0001) 불변.

## ADR

N/A — 버그 fix, load-bearing 결정·측정 표면 변경 없음 (run_real_eval_delta.py 는 `LOAD_BEARING_PATHS` 미포함). 기존 ADR 0005 경계 강화일 뿐 새 계약 도입 없음.

## 5a (합성 CI 델타)

N/A — extractor 익명화 로직 변경. 합성 eval 메트릭 산출 경로 불변 (idempotent 확인).

## 5b (real-data 델타)

N/A — `run_real_eval_delta.py` 는 `LOAD_BEARING_PATHS` 미포함이라 §5b 비대상. 단, 본 fix 의 목적이 곧 real-data 재생성 안전성 확보이며, 효과는 후속 #1287 baseline regen 의 privacy 게이트(green) 로 검증된다. 이 환경엔 private corpus 부재로 regen 미실행.

## Local gate

`make test-fast` (pytest -m "not slow" -n auto) — **2234 passed, 16 skipped**. FlagEmbedding 설치 worktree 라 real-model `slow` 스위트는 로컬 deselect, CI 에서 커버. ruff `All checks passed`. 따라서 **머지는 CI green 하드 게이트**.

Closes #1286