### PR TITLE
fix(eval): measure ADR 0056 answer_reasoning via stub full-trace capture

### DIFF
--- a/docs/adr/0056-rationality-judge-measurement-surface.md
+++ b/docs/adr/0056-rationality-judge-measurement-surface.md
@@ -1,7 +1,7 @@
 # ADR 0056 — Trajectory-rationality judge 를 새 측정 표면으로
 
 - Status: Accepted
-- Implemented: #987 (2026-05-18) — `eval/judges/rationality_judge.py` 3-axis trajectory surface (committed 측정은 2-axis 채움 + 1-axis `answer_reasoning` pending — #1297 정정)
+- Implemented: #987 (2026-05-18) — `eval/judges/rationality_judge.py` 3-axis trajectory surface. (#1297 (2026-05-22) 가 committed artifact 와의 모순을 정정해 일시적으로 2-axis measured + 1-axis `answer_reasoning` pending 으로 relabel; #1326 (2026-05-22) 가 stub full-trace 캡처 wiring 을 고쳐 **3-axis 모두 measured** 로 복원 — `answer_reasoning` effective_n=166)
 - Date: 2026-05-18
 - Authors: Hyunsoo Kim
 - Related: ADR 0006 (real-data LLM-judge), ADR 0012 (synthetic LLM-judge), ADR 0014 (RAGAS enrichment, Gate 3), ADR 0054 (conditional-on-substantive-answer scorer semantics), ADR 0055 (claim_validator)
@@ -43,7 +43,7 @@ Step 2 (PR #968, ADR-free) 의 trace schema v2 `synthesis_llm_call` 키 (`BIDMAT
    - aggregate `effective_n["answer_reasoning"]` 가 실제 측정 가능했던 케이스 수 보고.
    - mean 분모 제외 — sample 부재 axis 는 `mean = None`, `ci` 미발행.
 
-6. **첫 측정은 stub backend + n=221**. 비용 0, deterministic. 단 committed artifact (`reports/real100/rationality.aggregate.json`) 는 `cases_with_synthesis_llm_call=0` — `BIDMATE_TRACE_FULL=1` + synthesis trace 캡처가 동작하지 않아 `answer_reasoning` 은 미측정 (effective_n=0). 따라서 본 PR 의 측정 표면은 **2-axis (planner_decomposition / retrieval_recalls) measured + 1-axis (answer_reasoning) pending**. full-trace 캡처 + LLM backend 실측정은 별 PR (token budget + cost analysis 동반). `--expect-full-trace` (#1297) 가 effective_n=0 인 full-trace 기대 run 을 incomplete 로 표면화.
+6. **측정은 stub backend + n=221, 3-axis 모두 measured**. 비용 0, deterministic. committed artifact (`reports/real100/rationality.aggregate.json`) 는 `cases_with_synthesis_llm_call=166` / `answer_reasoning` effective_n=166 (나머지 55 케이스는 abstention 으로 synthesis 미수행 → 정상 drop). 이를 위한 두 전제: ① **`answer_reasoning` 측정은 synthesis 가 도는 run 한정** — eval_summary 의 `case_results` 는 primary run 것만 담으므로(`run_eval.py`), real config 의 `primary_run` 이 `agentic_full_llm`(`prompt_profile=llm_synthesis`) arm 을 가리켜야 한다(또는 judge 를 `--traces-dir .../full_llm` 로 override). extractive `full` primary 로는 synthesis trace 가 case_results 에 없어 effective_n=0. ② **stub synthesis backend 가 `BIDMATE_TRACE_FULL=1` 에서 full I/O 를 캡처** — #1326 이전엔 `_stub_backend` 가 `user_prompt_text`/`completion_text` 를 반환하지 않아 effective_n=0 였다(#1297 이 pending 으로 정직하게 표시했던 상태). #1326 이 stub 캡처를 live backend 와 동일하게 고쳐 ② 를 해소. LLM backend 실측정(`BIDMATE_RATIONALITY_BACKEND=openai_compatible`)은 별 PR (token budget + cost analysis 동반). `--expect-full-trace` (#1297) 가 effective_n=0 인 full-trace 기대 run 을 incomplete 로 표면화.
 
 ## Why these specific choices
 
@@ -61,7 +61,7 @@ Step 2 (PR #968, ADR-free) 의 trace schema v2 `synthesis_llm_call` 키 (`BIDMAT
 - **Phase 3 audit item 3 (✗ absent → ✓ present)** 폐쇄. 5-step portfolio narrative ("측정 → 함정 발견 → 함정 fix → 측정 표면 audit → 자동 게이트 도입 → process rationality 측정 도입") 의 step 3 (= 측정 표면 완비) 까지 달성.
 - 신규 `reports/real100/rationality.{md,aggregate.json}` 두 산출물 → eval surface 의 1-차원 추가.
 - judge LLM backend 의 실 측정 비용 (n=221 × 1 LLM call = 221 LLM call/run) 은 별 PR scope. 본 PR 의 measurement scope = stub backend (0 cost, deterministic).
-- `answer_reasoning` 의 effective_n 는 `BIDMATE_TRACE_FULL=1` + synthesis trace 캡처 여부에 의존. **본 committed 측정에서는 미캡처 → effective_n=0 (cases_with_synthesis_llm_call=0)** — 즉 answer_reasoning 은 full-trace 캡처가 동작하는 follow-up 까지 pending (#1297 정정; 이전 본문의 "모든 case cover" 는 artifact 와 모순이라 철회). `rationality.md` 표/CLI 가 해당 축을 `pending`/`incomplete` 로 표면화.
+- `answer_reasoning` 의 effective_n 는 `BIDMATE_TRACE_FULL=1` + synthesis trace 캡처 여부에 의존. **#1326 측정에서 effective_n=166 (cases_with_synthesis_llm_call=166)** — synthesis-primary run (`agentic_full_llm`) + stub full-trace 캡처 wiring fix 로 3-axis 모두 measured. 나머지 55 케이스는 abstention 으로 synthesis 미수행(정상 drop, ADR 0054 substantive-only semantics). (이력: #987 최초 measured 주장 → #1297 이 effective_n=0 artifact 와의 모순을 pending 으로 정직 정정 → #1326 이 wiring 을 고쳐 measured 복원. 이전 본문의 "모든 case cover" 표현은 abstention drop 을 누락했던 부정확 — "synthesis 수행 case 전부 cover" 가 정확.)
 - 향후 PR 에서 `Claim:` (ADR 0055) 으로 rationality axis 의 변화 보고 가능 — `Claim: planner_decomposition=+0.05pp` 식. 단 본 PR 에서는 baseline 측정만, claim 0건.
 
 ## Invariance check
@@ -86,16 +86,21 @@ Step 2 (PR #968, ADR-free) 의 trace schema v2 `synthesis_llm_call` 키 (`BIDMAT
 # Stub backend determinism + 6-case unit test
 EMBEDDING_BACKEND=hashing python3 -m pytest -q tests/test_rationality_judge.py
 
-# Real-eval regen at n=221 with BIDMATE_TRACE_FULL=1
+# Real-eval regen at n=221 with BIDMATE_TRACE_FULL=1.
+# answer_reasoning 측정은 synthesis 가 도는 run 한정 — local config 의
+# primary_run 이 `agentic_full_llm`(prompt_profile=llm_synthesis) arm 을
+# 가리켜야 case_results 에 synthesis trace 가 담긴다. extractive `full`
+# primary 로는 effective_n["answer_reasoning"]=0 (synthesis 미수행).
 BIDMATE_TRACE_FULL=1 BIDMATE_SYNTHESIS_BACKEND=stub make real-eval
 
-# Score traces (stub backend, 0 cost)
+# Score traces (stub backend, 0 cost). --expect-full-trace 로 answer_reasoning
+# effective_n==0 (silently-incomplete) 인 run 을 exit 3 으로 표면화.
 python3 scripts/run_rationality_judge.py \
   --eval-summary reports/real100/eval_summary.json \
   --output reports/real100/rationality.local.json \
   --out-aggregate reports/real100/rationality.aggregate.json \
   --out-md reports/real100/rationality.md \
-  --backend stub
+  --backend stub --expect-full-trace
 
 # Aggregate inspection
 python3 -c "import json; r=json.load(open('reports/real100/rationality.aggregate.json')); \

--- a/eval/real_config.example.yaml
+++ b/eval/real_config.example.yaml
@@ -12,6 +12,18 @@ ablation_runs:
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+  # ADR 0056 answer_reasoning axis (rationality judge) 를 측정하려면 synthesis 가
+  # 도는 run 이 필요하다. eval_summary 의 case_results 는 primary run 것만 담으므로
+  # (eval/run_eval.py), 아래 full_llm arm 을 활성화하고 `primary_run: full_llm` 로
+  # 설정한 뒤 `BIDMATE_TRACE_FULL=1 BIDMATE_SYNTHESIS_BACKEND=stub` 로 real-eval 을
+  # 돌린다 (또는 run_rationality_judge.py 를 `--traces-dir <out>/traces/full_llm`
+  # 로 override). extractive `full` primary 로는 answer_reasoning effective_n=0.
+  # - name: full_llm
+  #   pipeline: agentic_full_llm
+  #   metadata_first: true
+  #   rerank: true
+  #   verifier_retry: true
+  #   retrieval_mode: flat
 cases:
   - id: replace_single_doc_budget_schedule
     query_type: single_doc

--- a/rag_synthesis.py
+++ b/rag_synthesis.py
@@ -373,13 +373,25 @@ def _stub_backend(
             cid = citation.get("chunk_id")
             if cid and cid not in used:
                 used.append(str(cid))
-    return {
+    payload: dict[str, Any] = {
         "summary": summary,
         "used_chunk_ids": used,
         "model": "stub",
         "tokens_in": None,
         "tokens_out": None,
     }
+    if _trace_full_enabled():
+        # Trace v2 (issue #967): the stub backend must capture the same full
+        # I/O surface as the live backends so a `BIDMATE_TRACE_FULL=1
+        # BIDMATE_SYNTHESIS_BACKEND=stub` eval populates trace
+        # ``synthesis_llm_call`` — the input the ADR 0056 ``answer_reasoning``
+        # axis scores. ``completion_text`` mirrors the live backends' JSON
+        # tool-call payload shape (summary + used_chunk_ids).
+        payload["user_prompt_text"] = _build_user_prompt(query, analysis, answer, evidence)
+        payload["completion_text"] = json.dumps(
+            {"summary": summary, "used_chunk_ids": used}, ensure_ascii=False
+        )
+    return payload
 
 
 def _anthropic_backend(  # pragma: no cover - network

--- a/reports/real100/rationality.aggregate.json
+++ b/reports/real100/rationality.aggregate.json
@@ -1,30 +1,38 @@
 {
   "axis_cis": {
+    "answer_reasoning": {
+      "alpha": 0.05,
+      "ci_hi": 0.5387058989343325,
+      "ci_lo": 0.450707228692032,
+      "mean": 0.4980370954329726,
+      "n": 166,
+      "num_resamples": 1000
+    },
     "planner_decomposition": {
       "alpha": 0.05,
-      "ci_hi": 0.5171547668471324,
-      "ci_lo": 0.44022596363585886,
-      "mean": 0.47874358398165506,
+      "ci_hi": 0.5354072553136763,
+      "ci_lo": 0.46229589689616307,
+      "mean": 0.4968477003054273,
       "n": 221,
       "num_resamples": 1000
     },
     "retrieval_recalls": {
       "alpha": 0.05,
-      "ci_hi": 0.5439565760997993,
-      "ci_lo": 0.4693946896787718,
-      "mean": 0.5080500066532189,
+      "ci_hi": 0.5484641410595357,
+      "ci_lo": 0.47494046654659156,
+      "mean": 0.5107880502426011,
       "n": 221,
       "num_resamples": 1000
     }
   },
   "axis_means": {
-    "answer_reasoning": null,
-    "planner_decomposition": 0.47874358398165506,
-    "retrieval_recalls": 0.5080500066532186
+    "answer_reasoning": 0.4980370954329726,
+    "planner_decomposition": 0.4968477003054273,
+    "retrieval_recalls": 0.5107880502426012
   },
-  "cases_with_synthesis_llm_call": 0,
+  "cases_with_synthesis_llm_call": 166,
   "effective_n": {
-    "answer_reasoning": 0,
+    "answer_reasoning": 166,
     "planner_decomposition": 221,
     "retrieval_recalls": 221
   },

--- a/reports/real100/rationality.md
+++ b/reports/real100/rationality.md
@@ -1,6 +1,6 @@
 # Trajectory rationality (ADR 0056)
 
-- n: 221 (skipped_no_trace=0; cases_with_synthesis_llm_call=0)
+- n: 221 (skipped_no_trace=0; cases_with_synthesis_llm_call=166)
 - backend: stub
 - model: stub
 
@@ -8,9 +8,9 @@
 
 | axis | mean | 95 % CI | effective_n |
 |---|---:|---|---:|
-| `planner_decomposition` | 0.479 | (0.440, 0.517) | 221 |
-| `retrieval_recalls` | 0.508 | (0.469, 0.544) | 221 |
-| `answer_reasoning` | pending | (full-trace) | 0 |
+| `planner_decomposition` | 0.497 | (0.462, 0.535) | 221 |
+| `retrieval_recalls` | 0.511 | (0.475, 0.548) | 221 |
+| `answer_reasoning` | 0.498 | (0.451, 0.539) | 166 |
 
 ## Bottom 3 cases per axis (rationale review)
 
@@ -18,14 +18,18 @@
 
 ### `planner_decomposition` — bottom 3
 
-- #1 (slice=abstention) = 0.001 — stub: SHA-256(trace subset, axis, case_id)
-- #2 (slice=abstention) = 0.003 — stub: SHA-256(trace subset, axis, case_id)
-- #3 (slice=abstention) = 0.005 — stub: SHA-256(trace subset, axis, case_id)
+- #1 (slice=single_doc) = 0.001 — stub: SHA-256(trace subset, axis, case_id)
+- #2 (slice=single_doc) = 0.005 — stub: SHA-256(trace subset, axis, case_id)
+- #3 (slice=abstention) = 0.010 — stub: SHA-256(trace subset, axis, case_id)
 
 ### `retrieval_recalls` — bottom 3
 
 - #1 (slice=abstention) = 0.000 — stub: SHA-256(trace subset, axis, case_id)
 - #2 (slice=single_doc) = 0.004 — stub: SHA-256(trace subset, axis, case_id)
-- #3 (slice=abstention) = 0.013 — stub: SHA-256(trace subset, axis, case_id)
+- #3 (slice=single_doc) = 0.010 — stub: SHA-256(trace subset, axis, case_id)
 
-### `answer_reasoning` — pending (no synthesis LLM call captured; full-trace follow-up)
+### `answer_reasoning` — bottom 3
+
+- #1 (slice=abstention) = 0.006 — stub: SHA-256(trace subset, axis, case_id)
+- #2 (slice=single_doc) = 0.007 — stub: SHA-256(trace subset, axis, case_id)
+- #3 (slice=single_doc) = 0.008 — stub: SHA-256(trace subset, axis, case_id)

--- a/tests/test_llm_synthesis.py
+++ b/tests/test_llm_synthesis.py
@@ -207,6 +207,66 @@ class SynthesisUnitTest(unittest.TestCase):
         self.assertIn("backend_error", meta["fallback_reason"])
 
 
+class SynthesisStubFullTraceTest(unittest.TestCase):
+    """Trace v2 (issue #967) — the stub backend must capture the same
+    full prompt/completion I/O as the live backends under
+    ``BIDMATE_TRACE_FULL=1`` so a ``BIDMATE_SYNTHESIS_BACKEND=stub`` eval
+    populates trace ``synthesis_llm_call`` (the ADR 0056 answer_reasoning
+    axis input). ADR 0001 invariant: env-off keeps the fields absent."""
+
+    def _synthesize(self) -> dict[str, Any]:
+        _, meta = rag_synthesis.synthesize_answer(
+            query=ANSWERABLE_QUERY,
+            analysis={"query_type": "single_doc", "entities": ["기관 A"]},
+            answer=_make_answer(),
+            evidence=_make_evidence(),
+            backend="stub",
+        )
+        return meta
+
+    def test_env_on_captures_prompt_and_completion(self) -> None:
+        import os
+
+        from rag_tracing import _synthesis_llm_call_payload
+
+        prior = os.environ.get("BIDMATE_TRACE_FULL")
+        os.environ["BIDMATE_TRACE_FULL"] = "1"
+        try:
+            meta = self._synthesize()
+        finally:
+            if prior is None:
+                os.environ.pop("BIDMATE_TRACE_FULL", None)
+            else:
+                os.environ["BIDMATE_TRACE_FULL"] = prior
+
+        self.assertIn("user_prompt_text", meta)
+        self.assertIn("completion_text", meta)
+        # build_result_trace surfaces the captured I/O as synthesis_llm_call.
+        payload = _synthesis_llm_call_payload(meta)
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["backend"], "stub")
+        self.assertIn("기관", payload["user_prompt_text"])
+        self.assertIn("rfp-a::chunk-001", payload["completion_text"])
+
+    def test_env_off_omits_full_io(self) -> None:
+        import os
+
+        from rag_tracing import _synthesis_llm_call_payload
+
+        prior = os.environ.get("BIDMATE_TRACE_FULL")
+        os.environ.pop("BIDMATE_TRACE_FULL", None)
+        try:
+            meta = self._synthesize()
+        finally:
+            if prior is not None:
+                os.environ["BIDMATE_TRACE_FULL"] = prior
+
+        self.assertNotIn("user_prompt_text", meta)
+        self.assertNotIn("completion_text", meta)
+        self.assertIsNone(_synthesis_llm_call_payload(meta))
+
+
 class SynthesisPipelineIntegrationTest(unittest.TestCase):
     """End-to-end: ``agentic_full_llm`` with stub backend must be a
     zero-regression contract test against ``agentic_full``."""

--- a/tests/test_rationality_judge.py
+++ b/tests/test_rationality_judge.py
@@ -132,6 +132,22 @@ class TestAnswerReasoningEnvOffSkip(unittest.TestCase):
         self.assertEqual(aggregate["effective_n"]["planner_decomposition"], 3)
 
 
+class TestAnswerReasoningCaptured(unittest.TestCase):
+    """ADR 0056 follow-up (#1312 pending → measured): a trace carrying a
+    populated synthesis_llm_call must yield answer_reasoning effective_n > 0,
+    proving the BIDMATE_TRACE_FULL=1 stub-synthesis wiring reaches the axis."""
+
+    def test_synthesis_populated_trace_scores_answer_reasoning(self):
+        summary = _summary_with_inline_traces(n=4, with_synthesis=True)
+        local, aggregate = judge_rationality(summary, backend="stub")
+        # Every case carries a synthesis_llm_call → all scored.
+        self.assertEqual(aggregate["effective_n"]["answer_reasoning"], 4)
+        self.assertEqual(aggregate["cases_with_synthesis_llm_call"], 4)
+        self.assertIsNotNone(aggregate["axis_means"]["answer_reasoning"])
+        for case in local["cases"]:
+            self.assertIsNotNone(case["answer_reasoning"])
+
+
 class TestAggregateBootstrapCI(unittest.TestCase):
     def test_aggregate_includes_axis_means_and_cis(self):
         summary = _summary_with_inline_traces(n=10)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0056 trajectory-rationality judge 의 3번째 축 `answer_reasoning` 이 committed artifact 에서 미측정(effective_n=0)이던 것을 실제 측정(effective_n=166)으로 복원한다. 근본 원인은 2겹 wiring 결함: ① `rag_synthesis._stub_backend` 가 `BIDMATE_TRACE_FULL=1` 에서도 `user_prompt_text`/`completion_text` 를 반환하지 않아 `build_result_trace` 가 `synthesis_llm_call=None` 을 냄(stub 캡처 게이트 항상 False); ② eval_summary 의 `case_results` 는 primary run 것만 담는데(run_eval.py) real config 의 `primary_run` 이 extractive `full` 이라 synthesis trace 자체가 없었음. ①을 고치고, synthesis-primary(`agentic_full_llm`) run 으로 real100 을 재측정해 3-axis 모두 measured 로 만든다. PR #1312 가 정직하게 pending 으로 표시했던 상태를 measured 로 해소.

Closes #1326

## 2. 영향 파일

- `rag_synthesis.py` **(load-bearing? 아님 — supporting leaf)** — `_stub_backend` 가 `BIDMATE_TRACE_FULL=1` 시 live backend 와 동일하게 full I/O(`user_prompt_text`=`_build_user_prompt`, `completion_text`=payload JSON) 캡처. env-off 경로 불변(ADR 0001 byte-identical).
- `docs/adr/0056-rationality-judge-measurement-surface.md` **(load-bearing: docs/adr/)** — Implemented/Decision 6/Consequence/Verification 정정: "2-axis measured + 1-axis pending" → **3-axis measured**. synthesis-primary 요건 + abstention drop 명문화. Status/verifies-key 보존.
- `reports/real100/rationality.aggregate.json` **(load-bearing: eval/ aggregate)** — `answer_reasoning` effective_n 0→166, mean 0.498. planner/retrieval 은 synthesis-primary run 재측정으로 re-fingerprint.
- `reports/real100/rationality.md` — 동일 재생성(#1312 sanitize 컨벤션 유지: 익명 rank + slice + stub reason, qid 무노출).
- `eval/real_config.example.yaml` — answer_reasoning 측정용 `full_llm` ablation + primary_run 가이드(주석, 추가만).
- `tests/test_llm_synthesis.py` — `SynthesisStubFullTraceTest` (env-on 캡처 / env-off omit).
- `tests/test_rationality_judge.py` — `TestAnswerReasoningCaptured` (synthesis trace → effective_n>0).

## 3. 리스크

- 가장 가능성 높은 깨짐: ADR 0001 byte-identical 위반(env-off synthesis 출력이 달라짐). → env-off 경로는 `if _trace_full_enabled():` 안에서만 필드 추가하므로 기본 경로 불변. `tests/test_trace_schema_v2.py` env-off None + `test_byte_identical_traces` 그대로 통과. unit 재현으로 env-off `synthesis_llm_call=None` 확인.
- planner/retrieval mean 이 committed 값과 다름(0.479→0.497, 0.508→0.511): synthesis-primary run 의 trace 를 채점하므로 planner subset 의 `pipeline` 문자열(`agentic_full_llm`)이 stub SHA-256 입력에 들어가 deterministic fingerprint 가 달라진 결과 — **품질 지표가 아니라 deterministic hash 분포**라 회귀 아님. 3축이 한 run 에서 일관되게 측정되도록 의도.

## 4. 테스트

변경 전 fail / 후 pass:
- `SynthesisStubFullTraceTest::test_env_on_captures_prompt_and_completion` — 수정 전 stub meta 에 full I/O 없어 `synthesis_llm_call=None`, 수정 후 populated.
- `TestAnswerReasoningCaptured::test_synthesis_populated_trace_scores_answer_reasoning` — synthesis 채워진 trace → `effective_n["answer_reasoning"]>0`.
- env-off 회귀: `test_env_off_omits_full_io` (ADR 0001 invariant).
- 로컬 게이트: `make test-fast` (real-model `slow` 테스트는 로컬 제외, CI 커버) → 2280 passed / 16 skipped. `ruff check` clean. **이 PR 은 머지 전 `gh pr checks` green 필수**(로컬 full 커버리지 미검증분 CI 위임).

## 5. Eval 영향

합성 CI eval delta: All `·` (없음). RAG retrieval/verify/answer path 동작 무변경 — `synthesis_llm_call` 캡처는 `BIDMATE_TRACE_FULL=1` opt-in env-gated, 기본 off. naive_baseline/agentic_full 출력 byte-identical.

### 5b. Real-data delta

검색/검증/답변 path **동작 변화 없음**(env-gated opt-in, 기본 off → ADR 0001 baseline byte-identical). real-data 영향은 측정 표면(rationality aggregate) 한정:

| axis | committed (HEAD) | this PR | 비고 |
|---|---:|---:|---|
| `answer_reasoning` effective_n | 0 | **166** | 신규 측정 (이 PR 핵심). 나머지 55=abstention synthesis 미수행, 정상 drop |
| `answer_reasoning` mean | — (pending) | **0.498** | CI (0.451, 0.539) |
| `planner_decomposition` mean | 0.4787 | 0.4968 | synthesis-primary run re-fingerprint (stub SHA-256, 품질지표 아님) |
| `retrieval_recalls` mean | 0.5081 | 0.5108 | 동일 |

측정 환경: main repo prebuilt `data/index/real100`(hashing) + private n=221 config 의 synthesis-primary 파생본, `BIDMATE_TRACE_FULL=1 BIDMATE_SYNTHESIS_BACKEND=stub`. `run_rationality_judge.py --expect-full-trace` exit 0. per-case trace + `rationality.local.json` 은 gitignored(ADR 0005 aggregate-only), committed md/aggregate 에 qid/근거텍스트 무노출 확인.

## 6. 하위 호환

- ADR 0003 answer-contract 무관 (schema_version bump 불필요 — answer dict 변경 0).
- `synthesize_answer` meta: `user_prompt_text`/`completion_text` 는 `BIDMATE_TRACE_FULL=1` 일 때만 추가되는 opt-in 키 → 기존 consumer 영향 없음.
- CLI/스키마/doc link 변경 없음.

## 7. 범위 외

- LLM backend 실측정(`BIDMATE_RATIONALITY_BACKEND=openai_compatible`, n=221×1 call) — ADR 0056 이 이미 별 PR scope 로 명시.
- `make real-eval` 기본 경로(`real_config.local.yaml` primary_run=full)는 여전히 answer_reasoning=0 — example 에 enable 가이드만 추가(사용자 private config 직접 수정은 사용자 몫).
- `rag_synthesis.py:442` 의 pre-existing Pyright `reportArgumentType`(anthropic tools param) — 본 변경과 무관.