### PR TITLE
test(scripts): bash 3.2 empty-array regression guard for test.sh

### DIFF
--- a/tests/test_test_sh_bash32_regression.py
+++ b/tests/test_test_sh_bash32_regression.py
@@ -1,0 +1,98 @@
+"""Regression: scripts/test.sh empty-array expansion crashes macOS bash 3.2 (issue #1179).
+
+scripts/test.sh runs under `set -euo pipefail`, then expands four optional
+flag arrays (XDIST/COV/SPLIT/STORE_DURATIONS) onto the pytest call. macOS
+system bash (3.2.57) treats `"${ARR[@]}"` for an *empty* array as an
+unbound-variable error under `set -u` and aborts before pytest runs. The fix
+uses the bash-3.2-safe `"${ARR[@]+"${ARR[@]}"}"` idiom so empty arrays expand
+to nothing. Linux CI (bash 4+/5) never reproduced the runtime crash.
+
+Two complementary guards:
+  1. Static: each optional array at the call site uses the `[@]+` idiom.
+     Catches a revert to the bare form on any platform, including Linux CI
+     where the runtime crash does not reproduce.
+  2. Behavioral: scripts/test.sh, run with all four arrays forced empty (a
+     stubbed `python` whose `import` probes all fail) and a stubbed `pytest`,
+     reaches pytest and exits 0. On macOS /bin/bash 3.2 this is the actual
+     crash scenario; on bash 4+ it confirms the end-to-end stub path.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).parents[1]
+SCRIPT = REPO / "scripts" / "test.sh"
+OPTIONAL_ARRAYS = ("XDIST_FLAGS", "COV_FLAGS", "SPLIT_FLAGS", "STORE_DURATIONS_FLAGS")
+
+
+def _stub(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class TestTestShBash32(unittest.TestCase):
+    def test_call_site_guards_each_optional_array(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+        for name in OPTIONAL_ARRAYS:
+            needle = "${" + name + "[@]+"
+            self.assertIn(
+                needle,
+                text,
+                f"{name} must use the bash-3.2 empty-safe expansion "
+                f'"${{{name}[@]+"${{{name}[@]}}"}}" (issue #1179); a bare '
+                f'"${{{name}[@]}}" crashes macOS bash 3.2 under set -u.',
+            )
+
+    def test_reaches_pytest_with_all_arrays_empty(self) -> None:
+        tmp = tempfile.mkdtemp(prefix="test-sh-bash32-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        binp = Path(tmp)
+        # `python` whose every `-c "import ..."` probe fails -> all 4 arrays empty.
+        _stub(binp / "python", "#!/bin/sh\nexit 1\n")
+        # `ruff` no-op so the top lint gate passes instantly.
+        _stub(binp / "ruff", "#!/bin/sh\nexit 0\n")
+        # `pytest` records that it was reached, then exits 0 (never runs the suite).
+        _stub(binp / "pytest", '#!/bin/sh\necho "PYTEST_STUB_REACHED:$*"\nexit 0\n')
+
+        env = dict(os.environ)
+        env["PATH"] = f"{binp}{os.pathsep}{env['PATH']}"
+        # Default local run leaves the shard/duration env vars unset.
+        for var in (
+            "BIDMATE_PYTEST_SPLITS",
+            "BIDMATE_PYTEST_SHARD",
+            "BIDMATE_PYTEST_STORE_DURATIONS",
+        ):
+            env.pop(var, None)
+
+        # Prefer /bin/bash: on macOS it is the 3.2 build that reproduces the
+        # crash. On Linux it is bash 4+/5 and the test still passes.
+        bash = "/bin/bash" if Path("/bin/bash").exists() else "bash"
+        r = subprocess.run(
+            [bash, str(SCRIPT)],
+            cwd=REPO,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            0, r.returncode, f"test.sh crashed before reaching pytest:\n{r.stderr}"
+        )
+        # All four arrays empty -> pytest invoked with just `-q`.
+        self.assertIn(
+            "PYTEST_STUB_REACHED:-q",
+            r.stdout,
+            f"test.sh did not reach pytest with empty arrays:\n"
+            f"stdout={r.stdout!r}\nstderr={r.stderr!r}",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1223

#1179 의 macOS 시스템 bash(3.2.57) empty-array 크래시는 #1202 에서 `scripts/test.sh` 의 네 optional flag 배열에 bash-3.2 안전 idiom `"${ARR[@]+"${ARR[@]}"}"` 를 적용해 수정됐다. 그러나 **회귀 테스트가 추가되지 않아**, 누군가 bare `"${ARR[@]}"` 형태로 되돌리면 Linux CI(bash 4+/5)는 통과하고 macOS 로컬(bash 3.2)에서만 깨지는 silent regression 이 가능하다.

원래 #1188 에 포함됐던 98줄 테스트(`tests/test_test_sh_bash32_regression.py`)를 분리 보존한다. #1188 의 fix 부분은 #1202 와 중복이므로 본 PR 은 **테스트만** 추가한다.

## 2. 영향 파일

- `tests/test_test_sh_bash32_regression.py` — 신규 회귀 테스트 (정적 가드 + 행동 가드)

`scripts/test.sh` 는 변경 없음 (fix 는 #1202 에서 이미 머지).

## 3. 리스크

테스트만 추가하므로 런타임 동작 변화 없음. 가장 가능성 높은 깨짐은 행동 가드가 다른 환경에서 flaky 한 경우지만, stub `python`/`pytest`/`ruff` 를 PATH 앞에 두어 환경 의존성을 제거했다.

## 4. 테스트

`tests/test_test_sh_bash32_regression.py` (2 케이스):
1. **정적** — call site 의 네 배열(`XDIST_FLAGS`/`COV_FLAGS`/`SPLIT_FLAGS`/`STORE_DURATIONS_FLAGS`)이 `[@]+` 가드를 쓰는지 검사. bare 형태 revert 시 실패 — Linux CI 에서 런타임 크래시가 재현 안 되는 갭을 메움.
2. **행동** — `/bin/bash` 로 `scripts/test.sh` 를 네 배열 전부 빈 상태(stub `python` import probe 실패)로 실행, pytest 도달(`PYTEST_STUB_REACHED:-q`) + exit 0 검사.

로컬 py3.11 venv 로 2/2 통과 확인.

## 5. Eval 영향

All `·` — RAG 파이프라인(retrieval/verifier/answer/eval) 미변경. 테스트 파일 추가만.

### 5b. Real-data delta

N/A — `scripts/test.sh` 는 load-bearing path 아님 (SSoT `scripts/_governance.py` `LOAD_BEARING_PATHS`). 신규 파일은 테스트 전용. 검색/검증/평가/수집 path 동작 변화 없음.

## 6. 하위 호환

깨짐 없음. CLI flag·답변 계약(ADR 0003)·doc link 무변경.

## 7. 범위 외

- `scripts/test.sh` fix 자체 — #1202 에서 이미 머지.
- pyenv shim 손상 등 로컬 환경 이슈 — 본 PR 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)