### PR TITLE
fix(eval): anonymize stale top-10 agency names in committed eda.md

### DIFF
--- a/reports/real100/eda.md
+++ b/reports/real100/eda.md
@@ -1,6 +1,6 @@
 # Real-100 Corpus EDA
 
-Aggregate-only profile of the private 100-document RFP dataset. ADR 0005 boundary: 사업명 / 사업 요약 / 텍스트 / 파일명 are read for length statistics only; never rendered. Agency names beyond rank 10 are anonymized to `agency_NN` labels.
+Aggregate-only profile of the private 100-document RFP dataset. ADR 0005 boundary: 사업명 / 사업 요약 / 텍스트 / 파일명 are read for length statistics only; never rendered. All agency names are anonymized to `agency_NN` rank labels.
 
 Sources: `data/data_list.csv`, `data/index/real100/index.json`, `reports/real100/baseline.aggregate.json`
 
@@ -14,16 +14,16 @@ Sources: `data/data_list.csv`, `data/index/real100/index.json`, `reports/real100
 
 | rank | agency | doc count |
 |---|---|---|
-| 1 | 한국수자원공사 | 3 |
-| 2 | 한국철도공사 (용역) | 3 |
-| 3 | 한국연구재단 | 2 |
-| 4 | 한국생산기술연구원 | 2 |
-| 5 | 인천광역시 | 2 |
-| 6 | 국방과학연구소 | 2 |
-| 7 | 수협중앙회 | 2 |
-| 8 | 한국농어촌공사 | 2 |
-| 9 | 축산물품질평가원 | 2 |
-| 10 | 광주과학기술원 | 2 |
+| 1 | agency_01 | 3 |
+| 2 | agency_02 | 3 |
+| 3 | agency_03 | 2 |
+| 4 | agency_04 | 2 |
+| 5 | agency_05 | 2 |
+| 6 | agency_06 | 2 |
+| 7 | agency_07 | 2 |
+| 8 | agency_08 | 2 |
+| 9 | agency_09 | 2 |
+| 10 | agency_10 | 2 |
 | … | _(rank 11+, anonymized)_ | 78 |
 
 ### Budget (KRW) — available rows only

--- a/tests/test_eval_artifact_privacy_regression.py
+++ b/tests/test_eval_artifact_privacy_regression.py
@@ -22,6 +22,7 @@ covers a fixed forbidden-key set under ``reports/retrieval/phase4*``.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from scripts._governance import (
@@ -112,3 +113,38 @@ def test_tracked_artifacts_parse_as_json() -> None:
     # actually valid JSON so a corrupt artifact can't hide a leak.
     for rel in eval_privacy_artifact_paths(str(REPO_ROOT)):
         json.loads((REPO_ROOT / rel).read_text(encoding="utf-8"))
+
+
+_HANGUL_RE = re.compile(r"[가-힣]")
+
+
+def test_eda_md_agency_table_has_no_raw_agency_names() -> None:
+    # eda_real100.py anonymizes every agency rank to ``agency_NN`` (#1204), but
+    # the rendered ``eda.md`` is a ``*.json``-excluded artifact the structural
+    # gate never scans — so a stale committed render can re-leak the top-N
+    # 발주기관 names (the #1387 live leak: #1211 fixed the generator + the JSON
+    # but never regenerated eda.md). The .md elsewhere carries legitimate
+    # Korean prose (header policy line, 사업명/사업 요약 row labels), so this
+    # guard is scoped to the agency-distribution table rows only: the agency
+    # column there must be an ``agency_NN`` label or the anonymized tail marker
+    # — never a raw Hangul name.
+    eda = REPO_ROOT / "reports" / "real100" / "eda.md"
+    if not eda.exists():
+        return
+    in_table = False
+    offenders: list[str] = []
+    for line in eda.read_text(encoding="utf-8").splitlines():
+        if line.startswith("### Agency distribution"):
+            in_table = True
+            continue
+        if in_table:
+            if line.startswith("#"):  # next section ends the table
+                break
+            if not line.startswith("|"):
+                continue
+            if _HANGUL_RE.search(line):
+                offenders.append(line.strip())
+    assert offenders == [], (
+        "eda.md agency-distribution table leaks raw agency names "
+        "(must be agency_NN labels): " + "; ".join(offenders)
+    )


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`reports/real100/eda.md` 의 "Agency distribution (top)" 표가 **top-10 실제 발주기관명을 평문 렌더**해 ADR 0005 / non-goal #1 (비공개 RFP 식별자) 위반 — 공개 repo committed tree 에 live. 생성기 `scripts/eda_real100.py` 는 #1211/#1204 로 모든 rank 를 `agency_NN` 익명화하도록 이미 수정됐으나, 그때 코드 + `eda.aggregate.json` 만 고치고 **렌더된 `eda.md` 는 재생성/커밋하지 않아** #1211 이전 평문 render 가 잔존. 구조적 privacy 게이트(`scan_eval_artifacts_for_private_text`)는 `*.json` 만 스캔(`eval_privacy_artifact_paths` 의 `.endswith(".json")`)하므로 `.md` 인 eda.md 가 검사 밖이라 통과.

Closes #1387

## 2. 영향 파일

- `reports/real100/eda.md` (load-bearing 아님) — top-10 표를 생성기 출력과 동일하게 `agency_01`..`agency_10` in-place 익명화 + stale header 줄을 현재 생성기 문구로 갱신. 다른 축·수치 무변경.
- `tests/test_eval_artifact_privacy_regression.py` (load-bearing 아님) — eda.md agency-distribution 표에 raw 한글 기관명 부재를 구조적으로 assert 하는 회귀 테스트 추가.

생성기 `scripts/eda_real100.py` 는 **무변경** (이미 올바름). 비공개 데이터 재생성 불요 — #1211 의 "migrate committed artifacts in place" 접근.

## 3. 리스크

- 낮음. eda.md 표 라벨만 교체(분포 shape·count 보존). 깨질 수 있는 경로 = 새 테스트의 표 파싱 / privacy 게이트. `--check-eval-privacy` exit 0, `check_doc_links --check-all` OK, 새 테스트 fail-before(누출 10행 검출)/pass-after 확인.

## 4. 테스트

- 신규 `test_eda_md_agency_table_has_no_raw_agency_names`: leaked 버전에서 10행 검출(fail), 수정본에서 통과(pass). `pytest tests/test_eval_artifact_privacy_regression.py` 7 passed.

## 5. Eval 영향

- All `·` (eda.md 는 EDA 산출물 문서, RAG path·메트릭 무관).

### 5b. Real-data delta

> **Reviewer 책임 (issue #1027):** §5b CI gate 는 섹션·표·escape 문장의 *존재* 만 강제한다.

검색/검증 path 동작 변화 없음. committed EDA 산출물의 라벨 익명화 + 테스트 only — baseline / eval_summary / 메트릭 무변경.

## 6. 하위 호환

- 영향 없음. 답변 계약(ADR 0003) / CLI / schema 무관. doc-link 무파손.

## 7. 범위 외

- `.md` artifact 까지 스캔하는 production privacy 게이트 확장 = 별건 (legit 산문 false-positive 회피 설계 필요, #1177 scanner follow-up lineage). 본 PR 은 targeted 회귀 테스트로 이 특정 재발 벡터만 차단.
- pre-#1211 history 의 multi-vector 잔존(retry_reason + qid `real_<기관>` + eda 기관명) = **issue #1382** (포괄적 git-history rewrite, destructive, 별도 명시 승인 대상). 본 PR 은 live committed 누출만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)