### PR TITLE
docs: restore legacy anchors broken by Korean heading translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ INFO bidmate.rag_core: query_complete  status='supported'  query_type='compariso
 
 데모 UI 는 3 파이프라인 preset (`naive_baseline` · `agentic_full` · `agentic_full_llm`) 을 라디오 버튼으로 전환, extractive vs LLM 합성 답변 side-by-side 비교.
 
+<a id="why-extractive-not-generative"></a>
+
 ## 왜 추출형(extractive)인가, 생성형(generative)이 아닌가?
 
 기본 파이프라인 (`naive_baseline`, `agentic_full`) 은 외부 LLM 호출 없이 retrieved evidence 에서 claim 을 추출하는 **추출형 근거 답변**. 생성기를 의도적으로 추출형으로 한정한 4가지 이유:

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -100,6 +100,8 @@ Meta/parent issue (예: #118 포트폴리오, #187 phase 향상 백로그) 는 �
 - **결정 세탁** — load-bearing 선택이 리팩터 PR 에 묻힘. *방지*: CLAUDE.md Core principles 의 ADR 임계값 + [`docs/adr/README.md`](./adr/README.md); PR 템플릿이 질문 강제
 - **리뷰 중 scope 증가** — "while I was here" fix 가 PR 비대화. *방지*: CLAUDE.md "one PR, one concern"; follow-up issue spawn
 
+<a id="governance-saves-real-incidents-prevented"></a>
+
 ## Governance saves: 실제 막은 인시던트
 
 위 목록은 *설계* — 규칙과 가드. 이 섹션은 *증거* — 실제 발생한 인시던트와 사후 추가된 hook/ADR/규칙. 거버넌스가 *있다* 가 아니라 *rent 를 냈다* 가 reviewer 의 30초 질문. 각 항목 = rent 1회.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

#921 (cd5337c) 의 core docs 한국어 번역이 README.md 와 docs/engineering-governance.md 의 영어 heading 을 번역하면서, GitHub/Jekyll 가 생성하던 영어 anchor 2개(`#why-extractive-not-generative`, `#governance-saves-real-incidents-prevented`)를 소멸시켰다. 이 anchor 를 참조하는 포트폴리오 블로그(`docs/blog/2026-05-extractive-baseline.md`, Jekyll/GitHub Pages 게시 자산)의 inbound 링크 2개가 외부 노출 dead link 가 됐다. 번역된 heading 바로 앞에 backward-compatible legacy `<a id>` anchor 를 추가해 기존 링크를 복원한다 (heading 은 한국어 유지). `<a id>` 는 heading 파생이 아닌 고정 anchor 라 향후 재번역에도 안 깨진다.

Closes #1402

## 2. 영향 파일

- `README.md` — `## 왜 추출형(extractive)인가...` heading 앞에 `<a id="why-extractive-not-generative"></a>` 추가
- `docs/engineering-governance.md` — `## Governance saves: 실제 막은 인시던트` heading 앞에 `<a id="governance-saves-real-incidents-prevented"></a>` 추가

load-bearing 파일 없음 (docs-only).

## 3. 리스크

- 가장 가능성 높은 깨짐: slug 불일치로 anchor 가 여전히 안 맞음. **확인**: `check_doc_links.collect_anchors` 로 두 파일에서 `#why-extractive-not-generative` / `#governance-saves-real-incidents-prevented` 가 수집됨을 검증. 전체 tree 161 파일 `--check-all` (links + ADR refs + fragments) 통과.
- 블로그 line 40 의 `#핵심-성능표-실측` 링크는 번역 후 갱신되어 이미 정상 (README:95 `## 핵심 성능표 (실측)` 와 매칭) — 손대지 않음.

## 4. 테스트

기존 `tests/test_doc_links.py::test_repo_has_no_broken_fragments_today` 가 회귀 sentinel. 본 변경은 명시적 `<a id>` anchor 추가라 `collect_anchors` 가 즉시 인식. 두 dead link 는 외부 URL / Jekyll permalink 라 기존 fragment 체커 설계상 skip 대상 — 신규 테스트보다 anchor 고정이 더 견고한 방어 (회귀 방지 범위는 anchor-only 로 합의, 체커 확장은 별도 issue 후보).

## 5. Eval 영향

All `·` — docs-only, RAG path 무변경.

### 5b. Real-data delta

N/A — load-bearing path 변경 없음. 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

doc link 복원이 목적. 기존 계약/스키마/CLI flag 무변경. answer-contract (ADR 0003) 무관 → `schema_version` bump 불필요.

## 7. 범위 외

- check_doc_links.py 의 Jekyll permalink fragment / 자기 repo 외부 URL anchor 검증 확장 — 구조적 사각지대지만 본 PR scope 밖 (별도 issue 후보, 사용자와 anchor-only 합의).
- #921 이 번역한 다른 docs heading 의 cross-ref 는 `--check-all` 전수 통과로 깨진 것 없음 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)