### PR TITLE
feat(eval): add private real-eval baseline workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,14 @@ venv/
 !.claude/agents/**
 
 # Local/private source data
+configs/eval/private_real_eval.local.yaml
+data/private/
 data/files/
 data/files_kordoc/
 data/private/
 data/data_list.csv
 data/data_list.xlsx
+eval/real_config.local.yaml
 eval/*.local.yaml
 configs/eval/*.local.yaml
 원본 데이터/
@@ -56,6 +59,8 @@ data/korean_public/
 # Generated artifacts: keep committed portfolio samples, ignore extra outputs
 data/index/*
 !data/index/index.json
+data/index/private*/
+data/index/real*/
 data/index/real100*/
 data/index/**/*.faiss
 data/index/**/*.index
@@ -96,6 +101,7 @@ notebooks/_artifacts/
 outputs/*
 !outputs/answer.json
 reports/*
+reports/real*/
 reports/**/*.local.json
 reports/**/*.jsonl
 reports/**/*.parquet
@@ -299,6 +305,7 @@ artifacts/benchmarks/
 artifacts/runs/
 artifacts/matrices/
 experiments/runs/
+experiments/private_runs/
 
 # Naive RAG eval contract run artifacts. The contract/config/sample data are
 # committed; timestamped run outputs are reproducible and stay local.

--- a/configs/eval/private_real_eval.template.yaml
+++ b/configs/eval/private_real_eval.template.yaml
@@ -1,0 +1,79 @@
+benchmark_type: private_real_eval
+not_ci_smoke: true
+is_private_data: true
+description: Local-only private real-data evaluation for the true Naive RAG baseline. Copy to configs/eval/private_real_eval.local.yaml before use.
+
+# Local private inputs. These are placeholders only; do not commit real paths,
+# private filenames, raw questions, raw answers, or private document text.
+documents_dir: data/private/files
+data_list_path: data/private/data_list.csv
+questions_path: data/private/gold_evidence.jsonl
+gold_evidence_path: data/private/gold_evidence.jsonl
+index_dir: data/private/index
+output_dir: experiments/private_runs
+
+top_k: 10
+minimums:
+  min_documents: 50
+  min_questions: 13
+  min_answerable_questions: 10
+  min_unanswerable_questions: 3
+
+pipeline:
+  name: naive_baseline
+  retrieval_mode: flat
+  retrieval_backend: dense
+  metadata_first: false
+  rerank: false
+  verifier_retry: false
+  query_expansion: identity
+  prompt_profile: minimal_grounded_extractive
+  bm25_tokenizer: regex
+  bm25_backend: okapi
+
+index_build:
+  mode: build_if_missing
+  embedding_backend: sentence-transformers
+  model: sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
+  ingestion_mode: csv-text
+  hwp_loader: kordoc
+  pdf_loader: kordoc
+  chunking_strategy: fixed
+
+metrics:
+  retrieval:
+    - recall_at_5
+    - recall_at_10
+    - mrr_at_5
+    - ndcg_at_5
+  citation:
+    - citation_accuracy
+  answer_control:
+    - faithfulness
+    - answer_relevancy
+    - hallucination_flag
+    - unanswerable_detection_flag
+
+latency_scope: private_runner_wall_clock
+answer_metric_mode: deterministic_contract_v1
+redaction_policy:
+  summary_only: true
+  redact_private_paths: true
+  redact_document_names: true
+  redact_questions: true
+  redact_answers: true
+  redact_document_text: true
+  excluded_fields:
+    - question
+    - answer
+    - answer_text
+    - claims
+    - citations
+    - gold_evidence
+    - retrieved_chunks
+    - text
+    - text_preview
+    - doc_id
+    - chunk_id
+    - file_name
+    - path

--- a/docs/evaluation/private_real_eval_baseline_report.template.md
+++ b/docs/evaluation/private_real_eval_baseline_report.template.md
@@ -1,0 +1,68 @@
+# Private Real-Eval Baseline Report Template
+
+This template is for redacted aggregate reporting only. Do not include raw private questions, raw answers, document text, private filenames, customer names, exact local paths, `doc_id`, or `chunk_id`.
+
+## Run Metadata
+
+- Run ID: `TBD`
+- System: Naive Dense RAG
+- Data boundary: private local data, aggregate-only report
+- Runner: `python3 -m eval.naive_rag.private_real_eval`
+- Status: not executed until local validation passes
+
+## Dataset Summary
+
+| Metric | Value |
+|---|---:|
+| Documents | TBD |
+| Chunks | TBD |
+| Questions | TBD |
+| Answerable questions | TBD |
+| Unanswerable questions | TBD |
+
+## Aggregate Metrics
+
+| Metric | Mean | n | Missing |
+|---|---:|---:|---:|
+| Recall@5 | TBD | TBD | TBD |
+| Recall@10 | TBD | TBD | TBD |
+| MRR@5 | TBD | TBD | TBD |
+| nDCG@5 | TBD | TBD | TBD |
+| Citation accuracy | TBD | TBD | TBD |
+| Faithfulness | TBD | TBD | TBD |
+| Answer relevancy | TBD | TBD | TBD |
+| Hallucination flag | TBD | TBD | TBD |
+| Unanswerable detection flag | TBD | TBD | TBD |
+
+## Latency Summary
+
+| Metric | Value |
+|---|---:|
+| Scope | `private_runner_wall_clock` |
+| Total wall-clock ms | TBD |
+| Mean wall-clock ms per question | TBD |
+
+## Failure Type Counts
+
+| Failure type | Count |
+|---|---:|
+| TBD | TBD |
+
+## Readiness Decision
+
+Ready for improvement experiments only if all are true:
+
+- At least 30 questions exist.
+- Answerable and unanswerable split exists.
+- Explicit gold evidence exists for answerable questions.
+- Retrieval metrics are non-trivial and not saturated at 1.0.
+- `failure_cases.jsonl` contains useful failure types.
+- `redacted_summary.json` is generated.
+- No private data, local config, or raw private output is committed.
+
+## Known Limitations
+
+- Private aggregate only; raw cases and traces remain local.
+- Answer metrics are deterministic contract checks, not an LLM judge.
+- Latency is runner wall-clock unless a narrower local profiler is added.
+- No retrieval, reranking, prompt, chunking, verifier, or self-correction improvement is included.

--- a/docs/evaluation/private_real_eval_summary_template.md
+++ b/docs/evaluation/private_real_eval_summary_template.md
@@ -1,0 +1,64 @@
+# Private Real-Eval Redacted Summary Template
+
+이 파일은 private real-eval 결과를 공개 가능한 형태로 요약할 때의 필드 계약(contract)이다. 실제 raw 질문(question), 답변(answer), 근거(evidence), 파일명, 고객명, private path는 포함하지 않는다.
+
+```json
+{
+  "schema_version": 1,
+  "benchmark_type": "private_real_eval",
+  "system": "Naive Dense RAG",
+  "not_ci_smoke": true,
+  "is_private_data": true,
+  "dataset": {
+    "num_documents": 100,
+    "num_chunks": 25000,
+    "num_questions": 221,
+    "answerable_count": 180,
+    "unanswerable_count": 41
+  },
+  "pipeline": {
+    "name": "naive_baseline",
+    "top_k": 10,
+    "retrieval_backend": "dense",
+    "metadata_first": false,
+    "rerank": false,
+    "verifier_retry": false,
+    "query_expansion": "identity"
+  },
+  "metrics": {
+    "retrieval": {
+      "recall_at_5": {"mean": 0.0, "n": 0, "missing": 0},
+      "recall_at_10": {"mean": 0.0, "n": 0, "missing": 0},
+      "mrr_at_5": {"mean": 0.0, "n": 0, "missing": 0},
+      "ndcg_at_5": {"mean": 0.0, "n": 0, "missing": 0}
+    },
+    "citation_and_answer_control": {
+      "faithfulness": {"mean": 0.0, "n": 0, "missing": 0},
+      "answer_relevancy": {"mean": 0.0, "n": 0, "missing": 0},
+      "citation_accuracy": {"mean": 0.0, "n": 0, "missing": 0},
+      "hallucination_flag": {"mean": 0.0, "n": 0, "missing": 0},
+      "unanswerable_detection_flag": {"mean": 0.0, "n": 0, "missing": 0}
+    }
+  },
+  "failure_type_counts": {
+    "retrieval_failure.gold_evidence_not_in_top_k": 0
+  },
+  "latency_summary": {
+    "scope": "private_runner_wall_clock",
+    "total_wall_clock_ms": 0.0,
+    "mean_wall_clock_ms_per_question": 0.0
+  },
+  "known_limitations": [
+    "Private aggregate only; raw cases and traces remain local.",
+    "Answer metrics are deterministic contract checks, not an LLM judge.",
+    "No retrieval, reranking, prompt, chunking, or verifier optimization is included."
+  ]
+}
+```
+
+금지 필드:
+
+- raw `question`, `answer`, `answer_text`, `claims`, `citations`
+- `gold_evidence`, `retrieved_chunks`, `text`, `text_preview`
+- customer/project names, private document filenames, exact private paths
+- `doc_id`, `chunk_id`처럼 private corpus를 역추적할 수 있는 per-case identifier

--- a/docs/evaluation/private_real_eval_workflow.md
+++ b/docs/evaluation/private_real_eval_workflow.md
@@ -4,26 +4,46 @@ Smoke eval is CI/regression only.
 Synthetic benchmark is public reproducibility and ablation only.
 Private real-eval is required for credible real-world baseline claims.
 
-이 workflow는 private data 없이 repository를 준비하는 scaffold다. 현재 이 문서는
-Naive RAG 기준선(baseline)을 측정했다는 증거가 아니며, private raw content는
-커밋하지 않는다.
+This workflow prepares and runs a local-only private real-eval path for the
+Naive RAG baseline. It is not itself proof that a private baseline has been
+measured; private documents, raw questions, raw answers, raw evidence, and raw
+run outputs must stay local. Only redacted aggregate summaries may be reviewed
+for commit.
 
 ## Why This Exists
 
-Public smoke(smoke)와 synthetic benchmark(합성 벤치마크)는 재현성(reproducibility)과
-회귀(regression) 확인에 충분하지만, 실제 RFP 문서에서 baseline claim을 하려면
-private real-eval이 필요하다. 단, private real-eval은 문서·질문·근거(evidence)가
-민감하므로 raw output은 local-only로 두고 redacted aggregate만 검토 후 커밋한다.
+Public smoke(smoke) and synthetic benchmark(합성 벤치마크) surfaces are useful
+for reproducibility(reproducibility), ablation(절제), and regression(회귀)
+checks, but they are not sufficient for real RFP baseline claims. Private
+real-eval is the credible measurement path because it uses local private
+documents and explicit gold evidence(근거).
 
-Required wording:
+This workflow measures the existing Naive RAG baseline only. It does not
+improve retrieval(검색), reranking(재순위), prompts(프롬프트), chunking(청킹),
+verification(검증), or self-correction(자가수정).
 
-- Smoke eval is CI/regression only.
-- Synthetic benchmark is public reproducibility and ablation only.
-- Private real-eval is required for credible real-world baseline claims.
-- No private raw content should be committed.
-- Redacted aggregate summaries may be committed only if they pass privacy checks.
+## Evaluation Surfaces
 
-## Local File Layout
+| Surface | Data | Purpose | Valid for performance claims |
+|---|---|---|---|
+| Smoke eval | committed fixture | CI/regression sanity | No |
+| Synthetic benchmark | committed/generated public data | reproducible framework validation | Provisional only |
+| Private real-eval | local private documents | credible baseline measurement | Yes, aggregate-only |
+
+## Supported Local Layouts
+
+Preferred Naive RAG contract layout:
+
+```text
+configs/eval/private_real_eval.local.yaml
+data/private/files/
+data/private/data_list.csv
+data/private/gold_evidence.jsonl
+data/private/index/
+experiments/private_runs/
+```
+
+Readiness scaffold / older real-eval convention:
 
 ```text
 eval/real_config.local.yaml
@@ -36,38 +56,65 @@ experiments/private_runs/
 reports/private_real_eval_summary.redacted.json
 ```
 
-All raw private inputs and run artifacts above are ignored except the redacted
-summary output path, which is allowlisted only for aggregate-only summaries that
-pass privacy checks.
+Use `configs/eval/private_real_eval.local.yaml` when the goal is the Naive RAG
+baseline contract runner. Use `eval/real_config.local.yaml` and the readiness
+scripts when checking whether the local private corpus is prepared.
 
-## Config
+## Local Config
 
-Create the local config from the committed template:
+For readiness checks:
 
 ```bash
 cp eval/real_config.template.yaml eval/real_config.local.yaml
 ```
 
-Then edit local paths manually. Do not put machine-specific absolute paths in
-the committed template. `eval/real_config.local.yaml` is gitignored.
+For the Naive RAG contract runner:
+
+```bash
+cp configs/eval/private_real_eval.template.yaml configs/eval/private_real_eval.local.yaml
+```
+
+Fill only local paths and local measurement settings. Do not put
+machine-specific absolute paths, private filenames, raw questions, raw answers,
+or private document text in committed files.
+
+## Gold Evidence Schema
+
+`gold_evidence_path` is JSONL. Each answerable row needs explicit
+`gold_evidence[].chunk_id`; unanswerable rows use an empty `gold_evidence` list.
+
+```json
+{"question_id":"case-001","question":"...local private question...","answerable":true,"expected_terms":["..."],"gold_evidence":[{"doc_id":"...","chunk_id":"..."}]}
+{"question_id":"case-002","question":"...local private unanswerable question...","answerable":false,"gold_evidence":[]}
+```
+
+Raw questions can be sensitive, so this file is local-only and gitignored.
 
 ## Gitignore Safety
 
-The scaffold expects these private paths to remain ignored:
+The workflow expects these private paths to remain ignored:
 
+- `configs/eval/private_real_eval.local.yaml`
 - `eval/real_config.local.yaml`
 - `configs/eval/*.local.yaml`
+- `data/private/`
 - `data/files/`
 - `data/files_kordoc/`
-- `data/private/`
 - `data/data_list.csv`
+- `data/index/private*/`
+- `data/index/real*/`
 - `data/index/real100/`
 - `data/index/real100_kordoc/`
 - `data/index-private-hardcase/`
 - `experiments/private_runs/`
+- `reports/real*/`
 - `reports/real100/eval_summary.json`
 - `reports/real100/raw/`
 - `reports/private_real_eval_summary.raw.json`
+
+The private runner validates that `documents_dir`, `data_list_path`,
+`questions_path`, `gold_evidence_path`, `index_dir`, and `output_dir` are
+gitignored or outside the repo before it processes local data.
 
 ## Validate Readiness
 
@@ -87,10 +134,15 @@ The validator reports counts and blockers only. It does not print private
 filenames, raw questions, raw answers, support text, document text, customer
 names, or absolute local paths.
 
-## Index Build Expectation
+## Build Or Load The Private Index
 
-When documents and manifest are present, build the local private index under an
-ignored directory. The readiness validator prints the command shape:
+The contract runner builds the index when `index_build.mode: build_if_missing`
+and `<index_dir>/index.json` is absent. It loads the existing index when
+`index.json` is present. The template uses the project MiniLM default so the
+private run measures dense semantic retrieval, not the hashing smoke fallback.
+
+The readiness scaffold also prints the expected build command shape when local
+private documents and manifest are present:
 
 ```bash
 python3 scripts/build_index.py \
@@ -102,21 +154,74 @@ python3 scripts/build_index.py \
   --embedding_backend hashing
 ```
 
-This is infrastructure readiness only. It does not tune retrieval(retrieval),
-reranking(reranking), prompts, chunking, verifier, or self-correction.
+## Validate Private Naive RAG Inputs
+
+```bash
+python3 -m eval.naive_rag.private_real_eval \
+  --config configs/eval/private_real_eval.local.yaml \
+  --validate-only
+```
+
+Validation is fail-closed for missing documents, missing metadata, missing gold
+evidence, missing answerable/unanswerable split, missing explicit
+`gold_evidence[].chunk_id` on answerable rows, non-empty gold evidence on
+unanswerable rows, and private paths that are not gitignored or outside the
+repo.
 
 ## Run Private Naive RAG Eval
+
+Preferred contract runner:
+
+```bash
+python3 -m eval.naive_rag.private_real_eval \
+  --config configs/eval/private_real_eval.local.yaml
+```
+
+Readiness scaffold wrapper:
 
 ```bash
 python3 scripts/run_private_real_eval.py --config eval/real_config.local.yaml
 ```
 
-The wrapper calls the readiness validator first. If files are missing, it fails
-without writing private raw output. If runnable, it delegates to the existing
-Naive RAG contract and writes raw artifacts only under ignored
-`experiments/private_runs/`.
+Generated raw artifacts stay under ignored `experiments/private_runs/<run_id>/`.
+The contract runner writes:
 
-## Export Redacted Summary
+```text
+experiments/private_runs/<run_id>/
+metrics.json
+retrieved_chunks.jsonl
+answers.jsonl
+failure_cases.jsonl
+summary.md
+redacted_summary.json
+```
+
+## Metrics
+
+Trustworthy within this workflow:
+
+- retrieval metrics: `recall_at_5`, `recall_at_10`, `mrr_at_5`, `ndcg_at_5`
+- citation/control metrics: `citation_accuracy`, `faithfulness`,
+  `answer_relevancy`, `hallucination_flag`, `unanswerable_detection_flag`
+- aggregate failure type counts
+- dataset cardinalities and index chunk counts
+
+Still provisional:
+
+- answer quality as judged by deterministic term checks
+- wall-clock latency unless the same hardware/process warmup is used
+- any comparison against non-naive systems unless the same private set and
+  index provenance are held fixed
+
+## Redacted Summary
+
+The contract runner writes:
+
+```text
+experiments/private_runs/<run_id>/redacted_summary.json
+```
+
+The readiness scaffold exporter writes:
 
 ```bash
 python3 scripts/export_private_real_eval_summary.py \
@@ -124,22 +229,21 @@ python3 scripts/export_private_real_eval_summary.py \
   --out reports/private_real_eval_summary.redacted.json
 ```
 
-The redacted summary may include aggregate document count, chunk count, question
+Redacted summaries may include aggregate document count, chunk count, question
 count, retrieval metrics, citation metrics, answer/control metrics, latency
 metrics, failure type counts, and known limitations.
 
-The redacted summary must not include raw document text, raw questions, raw
-generated answers, `support_text`, customer names, private filenames, absolute
-local paths, or sensitive private file ids.
+They must not include raw document text, raw questions, raw generated answers,
+`support_text`, customer names, private filenames, absolute local paths,
+`doc_id`, `chunk_id`, or sensitive private file ids.
 
 ## What Can Be Committed
 
-- `eval/real_config.template.yaml`
+- config templates
 - readiness/run/export scripts
 - schema docs and workflow docs
 - tests and governance checks
-- `reports/private_real_eval_summary.redacted.json` only after exporter and
-  governance privacy checks pass
+- redacted aggregate reports only after exporter and privacy checks pass
 
 ## What Must Never Be Committed
 
@@ -155,17 +259,25 @@ local paths, or sensitive private file ids.
 
 ## Current Readiness Status
 
-Current repository status remains **A. Not ready** until local private files are
-provided. No Naive RAG real baseline has been measured yet.
+Current repository status remains **A. Not ready** until local private files and
+explicit gold evidence are provided. No Naive RAG real baseline has been
+measured by this repository state.
 
 ## Next Manual Steps
 
-1. Copy the template to `eval/real_config.local.yaml`.
+1. Copy the relevant template to a local ignored config.
 2. Place private documents, manifest, questions, and gold evidence in ignored
    local paths.
-3. Run the readiness validator.
-4. Build the private index if the validator reports only index blockers.
-5. Run the private Naive RAG wrapper.
-6. Export the redacted summary.
+3. Run readiness validation or the contract runner with `--validate-only`.
+4. Build the private index if validation reports only index blockers.
+5. Run the private Naive RAG baseline.
+6. Export or inspect only redacted aggregate summaries.
 7. Run governance and tests before committing any redacted aggregate.
 
+## Non-Goals
+
+This workflow intentionally does not add hybrid search, reranking, query
+expansion, prompt tuning, chunking changes, citation verifier optimization,
+self-correction, or any other RAG performance improvement. It only creates a
+safe local-only path to measure the Naive RAG baseline on private real
+documents.

--- a/docs/evaluation/private_real_eval_workflow.md
+++ b/docs/evaluation/private_real_eval_workflow.md
@@ -3,6 +3,8 @@
 Smoke eval is CI/regression only.
 Synthetic benchmark is public reproducibility and ablation only.
 Private real-eval is required for credible real-world baseline claims.
+No private raw content should be committed.
+Redacted aggregate summaries may be committed only if they pass privacy checks.
 
 This workflow prepares and runs a local-only private real-eval path for the
 Naive RAG baseline. It is not itself proof that a private baseline has been
@@ -262,6 +264,8 @@ They must not include raw document text, raw questions, raw generated answers,
 Current repository status remains **A. Not ready** until local private files and
 explicit gold evidence are provided. No Naive RAG real baseline has been
 measured by this repository state.
+
+No Naive RAG real baseline has been measured yet.
 
 ## Next Manual Steps
 

--- a/eval/naive_rag/private_real_eval.py
+++ b/eval/naive_rag/private_real_eval.py
@@ -1,0 +1,758 @@
+"""Private real-data runner for the Naive RAG baseline.
+
+This module adds only a local/private evaluation workflow. It does not change
+retrieval, reranking, chunking, prompts, verifier behavior, or answer policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from eval.naive_rag.run_eval import run_from_config  # noqa: E402
+
+
+REQUIRED_CONFIG_KEYS = (
+    "benchmark_type",
+    "not_ci_smoke",
+    "is_private_data",
+    "documents_dir",
+    "data_list_path",
+    "gold_evidence_path",
+    "index_dir",
+    "output_dir",
+    "top_k",
+    "metrics",
+    "latency_scope",
+    "answer_metric_mode",
+    "redaction_policy",
+)
+DEFAULT_MINIMUMS = {
+    "min_documents": 50,
+    "min_questions": 13,
+    "min_answerable_questions": 10,
+    "min_unanswerable_questions": 3,
+}
+FORBIDDEN_REDACTED_KEYS = {
+    "question",
+    "questions_path",
+    "answer",
+    "answer_text",
+    "claims",
+    "citations",
+    "gold_evidence",
+    "retrieved_chunks",
+    "text",
+    "text_preview",
+    "doc_id",
+    "chunk_id",
+    "file",
+    "file_name",
+    "filename",
+    "path",
+    "config_path",
+    "index_dir",
+    "output_dir",
+}
+SAFE_RETRIEVAL_METRIC_KEYS = {"recall_at_5", "recall_at_10", "mrr_at_5", "ndcg_at_5"}
+SAFE_ANSWER_METRIC_KEYS = {
+    "faithfulness",
+    "answer_relevancy",
+    "citation_accuracy",
+    "hallucination_flag",
+    "unanswerable_detection_flag",
+}
+SAFE_METRIC_VALUE_KEYS = {"mean", "n", "missing"}
+ENV_DEFAULT_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+
+
+class PrivateRealEvalError(ValueError):
+    """Raised when local-only private eval validation fails."""
+
+
+def _expand_env_defaults(value: Any, environ: Mapping[str, str] | None = None) -> Any:
+    env = environ if environ is not None else os.environ
+    if isinstance(value, dict):
+        return {key: _expand_env_defaults(item, env) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_expand_env_defaults(item, env) for item in value]
+    if not isinstance(value, str):
+        return value
+
+    def repl(match: re.Match[str]) -> str:
+        env_key = match.group(1)
+        default = match.group(2) or ""
+        return env.get(env_key) or default
+
+    return ENV_DEFAULT_RE.sub(repl, value)
+
+
+def repo_path(value: str | Path, root: Path = ROOT_DIR) -> Path:
+    path = Path(str(value))
+    return path if path.is_absolute() else root / path
+
+
+def rel_or_abs(path: Path, root: Path = ROOT_DIR) -> str:
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def load_private_config(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise PrivateRealEvalError(f"Config must be a mapping: {path}")
+    return _expand_env_defaults(payload)
+
+
+def validate_template_schema(config: Mapping[str, Any]) -> None:
+    missing = [key for key in REQUIRED_CONFIG_KEYS if key not in config]
+    errors: list[str] = []
+    if missing:
+        errors.append("missing required config keys: " + ", ".join(missing))
+    if config.get("benchmark_type") != "private_real_eval":
+        errors.append("benchmark_type must be private_real_eval")
+    if config.get("not_ci_smoke") is not True:
+        errors.append("not_ci_smoke must be true")
+    if config.get("is_private_data") is not True:
+        errors.append("is_private_data must be true")
+    try:
+        top_k = int(config.get("top_k"))
+    except (TypeError, ValueError):
+        top_k = 0
+    if top_k < 10:
+        errors.append("top_k must be >= 10 for the Naive RAG contract")
+    metrics = config.get("metrics")
+    if not isinstance(metrics, Mapping):
+        errors.append("metrics must be a mapping")
+    else:
+        for group in ("retrieval", "citation", "answer_control"):
+            if not isinstance(metrics.get(group), list) or not metrics.get(group):
+                errors.append(f"metrics.{group} must be a non-empty list")
+    redaction = config.get("redaction_policy")
+    if not isinstance(redaction, Mapping):
+        errors.append("redaction_policy must be a mapping")
+    if errors:
+        raise PrivateRealEvalError("Private real-eval config is invalid:\n- " + "\n- ".join(errors))
+
+
+def _jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise PrivateRealEvalError(f"Invalid JSONL at {path}:{lineno}: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise PrivateRealEvalError(f"JSONL row must be an object at {path}:{lineno}")
+        rows.append(payload)
+    return rows
+
+
+def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _count_documents(documents_dir: Path) -> int:
+    if not documents_dir.is_dir():
+        return 0
+    return sum(
+        1
+        for path in documents_dir.rglob("*")
+        if path.is_file() and not any(part.startswith(".") for part in path.parts)
+    )
+
+
+def _index_counts(index_dir: Path) -> tuple[int | None, int | None]:
+    index_json = index_dir / "index.json"
+    if not index_json.is_file():
+        return None, None
+    try:
+        payload = json.loads(index_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None, None
+    build = payload.get("build") if isinstance(payload, dict) else {}
+    if not isinstance(build, dict):
+        build = {}
+    docs = build.get("num_documents")
+    chunks = build.get("num_chunks")
+    if docs is None and isinstance(payload, dict):
+        docs = len(payload.get("documents") or [])
+    if chunks is None and isinstance(payload, dict):
+        chunks = len(payload.get("chunks") or [])
+    try:
+        doc_count = int(docs) if docs is not None else None
+    except (TypeError, ValueError):
+        doc_count = None
+    try:
+        chunk_count = int(chunks) if chunks is not None else None
+    except (TypeError, ValueError):
+        chunk_count = None
+    return doc_count, chunk_count
+
+
+def _is_inside_repo(path: Path, root: Path = ROOT_DIR) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def git_ignores_path(path: Path, root: Path = ROOT_DIR) -> bool:
+    """Return true when git ignores the path or the path is outside the repo."""
+    if not _is_inside_repo(path, root):
+        return True
+    candidates = [path, path / ".private_real_eval_probe"]
+    for candidate in candidates:
+        rel = rel_or_abs(candidate, root)
+        result = subprocess.run(
+            ["git", "check-ignore", "--quiet", rel],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True
+    return False
+
+
+def _gold_items(row: Mapping[str, Any]) -> list[dict[str, Any]]:
+    evidence = row.get("gold_evidence")
+    if evidence is None:
+        direct = {
+            key: row.get(key)
+            for key in ("doc_id", "chunk_id", "page_span", "support_claim", "required_terms")
+            if row.get(key) is not None
+        }
+        evidence = [direct] if direct else []
+    if not isinstance(evidence, list):
+        raise PrivateRealEvalError(
+            f"gold_evidence must be a list for question_id={row.get('question_id')}"
+        )
+    cleaned: list[dict[str, Any]] = []
+    for item in evidence:
+        if not isinstance(item, dict):
+            raise PrivateRealEvalError(
+                f"gold_evidence item must be an object for question_id={row.get('question_id')}"
+            )
+        cleaned.append(dict(item))
+    return cleaned
+
+
+def _questions_from_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        qid = str(row.get("question_id") or "").strip()
+        if not qid:
+            raise PrivateRealEvalError("Every question/gold row must include question_id")
+        if qid in by_id:
+            continue
+        question = str(row.get("question") or "").strip()
+        if not question:
+            raise PrivateRealEvalError(f"Question row missing question text: {qid}")
+        by_id[qid] = {
+            "question_id": qid,
+            "question": question,
+            "answerable": bool(row.get("answerable", True)),
+            "query_type": row.get("query_type"),
+            "expected_answer": row.get("expected_answer"),
+            "expected_terms": row.get("expected_terms") or [],
+        }
+    return list(by_id.values())
+
+
+def _gold_by_question(rows: Sequence[Mapping[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    by_question: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        qid = str(row.get("question_id") or "").strip()
+        if not qid:
+            raise PrivateRealEvalError("Every gold evidence row must include question_id")
+        by_question.setdefault(qid, []).extend(_gold_items(row))
+    return by_question
+
+
+def _minimums(config: Mapping[str, Any]) -> dict[str, int]:
+    raw = config.get("minimums") if isinstance(config.get("minimums"), Mapping) else {}
+    result = dict(DEFAULT_MINIMUMS)
+    for key in result:
+        if key in raw:
+            result[key] = max(int(raw[key]), DEFAULT_MINIMUMS[key])
+    return result
+
+
+def validate_private_inputs(
+    config: Mapping[str, Any],
+    *,
+    root: Path = ROOT_DIR,
+) -> dict[str, Any]:
+    validate_template_schema(config)
+    documents_dir = repo_path(str(config["documents_dir"]), root)
+    data_list_path = repo_path(str(config["data_list_path"]), root)
+    gold_evidence_path = repo_path(str(config["gold_evidence_path"]), root)
+    questions_path = repo_path(str(config.get("questions_path") or gold_evidence_path), root)
+    index_dir = repo_path(str(config["index_dir"]), root)
+    output_dir = repo_path(str(config["output_dir"]), root)
+    index_build = (
+        config.get("index_build") if isinstance(config.get("index_build"), Mapping) else {}
+    )
+    build_mode = str(index_build.get("mode") or "build_if_missing")
+    can_build_index = build_mode in {"build_if_missing", "rebuild"}
+
+    errors: list[str] = []
+    if not documents_dir.is_dir():
+        errors.append(f"documents_dir does not exist: {documents_dir}")
+    if not data_list_path.is_file():
+        errors.append(f"data_list_path does not exist: {data_list_path}")
+    if not gold_evidence_path.is_file():
+        errors.append(f"gold_evidence_path does not exist: {gold_evidence_path}")
+    if config.get("questions_path") and not questions_path.is_file():
+        errors.append(f"questions_path does not exist: {questions_path}")
+    if not git_ignores_path(output_dir, root):
+        errors.append(f"output_dir must be ignored by git or outside the repo: {output_dir}")
+    if not git_ignores_path(index_dir, root):
+        errors.append(f"index_dir must be ignored by git or outside the repo: {index_dir}")
+    if not (index_dir / "index.json").is_file() and not can_build_index:
+        errors.append(
+            f"index_dir has no index.json and index_build.mode={build_mode!r} cannot build it: {index_dir}"
+        )
+
+    document_count = _count_documents(documents_dir)
+    questions: list[dict[str, Any]] = []
+    gold_by_qid: dict[str, list[dict[str, Any]]] = {}
+    if documents_dir.is_dir():
+        min_docs = _minimums(config)["min_documents"]
+        if document_count < min_docs:
+            errors.append(
+                f"documents_dir has {document_count} documents; require at least {min_docs}"
+            )
+    if gold_evidence_path.is_file() and (
+        questions_path.is_file() or not config.get("questions_path")
+    ):
+        gold_rows = _jsonl_rows(gold_evidence_path)
+        question_rows = _jsonl_rows(questions_path) if config.get("questions_path") else gold_rows
+        questions = _questions_from_rows(question_rows)
+        gold_by_qid = _gold_by_question(gold_rows)
+        mins = _minimums(config)
+        answerable = [q for q in questions if q.get("answerable", True)]
+        unanswerable = [q for q in questions if not q.get("answerable", True)]
+        if len(questions) < mins["min_questions"]:
+            errors.append(
+                f"question set has {len(questions)} questions; require at least {mins['min_questions']}"
+            )
+        if len(answerable) < mins["min_answerable_questions"]:
+            errors.append(
+                f"answerable split has {len(answerable)} questions; require at least {mins['min_answerable_questions']}"
+            )
+        if len(unanswerable) < mins["min_unanswerable_questions"]:
+            errors.append(
+                f"unanswerable split has {len(unanswerable)} questions; require at least {mins['min_unanswerable_questions']}"
+            )
+        missing_gold = [
+            str(q["question_id"])
+            for q in answerable
+            if not any(
+                str(item.get("chunk_id") or "").strip()
+                for item in gold_by_qid.get(str(q["question_id"]), [])
+            )
+        ]
+        if missing_gold:
+            errors.append(
+                "answerable questions require explicit gold_evidence[].chunk_id; missing for: "
+                + ", ".join(missing_gold[:10])
+            )
+        unanswerable_with_gold = [
+            str(q["question_id"]) for q in unanswerable if gold_by_qid.get(str(q["question_id"]))
+        ]
+        if unanswerable_with_gold:
+            errors.append(
+                "unanswerable questions must use empty gold_evidence; found gold for: "
+                + ", ".join(unanswerable_with_gold[:10])
+            )
+
+    index_docs, index_chunks = _index_counts(index_dir)
+    if errors:
+        raise PrivateRealEvalError("Private real-eval validation failed:\n- " + "\n- ".join(errors))
+    return {
+        "documents_dir": documents_dir,
+        "data_list_path": data_list_path,
+        "questions_path": questions_path,
+        "gold_evidence_path": gold_evidence_path,
+        "index_dir": index_dir,
+        "output_dir": output_dir,
+        "document_count": document_count,
+        "question_count": len(questions),
+        "answerable_count": sum(1 for q in questions if q.get("answerable", True)),
+        "unanswerable_count": sum(1 for q in questions if not q.get("answerable", True)),
+        "index_exists": (index_dir / "index.json").is_file(),
+        "index_document_count": index_docs,
+        "index_chunk_count": index_chunks,
+        "build_mode": build_mode,
+    }
+
+
+def build_index_command(
+    config: Mapping[str, Any], validation: Mapping[str, Any]
+) -> list[str] | None:
+    index_dir = Path(validation["index_dir"])
+    index_build = (
+        config.get("index_build") if isinstance(config.get("index_build"), Mapping) else {}
+    )
+    mode = str(index_build.get("mode") or "build_if_missing")
+    if (index_dir / "index.json").is_file() and mode != "rebuild":
+        return None
+    if mode == "load_only":
+        raise PrivateRealEvalError(f"index_build.mode=load_only but index is missing: {index_dir}")
+
+    command = [
+        sys.executable,
+        "scripts/build_index.py",
+        "--metadata_csv",
+        rel_or_abs(Path(validation["data_list_path"])),
+        "--files_dir",
+        rel_or_abs(Path(validation["documents_dir"])),
+        "--output_dir",
+        rel_or_abs(index_dir),
+        "--embedding_backend",
+        str(index_build.get("embedding_backend") or "auto"),
+        "--ingestion_mode",
+        str(index_build.get("ingestion_mode") or "csv-text"),
+        "--chunking_strategy",
+        str(index_build.get("chunking_strategy") or "fixed"),
+    ]
+    for key, flag in (
+        ("model", "--model"),
+        ("hwp_loader", "--hwp_loader"),
+        ("pdf_loader", "--pdf_loader"),
+    ):
+        value = str(index_build.get(key) or "").strip()
+        if value:
+            command.extend([flag, value])
+    return command
+
+
+def build_or_load_private_index(
+    config: Mapping[str, Any], validation: Mapping[str, Any]
+) -> list[str] | None:
+    command = build_index_command(config, validation)
+    if command is None:
+        print(f"[OK] Loading existing private index: {validation['index_dir']}")
+        return None
+    print("[INFO] Building private index for Naive RAG eval")
+    result = subprocess.run(command, cwd=ROOT_DIR, check=False, text=True)
+    if result.returncode != 0:
+        raise PrivateRealEvalError("private index build failed: " + " ".join(command))
+    return command
+
+
+def _private_questions_path(
+    config: Mapping[str, Any], validation: Mapping[str, Any], run_dir: Path
+) -> Path:
+    if config.get("questions_path"):
+        return Path(validation["questions_path"])
+    rows = _jsonl_rows(Path(validation["gold_evidence_path"]))
+    questions = _questions_from_rows(rows)
+    generated = run_dir / "_inputs" / "questions.generated.jsonl"
+    _write_jsonl(generated, questions)
+    return generated
+
+
+def write_contract_config(
+    config: Mapping[str, Any],
+    validation: Mapping[str, Any],
+    *,
+    run_id: str,
+) -> Path:
+    output_dir = Path(validation["output_dir"])
+    run_dir = output_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    questions_path = _private_questions_path(config, validation, run_dir)
+    pipeline = config.get("pipeline") if isinstance(config.get("pipeline"), Mapping) else {}
+    top_k = int(config["top_k"])
+    contract = {
+        "schema_version": 1,
+        "name": "private_real_eval_naive_baseline",
+        "description": "Generated local-only config for private real-data Naive RAG eval.",
+        "index_dir": str(Path(validation["index_dir"])),
+        "questions_path": str(questions_path),
+        "gold_evidence_path": str(Path(validation["gold_evidence_path"])),
+        "output_root": str(output_dir),
+        "pipeline": {
+            "name": "naive_baseline",
+            "top_k": top_k,
+            "retrieval_mode": str(pipeline.get("retrieval_mode", "flat")),
+            "retrieval_backend": "dense",
+            "metadata_first": False,
+            "rerank": False,
+            "verifier_retry": False,
+            "query_expansion": "identity",
+            "prompt_profile": str(pipeline.get("prompt_profile") or "minimal_grounded_extractive"),
+            "bm25_tokenizer": str(pipeline.get("bm25_tokenizer") or "regex"),
+            "bm25_backend": str(pipeline.get("bm25_backend") or "okapi"),
+        },
+        "metrics": {
+            "retrieval": list((config.get("metrics") or {}).get("retrieval") or []),
+            "answer": [
+                *list((config.get("metrics") or {}).get("citation") or []),
+                *list((config.get("metrics") or {}).get("answer_control") or []),
+            ],
+        },
+    }
+    path = run_dir / "_inputs" / "contract.naive_baseline.generated.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(contract, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    return path
+
+
+def default_run_id() -> str:
+    return "private_real_eval_" + dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _safe_metric_block(block: Any, allowed_keys: set[str]) -> dict[str, Any]:
+    if not isinstance(block, Mapping):
+        return {}
+    safe: dict[str, Any] = {}
+    for key, value in block.items():
+        key_text = str(key)
+        if key_text not in allowed_keys:
+            continue
+        if isinstance(value, Mapping):
+            safe[key_text] = {
+                str(metric_key): metric_value
+                for metric_key, metric_value in value.items()
+                if str(metric_key) in SAFE_METRIC_VALUE_KEYS
+                and isinstance(metric_value, (int, float, type(None)))
+            }
+        elif isinstance(value, (int, float, type(None))):
+            safe[key_text] = value
+    return safe
+
+
+def build_redacted_summary(
+    metrics_payload: Mapping[str, Any],
+    validation: Mapping[str, Any],
+    config: Mapping[str, Any],
+    *,
+    elapsed_ms: float,
+) -> dict[str, Any]:
+    dataset = (
+        metrics_payload.get("dataset")
+        if isinstance(metrics_payload.get("dataset"), Mapping)
+        else {}
+    )
+    question_count = int(dataset.get("num_questions") or validation.get("question_count") or 0)
+    index_docs, index_chunks = _index_counts(Path(validation["index_dir"]))
+    payload = {
+        "schema_version": 1,
+        "benchmark_type": "private_real_eval",
+        "system": "Naive Dense RAG",
+        "not_ci_smoke": True,
+        "is_private_data": True,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "dataset": {
+            "num_documents": index_docs or validation.get("document_count"),
+            "num_chunks": index_chunks,
+            "num_questions": question_count,
+            "answerable_count": dataset.get("answerable_count")
+            or validation.get("answerable_count"),
+            "unanswerable_count": dataset.get("unanswerable_count")
+            or validation.get("unanswerable_count"),
+        },
+        "pipeline": {
+            "name": "naive_baseline",
+            "top_k": int(config["top_k"]),
+            "retrieval_backend": "dense",
+            "metadata_first": False,
+            "rerank": False,
+            "verifier_retry": False,
+            "query_expansion": "identity",
+        },
+        "metrics": {
+            "retrieval": _safe_metric_block(
+                metrics_payload.get("retrieval_metrics"),
+                SAFE_RETRIEVAL_METRIC_KEYS,
+            ),
+            "citation_and_answer_control": _safe_metric_block(
+                metrics_payload.get("answer_metrics"),
+                SAFE_ANSWER_METRIC_KEYS,
+            ),
+        },
+        "failure_type_counts": dict(metrics_payload.get("failure_counts") or {}),
+        "latency_summary": {
+            "scope": str(config.get("latency_scope") or "private_runner_wall_clock"),
+            "total_wall_clock_ms": round(float(elapsed_ms), 3),
+            "mean_wall_clock_ms_per_question": (
+                round(float(elapsed_ms) / question_count, 3) if question_count else None
+            ),
+        },
+        "redaction_policy": {
+            "summary_only": True,
+            "raw_questions_excluded": True,
+            "raw_answers_excluded": True,
+            "document_text_excluded": True,
+            "document_names_excluded": True,
+            "private_paths_excluded": True,
+        },
+        "known_limitations": [
+            "Private aggregate only; raw cases and traces remain local.",
+            "Answer metrics are deterministic contract checks, not an LLM judge.",
+            "Latency is runner wall-clock unless a narrower local profiler is added.",
+            "This run does not improve retrieval, reranking, prompts, chunking, or verification.",
+        ],
+    }
+    assert_redacted_summary_safe(payload)
+    return payload
+
+
+def assert_redacted_summary_safe(payload: Mapping[str, Any]) -> None:
+    violations: list[str] = []
+
+    def walk(value: Any, trail: str) -> None:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                key_text = str(key)
+                if key_text in FORBIDDEN_REDACTED_KEYS:
+                    violations.append(f"{trail}.{key_text}".strip("."))
+                walk(item, f"{trail}.{key_text}".strip("."))
+        elif isinstance(value, list):
+            for index, item in enumerate(value):
+                walk(item, f"{trail}[{index}]")
+
+    walk(payload, "")
+    if violations:
+        raise PrivateRealEvalError(
+            "redacted summary includes forbidden private fields: " + ", ".join(violations)
+        )
+
+
+def write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def write_private_run_metadata(
+    run_dir: Path,
+    validation: Mapping[str, Any],
+    *,
+    build_command: Sequence[str] | None,
+    elapsed_ms: float,
+) -> None:
+    payload = {
+        "schema_version": 1,
+        "benchmark_type": "private_real_eval",
+        "local_only": True,
+        "validation": {
+            "document_count": validation.get("document_count"),
+            "question_count": validation.get("question_count"),
+            "answerable_count": validation.get("answerable_count"),
+            "unanswerable_count": validation.get("unanswerable_count"),
+            "index_exists_before_run": validation.get("index_exists"),
+        },
+        "index_build_command": list(build_command) if build_command else None,
+        "elapsed_ms": round(float(elapsed_ms), 3),
+    }
+    write_json(run_dir / "private_real_eval_run.json", payload)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run local/private real-data eval for the Naive RAG baseline."
+    )
+    parser.add_argument(
+        "--config",
+        default="configs/eval/private_real_eval.local.yaml",
+        help="Local private config copied from configs/eval/private_real_eval.template.yaml.",
+    )
+    parser.add_argument("--run-id", default=None, help="Optional deterministic run id.")
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Validate local private inputs without building/running.",
+    )
+    parser.add_argument(
+        "--redacted-summary-path",
+        default=None,
+        help="Optional safe aggregate summary path. Defaults to <output_dir>/<run_id>/redacted_summary.json.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    config_path = repo_path(args.config)
+    try:
+        config = load_private_config(config_path)
+        validation = validate_private_inputs(config)
+        print(
+            "[OK] Private real-eval inputs validated: "
+            f"{validation['document_count']} docs, "
+            f"{validation['question_count']} questions "
+            f"({validation['answerable_count']} answerable, "
+            f"{validation['unanswerable_count']} unanswerable)"
+        )
+        if args.validate_only:
+            return 0
+        build_command = build_or_load_private_index(config, validation)
+        run_id = args.run_id or str(config.get("run_id") or "").strip() or default_run_id()
+        contract_path = write_contract_config(config, validation, run_id=run_id)
+        started = time.perf_counter()
+        run_dir = run_from_config(
+            contract_path,
+            output_root_override=Path(validation["output_dir"]),
+            run_id_override=run_id,
+        )
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        metrics_path = run_dir / "metrics.json"
+        metrics_payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+        write_private_run_metadata(
+            run_dir, validation, build_command=build_command, elapsed_ms=elapsed_ms
+        )
+        redacted_summary = build_redacted_summary(
+            metrics_payload,
+            validation,
+            config,
+            elapsed_ms=elapsed_ms,
+        )
+        summary_path = (
+            repo_path(args.redacted_summary_path)
+            if args.redacted_summary_path
+            else run_dir / "redacted_summary.json"
+        )
+        write_json(summary_path, redacted_summary)
+    except Exception as exc:
+        print(f"[ERROR] Private real-eval failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"[OK] Private Naive RAG eval artifacts written: {run_dir}")
+    print(f"[OK] Redacted summary written: {summary_path}")
+    print("[INFO] No RAG performance improvement was implemented by this runner.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/naive_rag/private_real_eval.py
+++ b/eval/naive_rag/private_real_eval.py
@@ -263,6 +263,22 @@ def _gold_items(row: Mapping[str, Any]) -> list[dict[str, Any]]:
     return cleaned
 
 
+def _parse_answerable(row: Mapping[str, Any]) -> bool:
+    value = row.get("answerable", True)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise PrivateRealEvalError(
+        "answerable must be a boolean or explicit 'true'/'false' string "
+        f"for question_id={row.get('question_id')}"
+    )
+
+
 def _questions_from_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     by_id: dict[str, dict[str, Any]] = {}
     for row in rows:
@@ -277,7 +293,7 @@ def _questions_from_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, An
         by_id[qid] = {
             "question_id": qid,
             "question": question,
-            "answerable": bool(row.get("answerable", True)),
+            "answerable": _parse_answerable(row),
             "query_type": row.get("query_type"),
             "expected_answer": row.get("expected_answer"),
             "expected_terms": row.get("expected_terms") or [],
@@ -331,6 +347,15 @@ def validate_private_inputs(
         errors.append(f"gold_evidence_path does not exist: {gold_evidence_path}")
     if config.get("questions_path") and not questions_path.is_file():
         errors.append(f"questions_path does not exist: {questions_path}")
+    private_input_paths = {
+        "documents_dir": documents_dir,
+        "data_list_path": data_list_path,
+        "gold_evidence_path": gold_evidence_path,
+        "questions_path": questions_path,
+    }
+    for name, private_path in private_input_paths.items():
+        if not git_ignores_path(private_path, root):
+            errors.append(f"{name} must be ignored by git or outside the repo: {private_path}")
     if not git_ignores_path(output_dir, root):
         errors.append(f"output_dir must be ignored by git or outside the repo: {output_dir}")
     if not git_ignores_path(index_dir, root):

--- a/tests/test_private_real_eval_workflow.py
+++ b/tests/test_private_real_eval_workflow.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from eval.naive_rag import private_real_eval as pre
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_private_real_eval_template_schema() -> None:
+    config = yaml.safe_load(
+        (REPO_ROOT / "configs" / "eval" / "private_real_eval.template.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    pre.validate_template_schema(config)
+
+    assert config["benchmark_type"] == "private_real_eval"
+    assert config["not_ci_smoke"] is True
+    assert config["is_private_data"] is True
+    assert int(config["top_k"]) >= 10
+    assert "retrieval" in config["metrics"]
+    assert "answer_control" in config["metrics"]
+
+
+def _is_ignored(path: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "--quiet", path],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def test_private_local_configs_and_data_paths_are_gitignored() -> None:
+    ignored_paths = [
+        "configs/eval/private_real_eval.local.yaml",
+        "eval/real_config.local.yaml",
+        "data/private/files/private.pdf",
+        "data/private/data_list.csv",
+        "data/private/gold_evidence.jsonl",
+        "data/private/index/index.json",
+        "data/files/private.pdf",
+        "data/files_kordoc/private.json",
+        "data/data_list.csv",
+        "data/index/private-real/index.json",
+        "data/index/real221/index.json",
+        "experiments/private_runs/run/metrics.json",
+        "reports/real100/eval_summary.json",
+        "reports/real221/eval_summary.json",
+    ]
+
+    missing = [path for path in ignored_paths if not _is_ignored(path)]
+
+    assert missing == []
+
+
+def test_private_runner_fails_clearly_when_private_files_missing(tmp_path: Path) -> None:
+    config_path = tmp_path / "private_real_eval.local.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "benchmark_type": "private_real_eval",
+                "not_ci_smoke": True,
+                "is_private_data": True,
+                "documents_dir": "data/private/files",
+                "data_list_path": "data/private/data_list.csv",
+                "gold_evidence_path": "data/private/gold_evidence.jsonl",
+                "index_dir": "data/private/index",
+                "output_dir": "experiments/private_runs/missing",
+                "top_k": 10,
+                "metrics": {
+                    "retrieval": ["recall_at_5"],
+                    "citation": ["citation_accuracy"],
+                    "answer_control": ["unanswerable_detection_flag"],
+                },
+                "latency_scope": "private_runner_wall_clock",
+                "answer_metric_mode": "deterministic_contract_v1",
+                "redaction_policy": {"summary_only": True},
+                "minimums": {
+                    "min_documents": 1,
+                    "min_questions": 1,
+                    "min_answerable_questions": 1,
+                    "min_unanswerable_questions": 0,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "python3",
+            "-m",
+            "eval.naive_rag.private_real_eval",
+            "--config",
+            str(config_path),
+            "--validate-only",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "Private real-eval validation failed" in result.stderr
+    assert "documents_dir does not exist" in result.stderr
+    assert "data_list_path does not exist" in result.stderr
+    assert "gold_evidence_path does not exist" in result.stderr
+
+
+def test_redacted_summary_excludes_private_raw_fields() -> None:
+    metrics_payload = {
+        "dataset": {
+            "num_questions": 2,
+            "answerable_count": 1,
+            "unanswerable_count": 1,
+            "questions_path": "data/private/gold_evidence.jsonl",
+        },
+        "retrieval_metrics": {"recall_at_5": {"mean": 0.5, "n": 1, "missing": 0}},
+        "answer_metrics": {
+            "citation_accuracy": {"mean": 0.5, "n": 1, "missing": 0},
+            "answer_text": "PRIVATE RAW ANSWER",
+        },
+        "failure_counts": {"retrieval_failure.gold_evidence_not_in_top_k": 1},
+        "case_results": [
+            {
+                "question": "PRIVATE RAW QUESTION",
+                "answer": "PRIVATE RAW ANSWER",
+                "retrieved_chunks": [{"text_preview": "PRIVATE DOC TEXT"}],
+            }
+        ],
+    }
+    validation = {
+        "document_count": 3,
+        "question_count": 2,
+        "answerable_count": 1,
+        "unanswerable_count": 1,
+        "index_dir": REPO_ROOT / "does-not-exist",
+    }
+    config = {"top_k": 10, "latency_scope": "private_runner_wall_clock"}
+
+    summary = pre.build_redacted_summary(metrics_payload, validation, config, elapsed_ms=123.4)
+    rendered = json.dumps(summary, ensure_ascii=False)
+
+    assert "PRIVATE RAW QUESTION" not in rendered
+    assert "PRIVATE RAW ANSWER" not in rendered
+    assert "PRIVATE DOC TEXT" not in rendered
+    assert "questions_path" not in rendered
+    assert "answer_text" not in rendered
+    assert "retrieved_chunks" not in rendered
+
+
+def test_public_smoke_and_synthetic_configs_remain_unaffected() -> None:
+    public_contract = yaml.safe_load(
+        (REPO_ROOT / "configs" / "eval" / "rag_quality_v1.yaml").read_text(encoding="utf-8")
+    )
+    smoke_config = yaml.safe_load((REPO_ROOT / "eval" / "config.yaml").read_text(encoding="utf-8"))
+    registry = json.loads((REPO_ROOT / "benchmarks" / "registry.json").read_text(encoding="utf-8"))
+
+    assert public_contract["name"] == "rag_quality_v1"
+    assert public_contract["pipeline"]["name"] == "naive_baseline"
+    assert public_contract["pipeline"]["retrieval_backend"] == "dense"
+    assert any(run.get("name") == "naive_baseline" for run in smoke_config["ablation_runs"])
+    assert "private_real_eval" not in json.dumps(registry)

--- a/tests/test_private_real_eval_workflow.py
+++ b/tests/test_private_real_eval_workflow.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 from eval.naive_rag import private_real_eval as pre
@@ -117,6 +118,60 @@ def test_private_runner_fails_clearly_when_private_files_missing(tmp_path: Path)
     assert "documents_dir does not exist" in result.stderr
     assert "data_list_path does not exist" in result.stderr
     assert "gold_evidence_path does not exist" in result.stderr
+
+
+def test_private_runner_requires_private_inputs_to_be_gitignored() -> None:
+    config = {
+        "benchmark_type": "private_real_eval",
+        "not_ci_smoke": True,
+        "is_private_data": True,
+        "documents_dir": "docs",
+        "data_list_path": "docs/not_ignored_data_list.csv",
+        "gold_evidence_path": "docs/not_ignored_gold_evidence.jsonl",
+        "questions_path": "docs/not_ignored_gold_evidence.jsonl",
+        "index_dir": "data/private/index",
+        "output_dir": "experiments/private_runs/not_ignored_guard",
+        "top_k": 10,
+        "metrics": {
+            "retrieval": ["recall_at_5"],
+            "citation": ["citation_accuracy"],
+            "answer_control": ["unanswerable_detection_flag"],
+        },
+        "latency_scope": "private_runner_wall_clock",
+        "answer_metric_mode": "deterministic_contract_v1",
+        "redaction_policy": {"summary_only": True},
+        "minimums": {
+            "min_documents": 1,
+            "min_questions": 1,
+            "min_answerable_questions": 1,
+            "min_unanswerable_questions": 0,
+        },
+    }
+
+    with pytest.raises(pre.PrivateRealEvalError) as exc_info:
+        pre.validate_private_inputs(config)
+
+    message = str(exc_info.value)
+    assert "documents_dir must be ignored by git or outside the repo" in message
+    assert "data_list_path must be ignored by git or outside the repo" in message
+    assert "gold_evidence_path must be ignored by git or outside the repo" in message
+    assert "questions_path must be ignored by git or outside the repo" in message
+
+
+def test_answerable_strings_are_parsed_strictly() -> None:
+    questions = pre._questions_from_rows(
+        [
+            {"question_id": "q1", "question": "Answerable?", "answerable": "true"},
+            {"question_id": "q2", "question": "Unanswerable?", "answerable": "false"},
+        ]
+    )
+
+    assert [question["answerable"] for question in questions] == [True, False]
+
+    with pytest.raises(pre.PrivateRealEvalError, match="answerable must be a boolean"):
+        pre._questions_from_rows(
+            [{"question_id": "q3", "question": "Ambiguous?", "answerable": "no"}]
+        )
 
 
 def test_redacted_summary_excludes_private_raw_fields() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Private Real-Eval Naive RAG baseline을 local-only로 실행/검증하기 위한 wrapper, config template, workflow docs, redacted summary template, redacted baseline report template, privacy regression tests를 추가했습니다. 이번 변경은 측정 경로 추가이며 retrieval(검색), reranking(재순위), prompt(프롬프트), chunking(청킹), verifier(검증기), self-correction 동작 개선을 포함하지 않습니다.

Closes #1431

## 2. 영향 파일

- `.gitignore` — private local config/data/index/run output ignore 경계 추가
- `configs/eval/private_real_eval.template.yaml` — local-only private eval config template
- `docs/evaluation/private_real_eval_workflow.md` — private workflow 문서
- `docs/evaluation/private_real_eval_summary_template.md` — redacted summary 계약(contract)
- `docs/evaluation/private_real_eval_baseline_report.template.md` — aggregate-only baseline report template
- `eval/naive_rag/private_real_eval.py` — load-bearing `eval/` 측정 wrapper
- `tests/test_private_real_eval_workflow.py` — schema, ignore, validation, redaction, smoke/synthetic non-regression tests

## 3. 리스크

가장 큰 리스크는 private 질문(question), 답변(answer), 문서명, doc_id/chunk_id, raw 근거(evidence)가 public artifact에 섞이는 것입니다. `.gitignore` 경계와 `redacted_summary` forbidden-field 검증, missing-input validation test로 방어했습니다. 두 번째 리스크는 local private data가 없을 때 runner가 모호하게 실패하는 것인데, validate-only가 누락 경로를 명시하도록 확인했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_private_real_eval_workflow.py tests/test_private_real_eval_artifacts.py` — pass
- `bash scripts/test.sh` — `2355 passed, 16 skipped, 69 deselected, 251 subtests passed`
- `python3 -m eval.naive_rag.private_real_eval --config configs/eval/private_real_eval.local.yaml --validate-only` — expected failure in this workspace because local private data is absent; missing `data/private/files`, `data/private/data_list.csv`, `data/private/gold_evidence.jsonl`, and `questions_path`.

## 5. Eval 영향

No RAG performance improvement or scoring tune is included. Smoke eval and synthetic benchmark surfaces remain intact; the full test suite passed. Private real-eval was not executed because this workspace has no local private corpus or explicit gold evidence file.

### 5b. Real-data delta

검색(retrieval)/검증(verifier) path 동작 변화 없음. This PR adds an additive private measurement wrapper and templates only; it does not change `rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`, chunking, prompts, reranking, hybrid retrieval, or answer policy.

Private real-data delta is not available in this workspace because validate-only blocks on missing local-only inputs:

| Check | Result |
|---|---|
| `data/private/files` | missing |
| `data/private/data_list.csv` | missing |
| `data/private/gold_evidence.jsonl` | missing |
| `questions_path` | missing |

The added runner is intentionally fail-closed until explicit gold evidence exists.

## 6. 하위 호환

Additive only. Existing smoke eval, synthetic benchmark config, and Naive RAG contract remain unchanged. The new CLI is separate: `python3 -m eval.naive_rag.private_real_eval --config configs/eval/private_real_eval.local.yaml`.

## 7. 범위 외

- Retrieval/reranker/hybrid search improvements
- Prompt tuning
- Chunking changes
- Verifier optimization
- Self-correction
- Fabricating private labels or committing private raw outputs