### PR TITLE
test(eval): guard real-100 EDA against raw agency-name leak

### DIFF
--- a/tests/test_eda_real100.py
+++ b/tests/test_eda_real100.py
@@ -2,9 +2,13 @@
 
 Covers:
   - ADR 0005 boundary leak guard: sentinel strings planted in raw CSV fields
-    (사업명 / 사업 요약 / 텍스트 / 파일명) and chunk text never appear in the
-    rendered eda.md or eda.aggregate.json.
-  - Tail agencies (rank > top-N) are anonymized to ``agency_NN`` labels.
+    (사업명 / 사업 요약 / 텍스트 / 파일명 / 발주 기관) and chunk text never appear
+    in the rendered eda.md or eda.aggregate.json.
+  - Every agency (top-N and tail) is anonymized to ``agency_NN`` — the
+    SENTINEL_AGENCY guard in the fixture catches a top-N raw-name regression
+    (the #1389 leak class).
+  - The *committed* reports/real100/eda.{md,aggregate.json} carry no raw 발주
+    기관 name (defense-in-depth against the path-based pre-commit gap, #1177).
   - Deterministic output: running the script twice on the same fixture yields
     byte-identical md and json.
   - Eval cross degrades cleanly when eval_summary.json is absent.
@@ -32,6 +36,7 @@ SENTINEL_SUMMARY = "SECRET_SUMMARY_XYZ_ZZ"
 SENTINEL_BODY = "SECRET_BODY_XYZ_ZZ"
 SENTINEL_FILENAME = "SECRET_FILENAME_XYZ_ZZ"
 SENTINEL_CHUNK_TEXT = "SECRET_CHUNK_TEXT_XYZ_ZZ"
+SENTINEL_AGENCY = "SECRET_AGENCY_XYZ_ZZ"
 
 ALL_SENTINELS = (
     SENTINEL_TITLE,
@@ -39,6 +44,7 @@ ALL_SENTINELS = (
     SENTINEL_BODY,
     SENTINEL_FILENAME,
     SENTINEL_CHUNK_TEXT,
+    SENTINEL_AGENCY,
 )
 
 
@@ -56,7 +62,7 @@ def _make_fixture(tmp_path: Path) -> dict[str, Path]:
     rows: list[dict[str, str]] = []
     chunks: list[dict[str, object]] = []
     for i in range(12):
-        agency = f"발주기관_{i % 11:02d}"  # 11 unique → 1 in tail beyond top-10
+        agency = f"{SENTINEL_AGENCY}_{i % 11:02d}"  # 11 unique → 1 in tail beyond top-10; sentinel guards top-N + tail leak
         notice = f"NOTICE-{i:05d}"
         doc_id = f"{notice}-0.0"
         fmt = "hwp" if i % 4 != 0 else "pdf"
@@ -247,6 +253,38 @@ def test_aggregate_json_keys_allowlist(tmp_path: Path) -> None:
         "axis4_eval_cross",
     }
     assert set(aggregate.keys()) == expected_top, f"unexpected top-level keys: {set(aggregate.keys()) - expected_top}"
+
+
+def test_committed_outputs_no_raw_agency() -> None:
+    """Defense-in-depth on the *shipped* artifact (not the fixture).
+
+    #898 leaked real top-10 발주 기관 names into the committed reports/real100/
+    eda.md + eda.aggregate.json; #1389 fixed the renderer but added no guard.
+    The path-based pre-commit ADR 0005 hook does not scan content of
+    allowlisted files (#1177 gap), so guard the actual files against both the
+    specific names that leaked and the generic public-org suffix pattern — any
+    future regeneration drift on the private machine is caught here.
+    """
+    import re
+
+    reports_dir = REPO_ROOT / "reports" / "real100"
+    targets = [reports_dir / "eda.md", reports_dir / "eda.aggregate.json"]
+    leaked_names = (
+        "한국수자원공사", "한국철도공사", "한국연구재단", "한국생산기술연구원",
+        "인천광역시", "국방과학연구소", "수협중앙회", "한국농어촌공사",
+        "축산물품질평가원", "광주과학기술원",
+    )
+    # Generic Korean public-org suffixes — catches new agency names too.
+    org_suffix = re.compile(r"공사|공단|재단|연구원|연구소|중앙회|광역시")
+
+    for path in targets:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for name in leaked_names:
+            assert name not in text, f"raw agency {name!r} present in {path.name}"
+        hit = org_suffix.search(text)
+        assert hit is None, f"org-suffix pattern {hit.group()!r} present in {path.name}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/eda_real100.py` (#898) 가 top-N **발주 기관 실명**을 committed 산출물에 노출한 ADR 0005/0012 경계 누출이 있었고, **코드 수정은 #1389 로 이미 main 에 머지**됐다. 그러나 #1389 는 회귀 가드를 남기지 않았다. 이 PR 은 그 위에 **회귀 테스트만** 추가한다 (재수정 아님). 처음엔 독립 수정으로 출발했으나 #1389 와 중복 확인 후 테스트 전용으로 축소.

Closes #1390

## 2. 영향 파일

- `tests/test_eda_real100.py` — (a) fixture 의 `발주 기관` 필드에 `SENTINEL_AGENCY` 를 심어 top-N raw-name 회귀(#1389 누출 class)를 잡고, (b) `test_committed_outputs_no_raw_agency` 로 실제 `reports/real100/eda.{md,aggregate.json}` 를 직접 스캔. **(load-bearing 아님)**

## 3. 리스크

테스트 전용 — 프로덕션 동작 무변경. fixture sentinel 테스트는 main 의 #1389 산출 구조(top key=`name`, value=`agency_NN`)에 대해 통과 확인. committed-artifact 스캔은 키 구조 무관(텍스트 스캔)이라 main scrub 산출물에서 통과.

## 4. 테스트

- `test_no_sentinel_leak_in_outputs`: `ALL_SENTINELS` 에 `SENTINEL_AGENCY` 추가 → 스크립트 산출 md/json 에 raw 기관명(top-N+tail) 부재 검증. #1389 이전이라면 top-N 에서 fail 하는 회귀 가드.
- `test_committed_outputs_no_raw_agency` (defense-in-depth): 누출 기관명 10종 + 일반 패턴(`공사|공단|재단|연구원|연구소|중앙회|광역시`) 을 실제 committed 산출물에서 스캔. path-based pre-commit 이 못 잡는 #1177 갭 방어.
- 로컬 `pytest tests/test_eda_real100.py -m ""` 7/7 pass, ruff clean.

## 5. Eval 영향

All `·` — RAG 파이프라인 동작 변경 없음. 테스트 추가만.

### 5b. Real-data delta

N/A — load-bearing path 미변경 (테스트 파일만). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

N/A — 테스트 추가만. 계약/스키마 변경 없음.

## 7. 범위 외

- **히스토리 재작성** (파괴적, public force-push): 기관명이 #898 머지 커밋 히스토리에 남아있음. #944 의 retry_reason 누출과 동일 .gitignore content-scan 갭 + filter-repo 필요 → 한 번의 force-push 로 묶어 별도 처리 (사용자 명시 승인 후).
- **content scanner (#1177)**: retry_reason 접미사 + agency name 필드 양쪽을 잡는 스캐너 — 별도 PR.