### PR TITLE
fix(governance): validate #anchors on Jekyll directory permalinks

### DIFF
--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -28,11 +28,16 @@ Scope (deliberately narrow to keep false positives near zero):
     validation was added after issue #1152: Korean-izing a heading changes
     its auto-generated slug, silently breaking inbound `#old-english-anchor`
     links that a file-existence-only check cannot see.
-  - NOT checked: external URLs (network dependency), site-absolute `/...`
-    and directory-style Jekyll permalinks (the docs render via
+  - NOT checked: external URLs (network dependency), site-absolute `/...`,
+    the EXISTENCE of directory-style Jekyll permalinks (the docs render via
     `permalink: pretty`, so `[x](../foo/)` is a valid page link that has no
     filesystem target), and `#fragment`s on non-`.md` targets (e.g. a
     `foo.py#L10` GitHub line anchor — we only enumerate markdown anchors).
+  - Partially checked: a `#fragment` on a directory-style permalink. The page
+    has no filesystem target for the existence check, but `permalink: pretty`
+    maps `[x](../foo/#frag)` to the backing `docs/foo.md`, so the anchor IS
+    validated against that file's slugs when it exists (issue #1406 closed the
+    blind spot where a translated heading could break such a link unseen).
 
 Zero runtime dependencies (Python stdlib + `git ls-files`).
 
@@ -202,10 +207,15 @@ def split_fragment(raw: str) -> tuple[str, str] | None:
 
     Returns ``("", frag)`` for a same-file `#frag` link. Returns None for:
     links with no `#`, external/protocol-relative/site-absolute links, an
-    empty fragment, and cross-file links whose target is not a `.md`/`.markdown`
-    file (only markdown anchors are enumerable). Mirrors `normalize_target`'s
-    angle-bracket and trailing-``"title"`` stripping, but — unlike it — KEEPS
-    the fragment, which is the whole point.
+    empty fragment, and cross-file links whose target is a non-markdown file
+    with a recognized extension (`foo.py#L10`, `img.png#x` — only markdown
+    anchors are enumerable). A direct `.md`/`.markdown` target and a
+    directory-style Jekyll permalink (extensionless / trailing-slash, e.g.
+    `../engineering-governance/#frag`) are BOTH kept: the permalink's
+    `<path>/` → `<path>.md` resolution is deferred to `find_broken_fragments`,
+    which validates the anchor only when a backing markdown file exists.
+    Mirrors `normalize_target`'s angle-bracket and trailing-``"title"``
+    stripping, but — unlike it — KEEPS the fragment, which is the whole point.
     """
     t = raw.strip()
     if t.startswith("<") and t.endswith(">"):
@@ -223,9 +233,37 @@ def split_fragment(raw: str) -> tuple[str, str] | None:
         return ("", frag)
     path_part = re.sub(r":\d+(?:-\d+)?$", "", path_part)  # drop `path:line`
     final_segment = path_part.rstrip("/").rsplit("/", 1)[-1]
-    if not _MD_TARGET_RE.search(final_segment):
-        return None
+    if _MD_TARGET_RE.search(final_segment):
+        return (path_part, frag)  # direct markdown target
+    if _KNOWN_EXT_RE.search(final_segment):
+        return None  # non-md file (.py/.png/…): no enumerable anchor set
+    # Extensionless / trailing-slash → Jekyll `permalink: pretty` directory
+    # permalink (docs/_config.yml). Keep it; find_broken_fragments resolves
+    # `<path>/` → `<path>.md` and only checks the anchor when that file exists.
     return (path_part, frag)
+
+
+def _resolve_fragment_target(
+    src_dir: str, path_part: str, root: Path
+) -> str | None:
+    """Resolve a fragment link's path (``#`` already stripped) to an existing
+    markdown file relative to its source dir, or None.
+
+    A direct `.md`/`.markdown` target resolves to itself when present. An
+    extensionless / trailing-slash target is a Jekyll `permalink: pretty`
+    directory permalink (docs/_config.yml): it maps to the sibling
+    `<path>.md`, then `<path>/index.md`. Returns None when no markdown file
+    backs the link — a missing `.md` is `find_broken_links`' job, and an
+    unresolvable permalink has no anchor set to check, so staying silent keeps
+    false positives at zero.
+    """
+    base = os.path.normpath(os.path.join(src_dir, path_part))
+    if _MD_TARGET_RE.search(base):
+        return base if (root / base).exists() else None
+    for cand in (f"{base}.md", os.path.join(base, "index.md")):
+        if (root / cand).exists():
+            return cand
+    return None
 
 
 def find_broken_fragments(
@@ -269,9 +307,10 @@ def find_broken_fragments(
             if path_part == "":
                 target = src
             else:
-                target = os.path.normpath(os.path.join(src_dir, path_part))
-                if not (root / target).exists():
-                    continue  # missing file → reported by find_broken_links
+                resolved = _resolve_fragment_target(src_dir, path_part, root)
+                if resolved is None:
+                    continue  # missing file / unresolvable permalink → not our report
+                target = resolved
             anchors = anchors_for(target)
             if anchors is None:
                 continue

--- a/tests/test_doc_links.py
+++ b/tests/test_doc_links.py
@@ -231,7 +231,7 @@ def test_collect_anchors_dedup_explicit_and_skips() -> None:
         "https://x.com#frag",  # external
         "/site/abs.md#frag",  # site-absolute
         "../code.py#L10",  # non-markdown target (anchors not enumerable)
-        "../dir/#frag",  # directory-style permalink
+        "../img.png#x",  # non-markdown target with recognized extension
         "../foo.md#",  # empty fragment
     ],
 )
@@ -247,6 +247,10 @@ def test_split_fragment_skips(href: str) -> None:
         ("../foo.md:120#section", ("../foo.md", "section")),  # path:line dropped
         ("<../foo.md#section>", ("../foo.md", "section")),  # angle brackets
         ('../foo.md#section "Title"', ("../foo.md", "section")),  # link title
+        # Directory-style Jekyll permalink: kept (was None before #1406), the
+        # `<path>/` → `<path>.md` resolution happens in find_broken_fragments.
+        ("../dir/#frag", ("../dir/", "frag")),
+        ("../engineering-governance#frag", ("../engineering-governance", "frag")),
     ],
 )
 def test_split_fragment_parses(href: str, expected: tuple[str, str]) -> None:
@@ -307,6 +311,69 @@ def test_find_broken_fragments_valid_anchor_and_no_false_positives(
         "[gone](../nope.md#frag)\n"  # missing FILE — find_broken_links' job
         "[dir](../somedir/#frag)\n",  # directory permalink — skipped
     )
+    assert cdl.find_broken_fragments(["docs/src.md"], tmp_path) == []
+
+
+# ---- fragment anchors: Jekyll directory permalinks (issue #1406) -----------
+
+
+def test_find_broken_fragments_dir_permalink_broken(tmp_path: Path) -> None:
+    # The #1406 blind spot: a blog page links a directory-style permalink
+    # (`permalink: pretty`, no `.md`), and the backing page's heading was
+    # translated, so the old English #anchor no longer resolves. The link
+    # existence check skips permalinks, so only the fragment check can see it.
+    _write(tmp_path / "docs" / "engineering-governance.md", "# 거버넌스 노트\n")
+    _write(
+        tmp_path / "docs" / "blog" / "post.md",
+        "[x](../engineering-governance/#governance-saves-real-incidents)\n",
+    )
+    broken = cdl.find_broken_fragments(
+        ["docs/blog/post.md", "docs/engineering-governance.md"], tmp_path
+    )
+    assert broken == [
+        (
+            "docs/blog/post.md",
+            "../engineering-governance/#governance-saves-real-incidents",
+            "governance-saves-real-incidents",
+        )
+    ]
+
+
+def test_find_broken_fragments_dir_permalink_stable_anchor(tmp_path: Path) -> None:
+    # The PR #1403 fix: a stable <a id> on the backing page keeps the legacy
+    # English anchor alive through the directory permalink.
+    _write(
+        tmp_path / "docs" / "engineering-governance.md",
+        '<a id="governance-saves-real-incidents"></a>\n\n# 거버넌스 노트\n',
+    )
+    _write(
+        tmp_path / "docs" / "blog" / "post.md",
+        "[x](../engineering-governance/#governance-saves-real-incidents)\n",
+    )
+    assert (
+        cdl.find_broken_fragments(
+            ["docs/blog/post.md", "docs/engineering-governance.md"], tmp_path
+        )
+        == []
+    )
+
+
+def test_find_broken_fragments_dir_permalink_index_md(tmp_path: Path) -> None:
+    # `permalink: pretty` also serves `<path>/index.md` at `<path>/`.
+    _write(tmp_path / "docs" / "guide" / "index.md", "## 시작\n")
+    _write(tmp_path / "docs" / "src.md", "[x](guide/#시작)\n")
+    assert cdl.find_broken_fragments(["docs/src.md"], tmp_path) == []
+    _write(tmp_path / "docs" / "bad.md", "[x](guide/#missing)\n")
+    broken = cdl.find_broken_fragments(["docs/bad.md"], tmp_path)
+    assert broken == [("docs/bad.md", "guide/#missing", "missing")]
+
+
+def test_find_broken_fragments_dir_permalink_no_backing_md_skipped(
+    tmp_path: Path,
+) -> None:
+    # No backing `<path>.md` (and no `<path>/index.md`) → unresolvable
+    # permalink → skipped, never a false positive.
+    _write(tmp_path / "docs" / "src.md", "[x](../nonexistent-page/#frag)\n")
     assert cdl.find_broken_fragments(["docs/src.md"], tmp_path) == []
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/check_doc_links.py` 의 fragment-anchor 체커가 디렉터리-style Jekyll `permalink: pretty` 링크(`../foo/#frag`, `.md` 확장자 없음)를 검증하지 못하던 **설계상 사각지대**를 닫는다. PR #1403(issue #1402)에서 #921 한국어 heading 번역이 깨뜨린 블로그 dead anchor를 `<a id>` 로 고쳤지만, 그 링크가 애초에 체커에 안 걸린 이유가 이 사각지대였다 — 즉 새 heading 번역이 새 permalink-style anchor 링크를 깨도 체커가 못 잡았다. `split_fragment` 가 permalink href를 보존하고, `find_broken_fragments` 가 `<path>/` → `<path>.md` / `<path>/index.md` 로 resolve하여 backing 마크다운 파일이 실제 존재할 때만 anchor를 검증한다.

Closes #1406

## 2. 영향 파일

- `scripts/check_doc_links.py` — governance 단일 출처(pre-commit + pr-eval.yml pytest gate + Makefile). **load-bearing 아님** (`_governance.py --is-load-bearing` exit 1 확인). `split_fragment` 확장 + `_resolve_fragment_target` 신규 + `find_broken_fragments` resolve 경로 + docstring.
- `tests/test_doc_links.py` — 회귀 테스트 4종 + `split_fragment` 파라미터 케이스 갱신.

## 3. 리스크

가장 가능성 높은 깨짐 경로 = false positive (정상 permalink 링크를 dead로 오판). 이를 배제하기 위해: backing `.md` 가 **실제 존재할 때만** 검증하고, 대응 파일이 없으면 기존대로 skip — 이 체커의 "false-positive near zero" 설계 원칙 유지. 또한 non-md known-extension(`.py`/`.png` 등)은 계속 reject해 anchor 미열거 타겟을 건드리지 않는다. 전체 트리 `--check-all` 173 files green으로 기존 링크가 새로 red되지 않음을 확인.

## 4. 테스트

동작 변경 ↔ 테스트 변경 동반(CLAUDE.md). 추가 회귀:
- `test_find_broken_fragments_dir_permalink_broken` — permalink + 번역된 heading으로 깨진 anchor 검출 (#1406 사각지대 재현).
- `test_find_broken_fragments_dir_permalink_stable_anchor` — `<a id>` 보존 시 통과 (PR #1403 fix 패턴).
- `test_find_broken_fragments_dir_permalink_index_md` — `<path>/index.md` 매핑.
- `test_find_broken_fragments_dir_permalink_no_backing_md_skipped` — backing `.md` 부재 시 skip (false positive 0).
- `test_split_fragment_parses` / `_skips` — permalink href가 이제 파싱되는 새 계약 반영.

Local gate: `make test-fast` (2433 passed) + `ruff check .` — real-model `slow` 테스트는 로컬 제외, CI에서 커버.

## 5. Eval 영향

All `·` — RAG 파이프라인(검색/검증/답변/eval) 무관, 문서 링크 무결성 governance 체커 한정.

### 5b. Real-data delta

> **Reviewer 책임 (issue #1027):** §5b CI gate 는 섹션·표·escape 문장의 *존재* 만 강제한다.

검색/검증 path 동작 변화 없음. Load-bearing path(`_governance.py --is-load-bearing` exit 1) 미변경 — `scripts/check_doc_links.py` 는 LOAD_BEARING_PATHS에 없음.

## 6. 하위 호환

`split_fragment` 의 순수-파싱 계약이 미세 변경됨: 디렉터리-style permalink href(`../dir/#frag`)가 이전엔 `None` 을 반환했으나 이제 `("../dir/", "frag")` 를 반환. 단 이는 내부 헬퍼이고 `find_broken_fragments` 가 backing `.md` 실재 시에만 검증하므로 외부 동작(체커 결과)은 strictly 더 많은 진짜 dead link를 잡는 방향으로만 변화. doc-link/answer-contract/CLI flag 깨짐 없음.

## 7. 범위 외

외부-URL anchor 검증(`https://github.com/.../#frag`). repo URL 하드코딩이 필요해 brittle하므로 이 PR에서 제외 (issue #1406 본문에 기록). 원하면 별도 follow-up.