### PR TITLE
docs(adr): collapse duplicate ## Measurement H2 headers in ADR 0057

### DIFF
--- a/docs/adr/0057-bm25s-additive-backend.md
+++ b/docs/adr/0057-bm25s-additive-backend.md
@@ -50,7 +50,9 @@ additive opt-in 백엔드 (`bm25_backend: bm25s`) 추가 자체는 `accepted` �
 
 조건 1 충족 + 조건 2 미충족 시 (ADR 0019/0021/0031 이 임베딩/토크나이저에서 발견한 `0pp-on-hybrid` 패턴이 BM25 backend 에도 성립), 이 ADR 은 `accepted` 상태 유지 (default flip 만 deferred) 하고 공개 합성 eval surface 에 측정 부록만 추가 — 측정 폐루프 작동.
 
-## Measurement (real-100, 2026-05-22)
+## Measurement
+
+### 2026-05-22 — retrieval-channel A/B (top-N overlap, real-100)
 
 [PR #1303](https://github.com/hskim-solv/BidMate-DocAgent/pull/1303) (issue #1299) 이 `bm25_backend` 를 `make_plan` → plan dict → `retrieve_candidates` 로 threading 하기 전까지 `full_bm25s` 행은 plan 에 backend 키가 도달하지 않아 silently okapi 로 fallback 했다 (`bm25s` 라벨이지만 실제 okapi 측정). #1303 머지 + `requirements-bm25s.txt` 설치 후, 비공개 real-100 corpus 에서 Re-open 조건 (1)+(2)-③ 을 실측했다.
 
@@ -72,11 +74,9 @@ additive opt-in 백엔드 (`bm25_backend: bm25s`) 추가 자체는 `accepted` �
 
 **결정** — 조건 (1) 충족 + 조건 (2) 실질 미충족 (parity 는 안전성 신호일 뿐 lift 아님; ADR 0019/0021/0031 의 `0pp-on-hybrid` 패턴이 BM25 backend 에도 성립). 위 "Re-open 조건" 의 line — *조건 1 충족 + 조건 2 미충족 시 측정 부록만 추가* — 경로를 따라 **`bm25_backend` 기본값 flip 보류**, `bm25s` 는 opt-in additive 백엔드로 유지. 후속 ADR (조건 3) 은 열지 않는다. 측정 폐루프 작동.
 
-## Measurement
-
 ### 2026-05-22 — 풀 파이프라인 end-to-end 측정 (비공개 real-100, n=221)
 
-2026-05-22 의 retrieval-channel A/B (아래 "범위 외" 항목) 는 top-N overlap 만 측정하고 end-to-end accuracy / citation_precision / latency delta 는 deferred 였다. 이번에 그 deferred 분을 실측하여 re-open 조건 (1) + (2)-①② 충족 여부를 확정한다.
+2026-05-22 의 retrieval-channel A/B (위 항목) 는 top-N overlap 만 측정하고 end-to-end accuracy / citation_precision / latency delta 는 deferred 였다. 이번에 그 deferred 분을 실측하여 re-open 조건 (1) + (2)-①② 충족 여부를 확정한다.
 
 - **Surface**: 비공개 real-100 eval, n=221 cases (answerable 118 / abstention 103). subset 없이 전체 — full bootstrap 검정력 유지.
 - **Index**: prebuilt `data/index/real100` (26376 chunks, `EMBEDDING_BACKEND=hashing` 오프라인 기본 경로). 재빌드 없이 prebuilt 재사용.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0057 (`docs/adr/0057-bm25s-additive-backend.md`) 에 측정 부록을 추가한 두 PR (#1317 retrieval-channel A/B, #1334 end-to-end full-pipeline) 이 각각 `## Measurement` H2 를 도입하면서 동일 레벨 H2 헤더가 중복됐다. 단일 `## Measurement` H2 아래 두 개의 `###` subsection 으로 통합하고, end-to-end subsection 의 stale cross-reference ("아래 범위 외 항목" — A/B 가 이제 위에 위치) 를 "위 항목" 으로 정정. docs-only, 측정 수치/판정/결론 텍스트는 일절 변경 없음.

Closes #1350

## 2. 영향 파일

- `docs/adr/0057-bm25s-additive-backend.md` (**load-bearing path**: `docs/adr/`) — H2 헤더 구조만 변경 (4 insertions / 4 deletions)

## 3. 리스크

- governance lint 회귀: `--lint-adr-consequences docs/adr/0057-...md` + `--check-adr-readme-status` 둘 다 변경 후 EXIT=0 확인 (Consequences/Verification 섹션 무손상, README Status 컬럼 'accepted' 동기 유지).
- 헤더 레벨 변경이 다른 cross-reference link 를 깨뜨릴 가능성 → 0057 은 anchor 기반 inbound link 없음, `--check-adr-readme-status` 통과로 배제.

## 4. 테스트

테스트 미추가 — 동작 변경 없는 docs-only (ADR 본문 마크다운 헤더 재구조화). 회귀 표면 없음. 로컬 게이트: `make test-fast` (2335 passed, 16 skipped) — real-model `slow` 테스트는 로컬 제외, CI 가 커버.

## 5. Eval 영향

All `·` — eval surface 변경 없음. ADR 텍스트 마크다운 구조만 편집, `eval/config.yaml` / scorer / preset 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

`docs/adr/` 가 load-bearing path 라 본 섹션 필수이나, 변경은 ADR 마크다운 헤더 재구조화 한정 — retrieval / verifier / answer / planner 코드 경로 및 측정 수치 일절 미변경.

## 6. 하위 호환

계약/스키마/CLI flag 변경 없음. ADR 0003 answer-contract 무관, `schema_version` bump 불필요. 0057 내부 H2 → H3 재구조화는 외부 inbound anchor link 없음.

## 7. 범위 외

- 0057 의 측정 수치 자체 재검증 — #1317/#1334 가 이미 머지·확정, 본 PR 은 구조 정리만.
- 다른 ADR 의 유사 중복 헤더 점검 — 현재 0057 한정 관찰, 필요 시 별도 sweep.