### PR TITLE
[codex] Add page-aware parser contract

### DIFF
--- a/docs/evaluation/page_aware_parser_contract.md
+++ b/docs/evaluation/page_aware_parser_contract.md
@@ -1,0 +1,107 @@
+# Page-Aware Parser Output Contract
+
+## TL;DR
+
+Phase A adds a parser-output contract and validation surface for page metadata.
+It does not change retrieval, verifier, prompt, reranker, answer generation, or
+citation selection behavior.
+
+Full re-index remains blocked until parser output has valid non-zero
+`sections[].page_span` or `sections[].regions[].page_number` coverage.
+
+## Section Contract
+
+Parser outputs may attach page metadata to each section:
+
+```json
+{
+  "sections": [
+    {
+      "heading": "1. Scope",
+      "text": "Public synthetic section text.",
+      "page_span": [1, 2],
+      "regions": [
+        {
+          "page_number": 1,
+          "bbox": [10.0, 20.0, 110.0, 160.0],
+          "source": "visual_parser",
+          "type": "text",
+          "block_id": "public-synthetic::p001::b001"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Contract rules:
+
+- `sections[].page_span` is optional.
+- `sections[].regions` is optional.
+- `regions[].page_number` is optional.
+- `page_span` must be `[start:int, end:int]`.
+- `page_span` is valid only when `start <= end`.
+- If both `page_span` and `regions[].page_number` exist, every region page
+  number must fall inside the span.
+- Missing page metadata is valid, but counts as uncovered.
+
+The contract is validated by `parser_page_metadata_contract.py`. Runtime
+normalization helpers remain behavior-compatible and are not made fail-loud.
+
+## Validation Output
+
+`validate_page_metadata_sections(sections, source_group=None)` returns
+aggregate-only coverage:
+
+- total section count
+- count and rate with `page_span`
+- count and rate with `regions.page_number`
+- count and rate with any page metadata
+- uncovered count/rate
+- malformed category counts
+- `page_metadata_capability`: `page_aware_capable`, `page_blind`, or
+  `adapter_spike_required`
+
+Malformed metadata raises `PageMetadataContractError`, a `ValueError` subclass.
+The exception message and attached report include only aggregate categories and
+counts.
+
+## Privacy Boundary
+
+Validation reports must never include:
+
+- raw section text
+- private evidence snippets
+- `doc_id`
+- `chunk_id`
+- filenames
+- exact local paths
+- raw artifacts
+
+Committed fixtures for this surface are public synthetic fixtures only:
+`eval/fixtures/page_aware_parser_contract/`.
+
+## Adapter Boundaries
+
+Phase A only classifies source groups:
+
+- `page_aware_capable`: parser output already has valid page metadata coverage.
+- `adapter_spike_required`: the source type plausibly can become page-aware,
+  but needs adapter work first, such as kordoc/HWP page-aware extraction,
+  visual PDF/image artifact mapping, or HWP render-to-PDF/image processing.
+- `page_blind`: current output has no page boundary signal and cannot support
+  page-aware re-index without reparsing from a better source.
+
+No full HWP/PDF parser implementation is included in Phase A.
+
+## Re-Index Readiness
+
+A page-aware re-index is ready only when parser output validation reports:
+
+- `ok: true`
+- `with_any_page_metadata_count > 0`
+- no malformed `page_span` or `regions.page_number` metadata
+- aggregate-only reports with no private content leakage
+
+Until then, page-level citation claims remain blocked and the current index
+should not be rebuilt for page metadata.

--- a/docs/evaluation/page_metadata_recovery_plan.md
+++ b/docs/evaluation/page_metadata_recovery_plan.md
@@ -12,6 +12,12 @@ chunking, reranker, or answer runtime behavior.
 
 Single recommendation: **full re-index** after page-aware parser output exists.
 
+Phase A is now explicitly contract/adapter/test/docs only. It adds the
+page-aware parser output contract documented in
+[`page_aware_parser_contract.md`](page_aware_parser_contract.md), but does not
+perform a full re-index and does not change retrieval, verifier, prompt,
+reranker, answer generation, citation selection, or other RAG runtime behavior.
+
 ## Current Boundary
 
 | boundary | current page metadata state | readiness implication |
@@ -23,6 +29,7 @@ Single recommendation: **full re-index** after page-aware parser output exists.
 | index build payload | `index.json` schema v2 can store optional chunk/parent page metadata. | Re-index is required once parser output is page-aware. |
 | eval summary rendering | Citation page/region coverage and precision aggregates already exist. | Re-evaluation can stay aggregate-only. |
 | citation renderer | `make_citation()` already propagates optional `regions` and `page_span`. | No citation selection or answer behavior change is required. |
+| parser output contract | `sections[].page_span` and `sections[].regions[].page_number` now have a fail-loud validation surface. | Re-index remains blocked until validated parser output coverage is greater than zero. |
 
 ## Recoverability
 
@@ -54,6 +61,8 @@ Phase A: restore page metadata only.
 - Run `scripts/page_metadata_recovery_audit.py` against local private index and optional local artifacts.
 - Keep outputs aggregate-only and commit no raw private text, evidence, filenames, `doc_id`, `chunk_id`, or local paths.
 - Rebuild a page-aware index only after parser output has `sections[].page_span` or `sections[].regions`.
+- Validate parser section output with `parser_page_metadata_contract.py`; malformed page metadata fails loudly, while missing page metadata is allowed and counted as uncovered.
+- Treat Phase A as contract/adapter/test/docs only. Full HWP/PDF parsing and full re-index remain follow-up work.
 
 Phase B: page-aware chunk serialization.
 
@@ -76,6 +85,7 @@ Phase D: optional visual/table-aware ingestion.
 ## Readiness Checks
 
 - `page_metadata_coverage_gt_0`: at least one chunk has `page_span` or `regions.page_number`.
+- `parser_output_page_metadata_coverage_gt_0`: at least one parser section has valid `page_span` or `regions.page_number`.
 - `chunk_page_span_integrity`: page spans are valid and region pages do not fall outside spans.
 - `citation_renderer_compatible`: existing renderer can propagate page metadata without behavior changes.
 - `no_private_path_leakage`: committed artifacts omit exact local paths and filenames.

--- a/eval/fixtures/page_aware_parser_contract/invalid_page_span.json
+++ b/eval/fixtures/page_aware_parser_contract/invalid_page_span.json
@@ -1,0 +1,15 @@
+{
+  "doc_id": "synthetic-page-contract-invalid-span",
+  "title": "Synthetic Invalid Page Span",
+  "metadata": {
+    "document_type": "public_synthetic_page_contract",
+    "synthetic": true
+  },
+  "sections": [
+    {
+      "heading": "Invalid Span",
+      "text": "This public synthetic section has malformed page metadata.",
+      "page_span": [4, 2]
+    }
+  ]
+}

--- a/eval/fixtures/page_aware_parser_contract/invalid_region_outside_span.json
+++ b/eval/fixtures/page_aware_parser_contract/invalid_region_outside_span.json
@@ -1,0 +1,22 @@
+{
+  "doc_id": "synthetic-page-contract-invalid-region",
+  "title": "Synthetic Invalid Region Page",
+  "metadata": {
+    "document_type": "public_synthetic_page_contract",
+    "synthetic": true
+  },
+  "sections": [
+    {
+      "heading": "Invalid Region",
+      "text": "This public synthetic section has a region outside its page span.",
+      "page_span": [2, 2],
+      "regions": [
+        {
+          "page_number": 3,
+          "bbox": [10.0, 20.0, 110.0, 160.0],
+          "source": "synthetic_fixture"
+        }
+      ]
+    }
+  ]
+}

--- a/eval/fixtures/page_aware_parser_contract/valid_sections.json
+++ b/eval/fixtures/page_aware_parser_contract/valid_sections.json
@@ -1,0 +1,34 @@
+{
+  "doc_id": "synthetic-page-contract-doc",
+  "title": "Synthetic Page Contract RFP",
+  "agency": "Synthetic Public Agency",
+  "project": "Page Metadata Contract Validation",
+  "metadata": {
+    "document_type": "public_synthetic_page_contract",
+    "file_format": "pdf",
+    "text_source": "visual_parsing_v2",
+    "synthetic": true
+  },
+  "sections": [
+    {
+      "heading": "1. Scope",
+      "section_path": ["1. Scope"],
+      "text": "This public synthetic section validates page_span propagation.",
+      "page_span": [1, 2]
+    },
+    {
+      "heading": "2. Region Evidence",
+      "section_path": ["2. Region Evidence"],
+      "text": "This public synthetic section validates region page metadata.",
+      "regions": [
+        {
+          "page_number": 3,
+          "bbox": [10.0, 20.0, 110.0, 160.0],
+          "source": "synthetic_fixture",
+          "type": "text",
+          "block_id": "synthetic-page-contract-doc::p003::b001"
+        }
+      ]
+    }
+  ]
+}

--- a/ingestion.py
+++ b/ingestion.py
@@ -688,6 +688,10 @@ def build_sections_with_native_tables(
     ``native_tables`` parameter is retained for signature compatibility
     but is asserted empty — ADR 0049 supersedes the per-table-section
     surface ADR 0036 introduced.
+
+    TODO(page-aware parser contract): kordoc/HWP and PDF text extraction stays
+    page-blind here until the adapter can emit section-level ``page_span`` or
+    ``regions[].page_number``. Do not infer pages from plain text offsets.
     """
     return [{"heading": "본문", "text": body_text}]
 

--- a/parser_page_metadata_contract.py
+++ b/parser_page_metadata_contract.py
@@ -1,0 +1,234 @@
+"""Parser output contract for optional section page metadata.
+
+This module validates parser-produced ``sections`` before page-aware re-index
+work. It is intentionally independent from RAG runtime normalizers so existing
+retrieval, verifier, answer, and citation behavior stays unchanged.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import re
+from typing import Any, Mapping, Sequence
+
+
+PAGE_AWARE_CAPABLE = "page_aware_capable"
+PAGE_BLIND = "page_blind"
+ADAPTER_SPIKE_REQUIRED = "adapter_spike_required"
+SAFE_SOURCE_GROUP_RE = re.compile(r"^[A-Za-z0-9_:/-]+$")
+PRIVATE_SOURCE_VALUE_RE = re.compile(
+    r"(^|[\s\"'`])(/Users/|/private/|/tmp/|/var/|/home/|/Volumes/|[A-Za-z]:\\)"
+)
+FILENAME_VALUE_RE = re.compile(
+    r"(^|[\s\"'`])[^/\s\"'`]+\.(pdf|hwp|hwpx|docx|xlsx|csv|jsonl|md|txt)\b",
+    re.IGNORECASE,
+)
+
+
+class PageMetadataContractError(ValueError):
+    """Raised when parser section page metadata violates the contract."""
+
+    def __init__(self, message: str, report: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.report = dict(report)
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 6)
+
+
+def _strict_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _safe_source_group(value: str | None) -> str:
+    label = str(value or "").strip()
+    if not label:
+        return "<unspecified>"
+    if PRIVATE_SOURCE_VALUE_RE.search(label) or FILENAME_VALUE_RE.search(label):
+        return "<redacted_source_group>"
+    if not SAFE_SOURCE_GROUP_RE.fullmatch(label):
+        return "<redacted_source_group>"
+    return label
+
+
+def _page_span(value: Any) -> tuple[int, int] | None:
+    if not isinstance(value, list) or len(value) != 2:
+        return None
+    if not all(_strict_int(page) for page in value):
+        return None
+    start, end = value
+    if start > end:
+        return None
+    return start, end
+
+
+def classify_parser_source_group(
+    *,
+    file_format: str | None = None,
+    text_source: str | None = None,
+    document_type: str | None = None,
+    any_page_metadata_coverage: float = 0.0,
+    parent_any_page_metadata_coverage: float = 0.0,
+) -> str:
+    """Classify whether a parser source group can support page-aware re-index.
+
+    The classification is aggregate-only and does not include identifiers,
+    filenames, source paths, or raw text.
+    """
+
+    if any_page_metadata_coverage > 0 or parent_any_page_metadata_coverage > 0:
+        return PAGE_AWARE_CAPABLE
+
+    file_format = str(file_format or "")
+    text_source = str(text_source or "")
+    document_type = str(document_type or "")
+
+    if "visual" in text_source and "fallback" not in text_source:
+        return ADAPTER_SPIKE_REQUIRED
+    if "visual" in document_type and "fallback" not in document_type:
+        return ADAPTER_SPIKE_REQUIRED
+    if file_format == "pdf" and text_source == "kordoc":
+        return ADAPTER_SPIKE_REQUIRED
+    if file_format == "hwp" and text_source == "kordoc":
+        return ADAPTER_SPIKE_REQUIRED
+    if file_format == "hwp" and "fallback" in document_type:
+        return ADAPTER_SPIKE_REQUIRED
+    return PAGE_BLIND
+
+
+def _empty_report(source_group: str | None) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "source_group": _safe_source_group(source_group),
+        "section_count": 0,
+        "with_page_span_count": 0,
+        "with_regions_page_number_count": 0,
+        "with_any_page_metadata_count": 0,
+        "uncovered_count": 0,
+        "uncovered_rate": 0.0,
+        "page_span_coverage": 0.0,
+        "regions_page_number_coverage": 0.0,
+        "any_page_metadata_coverage": 0.0,
+        "malformed_counts": {},
+        "ok": True,
+        "page_aware_capable": False,
+        "page_metadata_capability": PAGE_BLIND,
+        "privacy": {
+            "aggregate_only": True,
+            "omits_raw_text": True,
+            "omits_doc_ids": True,
+            "omits_chunk_ids": True,
+            "omits_file_names": True,
+            "omits_source_paths": True,
+        },
+    }
+
+
+def validate_page_metadata_sections(
+    sections: Sequence[Mapping[str, Any]],
+    source_group: str | None = None,
+) -> dict[str, Any]:
+    """Validate parser output page metadata and return aggregate coverage.
+
+    Missing page metadata is valid and counted as uncovered. Malformed
+    ``page_span`` / ``regions`` metadata raises ``PageMetadataContractError``
+    with aggregate counts only.
+    """
+
+    if not isinstance(sections, Sequence) or isinstance(sections, (str, bytes)):
+        report = _empty_report(source_group)
+        report["malformed_counts"] = {"sections_not_sequence": 1}
+        report["ok"] = False
+        raise PageMetadataContractError(
+            "parser page metadata contract failed: sections_not_sequence=1",
+            report,
+        )
+
+    section_count = len(sections)
+    with_page_span = 0
+    with_region_page = 0
+    with_any_page = 0
+    malformed: Counter[str] = Counter()
+
+    for section in sections:
+        if not isinstance(section, Mapping):
+            malformed["section_not_object"] += 1
+            continue
+
+        raw_page_span = section.get("page_span")
+        has_page_span_key = "page_span" in section and raw_page_span is not None
+        page_span = _page_span(raw_page_span) if has_page_span_key else None
+        if has_page_span_key and page_span is None:
+            malformed["invalid_page_span"] += 1
+
+        raw_regions = section.get("regions")
+        regions: list[Mapping[str, Any]] = []
+        if "regions" in section and raw_regions is not None:
+            if not isinstance(raw_regions, list):
+                malformed["regions_not_list"] += 1
+            else:
+                for region in raw_regions:
+                    if not isinstance(region, Mapping):
+                        malformed["region_not_object"] += 1
+                        continue
+                    regions.append(region)
+
+        section_has_region_page = False
+        for region in regions:
+            if "page_number" not in region or region.get("page_number") is None:
+                continue
+            page_number = region.get("page_number")
+            if not _strict_int(page_number):
+                malformed["invalid_region_page_number"] += 1
+                continue
+            section_has_region_page = True
+            if page_span is not None:
+                start, end = page_span
+                if not (start <= page_number <= end):
+                    malformed["region_page_outside_page_span"] += 1
+
+        if page_span is not None:
+            with_page_span += 1
+        if section_has_region_page:
+            with_region_page += 1
+        if page_span is not None or section_has_region_page:
+            with_any_page += 1
+
+    uncovered = section_count - with_any_page
+    report = {
+        "schema_version": 1,
+        "source_group": _safe_source_group(source_group),
+        "section_count": section_count,
+        "with_page_span_count": with_page_span,
+        "with_regions_page_number_count": with_region_page,
+        "with_any_page_metadata_count": with_any_page,
+        "uncovered_count": uncovered,
+        "uncovered_rate": _rate(uncovered, section_count),
+        "page_span_coverage": _rate(with_page_span, section_count),
+        "regions_page_number_coverage": _rate(with_region_page, section_count),
+        "any_page_metadata_coverage": _rate(with_any_page, section_count),
+        "malformed_counts": dict(sorted(malformed.items())),
+        "ok": not malformed,
+        "page_aware_capable": with_any_page > 0 and not malformed,
+        "page_metadata_capability": (
+            PAGE_AWARE_CAPABLE if with_any_page > 0 and not malformed else PAGE_BLIND
+        ),
+        "privacy": {
+            "aggregate_only": True,
+            "omits_raw_text": True,
+            "omits_doc_ids": True,
+            "omits_chunk_ids": True,
+            "omits_file_names": True,
+            "omits_source_paths": True,
+        },
+    }
+    if malformed:
+        detail = ", ".join(f"{key}={value}" for key, value in sorted(malformed.items()))
+        raise PageMetadataContractError(
+            f"parser page metadata contract failed: {detail}",
+            report,
+        )
+    return report

--- a/scripts/page_metadata_recovery_audit.py
+++ b/scripts/page_metadata_recovery_audit.py
@@ -18,6 +18,12 @@ import re
 import sys
 from typing import Any, Iterable, Mapping, Sequence
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from parser_page_metadata_contract import classify_parser_source_group
+
 
 SAFE_LABEL_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 PAGE_LIKE_KEY_RE = re.compile(r"page|bbox|region", re.IGNORECASE)
@@ -402,6 +408,13 @@ def source_group_coverage(
             "regions_bbox_coverage": chunk_block["regions_bbox_coverage"],
             "parent_any_page_metadata_coverage": parent_block["any_page_metadata_coverage"],
         }
+        result["page_metadata_capability"] = classify_parser_source_group(
+            file_format=result["file_format"],
+            text_source=result["text_source"],
+            document_type=result["document_type"],
+            any_page_metadata_coverage=result["any_page_metadata_coverage"],
+            parent_any_page_metadata_coverage=result["parent_any_page_metadata_coverage"],
+        )
         result["decision"] = _group_decision(result)
         results.append(result)
     return results
@@ -531,6 +544,7 @@ def visual_artifact_audit(artifact_dir: Path | None) -> dict[str, Any]:
                 blocks_with_page += int(isinstance(block.get("page_number"), int))
                 blocks_with_bbox += int(_is_bbox(block.get("bbox")))
 
+    section_page_coverage = _rate(sections_with_page, section_count)
     return {
         "present": True,
         "status": "ok",
@@ -538,10 +552,15 @@ def visual_artifact_audit(artifact_dir: Path | None) -> dict[str, Any]:
         "page_count": page_count,
         "section_count": section_count,
         "sections_with_any_page_metadata_count": sections_with_page,
-        "section_page_metadata_coverage": _rate(sections_with_page, section_count),
+        "section_page_metadata_coverage": section_page_coverage,
         "blocks_with_page_number_count": blocks_with_page,
         "blocks_with_bbox_count": blocks_with_bbox,
         "has_recoverable_page_metadata": sections_with_page > 0 or blocks_with_page > 0,
+        "page_metadata_capability": classify_parser_source_group(
+            text_source="visual_artifacts",
+            document_type="visual_artifacts",
+            any_page_metadata_coverage=section_page_coverage,
+        ),
     }
 
 
@@ -709,6 +728,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             f"page_span=`{group['page_span_coverage']}`, "
             f"regions.page_number=`{group['regions_page_number_coverage']}`, "
             f"regions.bbox=`{group['regions_bbox_coverage']}`, "
+            f"capability=`{group.get('page_metadata_capability')}`, "
             f"decision=`{group['decision']}`"
         )
     lines.extend(

--- a/tests/test_page_aware_parser_contract.py
+++ b/tests/test_page_aware_parser_contract.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from parser_page_metadata_contract import (
+    ADAPTER_SPIKE_REQUIRED,
+    PAGE_AWARE_CAPABLE,
+    PAGE_BLIND,
+    PageMetadataContractError,
+    classify_parser_source_group,
+    validate_page_metadata_sections,
+)
+from rag_indexing import build_chunks, normalize_json_document
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = ROOT_DIR / "eval" / "fixtures" / "page_aware_parser_contract"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_valid_page_span_passes() -> None:
+    report = validate_page_metadata_sections(
+        [{"heading": "Scope", "text": "Synthetic text.", "page_span": [1, 2]}],
+        source_group="pdf/visual_parsing_v2/public_synthetic_page_contract",
+    )
+
+    assert report["ok"] is True
+    assert report["section_count"] == 1
+    assert report["with_page_span_count"] == 1
+    assert report["with_any_page_metadata_count"] == 1
+    assert report["page_aware_capable"] is True
+    assert report["page_metadata_capability"] == PAGE_AWARE_CAPABLE
+
+
+def test_invalid_page_span_fails_loudly_without_raw_values() -> None:
+    with pytest.raises(PageMetadataContractError) as exc_info:
+        validate_page_metadata_sections(
+            [
+                {
+                    "heading": "Synthetic heading must not leak",
+                    "text": "SYNTHETIC_SNIPPET_SHOULD_NOT_LEAK",
+                    "doc_id": "synthetic-doc-id-should-not-leak",
+                    "chunk_id": "synthetic-chunk-id-should-not-leak",
+                    "source_path": "synthetic-source.pdf",
+                    "file_name": "synthetic-source.pdf",
+                    "page_span": [3, 1],
+                }
+            ],
+            source_group="synthetic-source.pdf",
+        )
+
+    message = str(exc_info.value)
+    encoded_report = json.dumps(exc_info.value.report, ensure_ascii=False)
+    assert "invalid_page_span=1" in message
+    assert exc_info.value.report["source_group"] == "<redacted_source_group>"
+    for forbidden in (
+        "SYNTHETIC_SNIPPET_SHOULD_NOT_LEAK",
+        "synthetic-doc-id-should-not-leak",
+        "synthetic-chunk-id-should-not-leak",
+        "synthetic-source.pdf",
+    ):
+        assert forbidden not in message
+        assert forbidden not in encoded_report
+
+
+def test_region_page_outside_page_span_fails() -> None:
+    with pytest.raises(PageMetadataContractError) as exc_info:
+        validate_page_metadata_sections(
+            [
+                {
+                    "heading": "Region",
+                    "text": "Synthetic text.",
+                    "page_span": [2, 2],
+                    "regions": [{"page_number": 3}],
+                }
+            ]
+        )
+
+    assert exc_info.value.report["malformed_counts"] == {
+        "region_page_outside_page_span": 1
+    }
+
+
+def test_missing_page_metadata_is_allowed_and_counted_uncovered() -> None:
+    report = validate_page_metadata_sections(
+        [
+            {"heading": "Body", "text": "Synthetic text without page metadata."},
+            {"heading": "Scope", "text": "Synthetic text.", "page_span": [1, 1]},
+        ]
+    )
+
+    assert report["ok"] is True
+    assert report["section_count"] == 2
+    assert report["with_any_page_metadata_count"] == 1
+    assert report["uncovered_count"] == 1
+    assert report["uncovered_rate"] == 0.5
+
+
+def test_region_page_number_must_be_int_when_present() -> None:
+    with pytest.raises(PageMetadataContractError) as exc_info:
+        validate_page_metadata_sections(
+            [
+                {
+                    "heading": "Region",
+                    "text": "Synthetic text.",
+                    "regions": [{"page_number": "2"}],
+                }
+            ]
+        )
+
+    assert exc_info.value.report["malformed_counts"] == {
+        "invalid_region_page_number": 1
+    }
+
+
+def test_source_group_capability_classification() -> None:
+    assert (
+        classify_parser_source_group(
+            file_format="pdf",
+            text_source="visual_parsing_v2",
+            document_type="visual_parsing_v2",
+            any_page_metadata_coverage=1.0,
+        )
+        == PAGE_AWARE_CAPABLE
+    )
+    assert (
+        classify_parser_source_group(
+            file_format="hwp",
+            text_source="kordoc",
+            document_type="private_pdf_hwp_csv_text",
+        )
+        == ADAPTER_SPIKE_REQUIRED
+    )
+    assert (
+        classify_parser_source_group(
+            file_format="pdf",
+            text_source="data_list_csv_text",
+            document_type="private_pdf_hwp_csv_text",
+        )
+        == PAGE_BLIND
+    )
+
+
+def test_public_fixture_roundtrip_preserves_page_metadata() -> None:
+    payload = _load_fixture("valid_sections.json")
+    report = validate_page_metadata_sections(payload["sections"])
+    document = normalize_json_document(payload, FIXTURE_DIR / "valid_sections.json")
+    chunks = build_chunks([document], chunking_strategy="section", max_chars=1000)
+
+    assert report["with_page_span_count"] == 1
+    assert report["with_regions_page_number_count"] == 1
+    assert chunks[0]["page_span"] == [1, 2]
+    assert chunks[1]["page_span"] == [3, 3]
+    assert chunks[1]["regions"][0]["page_number"] == 3
+    assert chunks[1]["regions"][0]["bbox"] == [10.0, 20.0, 110.0, 160.0]
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "malformed_key"),
+    [
+        ("invalid_page_span.json", "invalid_page_span"),
+        ("invalid_region_outside_span.json", "region_page_outside_page_span"),
+    ],
+)
+def test_malformed_public_fixtures_fail(fixture_name: str, malformed_key: str) -> None:
+    payload = _load_fixture(fixture_name)
+
+    with pytest.raises(PageMetadataContractError) as exc_info:
+        validate_page_metadata_sections(payload["sections"])
+
+    assert exc_info.value.report["malformed_counts"][malformed_key] == 1

--- a/visual_ingestion.py
+++ b/visual_ingestion.py
@@ -780,6 +780,9 @@ def finalize_visual_artifact(artifact: dict[str, Any]) -> None:
     if heuristic_tables:
         artifact["tables"].extend(heuristic_tables)
     artifact["field_candidates"] = extract_field_candidates(blocks)
+    # TODO(page-aware parser contract): visual PDF/image artifacts are the
+    # intended page-aware path; keep this boundary explicit when adding richer
+    # layout/OCR adapters so section ``page_span`` remains parser-owned.
     artifact["sections"] = build_sections_from_blocks(blocks)
 
     if not artifact["sections"]:
@@ -823,6 +826,8 @@ def make_hwp_fallback_document(
         mark_failed(artifact, "empty_text")
         return None, artifact
 
+    # TODO(page-aware parser contract): replace this page-blind fallback only
+    # with a real HWP render-to-PDF/image path or page-aware HWP extraction.
     region = {
         "page_number": None,
         "bbox": None,
@@ -1231,4 +1236,3 @@ def make_visual_report(
         "summary": summary,
         "records": [asdict(record) for record in records],
     }
-


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1475

Phase A page-aware parser output contract를 추가했습니다. parser section의 optional page_span / regions.page_number를 fail-loud로 검증하고 aggregate-only coverage를 보고해, full re-index 전에 parser output이 page-aware 준비 상태인지 판단할 수 있게 합니다. RAG runtime retrieval/verifier/prompt/reranker/answer/citation selection 동작은 바꾸지 않았습니다.

## 2. 영향 파일

- `parser_page_metadata_contract.py` — parser page metadata validation helper와 source group capability 분류 추가.
- `tests/test_page_aware_parser_contract.py`, `eval/fixtures/page_aware_parser_contract/` — public synthetic fixture와 malformed fixture test 추가. (load-bearing: `eval/`)
- `scripts/page_metadata_recovery_audit.py` — aggregate-only source group capability 필드 추가. 동작 분기 없음.
- `ingestion.py`, `visual_ingestion.py` — adapter spike TODO 경계만 추가. (load-bearing)
- `docs/evaluation/page_aware_parser_contract.md`, `docs/evaluation/page_metadata_recovery_plan.md` — contract와 re-index block 조건 문서화.

## 3. 리스크

- 가장 큰 리스크는 malformed page metadata를 조용히 통과시키거나, validation report에 raw text / filename / id / path가 새는 것입니다. 새 helper는 aggregate count만 반환하고 tests에서 raw-like synthetic values가 메시지와 report에 없는지 확인했습니다.
- `scripts/page_metadata_recovery_audit.py`에 capability field가 추가되어 markdown output이 약간 늘어납니다. 기존 coverage/decision semantics는 유지했습니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_page_metadata_recovery_audit.py tests/test_page_aware_parser_contract.py tests/test_visual_ingestion.py tests/test_ingestion_kordoc_regression.py`
- Result: 58 passed, 11 existing warnings, 2 subtests passed.

## 5. Eval 영향

- Runtime retrieval/verifier/prompt/reranker/answer/citation selection 경로 변화 없음.
- Full re-index는 수행하지 않았습니다.
- Public synthetic parser contract fixture만 추가했습니다.

### 5b. Real-data delta

> **Reviewer 책임 (issue #1027):** §5b CI gate (`scripts/check_branch_and_issue.py --check-5b`) 는 **섹션·표·escape 문장의 *존재* 만** 강제한다. 표 안 숫자의 정확성, escape 문장 claim 의 진위는 자동 검증 불가 — reviewer 가 확인해야 한다. **CI 통과 ≠ §5b 내용 검증 완료.**

검색/검증 path 동작 변화 없음.

Reason: this PR adds parser-output contract validation, public synthetic fixtures, docs, and adapter TODO boundaries only. It does not change retrieval, verifier, prompt, reranker, answer generation, citation selection, chunk serialization semantics, or run a full re-index.

## 6. 하위 호환

- Existing runtime normalizers remain behavior-compatible.
- Existing answer/citation contract schema is unchanged; no ADR 0003 schema_version bump.
- New validation helper is additive and opt-in for parser contract/readiness checks.

## 7. 범위 외

- Full HWP/PDF page-aware parser implementation.
- HWP render-to-PDF/image path.
- Full re-index or private real-data artifact updates.
