### PR TITLE
chore(eval): reflect #1276 classify_failure correction in real-100 baseline

### DIFF
--- a/reports/real100/baseline.aggregate.json
+++ b/reports/real100/baseline.aggregate.json
@@ -214,11 +214,11 @@
       "failure_category_counts": {
         "context_dilution": 0,
         "generator_hallucination": 1,
-        "planner_under_decomposition": 1,
-        "retrieval_miss": 64,
-        "unknown": 35,
+        "planner_under_decomposition": 3,
+        "retrieval_miss": 67,
+        "unknown": 33,
         "verifier_false_negative": 75,
-        "verifier_false_positive": 3
+        "verifier_false_positive": 0
       },
       "groundedness": 0.19491525423728814,
       "iterations": {
@@ -984,11 +984,11 @@
       "failure_category_counts": {
         "context_dilution": 0,
         "generator_hallucination": 1,
-        "planner_under_decomposition": 0,
-        "retrieval_miss": 56,
-        "unknown": 24,
+        "planner_under_decomposition": 2,
+        "retrieval_miss": 58,
+        "unknown": 22,
         "verifier_false_negative": 2,
-        "verifier_false_positive": 2
+        "verifier_false_positive": 0
       },
       "groundedness": 0.13978494623655913,
       "iterations": {
@@ -1184,9 +1184,9 @@
       "failure_category_counts": {
         "context_dilution": 0,
         "generator_hallucination": 0,
-        "planner_under_decomposition": 0,
+        "planner_under_decomposition": 1,
         "retrieval_miss": 0,
-        "unknown": 6,
+        "unknown": 5,
         "verifier_false_negative": 75,
         "verifier_false_positive": 0
       },
@@ -1407,11 +1407,11 @@
   "failure_category_counts": {
     "context_dilution": 0,
     "generator_hallucination": 1,
-    "planner_under_decomposition": 1,
-    "retrieval_miss": 64,
-    "unknown": 35,
+    "planner_under_decomposition": 3,
+    "retrieval_miss": 67,
+    "unknown": 33,
     "verifier_false_negative": 76,
-    "verifier_false_positive": 3
+    "verifier_false_positive": 0
   },
   "groundedness": 0.19491525423728814,
   "latency": {

--- a/reports/real100/history/20260519T030310Z_a7fd711d0573.aggregate.json
+++ b/reports/real100/history/20260519T030310Z_a7fd711d0573.aggregate.json
@@ -214,11 +214,11 @@
       "failure_category_counts": {
         "context_dilution": 0,
         "generator_hallucination": 1,
-        "planner_under_decomposition": 1,
-        "retrieval_miss": 64,
-        "unknown": 35,
+        "planner_under_decomposition": 3,
+        "retrieval_miss": 67,
+        "unknown": 33,
         "verifier_false_negative": 75,
-        "verifier_false_positive": 3
+        "verifier_false_positive": 0
       },
       "groundedness": 0.19491525423728814,
       "iterations": {
@@ -984,11 +984,11 @@
       "failure_category_counts": {
         "context_dilution": 0,
         "generator_hallucination": 1,
-        "planner_under_decomposition": 0,
-        "retrieval_miss": 56,
-        "unknown": 24,
+        "planner_under_decomposition": 2,
+        "retrieval_miss": 58,
+        "unknown": 22,
         "verifier_false_negative": 2,
-        "verifier_false_positive": 2
+        "verifier_false_positive": 0
       },
       "groundedness": 0.13978494623655913,
       "iterations": {
@@ -1184,9 +1184,9 @@
       "failure_category_counts": {
         "context_dilution": 0,
         "generator_hallucination": 0,
-        "planner_under_decomposition": 0,
+        "planner_under_decomposition": 1,
         "retrieval_miss": 0,
-        "unknown": 6,
+        "unknown": 5,
         "verifier_false_negative": 75,
         "verifier_false_positive": 0
       },
@@ -1407,11 +1407,11 @@
   "failure_category_counts": {
     "context_dilution": 0,
     "generator_hallucination": 1,
-    "planner_under_decomposition": 1,
-    "retrieval_miss": 64,
-    "unknown": 35,
+    "planner_under_decomposition": 3,
+    "retrieval_miss": 67,
+    "unknown": 33,
     "verifier_false_negative": 76,
-    "verifier_false_positive": 3
+    "verifier_false_positive": 0
   },
   "groundedness": 0.19491525423728814,
   "latency": {


### PR DESCRIPTION
## 무엇을 / 왜

#1276 (closes #1275) 이 ADR 0059 `classify_failure` 의 taxonomy 버그 3개를 정정했으나, committed real-100 baseline 은 **재생성하지 않고** main 의 깨끗한 버전을 유지했다 — 당시 표준 regen 이 `by_format`/`by_hardcase` 슬라이스의 nested `retry_reason_counts` 누출을 재유입했기 때문(이후 #1286/#1302 가 extractor 에서 수정). 그 갭이 닫혔으므로, 정정된 failure taxonomy 를 committed baseline 으로 승격한다 (#1287).

## 어떻게 — 재채점(re-score), 파이프라인 재실행 아님

`classify_failure` 는 `case_results` 에 대한 **사후 SCORER** 이며 #1276 은 scorer 만 고쳤다(파이프라인 불변). 파이프라인은 결정론적 — 로컬 `eval_summary` 의 headline 메트릭(accuracy=0.16101694915254236 등)이 committed baseline 과 **byte-identical**, config_sha256 동일. 따라서 ~1h 파이프라인 재실행은 동일 `case_results` 를 재생산할 뿐이다. 대신 **정정된 classifier 를 기존 결정론적 case_results 에 재적용**하고 `failure_category_counts` 를 run_eval 자체의 `summarize_run()`(동일 per-slice 버킷팅)으로 재집계했다.

**범위 = 분류기 정정만 (option B).** `failure_category_counts`(top-level + `by_format` + `by_hardcase` 의 `multi_hop`/`no_answer`)만 갱신하고, 그 외 전 필드 — 특히 run/머신마다 달라지는 **비결정적 wall-clock latency** — 는 byte-identical 로 보존했다. 이 PR 에 범위 밖 latency 델타가 섞이지 않도록 한 결정.

## 델타 (n=221, TOTAL=180 불변)

| category | 전 → 후 |
|---|---|
| retrieval_miss | 64 → 67 |
| planner_under_decomposition | 1 → 3 |
| verifier_false_positive | 3 → 0 |
| unknown | 35 → 33 |
| verifier_false_negative | 76 → 76 (불변; `== abstention_outcomes.incorrect_answer`) |

retrieval_miss rate 0.290 → 0.303 (< 0.34 ceiling → `ALLOW_REGRESSION` 불필요).

## 테스트 / 검증

- `tests/test_failure_rate_regression.py` + `test_eval_artifact_privacy_regression.py` + `test_write_real_eval_baseline.py` + `test_render_real_eval_history.py` green (48 passed).
- privacy scan: baseline + 갱신 history 엔트리 모두 `{}` (hangul/colon 0).
- 계약 `verifier_false_negative == abstention_outcomes.incorrect_answer` (76==76) 유지.
- `make real-eval-history-render --check` PASS (history 테이블은 fcc 컬럼 없음 → render-neutral).
- git diff 는 fcc 값 라인에만 국한(28±, sort_keys 로 키순서 안정).

## ADR

N/A — 버그 fix 의 출력 승격. 새 측정 표면·계약 도입 없음(`failure_category_counts` 는 기존 ADR 0059 표면, #1276 가 정정). `reports/real100/` 는 `LOAD_BEARING_PATHS` 미포함(`--is-load-bearing` exit 1).

## 5a (합성 CI 델타)

N/A — real-100 비공개 eval 아티팩트만 변경. 합성 eval 경로 불변.

## 5b (real-data 델타)

위 "델타" 표가 곧 real-data 델타. `run_real_eval_delta.py`/`reports/real100/` 는 load-bearing 미포함이나, 변경 본질이 real-data 분류 분포이므로 명시. 메트릭(accuracy/groundedness/abstention/retry/latency)은 전부 불변(재채점은 failure_category_counts 만 변경).

## Local gate

`make test-fast` (pytest -m "not slow" -n auto) — **2282 passed, 11 skipped**. FlagEmbedding 설치 worktree 라 real-model `slow` 스위트는 로컬 deselect, CI 커버. ruff `All checks passed`. → **머지는 CI green 하드 게이트**.

## 비고

#1286(#1302) 머지 후속. eval_summary 산출물은 로컬 전용(gitignore). 재채점 절차/결정론 증명은 commit b7e147c 메시지에 상세 기록.

Closes #1287