### PR TITLE
[codex] Refine AI next-action planner triage

### DIFF
--- a/scripts/ai_next_actions.py
+++ b/scripts/ai_next_actions.py
@@ -26,11 +26,12 @@ DEFAULT_OUT_MD = ROOT_DIR / "reports" / "ai_next_actions.md"
 DEFAULT_TASKS_DIR = ROOT_DIR / "reports" / "codex_tasks"
 
 CLASSIFICATION_ORDER = {
-    "blocked": 0,
-    "needs_private_delta": 1,
-    "ready_for_review": 2,
-    "failed_experiment": 3,
-    "next_experiment_candidate": 4,
+    "failed_experiment": 0,
+    "close_superseded": 1,
+    "blocked": 2,
+    "needs_private_delta": 3,
+    "ready_for_review": 4,
+    "next_experiment_candidate": 5,
 }
 FAILED_CHECK_CONCLUSIONS = {
     "ACTION_REQUIRED",
@@ -53,8 +54,25 @@ REQUIRED_PR_FIELDS = (
 PRIVATE_DELTA_RE = re.compile(r"(#1448|\b1448\b|private[-_\s]+delta)", re.IGNORECASE)
 LOAD_BEARING_RE = re.compile(r"(load[-_\s]+bearing|\b5b\b|real[-_\s]+data\s+delta)", re.IGNORECASE)
 NEGATIVE_EXPERIMENT_RE = re.compile(
-    r"(NO-GO|negative\s+delta|regression|failed\s+experiment)",
+    r"(NO-GO|not\s+claim[-\s]+ready|negative\s+delta|failed\s+experiment|"
+    r"\bregressed\b|materially\s+regress)",
     re.IGNORECASE,
+)
+STALE_SUPERSEDED_RE = re.compile(
+    r"(stale|superseded|obsolete|replaced\s+by|closed\s+by|do\s+not\s+merge|"
+    r"separate\s+smoke\s+eval\s+from\s+naive\s+rag\s+benchmark)",
+    re.IGNORECASE,
+)
+MAPPING_DOC_CANDIDATES = (
+    "docs/audits/retrieval-miss-inspection.md",
+    "docs/audits/variance-source-inspection.md",
+    "docs/adr/0075-normalized-failure-taxonomy.md",
+)
+REAL100_AGGREGATE_FILES = (
+    "failure_distribution.aggregate.json",
+    "failure_slices.aggregate.json",
+    "variance_measurement/aggregate.json",
+    "multi_chunk_evidence_failures.aggregate.json",
 )
 
 
@@ -155,6 +173,76 @@ def _failing_checks(pr: Mapping[str, Any]) -> list[str]:
         elif status == "COMPLETED" and conclusion and conclusion not in {"SUCCESS", "SKIPPED", "NEUTRAL"}:
             failed.append(name)
     return sorted(set(failed))
+
+
+def _nested_int(payload: Mapping[str, Any], path: Sequence[str]) -> int | None:
+    value: Any = payload
+    for key in path:
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(key)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _nested_float(payload: Mapping[str, Any], path: Sequence[str]) -> float | None:
+    value: Any = payload
+    for key in path:
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(key)
+    return _as_float(value)
+
+
+def _retrieval_miss_mapping_fix_available(repo_root: Path = ROOT_DIR) -> bool:
+    """Return whether the retrieval_miss mapping audit is already covered.
+
+    The planner should not keep recommending a mapping audit when the delta
+    renderer distinguishes missing values from numeric zero and the docs pin
+    the retrieval_miss source/comparability contract.
+    """
+    try:
+        delta_text = (repo_root / "scripts" / "run_real_eval_delta.py").read_text(
+            encoding="utf-8"
+        )
+    except OSError:
+        return False
+    has_delta_handling = all(
+        token in delta_text
+        for token in (
+            "SAFE_FAILURE_CATEGORY_KEYS",
+            '"retrieval_miss"',
+            "failure_category_counts",
+        )
+    )
+    try:
+        helper_text = (repo_root / "scripts" / "_eval_delta.py").read_text(
+            encoding="utf-8"
+        )
+    except OSError:
+        helper_text = ""
+    has_missing_vs_zero = "if value is None" in helper_text and 'return "—"' in helper_text
+    doc_text_parts: list[str] = []
+    for rel in MAPPING_DOC_CANDIDATES:
+        try:
+            doc_text_parts.append((repo_root / rel).read_text(encoding="utf-8"))
+        except OSError:
+            continue
+    doc_text = "\n".join(doc_text_parts)
+    has_source_docs = all(
+        token in doc_text
+        for token in (
+            "retrieval_miss",
+            "failure_distribution.aggregate.json",
+            "failure_slices.aggregate.json",
+        )
+    )
+    has_comparability_docs = "cross-HEAD" in doc_text or "정본 baseline" in doc_text
+    return has_delta_handling and has_missing_vs_zero and has_source_docs and has_comparability_docs
 
 
 def _readiness_page_state(summary: Mapping[str, Any]) -> tuple[str, float | None]:
@@ -266,6 +354,39 @@ def _pr_work_items(prs: Sequence[Mapping[str, Any]], readiness_blocked: bool) ->
         if failing:
             blocked_reasons.append("failing checks: " + ", ".join(failing[:3]))
 
+        if NEGATIVE_EXPERIMENT_RE.search(text):
+            not_ready_reason = "PR reports NO-GO/not claim-ready failed measurement"
+            if merge_state:
+                not_ready_reason += f"; not merge-ready (merge state is {merge_state})"
+            items.append(
+                WorkItem(
+                    classification="failed_experiment",
+                    title=f"Do not merge {source}: {title}",
+                    reason=not_ready_reason,
+                    source=source,
+                    slug="failed-measurement-pr",
+                    goal="Convert the failed measurement into a documented no-go or a narrower follow-up task.",
+                    expected_evidence="The PR remains draft or explicitly documents NO-GO aggregate evidence without claiming improvement.",
+                    verification=f"gh pr view {number} --json isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,body",
+                )
+            )
+            continue
+
+        if draft and STALE_SUPERSEDED_RE.search(text):
+            items.append(
+                WorkItem(
+                    classification="close_superseded",
+                    title=f"Close superseded {source}: {title}",
+                    reason="draft PR appears stale or superseded; do not treat as an unblock candidate",
+                    source=source,
+                    slug="close-superseded-pr",
+                    goal="Close or clearly mark the stale draft so active next-action planning is not polluted.",
+                    expected_evidence="The PR is closed, or its body explicitly points to the replacement work.",
+                    verification=f"gh pr view {number} --json state,isDraft,title,body,updatedAt",
+                )
+            )
+            continue
+
         if blocked_reasons:
             items.append(
                 WorkItem(
@@ -323,6 +444,107 @@ def _pr_work_items(prs: Sequence[Mapping[str, Any]], readiness_blocked: bool) ->
                 )
             )
     return items
+
+
+def _real100_aggregate_items(
+    real100_dir: Path,
+    *,
+    retrieval_miss_mapping_fix_done: bool = False,
+) -> list[WorkItem]:
+    items: list[WorkItem] = []
+    payloads: dict[str, Mapping[str, Any]] = {}
+    for rel in REAL100_AGGREGATE_FILES:
+        path = real100_dir / rel
+        try:
+            payload = _load_json(path)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, Mapping):
+            payloads[rel] = payload
+
+    distribution = payloads.get("failure_distribution.aggregate.json", {})
+    slices = payloads.get("failure_slices.aggregate.json", {})
+    variance = payloads.get("variance_measurement/aggregate.json", {})
+    distribution_miss = _nested_int(distribution, ("failure_category_counts", "retrieval_miss"))
+    slices_miss = _nested_int(slices, ("categories", "retrieval_miss", "total"))
+    variance_miss = _nested_int(variance, ("category_stats", "retrieval_miss", "mean"))
+    observed = {
+        "failure_distribution": distribution_miss,
+        "failure_slices": slices_miss,
+        "variance": variance_miss,
+    }
+    present_values = {key: value for key, value in observed.items() if value is not None}
+    if len(set(present_values.values())) > 1 and not retrieval_miss_mapping_fix_done:
+        reason = ", ".join(f"{key}={value}" for key, value in present_values.items())
+        items.append(
+            WorkItem(
+                classification="next_experiment_candidate",
+                title="Audit retrieval_miss aggregate mapping",
+                reason=f"retrieval_miss aggregate signals differ: {reason}",
+                source=_repo_display(real100_dir),
+                slug="retrieval-miss-mapping-audit",
+                goal="Reconcile failure taxonomy and aggregate renderers before planning retrieval behavior changes.",
+                expected_evidence="A counts-only audit identifies whether the difference is taxonomy drift, run mismatch, or renderer mapping.",
+                verification="python3 -m pytest -q tests/test_render_failure_distribution.py tests/test_render_failure_slices.py tests/test_measure_variance_regression.py",
+            )
+        )
+
+    multi = payloads.get("multi_chunk_evidence_failures.aggregate.json", {})
+    multi_cases = _nested_int(multi, ("population", "multi_chunk_gold_cases"))
+    top10_failures = _nested_int(multi, ("population", "multi_chunk_top10_evidence_failures"))
+    unknown_limited = _nested_int(multi, ("expected_impact", "unknown_due_to_limited_depth"))
+    if multi_cases:
+        items.append(
+            WorkItem(
+                classification="next_experiment_candidate",
+                title="Use multi-chunk evidence analysis for the next retrieval follow-up",
+                reason=(
+                    f"multi-chunk aggregate is available: {top10_failures or 0}/"
+                    f"{multi_cases} top-10 failures; "
+                    f"{unknown_limited or 0} limited-depth cases"
+                ),
+                source=_repo_display(real100_dir / "multi_chunk_evidence_failures.aggregate.json"),
+                slug="multi-chunk-follow-up",
+                goal="Turn the aggregate multi-chunk evidence split into one scoped measurement follow-up.",
+                expected_evidence="The follow-up chooses pool/rerank, decomposition, or section-expansion measurement using aggregate counts only.",
+                verification="python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py",
+            )
+        )
+
+    return items
+
+
+def _page_metadata_audit_item(index_dir: Path) -> tuple[WorkItem | None, str]:
+    try:
+        from scripts.page_metadata_recovery_audit import build_audit_report
+    except ImportError:
+        return None, "UNKNOWN"
+    report = build_audit_report(index_dir)
+    if not isinstance(report, Mapping):
+        return None, "UNKNOWN"
+    decision = report.get("decision")
+    gate = "UNKNOWN"
+    if isinstance(decision, Mapping):
+        raw_gate = decision.get("citation_page_claim_go_no_go")
+        if raw_gate in {"GO", "NO-GO"}:
+            gate = str(raw_gate)
+    coverage = _nested_float(report, ("index", "chunk", "any_page_metadata_coverage"))
+    if gate != "NO-GO":
+        return None, gate
+    coverage_text = "unknown" if coverage is None else f"{coverage:.1f}"
+    return (
+        WorkItem(
+            classification="failed_experiment",
+            title="Keep page-level citation claims disabled",
+            reason=f"page metadata recovery audit is NO-GO; chunk page coverage is {coverage_text}",
+            source=_repo_display(index_dir),
+            slug="page-level-citation-no-go",
+            goal="Keep page-level citation claims disabled until page metadata is recoverable from the index.",
+            expected_evidence="A fresh page metadata recovery audit reports non-zero page metadata coverage before any page-level claim.",
+            verification=f"python3 scripts/page_metadata_recovery_audit.py --index-dir {_repo_display(index_dir)} --format markdown",
+        ),
+        gate,
+    )
 
 
 def _read_report_items(reports: Sequence[Path]) -> list[WorkItem]:
@@ -443,6 +665,7 @@ def render_task_markdown(item: WorkItem) -> str:
             "",
             f"- Classification: `{item.classification}`",
             f"- Source: `{item.source}`",
+            f"- Reason: {item.reason}",
             "",
             "## Goal",
             "",
@@ -483,6 +706,8 @@ def build_plan(
     readiness_summaries: Sequence[Path],
     readiness_reports: Sequence[Path],
     pr_json: Path | None,
+    real100_dir: Path | None = None,
+    page_metadata_index_dir: Path | None = None,
 ) -> tuple[list[WorkItem], list[SourceState], str, bool]:
     sources: list[SourceState] = []
     items: list[WorkItem] = []
@@ -508,6 +733,23 @@ def build_plan(
     for path in sorted(readiness_reports, key=lambda p: _repo_display(p)):
         sources.append(SourceState("readiness_report", _repo_display(path), False))
     items.extend(_read_report_items(readiness_reports))
+
+    if real100_dir is not None:
+        sources.append(SourceState("real100_aggregates", _repo_display(real100_dir), False))
+        items.extend(
+            _real100_aggregate_items(
+                real100_dir,
+                retrieval_miss_mapping_fix_done=_retrieval_miss_mapping_fix_available(),
+            )
+        )
+
+    if page_metadata_index_dir is not None:
+        sources.append(SourceState("page_metadata_index", _repo_display(page_metadata_index_dir), False))
+        item, current_gate = _page_metadata_audit_item(page_metadata_index_dir)
+        if current_gate == "NO-GO" or page_gate == "UNKNOWN":
+            page_gate = current_gate
+        if item is not None:
+            items.append(item)
 
     if pr_json is not None:
         payload = _load_json(pr_json)
@@ -542,6 +784,18 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Optional JSON array exported by gh pr list --json ...",
     )
+    parser.add_argument(
+        "--real100-dir",
+        type=Path,
+        default=None,
+        help="Optional directory containing public-safe reports/real100 aggregate JSON files.",
+    )
+    parser.add_argument(
+        "--page-metadata-index-dir",
+        type=Path,
+        default=None,
+        help="Optional index directory to audit for page metadata recovery.",
+    )
     parser.add_argument("--out-md", type=Path, default=DEFAULT_OUT_MD)
     parser.add_argument("--tasks-dir", type=Path, default=DEFAULT_TASKS_DIR)
     args = parser.parse_args(argv)
@@ -550,6 +804,8 @@ def main(argv: list[str] | None = None) -> int:
         args.readiness_summary,
         args.readiness_report,
         args.pr_json,
+        args.real100_dir,
+        args.page_metadata_index_dir,
     )
     markdown = render_summary_markdown(
         items,

--- a/tests/test_ai_next_actions.py
+++ b/tests/test_ai_next_actions.py
@@ -29,7 +29,14 @@ def _summary(**overrides: object) -> dict[str, object]:
     return payload
 
 
-def _run(tmp_path: Path, *, summary: dict | None = None, prs: list[dict] | None = None) -> tuple[str, dict[str, str]]:
+def _run(
+    tmp_path: Path,
+    *,
+    summary: dict | None = None,
+    prs: list[dict] | None = None,
+    real100_dir: Path | None = None,
+    page_metadata_index_dir: Path | None = None,
+) -> tuple[str, dict[str, str]]:
     tmp_path.mkdir(parents=True, exist_ok=True)
     args: list[str] = []
     if summary is not None:
@@ -40,6 +47,10 @@ def _run(tmp_path: Path, *, summary: dict | None = None, prs: list[dict] | None 
         pr_path = tmp_path / "prs.json"
         pr_path.write_text(json.dumps(prs, sort_keys=True), encoding="utf-8")
         args.extend(["--pr-json", str(pr_path)])
+    if real100_dir is not None:
+        args.extend(["--real100-dir", str(real100_dir)])
+    if page_metadata_index_dir is not None:
+        args.extend(["--page-metadata-index-dir", str(page_metadata_index_dir)])
     out_md = tmp_path / "reports" / "ai_next_actions.md"
     tasks_dir = tmp_path / "reports" / "codex_tasks"
     rc = planner.main([*args, "--out-md", str(out_md), "--tasks-dir", str(tasks_dir)])
@@ -104,6 +115,57 @@ def test_1448_pending_private_delta_recommends_private_delta(tmp_path: Path) -> 
     assert any(name.endswith("run-private-delta.md") for name in tasks)
 
 
+def test_no_go_pr_is_failed_experiment_before_unstable_merge_state(tmp_path: Path) -> None:
+    md, tasks = _run(
+        tmp_path,
+        summary=_summary(),
+        prs=[
+            _pr(
+                number=1448,
+                title="Add hybrid BM25 dense retrieval v1 eval row",
+                headRefName="feat/issue-1447-hybrid-bm25-dense-v1",
+                isDraft=True,
+                mergeStateStatus="UNSTABLE",
+                body=(
+                    "Latest private aggregate experiment is NO-GO and not "
+                    "claim-ready; keep this as a draft measurement PR."
+                ),
+            ),
+            _pr(
+                number=1430,
+                title="[codex] Separate smoke eval from naive RAG benchmark",
+                isDraft=True,
+                mergeStateStatus="UNSTABLE",
+            ),
+        ],
+    )
+
+    assert "Top task: `failed_experiment` - Do not merge PR #1448" in md
+    assert "not merge-ready" in md
+    assert "Latest private aggregate experiment" not in "\n".join(tasks.values())
+    assert any(name.endswith("failed-measurement-pr.md") for name in tasks)
+
+
+def test_superseded_draft_pr_is_close_candidate_not_unblock(tmp_path: Path) -> None:
+    md, tasks = _run(
+        tmp_path,
+        summary=_summary(),
+        prs=[
+            _pr(
+                number=1430,
+                title="[codex] Separate smoke eval from naive RAG benchmark",
+                isDraft=True,
+                mergeStateStatus="UNSTABLE",
+                body="Superseded by the newer planner PR; do not merge.",
+            )
+        ],
+    )
+
+    assert "Close superseded PR #1430" in md
+    assert "Unblock PR #1430" not in md
+    assert any(name.endswith("close-superseded-pr.md") for name in tasks)
+
+
 def test_missing_page_metadata_rate_marks_page_citation_no_go(tmp_path: Path) -> None:
     md, tasks = _run(
         tmp_path,
@@ -122,6 +184,101 @@ def test_missing_page_metadata_rate_marks_page_citation_no_go(tmp_path: Path) ->
     joined_tasks = "\n".join(tasks.values())
     assert "page citation accuracy claims" in joined_tasks
     assert "Readiness summary reports page citation/page claim as GO." in joined_tasks
+
+
+def test_real100_aggregates_add_retrieval_miss_task_when_mapping_fix_absent(tmp_path: Path) -> None:
+    real100_dir = tmp_path / "real100"
+    variance_dir = real100_dir / "variance_measurement"
+    variance_dir.mkdir(parents=True)
+    (real100_dir / "failure_distribution.aggregate.json").write_text(
+        json.dumps({"failure_category_counts": {"retrieval_miss": 0}}),
+        encoding="utf-8",
+    )
+    (real100_dir / "failure_slices.aggregate.json").write_text(
+        json.dumps({"categories": {"retrieval_miss": {"total": 67}}}),
+        encoding="utf-8",
+    )
+    (variance_dir / "aggregate.json").write_text(
+        json.dumps({"category_stats": {"retrieval_miss": {"mean": 64}}}),
+        encoding="utf-8",
+    )
+    (real100_dir / "multi_chunk_evidence_failures.aggregate.json").write_text(
+        json.dumps(
+            {
+                "population": {
+                    "multi_chunk_gold_cases": 99,
+                    "multi_chunk_top10_evidence_failures": 97,
+                },
+                "expected_impact": {"unknown_due_to_limited_depth": 97},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    items = planner._real100_aggregate_items(
+        real100_dir,
+        retrieval_miss_mapping_fix_done=False,
+    )
+    generated = "\n".join(planner.render_task_markdown(item) for item in items)
+
+    assert "Audit retrieval_miss aggregate mapping" in generated
+    assert "retrieval_miss aggregate signals differ" in generated
+    assert "Use multi-chunk evidence analysis" in generated
+    assert "97/99 top-10 failures" in generated
+
+
+def test_real100_aggregates_skip_retrieval_miss_task_when_mapping_fix_exists(tmp_path: Path) -> None:
+    real100_dir = tmp_path / "real100"
+    variance_dir = real100_dir / "variance_measurement"
+    variance_dir.mkdir(parents=True)
+    (real100_dir / "failure_distribution.aggregate.json").write_text(
+        json.dumps({"failure_category_counts": {"retrieval_miss": 0}}),
+        encoding="utf-8",
+    )
+    (variance_dir / "aggregate.json").write_text(
+        json.dumps({"category_stats": {"retrieval_miss": {"mean": 64}}}),
+        encoding="utf-8",
+    )
+    (real100_dir / "multi_chunk_evidence_failures.aggregate.json").write_text(
+        json.dumps(
+            {
+                "population": {
+                    "multi_chunk_gold_cases": 99,
+                    "multi_chunk_top10_evidence_failures": 97,
+                },
+                "expected_impact": {"unknown_due_to_limited_depth": 97},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    md, tasks = _run(tmp_path, real100_dir=real100_dir)
+    generated = md + "\n".join(tasks.values())
+
+    assert planner._retrieval_miss_mapping_fix_available()
+    assert "Audit retrieval_miss aggregate mapping" not in generated
+    assert "Use multi-chunk evidence analysis" in generated
+
+
+def test_page_metadata_index_dir_marks_page_level_claim_no_go(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    index_dir.mkdir()
+    (index_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "documents": [{"doc_id": "doc-a", "metadata": {}}],
+                "parent_sections": [],
+                "chunks": [{"chunk_id": "doc-a::chunk-1", "doc_id": "doc-a"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    md, tasks = _run(tmp_path, page_metadata_index_dir=index_dir)
+
+    assert "Page citation claim: `NO-GO`" in md
+    assert any("Keep page-level citation claims disabled" in body for body in tasks.values())
 
 
 def test_forbidden_private_keys_do_not_leak_to_generated_reports(tmp_path: Path) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

AI next-action planner가 stale/superseded draft PR과 failed measurement PR을 더 정확히 분류하도록 보강했습니다. #1448은 NO-GO/not claim-ready 신호를 merge-state blocker보다 먼저 읽어 failed_experiment로 유지하고, #1430 같은 superseded draft는 unblock 후보가 아니라 close_superseded 후보로 분류합니다. 또한 real100 aggregate 입력과 page metadata audit 입력을 받아 retrieval_miss mapping audit 중복 추천을 피하고 multi-chunk/page-citation follow-up을 유지합니다.

Closes #1461

## 2. 영향 파일

- `scripts/ai_next_actions.py` — planner/report generation surface. Load-bearing 아님.
- `tests/test_ai_next_actions.py` — planner classification regression tests.

## 3. 리스크

- PR body/title 키워드 기반 stale 판정이 과하게 잡힐 수 있습니다. draft PR에만 적용하고 NO-GO failed_experiment 판정을 먼저 수행하도록 순서를 고정했습니다.
- retrieval_miss mapping audit skip은 기존 delta renderer와 docs 신호를 확인하는 read-only heuristic입니다. 검색(retrieval) 또는 검증(verifier) 동작에는 관여하지 않습니다.
- 생성 reports는 `reports/*` gitignore 아래 local workflow artifact로 유지됩니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_ai_next_actions.py`
- `python3 -m py_compile scripts/ai_next_actions.py tests/test_ai_next_actions.py`
- `git diff --check`
- generated planner output privacy scan: `{}` via `find_redacted_summary_forbidden_fields`

## 5. Eval 영향

All `·`. Planner/report generation만 변경하며 RAG runtime, retrieval ranking, verifier, prompt, chunking, answer generation은 변경하지 않았습니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. 이 PR은 local planner triage와 aggregate report 소비 로직만 변경합니다.

## 6. 하위 호환

기존 `scripts/ai_next_actions.py` CLI 인자는 유지하고, `--real100-dir`, `--page-metadata-index-dir` 옵션만 additive로 추가했습니다. Answer-contract schema 변경 없음.

## 7. 범위 외

- #1430 실제 close 실행
- #1448 merge/rework
- page metadata recovery implementation
- multi-chunk retrieval behavior change
