### PR TITLE
docs: reframe README top for reviewer impact + add module-map/failure-modes/pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,27 @@
 
 ![BidMate-DocAgent live demo (5s walkthrough — comparison query, extractive, no LLM)](docs/assets/demo.gif)
 
-> 한국 공공·B2B 입찰 RFP 에서 비교·요건 추출 질의를 **근거 기반 답변**으로 돌려주는 한국어 도메인 특화 RAG. 외부 LLM 호출 없이 추출형(extractive) grounding 으로 hallucination 을 구조적으로 차단.
-> **차별점**: 비교 질의에서 두 기관 문서를 균등 인용하는 [comparison-aware balanced retrieval](#핵심-기술-기여--comparison-aware-balanced-top-k), 메타데이터 우선 검색 ([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)), 근거 불충분 시 보류(abstention) 명시 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)).
+## 30초 요약 — What this proves
+
+> 한 줄: 한국 공공·B2B 입찰 RFP 에서 발생하는 **검색 실패 · 근거 부족 · 비교 질의 편향을 failure mode 로 정의**하고, 이를 baseline / ablation / eval / CI 로 검증 가능하게 만든 **근거 기반(citation-grounded) 추출형 RAG** 시스템.
+
+| | |
+|---|---|
+| **무엇을 (what)** | RFP 문서용 citation-grounded **extractive** RAG — 외부 LLM 호출 없이 retrieved evidence 에서 claim 추출 + citation 잠금 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)) |
+| **왜 어려운지 (why hard)** | 한국어 공공/B2B RFP 는 길고 noisy 하며, 기관·사업명이 유사해 문서 간 비교·요건 추출이 구조적으로 어렵다 |
+| **무엇을 엔지니어링 (engineered)** | 메타데이터 우선 검색 ([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)) + [comparison-aware balanced top-k](#핵심-기술-기여--comparison-aware-balanced-top-k) + verifier/retry + 근거 불충분 시 보류(abstention) |
+| **어떻게 평가 (evaluated)** | baseline 보존 ablation ([ADR 0001](docs/adr/0001-preserve-naive-baseline.md)) + 공개 합성·비공개 real-eval 분리 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)) + PR 마다 회귀 게이트 ([pr-eval.yml](.github/workflows/pr-eval.yml)) + 72 ADR |
+| **어떻게 실행 (run it)** | `make index && make demo`, 또는 [5분 quickstart](#실행-5분-quickstart) · [Colab](https://colab.research.google.com/github/hskim-solv/BidMate-DocAgent/blob/main/demo/bidmate_quickstart.ipynb) · [Live demo](https://bidmate-docagent-demo.fly.dev/) |
+
+> **Portfolio signal**: 외부 LLM API 를 호출하는 RAG 데모가 아니라, RFP 도메인의 실패 모드를 직접 정의하고 그것을 막는 평가·CI·provenance 게이트를 **소유(system ownership)** 한 사례. 리뷰어용 진입점 → [모듈 맵](docs/architecture/module-map.md) · [실패 모드 케이스 스터디](docs/case-studies/failure-modes.md) · [면접 피치](docs/portfolio-pitch.md).
+
+> **real-eval 읽는 법 (오해 방지)**: 비공개 real-eval (n=221) accuracy 16.10% 는 *제품 성공 지표가 아니라 hardcase 스트레스 테스트* 다 — 실패 모드를 노출하고, ablation 의 distinguishing power(변별력) 를 시험하며, 다음 개선을 안내하는 용도. 공개 합성 eval(품질 회귀 감시)과 비공개 real-eval(난이도 상한 탐침)은 **목적이 다르다** ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)). 낮은 hardcase 수치는 숨기지 않고 **엔지니어링 증거로 의도적으로 노출**한다 ([ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md)).
+
+<details><summary><b>측정 상세 (over-claim 가드 — 펼치기)</b></summary>
+
 > **측정**: 공개 합성 (`agentic_full`, n=100): accuracy 0.718 ± 0.10, citation_precision 0.705 ± 0.08 (95% CI). 비공개 real-eval (100-doc RFP, n=221 hardcase, [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md)): accuracy 16.10%. distinguishing-power gauge — 점추정(point estimate)으로는 4/5 metric 이 `random_retrieval` + `single_chunk` 두 floor 를 상회 (groundedness +16.95pp · accuracy +13.56pp · citation_precision +10.45pp · claim_citation_alignment +6.10pp vs random_retrieval) 하나, **CI-aware 비중첩 95% CI 테스트에서는 n=221 에서 5/5 모두 분리 미달 — 4 metric `uncertain`, answer_format_compliance −4.02pp `dead`** (게이지의 보수적 판정이 over-claim 을 차단). Goodhart 폐루프 ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) 첫 측정 발견 → [ADR 0054](docs/adr/0054-conditional-on-answer-scorer-semantics.md) scorer 정정 → CI-aware 판정, [reports/real100/distinguishing_power.md](reports/real100/distinguishing_power.md)). 공개 합성 + 비공개 real-data 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 72개 설계 결정 (ADR).
+
+</details>
 
 ### 5초 비주얼 훅 — 실제 `comparison` 질의 한 건 (extractive, no LLM)
 
@@ -66,16 +84,6 @@ LLM synthesis opt-in (`agentic_full_llm`, [ADR 0011](docs/adr/0011-llm-synthesis
 
 > **완료 ([issue #570](https://github.com/hskim-solv/BidMate-DocAgent/issues/570))**: 공개 합성 n=42 → **n=100 확장** (single_doc 34 / comparison 24 / follow_up 21 / abstention 21). Bootstrap CI 폭 이론 수축 ×0.65 (√42/100). **비공개 real-eval n=21 → n=221 확장** ([ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md), [issue #942](https://github.com/hskim-solv/BidMate-DocAgent/issues/942)) — LLM-assisted hardcase generator + distinguishing-power floor ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md)) 으로 ablation 통계 분리 가능 단계 도달. Detection-blind 분석 변형 real-eval 측정은 별도 follow-up
 
-## TL;DR
-
-- **문제**: 길고 복잡한 RFP 문서에서 실무 의사결정용 핵심 조건 (예산/일정/요구사항/제출조건) 을 빠르게 찾기 어려움
-- **해결**: 질문 유형 분석 + 메타데이터 우선 검색 + local dense retrieval/reranking + 근거 검증/재시도를 결합한 Agentic RAG
-- **시스템 설계**: 외부 LLM 호출 없이 evidence 에서 claim 추출 + citation 연결하는 **추출형 근거 답변 파이프라인** ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md))
-- **성과**: 공개 합성 n=100 (single_doc 34 / comparison 24 / follow_up 21 / abstention 21) 기준 근거 기반 응답 품질 검증. Abstention **+77.8pp** / Citation Precision **+39.3pp** (CI 분리, 통계 유의). [평가셋 spec](docs/eval/eval-dataset-spec.md)
-- **Latency** (naive_baseline, hashing, macOS CPU, n=100): p50 1.7ms / p95 3.1ms
-
----
-
 ## 핵심 기술 기여 — comparison-aware balanced top-k
 
 RFP 비교 질의 (`query_type == "comparison"`) 에서 발생하는 한쪽 문서 starvation 을 막는 **balanced top-k 검색 ranking**. 일반 agentic RAG 튜토리얼에 없는 RFP 도메인 특화 결정.
@@ -104,6 +112,8 @@ RFP 비교 질의 (`query_type == "comparison"`) 에서 발생하는 한쪽 문�
 - **헤드라인 latency 기준**: naive_baseline p95 (3.1ms) 가 CI source of truth. `agentic_full_llm` 은 LLM 레이턴시 포함 환경 의존이라 CI 고정 대상 아님
 - **`agentic_full_llm` backend**: 분석 변형 표의 `full_llm` 행은 `BIDMATE_SYNTHESIS_BACKEND=stub` (token-less, deterministic; [ADR 0011](docs/adr/0011-llm-synthesis-as-additive-ablation.md)). stub 은 pass-through 합성이라 `full` 과 동일 메트릭이 *정상*
 - **Rerank 종류**: `Rerank on` 행 대부분 weighted-score rerank. `full_reranker` 만 cross-encoder rerank ([rag_rerank.py](rag_rerank.py)) — CI default `stub` 이라 `full` 과 수치 일치
+
+> **표 읽는 법 — 안전성/품질 trade-off (over-claim 아님)**: `agentic_full` 은 **raw answer rate 를 극대화하도록 튜닝된 파이프라인이 아니다.** 답변율(answer rate) 일부를 내주는 대신 **citation precision +18.0pp** (0.705 vs 0.525) 과 **abstention accuracy +57.1pp** (0.810 vs 0.238) 을 얻는 **safety-oriented** 설계다. 그래서 overall accuracy 는 `naive_baseline` 이 더 높을 수 있고 (0.782 vs 0.718, −6.4pp), 이는 *실패한 최적화가 아니라 의도된 trade-off* 다 — 근거 없는 답변보다 근거 있는 보류를 우선한다 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md) · [ADR 0004](docs/adr/0004-verifier-retry-policy.md)). 따라서 아래 표는 **하나의 평탄한 leaderboard 가 아니라 slice 별로** 읽어야 한다 — comparison · follow-up · hardcase 는 각각 다른 실패 모드를 측정한다. slice 별 설계 대응: [실패 모드 케이스 스터디](docs/case-studies/failure-modes.md).
 
 <!-- METRICS_TABLE:START -->
 | Category | Metric | agentic_full (95% CI) | naive_baseline (95% CI) | Δ |
@@ -215,6 +225,18 @@ python3 scripts/update_readme_metrics.py --report reports/eval_summary.json --re
 ```
 
 상세 실행 (FastAPI 데모, PDF/HWP ingestion, visual parsing v2, 비공개 100-doc eval, harness): [`docs/operations/api-demo.md`](docs/operations/api-demo.md).
+
+---
+
+## 면접에서 이 프로젝트를 설명하는 법
+
+> 이 프로젝트에서 저는 RAG 파이프라인을 단순 구현한 것이 아니라, RFP 문서에서 실제로 발생하는 **검색 실패 · 근거 부족 · 비교 질의 편향을 failure mode 로 정의**하고, 이를 **baseline / ablation / eval / CI 로 검증 가능한 시스템**으로 만들었습니다.
+
+- **Baseline preservation** — `naive_baseline` 을 byte-identical 로 보존해 모든 개선을 *additive ablation* 으로만 측정 ([ADR 0001](docs/adr/0001-preserve-naive-baseline.md))
+- **Failure-mode-driven design** — comparison starvation · metadata ambiguity · abstention · follow-up · citation drift 5개 실패 모드를 명시하고 각각에 설계로 대응 ([실패 모드](docs/case-studies/failure-modes.md))
+- **Eval/CI regression prevention** — PR 마다 회귀 게이트 + failure-rate ratchet 으로 품질 후퇴 차단 ([pr-eval.yml](.github/workflows/pr-eval.yml) · [ADR 0062](docs/adr/0062-failure-rate-regression-contract.md))
+
+전체 피치 (STAR 정리 + 인터뷰 답변): [`docs/portfolio-pitch.md`](docs/portfolio-pitch.md).
 
 ---
 

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -1,0 +1,57 @@
+# 모듈 맵 (리뷰어용)
+
+이 문서는 코드를 처음 보는 리뷰어가 **파이프라인 단계 → 책임 모듈 → 근거 문서**를 한눈에 따라갈 수 있도록 정리한 진입점이다. 깊은 설계 근거는 각 ADR / deep-dive 로 링크한다. 전체 흐름도(flowchart)는 [`docs/architecture-deep-dive.md`](../architecture-deep-dive.md) 의 ADR-labeled diagram 을 참조하고, 본 문서는 단계별 **모듈 소유권**과 호출 순서(sequence)에 집중한다.
+
+파이프라인: ingestion → 메타데이터 정규화 → 청킹 → 검색 → 재순위/계획 → 근거 집계 → 근거 기반 답변 → 검증 → 평가 → reviewer 문서.
+
+## 단계별 모듈
+
+| 단계 | 주요 모듈 | 책임 |
+|---|---|---|
+| **질의 분석 (query analysis)** | [`rag_query.py`](../../rag_query.py) | `analyze_query` / `make_plan` — 질의 유형(single_doc / comparison / follow_up / abstention) 분류, 비교 target 추출, 검색 계획 수립 |
+| ↳ 계획·보조 | [`rag_planner.py`](../../rag_planner.py), [`rag_clarification.py`](../../rag_clarification.py), [`rag_conversation_state.py`](../../rag_conversation_state.py) | 검색 계획, 메타데이터/문맥 모호성 시 clarification, 멀티턴 대화 상태 |
+| **검색 (retrieval)** | [`rag_retrieval.py`](../../rag_retrieval.py) | `retrieve_candidates`, 4 유사도 primitive, BM25, RRF fusion, comparison-aware balance, parent-section 재조립 ([ADR 0010](../adr/0010-hybrid-bm25-dense-retrieval-rrf.md) · [ADR 0058](../adr/0058-phase35-mode-winner.md)) |
+| ↳ 검색 보조 | [`rag_vector_store.py`](../../rag_vector_store.py), [`rag_reranker.py`](../../rag_reranker.py) / [`rag_rerank.py`](../../rag_rerank.py), [`rag_query_expansion.py`](../../rag_query_expansion.py) | `VectorStore` Protocol (memory/Qdrant), cross-encoder 재순위, HyDE opt-in 확장 |
+| **검증 (verification)** | [`rag_verifier.py`](../../rag_verifier.py) | `verify_evidence`, topic 추출, evidence boundary + 명령 패턴 중화 ([ADR 0008](../adr/0008-evidence-boundary.md)) |
+| **답변 계약 (answer contract)** | [`rag_answer.py`](../../rag_answer.py), [`rag_answer_schema.py`](../../rag_answer_schema.py) | 검증된 근거 → ADR 0003 답변 dict (`claims` + `citations` + `status`), `schema_version: 2` 계약 ([ADR 0003](../adr/0003-structured-answer-citation-contract.md)) |
+| **인덱싱/청킹 (indexing)** | [`rag_indexing.py`](../../rag_indexing.py) | 청킹·인덱스 빌드 ([`scripts/build_index.py`](../../scripts/build_index.py) 진입점) |
+| **임베딩 (embedding)** | [`rag_embedding.py`](../../rag_embedding.py) | dense 임베딩 primitive — 기본 오프라인 경로 `hashing`, 옵션 MiniLM/BGE-M3 |
+| **수집 (ingestion)** | [`ingestion.py`](../../ingestion.py), [`visual_ingestion.py`](../../visual_ingestion.py) | 문서 로딩/파싱. HWP/PDF backend ([ADR 0049](../adr/0049-kordoc-replaces-pyhwp-backend.md)), `csv_text` fallback |
+| **API** | [`api/main.py`](../../api/main.py), [`api/schemas.py`](../../api/schemas.py) | FastAPI 데모 서버 + request/response 스키마 (`api/` 전체가 SSoT) |
+| **평가 (evaluation)** | [`eval/run_eval.py`](../../eval/run_eval.py), [`eval/scorers/`](../../eval/scorers/) | end-to-end eval harness + scorer 모듈 (`citation.py`, `alignment.py`, `format.py`, `failure_classifier.py`, `chunk_metrics.py` …) |
+| **거버넌스/CI** | [`.github/workflows/pr-eval.yml`](../../.github/workflows/pr-eval.yml), `scripts/check_*.py` | PR-time 회귀 게이트 + lint. check 스크립트: `check_baseline_provenance.py`, `check_branch_and_issue.py`, `check_doc_links.py`, `check_embedding_routed_spread.py`, `check_latency_slo.py` |
+| **데모 (demo)** | [`demo/streamlit_app.py`](../../demo/streamlit_app.py) | Streamlit UI — 3 preset side-by-side |
+| **운영 (operations)** | [`docs/operations/`](../operations/) | 배포, harness, auto-ship, observability, failure-mode-harden-process |
+
+## `rag_core.py` 는 왜 아직 존재하는가
+
+`rag_core.py` 는 **사고로 비대해진 monolith 가 아니라, 단계적으로 분해(decompose)된 파이프라인의 호환 facade + 오케스트레이션 레이어**다 ([ADR 0045](../adr/0045-rag-core-leaf-migration-plan.md)):
+
+- **Compatibility facade** — `rag_retrieval` / `rag_verifier` / `rag_answer` / `rag_query` / `rag_embedding` 등에서 100+ 심볼을 re-export 해, 기존 호출자(FastAPI 서버 · CLI · 벤치마크 · Streamlit 데모 · 테스트)가 import 경로 변경 없이 동작한다.
+- **Stable import surface** — 분해가 진행돼도 `from rag_core import ...` 가 깨지지 않는 안정 경계. 테스트/스크립트가 내부 모듈 재배치에 결합되지 않는다.
+- **Orchestration** — `_phase_analyze` / `_phase_build_answer` 등 고수준 단계 chaining + direct 경로와 LangGraph 경로([`rag_graph_agentic_full.py`](../../rag_graph_agentic_full.py) · [`rag_graph_react.py`](../../rag_graph_react.py)) 를 함께 구동.
+- **Zero back-edge 검증** — leaf 모듈은 `rag_core` 로 되돌아 import 하지 않는다(back-edge 0, [ADR 0045](../adr/0045-rag-core-leaf-migration-plan.md) 검증). 분해는 호출자를 깨지 않으면서 점진적으로 진행됐다.
+
+## 요청 흐름 (sequence)
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant Q as Query Analysis<br/>(rag_query.py)
+    participant P as Retrieval Plan<br/>(rag_planner.py)
+    participant R as Candidate Retrieval<br/>(rag_retrieval.py)
+    participant V as Verification / Retry<br/>(rag_verifier.py)
+    participant A as Answer Builder<br/>(rag_answer.py)
+    participant E as Eval / Diagnostics<br/>(eval/run_eval.py)
+
+    U->>Q: 자연어 질의
+    Q->>P: query_type + 비교 target
+    P->>R: 검색 계획 (metadata-first, comparison-aware top-k)
+    R->>V: 후보 evidence
+    V-->>R: 근거 부족 시 bounded 재시도
+    V->>A: 검증된 evidence (또는 보류 신호)
+    A->>U: citation-grounded 응답 (claims + citations + status)
+    A-->>E: 답변 dict → 회귀/진단 측정
+```
+
+> 위 sequence 는 단계별 모듈 소유권을 보여주는 것이 목적이며, fusion 채널·classDef 강조가 포함된 전체 데이터 흐름도는 [`docs/architecture-deep-dive.md`](../architecture-deep-dive.md) 에 있다. 실패 모드별 설계 대응은 [실패 모드 케이스 스터디](../case-studies/failure-modes.md) 참조.

--- a/docs/case-studies/failure-modes.md
+++ b/docs/case-studies/failure-modes.md
@@ -1,0 +1,60 @@
+# RAG 실패 모드 케이스 스터디 (리뷰어용)
+
+이 문서는 RFP 문서 RAG 에서 실제로 발생하는 **대표 실패 모드 5가지**를, 증상 → 근본 원인 → 설계 대응 → 회귀 가드 → 리뷰어 시사점 순으로 정리한 리뷰어 진입점이다. RAG 데모를 "구현"한 것이 아니라, 실패 모드를 **정의하고 측정 가능하게 막은** 시스템 소유(system ownership) 증거를 보이는 것이 목적이다.
+
+본 문서는 요약이며, 정본(canonical) 데이터는 다음을 참조한다 (중복 서술하지 않음):
+
+- [`docs/real-data/real-data-failure-taxonomy.md`](../real-data/real-data-failure-taxonomy.md) — real100 기반 6-카테고리(C1–C6) 정본 분류
+- [`docs/agentic/agent-failure-modes-analysis.md`](../agentic/agent-failure-modes-analysis.md) — LangGraph 오케스트레이션 실패 패턴
+- [`docs/operations/failure-mode-harden-process.md`](../operations/failure-mode-harden-process.md) — monotone-ratchet 하드닝 프로세스
+- [ADR 0059](../adr/0059-failure-mode-classifier-as-measurement-surface.md) (failure classifier) · [ADR 0062](../adr/0062-failure-rate-regression-contract.md) (회귀 ceiling 계약)
+
+아래 5개 모드는 정본 taxonomy 의 C1–C6 에 대응한다 (A=C2, B=C1/C2, C=C6, D=C4, E=C5).
+
+---
+
+## A. Comparison query starvation (비교 질의 한쪽 문서 기아)
+
+- **Symptom**: 비교 질의(`query_type == "comparison"`)에서 글로벌 top-k 가 score 높은 한 기관/문서로 슬롯을 과점 → 다른 비교 대상 문서의 evidence 가 누락된다.
+- **Root cause**: 단순 global top-k cut 은 비교 대상이 둘 이상이라는 질의 의도를 무시한다. 한쪽 문서가 검색 점수를 독식하면 반대쪽 근거가 잘려 나간다.
+- **Design response**: comparison-aware **balanced top-k** — Query Analyzer 가 추출한 비교 target 별로 `min_per_target ≥ 1` evidence 를 보장하고, 남은 슬롯만 글로벌 score 순으로 채운다. 단일 문서 질의에서는 no-op(추가 비용 0). 설계: [`docs/retrieval/comparison-ranking.md`](../retrieval/comparison-ranking.md).
+- **Regression guard**: [`tests/test_fuzzy_retrieval.py`](../../tests/test_fuzzy_retrieval.py) — asymmetric corpus 에서 균등 보장, disabled 시 global ordering 보존, single-doc no-op 을 회귀로 고정.
+- **Reviewer takeaway**: 일반 RAG 튜토리얼에 없는 **RFP 도메인 특화 검색 결정**. 실패 패턴을 먼저 발견하고 ranking 전략으로 구조적으로 막은 뒤 테스트로 잠갔다.
+
+## B. Metadata ambiguity (기관·사업명 모호성)
+
+- **Symptom**: 발주기관/사업명이 유사한 substring 을 공유해 여러 문서가 동시에 매칭 → 시스템이 잘못된 문서로 답할 위험 (정본 taxonomy C2; C1 엔터티 정규화와 인접).
+- **Root cause**: 한국 공공/B2B RFP 는 기관·사업명이 길고 부분 중복이 많아, 단순 substring/유사도 매칭만으로는 정답 문서를 단일 확정할 수 없다.
+- **Design response**: 메타데이터 우선 검색([ADR 0002](../adr/0002-metadata-first-retrieval.md))으로 후보를 좁히고, 모호도가 임계 이내로 근접하면 답을 강행하지 않고 **clarification** 으로 분기한다 — [`rag_clarification.py`](../../rag_clarification.py) 의 `metadata_clarification_answer` / `make_metadata_clarification_result`.
+- **Regression guard**: [`tests/test_single_turn_ambiguity.py`](../../tests/test_single_turn_ambiguity.py) — 모호 질의가 잘못된 후보로 fallback 하지 않고 clarification 경로를 타는지 고정.
+- **Reviewer takeaway**: "근접 후보가 둘이면 추측보다 되묻는다" 는 정책을 코드 경로로 명시. 잘못된 문서 기반 자신만만한 오답을 구조적으로 차단.
+
+## C. Unsupported / out-of-scope question (근거 없는 질의)
+
+- **Symptom**: 사용자가 evidence 에 존재하지 않는 정보를 요구 → 생성형이라면 hallucination, 추출형이라도 약한 근거로 답할 위험 (정본 taxonomy C6).
+- **Root cause**: 검색이 관련 evidence 를 못 찾았는데도 파이프라인이 "무언가" 답하려 하면 근거 없는 응답이 나온다.
+- **Design response**: verifier/retry + **abstention(보류)** — 근거가 불충분하면 bounded 재시도 후, 일급 응답 상태 `status: insufficient` 로 보류한다([ADR 0003](../adr/0003-structured-answer-citation-contract.md) · [ADR 0004](../adr/0004-verifier-retry-policy.md)). 보류는 fallback/error 가 아니라 **의도된 답변 상태**다.
+- **Regression guard**: [`tests/test_scorers_case_abstention.py`](../../tests/test_scorers_case_abstention.py) — abstention 케이스의 quality metric 처리(보류 시 accuracy=none) 를 고정.
+- **Reviewer takeaway**: README 메트릭에서 `agentic_full` 의 **abstention accuracy +57.1pp** 가 이 설계의 정량 증거. raw answer rate 를 일부 내주고 "모르면 모른다" 의 신뢰성을 산다.
+
+## D. Follow-up query resolution (후속 질문 문맥 소실)
+
+- **Symptom**: "그 사업", "거기 일정은?" 같은 암시적 지시어가 직전 문맥(active document)을 필요로 하는데, 이를 해소하지 못해 엉뚱한 문서로 검색된다 (정본 taxonomy C4).
+- **Root cause**: 멀티턴에서 직전 턴의 entity 가 현재 질의에 명시되지 않으면, 검색기는 지시어만으로 정답 문서를 찾지 못한다.
+- **Design response**: [`rag_conversation_state.py`](../../rag_conversation_state.py) 가 대화 상태를 유지하고, 해소된 entity 를 질의에 주입(`resolve_conversation_context` → `inject_entities_into_query`)해 검색 anchor 를 보강한다.
+- **Regression guard**: [`tests/test_followup_entity_injection.py`](../../tests/test_followup_entity_injection.py) — `test_resolved_query_contains_entity_anchor` 등으로 해소된 질의가 entity anchor 를 포함하는지 고정.
+- **Reviewer takeaway**: 단일 질의 정확도만 본 RAG 와 달리, **세션 상태를 일급으로 다뤄** 실무 대화형 사용에서의 문맥 소실을 막는다.
+
+## E. Citation drift / unsupported claims (인용 표류)
+
+- **Symptom**: 답변이 citation 을 달고 있지만 그 claim 이 실제 evidence chunk 와 정합하지 않는다 — 인용처럼 보이는 비근거 답변 (정본 taxonomy C5).
+- **Root cause**: claim 과 citation 의 정렬을 강제하지 않으면, 출처를 붙였더라도 본문이 출처를 실제로 지지하지 않을 수 있다.
+- **Design response**: 구조화 답변 스키마([`rag_answer_schema.py`](../../rag_answer_schema.py), [ADR 0003](../adr/0003-structured-answer-citation-contract.md))로 `claims` ↔ `citations` 정렬을 계약화하고, claim-citation alignment 를 평가 지표로 측정한다.
+- **Regression guard**: [`tests/test_citation_coverage_regression.py`](../../tests/test_citation_coverage_regression.py) — claim·page·region coverage 정합을 회귀로 고정.
+- **Reviewer takeaway**: README 메트릭의 **citation precision +18.0pp** + claim-citation alignment 가 이 계약의 정량 증거. "출처 있어 보임" 이 아니라 "출처가 실제로 지지함" 을 측정한다.
+
+---
+
+## 실패 → 하드닝 → 회귀 차단의 폐루프
+
+위 대응들은 일회성 fix 가 아니라 **monotone-ratchet 프로세스**로 운영된다: 감사로 실패 표면 식별 → 카테고리 lock → hardcase 예제 추가 → ceiling 회귀 게이트 → fix → ceiling tighten. 프로세스: [`docs/operations/failure-mode-harden-process.md`](../operations/failure-mode-harden-process.md). 측정 표면·회귀 계약: [ADR 0059](../adr/0059-failure-mode-classifier-as-measurement-surface.md) · [ADR 0062](../adr/0062-failure-rate-regression-contract.md). PR 마다 [pr-eval.yml](../../.github/workflows/pr-eval.yml) 이 회귀를 게이트한다.

--- a/docs/portfolio-pitch.md
+++ b/docs/portfolio-pitch.md
@@ -1,0 +1,48 @@
+# 면접에서 이 프로젝트를 설명하는 법
+
+리뷰어/면접관에게 30초 ~ 2분 안에 이 프로젝트의 시니어 시그널을 전달하기 위한 피치 모음. 수치는 모두 README 메트릭 표(자동 생성, source of truth)와 ADR 에서 인용하며, 새 숫자를 만들지 않는다.
+
+## 30초 피치
+
+> 이 프로젝트에서 저는 RAG 파이프라인을 단순 구현한 것이 아니라, RFP 문서에서 실제로 발생하는 **검색 실패 · 근거 부족 · 비교 질의 편향을 failure mode 로 정의**하고, 이를 **baseline / ablation / eval / CI 로 검증 가능한 시스템**으로 만들었습니다.
+
+핵심 한 문장: "RAG 데모를 만든 게 아니라, RFP 도메인의 실패 모드를 정의하고 그것을 막는 평가·CI·provenance 게이트를 소유했습니다."
+
+## 3개 핵심 시그널
+
+### 1. Baseline preservation (기준선 보존)
+
+- `naive_baseline` 을 byte-identical 로 보존해 모든 개선을 *additive ablation* 으로만 측정한다. 새 기능이 기준선을 대체하지 않으므로, 어떤 변경이 무엇을 얼마나 바꿨는지 항상 분리 측정 가능하다.
+- 근거: [ADR 0001](adr/0001-preserve-naive-baseline.md). `eval/config.yaml` 의 `naive_baseline` preset 은 제거 금지(거버넌스 규칙).
+- 면접 답변: "개선을 자랑하기 전에, *비교 기준이 흔들리지 않는다*는 걸 먼저 보장했습니다. 그래서 모든 ablation 이 기준선 대비 정직한 delta 입니다."
+
+### 2. Failure-mode-driven design (실패 모드 주도 설계)
+
+- comparison starvation · metadata ambiguity · unsupported-question abstention · follow-up 문맥 소실 · citation drift 5개 실패 모드를 명시하고, 각각에 코드 경로 + 회귀 테스트로 대응한다.
+- 근거: [실패 모드 케이스 스터디](case-studies/failure-modes.md) (정본 taxonomy [`docs/real-data/real-data-failure-taxonomy.md`](real-data/real-data-failure-taxonomy.md) C1–C6 대응).
+- 면접 답변: "기능부터 쌓은 게 아니라, *이 도메인에서 무엇이 깨지는가*를 먼저 분류하고 거기서 설계를 역산했습니다. 예: 비교 질의에서 한쪽 문서가 검색 슬롯을 독식하는 starvation 을 발견하고 balanced top-k 로 막았습니다."
+
+### 3. Eval/CI regression prevention (평가·CI 회귀 차단)
+
+- PR 마다 회귀 게이트가 돌고, failure-rate ceiling 이 ratchet(단조 강화)되어 품질 후퇴를 머지 전에 차단한다. 공개 합성 / 비공개 real-eval 을 분리해 서로 다른 목적(품질 회귀 감시 vs 난이도 상한 탐침)으로 운용한다.
+- 근거: [pr-eval.yml](../.github/workflows/pr-eval.yml) · [ADR 0062](adr/0062-failure-rate-regression-contract.md) (회귀 ceiling 계약) · [ADR 0005](adr/0005-eval-split-public-synthetic-private-local.md) (eval 분리).
+- 면접 답변: "측정은 일회성이 아니라 *상시 게이트*입니다. 회귀가 들어오면 CI 가 막고, 실패율 상한은 내려가기만 합니다."
+
+## 안전성/품질 trade-off 를 정직하게 설명하기
+
+면접관이 "그런데 `agentic_full` 이 raw accuracy 는 더 낮네요?"라고 물으면:
+
+> "맞습니다. 그건 *실패한 최적화가 아니라 의도된 trade-off* 입니다. `agentic_full` 은 답변율을 극대화하도록 튜닝한 게 아니라, citation precision **+18.0pp** 와 abstention accuracy **+57.1pp** 를 얻는 safety-oriented 파이프라인입니다. RFP 의사결정 맥락에서는 근거 없는 답변보다 근거 있는 보류가 더 안전하니까요. 그래서 메트릭은 하나의 평탄한 leaderboard 가 아니라 slice 별로 읽어야 합니다."
+
+real-eval hardcase(n=221, accuracy 16.10%)를 물으면:
+
+> "그건 제품 성공 지표가 아니라 hardcase 스트레스 테스트입니다. 일부러 어려운 케이스로 실패 모드를 노출하고 ablation 변별력을 시험하는 용도라, 낮은 수치를 숨기지 않고 엔지니어링 증거로 드러냅니다." ([ADR 0052](adr/0052-real-eval-hardcase-expansion-to-200.md))
+
+## STAR 정리 (핵심 기여 1건)
+
+- **Situation**: 한국 공공/B2B RFP 는 길고 noisy 하며, 비교 질의에서 기관 문서 간 균형 잡힌 근거 수집이 어렵다.
+- **Task**: 비교 질의에서 한쪽 문서가 누락되지 않도록 검색 결과를 균형화하되, 단일 문서 질의 비용은 늘리지 않는다.
+- **Action**: 비교 target 별 `min_per_target ≥ 1` 을 보장하는 comparison-aware balanced top-k 를 설계·구현하고, asymmetric corpus / disabled / single-doc no-op 을 회귀 테스트로 고정했다 ([`tests/test_fuzzy_retrieval.py`](../tests/test_fuzzy_retrieval.py)).
+- **Result**: 비교 질의에서 양쪽 기관이 모두 인용되는 동작을 구조적으로 보장(README 5초 비주얼 훅에서 재현). 일반 RAG 튜토리얼에 없는 도메인 특화 결정을 발견→설계→검증까지 소유했다.
+
+> 추가 STAR ammo · slice 별 수치 분해: [`docs/rag-challenges-solved.md`](rag-challenges-solved.md) · [`docs/performance-evolution.md`](performance-evolution.md).


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

README 상단이 배지+메트릭 표로 시작해 핵심 스토리(failure-mode 주도 엔지니어링)가 묻히고, `agentic_full` 의 raw accuracy 가 `naive_baseline` 보다 낮은 것이 안전성/품질 trade-off 로 프레이밍되지 않아 실패한 최적화처럼 읽혔다. 리뷰어가 30초 안에 가치를 파악하도록 README 상단을 재구성하고, 메트릭/real-eval 을 정직하게 프레이밍하며, 모듈맵·실패모드·면접피치 문서를 추가했다. 문서 전용 — runtime/메트릭 무변경.

Closes #1395

## 2. 영향 파일

- `README.md` — 상단 **30초 요약(What this proves)** 블록, 메트릭 표 직전 **safety/quality trade-off** 프레이밍, **real-eval 읽는 법** 노트, **면접 피치** 티저 추가. 표와 모순되던 `## TL;DR`(+77.8/+39.3pp) dedupe 제거. `<!-- METRICS_TABLE -->` 블록은 byte-identical (수정 안 함)
- `docs/architecture/module-map.md` (신규) — 단계별 모듈 맵 + `rag_core.py` facade/오케스트레이션 설명(ADR 0045) + Mermaid sequence diagram
- `docs/case-studies/failure-modes.md` (신규) — 5 실패모드(A~E) × Symptom/Root cause/Design response/Regression guard/Reviewer takeaway, 정본 C1–C6 taxonomy 링크
- `docs/portfolio-pitch.md` (신규) — 면접 피치 + 3 시그널 + STAR

load-bearing 경로 없음 (`scripts/_governance.py --is-load-bearing` 전부 exit=1).

## 3. 리스크

가장 가능성 높은 깨짐: 새 doc 의 상대 링크/ADR 참조/anchor fragment 오류. `scripts/check_doc_links.py --check-all` 로 4 파일 검증 완료 (broken 0). 추측한 ADR 파일명 2건(0008→evidence-boundary, 0049→kordoc-replaces-pyhwp) 발견 즉시 정정. 메트릭 값 변조 리스크: `<!-- METRICS_TABLE -->` 블록을 HEAD 와 diff 해 byte-identical 확인.

## 4. 테스트

문서 전용 변경으로 신규 동작 없음 → 동작 테스트 추가 해당 없음. 검증은 `check_doc_links.py --check-all` (링크/ADR/fragment 4파일 OK) + `ruff check .` (pass) + METRICS_TABLE 블록 HEAD 대비 byte-identical 확인.

## 5. Eval 영향

All `·` — RAG 파이프라인/eval surface 무변경. 메트릭 값 인용만 하며 재계산 없음.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing 경로 미변경(전부 non-load-bearing) — §5b 해당 없음.

## 6. 하위 호환

깨짐 없음. 답변 계약(ADR 0003) 무변경, `schema_version` bump 불필요. CLI flag 무변경. 기존 doc 링크는 추가만 했고 제거한 것은 표와 모순되던 TL;DR 섹션(고유 링크 없음 — eval-spec/latency 는 다른 곳 잔존).

## 7. 범위 외

- README 하단 섹션(라이브 데모, Claude 협업 등) 구조 유지 — 이번 PR 범위 밖
- 메트릭 스냅샷 재생성 안 함 (의도적 — 값 보존)