### PR TITLE
chore: finish public synthetic eval cleanup follow-up

### DIFF
--- a/.claude/skills/eval-baseline-regen/SKILL.md
+++ b/.claude/skills/eval-baseline-regen/SKILL.md
@@ -5,7 +5,7 @@ description: |
 
   Trigger phrases: "real100 baseline regen", "eval baseline 재생성", "베이스라인 갱신 PR", "chore(eval) regen", "post-#N baseline 갱신", "real-eval baseline 업데이트해줘". Trigger when the user wants to refresh the committed real100 baseline after merges. Trigger even if the user does not say "skill".
 
-  Do NOT trigger for: retrieval measurement (use `retrieval-eval`), eval-framework gap audit (use `eval-framework-progressive-audit`), drafting an ADR from eval results (use the `eval-to-adr-bridge` agent), generic PR shipping (use `ship-pr`), synthetic leaderboard / cost_frontier / README freshness (already CI-gated via `make leaderboard-check`), or running the eval itself (`make real-eval` — that produces the local eval_summary this skill consumes).
+  Do NOT trigger for: retrieval measurement (use `retrieval-eval`), eval-framework gap audit (use `eval-framework-progressive-audit`), drafting an ADR from eval results (use the `eval-to-adr-bridge` agent), generic PR shipping (use `ship-pr`), removed public-eval artifact freshness (former leaderboard / cost_frontier / judge aggregate / README freshness), or running the eval itself (`make real-eval` — that produces the local eval_summary this skill consumes).
 ---
 
 # /eval-baseline-regen — real100 baseline 재생성 (provenance·판단·컨벤션 레이어)
@@ -14,7 +14,7 @@ private real-100 eval 베이스라인(`reports/real100/baseline.aggregate.json` 
 
 ## Scope
 
-- `reports/real100/baseline.aggregate.json` + `reports/real100/history/*.aggregate.json` regen 한정. **synthetic 산출물(leaderboard / cost_frontier / synthetic_judge / README) 은 out of scope** — 이미 `make leaderboard-check` CI freshness gate 가 강제.
+- `reports/real100/baseline.aggregate.json` + `reports/real100/history/*.aggregate.json` regen 한정. **삭제된 public-eval 산출물(구 leaderboard / cost_frontier / judge aggregate / README freshness) 재생성은 out of scope** — 이 skill 은 private/internal baseline 만 다룬다.
 - One regen per invocation. 여러 베이스라인 표면(예: `failure_distribution`, `distinguishing_power`)을 한 번에 묶지 않음 — 각각 별도 호출.
 - Helper code inline 작성 금지. 새 측정 로직·스크립트가 필요하면 별개 PR 로 선행.
 - ADR 초안 / push / PR / merge 안 함. eval→ADR 는 `eval-to-adr-bridge` agent, remote shipping 은 `ship-pr` 담당.
@@ -70,11 +70,11 @@ go-ahead(진행): "진행" / "ㄱㄱ" / "ㅇㅋ" / "ok" / "go". 질문(답변만
 - **"real-eval 생략하고 베이스라인만 갱신"** → 거부. `eval_summary.json` 없이는 baseline 작성 불가([`write_real_eval_baseline.py`](../../../scripts/write_real_eval_baseline.py) `main`), private 데이터(ADR 0005)라 skill 이 대신 생성 못 함.
 - **"provenance skew 무시"** → `STRICT` 끄면 가능하나 #160 사유(metric/provenance 불일치 침묵 오염) 경고 후 사용자 선택. 기본은 `STRICT=1` 권장.
 - **"dirty 인데 그냥 baseline 떠"** → 비용 명시: dirty eval 은 SHA 가 HEAD 와 같아도 uncommitted 변경의 metric 을 박제 → 재현 불가, 이후 모든 델타 비교의 기준선 오염(#1148, skew check 가 못 잡는 #160 잔여 구멍). 권고는 commit/stash 후 clean 재실행. 의도적이면 1회 명시 확인 후 `ALLOW_DIRTY=1`.
-- **"synthetic leaderboard 도 같이 갱신"** → out of scope. `make leaderboard` / `make cost-frontier` 는 별도, leaderboard freshness 는 이미 `make leaderboard-check` CI 가 강제. 묶지 않음.
+- **"legacy public eval artifacts 도 같이 갱신"** → out of scope. public eval leaderboard / public judge aggregate 는 제거된 표면이므로 재생성하지 않고, private/internal baseline regen 과 묶지 않음.
 
 ## References
 
-- [Makefile](../../../Makefile) `real-eval-baseline-update` (`STRICT` 지원), `real-eval-delta`, `leaderboard-check`.
+- [Makefile](../../../Makefile) `real-eval-baseline-update` (`STRICT` 지원), `real-eval-delta`.
 - [scripts/write_real_eval_baseline.py](../../../scripts/write_real_eval_baseline.py) — baseline + history 작성, provenance skew 가드(`_warn_if_stale`) + dirty-state 가드(`_warn_if_dirty`, #1148), `STRICT`/`--allow-dirty` 해석, eval_summary 부재 처리(`main`), `provenance` 기록.
 - [scripts/check_baseline_provenance.py](../../../scripts/check_baseline_provenance.py) — committed baseline 의 `provenance.git_commit` reachability(origin/main).
 - [.githooks/pre-commit](../../../.githooks/pre-commit) — ADR 0005 allowlist(real100 baseline / history 만 통과).
@@ -85,7 +85,7 @@ go-ahead(진행): "진행" / "ㄱㄱ" / "ㅇㅋ" / "ok" / "go". 질문(답변만
 ## What this skill does NOT do
 
 - Does NOT write helper code — 기존 make 타깃 / 스크립트만 오케스트레이션.
-- Does NOT regen synthetic 산출물(leaderboard / cost_frontier / synthetic_judge / README). `make leaderboard-check` CI 가 freshness 강제.
+- Does NOT regen or recreate removed public-eval artifacts (former leaderboard / cost_frontier / judge aggregate / README freshness).
 - Does NOT run `make real-eval` — private 데이터 필요, 사용자가 HEAD 에서 실행. skill 은 결과(`eval_summary.json`)를 소비.
 - Does NOT draft an ADR — `eval-to-adr-bridge` agent 담당.
 - Does NOT push / open PR / merge — `ship-pr` 담당.

--- a/.claude/skills/self-review-quarterly/SKILL.md
+++ b/.claude/skills/self-review-quarterly/SKILL.md
@@ -100,7 +100,7 @@ This skill writes to a **committed git file**. Privacy violations cannot be retr
 | 1 | 엔지니어링 디스플린 | ✓ / △ — <사유> / ✗ — <사유> | `PR #458`, `docs/engineering-governance.md` | <1-line, ≤80자> |
 | 2 | 아키텍처 결정 정합성 | ... | `ADR 0028`, `docs/adr/README.md` | ... |
 | 3 | 평가 견고성 (LLM Ops) | ... | `eval/config.yaml`, `reports/eval_summary.json` | ... |
-| 4 | 시장 가시성 | ... | `docs/portfolio-launch-checklist.md`, `docs/eval/leaderboard.md` | ... |
+| 4 | 시장 가시성 | ... | `docs/portfolio-pitch.md`, `docs/performance-evolution.md` | ... |
 
 ## 5축 진단 (Claude 협업)
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 # BidMate-DocAgent Docker build context allowlist.
 #
 # The Dockerfile uses explicit COPY of named files (rag_core.py, api/,
-# demo/, scripts/build_index.py, data/raw/, docker-entrypoint.sh —
+# demo/, scripts/build_index.py, eval/fixtures/smoke_rfp/raw/,
+# docker-entrypoint.sh —
 # see Dockerfile lines 35-40), so the image content is already
 # tightly scoped. This file shrinks the *build context* the daemon
 # receives, which speeds up local and remote builds and avoids

--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,8 @@ reports/real100/history/*
 # Issue #897 — RAG pipeline EDA aggregate (script:
 # scripts/rag_pipeline_eda.py). 7-axis pipeline-dynamics profile derived
 # from eval_summary.json::case_results. Two surfaces:
-#   - reports/rag_pipeline.* (synthetic public eval, ADR 0012 surface)
-#   - reports/real100/rag_pipeline.* (private 100-doc real eval, ADR 0005)
+#   - reports/rag_pipeline.* (public fixture smoke / local pipeline aggregate)
+#   - reports/real100/rag_pipeline.* (private/internal real eval, ADR 0005)
 # ADR 0005 boundary preserved by the script (no case IDs, chunk IDs, or
 # raw text; retry reason prefixes only).
 !reports/rag_pipeline.md

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -53,12 +53,20 @@ stage_latency_budgets:
 ablation_runs:
   - name: naive_baseline
     pipeline: naive_baseline
+    metadata_first: false
+    rerank: false
+    verifier_retry: false
+    retrieval_mode: flat
+    retrieval_backend: dense
+    query_expansion: identity
   - name: full
     pipeline: agentic_full
     metadata_first: true
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
     metadata_backend: regex
   - name: full_dense
     pipeline: agentic_full
@@ -66,6 +74,7 @@ ablation_runs:
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    query_expansion: identity
     metadata_backend: regex
     retrieval_backend: dense
   - name: full_llm
@@ -74,12 +83,16 @@ ablation_runs:
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
   - name: full_llm_metadata
     pipeline: agentic_full
     metadata_first: true
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
     metadata_backend: anthropic_tool_use
   - name: no_metadata_first
     pipeline: agentic_full
@@ -87,33 +100,49 @@ ablation_runs:
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
   - name: no_rerank
     pipeline: agentic_full
     metadata_first: true
     rerank: false
     verifier_retry: true
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
   - name: no_verifier_retry
     pipeline: agentic_full
     metadata_first: true
     rerank: true
     verifier_retry: false
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
   - name: retrieval_only
     pipeline: agentic_full
     metadata_first: true
     rerank: false
     verifier_retry: false
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
   - name: full_bm25s
     pipeline: agentic_full
     metadata_first: true
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
     bm25_backend: bm25s
   - name: single_chunk
     pipeline: single_chunk
+    metadata_first: false
+    rerank: false
+    verifier_retry: false
+    retrieval_mode: flat
+    retrieval_backend: dense
+    query_expansion: identity
   - name: random_retrieval
     pipeline: agentic_full
     metadata_first: false
@@ -121,12 +150,15 @@ ablation_runs:
     verifier_retry: false
     retrieval_mode: flat
     retrieval_backend: random
+    query_expansion: identity
   - name: agent_react
     pipeline: agent_react
     metadata_first: true
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
     planner_backend: static
   - name: agentic_full_finetuned
     pipeline: agentic_full
@@ -134,11 +166,19 @@ ablation_runs:
     rerank: true
     verifier_retry: true
     retrieval_mode: flat
+    retrieval_backend: hybrid
+    query_expansion: identity
     metadata_backend: regex
     embedding_model: nlpai-lab/KURE-v1
     embedding_lora_adapter: bidmate/embedding-lora-kure-rfp-ko-v1@<sha>
   - name: naive_baseline_finetuned
     pipeline: naive_baseline
+    metadata_first: false
+    rerank: false
+    verifier_retry: false
+    retrieval_mode: flat
+    retrieval_backend: dense
+    query_expansion: identity
     embedding_model: nlpai-lab/KURE-v1
     embedding_lora_adapter: bidmate/embedding-lora-kure-rfp-ko-v1@<sha>
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -4,6 +4,7 @@ export PYTHONDONTWRITEBYTECODE=1
 # Avoid macOS arm64 libomp shared-memory aborts during local smoke eval.
 export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 export KMP_USE_SHM="${KMP_USE_SHM:-FALSE}"
+export KMP_INIT_AT_FORK="${KMP_INIT_AT_FORK:-FALSE}"
 
 # Minimal end-to-end smoke test for Agentic-VLM.
 # Run from the repository root:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Match scripts/smoke.sh: OpenMP SHM can SIGABRT under macOS sandboxed
+# subprocess-heavy pytest runs, so default to the stable local settings.
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+export KMP_USE_SHM="${KMP_USE_SHM:-FALSE}"
+export KMP_INIT_AT_FORK="${KMP_INIT_AT_FORK:-FALSE}"
+
 # Issue #334 (G8 of #284): opt-in ruff lint gate.
 # Ruff is treated as an optional dev dependency — if it is not on PATH we
 # print a one-line install hint and continue, so minimal envs (smoke runs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,51 @@
 """Shared pytest fixtures for the tests/ tree (issue #258)."""
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Iterator
+
+_OPENMP_DEFAULTS = {
+    "OMP_NUM_THREADS": "1",
+    "KMP_USE_SHM": "FALSE",
+    "KMP_INIT_AT_FORK": "FALSE",
+}
+
+
+def _ensure_openmp_startup_env() -> None:
+    """Restart direct pytest runs once with macOS-safe OpenMP defaults.
+
+    Some native runtimes read KMP_* only at process startup. Setting them later
+    is too late to prevent libomp SHM/fork aborts in subprocess-heavy tests.
+    """
+    missing = {
+        key: value for key, value in _OPENMP_DEFAULTS.items() if key not in os.environ
+    }
+    if (
+        sys.platform == "darwin"
+        and missing
+        and os.environ.get("BIDMATE_PYTEST_OPENMP_REEXEC") != "1"
+    ):
+        env = os.environ.copy()
+        env.update(missing)
+        env["BIDMATE_PYTEST_OPENMP_REEXEC"] = "1"
+        code = subprocess.call(
+            [sys.executable, "-m", "pytest", *sys.argv[1:]],
+            env=env,
+            stdout=sys.__stdout__,
+            stderr=sys.__stderr__,
+        )
+        sys.__stdout__.flush()
+        sys.__stderr__.flush()
+        os._exit(code)
+
+    for key, value in _OPENMP_DEFAULTS.items():
+        os.environ.setdefault(key, value)
+
+
+_ensure_openmp_startup_env()
 
 import pytest
 


### PR DESCRIPTION
Closes #1415

## Summary
- Make ADR 0074 eval stage knobs explicit for all ablation runs.
- Remove remaining functional stale references to removed public synthetic eval artifacts.
- Stabilize macOS sandboxed Python/pytest runs by defaulting OpenMP fork/SHM settings in smoke/test entrypoints and direct pytest runs.

## Validation
- bash scripts/smoke.sh
- python3 scripts/check_latency_slo.py --config eval/config.yaml --summary reports/eval_summary.json
- python3 -m pytest -m "not slow" -q
- python3 scripts/check_doc_links.py --check-all
- bash scripts/test.sh

## Notes
- Real/private eval delta was not run because this follow-up must not require private data or add new network/data requirements.
- No public synthetic eval surface was restored.