### PR TITLE
fix(eval): CI-aware signal_alive + provenance in distinguishing-power gauge

### DIFF
--- a/docs/adr/0053-distinguishing-power-floor-ablations.md
+++ b/docs/adr/0053-distinguishing-power-floor-ablations.md
@@ -74,6 +74,14 @@
 - **`eval/real_config.local.yaml` 의 real-eval `random_retrieval` row** — eval-row provenance 일관성 위해 PR-B (n=200 baseline regen 과 페어) 에서 추가.
 - **`_build_candidate_item` helper 추출 리팩터** — cleanup PR 까지 연기; 30-LOC 중복은 의도된 명료성이지 아직 technical debt 아님.
 
+## Amended by
+
+- **issue #1367** (`scripts/distinguishing_power.py` 측정 신뢰성 hardening, 2026-05-23) — 두 결함 정정:
+  - **F1 — `signal_alive` 가 CI-aware 로 강화.** 도입 당시 구현은 점추정 gap(default−floor)>0 만으로 `signal_alive=True` 를 확정했다 — 이 ADR §Context/§"Why these two, why now" 의 noise-aware 동기("noise floor 가 gap 아래인 n=200 에서만 의미")와 불일치. 이제 default 의 95% bootstrap CI 하한이 **두 floor 의 CI 상한을 모두 초과**할 때만 `signal_alive=True`. 새 3-state `signal_state`: `alive`(CI 분리) / `uncertain`(점추정은 양수지만 CI 겹침 또는 CI 부재) / `dead`(점추정상 floor 미달) / `n/a`(floor 결측). `signal_alive == (signal_state == "alive")`. 이로써 게이지가 noise 내 미세 양수 차이를 'alive' 로 과장하지 않는다. **이것이 ADR §Decision 의 "반증 가능한 하한선" 의도의 정확한 통계적 구현** — 점추정 비교는 그 의도의 약한 근사였다.
+  - **F2 — committed aggregate 에 provenance 전파.** 도입 당시 `distinguishing_power.aggregate.json` 은 `{gauge, num_predictions, runs}` 만 담아, 원본 eval_summary (private/gitignored) 가 어느 commit·dirty·config 에서 나왔는지 검증 불가였다. 이제 aggregate 가 source eval_summary 의 `provenance` + `run_manifest` 를 전파하고, `check_provenance_skew` 가 현재 HEAD 대비 commit skew / dirty source 를 경고 (`--strict` 시 비0 종료). sibling `baseline.aggregate.json` 의 baseline-provenance 패턴 (pr-eval.yml, #160/#413) 을 게이지 표면에 재사용.
+  - 회귀 테스트: `tests/test_distinguishing_power.py` 의 `CISignalTest` (alive/uncertain/dead/CI 부재) + `ProvenanceTest` (전파 + skew + strict).
+  - **주의 (stale 발견):** 이 amendment 시점의 committed `distinguishing_power.{md,aggregate.json}` (full accuracy 0.2966, "4/5 alive") 은 provenance 부재로 stale 상태였고, 같은 디렉터리 `baseline.aggregate.json` (full accuracy 0.1610, post-ADR-0054) 및 현재 canonical eval_summary 와 불일치 — 정확히 F2 가 잡으려던 문제. committed artifact + README.md:12 헤드라인 숫자 재생성은 통제된 clean-checkout run + eval-baseline-regen 규율로 다루는 **별도 follow-up (#1371)** (이 PR 범위 밖, one-PR-one-concern).
+
 ## Verification
 
 <!-- verifies-key: rag_pipeline_presets.py:VALID_RETRIEVAL_BACKENDS -->

--- a/scripts/distinguishing_power.py
+++ b/scripts/distinguishing_power.py
@@ -42,6 +42,13 @@ from typing import Any
 # ``scripts.distinguishing_power`` from the test suite.
 ROOT = Path(__file__).resolve().parents[1]
 
+# scripts-dir-on-path so ``build_provenance`` imports cleanly whether the
+# script is run directly (sys.path[0] == scripts/) or imported as
+# ``scripts.distinguishing_power`` from pytest (repo root on path). Matches
+# the sibling pattern documented in scripts/_utils.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _utils import build_provenance  # noqa: E402
+
 # Default I/O paths — all relative to repo root. Overridable via CLI.
 DEFAULT_SUMMARY = ROOT / "reports" / "real100" / "eval_summary.json"
 DEFAULT_OUT_MD = ROOT / "reports" / "real100" / "distinguishing_power.md"
@@ -199,6 +206,74 @@ def _safe_abstention(run: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _safe_ci(run: dict[str, Any], metric: str) -> dict[str, float] | None:
+    """Pull a metric's bootstrap CI ``{ci_lo, ci_hi}`` from an ablation run.
+
+    The eval_summary writes a per-run ``ci`` block keyed by metric name, each
+    value ``{mean, ci_lo, ci_hi, n, num_resamples, alpha}`` (eval/bootstrap.py).
+    Returns ``None`` (rather than raising) when the block, the metric, or either
+    bound is absent — the gauge then reports CI separation as ``n/a`` for that
+    metric instead of over-claiming ``alive``.
+    """
+    ci = run.get("ci")
+    if not isinstance(ci, dict):
+        return None
+    block = ci.get(metric)
+    if not isinstance(block, dict):
+        return None
+    lo = block.get("ci_lo")
+    hi = block.get("ci_hi")
+    if lo is None or hi is None:
+        return None
+    try:
+        return {"ci_lo": float(lo), "ci_hi": float(hi)}
+    except (TypeError, ValueError):
+        return None
+
+
+def _ci_separated(
+    default_ci: dict[str, float] | None, floor_ci: dict[str, float] | None
+) -> bool | None:
+    """Is the default CI strictly above the floor CI?
+
+    Returns ``True`` when ``default.ci_lo > floor.ci_hi`` (the two 95% CIs do
+    not overlap and the default is the higher one), ``False`` when they overlap
+    or the default is below, and ``None`` when either CI is missing — the
+    "cannot verify separation" state. This is a deliberately conservative
+    non-overlap test (stricter than a paired-difference test) per ADR 0053's
+    noise-aware framing.
+    """
+    if not default_ci or not floor_ci:
+        return None
+    return default_ci["ci_lo"] > floor_ci["ci_hi"]
+
+
+def _signal_state(vs_random: dict[str, Any], vs_single: dict[str, Any]) -> str:
+    """Derive the 3-state distinguishing-power verdict for one metric.
+
+    States (ADR 0053 §Consequences, CI-aware amendment):
+
+    * ``n/a``       — a floor is missing this metric (gap is ``None``).
+    * ``dead``      — default at or below a floor on the point estimate
+                      (``gap <= 0``). The Goodhart warning state.
+    * ``alive``     — default beats both floors AND its CI is strictly above
+                      both floors' CIs (separated). The only state that licenses
+                      a "distinguishing power" claim in README / portfolio.
+    * ``uncertain`` — default beats both floors on the point estimate but at
+                      least one CI overlaps (or is missing). Positive but not
+                      yet distinguishable from noise.
+    """
+    gr = vs_random["gap"]
+    gs = vs_single["gap"]
+    if gr is None or gs is None:
+        return "n/a"
+    if gr <= 0 or gs <= 0:
+        return "dead"
+    if vs_random["ci_separated"] is True and vs_single["ci_separated"] is True:
+        return "alive"
+    return "uncertain"
+
+
 def _gauge_row(default: float | None, floor: float | None) -> dict[str, Any]:
     """Compute the raw gap + normalized headroom score for one (metric, floor).
 
@@ -230,6 +305,8 @@ def compute_gauge(summary: dict[str, Any]) -> dict[str, Any]:
 
         {
           "num_predictions": int,
+          "provenance":   {git_commit, git_dirty, generated_at} | None,
+          "run_manifest": {git_commit, config_sha256, ...}        | None,
           "runs": {
             "full":             {"accuracy": 0.297, ...},
             "random_retrieval": {"accuracy": 0.025, ...},
@@ -238,13 +315,22 @@ def compute_gauge(summary: dict[str, Any]) -> dict[str, Any]:
           "gauge": {
             "accuracy": {
               "default":      0.297,
-              "vs_random":    {"gap": 0.272, "normalized": 0.279},
-              "vs_single":    {"gap": 0.229, "normalized": 0.245},
-              "signal_alive": True,  # both gauges > 0
+              "default_ci":   {"ci_lo": 0.21, "ci_hi": 0.38} | None,
+              "vs_random":    {"gap": 0.272, "normalized": 0.279,
+                               "floor_ci": {...} | None, "ci_separated": True},
+              "vs_single":    {"gap": 0.229, "normalized": 0.245,
+                               "floor_ci": {...} | None, "ci_separated": True},
+              "signal_state": "alive",  # alive | uncertain | dead | n/a
+              "signal_alive": True,     # == (signal_state == "alive")
             },
             ...
           }
         }
+
+    ``signal_alive`` is CI-aware (ADR 0053 amendment): it is ``True`` only when
+    the default's 95% CI is strictly above both floors' CIs. A positive point
+    gap whose CI overlaps a floor yields ``signal_state == "uncertain"`` and
+    ``signal_alive == False`` — the gauge no longer over-claims on noise.
     """
     runs = _runs_by_name(summary)
     default = runs[DEFAULT_RUN]
@@ -263,7 +349,8 @@ def compute_gauge(summary: dict[str, Any]) -> dict[str, Any]:
             "metric_n": {m: _safe_metric_n(runs[name], m) for m in GAUGED_METRICS},
             # ADR 0054 — transparency fields next to metrics so a reader can
             # see at a glance why a high-abstention run's pre-fix means were
-            # inflated. signal_alive logic is intentionally NOT modified.
+            # inflated. These are independent of signal_state (which is driven
+            # by GAUGED_METRICS + their CIs only).
             **_safe_abstention(runs[name]),
         }
         for name in REQUIRED_RUNS
@@ -273,25 +360,77 @@ def compute_gauge(summary: dict[str, Any]) -> dict[str, Any]:
         d = _safe_metric(default, metric)
         r = _safe_metric(random_run, metric)
         s = _safe_metric(single_run, metric)
-        vs_random = _gauge_row(d, r)
-        vs_single = _gauge_row(d, s)
-        signal_alive = (
-            vs_random["gap"] is not None
-            and vs_single["gap"] is not None
-            and vs_random["gap"] > 0
-            and vs_single["gap"] > 0
-        )
+        d_ci = _safe_ci(default, metric)
+        vs_random = {
+            **_gauge_row(d, r),
+            "floor_ci": _safe_ci(random_run, metric),
+            "ci_separated": None,
+        }
+        vs_random["ci_separated"] = _ci_separated(d_ci, vs_random["floor_ci"])
+        vs_single = {
+            **_gauge_row(d, s),
+            "floor_ci": _safe_ci(single_run, metric),
+            "ci_separated": None,
+        }
+        vs_single["ci_separated"] = _ci_separated(d_ci, vs_single["floor_ci"])
+        state = _signal_state(vs_random, vs_single)
         gauge[metric] = {
             "default": d,
+            "default_ci": d_ci,
             "vs_random": vs_random,
             "vs_single": vs_single,
-            "signal_alive": signal_alive,
+            "signal_state": state,
+            "signal_alive": state == "alive",
         }
     return {
         "num_predictions": n,
+        "provenance": summary.get("provenance"),
+        "run_manifest": summary.get("run_manifest"),
         "runs": out_runs,
         "gauge": gauge,
     }
+
+
+def check_provenance_skew(
+    gauge: dict[str, Any], head_provenance: dict[str, Any] | None = None
+) -> list[str]:
+    """Return human-readable warnings about source-vs-HEAD provenance skew.
+
+    The committed gauge aggregate is derived from a private (gitignored)
+    eval_summary, so a reviewer cannot otherwise tell which commit / dirty
+    state produced the numbers (issue #1367 F2). This mirrors the
+    baseline-provenance guard (pr-eval.yml, #160/#413) at the gauge surface:
+
+    * no ``provenance`` block → cannot verify at all.
+    * source ``git_commit`` != current HEAD → numbers are stale relative to HEAD.
+    * source ``git_dirty`` → numbers may include uncommitted changes.
+
+    ``head_provenance`` is injectable for tests; defaults to the current HEAD
+    via ``build_provenance()``.
+    """
+    warnings: list[str] = []
+    prov = gauge.get("provenance") or {}
+    src_commit = prov.get("git_commit")
+    if not src_commit:
+        warnings.append(
+            "source eval_summary has no provenance block — cannot verify which "
+            "commit produced these numbers. Regenerate with `make real-eval` on "
+            "a clean checkout of a known HEAD."
+        )
+        return warnings
+    head = head_provenance or build_provenance()
+    head_commit = str(head.get("git_commit"))
+    if str(src_commit) != head_commit:
+        warnings.append(
+            f"provenance skew — gauge numbers were produced at {src_commit} but "
+            f"current HEAD is {head_commit}. Regenerate on a clean checkout of HEAD."
+        )
+    if prov.get("git_dirty"):
+        warnings.append(
+            f"source run at {src_commit} was git_dirty=True — numbers may include "
+            f"uncommitted changes (regenerate from a clean tree)."
+        )
+    return warnings
 
 
 def _fmt_pct(value: float | None) -> str:
@@ -307,6 +446,18 @@ def _fmt_pp(value: float | None) -> str:
     return f"{sign}{value * 100:.2f}pp"
 
 
+def _fmt_ci(ci: dict[str, float] | None) -> str:
+    if not ci:
+        return "n/a"
+    return f"[{ci['ci_lo'] * 100:.1f}, {ci['ci_hi'] * 100:.1f}]"
+
+
+def _fmt_sep(value: bool | None) -> str:
+    if value is None:
+        return "n/a"
+    return "yes" if value else "no"
+
+
 def render_markdown(gauge: dict[str, Any]) -> str:
     """Render the gauge as a markdown report.
 
@@ -317,10 +468,24 @@ def render_markdown(gauge: dict[str, Any]) -> str:
     * One-line verdict per metric
     """
     n = gauge["num_predictions"]
+    prov = gauge.get("provenance") or {}
+    if prov.get("git_commit"):
+        prov_line = (
+            f"source: `{prov.get('git_commit')}` "
+            f"(git_dirty={prov.get('git_dirty')}) · generated_at {prov.get('generated_at')}"
+        )
+    else:
+        prov_line = "source: _provenance unavailable — regenerate via `make real-eval` (issue #1367 F2)._"
     lines: list[str] = [
         "# Distinguishing-power gauge (real-eval, ADR 0053 §Consequences)",
         "",
         f"`num_predictions = {n}` · 3 ablation_runs: `full` / `random_retrieval` / `single_chunk`",
+        "",
+        prov_line,
+        "",
+        "`signal` is CI-aware (ADR 0053 amendment, issue #1367): `alive` only when the "
+        "default's 95% CI is strictly above **both** floors' CIs; a positive point gap "
+        "with overlapping CI is `uncertain`, not `alive`.",
         "",
         "Per ADR 0053 §Consequences:",
         "> PR-5b's `scripts/distinguishing_power.py` can compute "
@@ -388,22 +553,22 @@ def render_markdown(gauge: dict[str, Any]) -> str:
 
     lines += [
         "",
-        "## Gauge — default vs floors",
+        "## Gauge — default vs floors (CI-aware)",
         "",
-        "| metric | default | gap vs random | normalized vs random | gap vs single_chunk | normalized vs single_chunk | signal alive |",
-        "|---|---:|---:|---:|---:|---:|:---:|",
+        "| metric | default | default 95% CI | gap vs random | CI-sep vs random | gap vs single_chunk | CI-sep vs single_chunk | signal |",
+        "|---|---:|---:|---:|:---:|---:|:---:|:---:|",
     ]
     for metric in GAUGED_METRICS:
         g = gauge["gauge"][metric]
-        signal_glyph = "yes" if g["signal_alive"] else "no"
         row = [
             metric,
             _fmt_pct(g["default"]),
+            _fmt_ci(g.get("default_ci")),
             _fmt_pp(g["vs_random"]["gap"]),
-            _fmt_pct(g["vs_random"]["normalized"]),
+            _fmt_sep(g["vs_random"].get("ci_separated")),
             _fmt_pp(g["vs_single"]["gap"]),
-            _fmt_pct(g["vs_single"]["normalized"]),
-            signal_glyph,
+            _fmt_sep(g["vs_single"].get("ci_separated")),
+            g["signal_state"],
         ]
         lines.append("| " + " | ".join(row) + " |")
 
@@ -414,17 +579,26 @@ def render_markdown(gauge: dict[str, Any]) -> str:
     ]
     for metric in GAUGED_METRICS:
         g = gauge["gauge"][metric]
-        if g["signal_alive"]:
+        state = g["signal_state"]
+        if state == "alive":
             lines.append(
-                f"- **{metric}**: signal alive — default beats both floors "
-                f"({_fmt_pp(g['vs_random']['gap'])} vs random, "
-                f"{_fmt_pp(g['vs_single']['gap'])} vs single_chunk)."
+                f"- **{metric}**: signal alive — default's CI is strictly above "
+                f"both floors ({_fmt_pp(g['vs_random']['gap'])} vs random, "
+                f"{_fmt_pp(g['vs_single']['gap'])} vs single_chunk; CIs non-overlapping)."
             )
-        elif g["vs_random"]["gap"] is None or g["vs_single"]["gap"] is None:
+        elif state == "n/a":
             lines.append(
                 f"- **{metric}**: n/a — one or both floors missing this metric."
             )
-        else:
+        elif state == "uncertain":
+            lines.append(
+                f"- **{metric}**: ⚠️ signal uncertain — default beats both floors on "
+                f"the point estimate ({_fmt_pp(g['vs_random']['gap'])} vs random, "
+                f"{_fmt_pp(g['vs_single']['gap'])} vs single_chunk) but its 95% CI "
+                f"overlaps at least one floor (not CI-separated). Not yet "
+                f"distinguishable from noise."
+            )
+        else:  # dead
             lines.append(
                 f"- **{metric}**: ⚠️ signal NOT alive — default does not beat "
                 f"both floors ({_fmt_pp(g['vs_random']['gap'])} vs random, "
@@ -440,7 +614,7 @@ def render_markdown(gauge: dict[str, Any]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument(
         "--summary",
         type=Path,
@@ -464,11 +638,28 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print markdown to stdout, do not write files.",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if the source eval_summary is stale relative to the "
+        "current HEAD or was produced from a dirty tree (provenance skew, #1367 F2).",
+    )
     args = parser.parse_args(argv)
 
     summary = _load_summary(args.summary)
     gauge = compute_gauge(summary)
     md = render_markdown(gauge)
+
+    skew_warnings = check_provenance_skew(gauge)
+    for warning in skew_warnings:
+        print(f"[WARN] {warning}", file=sys.stderr)
+    if args.strict and skew_warnings:
+        print(
+            "[ERROR] --strict: provenance skew detected (see warnings above). "
+            "Refusing to write stale gauge artifacts.",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.print_only:
         sys.stdout.write(md)

--- a/tests/test_distinguishing_power.py
+++ b/tests/test_distinguishing_power.py
@@ -7,15 +7,19 @@ gauge from ADR 0053 §Consequences. These tests lock in:
    hand-computable fixtures.
 2. **Schema**: the output JSON has the exact shape PR-D (README auto-regen)
    will consume.
-3. **Verdict logic**: ``signal_alive`` is ``True`` iff default beats BOTH
-   floors on raw gap (gap > 0). Beating only one floor is ``False`` — the
-   strict version of the gauge per ADR 0053 §Decision ("falsifiable lower
-   bounds — any future improvement that doesn't beat random_retrieval is by
-   definition not a real improvement").
+3. **Verdict logic (CI-aware, ADR 0053 amendment, #1367 F1)**: ``signal_state``
+   is ``alive`` only when default beats BOTH floors on point gap AND its 95% CI
+   is strictly above both floors' CIs. A positive gap with overlapping/absent CI
+   is ``uncertain``; ``gap <= 0`` against either floor is ``dead``.
+   ``signal_alive == (signal_state == "alive")`` — the gauge no longer
+   over-claims on noise.
 4. **Missing-data tolerance**: floors with ``None`` for a metric produce
-   ``signal_alive: False`` and ``gap: None`` rather than raising.
+   ``signal_state: "n/a"`` and ``gap: None`` rather than raising.
 5. **Required-runs validation**: missing one of the 3 ablations exits
    non-zero with a useful error message (not a stack trace).
+6. **Provenance (#1367 F2)**: the aggregate propagates the source eval_summary's
+   ``provenance`` + ``run_manifest``; ``check_provenance_skew`` warns when those
+   are absent / stale-vs-HEAD / dirty.
 
 The fixtures are inline dicts — no real eval_summary.json read — so these
 tests are stable against future schema additions and have zero runtime cost.
@@ -31,10 +35,26 @@ from scripts.distinguishing_power import (
     FLOOR_RUNS,
     GAUGED_METRICS,
     REQUIRED_RUNS,
+    check_provenance_skew,
     compute_gauge,
     main,
     render_markdown,
 )
+
+
+def _ci(metric_to_bounds: dict[str, tuple[float, float]]) -> dict[str, dict]:
+    """Build a per-run ``ci`` block from ``{metric: (ci_lo, ci_hi)}`` pairs."""
+    return {
+        metric: {
+            "ci_lo": lo,
+            "ci_hi": hi,
+            "mean": (lo + hi) / 2,
+            "n": 118,
+            "num_resamples": 1000,
+            "alpha": 0.05,
+        }
+        for metric, (lo, hi) in metric_to_bounds.items()
+    }
 
 
 def _make_summary(
@@ -42,46 +62,68 @@ def _make_summary(
     random_retrieval: dict[str, float | None],
     single_chunk: dict[str, float | None],
     n: int = 221,
+    full_ci: dict[str, dict] | None = None,
+    random_ci: dict[str, dict] | None = None,
+    single_ci: dict[str, dict] | None = None,
     ci_n: dict[str, dict[str, int]] | None = None,
+    provenance: dict | None = None,
+    run_manifest: dict | None = None,
 ) -> dict:
     """Build a minimal eval_summary.json shape with 3 ablation runs.
 
-    ``ci_n`` (optional) attaches a per-run ``ci`` block carrying per-metric
-    ``n`` denominators — mirrors the real eval_summary shape so tests can
-    assert the ADR 0054 per-metric denominator disclosure. Omitting it keeps
+    ``*_ci`` blocks (per-metric ``{ci_lo, ci_hi, ...}``) are optional — when
+    absent the gauge cannot assess CI separation and reports ``signal_state``
+    as ``uncertain`` for any positive-gap metric (#1367 F1).
+
+    ``ci_n`` (optional) attaches per-(metric, run) ``n`` denominators into the
+    same ``ci`` block — mirrors the real eval_summary shape so tests can assert
+    the ADR 0054 per-metric denominator disclosure (#1368). Omitting both keeps
     the legacy (ci-less) fixture shape that the older tests rely on.
     """
 
-    def _run(name: str, values: dict[str, float | None]) -> dict:
-        run = {
+    def _run(name: str, values: dict[str, float | None], ci: dict | None) -> dict:
+        run: dict = {
             "name": name,
             "num_predictions": n,
             **values,
         }
+        if ci is not None:
+            run["ci"] = ci
         if ci_n and name in ci_n:
-            run["ci"] = {m: {"n": cnt} for m, cnt in ci_n[name].items()}
+            block = run.setdefault("ci", {})
+            for metric, cnt in ci_n[name].items():
+                block.setdefault(metric, {})["n"] = cnt
         return run
 
-    return {
+    summary: dict = {
         "num_predictions": n,
         "ablation": {
             "runs": [
-                _run("full", full),
-                _run("random_retrieval", random_retrieval),
-                _run("single_chunk", single_chunk),
+                _run("full", full, full_ci),
+                _run("random_retrieval", random_retrieval, random_ci),
+                _run("single_chunk", single_chunk, single_ci),
             ]
         },
     }
+    if provenance is not None:
+        summary["provenance"] = provenance
+    if run_manifest is not None:
+        summary["run_manifest"] = run_manifest
+    return summary
 
 
 class GaugeMathTest(unittest.TestCase):
     """The (default - floor) / (1 - floor) formula on hand-computable inputs."""
 
     def test_perfect_signal(self) -> None:
+        # Wide-apart, non-overlapping CIs → CI-separated from both floors → alive.
         summary = _make_summary(
             full={m: 0.50 for m in GAUGED_METRICS},
             random_retrieval={m: 0.10 for m in GAUGED_METRICS},
             single_chunk={m: 0.20 for m in GAUGED_METRICS},
+            full_ci=_ci({m: (0.45, 0.55) for m in GAUGED_METRICS}),
+            random_ci=_ci({m: (0.05, 0.15) for m in GAUGED_METRICS}),
+            single_ci=_ci({m: (0.15, 0.25) for m in GAUGED_METRICS}),
         )
         g = compute_gauge(summary)
         for metric in GAUGED_METRICS:
@@ -95,6 +137,9 @@ class GaugeMathTest(unittest.TestCase):
             self.assertAlmostEqual(
                 cell["vs_single"]["normalized"], 0.30 / 0.80, places=6
             )
+            self.assertTrue(cell["vs_random"]["ci_separated"])
+            self.assertTrue(cell["vs_single"]["ci_separated"])
+            self.assertEqual("alive", cell["signal_state"])
             self.assertTrue(cell["signal_alive"])
 
     def test_dead_signal_below_random(self) -> None:
@@ -109,6 +154,7 @@ class GaugeMathTest(unittest.TestCase):
         for metric in GAUGED_METRICS:
             cell = g["gauge"][metric]
             self.assertLess(cell["vs_random"]["gap"], 0)
+            self.assertEqual("dead", cell["signal_state"])
             self.assertFalse(
                 cell["signal_alive"],
                 f"{metric}: default 0.10 < random 0.30 must mark signal dead",
@@ -127,6 +173,7 @@ class GaugeMathTest(unittest.TestCase):
             cell = g["gauge"][metric]
             self.assertGreater(cell["vs_single"]["gap"], 0)
             self.assertLess(cell["vs_random"]["gap"], 0)
+            self.assertEqual("dead", cell["signal_state"])
             self.assertFalse(cell["signal_alive"])
 
 
@@ -140,7 +187,10 @@ class SchemaTest(unittest.TestCase):
             single_chunk={m: 0.2 for m in GAUGED_METRICS},
         )
         g = compute_gauge(summary)
-        self.assertEqual({"num_predictions", "runs", "gauge"}, set(g.keys()))
+        self.assertEqual(
+            {"num_predictions", "provenance", "run_manifest", "runs", "gauge"},
+            set(g.keys()),
+        )
         self.assertEqual(set(REQUIRED_RUNS), set(g["runs"].keys()))
         self.assertEqual(set(GAUGED_METRICS), set(g["gauge"].keys()))
 
@@ -154,12 +204,20 @@ class SchemaTest(unittest.TestCase):
         for metric in GAUGED_METRICS:
             cell = g["gauge"][metric]
             self.assertEqual(
-                {"default", "vs_random", "vs_single", "signal_alive"},
+                {
+                    "default",
+                    "default_ci",
+                    "vs_random",
+                    "vs_single",
+                    "signal_state",
+                    "signal_alive",
+                },
                 set(cell.keys()),
             )
             for floor_key in ("vs_random", "vs_single"):
                 self.assertEqual(
-                    {"gap", "normalized"}, set(cell[floor_key].keys())
+                    {"gap", "normalized", "floor_ci", "ci_separated"},
+                    set(cell[floor_key].keys()),
                 )
 
     def test_floor_runs_constant_matches_decision(self) -> None:
@@ -182,6 +240,7 @@ class MissingDataTest(unittest.TestCase):
             cell = g["gauge"][metric]
             self.assertIsNone(cell["vs_random"]["gap"])
             self.assertIsNone(cell["vs_random"]["normalized"])
+            self.assertEqual("n/a", cell["signal_state"])
             self.assertFalse(cell["signal_alive"])
 
 
@@ -214,7 +273,10 @@ class CLITest(unittest.TestCase):
             self.assertTrue(out_md.exists())
             self.assertTrue(out_json.exists())
             written = json.loads(out_json.read_text())
-            self.assertEqual({"num_predictions", "runs", "gauge"}, set(written.keys()))
+            self.assertEqual(
+                {"num_predictions", "provenance", "run_manifest", "runs", "gauge"},
+                set(written.keys()),
+            )
             md = out_md.read_text()
             # Header + verdict section must be present.
             self.assertIn("Distinguishing-power gauge", md)
@@ -351,6 +413,154 @@ class PerMetricDenominatorTest(unittest.TestCase):
             for metric in GAUGED_METRICS:
                 self.assertIsNone(g["runs"][run_name]["metric_n"][metric])
         self.assertNotIn("(n=", render_markdown(g))
+
+
+class CISignalTest(unittest.TestCase):
+    """CI-aware signal_state (#1367 F1) — the core hardening contract."""
+
+    def test_small_positive_gap_overlapping_ci_is_uncertain(self) -> None:
+        # default beats both floors on point estimate by a hair, but its CI
+        # overlaps both floors → must be "uncertain", NOT "alive".
+        summary = _make_summary(
+            full={m: 0.32 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.28 for m in GAUGED_METRICS},
+            single_chunk={m: 0.29 for m in GAUGED_METRICS},
+            full_ci=_ci({m: (0.22, 0.42) for m in GAUGED_METRICS}),
+            random_ci=_ci({m: (0.18, 0.38) for m in GAUGED_METRICS}),
+            single_ci=_ci({m: (0.19, 0.39) for m in GAUGED_METRICS}),
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertGreater(cell["vs_random"]["gap"], 0)
+            self.assertGreater(cell["vs_single"]["gap"], 0)
+            self.assertFalse(cell["vs_random"]["ci_separated"])
+            self.assertEqual("uncertain", cell["signal_state"])
+            self.assertFalse(cell["signal_alive"])
+
+    def test_large_gap_nonoverlapping_ci_is_alive(self) -> None:
+        summary = _make_summary(
+            full={m: 0.50 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.05 for m in GAUGED_METRICS},
+            single_chunk={m: 0.10 for m in GAUGED_METRICS},
+            full_ci=_ci({m: (0.42, 0.58) for m in GAUGED_METRICS}),
+            random_ci=_ci({m: (0.01, 0.10) for m in GAUGED_METRICS}),
+            single_ci=_ci({m: (0.05, 0.16) for m in GAUGED_METRICS}),
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertTrue(cell["vs_random"]["ci_separated"])
+            self.assertTrue(cell["vs_single"]["ci_separated"])
+            self.assertEqual("alive", cell["signal_state"])
+            self.assertTrue(cell["signal_alive"])
+
+    def test_separated_from_one_floor_only_is_uncertain(self) -> None:
+        # CI-separated from random but overlapping single_chunk → uncertain
+        # (both floors must be CI-separated for "alive").
+        summary = _make_summary(
+            full={m: 0.40 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.05 for m in GAUGED_METRICS},
+            single_chunk={m: 0.35 for m in GAUGED_METRICS},
+            full_ci=_ci({m: (0.32, 0.48) for m in GAUGED_METRICS}),
+            random_ci=_ci({m: (0.01, 0.10) for m in GAUGED_METRICS}),
+            single_ci=_ci({m: (0.28, 0.42) for m in GAUGED_METRICS}),
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertTrue(cell["vs_random"]["ci_separated"])
+            self.assertFalse(cell["vs_single"]["ci_separated"])
+            self.assertEqual("uncertain", cell["signal_state"])
+
+    def test_missing_ci_with_positive_gap_is_uncertain(self) -> None:
+        # No ci blocks at all + positive point gap → cannot verify separation,
+        # so the gauge refuses to claim "alive".
+        summary = _make_summary(
+            full={m: 0.50 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.10 for m in GAUGED_METRICS},
+            single_chunk={m: 0.20 for m in GAUGED_METRICS},
+        )
+        g = compute_gauge(summary)
+        for metric in GAUGED_METRICS:
+            cell = g["gauge"][metric]
+            self.assertGreater(cell["vs_random"]["gap"], 0)
+            self.assertIsNone(cell["vs_random"]["ci_separated"])
+            self.assertIsNone(cell["default_ci"])
+            self.assertEqual("uncertain", cell["signal_state"])
+            self.assertFalse(cell["signal_alive"])
+
+    def test_markdown_surfaces_uncertain_state(self) -> None:
+        summary = _make_summary(
+            full={m: 0.32 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.28 for m in GAUGED_METRICS},
+            single_chunk={m: 0.29 for m in GAUGED_METRICS},
+            full_ci=_ci({m: (0.22, 0.42) for m in GAUGED_METRICS}),
+            random_ci=_ci({m: (0.18, 0.38) for m in GAUGED_METRICS}),
+            single_ci=_ci({m: (0.19, 0.39) for m in GAUGED_METRICS}),
+        )
+        md = render_markdown(compute_gauge(summary))
+        self.assertIn("signal uncertain", md)
+        self.assertIn("CI-sep vs random", md)
+
+
+class ProvenanceTest(unittest.TestCase):
+    """Aggregate provenance propagation + skew detection (#1367 F2)."""
+
+    def _summary(self, **kw) -> dict:
+        return _make_summary(
+            full={m: 0.5 for m in GAUGED_METRICS},
+            random_retrieval={m: 0.1 for m in GAUGED_METRICS},
+            single_chunk={m: 0.2 for m in GAUGED_METRICS},
+            **kw,
+        )
+
+    def test_provenance_propagated_into_aggregate(self) -> None:
+        prov = {"git_commit": "abc123", "git_dirty": False, "generated_at": "2026-05-23T00:00:00Z"}
+        manifest = {"git_commit": "abc123", "config_sha256": "deadbeef", "config_path": "eval/real_config.local.yaml"}
+        g = compute_gauge(self._summary(provenance=prov, run_manifest=manifest))
+        self.assertEqual(prov, g["provenance"])
+        self.assertEqual(manifest, g["run_manifest"])
+
+    def test_missing_provenance_is_none(self) -> None:
+        g = compute_gauge(self._summary())
+        self.assertIsNone(g["provenance"])
+        self.assertIsNone(g["run_manifest"])
+
+    def test_skew_warns_when_provenance_absent(self) -> None:
+        g = compute_gauge(self._summary())
+        warnings = check_provenance_skew(g, head_provenance={"git_commit": "head99"})
+        self.assertEqual(1, len(warnings))
+        self.assertIn("no provenance", warnings[0])
+
+    def test_skew_warns_on_commit_mismatch(self) -> None:
+        prov = {"git_commit": "old111", "git_dirty": False, "generated_at": "x"}
+        g = compute_gauge(self._summary(provenance=prov))
+        warnings = check_provenance_skew(g, head_provenance={"git_commit": "head99"})
+        self.assertTrue(any("skew" in w for w in warnings))
+
+    def test_skew_warns_on_dirty_source(self) -> None:
+        prov = {"git_commit": "head99", "git_dirty": True, "generated_at": "x"}
+        g = compute_gauge(self._summary(provenance=prov))
+        warnings = check_provenance_skew(g, head_provenance={"git_commit": "head99"})
+        self.assertTrue(any("git_dirty" in w for w in warnings))
+
+    def test_no_skew_when_clean_and_matching(self) -> None:
+        prov = {"git_commit": "head99", "git_dirty": False, "generated_at": "x"}
+        g = compute_gauge(self._summary(provenance=prov))
+        warnings = check_provenance_skew(g, head_provenance={"git_commit": "head99"})
+        self.assertEqual([], warnings)
+
+    def test_strict_mode_exits_nonzero_on_skew(self) -> None:
+        prov = {"git_commit": "old111", "git_dirty": True, "generated_at": "x"}
+        summary = self._summary(provenance=prov)
+        with TemporaryDirectory() as td:
+            tdp = Path(td)
+            summary_path = tdp / "eval_summary.json"
+            summary_path.write_text(json.dumps(summary))
+            rc = main(["--summary", str(summary_path), "--print-only", "--strict"])
+            # old111 != real HEAD (and dirty) → strict refuses with non-zero rc.
+            self.assertEqual(1, rc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/distinguishing_power.py` (ADR 0053, PR #946) 게이지의 측정 신뢰성 결함 2건을 정정한다. 이 게이지는 README.md:12 ("distinguishing-power gauge 4/5 signal alive") + 포트폴리오 서사가 의존하는 load-bearing 측정 표면이다. **F1** — `signal_alive` 가 점추정 gap>0 만으로 판정해 noise 내 미세 양수 차이도 'alive' 로 과장 → eval_summary 의 bootstrap CI 를 읽어 default CI 하한 > floor CI 상한일 때만 alive (3-state `signal_state`: alive/uncertain/dead/n-a). **F2** — committed aggregate 에 provenance 부재로 stale 미탐지 → source eval_summary 의 `provenance`/`run_manifest` 전파 + `check_provenance_skew`/`--strict`.

Closes #1367

## 2. 영향 파일

- `scripts/distinguishing_power.py` — CI-aware signal_state + provenance 전파 + skew 검사 (load-bearing 아님)
- `tests/test_distinguishing_power.py` — CISignalTest + ProvenanceTest 추가, 기존 schema/verdict 단언 갱신
- **`docs/adr/0053-distinguishing-power-floor-ablations.md`** (load-bearing) — `## Amended by` 에 CI-separation 기준 + provenance 요구 명문화

## 3. 리스크

- 가장 가능성 높은 깨짐: aggregate JSON 스키마 변경(신규 키 `signal_state`/`default_ci`/`floor_ci`/`ci_separated`/`provenance`/`run_manifest`)으로 다운스트림 소비자 파손. 확인: 저장소 전체 grep 결과 게이지 aggregate 의 기계 소비자 없음(README auto-regen 도 미연결); `signal_alive` bool 필드는 유지(의미만 강화)해 하위 키 호환.
- CI 부재 시 over-claim 방지: ci 블록 없으면 `ci_separated=None` → `uncertain` (alive 거부). MissingDataTest + CISignalTest 로 고정.

## 4. 테스트

- 변경 전 fail / 변경 후 pass: `CISignalTest.test_small_positive_gap_overlapping_ci_is_uncertain` (점추정 양수+CI 겹침 → 구 코드는 alive, 신 코드는 uncertain), `test_large_gap_nonoverlapping_ci_is_alive`, `test_separated_from_one_floor_only_is_uncertain`, `test_missing_ci_with_positive_gap_is_uncertain`.
- `ProvenanceTest` 6종: 전파 / 결측 / skew(absent·mismatch·dirty) / clean-match / `--strict` 비0 종료.
- 전체 23 passed.

## 5. Eval 영향

합성 CI eval delta: All `·` — RAG 파이프라인(retrieval/verifier/answer/query) 동작 무변경. 변경 표면은 측정-리포팅 게이지 스크립트 + ADR 문서뿐.

### 5b. Real-data delta

**검색/검증 path 동작 변화 없음.** 본 PR 은 게이지 코드(측정 표면)와 ADR 문서만 변경하며 파이프라인/scorer/preset 을 건드리지 않으므로 real-eval 메트릭에 영향 없음. committed `distinguishing_power.{md,aggregate.json}` 및 README:12 헤드라인 숫자는 **의도적으로 재생성하지 않음** — 별도 follow-up #1371 (통제된 clean-checkout run + eval-baseline-regen 규율). 참고: 새 CI-aware 게이지를 현재 canonical(post-ADR-0054) summary 에 돌리면 4/5 metric 이 `uncertain`(full CI 가 single_chunk 와 겹침) 으로 나와 F1 정정의 타당성을 실증 — 이는 파이프라인 회귀가 아니라 게이지가 이제 정직하게 보고함을 보여준다.

## 6. 하위 호환

답변 계약(ADR 0003) 무관 — `schema_version` bump 불필요. 게이지 aggregate JSON 에 신규 키 추가(가산적); `signal_alive` bool 은 유지하되 판정이 stricter 로 강화(의미 변경). CLI 에 `--strict` flag 추가(가산적, 기본 동작 무변경).

## 7. 범위 외

- committed artifact + README:12 헤드라인 숫자 재생성 → #1371 (stale aggregate 0.2966 vs baseline 0.1610 정합화, eval-baseline-regen).
- `docs/blog/2026-05-goodhart-closed-loop.md` 의 signal_alive 표(frozen 서사) 미수정.
- per-metric CI n 분모 disclosure chip (idx80/#959) — 별개 이슈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)