### PR TITLE
chore: package naive baseline report (#1420)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,6 +289,7 @@ reports/self_review_agreement/*
 artifacts/benchmarks/
 artifacts/runs/
 artifacts/matrices/
+experiments/runs/
 
 # Harness private overlays (paired with eval/*.local.yaml). Only the
 # *.example.yaml templates are committed.

--- a/docs/evaluation/naive_rag_baseline_report.md
+++ b/docs/evaluation/naive_rag_baseline_report.md
@@ -1,0 +1,113 @@
+# Naive RAG Baseline Report
+
+이 문서는 공개 fixture smoke 계약으로 현재 naive baseline을 측정한 첫 재현 가능 baseline report입니다. 실제 성능 claim은 private/internal eval aggregate에서만 판단합니다.
+
+## Evaluation Command
+
+```bash
+python3 eval/run_eval.py --config experiments/runs/naive_baseline_20260524T054514Z/config.naive.yaml --index_dir data/index --output_dir experiments/runs/naive_baseline_20260524T054514Z
+```
+
+## Run Metadata
+
+- run_id: `naive_baseline_20260524T054514Z`
+- dataset size: 5
+- answerable questions: 4
+- unanswerable questions: 1
+- gold evidence source: 0 explicit, 4 derived from `expected_doc_ids` + `expected_terms`
+
+## Metric Summary
+
+| System | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation Acc. | Faithfulness | Hallucination | P95 Latency |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Naive Dense RAG | 1.000 | 1.000 | 1.000 | 1.000 | 0.875 | 1.000 | 0.000 | 2.52 ms |
+
+## Failure Categories
+
+### Retrieval Failures
+- gold evidence not in top-k: 0
+- gold evidence ranked too low: 0
+- wrong similar clause: 0
+- chunk boundary split: 0
+- query wording mismatch: 0
+- multi-chunk evidence missing: 0
+
+### Parsing Failures
+- table content lost: 0
+- figure content ignored: 0
+- page metadata missing: 5
+- header/footer noise: 0
+- Korean/English mixed text issue: 0
+
+### Citation Failures
+- correct answer but wrong citation: 1
+- insufficient citation: 0
+- missing page number: 5
+- citation does not support claim: 0
+- vague citation for multiple claims: 0
+
+### Answer Failures
+- hallucinated requirement: 0
+- partial answer: 0
+- overconfident weak evidence: 0
+- wrong synthesis: 0
+- failed to abstain: 1
+
+### Evaluation Failures
+- missing gold evidence: 0
+- metric missing: 0
+- failure case not saved: 0
+- schema mismatch: 0
+
+## Top Failure Categories
+
+- citation: missing page number: 5
+- parsing: page metadata missing: 5
+- answer: failed to abstain: 1
+- citation: correct answer but wrong citation: 1
+
+## Representative Failure Cases
+
+- `smoke_single_doc_security` (single_doc): citation: correct answer but wrong citation
+  - expected: 보안 통제; 로그 추적
+  - generated: AI 요구사항 개요 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 보안 및 감사 모든 승인 이력은 감사 로그로 남겨야 하며 운영자는 월간 감사 리포트를 생성할 수 있어야 한다. AI 요구사항 개요 핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 보안 및 감사 모든 승인 이력은 감사 로그로 남겨야 하며 운영자는 월간 감사 리포트를 생성할 수 있어야 한다. 
+- `smoke_abstention_missing_blockchain` (abstention): answer: failed to abstain
+  - expected: 블록체인
+  - generated: 납품 기한은 계약 체결일로부터 6개월이며 인수 시험은 단계별로 진행한다. 납품 기한은 계약 체결일로부터 6개월이며 인수 시험은 단계별로 진행한다. - 기관 A: 납품 기한은 계약 체결일로부터 6개월이며 인수 시험은 단계별로 진행한다. [rfp-agency-a-ai-quality::chunk-001] 납품 기한은 계약 체결일로부터 6개월이며 인수 시험은 단계별로 진행한다. 사업 개요 기관 A는
+
+## What The Naive Baseline Does Reasonably Well
+
+- Dense top-k retrieval found all derived gold chunks in the public fixture smoke set.
+- Answerable fixture cases scored as relevant and faithful under the current rule-based scorer.
+
+## What The Naive Baseline Fails At
+
+- Citation accuracy is below perfect, so answers are not always tied to sufficient evidence.
+- The baseline failed to abstain on at least one unanswerable case and answered with weak evidence.
+- Parser/index metadata limitations affect simple source references such as page numbers.
+
+## Recommended Next Experiments
+
+### Audit citation support gaps in naive baseline answers
+- problem: Observed citations are incomplete, vague, or not aligned with the generated claims.
+- why it matters: RFP review needs claim-to-evidence traceability even when the textual answer is mostly correct.
+- expected metric impact: Citation accuracy and claim-citation alignment should become explainable before verifier work starts.
+- files likely to change: `eval/scorers/citation.py, eval/scorers/alignment.py, docs/evaluation/naive_rag_baseline_report.md`
+- acceptance criteria: Each citation failure case has a deterministic reason code and a representative example.
+- suitable for parallel AI-assisted coding: Yes
+
+### Measure page metadata coverage for baseline citations
+- problem: The current index/eval output exposes missing or weak page metadata as a baseline limitation.
+- why it matters: Simple source references require stable page/chunk identifiers before richer grounding can be trusted.
+- expected metric impact: Citation page coverage and missing-page-number counts become measurable.
+- files likely to change: `ingestion.py, scripts/build_index.py, eval/scorers/citation.py`
+- acceptance criteria: Smoke eval reports page metadata coverage without changing naive retrieval ranking.
+- suitable for parallel AI-assisted coding: Yes
+
+### Catalog naive answer failure modes without prompt tuning
+- problem: The baseline produced an answer-policy failure on observed cases, including failed abstention when evidence was insufficient.
+- why it matters: Answer failures must be separated from retrieval misses before prompt or verifier experiments.
+- expected metric impact: Faithfulness, answer relevancy, hallucination, and abstention error rates get cleaner attribution.
+- files likely to change: `docs/evaluation/naive_rag_baseline_report.md, eval/scorers/case.py`
+- acceptance criteria: Failure cases distinguish partial answer, weak evidence, wrong synthesis, and failed abstention.
+- suitable for parallel AI-assisted coding: Yes

--- a/scripts/run_naive_baseline_eval.py
+++ b/scripts/run_naive_baseline_eval.py
@@ -325,7 +325,7 @@ def validate_metrics(metrics: dict[str, Any]) -> None:
             missing.append(group)
             continue
         for key in keys:
-            if key not in block:
+            if key not in block or block[key] is None:
                 missing.append(f"{group}.{key}")
     if missing:
         raise ValueError("metrics.json missing required keys: " + ", ".join(sorted(missing)))
@@ -428,10 +428,12 @@ def categorize_failures(
         hardcase = set(case.get("hardcase_categories") or [])
         query = str(case.get("query") or "")
 
+        retrieval_gap_counted = False
         if answerable and isinstance(recall5, (int, float)):
             if recall5 == 0.0:
                 buckets["retrieval_failures"]["gold evidence not in top-k"] += 1
                 case_labels.append("retrieval: gold evidence not in top-k")
+                retrieval_gap_counted = True
             elif recall5 < 1.0:
                 if isinstance(recall10, (int, float)) and recall10 > recall5:
                     buckets["retrieval_failures"]["gold evidence ranked too low"] += 1
@@ -439,6 +441,7 @@ def categorize_failures(
                 else:
                     buckets["retrieval_failures"]["multi-chunk evidence missing"] += 1
                     case_labels.append("retrieval: multi-chunk evidence missing")
+                retrieval_gap_counted = True
             if "chunk_boundary" in hardcase and recall5 < 1.0:
                 buckets["retrieval_failures"]["chunk boundary split"] += 1
                 case_labels.append("retrieval: chunk boundary split")
@@ -448,6 +451,7 @@ def categorize_failures(
             and case.get("query_type") == "comparison"
             and isinstance(case.get("comparison_target_recall"), (int, float))
             and case.get("comparison_target_recall") < 1.0
+            and not retrieval_gap_counted
         ):
             buckets["retrieval_failures"]["multi-chunk evidence missing"] += 1
             case_labels.append("retrieval: multi-chunk evidence missing")

--- a/scripts/run_naive_baseline_eval.py
+++ b/scripts/run_naive_baseline_eval.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""Run and package the current naive RAG baseline evaluation.
+
+This is an eval wrapper only. It filters an existing eval config down to the
+ADR 0001 naive_baseline row, delegates execution to eval/run_eval.py, then
+exports the requested experiment artifacts without changing retrieval,
+chunking, prompting, verifier, or answer behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from copy import deepcopy
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_REPORT_PATH = ROOT_DIR / "docs" / "evaluation" / "naive_rag_baseline_report.md"
+
+RETRIEVAL_LABELS = {
+    "Recall@5": "chunk_recall_at_5",
+    "Recall@10": "chunk_recall_at_10",
+    "MRR@5": "chunk_mrr_at_5",
+    "nDCG@5": "chunk_ndcg_at_5",
+}
+ANSWER_LABELS = {
+    "Faithfulness": "groundedness",
+    "Answer relevancy": "accuracy",
+    "Citation accuracy": "citation_precision",
+}
+REQUIRED_FAILURE_BUCKETS = {
+    "retrieval_failures": (
+        "gold evidence not in top-k",
+        "gold evidence ranked too low",
+        "wrong similar clause",
+        "chunk boundary split",
+        "query wording mismatch",
+        "multi-chunk evidence missing",
+    ),
+    "parsing_failures": (
+        "table content lost",
+        "figure content ignored",
+        "page metadata missing",
+        "header/footer noise",
+        "Korean/English mixed text issue",
+    ),
+    "citation_failures": (
+        "correct answer but wrong citation",
+        "insufficient citation",
+        "missing page number",
+        "citation does not support claim",
+        "vague citation for multiple claims",
+    ),
+    "answer_failures": (
+        "hallucinated requirement",
+        "partial answer",
+        "overconfident weak evidence",
+        "wrong synthesis",
+        "failed to abstain",
+    ),
+    "evaluation_failures": (
+        "missing gold evidence",
+        "metric missing",
+        "failure case not saved",
+        "schema mismatch",
+    ),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run eval/config.yaml's naive_baseline row and export baseline artifacts."
+    )
+    parser.add_argument("--config", default="eval/config.yaml", help="Source eval config YAML.")
+    parser.add_argument("--index_dir", default="data/index", help="Existing index directory.")
+    parser.add_argument(
+        "--output_root",
+        default="experiments/runs",
+        help="Directory under which <run_id>/ artifacts are written.",
+    )
+    parser.add_argument("--run_id", default=None, help="Optional stable run id.")
+    parser.add_argument(
+        "--report_path",
+        default=str(DEFAULT_REPORT_PATH.relative_to(ROOT_DIR)),
+        help="Markdown baseline report to create/update.",
+    )
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing run dir.")
+    return parser.parse_args()
+
+
+def repo_path(value: str | Path) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def rel_path(path: str | Path) -> str:
+    p = Path(path)
+    try:
+        return str(p.resolve().relative_to(ROOT_DIR.resolve()))
+    except ValueError:
+        return str(p)
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML root must be a mapping: {path}")
+    return data
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows)
+    path.write_text(text, encoding="utf-8")
+
+
+def default_run_id() -> str:
+    return f"naive_baseline_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+
+
+def select_naive_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep-copied config containing only the naive_baseline row."""
+    filtered = deepcopy(config)
+    runs = filtered.get("ablation_runs")
+    if not isinstance(runs, list) or not runs:
+        filtered["ablation_runs"] = [{"name": "naive_baseline", "pipeline": "naive_baseline"}]
+    else:
+        matches = [
+            deepcopy(run)
+            for run in runs
+            if isinstance(run, dict)
+            and str(run.get("name") or "") == "naive_baseline"
+            and str(run.get("pipeline") or "naive_baseline") == "naive_baseline"
+        ]
+        if not matches:
+            raise ValueError("Source config has no naive_baseline ablation row")
+        filtered["ablation_runs"] = [matches[0]]
+    filtered["primary_run"] = "naive_baseline"
+    return filtered
+
+
+def build_eval_command(config_path: Path, index_dir: Path, run_dir: Path) -> list[str]:
+    return [
+        "python3",
+        "eval/run_eval.py",
+        "--config",
+        rel_path(config_path),
+        "--index_dir",
+        rel_path(index_dir),
+        "--output_dir",
+        rel_path(run_dir),
+    ]
+
+
+def run_eval_command(command: list[str], log_path: Path) -> None:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log_file:
+        log_file.write("$ " + " ".join(command) + "\n\n")
+        log_file.flush()
+        result = subprocess.run(
+            command,
+            cwd=ROOT_DIR,
+            env=env,
+            text=True,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+    if result.returncode != 0:
+        raise RuntimeError(f"naive baseline eval failed; see {rel_path(log_path)}")
+
+
+def dataset_counts(config: dict[str, Any]) -> dict[str, int]:
+    cases = config.get("cases") or []
+    answerable = sum(1 for case in cases if bool(case.get("answerable", True)))
+    unanswerable = sum(1 for case in cases if case.get("answerable") is False)
+    explicit_gold = sum(
+        1 for case in cases if case.get("gold_evidence") or case.get("gold_chunk_ids")
+    )
+    expected_gold = sum(
+        1
+        for case in cases
+        if case.get("expected_doc_ids") and case.get("expected_terms")
+    )
+    return {
+        "dataset_size": len(cases),
+        "answerable_questions": answerable,
+        "unanswerable_questions": unanswerable,
+        "explicit_gold_evidence_cases": explicit_gold,
+        "derived_gold_evidence_cases": expected_gold,
+    }
+
+
+def _stage_value(summary: dict[str, Any], stage: str, stat: str) -> float | None:
+    value = ((summary.get("stage_latency") or {}).get(stage) or {}).get(stat)
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _metric(summary: dict[str, Any], key: str) -> float | None:
+    value = summary.get(key)
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _failure_rate(summary: dict[str, Any], key: str) -> float | None:
+    total = summary.get("num_predictions")
+    count = (summary.get("failure_category_counts") or {}).get(key)
+    if not isinstance(total, int) or total <= 0 or not isinstance(count, int):
+        return None
+    return count / total
+
+
+def _total_latency_ms(summary: dict[str, Any]) -> float | None:
+    values = [
+        float(case["latency_ms"])
+        for case in summary.get("case_results") or []
+        if isinstance(case.get("latency_ms"), (int, float))
+    ]
+    if values:
+        return sum(values)
+    latency = summary.get("latency") or {}
+    mean = latency.get("mean")
+    n = summary.get("num_predictions")
+    if isinstance(mean, (int, float)) and isinstance(n, int):
+        return float(mean) * n
+    return None
+
+
+def build_metrics_json(
+    summary: dict[str, Any],
+    config: dict[str, Any],
+    *,
+    run_id: str,
+    command: list[str],
+    artifact_paths: dict[str, str],
+) -> dict[str, Any]:
+    failure_counts = summary.get("failure_category_counts") or {}
+    hallucination_count = int(failure_counts.get("generator_hallucination") or 0)
+    metrics = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "system": "Naive Dense RAG",
+        "evaluation_command": " ".join(command),
+        "config": summary.get("config"),
+        "index_dir": summary.get("index_dir"),
+        "dataset": dataset_counts(config),
+        "artifacts": artifact_paths,
+        "Retrieval metrics": {
+            label: _metric(summary, key) for label, key in RETRIEVAL_LABELS.items()
+        },
+        "Answer/evidence metrics": {
+            "Faithfulness": _metric(summary, "groundedness"),
+            "Answer relevancy": _metric(summary, "accuracy"),
+            "Citation accuracy": _metric(summary, "citation_precision"),
+            "Hallucination rate": _failure_rate(summary, "generator_hallucination"),
+            "Hallucination count": hallucination_count,
+            "Unanswerable detection rate": _metric(summary, "abstention"),
+            "Unanswerable outcomes": summary.get("abstention_outcomes"),
+        },
+        "Operational metrics": {
+            "total latency ms": _total_latency_ms(summary),
+            "retrieval latency mean ms": _stage_value(summary, "retrieve_ms", "mean"),
+            "retrieval latency p50 ms": _stage_value(summary, "retrieve_ms", "p50"),
+            "retrieval latency p95 ms": _stage_value(summary, "retrieve_ms", "p95"),
+            "generation latency mean ms": _stage_value(summary, "answer_generation_ms", "mean"),
+            "generation latency p50 ms": _stage_value(summary, "answer_generation_ms", "p50"),
+            "generation latency p95 ms": _stage_value(summary, "answer_generation_ms", "p95"),
+            "P50 latency ms": (summary.get("latency") or {}).get("p50"),
+            "P95 latency ms": (summary.get("latency") or {}).get("p95"),
+        },
+        "raw_eval_summary_keys": {
+            "accuracy": summary.get("accuracy"),
+            "groundedness": summary.get("groundedness"),
+            "citation_precision": summary.get("citation_precision"),
+            "claim_citation_alignment": summary.get("claim_citation_alignment"),
+            "failure_category_counts": failure_counts,
+            "latency": summary.get("latency"),
+            "stage_latency": summary.get("stage_latency"),
+        },
+    }
+    validate_metrics(metrics)
+    return metrics
+
+
+def validate_metrics(metrics: dict[str, Any]) -> None:
+    required = {
+        "Retrieval metrics": ("Recall@5", "Recall@10", "MRR@5", "nDCG@5"),
+        "Answer/evidence metrics": (
+            "Faithfulness",
+            "Answer relevancy",
+            "Citation accuracy",
+            "Hallucination rate",
+            "Unanswerable detection rate",
+        ),
+        "Operational metrics": (
+            "total latency ms",
+            "retrieval latency mean ms",
+            "generation latency mean ms",
+            "P50 latency ms",
+            "P95 latency ms",
+        ),
+    }
+    missing: list[str] = []
+    for group, keys in required.items():
+        block = metrics.get(group)
+        if not isinstance(block, dict):
+            missing.append(group)
+            continue
+        for key in keys:
+            if key not in block:
+                missing.append(f"{group}.{key}")
+    if missing:
+        raise ValueError("metrics.json missing required keys: " + ", ".join(sorted(missing)))
+
+
+def answers_rows(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for case in summary.get("case_results") or []:
+        hallucination_flag = case.get("failure_category") == "generator_hallucination"
+        unanswerable_flag = (
+            bool(case.get("abstained")) if case.get("answerable") is False else None
+        )
+        rows.append(
+            {
+                "case_id": case.get("id"),
+                "query": case.get("query"),
+                "query_type": case.get("query_type"),
+                "answerable": case.get("answerable"),
+                "expected_answer": case.get("expected_answer") or "; ".join(case.get("expected_terms") or []),
+                "answer": case.get("answer"),
+                "citations": case.get("citation") or [],
+                "metrics": {
+                    "faithfulness": case.get("groundedness"),
+                    "answer_relevancy": case.get("accuracy"),
+                    "citation_accuracy": case.get("citation_precision"),
+                    "claim_citation_alignment": case.get("claim_citation_alignment"),
+                    "abstention": case.get("abstention"),
+                },
+                "hallucination_flag": hallucination_flag,
+                "unanswerable_detection_flag": unanswerable_flag,
+                "failure_category": case.get("failure_category"),
+            }
+        )
+    return rows
+
+
+def retrieved_chunk_rows(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for case in summary.get("case_results") or []:
+        rows.append(
+            {
+                "case_id": case.get("id"),
+                "query": case.get("query"),
+                "query_type": case.get("query_type"),
+                "answerable": case.get("answerable"),
+                "gold_evidence": case.get("gold_evidence") or [],
+                "gold_chunk_ids": case.get("gold_chunk_ids") or [],
+                "retrieved_chunks": case.get("retrieved_chunks") or [],
+                "retrieval_metrics": {
+                    "Recall@5": case.get("chunk_recall_at_5"),
+                    "Recall@10": case.get("chunk_recall_at_10"),
+                    "MRR@5": case.get("chunk_mrr_at_5"),
+                    "nDCG@5": case.get("chunk_ndcg_at_5"),
+                },
+                "failure_category": case.get("failure_category"),
+            }
+        )
+    return rows
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists() or not path.read_text(encoding="utf-8").strip():
+        return []
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def _bucket_template() -> dict[str, Counter[str]]:
+    return {group: Counter({name: 0 for name in names}) for group, names in REQUIRED_FAILURE_BUCKETS.items()}
+
+
+def categorize_failures(
+    summary: dict[str, Any],
+    *,
+    metric_errors: list[str] | None = None,
+) -> dict[str, Any]:
+    buckets = _bucket_template()
+    representative: list[dict[str, Any]] = []
+    case_results = summary.get("case_results") or []
+    index_coverage = summary.get("index_citation_metadata_coverage") or {}
+    if index_coverage.get("coverage_reason") == "index_lacks_page_region_metadata":
+        buckets["parsing_failures"]["page metadata missing"] += len(case_results)
+        cited_cases = sum(
+            1 for case in case_results if case.get("citation") or case.get("evidence_doc_ids")
+        )
+        buckets["citation_failures"]["missing page number"] += cited_cases
+
+    for case in case_results:
+        case_labels: list[str] = []
+        answerable = bool(case.get("answerable", True))
+        recall5 = case.get("chunk_recall_at_5")
+        recall10 = case.get("chunk_recall_at_10")
+        accuracy = case.get("accuracy")
+        citation = case.get("citation_precision")
+        alignment = case.get("claim_citation_alignment")
+        failure_category = case.get("failure_category")
+        hardcase = set(case.get("hardcase_categories") or [])
+        query = str(case.get("query") or "")
+
+        if answerable and isinstance(recall5, (int, float)):
+            if recall5 == 0.0:
+                buckets["retrieval_failures"]["gold evidence not in top-k"] += 1
+                case_labels.append("retrieval: gold evidence not in top-k")
+            elif recall5 < 1.0:
+                if isinstance(recall10, (int, float)) and recall10 > recall5:
+                    buckets["retrieval_failures"]["gold evidence ranked too low"] += 1
+                    case_labels.append("retrieval: gold evidence ranked too low")
+                else:
+                    buckets["retrieval_failures"]["multi-chunk evidence missing"] += 1
+                    case_labels.append("retrieval: multi-chunk evidence missing")
+            if "chunk_boundary" in hardcase and recall5 < 1.0:
+                buckets["retrieval_failures"]["chunk boundary split"] += 1
+                case_labels.append("retrieval: chunk boundary split")
+
+        if (
+            answerable
+            and case.get("query_type") == "comparison"
+            and isinstance(case.get("comparison_target_recall"), (int, float))
+            and case.get("comparison_target_recall") < 1.0
+        ):
+            buckets["retrieval_failures"]["multi-chunk evidence missing"] += 1
+            case_labels.append("retrieval: multi-chunk evidence missing")
+
+        if answerable and any("A" <= ch <= "z" for ch in query) and accuracy != 1.0:
+            buckets["parsing_failures"]["Korean/English mixed text issue"] += 1
+            case_labels.append("parsing: Korean/English mixed text issue")
+
+        if citation is not None and citation < 1.0:
+            if accuracy == 1.0:
+                buckets["citation_failures"]["correct answer but wrong citation"] += 1
+                case_labels.append("citation: correct answer but wrong citation")
+            else:
+                buckets["citation_failures"]["insufficient citation"] += 1
+                case_labels.append("citation: insufficient citation")
+        if isinstance(alignment, (int, float)) and alignment < 1.0:
+            buckets["citation_failures"]["citation does not support claim"] += 1
+            case_labels.append("citation: citation does not support claim")
+        if case.get("query_type") == "comparison" and citation is not None and citation < 1.0:
+            buckets["citation_failures"]["vague citation for multiple claims"] += 1
+            case_labels.append("citation: vague citation for multiple claims")
+        if case.get("citation_page_coverage_reason") in {"no_citations", "no_gold_pages"}:
+            buckets["citation_failures"]["missing page number"] += 1
+
+        if answerable and accuracy != 1.0:
+            if failure_category == "generator_hallucination":
+                buckets["answer_failures"]["hallucinated requirement"] += 1
+                case_labels.append("answer: hallucinated requirement")
+            elif case.get("groundedness") != 1.0:
+                buckets["answer_failures"]["overconfident weak evidence"] += 1
+                case_labels.append("answer: overconfident weak evidence")
+            elif case.get("term_match") is False:
+                buckets["answer_failures"]["partial answer"] += 1
+                case_labels.append("answer: partial answer")
+            else:
+                buckets["answer_failures"]["wrong synthesis"] += 1
+                case_labels.append("answer: wrong synthesis")
+        if not answerable and case.get("abstention") != 1.0:
+            buckets["answer_failures"]["failed to abstain"] += 1
+            case_labels.append("answer: failed to abstain")
+
+        if answerable and not case.get("gold_chunk_ids"):
+            buckets["evaluation_failures"]["missing gold evidence"] += 1
+            case_labels.append("evaluation: missing gold evidence")
+
+        if case_labels:
+            representative.append(
+                {
+                    "case_id": case.get("id"),
+                    "query_type": case.get("query_type"),
+                    "labels": case_labels,
+                    "expected": case.get("expected_answer") or "; ".join(case.get("expected_terms") or []),
+                    "answer": case.get("answer"),
+                    "failure_category": failure_category,
+                }
+            )
+
+    for err in metric_errors or []:
+        key = "metric missing" if "missing" in err.lower() else "schema mismatch"
+        buckets["evaluation_failures"][key] += 1
+
+    compact = {group: dict(counter) for group, counter in buckets.items()}
+    totals = {
+        group: sum(count for count in counter.values())
+        for group, counter in compact.items()
+    }
+    return {
+        "buckets": compact,
+        "totals": totals,
+        "representative_cases": representative[:5],
+    }
+
+
+def _fmt_number(value: Any, digits: int = 3) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, (int, float)):
+        return f"{float(value):.{digits}f}"
+    return str(value)
+
+
+def _fmt_ms(value: Any) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, (int, float)):
+        return f"{float(value):.2f} ms"
+    return str(value)
+
+
+def _top_nonzero(buckets: dict[str, dict[str, int]], limit: int = 6) -> list[tuple[str, int]]:
+    counts = []
+    for group, bucket in buckets.items():
+        prefix = group.replace("_", " ").replace("failures", "").strip()
+        for name, count in bucket.items():
+            if count:
+                counts.append((f"{prefix}: {name}", count))
+    return sorted(counts, key=lambda item: (-item[1], item[0]))[:limit]
+
+
+def recommend_issues(analysis: dict[str, Any], metrics: dict[str, Any]) -> list[dict[str, Any]]:
+    buckets = analysis["buckets"]
+    retrieval_total = analysis["totals"].get("retrieval_failures", 0)
+    citation_total = analysis["totals"].get("citation_failures", 0)
+    parsing_total = analysis["totals"].get("parsing_failures", 0)
+    answer_total = analysis["totals"].get("answer_failures", 0)
+    evaluation_total = analysis["totals"].get("evaluation_failures", 0)
+
+    issues: list[dict[str, Any]] = []
+    if retrieval_total:
+        issues.append(
+            {
+                "title": "Measure dense retrieval miss patterns before adding reranking",
+                "problem": "Naive dense retrieval missed or under-ranked gold chunks on observed fixture cases.",
+                "why_it_matters": "Recall is the first bottleneck; answer changes cannot recover evidence that never enters context.",
+                "expected_metric_impact": "Recall@5/Recall@10 and MRR@5 diagnostics become actionable for later retrieval experiments.",
+                "files_likely_to_change": "eval/config.yaml, docs/evaluation/naive_rag_baseline_report.md, optional scripts/* analysis helper",
+                "acceptance_criteria": "A retrieval-only follow-up report separates not-in-top-k, ranked-too-low, boundary, and multi-chunk misses.",
+                "parallel_ai_assisted": "Yes",
+            }
+        )
+    if citation_total:
+        issues.append(
+            {
+                "title": "Audit citation support gaps in naive baseline answers",
+                "problem": "Observed citations are incomplete, vague, or not aligned with the generated claims.",
+                "why_it_matters": "RFP review needs claim-to-evidence traceability even when the textual answer is mostly correct.",
+                "expected_metric_impact": "Citation accuracy and claim-citation alignment should become explainable before verifier work starts.",
+                "files_likely_to_change": "eval/scorers/citation.py, eval/scorers/alignment.py, docs/evaluation/naive_rag_baseline_report.md",
+                "acceptance_criteria": "Each citation failure case has a deterministic reason code and a representative example.",
+                "parallel_ai_assisted": "Yes",
+            }
+        )
+    if parsing_total:
+        issues.append(
+            {
+                "title": "Measure page metadata coverage for baseline citations",
+                "problem": "The current index/eval output exposes missing or weak page metadata as a baseline limitation.",
+                "why_it_matters": "Simple source references require stable page/chunk identifiers before richer grounding can be trusted.",
+                "expected_metric_impact": "Citation page coverage and missing-page-number counts become measurable.",
+                "files_likely_to_change": "ingestion.py, scripts/build_index.py, eval/scorers/citation.py",
+                "acceptance_criteria": "Smoke eval reports page metadata coverage without changing naive retrieval ranking.",
+                "parallel_ai_assisted": "Yes",
+            }
+        )
+    if answer_total:
+        issues.append(
+            {
+                "title": "Catalog naive answer failure modes without prompt tuning",
+                "problem": "The baseline produced an answer-policy failure on observed cases, including failed abstention when evidence was insufficient.",
+                "why_it_matters": "Answer failures must be separated from retrieval misses before prompt or verifier experiments.",
+                "expected_metric_impact": "Faithfulness, answer relevancy, hallucination, and abstention error rates get cleaner attribution.",
+                "files_likely_to_change": "docs/evaluation/naive_rag_baseline_report.md, eval/scorers/case.py",
+                "acceptance_criteria": "Failure cases distinguish partial answer, weak evidence, wrong synthesis, and failed abstention.",
+                "parallel_ai_assisted": "Yes",
+            }
+        )
+    if evaluation_total:
+        issues.append(
+            {
+                "title": "Harden gold evidence and metric schema checks",
+                "problem": "The baseline run surfaced evaluation contract gaps such as missing gold evidence or missing metrics.",
+                "why_it_matters": "Bad or incomplete evaluation artifacts can hide real baseline limitations.",
+                "expected_metric_impact": "Metric coverage improves; evaluation failures stop being mixed into RAG failures.",
+                "files_likely_to_change": "eval/config.yaml, eval/scorers/chunk_metrics.py, tests/test_run_naive_baseline_eval.py",
+                "acceptance_criteria": "Eval fails loud when required metric keys or answerable-case gold evidence are unavailable.",
+                "parallel_ai_assisted": "Yes",
+            }
+        )
+
+    if len(issues) < 3:
+        issues.append(
+            {
+                "title": "Expand public fixture baseline slices with observed weak areas",
+                "problem": "The current public fixture is small, so observed gaps need a few targeted cases to avoid overfitting interpretation.",
+                "why_it_matters": "A measurable baseline needs enough cases to separate retrieval, citation, answer, and parsing failures.",
+                "expected_metric_impact": "Recall@k, citation accuracy, faithfulness, and abstention rates become less brittle.",
+                "files_likely_to_change": "eval/config.yaml, eval/fixtures/smoke_rfp/raw/*, docs/evaluation/naive_rag_baseline_report.md",
+                "acceptance_criteria": "New cases are public-fixture safe and each maps to one observed failure category.",
+                "parallel_ai_assisted": "Yes",
+            }
+        )
+    if len(issues) < 3:
+        issues.append(
+            {
+                "title": "Add a reproducibility check for packaged baseline artifacts",
+                "problem": "The wrapper exports multiple files, and schema drift should fail before report numbers are trusted.",
+                "why_it_matters": "The baseline report depends on metrics.json, retrieved_chunks.jsonl, answers.jsonl, and failure_cases.jsonl staying aligned.",
+                "expected_metric_impact": "No direct quality lift; improves evaluation reliability.",
+                "files_likely_to_change": "scripts/run_naive_baseline_eval.py, tests/test_run_naive_baseline_eval.py",
+                "acceptance_criteria": "A test fixture verifies all required artifact schemas from a minimal eval_summary.json.",
+                "parallel_ai_assisted": "Yes",
+            }
+        )
+    return issues[:6]
+
+
+def render_summary_md(
+    *,
+    run_id: str,
+    command: list[str],
+    metrics: dict[str, Any],
+    analysis: dict[str, Any],
+) -> str:
+    retrieval = metrics["Retrieval metrics"]
+    answer = metrics["Answer/evidence metrics"]
+    ops = metrics["Operational metrics"]
+    top = _top_nonzero(analysis["buckets"])
+    lines = [
+        f"# Naive RAG Baseline Run: {run_id}",
+        "",
+        "## Command",
+        "",
+        "```bash",
+        " ".join(command),
+        "```",
+        "",
+        "## Experiment Summary",
+        "",
+        "| System | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation Acc. | Faithfulness | Hallucination | P95 Latency |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+        (
+            "| Naive Dense RAG | "
+            f"{_fmt_number(retrieval['Recall@5'])} | "
+            f"{_fmt_number(retrieval['Recall@10'])} | "
+            f"{_fmt_number(retrieval['MRR@5'])} | "
+            f"{_fmt_number(retrieval['nDCG@5'])} | "
+            f"{_fmt_number(answer['Citation accuracy'])} | "
+            f"{_fmt_number(answer['Faithfulness'])} | "
+            f"{_fmt_number(answer['Hallucination rate'])} | "
+            f"{_fmt_ms(ops['P95 latency ms'])} |"
+        ),
+        "",
+        "## Top Failure Categories",
+        "",
+    ]
+    if top:
+        lines.extend(f"- {name}: {count}" for name, count in top)
+    else:
+        lines.append("- No nonzero failure categories observed.")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def render_report(
+    *,
+    run_id: str,
+    command: list[str],
+    metrics: dict[str, Any],
+    analysis: dict[str, Any],
+    issues: list[dict[str, Any]],
+) -> str:
+    counts = metrics["dataset"]
+    retrieval = metrics["Retrieval metrics"]
+    answer = metrics["Answer/evidence metrics"]
+    ops = metrics["Operational metrics"]
+    top = _top_nonzero(analysis["buckets"])
+    lines = [
+        "# Naive RAG Baseline Report",
+        "",
+        "이 문서는 공개 fixture smoke 계약으로 현재 naive baseline을 측정한 첫 재현 가능 baseline report입니다. 실제 성능 claim은 private/internal eval aggregate에서만 판단합니다.",
+        "",
+        "## Evaluation Command",
+        "",
+        "```bash",
+        " ".join(command),
+        "```",
+        "",
+        "## Run Metadata",
+        "",
+        f"- run_id: `{run_id}`",
+        f"- dataset size: {counts['dataset_size']}",
+        f"- answerable questions: {counts['answerable_questions']}",
+        f"- unanswerable questions: {counts['unanswerable_questions']}",
+        f"- gold evidence source: {counts['explicit_gold_evidence_cases']} explicit, {counts['derived_gold_evidence_cases']} derived from `expected_doc_ids` + `expected_terms`",
+        "",
+        "## Metric Summary",
+        "",
+        "| System | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation Acc. | Faithfulness | Hallucination | P95 Latency |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+        (
+            "| Naive Dense RAG | "
+            f"{_fmt_number(retrieval['Recall@5'])} | "
+            f"{_fmt_number(retrieval['Recall@10'])} | "
+            f"{_fmt_number(retrieval['MRR@5'])} | "
+            f"{_fmt_number(retrieval['nDCG@5'])} | "
+            f"{_fmt_number(answer['Citation accuracy'])} | "
+            f"{_fmt_number(answer['Faithfulness'])} | "
+            f"{_fmt_number(answer['Hallucination rate'])} | "
+            f"{_fmt_ms(ops['P95 latency ms'])} |"
+        ),
+        "",
+        "## Failure Categories",
+        "",
+    ]
+    for group, bucket in analysis["buckets"].items():
+        title = group.replace("_", " ").title()
+        lines.append(f"### {title}")
+        for name, count in bucket.items():
+            lines.append(f"- {name}: {count}")
+        lines.append("")
+
+    lines.append("## Top Failure Categories")
+    lines.append("")
+    if top:
+        lines.extend(f"- {name}: {count}" for name, count in top)
+    else:
+        lines.append("- No nonzero failure categories observed.")
+    lines.append("")
+
+    lines.append("## Representative Failure Cases")
+    lines.append("")
+    reps = analysis["representative_cases"]
+    if reps:
+        for case in reps:
+            labels = "; ".join(case["labels"])
+            answer_text = str(case.get("answer") or "").replace("\n", " ")[:220]
+            expected = str(case.get("expected") or "").replace("\n", " ")[:180]
+            lines.extend(
+                [
+                    f"- `{case['case_id']}` ({case['query_type']}): {labels}",
+                    f"  - expected: {expected or 'N/A'}",
+                    f"  - generated: {answer_text or 'N/A'}",
+                ]
+            )
+    else:
+        lines.append("- No representative failure cases were emitted.")
+    lines.append("")
+
+    good = []
+    if retrieval["Recall@5"] == 1.0:
+        good.append("Dense top-k retrieval found all derived gold chunks in the public fixture smoke set.")
+    if answer["Unanswerable detection rate"] == 1.0:
+        good.append("The unanswerable smoke case was detected as insufficient.")
+    if answer["Answer relevancy"] == 1.0 and answer["Faithfulness"] == 1.0:
+        good.append("Answerable fixture cases scored as relevant and faithful under the current rule-based scorer.")
+    if not good:
+        good.append("The run is reproducible and emits separated retrieval, answer/evidence, citation, failure, and latency artifacts.")
+    lines.append("## What The Naive Baseline Does Reasonably Well")
+    lines.append("")
+    lines.extend(f"- {item}" for item in good)
+    lines.append("")
+
+    weak = []
+    if retrieval["Recall@5"] != 1.0:
+        weak.append("Dense-only retrieval has observable recall/ranking gaps before any answer logic is considered.")
+    if answer["Citation accuracy"] != 1.0:
+        weak.append("Citation accuracy is below perfect, so answers are not always tied to sufficient evidence.")
+    if answer["Faithfulness"] != 1.0:
+        weak.append("Faithfulness is below perfect, showing unsupported or partial evidence use.")
+    if answer["Unanswerable detection rate"] != 1.0:
+        weak.append("The baseline failed to abstain on at least one unanswerable case and answered with weak evidence.")
+    if analysis["totals"].get("parsing_failures", 0):
+        weak.append("Parser/index metadata limitations affect simple source references such as page numbers.")
+    if not weak:
+        weak.append("This small public fixture is too small to expose all expected naive baseline limitations; private/internal eval remains necessary.")
+    lines.append("## What The Naive Baseline Fails At")
+    lines.append("")
+    lines.extend(f"- {item}" for item in weak)
+    lines.append("")
+
+    lines.append("## Recommended Next Experiments")
+    lines.append("")
+    for issue in issues:
+        lines.extend(
+            [
+                f"### {issue['title']}",
+                f"- problem: {issue['problem']}",
+                f"- why it matters: {issue['why_it_matters']}",
+                f"- expected metric impact: {issue['expected_metric_impact']}",
+                f"- files likely to change: `{issue['files_likely_to_change']}`",
+                f"- acceptance criteria: {issue['acceptance_criteria']}",
+                f"- suitable for parallel AI-assisted coding: {issue['parallel_ai_assisted']}",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def export_artifacts(
+    *,
+    run_id: str,
+    run_dir: Path,
+    command: list[str],
+    config: dict[str, Any],
+    report_path: Path,
+) -> dict[str, Any]:
+    summary_path = run_dir / "eval_summary.json"
+    if not summary_path.exists():
+        raise FileNotFoundError(f"eval_summary.json missing: {summary_path}")
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    failure_source = run_dir / "failures" / "naive_baseline.jsonl"
+    failure_rows = load_jsonl(failure_source)
+    failure_cases_path = run_dir / "failure_cases.jsonl"
+    write_jsonl(failure_cases_path, failure_rows)
+
+    artifact_paths = {
+        "metrics": rel_path(run_dir / "metrics.json"),
+        "retrieved_chunks": rel_path(run_dir / "retrieved_chunks.jsonl"),
+        "answers": rel_path(run_dir / "answers.jsonl"),
+        "failure_cases": rel_path(failure_cases_path),
+        "summary": rel_path(run_dir / "summary.md"),
+        "eval_summary": rel_path(summary_path),
+        "eval_log": rel_path(run_dir / "logs" / "eval.log"),
+    }
+    metrics = build_metrics_json(
+        summary,
+        config,
+        run_id=run_id,
+        command=command,
+        artifact_paths=artifact_paths,
+    )
+    analysis = categorize_failures(summary)
+    issues = recommend_issues(analysis, metrics)
+
+    write_json(run_dir / "metrics.json", metrics)
+    write_jsonl(run_dir / "retrieved_chunks.jsonl", retrieved_chunk_rows(summary))
+    write_jsonl(run_dir / "answers.jsonl", answers_rows(summary))
+    (run_dir / "summary.md").write_text(
+        render_summary_md(
+            run_id=run_id,
+            command=command,
+            metrics=metrics,
+            analysis=analysis,
+        ),
+        encoding="utf-8",
+    )
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        render_report(
+            run_id=run_id,
+            command=command,
+            metrics=metrics,
+            analysis=analysis,
+            issues=issues,
+        ),
+        encoding="utf-8",
+    )
+    return {
+        "metrics": metrics,
+        "analysis": analysis,
+        "issues": issues,
+        "artifact_paths": artifact_paths,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    source_config_path = repo_path(args.config)
+    index_dir = repo_path(args.index_dir)
+    output_root = repo_path(args.output_root)
+    report_path = repo_path(args.report_path)
+    run_id = args.run_id or default_run_id()
+    run_dir = output_root / run_id
+
+    if run_dir.exists():
+        if not args.force:
+            print(f"[ERROR] Run directory already exists: {rel_path(run_dir)}", file=sys.stderr)
+            return 2
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    source_config = load_yaml(source_config_path)
+    naive_config = select_naive_config(source_config)
+    run_config_path = run_dir / "config.naive.yaml"
+    run_config_path.write_text(
+        yaml.safe_dump(naive_config, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    command = build_eval_command(run_config_path, index_dir, run_dir)
+    try:
+        run_eval_command(command, run_dir / "logs" / "eval.log")
+        result = export_artifacts(
+            run_id=run_id,
+            run_dir=run_dir,
+            command=command,
+            config=naive_config,
+            report_path=report_path,
+        )
+    except Exception as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
+
+    print(f"[OK] Naive baseline run written: {rel_path(run_dir)}")
+    print(f"[OK] metrics.json: {result['artifact_paths']['metrics']}")
+    print(f"[OK] failure_cases.jsonl: {result['artifact_paths']['failure_cases']}")
+    print(f"[OK] report: {rel_path(report_path)}")
+    print(f"run_id={run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hook_pretooluse_bash_guard.py
+++ b/tests/test_hook_pretooluse_bash_guard.py
@@ -330,6 +330,7 @@ class TestPreToolUseBashGuard(unittest.TestCase):
 # Scripts the §5b check (issue #1097) pulls in beyond the base harness.
 SHIP_PR_BODY = REPO / "scripts" / "claude-hooks" / "_ship_pr_body.py"
 CHECK_BRANCH = REPO / "scripts" / "check_branch_and_issue.py"
+REAL_EVAL_PATHS = REPO / "scripts" / "real_eval_paths.py"
 
 
 class TestBashGuard5bSoftWarn(unittest.TestCase):
@@ -352,6 +353,7 @@ class TestBashGuard5bSoftWarn(unittest.TestCase):
         shutil.copy(SHIP_PR_BODY, ch / SHIP_PR_BODY.name)
         shutil.copy(GOVERNANCE, self._tmp_repo / "scripts" / GOVERNANCE.name)
         shutil.copy(CHECK_BRANCH, self._tmp_repo / "scripts" / CHECK_BRANCH.name)
+        shutil.copy(REAL_EVAL_PATHS, self._tmp_repo / "scripts" / REAL_EVAL_PATHS.name)
         self._hook = ch / HOOK.name
         self._fires_log = self._tmp_repo / ".claude" / ".hook-fires.log"
 

--- a/tests/test_run_naive_baseline_eval.py
+++ b/tests/test_run_naive_baseline_eval.py
@@ -1,0 +1,211 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts import run_naive_baseline_eval as nb
+
+
+class NaiveBaselineEvalWrapperTest(unittest.TestCase):
+    def test_select_naive_config_filters_without_mutating_source(self) -> None:
+        source = {
+            "primary_run": "full",
+            "ablation_runs": [
+                {"name": "naive_baseline", "pipeline": "naive_baseline"},
+                {"name": "full", "pipeline": "agentic_full"},
+            ],
+            "cases": [{"id": "c1", "query": "q"}],
+        }
+
+        filtered = nb.select_naive_config(source)
+
+        self.assertEqual("naive_baseline", filtered["primary_run"])
+        self.assertEqual(
+            [{"name": "naive_baseline", "pipeline": "naive_baseline"}],
+            filtered["ablation_runs"],
+        )
+        self.assertEqual(2, len(source["ablation_runs"]))
+
+    def test_build_eval_command_delegates_to_existing_runner(self) -> None:
+        command = nb.build_eval_command(
+            Path("experiments/runs/r/config.naive.yaml"),
+            Path("data/index"),
+            Path("experiments/runs/r"),
+        )
+
+        self.assertEqual("python3", command[0])
+        self.assertEqual("eval/run_eval.py", command[1])
+        self.assertIn("--config", command)
+        self.assertIn("--index_dir", command)
+        self.assertIn("--output_dir", command)
+
+    def test_validate_metrics_fails_when_required_metric_missing(self) -> None:
+        with self.assertRaisesRegex(ValueError, "metrics.json missing required keys"):
+            nb.validate_metrics(
+                {
+                    "Retrieval metrics": {"Recall@5": 1.0},
+                    "Answer/evidence metrics": {},
+                    "Operational metrics": {},
+                }
+            )
+
+    def test_export_artifacts_writes_required_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / "experiments" / "runs" / "unit_run"
+            (run_dir / "failures").mkdir(parents=True)
+            report_path = root / "docs" / "evaluation" / "naive_rag_baseline_report.md"
+            summary = self._summary_fixture()
+            (run_dir / "eval_summary.json").write_text(
+                json.dumps(summary, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            (run_dir / "failures" / "naive_baseline.jsonl").write_text(
+                json.dumps(
+                    {
+                        "question_id": "c1",
+                        "failure_type": "retrieval_miss",
+                        "generated_answer": "missing",
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            config = {
+                "cases": [
+                    {
+                        "id": "c1",
+                        "answerable": True,
+                        "expected_doc_ids": ["doc-a"],
+                        "expected_terms": ["보안"],
+                    },
+                    {"id": "c2", "answerable": False},
+                ]
+            }
+
+            result = nb.export_artifacts(
+                run_id="unit_run",
+                run_dir=run_dir,
+                command=["python3", "eval/run_eval.py"],
+                config=config,
+                report_path=report_path,
+            )
+
+            for name in (
+                "metrics.json",
+                "retrieved_chunks.jsonl",
+                "answers.jsonl",
+                "failure_cases.jsonl",
+                "summary.md",
+            ):
+                self.assertTrue((run_dir / name).is_file(), name)
+            self.assertTrue(report_path.is_file())
+            self.assertEqual(
+                0.5,
+                result["metrics"]["Retrieval metrics"]["Recall@5"],
+            )
+            self.assertIn("retrieval_failures", result["analysis"]["buckets"])
+
+    @staticmethod
+    def _summary_fixture() -> dict:
+        return {
+            "config": "eval/config.yaml",
+            "index_dir": "data/index",
+            "num_predictions": 2,
+            "chunk_recall_at_5": 0.5,
+            "chunk_recall_at_10": 1.0,
+            "chunk_mrr_at_5": 0.5,
+            "chunk_ndcg_at_5": 0.5,
+            "groundedness": 0.5,
+            "accuracy": 0.5,
+            "citation_precision": 0.5,
+            "claim_citation_alignment": 0.5,
+            "abstention": 1.0,
+            "abstention_outcomes": {
+                "correct_refusal": 1,
+                "incorrect_answer": 0,
+                "boundary_partial": 0,
+            },
+            "failure_category_counts": {
+                "retrieval_miss": 1,
+                "planner_under_decomposition": 0,
+                "verifier_false_negative": 0,
+                "verifier_false_positive": 0,
+                "generator_hallucination": 0,
+                "context_dilution": 0,
+                "unknown": 0,
+            },
+            "latency": {"p50": 10.0, "p95": 20.0, "mean": 15.0},
+            "stage_latency": {
+                "retrieve_ms": {"p50": 2.0, "p95": 3.0, "mean": 2.5, "count": 2},
+                "answer_generation_ms": {
+                    "p50": 4.0,
+                    "p95": 5.0,
+                    "mean": 4.5,
+                    "count": 2,
+                },
+            },
+            "index_citation_metadata_coverage": {"coverage_reason": "ok"},
+            "case_results": [
+                {
+                    "id": "c1",
+                    "query": "기관 A의 보안 요구사항은?",
+                    "query_type": "single_doc",
+                    "hardcase_categories": [],
+                    "answerable": True,
+                    "expected_doc_ids": ["doc-a"],
+                    "expected_terms": ["보안"],
+                    "gold_evidence": [{"doc_id": "doc-a", "chunk_id": "doc-a::1"}],
+                    "gold_chunk_ids": ["doc-a::1"],
+                    "retrieved_chunks": [{"rank": 1, "chunk_id": "doc-b::1"}],
+                    "chunk_recall_at_5": 0.0,
+                    "chunk_recall_at_10": 1.0,
+                    "chunk_mrr_at_5": 0.0,
+                    "chunk_ndcg_at_5": 0.0,
+                    "comparison_target_recall": None,
+                    "accuracy": 0.0,
+                    "groundedness": 0.0,
+                    "citation_precision": 0.0,
+                    "claim_citation_alignment": 0.0,
+                    "abstention": None,
+                    "abstained": False,
+                    "evidence_doc_ids": [],
+                    "answer": "missing",
+                    "citation": [],
+                    "failure_category": "retrieval_miss",
+                    "latency_ms": 10.0,
+                },
+                {
+                    "id": "c2",
+                    "query": "없는 요구사항은?",
+                    "query_type": "abstention",
+                    "hardcase_categories": ["abstention"],
+                    "answerable": False,
+                    "expected_doc_ids": [],
+                    "expected_terms": [],
+                    "gold_evidence": [],
+                    "gold_chunk_ids": [],
+                    "retrieved_chunks": [],
+                    "chunk_recall_at_5": None,
+                    "chunk_recall_at_10": None,
+                    "chunk_mrr_at_5": None,
+                    "chunk_ndcg_at_5": None,
+                    "accuracy": None,
+                    "groundedness": None,
+                    "citation_precision": None,
+                    "claim_citation_alignment": None,
+                    "abstention": 1.0,
+                    "abstained": True,
+                    "evidence_doc_ids": [],
+                    "answer": "",
+                    "citation": [],
+                    "failure_category": None,
+                    "latency_ms": 20.0,
+                },
+            ],
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_naive_baseline_eval.py
+++ b/tests/test_run_naive_baseline_eval.py
@@ -49,6 +49,50 @@ class NaiveBaselineEvalWrapperTest(unittest.TestCase):
                 }
             )
 
+    def test_validate_metrics_fails_when_required_metric_null(self) -> None:
+        metrics = self._valid_metrics()
+        metrics["Retrieval metrics"]["Recall@5"] = None
+
+        with self.assertRaisesRegex(ValueError, "Retrieval metrics.Recall@5"):
+            nb.validate_metrics(metrics)
+
+    def test_comparison_retrieval_gap_is_not_double_counted(self) -> None:
+        summary = {
+            "index_citation_metadata_coverage": {"coverage_reason": "ok"},
+            "case_results": [
+                {
+                    "id": "c1",
+                    "query": "Compare A and B requirements",
+                    "query_type": "comparison",
+                    "hardcase_categories": [],
+                    "answerable": True,
+                    "chunk_recall_at_5": 0.5,
+                    "chunk_recall_at_10": 0.5,
+                    "comparison_target_recall": 0.5,
+                    "accuracy": 1.0,
+                    "groundedness": 1.0,
+                    "citation_precision": 1.0,
+                    "claim_citation_alignment": 1.0,
+                    "abstained": False,
+                    "failure_category": None,
+                    "answer": "answer",
+                }
+            ],
+        }
+
+        analysis = nb.categorize_failures(summary, metric_errors=[])
+
+        self.assertEqual(
+            1,
+            analysis["buckets"]["retrieval_failures"]["multi-chunk evidence missing"],
+        )
+        self.assertEqual(
+            1,
+            analysis["representative_cases"][0]["labels"].count(
+                "retrieval: multi-chunk evidence missing"
+            ),
+        )
+
     def test_export_artifacts_writes_required_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -106,6 +150,31 @@ class NaiveBaselineEvalWrapperTest(unittest.TestCase):
                 result["metrics"]["Retrieval metrics"]["Recall@5"],
             )
             self.assertIn("retrieval_failures", result["analysis"]["buckets"])
+
+    @staticmethod
+    def _valid_metrics() -> dict:
+        return {
+            "Retrieval metrics": {
+                "Recall@5": 1.0,
+                "Recall@10": 1.0,
+                "MRR@5": 1.0,
+                "nDCG@5": 1.0,
+            },
+            "Answer/evidence metrics": {
+                "Faithfulness": 1.0,
+                "Answer relevancy": 1.0,
+                "Citation accuracy": 1.0,
+                "Hallucination rate": 0.0,
+                "Unanswerable detection rate": 1.0,
+            },
+            "Operational metrics": {
+                "total latency ms": 10.0,
+                "retrieval latency mean ms": 2.0,
+                "generation latency mean ms": 4.0,
+                "P50 latency ms": 10.0,
+                "P95 latency ms": 20.0,
+            },
+        }
 
     @staticmethod
     def _summary_fixture() -> dict:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Naive RAG baseline을 기존 `eval/run_eval.py`로 실행하되, 요청된 `experiments/runs/<run_id>/` artifact layout과 재현 가능한 baseline report로 패키징하는 wrapper를 추가했습니다. RAG 동작, retrieval, chunking, prompt, verifier, reranker, self-correction은 변경하지 않았습니다.

Closes #1420

## 2. 영향 파일

- `.gitignore` — local-only `experiments/runs/` 산출물 제외
- `scripts/run_naive_baseline_eval.py` — naive baseline eval wrapper 및 artifact/report exporter
- `tests/test_run_naive_baseline_eval.py` — wrapper config filtering, required metrics, artifact export test
- `docs/evaluation/naive_rag_baseline_report.md` — 첫 public fixture naive baseline report

## 3. 리스크

- Wrapper가 기존 eval runner output schema에 의존하므로 `eval_summary.json` key drift 시 export가 실패할 수 있습니다.
- 이를 줄이기 위해 required metric key validation과 artifact export unit test를 추가했습니다.
- `experiments/runs/`는 raw per-case local artifact라 `.gitignore`에 추가해 PR diff에 들어가지 않게 했습니다.

## 4. 테스트

- `python3 -m pytest tests/test_run_naive_baseline_eval.py tests/test_eval_metrics.py tests/test_chunk_metrics_regression.py -q`
- `python3 scripts/regen_naive_baseline_golden.py --check`
- `python3 scripts/run_naive_baseline_eval.py --config eval/config.yaml --index_dir data/index --output_root experiments/runs`
- `python3 scripts/check_latency_slo.py --config eval/config.yaml --summary experiments/runs/naive_baseline_20260524T054514Z/eval_summary.json`
- `python3 scripts/check_doc_links.py --check-all`

## 5. Eval 영향

Public fixture smoke 기준 naive baseline 측정 report를 추가했습니다. 기본 eval config, naive baseline pipeline, retrieval ranking, answer contract는 변경하지 않았습니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. 이 PR은 existing eval runner를 호출하는 packaging wrapper와 public fixture report 추가이며, private/internal real-data eval 동작을 변경하지 않습니다.

## 6. 하위 호환

기존 CLI/API/answer schema를 변경하지 않습니다. 새 script는 additive entrypoint이고 기존 `eval/run_eval.py` invocation은 그대로 유지됩니다.

## 7. 범위 외

- Retrieval 성능 개선, reranking, hybrid search, metadata filtering, chunking 변경은 하지 않았습니다.
- Prompt tuning, citation verifier logic, abstention classifier, self-correction도 추가하지 않았습니다.
- Private/internal real eval은 이 PR에서 실행하거나 커밋하지 않았습니다.