### PR TITLE
test(retrieval-eval): pin RRF-applied invariant in phase35 m3 ablation

### DIFF
--- a/tests/test_phase35_m3_ablation.py
+++ b/tests/test_phase35_m3_ablation.py
@@ -22,9 +22,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.phase35_m3_ablation import (  # noqa: E402
+    VariantSpec,
     _prime_m3_index_cache_and_colbert,
     _resolve_specs,
     main,
+    run_single_case,
 )
 
 
@@ -274,6 +276,134 @@ class PrimeColbertInt8RegressionTest(unittest.TestCase):
             np.sum(np.max(q.astype(np.float32) @ c0.astype(np.float32).T, axis=1))
         )
         self.assertLess(s0_fast, raw_unscaled * 0.5)
+
+
+class RrfApplicationRegressionTest(unittest.TestCase):
+    """Regression guard for issue #1375 — the same bug that shipped broken
+    Phase 3 numbers (#956, fixed in #994 / #1366): ``run_single_case``
+    sorted hybrid candidates by ``c["score"]``, but ``rag_retrieval`` sets
+    ``score = 0.0`` for RRF backends and defers ranking to
+    ``apply_fusion_and_reranking``. With every score equal, Python's stable
+    sort fell back to candidate (index) insertion order, so RRF never ran
+    and ``rrf_k`` had zero effect on the output. The Phase 3.5 runner
+    shipped already-fixed in #966 (it carried both calls from birth, having
+    learned from #956), but had no test pinning the invariant — so a future
+    revert would silently degenerate the hybrid + m3 ranks. These tests pin
+    it so the revert is caught in CI instead of in a published REPORT.md.
+
+    CI-safe: exercises only the ``hybrid`` variant path (hashing index) and
+    ``apply_fusion_and_reranking`` directly — no FlagEmbedding / BGE-M3
+    import, so the ``m3`` 3-channel variant (which OOMs locally) is out of
+    scope here, mirroring the Phase 3 test.
+    """
+
+    def test_rrf_k_changes_per_item_fusion_score(self) -> None:
+        # ``apply_fusion_and_reranking`` is the stage the broken runner
+        # skipped. Feed it a pre-fusion candidate list where the dense
+        # and bm25 channels disagree, then fuse with rrf_k=30 vs k=100.
+        # The bug signature was "rrf_k has no effect"; the contract is
+        # that (a) every fused score becomes non-zero and (b) the rrf_k
+        # value flows into the numeric score (RRF normalization is
+        # rrf_k / n_channels, so the scores differ even when the final
+        # ranking happens to be stable across k).
+        from rag_retrieval import apply_fusion_and_reranking
+
+        def _candidates() -> list[dict[str, object]]:
+            # dense prefers c0 > c1 > c2; bm25 prefers c2 > c1 > c0.
+            return [
+                {"chunk_id": "c0", "score": 0.0,
+                 "score_parts": {"dense": 0.9, "bm25": 0.1}},
+                {"chunk_id": "c1", "score": 0.0,
+                 "score_parts": {"dense": 0.5, "bm25": 0.5}},
+                {"chunk_id": "c2", "score": 0.0,
+                 "score_parts": {"dense": 0.1, "bm25": 0.9}},
+            ]
+
+        analysis = {"query_type": "single_doc"}
+        base_plan = {
+            "retrieval_backend": "hybrid",
+            "metadata_filters": {},
+            "top_k": 10,
+        }
+
+        fused_k30 = apply_fusion_and_reranking(
+            _candidates(), {}, "q", analysis, {**base_plan, "rrf_k": 30}
+        )
+        fused_k100 = apply_fusion_and_reranking(
+            _candidates(), {}, "q", analysis, {**base_plan, "rrf_k": 100}
+        )
+
+        # (a) RRF actually ran — no fused score is left at the 0.0
+        # placeholder the candidate stage emits for hybrid.
+        self.assertTrue(all(item["score"] > 0.0 for item in fused_k30))
+        self.assertTrue(all(item["score"] > 0.0 for item in fused_k100))
+
+        # (b) rrf_k reaches the output: the per-chunk fused score differs
+        # between k=30 and k=100 for every chunk.
+        scores_k30 = {it["chunk_id"]: it["score"] for it in fused_k30}
+        scores_k100 = {it["chunk_id"]: it["score"] for it in fused_k100}
+        self.assertEqual(set(scores_k30), set(scores_k100))
+        for cid in scores_k30:
+            self.assertNotEqual(
+                scores_k30[cid], scores_k100[cid],
+                f"rrf_k had no effect on {cid}'s fused score — "
+                "RRF fusion likely skipped (issue #1375 regression).",
+            )
+
+    def test_run_single_case_hybrid_is_not_index_order(self) -> None:
+        # End-to-end guard at the runner boundary: with the fusion call
+        # in place, the hybrid top-1 must be the chunk both channels
+        # favor, NOT the first chunk in index insertion order (which is
+        # what the broken score=0.0 stable sort returned). We pin the
+        # disagreement deterministically: the LAST-inserted chunk (c3)
+        # carries the only query-term match (bm25 rank 0) AND its inline
+        # embedding equals the query embedding (dense cosine 1.0), so RRF
+        # must surface c3 first. Under the #956 bug the result would be
+        # c0 (insertion order). Uses the hashing index path + the
+        # hybrid_bm25_k60_m3 spec, so no FlagEmbedding / BGE-M3 load.
+        import numpy as np
+
+        from rag_retrieval import embed_query_for_index
+
+        dim = 16
+        embedding_cfg = {"backend": "hashing", "model": "local-hashing-bow",
+                         "dimension": dim, "normalized": True}
+        query = "알파베타감마독점토큰"
+        qe = embed_query_for_index(query, embedding_cfg)
+        away = (-np.asarray(qe, dtype=np.float32)).tolist()
+
+        def _chunk(cid: str, text: str, emb: list[float]) -> dict[str, object]:
+            return {
+                "chunk_id": cid, "doc_id": "d0", "title": "t",
+                "section": "s", "section_id": "s0",
+                "text": text, "embedding": emb,
+            }
+
+        # c0..c2 share filler text (no query-term hit); c3 holds the
+        # distinctive query token and the query-aligned embedding.
+        index = {
+            "embedding": embedding_cfg,
+            "chunks": [
+                _chunk("c0", "공통 본문 내용 하나", away),
+                _chunk("c1", "공통 본문 내용 둘", away),
+                _chunk("c2", "공통 본문 내용 셋", away),
+                _chunk("c3", f"공통 본문 {query} 내용 넷", list(qe)),
+            ],
+        }
+        spec = VariantSpec(
+            name="hybrid_bm25_k60_m3", retrieval_backend="hybrid",
+            rrf_k=60, index_dir=Path("data/index/real100_m3"),
+        )
+        retrieved_ids, _ = run_single_case(index, {"query": query}, spec, top_k=10)
+
+        # Insertion (degenerate) order top-1 is c0; RRF must instead rank
+        # c3 first since both channels favor it.
+        self.assertEqual(
+            retrieved_ids[0], "c3",
+            "hybrid top-1 fell back to index insertion order — "
+            "apply_fusion_and_reranking was not applied (issue #1375).",
+        )
+        self.assertNotEqual(retrieved_ids[0], "c0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `tests/test_phase35_m3_ablation.py` 에 `RrfApplicationRegressionTest` 추가 — PR #1370(issue #1366)이 phase3 에 추가한 것과 동등한 회귀 가드를 phase35 에 port.
- phase35 runner 는 #966 에서 이미 `retrieve_candidates` + `apply_fusion_and_reranking` 두 호출을 모두 포함한 채 출하됐으나(phase3 #956 버그를 학습), RRF 적용 invariant 를 고정하는 테스트가 없었다 — phase3 의 #956 버그가 detection 없이 ship 된 것과 같은 갭.
- 두 invariant 고정: (1) `apply_fusion_and_reranking` 가 `rrf_k` 에 따라 per-item fused score 를 바꾸고 모든 score 가 non-zero; (2) hybrid spec 의 `run_single_case` 가 RRF/양 채널 favored chunk(c3)를 first 로 반환(삽입 순서 c0 아님). fusion 호출 revert 시 test (2) 가 'c0'!='c3' 로 실패함을 확인.

## 부수 확인 — raw_results staleness (issue body)

`reports/retrieval/phase35_m3_*/raw_results.json` 이 #966 runner 수정 이후 생성됐는지 검증: **stale 아님**. phase3(#956 깨진 채 ship → #994 코드만 수정, 데이터 미재생성 md5 불변 → stale)와 달리, phase35 runner 는 #966(9687a16)에서 이미 두 호출을 가진 채 데이터와 **동시** 출하됐고 #998 도 이를 유지. 커밋된 두 데이터셋 모두 working-RRF 시그니처(main: dense_m3 0.503 / hybrid 0.534 / m3 0.514; kordoc: dense 0.288 / hybrid 0.340 — hybrid > dense, 삽입순서 붕괴 부재)를 보임. 로컬 real100_m3 인덱스 부재 + BGE-M3 OOM 으로 재생성도 불가하나, 재생성 불필요.

## CI-safe

`hybrid` variant path(hashing 인덱스) + `apply_fusion_and_reranking` 직접 호출만 사용. FlagEmbedding / BGE-M3 import 없음 — `m3` 3-channel variant(OOM)는 범위 외, phase3 테스트와 동일 규율.

## Test plan

- [x] `python3 -m pytest tests/test_phase35_m3_ablation.py -q` → 4 passed
- [x] fusion 호출 revert 시 `test_run_single_case_hybrid_is_not_index_order` FAIL 재현('c0' != 'c3')

## PR 템플릿 섹션

- **5b (real-data 델타)**: N/A — `tests/` 는 load-bearing 아님(`scripts/_governance.py LOAD_BEARING_PATHS` 미포함). 동작 변경 없음, 테스트 추가만.
- **ADR 0005 경계**: 신규 데이터 산출물 없음. raw_results 재생성 미수행(데이터 staleness 부재 확인). 테스트 fixture 는 hand-built hashing 인덱스로 비공개 데이터 미접촉.

Closes #1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)