### PR TITLE
test(eval): make real-100 leak guard name-free (ADR 0005)

### DIFF
--- a/tests/test_eda_real100.py
+++ b/tests/test_eda_real100.py
@@ -256,35 +256,74 @@ def test_aggregate_json_keys_allowlist(tmp_path: Path) -> None:
 
 
 def test_committed_outputs_no_raw_agency() -> None:
-    """Defense-in-depth on the *shipped* artifact (not the fixture).
+    """Defense-in-depth on the *shipped* real100 artifacts (not the fixture).
 
-    #898 leaked real top-10 발주 기관 names into the committed reports/real100/
-    eda.md + eda.aggregate.json; #1389 fixed the renderer but added no guard.
-    The path-based pre-commit ADR 0005 hook does not scan content of
-    allowlisted files (#1177 gap), so guard the actual files against both the
-    specific names that leaked and the generic public-org suffix pattern — any
-    future regeneration drift on the private machine is caught here.
+    #898 leaked real top-N 발주 기관 names into the committed eda.{md,aggregate.json};
+    a sibling leak embedded agency/doc-id/title strings as suffixes inside
+    retry_reason_counts keys of the baseline/history aggregates. #1389 fixed the
+    eda renderer but shipped no guard, and the path-based pre-commit ADR 0005
+    hook does not scan allowlisted-file *content* (#1177 gap).
+
+    The checks are *structural and name-free* on purpose — asserting a positive
+    shape (agency fields are ``agency_NN``; retry keys are ASCII enums) rather
+    than blocklisting specific names. A blocklist would have to embed the very
+    private names it guards (an ADR 0005 violation in itself) and rots as new
+    agencies appear.
     """
     import re
 
     reports_dir = REPO_ROOT / "reports" / "real100"
-    targets = [reports_dir / "eda.md", reports_dir / "eda.aggregate.json"]
-    leaked_names = (
-        "한국수자원공사", "한국철도공사", "한국연구재단", "한국생산기술연구원",
-        "인천광역시", "국방과학연구소", "수협중앙회", "한국농어촌공사",
-        "축산물품질평가원", "광주과학기술원",
-    )
-    # Generic Korean public-org suffixes — catches new agency names too.
-    org_suffix = re.compile(r"공사|공단|재단|연구원|연구소|중앙회|광역시")
+    hangul = re.compile(r"[가-힣]")
+    agency_label = re.compile(r"^agency_\d+$")
 
-    for path in targets:
-        if not path.exists():
-            continue
-        text = path.read_text(encoding="utf-8")
-        for name in leaked_names:
-            assert name not in text, f"raw agency {name!r} present in {path.name}"
-        hit = org_suffix.search(text)
-        assert hit is None, f"org-suffix pattern {hit.group()!r} present in {path.name}"
+    # --- eda.aggregate.json: every agency name/label must be agency_NN ---
+    eda_json = reports_dir / "eda.aggregate.json"
+    if eda_json.exists():
+        agency = (
+            json.loads(eda_json.read_text(encoding="utf-8"))
+            .get("axis1_metadata", {})
+            .get("agency", {})
+        )
+        for entry in (agency.get("top") or []) + (agency.get("tail_anonymized") or []):
+            for key in ("name", "label"):
+                if key in entry:
+                    assert agency_label.fullmatch(str(entry[key])), (
+                        f"non-anonymized agency {entry[key]!r} in eda.aggregate.json"
+                    )
+
+    # --- eda.md: agency-distribution table cells must be agency_NN ---
+    eda_md = reports_dir / "eda.md"
+    if eda_md.exists():
+        in_table = False
+        for line in eda_md.read_text(encoding="utf-8").splitlines():
+            if line.strip() == "| rank | agency | doc count |":
+                in_table = True
+                continue
+            if in_table:
+                m = re.match(r"^\| (\d+) \| (.+?) \| (\d+) \|$", line)
+                if m:
+                    assert agency_label.fullmatch(m.group(2).strip()), (
+                        f"non-anonymized agency {m.group(2)!r} in eda.md"
+                    )
+                elif line.strip() == "":
+                    in_table = False
+
+    # --- aggregates: retry_reason_counts keys must be ASCII enums (no Hangul) ---
+    def assert_retry_keys_ascii(obj: object, src: str) -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if k == "retry_reason_counts" and isinstance(v, dict):
+                    for kk in v:
+                        assert not hangul.search(kk), (
+                            f"Hangul (likely agency/title) in retry key {kk!r} of {src}"
+                        )
+                assert_retry_keys_ascii(v, src)
+        elif isinstance(obj, list):
+            for item in obj:
+                assert_retry_keys_ascii(item, src)
+
+    for agg in sorted(reports_dir.rglob("*.aggregate.json")):
+        assert_retry_keys_ascii(json.loads(agg.read_text(encoding="utf-8")), agg.name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR #1391 에서 추가한 `test_committed_outputs_no_raw_agency` 가 누출 검사를 위해 private 100-doc corpus 의 실제 발주 기관명 10개를 평문 literal 로 하드코딩했다 — 가드 자신이 ADR 0005/0012("원본 기관명을 넣지 않는다")를 위반하며 같은 이름을 HEAD 에 재노출. 또 `org_suffix` 정규식이 불완전(`평가원`/`기술원` 누락)했다. blocklist 를 **이름 없는 구조적(positive-shape) 검사**로 교체한다.

Closes #1392

## 2. 영향 파일

- `tests/test_eda_real100.py` — `test_committed_outputs_no_raw_agency` 재작성 (literal blocklist 제거). **(load-bearing 아님)**

## 3. 리스크

테스트 전용, 프로덕션 무변경. 구조적 검사가 현재 clean HEAD 산출물(eda agency_NN, retry 키 ASCII enum)에 대해 통과 확인. eda 파일 부재 시 graceful skip.

## 4. 테스트

- `test_committed_outputs_no_raw_agency` (재작성): eda.aggregate.json 의 agency.top[]/tail_anonymized[] name|label 이 `^agency_\d+$` 인지, eda.md 표 셀이 agency_NN 인지, 모든 reports/real100/*.aggregate.json 의 retry_reason_counts 키에 한글 부재인지 검증. 두 누출 class(eda 이름 + retry 접미사)를 name-free 로 커버.
- `pytest tests/test_eda_real100.py -m ""` 7/7 pass, ruff clean. 테스트 내 private 실명 literal 0개 확인.

## 5. Eval 영향

All `·` — RAG 파이프라인 동작 무변경. 테스트만.

### 5b. Real-data delta

N/A — load-bearing path 미변경 (테스트 파일만). 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

N/A — 테스트 추가/수정만. 계약/스키마 변경 없음.

## 7. 범위 외

- **히스토리 재작성** (파괴적, public force-push): #898 eda 기관명 + retry_reason 접미사(국민연금공단 등)가 과거 커밋 + 방금 머지된 #1391(c77ad64)의 test literal 에 남아있음. 검증된 filter-repo blob-callback 스크립트로 한 번에 scrub 예정 — 사용자 명시 승인 후 별도 실행.
- (C) eval/data 공개 합성 데이터(`dev_queries_v1.jsonl`, `rfp_agency_*.json`, `index.json`)의 공공기관명은 공개/합성 표면 정상 사용으로 판단, 범위 외.
- content scanner (#1177): 별도 PR.