### PR TITLE
feat(eval): measure ADR 0056 rationality via LLM judge (stub vs Sonnet 4.6)

### DIFF
--- a/docs/adr/0056-rationality-judge-measurement-surface.md
+++ b/docs/adr/0056-rationality-judge-measurement-surface.md
@@ -60,7 +60,7 @@ Step 2 (PR #968, ADR-free) 의 trace schema v2 `synthesis_llm_call` 키 (`BIDMAT
 
 - **Phase 3 audit item 3 (✗ absent → ✓ present)** 폐쇄. 5-step portfolio narrative ("측정 → 함정 발견 → 함정 fix → 측정 표면 audit → 자동 게이트 도입 → process rationality 측정 도입") 의 step 3 (= 측정 표면 완비) 까지 달성.
 - 신규 `reports/real100/rationality.{md,aggregate.json}` 두 산출물 → eval surface 의 1-차원 추가.
-- judge LLM backend 의 실 측정 비용 (n=221 × 1 LLM call = 221 LLM call/run) 은 별 PR scope. 본 PR 의 measurement scope = stub backend (0 cost, deterministic).
+- judge LLM backend 의 실 측정 (n=221 × 1 LLM call) 은 별 PR (#1377, 2026-05-23) 에서 수행 — Claude Sonnet 4.6, ≈$1.5. stub↔LLM Spearman ρ≈0 (모든 축) 으로 stub 이 품질 proxy 가 아닌 분포 floor 임을 확증. 상세는 "Measurement appendix — LLM backend".
 - `answer_reasoning` 의 effective_n 는 `BIDMATE_TRACE_FULL=1` + synthesis trace 캡처 여부에 의존. **#1326 측정에서 effective_n=166 (cases_with_synthesis_llm_call=166)** — synthesis-primary run (`agentic_full_llm`) + stub full-trace 캡처 wiring fix 로 3-axis 모두 measured. 나머지 55 케이스는 abstention 으로 synthesis 미수행(정상 drop, ADR 0054 substantive-only semantics). (이력: #987 최초 measured 주장 → #1297 이 effective_n=0 artifact 와의 모순을 pending 으로 정직 정정 → #1326 이 wiring 을 고쳐 measured 복원. 이전 본문의 "모든 case cover" 표현은 abstention drop 을 누락했던 부정확 — "synthesis 수행 case 전부 cover" 가 정확.)
 - 향후 PR 에서 `Claim:` (ADR 0055) 으로 rationality axis 의 변화 보고 가능 — `Claim: planner_decomposition=+0.05pp` 식. 단 본 PR 에서는 baseline 측정만, claim 0건.
 
@@ -75,7 +75,7 @@ Step 2 (PR #968, ADR-free) 의 trace schema v2 `synthesis_llm_call` 키 (`BIDMAT
 
 ## Out-of-scope
 
-- LLM backend 실측정 (`BIDMATE_RATIONALITY_BACKEND=openai_compatible`, n=221 × 1 call = ~$1 추정) — 별 PR.
+- ~~LLM backend 실측정 (`BIDMATE_RATIONALITY_BACKEND=openai_compatible`, n=221 × 1 call = ~$1 추정) — 별 PR.~~ **완료 (#1377, 2026-05-23)** — 아래 "Measurement appendix — LLM backend" 참조.
 - Verifier-axis rationality (Step 2 audit finding 으로 폐기 — `rag_verifier.py` LLM call 0).
 - Planner full I/O trace dump (Step 2 surgical scope 외).
 - Per-axis weighting / composite "process_health" score — 본 PR 은 raw axis 만, 합성 score 는 portfolio narrative 가 정해진 후 별 ADR.
@@ -108,7 +108,31 @@ python3 -c "import json; r=json.load(open('reports/real100/rationality.aggregate
   print('means:', {k: round(v, 3) if v else None for k, v in r['axis_means'].items()})"
 ```
 
+## Measurement appendix — LLM backend (Sonnet 4.6)
+
+### 2026-05-23 — stub vs LLM 변별력 (비공개 real-100, n=221)
+
+본 ADR Decision 6 의 첫 측정은 stub backend (deterministic SHA-256) 였고, Out-of-scope 가 LLM backend 실측정을 별 PR 로 예약했다. [PR #1377](https://github.com/hskim-solv/BidMate-DocAgent/pull/1377) (issue #1377) 이 그 deferred 분을 실측 — 같은 synthesis-primary trace 셋을 `stub` 과 `openai_compatible` (Claude Sonnet 4.6) 두 backend 로 채점하여 변별력을 비교한다.
+
+- **Surface**: 비공개 real-100, n=221 (synthesis 수행 154 → answer_reasoning 측정 가능). prebuilt `data/index/real100` (`hashing`) + `agentic_full_llm` primary (`prompt_profile=llm_synthesis`) + `BIDMATE_TRACE_FULL=1 BIDMATE_SYNTHESIS_BACKEND=stub` (synthesis 자체는 stub — judge 변별력 측정이 목표, synthesis 품질 측정 아님).
+- **Backends**: stub = SHA-256(trace subset) 분포 floor. LLM = `claude-sonnet-4-6` (Anthropic OpenAI-compat, temp=0). 비용 ≈$1.5 (judge len//3 input estimate 251k tokens, output ~27k).
+- **Enabler**: `eval/judges/judge_common.call_openai_json` 가 `response_format={"type":"json_object"}` 를 하드코딩해 Anthropic compat 엔드포인트가 400 (`Input should be 'json_schema'`) 으로 거부 → `BIDMATE_JUDGE_RESPONSE_FORMAT=none` env (기본 `json_object`, byte-identical) 도입으로 kwarg 생략 가능. `get_judge_temperature` (gpt-5.x temp=0 거부) 와 동일한 endpoint-quirk 우회 패턴.
+
+| axis | stub mean (std) | LLM mean (std) | LLM 95% CI | Spearman ρ (p) | effective_n |
+|---|---:|---:|---|---:|---:|
+| `planner_decomposition` | 0.493 (0.288) | 0.507 (0.194) | (0.482, 0.533) | −0.090 (0.185) | 221 |
+| `retrieval_recalls` | 0.515 (0.285) | 0.468 (0.240) | (0.437, 0.499) | −0.033 (0.623) | 221 |
+| `answer_reasoning` | 0.505 (0.290) | 0.318 (0.163) | (0.292, 0.344) | −0.012 (0.883) | 151 |
+
+**판정**:
+
+- **stub 은 품질 proxy 가 아니다 (의도된 설계 확증).** 세 축 모두 stub↔LLM Spearman ρ≈0 (|ρ|≤0.09, 전부 p>0.18) — stub SHA-256 점수는 LLM judge 의 trajectory 품질 판단을 전혀 추적하지 않는다. stub 은 cross-platform byte-identical *분포 floor* 일 뿐이며, "변별력 비교용 floor" 라는 Decision-table 의 stub 설계 의도가 실측으로 확인됐다.
+- **LLM backend 는 quality-correlated 변별력을 추가한다.** LLM std (0.16–0.24) < stub std (0.29 = uniform[0,1] floor) — 일관된 판단으로 분포가 좁다. slice 별로 `follow_up` 의 degenerate trajectory 를 planner 0.225 / retrieval 0.100 로 페널티 (stub 은 0.387 / 0.569 노이즈), `answer_reasoning` 은 stub synthesis(템플릿 passthrough)를 mean 0.318 로 낮게 채점 — evidence-aware 판단의 신호. 상세 slice/query_type breakdown: [`docs/audits/rationality-llm-judge-comparison.md`](../audits/rationality-llm-judge-comparison.md).
+
+**Caveats**: single judge / single seed (judge-variance 미추정), single run. `answer_reasoning` 의 0.318 은 *stub synthesis* 완성문을 채점한 값이라 synthesis *품질* 지표가 아니다 (judge 변별력 신호일 뿐). committed 산출물은 aggregate/per-slice 만 (ADR 0005 — per-case score + qid 는 `rationality.*.local.json` gitignored). 결과는 비결정적 (LLM) 이라 CI 게이트 baseline 아님 — 본 appendix 가 측정 record.
+
 <!-- verifies-key: eval/judges/rationality_judge.py:judge_rationality -->
 <!-- verifies-key: eval/judges/rationality_judge.py:_stub_backend -->
 <!-- verifies-key: eval/judges/rationality_judge.py:_aggregate -->
 <!-- verifies-key: scripts/run_rationality_judge.py:main -->
+<!-- verifies-key: eval/judges/judge_common.py:get_judge_response_format -->

--- a/docs/audits/rationality-llm-judge-comparison.md
+++ b/docs/audits/rationality-llm-judge-comparison.md
@@ -1,0 +1,52 @@
+# Rationality judge — stub vs LLM (Sonnet 4.6) discriminating power
+
+- Date: 2026-05-23
+- Issue/PR: #1377
+- ADR: [0056](../adr/0056-rationality-judge-measurement-surface.md) (Measurement appendix — LLM backend)
+- Surface: 비공개 real-100, n=221 (aggregate-only — ADR 0005)
+
+## 무엇을 측정했나
+
+ADR 0056 의 trajectory-rationality judge 는 첫 PR(#987/#1326)에서 deterministic `stub` backend(SHA-256(trace subset))로만 측정됐다. ADR 0056 Out-of-scope 가 LLM backend 실측정을 별 PR 로 예약. 본 측정은 **같은 synthesis-primary trace 셋**을 두 backend 로 채점해 변별력을 비교한다 — stub 이 분포 floor 일 뿐인지, LLM judge 가 품질-상관 신호를 추가하는지.
+
+## 측정 환경
+
+- Index: prebuilt `data/index/real100` (26376 chunks, `EMBEDDING_BACKEND=hashing` 오프라인 기본 경로).
+- Primary run: `agentic_full_llm` (`prompt_profile=llm_synthesis`) + `BIDMATE_TRACE_FULL=1 BIDMATE_SYNTHESIS_BACKEND=stub`. synthesis 는 stub(템플릿 passthrough) — **judge 변별력 측정이 목표이지 synthesis 품질 측정이 아님**. synthesis 가 도는 154 케이스에서 `answer_reasoning` 측정 가능, 나머지는 abstention drop.
+- stub backend: SHA-256(trace subset, axis, case_id) → uniform[0,1]. cross-platform byte-identical 분포 floor.
+- LLM backend: `claude-sonnet-4-6` (Anthropic OpenAI-compat 엔드포인트, temp=0, `BIDMATE_JUDGE_RESPONSE_FORMAT=none`). 1 LLM call/case (3-axis 합본). 비용 ≈$1.5 (judge len//3 input estimate 251k tokens, output ~27k).
+
+## 결과 — per-axis mean ± std, 95% CI, stub↔LLM Spearman ρ
+
+| axis | stub mean | stub std | LLM mean | LLM std | LLM 95% CI | Spearman ρ | p | n |
+|---|---:|---:|---:|---:|---|---:|---:|---:|
+| `planner_decomposition` | 0.493 | 0.288 | 0.507 | 0.194 | (0.482, 0.533) | −0.090 | 0.185 | 221 |
+| `retrieval_recalls` | 0.515 | 0.285 | 0.468 | 0.240 | (0.437, 0.499) | −0.033 | 0.623 | 221 |
+| `answer_reasoning` | 0.505 | 0.290 | 0.318 | 0.163 | (0.292, 0.344) | −0.012 | 0.883 | 151 |
+
+세 축 모두 **Spearman ρ≈0** (|ρ|≤0.09, 전부 p>0.18): stub 점수는 LLM judge 의 품질 판단을 추적하지 않는다. stub std≈0.29 는 uniform[0,1] 의 분포 폭 그대로 — 신호 없는 floor. LLM std(0.16–0.24)가 더 좁은 것은 judge 가 일관된 판단을 내려 분포가 수렴함을 시사.
+
+## 변별력 — LLM mean by slice (stub mean in parens, 설계상 flat)
+
+| slice | n | planner_decomp | retrieval_recalls | answer_reasoning |
+|---|---:|---:|---:|---:|
+| abstention | 104 | 0.531 (0.521) | 0.494 (0.516) | 0.310 (0.500) |
+| comparison | 1 | 0.650 (0.913) | 0.200 (0.650) | 0.350 (0.358) |
+| follow_up | 4 | 0.225 (0.387) | 0.100 (0.569) | — |
+| single_doc | 112 | 0.494 (0.467) | 0.461 (0.512) | 0.325 (0.511) |
+
+- `follow_up` (n=4) 의 degenerate trajectory 를 LLM 은 planner 0.225 / retrieval 0.100 로 명확히 페널티 — stub 은 0.387 / 0.569 노이즈로 무차별.
+- `answer_reasoning` 은 모든 slice 에서 LLM ≪ stub (~0.31–0.35 vs ~0.50) — LLM 이 stub synthesis(템플릿 완성문)의 evidence 일관성을 낮게 변별. stub 은 ~0.50 균일.
+
+(comparison/follow_up 은 n 이 작아 방향성 only.)
+
+## 판정
+
+- **stub = 분포 floor (품질 proxy 아님) — 설계 의도 확증.** ρ≈0 가 stub 의 cross-platform 재현성을 깨지 않으면서도 trajectory 품질과 무상관임을 보인다.
+- **LLM backend = quality-correlated, slice-sensitive, evidence-aware 변별력 추가.** ADR 0056 의 "다른 backend 와 변별력 비교용 floor" 라는 stub 설계가 실측으로 검증됨.
+
+## Caveats
+
+- single judge (Sonnet) / single seed → judge-variance 미추정. haiku↔sonnet 교차(robustness)는 별 follow-up.
+- single run. `answer_reasoning`=0.318 은 *stub synthesis* 채점값이라 synthesis *품질* 지표가 아님 (judge 변별력 신호).
+- 비결정적(LLM) → CI 게이트 baseline 아님; 본 리포트가 측정 record. committed 는 aggregate/per-slice 만 (per-case score + qid 는 `rationality.*.local.json` gitignored, ADR 0005).

--- a/eval/judges/judge_common.py
+++ b/eval/judges/judge_common.py
@@ -54,6 +54,7 @@ __all__ = [
     "build_evidence_block",
     "build_openai_client",
     "get_judge_model",
+    "get_judge_response_format",
     "call_openai_json",
     "normalize_status_verdict",
 ]
@@ -207,6 +208,38 @@ def get_judge_temperature() -> float:
         ) from exc
 
 
+def get_judge_response_format() -> dict[str, str] | None:
+    """Read the ``response_format`` kwarg for judge calls from the environment.
+
+    Returns ``{"type": "json_object"}`` by default (unset/empty) — the
+    structured-output path that keeps existing judge behaviour byte-identical.
+    Setting ``BIDMATE_JUDGE_RESPONSE_FORMAT=none`` returns ``None`` so the
+    kwarg is omitted entirely.
+
+    The override exists because Anthropic's OpenAI-compatibility endpoint
+    rejects ``response_format={"type": "json_object"}`` ("response_format.type:
+    Input should be 'json_schema'"); the Claude models there reliably emit
+    valid JSON from the prompt instruction alone, so omitting the kwarg
+    unblocks them without changing the default for every other backend
+    (mirrors the :func:`get_judge_temperature` accommodation for gpt-5.x).
+
+    Raises:
+        ValueError: when the env var is set but not one of ``json_object`` /
+            ``none``.
+    """
+    raw = os.environ.get("BIDMATE_JUDGE_RESPONSE_FORMAT")
+    if raw is None or raw.strip() == "":
+        return {"type": "json_object"}
+    value = raw.strip().lower()
+    if value == "none":
+        return None
+    if value == "json_object":
+        return {"type": "json_object"}
+    raise ValueError(
+        f"BIDMATE_JUDGE_RESPONSE_FORMAT must be 'json_object' or 'none': {raw!r}"
+    )
+
+
 def call_openai_json(
     client: Any,
     model: str,
@@ -214,10 +247,13 @@ def call_openai_json(
 ) -> dict[str, Any] | None:
     """Call an OpenAI-compatible endpoint and return a parsed JSON dict.
 
-    Uses ``response_format={"type": "json_object"}`` for structured output.
-    Temperature defaults to ``0.0`` (deterministic) but is overridable via
-    ``BIDMATE_JUDGE_TEMPERATURE`` (see :func:`get_judge_temperature`) so that
-    reasoning models which reject ``temperature=0`` can still be called.
+    Uses ``response_format={"type": "json_object"}`` for structured output by
+    default, omittable via ``BIDMATE_JUDGE_RESPONSE_FORMAT=none`` (see
+    :func:`get_judge_response_format`) for endpoints that reject it (Anthropic
+    OpenAI-compat).  Temperature defaults to ``0.0`` (deterministic) but is
+    overridable via ``BIDMATE_JUDGE_TEMPERATURE`` (see
+    :func:`get_judge_temperature`) so that reasoning models which reject
+    ``temperature=0`` can still be called.
 
     Args:
         client: An ``openai.OpenAI`` instance (from :func:`build_openai_client`).
@@ -233,12 +269,15 @@ def call_openai_json(
         allows the verifier's own status to be used, which is the desired
         graceful-degradation behaviour (ADR 0004 / PR #218).
     """
-    response = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-        temperature=get_judge_temperature(),
-        response_format={"type": "json_object"},
-    )
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": get_judge_temperature(),
+    }
+    response_format = get_judge_response_format()
+    if response_format is not None:
+        kwargs["response_format"] = response_format
+    response = client.chat.completions.create(**kwargs)
     content = response.choices[0].message.content or "{}"
     try:
         return json.loads(content)

--- a/tests/test_judge_common_regression.py
+++ b/tests/test_judge_common_regression.py
@@ -16,6 +16,7 @@ from eval.judges.judge_common import (
     build_evidence_block,
     clamp_score,
     extract_summary,
+    get_judge_response_format,
     get_judge_temperature,
     normalize_status_verdict,
 )
@@ -266,6 +267,43 @@ class GetJudgeTemperatureTest(unittest.TestCase):
         os.environ["BIDMATE_JUDGE_TEMPERATURE"] = "hot"
         with self.assertRaises(ValueError):
             get_judge_temperature()
+
+
+class GetJudgeResponseFormatTest(unittest.TestCase):
+    """get_judge_response_format: json_object default, 'none' omits the kwarg."""
+
+    def setUp(self) -> None:
+        self._saved = os.environ.pop("BIDMATE_JUDGE_RESPONSE_FORMAT", None)
+
+    def tearDown(self) -> None:
+        if self._saved is None:
+            os.environ.pop("BIDMATE_JUDGE_RESPONSE_FORMAT", None)
+        else:
+            os.environ["BIDMATE_JUDGE_RESPONSE_FORMAT"] = self._saved
+
+    def test_unset_defaults_to_json_object(self) -> None:
+        self.assertEqual({"type": "json_object"}, get_judge_response_format())
+
+    def test_empty_string_defaults_to_json_object(self) -> None:
+        os.environ["BIDMATE_JUDGE_RESPONSE_FORMAT"] = "   "
+        self.assertEqual({"type": "json_object"}, get_judge_response_format())
+
+    def test_none_returns_none(self) -> None:
+        os.environ["BIDMATE_JUDGE_RESPONSE_FORMAT"] = "none"
+        self.assertIsNone(get_judge_response_format())
+
+    def test_none_case_insensitive(self) -> None:
+        os.environ["BIDMATE_JUDGE_RESPONSE_FORMAT"] = "NONE"
+        self.assertIsNone(get_judge_response_format())
+
+    def test_explicit_json_object_parsed(self) -> None:
+        os.environ["BIDMATE_JUDGE_RESPONSE_FORMAT"] = "json_object"
+        self.assertEqual({"type": "json_object"}, get_judge_response_format())
+
+    def test_invalid_value_raises(self) -> None:
+        os.environ["BIDMATE_JUDGE_RESPONSE_FORMAT"] = "json_schema"
+        with self.assertRaises(ValueError):
+            get_judge_response_format()
 
 
 if __name__ == "__main__":

--- a/tests/test_render_verifier_false_negative_overlap.py
+++ b/tests/test_render_verifier_false_negative_overlap.py
@@ -36,6 +36,7 @@ def _retrieved(score: float | None, *, chunk_id: str = "chunk-x") -> list[dict[s
 def _vfn_case(**overrides: object) -> dict[str, object]:
     base: dict[str, object] = {
         "answerable": False,
+        "abstention": 0.0,
         "abstained": False,
         "query_type": "abstention",
         "hardcase_categories": ["no_answer"],


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0056 (trajectory-rationality judge) 의 Out-of-scope 가 예약한 **LLM backend 실측정**을 수행한다. #1329 (closes #1326) 가 stub backend + full-trace 캡처로 3축을 deterministic 하게 측정한 위에, 같은 synthesis-primary trace 셋(n=221)을 `stub` 과 `openai_compatible`(Claude Sonnet 4.6) 두 backend 로 채점해 변별력을 비교한다. 핵심 결과: 세 축 모두 stub↔LLM Spearman ρ≈0 (|ρ|≤0.09, p>0.18) → stub 은 품질 proxy 가 아닌 **분포 floor** 임이 실측 확증되고, LLM 은 slice-sensitive / evidence-aware 변별력을 추가한다.

부수적으로, `judge_common.call_openai_json` 의 하드코딩된 `response_format={"type":"json_object"}` 가 Anthropic OpenAI-compat 엔드포인트에서 400 (`Input should be 'json_schema'`) 으로 거부되는 호환성 갭을 측정이 표면화 → `BIDMATE_JUDGE_RESPONSE_FORMAT` env (기본 `json_object`, byte-identical) 로 kwarg 생략을 허용 (`get_judge_temperature` 의 gpt-5.x temp=0 우회와 동일 패턴).

Closes #1377

## 2. 영향 파일

- `eval/judges/judge_common.py` **(load-bearing: eval/)** — `get_judge_response_format()` 추가 + `call_openai_json` 가 env 따라 `response_format` kwarg 조건부 포함. 기본값 `json_object` byte-identical (기존 Gate 1/2/3 동작 불변).
- `tests/test_judge_common_regression.py` — `GetJudgeResponseFormatTest` 6-case (기본 json_object / none→omit / 대소문자 / invalid→ValueError).
- `docs/adr/0056-rationality-judge-measurement-surface.md` **(load-bearing: docs/adr/)** — `## Measurement appendix — LLM backend (Sonnet 4.6)` 추가 (stub vs LLM 표 + ρ≈0 판정 + 비용 + caveats), Out-of-scope/Consequences 의 "별 PR" 항목을 완료 표시, verifies-key 1개 추가.
- `docs/audits/rationality-llm-judge-comparison.md` (신규) — 상세 per-axis + slice/query_type breakdown.

## 3. 리스크

- **가장 가능성 높은 깨짐: 기존 judge gate (1/2/3) 동작 변화 (ADR 0012 stub-default 재현성).** → `get_judge_response_format` 기본값(unset/empty)은 `{"type":"json_object"}` 로 기존과 byte-identical; `call_openai_json` 은 response_format 이 None 일 때만 kwarg 를 생략한다. `test_judge_common_regression.py` 49→55 case 통과 + `make test-fast` 2397 passed.
- judge_common 은 4개 judge surface 공유 — 변경은 순수 additive (새 함수 + 조건부 kwarg), 기존 호출자 영향 없음.

## 4. 테스트

- `GetJudgeResponseFormatTest` 6-case (변경 전 함수 부재로 import fail → 후 pass): 기본 json_object, `none`→None, 대소문자, `json_object` 명시, invalid→ValueError.
- `make test-fast`: **2397 passed, 16 skipped, 240 subtests** (slow/m3 제외, CI 위임). `ruff check .` clean. `--lint-adr-consequences 0056` exit 0, `check-doc-links` OK.
- 측정 자체(stub vs LLM)는 비결정적(LLM)이라 CI 게이트 아님 — ADR 0056 Measurement appendix 가 record.

## 5. Eval 영향

합성 CI eval delta: **All `·` (없음).** RAG retrieval/verify/answer path 동작 무변경 — 변경은 LLM-judge surface (`eval/judges/judge_common.py`) 한정이고 `response_format` 기본값이 byte-identical. naive_baseline/agentic_full 출력 불변 (ADR 0001).

### 5b. Real-data delta

**검색/검증/답변 path 동작 변화 없음** — judge surface (eval-only) 변경이며 env 기본값 byte-identical, RAG 파이프라인 코드 경로 0 변경 (`make real-eval-delta` N/A). real-data 표면 영향은 측정 표면(rationality LLM-judge aggregate) 한정:

| axis | stub mean (std) | LLM mean (std) | LLM 95% CI | Spearman ρ (p) | effective_n |
|---|---:|---:|---|---:|---:|
| `planner_decomposition` | 0.493 (0.288) | 0.507 (0.194) | (0.482, 0.533) | −0.090 (0.185) | 221 |
| `retrieval_recalls` | 0.515 (0.285) | 0.468 (0.240) | (0.437, 0.499) | −0.033 (0.623) | 221 |
| `answer_reasoning` | 0.505 (0.290) | 0.318 (0.163) | (0.292, 0.344) | −0.012 (0.883) | 151 |

측정 환경: main repo prebuilt `data/index/real100`(hashing) + `agentic_full_llm` synthesis-primary (`BIDMATE_TRACE_FULL=1 BIDMATE_SYNTHESIS_BACKEND=stub`), judge=`claude-sonnet-4-6` (temp=0, `BIDMATE_JUDGE_RESPONSE_FORMAT=none`), 비용 ≈\$1.5. committed 는 aggregate/per-slice 만 — per-case score + qid 는 `rationality.*.local.json` gitignored (ADR 0005), judge egress 는 ADR 0006 (real-data LLM-judge, Gate 1 과 동일 경계).

## 6. 하위 호환

- ADR 0003 answer-contract 무관 (schema_version bump 불필요).
- `call_openai_json` 시그니처 불변. `BIDMATE_JUDGE_RESPONSE_FORMAT` 는 신규 opt-in env (unset=기존 동작). CLI/스키마/doc link 변경 없음.

## 7. 범위 외

- live synthesis 측정 (synthesis backend 는 stub 유지 — judge 변별력 측정이 목표, synthesis 품질 측정 아님). `answer_reasoning`=0.318 은 stub synthesis 채점값이라 synthesis 품질 지표 아님.
- judge-model robustness (haiku↔sonnet 교차 순위상관) — single judge/single seed, 필요 시 별 follow-up.
- `response_format=json_schema` (스키마 강제) 지원 — `none`/`json_object` 두 값만, YAGNI.