### PR TITLE
feat(governance): ADR↔ADR supersede cross-ref integrity gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -209,6 +209,27 @@ if [[ -n "$adr_or_readme_touched" ]]; then
   fi
 fi
 
+# Guard: ADR ↔ ADR supersede cross-ref integrity (issue #1077). When an ADR
+# supersedes / changes the invariant of an older ADR, the older ADR's Status
+# block + cross-ref must stay in sync. The #1181 guard above covers ADR-file ↔
+# README-index drift; this covers ADR-file ↔ ADR-file drift (a `Superseded by`
+# pointer with a stale Status, a dangling supersede target, or a structured
+# `Supersedes` whose target lacks the reciprocal back-pointer). ADR 0022's
+# proposed->accepted flip surfaced only in a later external-review round
+# because no PR-time gate fired (PR #1068/#1075 patched after the fact).
+# Fires on any ADR-file modification (ACMR); working-tree scan, like the
+# #1181 guard. Canonical gate is tests/test_governance.py post-push.
+#
+# Bypass with --no-verify only mid-merge; open a follow-up to re-sync.
+adr_touched=$(git diff --cached --name-only --diff-filter=ACMR -- 'docs/adr/[0-9]*.md' 2>/dev/null || true)
+if [[ -n "$adr_touched" ]]; then
+  crossref_out=$(python3 scripts/_governance.py --check-adr-crossref 2>&1)
+  if [[ $? -ne 0 ]]; then
+    echo "$crossref_out" >&2
+    exit 1
+  fi
+fi
+
 # Guard: markdown cross-reference dead links (issue #1060).
 # Whenever any `.md` is staged, scan the WHOLE doc tree (not just the staged
 # files): the recurring failure is a file MOVE that breaks an inbound link

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -538,6 +538,177 @@ def adr_readme_status_violations(
     return violations
 
 
+# ---------------------------------------------------------------------------
+# ADR ↔ ADR supersede cross-ref integrity (issue #1077). The fourth ADR
+# integrity lint, alongside the README-parity trio (#803 membership / #1156
+# count / #1181 status). Those three compare an ADR file against its
+# docs/adr/README.md row; this one compares *ADR files against each other*.
+#
+# The recurrence #1077 targets: an ADR that supersedes / changes the invariant
+# of an older ADR lands without the older ADR getting its Status block +
+# cross-ref updated (ADR 0022's proposed->accepted flip surfaced only in a
+# later external-review round). PR #1068/#1075 patched instances after the
+# fact; this shifts the *structural* half left to PR time.
+#
+# Hard semantic enforcement is impossible without false positives (issue
+# #1027 philosophy: CI enforces structure, reviewers enforce meaning). The
+# repo's accepted consolidation convention (e.g. ADR 0005/0011 absorb several
+# ADRs in prose, NOT via a structured `Supersedes` field) means a full
+# reciprocity rule would mis-fire on ~10 legitimate pairs. So this lint is
+# scoped to three rules that pass clean on the current tree:
+#
+#   R1 self-consistency : an ADR carrying a `Superseded by NNNN` cross-ref
+#                         must have 'superseded' in its Status (catches a
+#                         back-pointer added without flipping Status).
+#   R2 dangling         : every `Superseded by` / `Supersedes` target NNNN
+#                         must be an ADR file that exists (catches typos).
+#   R3 forward recip.   : an ADR declaring `Supersedes NNNN` via the
+#                         structured field must have the target carry a
+#                         matching `Superseded by` back-pointer (catches the
+#                         #1077 forget-to-update-target case; also nudges new
+#                         ADRs toward the structured field).
+#
+# Deliberately NOT enforced: reverse reciprocity (`Superseded by` ⇒ the
+# superseder must declare a structured `Supersedes`). That conflicts with the
+# prose-consolidation convention. README Status-column drift is already owned
+# by adr_readme_status_violations (#1181), so it is not re-checked here.
+# ---------------------------------------------------------------------------
+
+# Dedicated metablock-or-list fields. Tolerant of a leading table pipe
+# (`| **Superseded by** | ... |`) and a list bullet (`- **Superseded by**:`).
+# `[:|]` accepts both the `: value` (list) and `| value` (table) separators.
+_ADR_SUPERSEDED_BY_FIELD_RE = re.compile(
+    r"^[ \t]*(?:\|[ \t]*)?(?:[-*][ \t]*)?\*\*Superseded by\*\*"
+    r"[ \t]*[:|][ \t]*(?P<val>.+?)[ \t]*\|?[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_ADR_SUPERSEDES_FIELD_RE = re.compile(
+    r"^[ \t]*(?:\|[ \t]*)?(?:[-*][ \t]*)?\*\*Supersedes\*\*"
+    r"[ \t]*[:|][ \t]*(?P<val>.+?)[ \t]*\|?[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+# A "superseded by ... NNNN" relationship can also live inside the Status
+# value (e.g. ADR 0036: `Status: superseded by [0049](...)`). Non-greedy so it
+# binds the FIRST 4-digit run after "superseded by" (the target), not a later
+# year/number elsewhere in the value.
+_ADR_STATUS_SUPERSEDED_BY_RE = re.compile(
+    r"superseded\s+by\b.*?(\d{4})", re.IGNORECASE
+)
+# Target extractor for a FIELD value: a markdown link (`[0049]` / `[ADR 0005]`)
+# or an `ADR NNNN` prose ref. Bare 4-digit runs are intentionally NOT matched
+# so a stray year (e.g. "2026") in a free-form field can't become a phantom
+# dangling-pointer target.
+_ADR_FIELD_TARGET_RE = re.compile(
+    r"\[(?:ADR\s*)?(\d{4})\]|ADR\s*(\d{4})", re.IGNORECASE
+)
+
+
+def _adr_field_targets(value: str) -> set[str]:
+    """Return the set of ADR numbers referenced in a supersede field value.
+
+    Em-dash / 'N/A' / empty placeholders (`| **Supersedes** | — |`) yield an
+    empty set because they contain no link or `ADR NNNN` token.
+    """
+    return {
+        next(g for g in m.groups() if g)
+        for m in _ADR_FIELD_TARGET_RE.finditer(value)
+    }
+
+
+def _collect_adr_supersede_pointers(
+    adr_dir: str | Path,
+) -> tuple[dict[str, set[str]], dict[str, set[str]], dict[str, bool]]:
+    """Scan ``adr_dir`` and return three maps keyed by ADR number (NNNN str):
+
+      - ``superseded_by``: NNNN -> {targets it claims supersede it}
+      - ``supersedes``:    NNNN -> {targets it claims to supersede}
+      - ``status_superseded``: NNNN -> Status contains 'superseded'
+
+    ``superseded_by`` unions the dedicated `**Superseded by**` field and any
+    `superseded by NNNN` form embedded in the Status value; ``supersedes``
+    reads only the dedicated `**Supersedes**` field.
+    """
+    superseded_by: dict[str, set[str]] = {}
+    supersedes: dict[str, set[str]] = {}
+    status_superseded: dict[str, bool] = {}
+    for path in sorted(Path(adr_dir).glob("[0-9][0-9][0-9][0-9]-*.md")):
+        num = path.name[:4]
+        text = path.read_text(encoding="utf-8", errors="replace")
+        status = parse_adr_status(path) or ""
+        status_superseded[num] = "superseded" in status
+
+        sb: set[str] = set()
+        for m in _ADR_SUPERSEDED_BY_FIELD_RE.finditer(text):
+            sb |= _adr_field_targets(m.group("val"))
+        for m in _ADR_STATUS_SUPERSEDED_BY_RE.finditer(status):
+            sb.add(m.group(1))
+        if sb:
+            superseded_by[num] = sb
+
+        sup: set[str] = set()
+        for m in _ADR_SUPERSEDES_FIELD_RE.finditer(text):
+            sup |= _adr_field_targets(m.group("val"))
+        if sup:
+            supersedes[num] = sup
+
+    return superseded_by, supersedes, status_superseded
+
+
+def adr_supersede_crossref_violations(adr_dir: str | Path) -> list[str]:
+    """Return messages for broken ADR↔ADR supersede cross-refs (issue #1077).
+
+    Empty list = clean. Implements R1 (self-consistency), R2 (dangling
+    target), R3 (forward reciprocity) described in the section comment above.
+    Pure filesystem read of ``adr_dir``; no git, no README.
+    """
+    superseded_by, supersedes, status_superseded = (
+        _collect_adr_supersede_pointers(adr_dir)
+    )
+    present = {
+        p.name[:4]
+        for p in Path(adr_dir).glob("[0-9][0-9][0-9][0-9]-*.md")
+    }
+    violations: list[str] = []
+
+    # R1 — a Superseded-by cross-ref without a 'superseded' Status.
+    for x, targets in sorted(superseded_by.items()):
+        if not status_superseded.get(x):
+            violations.append(
+                f"{x}: carries a 'Superseded by {sorted(targets)}' cross-ref "
+                "but its Status block does not contain 'superseded' — flip "
+                "the Status (the back-pointer and Status drifted apart)."
+            )
+
+    # R2 — dangling supersede targets in either direction.
+    for x, targets in sorted(superseded_by.items()):
+        for y in sorted(targets):
+            if y not in present:
+                violations.append(
+                    f"{x}: 'Superseded by {y}' points at ADR {y}, which has "
+                    "no file in docs/adr/ (typo'd or deleted cross-ref)."
+                )
+    for x, targets in sorted(supersedes.items()):
+        for y in sorted(targets):
+            if y not in present:
+                violations.append(
+                    f"{x}: 'Supersedes {y}' points at ADR {y}, which has no "
+                    "file in docs/adr/ (typo'd or deleted cross-ref)."
+                )
+
+    # R3 — a structured `Supersedes Y` must be reciprocated by Y's
+    # `Superseded by X` back-pointer. This is the #1077 forget-to-update catch.
+    for x, targets in sorted(supersedes.items()):
+        for y in sorted(targets):
+            if y in present and x not in superseded_by.get(y, set()):
+                violations.append(
+                    f"{x}: declares 'Supersedes {y}' but ADR {y} has no "
+                    f"'Superseded by {x}' back-pointer (add it to {y}'s "
+                    "Status block or a dedicated `**Superseded by**` field)."
+                )
+
+    return violations
+
+
 def adr_has_verification_section(adr_path: str | Path) -> bool:
     """Return True if the ADR file contains a `## Verification` H2 header."""
     p = Path(adr_path)
@@ -1053,6 +1224,36 @@ def _cmd_check_adr_readme_status(adr_dir: str, readme_path: str) -> int:
     return 1
 
 
+def _cmd_check_adr_crossref(adr_dir: str) -> int:
+    """Working-tree ADR↔ADR supersede cross-ref integrity check (issue #1077).
+
+    Scans every ADR file in ``adr_dir`` and reports broken supersede
+    cross-refs (R1 status/back-pointer drift, R2 dangling target, R3 missing
+    reciprocal back-pointer). The canonical gate is the pytest
+    (tests/test_governance.py); the pre-commit hook calls this on the working
+    tree (mirroring --check-adr-readme-status / the deadlink guard).
+    """
+    violations = adr_supersede_crossref_violations(adr_dir)
+    if not violations:
+        return 0
+    sys.stderr.write(
+        "\n❌ ADR ↔ ADR supersede cross-ref check failed (issue #1077):\n\n"
+    )
+    for v in violations:
+        sys.stderr.write(f"     - {v}\n")
+    sys.stderr.write(
+        "\n   When an ADR supersedes another, BOTH files must stay in sync:\n"
+        "     - the superseded ADR's Status block contains 'superseded' and a\n"
+        "       `Superseded by [ADR NNNN]` pointer to the superseder, and\n"
+        "     - if the superseder uses a `**Supersedes**` field, its target\n"
+        "       carries the matching back-pointer.\n"
+        "   This complements the README parity checks (membership / count /\n"
+        "   status); it compares ADR files against each other, not the index.\n\n"
+        "   Bypass with --no-verify only mid-merge; open a follow-up to sync.\n\n"
+    )
+    return 1
+
+
 def _cmd_check_adr_collision(adr_dir: str) -> int:
     dups = find_duplicate_adr_numbers(adr_dir)
     if not dups:
@@ -1410,6 +1611,15 @@ def main() -> int:
              "(issue #1181). Reuses --readme-path / --adr-dir.",
     )
     g.add_argument(
+        "--check-adr-crossref", action="store_true",
+        help="Check ADR↔ADR supersede cross-ref integrity (issue #1077): a "
+             "Superseded-by pointer implies a 'superseded' Status (R1), every "
+             "supersede target file must exist (R2), and a structured "
+             "`**Supersedes**` field must be reciprocated by the target's "
+             "`Superseded by` back-pointer (R3). Compares ADR files against "
+             "each other, not the README index. Reuses --adr-dir.",
+    )
+    g.add_argument(
         "--emit-fire", action="store_true",
         help="Append a v2-5field event to .claude/.hook-fires.log "
              "(ADR 0060). Requires --outcome and --hook. Optional: "
@@ -1515,6 +1725,8 @@ def main() -> int:
         )
     if args.check_adr_readme_status:
         return _cmd_check_adr_readme_status(args.adr_dir, args.readme_path)
+    if args.check_adr_crossref:
+        return _cmd_check_adr_crossref(args.adr_dir)
     if args.emit_fire:
         if not args.outcome or not args.hook:
             sys.stderr.write(

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -456,6 +456,97 @@ def test_status_parity_fails_loud_and_normalizes():
 
 
 # ---------------------------------------------------------------------------
+# G4 (crossref) — ADR ↔ ADR supersede cross-ref integrity (issue #1077).
+# Fourth ADR integrity lint: the README-parity trio compares an ADR file to
+# its index row; this compares ADR files against each other. Catches the
+# recurrence where an ADR supersedes an older one but the older ADR's Status
+# block / back-pointer is never updated (ADR 0022 flip; PR #1068/#1075).
+# ---------------------------------------------------------------------------
+
+
+def test_adr_supersede_crossref_is_clean_on_disk():
+    # The committed ADR tree must satisfy R1/R2/R3 (this is the canonical CI
+    # gate the pre-commit hook shifts left).
+    violations = gov.adr_supersede_crossref_violations(ROOT_DIR / "docs" / "adr")
+    assert not violations, (
+        "ADR↔ADR supersede cross-refs are broken:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+        + "\n\nIssue #1077: keep the superseded ADR's Status + back-pointer in "
+        "sync with the superseder."
+    )
+
+
+def _write(tmp_path, name, body):
+    (tmp_path / name).write_text(body, encoding="utf-8")
+
+
+def test_crossref_r1_status_must_say_superseded(tmp_path):
+    # A `Superseded by` pointer with a non-superseded Status is an R1 drift.
+    _write(tmp_path, "0001-old.md",
+           "- **Status**: accepted\n- **Superseded by**: [ADR 0002](./0002-new.md)\n")
+    _write(tmp_path, "0002-new.md", "- **Status**: accepted\n")
+    v = gov.adr_supersede_crossref_violations(tmp_path)
+    assert len(v) == 1 and v[0].startswith("0001:") and "does not contain" in v[0], v
+
+    # Flipping the Status to superseded clears it (and the back-pointer keeps
+    # the relationship; 0002 has no structured Supersedes, so no R3 here).
+    _write(tmp_path, "0001-old.md",
+           "- **Status**: superseded\n- **Superseded by**: [ADR 0002](./0002-new.md)\n")
+    assert gov.adr_supersede_crossref_violations(tmp_path) == []
+
+
+def test_crossref_r1_accepts_accepted_superseded_hybrid(tmp_path):
+    # ADR 0044's real form: `Accepted (Superseded by ADR NNNN)` — leading word
+    # is 'accepted' but the value contains 'superseded', so R1 must pass.
+    _write(tmp_path, "0044-old.md",
+           "| **Status** | Accepted (Superseded by ADR 0052) |\n"
+           "| **Superseded by** | ADR 0052 (step-change) |\n")
+    _write(tmp_path, "0052-new.md",
+           "| **Status** | Proposed |\n| **Supersedes** | ADR 0044 (trajectory) |\n")
+    assert gov.adr_supersede_crossref_violations(tmp_path) == []
+
+
+def test_crossref_r2_dangling_target(tmp_path):
+    _write(tmp_path, "0001-old.md",
+           "- **Status**: superseded\n- **Superseded by**: [ADR 0099](./0099-ghost.md)\n")
+    v = gov.adr_supersede_crossref_violations(tmp_path)
+    assert len(v) == 1 and "0099" in v[0] and "no file" in v[0], v
+
+
+def test_crossref_r3_supersedes_needs_back_pointer(tmp_path):
+    # 0002 declares it supersedes 0001, but 0001 carries no `Superseded by`.
+    _write(tmp_path, "0001-old.md", "- **Status**: accepted\n")
+    _write(tmp_path, "0002-new.md",
+           "- **Status**: proposed\n- **Supersedes**: [ADR 0001](./0001-old.md)\n")
+    v = gov.adr_supersede_crossref_violations(tmp_path)
+    assert len(v) == 1 and v[0].startswith("0002:") and "back-pointer" in v[0], v
+
+    # Add the reciprocal back-pointer (+ superseded Status to satisfy R1) → clean.
+    _write(tmp_path, "0001-old.md",
+           "- **Status**: superseded\n- **Superseded by**: [ADR 0002](./0002-new.md)\n")
+    assert gov.adr_supersede_crossref_violations(tmp_path) == []
+
+
+def test_crossref_status_line_superseded_by_is_a_pointer(tmp_path):
+    # The `Superseded by NNNN` form embedded in the Status value (ADR 0036)
+    # counts as a back-pointer — both R1 and R3 are satisfied by it.
+    _write(tmp_path, "0036-old.md",
+           "- **Status**: superseded by [0049](./0049-new.md)\n")
+    _write(tmp_path, "0049-new.md",
+           "- **Status**: accepted\n- **Supersedes**: [ADR 0036](./0036-old.md)\n")
+    assert gov.adr_supersede_crossref_violations(tmp_path) == []
+
+
+def test_crossref_em_dash_placeholder_is_not_a_pointer(tmp_path):
+    # `| **Supersedes** | — |` / `| **Superseded by** | — |` (ADR 0034) carry
+    # no target and must not trip R2/R3.
+    _write(tmp_path, "0034-x.md",
+           "| **Status** | Accepted |\n| **Supersedes** | — |\n"
+           "| **Superseded by** | — |\n")
+    assert gov.adr_supersede_crossref_violations(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
 # G5 — rag_core.py must not introduce a pydantic/TypedDict class that
 # shadows the answer dict (CLAUDE.md "Prohibited"; ADR 0003).
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 이 다른 ADR 을 supersede 하거나 invariant 를 바꿀 때, 영향받는(superseded) ADR 의 Status 블록·cross-ref 가 업데이트 안 된 채 머지되는 패턴이 반복됐다 (ADR 0022 proposed→accepted flip 이 외부 리뷰 정정 라운드에서야 발견; PR #1068/#1075 가 사후 보강). PR 시점에 강제/환기하는 게이트가 없었다. README-parity 트리오(#803 membership / #1156 count / #1181 status)의 4번째 ADR 무결성 lint 로, **ADR 파일을 README 인덱스가 아니라 서로 비교**한다.

Closes #1077

## 2. 영향 파일

- `scripts/_governance.py` — `adr_supersede_crossref_violations()` + `_collect_adr_supersede_pointers()` + `_adr_field_targets()` + `_cmd_check_adr_crossref()` + `--check-adr-crossref` CLI flag. (load-bearing 아님 — `--is-load-bearing` 확인)
- `.githooks/pre-commit` — ADR 파일 ACMR 시 working-tree 스캔 (#1181 status 가드 바로 뒤, 동형)
- `tests/test_governance.py` — canonical CI 게이트 1개 + 회귀 테스트 7개

## 3. 리스크

가장 가능성 높은 깨짐: regex 오탐으로 기존 ADR 트리에 false positive → 모든 ADR-touch 커밋이 차단. 배제: 66개 실 ADR 에 대해 `adr_supersede_crossref_violations` = **0 violation** 실증 확인. em-dash placeholder(`| **Supersedes** | — |`), Status-line 임베디드 포인터(`superseded by [0049]`), `Accepted (Superseded by ADR NNNN)` 하이브리드 form 모두 회귀 테스트로 커버. bare 4-digit(연도 등) 은 의도적으로 target 추출에서 제외 — phantom dangling 방지.

## 4. 테스트

- `test_adr_supersede_crossref_is_clean_on_disk` — canonical CI 게이트 (현재 트리 clean)
- R1/R2/R3 각각 + 하이브리드 Status / Status-line 포인터 / em-dash placeholder 회귀 테스트 6개
- `make test-fast`: 2108 passed, 16 skipped. negative 케이스 CLI exit 1 확인.

## 5. Eval 영향

All `·` — governance lint 전용, RAG 검색/검증/답변 path 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing path(`scripts/_governance.py` LOAD_BEARING_PATHS) 미변경 — `--is-load-bearing scripts/_governance.py` = no.

## 6. 하위 호환

기존 계약 깨짐 없음. 신규 CLI flag `--check-adr-crossref` 추가(additive). 답변 계약(ADR 0003) 무관.

## 7. 범위 외

- **역방향 reciprocity 미강제** (의도적): `Superseded by` ⇒ superseder 가 구조화 `Supersedes` 선언 강제는 prose-consolidation 컨벤션(ADR 0005/0011 등)과 충돌해 ~10 false positive. structured `Supersedes` 사용 시에만 R3 발동.
- README Status-column drift 는 이미 #1181 `--check-adr-readme-status` 가 커버 — 중복 안 함.
- #1069(번호충돌)/#1060(dead-link) 등 다른 거버넌스 축은 별개 issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)