### PR TITLE
docs(adr): clarify ADR 0052 §3 commit-boundary (only ablation_full committed)

### DIFF
--- a/docs/adr/0052-real-eval-hardcase-expansion-to-200.md
+++ b/docs/adr/0052-real-eval-hardcase-expansion-to-200.md
@@ -37,7 +37,7 @@ ADR 0044 의 incremental trajectory 대체. real-eval 케이스 cardinality 를 
 
 1. **신규 200 hardcase**: `scripts/generate_real_cases.py` 으로 100 doc 각 2 case 생성. 5 enum (`distractor_heavy` / `ambiguous_query` / `multi_hop` / `no_answer` / `long_context`) 분포 target. 평범한 fact-lookup 쿼리 (사업기간 / 예산 단순 lookup) 명시 금지.
 2. **기존 21 케이스 유지**: cross-version 회귀 신호 보존. baseline 의 byte-level reproducibility 침해 없음.
-3. **3 ablation_runs**: `full` (default agentic_full + flat), `random_retrieval` (default + retrieval_backend=random, ADR 0053), `single_chunk` (pipeline=single_chunk preset, ADR 0053).
+3. **3 ablation_runs**: `full` (default agentic_full + flat), `random_retrieval` (default + retrieval_backend=random, ADR 0053), `single_chunk` (pipeline=single_chunk preset, ADR 0053). 단, 이 3-run 은 **eval RUN config** (`eval/real_config.local.yaml`) 의 사실이지 committed baseline 의 사실이 아니다 — `scripts/run_real_eval_delta.py::extract_aggregate` 의 `SAFE_TOPLEVEL_KEYS` 가 `ablation_full` 만 commit 경계를 넘기므로 `reports/real100/baseline.aggregate.json` 에는 `ablation_full` 하나만 존재한다. `random_retrieval` / `single_chunk` 의 distinguishing-power floor 수치는 gitignored `reports/real100/eval_summary.json` 과 `docs/audits/distinguishing_power.md` 에만 산다 (ADR 0005 경계).
 4. **baseline 1회 commit**: `reports/real100/baseline.aggregate.json` 을 n=221 시점 1회 regen 후 ADR 0044 §결과 의 update protocol (= `make real-eval-baseline-update`) 그대로 유지.
 5. **케이스 정의 gitignored 유지**: `eval/real_config.local.yaml` 은 ADR 0005 의 private 경계 보존 — aggregate-only 공개.
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0052 §3 의 "3 ablation_runs (`full` / `random_retrieval` / `single_chunk`)" 문구가 committed `baseline.aggregate.json` 에 3-run 이 모두 들어있다고 읽힐 수 있으나, `scripts/run_real_eval_delta.py::extract_aggregate` 의 `SAFE_TOPLEVEL_KEYS` 는 `ablation_full` 하나만 commit 경계를 넘긴다. §3 에 "3-run 은 eval RUN config 의 사실이지 committed baseline 의 사실이 아니며, random_retrieval/single_chunk floor 수치는 gitignored `eval_summary.json` + `docs/audits/distinguishing_power.md` 에만 산다 (ADR 0005 경계)" 는 한 절을 추가해 정합성 갭을 닫음. 누출 아님 — 문서-claim vs committed-artifact 정합성.

Closes #1383

## 2. 영향 파일

- `docs/adr/0052-real-eval-hardcase-expansion-to-200.md` (load-bearing — docs/adr/) — §3 point 3 에 commit-boundary 명시 1줄 추가. Status / Verification verifies-key / 결정·결과 본문 무변경.

## 3. 리스크

- 거의 없음 (docs-only, 1-line insertion). 깨질 수 있는 경로 = ADR↔README index 정합성 / doc-link / verifies-key. `make governance-check` 로 6개 게이트 (branch+leaderboard+real-eval-history+baseline-provenance+doc-links+readme-metric-sync) 전부 OK 확인. Status 미변경이라 README parity 영향 없음.

## 4. 테스트

- N/A — 동작 변경 없음 (문서 문구 명확화). 검증은 `make governance-check` (doc-link + ADR-README parity) 로 충분.

## 5. Eval 영향

- All `·` (RAG path 무변경, eval 산출물 무관).

### 5b. Real-data delta

> **Reviewer 책임 (issue #1027):** §5b CI gate 는 섹션·표·escape 문장의 *존재* 만 강제한다.

검색/검증 path 동작 변화 없음. docs/adr/ 문구 명확화 only — baseline / eval_summary / 메트릭 무변경.

## 6. 하위 호환

- 영향 없음. ADR 0003 답변 계약 / CLI flag / schema 무관. ADR governance 토큰 (## Status / ## Verification verifies-key) 보존, doc-link 무파손.

## 7. 범위 외

- F1 (git-history 의 retry_reason_counts 원문 식별자 잔존, ~129 reachable commit) = **issue #1382** (`confidentiality`, destructive history rewrite 라 별도 명시 승인 대상) 로 분리. 본 PR 과 독립.

🤖 Generated with [Claude Code](https://claude.com/claude-code)