### PR TITLE
chore: add private real-eval readiness scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,11 @@ venv/
 # Local/private source data
 data/files/
 data/files_kordoc/
+data/private/
 data/data_list.csv
 data/data_list.xlsx
 eval/*.local.yaml
+configs/eval/*.local.yaml
 원본 데이터/
 .cache/
 .cache/real_eval/
@@ -251,6 +253,7 @@ reports/retrieval/phase4_realistic_metadata_*/*
 # via scripts/build_index.py --hwp_loader kordoc --pdf_loader kordoc
 # --embedding_backend hashing with BIDMATE_KORDOC_CACHE_DIR=data/files_kordoc.
 data/index/real100_kordoc/
+data/index-private-hardcase/
 # Issue #237 — harness aggregate snapshots. Generated per ``run_harness``
 # invocation; untracked by default to keep developer working trees
 # clean. Harness history is isolated from committed private/internal
@@ -260,6 +263,12 @@ reports/harness_history/
 # aggregate is folded into baseline.aggregate.json. Explicit ignore
 # for clarity (already caught by reports/real100/* above).
 reports/real100/judge.local.json
+reports/real100/eval_summary.json
+reports/real100/raw/
+reports/private_real_eval_summary.raw.json
+# Aggregate-only private real-eval summaries may cross the commit boundary
+# only after the exporter/governance redaction checks pass.
+!reports/private_real_eval_summary.redacted.json
 
 # ADR 0032 — routed-subset embedding comparison aggregate is committable;
 # raw per-model index dirs + trace files stay local (.routed_measurement_tmp/).
@@ -294,6 +303,7 @@ experiments/runs/
 # Naive RAG eval contract run artifacts. The contract/config/sample data are
 # committed; timestamped run outputs are reproducible and stay local.
 experiments/runs/
+experiments/private_runs/
 
 # Harness private overlays (paired with eval/*.local.yaml). Only the
 # *.example.yaml templates are committed.

--- a/docs/evaluation/private_real_eval_gold_evidence_schema.md
+++ b/docs/evaluation/private_real_eval_gold_evidence_schema.md
@@ -1,0 +1,33 @@
+# Private Real-Eval Gold Evidence Schema
+
+Gold evidence lives in ignored local JSONL, normally
+`data/private/gold_evidence.jsonl`. Every answerable question needs explicit
+evidence. Evidence derived only from `expected_terms` is not acceptable for a
+credible private retrieval(retrieval) baseline.
+
+## Required Fields
+
+| field | purpose |
+|---|---|
+| `evidence_id` | Stable anonymized id. Example: `ev_q001_001`. |
+| `question_id` | Question id this evidence supports. Example: `q001`. |
+| `doc_id` | Anonymized manifest doc id. Example: `doc_001`. |
+| `chunk_id` | Stable chunk id from the private index. Example: `doc_001::chunk-003`. |
+
+## Recommended Fields
+
+| field | purpose |
+|---|---|
+| `page` or `page_span` | Page metadata for citation checks. |
+| `support_text` | Local-only support snippet. The validator counts presence but never prints it. |
+| `support_claim` | Local-only short claim label if needed. |
+
+## Example
+
+```jsonl
+{"evidence_id":"ev_q001_001","question_id":"q001","doc_id":"doc_001","chunk_id":"doc_001::chunk-003","page_span":[4,4],"support_text":"PLACEHOLDER local-only support text"}
+```
+
+Committed summaries must not include `support_text`, raw document text, raw
+questions, raw generated answers, private filenames, or absolute local paths.
+

--- a/docs/evaluation/private_real_eval_manifest_schema.md
+++ b/docs/evaluation/private_real_eval_manifest_schema.md
@@ -1,0 +1,34 @@
+# Private Real-Eval Manifest Schema
+
+이 manifest는 private real-eval의 문서 inventory 단일 출처(source of truth)다.
+원문 파일명이나 고객명은 커밋하지 않는다. 아래 값은 모두 fake placeholder다.
+
+## Required Columns
+
+| column | purpose |
+|---|---|
+| `doc_id` | Stable anonymized document id. Example: `doc_001`. |
+| `file_path` | Local private file path, usually under ignored `data/files_kordoc/`. |
+| `document_type` | File family such as `pdf`, `hwp`, or `hwpx`. |
+| `split` | Eval split, for example `private_real_eval`. |
+
+## Recommended Columns
+
+| column | purpose |
+|---|---|
+| `page_count` | Page count when available. |
+| `source_category` | Coarse non-sensitive source bucket. |
+| `privacy_redaction` | Local handling marker such as `raw_private`. |
+| `source_digest` | Optional local digest for stale-file detection. |
+
+## Example
+
+```csv
+doc_id,file_path,document_type,split,page_count,source_category,privacy_redaction,source_digest
+doc_001,data/files_kordoc/doc_001.pdf,pdf,private_real_eval,12,rfp,raw_private,sha256-placeholder
+doc_002,data/files_kordoc/doc_002.hwp,hwp,private_real_eval,8,rfp,raw_private,sha256-placeholder
+```
+
+`support_text`, raw document text, real filenames, customer names, and absolute
+local paths must stay out of committed docs and summaries.
+

--- a/docs/evaluation/private_real_eval_question_schema.md
+++ b/docs/evaluation/private_real_eval_question_schema.md
@@ -1,0 +1,32 @@
+# Private Real-Eval Question Schema
+
+Private questions live in ignored local JSONL, normally
+`data/private/questions.jsonl`. The readiness validator reports counts only and
+does not print question text. Examples below are fake placeholders.
+
+## Required Fields
+
+| field | purpose |
+|---|---|
+| `question_id` | Stable anonymized id. Example: `q001`. |
+| `question` | Private raw question text. Must remain local-only. |
+| `answerable` | `true` when explicit gold evidence exists, `false` for abstention cases. |
+
+## Recommended Fields
+
+| field | purpose |
+|---|---|
+| `query_type` | Coarse type such as `single_doc`, `comparison`, `multi_hop`, or `abstention`. |
+| `expected_doc_ids` | Optional anonymized expected doc ids for local review. |
+| `category` | Coarse non-sensitive difficulty bucket. |
+
+## Example
+
+```jsonl
+{"question_id":"q001","question":"PLACEHOLDER private question text","answerable":true,"query_type":"single_doc","expected_doc_ids":["doc_001"]}
+{"question_id":"q002","question":"PLACEHOLDER unanswerable question text","answerable":false,"query_type":"abstention","expected_doc_ids":[]}
+```
+
+Do not commit raw questions, expected private answers, customer names, or
+question text copied from real RFP documents.
+

--- a/docs/evaluation/private_real_eval_workflow.md
+++ b/docs/evaluation/private_real_eval_workflow.md
@@ -1,0 +1,171 @@
+# Private Real-Eval Workflow
+
+Smoke eval is CI/regression only.
+Synthetic benchmark is public reproducibility and ablation only.
+Private real-eval is required for credible real-world baseline claims.
+
+이 workflow는 private data 없이 repository를 준비하는 scaffold다. 현재 이 문서는
+Naive RAG 기준선(baseline)을 측정했다는 증거가 아니며, private raw content는
+커밋하지 않는다.
+
+## Why This Exists
+
+Public smoke(smoke)와 synthetic benchmark(합성 벤치마크)는 재현성(reproducibility)과
+회귀(regression) 확인에 충분하지만, 실제 RFP 문서에서 baseline claim을 하려면
+private real-eval이 필요하다. 단, private real-eval은 문서·질문·근거(evidence)가
+민감하므로 raw output은 local-only로 두고 redacted aggregate만 검토 후 커밋한다.
+
+Required wording:
+
+- Smoke eval is CI/regression only.
+- Synthetic benchmark is public reproducibility and ablation only.
+- Private real-eval is required for credible real-world baseline claims.
+- No private raw content should be committed.
+- Redacted aggregate summaries may be committed only if they pass privacy checks.
+
+## Local File Layout
+
+```text
+eval/real_config.local.yaml
+data/data_list.csv
+data/files_kordoc/
+data/private/questions.jsonl
+data/private/gold_evidence.jsonl
+data/index/real100_kordoc/
+experiments/private_runs/
+reports/private_real_eval_summary.redacted.json
+```
+
+All raw private inputs and run artifacts above are ignored except the redacted
+summary output path, which is allowlisted only for aggregate-only summaries that
+pass privacy checks.
+
+## Config
+
+Create the local config from the committed template:
+
+```bash
+cp eval/real_config.template.yaml eval/real_config.local.yaml
+```
+
+Then edit local paths manually. Do not put machine-specific absolute paths in
+the committed template. `eval/real_config.local.yaml` is gitignored.
+
+## Gitignore Safety
+
+The scaffold expects these private paths to remain ignored:
+
+- `eval/real_config.local.yaml`
+- `configs/eval/*.local.yaml`
+- `data/files/`
+- `data/files_kordoc/`
+- `data/private/`
+- `data/data_list.csv`
+- `data/index/real100/`
+- `data/index/real100_kordoc/`
+- `data/index-private-hardcase/`
+- `experiments/private_runs/`
+- `reports/real100/eval_summary.json`
+- `reports/real100/raw/`
+- `reports/private_real_eval_summary.raw.json`
+
+## Validate Readiness
+
+```bash
+python3 scripts/check_private_real_eval_readiness.py --config eval/real_config.local.yaml
+```
+
+The validator prints a readiness verdict:
+
+- `A. Not ready`
+- `B. Config ready, data missing`
+- `C. Data present, labels/index missing`
+- `D. First baseline runnable`
+- `E. Portfolio-level readiness possible after manual review`
+
+The validator reports counts and blockers only. It does not print private
+filenames, raw questions, raw answers, support text, document text, customer
+names, or absolute local paths.
+
+## Index Build Expectation
+
+When documents and manifest are present, build the local private index under an
+ignored directory. The readiness validator prints the command shape:
+
+```bash
+python3 scripts/build_index.py \
+  --metadata_csv data/data_list.csv \
+  --files_dir data/files_kordoc \
+  --output_dir data/index/real100_kordoc \
+  --hwp_loader kordoc \
+  --pdf_loader kordoc \
+  --embedding_backend hashing
+```
+
+This is infrastructure readiness only. It does not tune retrieval(retrieval),
+reranking(reranking), prompts, chunking, verifier, or self-correction.
+
+## Run Private Naive RAG Eval
+
+```bash
+python3 scripts/run_private_real_eval.py --config eval/real_config.local.yaml
+```
+
+The wrapper calls the readiness validator first. If files are missing, it fails
+without writing private raw output. If runnable, it delegates to the existing
+Naive RAG contract and writes raw artifacts only under ignored
+`experiments/private_runs/`.
+
+## Export Redacted Summary
+
+```bash
+python3 scripts/export_private_real_eval_summary.py \
+  --run-dir experiments/private_runs/<run_id> \
+  --out reports/private_real_eval_summary.redacted.json
+```
+
+The redacted summary may include aggregate document count, chunk count, question
+count, retrieval metrics, citation metrics, answer/control metrics, latency
+metrics, failure type counts, and known limitations.
+
+The redacted summary must not include raw document text, raw questions, raw
+generated answers, `support_text`, customer names, private filenames, absolute
+local paths, or sensitive private file ids.
+
+## What Can Be Committed
+
+- `eval/real_config.template.yaml`
+- readiness/run/export scripts
+- schema docs and workflow docs
+- tests and governance checks
+- `reports/private_real_eval_summary.redacted.json` only after exporter and
+  governance privacy checks pass
+
+## What Must Never Be Committed
+
+- real private documents
+- private raw questions
+- private gold evidence
+- private raw outputs
+- `support_text`
+- customer names
+- private filenames
+- absolute local paths
+- raw generated answers
+
+## Current Readiness Status
+
+Current repository status remains **A. Not ready** until local private files are
+provided. No Naive RAG real baseline has been measured yet.
+
+## Next Manual Steps
+
+1. Copy the template to `eval/real_config.local.yaml`.
+2. Place private documents, manifest, questions, and gold evidence in ignored
+   local paths.
+3. Run the readiness validator.
+4. Build the private index if the validator reports only index blockers.
+5. Run the private Naive RAG wrapper.
+6. Export the redacted summary.
+7. Run governance and tests before committing any redacted aggregate.
+

--- a/eval/real_config.template.yaml
+++ b/eval/real_config.template.yaml
@@ -1,0 +1,54 @@
+eval_type: private_real_eval
+benchmark_type: private_real_eval
+baseline_system: naive_rag
+not_ci_smoke: true
+is_private_data: true
+
+documents_dir: data/files_kordoc
+data_list_path: data/data_list.csv
+questions_path: data/private/questions.jsonl
+gold_evidence_path: data/private/gold_evidence.jsonl
+index_dir: data/index/real100_kordoc
+output_dir: experiments/private_runs
+redacted_summary_path: reports/private_real_eval_summary.redacted.json
+
+top_k: 10
+
+metrics:
+  retrieval:
+    - recall_at_5
+    - recall_at_10
+    - mrr_at_5
+    - ndcg_at_5
+  citation:
+    - citation_accuracy
+    - citation_page_coverage
+  answer_control:
+    - rule_based_groundedness
+    - term_coverage_accuracy
+    - hallucination_flag
+    - unanswerable_detection_flag
+
+answer_metric_mode: rule_based_proxy_not_semantic_judge
+
+latency_scope:
+  query_latency: warm_in_process
+  includes_index_load: false
+  includes_ingestion: false
+  includes_index_build: false
+  report_stage_latency: true
+
+privacy_policy:
+  local_config_path: eval/real_config.local.yaml
+  no_private_raw_content_in_git: true
+  raw_outputs_must_be_gitignored: true
+  redacted_summary_only: true
+  forbidden_redacted_keys:
+    - question
+    - answer
+    - support_text
+    - document_text
+    - raw_text
+    - file_path
+    - absolute_path
+

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -227,6 +227,43 @@ PHASE4_ARTIFACT_GLOB = "reports/retrieval/phase4*"
 EVAL_PRIVACY_ARTIFACT_GLOBS = ("reports/retrieval", "reports/real100")
 _EVAL_PRIVACY_HANGUL_RE = re.compile(r"[가-힣ᄀ-ᇿ㄰-㆏ꥠ-꥿]")
 
+# Private real-eval readiness scaffold: local inputs, raw outputs, and private
+# indexes must remain ignored. The redacted aggregate summary is the only
+# default private-real output path that may cross the commit boundary after
+# exporter + governance checks pass.
+PRIVATE_REAL_EVAL_REQUIRED_IGNORES: tuple[str, ...] = (
+    "eval/real_config.local.yaml",
+    "configs/eval/private_real_eval.local.yaml",
+    "data/files/",
+    "data/files_kordoc/",
+    "data/private/",
+    "data/data_list.csv",
+    "data/index/real100/",
+    "data/index/real100_kordoc/",
+    "data/index-private-hardcase/",
+    "experiments/private_runs/",
+    "reports/real100/eval_summary.json",
+    "reports/real100/raw/",
+    "reports/private_real_eval_summary.raw.json",
+)
+PRIVATE_REAL_EVAL_REDACTED_SUMMARIES: tuple[str, ...] = (
+    "reports/private_real_eval_summary.redacted.json",
+)
+PRIVATE_REDACTED_FORBIDDEN_KEYS: frozenset[str] = frozenset(
+    {
+        "question",
+        "answer",
+        "support_text",
+        "document_text",
+        "raw_text",
+        "file_path",
+        "absolute_path",
+    }
+)
+_ABSOLUTE_LOCAL_PATH_RE = re.compile(
+    r"(^|[\s'\"])/(Users|home|private|var|tmp|Volumes)/[^\s'\"]+"
+)
+
 # Issue #818: detection-only relaxation. The kebab-lowercase slug remains the
 # *convention* (see ``docs/adr/README.md`` File layout), but the live bug
 # discovery on ``0044-realN-eval-case-expansion.md`` showed that a strict
@@ -1471,31 +1508,164 @@ def scan_eval_artifacts_for_private_text(
     return violations
 
 
+def _git_check_ignored(repo_root: str, rel_path: str) -> bool:
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo_root, "check-ignore", "-q", "--", rel_path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
+def private_real_eval_gitignore_violations(repo_root: str = ".") -> dict[str, list[str]]:
+    """Return private real-eval path ignore drift.
+
+    ``missing_ignored`` entries are local/private paths that must be ignored.
+    ``unexpectedly_ignored`` entries are redacted aggregate paths that must be
+    committable after privacy checks.
+    """
+    missing_ignored = [
+        rel
+        for rel in PRIVATE_REAL_EVAL_REQUIRED_IGNORES
+        if not _git_check_ignored(repo_root, rel)
+    ]
+    unexpectedly_ignored = [
+        rel
+        for rel in PRIVATE_REAL_EVAL_REDACTED_SUMMARIES
+        if _git_check_ignored(repo_root, rel)
+    ]
+    out: dict[str, list[str]] = {}
+    if missing_ignored:
+        out["missing_ignored"] = missing_ignored
+    if unexpectedly_ignored:
+        out["unexpectedly_ignored"] = unexpectedly_ignored
+    return out
+
+
+def find_redacted_summary_forbidden_fields(obj: object) -> dict[str, int]:
+    """Scan a redacted summary candidate for forbidden raw/private keys.
+
+    This is intentionally exact-key based for the requested contract:
+    ``question`` is forbidden, while aggregate names such as
+    ``question_count`` remain valid.
+    """
+    found: dict[str, int] = {}
+
+    def _bump(sig: str, n: int = 1) -> None:
+        found[sig] = found.get(sig, 0) + n
+
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                key_text = str(key).lower()
+                if key_text in PRIVATE_REDACTED_FORBIDDEN_KEYS:
+                    _bump(key_text)
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+        elif isinstance(node, str):
+            if _ABSOLUTE_LOCAL_PATH_RE.search(node):
+                _bump("absolute_path_value")
+
+    _walk(obj)
+    return found
+
+
+def redacted_summary_artifact_paths(repo_root: str = ".") -> list[str]:
+    """Return tracked or present redacted private summary JSON paths."""
+    import subprocess
+
+    paths: set[str] = set()
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", repo_root, "ls-files", *PRIVATE_REAL_EVAL_REDACTED_SUMMARIES],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        paths.update(p for p in out.splitlines() if p.endswith(".json"))
+    except (subprocess.CalledProcessError, OSError):
+        pass
+    for rel in PRIVATE_REAL_EVAL_REDACTED_SUMMARIES:
+        if (Path(repo_root) / rel).is_file():
+            paths.add(rel)
+    return sorted(paths)
+
+
+def scan_redacted_summaries_for_forbidden_fields(
+    repo_root: str = ".",
+) -> list[tuple[str, dict[str, int]]]:
+    import json
+
+    violations: list[tuple[str, dict[str, int]]] = []
+    for rel in redacted_summary_artifact_paths(repo_root):
+        try:
+            data = json.loads((Path(repo_root) / rel).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        found = find_redacted_summary_forbidden_fields(data)
+        if found:
+            violations.append((rel, found))
+    return violations
+
+
 def _cmd_check_eval_privacy(repo_root: str) -> int:
     violations = scan_eval_artifacts_for_private_text(repo_root)
-    if not violations:
+    ignore_violations = private_real_eval_gitignore_violations(repo_root)
+    redacted_violations = scan_redacted_summaries_for_forbidden_fields(repo_root)
+    if not violations and not ignore_violations and not redacted_violations:
         return 0
     # Print signature names + counts only — never the offending text itself.
-    sys.stderr.write(
-        "\n❌ Eval artifact privacy gate: committed eval-data JSON carries "
-        "private text.\n\n"
-        "   Committable eval artifacts must hold qid + categories + metric "
-        "values only (ADR 0005 private-local + ADR 0065). These git-tracked "
-        "files break that boundary:\n\n"
-    )
-    for rel, found in violations:
-        detail = ", ".join(f"{k}×{n}" for k, n in sorted(found.items()))
-        sys.stderr.write(f"     - {rel}: {detail}\n")
-    sys.stderr.write(
-        "\n   `hangul` = Korean text (agency/사업명) in a qid or value; "
-        "`colon_keys` = un-stripped retry-reason payload "
-        "(`missing_comparison_*:<agency-or-docid>`).\n"
-        "   Fix: regenerate with the sanitized generators — ablation runners "
-        "write `anon_qid(qid)`, run_real_eval_delta strips retry-reason "
-        "payloads, eda_real100 anonymizes every agency rank — or migrate the "
-        "tracked file in place. Raw labels / query text stay local "
-        "(gitignored).\n\n"
-    )
+    if violations:
+        sys.stderr.write(
+            "\n❌ Eval artifact privacy gate: committed eval-data JSON carries "
+            "private text.\n\n"
+            "   Committable eval artifacts must hold qid + categories + metric "
+            "values only (ADR 0005 private-local + ADR 0065). These git-tracked "
+            "files break that boundary:\n\n"
+        )
+        for rel, found in violations:
+            detail = ", ".join(f"{k}×{n}" for k, n in sorted(found.items()))
+            sys.stderr.write(f"     - {rel}: {detail}\n")
+        sys.stderr.write(
+            "\n   `hangul` = Korean text (agency/사업명) in a qid or value; "
+            "`colon_keys` = un-stripped retry-reason payload "
+            "(`missing_comparison_*:<agency-or-docid>`).\n"
+            "   Fix: regenerate with the sanitized generators — ablation runners "
+            "write `anon_qid(qid)`, run_real_eval_delta strips retry-reason "
+            "payloads, eda_real100 anonymizes every agency rank — or migrate the "
+            "tracked file in place. Raw labels / query text stay local "
+            "(gitignored).\n\n"
+        )
+    if ignore_violations:
+        sys.stderr.write(
+            "\n❌ Private real-eval gitignore gate: local private paths are not "
+            "covered correctly.\n\n"
+        )
+        for rel in ignore_violations.get("missing_ignored", []):
+            sys.stderr.write(f"     - must be ignored: {rel}\n")
+        for rel in ignore_violations.get("unexpectedly_ignored", []):
+            sys.stderr.write(f"     - redacted summary should be committable after checks: {rel}\n")
+        sys.stderr.write("\n")
+    if redacted_violations:
+        sys.stderr.write(
+            "\n❌ Redacted private real-eval summary gate: forbidden raw/private "
+            "fields are present.\n\n"
+        )
+        for rel, found in redacted_violations:
+            detail = ", ".join(f"{k}×{n}" for k, n in sorted(found.items()))
+            sys.stderr.write(f"     - {rel}: {detail}\n")
+        sys.stderr.write(
+            "\n   Redacted summaries may include aggregate counts/metrics only. "
+            "Raw question, answer, support_text, document_text, raw_text, "
+            "file_path, and absolute_path fields stay local.\n\n"
+        )
     return 1
 
 
@@ -1637,8 +1807,10 @@ def main() -> int:
         help="Structurally scan git-tracked reports/retrieval/ + "
              "reports/real100/ JSON for private text (Hangul anywhere, or "
              "colon-bearing dict keys) that breaks the ADR 0005 / ADR 0065 "
-             "committable boundary; exit 1 with offending files + signature "
-             "counts (never the text) if any are found. Uses no name list.",
+             "committable boundary; also verify private real-eval local paths "
+             "are gitignored and redacted private summaries omit forbidden raw "
+             "keys; exit 1 with offending files + signature counts (never the "
+             "text) if any are found. Uses no name list.",
     )
     g.add_argument(
         "--proposed-adr-age", action="store_true",

--- a/scripts/check_private_real_eval_readiness.py
+++ b/scripts/check_private_real_eval_readiness.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Local-only readiness validator for private Naive RAG real-eval inputs.
+
+The validator reports structure, counts, and privacy safety only. It never
+prints raw questions, document names, support text, generated answers, or
+customer-specific paths.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import asdict, dataclass, field
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Iterable, Mapping
+
+import yaml
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+REQUIRED_CONFIG_FIELDS = (
+    "documents_dir",
+    "data_list_path",
+    "questions_path",
+    "gold_evidence_path",
+    "index_dir",
+    "output_dir",
+    "redacted_summary_path",
+    "top_k",
+    "metrics",
+    "answer_metric_mode",
+    "latency_scope",
+    "privacy_policy",
+)
+PRIVATE_MANIFEST_COLUMNS = {"doc_id", "file_path"}
+LEGACY_MANIFEST_COLUMNS = {"공고 번호", "사업명", "발주 기관", "파일형식", "파일명", "텍스트"}
+RUNNABLE_MIN_ANSWERABLE = 10
+RUNNABLE_MIN_UNANSWERABLE = 3
+PORTFOLIO_MIN_QUESTIONS = 100
+PORTFOLIO_MIN_DOCUMENTS = 50
+
+PRIVATE_PATHS_THAT_MUST_BE_IGNORED = (
+    "eval/real_config.local.yaml",
+    "configs/eval/private_real_eval.local.yaml",
+    "data/files/",
+    "data/files_kordoc/",
+    "data/private/",
+    "data/data_list.csv",
+    "data/index/real100/",
+    "data/index/real100_kordoc/",
+    "data/index-private-hardcase/",
+    "experiments/private_runs/",
+    "reports/real100/eval_summary.json",
+    "reports/real100/raw/",
+    "reports/private_real_eval_summary.raw.json",
+)
+
+VERDICT_LABELS = {
+    "A": "A. Not ready",
+    "B": "B. Config ready, data missing",
+    "C": "C. Data present, labels/index missing",
+    "D": "D. First baseline runnable",
+    "E": "E. Portfolio-level readiness possible after manual review",
+}
+
+
+@dataclass
+class ReadinessReport:
+    verdict: str
+    ready_to_run: bool
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    counts: dict[str, Any] = field(default_factory=dict)
+    checks: dict[str, Any] = field(default_factory=dict)
+    build_command_available: bool = False
+    build_command: list[str] = field(default_factory=list)
+
+    @property
+    def verdict_label(self) -> str:
+        return VERDICT_LABELS[self.verdict]
+
+    def to_json(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["verdict_label"] = self.verdict_label
+        return payload
+
+
+def _repo_path(value: str | Path, repo_root: Path = ROOT_DIR) -> Path:
+    path = Path(str(value))
+    return path if path.is_absolute() else repo_root / path
+
+
+def _relative_to_repo(path: Path, repo_root: Path = ROOT_DIR) -> str | None:
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return None
+
+
+def _load_yaml(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return None, "config file is missing"
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        return None, f"config YAML is invalid: {exc.__class__.__name__}"
+    if not isinstance(payload, dict):
+        return None, "config root must be a mapping"
+    return payload, None
+
+
+def _boolish(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _jsonl_rows(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    rows: list[dict[str, Any]] = []
+    errors: list[str] = []
+    if not path.exists():
+        return rows, ["file is missing"]
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            errors.append(f"invalid JSONL at line {lineno}")
+            continue
+        if not isinstance(payload, dict):
+            errors.append(f"JSONL row at line {lineno} is not an object")
+            continue
+        rows.append(payload)
+    return rows, errors
+
+
+def _is_git_ignored(path: Path, repo_root: Path = ROOT_DIR) -> tuple[bool, str]:
+    rel = _relative_to_repo(path, repo_root)
+    if rel is None:
+        return True, "outside_repo"
+    candidates = [rel]
+    if not rel.endswith("/"):
+        candidates.append(rel + "/")
+        candidates.append(rel + "/.private-real-eval-sentinel")
+    for candidate in candidates:
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", "--", candidate],
+            cwd=repo_root,
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            return True, "gitignored"
+        if result.returncode not in (0, 1):
+            return False, "git_check_failed"
+    return False, "not_ignored"
+
+
+def _safe_path_for_manifest(value: str, documents_dir: Path, repo_root: Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    if value.startswith("data/") or value.startswith("./data/"):
+        return _repo_path(path, repo_root)
+    return documents_dir / path
+
+
+def _manifest_doc_id(row: Mapping[str, Any]) -> str:
+    for key in ("doc_id", "공고 번호", "notice_id"):
+        value = str(row.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _manifest_file_path(row: Mapping[str, Any]) -> str:
+    for key in ("file_path", "파일명", "file_name"):
+        value = str(row.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _page_metadata_present(item: Mapping[str, Any]) -> bool:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), Mapping) else {}
+    for node in (item, metadata):
+        for key in ("page", "page_number", "page_span", "page_start", "page_end", "pages"):
+            value = node.get(key)
+            if value not in (None, "", []):
+                return True
+    return False
+
+
+def _index_counts(payload: Mapping[str, Any]) -> tuple[int | None, int | None]:
+    build = payload.get("build") if isinstance(payload.get("build"), Mapping) else {}
+    docs = build.get("num_documents")
+    chunks = build.get("num_chunks")
+    if docs is None:
+        docs = len(payload.get("documents") or []) if isinstance(payload.get("documents"), list) else None
+    if chunks is None:
+        chunks = len(payload.get("chunks") or []) if isinstance(payload.get("chunks"), list) else None
+    try:
+        doc_count = int(docs) if docs is not None else None
+    except (TypeError, ValueError):
+        doc_count = None
+    try:
+        chunk_count = int(chunks) if chunks is not None else None
+    except (TypeError, ValueError):
+        chunk_count = None
+    return doc_count, chunk_count
+
+
+def _evidence_items(row: Mapping[str, Any]) -> Iterable[dict[str, Any]]:
+    wrapped = row.get("gold_evidence")
+    if isinstance(wrapped, list):
+        for item in wrapped:
+            if isinstance(item, dict):
+                merged = dict(item)
+                if "question_id" not in merged and row.get("question_id"):
+                    merged["question_id"] = row.get("question_id")
+                yield merged
+        return
+    yield dict(row)
+
+
+def _derived_from_expected_terms(item: Mapping[str, Any]) -> bool:
+    marker = str(item.get("derived_from") or item.get("source") or item.get("method") or "").lower()
+    if "expected_terms" in marker:
+        return True
+    return bool(item.get("expected_terms")) and not (item.get("doc_id") and item.get("chunk_id"))
+
+
+def assess_readiness(config_path: Path, repo_root: Path = ROOT_DIR) -> ReadinessReport:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    counts: dict[str, Any] = {
+        "document_count": 0,
+        "manifest_rows": 0,
+        "manifest_missing_files": 0,
+        "question_count": 0,
+        "answerable_count": 0,
+        "unanswerable_count": 0,
+        "gold_evidence_count": 0,
+        "gold_evidence_with_page_metadata": 0,
+        "gold_evidence_with_support_text": 0,
+        "index_document_count": None,
+        "chunk_count": None,
+        "chunk_top_k_ratio": None,
+    }
+    checks: dict[str, Any] = {}
+
+    config_path = _repo_path(config_path, repo_root)
+    config, config_error = _load_yaml(config_path)
+    if config_error:
+        blockers.append("config_file_missing_or_invalid")
+        return ReadinessReport("A", False, blockers, warnings, counts, {"config": config_error})
+
+    assert config is not None
+    config_blockers: list[str] = []
+    if not (
+        config.get("eval_type") == "private_real_eval"
+        or config.get("benchmark_type") == "private_real_eval"
+    ):
+        config_blockers.append("eval_type_or_benchmark_type_must_be_private_real_eval")
+    if config.get("baseline_system") != "naive_rag":
+        config_blockers.append("baseline_system_must_be_naive_rag")
+    if not _boolish(config.get("not_ci_smoke")):
+        config_blockers.append("not_ci_smoke_must_be_true")
+    if not _boolish(config.get("is_private_data")):
+        config_blockers.append("is_private_data_must_be_true")
+    missing_fields = [field for field in REQUIRED_CONFIG_FIELDS if field not in config]
+    if missing_fields:
+        config_blockers.append("required_config_fields_missing")
+    try:
+        top_k = int(config.get("top_k") or 0)
+    except (TypeError, ValueError):
+        top_k = 0
+    if top_k <= 0:
+        config_blockers.append("top_k_must_be_positive")
+    checks["config"] = {
+        "ok": not config_blockers,
+        "missing_field_count": len(missing_fields),
+        "top_k": top_k,
+    }
+    blockers.extend(config_blockers)
+
+    path_fields = {
+        "documents_dir": config.get("documents_dir"),
+        "data_list_path": config.get("data_list_path"),
+        "questions_path": config.get("questions_path"),
+        "gold_evidence_path": config.get("gold_evidence_path"),
+        "index_dir": config.get("index_dir"),
+        "output_dir": config.get("output_dir"),
+        "redacted_summary_path": config.get("redacted_summary_path"),
+    }
+    if any(not value for value in path_fields.values()):
+        blockers.append("required_path_field_missing")
+        return ReadinessReport("A", False, blockers, warnings, counts, checks)
+
+    documents_dir = _repo_path(str(path_fields["documents_dir"]), repo_root)
+    data_list_path = _repo_path(str(path_fields["data_list_path"]), repo_root)
+    questions_path = _repo_path(str(path_fields["questions_path"]), repo_root)
+    gold_path = _repo_path(str(path_fields["gold_evidence_path"]), repo_root)
+    index_dir = _repo_path(str(path_fields["index_dir"]), repo_root)
+    output_dir = _repo_path(str(path_fields["output_dir"]), repo_root)
+    redacted_summary_path = _repo_path(str(path_fields["redacted_summary_path"]), repo_root)
+
+    for label, candidate in (
+        ("local_config", config_path),
+        ("documents_dir", documents_dir),
+        ("data_list_path", data_list_path),
+        ("questions_path", questions_path),
+        ("gold_evidence_path", gold_path),
+        ("index_dir", index_dir),
+        ("output_dir", output_dir),
+    ):
+        ignored, source = _is_git_ignored(candidate, repo_root)
+        checks.setdefault("privacy", {})[label] = source
+        if not ignored:
+            blockers.append(f"{label}_must_be_gitignored_or_outside_repo")
+
+    for rel in PRIVATE_PATHS_THAT_MUST_BE_IGNORED:
+        ignored, source = _is_git_ignored(repo_root / rel, repo_root)
+        checks.setdefault("privacy", {})[rel] = source
+        if not ignored:
+            blockers.append(f"private_path_not_gitignored:{rel}")
+
+    redacted_ignored, redacted_source = _is_git_ignored(redacted_summary_path, repo_root)
+    checks.setdefault("privacy", {})["redacted_summary_path"] = redacted_source
+    if redacted_ignored:
+        blockers.append("redacted_summary_path_must_be_committable_after_checks")
+    if not redacted_summary_path.name.endswith(".redacted.json"):
+        blockers.append("redacted_summary_path_must_end_with_redacted_json")
+
+    data_blockers: list[str] = []
+    manifest_doc_ids: set[str] = set()
+    if not documents_dir.is_dir():
+        data_blockers.append("documents_dir_missing")
+    if not data_list_path.is_file():
+        data_blockers.append("data_list_path_missing")
+    if documents_dir.is_dir() and data_list_path.is_file():
+        with data_list_path.open("r", encoding="utf-8-sig", newline="") as f:
+            reader = csv.DictReader(f)
+            columns = set(reader.fieldnames or [])
+            private_schema = PRIVATE_MANIFEST_COLUMNS.issubset(columns)
+            legacy_schema = LEGACY_MANIFEST_COLUMNS.issubset(columns)
+            checks["manifest_schema"] = (
+                "private_real_eval_v1" if private_schema else "legacy_data_list" if legacy_schema else "unknown"
+            )
+            if not (private_schema or legacy_schema):
+                data_blockers.append("data_list_required_columns_missing")
+            seen_doc_ids: set[str] = set()
+            duplicate_doc_ids = 0
+            missing_doc_ids = 0
+            missing_files = 0
+            rows = list(reader)
+            counts["manifest_rows"] = len(rows)
+            for row in rows:
+                doc_id = _manifest_doc_id(row)
+                file_value = _manifest_file_path(row)
+                if not doc_id:
+                    missing_doc_ids += 1
+                elif doc_id in seen_doc_ids:
+                    duplicate_doc_ids += 1
+                else:
+                    seen_doc_ids.add(doc_id)
+                    manifest_doc_ids.add(doc_id)
+                if not file_value or not _safe_path_for_manifest(file_value, documents_dir, repo_root).exists():
+                    missing_files += 1
+            counts["document_count"] = len(manifest_doc_ids) or len(rows)
+            counts["manifest_missing_files"] = missing_files
+            if missing_doc_ids:
+                data_blockers.append("manifest_doc_id_values_missing")
+            if duplicate_doc_ids:
+                data_blockers.append("manifest_doc_id_values_not_unique")
+            if missing_files:
+                data_blockers.append("manifest_referenced_files_missing")
+    blockers.extend(data_blockers)
+
+    question_blockers: list[str] = []
+    question_rows, question_errors = _jsonl_rows(questions_path)
+    if question_errors:
+        question_blockers.extend(f"questions_{error.replace(' ', '_')}" for error in question_errors[:3])
+    question_ids: set[str] = set()
+    duplicate_question_ids = 0
+    missing_question_ids = 0
+    answerable_ids: set[str] = set()
+    for row in question_rows:
+        qid = str(row.get("question_id") or "").strip()
+        if not qid:
+            missing_question_ids += 1
+            continue
+        if qid in question_ids:
+            duplicate_question_ids += 1
+        question_ids.add(qid)
+        answerable = _boolish(row.get("answerable", True))
+        if answerable:
+            answerable_ids.add(qid)
+    counts["question_count"] = len(question_rows)
+    counts["answerable_count"] = len(answerable_ids)
+    counts["unanswerable_count"] = len(question_rows) - len(answerable_ids)
+    if missing_question_ids:
+        question_blockers.append("question_ids_missing")
+    if duplicate_question_ids:
+        question_blockers.append("question_ids_not_unique")
+    if question_rows and counts["answerable_count"] < RUNNABLE_MIN_ANSWERABLE:
+        question_blockers.append("answerable_question_count_below_naive_runner_minimum")
+    if question_rows and counts["unanswerable_count"] < RUNNABLE_MIN_UNANSWERABLE:
+        question_blockers.append("unanswerable_question_count_below_naive_runner_minimum")
+    blockers.extend(question_blockers)
+
+    gold_blockers: list[str] = []
+    gold_rows, gold_errors = _jsonl_rows(gold_path)
+    if gold_errors:
+        gold_blockers.extend(f"gold_evidence_{error.replace(' ', '_')}" for error in gold_errors[:3])
+    evidence_ids: set[str] = set()
+    duplicate_evidence_ids = 0
+    missing_evidence_ids = 0
+    explicit_by_question: dict[str, int] = {}
+    invalid_doc_refs = 0
+    derived_gold = 0
+    for row in gold_rows:
+        for item in _evidence_items(row):
+            qid = str(item.get("question_id") or row.get("question_id") or "").strip()
+            evidence_id = str(item.get("evidence_id") or "").strip()
+            if not evidence_id:
+                missing_evidence_ids += 1
+            elif evidence_id in evidence_ids:
+                duplicate_evidence_ids += 1
+            else:
+                evidence_ids.add(evidence_id)
+            if _derived_from_expected_terms(item):
+                derived_gold += 1
+            doc_id = str(item.get("doc_id") or "").strip()
+            chunk_id = str(item.get("chunk_id") or "").strip()
+            if doc_id and manifest_doc_ids and doc_id not in manifest_doc_ids:
+                invalid_doc_refs += 1
+            if qid and doc_id and chunk_id:
+                explicit_by_question[qid] = explicit_by_question.get(qid, 0) + 1
+            if _page_metadata_present(item):
+                counts["gold_evidence_with_page_metadata"] += 1
+            if str(item.get("support_text") or "").strip():
+                counts["gold_evidence_with_support_text"] += 1
+    counts["gold_evidence_count"] = len(evidence_ids)
+    if missing_evidence_ids:
+        gold_blockers.append("gold_evidence_ids_missing")
+    if duplicate_evidence_ids:
+        gold_blockers.append("gold_evidence_ids_not_unique")
+    if derived_gold:
+        gold_blockers.append("gold_evidence_must_not_be_derived_from_expected_terms")
+    if invalid_doc_refs:
+        gold_blockers.append("gold_evidence_doc_id_references_invalid")
+    if answerable_ids:
+        missing_gold_for_answerable = sorted(qid for qid in answerable_ids if explicit_by_question.get(qid, 0) == 0)
+        if missing_gold_for_answerable:
+            gold_blockers.append("answerable_questions_missing_explicit_gold_evidence")
+    blockers.extend(gold_blockers)
+
+    index_blockers: list[str] = []
+    build_script = repo_root / "scripts" / "build_index.py"
+    build_command_available = build_script.exists()
+    build_command = [
+        "python3",
+        "scripts/build_index.py",
+        "--metadata_csv",
+        "<data_list_path>",
+        "--files_dir",
+        "<documents_dir>",
+        "--output_dir",
+        "<index_dir>",
+        "--hwp_loader",
+        "kordoc",
+        "--pdf_loader",
+        "kordoc",
+        "--embedding_backend",
+        "hashing",
+    ]
+    if not index_dir.is_dir():
+        index_blockers.append("index_dir_missing")
+    else:
+        index_json = index_dir / "index.json"
+        if not index_json.is_file():
+            index_blockers.append("index_metadata_missing")
+        else:
+            try:
+                payload = json.loads(index_json.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                payload = {}
+                index_blockers.append("index_metadata_invalid_json")
+            if isinstance(payload, dict):
+                doc_count, chunk_count = _index_counts(payload)
+                counts["index_document_count"] = doc_count
+                counts["chunk_count"] = chunk_count
+                if chunk_count is not None and top_k:
+                    counts["chunk_top_k_ratio"] = round(chunk_count / top_k, 3)
+                chunks = payload.get("chunks") if isinstance(payload.get("chunks"), list) else []
+                if chunks:
+                    chunk_id_coverage = sum(1 for chunk in chunks if isinstance(chunk, dict) and chunk.get("chunk_id"))
+                    doc_id_coverage = sum(1 for chunk in chunks if isinstance(chunk, dict) and chunk.get("doc_id"))
+                    page_coverage = sum(
+                        1 for chunk in chunks if isinstance(chunk, dict) and _page_metadata_present(chunk)
+                    )
+                    checks["index_metadata"] = {
+                        "chunk_id_coverage": f"{chunk_id_coverage}/{len(chunks)}",
+                        "doc_id_coverage": f"{doc_id_coverage}/{len(chunks)}",
+                        "page_metadata_coverage": f"{page_coverage}/{len(chunks)}",
+                    }
+                    if chunk_id_coverage != len(chunks):
+                        index_blockers.append("index_chunk_id_metadata_incomplete")
+                    if doc_id_coverage != len(chunks):
+                        index_blockers.append("index_doc_id_metadata_incomplete")
+    blockers.extend(index_blockers)
+
+    data_present = documents_dir.is_dir() and data_list_path.is_file() and not data_blockers
+    labels_present = bool(question_rows) and bool(gold_rows) and not question_blockers and not gold_blockers
+    index_ready = index_dir.is_dir() and not index_blockers
+    config_ok = not config_blockers and not any(
+        b.endswith("_must_be_gitignored_or_outside_repo")
+        or b.startswith("private_path_not_gitignored:")
+        or b.startswith("redacted_summary_path")
+        for b in blockers
+    )
+    ready_to_run = config_ok and data_present and labels_present and index_ready
+
+    if not config_ok:
+        verdict = "A"
+    elif not data_present:
+        verdict = "B"
+    elif not (labels_present and index_ready):
+        verdict = "C"
+    elif (
+        counts["question_count"] >= PORTFOLIO_MIN_QUESTIONS
+        and counts["document_count"] >= PORTFOLIO_MIN_DOCUMENTS
+    ):
+        verdict = "E"
+        warnings.append("portfolio_readiness_still_requires_manual_privacy_and_label_review")
+    else:
+        verdict = "D"
+
+    return ReadinessReport(
+        verdict,
+        ready_to_run,
+        blockers,
+        warnings,
+        counts,
+        checks,
+        build_command_available,
+        build_command,
+    )
+
+
+def _render_report(report: ReadinessReport) -> str:
+    lines = [f"Private real-eval readiness verdict: {report.verdict_label}", ""]
+    lines.append("Counts:")
+    for key in (
+        "document_count",
+        "manifest_rows",
+        "manifest_missing_files",
+        "question_count",
+        "answerable_count",
+        "unanswerable_count",
+        "gold_evidence_count",
+        "gold_evidence_with_page_metadata",
+        "gold_evidence_with_support_text",
+        "index_document_count",
+        "chunk_count",
+        "chunk_top_k_ratio",
+    ):
+        lines.append(f"- {key}: {report.counts.get(key)}")
+    if report.blockers:
+        lines.extend(["", "Blockers:"])
+        for blocker in report.blockers:
+            lines.append(f"- {blocker}")
+    if report.warnings:
+        lines.extend(["", "Warnings:"])
+        for warning in report.warnings:
+            lines.append(f"- {warning}")
+    if report.build_command_available:
+        lines.extend(["", "Index build command shape:"])
+        lines.append("$ " + " ".join(report.build_command))
+    lines.extend(
+        [
+            "",
+            "Privacy note: raw document names, question text, answer text, support_text, and absolute local paths are omitted.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="eval/real_config.local.yaml")
+    parser.add_argument("--json", action="store_true", help="Emit sanitized machine-readable readiness JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = assess_readiness(Path(args.config))
+    if args.json:
+        print(json.dumps(report.to_json(), ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(_render_report(report))
+    return 0 if report.ready_to_run else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_private_real_eval_summary.py
+++ b/scripts/export_private_real_eval_summary.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Export an aggregate-only redacted private real-eval summary."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+FORBIDDEN_REDACTED_KEYS = {
+    "question",
+    "answer",
+    "support_text",
+    "document_text",
+    "raw_text",
+    "file_path",
+    "absolute_path",
+}
+ABSOLUTE_PATH_RE = re.compile(r"(^|[\s'\"])/(Users|home|private|var|tmp|Volumes)/[^\s'\"]+")
+
+
+def _repo_path(value: str | Path) -> Path:
+    path = Path(str(value))
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path.name}")
+    return payload
+
+
+def _forbidden_hits(obj: Any, *, path: str = "$", include_absolute_values: bool = True) -> list[str]:
+    hits: list[str] = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            key_text = str(key)
+            if key_text.lower() in FORBIDDEN_REDACTED_KEYS:
+                hits.append(f"{path}.{key_text}")
+            hits.extend(
+                _forbidden_hits(
+                    value,
+                    path=f"{path}.{key_text}",
+                    include_absolute_values=include_absolute_values,
+                )
+            )
+    elif isinstance(obj, list):
+        for idx, item in enumerate(obj):
+            hits.extend(
+                _forbidden_hits(
+                    item,
+                    path=f"{path}[{idx}]",
+                    include_absolute_values=include_absolute_values,
+                )
+            )
+    elif isinstance(obj, str):
+        if include_absolute_values and ABSOLUTE_PATH_RE.search(obj):
+            hits.append(f"{path}:absolute_path_value")
+    return hits
+
+
+def _metric_block(metrics: dict[str, Any], key: str) -> Any:
+    value = metrics.get(key)
+    if isinstance(value, dict):
+        return value
+    return None
+
+
+def _redacted_run_id(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+    return f"redacted_{digest}"
+
+
+def build_redacted_summary(metrics: dict[str, Any]) -> dict[str, Any]:
+    dataset = metrics.get("dataset") if isinstance(metrics.get("dataset"), dict) else {}
+    retrieval = metrics.get("retrieval_metrics") if isinstance(metrics.get("retrieval_metrics"), dict) else {}
+    answer = metrics.get("answer_metrics") if isinstance(metrics.get("answer_metrics"), dict) else {}
+    failure_counts = metrics.get("failure_counts") if isinstance(metrics.get("failure_counts"), dict) else {}
+    latency = metrics.get("latency_metrics") if isinstance(metrics.get("latency_metrics"), dict) else {}
+
+    return {
+        "schema_version": 1,
+        "eval_type": "private_real_eval",
+        "benchmark_type": "private_real_eval",
+        "baseline_system": "naive_rag",
+        "run_id": _redacted_run_id(metrics.get("run_id")),
+        "run_id_redacted": bool(str(metrics.get("run_id") or "").strip()),
+        "document_count": metrics.get("document_count"),
+        "chunk_count": metrics.get("chunk_count"),
+        "question_count": dataset.get("num_questions"),
+        "answerable_count": dataset.get("answerable_count"),
+        "unanswerable_count": dataset.get("unanswerable_count"),
+        "aggregate_retrieval_metrics": retrieval,
+        "aggregate_citation_metrics": {
+            "citation_accuracy": _metric_block(answer, "citation_accuracy"),
+        },
+        "aggregate_answer_control_metrics": {
+            "rule_based_groundedness": _metric_block(answer, "faithfulness"),
+            "term_coverage_accuracy": _metric_block(answer, "answer_relevancy"),
+            "hallucination_flag": _metric_block(answer, "hallucination_flag"),
+            "unanswerable_detection_flag": _metric_block(answer, "unanswerable_detection_flag"),
+        },
+        "aggregate_latency_metrics": latency,
+        "failure_type_counts": failure_counts,
+        "known_limitations": [
+            "No raw document text, questions, generated answers, support_text, filenames, or absolute local paths are included.",
+            "rule_based_groundedness and term_coverage_accuracy are deterministic proxy metrics, not semantic judge metrics.",
+            "Private real-eval aggregate summaries require manual privacy review before commit.",
+        ],
+    }
+
+
+def export_summary(run_dir: Path, out_path: Path) -> dict[str, Any]:
+    if not out_path.name.endswith(".redacted.json"):
+        raise ValueError("--out must end with .redacted.json")
+    metrics_path = run_dir / "metrics.json"
+    if not metrics_path.is_file():
+        raise FileNotFoundError("run_dir must contain metrics.json")
+    metrics = _load_json(metrics_path)
+    source_hits = _forbidden_hits(metrics, include_absolute_values=False)
+    if source_hits:
+        raise ValueError(
+            "source metrics.json contains forbidden raw/private keys; refusing export: "
+            + ", ".join(source_hits[:5])
+        )
+    summary = build_redacted_summary(metrics)
+    summary_hits = _forbidden_hits(summary)
+    if summary_hits:
+        raise ValueError(
+            "redacted summary contains forbidden raw/private keys: "
+            + ", ".join(summary_hits[:5])
+        )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--out", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        summary = export_summary(_repo_path(args.run_dir), _repo_path(args.out))
+    except Exception as exc:
+        print(f"[ERROR] redacted summary export failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "Wrote redacted private real-eval summary "
+        f"for run_id={summary.get('run_id') or '<unset>'}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/real_eval_paths.py
+++ b/scripts/real_eval_paths.py
@@ -20,6 +20,11 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+try:
+    from scripts._governance import private_real_eval_gitignore_violations
+except ImportError:  # pragma: no cover - direct script execution
+    from _governance import private_real_eval_gitignore_violations  # type: ignore
+
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 PRIVATE_REAL_MIN_DOCS = 50
@@ -458,6 +463,11 @@ def missing_required(entries: Sequence[PathEntry]) -> list[PathEntry]:
     return [e for e in entries if e.required_before_run and not e.exists]
 
 
+def privacy_guard_violations(repo_root: Path | str = ROOT_DIR) -> dict[str, list[str]]:
+    """Return private real-eval gitignore drift from the governance SSoT."""
+    return private_real_eval_gitignore_violations(str(repo_root))
+
+
 def _table(entries: Sequence[PathEntry]) -> str:
     headers = [
         "name",
@@ -561,6 +571,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             "REAL_EVAL_* env vars at the private eval root.",
             file=sys.stderr,
         )
+        return 1
+    privacy_violations = privacy_guard_violations(ROOT_DIR)
+    if privacy_violations:
+        print("\nPrivate real-eval privacy guard violations:", file=sys.stderr)
+        for rel in privacy_violations.get("missing_ignored", []):
+            print(f"- must be ignored: {rel}", file=sys.stderr)
+        for rel in privacy_violations.get("unexpectedly_ignored", []):
+            print(f"- redacted summary should be committable after checks: {rel}", file=sys.stderr)
         return 1
     invalid = [e for e in entries if e.status == "invalid"]
     if invalid:

--- a/scripts/run_private_real_eval.py
+++ b/scripts/run_private_real_eval.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Safe wrapper for the private Naive RAG real-eval run.
+
+The wrapper validates readiness first, writes all runtime artifacts under the
+gitignored private output directory, and delegates execution to the existing
+Naive RAG evaluation contract only when the local private inputs are present.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+if str(ROOT_DIR / "scripts") not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR / "scripts"))
+
+from check_private_real_eval_readiness import assess_readiness  # noqa: E402
+from eval.naive_rag.run_eval import run_from_config  # noqa: E402
+
+
+def _repo_path(value: str | Path) -> Path:
+    path = Path(str(value))
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("private real-eval config root must be a mapping")
+    return payload
+
+
+def _default_run_id() -> str:
+    return "private_real_eval_naive_rag_" + dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _runtime_contract(config: dict[str, Any], run_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "name": "private_real_eval_naive_rag",
+        "description": "Private real-eval Naive RAG runtime config. Raw artifact; keep gitignored.",
+        "eval_type": "private_real_eval",
+        "benchmark_type": "private_real_eval",
+        "baseline_system": "naive_rag",
+        "run_id": run_id,
+        "index_dir": str(config["index_dir"]),
+        "questions_path": str(config["questions_path"]),
+        "gold_evidence_path": str(config["gold_evidence_path"]),
+        "output_root": str(config["output_dir"]),
+        "pipeline": {
+            "name": "naive_baseline",
+            "top_k": int(config.get("top_k") or 10),
+            "retrieval_mode": "flat",
+            "retrieval_backend": "dense",
+            "metadata_first": False,
+            "rerank": False,
+            "verifier_retry": False,
+            "query_expansion": "identity",
+            "prompt_profile": "minimal_grounded_extractive",
+            "bm25_tokenizer": "regex",
+            "bm25_backend": "okapi",
+        },
+        "metrics": config.get("metrics") or {},
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="eval/real_config.local.yaml")
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Run readiness validation and stop before executing the baseline.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config_path = _repo_path(args.config)
+    report = assess_readiness(config_path)
+    print(f"Private real-eval readiness verdict: {report.verdict_label}")
+    if not report.ready_to_run:
+        print("Private Naive RAG baseline was not run. Blockers:")
+        for blocker in report.blockers:
+            print(f"- {blocker}")
+        print("No private raw output was written.")
+        return 1
+    if args.validate_only:
+        print("Readiness passed; validate-only requested, so no private run was executed.")
+        return 0
+
+    try:
+        config = _load_config(config_path)
+        run_id = args.run_id or _default_run_id()
+        output_root = _repo_path(str(config["output_dir"]))
+        runtime_dir = output_root / "_runtime"
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        runtime_config = runtime_dir / f"{run_id}.yaml"
+        runtime_config.write_text(
+            yaml.safe_dump(_runtime_contract(config, run_id), sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        run_dir = run_from_config(runtime_config, output_root_override=output_root, run_id_override=run_id)
+    except Exception as exc:
+        print(f"[ERROR] private Naive RAG eval failed before completion: {exc}", file=sys.stderr)
+        return 2
+
+    marker = run_dir / "PRIVATE_REAL_EVAL_README.txt"
+    marker.write_text(
+        "\n".join(
+            [
+                "private_real_eval / naive_rag",
+                "This directory may contain raw private questions, answers, evidence, and retrieved chunks.",
+                "Keep it gitignored. Export only redacted aggregate summaries.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print("Private real-eval / naive_rag run completed.")
+    print("Raw artifacts were written under the configured gitignored output_dir.")
+    print("No performance-improvement claim is implied by this run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/test_private_real_eval_readiness.py
+++ b/tests/test_private_real_eval_readiness.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+import yaml
+
+from scripts._governance import (
+    find_redacted_summary_forbidden_fields,
+    private_real_eval_gitignore_violations,
+)
+from scripts.export_private_real_eval_summary import export_summary
+from scripts.real_eval_paths import privacy_guard_violations
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "eval" / "real_config.template.yaml"
+
+
+def test_private_real_config_template_exists_and_pins_naive_contract() -> None:
+    payload = yaml.safe_load(TEMPLATE.read_text(encoding="utf-8"))
+
+    assert payload["eval_type"] == "private_real_eval"
+    assert payload["benchmark_type"] == "private_real_eval"
+    assert payload["baseline_system"] == "naive_rag"
+    assert payload["not_ci_smoke"] is True
+    assert payload["is_private_data"] is True
+    for key in (
+        "documents_dir",
+        "data_list_path",
+        "questions_path",
+        "gold_evidence_path",
+        "index_dir",
+        "output_dir",
+        "redacted_summary_path",
+        "top_k",
+        "metrics",
+        "answer_metric_mode",
+        "latency_scope",
+        "privacy_policy",
+    ):
+        assert key in payload
+
+
+def test_private_local_paths_are_gitignored_and_redacted_summary_is_allowlisted() -> None:
+    assert private_real_eval_gitignore_violations(str(ROOT)) == {}
+    assert privacy_guard_violations(ROOT) == {}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "eval/real_config.local.yaml",
+        "configs/eval/private_real_eval.local.yaml",
+        "data/files/example.pdf",
+        "data/files_kordoc/example.pdf",
+        "data/private/questions.jsonl",
+        "data/data_list.csv",
+        "data/index/real100/index.json",
+        "data/index/real100_kordoc/index.json",
+        "data/index-private-hardcase/index.json",
+        "experiments/private_runs/run/metrics.json",
+        "reports/real100/eval_summary.json",
+        "reports/real100/raw/cases.jsonl",
+        "reports/private_real_eval_summary.raw.json",
+    ],
+)
+def test_private_data_index_and_raw_output_paths_are_gitignored(path: str) -> None:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--", path],
+        cwd=ROOT,
+        text=True,
+    )
+    assert result.returncode == 0, path
+
+
+def test_redacted_summary_path_is_not_gitignored() -> None:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--", "reports/private_real_eval_summary.redacted.json"],
+        cwd=ROOT,
+        text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_readiness_validator_fails_clearly_when_private_files_are_missing(tmp_path: Path) -> None:
+    local_config = tmp_path / "real_config.local.yaml"
+    local_config.write_text(TEMPLATE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "python3",
+            "scripts/check_private_real_eval_readiness.py",
+            "--config",
+            str(local_config),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "B. Config ready, data missing" in result.stdout
+    assert "documents_dir_missing" in result.stdout
+    assert "No private raw" not in result.stdout
+    assert "support_text" in result.stdout
+
+
+def _clean_metrics() -> dict:
+    return {
+        "run_id": "run_001",
+        "dataset": {
+            "num_questions": 13,
+            "answerable_count": 10,
+            "unanswerable_count": 3,
+        },
+        "retrieval_metrics": {
+            "recall_at_10": {"mean": 0.5, "n": 10, "missing": 3},
+        },
+        "answer_metrics": {
+            "faithfulness": {"mean": 0.4, "n": 10, "missing": 3},
+            "answer_relevancy": {"mean": 0.3, "n": 10, "missing": 3},
+            "citation_accuracy": {"mean": 0.2, "n": 10, "missing": 3},
+            "hallucination_flag": {"mean": 0.1, "n": 13, "missing": 0},
+            "unanswerable_detection_flag": {"mean": 1.0, "n": 3, "missing": 10},
+        },
+        "failure_counts": {
+            "retrieval_failure.gold_evidence_not_in_top_k": 2,
+        },
+    }
+
+
+def test_redacted_summary_exporter_rejects_unsafe_fields(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    unsafe = _clean_metrics()
+    unsafe["question"] = "PLACEHOLDER raw question must not export"
+    (run_dir / "metrics.json").write_text(json.dumps(unsafe), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="forbidden raw/private keys"):
+        export_summary(run_dir, tmp_path / "summary.redacted.json")
+
+
+def test_redacted_summary_exporter_writes_aggregate_only_payload(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "metrics.json").write_text(json.dumps(_clean_metrics()), encoding="utf-8")
+    out = tmp_path / "private_real_eval_summary.redacted.json"
+
+    payload = export_summary(run_dir, out)
+
+    assert out.is_file()
+    assert payload["eval_type"] == "private_real_eval"
+    assert payload["baseline_system"] == "naive_rag"
+    assert payload["run_id"].startswith("redacted_")
+    assert payload["run_id"] != "run_001"
+    assert payload["run_id_redacted"] is True
+    assert "question_count" in payload
+    assert find_redacted_summary_forbidden_fields(payload) == {}
+
+
+def test_governance_redacted_summary_scanner_flags_forbidden_keys() -> None:
+    found = find_redacted_summary_forbidden_fields(
+        {
+            "question": "PLACEHOLDER",
+            "nested": {"support_text": "PLACEHOLDER"},
+            "path": "/Users/example/private/file.pdf",
+        }
+    )
+    assert found["question"] == 1
+    assert found["support_text"] == 1
+    assert found["absolute_path_value"] == 1
+
+
+def test_private_real_eval_workflow_doc_exists_with_required_wording() -> None:
+    text = (ROOT / "docs" / "evaluation" / "private_real_eval_workflow.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Smoke eval is CI/regression only." in text
+    assert "Synthetic benchmark is public reproducibility and ablation only." in text
+    assert "Private real-eval is required for credible real-world baseline claims." in text
+    assert "No private raw content should be committed." in text
+    assert "Redacted aggregate summaries may be committed only if they pass privacy checks." in text
+    assert "No Naive RAG real baseline has been measured yet." in text
+
+
+def test_smoke_and_synthetic_benchmark_configs_remain_unaffected() -> None:
+    rag_quality = yaml.safe_load((ROOT / "configs" / "eval" / "rag_quality_v1.yaml").read_text())
+    assert rag_quality["index_dir"] == "data/index"
+    assert rag_quality["questions_path"] == "data/eval/rag_questions.jsonl"
+    assert rag_quality["gold_evidence_path"] == "data/eval/gold_evidence.jsonl"
+    assert rag_quality["output_root"] == "experiments/runs"
+
+    eval_config = yaml.safe_load((ROOT / "eval" / "config.yaml").read_text())
+    runs = eval_config.get("ablation_runs") or []
+    assert any(run.get("name") == "naive_baseline" for run in runs if isinstance(run, dict))


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1432

Private real-eval을 나중에 안전하게 실행할 수 있도록, private 데이터 없이 config template, readiness validator, safe run wrapper, redacted summary exporter, schema docs, workflow docs, gitignore/governance checks, tests를 추가했다. 이 PR은 RAG 성능 개선이나 private real-eval 실행이 아니라 readiness scaffold만 다룬다.

## 2. 영향 파일

- `.gitignore`
- `eval/real_config.template.yaml` (load-bearing: `eval/`)
- `scripts/check_private_real_eval_readiness.py`
- `scripts/run_private_real_eval.py`
- `scripts/export_private_real_eval_summary.py`
- `scripts/_governance.py`
- `scripts/real_eval_paths.py`
- `docs/evaluation/private_real_eval_workflow.md`
- `docs/evaluation/private_real_eval_manifest_schema.md`
- `docs/evaluation/private_real_eval_question_schema.md`
- `docs/evaluation/private_real_eval_gold_evidence_schema.md`
- `tests/test_private_real_eval_readiness.py`

## 3. 리스크

가장 큰 리스크는 private 경로 ignore drift 또는 redacted summary에 raw/private key가 섞이는 것이다. 이를 `scripts/_governance.py --check-eval-privacy`, explicit gitignore tests, redacted exporter rejection tests로 확인했다.

## 4. 테스트

- `python3 scripts/_governance.py --check-eval-privacy`
- `python3 scripts/_governance.py --check-phase4-privacy`
- `python3 -m pytest tests/test_private_real_eval_readiness.py tests/test_eval_artifact_privacy_regression.py tests/test_private_real_eval_artifacts.py tests/test_real_eval_paths.py tests/test_naive_rag_eval_contract.py -q`
- `git diff --check`

## 5. Eval 영향

Private real-eval readiness scaffold only. Public smoke eval and synthetic benchmark configs remain unchanged. No retrieval, reranking, chunking, prompt, verifier, or answer behavior was tuned.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

No private real-eval was run in this PR, no private raw content was committed, and no Naive RAG real baseline has been measured yet. The changed `eval/` path is a template-only scaffold for future local private runs.

## 6. 하위 호환

Existing public fixture Naive RAG config remains pointed at `data/index`, `data/eval/rag_questions.jsonl`, and `data/eval/gold_evidence.jsonl`. No answer contract schema or existing CLI behavior is changed.

## 7. 범위 외

- No private documents, questions, gold evidence, indexes, or raw outputs added.
- No RAG performance improvement attempted.
- No reranking, hybrid search, prompt tuning, chunking change, verifier optimization, or self-correction change.