### PR TITLE
Add hybrid BM25 dense retrieval v1 eval row

### DIFF
--- a/docs/real-data/private-100-doc-experiments.md
+++ b/docs/real-data/private-100-doc-experiments.md
@@ -69,6 +69,14 @@ python3 scripts/summarize_benchmark.py \
 
 이 섹션은 retrieval / verifier policy 변경의 **real-data aggregate-only** before/after를 기록한다. ADR 0005의 commit boundary를 준수해 case ID·query text·doc ID·파일명은 절대 포함하지 않는다. 목적은 "왜 이렇게 짰는가?" 그리고 "그 결정이 real-data에서 어떻게 작동했는가?" 두 질문에 답할 수 있는 자료를 남기는 것이다.
 
+### Note: `retrieval_miss` 해석 기준
+
+`retrieval_miss` 는 `eval/scorers/failure_classifier.py::classify_failure` 가 만든 per-case `failure_category` 를 `aggregate_failure_categories` 로 합산한 `failure_category_counts.retrieval_miss` 이다. `failure_type_counts`, Recall@K, MRR, nDCG 에서 파생하지 않는다.
+
+GO/NO-GO 표에서 이 값은 양쪽 run 이 같은 case set 과 호환되는 taxonomy/classifier 버전으로 생성한 `failure_category_counts.retrieval_miss` 를 명시적으로 포함할 때만 비교한다. selected ablation run 에 이 key 가 없으면 `0` 이 아니라 missing/`—` 로 해석한다.
+
+PR #1448 의 `full_dense` vs `hybrid_bm25_dense_v1` 표에서 `retrieval_miss 0 -> 0` 은 두 selected run 의 `eval_summary.json::ablation.runs[]::failure_category_counts.retrieval_miss` 에 명시된 값이었다. 같은 시점 readiness audit 에서 보인 meaningful `retrieval_miss` count 는 별도 latest eval summary aggregate 에서 온 것이므로, #1448 selected-run delta 의 GO/NO-GO 근거와 직접 비교하지 않는다.
+
 ### Entry: 2026-05-11 — Partial-topic grounding @ fraction=0.5 (#69)
 
 **변경(Change).** `verify_evidence`에 `allow_partial_topic` 추가, 마지막 retrieval 시도에서 verification topics의 ≥50%가 evidence에 매칭되면 `partial_topic_grounding` reason으로 `verified=True`를 반환하고 status는 `partial`로 surface ([ADR 0004](../adr/0004-verifier-retry-policy.md) anticipated knob).

--- a/eval/config.yaml
+++ b/eval/config.yaml
@@ -16,6 +16,7 @@ latency_budgets:
   naive_baseline: {p95_ms: 1200}
   full: {p95_ms: 2500}
   full_dense: {p95_ms: 2500}
+  hybrid_bm25_dense_v1: {p95_ms: 2500}
   full_llm: {p95_ms: 3000}
   full_llm_metadata: {p95_ms: 2500}
   no_metadata_first: {p95_ms: 2500}
@@ -77,6 +78,18 @@ ablation_runs:
     query_expansion: identity
     metadata_backend: regex
     retrieval_backend: dense
+  - name: hybrid_bm25_dense_v1
+    pipeline: agentic_full
+    metadata_first: true
+    rerank: true
+    verifier_retry: true
+    retrieval_mode: flat
+    retrieval_backend: hybrid
+    rrf_k: 60
+    bm25_backend: okapi
+    bm25_tokenizer: regex
+    query_expansion: identity
+    metadata_backend: regex
   - name: full_llm
     pipeline: agentic_full_llm
     metadata_first: true

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -70,6 +70,10 @@ SAFE_TOPLEVEL_KEYS = frozenset(
         "citation_precision",
         "citation_grounding",
         "claim_citation_alignment",
+        "chunk_recall_at_5",
+        "chunk_recall_at_10",
+        "chunk_mrr_at_5",
+        "chunk_ndcg_at_5",
         "answer_format_compliance",
         "abstention",
         "retry",
@@ -203,6 +207,10 @@ SAFE_ABLATION_FULL_SCALAR_KEYS = (
     "citation_precision",
     "citation_grounding",
     "claim_citation_alignment",
+    "chunk_recall_at_5",
+    "chunk_recall_at_10",
+    "chunk_mrr_at_5",
+    "chunk_ndcg_at_5",
     "answer_format_compliance",
     "abstention",
     "retry",
@@ -220,6 +228,10 @@ SAFE_CI_METRIC_KEYS = (
     "citation_region_precision",
     "citation_grounding",
     "claim_citation_alignment",
+    "chunk_recall_at_5",
+    "chunk_recall_at_10",
+    "chunk_mrr_at_5",
+    "chunk_ndcg_at_5",
     "answer_format_compliance",
     "abstention",
     "retry",
@@ -301,9 +313,14 @@ FORBIDDEN_KEYS = frozenset(
 # Metric direction for the rendered delta arrow.
 # (path, label, higher_is_better)
 METRICS: list[tuple[str, str, bool]] = [
+    ("chunk_recall_at_5", "Recall@5", True),
+    ("chunk_recall_at_10", "Recall@10", True),
+    ("chunk_mrr_at_5", "MRR@5", True),
+    ("chunk_ndcg_at_5", "nDCG@5", True),
+    ("citation_precision", "citation_accuracy", True),
+    ("failure_category_counts.retrieval_miss", "retrieval_miss", False),
     ("accuracy", "accuracy", True),
     ("groundedness", "groundedness", True),
-    ("citation_precision", "citation_precision", True),
     ("citation_grounding", "citation_grounding", True),
     ("claim_citation_alignment", "claim_citation_alignment", True),
     ("answer_format_compliance", "answer_format_compliance", True),
@@ -948,6 +965,54 @@ def append_decision_log_stub(
         fh.write(body)
 
 
+def select_ablation_run(
+    summary: dict[str, Any],
+    run_name: str | None,
+    *,
+    source_label: str,
+) -> dict[str, Any]:
+    """Select a named run from ``eval_summary.json::ablation.runs[]``.
+
+    The returned dict is still passed through :func:`extract_aggregate`, so
+    choosing a primary run that carries ``case_results`` cannot leak private
+    payload into the rendered delta.  This is used for intra-summary private
+    comparisons such as ``full_dense`` vs ``hybrid_bm25_dense_v1``.
+    """
+    if not run_name:
+        return summary
+    if not isinstance(summary, dict):
+        raise ValueError(f"{source_label} summary must be a JSON object")
+
+    if summary.get("name") == run_name or summary.get("primary_run") == run_name:
+        selected = dict(summary)
+    else:
+        ablation = summary.get("ablation")
+        runs = (ablation or {}).get("runs") if isinstance(ablation, dict) else []
+        selected = next(
+            (
+                dict(run)
+                for run in runs or []
+                if isinstance(run, dict) and run.get("name") == run_name
+            ),
+            None,
+        )
+        if selected is None:
+            available = [
+                str(run.get("name"))
+                for run in runs or []
+                if isinstance(run, dict) and run.get("name")
+            ]
+            raise ValueError(
+                f"{source_label} run {run_name!r} not found in ablation.runs"
+                + (f" (available: {', '.join(available)})" if available else "")
+            )
+    selected.setdefault("primary_run", run_name)
+    for inherited_key in ("provenance", "run_manifest"):
+        if inherited_key not in selected and isinstance(summary.get(inherited_key), dict):
+            selected[inherited_key] = dict(summary[inherited_key])
+    return selected
+
+
 # -----------------------------------------------------------------------------
 # CLI
 # -----------------------------------------------------------------------------
@@ -978,6 +1043,16 @@ def parse_args() -> argparse.Namespace:
         "--base",
         default=_default_base_path(),
         help="Committed baseline aggregate snapshot path.",
+    )
+    ap.add_argument(
+        "--base-run",
+        default=None,
+        help="Select this ablation run from --base before rendering the delta.",
+    )
+    ap.add_argument(
+        "--head-run",
+        default=None,
+        help="Select this ablation run from --head before rendering the delta.",
     )
     ap.add_argument("--title", default="Real-data eval delta")
     ap.add_argument(
@@ -1018,6 +1093,12 @@ def main() -> int:
 
     head_raw = json.loads(head_path.read_text(encoding="utf-8"))
     base_raw = json.loads(base_path.read_text(encoding="utf-8"))
+    try:
+        head_raw = select_ablation_run(head_raw, args.head_run, source_label="head")
+        base_raw = select_ablation_run(base_raw, args.base_run, source_label="base")
+    except ValueError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
 
     head = extract_aggregate(head_raw)
 
@@ -1027,7 +1108,7 @@ def main() -> int:
     # user just ran `make real-eval-with-judge`. The per-case judge
     # text is never copied into the head aggregate.
     judge_local = head_path.parent / "judge.local.json"
-    if judge_local.exists():
+    if not args.head_run and judge_local.exists():
         from collections import Counter
 
         judge_payload = json.loads(judge_local.read_text(encoding="utf-8"))

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -755,6 +755,69 @@ def _fmt_ci(summary: dict[str, Any], metric_key: str) -> str:
     return f" [{lo:.3f}, {hi:.3f}]"
 
 
+def _md_cell(value: Any) -> str:
+    """Escape one GitHub Markdown table cell."""
+    text = str(value)
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def _md_row(cells: list[Any]) -> str:
+    return "| " + " | ".join(_md_cell(cell) for cell in cells) + " |"
+
+
+def _numeric_path(summary: dict[str, Any], path: str) -> float | None:
+    value = _get_path(summary, path)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _no_go_interpretation_lines(base: dict[str, Any], head: dict[str, Any]) -> list[str]:
+    """Return the #1448 private-delta interpretation when all signals match."""
+    recall10_base = _numeric_path(base, "chunk_recall_at_10")
+    recall10_head = _numeric_path(head, "chunk_recall_at_10")
+    mrr5_base = _numeric_path(base, "chunk_mrr_at_5")
+    mrr5_head = _numeric_path(head, "chunk_mrr_at_5")
+    ndcg5_base = _numeric_path(base, "chunk_ndcg_at_5")
+    ndcg5_head = _numeric_path(head, "chunk_ndcg_at_5")
+    citation_base = _numeric_path(base, "citation_precision")
+    citation_head = _numeric_path(head, "citation_precision")
+    p50_base = _numeric_path(base, "latency.p50")
+    p50_head = _numeric_path(head, "latency.p50")
+    p95_base = _numeric_path(base, "latency.p95")
+    p95_head = _numeric_path(head, "latency.p95")
+
+    recall10_up = (
+        recall10_base is not None
+        and recall10_head is not None
+        and recall10_head > recall10_base
+    )
+    mrr5_down = mrr5_base is not None and mrr5_head is not None and mrr5_head < mrr5_base
+    ndcg5_down = ndcg5_base is not None and ndcg5_head is not None and ndcg5_head < ndcg5_base
+    citation_down = (
+        citation_base is not None
+        and citation_head is not None
+        and citation_head < citation_base
+    )
+    latency_up = (
+        (p50_base is not None and p50_head is not None and p50_head > p50_base)
+        or (p95_base is not None and p95_head is not None and p95_head > p95_base)
+    )
+    if not (recall10_up and mrr5_down and ndcg5_down and citation_down and latency_up):
+        return []
+    return [
+        "",
+        "#### GO/NO-GO interpretation",
+        "",
+        "- Recall@10 slightly improved.",
+        "- MRR@5 regressed.",
+        "- nDCG@5 regressed.",
+        "- citation_accuracy regressed.",
+        "- latency regressed.",
+        "- Decision: NO-GO; this result is not merge-ready as an improvement claim.",
+    ]
+
+
 def render_markdown(
     base: dict[str, Any],
     head: dict[str, Any],
@@ -781,16 +844,19 @@ def render_markdown(
             f"- silence band: ±{_silence_threshold(n_min):.3f} (N={n_min})"
         )
     lines.append("")
-    lines.append("| metric | base (95% CI) | head (95% CI) | Δ |")
+    lines.append(_md_row(["metric", "base (95% CI)", "head (95% CI)", "Δ"]))
     lines.append("|---|---|---|---|")
     for path, label, higher in METRICS:
         b = _get_path(base, path)
         h = _get_path(head, path)
-        lines.append(
-            f"| {label} | {_fmt_value(b)}{_fmt_ci(base, path)} "
-            f"| {_fmt_value(h)}{_fmt_ci(head, path)} "
-            f"| {_fmt_delta(b, h, higher, n_min=n_min)} |"
-        )
+        lines.append(_md_row([
+            label,
+            f"{_fmt_value(b)}{_fmt_ci(base, path)}",
+            f"{_fmt_value(h)}{_fmt_ci(head, path)}",
+            _fmt_delta(b, h, higher, n_min=n_min),
+        ]))
+
+    lines.extend(_no_go_interpretation_lines(base, head))
 
     # Slice-level abstention is the most important signal we surfaced
     # from #69 — render it explicitly so future regressions are obvious.
@@ -801,15 +867,17 @@ def render_markdown(
         lines.append("")
         lines.append("#### Slice abstention rate (intended-abstention preservation)")
         lines.append("")
-        lines.append("| slice | base | head | Δ |")
+        lines.append(_md_row(["slice", "base", "head", "Δ"]))
         lines.append("|---|---|---|---|")
         for name in slice_names:
             b = (base_slices.get(name) or {}).get("abstention")
             h = (head_slices.get(name) or {}).get("abstention")
-            lines.append(
-                f"| {name} | {_fmt_value(b)} | {_fmt_value(h)} | "
-                f"{_fmt_delta(b, h, True, n_min=n_min)} |"
-            )
+            lines.append(_md_row([
+                name,
+                _fmt_value(b),
+                _fmt_value(h),
+                _fmt_delta(b, h, True, n_min=n_min),
+            ]))
 
     # Issue #463: 3-bin breakdown so a confident-refusal → hallucination
     # regression and a confident-refusal → boundary-partial regression
@@ -820,12 +888,12 @@ def render_markdown(
         lines.append("")
         lines.append("#### Abstention outcome breakdown (intended-abstention slice)")
         lines.append("")
-        lines.append("| outcome | base | head |")
+        lines.append(_md_row(["outcome", "base", "head"]))
         lines.append("|---|---:|---:|")
         for outcome_key in SAFE_ABSTENTION_OUTCOME_KEYS:
             b_count = (base_outcomes or {}).get(outcome_key, 0)
             h_count = (head_outcomes or {}).get(outcome_key, 0)
-            lines.append(f"| {outcome_key} | {b_count} | {h_count} |")
+            lines.append(_md_row([outcome_key, b_count, h_count]))
 
     base_reasons = base.get("retry_reason_counts") or {}
     head_reasons = head.get("retry_reason_counts") or {}
@@ -833,13 +901,14 @@ def render_markdown(
         lines.append("")
         lines.append("#### Retry reason counts")
         lines.append("")
-        lines.append("| reason | base | head |")
+        lines.append(_md_row(["reason", "base", "head"]))
         lines.append("|---|---:|---:|")
         for reason in sorted(set(base_reasons) | set(head_reasons)):
-            lines.append(
-                f"| `{reason}` | {base_reasons.get(reason, 0)} | "
-                f"{head_reasons.get(reason, 0)} |"
-            )
+            lines.append(_md_row([
+                f"`{reason}`",
+                base_reasons.get(reason, 0),
+                head_reasons.get(reason, 0),
+            ]))
 
     base_retry_eff = base.get("retry_effectiveness") or {}
     head_retry_eff = head.get("retry_effectiveness") or {}
@@ -847,7 +916,7 @@ def render_markdown(
         lines.append("")
         lines.append("#### Retry effectiveness (#120)")
         lines.append("")
-        lines.append("| metric | base | head | Δ |")
+        lines.append(_md_row(["metric", "base", "head", "Δ"]))
         lines.append("|---|---|---|---|")
         for key, label, higher in (
             ("recovery_rate", "recovery_rate", True),
@@ -857,10 +926,12 @@ def render_markdown(
         ):
             b = base_retry_eff.get(key)
             h = head_retry_eff.get(key)
-            lines.append(
-                f"| {label} | {_fmt_value(b)} | {_fmt_value(h)} | "
-                f"{_fmt_delta(b, h, higher, n_min=n_min)} |"
-            )
+            lines.append(_md_row([
+                label,
+                _fmt_value(b),
+                _fmt_value(h),
+                _fmt_delta(b, h, higher, n_min=n_min),
+            ]))
         base_cross = base_retry_eff.get("cross_ablation") or {}
         head_cross = head_retry_eff.get("cross_ablation") or {}
         if base_cross or head_cross:
@@ -878,15 +949,17 @@ def render_markdown(
         lines.append("")
         lines.append("#### RAGAS judge (opt-in)")
         lines.append("")
-        lines.append("| metric | base | head | Δ |")
+        lines.append(_md_row(["metric", "base", "head", "Δ"]))
         lines.append("|---|---|---|---|")
         for metric in SAFE_JUDGE_RAGAS_METRIC_KEYS:
             b = base_ragas.get(metric)
             h = head_ragas.get(metric)
-            lines.append(
-                f"| {metric} | {_fmt_value(b)} | {_fmt_value(h)} | "
-                f"{_fmt_delta(b, h, True, n_min=n_min)} |"
-            )
+            lines.append(_md_row([
+                metric,
+                _fmt_value(b),
+                _fmt_value(h),
+                _fmt_delta(b, h, True, n_min=n_min),
+            ]))
 
     base_judge = base.get("judge") or {}
     head_judge = head.get("judge") or {}
@@ -894,7 +967,7 @@ def render_markdown(
         lines.append("")
         lines.append("#### LLM-judge aggregate (ADR 0006)")
         lines.append("")
-        lines.append("| metric | base | head | Δ |")
+        lines.append(_md_row(["metric", "base", "head", "Δ"]))
         lines.append("|---|---|---|---|")
         for key, label, higher in (
             ("grounded_rate", "judge_grounded_rate", True),
@@ -902,22 +975,21 @@ def render_markdown(
         ):
             b = base_judge.get(key)
             h = head_judge.get(key)
-            lines.append(
-                f"| {label} | {_fmt_value(b)} | {_fmt_value(h)} | "
-                f"{_fmt_delta(b, h, higher, n_min=n_min)} |"
-            )
+            lines.append(_md_row([
+                label,
+                _fmt_value(b),
+                _fmt_value(h),
+                _fmt_delta(b, h, higher, n_min=n_min),
+            ]))
         base_dist = base_judge.get("status_distribution") or {}
         head_dist = head_judge.get("status_distribution") or {}
         statuses = sorted(set(base_dist) | set(head_dist))
         if statuses:
             lines.append("")
-            lines.append("| judge_status | base count | head count |")
+            lines.append(_md_row(["judge_status", "base count", "head count"]))
             lines.append("|---|---:|---:|")
             for status in statuses:
-                lines.append(
-                    f"| {status} | {base_dist.get(status, 0)} | "
-                    f"{head_dist.get(status, 0)} |"
-                )
+                lines.append(_md_row([status, base_dist.get(status, 0), head_dist.get(status, 0)]))
 
     lines.append("")
     lines.append(

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -318,6 +318,8 @@ METRICS: list[tuple[str, str, bool]] = [
     ("chunk_mrr_at_5", "MRR@5", True),
     ("chunk_ndcg_at_5", "nDCG@5", True),
     ("citation_precision", "citation_accuracy", True),
+    # ADR 0075 taxonomy count. Missing stays missing (`—`) via `_get_path`;
+    # never coerce absent selected-run failure counts to numeric zero.
     ("failure_category_counts.retrieval_miss", "retrieval_miss", False),
     ("accuracy", "accuracy", True),
     ("groundedness", "groundedness", True),

--- a/tests/test_full_dense_control_row_regression.py
+++ b/tests/test_full_dense_control_row_regression.py
@@ -21,10 +21,11 @@ so the assertions match what the eval runner actually executes:
 1.  ``full_dense`` row exists.
 2.  ``full`` resolves to hybrid (ADR 0058 Scenario A on the headline row).
 3.  ``full_dense`` resolves to dense (the restored control arm).
-4.  ``naive_baseline`` resolves to dense (ADR 0001 byte-identity sentinel).
-5.  ``full`` and ``full_dense`` differ by exactly ``{name, retrieval_backend}``
+4.  ``hybrid_bm25_dense_v1`` resolves to hybrid + RRF k=60 + okapi BM25.
+5.  ``naive_baseline`` resolves to dense (ADR 0001 byte-identity sentinel).
+6.  ``full`` and ``full_dense`` differ by exactly ``{name, retrieval_backend}``
     (the control row varies exactly one knob).
-6.  Every eval row explicitly declares the core stage-separation knobs.
+7.  Every eval row explicitly declares the core stage-separation knobs.
 """
 from __future__ import annotations
 
@@ -86,6 +87,30 @@ class TestFullDenseControlRow(unittest.TestCase):
             "dense",
             "full_dense must resolve to 'dense' — it is the explicit dense "
             "control arm for ADR 0058 reproducibility (issue #1285).",
+        )
+
+    def test_hybrid_bm25_dense_v1_row_exists(self) -> None:
+        self.assertIn(
+            "hybrid_bm25_dense_v1",
+            self.ablation_by_name,
+            "Ablation row 'hybrid_bm25_dense_v1' missing from eval/config.yaml. "
+            "It is the explicit BM25+dense RRF v1 row for issue #1447.",
+        )
+
+    def test_hybrid_bm25_dense_v1_resolves_to_rrf_hybrid(self) -> None:
+        resolved = normalize_run_config(self.ablation_by_name["hybrid_bm25_dense_v1"])
+        self.assertEqual(resolved["retrieval_backend"], "hybrid")
+        self.assertEqual(resolved["rrf_k"], 60)
+        self.assertEqual(resolved["bm25_backend"], "okapi")
+        self.assertEqual(resolved["bm25_tokenizer"], "regex")
+
+    def test_hybrid_bm25_dense_v1_has_latency_budget(self) -> None:
+        budgets = self.config.get("latency_budgets") or {}
+        self.assertIn(
+            "hybrid_bm25_dense_v1",
+            budgets,
+            "hybrid_bm25_dense_v1 must have a latency budget so the SLO "
+            "checker can report the row when public smoke eval runs.",
         )
 
     def test_naive_baseline_stays_dense(self) -> None:

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -222,6 +222,44 @@ class ExtractAggregateTest(unittest.TestCase):
         ):
             self.assertIn(label, md)
 
+    def test_render_retrieval_miss_nonzero_count_as_numeric(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "failure_category_counts": {
+                    **FULL_SUMMARY["failure_category_counts"],
+                    "retrieval_miss": 1,
+                },
+            }
+        )
+        md = render_markdown(base, head, "test")
+        self.assertIn("| retrieval_miss | 2 | 1 | -1.000 ✅ |", md)
+
+    def test_render_retrieval_miss_missing_as_dash_not_zero(self) -> None:
+        base_summary = {k: v for k, v in FULL_SUMMARY.items() if k != "failure_category_counts"}
+        head_summary = {
+            **FULL_SUMMARY,
+            "failure_category_counts": {
+                "verifier_false_negative": 1,
+            },
+        }
+        base = extract_aggregate(base_summary)
+        head = extract_aggregate(head_summary)
+        md = render_markdown(base, head, "test")
+        self.assertIn("| retrieval_miss | — | — | — |", md)
+        self.assertNotIn("| retrieval_miss | 0 | 0 |", md)
+
+    def test_render_retrieval_miss_explicit_zero_as_zero(self) -> None:
+        zero_counts = {
+            **FULL_SUMMARY["failure_category_counts"],
+            "retrieval_miss": 0,
+        }
+        base = extract_aggregate({**FULL_SUMMARY, "failure_category_counts": zero_counts})
+        head = extract_aggregate({**FULL_SUMMARY, "failure_category_counts": zero_counts})
+        md = render_markdown(base, head, "test")
+        self.assertIn("| retrieval_miss | 0 | 0 | · |", md)
+
     def test_render_includes_slice_abstention(self) -> None:
         base = extract_aggregate(FULL_SUMMARY)
         head = extract_aggregate({**FULL_SUMMARY, "accuracy": 0.6})
@@ -240,6 +278,10 @@ class ExtractAggregateTest(unittest.TestCase):
                         "name": "full_dense",
                         "primary_run": "full_dense",
                         "chunk_recall_at_5": 0.1,
+                        "run_manifest": {
+                            "config_path": "/Users/hskim/private/real_config.local.yaml",
+                            "config_sha256": "safe-sha",
+                        },
                         "case_results": [{"query": "private base leak"}],
                     },
                     {
@@ -247,7 +289,22 @@ class ExtractAggregateTest(unittest.TestCase):
                         "name": "hybrid_bm25_dense_v1",
                         "primary_run": "hybrid_bm25_dense_v1",
                         "chunk_recall_at_5": 0.2,
-                        "case_results": [{"query": "private head leak"}],
+                        "trace_dir": "/Users/hskim/private/run/traces",
+                        "case_results": [
+                            {
+                                "query": "private head leak",
+                                "answer": "private generated answer leak",
+                                "answer_text": "private answer text leak",
+                                "evidence": [
+                                    {
+                                        "doc_id": "private_doc_1",
+                                        "chunk_id": "private_chunk_1",
+                                        "text": "private evidence text",
+                                        "filename": "private_file.pdf",
+                                    }
+                                ],
+                            }
+                        ],
                     },
                 ]
             },
@@ -261,7 +318,81 @@ class ExtractAggregateTest(unittest.TestCase):
         self.assertEqual(agg["primary_run"], "hybrid_bm25_dense_v1")
         self.assertEqual(agg["chunk_recall_at_5"], 0.2)
         flat = json.dumps(agg, ensure_ascii=False)
-        self.assertNotIn("private head leak", flat)
+        md = render_markdown(
+            extract_aggregate(select_ablation_run(summary, "full_dense", source_label="base")),
+            agg,
+            "test",
+        )
+        for payload in (
+            "private head leak",
+            "private generated answer leak",
+            "private answer text leak",
+            "private evidence text",
+            "private_doc_1",
+            "private_chunk_1",
+            "private_file.pdf",
+            "/Users/hskim/private",
+        ):
+            self.assertNotIn(payload, flat)
+            self.assertNotIn(payload, md)
+
+    def test_selected_ablation_run_does_not_inherit_top_level_failure_counts(self) -> None:
+        summary = {
+            **FULL_SUMMARY,
+            "failure_category_counts": {
+                **FULL_SUMMARY["failure_category_counts"],
+                "retrieval_miss": 99,
+            },
+            "ablation": {
+                "runs": [
+                    {
+                        "name": "full_dense",
+                        "primary_run": "full_dense",
+                        "num_predictions": 21,
+                        "chunk_recall_at_5": 0.1,
+                    },
+                ]
+            },
+        }
+        selected = select_ablation_run(summary, "full_dense", source_label="base")
+        agg = extract_aggregate(selected)
+        self.assertNotIn("failure_category_counts", agg)
+
+    def test_selected_run_missing_retrieval_miss_renders_missing_not_zero(self) -> None:
+        summary = {
+            **FULL_SUMMARY,
+            "failure_category_counts": {
+                **FULL_SUMMARY["failure_category_counts"],
+                "retrieval_miss": 99,
+            },
+            "ablation": {
+                "runs": [
+                    {
+                        **FULL_SUMMARY,
+                        "name": "full_dense",
+                        "primary_run": "full_dense",
+                        "failure_category_counts": {
+                            "verifier_false_negative": 1,
+                        },
+                    },
+                    {
+                        **FULL_SUMMARY,
+                        "name": "hybrid_bm25_dense_v1",
+                        "primary_run": "hybrid_bm25_dense_v1",
+                        "failure_category_counts": {
+                            "verifier_false_negative": 2,
+                        },
+                    },
+                ]
+            },
+        }
+        base = extract_aggregate(select_ablation_run(summary, "full_dense", source_label="base"))
+        head = extract_aggregate(
+            select_ablation_run(summary, "hybrid_bm25_dense_v1", source_label="head")
+        )
+        md = render_markdown(base, head, "test")
+        self.assertIn("| retrieval_miss | — | — | — |", md)
+        self.assertNotIn("| retrieval_miss | 0 | 0 |", md)
 
     def test_select_ablation_run_missing_fails_loudly(self) -> None:
         with self.assertRaisesRegex(ValueError, "not found"):

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -80,6 +80,25 @@ FULL_SUMMARY = {
 }
 
 
+def _unescaped_pipe_count(line: str) -> int:
+    return sum(1 for i, char in enumerate(line) if char == "|" and (i == 0 or line[i - 1] != "\\"))
+
+
+def _markdown_table_blocks(md: str) -> list[list[str]]:
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in md.splitlines():
+        if line.startswith("|"):
+            current.append(line)
+            continue
+        if current:
+            blocks.append(current)
+            current = []
+    if current:
+        blocks.append(current)
+    return blocks
+
+
 def test_parse_args_defaults_follow_real_eval_report_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REAL_EVAL_REPORT_DIR", "tmp/private-reports")
     monkeypatch.delenv("REAL_EVAL_BASELINE_SUMMARY", raising=False)
@@ -195,6 +214,41 @@ class ExtractAggregateTest(unittest.TestCase):
         self.assertIn("0.471", md)
         self.assertIn("0.600", md)
 
+    def test_render_markdown_has_no_fenced_code_blocks(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate({**FULL_SUMMARY, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+        self.assertNotIn("```", md)
+
+    def test_generated_markdown_tables_have_stable_column_count(self) -> None:
+        base = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "by_query_type": {
+                    "single|doc": {"num_predictions": 1, "abstention": 0.0},
+                },
+                "retry_reason_counts": {"topic|not_grounded": 1},
+                "judge": {"status_distribution": {"needs|review": 1}},
+            }
+        )
+        head = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "by_query_type": {
+                    "single|doc": {"num_predictions": 1, "abstention": 1.0},
+                },
+                "retry_reason_counts": {"topic|not_grounded": 2},
+                "judge": {"status_distribution": {"needs|review": 2}},
+            }
+        )
+        md = render_markdown(base, head, "test")
+        self.assertIn("single\\|doc", md)
+        self.assertIn("topic\\|not_grounded", md)
+        for block in _markdown_table_blocks(md):
+            expected = _unescaped_pipe_count(block[0])
+            for row in block:
+                self.assertEqual(expected, _unescaped_pipe_count(row), row)
+
     def test_render_markdown_includes_retrieval_and_failure_metrics(self) -> None:
         base = extract_aggregate(FULL_SUMMARY)
         head = extract_aggregate(
@@ -259,6 +313,28 @@ class ExtractAggregateTest(unittest.TestCase):
         head = extract_aggregate({**FULL_SUMMARY, "failure_category_counts": zero_counts})
         md = render_markdown(base, head, "test")
         self.assertIn("| retrieval_miss | 0 | 0 | · |", md)
+
+    def test_render_includes_private_delta_no_go_interpretation(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "chunk_recall_at_10": 0.244,
+                "chunk_mrr_at_5": 0.300,
+                "chunk_ndcg_at_5": 0.400,
+                "citation_precision": 0.200,
+                "latency": {"p50": 200.0, "p95": 500.0, "mean": 250.0},
+            }
+        )
+        md = render_markdown(base, head, "test")
+        self.assertIn("GO/NO-GO interpretation", md)
+        self.assertIn("Recall@10 slightly improved", md)
+        self.assertIn("MRR@5 regressed", md)
+        self.assertIn("nDCG@5 regressed", md)
+        self.assertIn("citation_accuracy regressed", md)
+        self.assertIn("latency regressed", md)
+        self.assertIn("NO-GO", md)
+        self.assertIn("not merge-ready", md)
 
     def test_render_includes_slice_abstention(self) -> None:
         base = extract_aggregate(FULL_SUMMARY)

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -22,6 +22,7 @@ from scripts.run_real_eval_delta import (
     extract_aggregate,
     parse_args,
     render_markdown,
+    select_ablation_run,
 )
 
 
@@ -34,8 +35,21 @@ FULL_SUMMARY = {
     "accuracy": 0.471,
     "groundedness": 0.476,
     "citation_precision": 0.286,
+    "chunk_recall_at_5": 0.111,
+    "chunk_recall_at_10": 0.222,
+    "chunk_mrr_at_5": 0.333,
+    "chunk_ndcg_at_5": 0.444,
     "abstention": 0.5,
     "retry": 0.429,
+    "failure_category_counts": {
+        "retrieval_miss": 2,
+        "planner_under_decomposition": 0,
+        "verifier_false_negative": 1,
+        "verifier_false_positive": 0,
+        "generator_hallucination": 0,
+        "context_dilution": 0,
+        "unknown": 0,
+    },
     "latency": {"p50": 100.0, "p95": 300.0, "mean": 150.0},
     "stage_latency": {
         "retrieve_ms": {"p50": 5.0, "p95": 20.0, "mean": 8.0, "count": 21}
@@ -84,6 +98,22 @@ def test_parse_args_baseline_env_overrides_report_default(monkeypatch: pytest.Mo
     assert args.base == "tmp/baseline.json"
 
 
+def test_parse_args_accepts_ablation_run_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_real_eval_delta.py",
+            "--base-run",
+            "full_dense",
+            "--head-run",
+            "hybrid_bm25_dense_v1",
+        ],
+    )
+    args = parse_args()
+    assert args.base_run == "full_dense"
+    assert args.head_run == "hybrid_bm25_dense_v1"
+
+
 class ExtractAggregateTest(unittest.TestCase):
     def test_extracts_top_level_aggregates(self) -> None:
         agg = extract_aggregate(FULL_SUMMARY)
@@ -94,6 +124,14 @@ class ExtractAggregateTest(unittest.TestCase):
         self.assertEqual(
             agg["retry_reason_counts"], {"topic_not_grounded": 12}
         )
+
+    def test_extracts_retrieval_delta_metrics(self) -> None:
+        agg = extract_aggregate(FULL_SUMMARY)
+        self.assertEqual(agg["chunk_recall_at_5"], 0.111)
+        self.assertEqual(agg["chunk_recall_at_10"], 0.222)
+        self.assertEqual(agg["chunk_mrr_at_5"], 0.333)
+        self.assertEqual(agg["chunk_ndcg_at_5"], 0.444)
+        self.assertEqual(agg["failure_category_counts"]["retrieval_miss"], 2)
 
     def test_drops_case_results(self) -> None:
         agg = extract_aggregate(FULL_SUMMARY)
@@ -157,6 +195,33 @@ class ExtractAggregateTest(unittest.TestCase):
         self.assertIn("0.471", md)
         self.assertIn("0.600", md)
 
+    def test_render_markdown_includes_retrieval_and_failure_metrics(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "chunk_recall_at_5": 0.211,
+                "chunk_recall_at_10": 0.322,
+                "chunk_mrr_at_5": 0.433,
+                "chunk_ndcg_at_5": 0.544,
+                "citation_precision": 0.386,
+                "failure_category_counts": {
+                    **FULL_SUMMARY["failure_category_counts"],
+                    "retrieval_miss": 1,
+                },
+            }
+        )
+        md = render_markdown(base, head, "test")
+        for label in (
+            "Recall@5",
+            "Recall@10",
+            "MRR@5",
+            "nDCG@5",
+            "citation_accuracy",
+            "retrieval_miss",
+        ):
+            self.assertIn(label, md)
+
     def test_render_includes_slice_abstention(self) -> None:
         base = extract_aggregate(FULL_SUMMARY)
         head = extract_aggregate({**FULL_SUMMARY, "accuracy": 0.6})
@@ -164,6 +229,47 @@ class ExtractAggregateTest(unittest.TestCase):
         # Slice section should be present.
         self.assertIn("Slice abstention", md)
         self.assertIn("abstention", md)
+
+    def test_select_ablation_run_by_name(self) -> None:
+        summary = {
+            **FULL_SUMMARY,
+            "ablation": {
+                "runs": [
+                    {
+                        **FULL_SUMMARY,
+                        "name": "full_dense",
+                        "primary_run": "full_dense",
+                        "chunk_recall_at_5": 0.1,
+                        "case_results": [{"query": "private base leak"}],
+                    },
+                    {
+                        **FULL_SUMMARY,
+                        "name": "hybrid_bm25_dense_v1",
+                        "primary_run": "hybrid_bm25_dense_v1",
+                        "chunk_recall_at_5": 0.2,
+                        "case_results": [{"query": "private head leak"}],
+                    },
+                ]
+            },
+        }
+        selected = select_ablation_run(
+            summary,
+            "hybrid_bm25_dense_v1",
+            source_label="head",
+        )
+        agg = extract_aggregate(selected)
+        self.assertEqual(agg["primary_run"], "hybrid_bm25_dense_v1")
+        self.assertEqual(agg["chunk_recall_at_5"], 0.2)
+        flat = json.dumps(agg, ensure_ascii=False)
+        self.assertNotIn("private head leak", flat)
+
+    def test_select_ablation_run_missing_fails_loudly(self) -> None:
+        with self.assertRaisesRegex(ValueError, "not found"):
+            select_ablation_run(
+                {"ablation": {"runs": [{"name": "full_dense"}]}},
+                "hybrid_bm25_dense_v1",
+                source_label="head",
+            )
 
     def test_provenance_passes_through_extraction(self) -> None:
         """Issue #160: provenance is metadata about run state (no per-case
@@ -675,6 +781,62 @@ class FullScriptInvocationTest(unittest.TestCase):
             self.assertIn("0.600", result.stdout)
             self.assertIn("+0.129", result.stdout)
             # Privacy assertion at the CLI boundary:
+            for leak in ["real_secret_case", "진짜 비공개", "private_doc_1"]:
+                self.assertNotIn(leak, result.stdout)
+
+    def test_end_to_end_selects_ablation_runs(self) -> None:
+        import subprocess
+        import sys
+
+        summary = {
+            **FULL_SUMMARY,
+            "ablation": {
+                "runs": [
+                    {
+                        **FULL_SUMMARY,
+                        "name": "full_dense",
+                        "primary_run": "full_dense",
+                        "chunk_recall_at_5": 0.1,
+                    },
+                    {
+                        **FULL_SUMMARY,
+                        "name": "hybrid_bm25_dense_v1",
+                        "primary_run": "hybrid_bm25_dense_v1",
+                        "chunk_recall_at_5": 0.2,
+                        "failure_category_counts": {
+                            **FULL_SUMMARY["failure_category_counts"],
+                            "retrieval_miss": 1,
+                        },
+                    },
+                ]
+            },
+        }
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "eval_summary.json"
+            path.write_text(json.dumps(summary))
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/run_real_eval_delta.py",
+                    "--base",
+                    str(path),
+                    "--head",
+                    str(path),
+                    "--base-run",
+                    "full_dense",
+                    "--head-run",
+                    "hybrid_bm25_dense_v1",
+                    "--title",
+                    "hybrid delta",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("hybrid delta", result.stdout)
+            self.assertIn("primary run: `hybrid_bm25_dense_v1`", result.stdout)
+            self.assertIn("Recall@5", result.stdout)
+            self.assertIn("retrieval_miss", result.stdout)
             for leak in ["real_secret_case", "진짜 비공개", "private_doc_1"]:
                 self.assertNotIn(leak, result.stdout)
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`hybrid_bm25_dense_v1` eval row를 추가해 `agentic_full` 스택 안에서 MiniLM dense 후보와 BM25 lexical 후보를 RRF `k=60`으로 fusion하는 별도 측정 arm을 만들었습니다. `full_dense`는 dense control로 유지하고, `naive_baseline`은 ADR 0001 기준선 그대로 보존합니다.

Closes #1447

## 2. 영향 파일

- `eval/config.yaml` — load-bearing. `hybrid_bm25_dense_v1` ablation row와 latency budget 추가.
- `scripts/run_real_eval_delta.py` — private aggregate delta renderer에 `--base-run` / `--head-run` 선택과 retrieval metric table 추가.
- `tests/test_full_dense_control_row_regression.py` — config row/regression guard 추가.
- `tests/test_run_real_eval_delta.py` — aggregate-only extraction, run selection, metric rendering privacy guard 추가.

## 3. 리스크

- `full`이 이미 hybrid라 새 row가 기능적으로 겹칠 수 있음. 이 PR은 canonical `full`을 바꾸지 않고, 명시 이름 `hybrid_bm25_dense_v1`로 별도 output을 남겨 비교 가능하게 합니다.
- delta renderer가 case-level/private payload를 읽거나 렌더링하면 ADR 0005 위반입니다. 기존 forbidden-key guard를 유지하고, selected ablation run에 `case_results`가 있어도 aggregate extraction에서 제거되는 테스트를 추가했습니다.
- verifier, prompt, chunking, answer generation은 변경하지 않았습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_full_dense_control_row_regression.py tests/test_run_real_eval_delta.py`
- `make smoke`
- `python3 scripts/run_real_eval_delta.py --base reports/eval_summary.json --head reports/eval_summary.json --base-run full_dense --head-run hybrid_bm25_dense_v1 --title "Hybrid BM25 dense v1 delta"`
- After rebasing on latest `main`: `python3 -m pytest -q tests/test_full_dense_control_row_regression.py tests/test_run_real_eval_delta.py`

## 5. Eval 영향

- Public fixture smoke에서 `hybrid_bm25_dense_v1` row가 별도 ablation으로 실행되고 latency budget check에 포함됨을 확인했습니다.
- Baseline dense config/result는 보존됩니다: `naive_baseline` remains `retrieval_backend: dense`; `full_dense` remains the dense control.
- Hybrid output is separate: `hybrid_bm25_dense_v1` is a separate ablation row, not a replacement for `full`, `full_dense`, or `naive_baseline`.

### 5b. Real-data delta

**Draft / claim-readiness status:** The previous `answerable_without_gold_evidence` readiness blocker has been fixed locally and re-audited, but this PR remains **not claim-ready** as a performance-improvement merge. The latest private aggregate experiment is **NO-GO** under the requested rule: Recall@10 improves, but `retrieval_miss` does not decrease, `citation_accuracy` regresses materially, and latency p50/p95 regress materially.

Readiness audit on the updated local private set:

| readiness check | value |
|---|---:|
| ready_for_improvement | true |
| blocker_count | 0 |
| answerable_without_gold_evidence_count | 0 |
| gold_chunk_missing_from_index_count | 0 |
| duplicate_question_id_count | 0 |
| unanswerable_with_gold_evidence_count | 0 |

Private aggregate delta, `full_dense` vs `hybrid_bm25_dense_v1`:

| metric | full_dense | hybrid_bm25_dense_v1 | Δ | status |
|---|---:|---:|---:|---|
| Recall@5 | 0.209 | 0.210 | +0.001 | neutral; within ±0.002 silence band |
| Recall@10 | 0.239 | 0.244 | +0.005 | improved |
| MRR@5 | 0.445 | 0.404 | -0.042 | regressed |
| nDCG@5 | 0.282 | 0.262 | -0.019 | regressed |
| citation_accuracy | 0.192 | 0.158 | -0.034 | regressed; maps to existing `citation_precision` aggregate |
| latency_p50_ms | 1698.570 | 3060.620 | +1362.050 | regressed |
| latency_p95_ms | 2870.560 | 4952.060 | +2081.500 | regressed |
| retrieval_miss | 0 | 0 | 0 | unchanged; GO criterion not met |

**GO/NO-GO:** NO-GO. Recall@10 improved, but retrieval miss did not decrease, citation accuracy regressed, and latency p50/p95 regressed materially. Keep this as a draft measurement PR; do not merge as an improvement claim.

Reproduction commands used locally, with private inputs and outputs kept gitignored:

```bash
python3 scripts/audit_private_data_readiness.py \
  --config eval/real_config.local.yaml \
  --out-dir experiments/private_runs/readiness_audit

EMBEDDING_BACKEND=sentence-transformers python3 eval/run_eval.py \
  --index_dir data/index/real100_minilm_hybrid_v1 \
  --output_dir reports/real100_minilm_hybrid_v1_latest_pr1448_b126b9b \
  --config experiments/private_runs/hybrid_bm25_dense_v1_eval_config.local.yaml

python3 scripts/run_real_eval_delta.py \
  --base reports/real100_minilm_hybrid_v1_latest_pr1448_b126b9b/eval_summary.json \
  --head reports/real100_minilm_hybrid_v1_latest_pr1448_b126b9b/eval_summary.json \
  --base-run full_dense \
  --head-run hybrid_bm25_dense_v1 \
  --title "Private real-data delta - full_dense vs hybrid_bm25_dense_v1"
```

Notes:

- The private MiniLM index was reused and confirmed as `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`.
- The compatibility path `configs/eval/private_real_eval.local.yaml` was absent in the local checkout; current project docs use `eval/real_config.local.yaml` as the canonical private config.
- No private raw content, raw questions, raw answers, evidence text, private document IDs, private chunk IDs, private filenames, exact local paths, or ignored run artifacts are committed or included in this PR body.

## 6. 하위 호환

- Answer-contract schema 변경 없음.
- `naive_baseline` preset/config row 변경 없음.
- Existing delta mode remains backward-compatible when `--base-run` / `--head-run` are omitted.

## 7. 범위 외

- verifier, prompt, chunking, answer generation 변경 없음.
- private raw content 또는 ignored private eval outputs commit 없음.