### PR TITLE
feat: add AI next-action planner

### DIFF
--- a/docs/operations/ai-codex-workflow.md
+++ b/docs/operations/ai-codex-workflow.md
@@ -1,0 +1,56 @@
+# AI Codex Workflow
+
+이 문서는 ChatGPT + Codex 반복 작업을 결정 표면별로 나누는 운영 계약이다.
+목표는 사람이 매번 repo 상태, readiness audit, open PR 상태를 다시 읽고 다음
+Codex 작업을 손으로 고르는 비용을 줄이는 것이다.
+
+## Roles
+
+| Role | Responsibility |
+|---|---|
+| ChatGPT | Planner/reviewer. repo 상태, readiness aggregate, PR 상태를 읽고 다음 작업을 고른다. |
+| Codex | Scoped executor. 한 번에 하나의 좁은 task를 구현하고 focused verification을 남긴다. |
+| GitHub | State store. issue, PR, review, CI, merge state를 보관한다. |
+| Human | Merge authority. 최종 merge와 scope 판단의 책임자는 사람이다. |
+
+## Planner Surface
+
+`scripts/ai_next_actions.py`는 외부 LLM API를 호출하지 않는 deterministic planner다.
+입력은 public-safe aggregate readiness summary/report와 `gh pr list --json ...`
+export다. 스크립트는 기본적으로 다음 로컬 생성물을 쓴다.
+
+```bash
+python3 scripts/ai_next_actions.py \
+  --readiness-summary experiments/private_runs/readiness_audit/readiness_summary.json \
+  --readiness-report experiments/private_runs/readiness_audit/readiness_report.md \
+  --pr-json tmp/open-prs.json
+```
+
+- `reports/ai_next_actions.md`: 현재 상태와 최우선 Codex task
+- `reports/codex_tasks/*.md`: Codex에게 넘길 scoped task briefs
+
+`reports/*`는 기본 gitignore 대상이므로 이 산출물은 로컬 workflow artifact다.
+committable evidence가 필요하면 별도 redacted aggregate 산출물로 승격해야 한다.
+
+## Classification Contract
+
+Planner는 다음 순서로 active work를 분류한다.
+
+| Classification | Meaning |
+|---|---|
+| `blocked` | readiness blocker, requested changes, merge blocker, failing check가 있다. |
+| `needs_private_delta` | private delta evidence가 필요한 PR 또는 load-bearing change가 있다. |
+| `ready_for_review` | blocker-free 상태라 reviewer handoff가 가능하다. |
+| `failed_experiment` | NO-GO 또는 negative experiment 신호가 있다. |
+| `next_experiment_candidate` | 위 신호가 없으므로 다음 측정 후보를 고른다. |
+
+Page citation claim은 readiness summary의 page metadata gate가 `NO-GO`이거나
+missing page metadata rate가 `1.0`이면 NO-GO로 취급한다. 이 경우 planner는
+page-aware parser/index rebuild 작업을 Codex 후보로 만든다.
+
+## Privacy Boundary
+
+Planner는 raw private content를 렌더링하지 않는다. 입력에서 forbidden raw/private
+field가 발견되면 값이나 키 목록을 출력하지 않고, sanitized input이 있었다는
+상태만 표시한다. reviewer-facing 문서에는 aggregate 또는 redacted artifact만
+사용한다.

--- a/scripts/ai_next_actions.py
+++ b/scripts/ai_next_actions.py
@@ -39,7 +39,17 @@ FAILED_CHECK_CONCLUSIONS = {
     "STARTUP_FAILURE",
     "TIMED_OUT",
 }
-BLOCKING_MERGE_STATES = {"BLOCKED", "DIRTY", "UNKNOWN"}
+BLOCKING_MERGE_STATES = {"BLOCKED", "DIRTY", "UNKNOWN", "UNSTABLE"}
+REQUIRED_PR_FIELDS = (
+    "number",
+    "title",
+    "headRefName",
+    "baseRefName",
+    "isDraft",
+    "reviewDecision",
+    "mergeStateStatus",
+    "statusCheckRollup",
+)
 PRIVATE_DELTA_RE = re.compile(r"(#1448|\b1448\b|private[-_\s]+delta)", re.IGNORECASE)
 LOAD_BEARING_RE = re.compile(r"(load[-_\s]+bearing|\b5b\b|real[-_\s]+data\s+delta)", re.IGNORECASE)
 NEGATIVE_EXPERIMENT_RE = re.compile(
@@ -240,12 +250,15 @@ def _pr_work_items(prs: Sequence[Mapping[str, Any]], readiness_blocked: bool) ->
         number = _as_int(pr.get("number"), 0)
         source = f"PR #{number}" if number else "PR"
         title = str(pr.get("title") or "(untitled)")
+        missing_fields = [field for field in REQUIRED_PR_FIELDS if field not in pr]
         review = str(pr.get("reviewDecision") or "").upper()
         merge_state = str(pr.get("mergeStateStatus") or "").upper()
         failing = _failing_checks(pr)
         draft = bool(pr.get("isDraft"))
         text = _pr_text(pr)
         blocked_reasons: list[str] = []
+        if missing_fields:
+            blocked_reasons.append("missing required PR JSON fields")
         if review == "CHANGES_REQUESTED":
             blocked_reasons.append("review changes requested")
         if merge_state in BLOCKING_MERGE_STATES:

--- a/scripts/ai_next_actions.py
+++ b/scripts/ai_next_actions.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Deterministic next-action planner for the ChatGPT + Codex workflow.
+
+This planner is intentionally rule-based. It reads public-safe aggregate
+readiness artifacts plus an optional ``gh pr list --json ...`` export and
+writes local-only Markdown suggestions for the next scoped Codex tasks.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any, Iterable, Mapping, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts._governance import find_redacted_summary_forbidden_fields
+
+
+DEFAULT_OUT_MD = ROOT_DIR / "reports" / "ai_next_actions.md"
+DEFAULT_TASKS_DIR = ROOT_DIR / "reports" / "codex_tasks"
+
+CLASSIFICATION_ORDER = {
+    "blocked": 0,
+    "needs_private_delta": 1,
+    "ready_for_review": 2,
+    "failed_experiment": 3,
+    "next_experiment_candidate": 4,
+}
+FAILED_CHECK_CONCLUSIONS = {
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "FAILURE",
+    "STARTUP_FAILURE",
+    "TIMED_OUT",
+}
+BLOCKING_MERGE_STATES = {"BLOCKED", "DIRTY", "UNKNOWN"}
+PRIVATE_DELTA_RE = re.compile(r"(#1448|\b1448\b|private[-_\s]+delta)", re.IGNORECASE)
+LOAD_BEARING_RE = re.compile(r"(load[-_\s]+bearing|\b5b\b|real[-_\s]+data\s+delta)", re.IGNORECASE)
+NEGATIVE_EXPERIMENT_RE = re.compile(
+    r"(NO-GO|negative\s+delta|regression|failed\s+experiment)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class SourceState:
+    kind: str
+    label: str
+    unsafe: bool = False
+
+
+@dataclass(frozen=True)
+class WorkItem:
+    classification: str
+    title: str
+    reason: str
+    source: str
+    slug: str
+    goal: str
+    expected_evidence: str
+    verification: str
+
+    @property
+    def priority(self) -> tuple[int, str, str]:
+        return (CLASSIFICATION_ORDER[self.classification], self.source, self.title)
+
+
+def _repo_display(path: Path, *, repo_root: Path = ROOT_DIR) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _labels(pr: Mapping[str, Any]) -> list[str]:
+    labels = pr.get("labels")
+    if not isinstance(labels, list):
+        return []
+    out: list[str] = []
+    for label in labels:
+        if isinstance(label, Mapping):
+            name = label.get("name")
+            if name:
+                out.append(str(name))
+        elif label:
+            out.append(str(label))
+    return sorted(out)
+
+
+def _pr_text(pr: Mapping[str, Any]) -> str:
+    parts = [
+        str(pr.get("number") or ""),
+        str(pr.get("title") or ""),
+        str(pr.get("headRefName") or ""),
+        str(pr.get("baseRefName") or ""),
+        str(pr.get("body") or ""),
+        " ".join(_labels(pr)),
+    ]
+    return "\n".join(parts)
+
+
+def _status_rollup_items(value: Any) -> list[Mapping[str, Any]]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, Mapping)]
+    if isinstance(value, Mapping):
+        nodes = value.get("nodes")
+        if isinstance(nodes, list):
+            return [item for item in nodes if isinstance(item, Mapping)]
+        return [value]
+    return []
+
+
+def _failing_checks(pr: Mapping[str, Any]) -> list[str]:
+    failed: list[str] = []
+    for item in _status_rollup_items(pr.get("statusCheckRollup")):
+        conclusion = str(item.get("conclusion") or "").upper()
+        status = str(item.get("status") or "").upper()
+        name = str(item.get("name") or item.get("workflowName") or item.get("context") or "check")
+        if conclusion in FAILED_CHECK_CONCLUSIONS:
+            failed.append(name)
+        elif status == "COMPLETED" and conclusion and conclusion not in {"SUCCESS", "SKIPPED", "NEUTRAL"}:
+            failed.append(name)
+    return sorted(set(failed))
+
+
+def _readiness_page_state(summary: Mapping[str, Any]) -> tuple[str, float | None]:
+    index = summary.get("index_integrity")
+    if not isinstance(index, Mapping):
+        return "UNKNOWN", None
+    page = index.get("page_metadata")
+    page_gate = "UNKNOWN"
+    missing_rate: float | None = None
+    if isinstance(page, Mapping):
+        gate = page.get("citation_page_claim_go_no_go")
+        if gate in {"GO", "NO-GO"}:
+            page_gate = str(gate)
+        chunk = page.get("chunk")
+        if isinstance(chunk, Mapping):
+            missing_rate = _as_float(chunk.get("missing_page_metadata_rate"))
+    if missing_rate is None:
+        missing_rate = _as_float(index.get("missing_page_metadata_rate"))
+    if missing_rate == 1.0:
+        page_gate = "NO-GO"
+    return page_gate, missing_rate
+
+
+def _summary_work_items(summary: Mapping[str, Any], source: SourceState) -> list[WorkItem]:
+    items: list[WorkItem] = []
+    flags = summary.get("flags_summary")
+    blocker_count = _as_int(flags.get("blocker") if isinstance(flags, Mapping) else 0)
+    ready = summary.get("ready_for_improvement")
+    page_gate, missing_rate = _readiness_page_state(summary)
+
+    if blocker_count > 0:
+        items.append(
+            WorkItem(
+                classification="blocked",
+                title="Fix readiness blockers",
+                reason=f"readiness blocker count is {blocker_count}",
+                source=source.label,
+                slug="fix-blocker",
+                goal="Remove readiness blockers before planning private evaluation or review work.",
+                expected_evidence="A fresh readiness audit reports zero blockers.",
+                verification="python3 scripts/audit_private_data_readiness.py --config eval/real_config.local.yaml",
+            )
+        )
+
+    if page_gate == "NO-GO":
+        rate_text = "unknown" if missing_rate is None else f"{missing_rate:.1f}"
+        items.append(
+            WorkItem(
+                classification="failed_experiment",
+                title="Rebuild page-aware index before page citation claims",
+                reason=f"page citation claim is NO-GO; missing page metadata rate is {rate_text}",
+                source=source.label,
+                slug="page-citation-no-go",
+                goal="Restore page metadata coverage before making page citation accuracy claims.",
+                expected_evidence="Readiness summary reports page citation/page claim as GO.",
+                verification="python3 scripts/audit_private_data_readiness.py --config eval/real_config.local.yaml",
+            )
+        )
+
+    if blocker_count == 0 and ready is True:
+        items.append(
+            WorkItem(
+                classification="ready_for_review",
+                title="Prepare readiness evidence for review",
+                reason="readiness summary is blocker-free and ready for improvement",
+                source=source.label,
+                slug="prepare-review-evidence",
+                goal="Collect the public-safe aggregate evidence needed for reviewer handoff.",
+                expected_evidence="Reviewer-facing summary cites only aggregate or redacted artifacts.",
+                verification="python3 -m pytest -q tests/test_private_real_eval_readiness.py",
+            )
+        )
+
+    if source.unsafe:
+        items.append(
+            WorkItem(
+                classification="blocked",
+                title="Sanitize planner input artifact",
+                reason="sanitized input contained forbidden fields",
+                source=source.label,
+                slug="sanitize-input",
+                goal="Regenerate the input artifact with aggregate-only fields before sharing planner output.",
+                expected_evidence="The planner privacy guard reports no forbidden fields.",
+                verification="python3 -m pytest -q tests/test_ai_next_actions.py",
+            )
+        )
+    return items
+
+
+def _pr_work_items(prs: Sequence[Mapping[str, Any]], readiness_blocked: bool) -> list[WorkItem]:
+    items: list[WorkItem] = []
+    for pr in sorted(prs, key=lambda p: _as_int(p.get("number"), 999999)):
+        number = _as_int(pr.get("number"), 0)
+        source = f"PR #{number}" if number else "PR"
+        title = str(pr.get("title") or "(untitled)")
+        review = str(pr.get("reviewDecision") or "").upper()
+        merge_state = str(pr.get("mergeStateStatus") or "").upper()
+        failing = _failing_checks(pr)
+        draft = bool(pr.get("isDraft"))
+        text = _pr_text(pr)
+        blocked_reasons: list[str] = []
+        if review == "CHANGES_REQUESTED":
+            blocked_reasons.append("review changes requested")
+        if merge_state in BLOCKING_MERGE_STATES:
+            blocked_reasons.append(f"merge state is {merge_state}")
+        if failing:
+            blocked_reasons.append("failing checks: " + ", ".join(failing[:3]))
+
+        if blocked_reasons:
+            items.append(
+                WorkItem(
+                    classification="blocked",
+                    title=f"Unblock {source}: {title}",
+                    reason="; ".join(blocked_reasons),
+                    source=source,
+                    slug="unblock-pr",
+                    goal="Resolve review, merge, or CI blockers before asking for review or merge.",
+                    expected_evidence="The PR has no requested changes, merge blocker, or failing required check.",
+                    verification=f"gh pr view {number} --json reviewDecision,mergeStateStatus,statusCheckRollup",
+                )
+            )
+            continue
+
+        if not readiness_blocked and (PRIVATE_DELTA_RE.search(text) or LOAD_BEARING_RE.search(text)):
+            items.append(
+                WorkItem(
+                    classification="needs_private_delta",
+                    title=f"Run private delta for {source}",
+                    reason="PR context indicates pending private delta evidence",
+                    source=source,
+                    slug="run-private-delta",
+                    goal="Produce public-safe private delta evidence before final review.",
+                    expected_evidence="PR body or reviewer note includes the redacted aggregate delta result.",
+                    verification="make real-eval-delta",
+                )
+            )
+            continue
+
+        if not draft:
+            items.append(
+                WorkItem(
+                    classification="ready_for_review",
+                    title=f"Review {source}: {title}",
+                    reason="PR has no detected blocker in exported GitHub state",
+                    source=source,
+                    slug="review-pr",
+                    goal="Perform a focused reviewer pass and identify any scoped Codex follow-up.",
+                    expected_evidence="Reviewer notes are either resolved or converted into a scoped follow-up task.",
+                    verification=f"gh pr view {number} --json reviewDecision,mergeStateStatus,statusCheckRollup",
+                )
+            )
+        else:
+            items.append(
+                WorkItem(
+                    classification="next_experiment_candidate",
+                    title=f"Continue draft {source}: {title}",
+                    reason="draft PR has no exported hard blocker",
+                    source=source,
+                    slug="continue-draft-pr",
+                    goal="Narrow the draft PR to its next verifiable milestone.",
+                    expected_evidence="Focused tests and updated PR notes describe the remaining gap.",
+                    verification=f"gh pr view {number} --json isDraft,reviewDecision,mergeStateStatus",
+                )
+            )
+    return items
+
+
+def _read_report_items(reports: Sequence[Path]) -> list[WorkItem]:
+    items: list[WorkItem] = []
+    for path in sorted(reports, key=lambda p: _repo_display(p)):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if NEGATIVE_EXPERIMENT_RE.search(text):
+            items.append(
+                WorkItem(
+                    classification="failed_experiment",
+                    title="Inspect negative readiness report signal",
+                    reason="readiness report text contains NO-GO or negative experiment language",
+                    source=_repo_display(path),
+                    slug="inspect-negative-report",
+                    goal="Turn the negative report signal into a concrete fix or a documented no-go.",
+                    expected_evidence="A follow-up note identifies the affected surface and next measurement.",
+                    verification="python3 -m pytest -q tests/test_ai_next_actions.py",
+                )
+            )
+    return items
+
+
+def _default_item() -> WorkItem:
+    return WorkItem(
+        classification="next_experiment_candidate",
+        title="Choose the next measurement candidate",
+        reason="no readiness summary or PR blocker produced a higher-priority action",
+        source="planner",
+        slug="next-experiment",
+        goal="Select one narrow experiment with a clear aggregate success metric.",
+        expected_evidence="A short task brief names the metric, fixture, and acceptance command.",
+        verification="python3 -m pytest -q tests/test_ai_next_actions.py",
+    )
+
+
+def _dedupe_items(items: Iterable[WorkItem]) -> list[WorkItem]:
+    seen: set[tuple[str, str, str]] = set()
+    out: list[WorkItem] = []
+    for item in sorted(items, key=lambda i: i.priority):
+        key = (item.classification, item.slug, item.source)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(item)
+    return out or [_default_item()]
+
+
+def _classification_counts(items: Sequence[WorkItem]) -> dict[str, int]:
+    counts = {name: 0 for name in CLASSIFICATION_ORDER}
+    for item in items:
+        counts[item.classification] += 1
+    return counts
+
+
+def _privacy_note(sources: Sequence[SourceState]) -> str:
+    if any(source.unsafe for source in sources):
+        return "sanitized input contained forbidden fields"
+    return "no forbidden fields detected in planner inputs"
+
+
+def render_summary_markdown(
+    items: Sequence[WorkItem],
+    sources: Sequence[SourceState],
+    *,
+    page_gate: str,
+    private_delta_needed: bool,
+) -> str:
+    top = items[0]
+    counts = _classification_counts(items)
+    lines = [
+        "# AI Next Actions",
+        "",
+        "## Current State",
+        "",
+        f"- Top task: `{top.classification}` - {top.title}",
+        f"- Page citation claim: `{page_gate}`",
+        f"- Private delta needed: `{private_delta_needed}`",
+        f"- Blocked: `{counts['blocked'] > 0}`",
+        f"- Privacy guard: {_privacy_note(sources)}",
+        "",
+        "## Active Work",
+        "",
+        "| Classification | Count |",
+        "|---|---:|",
+    ]
+    for name in CLASSIFICATION_ORDER:
+        lines.append(f"| `{name}` | {counts[name]} |")
+
+    lines.extend(
+        [
+            "",
+            "## Recommended Codex Task",
+            "",
+            f"- Classification: `{top.classification}`",
+            f"- Task: {top.title}",
+            f"- Reason: {top.reason}",
+            f"- Source: `{top.source}`",
+            "",
+            "## Follow-up Candidates",
+            "",
+        ]
+    )
+    for item in items[1:]:
+        lines.append(f"- `{item.classification}` - {item.title} ({item.source})")
+    if len(items) == 1:
+        lines.append("- None")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_task_markdown(item: WorkItem) -> str:
+    return "\n".join(
+        [
+            f"# {item.title}",
+            "",
+            f"- Classification: `{item.classification}`",
+            f"- Source: `{item.source}`",
+            "",
+            "## Goal",
+            "",
+            item.goal,
+            "",
+            "## Constraints",
+            "",
+            "- Keep retrieval, verifier, prompt, chunking, and answer behavior unchanged unless a separate task explicitly scopes that work.",
+            "- Use only aggregate or redacted artifacts in reviewer-facing notes.",
+            "- Keep the change scoped to the cited workflow surface.",
+            "",
+            "## Expected Evidence",
+            "",
+            item.expected_evidence,
+            "",
+            "## Verification",
+            "",
+            "```bash",
+            item.verification,
+            "```",
+            "",
+        ]
+    )
+
+
+def _write_outputs(out_md: Path, tasks_dir: Path, items: Sequence[WorkItem], markdown: str) -> None:
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    for stale in tasks_dir.glob("*.md"):
+        stale.unlink()
+    out_md.write_text(markdown, encoding="utf-8")
+    for idx, item in enumerate(items, start=1):
+        task_path = tasks_dir / f"{idx:03d}-{item.slug}.md"
+        task_path.write_text(render_task_markdown(item), encoding="utf-8")
+
+
+def build_plan(
+    readiness_summaries: Sequence[Path],
+    readiness_reports: Sequence[Path],
+    pr_json: Path | None,
+) -> tuple[list[WorkItem], list[SourceState], str, bool]:
+    sources: list[SourceState] = []
+    items: list[WorkItem] = []
+    page_gate = "UNKNOWN"
+    readiness_blocked = False
+
+    for path in sorted(readiness_summaries, key=lambda p: _repo_display(p)):
+        payload = _load_json(path)
+        if not isinstance(payload, Mapping):
+            continue
+        unsafe = bool(find_redacted_summary_forbidden_fields(payload))
+        source = SourceState("readiness_summary", _repo_display(path), unsafe)
+        sources.append(source)
+        flags = payload.get("flags_summary")
+        readiness_blocked = readiness_blocked or (
+            _as_int(flags.get("blocker") if isinstance(flags, Mapping) else 0) > 0
+        )
+        current_gate, _ = _readiness_page_state(payload)
+        if current_gate == "NO-GO" or page_gate == "UNKNOWN":
+            page_gate = current_gate
+        items.extend(_summary_work_items(payload, source))
+
+    for path in sorted(readiness_reports, key=lambda p: _repo_display(p)):
+        sources.append(SourceState("readiness_report", _repo_display(path), False))
+    items.extend(_read_report_items(readiness_reports))
+
+    if pr_json is not None:
+        payload = _load_json(pr_json)
+        prs = payload if isinstance(payload, list) else []
+        sources.append(SourceState("pr_json", _repo_display(pr_json), False))
+        items.extend(_pr_work_items([pr for pr in prs if isinstance(pr, Mapping)], readiness_blocked))
+
+    items = _dedupe_items(items)
+    private_delta_needed = any(item.classification == "needs_private_delta" for item in items)
+    return items, sources, page_gate, private_delta_needed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--readiness-summary",
+        action="append",
+        type=Path,
+        default=[],
+        help="Optional aggregate readiness summary JSON. Repeatable.",
+    )
+    parser.add_argument(
+        "--readiness-report",
+        action="append",
+        type=Path,
+        default=[],
+        help="Optional readiness report Markdown. Repeatable.",
+    )
+    parser.add_argument(
+        "--pr-json",
+        type=Path,
+        default=None,
+        help="Optional JSON array exported by gh pr list --json ...",
+    )
+    parser.add_argument("--out-md", type=Path, default=DEFAULT_OUT_MD)
+    parser.add_argument("--tasks-dir", type=Path, default=DEFAULT_TASKS_DIR)
+    args = parser.parse_args(argv)
+
+    items, sources, page_gate, private_delta_needed = build_plan(
+        args.readiness_summary,
+        args.readiness_report,
+        args.pr_json,
+    )
+    markdown = render_summary_markdown(
+        items,
+        sources,
+        page_gate=page_gate,
+        private_delta_needed=private_delta_needed,
+    )
+    _write_outputs(args.out_md, args.tasks_dir, items, markdown)
+    print(f"[OK] wrote {args.out_md} and {len(items)} task file(s) under {args.tasks_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ai_next_actions.py
+++ b/tests/test_ai_next_actions.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+from scripts import ai_next_actions as planner
+from scripts._governance import find_redacted_summary_forbidden_fields
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _summary(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "audit_type": "private_data_readiness",
+        "ready_for_improvement": True,
+        "flags_summary": {"blocker": 0, "warning": 0, "info": 0},
+        "index_integrity": {
+            "missing_page_metadata_rate": 0.0,
+            "page_metadata": {
+                "citation_page_claim_go_no_go": "GO",
+                "chunk": {"missing_page_metadata_rate": 0.0},
+            },
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _run(tmp_path: Path, *, summary: dict | None = None, prs: list[dict] | None = None) -> tuple[str, dict[str, str]]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    args: list[str] = []
+    if summary is not None:
+        summary_path = tmp_path / "readiness_summary.json"
+        summary_path.write_text(json.dumps(summary, sort_keys=True), encoding="utf-8")
+        args.extend(["--readiness-summary", str(summary_path)])
+    if prs is not None:
+        pr_path = tmp_path / "prs.json"
+        pr_path.write_text(json.dumps(prs, sort_keys=True), encoding="utf-8")
+        args.extend(["--pr-json", str(pr_path)])
+    out_md = tmp_path / "reports" / "ai_next_actions.md"
+    tasks_dir = tmp_path / "reports" / "codex_tasks"
+    rc = planner.main([*args, "--out-md", str(out_md), "--tasks-dir", str(tasks_dir)])
+    assert rc == 0
+    tasks = {path.name: path.read_text(encoding="utf-8") for path in sorted(tasks_dir.glob("*.md"))}
+    return out_md.read_text(encoding="utf-8"), tasks
+
+
+def test_blocker_present_recommends_blocker_fix(tmp_path: Path) -> None:
+    md, tasks = _run(
+        tmp_path,
+        summary=_summary(
+            ready_for_improvement=False,
+            flags_summary={"blocker": 2, "warning": 0, "info": 0},
+        ),
+    )
+
+    assert "Top task: `blocked` - Fix readiness blockers" in md
+    assert next(iter(tasks)).startswith("001-fix-blocker")
+    assert "Remove readiness blockers" in next(iter(tasks.values()))
+
+
+def test_1448_pending_private_delta_recommends_private_delta(tmp_path: Path) -> None:
+    md, tasks = _run(
+        tmp_path,
+        summary=_summary(),
+        prs=[
+            {
+                "number": 1449,
+                "title": "feat: pending private delta for #1448",
+                "headRefName": "feat/issue-1448-private-delta",
+                "baseRefName": "main",
+                "isDraft": False,
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [{"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+                "labels": [{"name": "private delta"}],
+                "body": "Needs private delta evidence before merge.",
+            }
+        ],
+    )
+
+    assert "Private delta needed: `True`" in md
+    assert "Run private delta for PR #1449" in md
+    assert any(name.endswith("run-private-delta.md") for name in tasks)
+
+
+def test_missing_page_metadata_rate_marks_page_citation_no_go(tmp_path: Path) -> None:
+    md, tasks = _run(
+        tmp_path,
+        summary=_summary(
+            index_integrity={
+                "missing_page_metadata_rate": 1.0,
+                "page_metadata": {
+                    "citation_page_claim_go_no_go": "GO",
+                    "chunk": {"missing_page_metadata_rate": 1.0},
+                },
+            },
+        ),
+    )
+
+    assert "Page citation claim: `NO-GO`" in md
+    joined_tasks = "\n".join(tasks.values())
+    assert "page citation accuracy claims" in joined_tasks
+    assert "Readiness summary reports page citation/page claim as GO." in joined_tasks
+
+
+def test_forbidden_private_keys_do_not_leak_to_generated_reports(tmp_path: Path) -> None:
+    unsafe = _summary(
+        **{
+            "question": "PRIVATE RAW QUERY",
+            "support_text": "PRIVATE SUPPORT",
+            "doc_id": "PRIVATE-DOC",
+            "path": "/Users/example/private/file.pdf",
+        }
+    )
+
+    md, tasks = _run(tmp_path, summary=unsafe)
+    generated = md + "\n".join(tasks.values())
+
+    assert "sanitized input contained forbidden fields" in generated
+    assert "PRIVATE RAW QUERY" not in generated
+    assert "PRIVATE SUPPORT" not in generated
+    assert "PRIVATE-DOC" not in generated
+    assert "/Users/example/private/file.pdf" not in generated
+    assert find_redacted_summary_forbidden_fields({"rendered": generated}) == {}
+
+
+def test_output_is_deterministic_from_fixture_inputs(tmp_path: Path) -> None:
+    summary = _summary()
+    prs = [
+        {
+            "number": 12,
+            "title": "chore: continue draft",
+            "headRefName": "chore/issue-12-draft",
+            "baseRefName": "main",
+            "isDraft": True,
+            "reviewDecision": "",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [],
+            "labels": [],
+            "body": "",
+        }
+    ]
+
+    first_md, first_tasks = _run(tmp_path / "first", summary=summary, prs=prs)
+    second_md, second_tasks = _run(tmp_path / "second", summary=summary, prs=prs)
+
+    assert first_md == second_md
+    assert first_tasks == second_tasks
+
+
+def test_default_outputs_are_gitignored() -> None:
+    for rel in ("reports/ai_next_actions.md", "reports/codex_tasks/001-example.md"):
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", "--", rel],
+            cwd=ROOT,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, rel

--- a/tests/test_ai_next_actions.py
+++ b/tests/test_ai_next_actions.py
@@ -48,6 +48,25 @@ def _run(tmp_path: Path, *, summary: dict | None = None, prs: list[dict] | None 
     return out_md.read_text(encoding="utf-8"), tasks
 
 
+def _pr(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "number": 12,
+        "title": "chore: fixture PR",
+        "url": "https://github.com/example/repo/pull/12",
+        "headRefName": "chore/issue-12-fixture",
+        "baseRefName": "main",
+        "isDraft": False,
+        "reviewDecision": "REVIEW_REQUIRED",
+        "mergeStateStatus": "CLEAN",
+        "statusCheckRollup": [],
+        "labels": [],
+        "body": "",
+        "updatedAt": "2026-05-24T00:00:00Z",
+    }
+    payload.update(overrides)
+    return payload
+
+
 def test_blocker_present_recommends_blocker_fix(tmp_path: Path) -> None:
     md, tasks = _run(
         tmp_path,
@@ -67,18 +86,16 @@ def test_1448_pending_private_delta_recommends_private_delta(tmp_path: Path) -> 
         tmp_path,
         summary=_summary(),
         prs=[
-            {
-                "number": 1449,
-                "title": "feat: pending private delta for #1448",
-                "headRefName": "feat/issue-1448-private-delta",
-                "baseRefName": "main",
-                "isDraft": False,
-                "reviewDecision": "REVIEW_REQUIRED",
-                "mergeStateStatus": "CLEAN",
-                "statusCheckRollup": [{"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"}],
-                "labels": [{"name": "private delta"}],
-                "body": "Needs private delta evidence before merge.",
-            }
+            _pr(
+                number=1449,
+                title="feat: pending private delta for #1448",
+                headRefName="feat/issue-1448-private-delta",
+                statusCheckRollup=[
+                    {"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"}
+                ],
+                labels=[{"name": "private delta"}],
+                body="Needs private delta evidence before merge.",
+            )
         ],
     )
 
@@ -131,18 +148,12 @@ def test_forbidden_private_keys_do_not_leak_to_generated_reports(tmp_path: Path)
 def test_output_is_deterministic_from_fixture_inputs(tmp_path: Path) -> None:
     summary = _summary()
     prs = [
-        {
-            "number": 12,
-            "title": "chore: continue draft",
-            "headRefName": "chore/issue-12-draft",
-            "baseRefName": "main",
-            "isDraft": True,
-            "reviewDecision": "",
-            "mergeStateStatus": "CLEAN",
-            "statusCheckRollup": [],
-            "labels": [],
-            "body": "",
-        }
+        _pr(
+            number=12,
+            title="chore: continue draft",
+            headRefName="chore/issue-12-draft",
+            isDraft=True,
+        )
     ]
 
     first_md, first_tasks = _run(tmp_path / "first", summary=summary, prs=prs)
@@ -161,3 +172,22 @@ def test_default_outputs_are_gitignored() -> None:
             check=False,
         )
         assert result.returncode == 0, rel
+
+
+def test_missing_required_pr_json_fields_fail_closed(tmp_path: Path) -> None:
+    incomplete = _pr()
+    incomplete.pop("mergeStateStatus")
+
+    md, tasks = _run(tmp_path, summary=_summary(), prs=[incomplete])
+
+    assert "Top task: `blocked` - Unblock PR #12" in md
+    assert "missing required PR JSON fields" in md
+    assert any("Resolve review, merge, or CI blockers" in body for body in tasks.values())
+
+
+def test_unstable_merge_state_is_blocked(tmp_path: Path) -> None:
+    md, tasks = _run(tmp_path, summary=_summary(), prs=[_pr(mergeStateStatus="UNSTABLE")])
+
+    assert "Top task: `blocked` - Unblock PR #12" in md
+    assert "merge state is UNSTABLE" in md
+    assert any("Resolve review, merge, or CI blockers" in body for body in tasks.values())


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

ChatGPT + Codex 반복 workflow에서 repo readiness, open PR 상태, private delta 필요 여부를 deterministic/rule-based로 요약하고 다음 Codex task를 생성하는 planner를 추가합니다. 외부 LLM API 호출 없이 aggregate/public-safe 입력만 읽고, 기본 출력은 gitignored local artifact인 reports/ai_next_actions.md 및 reports/codex_tasks/*.md에 씁니다.

Closes #1455

## 2. 영향 파일

- scripts/ai_next_actions.py — 새 deterministic planner CLI
- docs/operations/ai-codex-workflow.md — ChatGPT/Codex/GitHub/human 역할과 planner 운영 계약 문서
- tests/test_ai_next_actions.py — blocker, private delta, page citation NO-GO, privacy, deterministic output, gitignore 테스트

## 3. 리스크

가장 큰 리스크는 planner가 private raw field를 report/task markdown에 누출하거나, PR/readiness 상태를 비결정적으로 정렬하는 것입니다. 입력 payload를 직접 렌더링하지 않고 aggregate signal만 재구성하며, forbidden field fixture와 deterministic output 테스트로 확인했습니다.

## 4. 테스트

- PASS: python3 -m pytest -q tests/test_ai_next_actions.py
- PASS: python3 -m py_compile scripts/ai_next_actions.py
- PASS: python3 scripts/ai_next_actions.py --out-md /private/tmp/ai_next_actions_smoke.md --tasks-dir /private/tmp/ai_next_actions_tasks
- FAIL, unrelated/base-existing: bash scripts/test.sh fails in tests/test_render_verifier_false_negative_overlap.py with verifier_false_negative aggregate totals expected 1/2 but actual 0. The same file fails when run standalone, and this PR does not modify that script/test path.

## 5. Eval 영향

All `·` — planner/documentation/test-only addition. No retrieval, verifier, prompt, chunking, answer, eval scoring, or index behavior changes.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Load-bearing path는 변경하지 않았고, 새 script는 optional local planner artifact만 생성합니다. Private raw content is neither read into committed artifacts nor committed.

## 6. 하위 호환

기존 answer contract, retrieval CLI, verifier behavior, eval config schema, API behavior 변경 없음. 새 CLI는 additive입니다.

## 7. 범위 외

- 외부 LLM API 기반 planner
- retrieval/verifier/prompt/chunking/answer behavior 변경
- private raw content commit
- 기존 verifier_false_negative_overlap 테스트 실패 수정
