### PR TITLE
test(eval): shrink m3 + finetune corpus to cut pr-eval shard floor

### DIFF
--- a/tests/test_generate_finetune_pairs.py
+++ b/tests/test_generate_finetune_pairs.py
@@ -208,23 +208,44 @@ class PerDocCoverageTest(unittest.TestCase):
 
 class ContaminationRejectionThresholdTest(unittest.TestCase):
     def test_pipeline_fails_when_contamination_too_high(self) -> None:
-        # Force a high rejection rate by lowering the threshold to 0%
-        # and supplying a non-empty eval surface — the stub backend
-        # generates templates that include words like "보안 통제" which
-        # do appear in the eval surface, so some rejection is expected.
-        # The intent: a 0% threshold should always fail when *any*
-        # rejection occurs, proving the threshold is wired up.
+        # Contract: ``fail_threshold=0.0`` MUST raise when any generated
+        # query is contaminated, proving the threshold is wired up.
+        #
+        # Issue #1315 — this used to mine over the full 383-chunk data/raw
+        # corpus at queries_per_chunk=200 (316s, a pr-eval shard floor) and
+        # relied on volume to *probabilistically* trip a rejection — so it
+        # also tolerated the zero-rejection path, which never exercised the
+        # raise. We instead guarantee contamination deterministically: a
+        # 2-chunk tmp corpus whose section headings ARE real eval-surface
+        # queries (load_eval_queries — not a mock). The stub template wraps
+        # each heading verbatim, so the generated query's trigrams overlap
+        # the eval query above the 0.7 Jaccard threshold. Same raise path,
+        # against the real guard, in <1s instead of 316s.
+        eval_queries = load_eval_queries()
+        self.assertGreaterEqual(
+            len(eval_queries), 2, "eval surface must be populated to seed contamination"
+        )
+        doc = {
+            "doc_id": "fixture-contaminating",
+            "title": "오염 유발 픽스처",
+            "agency": "기관 X",
+            "project": "테스트",
+            "metadata": {},
+            "sections": [
+                {"heading": eval_queries[0], "text": f"{eval_queries[0]} 관련 본문."},
+                {"heading": eval_queries[1], "text": f"{eval_queries[1]} 관련 본문."},
+            ],
+        }
         with TemporaryDirectory() as tmp:
-            output = Path(tmp) / "pairs.jsonl"
-            # Inject a contaminating query by patching the eval surface:
-            # we use the real loader but assert that under fail_threshold=0
-            # we either succeed (zero rejections) or raise.
-            try:
+            (Path(tmp) / "doc.json").write_text(
+                json.dumps(doc, ensure_ascii=False), encoding="utf-8"
+            )
+            with self.assertRaises(RuntimeError) as ctx:
                 generate_pairs(
-                    input_dir=ROOT / "data" / "raw",
-                    output=output,
+                    input_dir=Path(tmp),
+                    output=Path(tmp) / "pairs.jsonl",
                     backend="stub",
-                    queries_per_chunk=200,
+                    queries_per_chunk=5,
                     neg_per_pos=3,
                     hard_neg_rank_window=(3, 15),
                     val_frac=0.10,
@@ -232,8 +253,7 @@ class ContaminationRejectionThresholdTest(unittest.TestCase):
                     max_chars=240,
                     fail_threshold=0.0,
                 )
-            except RuntimeError as exc:
-                self.assertIn("rejection rate", str(exc))
+            self.assertIn("rejection rate", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_m3_backend_regression.py
+++ b/tests/test_m3_backend_regression.py
@@ -39,6 +39,7 @@ from rag_core import (
     VALID_RETRIEVAL_BACKENDS,
     analyze_query,
     build_index_payload,
+    build_index_payload_from_documents,
     make_plan,
     metadata_targets,
     resolve_pipeline_config,
@@ -240,10 +241,44 @@ class M3EndToEndTest(unittest.TestCase):  # pragma: no cover — opt-in, gated o
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.index = build_index_payload(
-            Path("data/raw"),
+        # Issue #1315 — a ~6-chunk synthetic index, NOT the full 383-chunk
+        # data/raw corpus. The contract asserted below (score_parts carry
+        # all three m3 channels, RRF score normalized to [0, 1]) is
+        # backend-driven and corpus-size-independent, so the full corpus
+        # only inflated this test's m3 colbert encode to 737s (the pr-eval
+        # longest-shard floor, since pytest-split cannot subdivide a single
+        # test). The smaller fixture cuts that encode ~55x while exercising
+        # the identical dense + sparse + colbert wiring.
+        cls.index = build_index_payload_from_documents(
+            [
+                {
+                    "doc_id": "agency-a-security",
+                    "title": "기관 A 보안 통제 RFP",
+                    "agency": "기관 A",
+                    "project": "보안 통제 시스템",
+                    "metadata": {},
+                    "sections": [
+                        {"heading": "보안 통제", "text": "기관 A는 접근 통제와 보안 로그 보관을 요구한다."},
+                        {"heading": "요구사항", "text": "기관 A의 보안 통제 요구사항은 암호화와 감사 추적을 포함한다."},
+                        {"heading": "운영", "text": "보안 관제 센터는 24시간 상시 운영되어야 한다."},
+                    ],
+                    "source_path": "agency-a-security.txt",
+                },
+                {
+                    "doc_id": "agency-b-network",
+                    "title": "기관 B 네트워크 RFP",
+                    "agency": "기관 B",
+                    "project": "네트워크 고도화",
+                    "metadata": {},
+                    "sections": [
+                        {"heading": "네트워크", "text": "기관 B는 네트워크 이중화를 요구한다."},
+                        {"heading": "보안", "text": "기관 B의 방화벽 정책은 별도 보안 통제 대상이다."},
+                    ],
+                    "source_path": "agency-b-network.txt",
+                },
+            ],
+            source_dir="test-fixture",
             embedding_backend="hashing",
-            chunking_strategy="fixed",
         )
 
     def test_m3_score_parts_carry_sparse_and_colbert(self) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1315

pr-eval 최장 shard wall-clock(~15min)은 pytest-split이 쪼갤 수 없는 두 **단일 테스트**가 하한을 결정했다: `M3EndToEndTest::test_m3_score_parts_carry_sparse_and_colbert`(737s, full 383-chunk data/raw m3 colbert encode)와 `ContaminationRejectionThresholdTest`(316s, queries_per_chunk=200으로 full corpus에 대해 ~76k BM25 hard-neg mining). 두 테스트 모두 **corpus 크기와 무관한 계약**을 검증하므로, 각각 소형 fixture로 축소해 단일 테스트 floor를 제거한다.

## 2. 영향 파일

- `tests/test_m3_backend_regression.py` — `M3EndToEndTest.setUpClass`를 `build_index_payload(data/raw)`(383청크) → `build_index_payload_from_documents([...])`(~6청크 합성 인덱스)로 교체. 동일한 dense+sparse+colbert 3채널 배선 검증. (load-bearing 아님)
- `tests/test_generate_finetune_pairs.py` — `ContaminationRejectionThresholdTest`를 full corpus@qpc=200 → 2청크 tmp corpus로 교체. section heading을 **실제 eval 표면 query**(`load_eval_queries`)로 심어 0% threshold를 결정론적으로 trip. (load-bearing 아님)

두 파일 모두 `scripts/_governance.py --is-load-bearing` exit 1 (비 load-bearing).

## 3. 리스크

- **m3 fixture가 evidence 0건 반환** → `assertGreater(len(evidence), 0)` 실패. 완화: fixture가 query("기관 A의 보안 통제 요구사항은?")와 어휘 겹침. 로컬에서 인덱스 5청크 빌드 + analyze_query/make_plan(retrieval_backend=m3) 정상 확인(m3 encode는 BGE-M3 필요해 CI에서 검증).
- **finetune 오염이 trip 안 됨** → `assertRaises(RuntimeError)` 실패. 완화: 로컬 probe로 qpc=3/5 모두 결정론적 raise(rejection rate 33~40%, jaccard threshold 0.7) 확인. 기존 succeed-or-raise tolerance를 assertRaises로 **강화**(이전엔 zero-rejection 경로로 trivially pass 가능했음).
- m3 E2E는 로컬 BGE-M3 OOM으로 실행 불가 → 실제 pr-eval 4-shard CI run으로 최종 검증.

## 4. 테스트

동작 변경이 아니라 **테스트 자체의 fixture 축소** + 단언 강화. 변경된 두 테스트가 그대로 검증 대상:
- finetune contamination: 로컬 316s → **0.5s**, `assertRaises`로 raise 경로 보장(이전 tolerance보다 강함). 파일 전체 15 passed.
- m3 E2E: `--collect-only` + non-slow 9 passed/8 deselected 확인. CI(FlagEmbedding 설치)에서 5청크로 실행 → ~20s 예상.
- 트리거 불변 regression(`test_pr_gate_workflow_triggers_regression.py`) 3 passed (워크플로 무변경).

**Local gate: `make test-fast`** — 이 worktree에 FlagEmbedding 설치돼 full suite가 BGE-M3 로드로 hang/OOM. real-model `slow` 테스트는 로컬 제외, CI가 커버. 2267 passed / 16 skipped / 139s. ruff check . clean. → **merge는 CI green 하드 게이트**.

## 5. Eval 영향

All `·` — eval surface(`eval/`) 무변경. `tests/`만 변경, 검색/검증/답변 path 동작 불변. CI eval-delta는 `tests/`가 runtime-affecting 분류(`.py$`)라 트리거되나 델타 0 예상.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 — `tests/` 픽스처 축소만으로 production 코드(`rag_*.py`) 무변경. load-bearing path 미변경(두 파일 exit 1).

## 6. 하위 호환

깨짐 없음. 답변 계약(ADR 0003)/스키마/CLI flag 무관. `.test_durations`의 737s·316s 항목은 stale가 되나 pytest-split `least_duration`이 과대추정을 graceful 허용(빈 그룹 미발생, exit-5 없음) — balance만 일시 비최적, 정확성 무관.

## 7. 범위 외

- **`.test_durations` 재생성**: 의도적 보류. stale는 balance만 영향. full suite serial `--store-durations`는 m3 E2E(BGE-M3) 포함 → 로컬 OOM, PR #1298식 임시 CI 워크플로 필요 → 별도 follow-up.
- **finetune 파일의 다른 `_run` 테스트**(determinism/split 등, data/raw 전체 mining): 이 PR 범위 밖. `.test_durations` 기준 CI ~87s로 contamination 제거 후 파일의 잔여 비용이나 별 concern. 필요 시 follow-up.
- **HF/pip 캐시**(접근 a): 테스트 floor 제거 후 per-shard 의존성 install이 다음 병목 → 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)