### PR TITLE
chore(eval): make private real-eval baseline runnable locally

### DIFF
--- a/docs/evaluation/private_real_eval_workflow.md
+++ b/docs/evaluation/private_real_eval_workflow.md
@@ -62,6 +62,41 @@ Use `configs/eval/private_real_eval.local.yaml` when the goal is the Naive RAG
 baseline contract runner. Use `eval/real_config.local.yaml` and the readiness
 scripts when checking whether the local private corpus is prepared.
 
+## Local Inventory And Canonical Mapping
+
+As of 2026-05-24, the maintainer local working copy has enough private corpus
+cache to prepare the Naive RAG baseline runner, but not in the preferred
+`data/private/` layout:
+
+| Candidate category | Observed local state | Canonical target | Action |
+|---|---:|---|---|
+| Source documents | 100 files | `data/private/files/` | Symlink or copy locally; never commit. |
+| Kordoc cache | 101 files | `data/private/files_kordoc/` | Symlink as the sibling cache for `data/private/files/`. |
+| Manifest | 100 rows | `data/private/data_list.csv` | Symlink or copy locally; never commit. |
+| Existing index | 100 documents / 26,376 chunks | `data/private/index/` | Symlink only if it matches the manifest and corpus; otherwise rebuild. |
+| Gold labels/questions | No canonical file found | `data/private/gold_evidence.jsonl` | Regenerate or curate local-only labels with raw questions and explicit `gold_evidence[].chunk_id`. |
+| Redacted summary | Not present | `reports/private_real_eval_summary.redacted.json` | Generate only after a successful private run and redaction checks. |
+
+Use a local shell variable for the private cache root. Do not write its value
+into committed files:
+
+```bash
+PRIVATE_CACHE_ROOT=/path/to/local/main/worktree
+mkdir -p data/private
+ln -s "$PRIVATE_CACHE_ROOT/data/files" data/private/files
+ln -s "$PRIVATE_CACHE_ROOT/data/files_kordoc" data/private/files_kordoc
+ln -s "$PRIVATE_CACHE_ROOT/data/data_list.csv" data/private/data_list.csv
+ln -s "$PRIVATE_CACHE_ROOT/data/index/real100" data/private/index
+```
+
+If labels are converted from an older `eval/real_config.local.yaml`, write the
+result only to `data/private/gold_evidence.jsonl`. The converted file is
+runnable only after every answerable row has explicit chunk-level gold evidence
+and every unanswerable row has an empty `gold_evidence` list. Any answerable
+row that cannot be resolved to a chunk should be omitted from a temporary
+runnable subset or manually labeled before using the result for performance
+claims.
+
 ## Local Config
 
 For readiness checks:
@@ -170,6 +205,12 @@ evidence, missing answerable/unanswerable split, missing explicit
 unanswerable rows, and private paths that are not gitignored or outside the
 repo.
 
+On failure, the private runner reports only field names, categories, and
+counts, for example `missing_required_input: gold_evidence_path` or
+`missing_explicit_gold_chunk_id: answerable_questions count=N`. It must not
+print raw questions, raw answers, support text, document names, `doc_id`,
+`chunk_id`, or exact local paths.
+
 ## Run Private Naive RAG Eval
 
 Preferred contract runner:
@@ -177,6 +218,14 @@ Preferred contract runner:
 ```bash
 python3 -m eval.naive_rag.private_real_eval \
   --config configs/eval/private_real_eval.local.yaml
+```
+
+To also write the committable aggregate candidate:
+
+```bash
+python3 -m eval.naive_rag.private_real_eval \
+  --config configs/eval/private_real_eval.local.yaml \
+  --redacted-summary-path reports/private_real_eval_summary.redacted.json
 ```
 
 Readiness scaffold wrapper:

--- a/eval/naive_rag/private_real_eval.py
+++ b/eval/naive_rag/private_real_eval.py
@@ -78,6 +78,16 @@ SAFE_ANSWER_METRIC_KEYS = {
 }
 SAFE_METRIC_VALUE_KEYS = {"mean", "n", "missing"}
 ENV_DEFAULT_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+SAFE_FAILURE_COUNT_KEY_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+ABSOLUTE_PATH_VALUE_RE = re.compile(r"(^|[\s:])(?:/Users/|/private/|/home/|[A-Za-z]:[\\/])")
+PRIVATE_PATH_MARKERS = (
+    "data/private/",
+    "data/files/",
+    "data/files_kordoc/",
+    "data/index/real",
+    "experiments/private_runs/",
+    "reports/real",
+)
 
 
 class PrivateRealEvalError(ValueError):
@@ -151,6 +161,10 @@ def validate_template_schema(config: Mapping[str, Any]) -> None:
         raise PrivateRealEvalError("Private real-eval config is invalid:\n- " + "\n- ".join(errors))
 
 
+def _minimum_error(label: str, *, count: int, required: int) -> str:
+    return f"minimum_not_met: {label} count={count} required={required}"
+
+
 def _jsonl_rows(path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
@@ -178,11 +192,19 @@ def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
 def _count_documents(documents_dir: Path) -> int:
     if not documents_dir.is_dir():
         return 0
-    return sum(
-        1
-        for path in documents_dir.rglob("*")
-        if path.is_file() and not any(part.startswith(".") for part in path.parts)
-    )
+    search_dir = documents_dir.resolve() if documents_dir.is_symlink() else documents_dir
+    count = 0
+    for path in search_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            relative_parts = path.relative_to(search_dir).parts
+        except ValueError:
+            relative_parts = (path.name,)
+        if any(part.startswith(".") for part in relative_parts):
+            continue
+        count += 1
+    return count
 
 
 def _index_counts(index_dir: Path) -> tuple[int | None, int | None]:
@@ -211,6 +233,30 @@ def _index_counts(index_dir: Path) -> tuple[int | None, int | None]:
     except (TypeError, ValueError):
         chunk_count = None
     return doc_count, chunk_count
+
+
+def _index_embedding_summary(index_dir: Path) -> dict[str, Any]:
+    index_json = index_dir / "index.json"
+    if not index_json.is_file():
+        return {}
+    try:
+        payload = json.loads(index_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    embedding = payload.get("embedding") if isinstance(payload, dict) else {}
+    if not isinstance(embedding, Mapping):
+        return {}
+    summary: dict[str, Any] = {}
+    backend = str(embedding.get("backend") or "").strip()
+    if backend and not ABSOLUTE_PATH_VALUE_RE.search(backend):
+        summary["embedding_backend"] = backend
+    try:
+        dimension = int(embedding.get("dimension"))
+    except (TypeError, ValueError):
+        dimension = 0
+    if dimension > 0:
+        summary["embedding_dimension"] = dimension
+    return summary
 
 
 def _is_inside_repo(path: Path, root: Path = ROOT_DIR) -> bool:
@@ -340,13 +386,13 @@ def validate_private_inputs(
 
     errors: list[str] = []
     if not documents_dir.is_dir():
-        errors.append(f"documents_dir does not exist: {documents_dir}")
+        errors.append("missing_required_input: documents_dir")
     if not data_list_path.is_file():
-        errors.append(f"data_list_path does not exist: {data_list_path}")
+        errors.append("missing_required_input: data_list_path")
     if not gold_evidence_path.is_file():
-        errors.append(f"gold_evidence_path does not exist: {gold_evidence_path}")
+        errors.append("missing_required_input: gold_evidence_path")
     if config.get("questions_path") and not questions_path.is_file():
-        errors.append(f"questions_path does not exist: {questions_path}")
+        errors.append("missing_required_input: questions_path")
     private_input_paths = {
         "documents_dir": documents_dir,
         "data_list_path": data_list_path,
@@ -355,15 +401,13 @@ def validate_private_inputs(
     }
     for name, private_path in private_input_paths.items():
         if not git_ignores_path(private_path, root):
-            errors.append(f"{name} must be ignored by git or outside the repo: {private_path}")
+            errors.append(f"private_path_not_gitignored: {name}")
     if not git_ignores_path(output_dir, root):
-        errors.append(f"output_dir must be ignored by git or outside the repo: {output_dir}")
+        errors.append("private_path_not_gitignored: output_dir")
     if not git_ignores_path(index_dir, root):
-        errors.append(f"index_dir must be ignored by git or outside the repo: {index_dir}")
+        errors.append("private_path_not_gitignored: index_dir")
     if not (index_dir / "index.json").is_file() and not can_build_index:
-        errors.append(
-            f"index_dir has no index.json and index_build.mode={build_mode!r} cannot build it: {index_dir}"
-        )
+        errors.append(f"missing_private_index: index_dir mode={build_mode}")
 
     document_count = _count_documents(documents_dir)
     questions: list[dict[str, Any]] = []
@@ -371,52 +415,77 @@ def validate_private_inputs(
     if documents_dir.is_dir():
         min_docs = _minimums(config)["min_documents"]
         if document_count < min_docs:
-            errors.append(
-                f"documents_dir has {document_count} documents; require at least {min_docs}"
-            )
+            errors.append(_minimum_error("documents", count=document_count, required=min_docs))
     if gold_evidence_path.is_file() and (
         questions_path.is_file() or not config.get("questions_path")
     ):
-        gold_rows = _jsonl_rows(gold_evidence_path)
-        question_rows = _jsonl_rows(questions_path) if config.get("questions_path") else gold_rows
-        questions = _questions_from_rows(question_rows)
-        gold_by_qid = _gold_by_question(gold_rows)
-        mins = _minimums(config)
-        answerable = [q for q in questions if q.get("answerable", True)]
-        unanswerable = [q for q in questions if not q.get("answerable", True)]
-        if len(questions) < mins["min_questions"]:
-            errors.append(
-                f"question set has {len(questions)} questions; require at least {mins['min_questions']}"
+        try:
+            gold_rows = _jsonl_rows(gold_evidence_path)
+        except PrivateRealEvalError:
+            gold_rows = []
+            errors.append("invalid_jsonl: gold_evidence_path")
+        try:
+            question_rows = (
+                _jsonl_rows(questions_path) if config.get("questions_path") else gold_rows
             )
-        if len(answerable) < mins["min_answerable_questions"]:
-            errors.append(
-                f"answerable split has {len(answerable)} questions; require at least {mins['min_answerable_questions']}"
-            )
-        if len(unanswerable) < mins["min_unanswerable_questions"]:
-            errors.append(
-                f"unanswerable split has {len(unanswerable)} questions; require at least {mins['min_unanswerable_questions']}"
-            )
-        missing_gold = [
-            str(q["question_id"])
-            for q in answerable
-            if not any(
-                str(item.get("chunk_id") or "").strip()
-                for item in gold_by_qid.get(str(q["question_id"]), [])
-            )
-        ]
-        if missing_gold:
-            errors.append(
-                "answerable questions require explicit gold_evidence[].chunk_id; missing for: "
-                + ", ".join(missing_gold[:10])
-            )
-        unanswerable_with_gold = [
-            str(q["question_id"]) for q in unanswerable if gold_by_qid.get(str(q["question_id"]))
-        ]
-        if unanswerable_with_gold:
-            errors.append(
-                "unanswerable questions must use empty gold_evidence; found gold for: "
-                + ", ".join(unanswerable_with_gold[:10])
-            )
+        except PrivateRealEvalError:
+            question_rows = []
+            errors.append("invalid_jsonl: questions_path")
+        try:
+            questions = _questions_from_rows(question_rows)
+        except PrivateRealEvalError:
+            questions = []
+            errors.append("invalid_question_rows: questions_path")
+        try:
+            gold_by_qid = _gold_by_question(gold_rows)
+        except PrivateRealEvalError:
+            gold_by_qid = {}
+            errors.append("invalid_gold_evidence_rows: gold_evidence_path")
+        if questions:
+            mins = _minimums(config)
+            answerable = [q for q in questions if q.get("answerable", True)]
+            unanswerable = [q for q in questions if not q.get("answerable", True)]
+            if len(questions) < mins["min_questions"]:
+                errors.append(
+                    _minimum_error("questions", count=len(questions), required=mins["min_questions"])
+                )
+            if len(answerable) < mins["min_answerable_questions"]:
+                errors.append(
+                    _minimum_error(
+                        "answerable_questions",
+                        count=len(answerable),
+                        required=mins["min_answerable_questions"],
+                    )
+                )
+            if len(unanswerable) < mins["min_unanswerable_questions"]:
+                errors.append(
+                    _minimum_error(
+                        "unanswerable_questions",
+                        count=len(unanswerable),
+                        required=mins["min_unanswerable_questions"],
+                    )
+                )
+            missing_gold = [
+                q
+                for q in answerable
+                if not any(
+                    str(item.get("chunk_id") or "").strip()
+                    for item in gold_by_qid.get(str(q["question_id"]), [])
+                )
+            ]
+            if missing_gold:
+                errors.append(
+                    "missing_explicit_gold_chunk_id: "
+                    f"answerable_questions count={len(missing_gold)}"
+                )
+            unanswerable_with_gold = [
+                q for q in unanswerable if gold_by_qid.get(str(q["question_id"]))
+            ]
+            if unanswerable_with_gold:
+                errors.append(
+                    "unanswerable_gold_evidence_not_empty: "
+                    f"questions count={len(unanswerable_with_gold)}"
+                )
 
     index_docs, index_chunks = _index_counts(index_dir)
     if errors:
@@ -484,7 +553,7 @@ def build_or_load_private_index(
 ) -> list[str] | None:
     command = build_index_command(config, validation)
     if command is None:
-        print(f"[OK] Loading existing private index: {validation['index_dir']}")
+        print("[OK] Loading existing private index")
         return None
     print("[INFO] Building private index for Naive RAG eval")
     result = subprocess.run(command, cwd=ROOT_DIR, check=False, text=True)
@@ -576,6 +645,23 @@ def _safe_metric_block(block: Any, allowed_keys: set[str]) -> dict[str, Any]:
     return safe
 
 
+def _safe_count_block(block: Any) -> dict[str, int | float]:
+    if not isinstance(block, Mapping):
+        return {}
+    safe: dict[str, int | float] = {}
+    for key, value in block.items():
+        key_text = str(key)
+        if not SAFE_FAILURE_COUNT_KEY_RE.fullmatch(key_text):
+            continue
+        if key_text in FORBIDDEN_REDACTED_KEYS:
+            continue
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            safe[key_text] = value
+    return safe
+
+
 def build_redacted_summary(
     metrics_payload: Mapping[str, Any],
     validation: Mapping[str, Any],
@@ -615,6 +701,7 @@ def build_redacted_summary(
             "verifier_retry": False,
             "query_expansion": "identity",
         },
+        "index_provenance": _index_embedding_summary(Path(validation["index_dir"])),
         "metrics": {
             "retrieval": _safe_metric_block(
                 metrics_payload.get("retrieval_metrics"),
@@ -625,7 +712,7 @@ def build_redacted_summary(
                 SAFE_ANSWER_METRIC_KEYS,
             ),
         },
-        "failure_type_counts": dict(metrics_payload.get("failure_counts") or {}),
+        "failure_type_counts": _safe_count_block(metrics_payload.get("failure_counts")),
         "latency_summary": {
             "scope": str(config.get("latency_scope") or "private_runner_wall_clock"),
             "total_wall_clock_ms": round(float(elapsed_ms), 3),
@@ -661,10 +748,19 @@ def assert_redacted_summary_safe(payload: Mapping[str, Any]) -> None:
                 key_text = str(key)
                 if key_text in FORBIDDEN_REDACTED_KEYS:
                     violations.append(f"{trail}.{key_text}".strip("."))
+                if ABSOLUTE_PATH_VALUE_RE.search(key_text):
+                    violations.append(f"{trail}.{key_text}".strip("."))
+                if any(marker in key_text for marker in PRIVATE_PATH_MARKERS):
+                    violations.append(f"{trail}.{key_text}".strip("."))
                 walk(item, f"{trail}.{key_text}".strip("."))
         elif isinstance(value, list):
             for index, item in enumerate(value):
                 walk(item, f"{trail}[{index}]")
+        elif isinstance(value, str):
+            if ABSOLUTE_PATH_VALUE_RE.search(value) or any(
+                marker in value for marker in PRIVATE_PATH_MARKERS
+            ):
+                violations.append(trail)
 
     walk(payload, "")
     if violations:
@@ -773,8 +869,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"[ERROR] Private real-eval failed: {exc}", file=sys.stderr)
         return 2
 
-    print(f"[OK] Private Naive RAG eval artifacts written: {run_dir}")
-    print(f"[OK] Redacted summary written: {summary_path}")
+    print(f"[OK] Private Naive RAG eval artifacts written: {rel_or_abs(run_dir)}")
+    print(f"[OK] Redacted summary written: {rel_or_abs(summary_path)}")
     print("[INFO] No RAG performance improvement was implemented by this runner.")
     return 0
 

--- a/reports/private_real_eval_summary.redacted.json
+++ b/reports/private_real_eval_summary.redacted.json
@@ -1,0 +1,124 @@
+{
+  "benchmark_type": "private_real_eval",
+  "dataset": {
+    "answerable_count": 114,
+    "num_chunks": 26376,
+    "num_documents": 100,
+    "num_questions": 217,
+    "unanswerable_count": 103
+  },
+  "failure_type_counts": {
+    "answer_failure.failed_to_abstain": 96,
+    "answer_failure.hallucinated_requirement": 0,
+    "answer_failure.overconfident_weak_evidence": 0,
+    "answer_failure.partial_answer": 0,
+    "answer_failure.wrong_synthesis": 0,
+    "citation_failure.citation_does_not_support_claim": 2,
+    "citation_failure.correct_answer_wrong_citation": 0,
+    "citation_failure.insufficient_citation": 0,
+    "citation_failure.missing_page_number": 0,
+    "citation_failure.vague_citation_for_multiple_claims": 0,
+    "evaluation_failure.failure_case_not_saved": 0,
+    "evaluation_failure.metric_missing": 0,
+    "evaluation_failure.no_gold_evidence": 0,
+    "parsing_failure.figure_content_ignored": 0,
+    "parsing_failure.header_footer_noise": 0,
+    "parsing_failure.korean_english_mixed_text_issue": 0,
+    "parsing_failure.page_metadata_missing": 0,
+    "parsing_failure.table_content_lost": 0,
+    "retrieval_failure.chunk_boundary_split": 0,
+    "retrieval_failure.gold_evidence_not_in_top_k": 89,
+    "retrieval_failure.gold_evidence_ranked_too_low": 9,
+    "retrieval_failure.multi_chunk_evidence_missing": 14,
+    "retrieval_failure.query_wording_mismatch": 0,
+    "retrieval_failure.wrong_similar_clause": 0
+  },
+  "generated_at": "2026-05-24T10:52:50.831164+00:00",
+  "index_provenance": {
+    "embedding_backend": "hashing",
+    "embedding_dimension": 384
+  },
+  "is_private_data": true,
+  "known_limitations": [
+    "Private aggregate only; raw cases and traces remain local.",
+    "Answer metrics are deterministic contract checks, not an LLM judge.",
+    "Latency is runner wall-clock unless a narrower local profiler is added.",
+    "This run does not improve retrieval, reranking, prompts, chunking, or verification."
+  ],
+  "latency_summary": {
+    "mean_wall_clock_ms_per_question": 621.58,
+    "scope": "private_runner_wall_clock",
+    "total_wall_clock_ms": 134882.874
+  },
+  "metrics": {
+    "citation_and_answer_control": {
+      "answer_relevancy": {
+        "mean": 0.20942982456140352,
+        "missing": 103,
+        "n": 114
+      },
+      "citation_accuracy": {
+        "mean": 0.07017543859649122,
+        "missing": 103,
+        "n": 114
+      },
+      "faithfulness": {
+        "mean": 0.8421052631578947,
+        "missing": 103,
+        "n": 114
+      },
+      "hallucination_flag": {
+        "mean": 0.8387096774193549,
+        "missing": 0,
+        "n": 217
+      },
+      "unanswerable_detection_flag": {
+        "mean": 0.06796116504854369,
+        "missing": 114,
+        "n": 103
+      }
+    },
+    "retrieval": {
+      "mrr_at_5": {
+        "mean": 0.1043859649122807,
+        "missing": 103,
+        "n": 114
+      },
+      "ndcg_at_5": {
+        "mean": 0.06334448644544977,
+        "missing": 103,
+        "n": 114
+      },
+      "recall_at_10": {
+        "mean": 0.053285064194591045,
+        "missing": 103,
+        "n": 114
+      },
+      "recall_at_5": {
+        "mean": 0.0485062112249486,
+        "missing": 103,
+        "n": 114
+      }
+    }
+  },
+  "not_ci_smoke": true,
+  "pipeline": {
+    "metadata_first": false,
+    "name": "naive_baseline",
+    "query_expansion": "identity",
+    "rerank": false,
+    "retrieval_backend": "dense",
+    "top_k": 10,
+    "verifier_retry": false
+  },
+  "redaction_policy": {
+    "document_names_excluded": true,
+    "document_text_excluded": true,
+    "private_paths_excluded": true,
+    "raw_answers_excluded": true,
+    "raw_questions_excluded": true,
+    "summary_only": true
+  },
+  "schema_version": 1,
+  "system": "Naive Dense RAG"
+}

--- a/tests/test_private_real_eval_workflow.py
+++ b/tests/test_private_real_eval_workflow.py
@@ -38,7 +38,19 @@ def _is_ignored(path: str) -> bool:
         capture_output=True,
         text=True,
     )
-    return result.returncode == 0
+    if result.returncode == 0:
+        return True
+    candidate = REPO_ROOT / path
+    for parent in [candidate, *candidate.parents]:
+        try:
+            rel = parent.relative_to(REPO_ROOT)
+        except ValueError:
+            break
+        if str(rel) == ".":
+            break
+        if parent.is_symlink():
+            return _is_ignored(str(rel))
+    return False
 
 
 def test_private_local_configs_and_data_paths_are_gitignored() -> None:
@@ -72,10 +84,10 @@ def test_private_runner_fails_clearly_when_private_files_missing(tmp_path: Path)
                 "benchmark_type": "private_real_eval",
                 "not_ci_smoke": True,
                 "is_private_data": True,
-                "documents_dir": "data/private/files",
-                "data_list_path": "data/private/data_list.csv",
-                "gold_evidence_path": "data/private/gold_evidence.jsonl",
-                "index_dir": "data/private/index",
+                "documents_dir": "data/private/missing/files",
+                "data_list_path": "data/private/missing/data_list.csv",
+                "gold_evidence_path": "data/private/missing/gold_evidence.jsonl",
+                "index_dir": "data/private/missing/index",
                 "output_dir": "experiments/private_runs/missing",
                 "top_k": 10,
                 "metrics": {
@@ -115,9 +127,11 @@ def test_private_runner_fails_clearly_when_private_files_missing(tmp_path: Path)
 
     assert result.returncode == 2
     assert "Private real-eval validation failed" in result.stderr
-    assert "documents_dir does not exist" in result.stderr
-    assert "data_list_path does not exist" in result.stderr
-    assert "gold_evidence_path does not exist" in result.stderr
+    assert "missing_required_input: documents_dir" in result.stderr
+    assert "missing_required_input: data_list_path" in result.stderr
+    assert "missing_required_input: gold_evidence_path" in result.stderr
+    assert str(REPO_ROOT) not in result.stderr
+    assert "data/private" not in result.stderr
 
 
 def test_private_runner_requires_private_inputs_to_be_gitignored() -> None:
@@ -152,10 +166,85 @@ def test_private_runner_requires_private_inputs_to_be_gitignored() -> None:
         pre.validate_private_inputs(config)
 
     message = str(exc_info.value)
-    assert "documents_dir must be ignored by git or outside the repo" in message
-    assert "data_list_path must be ignored by git or outside the repo" in message
-    assert "gold_evidence_path must be ignored by git or outside the repo" in message
-    assert "questions_path must be ignored by git or outside the repo" in message
+    assert "private_path_not_gitignored: documents_dir" in message
+    assert "private_path_not_gitignored: data_list_path" in message
+    assert "private_path_not_gitignored: gold_evidence_path" in message
+    assert "private_path_not_gitignored: questions_path" in message
+    assert str(REPO_ROOT) not in message
+
+
+def test_private_runner_reports_label_gaps_without_private_ids(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "files"
+    docs_dir.mkdir()
+    (docs_dir / "private.pdf").write_text("placeholder", encoding="utf-8")
+    data_list = tmp_path / "data_list.csv"
+    data_list.write_text("placeholder\n", encoding="utf-8")
+    gold = tmp_path / "gold_evidence.jsonl"
+    gold.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "question_id": "PRIVATE-QID-001",
+                        "question": "PRIVATE RAW QUESTION",
+                        "answerable": True,
+                        "gold_evidence": [],
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "question_id": "PRIVATE-QID-002",
+                        "question": "PRIVATE RAW UNANSWERABLE",
+                        "answerable": False,
+                        "gold_evidence": [
+                            {"doc_id": "PRIVATE-DOC", "chunk_id": "PRIVATE-CHUNK"}
+                        ],
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config = {
+        "benchmark_type": "private_real_eval",
+        "not_ci_smoke": True,
+        "is_private_data": True,
+        "documents_dir": str(docs_dir),
+        "data_list_path": str(data_list),
+        "gold_evidence_path": str(gold),
+        "questions_path": str(gold),
+        "index_dir": str(tmp_path / "index"),
+        "output_dir": str(tmp_path / "runs"),
+        "top_k": 10,
+        "metrics": {
+            "retrieval": ["recall_at_5"],
+            "citation": ["citation_accuracy"],
+            "answer_control": ["unanswerable_detection_flag"],
+        },
+        "latency_scope": "private_runner_wall_clock",
+        "answer_metric_mode": "deterministic_contract_v1",
+        "redaction_policy": {"summary_only": True},
+        "minimums": {
+            "min_documents": 1,
+            "min_questions": 1,
+            "min_answerable_questions": 1,
+            "min_unanswerable_questions": 0,
+        },
+    }
+
+    with pytest.raises(pre.PrivateRealEvalError) as exc_info:
+        pre.validate_private_inputs(config)
+
+    message = str(exc_info.value)
+    assert "missing_explicit_gold_chunk_id: answerable_questions count=1" in message
+    assert "unanswerable_gold_evidence_not_empty: questions count=1" in message
+    assert "PRIVATE-QID" not in message
+    assert "PRIVATE-DOC" not in message
+    assert "PRIVATE-CHUNK" not in message
+    assert "PRIVATE RAW" not in message
 
 
 def test_answerable_strings_are_parsed_strictly() -> None:
@@ -174,6 +263,17 @@ def test_answerable_strings_are_parsed_strictly() -> None:
         )
 
 
+def test_document_count_follows_private_symlink_layout(tmp_path: Path) -> None:
+    source = tmp_path / "source-files"
+    source.mkdir()
+    (source / "one.pdf").write_text("placeholder", encoding="utf-8")
+    linked = tmp_path / "data" / "private" / "files"
+    linked.parent.mkdir(parents=True)
+    linked.symlink_to(source, target_is_directory=True)
+
+    assert pre._count_documents(linked) == 1
+
+
 def test_redacted_summary_excludes_private_raw_fields() -> None:
     metrics_payload = {
         "dataset": {
@@ -187,7 +287,12 @@ def test_redacted_summary_excludes_private_raw_fields() -> None:
             "citation_accuracy": {"mean": 0.5, "n": 1, "missing": 0},
             "answer_text": "PRIVATE RAW ANSWER",
         },
-        "failure_counts": {"retrieval_failure.gold_evidence_not_in_top_k": 1},
+        "failure_counts": {
+            "retrieval_failure.gold_evidence_not_in_top_k": 1,
+            "path": 1,
+            "/Users/example/private/file.pdf": 1,
+            "unsafe": "data/private/file.pdf",
+        },
         "case_results": [
             {
                 "question": "PRIVATE RAW QUESTION",
@@ -214,6 +319,38 @@ def test_redacted_summary_excludes_private_raw_fields() -> None:
     assert "questions_path" not in rendered
     assert "answer_text" not in rendered
     assert "retrieved_chunks" not in rendered
+    assert "/Users/example" not in rendered
+    assert "data/private" not in rendered
+    assert '"path"' not in rendered
+    assert "retrieval_failure.gold_evidence_not_in_top_k" in rendered
+    assert summary["index_provenance"] == {}
+
+
+def test_redacted_summary_rejects_path_like_values() -> None:
+    with pytest.raises(pre.PrivateRealEvalError, match="forbidden private fields"):
+        pre.assert_redacted_summary_safe({"safe_key": "/Users/example/private/file.pdf"})
+
+
+def test_index_embedding_summary_is_aggregate_only(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    index_dir.mkdir()
+    (index_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "embedding": {
+                    "backend": "hashing",
+                    "dimension": 384,
+                    "model": "/Users/example/private/model",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert pre._index_embedding_summary(index_dir) == {
+        "embedding_backend": "hashing",
+        "embedding_dimension": 384,
+    }
 
 
 def test_public_smoke_and_synthetic_configs_remain_unaffected() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1437

Private real-eval Naive RAG baseline runner를 실제 local private cache에서 실행 가능하게 정리했습니다. Validator 실패 출력은 raw path/id/text 대신 field/category/count만 보고하고, local inventory 및 canonical layout 연결 절차를 문서화했으며, redacted aggregate summary 후보를 생성했습니다.

## 2. 영향 파일

- Load-bearing: `eval/naive_rag/private_real_eval.py`
- `docs/evaluation/private_real_eval_workflow.md`
- `tests/test_private_real_eval_workflow.py`
- `reports/private_real_eval_summary.redacted.json`

## 3. 리스크

- Validator가 private raw path, question, answer, `doc_id`, `chunk_id`를 출력하면 ADR 0005 경계를 깰 수 있습니다. 테스트와 `scripts/_governance.py --check-eval-privacy`로 금지 필드/값을 확인했습니다.
- Local symlink layout에서 document count가 0으로 보일 수 있어 symlink target을 따라 count하도록 보정했습니다.

## 4. 테스트

- `python3 -m pytest tests/test_private_real_eval_workflow.py tests/test_private_real_eval_readiness.py tests/test_naive_rag_eval_contract.py -q -s`
- `python3 scripts/_governance.py --check-eval-privacy`
- `python3 -m eval.naive_rag.private_real_eval --config configs/eval/private_real_eval.local.yaml --validate-only`
- `python3 -m eval.naive_rag.private_real_eval --config configs/eval/private_real_eval.local.yaml --run-id private_real_eval_local_check --redacted-summary-path reports/private_real_eval_summary.redacted.json`

## 5. Eval 영향

Private local-only runner/reporting change. Public smoke and synthetic benchmark surfaces are unchanged. No behavior change in retrieval / verifier path.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

| Surface | Result | Notes |
|---|---:|---|
| Private Naive RAG local check | 217 questions, 100 documents, 26,376 chunks | Redacted aggregate only; raw artifacts stayed under ignored `experiments/private_runs/`. |
| Redaction governance | pass | `find_redacted_summary_forbidden_fields == {}` and `--check-eval-privacy` passed. |

## 6. 하위 호환

No CLI flag removal and no answer-contract/schema change. Existing runner output stays additive; redacted summary now includes safe aggregate `index_provenance` only.

## 7. 범위 외

- No retrieval, reranker, prompt, chunking, or verifier improvement.
- No private raw data, raw questions, raw answers, raw evidence, `doc_id`, `chunk_id`, filenames, or exact paths committed.
- Existing local index provenance is reported as `hashing`; MiniLM rebuild/performance claim calibration is left for a separate measurement decision.
