### PR TITLE
Add private hybrid retrieval sweep harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,8 @@ reports/retrieval/phase3_mode_*/*
 # pass the tracked-artifact regression guard before any explicit allowlist is
 # reintroduced.
 reports/retrieval/phase35_m3_*/
+# Private hybrid retrieval sweeps are local aggregate-only measurement outputs.
+reports/retrieval/hybrid_sweep_*/
 # Phase 4 retrieval-eval (metadata / filtering ablation) timestamped runs.
 # Same aggregate-only commit boundary as phase3_mode_* above. All 4 variants
 # share the kordoc 26k index; only plan['metadata_first'] / metadata_filters

--- a/docs/retrieval/hybrid-sweep-summary-template.md
+++ b/docs/retrieval/hybrid-sweep-summary-template.md
@@ -1,0 +1,32 @@
+# Private Hybrid Retrieval Sweep Summary Template
+
+This template is for privacy-safe aggregate reporting only. Do not include raw
+questions, generated answers, evidence text, `doc_id`, `chunk_id`, filenames,
+local paths, or document identifiers.
+
+## Run Metadata
+
+- Aggregate artifact: `reports/retrieval/hybrid_sweep_<timestamp>/aggregate.json` (local only, not for commit)
+- Config fingerprint: `<sha256>`
+- Index fingerprint: `<sha256>`
+- Variant count: `28`
+- Case count: `<n>`
+- Top K: `20`
+
+## Comparison
+
+Baseline: `full_dense_top20`
+
+Candidate family: `hybrid_bm25_dense_v1`
+
+| Variant | RRF k | Dense pool | BM25 pool | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Retrieval miss rate | Citation/chunk guardrail | p50 ms | p95 ms |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|
+| `<variant>` | `<k>` | `<n>` | `<n>` | `<aggregate>` | `<aggregate>` | `<aggregate>` | `<aggregate>` | `<aggregate>` | `<aggregate summary>` | `<aggregate>` | `<aggregate>` |
+
+## Notes
+
+- This is private-local aggregate measurement, not a public performance claim.
+- Verifier, prompt, chunking, reranker, and answer generation must match the
+  `full_dense` control path except for retrieval fusion parameters.
+- Weighted fusion is intentionally out of scope unless a separate PR adds it
+  with its own measurement contract.

--- a/rag_core.py
+++ b/rag_core.py
@@ -568,6 +568,7 @@ class _RunContext:
     verification_reasons: list[str] | None = None
     retrieved_chunk_ids: list[str] | None = None
     retrieved_chunks: list[dict[str, Any]] | None = None
+    plan_overrides: dict[str, Any] | None = None
 
 
 def _build_run_context(
@@ -591,6 +592,7 @@ def _build_run_context(
     bm25_tokenizer: str | None = None,
     bm25_backend: str | None = None,
     params: QueryParams | None = None,
+    plan_overrides: dict[str, Any] | None = None,
 ) -> _RunContext:
     """Normalize raw ``run_rag_query`` inputs into a :class:`_RunContext`.
 
@@ -765,6 +767,7 @@ def _build_run_context(
         trace_unavailable_reason=trace_unavailable_reason,
         trace_error=trace_error,
         trace_handle=trace_handle,
+        plan_overrides=plan_overrides,
     )
 
 
@@ -946,6 +949,39 @@ def _retrieved_chunk_diagnostics(
     return rows
 
 
+def _eval_plan_overrides(overrides: dict[str, Any] | None) -> dict[str, Any]:
+    """Validate private eval-only plan overrides.
+
+    The production query surface intentionally has no public
+    ``rrf_channel_pools`` argument. Private measurement harnesses can
+    use this narrow hook to alter retrieval fusion parameters after the
+    normal planner has produced its plan, without changing verifier,
+    prompt, chunking, reranker, or answer generation behavior.
+    """
+    if not overrides:
+        return {}
+    allowed = {"rrf_channel_pools"}
+    unknown = sorted(set(overrides) - allowed)
+    if unknown:
+        raise ValueError(f"unsupported eval plan override(s): {unknown}")
+    result: dict[str, Any] = {}
+    pools = overrides.get("rrf_channel_pools")
+    if pools is not None:
+        if not isinstance(pools, dict):
+            raise ValueError("rrf_channel_pools must be a mapping.")
+        coerced: dict[str, int] = {}
+        for key, value in pools.items():
+            channel = str(key)
+            if channel not in {"dense", "bm25"}:
+                raise ValueError("rrf_channel_pools only supports dense and bm25.")
+            limit = int(value)
+            if limit < 1:
+                raise ValueError("rrf_channel_pools values must be positive integers.")
+            coerced[channel] = limit
+        result["rrf_channel_pools"] = coerced
+    return result
+
+
 def _phase_retrieve_loop(ctx: _RunContext) -> None:
     """Run the metadata-stage retry loop (ADR 0022 stage 2).
 
@@ -1007,6 +1043,7 @@ def _phase_retrieve_loop(ctx: _RunContext) -> None:
                 bm25_tokenizer=ctx.bm25_tokenizer,
                 bm25_backend=ctx.bm25_backend,
             )
+            plan.update(_eval_plan_overrides(ctx.plan_overrides))
             evidence = retrieve(ctx.index, ctx.retrieval_query, analysis, plan)
         with _StageTimer(
             attempt_timings,
@@ -1440,6 +1477,63 @@ def run_rag_query_with_oracle_evidence(
     return _phase_build_answer(ctx)
 
 
+def _run_rag_query_with_plan_overrides(
+    index: dict[str, Any],
+    query: str,
+    *,
+    plan_overrides: dict[str, Any],
+    top_k: int | None = None,
+    context_entities: list[str] | None = None,
+    metadata_first: bool | None = None,
+    rerank: bool | None = None,
+    rerank_cross_encoder: bool | None = None,
+    verifier_retry: bool | None = None,
+    retrieval_mode: str | None = None,
+    retrieval_backend: str | None = None,
+    pipeline: str | None = None,
+    prompt_profile: str | None = None,
+    conversation_state: dict[str, Any] | None = None,
+    comparison_balance: dict[str, Any] | None = None,
+    rrf_k: int | None = None,
+    bm25_stopword_profile: str | None = None,
+    bm25_tokenizer: str | None = None,
+    bm25_backend: str | None = None,
+) -> dict[str, Any]:
+    """Private eval-only entry point for retrieval plan override probes.
+
+    This deliberately bypasses LangGraph/ReAct routing and only exists so
+    local measurement harnesses can compare retrieval-fusion knobs while
+    keeping the verifier and answer phases identical to the direct
+    ``run_rag_query`` path.
+    """
+    ctx = _build_run_context(
+        index,
+        query,
+        top_k=top_k,
+        context_entities=context_entities,
+        metadata_first=metadata_first,
+        rerank=rerank,
+        rerank_cross_encoder=rerank_cross_encoder,
+        verifier_retry=verifier_retry,
+        retrieval_mode=retrieval_mode,
+        retrieval_backend=retrieval_backend,
+        pipeline=pipeline,
+        prompt_profile=prompt_profile,
+        conversation_state=conversation_state,
+        comparison_balance=comparison_balance,
+        rrf_k=rrf_k,
+        bm25_stopword_profile=bm25_stopword_profile,
+        bm25_tokenizer=bm25_tokenizer,
+        bm25_backend=bm25_backend,
+        plan_overrides=_eval_plan_overrides(plan_overrides),
+    )
+    early_result = _phase_analyze(ctx)
+    if early_result is not None:
+        return early_result
+    _phase_retrieve_loop(ctx)
+    return _phase_build_answer(ctx)
+
+
 async def arun_rag_query(
     index: dict[str, Any],
     query: str,
@@ -1494,4 +1588,3 @@ async def arun_rag_query(
         bm25_tokenizer=bm25_tokenizer,
         bm25_backend=bm25_backend,
     )
-

--- a/rag_retrieval.py
+++ b/rag_retrieval.py
@@ -152,6 +152,17 @@ def apply_fusion_and_reranking(
     elif retrieval_backend == "m3":
         rrf_channel_keys = ("dense", "m3_sparse", "m3_colbert")
     if rrf_channel_keys and scored:
+        rrf_channel_pools_raw = plan.get("rrf_channel_pools")
+        rrf_channel_pools: dict[str, int] = {}
+        if retrieval_backend == "hybrid" and isinstance(rrf_channel_pools_raw, dict):
+            for key in rrf_channel_keys:
+                value = rrf_channel_pools_raw.get(key)
+                if value is None:
+                    continue
+                limit = int(value)
+                if limit < 1:
+                    raise ValueError("rrf_channel_pools values must be positive integers.")
+                rrf_channel_pools[key] = limit
         # Stable rank-by-channel: sort by (channel_score desc, chunk_id) so
         # ties resolve deterministically. Same idiom as the ADR 0010
         # hybrid path it replaces.
@@ -162,6 +173,8 @@ def apply_fusion_and_reranking(
                 key=lambda it, k=key: (it["score_parts"].get(k, 0.0), it["chunk_id"]),
                 reverse=True,
             )
+            if key in rrf_channel_pools:
+                ordered = ordered[: rrf_channel_pools[key]]
             channel_ranks[key] = {it["chunk_id"]: rank for rank, it in enumerate(ordered)}
         # Raw N-way RRF tops out at N/k. Normalize to [0,1] so the
         # verifier's score floor (rag_core.py:2254, threshold 0.18 tuned
@@ -172,7 +185,11 @@ def apply_fusion_and_reranking(
         rrf_norm = rrf_k / float(len(rrf_channel_keys))
         for item in scored:
             cid = item["chunk_id"]
-            rrf = sum(1.0 / (rrf_k + ranks[cid]) for ranks in channel_ranks.values())
+            rrf = sum(
+                1.0 / (rrf_k + ranks[cid])
+                for ranks in channel_ranks.values()
+                if cid in ranks
+            )
             item["score"] = round(float(rrf * rrf_norm), 6)
             item["score_parts"]["rank_rrf"] = round(float(rrf * rrf_norm), 6)
 

--- a/scripts/run_private_hybrid_sweep.py
+++ b/scripts/run_private_hybrid_sweep.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""Private aggregate-only hybrid retrieval parameter sweep.
+
+Compares the ``full_dense`` control path against hybrid BM25+dense RRF
+variants while keeping verifier, prompt, chunking, reranker, and answer
+generation unchanged. The output is intentionally aggregate-only: no raw
+questions, answers, evidence, doc_ids, chunk_ids, filenames, paths, or text
+previews are written.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from eval.run_eval import load_config, normalize_run_config  # noqa: E402
+from eval.scorers import derive_gold_evidence, score_case  # noqa: E402
+from eval.scorers.failure_classifier import classify_failure  # noqa: E402
+from rag_core import (  # noqa: E402
+    DEFAULT_RAG_PIPELINE_NAME,
+    _run_rag_query_with_plan_overrides,
+    load_index,
+    percentile,
+    rate,
+)
+
+
+RRF_K_VALUES = (20, 60, 100)
+POOL_VALUES = (20, 50, 100)
+TOP_K = 20
+FORBIDDEN_KEYS = {
+    "question",
+    "query",
+    "answer",
+    "evidence",
+    "doc_id",
+    "doc_ids",
+    "chunk_id",
+    "chunk_ids",
+    "file",
+    "file_name",
+    "filename",
+    "path",
+    "file_path",
+    "absolute_path",
+    "text",
+    "text_preview",
+    "raw_text",
+    "document_text",
+    "retrieved_chunks",
+    "retrieved_chunk_ids",
+    "gold_evidence",
+    "gold_chunk_ids",
+}
+FORBIDDEN_PATH_FRAGMENTS = (
+    "/Users/",
+    "Desktop/projects",
+    ".codex/worktrees",
+)
+ABSOLUTE_LOCAL_PATH_RE = re.compile(r"(^|[\s:=`'\"])(?:/(?!/)\S+|[A-Za-z]:[\\/]\S+)")
+
+
+@dataclass(frozen=True)
+class VariantSpec:
+    name: str
+    retrieval_backend: str
+    rrf_k: int | None
+    dense_pool: int | None
+    bm25_pool: int | None
+    top_k: int = TOP_K
+
+    @property
+    def plan_overrides(self) -> dict[str, Any]:
+        if self.retrieval_backend != "hybrid":
+            return {}
+        return {
+            "rrf_channel_pools": {
+                "dense": int(self.dense_pool or 0),
+                "bm25": int(self.bm25_pool or 0),
+            }
+        }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, help="Private/local eval config YAML.")
+    parser.add_argument("--index_dir", default="data/index/real100", help="Index directory.")
+    parser.add_argument(
+        "--output_dir",
+        default=None,
+        help="Output directory. Defaults to reports/retrieval/hybrid_sweep_<UTC timestamp>.",
+    )
+    parser.add_argument("--cases_subset_n", type=int, default=None)
+    parser.add_argument("--top_k", type=int, default=TOP_K)
+    parser.add_argument("--rrf_ks", default="20,60,100")
+    parser.add_argument("--dense_pools", default="20,50,100")
+    parser.add_argument("--bm25_pools", default="20,50,100")
+    return parser.parse_args(argv)
+
+
+def _csv_ints(value: str) -> tuple[int, ...]:
+    out = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    if not out or any(v < 1 for v in out):
+        raise ValueError("sweep integer lists must contain positive values")
+    return out
+
+
+def resolve_specs(
+    *,
+    top_k: int = TOP_K,
+    rrf_ks: tuple[int, ...] = RRF_K_VALUES,
+    dense_pools: tuple[int, ...] = POOL_VALUES,
+    bm25_pools: tuple[int, ...] = POOL_VALUES,
+) -> list[VariantSpec]:
+    specs = [
+        VariantSpec(
+            name=f"full_dense_top{top_k}",
+            retrieval_backend="dense",
+            rrf_k=None,
+            dense_pool=None,
+            bm25_pool=None,
+            top_k=top_k,
+        )
+    ]
+    for rrf_k in rrf_ks:
+        for dense_pool in dense_pools:
+            for bm25_pool in bm25_pools:
+                specs.append(
+                    VariantSpec(
+                        name=(
+                            "hybrid_bm25_dense_v1"
+                            f"_k{rrf_k}_dense{dense_pool}_bm25{bm25_pool}"
+                        ),
+                        retrieval_backend="hybrid",
+                        rrf_k=rrf_k,
+                        dense_pool=dense_pool,
+                        bm25_pool=bm25_pool,
+                        top_k=top_k,
+                    )
+                )
+    return specs
+
+
+def _base_full_dense_config(config: dict[str, Any]) -> dict[str, Any]:
+    for run in config.get("ablation_runs") or []:
+        if isinstance(run, dict) and run.get("name") == "full_dense":
+            base = normalize_run_config(run)
+            break
+    else:
+        base = normalize_run_config(
+            {
+                "name": "full_dense",
+                "pipeline": DEFAULT_RAG_PIPELINE_NAME,
+                "metadata_first": True,
+                "rerank": True,
+                "verifier_retry": True,
+                "retrieval_mode": "flat",
+                "retrieval_backend": "dense",
+                "query_expansion": "identity",
+            }
+        )
+    base["top_k"] = TOP_K
+    base["retrieval_backend"] = "dense"
+    return base
+
+
+def _config_for_variant(base: dict[str, Any], spec: VariantSpec) -> dict[str, Any]:
+    run_config = dict(base)
+    run_config["name"] = spec.name
+    run_config["top_k"] = spec.top_k
+    run_config["retrieval_backend"] = spec.retrieval_backend
+    if spec.rrf_k is not None:
+        run_config["rrf_k"] = spec.rrf_k
+    return run_config
+
+
+def _query_kwargs(
+    run_config: dict[str, Any],
+    *,
+    context_entities: list[str] | None = None,
+    conversation_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "pipeline": str(run_config.get("pipeline") or DEFAULT_RAG_PIPELINE_NAME),
+        "top_k": run_config.get("top_k"),
+        "context_entities": context_entities or [],
+        "metadata_first": bool(run_config.get("metadata_first", True)),
+        "rerank": bool(run_config.get("rerank", True)),
+        "rerank_cross_encoder": bool(run_config.get("rerank_cross_encoder", False)),
+        "verifier_retry": bool(run_config.get("verifier_retry", True)),
+        "retrieval_mode": str(run_config.get("retrieval_mode", "flat")),
+        "retrieval_backend": str(run_config.get("retrieval_backend", "dense")),
+        "prompt_profile": str(run_config.get("prompt_profile") or ""),
+        "conversation_state": conversation_state,
+        "rrf_k": int(run_config.get("rrf_k") or 60),
+        "bm25_stopword_profile": str(run_config.get("bm25_stopword_profile", "shared")),
+        "bm25_tokenizer": str(run_config.get("bm25_tokenizer", "regex")),
+        "bm25_backend": str(run_config.get("bm25_backend", "okapi")),
+    }
+
+
+def _run_prediction(
+    index: dict[str, Any],
+    query: str,
+    run_config: dict[str, Any],
+    plan_overrides: dict[str, Any],
+    *,
+    context_entities: list[str] | None = None,
+    conversation_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    kwargs = _query_kwargs(
+        run_config,
+        context_entities=context_entities,
+        conversation_state=conversation_state,
+    )
+    return _run_rag_query_with_plan_overrides(
+        index,
+        query,
+        plan_overrides=plan_overrides,
+        **kwargs,
+    )
+
+
+def evaluate_variant(
+    index: dict[str, Any],
+    cases: list[dict[str, Any]],
+    run_config: dict[str, Any],
+    plan_overrides: dict[str, Any],
+    answer_policy: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for case in cases:
+        conversation_state: dict[str, Any] = {}
+        for turn in case.get("prior_turns") or []:
+            prior_prediction = _run_prediction(
+                index,
+                str(turn["query"]),
+                run_config,
+                plan_overrides,
+                context_entities=turn.get("context_entities") or [],
+                conversation_state=conversation_state,
+            )
+            conversation_state = prior_prediction.get("conversation_state") or conversation_state
+        prediction = _run_prediction(
+            index,
+            str(case["query"]),
+            run_config,
+            plan_overrides,
+            context_entities=case.get("context_entities") or [],
+            conversation_state=conversation_state,
+        )
+        gold_evidence = derive_gold_evidence(case, index)
+        gold_chunk_ids = [
+            str(item.get("chunk_id") or "")
+            for item in gold_evidence
+            if isinstance(item, dict) and item.get("chunk_id")
+        ]
+        results.append(
+            score_case(
+                case,
+                prediction,
+                answer_policy,
+                gold_chunk_ids=gold_chunk_ids,
+                gold_evidence=gold_evidence,
+            )
+        )
+    return results
+
+
+def _metric_mean(results: list[dict[str, Any]], key: str) -> float | None:
+    return rate([float(row[key]) for row in results if row.get(key) is not None])
+
+
+def _count_rate(count: int, denominator: int) -> dict[str, Any]:
+    return {
+        "count": count,
+        "rate": (count / denominator) if denominator else None,
+        "denominator": denominator,
+    }
+
+
+def _less_than_one(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and float(value) < 1.0
+
+
+def summarize_variant(spec: VariantSpec, results: list[dict[str, Any]]) -> dict[str, Any]:
+    failure_categories = [classify_failure(row) for row in results]
+    total = len(results)
+    recall10_rows = [row for row in results if row.get("chunk_recall_at_10") is not None]
+    citation_claim_rows = [row for row in results if row.get("citation_claim_coverage") is not None]
+    citation_page_rows = [row for row in results if row.get("citation_page_coverage") is not None]
+    citation_region_rows = [row for row in results if row.get("citation_region_coverage") is not None]
+    latencies = [
+        float(row["latency_ms"])
+        for row in results
+        if row.get("latency_ms") is not None
+    ]
+    retrieval_miss_count = sum(1 for category in failure_categories if category == "retrieval_miss")
+    citation_issue_count = sum(
+        1 for category in failure_categories if category == "citation_or_page_metadata_issue"
+    )
+    return {
+        "name": spec.name,
+        "parameters": {
+            "retrieval_backend": spec.retrieval_backend,
+            "rrf_k": spec.rrf_k,
+            "dense_pool": spec.dense_pool,
+            "bm25_pool": spec.bm25_pool,
+            "top_k": spec.top_k,
+        },
+        "num_cases": total,
+        "metrics": {
+            "recall_at_5": _metric_mean(results, "chunk_recall_at_5"),
+            "recall_at_10": _metric_mean(results, "chunk_recall_at_10"),
+            "mrr_at_5": _metric_mean(results, "chunk_mrr_at_5"),
+            "ndcg_at_5": _metric_mean(results, "chunk_ndcg_at_5"),
+            "retrieval_miss": _count_rate(retrieval_miss_count, total),
+            "citation_chunk_guardrail": {
+                "chunk_recall_at_10_zero": _count_rate(
+                    sum(float(row.get("chunk_recall_at_10") or 0.0) == 0.0 for row in recall10_rows),
+                    len(recall10_rows),
+                ),
+                "citation_or_page_metadata_issue": _count_rate(citation_issue_count, total),
+                "claim_citation_incomplete": _count_rate(
+                    sum(_less_than_one(row.get("citation_claim_coverage")) for row in citation_claim_rows),
+                    len(citation_claim_rows),
+                ),
+                "citation_page_metadata_incomplete": _count_rate(
+                    sum(_less_than_one(row.get("citation_page_coverage")) for row in citation_page_rows),
+                    len(citation_page_rows),
+                ),
+                "citation_region_metadata_incomplete": _count_rate(
+                    sum(_less_than_one(row.get("citation_region_coverage")) for row in citation_region_rows),
+                    len(citation_region_rows),
+                ),
+            },
+            "latency_ms": {
+                "p50": percentile(latencies, 0.50),
+                "p95": percentile(latencies, 0.95),
+                "count": len(latencies),
+            },
+        },
+    }
+
+
+def _git_state() -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT_DIR,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        dirty = bool(
+            subprocess.check_output(
+                ["git", "status", "--porcelain"],
+                cwd=ROOT_DIR,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        )
+    except (OSError, subprocess.CalledProcessError):
+        commit = "unknown"
+        dirty = True
+    return {"git_commit": commit[:12], "git_dirty": dirty}
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def render_output_path(path: Path) -> str:
+    """Return a public-safe display path for operator logs."""
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(ROOT_DIR).as_posix()
+    except ValueError:
+        return path.name
+
+
+def assert_rendered_output_privacy_safe(text: str) -> None:
+    hits = [fragment for fragment in FORBIDDEN_PATH_FRAGMENTS if fragment in text]
+    if ABSOLUTE_LOCAL_PATH_RE.search(text):
+        hits.append("absolute_local_path")
+    if hits:
+        raise ValueError("rendered output failed privacy guard: " + ", ".join(sorted(set(hits))))
+
+
+def _index_fingerprint(index: dict[str, Any]) -> str:
+    payload = {
+        "build": index.get("build") or {},
+        "embedding": index.get("embedding") or {},
+        "num_documents": len(index.get("documents") or []),
+        "num_chunks": len(index.get("chunks") or []),
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def assert_aggregate_privacy_safe(obj: Any) -> None:
+    hits: list[str] = []
+
+    def walk(node: Any, trail: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                key_text = str(key)
+                if key_text.lower() in FORBIDDEN_KEYS:
+                    hits.append(f"{trail}.{key_text}")
+                walk(value, f"{trail}.{key_text}")
+        elif isinstance(node, list):
+            for idx, item in enumerate(node):
+                walk(item, f"{trail}[{idx}]")
+        elif isinstance(node, str):
+            for fragment in FORBIDDEN_PATH_FRAGMENTS:
+                if fragment in node:
+                    hits.append(f"{trail}:private_path_fragment")
+                    break
+            if ABSOLUTE_LOCAL_PATH_RE.search(node):
+                hits.append(f"{trail}:absolute_local_path")
+            if "/" in node or "\\" in node:
+                hits.append(f"{trail}:path_like_value")
+
+    walk(obj, "$")
+    if hits:
+        raise ValueError("aggregate artifact failed privacy guard: " + ", ".join(hits[:20]))
+
+
+def build_aggregate(
+    *,
+    config_path: Path,
+    index: dict[str, Any],
+    specs: list[VariantSpec],
+    variant_summaries: list[dict[str, Any]],
+    num_cases: int,
+) -> dict[str, Any]:
+    aggregate = {
+        "schema_version": 1,
+        "artifact_type": "private_hybrid_retrieval_sweep_aggregate",
+        "privacy_boundary": "aggregate_only_no_raw_questions_answers_evidence_ids_paths_or_filenames",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "provenance": {
+            **_git_state(),
+            "eval_config_sha256": _sha256_file(config_path),
+            "index_fingerprint_sha256": _index_fingerprint(index),
+        },
+        "sweep": {
+            "baseline": specs[0].name if specs else "full_dense_top20",
+            "candidate": "hybrid_bm25_dense_v1",
+            "top_k": specs[0].top_k if specs else TOP_K,
+            "rrf_k_values": sorted({spec.rrf_k for spec in specs if spec.rrf_k is not None}),
+            "dense_pool_values": sorted({spec.dense_pool for spec in specs if spec.dense_pool is not None}),
+            "bm25_pool_values": sorted({spec.bm25_pool for spec in specs if spec.bm25_pool is not None}),
+            "num_variants": len(specs),
+            "num_cases": num_cases,
+        },
+        "variants": variant_summaries,
+        "known_limits": [
+            "This aggregate is private-local measurement output, not a public performance claim.",
+            "No weighted fusion variant is included.",
+        ],
+    }
+    assert_aggregate_privacy_safe(aggregate)
+    return aggregate
+
+
+def default_output_dir() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return ROOT_DIR / "reports" / "retrieval" / f"hybrid_sweep_{stamp}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = ROOT_DIR / config_path
+    index_dir = Path(args.index_dir)
+    if not index_dir.is_absolute():
+        index_dir = ROOT_DIR / index_dir
+    out_dir = Path(args.output_dir) if args.output_dir else default_output_dir()
+    if not out_dir.is_absolute():
+        out_dir = ROOT_DIR / out_dir
+
+    config = load_config(config_path)
+    cases = list(config["cases"])
+    if args.cases_subset_n is not None:
+        cases = cases[: args.cases_subset_n]
+    index = load_index(index_dir)
+    specs = resolve_specs(
+        top_k=int(args.top_k),
+        rrf_ks=_csv_ints(args.rrf_ks),
+        dense_pools=_csv_ints(args.dense_pools),
+        bm25_pools=_csv_ints(args.bm25_pools),
+    )
+    base = _base_full_dense_config(config)
+    answer_policy = config.get("answer_policy") if isinstance(config.get("answer_policy"), dict) else {}
+
+    variant_summaries: list[dict[str, Any]] = []
+    for idx, spec in enumerate(specs, start=1):
+        print(f"[sweep] {idx}/{len(specs)} {spec.name}", flush=True)
+        run_config = _config_for_variant(base, spec)
+        results = evaluate_variant(index, cases, run_config, spec.plan_overrides, answer_policy)
+        variant_summaries.append(summarize_variant(spec, results))
+
+    aggregate = build_aggregate(
+        config_path=config_path,
+        index=index,
+        specs=specs,
+        variant_summaries=variant_summaries,
+        num_cases=len(cases),
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "aggregate.json"
+    out_path.write_text(json.dumps(aggregate, ensure_ascii=False, indent=2), encoding="utf-8")
+    rendered_path = render_output_path(out_path)
+    message = f"[OK] aggregate written: {rendered_path}"
+    assert_rendered_output_privacy_safe(message)
+    print(message, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_private_hybrid_sweep.py
+++ b/tests/test_private_hybrid_sweep.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.run_private_hybrid_sweep import (  # noqa: E402
+    FORBIDDEN_KEYS,
+    assert_aggregate_privacy_safe,
+    assert_rendered_output_privacy_safe,
+    main,
+    render_output_path,
+    resolve_specs,
+)
+
+
+def _candidate(chunk_id: str, dense: float, bm25: float, score: float = 0.0) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "score": score,
+        "score_parts": {"dense": dense, "bm25": bm25},
+    }
+
+
+class HybridSweepGridTest(unittest.TestCase):
+    def test_variant_grid_is_baseline_plus_27_hybrid_variants(self) -> None:
+        specs = resolve_specs()
+        self.assertEqual(len(specs), 28)
+        self.assertEqual(specs[0].name, "full_dense_top20")
+        self.assertEqual(specs[0].retrieval_backend, "dense")
+        hybrids = specs[1:]
+        self.assertEqual(len(hybrids), 27)
+        self.assertEqual({spec.rrf_k for spec in hybrids}, {20, 60, 100})
+        self.assertEqual({spec.dense_pool for spec in hybrids}, {20, 50, 100})
+        self.assertEqual({spec.bm25_pool for spec in hybrids}, {20, 50, 100})
+        self.assertTrue(
+            all(spec.name.startswith("hybrid_bm25_dense_v1_") for spec in hybrids)
+        )
+
+
+class RrfChannelPoolTest(unittest.TestCase):
+    def test_no_pool_matches_full_pool_behavior(self) -> None:
+        from rag_retrieval import apply_fusion_and_reranking
+
+        candidates_a = [
+            _candidate("c0", 0.9, 0.1),
+            _candidate("c1", 0.5, 0.5),
+            _candidate("c2", 0.1, 0.9),
+        ]
+        candidates_b = [
+            _candidate("c0", 0.9, 0.1),
+            _candidate("c1", 0.5, 0.5),
+            _candidate("c2", 0.1, 0.9),
+        ]
+        analysis = {"query_type": "single_doc"}
+        base_plan = {"retrieval_backend": "hybrid", "top_k": 10, "rrf_k": 60}
+        default = apply_fusion_and_reranking(candidates_a, {}, "q", analysis, dict(base_plan))
+        explicit_full = apply_fusion_and_reranking(
+            candidates_b,
+            {},
+            "q",
+            analysis,
+            {**base_plan, "rrf_channel_pools": {"dense": 3, "bm25": 3}},
+        )
+        self.assertEqual(
+            [(row["chunk_id"], row["score"]) for row in default],
+            [(row["chunk_id"], row["score"]) for row in explicit_full],
+        )
+
+    def test_dense_path_ignores_rrf_channel_pools(self) -> None:
+        from rag_retrieval import apply_fusion_and_reranking
+
+        candidates_a = [
+            _candidate("c0", 0.0, 0.0, score=0.2),
+            _candidate("c1", 0.0, 0.0, score=0.8),
+        ]
+        candidates_b = [
+            _candidate("c0", 0.0, 0.0, score=0.2),
+            _candidate("c1", 0.0, 0.0, score=0.8),
+        ]
+        analysis = {"query_type": "single_doc"}
+        base = apply_fusion_and_reranking(
+            candidates_a, {}, "q", analysis, {"retrieval_backend": "dense", "top_k": 10}
+        )
+        with_pools = apply_fusion_and_reranking(
+            candidates_b,
+            {},
+            "q",
+            analysis,
+            {
+                "retrieval_backend": "dense",
+                "top_k": 10,
+                "rrf_channel_pools": {"dense": 1, "bm25": 1},
+            },
+        )
+        self.assertEqual(
+            [(row["chunk_id"], row["score"]) for row in base],
+            [(row["chunk_id"], row["score"]) for row in with_pools],
+        )
+
+    def test_pool_caps_affect_only_specified_channels(self) -> None:
+        from rag_retrieval import apply_fusion_and_reranking
+
+        def candidates() -> list[dict]:
+            return [
+                _candidate("dense_top", 0.9, 0.1),
+                _candidate("bm25_top", 0.5, 0.9),
+                _candidate("tail", 0.1, 0.5),
+            ]
+
+        analysis = {"query_type": "single_doc"}
+        base_plan = {"retrieval_backend": "hybrid", "top_k": 10, "rrf_k": 60}
+        dense_only_cap = apply_fusion_and_reranking(
+            candidates(),
+            {},
+            "q",
+            analysis,
+            {**base_plan, "rrf_channel_pools": {"dense": 1}},
+        )
+        both_caps = apply_fusion_and_reranking(
+            candidates(),
+            {},
+            "q",
+            analysis,
+            {**base_plan, "rrf_channel_pools": {"dense": 1, "bm25": 1}},
+        )
+        dense_only_scores = {row["chunk_id"]: row["score"] for row in dense_only_cap}
+        both_scores = {row["chunk_id"]: row["score"] for row in both_caps}
+        self.assertGreater(dense_only_scores["tail"], 0.0)
+        self.assertEqual(both_scores["tail"], 0.0)
+
+
+class HybridSweepHarnessTest(unittest.TestCase):
+    def test_privacy_guard_rejects_raw_keys(self) -> None:
+        with self.assertRaisesRegex(ValueError, "privacy guard"):
+            assert_aggregate_privacy_safe({"variants": [{"doc_id": "raw-private-id"}]})
+
+    def test_privacy_guard_rejects_private_path_fragments(self) -> None:
+        with self.assertRaisesRegex(ValueError, "privacy guard"):
+            assert_aggregate_privacy_safe({"safe_key": "/Users/example/private/file.pdf"})
+        with self.assertRaisesRegex(ValueError, "privacy guard"):
+            assert_aggregate_privacy_safe({"safe_key": "Desktop/projects/private"})
+        with self.assertRaisesRegex(ValueError, "privacy guard"):
+            assert_aggregate_privacy_safe({"safe_key": ".codex/worktrees/private"})
+
+    def test_rendered_output_allows_relative_paths_only(self) -> None:
+        relative = "reports/retrieval/hybrid_sweep_<timestamp>/aggregate.json"
+        assert_rendered_output_privacy_safe(relative)
+
+        with self.assertRaisesRegex(ValueError, "rendered output"):
+            assert_rendered_output_privacy_safe(
+                "/Users/hskim/.codex/worktrees/example/reports/retrieval/aggregate.json"
+            )
+        with self.assertRaisesRegex(ValueError, "rendered output"):
+            assert_rendered_output_privacy_safe(
+                "/Users/hskim/Desktop/projects/BidMate-DocAgent/data/index/real100"
+            )
+        with self.assertRaisesRegex(ValueError, "rendered output"):
+            assert_rendered_output_privacy_safe("/opt/local/output/aggregate.json")
+
+    def test_render_output_path_uses_repo_relative_path(self) -> None:
+        rendered = render_output_path(
+            REPO_ROOT / "reports" / "retrieval" / "hybrid_sweep_example" / "aggregate.json"
+        )
+        self.assertEqual(rendered, "reports/retrieval/hybrid_sweep_example/aggregate.json")
+        assert_rendered_output_privacy_safe(rendered)
+
+    def test_smoke_public_fixture_writes_aggregate_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "hybrid_sweep"
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                rc = main(
+                    [
+                        "--config",
+                        "eval/config.yaml",
+                        "--index_dir",
+                        "data/index",
+                        "--output_dir",
+                        str(out_dir),
+                        "--cases_subset_n",
+                        "3",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            rendered_output = stdout.getvalue()
+            assert_rendered_output_privacy_safe(rendered_output)
+            self.assertNotIn("/Users/", rendered_output)
+            self.assertNotIn("Desktop/projects", rendered_output)
+            self.assertNotIn(".codex/worktrees", rendered_output)
+            self.assertIn("aggregate.json", rendered_output)
+            aggregate_path = out_dir / "aggregate.json"
+            self.assertTrue(aggregate_path.exists())
+            payload = json.loads(aggregate_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["sweep"]["num_variants"], 28)
+            self.assertEqual(payload["sweep"]["num_cases"], 3)
+            self.assertEqual(len(payload["variants"]), 28)
+            assert_aggregate_privacy_safe(payload)
+
+            rendered = json.dumps(payload, ensure_ascii=False)
+            public_cfg = yaml.safe_load((REPO_ROOT / "eval/config.yaml").read_text(encoding="utf-8"))
+            for case in public_cfg["cases"][:3]:
+                self.assertNotIn(str(case["query"]), rendered)
+                for doc_id in case.get("expected_doc_ids") or []:
+                    self.assertNotIn(str(doc_id), rendered)
+
+            def walk_keys(node: object) -> list[str]:
+                keys: list[str] = []
+                if isinstance(node, dict):
+                    for key, value in node.items():
+                        keys.append(str(key).lower())
+                        keys.extend(walk_keys(value))
+                elif isinstance(node, list):
+                    for item in node:
+                        keys.extend(walk_keys(item))
+                return keys
+
+            self.assertTrue(FORBIDDEN_KEYS.isdisjoint(set(walk_keys(payload))))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Private aggregate-only hybrid retrieval sweep harness를 추가해 `full_dense_top20` baseline과 `hybrid_bm25_dense_v1` RRF/channel-pool variants를 비교할 수 있게 했습니다. Public runtime defaults와 verifier/prompt/chunking/reranker/answer generation path는 유지하고, private/local aggregate artifact만 생성합니다.

Closes #1463

## 2. 영향 파일

- `.gitignore`: private hybrid sweep aggregate output ignore rule 추가
- `rag_core.py` (load-bearing): private eval-only plan override helper 추가, public `run_rag_query`/`QueryParams` signature 변경 없음
- `rag_retrieval.py` (load-bearing): opt-in hybrid RRF channel pool cap 지원, absent key preserves existing behavior
- `scripts/run_private_hybrid_sweep.py`: aggregate-only private sweep harness 추가
- `tests/test_private_hybrid_sweep.py`: sweep grid, RRF pool behavior, aggregate privacy, rendered path privacy regression 추가
- `docs/retrieval/hybrid-sweep-summary-template.md`: privacy-safe summary template 추가

## 3. 리스크

- RRF pool cap이 기본 hybrid ranking을 바꿀 위험: absent `rrf_channel_pools` case와 explicit full-pool equivalence test로 확인했습니다.
- Dense path에 hybrid-only knob가 섞일 위험: dense ignores pool knobs regression으로 확인했습니다.
- Private raw content 또는 local absolute path가 artifact/log에 노출될 위험: aggregate key guard와 rendered-output path guard를 추가했습니다.

## 4. 테스트

- `python3 -m py_compile rag_core.py rag_retrieval.py scripts/run_private_hybrid_sweep.py tests/test_private_hybrid_sweep.py`
- `python3 -m pytest -q tests/test_private_hybrid_sweep.py tests/test_query_params.py tests/test_phase_mutation_contract.py tests/test_hybrid_retrieval_regression.py`
- `python3 scripts/_governance.py --check-eval-privacy`
- `git diff --check`
- `git diff --cached --check`

## 5. Eval 영향

Private measurement infrastructure only. No README/docs public metrics or public performance claims were updated. The harness writes ignored local aggregate output only.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

`rrf_channel_pools` is private eval-only and opt-in; absent key preserves existing hybrid behavior. A private full sweep was executed locally as aggregate-only output, but private aggregate metrics and local filesystem paths are intentionally not pasted into this public PR body.

## 6. 하위 호환

No public API signature change to `run_rag_query` or `QueryParams`. Existing retrieval defaults remain compatible; dense baseline is preserved.

## 7. 범위 외

- Weighted fusion not added.
- Public performance claims not updated.
- Private aggregate output not committed or published.
