### PR TITLE
fix(eval): null-safety guards in rationality_judge trace subset extractors

### DIFF
--- a/eval/judges/rationality_judge.py
+++ b/eval/judges/rationality_judge.py
@@ -131,32 +131,39 @@ def _load_trace(case: dict[str, Any], traces_dir: Path | None) -> dict[str, Any]
         return None
 
 
+def _inner_planner(trace: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the planner dict, tolerating the optional ``trace`` nesting.
+
+    Hoists each ``.get`` result into a local so the ``isinstance`` guard
+    narrows it — behaviour is identical to inlining the checks, but the
+    type checker can no longer see a ``None`` member access.
+    """
+    nested = trace.get("trace")
+    inner = nested if isinstance(nested, dict) else trace
+    planner = inner.get("planner")
+    return planner if isinstance(planner, dict) else {}
+
+
 def _planner_subset(trace: dict[str, Any]) -> dict[str, Any]:
     """Extract the planner-side input subset for the planner_decomposition axis."""
-    inner = trace.get("trace") if isinstance(trace.get("trace"), dict) else trace
-    planner = (
-        inner.get("planner") if isinstance(inner.get("planner"), dict) else {}
-    )
+    planner = _inner_planner(trace)
+    budget = planner.get("retrieval_budget")
     return {
         "query_type": planner.get("query_type"),
         "pipeline": planner.get("pipeline"),
         "stage_sequence": planner.get("stage_sequence"),
         "selected_top_k": planner.get("selected_top_k"),
         "retrieval_budget_reason": (
-            (planner.get("retrieval_budget") or {}).get("reason")
-            if isinstance(planner.get("retrieval_budget"), dict)
-            else None
+            budget.get("reason") if isinstance(budget, dict) else None
         ),
     }
 
 
 def _retrieval_subset(trace: dict[str, Any]) -> list[list[str]]:
     """Extract per-attempt verification_reasons for the retrieval_recalls axis."""
-    inner = trace.get("trace") if isinstance(trace.get("trace"), dict) else trace
-    planner = (
-        inner.get("planner") if isinstance(inner.get("planner"), dict) else {}
-    )
-    attempts = planner.get("attempts") if isinstance(planner.get("attempts"), list) else []
+    planner = _inner_planner(trace)
+    attempts_raw = planner.get("attempts")
+    attempts = attempts_raw if isinstance(attempts_raw, list) else []
     return [
         list(att.get("verification_reasons") or [])
         for att in attempts
@@ -170,7 +177,8 @@ def _synthesis_subset(trace: dict[str, Any]) -> dict[str, Any] | None:
     Returns ``None`` when the case ran without ``BIDMATE_TRACE_FULL=1`` —
     the synthesis_llm_call key is then absent or ``None``.
     """
-    inner = trace.get("trace") if isinstance(trace.get("trace"), dict) else trace
+    nested = trace.get("trace")
+    inner = nested if isinstance(nested, dict) else trace
     # Step 2 (#968) puts synthesis_llm_call at trace top-level (sibling of
     # planner / answer_schema); some older shapes may nest under "trace".
     call = inner.get("synthesis_llm_call") or trace.get("synthesis_llm_call")

--- a/tests/test_rationality_judge.py
+++ b/tests/test_rationality_judge.py
@@ -22,6 +22,9 @@ if str(ROOT) not in sys.path:
 
 from eval.judges.rationality_judge import (  # noqa: E402
     RATIONALITY_AXES,
+    _planner_subset,
+    _retrieval_subset,
+    _synthesis_subset,
     judge_rationality,
     render_markdown,
 )
@@ -213,6 +216,45 @@ class TestMarkdownSanitizesCaseIds(unittest.TestCase):
         self.assertIn(
             "`answer_reasoning` — pending (no synthesis LLM call captured", md
         )
+
+
+class TestMalformedTraceNullSafety(unittest.TestCase):
+    """Guard paths for nested ``None`` values in the trace dict.
+
+    The subset extractors must tolerate ``planner`` / ``attempts`` /
+    ``retrieval_budget`` being ``None`` (or otherwise non-dict/non-list)
+    without raising, falling back to the same empty-defaults the
+    isinstance guards always intended.
+    """
+
+    def test_planner_none_yields_all_none_fields(self):
+        subset = _planner_subset({"trace": {"planner": None}})
+        self.assertEqual(
+            subset,
+            {
+                "query_type": None,
+                "pipeline": None,
+                "stage_sequence": None,
+                "selected_top_k": None,
+                "retrieval_budget_reason": None,
+            },
+        )
+
+    def test_retrieval_budget_non_dict_yields_none_reason(self):
+        subset = _planner_subset(
+            {"trace": {"planner": {"retrieval_budget": "not-a-dict"}}}
+        )
+        self.assertIsNone(subset["retrieval_budget_reason"])
+
+    def test_attempts_none_yields_empty_list(self):
+        self.assertEqual(_retrieval_subset({"trace": {"planner": {"attempts": None}}}), [])
+
+    def test_missing_nested_trace_key_falls_back_to_top_level(self):
+        # No "trace" nesting: planner sits at top level.
+        self.assertEqual(_retrieval_subset({"planner": {"attempts": None}}), [])
+
+    def test_synthesis_call_non_dict_returns_none(self):
+        self.assertIsNone(_synthesis_subset({"trace": {"synthesis_llm_call": None}}))
 
 
 class TestEndToEndCLI(unittest.TestCase):


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`eval/judges/rationality_judge.py` 의 trace subset 추출 함수가 중첩 dict 접근 시 `.get()` 결과를 isinstance 가드 전에 다시 호출하는 패턴(`inner = trace.get("trace") if isinstance(trace.get("trace"), dict) else trace`)을 써서, 타입 체커가 narrowing 하지 못하고 `None` 멤버 접근으로 봤다. Pyright(strict) 가 line 138/141-147/157/159/162/176 영역에서 `reportOptionalMemberAccess` / `reportOptionalIterable` 14건을 냈다. `.get()` 결과를 지역 변수로 hoist 하여 기존 isinstance 가드가 narrowing 되도록 하는 **순수 null-safety 리팩터**다. 스코어링 값·집계·계약은 일절 변경하지 않는다. PR #1312 작업 중 발견했으나 one-PR-one-concern 원칙으로 분리한 pre-existing 이슈.

Closes #1320

## 2. 영향 파일

- `eval/judges/rationality_judge.py` (**load-bearing**, `eval/`) — 신규 `_inner_planner` 헬퍼 추출 + `_planner_subset` / `_retrieval_subset` / `_synthesis_subset` null-safety 가드. 동작 불변.
- `tests/test_rationality_judge.py` — 중첩 None 가드 경로 회귀 테스트 5개 추가 (`TestMalformedTraceNullSafety`).

## 3. 리스크

가장 가능성 높은 깨짐 경로 = budget reason 추출 로직(`(planner.get("retrieval_budget") or {}).get("reason")` → `budget.get("reason") if isinstance(budget, dict) else None`)이 미묘하게 동작을 바꾸는 것. 빈 dict `{}` 케이스(falsy)에서 양쪽 모두 `None` 을 반환함을 확인했고, 기존 6개 테스트가 그대로 통과(동작 보존 증거). `_inner_planner` 는 두 함수가 공유하던 inline 로직을 그대로 추출한 것이라 출력 동일.

## 4. 테스트

- 기존 `tests/test_rationality_judge.py` 6개 그대로 통과 (동작 보존 회귀 게이트).
- 신규 5개: `planner=None` / `retrieval_budget` non-dict / `attempts=None` / nested-`trace` 키 부재 fallback / `synthesis_llm_call=None` — 새로 명시화된 가드 경로 커버.
- 전체 `not slow` 스위트: 2106 passed, 16 skipped, 0 failed (직렬). slow-marked 68건은 로컬 메모리 제약으로 deselect → CI 샤딩 매트릭스가 커버.
- `ruff check .` clean. Pyright reportOptional 14건 → 0건.

## 5. Eval 영향

All `·` — RAG 검색/검증/답변 파이프라인 변경 없음. `rationality_judge.py` 는 trace JSON 의 read-only consumer (모듈 docstring: production code path 가 import 하지 않음)로, eval 답변 스코어에 들어가지 않는다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음 — 순수 null-safety 리팩터. `_stub_score` / `_aggregate` 스코어링 함수와 `reports/real100/rationality.aggregate.json` 은 불변이며, well-formed trace 에 대한 subset 추출 출력이 byte-identical(기존 6개 동작 보존 테스트로 증명)하므로 real-data 답변 파이프라인 델타는 구조적으로 0이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)