### PR TITLE
chore(deps): bump sentence-transformers to >=5.0 for EmbeddingGemma/Qwen3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,15 @@
 numpy>=2.4.4,<2.5
 PyYAML>=6.0.3
 rank-bm25>=0.2.2,<1.0
-sentence-transformers>=2.7,<3.0
+# Floor bumped 2.7 → 5.0 (issue #1357): EmbeddingGemma-300M
+# (google/embeddinggemma-300m) ships a Gemma3-based dense+normalize module
+# stack that only loads on sentence-transformers>=5.0; Qwen3-Embedding-0.6B
+# also wants the >=4.x loader. ST 5.x requires transformers>=4.41,<5.0 (matches
+# the pin below) and torch>=2.6 (matches line ~21). naive_baseline stays
+# byte-identical — it runs the EMBEDDING_BACKEND=hashing path, never ST
+# (ADR 0001). Env upgrade kept a separate concern from the measurement PR
+# per ADR 0019 ("env upgrade yak-shaving violates one-PR-one-concern").
+sentence-transformers>=5.0,<6.0
 transformers>=4.41,<5.0
 # ADR 0019 condition 1 — torch>=2.6 is the CVE-2025-32434 mitigation
 # enforced inside sentence_transformers' load path for BAAI/bge-m3 and


### PR DESCRIPTION
## 무엇을 / 왜

`sentence-transformers>=2.7,<3.0` 핀이 신규 임베딩 후보를 막아, 곧 진행할 **real100 retrieval-surface 임베딩 ablation**(PR #1331 / ADR 0069 가 노출한 `chunk_recall@k` aggregate 의 첫 소비자)의 전제조건을 차단했다:

- **EmbeddingGemma-300M** (`google/embeddinggemma-300m`, 2025-09) — `sentence-transformers>=5.0` 필수
- **Qwen3-Embedding-0.6B** (`Qwen/Qwen3-Embedding-0.6B`, 2025-06) — `>=4.x` 로더 요구

ADR 0019 선례("env 업그레이드는 측정과 별도 concern, one-PR-one-concern")에 따라 의존성 bump 를 독립 chore PR 로 분리. Phase 1.2→1.3 에서 `torch<2.6` 가 BGE-M3 를 막았을 때의 패턴 그대로.

## 변경

- `requirements.txt`: `sentence-transformers>=2.7,<3.0` → `>=5.0,<6.0` + 근거 주석
- `transformers>=4.41,<5.0` / `torch>=2.6` 호환 유지(ST 5.x 요구 범위 일치)

## 1. 범위 (One concern)

의존성 핀 1줄 + 주석. 모델 측정·default 변경 없음(후속 PR).

## 2. ADR 영향

신규 ADR 불필요(ADR 0019: env bump = 집중 chore). **ADR 0001 byte-identity 보존**: `naive_baseline` 은 `EMBEDDING_BACKEND=hashing`(ST 미사용) → ST 버전과 무관, ranking 영향 0.

## 3. 테스트

- `make test-fast` — **2335 passed, 16 slow-skipped** (slow = 실제 임베딩-모델 테스트, CI 가 ST 5.x 모델-로드 경로 검증)
- ST 5.5.1 하에서 실제 MiniLM 로드 OK (384-dim) + hashing byte-identity 경로 OK + repo embed API(`encode(normalize_embeddings=...)`) 무변경 확인

## 4. 하위 호환

ST encode/load API 는 2.x–5.x 안정. 기존 6개 측정 모델 로드 경로 영향 없음.

## 5. 안전

### 5a. 합성 CI 델타
N/A — 런타임 로직 무변경(의존성 핀만). CI 전체 suite(slow 포함)가 게이트.

### 5b. real-data 델타
N/A — `requirements.txt` 는 `LOAD_BEARING_PATHS` 밖이고 런타임 코드 경로 무변경. 실제 측정은 후속 PR(real100 임베딩 ablation)에서 §5b 로 다룬다.

Closes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)