### PR TITLE
chore(eval): repoint baseline provenance to rewritten SHA

### DIFF
--- a/reports/real100/baseline.aggregate.json
+++ b/reports/real100/baseline.aggregate.json
@@ -1425,7 +1425,7 @@
   "prompt_profile": "structured_grounded_claims",
   "provenance": {
     "generated_at": "2026-05-19T03:03:10.940691Z",
-    "git_commit": "de69c5c2d456",
+    "git_commit": "426dde4b6e2d",
     "git_dirty": true
   },
   "retry": 0.7647058823529411,
@@ -1465,7 +1465,7 @@
   "run_manifest": {
     "config_sha256": "cfb1fc68d994a4b7",
     "generated_at": "2026-05-19T03:01:21.745364Z",
-    "git_commit": "de69c5c2d456",
+    "git_commit": "426dde4b6e2d",
     "git_dirty": true
   },
   "stage_latency": {


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ADR 0005 히스토리 재작성(#1390/#1392 후속, filter-repo)으로 main 을 force-push 하면서 모든 커밋 SHA 가 바뀌었다. baseline 의 `provenance.git_commit`=`de69c5c2d456` 가 dangling 이 되어 `Baseline provenance reachability` 게이트가 실패한다(#160/#413). commit-map 의 동일-내용 재작성 SHA 로 repoint 한다.

Closes #1397

## 2. 영향 파일

- `reports/real100/baseline.aggregate.json` — `provenance.git_commit` + `run_manifest.git_commit`: `de69c5c2d456` → `426dde4b6e2d` (2곳). **(load-bearing 아님 — reports/)** 메트릭 값 무변경.

## 3. 리스크

SHA 포인터만 변경. `python scripts/check_baseline_provenance.py --ref origin/main` 가 변경 후 `[OK] ... reachable` 로 통과 확인. 재작성 SHA 426dde4b6e2d 는 새 origin/main 의 ancestor.

## 4. 테스트

`scripts/check_baseline_provenance.py` 게이트로 검증 (변경 전 ERROR/unreachable → 변경 후 OK). 별도 테스트 추가 불필요(거버넌스 게이트가 계약).

## 5. Eval 영향

All `·` — RAG 동작·메트릭 무변경, provenance 포인터만 갱신.

### 5b. Real-data delta

N/A — load-bearing path 미변경. 검색/검증 path 동작 변화 없음. baseline 메트릭 숫자 동일(SHA 문자열만 교체).

## 6. 하위 호환

N/A — provenance 메타데이터 SHA 갱신만. 계약/스키마 변경 없음.

## 7. 범위 외

- ADR 0005 히스토리 재작성 자체는 완료(force-push 됨). content scanner #1177 은 별도 PR.
- (C) eval/data 공개 합성 데이터의 공공기관명은 정상 사용으로 범위 외 유지.