### PR TITLE
chore(tests): correct stale failure-rate comment counts post-#1276/#1321

### DIFF
--- a/tests/test_failure_rate_regression.py
+++ b/tests/test_failure_rate_regression.py
@@ -3,7 +3,7 @@
 Closes the Phase 5 audit (#992) item 3 "closed error loop" gap: the
 ADR 0059 classifier (PR #1001) labels failures and the supply 2 dashboard
 (PR #1004) renders them, but nothing *prevents silent regression* of the
-dominant failure modes the audits surfaced (#1005 retrieval_miss=83,
+dominant failure modes the audits surfaced (#1005 retrieval_miss=67,
 #1020 verifier_false_negative=76, #1025 variance source).
 
 This test reads the committed ``reports/real100/baseline.aggregate.json``
@@ -40,10 +40,10 @@ BASELINE_PATH = REPO_ROOT / "reports" / "real100" / "baseline.aggregate.json"
 # land — never up without an [ALLOW_REGRESSION] justification in the PR that
 # regenerates the baseline.
 #
-# Current committed baseline (HEAD b5ae179, n=221):
+# Current committed baseline (n=221):
 #   total failures            180 / 221 = 0.814
 #   verifier_false_negative    76 / 221 = 0.344  (Finding #1, audit #1020)
-#   retrieval_miss             64 / 221 = 0.290  (dominant, audit #1005)
+#   retrieval_miss             67 / 221 = 0.303  (dominant, audit #1005)
 #
 # Initial ceilings = current rate + margin absorbing the cross-HEAD variance
 # the variance audit (#1025) measured (verifier_false_negative ranged


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`tests/test_failure_rate_regression.py` 의 docstring/ceiling 주석에 #1276 (ADR 0059 `classify_failure` taxonomy 3-bug fix) + #1321 (real-100 baseline regen) *이전* 의 failure_category_counts 절대 수치가 남아 committed `reports/real100/baseline.aggregate.json` 과 어긋났다. 테스트가 RATE 기반 + monotone-ratchet ceiling 이라 통과는 하지만 주석이 stale 하여, reviewer 가 잘못된 baseline 수치를 신뢰할 위험을 정정한다.

Closes #1337

## 2. 영향 파일

- `tests/test_failure_rate_regression.py` (non-load-bearing, 주석 3줄만) — `scripts/_governance.py --is-load-bearing` 결과 false

## 3. 리스크

없음에 가깝다. comment-only 변경 — ceiling 상수(0.86 / 0.40 / 0.34), 테스트 로직, assertion 모두 불변. 가장 가능성 높은 깨짐 경로(ceiling 변경으로 ratchet 무력화)는 diff 가 주석 3줄뿐임을 확인해 배제. `make test-fast` 로 5개 테스트 통과 확인.

## 4. 테스트

신규 테스트 불필요 — 동작 변경 없음(주석만). 기존 `FailureRateRegressionTest` 5개 + 4 subtests 통과 유지. 정정된 수치(retrieval_miss 67/221=0.303)는 baseline.aggregate.json 실값과 일치.

## 5. Eval 영향

All `·` — eval surface(`eval/`) 미변경. `tests/` 주석만 수정.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 — load-bearing path 미변경(`tests/` non-load-bearing). 주석 수치만 committed baseline 에 동기화.

## 6. 하위 호환

영향 없음. 계약/스키마/CLI/doc link 무변경. answer-contract(ADR 0003) 무관.

## 7. 범위 외

- baseline 재생성 / ceiling tightening 은 별도 harden-process(`docs/operations/failure-mode-harden-process.md`) 관할 — 이 PR 은 stale 주석 정정만.

---
**Local gate:** `make test-fast` + `ruff check .` — FlagEmbedding 설치 worktree 라 full `bash scripts/test.sh` 가 real-model `slow` 테스트 로딩으로 hang → fallback 사용 (slow 커버리지는 CI). 단, `test_langgraph_performance_profile.py::test_overhead_within_bound` 1건이 `-n auto` 병렬 CPU 경합으로 timing flake (격리 실행 시 ratio 1.33× 통과) — 본 변경과 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)