### PR TITLE
fix(governance): narrow ADR 0051 verifies-key markers to stated invariants

### DIFF
--- a/docs/adr/0051-flat-root-module-layout.md
+++ b/docs/adr/0051-flat-root-module-layout.md
@@ -100,9 +100,9 @@ knob: 본 결정에는 토글이 없다. 재검토 trigger 가 충족되면 별�
 
 본 결정의 commitment 는 세 measurement surface 에 wired:
 
-<!-- verifies-key: pyproject.toml:pythonpath -->
+<!-- verifies-key: pyproject.toml:pythonpath = ["."] -->
 <!-- verifies-key: scripts/_governance.py:LOAD_BEARING_PATHS -->
-<!-- verifies-key: tests/test_dependency_graph_invariance.py:rag_core -->
+<!-- verifies-key: tests/test_dependency_graph_invariance.py:test_leaf_module_has_zero_rag_core_back_edges -->
 
 - `pyproject.toml::pythonpath = ["."]` 가 사라지면 본 결정의 핵심 메커니즘 손실 — 재검토 트리거
 - `LOAD_BEARING_PATHS` 가 파일명 hard-code 를 떠나면 디렉토리 재구성 비용 가설(본 ADR consequences) 무효화 — 재검토 트리거


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`docs/adr/0051-flat-root-module-layout.md`의 verifies-key marker 2개가 너무 넓어, ADR 자신의 `## 결과`(Consequences)가 약속하는 구체적 불변량을 실제로 검증하지 못했다. `scripts/_governance.py`의 `--lint-adr-consequences`는 lenient whole-file substring 체크(`if key not in content`)라 broad marker는 불변량이 깨져도 false positive로 통과한다. ADR 0051 로컬 marker만 stated claim에 맞게 좁혔다 — lint 메커니즘 자체는 미변경. codex adversarial-review 발견.

- `pyproject.toml:pythonpath` → `pyproject.toml:pythonpath = ["."]` (Consequences line 107의 구체값과 일치; `["."]`→`["src"]` 변경 시 이제 marker fail)
- `tests/test_dependency_graph_invariance.py:rag_core` → `...:test_leaf_module_has_zero_rag_core_back_edges` (Consequences line 109이 주장하는 실제 back-edge 가드 함수명; docstring의 "rag_core" 단어만으로는 더 이상 통과 불가)

(marker `scripts/_governance.py:LOAD_BEARING_PATHS`는 구체 식별자라 미변경.)

Closes #1385

## 2. 영향 파일

- `docs/adr/0051-flat-root-module-layout.md` (load-bearing — `docs/adr/`) — Verification 섹션 marker 2줄

## 3. 리스크

좁힌 substring이 target 파일에 실제로 존재하지 않으면 lint가 자기 PR을 red. 두 식별자 모두 현재 파일에 존재함을 확인: `pyproject.toml:2` (`pythonpath = ["."]`), `tests/test_dependency_graph_invariance.py:82` (`def test_leaf_module_has_zero_rag_core_back_edges`). marker 파싱 regex는 key에서 `>` 외 모든 문자 허용 → `["."]` 안전. 검증: `--lint-adr-consequences` exit=0, `--check-adr-readme-parity` exit=0.

## 4. 테스트

docs-only governance marker 정밀화. 동작 변경 없음 — `scripts/_governance.py` 로직 무변경. 검증은 위 두 governance 명령으로 수행(둘 다 통과).

## 5. Eval 영향

All `·` — RAG 파이프라인 무관 docs 변경.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. ADR marker 텍스트 2줄만 변경, 코드 무변경.

## 6. 하위 호환

깨짐 없음. ADR Verification marker는 governance lint 전용 — 답변 계약/스키마/CLI 무관.

## 7. 범위 외

다른 ADR들의 broad verifies-key marker는 별도 범위. verifies-key lint의 lenient-substring 메커니즘 자체 강화(JSON path 등)도 별도 범위 — 이 PR은 ADR 0051 로컬 정밀화만.