### PR TITLE
fix(eval): harden generate_real_cases against silently-wrong gold

### DIFF
--- a/scripts/generate_real_cases.py
+++ b/scripts/generate_real_cases.py
@@ -72,6 +72,17 @@ HARDCASE_ENUMS = (
 
 VALID_QUERY_TYPES = ("single_doc", "comparison", "follow_up", "abstention")
 
+
+class CaseValidationError(ValueError):
+    """A backend-produced case violates the generator contract.
+
+    Raised by ``_normalize_case`` for malformed output (non-boolean
+    ``answerable``, empty/unknown ``hardcase_categories``, unrecognized
+    ``query_type``). ``generate_cases`` catches it, reports the offending
+    case to stderr, and drops it rather than coercing silently.
+    """
+
+
 DEFAULT_K = 2
 DEFAULT_MODEL = "claude-sonnet-4-6"
 DEFAULT_TEMPERATURE = 0.0
@@ -147,23 +158,38 @@ def _stub_backend(doc: dict[str, Any], k: int, seed: int) -> list[dict[str, Any]
 
     Cycles through the 5-enum templates so the canonical contract
     (every enum represented at least once when ``k=5``) is preserved
-    for tests.
+    for tests. ``expected_terms`` for answerable cases are derived from
+    the document's own headings/text (``_grounded_terms``) so the stub
+    never emits a positive-evidence assertion that is absent from the
+    source — an ungrounded gold case loads fine but fails eval for the
+    wrong reason (issue #1388 F4). The id carries the slugified
+    ``doc_id`` so same-agency multi-doc batches don't collide (F1).
     """
     rng = random.Random(f"{doc.get('doc_id', '')}-{seed}")
     agency = str(doc.get("agency") or "기관")
     doc_id = str(doc.get("doc_id") or "")
+    agency_slug = _slugify(agency)
+    doc_slug = _slugify(doc_id)
+    grounded = _grounded_terms(doc)
     templates = list(_STUB_TEMPLATES)
     rng.shuffle(templates)
     cases: list[dict[str, Any]] = []
     for i, tmpl in enumerate(templates[:k] or templates):
         category_slug = tmpl["hardcase_categories"][0]
+        if tmpl["answerable"] and grounded:
+            term = grounded[i % len(grounded)]
+            expected_terms = [term]
+            expected_citation_terms = [term]
+        else:
+            expected_terms = []
+            expected_citation_terms = []
         case = {
-            "id": f"real_{_slugify(agency)}_{category_slug}_{i + 1}",
+            "id": f"real_{agency_slug}_{doc_slug}_{category_slug}_{i + 1}",
             "query_type": tmpl["query_type"],
             "query": f"{agency} {tmpl['query_suffix']}",
             "expected_doc_ids": [doc_id] if tmpl["answerable"] and doc_id else [],
-            "expected_terms": list(tmpl["expected_terms"]),
-            "expected_citation_terms": list(tmpl["expected_citation_terms"]),
+            "expected_terms": expected_terms,
+            "expected_citation_terms": expected_citation_terms,
             "answerable": tmpl["answerable"],
             "hardcase_categories": list(tmpl["hardcase_categories"]),
             "generation_notes": tmpl["notes"],
@@ -208,12 +234,14 @@ HARDCASE_INSTRUCTION = """다음 RFP 문서를 기반으로 **하드케이스 �
 
 answerable=false 인 case 는 expected_terms 와 expected_citation_terms 모두 빈 배열 [].
 
+expected_terms / expected_citation_terms 의 각 string 은 **반드시 아래 제공된 문서 본문에 그대로(부분 문자열) 존재**해야 합니다. 원문에 없는 표현을 정답 근거로 쓰지 마세요 — 그런 케이스는 거부됩니다.
+
 문서 정보:
 - 기관: {agency}
 - 사업: {project}
 - doc_id: {doc_id}
 
-섹션 요약 (heading + 200자):
+섹션 발췌 (문서 후반부 / 부록 포함 전체 heading + 본문 발췌):
 {section_summary}
 """
 
@@ -240,11 +268,7 @@ def _anthropic_backend(
     model = os.environ.get("BIDMATE_HARDCASE_MODEL", DEFAULT_MODEL)
     temperature = float(os.environ.get("BIDMATE_HARDCASE_TEMP", DEFAULT_TEMPERATURE))
 
-    sections = doc.get("sections") or []
-    section_summary = "\n".join(
-        f"- {str(s.get('heading') or '')}: {str(s.get('text') or '')[:200]}"
-        for s in sections[:15]
-    )
+    section_summary = _build_section_summary(doc)
 
     prompt = HARDCASE_INSTRUCTION.format(
         k=k,
@@ -291,6 +315,91 @@ def _slugify(text: str) -> str:
     return "_".join(parts)[:40] or "doc"
 
 
+def _doc_text(doc: dict[str, Any]) -> str:
+    """Full searchable text of a doc (title + every heading + every section
+    body), used to verify generated gold terms are grounded in the source."""
+    parts: list[str] = [str(doc.get("title") or "")]
+    for section in doc.get("sections") or []:
+        parts.append(str(section.get("heading") or ""))
+        parts.append(str(section.get("text") or ""))
+    return "\n".join(parts)
+
+
+def _grounded_terms(doc: dict[str, Any]) -> list[str]:
+    """Candidate expected_terms drawn from the doc itself (headings first,
+    then leading body tokens). Every returned term is a substring of
+    ``_doc_text(doc)`` by construction, so the stub backend can assert
+    grounded gold without consulting an external model."""
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def _add(term: str) -> None:
+        term = term.strip()
+        if term and term not in seen:
+            candidates.append(term)
+            seen.add(term)
+
+    sections = doc.get("sections") or []
+    for section in sections:
+        _add(str(section.get("heading") or ""))
+    if not candidates:
+        for section in sections:
+            for token in str(section.get("text") or "").split():
+                if len(token) >= 2:
+                    _add(token)
+                    break
+    return candidates
+
+
+def _build_section_summary(
+    doc: dict[str, Any], per_section_chars: int = 300
+) -> str:
+    """Per-section excerpt over **all** sections (no head-of-document cap)
+    so tail/appendix headings reach the model (issue #1388 F3). The
+    grounding gate in ``generate_cases`` is the backstop; this just gives
+    the model a fair shot at producing answerable long_context cases."""
+    lines: list[str] = []
+    for idx, section in enumerate(doc.get("sections") or []):
+        heading = str(section.get("heading") or "")
+        text = str(section.get("text") or "")[:per_section_chars]
+        lines.append(f"- [{idx}] {heading}: {text}")
+    return "\n".join(lines)
+
+
+def _is_grounded(case: dict[str, Any], doc_text: str) -> bool:
+    """Answerable gold must assert only terms present in the source.
+
+    Mirrors ``eval/scorers/_shared.contains_all_terms`` (case-insensitive
+    substring) so a case that passes this gate is one the eval scorer can
+    actually credit against the document. Non-answerable (abstention)
+    cases carry no positive-evidence terms and are vacuously grounded.
+    """
+    if not case.get("answerable"):
+        return True
+    lowered = doc_text.lower()
+    terms = list(case.get("expected_terms") or []) + list(
+        case.get("expected_citation_terms") or []
+    )
+    return all(str(term).lower() in lowered for term in terms)
+
+
+def find_duplicate_ids(cases: list[dict[str, Any]]) -> list[str]:
+    """Return the set of case ids that appear more than once.
+
+    Eval traces and cross-run maps are keyed by case id; a duplicate id
+    silently overwrites a trace and corrupts the metric, so a batch with
+    collisions must fail before any YAML is written (issue #1388 F1).
+    """
+    seen: set[str] = set()
+    dups: set[str] = set()
+    for case in cases:
+        cid = str(case.get("id") or "")
+        if cid in seen:
+            dups.add(cid)
+        seen.add(cid)
+    return sorted(dups)
+
+
 def load_doc(raw_dir: Path, doc_id: str) -> dict[str, Any]:
     """Load a single RFP doc JSON by ``doc_id`` (matches both the JSON's
     ``doc_id`` field and the bare filename stem for convenience)."""
@@ -317,16 +426,61 @@ def list_doc_ids(raw_dir: Path) -> list[str]:
 
 
 def _normalize_case(case: dict[str, Any], doc: dict[str, Any]) -> dict[str, Any]:
-    """Coerce a raw backend output into the run_eval loader's schema.
+    """Validate + normalize a raw backend output for the run_eval loader.
+
+    Strict (issue #1388 F2): malformed cases are rejected with a
+    ``CaseValidationError`` rather than silently coerced —
+
+    * ``answerable`` must be a real JSON boolean (``"false"`` is a bug,
+      not ``True``);
+    * ``hardcase_categories`` must be a non-empty list of recognized
+      enums (hardcase-only policy);
+    * ``query_type`` must be one of ``VALID_QUERY_TYPES`` (unknown is
+      rejected, not rewritten to ``single_doc``).
 
     Enforces the abstention contract: ``answerable=false`` strips
-    ``expected_terms`` and ``expected_citation_terms`` so a regression
-    can't sneak a positive-evidence assertion into a no_answer case.
+    ``expected_terms``/``expected_citation_terms``. The id is forced to
+    carry the slugified ``doc_id`` so same-agency multi-doc batches don't
+    collide (F1).
     """
     if not isinstance(case, dict):
-        raise ValueError(f"Case must be a mapping: {case!r}")
+        raise CaseValidationError(f"Case must be a mapping: {case!r}")
     doc_id = str(doc.get("doc_id") or "")
-    answerable = bool(case.get("answerable", True))
+    doc_slug = _slugify(doc_id)
+
+    answerable = case.get("answerable")
+    if not isinstance(answerable, bool):
+        raise CaseValidationError(
+            f"answerable must be a JSON boolean, got "
+            f"{type(answerable).__name__} {answerable!r} (id={case.get('id')!r})"
+        )
+
+    categories = case.get("hardcase_categories")
+    if isinstance(categories, str):
+        categories = [categories]
+    if not categories or not isinstance(categories, list):
+        raise CaseValidationError(
+            f"hardcase_categories must be a non-empty list (id={case.get('id')!r}); "
+            "every case must carry at least one of "
+            f"{HARDCASE_ENUMS}"
+        )
+    unknown_categories = [c for c in categories if c not in HARDCASE_ENUMS]
+    if unknown_categories:
+        raise CaseValidationError(
+            f"unknown hardcase_categories {unknown_categories!r} (id={case.get('id')!r}); "
+            f"expected a subset of {HARDCASE_ENUMS}"
+        )
+
+    raw_query_type = case.get("query_type")
+    if raw_query_type is None or str(raw_query_type).strip() == "":
+        query_type = "single_doc"
+    else:
+        query_type = str(raw_query_type)
+        if query_type not in VALID_QUERY_TYPES:
+            raise CaseValidationError(
+                f"unknown query_type {query_type!r} (id={case.get('id')!r}); "
+                f"expected one of {VALID_QUERY_TYPES}"
+            )
 
     expected_doc_ids = case.get("expected_doc_ids") or ([doc_id] if answerable and doc_id else [])
     expected_terms = list(case.get("expected_terms") or [])
@@ -335,20 +489,13 @@ def _normalize_case(case: dict[str, Any], doc: dict[str, Any]) -> dict[str, Any]
         expected_terms = []
         expected_citation_terms = []
 
-    categories = case.get("hardcase_categories") or []
-    if isinstance(categories, str):
-        categories = [categories]
-
-    query_type = str(case.get("query_type") or "single_doc")
-    if query_type not in VALID_QUERY_TYPES:
-        query_type = "single_doc"
-
     raw_id = str(case.get("id") or "").strip()
     if not raw_id:
-        slug = categories[0] if categories else "misc"
-        raw_id = f"real_{_slugify(str(doc.get('agency') or 'unknown'))}_{slug}"
+        raw_id = f"real_{_slugify(str(doc.get('agency') or 'unknown'))}_{categories[0]}"
     if not raw_id.startswith("real_"):
         raw_id = "real_" + raw_id
+    if doc_slug and doc_slug not in raw_id:
+        raw_id = f"real_{doc_slug}_" + raw_id[len("real_"):]
 
     return {
         "id": raw_id,
@@ -366,13 +513,39 @@ def _normalize_case(case: dict[str, Any], doc: dict[str, Any]) -> dict[str, Any]
 def generate_cases(
     doc: dict[str, Any], k: int, backend: str, seed: int
 ) -> list[dict[str, Any]]:
-    """Run the chosen backend and normalize each case for the eval loader."""
+    """Run the chosen backend, validate + normalize, and ground-check each
+    case for the eval loader.
+
+    Malformed cases (``CaseValidationError``) and answerable cases whose
+    gold terms are absent from the source (``_is_grounded``) are dropped
+    with an explicit stderr report rather than emitted as silently-wrong
+    gold (issue #1388 F2/F3/F4).
+    """
     if backend not in _BACKENDS:
         raise ValueError(
             f"Unknown backend {backend!r}; expected one of {sorted(_BACKENDS)}"
         )
     raw_cases = _BACKENDS[backend](doc, k, seed)
-    return [_normalize_case(c, doc) for c in raw_cases]
+    doc_text = _doc_text(doc)
+    doc_id = str(doc.get("doc_id") or "")
+    cases: list[dict[str, Any]] = []
+    for raw in raw_cases:
+        try:
+            case = _normalize_case(raw, doc)
+        except CaseValidationError as exc:
+            print(f"  drop (invalid, doc={doc_id}): {exc}", file=sys.stderr)
+            continue
+        if not _is_grounded(case, doc_text):
+            print(
+                f"  drop (ungrounded, doc={doc_id}): id={case['id']!r} "
+                f"expected_terms not found in source: "
+                f"{case.get('expected_terms')!r} / "
+                f"{case.get('expected_citation_terms')!r}",
+                file=sys.stderr,
+            )
+            continue
+        cases.append(case)
+    return cases
 
 
 # -----------------------------------------------------------------------------
@@ -448,6 +621,16 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Skipping: {exc}", file=sys.stderr)
             continue
         all_cases.extend(generate_cases(doc, args.k, args.backend, args.seed))
+
+    duplicate_ids = find_duplicate_ids(all_cases)
+    if duplicate_ids:
+        print(
+            "error: duplicate case ids generated — eval traces are keyed by id "
+            f"and would collide/overwrite: {duplicate_ids}. "
+            "Refusing to write (issue #1388 F1).",
+            file=sys.stderr,
+        )
+        return 2
 
     payload = {"cases": all_cases}
     yaml_str = yaml.safe_dump(

--- a/tests/test_generate_real_cases.py
+++ b/tests/test_generate_real_cases.py
@@ -207,5 +207,248 @@ class CLIContractTest(unittest.TestCase):
             self.assertIn("BIDMATE_HARDCASE_API_KEY", str(ctx.exception))
 
 
+SAMPLE_DOC_SAME_AGENCY = {
+    "doc_id": "rfp-test-sample-2",
+    "title": "테스트 기관 X 후속 사업 RFP",
+    "agency": "기관 X",
+    "project": "후속 사업",
+    "sections": [
+        {"heading": "추진 배경", "text": "후속 사업의 배경을 기술한다."},
+        {"heading": "검수 기준", "text": "산출물 검수 위원회를 운영한다."},
+    ],
+}
+
+
+class IdCollisionTest(unittest.TestCase):
+    """F1 — case ids must embed doc_id so same-agency docs don't collide."""
+
+    def test_stub_ids_embed_slugified_doc_id(self) -> None:
+        doc_slug = generate_real_cases._slugify(SAMPLE_DOC["doc_id"])
+        cases = generate_real_cases.generate_cases(
+            SAMPLE_DOC, k=5, backend="stub", seed=17
+        )
+        self.assertTrue(cases)
+        for case in cases:
+            self.assertIn(
+                doc_slug,
+                case["id"],
+                f"case id {case['id']!r} missing doc slug {doc_slug!r}",
+            )
+
+    def test_same_agency_distinct_docs_produce_no_duplicate_ids(self) -> None:
+        # Pre-fix, both docs (same agency "기관 X") emitted
+        # real_x_<category>_<i> with no doc_id — guaranteed collision.
+        cases_a = generate_real_cases.generate_cases(
+            SAMPLE_DOC, k=5, backend="stub", seed=17
+        )
+        cases_b = generate_real_cases.generate_cases(
+            SAMPLE_DOC_SAME_AGENCY, k=5, backend="stub", seed=17
+        )
+        self.assertEqual(
+            [], generate_real_cases.find_duplicate_ids(cases_a + cases_b)
+        )
+
+    def test_find_duplicate_ids_flags_collisions(self) -> None:
+        cases = [
+            {"id": "real_x_a_1"},
+            {"id": "real_x_a_1"},
+            {"id": "real_x_b_2"},
+        ]
+        self.assertEqual(
+            ["real_x_a_1"], generate_real_cases.find_duplicate_ids(cases)
+        )
+
+    def test_main_fails_before_write_on_duplicate_ids(self) -> None:
+        colliding = {
+            "id": "real_dup_collision_1",
+            "query_type": "single_doc",
+            "query": "q",
+            "expected_doc_ids": [],
+            "expected_terms": [],
+            "expected_citation_terms": [],
+            "answerable": False,
+            "hardcase_categories": ["no_answer"],
+            "generation_notes": "",
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir) / "raw"
+            raw_dir.mkdir()
+            for stem, doc in (
+                ("d1", SAMPLE_DOC),
+                ("d2", SAMPLE_DOC_SAME_AGENCY),
+            ):
+                (raw_dir / f"{stem}.json").write_text(
+                    json.dumps(doc, ensure_ascii=False), encoding="utf-8"
+                )
+            out_path = Path(tmpdir) / "out.yaml"
+            buf = io.StringIO()
+            with mock.patch.object(
+                generate_real_cases, "generate_cases", return_value=[dict(colliding)]
+            ), redirect_stderr(buf):
+                rc = generate_real_cases.main(
+                    [
+                        "--batch", "2",
+                        "--raw-dir", str(raw_dir),
+                        "--output", str(out_path),
+                    ]
+                )
+            self.assertEqual(2, rc)
+            self.assertIn("duplicate case ids", buf.getvalue())
+            self.assertFalse(
+                out_path.exists(), "must refuse to write when ids collide"
+            )
+
+
+class StrictValidationTest(unittest.TestCase):
+    """F2 — _normalize_case rejects malformed output instead of coercing."""
+
+    def test_string_false_answerable_is_rejected(self) -> None:
+        with self.assertRaises(generate_real_cases.CaseValidationError):
+            generate_real_cases._normalize_case(
+                {
+                    "id": "real_x_no_answer_1",
+                    "query_type": "abstention",
+                    "query": "q",
+                    "answerable": "false",  # truthy string — must not pass as True
+                    "hardcase_categories": ["no_answer"],
+                },
+                SAMPLE_DOC,
+            )
+
+    def test_empty_hardcase_categories_is_rejected(self) -> None:
+        with self.assertRaises(generate_real_cases.CaseValidationError):
+            generate_real_cases._normalize_case(
+                {
+                    "id": "real_x_1",
+                    "query_type": "single_doc",
+                    "query": "q",
+                    "answerable": True,
+                    "hardcase_categories": [],
+                },
+                SAMPLE_DOC,
+            )
+
+    def test_unknown_hardcase_category_is_rejected(self) -> None:
+        with self.assertRaises(generate_real_cases.CaseValidationError):
+            generate_real_cases._normalize_case(
+                {
+                    "id": "real_x_1",
+                    "query_type": "single_doc",
+                    "query": "q",
+                    "answerable": True,
+                    "hardcase_categories": ["totally_made_up"],
+                },
+                SAMPLE_DOC,
+            )
+
+    def test_unknown_query_type_is_rejected_not_rewritten(self) -> None:
+        with self.assertRaises(generate_real_cases.CaseValidationError):
+            generate_real_cases._normalize_case(
+                {
+                    "id": "real_x_1",
+                    "query_type": "freeform_chat",
+                    "query": "q",
+                    "answerable": True,
+                    "hardcase_categories": ["multi_hop"],
+                },
+                SAMPLE_DOC,
+            )
+
+    def test_generate_cases_drops_invalid_and_reports(self) -> None:
+        fake_backend = lambda *_: [  # noqa: E731
+            {
+                "id": "real_x_good_1",
+                "query_type": "single_doc",
+                "query": "q",
+                "answerable": True,
+                "expected_terms": ["거버넌스"],
+                "expected_citation_terms": ["거버넌스"],
+                "hardcase_categories": ["multi_hop"],
+            },
+            {  # malformed: string answerable
+                "id": "real_x_bad_2",
+                "query_type": "single_doc",
+                "query": "q",
+                "answerable": "false",
+                "hardcase_categories": ["multi_hop"],
+            },
+        ]
+        buf = io.StringIO()
+        with mock.patch.dict(
+            generate_real_cases._BACKENDS, {"fake": fake_backend}, clear=False
+        ), redirect_stderr(buf):
+            cases = generate_real_cases.generate_cases(
+                SAMPLE_DOC, k=2, backend="fake", seed=17
+            )
+        self.assertEqual(1, len(cases))
+        self.assertEqual("real_rfp_test_sample_x_good_1", cases[0]["id"])
+        self.assertIn("drop (invalid", buf.getvalue())
+
+
+class GroundingTest(unittest.TestCase):
+    """F3/F4 — answerable gold terms must exist in the source document."""
+
+    def test_stub_answerable_terms_are_grounded_in_doc(self) -> None:
+        doc_text = generate_real_cases._doc_text(SAMPLE_DOC).lower()
+        cases = generate_real_cases.generate_cases(
+            SAMPLE_DOC, k=5, backend="stub", seed=17
+        )
+        answerable = [c for c in cases if c["answerable"]]
+        self.assertTrue(answerable)
+        for case in answerable:
+            for term in case["expected_terms"]:
+                self.assertIn(
+                    term.lower(),
+                    doc_text,
+                    f"stub emitted off-document term {term!r} for {case['id']!r}",
+                )
+
+    def test_stub_does_not_emit_fixed_offdoc_template_terms(self) -> None:
+        # SAMPLE_DOC contains neither "약칭" nor "부속서"; the pre-fix stub
+        # would have emitted them verbatim from its fixed templates.
+        cases = generate_real_cases.generate_cases(
+            SAMPLE_DOC, k=5, backend="stub", seed=17
+        )
+        emitted = {t for c in cases for t in c["expected_terms"]}
+        self.assertNotIn("약칭", emitted)
+        self.assertNotIn("부속서", emitted)
+
+    def test_generate_cases_drops_ungrounded_answerable_case(self) -> None:
+        fake_backend = lambda *_: [  # noqa: E731
+            {
+                "id": "real_x_hallucinated_1",
+                "query_type": "single_doc",
+                "query": "q",
+                "answerable": True,
+                "expected_terms": ["우주선 추진계"],  # absent from SAMPLE_DOC
+                "expected_citation_terms": [],
+                "hardcase_categories": ["long_context"],
+            }
+        ]
+        buf = io.StringIO()
+        with mock.patch.dict(
+            generate_real_cases._BACKENDS, {"fake": fake_backend}, clear=False
+        ), redirect_stderr(buf):
+            cases = generate_real_cases.generate_cases(
+                SAMPLE_DOC, k=1, backend="fake", seed=17
+            )
+        self.assertEqual([], cases)
+        self.assertIn("drop (ungrounded", buf.getvalue())
+
+    def test_build_section_summary_covers_tail_sections(self) -> None:
+        big_doc = {
+            "doc_id": "rfp-big",
+            "agency": "기관 Z",
+            "title": "대형 RFP",
+            "sections": [
+                {"heading": f"섹션 {i}", "text": f"본문 {i}"} for i in range(40)
+            ],
+        }
+        summary = generate_real_cases._build_section_summary(big_doc)
+        # Pre-fix the prompt truncated to sections[:15]; the appendix-style
+        # tail heading must now reach the model.
+        self.assertIn("섹션 39", summary)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

codex adversarial-review가 `scripts/generate_real_cases.py` (LLM-assisted real-eval hardcase generator, ADR 0052 prep, #936)에서 4개 결함을 발견했고 현재 main 코드에서 모두 재현 확인됨. human-in-the-loop이라 자동 오염은 아니나, F3/F4는 사람이 리뷰로도 놓치는 silently-wrong gold(로더는 통과하나 평가에서 엉뚱한 이유로 실패)를 만들고 F1은 promotable gold 품질을 떨어뜨림. 같은 파일이라 한 묶음으로 수정. **출력 schema 불변 → `eval/run_eval.py:load_config` 로더 호환 유지.**

Closes #1388

## 2. 영향 파일

- `scripts/generate_real_cases.py` — (load-bearing 아님; `scripts/build_index.py`만 load-bearing)
- `tests/test_generate_real_cases.py` — 회귀 테스트 14개 추가

## 3. 리스크

- **가장 가능성 높은 깨짐**: 엄격 검증(F2) / grounding 게이트(F3·F4)가 기존 stub 출력을 과도하게 drop → 기존 테스트(`k=5`→5케이스 기대) 붕괴. 이를 배제하기 위해 stub을 doc-derived term으로 재작성(F4)해 grounding을 구조적으로 보장, `make test-fast` 2114 passed로 확인.
- ID 포맷 변경(doc_id slug 삽입)으로 기존 생성 YAML의 id와 불일치 가능 — 단 consumer-zero(어떤 eval config도 아직 미연결, docstring L29-33)라 영향 없음.
- 실데이터 재현: 13개 공개 문서 × k=5 = 65 케이스 전부 unique(이전엔 기관 E 2개 문서가 `real_e_*_1` 충돌).

## 4. 테스트

신규 14개 (변경 전 fail / 변경 후 pass):
- F1: ID에 doc_id slug 임베드 / same-agency 무충돌 / `find_duplicate_ids` / `main()` 중복 시 write 전 rc=2 fail
- F2: string `"false"` answerable·빈/미지 enum·미지 query_type 거부 + `generate_cases` drop+report
- F3: `_build_section_summary` tail 섹션 커버(40섹션 중 39 포함) + ungrounded answerable drop
- F4: stub term이 문서 내 grounded / off-doc 고정 template term(`약칭`/`부속서`) 미방출

`make test-fast`: 2114 passed, 16 skipped. `ruff check` clean.

## 5. Eval 영향

All `·` — 이 스크립트는 consumer-zero(어떤 eval config/CI eval path에도 미연결). 생성된 YAML은 gitignored `eval/real_config.local.yaml`에 사람이 리뷰 후 append하는 로컬 워크플로 전용. CI eval delta 없음.

### 5b. Real-data delta

N/A — load-bearing path 변경 아님(`scripts/generate_real_cases.py`는 `scripts/_governance.py` LOAD_BEARING_PATHS에 부재; `--is-load-bearing` 빈 결과 확인). 검색/검증/답변 path 동작 변화 없음.

## 6. 하위 호환

출력 schema 불변(신규 필드 없음) → run_eval 로더 계약 유지, `schema_version` bump 불필요. 동작 변경: (a) malformed/ungrounded 케이스가 이전엔 강제 통과 → 이제 drop+report, (b) 생성 id에 doc_id slug 포함. 둘 다 consumer-zero라 기존 산출물 영향 없음. CLI flag 변경 없음.

## 7. 범위 외

- `_anthropic_backend`의 pre-existing Pyright nit(`response.content[0].text` 블록 타입) — opt-in 네트워크 경로(`# pragma: no cover`), 본 결함과 무관해 미수정.
- ADR 0052의 n=200 baseline regen은 PR-B 별도 작업(docstring L32-33).