### PR TITLE
docs(adr): record real-100 bm25s vs okapi measurement on ADR 0057

### DIFF
--- a/docs/adr/0057-bm25s-additive-backend.md
+++ b/docs/adr/0057-bm25s-additive-backend.md
@@ -50,6 +50,28 @@ context7 audit Tier 2 finding — 현재 `rag_retrieval.py:80` 가 `rank_bm25.BM
 
 조건 1 충족 + 조건 2 미충족 시 (ADR 0019/0021/0031 이 임베딩/토크나이저에서 발견한 `0pp-on-hybrid` 패턴이 BM25 backend 에도 성립), 이 ADR 은 `accepted` 상태 유지하고 공개 합성 eval surface 에 측정 부록만 추가 — 측정 폐루프 작동.
 
+## Measurement (real-100, 2026-05-22)
+
+[PR #1303](https://github.com/hskim-solv/BidMate-DocAgent/pull/1303) (issue #1299) 이 `bm25_backend` 를 `make_plan` → plan dict → `retrieve_candidates` 로 threading 하기 전까지 `full_bm25s` 행은 plan 에 backend 키가 도달하지 않아 silently okapi 로 fallback 했다 (`bm25s` 라벨이지만 실제 okapi 측정). #1303 머지 + `requirements-bm25s.txt` 설치 후, 비공개 real-100 corpus 에서 Re-open 조건 (1)+(2)-③ 을 실측했다.
+
+**방법** — backend 변수만 격리한 retrieval-channel A/B. [`rag_retrieval.bm25_scores_for_index`](../../rag_retrieval.py) (파이프라인의 BM25 채널 그대로) 를 `backend="okapi"` / `backend="bm25s"` 두 번 호출, 동일 query tokens (regex tokenizer, `shared` stopword profile) 로 top-N chunk 집합 overlap 을 측정. corpus = real-100 인덱스 (26376 chunks, `hashing` 임베딩 빌드), queries = `eval/real_config.local.yaml` 의 221 케이스 질의. 풀 agentic 파이프라인 (planner / verifier / answer / rerank) 은 backend 와 무관하므로 우회 — 같은 run 안 inter-backend 비교. aggregate-only (ADR 0005; per-case chunk 텍스트 미노출).
+
+| top-k | mean overlap | median | min | overlap≥0.95 비율 | exact 순서 일치 |
+|------:|-------------:|-------:|----:|-----------------:|----------------:|
+| 10    | 0.9819       | 1.00   | 0.60 | 91.4%           | 89.6%           |
+| 30    | 0.9836       | 1.00   | 0.70 | 91.0%           | 88.2%           |
+| 50    | 0.9854       | 1.00   | 0.62 | 90.5%           | 88.2%           |
+
+(n=221, empty-token 질의 0건, `bm25s.BM25(method="robertson", k1=1.5, b=0.75)`)
+
+**판정**
+
+- **조건 (1) 충족** — real n=221, `bm25s` 설치 상태에서 실제 `bm25s` 스코어링 실행. divergence 존재 (exact 순서 일치 88–90%, min overlap 0.60) 자체가 okapi silent fallback 이 **아님**을 증명한다 (fallback 이었다면 overlap 이 전부 1.0). #1303 plumbing + backend dispatch 가 진짜로 `bm25s` 경로를 행사.
+- **조건 (2)-③ 은 aggregate 로만 유지** — mean overlap 98.2–98.5% ≥ 0.95 이나, toy fixture 의 100% ranking parity 는 real corpus 에서 약화된다 (약 9–10% 질의가 overlap < 0.95, top-k 순서 완전 일치 ~88–90%). [`tests/test_bm25_backend_parity.py`](../../tests/test_bm25_backend_parity.py) 주석이 예고한 "larger fixtures or real corpora may erode this" 가 26376-chunk corpus 에서 실제 발생 — robertson vs okapi 의 IDF 분포 차이가 큰 corpus 의 tie-breaking 을 일부 바꾼다. 이 overlap 은 swap 의 **안전성** 신호이지 **개선** 신호가 아니다.
+- **조건 (2)-①② 는 별도 측정하지 않음** — rankings 가 거의 동일 (mean 98%+) 한 데다 RRF fusion + rerank 가 다운스트림을 추가로 평탄화하므로 `accuracy` / `citation_precision` 의 ≥ +3pp lift 가능성은 희박하다. 100-doc 도메인 latency 차는 sub-ms (`bm25s` 의 100–500x 이득은 1000+ docs 에서만 발현). end-to-end accuracy delta 의 풀 파이프라인 측정은 parity 가 이미 높아 ROI 가 낮아 deferred.
+
+**결정** — 조건 (1) 충족 + 조건 (2) 실질 미충족 (parity 는 안전성 신호일 뿐 lift 아님; ADR 0019/0021/0031 의 `0pp-on-hybrid` 패턴이 BM25 backend 에도 성립). 위 "Re-open 조건" 의 line — *조건 1 충족 + 조건 2 미충족 시 측정 부록만 추가* — 경로를 따라 **`bm25_backend` 기본값 flip 보류**, `bm25s` 는 opt-in additive 백엔드로 유지. 후속 ADR (조건 3) 은 열지 않는다. 측정 폐루프 작동.
+
 ## Consequences
 
 **이득**


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1316.

PR #1303 (issue #1299, MERGED) 이 `bm25_backend` 를 `make_plan` → plan dict → `retrieve_candidates` 로 threading 하도록 고쳐 `full_bm25s` 행이 실제 `bm25s` 를 측정하게 된 뒤, 비공개 real-100 corpus 에서 ADR 0057 re-open 조건 (1)+(2)-③ 을 실측하고 그 결과를 ADR 0057 의 `## Measurement` 부록으로 기록한다. **조건 (1) 충족 · 조건 (2) 실질 미충족 → `bm25_backend` 기본값 flip 보류, `bm25s` 는 opt-in additive 유지** (측정 폐루프). Refs #1303, #1299.

## 2. 영향 파일

- `docs/adr/0057-bm25s-additive-backend.md` **(load-bearing — `docs/adr/`)** — `## Measurement (real-100, 2026-05-22)` 부록 +22줄. 결정/계약 변경 없음, 측정 기록만. Status `proposed` 유지, `## Verification` / verifies-key 토큰 그대로.

## 3. 리스크

거의 없음 — 문서 1파일, 코드/계약/스키마 무변경. 가장 가능성 높은 깨짐 경로는 ADR governance 토큰(Status / `## Verification` / verifies-key) 훼손인데 미변경 확인. `check_doc_links.py` 통과 (162 files, no broken links). 측정값의 진위는 reviewer 확인 사항 — 방법(retrieval-channel A/B, `bm25_scores_for_index` okapi vs bm25s)을 부록에 명시해 재현 가능.

## 4. 테스트

동작 변경 없음(문서 only) → 신규 테스트 불필요. ADR 0057 의 contract 는 기존 `tests/test_bm25_backend_parity.py` 가 계속 lock (VALID_BM25_BACKENDS / preset okapi 기본값 / robertson↔okapi parity / 캐시 격리). 측정은 재현 가능: `rag_retrieval.bm25_scores_for_index` 를 backend okapi/bm25s 로 호출, regex tokenizer · shared stopword, 221 케이스 질의, 26376-chunk real-100 인덱스.

**Local gate:** `make test-fast` (2264 passed, 11 skipped, 231 subtests — FlagEmbedding 설치 환경이라 real-model `slow` 테스트는 로컬 제외, CI 가 커버) + `ruff check .` (통과).

## 5. Eval 영향

All `·` — eval surface(설정/코드/baseline) 무변경. `full_bm25s` 는 gitignored `eval/real_config.local.yaml` 의 local-only ablation 으로, 커밋된 `reports/real100/baseline.aggregate.json`(primary `ablation_full` only) · leaderboard 어디에도 포함되지 않음 → 커밋 surface 변동 0.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 — 코드 변경 0, `docs/adr/0057` 에 측정 결과만 기록. `make real-eval-delta` 대상 동작 변경 없음. (참고: 부록에 기록된 측정값은 retrieval-channel A/B aggregate — top-N overlap mean 0.9819@10 / 0.9836@30 / 0.9854@50, ADR 0005 aggregate-only, per-case chunk 텍스트 미노출.)

## 6. 하위 호환

계약/스키마/CLI flag/doc-link 깨짐 없음. ADR 0003 answer-contract 무관 → `schema_version` bump 불필요.

## 7. 범위 외

- 조건 (2)-①② 의 풀 파이프라인 accuracy/citation_precision/latency 측정: ranking parity 가 이미 높아(mean 98%+) RRF+rerank 가 다운스트림을 평탄화 → ≥3pp lift 가능성 희박, ROI 낮아 deferred. 필요 시 별도 이슈.
- ADR 0057 Status(`proposed`) ↔ Re-open 조건 line 의 "accepted 상태 유지" 표현 정합성: 별도 governance 정정 (측정 기록 PR 범위 외).
- 공개 합성 eval surface(n=42) 의 `full_bm25s` 측정: 본 PR 은 real-100 만.