### PR TITLE
chore: Add private data quality audits (#1441)

### DIFF
--- a/docs/evaluation/private_data_quality_audit.md
+++ b/docs/evaluation/private_data_quality_audit.md
@@ -1,0 +1,122 @@
+# Private Data Quality Audit
+
+This workflow validates private corpus parsing and private real-eval labels
+before any private baseline run. It is local-only. It does not change
+retrieval, verifier, reranker, prompt, chunking, or answer behavior.
+
+No public synthetic benchmark performance claim is produced by these audits.
+Private real-eval remains local-only; only redacted aggregate summaries may be
+reviewed as commit candidates.
+
+## Required Order Before Baseline Measurement
+
+1. Parse audit
+2. Eval dataset audit
+3. `private_real_eval` validate-only
+4. `private_real_eval` run
+5. Redacted summary review
+
+## Privacy Boundary
+
+The audit scripts may read private raw documents, raw questions, raw answers,
+raw evidence content, local filenames, exact local locations, and raw index
+identifiers. They must not write those values to their output artifacts.
+
+Public-safe audit artifacts use aggregate counts and redacted hash references
+only. They must not contain raw private keys such as `question`, `answer`,
+`answer_text`, `gold_evidence`, `retrieved_chunks`, `text`, `text_preview`,
+`doc_id`, `chunk_id`, `file_name`, or `path`.
+
+Outputs must be written under ignored local directories such as
+`experiments/private_runs/`, or outside the repository. The scripts refuse to
+write into non-ignored repo paths.
+
+## Parse Quality Audit
+
+```bash
+python3 scripts/audit_private_parse_quality.py \
+  --documents-dir data/private/files \
+  --data-list data/private/data_list.csv \
+  --index-dir data/private/index \
+  --out-dir experiments/private_runs/data_quality_audit
+```
+
+Outputs:
+
+```text
+experiments/private_runs/data_quality_audit/
+parse_quality_summary.json
+parse_quality_report.md
+parse_quality_flags.jsonl
+```
+
+Checks:
+
+- total document count
+- parse success/failure count
+- empty and very short document count
+- chunk count
+- chunk length min/p50/p95/max
+- duplicate chunk ratio
+- missing page metadata count/rate
+- high garbled-character ratio count
+- suspicious whitespace-only chunk count
+- table-like chunk count
+- date/amount/score-like token coverage count
+- failed/suspicious document category counts
+
+## Eval Dataset Audit
+
+```bash
+python3 scripts/audit_private_eval_dataset.py \
+  --questions data/private/gold_evidence.jsonl \
+  --gold-evidence data/private/gold_evidence.jsonl \
+  --index-dir data/private/index \
+  --out-dir experiments/private_runs/data_quality_audit
+```
+
+Outputs:
+
+```text
+experiments/private_runs/data_quality_audit/
+eval_dataset_summary.json
+eval_dataset_report.md
+eval_dataset_flags.jsonl
+```
+
+Checks:
+
+- question identifier uniqueness
+- answerable/unanswerable count
+- answerable rows have non-empty explicit evidence
+- unanswerable rows have empty evidence
+- every evidence document/chunk reference exists in the current index
+- expected terms coverage in evidence content
+- question type distribution when available
+- duplicate and near-duplicate question detection
+- overly copied question detection with redacted similarity scores only
+- retrieval saturation warning when Recall@10 is already saturated
+- minimum dataset size checks
+
+## Interpreting Results
+
+`passed: false` means at least one blocking error was found. Fix the private
+local data or labels before running `private_real_eval`.
+
+Warnings require review but do not by themselves prove the dataset is invalid.
+Examples include small dataset size, near-duplicate questions, missing page
+metadata, or retrieval saturation. Treat retrieval saturation as a dataset
+measurement warning, not as a system performance claim.
+
+## Follow-Up Validation
+
+After both audits pass, run the private real-eval validator:
+
+```bash
+python3 -m eval.naive_rag.private_real_eval \
+  --config configs/eval/private_real_eval.local.yaml \
+  --validate-only
+```
+
+Then run the private baseline only after validate-only passes. Review only
+redacted aggregate summaries before considering any commit.

--- a/scripts/audit_private_eval_dataset.py
+++ b/scripts/audit_private_eval_dataset.py
@@ -1,0 +1,778 @@
+#!/usr/bin/env python3
+"""Local-only aggregate audit for private real-eval dataset quality.
+
+The script validates label/index consistency before private real-eval runs.
+It writes only aggregate/redacted artifacts and does not change retrieval,
+reranking, prompts, chunking, or verifier behavior.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import datetime as dt
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any, Mapping
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+try:
+    from scripts.private_data_quality_audit_utils import (
+        assert_public_safe,
+        compact,
+        containment,
+        hash_ref,
+        jaccard,
+        jsonl_rows,
+        repo_path,
+        require_safe_out_dir,
+        write_json,
+        write_jsonl,
+    )
+except ImportError:  # pragma: no cover - direct script execution
+    from private_data_quality_audit_utils import (  # type: ignore
+        assert_public_safe,
+        compact,
+        containment,
+        hash_ref,
+        jaccard,
+        jsonl_rows,
+        repo_path,
+        require_safe_out_dir,
+        write_json,
+        write_jsonl,
+    )
+
+
+MIN_TOTAL_QUESTIONS = 13
+MIN_ANSWERABLE_QUESTIONS = 10
+MIN_UNANSWERABLE_QUESTIONS = 3
+NEAR_DUPLICATE_THRESHOLD = 0.90
+OVERLY_COPIED_THRESHOLD = 0.82
+RETRIEVAL_SATURATION_RECALL = 1.0
+RETRIEVAL_SATURATION_MIN_CASES = 1
+
+
+def _load_index_payload(index_dir: Path) -> dict[str, Any]:
+    index_file = index_dir / "index.json"
+    if not index_file.is_file():
+        raise FileNotFoundError("index metadata is missing")
+    payload = json.loads(index_file.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("index metadata root must be an object")
+    return payload
+
+
+def _parse_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y"}:
+            return True
+        if lowered in {"false", "0", "no", "n"}:
+            return False
+    return default
+
+
+def _row_evidence_items(row: Mapping[str, Any]) -> list[dict[str, Any]]:
+    wrapped = row.get("gold_evidence")
+    if isinstance(wrapped, list):
+        return [dict(item) for item in wrapped if isinstance(item, dict)]
+    direct_keys = {
+        "doc_id",
+        "chunk_id",
+        "support_text",
+        "support_claim",
+        "required_terms",
+        "expected_terms",
+        "page",
+        "page_span",
+    }
+    if any(row.get(key) not in (None, "", []) for key in direct_keys):
+        return [{key: row.get(key) for key in direct_keys if row.get(key) not in (None, "", [])}]
+    return []
+
+
+def _infer_answerable(row: Mapping[str, Any]) -> bool:
+    if "answerable" in row:
+        return _parse_bool(row.get("answerable"), default=True)
+    if "gold_evidence" in row:
+        evidence = row.get("gold_evidence")
+        return bool(evidence) if isinstance(evidence, list) else True
+    return True
+
+
+def _question_type(row: Mapping[str, Any]) -> str:
+    raw = str(row.get("query_type") or row.get("question_type") or row.get("type") or "").strip()
+    if not raw:
+        return "unspecified"
+    if re.fullmatch(r"[A-Za-z0-9_.:-]+", raw):
+        return raw[:60]
+    return "non_ascii_or_custom_type"
+
+
+def _term_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _load_questions(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    rows = jsonl_rows(path)
+    questions: list[dict[str, Any]] = []
+    flags: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row_index, row in enumerate(rows, start=1):
+        qid = str(row.get("question_id") or row.get("id") or "").strip()
+        row_ref = hash_ref(f"{row_index}:{qid}", namespace="question-row")
+        if not qid:
+            flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_eval_dataset",
+                    "severity": "error",
+                    "flag_type": "missing_question_identifier",
+                    "question_ref": row_ref,
+                }
+            )
+            qid = f"missing-question-id-{row_index}"
+        if qid in seen:
+            flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_eval_dataset",
+                    "severity": "error",
+                    "flag_type": "duplicate_question_identifier",
+                    "question_ref": hash_ref(qid, namespace="question"),
+                }
+            )
+        seen.add(qid)
+        questions.append(
+            {
+                "_qid": qid,
+                "_ref": hash_ref(qid, namespace="question"),
+                "_content": str(row.get("question") or row.get("query") or ""),
+                "_answerable": _infer_answerable(row),
+                "_type": _question_type(row),
+                "_expected_terms": _term_list(row.get("expected_terms") or row.get("required_terms")),
+            }
+        )
+    return questions, flags
+
+
+def _load_evidence_by_question(path: Path) -> dict[str, list[dict[str, Any]]]:
+    by_qid: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in jsonl_rows(path):
+        qid = str(row.get("question_id") or row.get("id") or "").strip()
+        if not qid:
+            continue
+        by_qid[qid].extend(_row_evidence_items(row))
+    return by_qid
+
+
+def _index_maps(index: Mapping[str, Any]) -> dict[str, Any]:
+    docs = [doc for doc in index.get("documents") or [] if isinstance(doc, dict)]
+    chunks = [chunk for chunk in index.get("chunks") or [] if isinstance(chunk, dict)]
+    document_refs = {str(doc.get("doc_id") or "") for doc in docs if str(doc.get("doc_id") or "").strip()}
+    chunk_refs = {str(chunk.get("chunk_id") or "") for chunk in chunks if str(chunk.get("chunk_id") or "").strip()}
+    content_by_chunk = {str(chunk.get("chunk_id") or ""): str(chunk.get("text") or "") for chunk in chunks}
+    document_by_chunk = {str(chunk.get("chunk_id") or ""): str(chunk.get("doc_id") or "") for chunk in chunks}
+    return {
+        "document_refs": document_refs,
+        "chunk_refs": chunk_refs,
+        "content_by_chunk": content_by_chunk,
+        "document_by_chunk": document_by_chunk,
+        "chunk_count": len(chunks),
+        "document_count": len(docs),
+    }
+
+
+def _evidence_content(items: list[dict[str, Any]], content_by_chunk: Mapping[str, str]) -> str:
+    parts: list[str] = []
+    for item in items:
+        for key in ("support_text", "support_claim"):
+            value = str(item.get(key) or "").strip()
+            if value:
+                parts.append(value)
+        chunk_ref = str(item.get("chunk_id") or "")
+        if chunk_ref and content_by_chunk.get(chunk_ref):
+            parts.append(str(content_by_chunk[chunk_ref]))
+    return "\n".join(parts)
+
+
+def _evidence_terms(question: Mapping[str, Any], items: list[dict[str, Any]]) -> list[str]:
+    terms: list[str] = list(question.get("_expected_terms") or [])
+    for item in items:
+        terms.extend(_term_list(item.get("required_terms")))
+        terms.extend(_term_list(item.get("expected_terms")))
+    seen: set[str] = set()
+    unique: list[str] = []
+    for term in terms:
+        key = term.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(term)
+    return unique
+
+
+def _coverage_ratio(terms: list[str], evidence_content: str) -> float | None:
+    if not terms:
+        return None
+    lowered = evidence_content.lower()
+    return sum(1 for term in terms if term.lower() in lowered) / len(terms)
+
+
+def _has_non_empty_evidence(items: list[dict[str, Any]]) -> bool:
+    return any(
+        str(item.get("doc_id") or item.get("chunk_id") or item.get("support_text") or "").strip()
+        for item in items
+    )
+
+
+def _reference_flags(
+    questions: list[dict[str, Any]],
+    evidence_by_qid: Mapping[str, list[dict[str, Any]]],
+    index_maps: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    flags: list[dict[str, Any]] = []
+    coverage_scores: list[float] = []
+    copied_scores: list[float] = []
+    expected_rows = 0
+    full_coverage_count = 0
+    answerable_missing_evidence = 0
+    unanswerable_with_evidence = 0
+    missing_document_ref_count = 0
+    missing_chunk_ref_count = 0
+    absent_document_count = 0
+    absent_chunk_count = 0
+    document_chunk_mismatch_count = 0
+
+    document_refs = set(index_maps["document_refs"])
+    chunk_refs = set(index_maps["chunk_refs"])
+    content_by_chunk = index_maps["content_by_chunk"]
+    document_by_chunk = index_maps["document_by_chunk"]
+
+    for question in questions:
+        qid = str(question["_qid"])
+        qref = str(question["_ref"])
+        items = list(evidence_by_qid.get(qid, []))
+        answerable = bool(question["_answerable"])
+        has_evidence = _has_non_empty_evidence(items)
+
+        if answerable and not has_evidence:
+            answerable_missing_evidence += 1
+            flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_eval_dataset",
+                    "severity": "error",
+                    "flag_type": "answerable_missing_evidence",
+                    "question_ref": qref,
+                }
+            )
+        if not answerable and has_evidence:
+            unanswerable_with_evidence += 1
+            flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_eval_dataset",
+                    "severity": "error",
+                    "flag_type": "unanswerable_has_evidence",
+                    "question_ref": qref,
+                }
+            )
+
+        for item in items:
+            document_ref = str(item.get("doc_id") or "").strip()
+            chunk_ref = str(item.get("chunk_id") or "").strip()
+            redacted_document_ref = hash_ref(document_ref, namespace="document")
+            redacted_chunk_ref = hash_ref(chunk_ref, namespace="chunk")
+            if answerable and not document_ref:
+                missing_document_ref_count += 1
+                flags.append(
+                    {
+                        "schema_version": 1,
+                        "audit_type": "private_eval_dataset",
+                        "severity": "error",
+                        "flag_type": "missing_evidence_document_reference",
+                        "question_ref": qref,
+                    }
+                )
+            if answerable and not chunk_ref:
+                missing_chunk_ref_count += 1
+                flags.append(
+                    {
+                        "schema_version": 1,
+                        "audit_type": "private_eval_dataset",
+                        "severity": "error",
+                        "flag_type": "missing_evidence_chunk_reference",
+                        "question_ref": qref,
+                        "document_ref": redacted_document_ref,
+                    }
+                )
+            if document_ref and document_ref not in document_refs:
+                absent_document_count += 1
+                flags.append(
+                    {
+                        "schema_version": 1,
+                        "audit_type": "private_eval_dataset",
+                        "severity": "error",
+                        "flag_type": "evidence_document_reference_absent_from_index",
+                        "question_ref": qref,
+                        "document_ref": redacted_document_ref,
+                    }
+                )
+            if chunk_ref and chunk_ref not in chunk_refs:
+                absent_chunk_count += 1
+                flags.append(
+                    {
+                        "schema_version": 1,
+                        "audit_type": "private_eval_dataset",
+                        "severity": "error",
+                        "flag_type": "evidence_chunk_reference_absent_from_index",
+                        "question_ref": qref,
+                        "chunk_ref": redacted_chunk_ref,
+                    }
+                )
+            if (
+                document_ref
+                and chunk_ref
+                and chunk_ref in document_by_chunk
+                and document_by_chunk[chunk_ref] != document_ref
+            ):
+                document_chunk_mismatch_count += 1
+                flags.append(
+                    {
+                        "schema_version": 1,
+                        "audit_type": "private_eval_dataset",
+                        "severity": "error",
+                        "flag_type": "evidence_document_chunk_mismatch",
+                        "question_ref": qref,
+                        "document_ref": redacted_document_ref,
+                        "chunk_ref": redacted_chunk_ref,
+                    }
+                )
+
+        evidence_content = _evidence_content(items, content_by_chunk)
+        terms_for_row = _evidence_terms(question, items)
+        coverage = _coverage_ratio(terms_for_row, evidence_content)
+        if coverage is not None:
+            expected_rows += 1
+            coverage_scores.append(coverage)
+            if coverage >= 1.0:
+                full_coverage_count += 1
+            else:
+                flags.append(
+                    {
+                        "schema_version": 1,
+                        "audit_type": "private_eval_dataset",
+                        "severity": "warning",
+                        "flag_type": "expected_terms_not_fully_covered",
+                        "question_ref": qref,
+                        "metrics": {"coverage_ratio": round(coverage, 4), "term_count": len(terms_for_row)},
+                    }
+                )
+        copied_score = containment(question.get("_content") or "", evidence_content)
+        if question.get("_content") and evidence_content:
+            copied_scores.append(copied_score)
+            if copied_score >= OVERLY_COPIED_THRESHOLD:
+                flags.append(
+                    {
+                        "schema_version": 1,
+                        "audit_type": "private_eval_dataset",
+                        "severity": "warning",
+                        "flag_type": "overly_copied_question",
+                        "question_ref": qref,
+                        "metrics": {"similarity_score": round(copied_score, 4)},
+                    }
+                )
+
+    mean_coverage = sum(coverage_scores) / len(coverage_scores) if coverage_scores else None
+    return flags, {
+        "answerable_missing_evidence_count": answerable_missing_evidence,
+        "unanswerable_with_evidence_count": unanswerable_with_evidence,
+        "missing_document_reference_count": missing_document_ref_count,
+        "missing_chunk_reference_count": missing_chunk_ref_count,
+        "absent_document_reference_count": absent_document_count,
+        "absent_chunk_reference_count": absent_chunk_count,
+        "document_chunk_mismatch_count": document_chunk_mismatch_count,
+        "expected_terms_rows": expected_rows,
+        "expected_terms_full_coverage_count": full_coverage_count,
+        "expected_terms_mean_coverage": round(mean_coverage, 6) if mean_coverage is not None else None,
+        "overly_copied_question_count": sum(1 for score in copied_scores if score >= OVERLY_COPIED_THRESHOLD),
+    }
+
+
+def _duplicate_content_flags(questions: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    flags: list[dict[str, Any]] = []
+    exact_buckets: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for question in questions:
+        content = compact(question.get("_content") or "").lower()
+        if content:
+            exact_buckets[content].append(question)
+
+    exact_duplicate_count = 0
+    near_duplicate_count = 0
+    for bucket in exact_buckets.values():
+        if len(bucket) <= 1:
+            continue
+        exact_duplicate_count += len(bucket) - 1
+        flags.append(
+            {
+                "schema_version": 1,
+                "audit_type": "private_eval_dataset",
+                "severity": "warning",
+                "flag_type": "duplicate_question_content",
+                "pair_ref": hash_ref("|".join(sorted(item["_qid"] for item in bucket)), namespace="question-pair"),
+                "metrics": {"duplicate_count": len(bucket)},
+            }
+        )
+
+    max_pairs = 100
+    pair_flags = 0
+    for idx, left in enumerate(questions):
+        left_content = str(left.get("_content") or "")
+        if not left_content:
+            continue
+        for right in questions[idx + 1 :]:
+            right_content = str(right.get("_content") or "")
+            if not right_content:
+                continue
+            if compact(left_content).lower() == compact(right_content).lower():
+                continue
+            score = jaccard(left_content, right_content)
+            if score >= NEAR_DUPLICATE_THRESHOLD:
+                near_duplicate_count += 1
+                if pair_flags < max_pairs:
+                    flags.append(
+                        {
+                            "schema_version": 1,
+                            "audit_type": "private_eval_dataset",
+                            "severity": "warning",
+                            "flag_type": "near_duplicate_question_content",
+                            "pair_ref": hash_ref(
+                                "|".join(sorted([str(left["_qid"]), str(right["_qid"])])),
+                                namespace="question-pair",
+                            ),
+                            "metrics": {"similarity_score": round(score, 4)},
+                        }
+                    )
+                    pair_flags += 1
+    return flags, {
+        "duplicate_content_count": exact_duplicate_count,
+        "near_duplicate_pair_count": near_duplicate_count,
+    }
+
+
+def _recall_at_10(retrieved: list[str], expected: list[str]) -> float | None:
+    expected_set = {item for item in expected if item}
+    if not expected_set:
+        return None
+    retrieved_set = set(retrieved[:10])
+    return len(expected_set & retrieved_set) / len(expected_set)
+
+
+def _retrieval_probe(
+    *,
+    questions: list[dict[str, Any]],
+    evidence_by_qid: Mapping[str, list[dict[str, Any]]],
+    index_dir: Path,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    flags: list[dict[str, Any]] = []
+    try:
+        from rag_indexing import load_index
+        from rag_retrieval import embed_query_for_index
+
+        index = load_index(index_dir)
+        vector_store = index.get("_vector_store")
+        if vector_store is None or len(vector_store) == 0:
+            raise ValueError("vector store unavailable")
+        index_to_chunk = {
+            int(chunk.get("embedding_idx")): str(chunk.get("chunk_id") or "")
+            for chunk in index.get("chunks") or []
+            if isinstance(chunk, dict) and chunk.get("embedding_idx") is not None
+        }
+        recalls: list[float] = []
+        for question in questions:
+            if not question.get("_answerable") or not question.get("_content"):
+                continue
+            gold_refs = [
+                str(item.get("chunk_id") or "")
+                for item in evidence_by_qid.get(str(question["_qid"]), [])
+                if str(item.get("chunk_id") or "").strip()
+            ]
+            if not gold_refs:
+                continue
+            query_vector = embed_query_for_index(
+                str(question["_content"]),
+                index.get("embedding") if isinstance(index.get("embedding"), dict) else {},
+            )
+            retrieved = [
+                index_to_chunk.get(int(idx), "")
+                for idx, _score in vector_store.query(query_vector, top_k=10)
+            ]
+            recall = _recall_at_10(retrieved, gold_refs)
+            if recall is not None:
+                recalls.append(recall)
+        mean_recall = sum(recalls) / len(recalls) if recalls else None
+        full_count = sum(1 for value in recalls if value >= RETRIEVAL_SATURATION_RECALL)
+        saturated = bool(
+            recalls
+            and len(recalls) >= RETRIEVAL_SATURATION_MIN_CASES
+            and full_count == len(recalls)
+        )
+        if saturated:
+            flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_eval_dataset",
+                    "severity": "warning",
+                    "flag_type": "retrieval_saturation_warning",
+                    "metrics": {"recall_at_10_mean": round(float(mean_recall), 6), "evaluated_count": len(recalls)},
+                }
+            )
+        return {
+            "attempted": True,
+            "evaluated_count": len(recalls),
+            "recall_at_10_mean": round(float(mean_recall), 6) if mean_recall is not None else None,
+            "full_recall_at_10_count": full_count,
+            "saturation_warning": saturated,
+        }, flags
+    except Exception:
+        return {
+            "attempted": False,
+            "evaluated_count": 0,
+            "recall_at_10_mean": None,
+            "full_recall_at_10_count": 0,
+            "saturation_warning": False,
+        }, []
+
+
+def _size_flags(total: int, answerable: int, unanswerable: int) -> list[dict[str, Any]]:
+    checks = [
+        ("minimum_total_questions", total, MIN_TOTAL_QUESTIONS),
+        ("minimum_answerable_questions", answerable, MIN_ANSWERABLE_QUESTIONS),
+        ("minimum_unanswerable_questions", unanswerable, MIN_UNANSWERABLE_QUESTIONS),
+    ]
+    flags: list[dict[str, Any]] = []
+    for flag_type, actual, minimum in checks:
+        if actual < minimum:
+            flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_eval_dataset",
+                    "severity": "warning",
+                    "flag_type": flag_type,
+                    "metrics": {"actual_count": actual, "minimum_count": minimum},
+                }
+            )
+    return flags
+
+
+def _render_report(summary: dict[str, Any]) -> str:
+    lines = [
+        "# Private Eval Dataset Audit",
+        "",
+        "Local-only aggregate audit. Raw prompts, answers, evidence content, exact local locations, and raw identifiers are omitted.",
+        "",
+        "## Verdict",
+        "",
+        f"- Passed: `{summary['passed']}`",
+        f"- Error flags: {summary['flag_counts']['error']}",
+        f"- Warning flags: {summary['flag_counts']['warning']}",
+        "",
+        "## Dataset Counts",
+        "",
+        f"- Total questions: {summary['question_count']}",
+        f"- Answerable: {summary['answerable_count']}",
+        f"- Unanswerable: {summary['unanswerable_count']}",
+        f"- Evidence records: {summary['evidence_record_count']}",
+        "",
+        "## Consistency",
+        "",
+        f"- Duplicate identifiers: {summary['question_identifier_uniqueness']['duplicate_count']}",
+        f"- Answerable missing evidence: {summary['label_consistency']['answerable_missing_evidence_count']}",
+        f"- Unanswerable with evidence: {summary['label_consistency']['unanswerable_with_evidence_count']}",
+        f"- Missing chunk references: {summary['index_reference_coverage']['missing_chunk_reference_count']}",
+        f"- Absent chunk references: {summary['index_reference_coverage']['absent_chunk_reference_count']}",
+        "",
+        "## Coverage",
+        "",
+        f"- Expected term rows: {summary['expected_terms_coverage']['row_count']}",
+        f"- Full expected term coverage rows: {summary['expected_terms_coverage']['full_coverage_count']}",
+        f"- Mean expected term coverage: {summary['expected_terms_coverage']['mean_coverage']}",
+        "",
+        "## Retrieval Saturation Probe",
+        "",
+        f"- Attempted: `{summary['retrieval_saturation_probe']['attempted']}`",
+        f"- Evaluated cases: {summary['retrieval_saturation_probe']['evaluated_count']}",
+        f"- Recall@10 mean: {summary['retrieval_saturation_probe']['recall_at_10_mean']}",
+        f"- Saturation warning: `{summary['retrieval_saturation_probe']['saturation_warning']}`",
+        "",
+        "## Question Type Distribution",
+        "",
+    ]
+    distribution = summary["question_type_distribution"]
+    if distribution:
+        for key, count in sorted(distribution.items()):
+            lines.append(f"- `{key}`: {count}")
+    else:
+        lines.append("- None")
+    return "\n".join(lines) + "\n"
+
+
+def build_eval_dataset_audit(
+    *,
+    questions_path: Path,
+    gold_evidence_path: Path,
+    index_dir: Path,
+) -> tuple[dict[str, Any], list[dict[str, Any]], str]:
+    questions, question_flags = _load_questions(questions_path)
+    evidence_by_qid = _load_evidence_by_question(gold_evidence_path)
+    index = _load_index_payload(index_dir)
+    maps = _index_maps(index)
+
+    flags: list[dict[str, Any]] = list(question_flags)
+    reference_flags, reference_summary = _reference_flags(questions, evidence_by_qid, maps)
+    duplicate_flags, duplicate_summary = _duplicate_content_flags(questions)
+    retrieval_probe, retrieval_flags = _retrieval_probe(
+        questions=questions,
+        evidence_by_qid=evidence_by_qid,
+        index_dir=index_dir,
+    )
+    flags.extend(reference_flags)
+    flags.extend(duplicate_flags)
+    flags.extend(retrieval_flags)
+
+    answerable_count = sum(1 for question in questions if question["_answerable"])
+    unanswerable_count = len(questions) - answerable_count
+    flags.extend(_size_flags(len(questions), answerable_count, unanswerable_count))
+
+    evidence_record_count = sum(len(items) for items in evidence_by_qid.values())
+    duplicate_identifier_count = sum(
+        1 for flag in flags if flag.get("flag_type") == "duplicate_question_identifier"
+    )
+    error_count = sum(1 for flag in flags if flag.get("severity") == "error")
+    warning_count = sum(1 for flag in flags if flag.get("severity") == "warning")
+    type_counts = Counter(str(question["_type"]) for question in questions)
+
+    summary = {
+        "schema_version": 1,
+        "audit_type": "private_eval_dataset",
+        "generated_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "passed": error_count == 0,
+        "question_count": len(questions),
+        "answerable_count": answerable_count,
+        "unanswerable_count": unanswerable_count,
+        "evidence_record_count": evidence_record_count,
+        "question_identifier_uniqueness": {
+            "unique_count": len({str(question["_qid"]) for question in questions}),
+            "duplicate_count": duplicate_identifier_count,
+        },
+        "label_consistency": {
+            "answerable_missing_evidence_count": reference_summary["answerable_missing_evidence_count"],
+            "unanswerable_with_evidence_count": reference_summary["unanswerable_with_evidence_count"],
+        },
+        "index_reference_coverage": {
+            "index_document_count": maps["document_count"],
+            "index_chunk_count": maps["chunk_count"],
+            "missing_document_reference_count": reference_summary["missing_document_reference_count"],
+            "missing_chunk_reference_count": reference_summary["missing_chunk_reference_count"],
+            "absent_document_reference_count": reference_summary["absent_document_reference_count"],
+            "absent_chunk_reference_count": reference_summary["absent_chunk_reference_count"],
+            "document_chunk_mismatch_count": reference_summary["document_chunk_mismatch_count"],
+        },
+        "expected_terms_coverage": {
+            "row_count": reference_summary["expected_terms_rows"],
+            "full_coverage_count": reference_summary["expected_terms_full_coverage_count"],
+            "mean_coverage": reference_summary["expected_terms_mean_coverage"],
+        },
+        "question_type_distribution": dict(sorted(type_counts.items())),
+        "duplicate_question_detection": duplicate_summary,
+        "overly_copied_question_detection": {
+            "flagged_count": reference_summary["overly_copied_question_count"],
+            "threshold": OVERLY_COPIED_THRESHOLD,
+        },
+        "retrieval_saturation_probe": retrieval_probe,
+        "minimum_size_checks": {
+            "minimum_total_questions": MIN_TOTAL_QUESTIONS,
+            "minimum_answerable_questions": MIN_ANSWERABLE_QUESTIONS,
+            "minimum_unanswerable_questions": MIN_UNANSWERABLE_QUESTIONS,
+        },
+        "flag_counts": {"error": error_count, "warning": warning_count, "total": len(flags)},
+        "privacy": {
+            "aggregate_only": True,
+            "redacted_references_only": True,
+            "raw_private_content_omitted": True,
+        },
+    }
+    assert_public_safe(summary)
+    for flag in flags:
+        assert_public_safe(flag)
+    return summary, flags, _render_report(summary)
+
+
+def run_audit(
+    *,
+    questions_path: Path,
+    gold_evidence_path: Path,
+    index_dir: Path,
+    out_dir: Path,
+) -> dict[str, Any]:
+    questions_path = repo_path(questions_path)
+    gold_evidence_path = repo_path(gold_evidence_path)
+    index_dir = repo_path(index_dir)
+    out_dir = repo_path(out_dir)
+    require_safe_out_dir(out_dir)
+
+    summary, flags, report = build_eval_dataset_audit(
+        questions_path=questions_path,
+        gold_evidence_path=gold_evidence_path,
+        index_dir=index_dir,
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_json(out_dir / "eval_dataset_summary.json", summary)
+    (out_dir / "eval_dataset_report.md").write_text(report, encoding="utf-8")
+    write_jsonl(out_dir / "eval_dataset_flags.jsonl", flags)
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--questions", required=True)
+    parser.add_argument("--gold-evidence", required=True)
+    parser.add_argument("--index-dir", required=True)
+    parser.add_argument("--out-dir", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        summary = run_audit(
+            questions_path=Path(args.questions),
+            gold_evidence_path=Path(args.gold_evidence),
+            index_dir=Path(args.index_dir),
+            out_dir=Path(args.out_dir),
+        )
+    except Exception as exc:
+        print(f"[ERROR] private eval dataset audit failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        "[OK]" if summary["passed"] else "[FAIL]",
+        "private eval dataset audit:",
+        f"questions={summary['question_count']}",
+        f"errors={summary['flag_counts']['error']}",
+        f"warnings={summary['flag_counts']['warning']}",
+    )
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_private_parse_quality.py
+++ b/scripts/audit_private_parse_quality.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Local-only aggregate audit for private parse/index quality.
+
+The script reads private inputs and index content, but every artifact it writes
+is aggregate/redacted only. It does not change ingestion, chunking, retrieval,
+reranking, prompt, or verifier behavior.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import csv
+import datetime as dt
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+try:  # direct script execution
+    from scripts.private_data_quality_audit_utils import (
+        assert_public_safe,
+        compact,
+        hash_ref,
+        page_metadata_present,
+        percentile,
+        repo_path,
+        require_safe_out_dir,
+        write_json,
+        write_jsonl,
+    )
+except ImportError:  # pragma: no cover
+    from private_data_quality_audit_utils import (  # type: ignore
+        assert_public_safe,
+        compact,
+        hash_ref,
+        page_metadata_present,
+        percentile,
+        repo_path,
+        require_safe_out_dir,
+        write_json,
+        write_jsonl,
+    )
+
+try:
+    from ingestion import canonical_doc_id, clean_cell, normalize_file_format
+except Exception:  # pragma: no cover - keeps audit usable if ingestion deps drift
+    canonical_doc_id = None  # type: ignore[assignment]
+
+    def clean_cell(value: Any) -> str:  # type: ignore[no-redef]
+        return compact(value)
+
+    def normalize_file_format(value: Any, file_name: str = "") -> str:  # type: ignore[no-redef]
+        raw = str(value or Path(file_name).suffix.lstrip(".") or "").strip().lower()
+        return raw
+
+
+EMPTY_DOC_CHAR_THRESHOLD = 1
+VERY_SHORT_DOC_CHAR_THRESHOLD = 200
+HIGH_GARBLED_RATIO = 0.02
+TABLE_LIKE_RE = re.compile(
+    r"(\|[^|\n]+?\||\t|[┌┬┐├┼┤└┴┘]|(?:^|\n)\s*(?:구분|항목|내용|배점|평가)\s+)",
+    re.MULTILINE,
+)
+DATE_RE = re.compile(
+    r"(?:20\d{2}[./-]\d{1,2}[./-]\d{1,2}|20\d{2}\s*년\s*\d{1,2}\s*월|\d{1,2}\s*월\s*\d{1,2}\s*일)"
+)
+AMOUNT_RE = re.compile(r"\d[\d,]*(?:\.\d+)?\s*(?:원|천원|만원|억원|%)|(?:예산|금액|사업비)")
+SCORE_RE = re.compile(r"\d+(?:\.\d+)?\s*(?:점|%)|(?:배점|평가점수|정량|정성)")
+GARBLED_RE = re.compile(r"[�□■◆◇●○▯�]")
+
+
+def _load_index(index_dir: Path) -> dict[str, Any]:
+    index_file = index_dir / "index.json"
+    if not index_file.is_file():
+        raise FileNotFoundError("index metadata is missing")
+    payload = json.loads(index_file.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("index metadata root must be an object")
+    return payload
+
+
+def _safe_format(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9_+-]+", "_", value.strip().lower()).strip("_")
+    return normalized[:40] if normalized else "unknown"
+
+
+def _manifest_document_ref(row: dict[str, str], row_number: int) -> str:
+    for key in ("doc_id", "document_id", "notice_id"):
+        value = clean_cell(row.get(key))
+        if value:
+            return value
+    notice_id = clean_cell(row.get("공고 번호"))
+    notice_round = clean_cell(row.get("공고 차수"))
+    file_value = clean_cell(row.get("file_path") or row.get("파일명") or row.get("file_name"))
+    if canonical_doc_id is not None:
+        candidate = canonical_doc_id(notice_id, notice_round, file_value)
+        if candidate:
+            return str(candidate)
+    if notice_id:
+        return f"{notice_id}-{notice_round}" if notice_round else notice_id
+    if file_value:
+        return Path(file_value).stem
+    return f"manifest-row-{row_number}"
+
+
+def _manifest_file_value(row: dict[str, str]) -> str:
+    return clean_cell(row.get("file_path") or row.get("파일명") or row.get("file_name"))
+
+
+def _source_exists(documents_dir: Path, file_value: str) -> bool:
+    if not file_value:
+        return False
+    candidate = Path(file_value)
+    if candidate.is_absolute():
+        return candidate.is_file()
+    return (documents_dir / candidate).is_file()
+
+
+def _load_manifest(documents_dir: Path, data_list: Path) -> dict[str, Any]:
+    if not data_list.is_file():
+        raise FileNotFoundError("data list is missing")
+    refs: list[str] = []
+    category_counts: Counter[str] = Counter()
+    format_counts: Counter[str] = Counter()
+    manifest_flags: list[dict[str, Any]] = []
+    seen_refs: set[str] = set()
+
+    with data_list.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row_number, row in enumerate(reader, start=2):
+            has_ref_signal = any(
+                clean_cell(row.get(key))
+                for key in ("doc_id", "document_id", "notice_id", "공고 번호", "file_path", "파일명", "file_name")
+            )
+            row_ref = _manifest_document_ref(row, row_number)
+            file_value = _manifest_file_value(row)
+            file_format = _safe_format(normalize_file_format(row.get("파일형식"), file_value))
+            refs.append(row_ref)
+            format_counts[file_format] += 1
+
+            row_categories: list[str] = []
+            if not has_ref_signal:
+                row_categories.append("missing_document_ref")
+            if row_ref in seen_refs:
+                row_categories.append("duplicate_document_ref")
+            seen_refs.add(row_ref)
+            if not file_value:
+                row_categories.append("missing_source_file_ref")
+            elif not _source_exists(documents_dir, file_value):
+                row_categories.append("missing_source_file")
+            if file_format not in {"pdf", "hwp", "hwpx", "json", "txt", "md"}:
+                row_categories.append("unsupported_or_unknown_format")
+            if "텍스트" in row and not clean_cell(row.get("텍스트")):
+                row_categories.append("empty_manifest_content")
+
+            for category in row_categories:
+                category_counts[category] += 1
+                manifest_flags.append(
+                    {
+                        "schema_version": 1,
+                        "audit_type": "private_parse_quality",
+                        "severity": "error" if category in {"missing_source_file", "empty_manifest_content"} else "warning",
+                        "flag_type": category,
+                        "subject_ref": hash_ref(f"{row_number}:{row_ref}:{file_value}", namespace="manifest-row"),
+                    }
+                )
+
+    return {
+        "row_count": len(refs),
+        "document_refs": refs,
+        "category_counts": dict(category_counts),
+        "format_distribution": dict(sorted(format_counts.items())),
+        "flags": manifest_flags,
+    }
+
+
+def _chunk_text(chunk: dict[str, Any]) -> str:
+    return str(chunk.get("text") or "")
+
+
+def _garbled_ratio(value: str) -> float:
+    compacted = re.sub(r"\s+", "", value)
+    if not compacted:
+        return 0.0
+    return len(GARBLED_RE.findall(value)) / len(compacted)
+
+
+def _has_date_amount_or_score(value: str) -> bool:
+    return bool(DATE_RE.search(value) or AMOUNT_RE.search(value) or SCORE_RE.search(value))
+
+
+def _document_ref_for_chunk(chunk: dict[str, Any]) -> str:
+    return str(chunk.get("doc_id") or chunk.get("metadata", {}).get("doc_id") or "")
+
+
+def _collect_chunk_metrics(index: dict[str, Any]) -> dict[str, Any]:
+    chunks = [chunk for chunk in index.get("chunks") or [] if isinstance(chunk, dict)]
+    documents = [doc for doc in index.get("documents") or [] if isinstance(doc, dict)]
+    doc_refs = {str(doc.get("doc_id") or "") for doc in documents if str(doc.get("doc_id") or "").strip()}
+
+    lengths = [len(_chunk_text(chunk)) for chunk in chunks]
+    normalized_contents = [compact(_chunk_text(chunk)).lower() for chunk in chunks]
+    non_empty_contents = [value for value in normalized_contents if value]
+    duplicate_excess = len(non_empty_contents) - len(set(non_empty_contents))
+
+    missing_page = 0
+    high_garbled = 0
+    whitespace_only = 0
+    table_like = 0
+    date_amount_score_coverage = 0
+    flags: list[dict[str, Any]] = []
+    chunks_by_doc: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for chunk in chunks:
+        raw = _chunk_text(chunk)
+        doc_ref = _document_ref_for_chunk(chunk)
+        chunk_ref = str(chunk.get("chunk_id") or f"{doc_ref}:{len(chunks_by_doc[doc_ref])}")
+        chunks_by_doc[doc_ref].append(chunk)
+        chunk_hash = hash_ref(chunk_ref, namespace="chunk")
+        doc_hash = hash_ref(doc_ref, namespace="document")
+
+        if not page_metadata_present(chunk):
+            missing_page += 1
+        ratio = _garbled_ratio(raw)
+        if ratio >= HIGH_GARBLED_RATIO:
+            high_garbled += 1
+            flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_parse_quality",
+                    "severity": "error",
+                    "flag_type": "high_garbled_character_ratio",
+                    "document_ref": doc_hash,
+                    "chunk_ref": chunk_hash,
+                    "metrics": {"garbled_ratio": round(ratio, 4), "content_chars": len(raw)},
+                }
+            )
+        if raw and not raw.strip():
+            whitespace_only += 1
+            flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_parse_quality",
+                    "severity": "error",
+                    "flag_type": "whitespace_only_chunk",
+                    "document_ref": doc_hash,
+                    "chunk_ref": chunk_hash,
+                    "metrics": {"content_chars": len(raw)},
+                }
+            )
+        if TABLE_LIKE_RE.search(raw):
+            table_like += 1
+        if _has_date_amount_or_score(raw):
+            date_amount_score_coverage += 1
+
+    document_category_counts: Counter[str] = Counter()
+    document_flags: list[dict[str, Any]] = []
+    all_doc_refs = set(doc_refs) | {doc_ref for doc_ref in chunks_by_doc if doc_ref}
+    for doc_ref in sorted(all_doc_refs):
+        doc_chunks = chunks_by_doc.get(doc_ref, [])
+        content_chars = sum(len(_chunk_text(chunk).strip()) for chunk in doc_chunks)
+        categories: list[tuple[str, str]] = []
+        if content_chars <= EMPTY_DOC_CHAR_THRESHOLD:
+            categories.append(("empty_document", "error"))
+        elif content_chars < VERY_SHORT_DOC_CHAR_THRESHOLD:
+            categories.append(("very_short_document", "warning"))
+        if doc_chunks and all(not page_metadata_present(chunk) for chunk in doc_chunks):
+            categories.append(("missing_page_metadata_document", "warning"))
+        if any(_garbled_ratio(_chunk_text(chunk)) >= HIGH_GARBLED_RATIO for chunk in doc_chunks):
+            categories.append(("high_garbled_document", "error"))
+        for category, severity in categories:
+            document_category_counts[category] += 1
+            document_flags.append(
+                {
+                    "schema_version": 1,
+                    "audit_type": "private_parse_quality",
+                    "severity": severity,
+                    "flag_type": category,
+                    "document_ref": hash_ref(doc_ref, namespace="document"),
+                    "metrics": {"chunk_count": len(doc_chunks), "content_chars": content_chars},
+                }
+            )
+
+    return {
+        "document_refs": doc_refs,
+        "chunk_count": len(chunks),
+        "lengths": lengths,
+        "duplicate_chunk_ratio": round((duplicate_excess / len(chunks)) if chunks else 0.0, 6),
+        "missing_page_metadata_count": missing_page,
+        "missing_page_metadata_rate": round((missing_page / len(chunks)) if chunks else 0.0, 6),
+        "high_garbled_character_ratio_count": high_garbled,
+        "suspicious_whitespace_only_chunk_count": whitespace_only,
+        "table_like_chunk_count": table_like,
+        "date_amount_score_like_token_coverage_count": date_amount_score_coverage,
+        "failed_suspicious_document_category_counts": dict(sorted(document_category_counts.items())),
+        "flags": flags + document_flags,
+    }
+
+
+def _length_block(lengths: list[int]) -> dict[str, Any]:
+    return {
+        "min": min(lengths) if lengths else None,
+        "p50": percentile(lengths, 0.50),
+        "p95": percentile(lengths, 0.95),
+        "max": max(lengths) if lengths else None,
+    }
+
+
+def _render_report(summary: dict[str, Any]) -> str:
+    chunk_lengths = summary["chunk_length_chars"]
+    lines = [
+        "# Private Parse Quality Audit",
+        "",
+        "Local-only aggregate audit. Raw content, source names, exact local locations, and raw identifiers are omitted.",
+        "",
+        "## Verdict",
+        "",
+        f"- Passed: `{summary['passed']}`",
+        f"- Error flags: {summary['flag_counts']['error']}",
+        f"- Warning flags: {summary['flag_counts']['warning']}",
+        "",
+        "## Counts",
+        "",
+        f"- Total documents: {summary['total_document_count']}",
+        f"- Parse success: {summary['parse_success_count']}",
+        f"- Parse failure: {summary['parse_failure_count']}",
+        f"- Empty documents: {summary['empty_document_count']}",
+        f"- Very short documents: {summary['very_short_document_count']}",
+        f"- Chunks: {summary['chunk_count']}",
+        "",
+        "## Chunk Lengths",
+        "",
+        "| min | p50 | p95 | max |",
+        "|---:|---:|---:|---:|",
+        f"| {chunk_lengths['min']} | {chunk_lengths['p50']} | {chunk_lengths['p95']} | {chunk_lengths['max']} |",
+        "",
+        "## Signals",
+        "",
+        f"- Duplicate chunk ratio: {summary['duplicate_chunk_ratio']}",
+        f"- Missing page metadata: {summary['missing_page_metadata_count']} ({summary['missing_page_metadata_rate']})",
+        f"- High garbled-character ratio chunks: {summary['high_garbled_character_ratio_count']}",
+        f"- Whitespace-only chunks: {summary['suspicious_whitespace_only_chunk_count']}",
+        f"- Table-like chunks: {summary['table_like_chunk_count']}",
+        f"- Date/amount/score-like token coverage chunks: {summary['date_amount_score_like_token_coverage_count']}",
+        "",
+        "## Document Categories",
+        "",
+    ]
+    categories = summary["failed_suspicious_document_category_counts"]
+    if categories:
+        for key, count in sorted(categories.items()):
+            lines.append(f"- `{key}`: {count}")
+    else:
+        lines.append("- None")
+    return "\n".join(lines) + "\n"
+
+
+def build_parse_quality_audit(
+    *,
+    documents_dir: Path,
+    data_list: Path,
+    index_dir: Path,
+) -> tuple[dict[str, Any], list[dict[str, Any]], str]:
+    manifest = _load_manifest(documents_dir, data_list)
+    index = _load_index(index_dir)
+    chunk_metrics = _collect_chunk_metrics(index)
+
+    manifest_refs = {str(ref) for ref in manifest["document_refs"] if str(ref).strip()}
+    index_doc_refs = set(chunk_metrics["document_refs"])
+    missing_manifest_refs = sorted(manifest_refs - index_doc_refs)
+    parse_success_count = len(manifest_refs & index_doc_refs) if manifest_refs else len(index_doc_refs)
+    parse_failure_count = len(missing_manifest_refs)
+
+    flags = list(manifest["flags"]) + list(chunk_metrics["flags"])
+    for ref in missing_manifest_refs:
+        flags.append(
+            {
+                "schema_version": 1,
+                "audit_type": "private_parse_quality",
+                "severity": "error",
+                "flag_type": "parse_failure_missing_from_index",
+                "document_ref": hash_ref(ref, namespace="document"),
+            }
+        )
+
+    category_counts = Counter(chunk_metrics["failed_suspicious_document_category_counts"])
+    category_counts.update(manifest["category_counts"])
+    if parse_failure_count:
+        category_counts["parse_failure_missing_from_index"] += parse_failure_count
+
+    error_count = sum(1 for flag in flags if flag.get("severity") == "error")
+    warning_count = sum(1 for flag in flags if flag.get("severity") == "warning")
+    lengths = [int(value) for value in chunk_metrics["lengths"]]
+    summary = {
+        "schema_version": 1,
+        "audit_type": "private_parse_quality",
+        "generated_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "passed": error_count == 0,
+        "total_document_count": manifest["row_count"] or len(index_doc_refs),
+        "parse_success_count": parse_success_count,
+        "parse_failure_count": parse_failure_count,
+        "empty_document_count": int(category_counts.get("empty_document", 0)),
+        "very_short_document_count": int(category_counts.get("very_short_document", 0)),
+        "chunk_count": chunk_metrics["chunk_count"],
+        "chunk_length_chars": _length_block(lengths),
+        "duplicate_chunk_ratio": chunk_metrics["duplicate_chunk_ratio"],
+        "missing_page_metadata_count": chunk_metrics["missing_page_metadata_count"],
+        "missing_page_metadata_rate": chunk_metrics["missing_page_metadata_rate"],
+        "high_garbled_character_ratio_count": chunk_metrics["high_garbled_character_ratio_count"],
+        "suspicious_whitespace_only_chunk_count": chunk_metrics["suspicious_whitespace_only_chunk_count"],
+        "table_like_chunk_count": chunk_metrics["table_like_chunk_count"],
+        "date_amount_score_like_token_coverage_count": chunk_metrics[
+            "date_amount_score_like_token_coverage_count"
+        ],
+        "failed_suspicious_document_category_counts": dict(sorted(category_counts.items())),
+        "source_format_distribution": manifest["format_distribution"],
+        "flag_counts": {"error": error_count, "warning": warning_count, "total": len(flags)},
+        "privacy": {
+            "aggregate_only": True,
+            "redacted_references_only": True,
+            "raw_private_content_omitted": True,
+        },
+    }
+    assert_public_safe(summary)
+    for flag in flags:
+        assert_public_safe(flag)
+    return summary, flags, _render_report(summary)
+
+
+def run_audit(
+    *,
+    documents_dir: Path,
+    data_list: Path,
+    index_dir: Path,
+    out_dir: Path,
+) -> dict[str, Any]:
+    documents_dir = repo_path(documents_dir)
+    data_list = repo_path(data_list)
+    index_dir = repo_path(index_dir)
+    out_dir = repo_path(out_dir)
+    require_safe_out_dir(out_dir)
+
+    summary, flags, report = build_parse_quality_audit(
+        documents_dir=documents_dir,
+        data_list=data_list,
+        index_dir=index_dir,
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_json(out_dir / "parse_quality_summary.json", summary)
+    (out_dir / "parse_quality_report.md").write_text(report, encoding="utf-8")
+    write_jsonl(out_dir / "parse_quality_flags.jsonl", flags)
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--documents-dir", required=True)
+    parser.add_argument("--data-list", required=True)
+    parser.add_argument("--index-dir", required=True)
+    parser.add_argument("--out-dir", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        summary = run_audit(
+            documents_dir=Path(args.documents_dir),
+            data_list=Path(args.data_list),
+            index_dir=Path(args.index_dir),
+            out_dir=Path(args.out_dir),
+        )
+    except Exception as exc:
+        print(f"[ERROR] private parse quality audit failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        "[OK]" if summary["passed"] else "[FAIL]",
+        "private parse quality audit:",
+        f"documents={summary['total_document_count']}",
+        f"chunks={summary['chunk_count']}",
+        f"errors={summary['flag_counts']['error']}",
+        f"warnings={summary['flag_counts']['warning']}",
+    )
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/private_data_quality_audit_utils.py
+++ b/scripts/private_data_quality_audit_utils.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Shared helpers for local-only private data quality audit scripts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import subprocess
+from typing import Any, Iterable
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+FORBIDDEN_PUBLIC_KEYS = frozenset(
+    {
+        "question",
+        "answer",
+        "answer_text",
+        "gold_evidence",
+        "retrieved_chunks",
+        "text",
+        "text_preview",
+        "doc_id",
+        "chunk_id",
+        "file_name",
+        "filename",
+        "file_path",
+        "source_path",
+        "path",
+        "absolute_path",
+        "support_text",
+        "raw_text",
+        "document_text",
+    }
+)
+ABSOLUTE_LOCAL_PATH_RE = re.compile(
+    r"(^|[\s'\"])/(Users|home|private|var|tmp|Volumes)/[^\s'\"]+"
+)
+TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]{2,}")
+
+
+class AuditPrivacyError(ValueError):
+    """Raised when an audit output would cross the private-data boundary."""
+
+
+def repo_path(value: str | Path, root: Path = ROOT_DIR) -> Path:
+    candidate = Path(str(value))
+    return candidate if candidate.is_absolute() else root / candidate
+
+
+def rel_to_repo(path: Path, root: Path = ROOT_DIR) -> str | None:
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return None
+
+
+def gitignored_or_outside_repo(path: Path, root: Path = ROOT_DIR) -> bool:
+    rel = rel_to_repo(path, root)
+    if rel is None:
+        return True
+    candidates = [rel]
+    if not rel.endswith("/"):
+        candidates.append(rel + "/")
+        candidates.append(rel + "/.private-data-quality-audit-probe")
+    for candidate in candidates:
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", "--", candidate],
+            cwd=root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True
+    return False
+
+
+def require_safe_out_dir(out_dir: Path, root: Path = ROOT_DIR) -> None:
+    if not gitignored_or_outside_repo(out_dir, root):
+        raise AuditPrivacyError(
+            "--out-dir must be outside the repo or under a gitignored local-only directory"
+        )
+
+
+def hash_ref(value: Any, *, namespace: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        raw = "<missing>"
+    digest = hashlib.sha256(f"{namespace}\x00{raw}".encode("utf-8")).hexdigest()[:16]
+    return f"redacted_{digest}"
+
+
+def compact(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()
+
+
+def tokens(value: Any) -> set[str]:
+    return {match.group(0).lower() for match in TOKEN_RE.finditer(str(value or ""))}
+
+
+def jaccard(left: Any, right: Any) -> float:
+    left_tokens = tokens(left)
+    right_tokens = tokens(right)
+    if not left_tokens or not right_tokens:
+        return 0.0
+    return len(left_tokens & right_tokens) / len(left_tokens | right_tokens)
+
+
+def containment(needle: Any, haystack: Any) -> float:
+    needle_tokens = tokens(needle)
+    haystack_tokens = tokens(haystack)
+    if not needle_tokens:
+        return 0.0
+    return len(needle_tokens & haystack_tokens) / len(needle_tokens)
+
+
+def percentile(values: list[int | float], q: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = (len(ordered) - 1) * q
+    low = math.floor(pos)
+    high = math.ceil(pos)
+    if low == high:
+        return ordered[int(pos)]
+    return ordered[low] + (ordered[high] - ordered[low]) * (pos - low)
+
+
+def page_metadata_present(item: dict[str, Any]) -> bool:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    for node in (item, metadata):
+        for key in ("page", "page_number", "page_span", "page_start", "page_end", "pages"):
+            value = node.get(key)
+            if value not in (None, "", []):
+                return True
+    regions = item.get("regions")
+    if isinstance(regions, list):
+        return any(
+            isinstance(region, dict) and region.get("page_number") not in (None, "")
+            for region in regions
+        )
+    return False
+
+
+def jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        text = line.strip()
+        if not text:
+            continue
+        payload = json.loads(text)
+        if not isinstance(payload, dict):
+            raise ValueError(f"JSONL row must be an object at line {lineno}")
+        rows.append(payload)
+    return rows
+
+
+def forbidden_output_hits(obj: Any, *, include_values: bool = True) -> dict[str, int]:
+    found: dict[str, int] = {}
+
+    def bump(key: str) -> None:
+        found[key] = found.get(key, 0) + 1
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                key_text = str(key).lower()
+                if key_text in FORBIDDEN_PUBLIC_KEYS:
+                    bump(key_text)
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+        elif include_values and isinstance(node, str):
+            if ABSOLUTE_LOCAL_PATH_RE.search(node):
+                bump("absolute_path_value")
+
+    walk(obj)
+    return found
+
+
+def assert_public_safe(obj: Any) -> None:
+    hits = forbidden_output_hits(obj)
+    if hits:
+        detail = ", ".join(f"{key}x{count}" for key, count in sorted(hits.items()))
+        raise AuditPrivacyError(f"audit output contains forbidden private fields: {detail}")
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    assert_public_safe(payload)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    lines: list[str] = []
+    for row in rows:
+        assert_public_safe(row)
+        lines.append(json.dumps(row, ensure_ascii=False, sort_keys=True))
+    path.write_text(("\n".join(lines) + ("\n" if lines else "")), encoding="utf-8")

--- a/tests/test_private_data_quality_audit.py
+++ b/tests/test_private_data_quality_audit.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import audit_private_eval_dataset as eval_audit
+from scripts import audit_private_parse_quality as parse_audit
+from scripts.private_data_quality_audit_utils import (
+    AuditPrivacyError,
+    assert_public_safe,
+    forbidden_output_hits,
+)
+
+
+FORBIDDEN_RAW_KEYS = {
+    "question",
+    "answer",
+    "answer_text",
+    "gold_evidence",
+    "retrieved_chunks",
+    "text",
+    "text_preview",
+    "doc_id",
+    "chunk_id",
+    "file_name",
+    "path",
+}
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _write_index(index_dir: Path) -> None:
+    index_dir.mkdir(parents=True)
+    payload = {
+        "schema_version": 2,
+        "mode": "rag",
+        "embedding": {"backend": "hashing", "dimension": 384, "storage": "sidecar_npy"},
+        "build": {"num_documents": 1, "num_chunks": 1},
+        "documents": [
+            {
+                "doc_id": "PRIVATE-DOC-001",
+                "title": "PRIVATE TITLE",
+                "agency": "PRIVATE AGENCY",
+                "project": "PRIVATE PROJECT",
+                "metadata": {},
+            }
+        ],
+        "chunks": [
+            {
+                "doc_id": "PRIVATE-DOC-001",
+                "chunk_id": "PRIVATE-DOC-001::chunk-001",
+                "title": "PRIVATE TITLE",
+                "section": "본문",
+                "metadata": {},
+                "page_span": [1, 1],
+                "embedding_idx": 0,
+                "text": "PRIVATE RAW EVIDENCE 예산 10억원, 평가점수 90점.",
+            }
+        ],
+    }
+    (index_dir / "index.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _write_parse_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    docs_dir = tmp_path / "files"
+    docs_dir.mkdir()
+    (docs_dir / "secret-private-file.pdf").write_text("placeholder", encoding="utf-8")
+    data_list = tmp_path / "data_list.csv"
+    with data_list.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["doc_id", "file_path"])
+        writer.writeheader()
+        writer.writerow({"doc_id": "PRIVATE-DOC-001", "file_path": "secret-private-file.pdf"})
+    index_dir = tmp_path / "index"
+    _write_index(index_dir)
+    return docs_dir, data_list, index_dir
+
+
+def _write_valid_eval_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    index_dir = tmp_path / "index"
+    _write_index(index_dir)
+    questions = tmp_path / "questions.jsonl"
+    evidence = tmp_path / "evidence.jsonl"
+    _write_jsonl(
+        questions,
+        [
+            {
+                "question_id": "PRIVATE-Q-001",
+                "question": "PRIVATE RAW QUESTION 예산은?",
+                "answerable": True,
+                "expected_terms": ["예산"],
+                "query_type": "single_doc",
+            },
+            {
+                "question_id": "PRIVATE-Q-002",
+                "question": "PRIVATE RAW QUESTION 없는 항목은?",
+                "answerable": False,
+                "query_type": "abstention",
+            },
+        ],
+    )
+    _write_jsonl(
+        evidence,
+        [
+            {
+                "question_id": "PRIVATE-Q-001",
+                "gold_evidence": [
+                    {
+                        "doc_id": "PRIVATE-DOC-001",
+                        "chunk_id": "PRIVATE-DOC-001::chunk-001",
+                        "required_terms": ["예산"],
+                        "support_text": "PRIVATE RAW EVIDENCE 예산 10억원",
+                    }
+                ],
+            },
+            {"question_id": "PRIVATE-Q-002", "gold_evidence": []},
+        ],
+    )
+    return questions, evidence, index_dir
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def test_public_safe_guard_rejects_forbidden_private_keys() -> None:
+    for key in FORBIDDEN_RAW_KEYS:
+        with pytest.raises(AuditPrivacyError):
+            assert_public_safe({key: "PRIVATE"})
+
+
+def test_parse_quality_summary_schema_and_privacy(tmp_path: Path) -> None:
+    docs_dir, data_list, index_dir = _write_parse_inputs(tmp_path)
+    out_dir = tmp_path / "audit"
+
+    summary = parse_audit.run_audit(
+        documents_dir=docs_dir,
+        data_list=data_list,
+        index_dir=index_dir,
+        out_dir=out_dir,
+    )
+
+    assert summary["schema_version"] == 1
+    assert summary["audit_type"] == "private_parse_quality"
+    assert summary["total_document_count"] == 1
+    assert summary["parse_success_count"] == 1
+    assert summary["parse_failure_count"] == 0
+    assert summary["chunk_count"] == 1
+    assert "chunk_length_chars" in summary
+    assert forbidden_output_hits(summary) == {}
+
+    report = (out_dir / "parse_quality_report.md").read_text(encoding="utf-8")
+    flags = _read_jsonl(out_dir / "parse_quality_flags.jsonl")
+    serialized = json.dumps(summary, ensure_ascii=False) + report + json.dumps(flags, ensure_ascii=False)
+    assert "PRIVATE-DOC-001" not in serialized
+    assert "secret-private-file.pdf" not in serialized
+    assert "PRIVATE RAW EVIDENCE" not in serialized
+    for flag in flags:
+        assert forbidden_output_hits(flag) == {}
+
+
+def test_eval_dataset_summary_schema_and_privacy(tmp_path: Path) -> None:
+    questions, evidence, index_dir = _write_valid_eval_inputs(tmp_path)
+    out_dir = tmp_path / "audit"
+
+    summary = eval_audit.run_audit(
+        questions_path=questions,
+        gold_evidence_path=evidence,
+        index_dir=index_dir,
+        out_dir=out_dir,
+    )
+
+    assert summary["schema_version"] == 1
+    assert summary["audit_type"] == "private_eval_dataset"
+    assert summary["question_count"] == 2
+    assert summary["answerable_count"] == 1
+    assert summary["unanswerable_count"] == 1
+    assert summary["evidence_record_count"] == 1
+    assert summary["label_consistency"]["answerable_missing_evidence_count"] == 0
+    assert summary["index_reference_coverage"]["absent_chunk_reference_count"] == 0
+    assert forbidden_output_hits(summary) == {}
+
+    report = (out_dir / "eval_dataset_report.md").read_text(encoding="utf-8")
+    flags = _read_jsonl(out_dir / "eval_dataset_flags.jsonl")
+    serialized = json.dumps(summary, ensure_ascii=False) + report + json.dumps(flags, ensure_ascii=False)
+    assert "PRIVATE-Q-001" not in serialized
+    assert "PRIVATE RAW QUESTION" not in serialized
+    assert "PRIVATE RAW EVIDENCE" not in serialized
+    assert "PRIVATE-DOC-001" not in serialized
+    assert "PRIVATE-DOC-001::chunk-001" not in serialized
+    for flag in flags:
+        assert forbidden_output_hits(flag) == {}
+
+
+def test_eval_dataset_fails_when_answerable_has_no_evidence(tmp_path: Path) -> None:
+    questions, evidence, index_dir = _write_valid_eval_inputs(tmp_path)
+    _write_jsonl(
+        evidence,
+        [
+            {"question_id": "PRIVATE-Q-001", "gold_evidence": []},
+            {"question_id": "PRIVATE-Q-002", "gold_evidence": []},
+        ],
+    )
+
+    summary = eval_audit.run_audit(
+        questions_path=questions,
+        gold_evidence_path=evidence,
+        index_dir=index_dir,
+        out_dir=tmp_path / "audit",
+    )
+
+    assert summary["passed"] is False
+    assert summary["label_consistency"]["answerable_missing_evidence_count"] == 1
+
+
+def test_eval_dataset_fails_when_unanswerable_has_evidence(tmp_path: Path) -> None:
+    questions, evidence, index_dir = _write_valid_eval_inputs(tmp_path)
+    _write_jsonl(
+        evidence,
+        [
+            {
+                "question_id": "PRIVATE-Q-001",
+                "gold_evidence": [
+                    {"doc_id": "PRIVATE-DOC-001", "chunk_id": "PRIVATE-DOC-001::chunk-001"}
+                ],
+            },
+            {
+                "question_id": "PRIVATE-Q-002",
+                "gold_evidence": [
+                    {"doc_id": "PRIVATE-DOC-001", "chunk_id": "PRIVATE-DOC-001::chunk-001"}
+                ],
+            },
+        ],
+    )
+
+    summary = eval_audit.run_audit(
+        questions_path=questions,
+        gold_evidence_path=evidence,
+        index_dir=index_dir,
+        out_dir=tmp_path / "audit",
+    )
+
+    assert summary["passed"] is False
+    assert summary["label_consistency"]["unanswerable_with_evidence_count"] == 1
+
+
+def test_eval_dataset_fails_when_chunk_reference_is_missing(tmp_path: Path) -> None:
+    questions, evidence, index_dir = _write_valid_eval_inputs(tmp_path)
+    _write_jsonl(
+        evidence,
+        [
+            {"question_id": "PRIVATE-Q-001", "gold_evidence": [{"doc_id": "PRIVATE-DOC-001"}]},
+            {"question_id": "PRIVATE-Q-002", "gold_evidence": []},
+        ],
+    )
+
+    summary = eval_audit.run_audit(
+        questions_path=questions,
+        gold_evidence_path=evidence,
+        index_dir=index_dir,
+        out_dir=tmp_path / "audit",
+    )
+
+    assert summary["passed"] is False
+    assert summary["index_reference_coverage"]["missing_chunk_reference_count"] == 1
+
+
+def test_eval_dataset_fails_when_chunk_reference_is_absent_from_index(tmp_path: Path) -> None:
+    questions, evidence, index_dir = _write_valid_eval_inputs(tmp_path)
+    _write_jsonl(
+        evidence,
+        [
+            {
+                "question_id": "PRIVATE-Q-001",
+                "gold_evidence": [
+                    {"doc_id": "PRIVATE-DOC-001", "chunk_id": "PRIVATE-DOC-001::missing"}
+                ],
+            },
+            {"question_id": "PRIVATE-Q-002", "gold_evidence": []},
+        ],
+    )
+
+    summary = eval_audit.run_audit(
+        questions_path=questions,
+        gold_evidence_path=evidence,
+        index_dir=index_dir,
+        out_dir=tmp_path / "audit",
+    )
+
+    assert summary["passed"] is False
+    assert summary["index_reference_coverage"]["absent_chunk_reference_count"] == 1
+
+
+def test_eval_dataset_fails_on_duplicate_question_identifier(tmp_path: Path) -> None:
+    questions, evidence, index_dir = _write_valid_eval_inputs(tmp_path)
+    _write_jsonl(
+        questions,
+        [
+            {
+                "question_id": "PRIVATE-Q-001",
+                "question": "PRIVATE RAW QUESTION A",
+                "answerable": True,
+            },
+            {
+                "question_id": "PRIVATE-Q-001",
+                "question": "PRIVATE RAW QUESTION B",
+                "answerable": True,
+            },
+        ],
+    )
+
+    summary = eval_audit.run_audit(
+        questions_path=questions,
+        gold_evidence_path=evidence,
+        index_dir=index_dir,
+        out_dir=tmp_path / "audit",
+    )
+
+    assert summary["passed"] is False
+    assert summary["question_identifier_uniqueness"]["duplicate_count"] == 1


### PR DESCRIPTION
## 1. What changed and why

chore: Add private data quality audits (#1441)

Closes #1441

🤖 Auto-shipped by scripts/claude-hooks/stop-ship.sh

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #1441

## 2. Files affected

- `docs/evaluation/private_data_quality_audit.md`
- `scripts/audit_private_eval_dataset.py`
- `scripts/audit_private_parse_quality.py`
- `scripts/private_data_quality_audit_utils.py`
- `tests/test_private_data_quality_audit.py`

## 3. Risks

Auto-generated PR; no load-bearing paths changed.

## 4. Tests

Local tests passed (bash scripts/test.sh).

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (no load-bearing path changed)

## 6. Backward compatibility

No public-API change detected.

## 7. Out of scope

N/A — single-concern auto-shipped PR.
