### PR TITLE
chore(eval): add READ-ONLY component-eval diagnostic scripts

### DIFF
--- a/scripts/component_eval/citation_asymmetry_analysis.py
+++ b/scripts/component_eval/citation_asymmetry_analysis.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Phase 2-bis B step — Citation asymmetry analysis (READ-ONLY, 0 LLM calls).
+
+Hypothesis: In Phase 2-bis v2, gold-chunk citation rate at position=first (0.857)
+is lower than middle/last (0.952 each). CI overlaps but margin is ~10pp.
+Re-analyze the raw .jsonl to either confirm or refute:
+  1. Paired bootstrap: per (case, seed) compute cite(first) - cite(last/middle), CI 95%
+  2. Per-case breakdown: list (case, seed) where first-position cite failed
+  3. Distractor-cite frequency: when LLM cites in first-position cases, what got cited?
+  4. Cite chunk_id histogram per position (gold vs distractor vs nothing)
+
+No LLM calls — reads Phase 2-bis raw and derives stats only.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from eval.bootstrap import bootstrap_ci  # noqa: E402
+
+CITE_RE = re.compile(r"\[([^\[\]]+?)\]")
+
+
+def extract_cites(text: str) -> list[str]:
+    """Return all [chunk_id] tokens from response text (unique-preserving order)."""
+    if not text:
+        return []
+    seen = set()
+    out = []
+    for m in CITE_RE.finditer(text):
+        cid = m.group(1).strip()
+        if cid and cid not in seen:
+            seen.add(cid)
+            out.append(cid)
+    return out
+
+
+def fmt_ci(vals: list[float]) -> str:
+    if not vals:
+        return "n=0"
+    c = bootstrap_ci(vals)
+    return f"mean={c['mean']:.3f} ci=[{c['ci_lo']:.3f}, {c['ci_hi']:.3f}] n={c['n']}"
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True, help="phase2_bis_raw.jsonl path")
+    p.add_argument("--output", required=True, help="output dir")
+    args = p.parse_args()
+
+    rows = [json.loads(l) for l in Path(args.input).read_text().splitlines() if l.strip()]
+    # only successful gen rows
+    ok_rows = [r for r in rows if r.get("position") and r.get("error") is None]
+    print(f"loaded {len(rows)} rows ({len(ok_rows)} successful gen)", file=sys.stderr)
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # ---- triple build ----
+    triples_cite: dict[tuple, dict[str, int]] = defaultdict(dict)  # 1=cited, 0=not
+    triples_distractor_cite: dict[tuple, dict[str, int]] = defaultdict(dict)  # cited a distractor
+    triples_no_cite: dict[tuple, dict[str, int]] = defaultdict(dict)  # cited nothing
+    per_call_cite_dist: dict[str, Counter] = {"first": Counter(), "middle": Counter(), "last": Counter()}
+
+    for r in ok_rows:
+        key = (r["case_id"], r["seed"])
+        pos = r["position"]
+        gold_cid = str(r["gold_chunk_id"])
+        hard_neg_cids = set(map(str, r.get("hard_neg_chunk_ids") or []))
+        cites = extract_cites(r.get("response_text") or "")
+        cite_set = set(cites)
+        cited_gold = 1 if gold_cid in cite_set else 0
+        cited_distractor = 1 if (cite_set & hard_neg_cids) else 0
+        no_cite = 1 if not cites else 0
+        triples_cite[key][pos] = cited_gold
+        triples_distractor_cite[key][pos] = cited_distractor
+        triples_no_cite[key][pos] = no_cite
+        # cite distribution: classify each citation
+        for cid in cites:
+            if cid == gold_cid:
+                per_call_cite_dist[pos]["gold"] += 1
+            elif cid in hard_neg_cids:
+                per_call_cite_dist[pos]["distractor"] += 1
+            else:
+                per_call_cite_dist[pos]["other"] += 1  # unknown — usually parse noise
+
+    full_triples = [(k, v, triples_distractor_cite[k], triples_no_cite[k])
+                    for k, v in triples_cite.items() if len(v) == 3]
+    print(f"complete triples: {len(full_triples)}", file=sys.stderr)
+
+    # paired diffs (gold citation)
+    diff_first_last = [v["first"] - v["last"] for k, v, _, _ in full_triples]
+    diff_first_middle = [v["first"] - v["middle"] for k, v, _, _ in full_triples]
+    diff_middle_last = [v["middle"] - v["last"] for k, v, _, _ in full_triples]
+
+    # paired diffs (distractor citation)
+    dd_first_last = [d["first"] - d["last"] for _, _, d, _ in full_triples]
+    dd_first_middle = [d["first"] - d["middle"] for _, _, d, _ in full_triples]
+
+    # per-position means (gold cite)
+    by_pos_cite = {"first": [], "middle": [], "last": []}
+    by_pos_distractor = {"first": [], "middle": [], "last": []}
+    by_pos_no_cite = {"first": [], "middle": [], "last": []}
+    for _, v, d, nc in full_triples:
+        for pos in ("first", "middle", "last"):
+            by_pos_cite[pos].append(v[pos])
+            by_pos_distractor[pos].append(d[pos])
+            by_pos_no_cite[pos].append(nc[pos])
+
+    # per-case breakdown: which (case, seed) had first=0 cite?
+    fail_cases = [(k, v) for k, v, _, _ in full_triples if v["first"] == 0]
+    fail_cases_first_only = [(k, v) for k, v, _, _ in full_triples
+                              if v["first"] == 0 and v["middle"] == 1 and v["last"] == 1]
+    # cases where first failed but middle/last succeeded — directly supports asymmetry hypothesis
+
+    # McNemar 2x2 (first vs last cite)
+    # b = first=1 & last=0; c = first=0 & last=1
+    b = sum(1 for _, v, _, _ in full_triples if v["first"] == 1 and v["last"] == 0)
+    c = sum(1 for _, v, _, _ in full_triples if v["first"] == 0 and v["last"] == 1)
+    n_disc = b + c
+    # exact McNemar p-value (binomial test, two-sided, p=0.5)
+    # approximate with chi-square if n_disc >= 25; exact otherwise
+    if n_disc > 0:
+        # exact binomial: 2 * sum(C(n,k) for k in [0..min(b,c)]) * 0.5**n
+        from math import comb
+        k_min = min(b, c)
+        p_one = sum(comb(n_disc, k) for k in range(0, k_min + 1)) * 0.5 ** n_disc
+        mcnemar_p = min(1.0, 2 * p_one)
+    else:
+        mcnemar_p = 1.0
+
+    # ---- manifest ----
+    manifest = {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "input": args.input,
+        "n_rows_input": len(rows),
+        "n_rows_ok": len(ok_rows),
+        "n_complete_triples": len(full_triples),
+        "n_first_fail_cases": len(fail_cases),
+        "n_first_fail_only": len(fail_cases_first_only),
+        "mcnemar_first_vs_last": {"b_first1_last0": b, "c_first0_last1": c, "p_two_sided_exact": round(mcnemar_p, 6)},
+    }
+
+    # ---- markdown report ----
+    L = []
+    L.append("# Phase 2-bis B — Citation asymmetry verification (READ-ONLY)\n")
+    L.append(f"- generated: {manifest['generated_at']}")
+    L.append(f"- input: `{args.input}`")
+    L.append(f"- n_rows: {manifest['n_rows_input']}, n_ok: {manifest['n_rows_ok']}, "
+             f"complete triples: {manifest['n_complete_triples']}")
+    L.append("")
+    L.append("## 1. Gold citation rate per position (paired bootstrap CI 95%)\n")
+    for pos in ("first", "middle", "last"):
+        L.append(f"- **{pos}**: {fmt_ci(by_pos_cite[pos])}")
+    L.append("")
+    L.append("## 2. Paired diffs — gold citation (within (case, seed))\n")
+    L.append(f"- cite(first) - cite(last):   {fmt_ci(diff_first_last)}")
+    L.append(f"- cite(first) - cite(middle): {fmt_ci(diff_first_middle)}")
+    L.append(f"- cite(middle) - cite(last):  {fmt_ci(diff_middle_last)}")
+    L.append("")
+    L.append("## 3. McNemar exact (first vs last gold-citation discordant)\n")
+    L.append(f"- b (first=1, last=0): {b}")
+    L.append(f"- c (first=0, last=1): {c}")
+    L.append(f"- discordant n: {n_disc}")
+    L.append(f"- two-sided exact p: {mcnemar_p:.4f}")
+    L.append(f"  ({'significant @ p<0.05' if mcnemar_p < 0.05 else 'NOT significant @ p<0.05'})")
+    L.append("")
+    L.append("## 4. Distractor citation rate per position\n")
+    L.append("- (cases where LLM cited any of the 5 hard-neg distractors)")
+    for pos in ("first", "middle", "last"):
+        L.append(f"- **{pos}**: {fmt_ci(by_pos_distractor[pos])}")
+    L.append("")
+    L.append("## 5. No-citation rate per position\n")
+    L.append("- (cases where LLM cited nothing at all)")
+    for pos in ("first", "middle", "last"):
+        L.append(f"- **{pos}**: {fmt_ci(by_pos_no_cite[pos])}")
+    L.append("")
+    L.append("## 6. Cite chunk_id classification per position\n")
+    L.append("- counts across all per-call cites; each call may contribute multiple")
+    L.append("| position | gold | distractor | other (unknown) |")
+    L.append("|----------|------|------------|-----------------|")
+    for pos in ("first", "middle", "last"):
+        d = per_call_cite_dist[pos]
+        L.append(f"| {pos} | {d['gold']} | {d['distractor']} | {d['other']} |")
+    L.append("")
+    L.append("## 7. Per-case breakdown — first-position cite failures\n")
+    L.append(f"- cases (= (case_id, seed)) where first=0: **{len(fail_cases)}**")
+    L.append(f"- of which first=0 AND middle=1 AND last=1 (asymmetry pattern): **{len(fail_cases_first_only)}**")
+    L.append("")
+    if fail_cases_first_only:
+        L.append("Asymmetric-fail (case_id, seed):")
+        for (cid, seed), _ in fail_cases_first_only[:20]:
+            L.append(f"  - `{cid}` seed={seed}")
+        if len(fail_cases_first_only) > 20:
+            L.append(f"  - ... +{len(fail_cases_first_only) - 20} more")
+        L.append("")
+    L.append("## 8. Distractor citation paired diff (within (case, seed))\n")
+    L.append(f"- distractor_cite(first) - distractor_cite(last):   {fmt_ci(dd_first_last)}")
+    L.append(f"- distractor_cite(first) - distractor_cite(middle): {fmt_ci(dd_first_middle)}")
+    L.append("- (positive = first position more likely to misattribute to distractor)")
+    L.append("")
+    L.append("## 9. 결론\n")
+    # judge significance
+    rng_low_high = lambda v: bootstrap_ci(v) if v else None
+    c_fl = rng_low_high(diff_first_last)
+    sig_paired = (c_fl is not None and (c_fl['ci_lo'] > 0 or c_fl['ci_hi'] < 0))
+    sig_mcnemar = mcnemar_p < 0.05
+    if sig_paired or sig_mcnemar:
+        L.append("- **citation asymmetry CONFIRMED** at first position")
+        if sig_paired:
+            L.append(f"  - paired bootstrap CI excludes 0: {fmt_ci(diff_first_last)}")
+        if sig_mcnemar:
+            L.append(f"  - McNemar exact p={mcnemar_p:.4f} < 0.05")
+    else:
+        L.append("- **citation asymmetry NOT confirmed** (보고된 ~10pp 차이는 noise 수준)")
+        L.append(f"  - paired diff CI {fmt_ci(diff_first_last)} crosses 0")
+        L.append(f"  - McNemar exact p={mcnemar_p:.4f} (no significance @ 0.05)")
+    if len(fail_cases_first_only) > 0:
+        L.append(f"- 비대칭 패턴 case 수: {len(fail_cases_first_only)} / {len(full_triples)} triples")
+    L.append("")
+    L.append("## 10. Honesty / caveats\n")
+    L.append("- 입력 = Phase 2-bis v2 (n=14 cases × 3 seeds × 3 positions). Small sample — sub-CI wide.")
+    L.append("- Citation = response text 에 `[chunk_id]` 패턴 검색. malformed cite (괄호 없음, typo) 는 miss.")
+    L.append("- McNemar exact 는 두 marginals 균등 (p=0.5) 가정. 작은 discordant n 에서 검정력 낮음.")
+    L.append("- 0 LLM call — Phase 2-bis 의 raw response 만 재사용.")
+    (out / "analysis.md").write_text("\n".join(L) + "\n")
+    (out / "analysis.json").write_text(json.dumps({
+        "manifest": manifest,
+        "per_position_gold_cite": {p: by_pos_cite[p] for p in ("first", "middle", "last")},
+        "per_position_distractor_cite": {p: by_pos_distractor[p] for p in ("first", "middle", "last")},
+        "per_position_no_cite": {p: by_pos_no_cite[p] for p in ("first", "middle", "last")},
+        "diff_first_last_gold": diff_first_last,
+        "diff_first_middle_gold": diff_first_middle,
+        "diff_middle_last_gold": diff_middle_last,
+        "diff_first_last_distractor": dd_first_last,
+        "fail_cases_first_only": [{"case_id": k[0], "seed": k[1]} for k, _ in fail_cases_first_only],
+        "cite_dist_per_position": {p: dict(per_call_cite_dist[p]) for p in ("first", "middle", "last")},
+    }, ensure_ascii=False, indent=2))
+    print(f"Wrote: {out}/analysis.md", file=sys.stderr)
+    print(f"Wrote: {out}/analysis.json", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/component_eval/gold_annotation_survey.py
+++ b/scripts/component_eval/gold_annotation_survey.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Gold-annotation health survey (READ-ONLY, 0 LLM).
+
+Component-level retrieval/verifier diagnosis depends on chunk-level gold
+annotations (gold_chunk_ids). This survey quantifies, across ALL eval cases,
+whether that annotation layer can actually support such diagnosis:
+
+  - coverage: how many cases carry gold_chunk_ids at all
+  - in-index: gold cid resolvable in current index.json
+  - drift: gold chunk text vs expected_terms (substring AND) —
+           present ⇒ annotation valid, absent ⇒ answer moved off chunk
+
+Per query_type breakdown. Reuses eval/scorers/_shared.py::contains_all_terms.
+No LLM calls.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from eval.scorers._shared import contains_all_terms  # noqa: E402
+
+
+def survey_case(c, yaml_terms, cid_to_text):
+    gold_cids = [str(g) for g in (c.get("gold_chunk_ids") or [])]
+    terms = yaml_terms.get(c.get("id")) or []
+    if not gold_cids:
+        return "no_gold"
+    in_index = [g for g in gold_cids if g in cid_to_text]
+    if not in_index:
+        return "gold_not_in_index"
+    if not terms:
+        return "gold_no_terms"  # has gold cid but no expected_terms to validate
+    gold_text = " ".join(cid_to_text.get(g, "") for g in gold_cids)
+    if contains_all_terms(gold_text, terms):
+        return "gold_valid"
+    return "gold_drift"
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True)
+    p.add_argument("--config", required=True)
+    p.add_argument("--index", required=True)
+    p.add_argument("--output", required=True)
+    args = p.parse_args()
+
+    es = json.loads(Path(args.input).read_text())
+    cfg = yaml.safe_load(Path(args.config).read_text())
+    yaml_terms = {c.get("id"): (c.get("expected_terms") or []) for c in (cfg.get("cases") or [])}
+    idx = json.loads(Path(args.index).read_text())
+    cid_to_text = {str(c["chunk_id"]): (c.get("text") or "") for c in idx.get("chunks") or []}
+    crs = es.get("case_results") or []
+
+    overall = Counter()
+    by_qt = defaultdict(Counter)
+    for c in crs:
+        v = survey_case(c, yaml_terms, cid_to_text)
+        overall[v] += 1
+        by_qt[c.get("query_type") or "?"][v] += 1
+
+    n = len(crs)
+    cats = ["gold_valid", "gold_drift", "gold_not_in_index", "gold_no_terms", "no_gold"]
+
+    def pct(v, tot):
+        return f"{(v/tot*100):.0f}%" if tot else "—"
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "input": args.input, "config": args.config, "index": args.index,
+        "n_cases": n,
+        "overall": dict(overall),
+        "by_query_type": {qt: dict(d) for qt, d in by_qt.items()},
+    }
+
+    has_gold = n - overall.get("no_gold", 0)
+    judgable = overall.get("gold_valid", 0) + overall.get("gold_drift", 0)
+    drift = overall.get("gold_drift", 0)
+
+    L = []
+    L.append("# Gold-annotation health survey (READ-ONLY, 0 LLM)\n")
+    L.append(f"- generated: {manifest['generated_at']}")
+    L.append(f"- input: `{args.input}`")
+    L.append(f"- index: `{args.index}`")
+    L.append(f"- n_cases: **{n}**")
+    L.append("")
+    L.append("## Overall\n")
+    L.append("| category | n | % of all | meaning |")
+    L.append("|---|---|---|---|")
+    meanings = {
+        "gold_valid": "chunk-gold 있고 답 텍스트도 일치 → diagnosis 가능",
+        "gold_drift": "chunk-gold 있으나 답이 다른 chunk 로 이동 → stale",
+        "gold_not_in_index": "gold cid 가 index 에 없음 → 완전 stale",
+        "gold_no_terms": "gold cid 있으나 expected_terms 없어 검증 불가",
+        "no_gold": "chunk-level gold annotation 자체가 없음",
+    }
+    for cat in cats:
+        if overall.get(cat):
+            L.append(f"| {cat} | {overall[cat]} | {pct(overall[cat], n)} | {meanings[cat]} |")
+    L.append("")
+    L.append(f"- chunk-gold 보유: **{has_gold}/{n} ({pct(has_gold, n)})**")
+    if judgable:
+        L.append(f"- terms-검증 가능 {judgable}건 중 **drift {drift} ({pct(drift, judgable)})**, valid {overall.get('gold_valid',0)}")
+    L.append("")
+    L.append("## Per query_type\n")
+    L.append("| query_type | n | gold_valid | gold_drift | no_gold | etc |")
+    L.append("|---|---|---|---|---|---|")
+    for qt in sorted(by_qt):
+        d = by_qt[qt]
+        tot = sum(d.values())
+        etc = d.get("gold_not_in_index", 0) + d.get("gold_no_terms", 0)
+        L.append(f"| {qt} | {tot} | {d.get('gold_valid',0)} | {d.get('gold_drift',0)} | "
+                 f"{d.get('no_gold',0)} | {etc} |")
+    L.append("")
+    L.append("## 결론\n")
+    L.append(f"- **chunk-level component diagnosis (retrieval recall / verifier status) 에 쓸 수 있는 깨끗한 케이스 = gold_valid {overall.get('gold_valid',0)}건 ({pct(overall.get('gold_valid',0), n)}).**")
+    L.append(f"- 나머지 {n - overall.get('gold_valid',0)}건은 no-gold / drift / stale 로 chunk-level 진단 불가.")
+    L.append("- → retrieval recall · verifier status 의 component-level 수치는 이 {n}건 전체로 내면 안 됨. gold_valid 부분집합에서만 유효.")
+    L.append("")
+    L.append("## Honesty / caveats\n")
+    L.append("- terms-test = substring AND (`contains_all_terms`). expected_terms 부분적이면 false drift.")
+    L.append("- no_gold 는 의도된 설계일 수 있음 (abstention 쿼리는 gold 없음이 정상). query_type 별 표로 구분.")
+    L.append("- 0 LLM call.")
+
+    (out / "report.md").write_text("\n".join(L) + "\n")
+    (out / "raw.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2))
+    print(f"Wrote: {out}/report.md", file=sys.stderr)
+    print(f"n={n} has_gold={has_gold} gold_valid={overall.get('gold_valid',0)} "
+          f"drift={drift} no_gold={overall.get('no_gold',0)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/component_eval/scorer_surface_form_diag.py
+++ b/scripts/component_eval/scorer_surface_form_diag.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Scorer surface-form mismatch diagnosis (READ-ONLY, 0 LLM).
+
+The chunk-level gold survey found only 14/221 (6%) cases have a "clean"
+substring-derivable gold set. Drilling into single_doc failures showed the
+answer IS in the indexed document body, but written in a surface form the
+substring scorer (`contains_all_terms`, used by BOTH gold derivation and the
+eval groundedness scorer) cannot match:
+
+  expected_term  '150,000,000원'   vs   doc text  '1억 5천만 원'
+  expected_term  '2025-01-08'      vs   doc text  '2025. 1. 8.'
+
+This script QUANTIFIES, with a numeric/date normalizer, how many
+substring-FAILING expected_terms are actually present in the expected
+document once Korean-myriad amounts and date separators are normalized.
+That separates "scorer surface-form artifact" from genuine term absence
+(textual terms that need a different fix).
+
+No LLM calls. No estimates — every number is measured against the index text.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+_BIGS = {"억": 10**8, "만": 10**4}
+_SMALLS = {"천": 10**3, "백": 10**2, "십": 10}
+_AMOUNT_SPAN = re.compile(r"[\d억만천백십,\.\s]*[\d억만천백십]\s*원")
+_DATE = re.compile(r"(\d{4})\D{0,3}?(\d{1,2})\D{0,3}?(\d{1,2})")
+
+
+def kor_amount_to_int(s: str) -> int | None:
+    """Parse Korean myriad or comma-grouped amount to int. None if unparseable."""
+    s = s.replace(" ", "").replace(",", "").replace("원", "").replace("정", "")
+    if not s:
+        return None
+    if not any(ch in s for ch in "억만천백십"):
+        return int(s) if s.isdigit() else None
+    total = section = num = 0
+    for ch in s:
+        if ch.isdigit():
+            num = num * 10 + int(ch)
+        elif ch in _SMALLS:
+            section += (num if num else 1) * _SMALLS[ch]
+            num = 0
+        elif ch in _BIGS:
+            section += num
+            total += section * _BIGS[ch]
+            section = num = 0
+        else:
+            return None  # stray char → give up (avoid false matches)
+    return total + section + num
+
+
+def amounts_in_text(text: str) -> set[int]:
+    out: set[int] = set()
+    for m in _AMOUNT_SPAN.finditer(text):
+        v = kor_amount_to_int(m.group())
+        if v is not None and v > 0:
+            out.add(v)
+    return out
+
+
+def dates_in_text(text: str) -> set[tuple[int, int, int]]:
+    out: set[tuple[int, int, int]] = set()
+    for m in _DATE.finditer(text):
+        y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if 2000 <= y <= 2099 and 1 <= mo <= 12 and 1 <= d <= 31:
+            out.add((y, mo, d))
+    return out
+
+
+def term_kind(t: str) -> str:
+    if re.search(r"[0-9][0-9,]*\s*원", t) or ("원" in t and any(c.isdigit() for c in t)):
+        return "amount"
+    if re.fullmatch(r"\d{4}[-.\s]*\d{1,2}[-.\s]*\d{1,2}\.?", t.strip()):
+        return "date"
+    if any(c.isdigit() for c in t):
+        return "other_numeric"
+    return "textual"
+
+
+def normalized_present(term: str, text: str, amt_set: set[int], date_set) -> bool:
+    kind = term_kind(term)
+    if kind == "amount":
+        v = kor_amount_to_int(term)
+        return v is not None and v in amt_set
+    if kind == "date":
+        m = _DATE.search(term)
+        if not m:
+            return False
+        key = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        return key in date_set
+    return False  # other_numeric / textual: not handled by this normalizer
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True, help="eval_summary.json")
+    p.add_argument("--config", required=True)
+    p.add_argument("--index", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--query-type", default="single_doc")
+    args = p.parse_args()
+
+    es = json.loads(Path(args.input).read_text())
+    cfg = yaml.safe_load(Path(args.config).read_text())
+    byid = {c.get("id"): c for c in (cfg.get("cases") or [])}
+    idx = json.loads(Path(args.index).read_text())
+    by_doc: dict[str, str] = {}
+    for c in idx.get("chunks") or []:
+        by_doc.setdefault(str(c.get("doc_id")), "")
+        by_doc[str(c.get("doc_id"))] += " " + str(c.get("text") or "")
+
+    crs = es.get("case_results") or []
+    cases = crs if args.query_type == "all" else [c for c in crs if c.get("query_type") == args.query_type]
+
+    kind_fail = Counter()
+    kind_recovered = Counter()
+    recovered_terms: list[tuple[str, str]] = []
+    still_absent_textual: list[str] = []
+    case_recover = Counter()  # how many cases flip all-numeric-terms recoverable
+
+    for c in cases:
+        cid = c.get("id")
+        cc = byid.get(cid)
+        if not cc:
+            continue
+        terms = cc.get("expected_terms") or []
+        docs = [str(d) for d in (cc.get("expected_doc_ids") or [])]
+        if not terms:
+            continue
+        text = " ".join(by_doc.get(d, "") for d in docs)
+        low = text.lower()
+        amt_set = amounts_in_text(text)
+        date_set = dates_in_text(text)
+        case_failing = [t for t in terms if t.lower() not in low]
+        if not case_failing:
+            continue
+        for t in case_failing:
+            k = term_kind(t)
+            kind_fail[k] += 1
+            if normalized_present(t, text, amt_set, date_set):
+                kind_recovered[k] += 1
+                if len(recovered_terms) < 40:
+                    recovered_terms.append((t, k))
+            elif k == "textual" and len(still_absent_textual) < 40:
+                still_absent_textual.append(t)
+        # case-level: did normalization recover ALL its failing numeric terms,
+        # leaving only textual (or nothing)?
+        numeric_fail = [t for t in case_failing if term_kind(t) != "textual"]
+        numeric_rec = [t for t in numeric_fail if normalized_present(t, text, amt_set, date_set)]
+        if numeric_fail and len(numeric_rec) == len(numeric_fail):
+            case_recover["all_numeric_recovered"] += 1
+
+    total_fail = sum(kind_fail.values())
+    total_rec = sum(kind_recovered.values())
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "input": args.input, "config": args.config, "index": args.index,
+        "query_type": args.query_type,
+        "failing_terms_total": total_fail,
+        "recovered_by_normalization": total_rec,
+        "kind_fail": dict(kind_fail),
+        "kind_recovered": dict(kind_recovered),
+        "cases_all_numeric_recovered": case_recover.get("all_numeric_recovered", 0),
+    }
+
+    def pct(v, t):
+        return f"{(v/t*100):.0f}%" if t else "—"
+
+    L = []
+    L.append("# Scorer surface-form mismatch diagnosis (READ-ONLY, 0 LLM)\n")
+    L.append(f"- generated: {manifest['generated_at']}")
+    L.append(f"- input: `{args.input}`")
+    L.append(f"- index: `{args.index}`")
+    L.append(f"- query_type: **{args.query_type}**")
+    L.append("")
+    L.append("## Substring-failing expected_terms — by kind, recovered by normalization\n")
+    L.append("| kind | failing | recovered (normalized) | recover % | normalizer handles? |")
+    L.append("|---|---|---|---|---|")
+    for k in ("amount", "date", "other_numeric", "textual"):
+        f = kind_fail.get(k, 0)
+        r = kind_recovered.get(k, 0)
+        handles = "yes" if k in ("amount", "date") else "no"
+        L.append(f"| {k} | {f} | {r} | {pct(r, f)} | {handles} |")
+    L.append(f"| **total** | **{total_fail}** | **{total_rec}** | {pct(total_rec, total_fail)} | |")
+    L.append("")
+    L.append(f"- cases where ALL substring-failing **numeric** terms become present after "
+             f"normalization: **{manifest['cases_all_numeric_recovered']}**")
+    L.append("")
+    L.append("## 결론\n")
+    L.append("- substring scorer (`contains_all_terms`) 가 못 잡는 expected_term 의 실패는 **두 갈래**:")
+    L.append(f"  1. **숫자/날짜 표면형** (amount+date {kind_fail.get('amount',0)+kind_fail.get('date',0)}건): "
+             f"한국식 만/억·날짜 구분자 정규화로 {kind_recovered.get('amount',0)+kind_recovered.get('date',0)}건 회복 — "
+             "**scorer artifact (답은 본문에 있음)**")
+    L.append(f"  2. **textual** ({kind_fail.get('textual',0)}건): 정규화 무관. expected_doc 오지정 / 동의어 / "
+             "OCR 누락 / 진짜 부재 등 별도 원인 — 추가 조사 필요")
+    L.append("- → 'verifier 30%' · chunk-level recall 수치는 (1) 만큼 **scorer 측정 오류로 부풀려진 실패**를 포함. "
+             "숫자 정규화 레이어 (gold derivation + groundedness scorer 양쪽) 가 선결 과제.")
+    L.append("")
+    L.append("## Sample recovered (substring-absent → normalized-present)\n")
+    for t, k in recovered_terms[:20]:
+        L.append(f"- `{t}` ({k})")
+    L.append("")
+    L.append("## Sample still-absent textual (정규화로 안 풀림)\n")
+    for t in still_absent_textual[:20]:
+        L.append(f"- `{t}`")
+    L.append("")
+    L.append("## Honesty / caveats\n")
+    L.append("- amount normalizer = Korean 억/만/천/백/십 + comma 파서. 텍스트의 amount-span 을 추출해 int 집합과 비교 (false-positive 회피 위해 stray char 시 포기).")
+    L.append("- date = (Y,M,D) 튜플 비교, 2000–2099 / 1–12 / 1–31 범위 가드.")
+    L.append("- other_numeric / textual 은 본 normalizer 범위 밖 — 'recovered' 0 으로 정직 보고.")
+    L.append("- 0 LLM call. 모든 수치 index 본문 실측.")
+
+    (out / "report.md").write_text("\n".join(L) + "\n")
+    (out / "raw.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2))
+    print(f"Wrote: {out}/report.md", file=sys.stderr)
+    print(f"failing={total_fail} recovered={total_rec} "
+          f"(amount {kind_recovered.get('amount',0)}/{kind_fail.get('amount',0)}, "
+          f"date {kind_recovered.get('date',0)}/{kind_fail.get('date',0)}), "
+          f"cases_all_numeric_recovered={manifest['cases_all_numeric_recovered']}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/component_eval/verifier_drift_check.py
+++ b/scripts/component_eval/verifier_drift_check.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Annotation-drift check for retrieval-miss cases (READ-ONLY, 0 LLM).
+
+The failure pivot found ~90% of single_doc failures = "gold chunk not retrieved".
+But gold_chunk_ids are fixed yaml annotations; a chunker rebuild can move the
+answer text to a different chunk number, faking a retrieval miss.
+
+Definitive automated test (no manual spot-check needed):
+  For each retrieval-miss case, fetch the gold chunk text FROM THE INDEX and
+  test contains_all_terms(gold_text, expected_terms):
+    - terms present  → annotation valid → GENUINE retrieval miss
+    - terms absent   → answer moved off the annotated chunk → ANNOTATION DRIFT
+    - gold cid not in index → annotation fully stale
+
+Reuses eval/scorers/_shared.py::contains_all_terms (same substring semantics the
+eval itself uses). No LLM calls.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from eval.scorers._shared import contains_all_terms  # noqa: E402
+
+
+def gold_retrieved(c: dict) -> bool:
+    gold = {str(g) for g in (c.get("gold_chunk_ids") or [])}
+    retr = {str(r) for r in (c.get("retrieved_chunk_ids") or [])}
+    return bool(gold & retr)
+
+
+def doc_matched(c: dict) -> bool:
+    exp = {str(d) for d in (c.get("expected_doc_ids") or [])}
+    ev = {str(d) for d in (c.get("evidence_doc_ids") or [])}
+    return bool(exp) and exp.issubset(ev)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True, help="eval_summary.json")
+    p.add_argument("--config", required=True, help="real_config.local.yaml (expected_terms)")
+    p.add_argument("--index", required=True, help="index.json (gold chunk text lookup)")
+    p.add_argument("--output", required=True)
+    p.add_argument("--query-type", default="single_doc")
+    args = p.parse_args()
+
+    es = json.loads(Path(args.input).read_text())
+    cfg = yaml.safe_load(Path(args.config).read_text())
+    yaml_terms = {c.get("id"): (c.get("expected_terms") or []) for c in (cfg.get("cases") or [])}
+    idx = json.loads(Path(args.index).read_text())
+    cid_to_text = {str(c["chunk_id"]): (c.get("text") or "") for c in idx.get("chunks") or []}
+
+    crs = es.get("case_results") or []
+    if args.query_type == "all":
+        cases = crs
+    else:
+        cases = [c for c in crs if c.get("query_type") == args.query_type]
+
+    # retrieval-miss cases: expected supported, status wrong, gold NOT retrieved
+    miss = [
+        c for c in cases
+        if c.get("expected_answer_status") == "supported"
+        and c.get("answer_status") != "supported"
+        and not gold_retrieved(c)
+    ]
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    verdict = Counter()
+    by_docmatch = defaultdict(Counter)
+    for c in miss:
+        cid = c.get("id")
+        gold_cids = [str(g) for g in (c.get("gold_chunk_ids") or [])]
+        terms = yaml_terms.get(cid) or []
+        in_index = [g for g in gold_cids if g in cid_to_text]
+        gold_text = " ".join(cid_to_text.get(g, "") for g in gold_cids)
+        dm = doc_matched(c)
+        dm_key = "right_doc" if dm else "wrong_doc"
+
+        if not gold_cids:
+            v = "no_gold_annotation"
+        elif not in_index:
+            v = "gold_cid_not_in_index"   # annotation fully stale
+        elif not terms:
+            v = "no_expected_terms"        # can't判定 via terms
+        elif contains_all_terms(gold_text, terms):
+            v = "annotation_valid"         # gold chunk really holds the answer → GENUINE retrieval miss
+        else:
+            v = "drift"                    # answer not on annotated chunk → ANNOTATION DRIFT
+        verdict[v] += 1
+        by_docmatch[dm_key][v] += 1
+        rows.append({
+            "id": cid, "verdict": v, "doc_matched": dm,
+            "n_gold": len(gold_cids), "n_gold_in_index": len(in_index),
+            "expected_terms": terms,
+            "gold_text_len": len(gold_text),
+        })
+
+    n = len(miss)
+    genuine = verdict.get("annotation_valid", 0)
+    drift = verdict.get("drift", 0)
+    stale = verdict.get("gold_cid_not_in_index", 0)
+    no_terms = verdict.get("no_expected_terms", 0)
+    judgable = genuine + drift  # cases where the terms-test gives a verdict
+
+    manifest = {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "input": args.input, "config": args.config, "index": args.index,
+        "query_type": args.query_type,
+        "n_retrieval_miss": n,
+        "verdict_counts": dict(verdict),
+        "genuine_miss": genuine,
+        "drift": drift,
+        "gold_cid_not_in_index": stale,
+        "no_expected_terms": no_terms,
+        "drift_fraction_of_judgable": round(drift / judgable, 4) if judgable else None,
+    }
+
+    L = []
+    L.append(f"# Annotation-drift check — retrieval-miss cases (query_type={args.query_type})\n")
+    L.append(f"- generated: {manifest['generated_at']}")
+    L.append(f"- input: `{args.input}`")
+    L.append(f"- index: `{args.index}`")
+    L.append(f"- retrieval-miss cases examined: **{n}**")
+    L.append("")
+    L.append("## Verdict (gold chunk text vs expected_terms)\n")
+    L.append("| verdict | n | meaning |")
+    L.append("|---------|---|---------|")
+    meanings = {
+        "annotation_valid": "gold chunk 에 답 있음 → **진짜 retrieval miss**",
+        "drift": "gold chunk 에 답 없음 → **annotation drift** (chunker rebuild artifact)",
+        "gold_cid_not_in_index": "gold chunk_id 가 index 에 아예 없음 → annotation 완전 stale",
+        "no_expected_terms": "yaml 에 expected_terms 없음 → terms-test 불가",
+        "no_gold_annotation": "gold_chunk_ids 없음",
+    }
+    for v in ("annotation_valid", "drift", "gold_cid_not_in_index", "no_expected_terms", "no_gold_annotation"):
+        if verdict.get(v):
+            L.append(f"| {v} | {verdict[v]} | {meanings[v]} |")
+    L.append("")
+    if judgable:
+        L.append(f"- **terms-test 판정 가능 {judgable}건 중 drift = {drift} ({manifest['drift_fraction_of_judgable']:.1%})**")
+        L.append(f"  - 진짜 retrieval miss: {genuine} ({genuine/judgable:.1%})")
+    L.append(f"- terms-test 불가 (no_expected_terms): {no_terms} / index-stale: {stale}")
+    L.append("")
+    L.append("## doc_matched 별 분해\n")
+    L.append("- right_doc = 정답 doc 가 evidence 에 있었으나 gold chunk 는 누락 (drift 유력 후보)")
+    L.append("- wrong_doc = 정답 doc 자체가 안 나옴 (genuine 검색 실패 유력)")
+    L.append("")
+    for dm_key in ("right_doc", "wrong_doc"):
+        d = by_docmatch.get(dm_key, {})
+        if d:
+            L.append(f"- **{dm_key}** (n={sum(d.values())}): {dict(d)}")
+    L.append("")
+    L.append("## 결론\n")
+    if judgable:
+        df = manifest["drift_fraction_of_judgable"]
+        if df is not None and df < 0.2:
+            L.append(f"- **drift 적음 ({df:.1%})** → 90% retrieval-miss 는 대체로 **진짜**. retrieval recall 이 진짜 병목 ★★★.")
+        elif df is not None and df > 0.5:
+            L.append(f"- **drift 많음 ({df:.1%})** → retrieval-miss 숫자가 chunker rebuild artifact 로 부풀려짐. eval_summary↔index 동기화부터 재검토 필요.")
+        else:
+            L.append(f"- **drift 중간 ({df:.1%})** → retrieval-miss 일부는 진짜, 일부는 artifact. 두 신호 분리해 보고.")
+    L.append("")
+    L.append("## Honesty / caveats\n")
+    L.append("- terms-test = `contains_all_terms` (substring AND, eval scorer 와 동일 함수). expected_terms 가 부분적이면 false drift 가능.")
+    L.append("- 'annotation_valid' = gold chunk 에 답이 있는데 retrieval 이 못 가져옴 = 진짜 검색 실패 (또는 ranking 이 top_k 밖).")
+    L.append("- 0 LLM call.")
+
+    (out / "report.md").write_text("\n".join(L) + "\n")
+    (out / "raw.json").write_text(json.dumps({"manifest": manifest, "rows": rows}, ensure_ascii=False, indent=2))
+    print(f"Wrote: {out}/report.md", file=sys.stderr)
+    print(f"n_miss={n}, genuine={genuine}, drift={drift}, stale={stale}, no_terms={no_terms}, "
+          f"drift_frac_judgable={manifest['drift_fraction_of_judgable']}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/component_eval/verifier_failure_pivot.py
+++ b/scripts/component_eval/verifier_failure_pivot.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Verifier failure-mode pivot — single_doc decomposition (READ-ONLY, 0 LLM).
+
+The headline "verifier accuracy 30.3% / single_doc 0.089" conflates two very
+different failure sources. This script separates them per case using fields
+already present in eval_summary case_results:
+
+  - gold_retrieved  = (gold_chunk_ids ∩ retrieved_chunk_ids) non-empty
+  - doc_matched     = expected_doc_ids ⊆ evidence_doc_ids
+  - answer_status vs expected_answer_status
+
+Failure taxonomy for expected=supported cases:
+  1. retrieval_miss_doc    — gold chunk NOT retrieved AND wrong doc      (retrieval fault)
+  2. retrieval_miss_chunk  — gold chunk NOT retrieved BUT right doc      (retrieval rank / re-chunk drift)
+  3. verifier_downgrade    — gold chunk retrieved, but status != supported (verifier fault candidate)
+  4. correct               — status == expected
+
+⚠️ Caveat: gold_chunk_ids are fixed yaml annotations. A chunker rebuild can
+move the answer text to a different chunk number, inflating retrieval_miss_*.
+We surface doc_matched separately so "right doc, wrong chunk" (drift-suspect)
+is distinguishable from "wrong doc" (genuine retrieval miss).
+
+No LLM calls.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+def gold_retrieved(c: dict) -> bool:
+    gold = {str(g) for g in (c.get("gold_chunk_ids") or [])}
+    retr = {str(r) for r in (c.get("retrieved_chunk_ids") or [])}
+    return bool(gold & retr)
+
+
+def doc_matched(c: dict) -> bool:
+    exp = {str(d) for d in (c.get("expected_doc_ids") or [])}
+    ev = {str(d) for d in (c.get("evidence_doc_ids") or [])}
+    return bool(exp) and exp.issubset(ev)
+
+
+def classify(c: dict) -> str:
+    actual = c.get("answer_status")
+    expected = c.get("expected_answer_status")
+    if actual == expected:
+        return "correct"
+    if expected == "supported":
+        if gold_retrieved(c):
+            return "verifier_downgrade"  # gold chunk present but not 'supported'
+        elif doc_matched(c):
+            return "retrieval_miss_chunk"  # right doc, gold chunk ranked out / drift
+        else:
+            return "retrieval_miss_doc"  # wrong doc entirely
+    if expected == "insufficient" and actual in ("supported", "partial"):
+        return "false_confident"
+    return f"other:{actual}->{expected}"
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", required=True, help="eval_summary.json")
+    p.add_argument("--output", required=True)
+    p.add_argument("--query-type", default="single_doc",
+                   help="focus query_type (default single_doc); 'all' for every type")
+    args = p.parse_args()
+
+    es = json.loads(Path(args.input).read_text())
+    crs = es.get("case_results") or []
+    if args.query_type == "all":
+        cases = crs
+    else:
+        cases = [c for c in crs if c.get("query_type") == args.query_type]
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # status confusion
+    confusion = defaultdict(lambda: defaultdict(int))
+    for c in cases:
+        confusion[c.get("answer_status")][c.get("expected_answer_status")] += 1
+
+    # classify each case
+    by_mode = defaultdict(list)
+    for c in cases:
+        by_mode[classify(c)].append(c)
+
+    n = len(cases)
+    correct = len(by_mode.get("correct", []))
+
+    # for verifier_downgrade — how many actually had correct answer (accuracy=1.0)?
+    downgrade = by_mode.get("verifier_downgrade", [])
+    downgrade_acc1 = sum(1 for c in downgrade if c.get("accuracy") == 1.0)
+    downgrade_status = Counter(c.get("answer_status") for c in downgrade)
+
+    # retrieval-miss cases: filter_stage + retry distribution
+    miss_doc = by_mode.get("retrieval_miss_doc", [])
+    miss_chunk = by_mode.get("retrieval_miss_chunk", [])
+    miss_all = miss_doc + miss_chunk
+    miss_status = Counter(c.get("answer_status") for c in miss_all)
+
+    def ids(cases_list, k=12):
+        out_ids = [str(c.get("id")) for c in cases_list[:k]]
+        if len(cases_list) > k:
+            out_ids.append(f"... +{len(cases_list)-k} more")
+        return out_ids
+
+    manifest = {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "input": args.input,
+        "query_type": args.query_type,
+        "n_cases": n,
+        "n_correct": correct,
+        "status_accuracy": round(correct / n, 4) if n else 0.0,
+        "mode_counts": {m: len(v) for m, v in sorted(by_mode.items())},
+        "retrieval_miss_total": len(miss_all),
+        "retrieval_miss_pct_of_failures": round(len(miss_all) / max(n - correct, 1), 4),
+        "verifier_downgrade_total": len(downgrade),
+        "verifier_downgrade_acc1": downgrade_acc1,
+    }
+
+    # ---- report ----
+    L = []
+    L.append(f"# Verifier failure-mode pivot — query_type={args.query_type} (READ-ONLY)\n")
+    L.append(f"- generated: {manifest['generated_at']}")
+    L.append(f"- input: `{args.input}`")
+    L.append(f"- n_cases: {n}, correct: {correct}, **status accuracy: {manifest['status_accuracy']:.3f}**")
+    L.append("")
+    L.append("## 1. Status confusion (actual verifier × expected yaml)\n")
+    statuses = ["insufficient", "partial", "supported"]
+    L.append("| actual\\expected | " + " | ".join(statuses) + " |")
+    L.append("|---|" + "---|" * len(statuses))
+    for a in statuses:
+        row = [str(confusion.get(a, {}).get(e, 0)) for e in statuses]
+        L.append(f"| **{a}** | " + " | ".join(row) + " |")
+    L.append("")
+    L.append("## 2. Failure-mode decomposition\n")
+    L.append("| mode | n | % of all | % of failures |")
+    L.append("|------|---|----------|---------------|")
+    fails = n - correct
+    for mode in ("correct", "verifier_downgrade", "retrieval_miss_chunk",
+                 "retrieval_miss_doc", "false_confident"):
+        cnt = len(by_mode.get(mode, []))
+        if cnt == 0 and mode not in ("correct",):
+            continue
+        pct_all = cnt / n if n else 0
+        pct_fail = cnt / fails if fails and mode != "correct" else 0
+        fail_str = f"{pct_fail:.1%}" if mode != "correct" else "—"
+        L.append(f"| {mode} | {cnt} | {pct_all:.1%} | {fail_str} |")
+    # any 'other:' modes
+    for mode, v in sorted(by_mode.items()):
+        if mode.startswith("other:"):
+            L.append(f"| {mode} | {len(v)} | {len(v)/n:.1%} | {len(v)/fails:.1%} |")
+    L.append("")
+    L.append(f"- **retrieval-miss total** (wrong doc + right-doc-wrong-chunk): "
+             f"{len(miss_all)} = **{manifest['retrieval_miss_pct_of_failures']:.1%} of failures**")
+    L.append(f"  - retrieval_miss_doc (wrong doc): {len(miss_doc)}")
+    L.append(f"  - retrieval_miss_chunk (right doc, gold chunk ranked out / re-chunk drift): {len(miss_chunk)}")
+    L.append(f"  - retrieval-miss status spread: {dict(miss_status)}")
+    L.append(f"- **verifier_downgrade** (gold retrieved but not 'supported'): {len(downgrade)}")
+    L.append(f"  - of which accuracy=1.0 (answer actually correct): {downgrade_acc1}")
+    L.append(f"  - their status spread: {dict(downgrade_status)}")
+    L.append("")
+    L.append("## 3. 결론 — single_doc 0.089 의 진짜 원인\n")
+    if len(miss_all) / max(fails, 1) >= 0.6:
+        L.append(f"- **retrieval recall 실패가 지배적** ({len(miss_all)}/{fails} = {len(miss_all)/fails:.0%} of failures).")
+        L.append("  gold chunk 가 애초에 retrieved 안 됨 → verifier 는 근거 없으니 partial/insufficient 정직 반환. **verifier 잘못 아님.**")
+        L.append(f"- verifier 자체 의심 (gold 있는데 downgrade) 은 {len(downgrade)} 건뿐, 그 중 정답 맞춘 건 {downgrade_acc1} 건.")
+    else:
+        L.append(f"- verifier_downgrade 가 {len(downgrade)} 건으로 무시 못 함 — substring AND-gate 영향 가능.")
+    L.append("")
+    L.append("## 4. ⚠️ Annotation-drift caveat\n")
+    L.append("- gold_chunk_ids 는 yaml 고정 annotation. chunker rebuild (2026-05-19) 가 답 텍스트를 다른 chunk 번호로 이동시켰을 수 있음.")
+    L.append(f"- `retrieval_miss_chunk` ({len(miss_chunk)} 건, right doc 인데 gold chunk 못 맞춤) 일부는 진짜 retrieval rank 문제가 아니라 **annotation drift** 일 수 있음.")
+    L.append(f"- `retrieval_miss_doc` ({len(miss_doc)} 건, 아예 다른 doc) 은 drift 아닌 genuine 검색 실패에 가까움.")
+    L.append("- 확정하려면 gold chunk 텍스트가 실제 답을 담는지 + retrieved doc 가 정답 doc 인지 수동 spot-check 필요 (별도 작업).")
+    L.append("")
+    L.append("## 5. Example case IDs\n")
+    L.append("### verifier_downgrade (gold retrieved, status != supported)")
+    for cid in ids(downgrade):
+        L.append(f"  - `{cid}`")
+    L.append("")
+    L.append("### retrieval_miss_chunk (right doc, gold chunk out — drift-suspect)")
+    for cid in ids(miss_chunk):
+        L.append(f"  - `{cid}`")
+    L.append("")
+    L.append("### retrieval_miss_doc (wrong doc)")
+    for cid in ids(miss_doc):
+        L.append(f"  - `{cid}`")
+    L.append("")
+    L.append("## 6. Honesty / caveats\n")
+    L.append("- 0 LLM call — eval_summary case_results 필드만 재분석.")
+    L.append("- expected_answer_status (yaml 수동 라벨) 를 ground truth 로 가정.")
+    L.append("- gold_retrieved/doc_matched 는 chunk_id / doc_id 집합 연산 — annotation 정확성에 의존.")
+    L.append("- single_doc 의 expected_answer_status 는 전부 'supported' (이 데이터셋), 그래서 false_confident 모드는 single_doc 에서 0.")
+
+    (out / "report.md").write_text("\n".join(L) + "\n")
+    (out / "raw.json").write_text(json.dumps({
+        "manifest": manifest,
+        "confusion": {a: dict(d) for a, d in confusion.items()},
+        "mode_case_ids": {m: [str(c.get("id")) for c in v] for m, v in by_mode.items()},
+    }, ensure_ascii=False, indent=2))
+    print(f"Wrote: {out}/report.md", file=sys.stderr)
+    print(f"Wrote: {out}/raw.json", file=sys.stderr)
+    print(f"status_accuracy={manifest['status_accuracy']:.3f}, "
+          f"retrieval_miss={manifest['retrieval_miss_pct_of_failures']:.1%} of failures, "
+          f"verifier_downgrade={len(downgrade)} (acc1={downgrade_acc1})", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Context-assembly 측정 중 retrieval/verifier 수치가 두 artifact (CSV-fallback ingestion #1129/#1133, hashing 임베딩 #1295) 로 오염됐음을 밝혀낸 **READ-ONLY 진단 도구 5개 (LLM 0)** 를 main 에 보존한다. 그동안 `eager-swartz-6eff63` 브랜치에만 살아있어 worktree cleanup 시 소실 위험이었다.

| script | 역할 | 발견 |
|---|---|---|
| `scorer_surface_form_diag.py` | substring-fail expected_terms 분류 (amount/date/numeric/textual) | "숫자 표면형 정규화하면 정답률 회복" 가설을 **1/402 회복으로 반증** |
| `gold_annotation_survey.py` | gold_chunk_id ↔ index 매칭율 전수조사 | CSV-fallback 으로 **86% silent skip** 표면화 |
| `verifier_failure_pivot.py` | single_doc 오분류 failure-mode pivot | verifier 30% 가 폴백 artifact 임을 분해 |
| `verifier_drift_check.py` | verifier 판정 drift 점검 | — |
| `citation_asymmetry_analysis.py` | phase2_bis 출력 재분석 (0 LLM) | first vs middle/last citation 비대칭 |

## Why

"내 가설을 코드로 falsify 하는 습관" 의 repo 물증. 일회성이지만 측정 도구도 측정 표면이고, 두 production 버그(#1133/#1295)의 진단 근거다.

## Scope 밖 (별도)

- LLM 호출 measurement harness (`context_assembly_phase1/2/2_bis.py`, `verifier_accuracy.py`) — 오염된 수치를 낸 측정기라 retrieval 재측정(별도 결정)과 함께 올린다.
- gitignored `reports/` — ADR 0005 경계: 도구만 commit, 데이터 아님.

## ADR

불필요 — reviewer-facing 계약(eval 슬라이스/리더보드 신호/self-review 축)이 아닌 ad-hoc 분석 도구.

## Test plan

- [x] `python3 -m py_compile scripts/component_eval/*.py` — 5/5 OK
- [x] 각 스크립트 `--help` 정상 (import 가 현재 main 의존성에 resolve)
- [x] READ-ONLY 확인: 모두 gitignored `reports/`·`data/index/` 입력만 읽고 파이프라인 surface 무변경

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. (No behavior change in retrieval / verifier / eval path.) 신규 파일 5개는 `scripts/component_eval/` 의 standalone 분석 스크립트로, import 외엔 어떤 production 모듈도 건드리지 않는다. (`scripts/component_eval/` 은 load-bearing 경로 아님.)

Closes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)