### PR TITLE
chore: Add page metadata recovery audit (#1456)

### DIFF
--- a/scripts/page_metadata_recovery_audit.py
+++ b/scripts/page_metadata_recovery_audit.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Aggregate-only page metadata recovery audit.
+
+This script answers one narrow question: can page citation metadata be recovered
+from existing local artifacts, or is a page-aware parser rebuild required?
+
+It intentionally does not import or call retrieval, verifier, prompt, answer, or
+index-writing code. Outputs are aggregate-only: no raw chunk text, doc_ids,
+filenames, source paths, or private snippets.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SAFE_LABEL_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+PAGE_LIKE_KEY_RE = re.compile(r"page|bbox|region", re.IGNORECASE)
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 6)
+
+
+def _safe_label(value: Any) -> str:
+    label = str(value or "").strip()
+    if not label:
+        return "<missing>"
+    return label if SAFE_LABEL_RE.fullmatch(label) else "<redacted_label>"
+
+
+def _load_json(path: Path) -> tuple[dict[str, Any], str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}, "missing"
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, f"unreadable:{type(exc).__name__}"
+    if not isinstance(payload, dict):
+        return {}, "not_object"
+    return payload, None
+
+
+def _is_page_span(value: Any) -> bool:
+    if not isinstance(value, list) or len(value) != 2:
+        return False
+    return all(isinstance(page, int) for page in value)
+
+
+def _is_bbox(value: Any) -> bool:
+    if not isinstance(value, list) or len(value) != 4:
+        return False
+    try:
+        [float(part) for part in value]
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _regions(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _has_region_page(item: Mapping[str, Any]) -> bool:
+    return any(isinstance(region.get("page_number"), int) for region in _regions(item.get("regions")))
+
+
+def _has_region_bbox(item: Mapping[str, Any]) -> bool:
+    return any(_is_bbox(region.get("bbox")) for region in _regions(item.get("regions")))
+
+
+def _has_page_metadata(item: Mapping[str, Any]) -> bool:
+    return _is_page_span(item.get("page_span")) or _has_region_page(item)
+
+
+def coverage_block(items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    total = len(items)
+    page_span = sum(1 for item in items if _is_page_span(item.get("page_span")))
+    region_page = sum(1 for item in items if _has_region_page(item))
+    region_bbox = sum(1 for item in items if _has_region_bbox(item))
+    any_page = sum(1 for item in items if _has_page_metadata(item))
+    return {
+        "count": total,
+        "with_any_page_metadata_count": any_page,
+        "with_page_span_count": page_span,
+        "with_regions_page_number_count": region_page,
+        "with_regions_bbox_count": region_bbox,
+        "any_page_metadata_coverage": _rate(any_page, total),
+        "page_span_coverage": _rate(page_span, total),
+        "regions_page_number_coverage": _rate(region_page, total),
+        "regions_bbox_coverage": _rate(region_bbox, total),
+    }
+
+
+def _metadata_for(item: Mapping[str, Any], docs_by_id: Mapping[str, Mapping[str, Any]]) -> Mapping[str, Any]:
+    doc = docs_by_id.get(str(item.get("doc_id") or ""))
+    doc_metadata = doc.get("metadata") if isinstance(doc, Mapping) else None
+    fallback = dict(doc_metadata) if isinstance(doc_metadata, Mapping) else {}
+    metadata = item.get("metadata")
+    if isinstance(metadata, Mapping):
+        fallback.update(
+            {
+                key: value
+                for key, value in metadata.items()
+                if value not in (None, "", [])
+            }
+        )
+    return fallback
+
+
+def _source_group_key(
+    item: Mapping[str, Any],
+    docs_by_id: Mapping[str, Mapping[str, Any]],
+) -> tuple[str, str, str, str]:
+    metadata = _metadata_for(item, docs_by_id)
+    return (
+        _safe_label(metadata.get("file_format")),
+        _safe_label(metadata.get("text_source")),
+        _safe_label(metadata.get("document_type")),
+        _safe_label(item.get("chunking_strategy")),
+    )
+
+
+def _group_decision(group: Mapping[str, Any]) -> str:
+    if group["any_page_metadata_coverage"] > 0:
+        return "page_metadata_available"
+    file_format = group["file_format"]
+    text_source = group["text_source"]
+    if text_source == "data_list_csv_text":
+        return "requires_raw_source_reparse"
+    if file_format == "hwp" and text_source == "kordoc":
+        return "requires_page_aware_hwp_parser_change"
+    if file_format == "pdf" and text_source == "kordoc":
+        return "requires_pdf_visual_ingestion_or_page_aware_parser"
+    return "requires_page_aware_reindex"
+
+
+def source_group_coverage(
+    chunks: Sequence[Mapping[str, Any]],
+    parent_sections: Sequence[Mapping[str, Any]],
+    documents: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    docs_by_id = {str(doc.get("doc_id") or ""): doc for doc in documents}
+    grouped: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+
+    for chunk in chunks:
+        key = _source_group_key(chunk, docs_by_id)
+        group = grouped.setdefault(
+            key,
+            {
+                "file_format": key[0],
+                "text_source": key[1],
+                "document_type": key[2],
+                "chunking_strategy": key[3],
+                "_doc_ids": set(),
+                "_chunks": [],
+                "_parents": [],
+            },
+        )
+        group["_chunks"].append(chunk)
+        if chunk.get("doc_id"):
+            group["_doc_ids"].add(str(chunk.get("doc_id")))
+
+    for parent in parent_sections:
+        key = _source_group_key(parent, docs_by_id)
+        group = grouped.setdefault(
+            key,
+            {
+                "file_format": key[0],
+                "text_source": key[1],
+                "document_type": key[2],
+                "chunking_strategy": key[3],
+                "_doc_ids": set(),
+                "_chunks": [],
+                "_parents": [],
+            },
+        )
+        group["_parents"].append(parent)
+        if parent.get("doc_id"):
+            group["_doc_ids"].add(str(parent.get("doc_id")))
+
+    results: list[dict[str, Any]] = []
+    for group in sorted(grouped.values(), key=lambda item: (
+        item["file_format"],
+        item["text_source"],
+        item["document_type"],
+        item["chunking_strategy"],
+    )):
+        chunk_block = coverage_block(group["_chunks"])
+        parent_block = coverage_block(group["_parents"])
+        result = {
+            "file_format": group["file_format"],
+            "text_source": group["text_source"],
+            "document_type": group["document_type"],
+            "chunking_strategy": group["chunking_strategy"],
+            "doc_count": len(group["_doc_ids"]),
+            "chunk_count": chunk_block["count"],
+            "parent_section_count": parent_block["count"],
+            "any_page_metadata_coverage": chunk_block["any_page_metadata_coverage"],
+            "page_span_coverage": chunk_block["page_span_coverage"],
+            "regions_page_number_coverage": chunk_block["regions_page_number_coverage"],
+            "regions_bbox_coverage": chunk_block["regions_bbox_coverage"],
+            "parent_any_page_metadata_coverage": parent_block["any_page_metadata_coverage"],
+        }
+        result["decision"] = _group_decision(result)
+        results.append(result)
+    return results
+
+
+def _count_page_like_keys(node: Any) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            key_text = str(key)
+            if PAGE_LIKE_KEY_RE.search(key_text):
+                counts[key_text] += 1
+            counts.update(_count_page_like_keys(value))
+    elif isinstance(node, list):
+        for item in node:
+            counts.update(_count_page_like_keys(item))
+    return counts
+
+
+def ingestion_report_audit(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {"present": False, "status": "not_provided"}
+    payload, error = _load_json(path)
+    if error:
+        return {"present": False, "status": error}
+    summary = payload.get("summary") if isinstance(payload.get("summary"), Mapping) else {}
+    text_source_counts = summary.get("text_source_counts") if isinstance(summary, Mapping) else {}
+    page_keys = _count_page_like_keys(payload)
+    return {
+        "present": True,
+        "status": "ok",
+        "has_text_source_counts": isinstance(text_source_counts, Mapping),
+        "page_like_key_counts": dict(sorted(page_keys.items())),
+        "has_page_like_keys": bool(page_keys),
+    }
+
+
+def kordoc_cache_audit(cache_dir: Path | None) -> dict[str, Any]:
+    if cache_dir is None:
+        return {"present": False, "status": "not_provided"}
+    if not cache_dir.is_dir():
+        return {"present": False, "status": "missing"}
+
+    manifest_payload, manifest_error = _load_json(cache_dir / "manifest.json")
+    entries = manifest_payload.get("entries") if isinstance(manifest_payload.get("entries"), Mapping) else {}
+    entry_key_counts: Counter[str] = Counter()
+    if isinstance(entries, Mapping):
+        for entry in entries.values():
+            if isinstance(entry, Mapping):
+                entry_key_counts.update(str(key) for key in entry.keys())
+
+    marker_counts = Counter()
+    md_count = 0
+    for md_path in cache_dir.glob("*.md"):
+        md_count += 1
+        try:
+            text = md_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        lower = text.lower()
+        marker_counts["formfeed_files"] += int("\f" in text)
+        marker_counts["html_page_break_files"] += int("page-break" in lower)
+        marker_counts["markdown_page_marker_files"] += int(
+            any(marker in lower for marker in ("page_number", "page number", "<!-- page", "[[page"))
+        )
+
+    page_like_entry_keys = {
+        key: count
+        for key, count in entry_key_counts.items()
+        if PAGE_LIKE_KEY_RE.search(key)
+    }
+    return {
+        "present": True,
+        "status": "ok",
+        "manifest_present": manifest_error is None,
+        "manifest_status": manifest_error or "ok",
+        "manifest_entry_count": len(entries) if isinstance(entries, Mapping) else 0,
+        "manifest_entry_key_counts": dict(sorted(entry_key_counts.items())),
+        "manifest_has_page_like_keys": bool(page_like_entry_keys),
+        "manifest_page_like_key_counts": dict(sorted(page_like_entry_keys.items())),
+        "markdown_file_count": md_count,
+        "markdown_page_marker_file_counts": dict(sorted(marker_counts.items())),
+        "markdown_has_page_markers": any(marker_counts.values()),
+    }
+
+
+def _iter_visual_artifact_paths(artifact_dir: Path) -> Iterable[Path]:
+    yield from artifact_dir.glob("*.visual.json")
+    for path in artifact_dir.glob("*.json"):
+        if path.name.endswith(".visual.json"):
+            continue
+        yield path
+
+
+def visual_artifact_audit(artifact_dir: Path | None) -> dict[str, Any]:
+    if artifact_dir is None:
+        return {"present": False, "status": "not_provided"}
+    if not artifact_dir.is_dir():
+        return {"present": False, "status": "missing"}
+
+    artifact_count = 0
+    page_count = 0
+    section_count = 0
+    sections_with_page = 0
+    blocks_with_page = 0
+    blocks_with_bbox = 0
+    for path in _iter_visual_artifact_paths(artifact_dir):
+        payload, error = _load_json(path)
+        if error:
+            continue
+        artifact_count += 1
+        pages = payload.get("pages") if isinstance(payload.get("pages"), list) else []
+        sections = payload.get("sections") if isinstance(payload.get("sections"), list) else []
+        page_count += len(pages)
+        for section in sections:
+            if not isinstance(section, Mapping):
+                continue
+            section_count += 1
+            sections_with_page += int(_has_page_metadata(section))
+        for page in pages:
+            if not isinstance(page, Mapping):
+                continue
+            blocks = page.get("blocks") if isinstance(page.get("blocks"), list) else []
+            for block in blocks:
+                if not isinstance(block, Mapping):
+                    continue
+                blocks_with_page += int(isinstance(block.get("page_number"), int))
+                blocks_with_bbox += int(_is_bbox(block.get("bbox")))
+
+    return {
+        "present": True,
+        "status": "ok",
+        "artifact_count": artifact_count,
+        "page_count": page_count,
+        "section_count": section_count,
+        "sections_with_any_page_metadata_count": sections_with_page,
+        "section_page_metadata_coverage": _rate(sections_with_page, section_count),
+        "blocks_with_page_number_count": blocks_with_page,
+        "blocks_with_bbox_count": blocks_with_bbox,
+        "has_recoverable_page_metadata": sections_with_page > 0 or blocks_with_page > 0,
+    }
+
+
+def _artifact_recoverability(
+    chunk_coverage: Mapping[str, Any],
+    parent_coverage: Mapping[str, Any],
+    visual_artifacts: Mapping[str, Any],
+    kordoc_cache: Mapping[str, Any],
+) -> str:
+    if chunk_coverage["any_page_metadata_coverage"] > 0:
+        return "recoverable_from_current_index"
+    if parent_coverage["any_page_metadata_coverage"] > 0:
+        return "recoverable_from_parent_sections_requires_rechunk"
+    if visual_artifacts.get("has_recoverable_page_metadata"):
+        return "recoverable_from_visual_artifacts_requires_reindex"
+    if kordoc_cache.get("manifest_has_page_like_keys") or kordoc_cache.get("markdown_has_page_markers"):
+        return "possibly_recoverable_from_kordoc_cache_requires_adapter"
+    return "not_recoverable_from_existing_artifacts"
+
+
+def _requires_parser_change(source_groups: Sequence[Mapping[str, Any]], recoverability: str) -> bool:
+    if recoverability in {
+        "recoverable_from_current_index",
+        "recoverable_from_parent_sections_requires_rechunk",
+        "recoverable_from_visual_artifacts_requires_reindex",
+    }:
+        return False
+    return any(
+        group["decision"]
+        in {
+            "requires_page_aware_hwp_parser_change",
+            "requires_pdf_visual_ingestion_or_page_aware_parser",
+        }
+        for group in source_groups
+    )
+
+
+def build_audit_report(
+    index_dir: Path,
+    *,
+    ingestion_report_path: Path | None = None,
+    kordoc_cache_dir: Path | None = None,
+    visual_artifact_dir: Path | None = None,
+) -> dict[str, Any]:
+    index_payload, index_error = _load_json(index_dir / "index.json")
+    if index_error:
+        return {
+            "schema_version": 1,
+            "status": "failed",
+            "error": f"index_json_{index_error}",
+            "index_dir_provided": True,
+        }
+
+    chunks = [item for item in index_payload.get("chunks") or [] if isinstance(item, Mapping)]
+    documents = [item for item in index_payload.get("documents") or [] if isinstance(item, Mapping)]
+    parent_sections = [
+        item for item in index_payload.get("parent_sections") or [] if isinstance(item, Mapping)
+    ]
+    chunk_coverage = coverage_block(chunks)
+    document_coverage = coverage_block(documents)
+    parent_coverage = coverage_block(parent_sections)
+    source_groups = source_group_coverage(chunks, parent_sections, documents)
+
+    ingestion_report_path = ingestion_report_path or (
+        index_dir / "ingestion_report.json" if (index_dir / "ingestion_report.json").exists() else None
+    )
+    ingestion = ingestion_report_audit(ingestion_report_path)
+    kordoc = kordoc_cache_audit(kordoc_cache_dir)
+    visual = visual_artifact_audit(visual_artifact_dir)
+
+    max_source_page_coverage = max(
+        (float(group["any_page_metadata_coverage"]) for group in source_groups),
+        default=0.0,
+    )
+    recoverability = _artifact_recoverability(chunk_coverage, parent_coverage, visual, kordoc)
+    requires_reindex = recoverability != "recoverable_from_current_index"
+    requires_parser_change = _requires_parser_change(source_groups, recoverability)
+
+    return {
+        "schema_version": 1,
+        "status": "ok",
+        "privacy": {
+            "aggregate_only": True,
+            "omits_raw_text": True,
+            "omits_doc_ids": True,
+            "omits_file_names": True,
+            "omits_source_paths": True,
+        },
+        "index": {
+            "schema_version": index_payload.get("schema_version"),
+            "document_count": len(documents),
+            "chunk_count": len(chunks),
+            "parent_section_count": len(parent_sections),
+            "chunk": chunk_coverage,
+            "document": document_coverage,
+            "parent_section": parent_coverage,
+            "source_groups": source_groups,
+        },
+        "artifacts": {
+            "ingestion_report": ingestion,
+            "kordoc_cache": kordoc,
+            "visual_artifacts": visual,
+        },
+        "decision": {
+            "citation_page_claim_go_no_go": "GO" if max_source_page_coverage > 0 else "NO-GO",
+            "page_claim_scope": (
+                "covered_source_groups_only" if max_source_page_coverage > 0 else "not_supported"
+            ),
+            "recoverability": recoverability,
+            "recoverable_from_existing_local_artifacts": recoverability
+            != "not_recoverable_from_existing_artifacts",
+            "requires_reindex": requires_reindex,
+            "requires_parser_change": requires_parser_change,
+            "current_index_behavior_change": False,
+            "retrieval_verifier_prompt_answer_change": False,
+        },
+        "follow_up_issue_plan": [
+            "Keep page-level citation claims disabled while source-group page coverage is zero.",
+            "Run a PDF visual-ingestion rebuild spike for PDF/kordoc source groups and verify non-zero regions.page_number coverage.",
+            "Evaluate a page-aware HWP parser or adapter; kordoc Markdown/cache without page markers is insufficient.",
+            "Rebuild the private index only after page-aware parser output populates sections[].regions or sections[].page_span.",
+            "Commit only aggregate reports; keep private raw content, filenames, doc_ids, and source paths out of artifacts.",
+        ],
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    if report.get("status") != "ok":
+        return f"# Page Metadata Recovery Audit\n\n- Status: `{report.get('status')}`\n"
+
+    decision = report["decision"]
+    index = report["index"]
+    lines = [
+        "# Page Metadata Recovery Audit",
+        "",
+        "## Decision",
+        f"- Citation page claim: `{decision['citation_page_claim_go_no_go']}`",
+        f"- Recoverability: `{decision['recoverability']}`",
+        f"- Requires re-index: `{decision['requires_reindex']}`",
+        f"- Requires parser change: `{decision['requires_parser_change']}`",
+        f"- Retrieval/verifier/prompt/answer behavior change: `{decision['retrieval_verifier_prompt_answer_change']}`",
+        "",
+        "## Coverage",
+        f"- Documents / chunks / parent sections: `{index['document_count']}` / `{index['chunk_count']}` / `{index['parent_section_count']}`",
+        f"- Chunk page metadata coverage: `{index['chunk']['any_page_metadata_coverage']}`",
+        f"- Chunk page_span coverage: `{index['chunk']['page_span_coverage']}`",
+        f"- Chunk regions.page_number coverage: `{index['chunk']['regions_page_number_coverage']}`",
+        f"- Chunk regions.bbox coverage: `{index['chunk']['regions_bbox_coverage']}`",
+        "",
+        "## Source Groups",
+    ]
+    for group in index["source_groups"]:
+        lines.append(
+            "- "
+            f"`{group['file_format']}/{group['text_source']}/{group['document_type']}/{group['chunking_strategy']}`: "
+            f"docs=`{group['doc_count']}`, chunks=`{group['chunk_count']}`, "
+            f"parents=`{group['parent_section_count']}`, "
+            f"page=`{group['any_page_metadata_coverage']}`, "
+            f"page_span=`{group['page_span_coverage']}`, "
+            f"regions.page_number=`{group['regions_page_number_coverage']}`, "
+            f"regions.bbox=`{group['regions_bbox_coverage']}`, "
+            f"decision=`{group['decision']}`"
+        )
+    lines.extend(["", "## Follow-Up Issue Plan"])
+    lines.extend(f"- {item}" for item in report["follow_up_issue_plan"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--index-dir", type=Path, required=True, help="Directory containing index.json.")
+    parser.add_argument(
+        "--ingestion-report",
+        type=Path,
+        default=None,
+        help="Optional ingestion_report.json. Defaults to <index-dir>/ingestion_report.json when present.",
+    )
+    parser.add_argument("--kordoc-cache-dir", type=Path, default=None)
+    parser.add_argument("--visual-artifact-dir", type=Path, default=None)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Optional directory for page_metadata_recovery_audit.json/.md.",
+    )
+    parser.add_argument("--format", choices=["json", "markdown"], default="json")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_audit_report(
+        args.index_dir,
+        ingestion_report_path=args.ingestion_report,
+        kordoc_cache_dir=args.kordoc_cache_dir,
+        visual_artifact_dir=args.visual_artifact_dir,
+    )
+    text = (
+        render_markdown(report)
+        if args.format == "markdown"
+        else json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    )
+    if args.output_dir:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        (args.output_dir / "page_metadata_recovery_audit.json").write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        (args.output_dir / "page_metadata_recovery_audit.md").write_text(
+            render_markdown(report),
+            encoding="utf-8",
+        )
+    sys.stdout.write(text)
+    return 0 if report.get("status") == "ok" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_page_metadata_recovery_audit.py
+++ b/tests/test_page_metadata_recovery_audit.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from rag_indexing import build_chunks
+from scripts.page_metadata_recovery_audit import build_audit_report, render_markdown
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _write_index(index_dir: Path, payload: dict) -> None:
+    index_dir.mkdir(parents=True)
+    (index_dir / "index.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _base_index(chunks: list[dict], parent_sections: list[dict] | None = None) -> dict:
+    return {
+        "schema_version": 2,
+        "mode": "rag",
+        "documents": [
+            {
+                "doc_id": "doc-a",
+                "title": "redacted synthetic",
+                "metadata": {
+                    "file_format": "hwp",
+                    "text_source": "kordoc",
+                    "document_type": "private_pdf_hwp_csv_text",
+                },
+            }
+        ],
+        "parent_sections": parent_sections or [],
+        "chunks": chunks,
+    }
+
+
+def test_page_aware_sections_pass_page_metadata_to_chunks() -> None:
+    chunks = build_chunks(
+        [
+            {
+                "doc_id": "visual-doc",
+                "title": "visual fixture",
+                "agency": "",
+                "project": "",
+                "metadata": {"file_format": "pdf", "text_source": "visual_parsing_v2"},
+                "sections": [
+                    {
+                        "heading": "Scope",
+                        "section_path": ["Scope"],
+                        "text": "Page-aware section text.",
+                        "page_span": [2, 3],
+                        "regions": [
+                            {
+                                "page_number": 2,
+                                "bbox": [10.0, 20.0, 100.0, 120.0],
+                                "source": "pdf_text_layer",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        chunking_strategy="section",
+    )
+
+    assert chunks[0]["page_span"] == [2, 3]
+    assert chunks[0]["regions"][0]["page_number"] == 2
+    assert chunks[0]["regions"][0]["bbox"] == [10.0, 20.0, 100.0, 120.0]
+
+
+def test_no_page_metadata_reports_no_go_and_parser_change(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    _write_index(
+        index_dir,
+        _base_index(
+            [
+                {
+                    "chunk_id": "doc-a::chunk-001",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "fixed",
+                    "metadata": {
+                        "file_format": "hwp",
+                        "text_source": "kordoc",
+                        "document_type": "private_pdf_hwp_csv_text",
+                    },
+                }
+            ],
+            parent_sections=[
+                {
+                    "section_id": "doc-a::section-001",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "fixed",
+                    "metadata": {
+                        "file_format": "hwp",
+                        "text_source": "kordoc",
+                        "document_type": "private_pdf_hwp_csv_text",
+                    },
+                }
+            ],
+        ),
+    )
+
+    report = build_audit_report(index_dir)
+
+    assert report["decision"]["citation_page_claim_go_no_go"] == "NO-GO"
+    assert report["decision"]["recoverability"] == "not_recoverable_from_existing_artifacts"
+    assert report["decision"]["requires_reindex"] is True
+    assert report["decision"]["requires_parser_change"] is True
+    assert report["index"]["source_groups"][0]["decision"] == "requires_page_aware_hwp_parser_change"
+    assert report["index"]["source_groups"][0]["any_page_metadata_coverage"] == 0.0
+
+
+def test_source_group_uses_document_metadata_for_missing_chunk_fields(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    _write_index(
+        index_dir,
+        _base_index(
+            [
+                {
+                    "chunk_id": "doc-a::chunk-001",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "fixed",
+                    "metadata": {"file_format": "hwp"},
+                }
+            ]
+        ),
+    )
+
+    report = build_audit_report(index_dir)
+
+    group = report["index"]["source_groups"][0]
+    assert group["file_format"] == "hwp"
+    assert group["text_source"] == "kordoc"
+    assert group["document_type"] == "private_pdf_hwp_csv_text"
+    assert group["decision"] == "requires_page_aware_hwp_parser_change"
+
+
+def test_reindex_only_group_does_not_force_parser_change(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    _write_index(
+        index_dir,
+        {
+            "schema_version": 2,
+            "mode": "rag",
+            "documents": [{"doc_id": "doc-a", "metadata": {}}],
+            "parent_sections": [],
+            "chunks": [
+                {
+                    "chunk_id": "doc-a::chunk-001",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "fixed",
+                    "metadata": {},
+                }
+            ],
+        },
+    )
+
+    report = build_audit_report(index_dir)
+
+    assert report["index"]["source_groups"][0]["decision"] == "requires_page_aware_reindex"
+    assert report["decision"]["requires_reindex"] is True
+    assert report["decision"]["requires_parser_change"] is False
+
+
+def test_nonzero_source_group_page_coverage_enables_page_claim_scope(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    _write_index(
+        index_dir,
+        _base_index(
+            [
+                {
+                    "chunk_id": "doc-a::chunk-001",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "section",
+                    "page_span": [4, 4],
+                    "regions": [{"page_number": 4, "bbox": [1, 2, 3, 4]}],
+                    "metadata": {
+                        "file_format": "pdf",
+                        "text_source": "visual_parsing_v2",
+                        "document_type": "visual_parsing_v2",
+                    },
+                }
+            ]
+        ),
+    )
+
+    report = build_audit_report(index_dir)
+
+    assert report["decision"]["citation_page_claim_go_no_go"] == "GO"
+    assert report["decision"]["page_claim_scope"] == "covered_source_groups_only"
+    assert report["decision"]["recoverability"] == "recoverable_from_current_index"
+    assert report["index"]["source_groups"][0]["regions_page_number_coverage"] == 1.0
+
+
+def test_aggregate_report_omits_private_text_filenames_and_paths(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    cache_dir = tmp_path / "files_kordoc"
+    cache_dir.mkdir()
+    secret_filename = "private_agency_secret.pdf"
+    secret_text = "SECRET_PRIVATE_SNIPPET page-break SHOULD_NOT_LEAK"
+    (cache_dir / "private_agency_secret.md").write_text(secret_text, encoding="utf-8")
+    (cache_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "entries": {
+                    "private_agency_secret": {
+                        "source_relpath": secret_filename,
+                        "source_sha256": "abc123",
+                        "source_size": 123,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_index(
+        index_dir,
+        _base_index(
+            [
+                {
+                    "chunk_id": "doc-a::chunk-001",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "fixed",
+                    "text": secret_text,
+                    "metadata": {
+                        "file_format": "pdf",
+                        "text_source": "kordoc",
+                        "document_type": "private_pdf_hwp_csv_text",
+                        "file_name": secret_filename,
+                    },
+                }
+            ]
+        ),
+    )
+
+    report = build_audit_report(index_dir, kordoc_cache_dir=cache_dir)
+    encoded = json.dumps(report, ensure_ascii=False)
+
+    assert "SECRET_PRIVATE_SNIPPET" not in encoded
+    assert "SHOULD_NOT_LEAK" not in encoded
+    assert secret_filename not in encoded
+    assert str(tmp_path) not in encoded
+    assert report["privacy"]["aggregate_only"] is True
+    assert report["artifacts"]["kordoc_cache"]["markdown_has_page_markers"] is True
+    assert report["artifacts"]["kordoc_cache"]["manifest_entry_key_counts"]["source_relpath"] == 1
+
+
+def test_markdown_and_cli_emit_aggregate_decision(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    out_dir = tmp_path / "out"
+    _write_index(
+        index_dir,
+        _base_index(
+            [
+                {
+                    "chunk_id": "doc-a::chunk-001",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "fixed",
+                    "metadata": {
+                        "file_format": "hwp",
+                        "text_source": "data_list_csv_text",
+                        "document_type": "private_pdf_hwp_csv_text",
+                    },
+                }
+            ]
+        ),
+    )
+
+    report = build_audit_report(index_dir)
+    markdown = render_markdown(report)
+    assert "Citation page claim: `NO-GO`" in markdown
+    assert "requires_raw_source_reparse" in markdown
+    assert report["decision"]["requires_parser_change"] is False
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT_DIR / "scripts" / "page_metadata_recovery_audit.py"),
+            "--index-dir",
+            str(index_dir),
+            "--output-dir",
+            str(out_dir),
+            "--format",
+            "markdown",
+        ],
+        cwd=ROOT_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Citation page claim: `NO-GO`" in completed.stdout
+    assert (out_dir / "page_metadata_recovery_audit.json").is_file()
+    assert (out_dir / "page_metadata_recovery_audit.md").is_file()


### PR DESCRIPTION
## 1. What changed and why

chore: Add page metadata recovery audit (#1456)

Closes #1456

🤖 Auto-shipped by scripts/claude-hooks/stop-ship.sh

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #1456

## 2. Files affected

- `scripts/page_metadata_recovery_audit.py`
- `tests/test_page_metadata_recovery_audit.py`

## 3. Risks

Auto-generated PR; no load-bearing paths changed.

## 4. Tests

Local test run not captured by dispatcher.

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (no load-bearing path changed)

## 6. Backward compatibility

No public-API change detected.

## 7. Out of scope

N/A — single-concern auto-shipped PR.
