### PR TITLE
fix(eval): render missing retrieval_miss distinctly

### DIFF
--- a/docs/real-data/private-100-doc-experiments.md
+++ b/docs/real-data/private-100-doc-experiments.md
@@ -69,6 +69,14 @@ python3 scripts/summarize_benchmark.py \
 
 이 섹션은 retrieval / verifier policy 변경의 **real-data aggregate-only** before/after를 기록한다. ADR 0005의 commit boundary를 준수해 case ID·query text·doc ID·파일명은 절대 포함하지 않는다. 목적은 "왜 이렇게 짰는가?" 그리고 "그 결정이 real-data에서 어떻게 작동했는가?" 두 질문에 답할 수 있는 자료를 남기는 것이다.
 
+### Note: `retrieval_miss` 해석 기준
+
+`retrieval_miss` 는 `eval/scorers/failure_classifier.py::classify_failure` 가 만든 per-case `failure_category` 를 `aggregate_failure_categories` 로 합산한 `failure_category_counts.retrieval_miss` 이다. `failure_type_counts`, Recall@K, MRR, nDCG 에서 파생하지 않는다.
+
+GO/NO-GO 표에서 이 값은 양쪽 run 이 같은 case set 과 호환되는 taxonomy/classifier 버전으로 생성한 `failure_category_counts.retrieval_miss` 를 명시적으로 포함할 때만 비교한다. selected ablation run 에 이 key 가 없으면 `0` 이 아니라 missing/`—` 로 해석한다. case count 가 다르면 raw count 의 방향성은 rate 와 달라질 수 있으므로 renderer 는 count 값만 표시하고 Δ 방향성은 `—` 로 둔다.
+
+PR #1448 의 `full_dense` vs `hybrid_bm25_dense_v1` 표에서 `retrieval_miss 0 -> 0` 은 두 selected run 의 `eval_summary.json::ablation.runs[]::failure_category_counts.retrieval_miss` 에 명시된 값이었다. 같은 시점 readiness audit 에서 보인 meaningful `retrieval_miss` count 는 별도 latest eval summary aggregate 에서 온 것이므로, #1448 selected-run delta 의 GO/NO-GO 근거와 직접 비교하지 않는다.
+
 ### Entry: 2026-05-11 — Partial-topic grounding @ fraction=0.5 (#69)
 
 **변경(Change).** `verify_evidence`에 `allow_partial_topic` 추가, 마지막 retrieval 시도에서 verification topics의 ≥50%가 evidence에 매칭되면 `partial_topic_grounding` reason으로 `verified=True`를 반환하고 status는 `partial`로 surface ([ADR 0004](../adr/0004-verifier-retry-policy.md) anticipated knob).

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -301,6 +301,10 @@ FORBIDDEN_KEYS = frozenset(
 # Metric direction for the rendered delta arrow.
 # (path, label, higher_is_better)
 METRICS: list[tuple[str, str, bool]] = [
+    # ADR 0075 taxonomy count. Missing stays missing (`—`) via `_get_path`;
+    # never coerce absent failure counts to numeric zero. Directional deltas
+    # are only meaningful when both summaries cover the same number of cases.
+    ("failure_category_counts.retrieval_miss", "retrieval_miss", False),
     ("accuracy", "accuracy", True),
     ("groundedness", "groundedness", True),
     ("citation_precision", "citation_precision", True),
@@ -312,6 +316,14 @@ METRICS: list[tuple[str, str, bool]] = [
     ("latency.p50", "latency_p50_ms", False),
     ("latency.p95", "latency_p95_ms", False),
 ]
+
+EQUAL_N_DELTA_METRICS = frozenset({"failure_category_counts.retrieval_miss"})
+
+
+def _same_num_predictions(base: dict[str, Any], head: dict[str, Any]) -> bool:
+    b = base.get("num_predictions")
+    h = head.get("num_predictions")
+    return isinstance(b, int) and isinstance(h, int) and b == h
 
 
 # -----------------------------------------------------------------------------
@@ -767,10 +779,14 @@ def render_markdown(
     for path, label, higher in METRICS:
         b = _get_path(base, path)
         h = _get_path(head, path)
+        if path in EQUAL_N_DELTA_METRICS and not _same_num_predictions(base, head):
+            delta = "—"
+        else:
+            delta = _fmt_delta(b, h, higher, n_min=n_min)
         lines.append(
             f"| {label} | {_fmt_value(b)}{_fmt_ci(base, path)} "
             f"| {_fmt_value(h)}{_fmt_ci(head, path)} "
-            f"| {_fmt_delta(b, h, higher, n_min=n_min)} |"
+            f"| {delta} |"
         )
 
     # Slice-level abstention is the most important signal we surfaced

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -36,6 +36,11 @@ FULL_SUMMARY = {
     "citation_precision": 0.286,
     "abstention": 0.5,
     "retry": 0.429,
+    "failure_category_counts": {
+        "retrieval_miss": 2,
+        "verifier_false_negative": 1,
+        "unknown": 0,
+    },
     "latency": {"p50": 100.0, "p95": 300.0, "mean": 150.0},
     "stage_latency": {
         "retrieve_ms": {"p50": 5.0, "p95": 20.0, "mean": 8.0, "count": 21}
@@ -58,7 +63,15 @@ FULL_SUMMARY = {
             "id": "real_secret_case",
             "query": "이건 진짜 비공개 질의 텍스트",
             "answer": "case-level answer leak",
-            "evidence": [{"doc_id": "private_doc_1", "text": "private text"}],
+            "evidence": [
+                {
+                    "doc_id": "private_doc_1",
+                    "chunk_id": "private_chunk_7",
+                    "filename": "private_contract.pdf",
+                    "local_path": "/redacted/private/private_contract.pdf",
+                    "text": "private text",
+                }
+            ],
             "expected_doc_ids": ["private_doc_1"],
         }
     ],
@@ -149,6 +162,9 @@ class ExtractAggregateTest(unittest.TestCase):
             "real_secret_case",
             "진짜 비공개",
             "private_doc_1",
+            "private_chunk_7",
+            "private_contract.pdf",
+            "/redacted/private",
             "case-level answer leak",
         ]:
             self.assertNotIn(leak, md)
@@ -156,6 +172,96 @@ class ExtractAggregateTest(unittest.TestCase):
         self.assertIn("accuracy", md)
         self.assertIn("0.471", md)
         self.assertIn("0.600", md)
+
+    def test_render_retrieval_miss_nonzero_count_as_numeric(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "failure_category_counts": {
+                    **FULL_SUMMARY["failure_category_counts"],
+                    "retrieval_miss": 1,
+                },
+            }
+        )
+        md = render_markdown(base, head, "test")
+        self.assertIn("| retrieval_miss | 2 | 1 | -1.000 ✅ |", md)
+
+    def test_render_retrieval_miss_missing_as_dash_not_zero(self) -> None:
+        base_summary = {k: v for k, v in FULL_SUMMARY.items() if k != "failure_category_counts"}
+        head_summary = {
+            **FULL_SUMMARY,
+            "failure_category_counts": {
+                "verifier_false_negative": 1,
+            },
+        }
+        base = extract_aggregate(base_summary)
+        head = extract_aggregate(head_summary)
+        md = render_markdown(base, head, "test")
+        self.assertIn("| retrieval_miss | — | — | — |", md)
+        self.assertNotIn("| retrieval_miss | 0 | 0 |", md)
+
+    def test_render_retrieval_miss_explicit_zero_as_zero(self) -> None:
+        zero_counts = {
+            **FULL_SUMMARY["failure_category_counts"],
+            "retrieval_miss": 0,
+        }
+        base = extract_aggregate({**FULL_SUMMARY, "failure_category_counts": zero_counts})
+        head = extract_aggregate({**FULL_SUMMARY, "failure_category_counts": zero_counts})
+        md = render_markdown(base, head, "test")
+        self.assertIn("| retrieval_miss | 0 | 0 | · |", md)
+
+    def test_render_retrieval_miss_unequal_n_has_no_directional_delta(self) -> None:
+        base = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "num_predictions": 100,
+                "failure_category_counts": {
+                    **FULL_SUMMARY["failure_category_counts"],
+                    "retrieval_miss": 20,
+                },
+            }
+        )
+        head = extract_aggregate(
+            {
+                **FULL_SUMMARY,
+                "num_predictions": 50,
+                "failure_category_counts": {
+                    **FULL_SUMMARY["failure_category_counts"],
+                    "retrieval_miss": 15,
+                },
+            }
+        )
+        md = render_markdown(base, head, "test")
+        self.assertIn("| retrieval_miss | 20 | 15 | — |", md)
+        self.assertNotIn("| retrieval_miss | 20 | 15 | -5.000 ✅ |", md)
+
+    def test_render_markdown_has_no_nested_fences(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate({**FULL_SUMMARY, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+        self.assertNotIn("```", md)
+
+    def test_render_markdown_tables_have_stable_column_counts(self) -> None:
+        base = extract_aggregate(FULL_SUMMARY)
+        head = extract_aggregate({**FULL_SUMMARY, "accuracy": 0.6})
+        md = render_markdown(base, head, "test")
+
+        table: list[str] = []
+        tables: list[list[str]] = []
+        for line in md.splitlines():
+            if line.startswith("|"):
+                table.append(line)
+            elif table:
+                tables.append(table)
+                table = []
+        if table:
+            tables.append(table)
+
+        self.assertGreaterEqual(len(tables), 1)
+        for table_lines in tables:
+            counts = [len(line.strip("|").split("|")) for line in table_lines]
+            self.assertEqual([counts[0]] * len(counts), counts)
 
     def test_render_includes_slice_abstention(self) -> None:
         base = extract_aggregate(FULL_SUMMARY)


### PR DESCRIPTION
## Summary

Fix `retrieval_miss` delta rendering so absent failure-category metrics are not silently displayed as numeric zero.

Fixes #1466

## What changed

- `failure_category_counts.retrieval_miss` now renders as:
  - numeric value when explicitly present
  - `0` when explicitly present as zero
  - `—` / missing when absent
- Added tests for nonzero, explicit zero, and missing `retrieval_miss`
- Documented `retrieval_miss` source and comparability constraints

## Source / interpretation

`retrieval_miss` is produced by:

`eval/scorers/failure_classifier.py::classify_failure`

then aggregated by:

`aggregate_failure_categories`

into:

`failure_category_counts.retrieval_miss`

It is NOT derived from:

- `failure_type_counts`
- Recall@K
- MRR
- nDCG

It should be used in GO/NO-GO tables only when both compared runs explicitly include:

`failure_category_counts.retrieval_miss`

from:

- the same case set
- compatible taxonomy/classifier version

## #1448 impact

The #1448 `retrieval_miss 0 -> 0` value came from explicit selected-run ablation aggregates and is not directly comparable to the readiness audit’s separate latest eval-summary aggregate.

The #1448 NO-GO conclusion remains unchanged because:

- MRR@5 regressed
- nDCG@5 regressed
- citation_accuracy regressed
- latency regressed

## Eval impact

No behavior change in retrieval / verifier path.

Reporting-only change.

## Privacy

No private raw content committed.