### PR TITLE
chore: unify private readiness config

### DIFF
--- a/docs/evaluation/pre_improvement_readiness_checklist.md
+++ b/docs/evaluation/pre_improvement_readiness_checklist.md
@@ -60,22 +60,25 @@ content가 제거된 aggregate summary 또는 문서화된 checklist뿐이다.
 
 ## Exact Local Commands
 
+이 readiness workflow의 단일 local config는 `eval/real_config.local.yaml`이다.
+별도의 `configs/eval/private_real_eval.local.yaml`를 만들지 않는다.
+
 Parse/data readiness audit:
 
 ```bash
-python3 scripts/audit_private_data_readiness.py --config configs/eval/private_real_eval.local.yaml --out-dir experiments/private_runs/readiness_audit
+python3 scripts/audit_private_data_readiness.py --config eval/real_config.local.yaml --out-dir experiments/private_runs/readiness_audit
 ```
 
 Validate-only:
 
 ```bash
-python3 -m eval.naive_rag.private_real_eval --config configs/eval/private_real_eval.local.yaml --validate-only
+python3 scripts/check_private_real_eval_readiness.py --config eval/real_config.local.yaml
 ```
 
 Baseline run:
 
 ```bash
-python3 -m eval.naive_rag.private_real_eval --config configs/eval/private_real_eval.local.yaml
+python3 scripts/run_private_real_eval.py --config eval/real_config.local.yaml
 ```
 
 ## Privacy Boundary

--- a/docs/evaluation/private_data_quality_audit.md
+++ b/docs/evaluation/private_data_quality_audit.md
@@ -113,9 +113,7 @@ measurement warning, not as a system performance claim.
 After both audits pass, run the private real-eval validator:
 
 ```bash
-python3 -m eval.naive_rag.private_real_eval \
-  --config configs/eval/private_real_eval.local.yaml \
-  --validate-only
+python3 scripts/check_private_real_eval_readiness.py --config eval/real_config.local.yaml
 ```
 
 Then run the private baseline only after validate-only passes. Review only

--- a/docs/evaluation/private_real_eval_workflow.md
+++ b/docs/evaluation/private_real_eval_workflow.md
@@ -34,33 +34,20 @@ verification(검증), or self-correction(자가수정).
 
 ## Supported Local Layouts
 
-Preferred Naive RAG contract layout:
-
-```text
-configs/eval/private_real_eval.local.yaml
-data/private/files/
-data/private/data_list.csv
-data/private/gold_evidence.jsonl
-data/private/index/
-experiments/private_runs/
-```
-
-Readiness scaffold / older real-eval convention:
+Canonical local layout:
 
 ```text
 eval/real_config.local.yaml
 data/data_list.csv
+data/files/
 data/files_kordoc/
-data/private/questions.jsonl
-data/private/gold_evidence.jsonl
-data/index/real100_kordoc/
-experiments/private_runs/
-reports/private_real_eval_summary.redacted.json
+data/index/real100/
+reports/real100/
 ```
 
-Use `configs/eval/private_real_eval.local.yaml` when the goal is the Naive RAG
-baseline contract runner. Use `eval/real_config.local.yaml` and the readiness
-scripts when checking whether the local private corpus is prepared.
+Use `eval/real_config.local.yaml` for the readiness audit, validate-only step,
+and local private baseline run. Do not create a second local config just to run
+the pre-improvement readiness workflow.
 
 ## Local Inventory And Canonical Mapping
 
@@ -70,45 +57,26 @@ cache to prepare the Naive RAG baseline runner, but not in the preferred
 
 | Candidate category | Observed local state | Canonical target | Action |
 |---|---:|---|---|
-| Source documents | 100 files | `data/private/files/` | Symlink or copy locally; never commit. |
-| Kordoc cache | 101 files | `data/private/files_kordoc/` | Symlink as the sibling cache for `data/private/files/`. |
-| Manifest | 100 rows | `data/private/data_list.csv` | Symlink or copy locally; never commit. |
-| Existing index | 100 documents / 26,376 chunks | `data/private/index/` | Symlink only if it matches the manifest and corpus; otherwise rebuild. |
-| Gold labels/questions | No canonical file found | `data/private/gold_evidence.jsonl` | Regenerate or curate local-only labels with raw questions and explicit `gold_evidence[].chunk_id`. |
-| Redacted summary | Not present | `reports/private_real_eval_summary.redacted.json` | Generate only after a successful private run and redaction checks. |
+| Source documents | 100 files | `data/files/` | Keep local-only; never commit. |
+| Kordoc cache | 101 files | `data/files_kordoc/` | Keep local-only as the parsed cache/source sibling. |
+| Manifest | 100 rows | `data/data_list.csv` | Keep local-only; never commit. |
+| Existing index | 100 documents / 26,376 chunks | `data/index/real100/` | Use only if it matches the manifest and corpus; otherwise rebuild. |
+| Gold labels/questions | `cases:` in local config | `eval/real_config.local.yaml` | Curate local-only cases; add explicit `gold_evidence` or `gold_chunk_ids` when needed. |
+| Redacted summary | Local reports | `reports/real100/` aggregate files | Generate only after a successful private run and redaction checks. |
 
-Use a local shell variable for the private cache root. Do not write its value
-into committed files:
+If an external private root is used, point `REAL_EVAL_ROOT` or the nested
+`real_eval:` paths in `eval/real_config.local.yaml` at that root. Do not write
+machine-specific absolute paths into committed files.
 
-```bash
-PRIVATE_CACHE_ROOT=/path/to/local/main/worktree
-mkdir -p data/private
-ln -s "$PRIVATE_CACHE_ROOT/data/files" data/private/files
-ln -s "$PRIVATE_CACHE_ROOT/data/files_kordoc" data/private/files_kordoc
-ln -s "$PRIVATE_CACHE_ROOT/data/data_list.csv" data/private/data_list.csv
-ln -s "$PRIVATE_CACHE_ROOT/data/index/real100" data/private/index
-```
-
-If labels are converted from an older `eval/real_config.local.yaml`, write the
-result only to `data/private/gold_evidence.jsonl`. The converted file is
-runnable only after every answerable row has explicit chunk-level gold evidence
-and every unanswerable row has an empty `gold_evidence` list. Any answerable
-row that cannot be resolved to a chunk should be omitted from a temporary
-runnable subset or manually labeled before using the result for performance
-claims.
+The readiness audit can derive chunk-level gold from `expected_doc_ids` +
+`expected_terms` when the index contains matching chunks. For performance
+claims, manually review the resolved evidence and prefer explicit local-only
+`gold_evidence` or `gold_chunk_ids` on answerable cases.
 
 ## Local Config
 
-For readiness checks:
-
 ```bash
 cp eval/real_config.template.yaml eval/real_config.local.yaml
-```
-
-For the Naive RAG contract runner:
-
-```bash
-cp configs/eval/private_real_eval.template.yaml configs/eval/private_real_eval.local.yaml
 ```
 
 Fill only local paths and local measurement settings. Do not put
@@ -117,22 +85,38 @@ or private document text in committed files.
 
 ## Gold Evidence Schema
 
-`gold_evidence_path` is JSONL. Each answerable row needs explicit
-`gold_evidence[].chunk_id`; unanswerable rows use an empty `gold_evidence` list.
+`eval/real_config.local.yaml` owns private questions and gold labels. Each
+answerable case should have either explicit `gold_evidence[].chunk_id`,
+`gold_chunk_ids`, or enough `expected_doc_ids` + `expected_terms` for the audit
+to resolve matching chunks from the local index. Unanswerable rows use no gold
+evidence.
 
-```json
-{"question_id":"case-001","question":"...local private question...","answerable":true,"expected_terms":["..."],"gold_evidence":[{"doc_id":"...","chunk_id":"..."}]}
-{"question_id":"case-002","question":"...local private unanswerable question...","answerable":false,"gold_evidence":[]}
+```yaml
+cases:
+  - id: case-001
+    query: "...local private question..."
+    answerable: true
+    expected_doc_ids: ["...local doc id..."]
+    expected_terms: ["...local expected term..."]
+    gold_evidence:
+      - doc_id: "...local doc id..."
+        chunk_id: "...local chunk id..."
+  - id: case-002
+    query: "...local private unanswerable question..."
+    answerable: false
+    expected_doc_ids: []
+    expected_terms: []
 ```
 
-Raw questions can be sensitive, so this file is local-only and gitignored.
+Raw questions and local identifiers can be sensitive, so this file is
+local-only and gitignored.
 
 ## Gitignore Safety
 
 The workflow expects these private paths to remain ignored:
 
-- `configs/eval/private_real_eval.local.yaml`
 - `eval/real_config.local.yaml`
+- `configs/eval/private_real_eval.local.yaml` (compatibility path only)
 - `configs/eval/*.local.yaml`
 - `data/private/`
 - `data/files/`
@@ -149,9 +133,8 @@ The workflow expects these private paths to remain ignored:
 - `reports/real100/raw/`
 - `reports/private_real_eval_summary.raw.json`
 
-The private runner validates that `documents_dir`, `data_list_path`,
-`questions_path`, `gold_evidence_path`, `index_dir`, and `output_dir` are
-gitignored or outside the repo before it processes local data.
+The readiness tools validate that private inputs and output paths are
+gitignored or outside the repo before they process local data.
 
 ## Validate Readiness
 
@@ -194,18 +177,14 @@ python3 scripts/build_index.py \
 ## Validate Private Naive RAG Inputs
 
 ```bash
-python3 -m eval.naive_rag.private_real_eval \
-  --config configs/eval/private_real_eval.local.yaml \
-  --validate-only
+python3 scripts/check_private_real_eval_readiness.py --config eval/real_config.local.yaml
 ```
 
 Validation is fail-closed for missing documents, missing metadata, missing gold
-evidence, missing answerable/unanswerable split, missing explicit
-`gold_evidence[].chunk_id` on answerable rows, non-empty gold evidence on
-unanswerable rows, and private paths that are not gitignored or outside the
-repo.
+evidence, missing answerable/unanswerable split, invalid answerable/unanswerable
+evidence shape, and private paths that are not gitignored or outside the repo.
 
-On failure, the private runner reports only field names, categories, and
+On failure, the validator reports only field names, categories, and
 counts, for example `missing_required_input: gold_evidence_path` or
 `missing_explicit_gold_chunk_id: answerable_questions count=N`. It must not
 print raw questions, raw answers, support text, document names, `doc_id`,
@@ -213,29 +192,26 @@ print raw questions, raw answers, support text, document names, `doc_id`,
 
 ## Run Private Naive RAG Eval
 
-Preferred contract runner:
-
-```bash
-python3 -m eval.naive_rag.private_real_eval \
-  --config configs/eval/private_real_eval.local.yaml
-```
-
-To also write the committable aggregate candidate:
-
-```bash
-python3 -m eval.naive_rag.private_real_eval \
-  --config configs/eval/private_real_eval.local.yaml \
-  --redacted-summary-path reports/private_real_eval_summary.redacted.json
-```
-
-Readiness scaffold wrapper:
+Run the local private baseline from the same config:
 
 ```bash
 python3 scripts/run_private_real_eval.py --config eval/real_config.local.yaml
 ```
 
-Generated raw artifacts stay under ignored `experiments/private_runs/<run_id>/`.
-The contract runner writes:
+Or use the Make target:
+
+```bash
+make real-eval
+```
+
+To write the committable aggregate candidate after review:
+
+```bash
+make real-eval-baseline-update
+```
+
+Generated raw artifacts stay under ignored local report/output paths. Depending
+on the runner, artifacts include:
 
 ```text
 experiments/private_runs/<run_id>/

--- a/scripts/audit_private_data_readiness.py
+++ b/scripts/audit_private_data_readiness.py
@@ -22,9 +22,14 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+try:
+    from scripts.real_eval_paths import resolve_entries
+except ImportError:  # pragma: no cover - direct script execution
+    from real_eval_paths import resolve_entries  # type: ignore
+
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-DEFAULT_CONFIG = "configs/eval/private_real_eval.local.yaml"
+DEFAULT_CONFIG = "eval/real_config.local.yaml"
 DEFAULT_OUT_DIR = "experiments/private_runs/readiness_audit"
 SCHEMA_VERSION = 1
 
@@ -204,6 +209,137 @@ def _csv_rows(path: Path) -> tuple[list[dict[str, str]], list[str]]:
         return [], ["csv_unreadable"]
 
 
+def _real_eval_path_map(config_path: Path, repo_root: Path) -> dict[str, Path]:
+    args = argparse.Namespace(
+        root=None,
+        config=str(config_path),
+        data_list=None,
+        data_dir=None,
+        kordoc_data_dir=None,
+        cache_dir=None,
+        index_dir=None,
+        report_dir=None,
+        baseline_summary=None,
+    )
+    return {
+        entry.name: Path(entry.path)
+        for entry in resolve_entries(args=args, repo_root=repo_root)
+    }
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _case_question_id(case: Mapping[str, Any]) -> str:
+    return str(case.get("question_id") or case.get("id") or "").strip()
+
+
+def _legacy_question_rows(cases: Sequence[Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for case in cases:
+        if not isinstance(case, Mapping):
+            continue
+        expected_doc_ids = _string_list(case.get("expected_doc_ids"))
+        rows.append(
+            {
+                "question_id": _case_question_id(case),
+                "question": case.get("query") or case.get("question") or "",
+                "answerable": _as_bool(
+                    case.get("answerable"),
+                    default=bool(expected_doc_ids),
+                ),
+                "expected_terms": _string_list(case.get("expected_terms")),
+                "query_type": case.get("query_type"),
+            }
+        )
+    return rows
+
+
+def _legacy_gold_evidence(case: Mapping[str, Any]) -> list[dict[str, Any]]:
+    explicit = case.get("gold_evidence")
+    if isinstance(explicit, list):
+        return [dict(item) for item in explicit if isinstance(item, Mapping)]
+
+    gold_chunk_ids = _string_list(case.get("gold_chunk_ids"))
+    if gold_chunk_ids:
+        return [{"chunk_id": chunk_id} for chunk_id in gold_chunk_ids]
+
+    if not _as_bool(case.get("answerable"), default=bool(case.get("expected_doc_ids"))):
+        return []
+
+    expected_terms = _string_list(case.get("expected_terms"))
+    return [
+        {"doc_id": doc_id, "required_terms": expected_terms}
+        for doc_id in _string_list(case.get("expected_doc_ids"))
+    ]
+
+
+def _legacy_gold_rows(cases: Sequence[Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for case in cases:
+        if not isinstance(case, Mapping):
+            continue
+        rows.append(
+            {
+                "question_id": _case_question_id(case),
+                "gold_evidence": _legacy_gold_evidence(case),
+            }
+        )
+    return rows
+
+
+def _normalize_audit_config(
+    config: Mapping[str, Any],
+    config_path: Path,
+    repo_root: Path,
+) -> dict[str, Any]:
+    normalized = dict(config)
+    cases = config.get("cases")
+    has_embedded_cases = isinstance(cases, list)
+    has_external_eval_files = bool(
+        config.get("questions_path") or config.get("gold_evidence_path")
+    )
+
+    if not has_embedded_cases or has_external_eval_files:
+        normalized["_config_format"] = "private_real_eval_path_config"
+        return normalized
+
+    entries = _real_eval_path_map(config_path, repo_root)
+    normalized.setdefault(
+        "documents_dir",
+        str(entries.get("data_dir") or repo_root / "data" / "files"),
+    )
+    normalized.setdefault(
+        "data_list_path",
+        str(entries.get("data_list") or repo_root / "data" / "data_list.csv"),
+    )
+    normalized.setdefault(
+        "index_dir",
+        str(
+            config.get("index_dir")
+            or entries.get("index_dir")
+            or repo_root / "data" / "index" / "real100"
+        ),
+    )
+    normalized.setdefault(
+        "output_dir",
+        str(
+            config.get("output_dir")
+            or entries.get("report_dir")
+            or repo_root / "reports" / "real100"
+        ),
+    )
+    normalized["_question_rows"] = _legacy_question_rows(cases)
+    normalized["_gold_rows"] = _legacy_gold_rows(cases)
+    normalized["_config_format"] = "real_config_local_cases"
+    return normalized
+
+
 def _text_from_manifest_row(row: Mapping[str, Any]) -> str:
     for key in ("텍스트", "text", "body", "content"):
         value = row.get(key)
@@ -349,8 +485,40 @@ def _evidence_items(row: Mapping[str, Any]) -> tuple[list[dict[str, Any]], bool]
     return items, invalid
 
 
+def _required_terms(item: Mapping[str, Any]) -> list[str]:
+    return _string_list(item.get("required_terms") or item.get("expected_terms"))
+
+
+def _resolve_gold_items(
+    items: Sequence[Mapping[str, Any]],
+    chunks_by_doc_id: Mapping[str, Sequence[Mapping[str, str]]],
+) -> list[dict[str, Any]]:
+    resolved: list[dict[str, Any]] = []
+    for item in items:
+        chunk_id = str(item.get("chunk_id") or "").strip()
+        if chunk_id:
+            resolved.append(dict(item))
+            continue
+        doc_id = str(item.get("doc_id") or "").strip()
+        terms = _required_terms(item)
+        if not doc_id or not terms:
+            resolved.append(dict(item))
+            continue
+        matched = False
+        for chunk in chunks_by_doc_id.get(doc_id, []):
+            text = str(chunk.get("text") or "")
+            if any(term in text for term in terms):
+                derived = dict(item)
+                derived["chunk_id"] = str(chunk.get("chunk_id") or "")
+                resolved.append(derived)
+                matched = True
+        if not matched:
+            resolved.append(dict(item))
+    return resolved
+
+
 def _evidence_has_payload(item: Mapping[str, Any]) -> bool:
-    for key in ("doc_id", "chunk_id", "page_span", "support_text"):
+    for key in ("doc_id", "chunk_id", "page_span", "support_text", "required_terms"):
         if item.get(key) not in (None, "", []):
             return True
     return False
@@ -372,11 +540,86 @@ def _metric_mean(block: Any) -> float | None:
     return None
 
 
+def _mean_case_metric(case_results: Any, key: str) -> float | None:
+    if not isinstance(case_results, list):
+        return None
+    values: list[float] = []
+    for row in case_results:
+        if not isinstance(row, Mapping):
+            continue
+        value = row.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            values.append(float(value))
+    if not values:
+        return None
+    return round(statistics.mean(values), 6)
+
+
+def _retrieval_metrics_from_payload(payload: Mapping[str, Any]) -> dict[str, float]:
+    retrieval = (
+        payload.get("retrieval_metrics")
+        if isinstance(payload.get("retrieval_metrics"), Mapping)
+        else {}
+    )
+    candidates = {
+        "recall_at_5": [
+            retrieval.get("recall_at_5"),
+            payload.get("chunk_recall_at_5"),
+            _mean_case_metric(payload.get("case_results"), "chunk_recall_at_5"),
+        ],
+        "recall_at_10": [
+            retrieval.get("recall_at_10"),
+            payload.get("chunk_recall_at_10"),
+            _mean_case_metric(payload.get("case_results"), "chunk_recall_at_10"),
+        ],
+        "mrr_at_5": [
+            retrieval.get("mrr_at_5"),
+            payload.get("chunk_mrr_at_5"),
+            _mean_case_metric(payload.get("case_results"), "chunk_mrr_at_5"),
+        ],
+        "ndcg_at_5": [
+            retrieval.get("ndcg_at_5"),
+            payload.get("chunk_ndcg_at_5"),
+            _mean_case_metric(payload.get("case_results"), "chunk_ndcg_at_5"),
+        ],
+    }
+    safe_metrics: dict[str, float] = {}
+    for key, values in candidates.items():
+        for value in values:
+            metric = _metric_mean(value)
+            if metric is not None:
+                safe_metrics[key] = metric
+                break
+    return safe_metrics
+
+
 def _latest_metrics(output_dir: Path, audit_out_dir: Path) -> tuple[dict[str, Any] | None, int]:
     if not output_dir.is_dir():
         return None, 0
     candidates: list[Path] = []
     for path in output_dir.rglob("metrics.json"):
+        try:
+            path.resolve().relative_to(audit_out_dir.resolve())
+            continue
+        except ValueError:
+            pass
+        candidates.append(path)
+    if not candidates:
+        return None, 0
+    candidates.sort(key=lambda item: item.stat().st_mtime, reverse=True)
+    payload, errors = _load_json(candidates[0])
+    if errors:
+        return None, len(candidates)
+    return payload, len(candidates)
+
+
+def _latest_eval_summary(output_dir: Path, audit_out_dir: Path) -> tuple[dict[str, Any] | None, int]:
+    if not output_dir.is_dir():
+        return None, 0
+    candidates: list[Path] = []
+    for path in output_dir.rglob("eval_summary.json"):
         try:
             path.resolve().relative_to(audit_out_dir.resolve())
             continue
@@ -425,6 +668,31 @@ def _safe_failure_counts(rows: Sequence[Mapping[str, Any]]) -> tuple[dict[str, i
                 rejected += 1
                 continue
             counts[label] = counts.get(label, 0) + 1
+    return counts, rejected
+
+
+def _safe_failure_count_mapping(raw: Any) -> tuple[dict[str, int], int]:
+    if not isinstance(raw, Mapping):
+        return {}, 0
+    counts: dict[str, int] = {}
+    rejected = 0
+    for key, value in raw.items():
+        label = str(key or "").strip()
+        if not label or not SAFE_FAILURE_TYPE_RE.fullmatch(label):
+            rejected += 1
+            continue
+        if isinstance(value, bool):
+            rejected += 1
+            continue
+        try:
+            count = int(value)
+        except (TypeError, ValueError):
+            rejected += 1
+            continue
+        if count < 0:
+            rejected += 1
+            continue
+        counts[label] = count
     return counts, rejected
 
 
@@ -536,13 +804,14 @@ def _audit_index(
     config: Mapping[str, Any],
     repo_root: Path,
     flags: list[dict[str, Any]],
-) -> tuple[dict[str, Any], dict[str, str], set[str]]:
+) -> tuple[dict[str, Any], dict[str, str], set[str], dict[str, list[dict[str, str]]]]:
     index_dir = repo_path(str(config.get("index_dir") or ""), repo_root)
     chunks, payload, errors = _index_chunks(index_dir)
     for error in errors:
         _flag(flags, severity="blocker", surface="index_integrity", code=error)
 
     chunk_text_by_id: dict[str, str] = {}
+    chunks_by_doc_id: dict[str, list[dict[str, str]]] = {}
     chunk_ids: set[str] = set()
     missing_chunk_id = 0
     lengths: list[int] = []
@@ -553,12 +822,17 @@ def _audit_index(
     chunk_texts: list[str] = []
     for chunk in chunks:
         chunk_id = str(chunk.get("chunk_id") or "").strip()
+        doc_id = str(chunk.get("doc_id") or "").strip()
         text = str(chunk.get("text") or "")
         if not chunk_id:
             missing_chunk_id += 1
         else:
             chunk_ids.add(chunk_id)
             chunk_text_by_id[chunk_id] = text
+            if doc_id:
+                chunks_by_doc_id.setdefault(doc_id, []).append(
+                    {"chunk_id": chunk_id, "text": text}
+                )
         length = _char_len(text)
         lengths.append(length)
         chunk_texts.append(text)
@@ -609,7 +883,7 @@ def _audit_index(
         "index_document_count": _build_count(payload, "num_documents"),
         "chunk_id_missing_count": missing_chunk_id,
     }
-    return summary, chunk_text_by_id, chunk_ids
+    return summary, chunk_text_by_id, chunk_ids, chunks_by_doc_id
 
 
 def _audit_eval_dataset(
@@ -617,12 +891,25 @@ def _audit_eval_dataset(
     repo_root: Path,
     chunk_text_by_id: Mapping[str, str],
     index_chunk_ids: set[str],
+    chunks_by_doc_id: Mapping[str, Sequence[Mapping[str, str]]],
     flags: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    gold_path = repo_path(str(config.get("gold_evidence_path") or ""), repo_root)
-    questions_path = repo_path(str(config.get("questions_path") or config.get("gold_evidence_path") or ""), repo_root)
-    question_rows, question_errors = _jsonl_rows(questions_path)
-    gold_rows, gold_errors = _jsonl_rows(gold_path)
+    if isinstance(config.get("_question_rows"), list):
+        question_rows = [row for row in config["_question_rows"] if isinstance(row, Mapping)]
+        question_errors: list[str] = []
+    else:
+        questions_path = repo_path(
+            str(config.get("questions_path") or config.get("gold_evidence_path") or ""),
+            repo_root,
+        )
+        question_rows, question_errors = _jsonl_rows(questions_path)
+
+    if isinstance(config.get("_gold_rows"), list):
+        gold_rows = [row for row in config["_gold_rows"] if isinstance(row, Mapping)]
+        gold_errors: list[str] = []
+    else:
+        gold_path = repo_path(str(config.get("gold_evidence_path") or ""), repo_root)
+        gold_rows, gold_errors = _jsonl_rows(gold_path)
     for error in question_errors:
         _flag(flags, severity="blocker", surface="eval_dataset_quality", code="questions_" + error)
     for error in gold_errors:
@@ -659,7 +946,7 @@ def _audit_eval_dataset(
             continue
         items, invalid = _evidence_items(row)
         invalid_gold_shape += int(invalid)
-        gold_by_qid.setdefault(qid, []).extend(items)
+        gold_by_qid.setdefault(qid, []).extend(_resolve_gold_items(items, chunks_by_doc_id))
 
     answerable_without_gold = 0
     unanswerable_with_gold = 0
@@ -781,6 +1068,10 @@ def _audit_baseline_metrics(
 ) -> dict[str, Any]:
     output_dir = repo_path(str(config.get("output_dir") or "experiments/private_runs"), repo_root)
     metrics, candidate_count = _latest_metrics(output_dir, audit_out_dir)
+    source = "metrics_json"
+    if metrics is None:
+        metrics, candidate_count = _latest_eval_summary(output_dir, audit_out_dir)
+        source = "eval_summary_json"
     if metrics is None:
         _flag(
             flags,
@@ -791,14 +1082,24 @@ def _audit_baseline_metrics(
         return {
             "available": False,
             "metrics_file_count": candidate_count,
+            "metrics_source": None,
             "retrieval_saturation_warning": False,
         }
-    retrieval = metrics.get("retrieval_metrics") if isinstance(metrics.get("retrieval_metrics"), Mapping) else {}
-    safe_metrics = {
-        key: _metric_mean(retrieval.get(key))
-        for key in ("recall_at_5", "recall_at_10", "mrr_at_5", "ndcg_at_5")
-        if _metric_mean(retrieval.get(key)) is not None
-    }
+    safe_metrics = _retrieval_metrics_from_payload(metrics)
+    if not safe_metrics:
+        _flag(
+            flags,
+            severity="blocker",
+            surface="baseline_metric_validity",
+            code="existing_baseline_metrics_missing",
+        )
+        return {
+            "available": False,
+            "metrics_file_count": candidate_count,
+            "metrics_source": source,
+            "retrieval_saturation_warning": False,
+        }
+
     recall10 = safe_metrics.get("recall_at_10")
     saturation = recall10 is not None and recall10 >= RETRIEVAL_SATURATION_RECALL10
     if saturation:
@@ -811,6 +1112,7 @@ def _audit_baseline_metrics(
     return {
         "available": True,
         "metrics_file_count": candidate_count,
+        "metrics_source": source,
         "retrieval_metrics": safe_metrics,
         "retrieval_saturation_warning": saturation,
     }
@@ -825,6 +1127,33 @@ def _audit_failure_taxonomy(
     output_dir = repo_path(str(config.get("output_dir") or "experiments/private_runs"), repo_root)
     failure_path = _failure_case_path(output_dir, audit_out_dir)
     if failure_path is None:
+        eval_summary, _ = _latest_eval_summary(output_dir, audit_out_dir)
+        if eval_summary is not None:
+            counts, rejected = _safe_failure_count_mapping(
+                eval_summary.get("failure_category_counts")
+            )
+            total = sum(counts.values())
+            top = sorted(
+                ((label, count) for label, count in counts.items() if count > 0),
+                key=lambda item: (-item[1], item[0]),
+            )[:5]
+            if top:
+                return {
+                    "available": True,
+                    "failure_case_count": total,
+                    "unique_failure_type_count": len(counts),
+                    "top_failure_type_available": True,
+                    "top_failure_types": [
+                        {
+                            "failure_type": label,
+                            "count": count,
+                            "share": _rate(count, total),
+                        }
+                        for label, count in top
+                    ],
+                    "rejected_failure_type_label_count": rejected,
+                    "source": "eval_summary_failure_category_counts",
+                }
         _flag(
             flags,
             severity="blocker",
@@ -836,6 +1165,7 @@ def _audit_failure_taxonomy(
             "failure_case_count": 0,
             "unique_failure_type_count": 0,
             "top_failure_type_available": False,
+            "source": None,
         }
     rows, errors = _jsonl_rows(failure_path)
     for error in errors:
@@ -869,6 +1199,7 @@ def _audit_failure_taxonomy(
             for label, count in top
         ],
         "rejected_failure_type_label_count": rejected,
+        "source": "failure_cases_jsonl",
     }
 
 
@@ -893,14 +1224,20 @@ def build_readiness_audit(
     config, config_errors = _load_yaml(resolved_config_path)
     for error in config_errors:
         _flag(flags, severity="blocker", surface="config", code=error)
+    config = _normalize_audit_config(config, resolved_config_path, repo_root)
 
     documents, document_texts = _audit_documents(config, repo_root, flags)
-    index, chunk_text_by_id, index_chunk_ids = _audit_index(config, repo_root, flags)
+    index, chunk_text_by_id, index_chunk_ids, chunks_by_doc_id = _audit_index(
+        config,
+        repo_root,
+        flags,
+    )
     eval_dataset = _audit_eval_dataset(
         config,
         repo_root,
         chunk_text_by_id,
         index_chunk_ids,
+        chunks_by_doc_id,
         flags,
     )
     baseline = _audit_baseline_metrics(config, repo_root, resolved_out_dir, flags)
@@ -922,6 +1259,7 @@ def build_readiness_audit(
         "schema_version": SCHEMA_VERSION,
         "audit_type": "private_data_readiness",
         "benchmark_type": "private_real_eval",
+        "config_format": str(config.get("_config_format") or "unknown"),
         "local_only": True,
         "public_safe": True,
         "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),

--- a/tests/test_audit_private_data_readiness.py
+++ b/tests/test_audit_private_data_readiness.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from scripts.audit_private_data_readiness import (
+    DEFAULT_CONFIG,
     DEFAULT_OUT_DIR,
     ROOT_DIR,
     assert_public_safe_payload,
@@ -150,6 +151,109 @@ def _make_fixture(tmp_path: Path) -> Path:
     return config_path
 
 
+def _make_legacy_real_config_fixture(tmp_path: Path) -> Path:
+    files_dir = tmp_path / "data" / "files"
+    index_dir = tmp_path / "data" / "index" / "real100"
+    report_dir = tmp_path / "reports" / "real100"
+    eval_dir = tmp_path / "eval"
+    files_dir.mkdir(parents=True)
+    index_dir.mkdir(parents=True)
+    report_dir.mkdir(parents=True)
+    eval_dir.mkdir()
+    (files_dir / "doc_a.pdf").write_text("placeholder", encoding="utf-8")
+    (files_dir / "doc_b.pdf").write_text("placeholder", encoding="utf-8")
+
+    long_a = (
+        "Budget 100000원 and schedule 2026.05.24 are specified. "
+        "| item | score | table | "
+        * 20
+    )
+    long_b = (
+        "Evaluation score 90점 and amount 200000원 are present. "
+        "The appendix has page metadata. "
+        * 20
+    )
+    (tmp_path / "data" / "data_list.csv").write_text(
+        "\n".join(
+            [
+                "공고 번호,사업명,발주 기관,파일형식,파일명,텍스트",
+                f"notice-a,project-a,agency-a,pdf,doc_a.pdf,{long_a}",
+                f"notice-b,project-b,agency-b,pdf,doc_b.pdf,{long_b}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (index_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "mode": "rag",
+                "build": {"num_documents": 2, "num_chunks": 2},
+                "chunks": [
+                    {
+                        "chunk_id": "notice-a::chunk-001",
+                        "doc_id": "notice-a",
+                        "text": long_a,
+                        "page_span": [1, 1],
+                    },
+                    {
+                        "chunk_id": "notice-b::chunk-001",
+                        "doc_id": "notice-b",
+                        "text": long_b,
+                        "page_span": [2, 2],
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    (report_dir / "eval_summary.json").write_text(
+        json.dumps(
+            {
+                "chunk_recall_at_5": 0.5,
+                "chunk_recall_at_10": 0.5,
+                "chunk_mrr_at_5": 0.5,
+                "chunk_ndcg_at_5": 0.5,
+                "failure_category_counts": {"retrieval_miss": 1, "unknown": 0},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    config_path = eval_dir / "real_config.local.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "mode": "rag",
+                "index_dir": "data/index/real100",
+                "cases": [
+                    {
+                        "id": "q1",
+                        "query": "private question placeholder",
+                        "query_type": "single_doc",
+                        "expected_doc_ids": ["notice-a"],
+                        "expected_terms": ["Budget"],
+                        "answerable": True,
+                    },
+                    {
+                        "id": "q2",
+                        "query": "private unanswerable placeholder",
+                        "query_type": "abstention",
+                        "expected_doc_ids": [],
+                        "expected_terms": [],
+                        "answerable": False,
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
 def _flag_codes(flags: list[dict]) -> set[str]:
     return {str(flag["code"]) for flag in flags}
 
@@ -281,6 +385,25 @@ def test_readiness_audit_missing_baseline_artifacts_fixture_fails(tmp_path: Path
     assert "failure_cases_missing" in _flag_codes(flags)
 
 
+def test_readiness_audit_accepts_legacy_real_config_local_cases(tmp_path: Path) -> None:
+    config_path = _make_legacy_real_config_fixture(tmp_path)
+    out_dir = tmp_path.parent / f"{tmp_path.name}-readiness-audit"
+
+    summary, flags, _ = build_readiness_audit(config_path, out_dir, repo_root=tmp_path)
+
+    assert flags == []
+    assert summary["ready_for_improvement"] is True
+    assert summary["config_format"] == "real_config_local_cases"
+    assert summary["parse_quality"]["document_count"] == 2
+    assert summary["eval_dataset_quality"]["question_count"] == 2
+    assert summary["eval_dataset_quality"]["answerable_without_gold_evidence_count"] == 0
+    assert summary["eval_dataset_quality"]["gold_chunk_missing_from_index_count"] == 0
+    assert summary["baseline_metric_validity"]["metrics_source"] == "eval_summary_json"
+    assert summary["failure_taxonomy_readiness"]["source"] == (
+        "eval_summary_failure_category_counts"
+    )
+
+
 def test_readiness_summary_schema_and_outputs(tmp_path: Path) -> None:
     config_path = _make_fixture(tmp_path)
     out_dir = tmp_path / "audit"
@@ -291,6 +414,7 @@ def test_readiness_summary_schema_and_outputs(tmp_path: Path) -> None:
     assert summary["schema_version"] == 1
     assert summary["audit_type"] == "private_data_readiness"
     assert summary["benchmark_type"] == "private_real_eval"
+    assert summary["config_format"] == "private_real_eval_path_config"
     assert summary["local_only"] is True
     assert summary["public_safe"] is True
     assert summary["ready_for_improvement"] is True
@@ -304,6 +428,7 @@ def test_readiness_summary_schema_and_outputs(tmp_path: Path) -> None:
 
 
 def test_default_readiness_audit_output_path_is_gitignored() -> None:
+    assert DEFAULT_CONFIG == "eval/real_config.local.yaml"
     assert is_gitignored_or_outside(ROOT_DIR / DEFAULT_OUT_DIR)
     result = subprocess.run(
         [


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

 eval/real_config.local.yaml 을 pre-improvement readiness workflow의 단일 local config로 통합했습니다. audit은 이제 기존 cases 포맷을 직접 읽고, 기존 reports/real100/eval_summary.json 의 aggregate metric/failure taxonomy도 baseline readiness 입력으로 인정합니다.

Closes #1445

## 2. 영향 파일

- scripts/audit_private_data_readiness.py — readiness audit config normalization, legacy cases support, eval_summary aggregate fallback
- tests/test_audit_private_data_readiness.py — legacy eval/real_config.local.yaml fixture coverage
- docs/evaluation/pre_improvement_readiness_checklist.md — 단일 config 명령으로 갱신
- docs/evaluation/private_real_eval_workflow.md — 두 local config 안내를 단일 canonical config로 정리
- docs/evaluation/private_data_quality_audit.md — validate command 갱신

## 3. 리스크

가장 큰 리스크는 기존 path-style private audit config 호환성 손상입니다. 기존 JSONL 기반 fixture를 유지하고 private_real_eval_path_config schema test를 그대로 통과시켜 배제했습니다.

## 4. 테스트

- python3 -m py_compile scripts/audit_private_data_readiness.py
- python3 -m pytest -q tests/test_audit_private_data_readiness.py tests/test_private_real_eval_readiness.py tests/test_private_real_eval_workflow.py tests/test_real_eval_paths.py
- git diff --check
- bash scripts/test.sh — 2410 passed, 16 skipped, 69 deselected, 251 subtests passed

## 5. Eval 영향

RAG runtime behavior change 없음. Audit/readiness tooling과 문서만 변경했습니다.

### 5b. Real-data delta

검색(retrieval)/검증(verifier) path 동작 변화 없음. No behavior change in retrieval / verifier path.

## 6. 하위 호환

기존 path-style configs/eval/private_real_eval.local.yaml audit config도 계속 지원합니다. 새 기본값과 문서화된 readiness command만 eval/real_config.local.yaml 로 통합했습니다.

## 7. 범위 외

- retrieval/reranker/prompt/chunking/verifier 개선 없음
- No private raw content committed.
- This PR only adds/readjusts readiness audit tooling before performance improvement.