### PR TITLE
refactor(scripts): dedupe sys.path/import block in render_failure_distribution

### DIFF
--- a/scripts/render_failure_distribution.py
+++ b/scripts/render_failure_distribution.py
@@ -67,14 +67,10 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from eval.scorers.failure_classifier import FAILURE_CATEGORIES  # noqa: E402
-
-# Ensure ``eval`` is importable when invoked as a bare script (sys.path[0]
-# would otherwise be ``scripts/``, not the repo root).
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from eval.scorers.failure_classifier import classify_failure  # noqa: E402
+from eval.scorers.failure_classifier import (  # noqa: E402
+    FAILURE_CATEGORIES,
+    classify_failure,
+)
 
 DEFAULT_SUMMARY = ROOT / "reports" / "real100" / "eval_summary.json"
 DEFAULT_OUT_MD = ROOT / "reports" / "real100" / "failure_distribution.md"


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR #1335(commit 48b23d3) 머지가 기존 PR(commit 421d0d75)의 import 블록 위에 같은 `sys.path` 가드 + import 패턴을 한 번 더 얹으면서 중복 머지 아티팩트가 생겼다. 두 번째 `if str(ROOT) not in sys.path:` 블록은 가드 때문에 no-op(dead-weight)이다. 단일 `sys.path` 블록 + 단일 combined import로 통합하고 중복 주석("Ensure ``eval`` is importable...")을 제거했다. 동작 변경 없음.

Closes #1344

## 2. 영향 파일

- `scripts/render_failure_distribution.py` (load-bearing 아님 — `scripts/_governance.py --is-load-bearing` exit=1로 확인)

## 3. 리스크

`from eval.scorers.failure_classifier import (...)` combined import의 심볼 누락 가능성이 유일한 깨짐 경로. `FAILURE_CATEGORIES`/`classify_failure` 둘 다 동일 모듈에서 오므로 단일 import로 안전하게 병합 가능. `ruff check .` + 기존 24개 renderer 테스트 통과로 import 해석 정상 확인.

## 4. 테스트

순수 정리(동작 변경 없음)라 신규 테스트 불필요. 기존 `tests/test_render_failure_distribution.py` 24개 모두 통과.

## 5. Eval 영향

All `·` — RAG 파이프라인 외 read-only 렌더러 스크립트의 import 정리. eval 산출물·메트릭 영향 없음.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing 아님(scripts/render_failure_distribution.py는 LOAD_BEARING_PATHS에 없음).

## 6. 하위 호환

깨짐 없음. 모듈 public 심볼·CLI flag·출력 포맷 모두 동일.

## 7. 범위 외

없음.

---
Local gate: `make test-fast` — real-model `slow` 테스트는 로컬 제외(FlagEmbedding 설치 환경 OOM 위험, `user_local_env_memory`), CI에서 커버. 2323 passed / 16 skipped + `ruff check .` clean.