### PR TITLE
[codex] Clarify PR smoke eval comment scope

### DIFF
--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -258,7 +258,8 @@ jobs:
           python pr/scripts/compare_eval.py \
             --base base/reports/eval_summary.json \
             --head pr/reports/eval_summary.json \
-            --title "Eval delta — \`full\` pipeline" > delta.md
+            --title "Public fixture smoke only - not real-data / not naive_baseline / not performance evidence" \
+            --scope-note 'Scope: public fixture smoke only (5 cases, hashing embedding, `full` run). This is a regression guard, not real-data evidence; use PR section 5b for private real-data decisions.' > delta.md
           cat delta.md
 
       - name: Validate improvement claims (ADR 0055)

--- a/scripts/compare_eval.py
+++ b/scripts/compare_eval.py
@@ -47,6 +47,14 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--head", required=True, help="Head (PR) eval_summary.json")
     ap.add_argument("--title", default="Eval delta")
     ap.add_argument(
+        "--scope-note",
+        default="",
+        help=(
+            "Optional markdown note rendered immediately under the title, "
+            "used by CI to make the measurement surface explicit."
+        ),
+    )
+    ap.add_argument(
         "--regression-threshold",
         type=float,
         default=DEFAULT_REGRESSION_THRESHOLD,
@@ -191,6 +199,9 @@ def main() -> int:
     lines: list[str] = []
     lines.append(f"### {args.title}")
     lines.append("")
+    if args.scope_note:
+        lines.append(f"> {args.scope_note}")
+        lines.append("")
     lines.append(
         f"- pipeline: `{head.get('pipeline', '?')}` "
         f"(primary run: `{head.get('primary_run', '?')}`)"

--- a/tests/test_compare_eval_regression_gate.py
+++ b/tests/test_compare_eval_regression_gate.py
@@ -250,6 +250,18 @@ class CompareEvalCliGateTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Gated quality metrics passed", result.stdout)
 
+    def test_scope_note_renders_under_title(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            result = self._run(
+                Path(td),
+                _base_summary(),
+                _base_summary(),
+                scope_note="Scope: public fixture smoke only.",
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("### Test\n\n> Scope: public fixture smoke only.", result.stdout)
+
     def test_regression_exits_one(self) -> None:
         import tempfile
         base = _base_summary()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR eval bot 댓글이 public fixture smoke 결과를 real-data 성능 근거처럼 보이게 만들 수 있어, 제목과 본문 scope note를 명시적으로 바꿨습니다.

Closes #1464

## 2. 영향 파일

- .github/workflows/pr-eval.yml - PR eval 댓글 제목과 scope note 전달 추가.
- scripts/compare_eval.py - 선택적 --scope-note markdown 렌더링 추가.
- tests/test_compare_eval_regression_gate.py - scope note 출력 회귀 테스트 추가.

## 3. 리스크

가장 큰 리스크는 compare_eval.py CLI 인자 추가가 기존 호출을 깨는 것입니다. 새 인자는 기본값이 빈 문자열이라 기존 호출은 동일하게 동작합니다.

## 4. 테스트

- python3 -m pytest -q tests/test_compare_eval_regression_gate.py tests/test_pr_gate_workflow_triggers_regression.py
- make check-branch

## 5. Eval 영향

Public fixture smoke eval 자체의 계산 로직은 변경하지 않았습니다. 댓글 문구와 markdown 렌더링만 바뀌므로 기대 delta는 All `·` 입니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. real-data eval 로직이나 private aggregate 추출을 바꾸지 않고 PR comment framing만 수정했습니다.

## 6. 하위 호환

기존 compare_eval.py 호출은 --scope-note 생략 시 동일한 출력 구조를 유지합니다. 답변 계약(schema_version) 변경 없음.

## 7. 범위 외

PR eval의 public fixture smoke 자체를 제거하거나 real-data 자동 실행으로 바꾸지는 않았습니다. 이번 PR은 혼동을 줄이는 표시 문구에 한정합니다.