### PR TITLE
docs(eval): document why baseline config_sha256 is not a staleness gate

### DIFF
--- a/scripts/check_baseline_provenance.py
+++ b/scripts/check_baseline_provenance.py
@@ -20,6 +20,20 @@ only main history is walked). See ADR 0067.
 Operational tail of issue #160; tracked as issue #413; squash-twin
 durable fix is issue #1222.
 
+Scope (issue #1095): this gate intentionally checks only commit
+*reachability*, not config *content* staleness. ``run_manifest.config_sha256``
+hashes the eval config passed to ``eval/run_eval.py`` — for the real-data
+cycle that is the gitignored, operator-private ``eval/real_config.local.yaml``
+(see ``scripts/smoke_real.sh``), not the committed ``eval/config.yaml``. CI
+cannot recompute it (the bytes are private under ADR 0005), and an
+operator-side hash-mismatch warning would fire on the normal resting state —
+the baseline is a deliberately pinned snapshot, every snapshot is generated
+dirty, and the local config legitimately drifts between deliberate bumps. So
+``config_sha256`` stays reproducibility *metadata*, not a staleness gate; the
+real failure modes are covered here (reachability), by the dirty-gate +
+strict mode in ``scripts/write_real_eval_baseline.py`` (#1148/#414), and by
+the behavioral §5b real-data delta in the PR body.
+
 Exit codes:
   0 — provenance commit OR tree is reachable from --ref (or
       --allow-equal-to).
@@ -145,6 +159,9 @@ def check(
 
     provenance_tree = _extract_provenance_tree(baseline)
 
+    # run_manifest.config_sha256 is deliberately NOT checked for staleness here
+    # — see the module docstring's Scope note (#1095). Only the commit/tree
+    # reachability below guards self-consistency.
     manifest_sha = _extract_run_manifest_sha(baseline)
     if manifest_sha is not None and manifest_sha != provenance_sha:
         return (


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

#1062 / PR #1072 가 naive_baseline golden 의 재생성 toil 을 `make regen-golden` + pre-push soft-warn 으로 자동화한 뒤, 또 다른 baseline surface 인 `reports/real100/baseline.aggregate.json` 에도 `eval/config.yaml` case/fixture 변경 시 content staleness 를 환기하는 게이트가 필요한지 #1095 가 물었다. 제안된 접근은 `run_manifest.config_sha256` ↔ 현재 `eval/config.yaml` 해시 비교.

**조사 결론: 추가 게이트 불필요.** 제안의 전제가 파일을 오인하고 있다.

- `config_sha256` 는 `eval/run_eval.py` 에 넘어가는 eval config 바이트를 해시한다. real-data 사이클에서 그건 `scripts/smoke_real.sh` 가 넘기는 **비공개·gitignored `eval/real_config.local.yaml`** 이지, committed `eval/config.yaml` 이 아니다. real-eval 은 `eval/config.yaml` 을 아예 쓰지 않으므로 그 변경은 real100 baseline 을 stale 하게 만들 수 없다.
- 따라서 CI 가 비교 대상 바이트를 재계산할 수 없다(ADR 0005 비공개 경계). 게이트 구현 자체가 불가능.
- operator-side soft-warn 변형은 nag 가 된다: baseline 은 deliberately-pinned snapshot 이고 모든 스냅샷이 dirty worktree 에서 생성된다(history 4/4 `git_dirty: true`). "로컬 config ≠ 스냅샷 config" 는 deliberate bump 사이의 정상 상태라, #1062 reminder #3 가 회피하려던 "확정 drift 아닌데 발화" 안티패턴이 된다.

진짜 staleness/재현성 실패 모드는 이미 커버됨: commit-reachability(이 스크립트, #160/#413), dirty-gate + strict mode (`write_real_eval_baseline.py`, #1148/#414), behavioral §5b real-data delta.

내구성 있는 산출물로, baseline 게이트 스크립트에 이 scope 경계를 명시하는 코멘트를 남겨 동일한 깨진 게이트의 재제안을 차단한다.

Closes #1095

## 2. 영향 파일

- `scripts/check_baseline_provenance.py` — 모듈 docstring 에 Scope(#1095) 단락 + `config_sha256` 미검사 인라인 코멘트 (+17줄). **load-bearing 아님** (`scripts/_governance.py --is-load-bearing` exit 1 확인; load-bearing 은 `scripts/build_index.py` 한정). 코드 경로 불변.

## 3. 리스크

없음 — 주석만 추가. `check()` 의 분기·exit code·git 호출 전부 불변. `python3 scripts/check_baseline_provenance.py --ref HEAD` → exit 0 유지.

## 4. 테스트

- `tests/test_check_baseline_provenance.py` 15 passed (기존 동작 보존 확인). `ruff check .` clean.
- 동작 변경 없음 → 신규 회귀 테스트 N/A (주석 전용).

## 5. Eval 영향

All `·` (no eval delta). 검색/계획/답변 파이프라인·eval 산식 미변경. governance 문서화 only.

### 5b. Real-data delta

N/A — load-bearing path 미변경 (`scripts/check_baseline_provenance.py` 는 LOAD_BEARING_PATHS 밖), 검색/검증 path 동작 변화 없음. (§5b CI gate 는 load-bearing 변경 시에만 강제 — 이 PR 해당 없음.)

## 6. 하위 호환

깨짐 없음. baseline 스키마·gate 의미·answer-contract (ADR 0003) 전부 불변.

## 7. 범위 외

- naive_baseline golden — 이미 #1062 / PR #1072 처리.
- real100 corpus 자체 재구성 — CLAUDE.md non-goal.
- operator-side `real_config.local.yaml` 해시 soft-warn 신설 — 위 분석대로 nag-prone, 의도적 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)