### PR TITLE
docs: Add page metadata recovery readiness surface (#1471)

### DIFF
--- a/docs/evaluation/page_metadata_recovery_plan.md
+++ b/docs/evaluation/page_metadata_recovery_plan.md
@@ -1,0 +1,91 @@
+# Page Metadata Recovery Plan
+
+## TL;DR
+
+Current difficulty profiling says the hard benchmark is difficult but not
+invalid. Naive dense-only retrieval is not completely broken, and the dominant
+bottleneck is now page metadata / citation grounding infrastructure.
+
+This plan moves the page metadata surface from audit-only NO-GO to an
+implementation-ready roadmap. It does not change retrieval, verifier, prompt,
+chunking, reranker, or answer runtime behavior.
+
+Single recommendation: **full re-index** after page-aware parser output exists.
+
+## Current Boundary
+
+| boundary | current page metadata state | readiness implication |
+|---|---|---|
+| parser output | Visual artifacts can carry `pages`, `blocks`, `regions`, and `page_span`; CSV/kordoc text path usually emits plain text sections only. | Page recovery must start before indexing. |
+| kordoc/HWP extraction | Kordoc Markdown preserves text/table structure but current cache manifest is not a page map. | HWP needs page-aware parser support or a render-to-visual path. |
+| PDF extraction | Visual ingestion can emit page/block metadata; kordoc/csv-text PDF path may not. | PDFs are the best Phase A candidate when visual artifacts exist. |
+| chunk serialization | `rag_indexing` already preserves optional `regions` and `page_span` from sections to chunks. | Contract exists; coverage is the missing piece. |
+| index build payload | `index.json` schema v2 can store optional chunk/parent page metadata. | Re-index is required once parser output is page-aware. |
+| eval summary rendering | Citation page/region coverage and precision aggregates already exist. | Re-evaluation can stay aggregate-only. |
+| citation renderer | `make_citation()` already propagates optional `regions` and `page_span`. | No citation selection or answer behavior change is required. |
+
+## Recoverability
+
+| evidence source | recoverability |
+|---|---|
+| Current chunks have `page_span` or `regions.page_number` | Recoverable from current index for covered source groups. |
+| Parent sections have page metadata but chunks do not | Recoverable via rechunk/re-index. |
+| Visual artifacts have page/block metadata | Recoverable via visual-artifact-based re-index. |
+| Kordoc cache has page markers | Possibly recoverable after adapter spike. |
+| Chunk offsets only | Not recoverable today; source page boundaries and chunk character offsets are not stored. |
+| HWP/PDF kordoc or CSV text without page markers | Requires page-aware parser output and full re-index. |
+
+## Implementation Matrix
+
+| source type | current coverage | recoverable? | requires parser change? | requires re-index? | requires OCR/visual ingestion? | estimated engineering cost | expected eval impact |
+|---|---:|---|---|---|---|---|---|
+| Existing index with no page fields | 0% | No | No | Yes | No | S | Enables coverage measurement only after rebuild. |
+| Existing index with parent-only page fields | parent >0%, chunk 0% | Yes, via rechunk | No | Yes | No | S-M | Citation page coverage can become GO for covered groups. |
+| Visual PDF/image artifacts | artifact page/block coverage >0 | Yes | No | Yes | Already visual | M | Strongest near-term page citation lift for PDFs/images. |
+| PDF via kordoc/csv-text with no markers | 0% | No | Yes or visual path | Yes | Prefer visual for scanned/weak text-layer PDFs | M-L | Page citation GO only after parser output carries page spans. |
+| HWP via kordoc with no markers | 0% | No | Yes | Yes | Usually no, unless rendered to PDF/images | M-L | Page citation GO requires page-aware HWP extraction or render+visual path. |
+| CSV text fallback | 0% | No | No for fallback; raw source reparse needed | Yes | Depends on source | S-M | Low confidence unless raw source can be reparsed. |
+| Public JSON/MD fixtures | 0% unless authored | Yes if fixture sections include page fields | No | Yes | No | S | Useful regression fixture, not a real performance claim. |
+
+## Roadmap
+
+Phase A: restore page metadata only.
+
+- Run `scripts/page_metadata_recovery_audit.py` against local private index and optional local artifacts.
+- Keep outputs aggregate-only and commit no raw private text, evidence, filenames, `doc_id`, `chunk_id`, or local paths.
+- Rebuild a page-aware index only after parser output has `sections[].page_span` or `sections[].regions`.
+
+Phase B: page-aware chunk serialization.
+
+- Preserve `page_span` and `regions` through section normalization, parent sections, chunks, index write/load, evidence, and citations.
+- Validate page spans as `[start:int, end:int]` with `start <= end`.
+- Validate region page numbers fall inside span when both are present.
+
+Phase C: page-grounded citation rendering and re-evaluation.
+
+- Use existing citation propagation; do not change citation selection.
+- Re-run aggregate-only `citation_page_coverage`, `citation_page_precision`, and citation coverage reason counts.
+- Mark citation/page claims GO only for source groups with non-zero page metadata coverage and compatible explicit page gold.
+
+Phase D: optional visual/table-aware ingestion.
+
+- Prefer visual ingestion for PDFs/images where text-layer or kordoc output lacks page markers.
+- Treat HWP visual rebuild as a separate spike: page-aware HWP parser or HWP-to-PDF/image render plus visual ingestion.
+- Table and bbox precision are optional and should not block Phase A page-span recovery.
+
+## Readiness Checks
+
+- `page_metadata_coverage_gt_0`: at least one chunk has `page_span` or `regions.page_number`.
+- `chunk_page_span_integrity`: page spans are valid and region pages do not fall outside spans.
+- `citation_renderer_compatible`: existing renderer can propagate page metadata without behavior changes.
+- `no_private_path_leakage`: committed artifacts omit exact local paths and filenames.
+- `aggregate_only_outputs`: reports contain counts, rates, source categories, and decisions only.
+
+## GO Criteria
+
+Citation/page claims can become GO only after recovery for the covered source
+groups. A global GO requires non-zero page metadata coverage across the target
+evaluation slice and explicit page gold for citation precision. Until then,
+page-level citation claims remain NO-GO even if Recall@K improves.
+
+Recommendation: **full re-index**.

--- a/scripts/page_metadata_recovery_audit.py
+++ b/scripts/page_metadata_recovery_audit.py
@@ -21,6 +21,13 @@ from typing import Any, Iterable, Mapping, Sequence
 
 SAFE_LABEL_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 PAGE_LIKE_KEY_RE = re.compile(r"page|bbox|region", re.IGNORECASE)
+ABSOLUTE_PATH_VALUE_RE = re.compile(
+    r"(^|[\s\"'`])(/Users/|/private/|/tmp/|/var/|/home/|/Volumes/|[A-Za-z]:\\)"
+)
+FILENAME_VALUE_RE = re.compile(
+    r"(^|[\s\"'`])[^/\s\"'`]+\.(pdf|hwp|hwpx|docx|xlsx|csv|jsonl|md|txt)\b",
+    re.IGNORECASE,
+)
 
 
 def _rate(numerator: int, denominator: int) -> float:
@@ -142,6 +149,190 @@ def _group_decision(group: Mapping[str, Any]) -> str:
     if file_format == "pdf" and text_source == "kordoc":
         return "requires_pdf_visual_ingestion_or_page_aware_parser"
     return "requires_page_aware_reindex"
+
+
+def _source_type(group: Mapping[str, Any]) -> str:
+    file_format = str(group.get("file_format") or "")
+    text_source = str(group.get("text_source") or "")
+    document_type = str(group.get("document_type") or "")
+    if float(group.get("any_page_metadata_coverage") or 0.0) > 0:
+        return "existing_index_with_page_fields"
+    if float(group.get("parent_any_page_metadata_coverage") or 0.0) > 0:
+        return "existing_index_parent_only_page_fields"
+    if document_type == "public_fixture_smoke":
+        return "public_json_md_fixtures"
+    if "visual" in text_source or "visual" in document_type:
+        return "visual_pdf_image_artifacts"
+    if text_source == "data_list_csv_text":
+        return "csv_text_fallback"
+    if file_format == "pdf" and text_source == "kordoc":
+        return "pdf_via_kordoc_or_csv_text"
+    if file_format == "hwp" and text_source == "kordoc":
+        return "hwp_via_kordoc"
+    return "existing_index_with_no_page_fields"
+
+
+def _matrix_row_for_group(group: Mapping[str, Any]) -> dict[str, Any]:
+    source_type = _source_type(group)
+    coverage = float(group.get("any_page_metadata_coverage") or 0.0)
+    parent_coverage = float(group.get("parent_any_page_metadata_coverage") or 0.0)
+
+    matrix_by_type: dict[str, dict[str, Any]] = {
+        "existing_index_with_page_fields": {
+            "recoverable": True,
+            "requires_parser_change": False,
+            "requires_reindex": False,
+            "requires_ocr_visual_ingestion": False,
+            "estimated_engineering_cost": "S",
+            "expected_eval_impact": "Citation page claims can be GO for covered source groups.",
+        },
+        "existing_index_parent_only_page_fields": {
+            "recoverable": True,
+            "requires_parser_change": False,
+            "requires_reindex": True,
+            "requires_ocr_visual_ingestion": False,
+            "estimated_engineering_cost": "S-M",
+            "expected_eval_impact": "Citation page coverage can become GO after rechunk/reindex.",
+        },
+        "visual_pdf_image_artifacts": {
+            "recoverable": True,
+            "requires_parser_change": False,
+            "requires_reindex": True,
+            "requires_ocr_visual_ingestion": False,
+            "estimated_engineering_cost": "M",
+            "expected_eval_impact": "Strongest near-term page citation lift for PDFs/images.",
+        },
+        "pdf_via_kordoc_or_csv_text": {
+            "recoverable": False,
+            "requires_parser_change": True,
+            "requires_reindex": True,
+            "requires_ocr_visual_ingestion": True,
+            "estimated_engineering_cost": "M-L",
+            "expected_eval_impact": "Page citation GO only after parser output carries page spans.",
+        },
+        "hwp_via_kordoc": {
+            "recoverable": False,
+            "requires_parser_change": True,
+            "requires_reindex": True,
+            "requires_ocr_visual_ingestion": False,
+            "estimated_engineering_cost": "M-L",
+            "expected_eval_impact": "Page citation GO requires page-aware HWP extraction or render+visual path.",
+        },
+        "csv_text_fallback": {
+            "recoverable": False,
+            "requires_parser_change": False,
+            "requires_reindex": True,
+            "requires_ocr_visual_ingestion": False,
+            "estimated_engineering_cost": "S-M",
+            "expected_eval_impact": "Low confidence unless raw source can be reparsed.",
+        },
+        "public_json_md_fixtures": {
+            "recoverable": bool(coverage or parent_coverage),
+            "requires_parser_change": False,
+            "requires_reindex": True,
+            "requires_ocr_visual_ingestion": False,
+            "estimated_engineering_cost": "S",
+            "expected_eval_impact": "Useful regression fixture, not a real performance claim.",
+        },
+        "existing_index_with_no_page_fields": {
+            "recoverable": False,
+            "requires_parser_change": False,
+            "requires_reindex": True,
+            "requires_ocr_visual_ingestion": False,
+            "estimated_engineering_cost": "S",
+            "expected_eval_impact": "Enables coverage measurement only after rebuild.",
+        },
+    }
+    row = dict(matrix_by_type[source_type])
+    row.update(
+        {
+            "source_type": source_type,
+            "current_coverage": coverage,
+            "parent_current_coverage": parent_coverage,
+            "source_group": (
+                f"{group['file_format']}/{group['text_source']}/"
+                f"{group['document_type']}/{group['chunking_strategy']}"
+            ),
+            "decision": group["decision"],
+        }
+    )
+    return row
+
+
+def implementation_matrix(source_groups: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [_matrix_row_for_group(group) for group in source_groups]
+
+
+def _page_span_integrity(items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    checked = 0
+    invalid = 0
+    region_outside_span = 0
+    for item in items:
+        page_span = item.get("page_span")
+        if page_span is None:
+            continue
+        checked += 1
+        if not _is_page_span(page_span) or int(page_span[0]) > int(page_span[1]):
+            invalid += 1
+            continue
+        start, end = int(page_span[0]), int(page_span[1])
+        for region in _regions(item.get("regions")):
+            page_number = region.get("page_number")
+            if isinstance(page_number, int) and not (start <= page_number <= end):
+                region_outside_span += 1
+    return {
+        "checked_count": checked,
+        "invalid_page_span_count": invalid,
+        "region_outside_page_span_count": region_outside_span,
+        "ok": invalid == 0 and region_outside_span == 0,
+    }
+
+
+def readiness_checks(
+    chunks: Sequence[Mapping[str, Any]],
+    report_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    chunk_coverage = coverage_block(chunks)
+    integrity = _page_span_integrity(chunks)
+    return {
+        "page_metadata_coverage_gt_0": chunk_coverage["any_page_metadata_coverage"] > 0,
+        "chunk_page_span_integrity": integrity,
+        "citation_renderer_compatible": integrity["ok"],
+        "no_private_path_leakage": not _has_private_path_or_filename_value(report_payload),
+        "aggregate_only_outputs": bool(
+            (report_payload.get("privacy") or {}).get("aggregate_only")
+        ),
+    }
+
+
+def _iter_string_values(node: Any) -> Iterable[str]:
+    if isinstance(node, Mapping):
+        for value in node.values():
+            yield from _iter_string_values(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_string_values(item)
+    elif isinstance(node, str):
+        yield node
+
+
+def _has_private_path_or_filename_value(payload: Mapping[str, Any]) -> bool:
+    for value in _iter_string_values(payload):
+        if ABSOLUTE_PATH_VALUE_RE.search(value) or FILENAME_VALUE_RE.search(value):
+            return True
+    return False
+
+
+def recovery_recommendation(recoverability: str, requires_reindex: bool) -> str:
+    if not requires_reindex and recoverability == "recoverable_from_current_index":
+        return "lightweight metadata recovery"
+    if recoverability == "possibly_recoverable_from_kordoc_cache_requires_adapter":
+        return "parser patch"
+    if recoverability == "recoverable_from_visual_artifacts_requires_reindex":
+        return "visual ingestion rebuild"
+    if requires_reindex:
+        return "full re-index"
+    return "impossible with current artifacts"
 
 
 def source_group_coverage(
@@ -428,17 +619,19 @@ def build_audit_report(
     recoverability = _artifact_recoverability(chunk_coverage, parent_coverage, visual, kordoc)
     requires_reindex = recoverability != "recoverable_from_current_index"
     requires_parser_change = _requires_parser_change(source_groups, recoverability)
-
-    return {
+    privacy = {
+        "aggregate_only": True,
+        "omits_raw_text": True,
+        "omits_doc_ids": True,
+        "omits_chunk_ids": True,
+        "omits_file_names": True,
+        "omits_source_paths": True,
+    }
+    matrix = implementation_matrix(source_groups)
+    report = {
         "schema_version": 1,
         "status": "ok",
-        "privacy": {
-            "aggregate_only": True,
-            "omits_raw_text": True,
-            "omits_doc_ids": True,
-            "omits_file_names": True,
-            "omits_source_paths": True,
-        },
+        "privacy": privacy,
         "index": {
             "schema_version": index_payload.get("schema_version"),
             "document_count": len(documents),
@@ -454,6 +647,7 @@ def build_audit_report(
             "kordoc_cache": kordoc,
             "visual_artifacts": visual,
         },
+        "implementation_matrix": matrix,
         "decision": {
             "citation_page_claim_go_no_go": "GO" if max_source_page_coverage > 0 else "NO-GO",
             "page_claim_scope": (
@@ -466,6 +660,7 @@ def build_audit_report(
             "requires_parser_change": requires_parser_change,
             "current_index_behavior_change": False,
             "retrieval_verifier_prompt_answer_change": False,
+            "recommendation": recovery_recommendation(recoverability, requires_reindex),
         },
         "follow_up_issue_plan": [
             "Keep page-level citation claims disabled while source-group page coverage is zero.",
@@ -475,6 +670,8 @@ def build_audit_report(
             "Commit only aggregate reports; keep private raw content, filenames, doc_ids, and source paths out of artifacts.",
         ],
     }
+    report["readiness_checks"] = readiness_checks(chunks, report)
+    return report
 
 
 def render_markdown(report: Mapping[str, Any]) -> str:
@@ -514,8 +711,44 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             f"regions.bbox=`{group['regions_bbox_coverage']}`, "
             f"decision=`{group['decision']}`"
         )
+    lines.extend(
+        [
+            "",
+            "## Implementation Matrix",
+            "| source type | current coverage | recoverable? | parser change? | re-index? | OCR/visual? | cost | expected eval impact |",
+            "|---|---:|---|---|---|---|---|---|",
+        ]
+    )
+    for row in report.get("implementation_matrix") or []:
+        lines.append(
+            "| "
+            f"`{row['source_type']}` | "
+            f"{row['current_coverage']:.6f} | "
+            f"{row['recoverable']} | "
+            f"{row['requires_parser_change']} | "
+            f"{row['requires_reindex']} | "
+            f"{row['requires_ocr_visual_ingestion']} | "
+            f"{row['estimated_engineering_cost']} | "
+            f"{row['expected_eval_impact']} |"
+        )
+    readiness = report.get("readiness_checks") or {}
+    integrity = readiness.get("chunk_page_span_integrity") or {}
+    lines.extend(
+        [
+            "",
+            "## Readiness Checks",
+            f"- Page metadata coverage > 0: `{readiness.get('page_metadata_coverage_gt_0')}`",
+            f"- Chunk page_span integrity: `{integrity.get('ok')}` "
+            f"(checked=`{integrity.get('checked_count')}`, invalid=`{integrity.get('invalid_page_span_count')}`, "
+            f"region_outside=`{integrity.get('region_outside_page_span_count')}`)",
+            f"- Citation renderer compatible: `{readiness.get('citation_renderer_compatible')}`",
+            f"- No private path leakage: `{readiness.get('no_private_path_leakage')}`",
+            f"- Aggregate-only outputs: `{readiness.get('aggregate_only_outputs')}`",
+        ]
+    )
     lines.extend(["", "## Follow-Up Issue Plan"])
     lines.extend(f"- {item}" for item in report["follow_up_issue_plan"])
+    lines.extend(["", "## Recommendation", f"`{decision['recommendation']}`"])
     lines.append("")
     return "\n".join(lines)
 

--- a/tests/test_page_metadata_recovery_audit.py
+++ b/tests/test_page_metadata_recovery_audit.py
@@ -6,7 +6,11 @@ import subprocess
 import sys
 
 from rag_indexing import build_chunks
-from scripts.page_metadata_recovery_audit import build_audit_report, render_markdown
+from scripts.page_metadata_recovery_audit import (
+    build_audit_report,
+    readiness_checks,
+    render_markdown,
+)
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -109,8 +113,17 @@ def test_no_page_metadata_reports_no_go_and_parser_change(tmp_path: Path) -> Non
     assert report["decision"]["recoverability"] == "not_recoverable_from_existing_artifacts"
     assert report["decision"]["requires_reindex"] is True
     assert report["decision"]["requires_parser_change"] is True
+    assert report["decision"]["recommendation"] == "full re-index"
     assert report["index"]["source_groups"][0]["decision"] == "requires_page_aware_hwp_parser_change"
     assert report["index"]["source_groups"][0]["any_page_metadata_coverage"] == 0.0
+    matrix_row = report["implementation_matrix"][0]
+    assert matrix_row["source_type"] == "hwp_via_kordoc"
+    assert matrix_row["current_coverage"] == 0.0
+    assert matrix_row["recoverable"] is False
+    assert matrix_row["requires_parser_change"] is True
+    assert matrix_row["requires_reindex"] is True
+    assert report["readiness_checks"]["page_metadata_coverage_gt_0"] is False
+    assert report["readiness_checks"]["aggregate_only_outputs"] is True
 
 
 def test_source_group_uses_document_metadata_for_missing_chunk_fields(tmp_path: Path) -> None:
@@ -192,7 +205,57 @@ def test_nonzero_source_group_page_coverage_enables_page_claim_scope(tmp_path: P
     assert report["decision"]["citation_page_claim_go_no_go"] == "GO"
     assert report["decision"]["page_claim_scope"] == "covered_source_groups_only"
     assert report["decision"]["recoverability"] == "recoverable_from_current_index"
+    assert report["decision"]["recommendation"] == "lightweight metadata recovery"
     assert report["index"]["source_groups"][0]["regions_page_number_coverage"] == 1.0
+    assert report["implementation_matrix"][0]["source_type"] == "existing_index_with_page_fields"
+    assert report["implementation_matrix"][0]["recoverable"] is True
+    assert report["implementation_matrix"][0]["requires_reindex"] is False
+    assert report["readiness_checks"]["page_metadata_coverage_gt_0"] is True
+    assert report["readiness_checks"]["chunk_page_span_integrity"]["ok"] is True
+
+
+def test_readiness_flags_invalid_page_span_integrity(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index"
+    _write_index(
+        index_dir,
+        _base_index(
+            [
+                {
+                    "chunk_id": "doc-a::chunk-001",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "section",
+                    "page_span": [5, 4],
+                    "regions": [{"page_number": 6, "bbox": [1, 2, 3, 4]}],
+                    "metadata": {
+                        "file_format": "pdf",
+                        "text_source": "visual_parsing_v2",
+                        "document_type": "visual_parsing_v2",
+                    },
+                },
+                {
+                    "chunk_id": "doc-a::chunk-002",
+                    "doc_id": "doc-a",
+                    "chunking_strategy": "section",
+                    "page_span": [2, 3],
+                    "regions": [{"page_number": 4, "bbox": [1, 2, 3, 4]}],
+                    "metadata": {
+                        "file_format": "pdf",
+                        "text_source": "visual_parsing_v2",
+                        "document_type": "visual_parsing_v2",
+                    },
+                },
+            ]
+        ),
+    )
+
+    report = build_audit_report(index_dir)
+    integrity = report["readiness_checks"]["chunk_page_span_integrity"]
+
+    assert integrity["checked_count"] == 2
+    assert integrity["invalid_page_span_count"] == 1
+    assert integrity["region_outside_page_span_count"] == 1
+    assert integrity["ok"] is False
+    assert report["readiness_checks"]["citation_renderer_compatible"] is False
 
 
 def test_aggregate_report_omits_private_text_filenames_and_paths(tmp_path: Path) -> None:
@@ -244,9 +307,23 @@ def test_aggregate_report_omits_private_text_filenames_and_paths(tmp_path: Path)
     assert "SHOULD_NOT_LEAK" not in encoded
     assert secret_filename not in encoded
     assert str(tmp_path) not in encoded
+    assert "doc-a::chunk-001" not in encoded
     assert report["privacy"]["aggregate_only"] is True
+    assert report["privacy"]["omits_chunk_ids"] is True
     assert report["artifacts"]["kordoc_cache"]["markdown_has_page_markers"] is True
     assert report["artifacts"]["kordoc_cache"]["manifest_entry_key_counts"]["source_relpath"] == 1
+
+
+def test_readiness_checks_scan_payload_for_private_path_values(tmp_path: Path) -> None:
+    report_payload = {
+        "privacy": {"aggregate_only": True, "omits_source_paths": True},
+        "future_field": str(tmp_path / "private_agency_secret.pdf"),
+    }
+
+    checks = readiness_checks([], report_payload)
+
+    assert checks["aggregate_only_outputs"] is True
+    assert checks["no_private_path_leakage"] is False
 
 
 def test_markdown_and_cli_emit_aggregate_decision(tmp_path: Path) -> None:
@@ -274,7 +351,12 @@ def test_markdown_and_cli_emit_aggregate_decision(tmp_path: Path) -> None:
     markdown = render_markdown(report)
     assert "Citation page claim: `NO-GO`" in markdown
     assert "requires_raw_source_reparse" in markdown
+    assert "## Implementation Matrix" in markdown
+    assert "## Readiness Checks" in markdown
+    assert markdown.rstrip().endswith("`full re-index`")
     assert report["decision"]["requires_parser_change"] is False
+    assert report["implementation_matrix"][0]["source_type"] == "csv_text_fallback"
+    assert report["implementation_matrix"][0]["requires_reindex"] is True
 
     completed = subprocess.run(
         [
@@ -295,5 +377,6 @@ def test_markdown_and_cli_emit_aggregate_decision(tmp_path: Path) -> None:
 
     assert completed.returncode == 0, completed.stderr
     assert "Citation page claim: `NO-GO`" in completed.stdout
+    assert completed.stdout.rstrip().endswith("`full re-index`")
     assert (out_dir / "page_metadata_recovery_audit.json").is_file()
     assert (out_dir / "page_metadata_recovery_audit.md").is_file()


### PR DESCRIPTION
## 1. What changed and why

docs: Add page metadata recovery readiness surface (#1471)

Closes #1471

🤖 Auto-shipped by scripts/claude-hooks/stop-ship.sh

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #1471

## 2. Files affected

- `docs/evaluation/page_metadata_recovery_plan.md`
- `scripts/page_metadata_recovery_audit.py`
- `tests/test_page_metadata_recovery_audit.py`

## 3. Risks

Auto-generated PR; no load-bearing paths changed.

## 4. Tests

Local tests passed (bash scripts/test.sh).

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (no load-bearing path changed)

## 6. Backward compatibility

No public-API change detected.

## 7. Out of scope

N/A — single-concern auto-shipped PR.
