### PR TITLE
chore: automate ship start and review gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,9 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 - `bash scripts/test.sh` — `pytest -q`, CI gate 와 동일
 - `make check-branch` — 현재 브랜치 ADR 0007 검증
 - `make real-eval` + `make real-eval-delta` — 비공개 100-doc eval, load-bearing 변경 시 필수
-- `make ship-arm` — Stop-hook 자동 ship 파이프라인 (commit → push → PR → CI → squash-merge). 게이트/단계/`STACKED=ack` 규율: [`docs/operations/auto-ship.md`](docs/operations/auto-ship.md)
+- `make ship-start TITLE="..." TYPE=chore` — issue 생성 + ADR 0007 브랜치 생성 front door.
+- `make ship-arm` — Stop-hook 자동 ship 파이프라인 (commit → push → PR → CI/review gate → squash-merge). 게이트/단계/`STACKED=ack` 규율: [`docs/operations/auto-ship.md`](docs/operations/auto-ship.md)
+- `make ship-review-gate PR=<N>` — requested changes / unresolved review thread 가 merge 를 막아야 하는지 수동 확인.
 - Latency 수치는 `reports/eval_summary.json` `stage_latency` 블록 — ad-hoc 측정 금지
 
 ## 금지 (자동화 비강제)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@
 
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
-.PHONY: ship-arm ship-disarm ship-status
+.PHONY: ship-start ship-arm ship-disarm ship-status ship-review-gate
 
 # Self-review (quarterly meta-feedback loop). Combines 4-axis portfolio
 # rubric + 5-axis Claude collaboration rubric. See SKILL at
@@ -532,6 +532,21 @@ DRAFT ?= false
 DRY_RUN ?= 0
 CROSS_OWNER ?=
 STACKED ?=
+TYPE ?= chore
+SLUG ?=
+LABELS ?=
+
+ship-start:
+	@if [ -z "$(TITLE)" ]; then \
+	  echo "Usage: make ship-start TITLE='Issue title' [TYPE=docs] [SLUG=short-slug] [BODY='...'] [LABELS=a,b]"; \
+	  exit 1; \
+	fi
+	@$(PYTHON) scripts/claude-hooks/_ship_start.py \
+	  --title "$(TITLE)" \
+	  --body "$(BODY)" \
+	  --type "$(TYPE)" \
+	  --slug "$(SLUG)" \
+	  --labels "$(LABELS)"
 
 ship-arm:
 	@$(PYTHON) scripts/claude-hooks/_ship_arm.py \
@@ -556,6 +571,9 @@ ship-status:
 	@if [ -f .claude/.ship-running.pid ]; then \
 	  echo "ship: pipeline running (pid=$$(cat .claude/.ship-running.pid))"; \
 	fi
+
+ship-review-gate:
+	@$(PYTHON) scripts/claude-hooks/_ship_review_gate.py $(if $(PR),--pr "$(PR)",)
 
 # ---------------------------------------------------------------------------
 # Self-review quarterly: meta-feedback loop over the past quarter.

--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -2,8 +2,9 @@
 
 auto-ship 파이프라인은 Stop-hook 가 구동하는 시퀀스로, feature 브랜치를
 로컬 커밋에서 `main` 의 squash-merge 된 PR 까지 한 번의 ack 으로
-가져간다: `make ship-arm`. 모든 사이클은 단발성(single-shot) — 성공이든
-실패든 트리거를 해제(disarm)한다.
+가져간다: `make ship-arm`. 이슈와 브랜치 생성까지 포함한 시작점은
+`make ship-start TITLE="..."` 이다. 모든 ship-arm 사이클은
+단발성(single-shot) — 성공이든 실패든 트리거를 해제(disarm)한다.
 
 이 페이지는 운영 계약을 문서화한다: 어떻게 arm 하는지, 각 게이트 / 스테이지가
 무엇을 강제하는지, 안전망(safety net)이 어디에 있는지, 그리고 우회할 때
@@ -12,8 +13,29 @@ auto-ship 파이프라인은 Stop-hook 가 구동하는 시퀀스로, feature �
 [`scripts/claude-hooks/stop-ship.sh`](../../scripts/claude-hooks/stop-ship.sh)
 (Stop hook 진입점)과
 [`scripts/claude-hooks/_ship_pr_body.py`](../../scripts/claude-hooks/_ship_pr_body.py)
-(PR body 생성기)에 있다. 등록 위치:
+(PR body 생성기),
+[`scripts/claude-hooks/_ship_start.py`](../../scripts/claude-hooks/_ship_start.py)
+(issue-linked branch 생성기), 그리고
+[`scripts/claude-hooks/_ship_review_gate.py`](../../scripts/claude-hooks/_ship_review_gate.py)
+(merge 전 review gate)에 있다. 등록 위치:
 [`.claude/settings.json`](../../.claude/settings.json) 의 `Stop` hook.
+
+## Start: `make ship-start`
+
+새 작업은 먼저 이슈와 ADR 0007 브랜치를 만든다:
+
+```bash
+make ship-start TITLE="자동화 범위 설명" TYPE=chore SLUG=short-slug
+```
+
+동작:
+
+1. dirty worktree 를 거부한다. 이 명령은 편집 전 front door 다.
+2. `gh issue create` 로 이슈를 만든다.
+3. 제목 또는 `SLUG` 로 `<type>/issue-<N>-<slug>` 브랜치를 만든다.
+4. `origin/main` 을 fetch 한 뒤 새 브랜치로 switch 한다.
+
+그 다음 파일을 수정하고 focused test 를 실행한 뒤 `make ship-arm` 한다.
 
 ## Arming: `make ship-arm`
 
@@ -38,6 +60,10 @@ auto-ship 파이프라인은 Stop-hook 가 구동하는 시퀀스로, feature �
 ## 파이프라인 개요
 
 ```
+make ship-start TITLE="..." TYPE=chore  (issue + branch)
+    ↓
+edit + local verification
+    ↓
 make ship-arm  (writes .claude/.ship-armed)
     ↓
 Claude Stop event  →  scripts/claude-hooks/stop-ship.sh fires
@@ -47,7 +73,7 @@ Gate 0 — 8 pre-checks (silent exit on any failure)
 Stage 1: commit   (private-path filter → multi-agent lock → tier-7 prefix gate → bash scripts/test.sh → git commit)
 Stage 2: push     (ADR 0007 branch check → git push)
 Stage 3: PR       (_ship_pr_body.py → §5b cascade → gh pr create)
-Stage 4: CI wait  (gh pr checks --watch, 30-min timeout)
+Stage 4: CI/review gate  (gh pr checks --watch → requested-changes/unresolved-thread gate)
 Stage 5: merge    (gh pr merge --squash --admin → git push origin --delete <branch> → checkout main → disarm)
 ```
 
@@ -111,11 +137,25 @@ body 를 생성하고(template §1–§7, 아래 §5b cascade 포함),
 커밋 subject 이므로, `main` 에 머지된 커밋은 title 을 첫 줄로 하여
 landing 된다.
 
-### Stage 4 — CI wait ([`stop-ship.sh:352-368`](../../scripts/claude-hooks/stop-ship.sh))
+### Stage 4 — CI wait + review gate ([`stop-ship.sh`](../../scripts/claude-hooks/stop-ship.sh))
 
 `timeout 1800 gh pr checks <N> --watch --interval 30`. 타임아웃 시
 (rc 124): PR 코멘트를 달고 abort 하며, **PR 을 열린 채로 둔다**. 0 이 아닌
 rc 시: comment + abort. 파이프라인은 red 상태에서 절대 머지하지 않는다.
+
+CI 가 green 이면
+[`_ship_review_gate.py`](../../scripts/claude-hooks/_ship_review_gate.py) 가
+merge 직전에 다음을 fail-closed 로 검사한다:
+
+- PR 이 open 이고 draft 가 아님.
+- `reviewDecision` 이 `CHANGES_REQUESTED` 가 아님.
+- unresolved 이고 outdated 가 아닌 review thread 가 없음.
+
+review gate 가 막으면 PR 을 열린 채로 두고 disarm 한다. 그 상태에서 Codex 의
+GitHub review-fix 루프를 실행해 코멘트를 처리하고, fix 커밋을 push 한 뒤
+다시 `make ship-arm` 한다. Shell hook 은 reviewer 코멘트를 임의로 수정하지
+않는다; patch 선택은 코드 맥락과 reviewer 의도를 읽어야 하므로 agent 판단
+단계로 남긴다.
 
 ### Stage 5 — squash-merge ([`stop-ship.sh:374-424`](../../scripts/claude-hooks/stop-ship.sh))
 
@@ -250,6 +290,7 @@ ADR 을 도입하는 커밋의 경우, 두 개의 분리된 PR 보다 같은 PR 
 | 브랜치 컨벤션 위반 또는 이슈 누락 | Stage 2 | push 전 abort |
 | §5b 검증 실패 (load-bearing 변경, body 에 delta 없음) | Stage 3 | `_ship_pr_body.py` exit 1, Stage 3 abort |
 | CI red 또는 timeout | Stage 4 | PR 코멘트 게시, abort, PR 열린 채 유지 |
+| requested changes / unresolved review thread | Stage 4 | PR 코멘트 게시, abort, PR 열린 채 유지 |
 | `gh pr merge` 거부 (admin merge 불가, branch protection) | Stage 5 | abort, PR 열린 채 유지 |
 | 머지 후 상태 ≠ `MERGED` | Stage 5 | arm 파일 그대로 두고 exit 1 |
 

--- a/scripts/claude-hooks/_ship_review_gate.py
+++ b/scripts/claude-hooks/_ship_review_gate.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Block auto-merge when PR review feedback still needs attention.
+
+`gh pr checks --watch` only answers the CI question. This gate answers the
+review question before Stage 5 merge: is the PR open, non-draft, free of
+requested changes, and free of unresolved non-outdated review threads?
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+GRAPHQL_REVIEW_THREADS = r"""
+query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          isResolved
+          isOutdated
+          comments(first: 20) {
+            nodes {
+              path
+              line
+              body
+              url
+              author {
+                login
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@dataclass(frozen=True)
+class ThreadSummary:
+    path: str
+    line: int | None
+    author: str
+    url: str
+    body: str
+
+
+def run(cmd: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(cmd),
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def resolve_pr_number(pr: str | None) -> int:
+    if pr:
+        return int(pr)
+    out = run(["gh", "pr", "view", "--json", "number", "--jq", ".number"]).stdout.strip()
+    return int(out)
+
+
+def resolve_repo(repo: str | None) -> tuple[str, str, str]:
+    if repo:
+        owner, name = repo.split("/", 1)
+        return repo, owner, name
+    full = run(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]).stdout.strip()
+    owner, name = full.split("/", 1)
+    return full, owner, name
+
+
+def pr_view(pr_number: int, repo_full_name: str) -> dict[str, Any]:
+    raw = run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            repo_full_name,
+            "--json",
+            "state,isDraft,reviewDecision,url",
+        ]
+    ).stdout
+    return json.loads(raw)
+
+
+def fetch_unresolved_threads(owner: str, repo: str, pr_number: int) -> list[ThreadSummary]:
+    cursor: str | None = None
+    unresolved: list[ThreadSummary] = []
+    while True:
+        cmd = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={GRAPHQL_REVIEW_THREADS}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"repo={repo}",
+            "-F",
+            f"number={pr_number}",
+        ]
+        if cursor:
+            cmd.extend(["-F", f"cursor={cursor}"])
+        payload = json.loads(run(cmd).stdout)
+        threads = payload["data"]["repository"]["pullRequest"]["reviewThreads"]
+        for node in threads["nodes"]:
+            if node.get("isResolved") or node.get("isOutdated"):
+                continue
+            comments = node.get("comments", {}).get("nodes", [])
+            if not comments:
+                continue
+            last = comments[-1]
+            unresolved.append(
+                ThreadSummary(
+                    path=last.get("path") or "(unknown path)",
+                    line=last.get("line"),
+                    author=(last.get("author") or {}).get("login") or "(unknown)",
+                    url=last.get("url") or "",
+                    body=(last.get("body") or "").replace("\n", " ")[:160],
+                )
+            )
+        page_info = threads["pageInfo"]
+        if not page_info["hasNextPage"]:
+            return unresolved
+        cursor = page_info["endCursor"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", help="PR number; defaults to current branch PR")
+    parser.add_argument("--repo", help="owner/name; defaults to `gh repo view`")
+    parser.add_argument(
+        "--allow-unresolved-threads",
+        action="store_true",
+        help="Only block CHANGES_REQUESTED, not unresolved review threads",
+    )
+    args = parser.parse_args()
+
+    pr_number = resolve_pr_number(args.pr)
+    repo_full_name, owner, repo = resolve_repo(args.repo)
+    info = pr_view(pr_number, repo_full_name)
+
+    blockers: list[str] = []
+    if info["state"] != "OPEN":
+        blockers.append(f"PR state is {info['state']}, expected OPEN")
+    if info["isDraft"]:
+        blockers.append("PR is draft")
+    if info.get("reviewDecision") == "CHANGES_REQUESTED":
+        blockers.append("reviewDecision is CHANGES_REQUESTED")
+
+    unresolved: list[ThreadSummary] = []
+    if not args.allow_unresolved_threads:
+        unresolved = fetch_unresolved_threads(owner, repo, pr_number)
+        if unresolved:
+            blockers.append(f"{len(unresolved)} unresolved review thread(s)")
+
+    if blockers:
+        sys.stderr.write(f"ship-review-gate: blocked PR #{pr_number} ({info['url']})\n")
+        for blocker in blockers:
+            sys.stderr.write(f"- {blocker}\n")
+        for thread in unresolved[:10]:
+            location = f"{thread.path}:{thread.line}" if thread.line else thread.path
+            suffix = f" — {thread.url}" if thread.url else ""
+            sys.stderr.write(f"- unresolved: {location} by {thread.author}: {thread.body}{suffix}\n")
+        if len(unresolved) > 10:
+            sys.stderr.write(f"- ... {len(unresolved) - 10} more unresolved thread(s)\n")
+        return 1
+
+    sys.stdout.write(f"ship-review-gate: PR #{pr_number} has no review blockers.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            "ship-review-gate: gh command failed; fail closed before merge.\n"
+            f"command: {' '.join(exc.cmd)}\n"
+            f"stderr: {exc.stderr}\n"
+        )
+        sys.exit(2)

--- a/scripts/claude-hooks/_ship_start.py
+++ b/scripts/claude-hooks/_ship_start.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Create an issue-linked shipping branch.
+
+This is the deterministic front door for the repo's auto-ship flow:
+
+    make ship-start TITLE="..." TYPE=docs
+
+It creates a GitHub issue, derives an ADR 0007-compliant branch name, fetches
+``origin/main``, and switches to the new branch. The script intentionally
+refuses to run with a dirty worktree because it is meant to happen before
+editing starts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from typing import Sequence
+
+
+ALLOWED_TYPES = {
+    "feat",
+    "fix",
+    "docs",
+    "chore",
+    "refactor",
+    "test",
+    "ci",
+    "perf",
+    "build",
+    "style",
+}
+ISSUE_URL_RE = re.compile(r"/issues/(\d+)(?:\b|$)")
+
+
+def run(cmd: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(cmd),
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def slugify(text: str, *, max_chars: int = 48) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    slug = re.sub(r"-{2,}", "-", slug)
+    if len(slug) <= max_chars:
+        return slug or "work"
+    trimmed = slug[:max_chars].rstrip("-")
+    return trimmed or "work"
+
+
+def ensure_clean_worktree() -> None:
+    status = run(["git", "status", "--porcelain"]).stdout.strip()
+    if status:
+        raise SystemExit(
+            "ship-start: refuse — worktree is dirty. Run this before editing "
+            "or commit/stash the existing changes first."
+        )
+
+
+def create_issue(title: str, body: str, labels: str | None) -> tuple[int, str]:
+    cmd = ["gh", "issue", "create", "--title", title, "--body", body]
+    if labels:
+        cmd.extend(["--label", labels])
+    url = run(cmd).stdout.strip()
+    m = ISSUE_URL_RE.search(url)
+    if not m:
+        raise SystemExit(f"ship-start: could not parse issue number from gh output: {url!r}")
+    return int(m.group(1)), url
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--title", required=True, help="GitHub issue title")
+    parser.add_argument("--body", default="", help="GitHub issue body")
+    parser.add_argument("--type", default="chore", choices=sorted(ALLOWED_TYPES))
+    parser.add_argument("--slug", default="", help="Branch slug; defaults to title slug")
+    parser.add_argument("--labels", default="", help="Comma-separated GitHub labels")
+    parser.add_argument("--base", default="origin/main", help="Base ref for the new branch")
+    parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Do not fetch origin/main before creating the branch",
+    )
+    args = parser.parse_args()
+
+    ensure_clean_worktree()
+
+    body = args.body.strip()
+    if not body:
+        body = (
+            "Created by `make ship-start`.\n\n"
+            "## Acceptance criteria\n\n"
+            "- Shipping branch follows ADR 0007.\n"
+            "- PR closes this issue.\n"
+        )
+
+    issue_number, issue_url = create_issue(args.title, body, args.labels or None)
+    slug = slugify(args.slug or args.title)
+    branch = f"{args.type}/issue-{issue_number}-{slug}"
+
+    if not args.no_fetch:
+        run(["git", "fetch", "origin", "main"])
+    run(["git", "switch", "-c", branch, args.base])
+
+    sys.stdout.write(
+        f"ship-start: created {issue_url}\n"
+        f"ship-start: switched to {branch}\n"
+        "Next: edit files, run focused tests, then `make ship-arm`.\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -365,13 +365,15 @@ stage_3_pr() {
 # ---------------------------------------------------------------------------
 
 stage_4_ci() {
-  log "s4" "Stage 4: CI wait (timeout 30min)"
+  log "s4" "Stage 4: CI wait + review gate (timeout 30min)"
   if [[ "$DRY_RUN" == "1" ]]; then
     log "s4" "[dry-run] gh pr checks $PR_NUMBER --watch --interval 30"
+    log "s4" "[dry-run] python3 scripts/claude-hooks/_ship_review_gate.py --pr $PR_NUMBER"
     return 0
   fi
-  if ! timeout 1800 gh pr checks "$PR_NUMBER" --watch --interval 30; then
-    local rc=$?
+  timeout 1800 gh pr checks "$PR_NUMBER" --watch --interval 30
+  local rc=$?
+  if (( rc != 0 )); then
     if (( rc == 124 )); then
       gh pr comment "$PR_NUMBER" --body "Auto-ship: CI timeout after 30min; PR left open." || true
       abort_disarm "s4" "CI timeout (30min)"
@@ -380,6 +382,13 @@ stage_4_ci() {
     abort_disarm "s4" "required CI check failed"
   fi
   log "s4" "all required checks green"
+  python3 scripts/claude-hooks/_ship_review_gate.py --pr "$PR_NUMBER"
+  local review_rc=$?
+  if (( review_rc != 0 )); then
+    gh pr comment "$PR_NUMBER" --body "Auto-ship: review gate blocked merge (rc=$review_rc). Address requested changes or unresolved review threads, push fixes, then re-arm with \`make ship-arm\`." || true
+    abort_disarm "s4" "review gate blocked merge"
+  fi
+  log "s4" "review gate clear"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ship_start_review_gate.py
+++ b/tests/test_ship_start_review_gate.py
@@ -1,0 +1,156 @@
+"""Regression tests for auto-ship start and review gate helpers."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "claude-hooks"))
+
+import _ship_review_gate as review_gate  # noqa: E402
+import _ship_start as ship_start  # noqa: E402
+
+
+def test_ship_start_slugifies_ascii_title() -> None:
+    assert (
+        ship_start.slugify("Automate ship start and review gate")
+        == "automate-ship-start-and-review-gate"
+    )
+
+
+def test_ship_start_korean_title_needs_explicit_slug() -> None:
+    assert ship_start.slugify("이슈 생성부터 머지까지 자동화") == "work"
+
+
+def test_ship_start_creates_issue_then_switches_branch(monkeypatch, capsys) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *, check=True):
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="")
+        if cmd[:3] == ["gh", "issue", "create"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="https://github.com/hskim-solv/BidMate-DocAgent/issues/1410\n",
+            )
+        if cmd[:3] == ["git", "switch", "-c"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(ship_start, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "_ship_start.py",
+            "--title",
+            "Automate ship start and review gate",
+            "--type",
+            "chore",
+            "--no-fetch",
+        ],
+    )
+
+    assert ship_start.main() == 0
+    assert ["git", "fetch", "origin", "main"] not in calls
+    assert [
+        "git",
+        "switch",
+        "-c",
+        "chore/issue-1410-automate-ship-start-and-review-gate",
+        "origin/main",
+    ] in calls
+    assert "created https://github.com/hskim-solv/BidMate-DocAgent/issues/1410" in capsys.readouterr().out
+
+
+def test_review_gate_passes_when_open_and_no_review_blockers(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(review_gate, "resolve_pr_number", lambda pr: 1410)
+    monkeypatch.setattr(
+        review_gate,
+        "resolve_repo",
+        lambda repo: ("hskim-solv/BidMate-DocAgent", "hskim-solv", "BidMate-DocAgent"),
+    )
+    monkeypatch.setattr(
+        review_gate,
+        "pr_view",
+        lambda pr, repo: {
+            "state": "OPEN",
+            "isDraft": False,
+            "reviewDecision": "",
+            "url": "https://github.com/hskim-solv/BidMate-DocAgent/pull/1411",
+        },
+    )
+    monkeypatch.setattr(review_gate, "fetch_unresolved_threads", lambda owner, repo, pr: [])
+    monkeypatch.setattr(sys, "argv", ["_ship_review_gate.py", "--pr", "1410"])
+
+    assert review_gate.main() == 0
+    assert "no review blockers" in capsys.readouterr().out
+
+
+def test_review_gate_blocks_requested_changes(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(review_gate, "resolve_pr_number", lambda pr: 1410)
+    monkeypatch.setattr(
+        review_gate,
+        "resolve_repo",
+        lambda repo: ("hskim-solv/BidMate-DocAgent", "hskim-solv", "BidMate-DocAgent"),
+    )
+    monkeypatch.setattr(
+        review_gate,
+        "pr_view",
+        lambda pr, repo: {
+            "state": "OPEN",
+            "isDraft": False,
+            "reviewDecision": "CHANGES_REQUESTED",
+            "url": "https://github.com/hskim-solv/BidMate-DocAgent/pull/1411",
+        },
+    )
+    monkeypatch.setattr(review_gate, "fetch_unresolved_threads", lambda owner, repo, pr: [])
+    monkeypatch.setattr(sys, "argv", ["_ship_review_gate.py", "--pr", "1410"])
+
+    assert review_gate.main() == 1
+    assert "CHANGES_REQUESTED" in capsys.readouterr().err
+
+
+def test_review_gate_blocks_unresolved_threads(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(review_gate, "resolve_pr_number", lambda pr: 1410)
+    monkeypatch.setattr(
+        review_gate,
+        "resolve_repo",
+        lambda repo: ("hskim-solv/BidMate-DocAgent", "hskim-solv", "BidMate-DocAgent"),
+    )
+    monkeypatch.setattr(
+        review_gate,
+        "pr_view",
+        lambda pr, repo: {
+            "state": "OPEN",
+            "isDraft": False,
+            "reviewDecision": "",
+            "url": "https://github.com/hskim-solv/BidMate-DocAgent/pull/1411",
+        },
+    )
+    monkeypatch.setattr(
+        review_gate,
+        "fetch_unresolved_threads",
+        lambda owner, repo, pr: [
+            review_gate.ThreadSummary(
+                path="Makefile",
+                line=10,
+                author="reviewer",
+                url="https://example.test/thread",
+                body="Please fix this.",
+            )
+        ],
+    )
+    monkeypatch.setattr(sys, "argv", ["_ship_review_gate.py", "--pr", "1410"])
+
+    assert review_gate.main() == 1
+    err = capsys.readouterr().err
+    assert "unresolved review thread" in err
+    assert "Makefile:10" in err


### PR DESCRIPTION
## Summary

- Add `make ship-start` to create a GitHub issue and switch to an ADR 0007-compliant branch before editing.
- Add a merge-time review gate that blocks auto-ship on draft PRs, requested changes, or unresolved non-outdated review threads.
- Wire the review gate into `stop-ship.sh` after CI and document the full issue → branch → edit → ship-arm → CI/review → merge flow.

Closes #1410

## Changed files

- `Makefile`
- `scripts/claude-hooks/_ship_start.py`
- `scripts/claude-hooks/_ship_review_gate.py`
- `scripts/claude-hooks/stop-ship.sh`
- `docs/operations/auto-ship.md`
- `CLAUDE.md`
- `tests/test_ship_start_review_gate.py`

## Rationale

The existing auto-ship path already handled commit, push, PR creation, CI wait, and squash merge. The missing deterministic pieces were the issue/branch front door and a review-aware merge gate.

## Risks

- `make ship-start` intentionally refuses dirty worktrees, so it must be used before editing.
- The review gate fails closed if `gh` cannot read PR review state, which can leave the PR open until auth/network is fixed.
- Shell automation still does not auto-edit code from review comments; it blocks merge and hands that loop back to Codex/user judgment.

## Tests

```bash
bash -n scripts/claude-hooks/stop-ship.sh
python3 -m py_compile scripts/claude-hooks/_ship_start.py scripts/claude-hooks/_ship_review_gate.py
python3 scripts/check_doc_links.py --check-all
python3 scripts/check_branch_and_issue.py --branch chore/issue-1410-ship-start-review-gate --check-issue
python3 scripts/claude-hooks/_ship_review_gate.py --pr 1409 --repo hskim-solv/BidMate-DocAgent
python3 -m pytest tests/test_ship_start_review_gate.py tests/test_ship_arm_mutex.py tests/test_ship_pr_body.py tests/test_ship_dispatcher_gates.py tests/test_doc_links.py -q
```

Note: `python3 scripts/claude-hooks/_ship_review_gate.py --pr 1409 ...` is expected to exit non-zero because PR #1409 is already merged; that verifies the gate fails closed on non-open PRs.

## Eval impact

No RAG, retrieval, verifier, ingestion, API, or eval runtime behavior changed.

### 5b. Real-data delta

No behavior change in retrieval / verifier / eval / api / ingestion path. This PR only changes shipping automation and docs.

## Backward compatibility

Existing `make ship-arm` usage remains valid. The new review gate only runs after CI passes and before auto-merge.
