### PR TITLE
fix(githooks): bound aggregate cherry walks + isolate phase 4 stdin to stop push-blocking OOM

### DIFF
--- a/.githooks/_pre-push-worktree-hygiene.sh
+++ b/.githooks/_pre-push-worktree-hygiene.sh
@@ -73,6 +73,18 @@ fi
 # realistically-mergeable branches. Overridable for debugging.
 cherry_max="${BIDMATE_WORKTREE_HYGIENE_CHERRY_MAX:-100}"
 
+# Aggregate cap on how many (b) patch-id walks run in a SINGLE push, across all
+# worktrees. `cherry_max` bounds the cost of ONE walk, but with many stale
+# worktrees the per-walk cost still SUMS: N small walks, layered on git's own
+# pack memory during the push, was enough to get the hook OOM-killed (SIGKILL →
+# broken pipe → push aborts 141) at 37 accumulated worktrees (issue #1251) even
+# though every individual walk was within cherry_max. Once the budget is spent
+# the remaining branches fall back to the cheap signals (a)/(c)/(d) only — they
+# still get flagged by ancestor / gone-upstream / opt-in gh, just not by the
+# patch-id walk. Soft-warn semantics are unchanged. Overridable for debugging.
+cherry_budget="${BIDMATE_WORKTREE_HYGIENE_CHERRY_BUDGET:-20}"
+cherry_walks=0
+
 _is_merged() {
   # Returns 0 (merged/stale) if any signal fires; 1 otherwise. Cheap local
   # signals first; the opt-in network call only for branches still unflagged.
@@ -90,7 +102,8 @@ _is_merged() {
   # ref never flags a branch.
   local ahead
   ahead=$(git rev-list --count "$base_ref..$branch" 2>/dev/null || echo 0)
-  if [[ "$ahead" =~ ^[0-9]+$ && "$ahead" -le "$cherry_max" ]]; then
+  if [[ "$ahead" =~ ^[0-9]+$ && "$ahead" -le "$cherry_max" && "$cherry_walks" -lt "$cherry_budget" ]]; then
+    cherry_walks=$((cherry_walks + 1))
     local cherry
     if cherry=$(git cherry "$base_ref" "$branch" 2>/dev/null); then
       printf '%s\n' "$cherry" | grep -q '^+' || return 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -49,6 +49,12 @@ bash "$HOOK_DIR/_pre-push-real-eval-reminder.sh" || true
 bash "$HOOK_DIR/_pre-push-test-coverage.sh" || true
 
 # Phase 4: soft-warn orphan-worktree hygiene.
-bash "$HOOK_DIR/_pre-push-worktree-hygiene.sh" || true
+# Detach this phase from git's ref-list stdin (</dev/null): it never reads the
+# ref list, and detaching guarantees that an abnormal termination of this
+# soft-warn phase — e.g. an OOM SIGKILL under many-worktree memory pressure
+# (#1251) — cannot break git's pre-push stdin pipe and abort the push with
+# SIGPIPE (141). `|| true` swallows ordinary and signal exits alike; a
+# soft-warn phase must never block a push.
+bash "$HOOK_DIR/_pre-push-worktree-hygiene.sh" </dev/null || true
 
 exit 0

--- a/tests/test_hook_pre_push_worktree_hygiene.py
+++ b/tests/test_hook_pre_push_worktree_hygiene.py
@@ -1,4 +1,4 @@
-"""Regression: pre-push orphan-worktree hygiene (issue #1052, #1163, #1270).
+"""Regression: pre-push orphan-worktree hygiene (issue #1052, #1163, #1270, #1251).
 
 Pins the soft-warn contract (always exit 0; warning only on stderr) for
 `.githooks/_pre-push-worktree-hygiene.sh`:
@@ -12,6 +12,8 @@ Pins the soft-warn contract (always exit 0; warning only on stderr) for
   7. gh PR MERGED + opt-in env                  → exit 0, stderr names it
   8. gh PR MERGED but opt-in OFF (default)      → exit 0, stderr quiet
   9. cherry walk capped by divergence (#1270)   → exit 0, walk skipped past cap
+ 10. aggregate cherry budget (#1251)             → exit 0, ≤budget walks run
+ 11. default budget never bites a small repo     → exit 0, all small branches flagged
 
 Scenarios 5-8 are the #1163 fix: `git branch --merged` only lists ancestor
 tips, so squash-merges (this repo's default merge path) were a silent
@@ -63,11 +65,15 @@ class TestPrePushWorktreeHygiene(unittest.TestCase):
             check=False,
         )
 
-    def _add_worktree(self, name: str, branch: str, *, extra_commit: bool) -> Path:
+    def _add_worktree(
+        self, name: str, branch: str, *, extra_commit: bool, fname: str = "extra.txt"
+    ) -> Path:
         wt = Path(self._tmp) / name
         self._git("worktree", "add", "-b", branch, str(wt), "main")
         if extra_commit:
-            (wt / "extra.txt").write_text("e\n", encoding="utf-8")
+            # Per-branch filename so two squash-merged branches don't collide on
+            # the same path when both are merged into main (budget tests).
+            (wt / fname).write_text("e\n", encoding="utf-8")
             self._git("add", "-A", cwd=wt)
             self._git("commit", "-q", "-m", "ahead of main", cwd=wt)
         return wt
@@ -207,6 +213,38 @@ class TestPrePushWorktreeHygiene(unittest.TestCase):
         self.assertEqual(0, r.returncode, r.stderr)
         # Walk skipped → signal (b) never fires → branch not flagged.
         self.assertNotIn("feat-squash", r.stderr)
+
+    def test_cherry_budget_bounds_aggregate_walks(self) -> None:
+        # #1251: cherry_max bounds ONE walk, but with many stale worktrees the
+        # per-walk cost SUMS — N small walks plus git's pack memory during the
+        # push OOM-killed the hook (SIGKILL → broken pipe → push aborts 141) at
+        # 37 worktrees. An aggregate budget caps how many (b) patch-id walks run
+        # per push. Two squash-merged branches (only signal b can flag each —
+        # non-ancestor, no gone upstream, no gh) + budget=1 ⇒ at most one walk
+        # runs, so at most one is flagged, order-independent.
+        self._add_worktree("wt_sq1", "feat-sq1", extra_commit=True, fname="a.txt")
+        self._squash_merge("feat-sq1")
+        self._add_worktree("wt_sq2", "feat-sq2", extra_commit=True, fname="b.txt")
+        self._squash_merge("feat-sq2")
+        env = {**os.environ, "BIDMATE_WORKTREE_HYGIENE_CHERRY_BUDGET": "1"}
+        r = self._run_hook(env=env)
+        self.assertEqual(0, r.returncode, r.stderr)
+        flagged = r.stderr.count("git worktree remove")
+        self.assertLessEqual(
+            flagged, 1, f"budget=1 must permit at most one walk: {r.stderr}"
+        )
+
+    def test_cherry_budget_default_flags_all_small_branches(self) -> None:
+        # Sanity: the default budget never bites in a normal small repo — both
+        # squash-merged branches are still flagged by the (b) walk.
+        self._add_worktree("wt_sq1", "feat-sq1", extra_commit=True, fname="a.txt")
+        self._squash_merge("feat-sq1")
+        self._add_worktree("wt_sq2", "feat-sq2", extra_commit=True, fname="b.txt")
+        self._squash_merge("feat-sq2")
+        r = self._run_hook()
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("feat-sq1", r.stderr)
+        self.assertIn("feat-sq2", r.stderr)
 
     def test_gh_signal_is_off_by_default(self) -> None:
         # Same setup, fake gh on PATH reports MERGED — but without the opt-in


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

worktree-hygiene pre-push 서브훅(phase 4, soft-warn)이 worktree 37개 누적 환경에서 push 중 **OOM(SIGKILL)** 으로 죽고, 깨진 stdin 파이프가 push 를 SIGPIPE(141)로 abort 시켜 `--no-verify` 우회를 강제하는 회귀를 수정. `cherry_max`(#1273)는 **단일** `git cherry` walk 비용만 제한하지만, walk 비용이 worktree 수만큼 **합산**되고 push 시점 git pack 메모리와 겹쳐 jetsam 이 훅을 SIGKILL 했다. soft-warn 게이트가 hard-fail 로 둔갑하던 구조를 두 축으로 차단: (a) push 1회당 전체 walk 횟수 상한(aggregate budget), (b) phase 4 를 git ref-list stdin 에서 분리해 비정상 종료가 push 파이프를 못 깨게 함.

Closes #1251

## 2. 영향 파일

- `.githooks/_pre-push-worktree-hygiene.sh` — aggregate cherry-walk budget (`BIDMATE_WORKTREE_HYGIENE_CHERRY_BUDGET`, 기본 20). 소진 후 나머지 브랜치는 cheap signal (a)/(c)/(d) 만 사용.
- `.githooks/pre-push` — phase 4 호출에 `</dev/null` (git ref-list stdin 분리).
- `tests/test_hook_pre_push_worktree_hygiene.py` — 회귀 2건 + per-branch filename 파라미터.

load-bearing 파일 없음 (`scripts/_governance.py` `LOAD_BEARING_PATHS` 미포함 — 3개 모두 `--is-load-bearing` exit 1 확인).

## 3. 리스크

- **가장 가능성 높은 깨짐**: budget 이 너무 낮으면 squash-merged 브랜치(오직 signal (b)로만 flagged)가 warn 누락. 완화: 기본 20 은 정상 소규모 repo 에서 절대 안 물림(테스트 `..._default_flags_all_small_branches`); 누락돼도 soft-warn 정보성 경고일 뿐이고 ancestor/gone-upstream/opt-in gh signal 은 budget 무관하게 계속 동작.
- soft-warn 계약(항상 exit 0) 불변 — 기존 9개 + 신규 2개 회귀 테스트가 고정.
- **dogfood 검증**: 이 PR 의 push 자체가 37-worktree 환경에서 수정된 phase 4 를 실행 — soft-warn 출력 후 exit 0, OOM 없이 push 정상 완료(재현 환경에서 직접 검증).

## 4. 테스트

회귀 2건 추가 (`tests/test_hook_pre_push_worktree_hygiene.py`):
- `test_cherry_budget_bounds_aggregate_walks` — squash-merged 2개 + budget=1 ⇒ walk ≤1, flagged ≤1 (order-independent). 수정 전엔 budget 개념 부재로 2개 모두 walk.
- `test_cherry_budget_default_flags_all_small_branches` — 기본 budget 에선 소규모 2개 모두 flagged (budget 이 정상 repo 를 안 무는지 sanity).

해당 파일 단독 실행 11 passed (기존 9 + 신규 2).

**Local gate (real-model fallback)**: 이 worktree 는 FlagEmbedding 설치 + `slow` 마커 존재 → full `bash scripts/test.sh` 가 real M3 모델 로드로 비현실적(skill step 6 fallback 조건). `ruff check .` 통과. `make test-fast` 는 이 메모리 압박 환경(37 worktree — 본 이슈의 그 조건)에서 xdist worker 가 collection 중 OOM 크래시(`KeyError: WorkerController`, "no tests ran")하여 로컬 full 커버리지 검증 불가. **머지는 CI green 하드 게이트** — 변경이 shell 훅 + 단일 테스트 파일에 격리돼 python 런타임 무영향.

## 5. Eval 영향

All `·` — githooks 전용 변경, RAG 파이프라인/eval surface 무관.

### 5b. Real-data delta

> **Reviewer 책임 (issue #1027):** §5b CI gate 는 섹션·표·escape 문장의 *존재* 만 강제한다. CI 통과 ≠ §5b 내용 검증 완료.

N/A — load-bearing path 미변경 (`.githooks/` 는 `LOAD_BEARING_PATHS` 밖). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

호환 유지. 신규 env var `BIDMATE_WORKTREE_HYGIENE_CHERRY_BUDGET` 는 opt-in override(기본 20), 기존 `BIDMATE_WORKTREE_HYGIENE_CHERRY_MAX` 와 직교. soft-warn 계약(exit 0)·기존 signal 의미 불변.

## 7. 범위 외

- 누적된 stale worktree 실제 정리(훅이 경고만, 자동 제거 안 함 — 설계 의도).
- xdist worker OOM 으로 인한 `make test-fast` 로컬 크래시는 별개의 테스트 인프라 이슈(본 PR 의 hook 수정과 무관, 동일 메모리 압박 근원이긴 함).