### PR TITLE
fix(eval): anonymize nested retry_reason_counts in aggregate slices (#1286)

### DIFF
--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -122,23 +122,15 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         # The extractor below explicitly whitelists each scalar + the
         # CI sub-block; case-level fields are dropped.
         "ablation_full",
-        # Issue #650 / ADR 0039: per-format accuracy breakdown keyed by
-        # document source_format (hwp / pdf / synthetic_public_sample).
-        # Bucket keys are whitelisted in SAFE_FORMAT_BUCKET_KEYS (fail-closed);
-        # metric sub-keys mirror SAFE_ABLATION_FULL_SCALAR_KEYS; no per-case
-        # payload crosses the boundary.
-        "by_format",
-        # Issue #845 / ADR 0039: per-hardcase-category accuracy breakdown,
-        # populated by run_eval.py:677-685 when cases carry the
-        # ``hardcase_categories`` field. Bucket keys are whitelisted in
-        # SAFE_HARDCASE_CATEGORY_BUCKET_KEYS (fail-closed) so the public
-        # taxonomy can never be silently widened on the committable surface.
-        "by_hardcase_category",
-        # Issue #870 / ADR 0048: per-metadata-field accuracy breakdown for
-        # the four single-doc fields (agency / project / budget / deadline).
-        # Bucket keys are whitelisted in SAFE_METADATA_FIELD_BUCKET_KEYS so
-        # the enum can never be silently widened on the committable surface.
-        "by_metadata_field",
+        # NOTE: by_format / by_hardcase_category / by_metadata_field are NOT
+        # listed here — like by_query_type, they are handled exclusively by
+        # their dedicated fail-closed extractors below (search "by_format
+        # aggregate"). Listing them here would route them through the main
+        # loop's `else: out[key] = value` raw passthrough, which survives
+        # whenever a slice carries no whitelisted bucket — leaking nested
+        # private payloads (#1286). The dedicated extractors only ever emit
+        # whitelisted buckets + whitelisted metrics, so dropping them from the
+        # top-level passthrough is the fix.
         # Issue #870 / ADR 0048: 10-bin ECE + Brier score over
         # (confidence, correctness) pairs. Numeric scalars only; the
         # extractor whitelists ece / brier / n / num_bins. Block is null
@@ -264,7 +256,11 @@ SAFE_RETRY_EFFECTIVENESS_CI_KEYS = ("recovery_rate", "residual_failure_rate")
 # canonical config identifier.
 SAFE_RUN_MANIFEST_KEYS = ("git_commit", "git_dirty", "config_sha256", "generated_at")
 
-# Per-slice subkeys extracted from `by_query_type`.
+# Per-slice subkeys extracted from `by_query_type` / `by_format` /
+# `by_hardcase_category` / `by_metadata_field`. ``abstention_outcomes`` and
+# ``retry_reason_counts`` are dicts that need their own anonymization in the
+# slice loops below (the latter via :func:`_collapse_retry_reason_counts`,
+# #1286); every other entry is a scalar copied verbatim.
 SAFE_SLICE_METRICS = (
     "num_predictions",
     "accuracy",
@@ -272,6 +268,7 @@ SAFE_SLICE_METRICS = (
     "abstention",
     "abstention_outcomes",
     "answer_format_compliance",
+    "retry_reason_counts",
 )
 
 # Keys that must never be read or written by this script. The
@@ -372,6 +369,25 @@ def _extract_ablation_full(run_summary: dict[str, Any]) -> dict[str, Any] | None
     return out or None
 
 
+def _collapse_retry_reason_counts(value: dict[str, Any]) -> dict[str, int]:
+    """Strip the private payload after the first ``:`` from retry-reason keys.
+
+    Reason keys are MOSTLY taxonomy codes (``topic_not_grounded``), but
+    comparison reasons embed private payloads after a colon — e.g.
+    ``missing_comparison_entity:<agency>`` (Korean agency names) or
+    ``missing_comparison_doc:<공고번호>`` (real doc ids). Persisting them
+    verbatim leaked private real-eval metadata (#1204). Keep only the enum
+    prefix before the first ``:`` and sum the counts of any keys that collapse
+    together. The taxonomy totals are preserved; only the identifying payload
+    is dropped. Shared by the top-level and per-slice extractors (#1286).
+    """
+    collapsed: dict[str, int] = {}
+    for k, v in value.items():
+        prefix = str(k).split(":", 1)[0]
+        collapsed[prefix] = collapsed.get(prefix, 0) + int(v)
+    return collapsed
+
+
 def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
     """Return a dict containing only ADR-0005-safe aggregate fields.
 
@@ -402,19 +418,7 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                 if isinstance(v, dict)
             }
         elif key == "retry_reason_counts" and isinstance(value, dict):
-            # Reason keys are MOSTLY taxonomy codes ("topic_not_grounded"),
-            # but comparison reasons embed private payloads after a colon —
-            # e.g. ``missing_comparison_entity:<agency>`` (Korean agency
-            # names) or ``missing_comparison_doc:<공고번호>`` (real doc ids).
-            # Persisting them verbatim leaked private real-eval metadata
-            # (#1204). Keep only the enum prefix before the first ``:`` and
-            # sum the counts of any keys that collapse together. The taxonomy
-            # totals are preserved; only the identifying payload is dropped.
-            collapsed: dict[str, int] = {}
-            for k, v in value.items():
-                prefix = str(k).split(":", 1)[0]
-                collapsed[prefix] = collapsed.get(prefix, 0) + int(v)
-            out[key] = collapsed
+            out[key] = _collapse_retry_reason_counts(value)
         elif key == "retry_effectiveness" and isinstance(value, dict):
             extracted: dict[str, Any] = {
                 sub: value.get(sub)
@@ -555,6 +559,8 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                     }
                     if bin_out:
                         extracted_slice[m] = bin_out
+                elif m == "retry_reason_counts" and isinstance(raw, dict):
+                    extracted_slice[m] = _collapse_retry_reason_counts(raw)
                 else:
                     extracted_slice[m] = raw
             slice_out[str(slice_name)] = extracted_slice
@@ -584,6 +590,8 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                     }
                     if bin_out:
                         extracted_bucket[m] = bin_out
+                elif m == "retry_reason_counts" and isinstance(raw, dict):
+                    extracted_bucket[m] = _collapse_retry_reason_counts(raw)
                 else:
                     extracted_bucket[m] = raw
             if extracted_bucket:
@@ -616,6 +624,8 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                     }
                     if bin_out:
                         extracted_bucket[m] = bin_out
+                elif m == "retry_reason_counts" and isinstance(raw, dict):
+                    extracted_bucket[m] = _collapse_retry_reason_counts(raw)
                 else:
                     extracted_bucket[m] = raw
             if extracted_bucket:
@@ -648,6 +658,8 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                     }
                     if bin_out:
                         extracted_bucket[m] = bin_out
+                elif m == "retry_reason_counts" and isinstance(raw, dict):
+                    extracted_bucket[m] = _collapse_retry_reason_counts(raw)
                 else:
                     extracted_bucket[m] = raw
             if extracted_bucket:

--- a/tests/test_eval_slice_retry_reason_privacy_regression.py
+++ b/tests/test_eval_slice_retry_reason_privacy_regression.py
@@ -1,0 +1,163 @@
+"""Regression guard for nested retry_reason_counts anonymization (issue #1286).
+
+#1211 (closes #1204) stripped the private payload after the first ``:`` from
+the **top-level** ``retry_reason_counts`` (``missing_comparison_entity:<agency>``
+/ ``missing_comparison_doc:<공고번호>``), but the per-slice copies inside
+``by_format`` / ``by_hardcase_category`` / ``by_metadata_field`` /
+``by_query_type`` were left unanonymized. Two compounding bugs leaked them:
+
+1. ``by_format`` / ``by_hardcase_category`` / ``by_metadata_field`` were listed
+   in ``SAFE_TOPLEVEL_KEYS``, so the main loop raw-passed the whole slice
+   (``else: out[key] = value``). The dedicated fail-closed extractors only
+   *overwrite* that passthrough when they find ≥1 whitelisted bucket — so a
+   slice carrying only private bucket names (``multi_hop`` etc.) kept its raw
+   nested ``retry_reason_counts`` with Korean agency names.
+2. ``retry_reason_counts`` was absent from ``SAFE_SLICE_METRICS``, so even a
+   whitelisted bucket dropped the (useful) retry-reason taxonomy entirely.
+
+The fix removes the three keys from ``SAFE_TOPLEVEL_KEYS`` (so only the
+fail-closed extractors emit them) and adds ``retry_reason_counts`` to
+``SAFE_SLICE_METRICS`` with the same ``:``-split collapse the top level uses,
+via the shared :func:`_collapse_retry_reason_counts` helper.
+"""
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from typing import Any
+
+from scripts.run_real_eval_delta import (
+    SAFE_SLICE_METRICS,
+    SAFE_TOPLEVEL_KEYS,
+    _collapse_retry_reason_counts,
+    extract_aggregate,
+)
+
+# A private agency name + a 공고번호-style doc id, used as colon payloads.
+_AGENCY = "한국전자통신연구원"
+_DOC_ID = "20240419765-0.0"
+
+
+def _all_strings(obj: Any) -> list[str]:
+    """Every dict key and string value reachable in ``obj``."""
+    out: list[str] = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            out.append(str(k))
+            out.extend(_all_strings(v))
+    elif isinstance(obj, list):
+        for item in obj:
+            out.extend(_all_strings(item))
+    elif isinstance(obj, str):
+        out.append(obj)
+    return out
+
+
+class TestCollapseHelper(unittest.TestCase):
+    def test_strips_colon_payload_and_sums_collisions(self) -> None:
+        collapsed = _collapse_retry_reason_counts(
+            {
+                "topic_not_grounded": 3,
+                f"missing_comparison_entity:{_AGENCY}": 1,
+                "missing_comparison_entity:서울시청": 2,
+                f"missing_comparison_doc:{_DOC_ID}": 4,
+            }
+        )
+        # Colliding enum prefixes are summed; payload dropped.
+        self.assertEqual(
+            collapsed,
+            {
+                "topic_not_grounded": 3,
+                "missing_comparison_entity": 3,
+                "missing_comparison_doc": 4,
+            },
+        )
+
+
+class TestSliceRetryReasonAnonymization(unittest.TestCase):
+    def _summary(self, **slices: Any) -> dict[str, Any]:
+        base: dict[str, Any] = {"num_predictions": 3, "accuracy": 1.0}
+        base.update(slices)
+        return base
+
+    def test_top_level_keys_no_longer_route_slices_through_passthrough(self) -> None:
+        # The structural fix: these three are handled exclusively by their
+        # dedicated fail-closed extractors, never the main-loop passthrough.
+        for key in ("by_format", "by_hardcase_category", "by_metadata_field"):
+            self.assertNotIn(key, SAFE_TOPLEVEL_KEYS)
+        self.assertIn("retry_reason_counts", SAFE_SLICE_METRICS)
+
+    def test_whitelisted_bucket_keeps_anonymized_retry_reasons(self) -> None:
+        summary = self._summary(
+            by_format={
+                "hwp": {
+                    "num_predictions": 2,
+                    "accuracy": 1.0,
+                    "retry_reason_counts": {
+                        "topic_not_grounded": 3,
+                        f"missing_comparison_entity:{_AGENCY}": 1,
+                    },
+                }
+            }
+        )
+        out = extract_aggregate(summary)
+        rrc = out["by_format"]["hwp"]["retry_reason_counts"]
+        # Taxonomy total preserved; identifying payload gone.
+        self.assertEqual(rrc, {"topic_not_grounded": 3, "missing_comparison_entity": 1})
+
+    def test_non_whitelisted_bucket_dropped_not_passed_through(self) -> None:
+        # The documented #1286 leak: a slice with ONLY private bucket names
+        # used to survive the raw passthrough with nested Korean payloads.
+        summary = self._summary(
+            by_hardcase_category={
+                "multi_hop": {
+                    "num_predictions": 1,
+                    "accuracy": 0.0,
+                    "retry_reason_counts": {f"missing_comparison_entity:{_AGENCY}": 1},
+                }
+            }
+        )
+        out = extract_aggregate(summary)
+        # No whitelisted bucket -> the key is absent entirely (fail-closed).
+        self.assertNotIn("by_hardcase_category", out)
+
+    def test_by_query_type_slice_anonymized(self) -> None:
+        summary = self._summary(
+            by_query_type={
+                "comparison": {
+                    "num_predictions": 4,
+                    "accuracy": 0.75,
+                    "retry_reason_counts": {f"missing_comparison_doc:{_DOC_ID}": 2},
+                }
+            }
+        )
+        out = extract_aggregate(summary)
+        rrc = out["by_query_type"]["comparison"]["retry_reason_counts"]
+        self.assertEqual(rrc, {"missing_comparison_doc": 2})
+
+    def test_no_hangul_or_colon_keys_anywhere(self) -> None:
+        # End-to-end: feed every slice a colon+Hangul payload and assert the
+        # committable aggregate carries neither signature (mirrors the
+        # structural gate in test_eval_artifact_privacy_regression.py).
+        leaky = {
+            "num_predictions": 1,
+            "accuracy": 1.0,
+            "retry_reason_counts": {f"missing_comparison_entity:{_AGENCY}": 1},
+        }
+        summary = self._summary(
+            by_format={"hwp": dict(leaky), "private_pdf_csv_text": dict(leaky)},
+            by_hardcase_category={"table_heavy": dict(leaky), "multi_hop": dict(leaky)},
+            by_metadata_field={"agency": dict(leaky), "발주처": dict(leaky)},
+            by_query_type={"comparison": dict(leaky)},
+        )
+        out = extract_aggregate(summary)
+        serialized = json.dumps(out, ensure_ascii=False)
+        self.assertEqual(re.findall(r"[가-힣]", serialized), [])
+        # No dict key may contain a colon.
+        for s in _all_strings(out):
+            self.assertNotIn(":", s)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/run_real_eval_delta.py` `extract_aggregate` 의 ADR 0005 경계가 **부분만** 닫혀 있었음. #1211 (closes #1204) 이 **top-level** `retry_reason_counts` 의 `:` 뒤 비공개 payload(`missing_comparison_entity:<발주기관>` / `missing_comparison_doc:<공고번호>`)를 enum prefix 로 strip 했으나, 슬라이스(`by_format`/`by_hardcase_category`/`by_metadata_field`/`by_query_type`) 안의 **nested** `retry_reason_counts` 는 그대로 노출됐다.

2중 버그:
1. `by_format`/`by_hardcase_category`/`by_metadata_field` 가 `SAFE_TOPLEVEL_KEYS` 에 있어 main loop 의 `else: out[key] = value` 로 슬라이스 전체가 **raw passthrough**. dedicated fail-closed extractor 는 whitelisted bucket 이 1개 이상일 때만 overwrite → whitelisted bucket 이 하나도 없는 슬라이스(예: `multi_hop`)는 raw 가 살아남아 nested `retry_reason_counts` 의 Korean 기관명이 그대로 커밋 경로에 노출.
2. `retry_reason_counts` 가 `SAFE_SLICE_METRICS` 에 없어 whitelisted bucket 에서도 익명화 경로 부재(드롭만 됨).

#1276 이 baseline regen 을 보류한 갭. 본 PR 머지 후 #1278 진행 가능.

Closes #1286

## 2. 영향 파일

- `scripts/run_real_eval_delta.py` (supporting; `--is-load-bearing` exit 1):
  - 세 키를 `SAFE_TOPLEVEL_KEYS` 에서 제거 → `by_query_type` 처럼 dedicated fail-closed extractor 만 emit (raw passthrough 누출 차단)
  - top-level inline `:`-split collapse(#1211)를 `_collapse_retry_reason_counts` 헬퍼로 추출 → top-level + 4개 슬라이스에서 재사용 (새 추상화 없이 단일 출처화)
  - `retry_reason_counts` 를 `SAFE_SLICE_METRICS` 에 추가 + 4개 슬라이스 루프에 collapse 분기 → whitelisted bucket 은 enum prefix 만 보존(taxonomy 총계 유지)
- `tests/test_eval_slice_retry_reason_privacy_regression.py` (신규 회귀 테스트)

**Load-bearing 변경 없음** (#1211 과 동일하게 전부 supporting).

## 3. 리스크

- **ADR 0001 baseline byte-identity**: whitelisted bucket 의 nested `retry_reason_counts` 는 이전엔 **드롭**되던 것이 이제 익명화되어 **추가**됨 — 즉 슬라이스에 정보가 늘어나는 방향(누출 아님). 비-whitelisted bucket 은 fail-closed 로 완전 드롭(이전엔 raw 누출). metric rate 불변.
- **fail-closed 회귀 없음**: 기존 `test_eval_by_format_aggregate_regression` / `test_eval_by_hardcase_category_aggregate_regression` / metadata_field·calibration 테스트 전부 green.

## 4. 테스트

- 신규 `tests/test_eval_slice_retry_reason_privacy_regression.py`: 헬퍼 collapse(충돌 prefix 합산) + whitelisted bucket 익명화 보존 + 비-whitelisted bucket 완전 드롭 + by_query_type 슬라이스 익명화 + end-to-end Hangul=0 / colon-key=0 구조 검증.
- 관련 묶음 green: privacy/by_format/by_hardcase/metadata/run_eval_metrics 56 passed + delta/baseline/history/provenance 95 passed.
- **Local gate**: `make test-fast` (FlagEmbedding 설치 worktree → real-model `slow` 테스트는 로컬 제외, CI 가 커버) — `2265 passed, 16 skipped`. `ruff check` 통과.

## 5. Eval 영향

검색/검증/답변 path 동작 변화 없음 — 변경은 (a) 커밋된 산출물의 *라벨* 익명화(metric rate 불변), (b) raw passthrough 누출 차단뿐. CI eval delta: all `·` 예상.

### 5b. Real-data delta

**검색/검증 path 동작 변화 없음.** Load-bearing path 미변경(전 supporting, `--is-load-bearing` exit 1). 변경은 committed aggregate 의 nested `retry_reason_counts` *라벨* 익명화 + 비-whitelisted 슬라이스 누출 차단이며 retrieval/verifier/answer metric rate 는 byte-동일(taxonomy 총계 보존). `make real-eval-delta` 재실행 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)