### PR TITLE
fix(ship): thread worktree-unique test-summary path into PR body builder

### DIFF
--- a/.claude/skills/self-review-quarterly/SKILL.md
+++ b/.claude/skills/self-review-quarterly/SKILL.md
@@ -28,11 +28,11 @@ Given a quarter (`Qx-YYYY`), produce a structured Markdown report with **two rub
    - 5-axis: `~/.claude/projects/-Users-hskim-Desktop-projects-BidMate-DocAgent/memory/feedback_collaboration_axes.md`
    - If either is missing or its referenced docs (e.g. `docs/senior-positioning.md`) are gone, stop and surface the broken pointer.
 
-3. **Collect raw stats.** Invoke the driver via Bash:
+3. **Collect raw stats.** Invoke the driver via Bash, writing to a worktree-unique temp file (never a fixed `/tmp/<name>` — concurrent worktrees would clobber it, issue #1274):
    ```bash
-   python scripts/claude-hooks/_self_review.py --quarter <Qx-YYYY> --emit-stats > /tmp/self-review-<Qx-YYYY>-stats.json
+   STATS=$(mktemp); python scripts/claude-hooks/_self_review.py --quarter <Qx-YYYY> --emit-stats > "$STATS"
    ```
-   Read `/tmp/.../stats.json` into the skill context. The driver guarantees body-free output by schema; trust it but spot-check (see step 8).
+   Read `$STATS` into the skill context. The driver guarantees body-free output by schema; trust it but spot-check (see step 8).
 
 4. **4-axis verdict table.** For each of the 4 portfolio axes, judge `✓` / `△ — <≤30자 사유>` / `✗ — <≤30자 사유>` using the rubric's signals + the stats. Cite metadata only (see "Citation policy" below).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 - 리뷰 중 무관한 커밋 추가 — follow-up PR 분리
 - `gh pr merge --delete-branch` 사용. 멀티 worktree 에서 gh 의 로컬 checkout-to-default 단계가 `main` 충돌로 실패해 원격 삭제 전에 명령을 abort 한다 (서버 머지는 성공, 원격 브랜치 잔존 — issue #1283). 머지는 `gh pr merge <N> --squash --admin`, 원격 브랜치 삭제는 별도 `git push origin --delete <branch>` (순수 원격, worktree-safe)
 - `git push origin --delete <branch>` (또는 `gh pr merge --delete-branch`) 를 `gh pr list --base <branch> --state open --json number` 확인 없이 실행. 결과가 비어있지 않으면 stacked dependent 존재 → 원격 삭제 생략하거나 child 를 main 위로 rebase 먼저. (후속 PreToolUse Bash 가드 훅이 두 형태 모두 자동 차단하지만, 훅 비활성화 시도 살아남도록 규칙 명시)
+- 명령 출력을 `/tmp/<고정이름>` 같은 **전역 고정경로**에 redirect (예: `git push > /tmp/push.txt 2>&1`). 상시 20~30 worktree 동시 가동 → 다른 worktree 세션과 같은 파일 공유, 자기 출력 대신 남의 출력을 읽어 false success signal (실측: #1257 작업 중 `/tmp/push3.txt` 가 다른 worktree 의 push 출력 — issue #1274). 임시 파일은 **`mktemp`** (고유 경로) 사용. 그리고 push/머지 성공 판정은 파일 내용이 아니라 `git ls-remote --heads origin <branch>` 등 **원격 상태 직접 조회**로 검증
 
 ## Non-goals (명시 요청 없을 시)
 

--- a/scripts/claude-hooks/_ship_pr_body.py
+++ b/scripts/claude-hooks/_ship_pr_body.py
@@ -172,8 +172,13 @@ def has_schema_version_change(base_ref: str) -> bool:
     )
 
 
-def test_summary() -> str:
-    summary_path = "/tmp/ship-test-summary.txt"
+def test_summary(summary_path: str | None) -> str:
+    # The dispatcher (stop-ship.sh) writes the local test output to a
+    # worktree-unique mktemp file (#571) and passes the path here. A fixed
+    # global path would let a concurrent worktree's stale file leak in as a
+    # false success signal (issue #1274).
+    if not summary_path:
+        return "Local test run not captured by dispatcher."
     if not os.path.exists(summary_path):
         return "Local test run not captured by dispatcher."
     try:
@@ -188,6 +193,7 @@ def build_body(
     base_ref: str,
     real_eval_mode: str,
     extra_body: str = "",
+    test_summary_path: str | None = None,
 ) -> str:
     issue_n = parse_branch(branch)
     files = changed_files(base_ref)
@@ -207,7 +213,7 @@ def build_body(
         else "Auto-generated PR; no load-bearing paths changed."
     )
 
-    test_block = test_summary()
+    test_block = test_summary(test_summary_path)
 
     eval_line = (
         "See §5b (load-bearing change touched)."
@@ -307,6 +313,11 @@ def main() -> int:
         choices=["auto", "skip", "async"],
     )
     p.add_argument("--extra-body", default="")
+    p.add_argument(
+        "--test-summary-path", metavar="PATH", default=None,
+        help="Path the dispatcher wrote local test output to (worktree-unique "
+             "mktemp, #1274). Omit for a 'not captured' note.",
+    )
     # Standalone §5b validation of an externally-provided body (issue #1097).
     # Mutually exclusive with the --branch body-generation mode below.
     p.add_argument(
@@ -339,7 +350,8 @@ def main() -> int:
 
     try:
         body = build_body(
-            args.branch, args.base_ref, args.real_eval_mode, args.extra_body
+            args.branch, args.base_ref, args.real_eval_mode, args.extra_body,
+            args.test_summary_path,
         )
     except ValueError:
         _log(f"branch '{args.branch}' violates ADR 0007 — cannot generate body.")

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -334,7 +334,8 @@ stage_3_pr() {
   if ! python3 scripts/claude-hooks/_ship_pr_body.py \
         --branch "$ARM_BRANCH" \
         --base-ref origin/main \
-        --real-eval-mode "$ARM_REAL_EVAL_MODE" > "$body_file"; then
+        --real-eval-mode "$ARM_REAL_EVAL_MODE" \
+        --test-summary-path "$TEST_SUMMARY_PATH" > "$body_file"; then
     abort_disarm "s3" "PR body generator failed (likely §5b validation)"
   fi
 

--- a/scripts/validate_claim.py
+++ b/scripts/validate_claim.py
@@ -28,7 +28,7 @@ escaped per ADR 0055 §Consequences.
 CLI:
 
     python3 scripts/validate_claim.py \\
-        --pr-body /tmp/pr-body.txt \\
+        --pr-body "$(mktemp)" \\
         --baseline base/reports/eval_summary.json \\
         --candidate pr/reports/eval_summary.json \\
         --min-sample 200 [--alpha 0.05]

--- a/tests/test_ship_pr_body.py
+++ b/tests/test_ship_pr_body.py
@@ -152,7 +152,7 @@ def test_build_body_includes_required_sections(monkeypatch):
     monkeypatch.setattr(pb, "commit_subject", lambda base: "docs: tweak readme (#999)")
     monkeypatch.setattr(pb, "commit_body", lambda base: "Tweak README.")
     monkeypatch.setattr(pb, "has_schema_version_change", lambda base: False)
-    monkeypatch.setattr(pb, "test_summary", lambda: "Local tests passed.")
+    monkeypatch.setattr(pb, "test_summary", lambda path=None: "Local tests passed.")
     body = pb.build_body("docs/issue-999-readme", "origin/main", "auto")
     for section in (
         "## 1. What changed and why",
@@ -173,9 +173,28 @@ def test_build_body_load_bearing_routes_through_5b(monkeypatch):
     monkeypatch.setattr(pb, "commit_subject", lambda base: "feat: foo (#238)")
     monkeypatch.setattr(pb, "commit_body", lambda base: "")
     monkeypatch.setattr(pb, "has_schema_version_change", lambda base: False)
-    monkeypatch.setattr(pb, "test_summary", lambda: "Local tests passed.")
+    monkeypatch.setattr(pb, "test_summary", lambda path=None: "Local tests passed.")
     monkeypatch.setattr(pb, "can_run_real_eval", lambda: False)
     body = pb.build_body("feat/issue-238-foo", "origin/main", "auto")
     assert "(load-bearing)" in body
     assert "See §5b" in body or "5b" in body
     assert pb.validate_5b(body, ["rag_core.py"]) is True
+
+
+# ---- test_summary path threading (issue #1274) ----
+
+def test_test_summary_reads_dispatcher_path(tmp_path):
+    p = tmp_path / "summary.txt"
+    p.write_text("Local tests passed (bash scripts/test.sh).")
+    assert pb.test_summary(str(p)) == "Local tests passed (bash scripts/test.sh)."
+
+
+def test_test_summary_none_path_not_captured():
+    # No path = dispatcher did not pass one; never falls back to a global
+    # /tmp file that a concurrent worktree could have left behind (#1274).
+    assert pb.test_summary(None) == "Local test run not captured by dispatcher."
+
+
+def test_test_summary_missing_path_not_captured(tmp_path):
+    missing = tmp_path / "does-not-exist.txt"
+    assert pb.test_summary(str(missing)) == "Local test run not captured by dispatcher."


### PR DESCRIPTION
## 1. What changed and why

`stop-ship.sh` switched `TEST_SUMMARY_PATH` to a worktree-unique `mktemp` file in #571 (2026-05-13) to fix concurrent-worktree collision, but `_ship_pr_body.py` was never updated — its `test_summary()` still read a hardcoded global `/tmp/ship-test-summary.txt` (from the original #381). Two consequences:

- **Broken contract:** the body builder never saw the dispatcher's actual test output → always rendered "Local test run not captured by dispatcher."
- **Collision / false signal:** in this repo's 20–30 concurrent-worktree environment, a stale fixed `/tmp/ship-test-summary.txt` left by any worktree could be read as *this* PR's test result (the #1274 false-success class, same as the measured `/tmp/push3.txt` cross-worktree leak).

Fix: thread the mktemp path through `--test-summary-path` → `build_body` → `test_summary(path)`; remove the hardcoded global path entirely. No path = explicit "not captured" note (never falls back to a global file).

Also swept guidance/example fixed paths to `mktemp` and documented the rule.

Closes #1274

## 2. Files affected

- `scripts/claude-hooks/_ship_pr_body.py` — `test_summary(path)` signature + `--test-summary-path` CLI arg, threaded via `build_body`
- `scripts/claude-hooks/stop-ship.sh` — pass `--test-summary-path "$TEST_SUMMARY_PATH"` to the body generator
- `tests/test_ship_pr_body.py` — 3 regression tests (reads path / None / missing-path), existing monkeypatch signatures updated
- `CLAUDE.md` — `## 금지` rule: no global `/tmp/<fixed>` redirect, use `mktemp` + verify push/merge via direct remote query
- `.claude/skills/self-review-quarterly/SKILL.md`, `scripts/validate_claim.py` — example/guidance fixed paths → `mktemp`

No load-bearing path changed (`scripts/_governance.py --is-load-bearing` = false for all three scripts).

## 3. Risks

Low. Confined to the auto-ship Stop-hook PR-body generator; behavior on the body-generation path improves (now reads real test output) and is covered by new tests. `--test-summary-path` defaults to None, preserving prior "not captured" output for any caller that omits it.

## 4. Tests

`tests/test_ship_pr_body.py` + `tests/test_ship_dispatcher_gates.py` — **30 passed** (serial, `EMBEDDING_BACKEND=hashing`). `ruff check` clean.

Local gate: full `make test-fast` is structurally impractical in this worktree (FlagEmbedding installed → real-model load during collection caused an xdist scheduler crash, then OOM). Per the ship-pr real-model fallback, the changed-file tests were run directly and **this PR's merge is hard-gated on CI green** (CI has no FlagEmbedding; `slow` real-model tests auto-skip there).

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier / answer path).

### 5b. Real-data delta

N/A — no load-bearing path changed; this is an automation-hook fix.

## 6. Backward compatibility

No public-API change. Answer contract (ADR 0003) untouched; no `schema_version` bump. `build_body` gained an optional trailing param with a default, so existing callers are unaffected.

## 7. Out of scope

`.claude/settings.local.json` `/tmp/*` entries are a gitignored local permission allowlist (not an output-redirect collision pattern) — intentionally left as-is.