### PR TITLE
fix(make): cap test-fast xdist workers to stop OOM-kill under memory pressure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,8 +285,19 @@ test:
 # tail latency; deselecting them keeps the local loop snappy. The CI gate
 # (`make test` / scripts/test.sh) still runs EVERYTHING — never rely on
 # test-fast for a merge decision.
+#
+# TEST_WORKERS caps xdist parallelism. Default 4 (not `-n auto`): a dev box
+# hosting many git worktrees runs under memory pressure, and `-n auto`
+# (one worker per logical core, 8–10 here) makes every worker re-collect +
+# import simultaneously at startup, spiking free RAM to near-zero. macOS
+# jetsam then OOM-kills a worker mid-schedule, and xdist references the dead
+# worker → `INTERNALERROR KeyError <WorkerController gwN>` after a 20-min
+# swap-thrash with zero tests run (issue #1318). Capping at 4 completes the
+# same suite in ~80s on that box. Override on a roomy machine/CI:
+# `make test-fast TEST_WORKERS=auto`.
+TEST_WORKERS ?= 4
 test-fast:
-	$(PYTHON) -m pytest -m "not slow" -n auto --dist loadfile -q
+	$(PYTHON) -m pytest -m "not slow" -n $(TEST_WORKERS) --dist loadfile -q
 
 # Fast P0 regression guards for the retrieval loop and answerable smoke path.
 # Run before any change to rag_core retrieval/verification or the eval pipeline.

--- a/tests/test_makefile_test_workers_regression.py
+++ b/tests/test_makefile_test_workers_regression.py
@@ -1,0 +1,74 @@
+"""Guards the `make test-fast` xdist worker cap (issue #1318).
+
+`-n auto` spawns one worker per logical core. On a dev box hosting many git
+worktrees the machine runs under memory pressure; the simultaneous
+worker-startup re-collection spikes free RAM to near-zero, macOS jetsam
+OOM-kills a worker mid-schedule, and xdist dies with
+`INTERNALERROR KeyError <WorkerController gwN>`. Capping the default worker
+count (overridable via TEST_WORKERS) keeps the local loop alive. These tests
+fail if someone reverts the recipe back to a hardcoded `-n auto`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+MAKEFILE = ROOT_DIR / "Makefile"
+
+
+def _test_fast_recipe() -> str:
+    """Return the shell command line(s) of the `test-fast` target."""
+    text = MAKEFILE.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    out: list[str] = []
+    in_target = False
+    for line in lines:
+        if line.startswith("test-fast:"):
+            in_target = True
+            continue
+        if in_target:
+            # Recipe lines are tab-indented; the target ends at the first
+            # line that is neither tab-indented nor blank.
+            if line.startswith("\t"):
+                out.append(line.lstrip("\t"))
+            elif line.strip() == "":
+                continue
+            else:
+                break
+    assert out, "could not locate the test-fast recipe in the Makefile"
+    return "\n".join(out)
+
+
+def test_test_fast_does_not_hardcode_n_auto() -> None:
+    recipe = _test_fast_recipe()
+    assert "-n auto" not in recipe, (
+        "test-fast must not hardcode `-n auto` — it OOM-kills xdist workers on "
+        "a memory-pressured multi-worktree box (issue #1318). Use "
+        "`-n $(TEST_WORKERS)` with a bounded default instead."
+    )
+
+
+def test_test_fast_uses_overridable_worker_var() -> None:
+    recipe = _test_fast_recipe()
+    assert "-n $(TEST_WORKERS)" in recipe, (
+        "test-fast should pass `-n $(TEST_WORKERS)` so the worker count is "
+        "overridable (e.g. `make test-fast TEST_WORKERS=auto` on a roomy box)."
+    )
+
+
+def test_test_workers_default_is_a_bounded_integer() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    m = re.search(r"^TEST_WORKERS\s*\?=\s*(\S+)\s*$", text, re.MULTILINE)
+    assert m, "missing `TEST_WORKERS ?= <n>` default assignment in the Makefile"
+    default = m.group(1)
+    assert default.isdigit(), (
+        f"TEST_WORKERS default must be a fixed integer cap, not {default!r} — "
+        "`auto` reintroduces the over-subscription that issue #1318 fixed."
+    )
+    assert 1 <= int(default) <= 8, (
+        f"TEST_WORKERS default {default} is outside the sane local-loop range "
+        "(1–8); pick a value that survives a memory-pressured box."
+    )


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make test-fast` 가 다수 worktree 누적 메모리 압박 환경에서 xdist `INTERNALERROR KeyError <WorkerController gw9>` 로 죽는다. 근본 원인은 `-n auto` 가 논리 코어 수(8~10)만큼 워커를 띄우는 것 — 메모리 압박 상태에서 모든 워커가 startup 시 re-collection+import 를 동시 수행해 free RAM 이 순간 ~72MB 로 추락 → macOS jetsam 이 워커를 OOM-kill → xdist 가 죽은 워커를 참조하다 KeyError, 20분 swap-thrash 후 0개 실행 종료. 워커 수를 `TEST_WORKERS ?= 4` 로 상한(override 가능)하면 동일 박스에서 동일 스위트가 ~37~80초에 green 완주. CI gate(`scripts/test.sh`)는 별도 샤딩이라 무영향 — test-fast 는 로컬 편집 루프 전용.

Closes #1318

## 2. 영향 파일

- `Makefile` — `TEST_WORKERS ?= 4` 추가, `-n auto` → `-n $(TEST_WORKERS)` (load-bearing 아님; `scripts/_governance.py --is-load-bearing Makefile` → exit 1)
- `tests/test_makefile_test_workers_regression.py` (신규) — `-n auto` 하드코딩 재발 방지 가드 3개

## 3. 리스크

- 가장 가능성 높은 깨짐: 깨끗한/RAM 많은 머신에서 기본 4 가 보수적이라 약간 느릴 수 있음 → `make test-fast TEST_WORKERS=auto` 로 override 가능(테스트로 override 경로 검증). 
- CI 영향: 없음 — CI 는 `scripts/test.sh` + pytest-split 샤딩 경로를 쓰며 이 타깃을 호출하지 않음. `make -n test-fast` dry-run 으로 `-n 4` 확정 + override 시 `-n auto` 복원 확인.

## 4. 테스트

- 신규 `tests/test_makefile_test_workers_regression.py` 3개: ① `-n auto` 하드코딩 금지 ② `-n $(TEST_WORKERS)` 사용 ③ 기본값이 1~8 정수. 변경 전(`-n auto`) fail / 변경 후 pass. 출시 회귀용 `tests/test_*_regression.py` 컨벤션 준수.
- 측정: `-n auto` = 20분 0개 실행 → KeyError gw9 / collection-only 단일 = 2283개 7초 OK / `-n 4` = 2270 passed, 16 skipped, 36.9~78초 green.

## 5. Eval 영향

All `·` — RAG 파이프라인(검색/검증/답변/eval) 코드 무변경. 빌드 도구(Makefile) + 테스트 가드만.

### 5b. Real-data delta

N/A — load-bearing path 무변경. `Makefile` 과 신규 테스트 파일 모두 `scripts/_governance.py --is-load-bearing` exit 1 (비-load-bearing). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

깨짐 없음. 기본 동작만 `-n auto` → `-n 4` 로 바뀌며 `TEST_WORKERS=auto` 로 기존 동작 완전 복원 가능. 답변 계약(ADR 0003)/CLI/스키마 무관.

## 7. 범위 외

- `scripts/test.sh` 의 `-n auto` 는 별도 surface(CI 샤딩, 러너별 RAM 상이) → 이번 PR 범위 외. 로컬 `make test` 가 같은 박스에서 OOM 시 별도 follow-up.
- 머지된 브랜치 worktree 정리(메모리 회복)는 위생 작업으로 별개 — 가드 PR 과 무관.

---
Local gate: `make test-fast` (real-model `slow` 테스트는 로컬 제외 — FlagEmbedding 설치 환경이라 full suite 가 hang, CI 가 8-shard 로 커버) + `ruff check .` all pass. 머지는 CI green hard-gate.