### PR TITLE
docs: add AI engineering operating system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 ## 여기서 시작
 
 - [`docs/engineering-governance.md`](docs/engineering-governance.md) — 워크플로 맵
+- [`docs/operations/ai-engineering-operating-system.md`](docs/operations/ai-engineering-operating-system.md) — AI-agent 역할(role) / task queue / plan / review / eval evidence 운영 모델
+- [`tasks/queue.md`](tasks/queue.md) — 세션 간 이어지는 persistent task queue
+- [`docs/evaluation/surface-map.md`](docs/evaluation/surface-map.md) — smoke / synthetic benchmark / private real-eval claim 경계
+- [`docs/reviews/ai-review-checklists.md`](docs/reviews/ai-review-checklists.md) — normal / adversarial / benchmark / regression review 체크리스트
 - [`docs/adr/README.md`](docs/adr/README.md) — 결정 인덱스
 - [`docs/multi-agent-ownership.md`](docs/multi-agent-ownership.md) — 여러 agent 가 병행 작업할 때 조율 모델
 - [`docs/audits/`](docs/audits/) — Phase 3/4/5 eval-framework 감사 + failure inspection (retrieval-miss / verifier-false-negative / variance-source)
@@ -53,6 +57,8 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 
 - **non-trivial 변경 전 Plan subagent.** >1 파일 또는 >50 LOC, 또는 plan mode 진입 시 Plan subagent 우선. 오타/단일 라인만 예외
 - **읽기 다발 시 Explore subagent.** Read ≥5회 누적 또는 단일 파일 >200줄 → Explore 위임
+- **장기 작업은 queue + plan.** multi-session, load-bearing, eval/benchmark, 또는 >1 파일/>50 LOC 작업은 [`tasks/queue.md`](tasks/queue.md)에 상태를 남기고 [`docs/plans/TEMPLATE.md`](docs/plans/TEMPLATE.md) 기반 plan doc 를 사용. context loss 전후 handoff 는 [`docs/operations/long-session-workflow.md`](docs/operations/long-session-workflow.md) 형식으로 남김
+- **Eval/benchmark claim 은 surface 먼저.** smoke / synthetic benchmark / private real-eval 중 어느 표면인지 [`docs/evaluation/surface-map.md`](docs/evaluation/surface-map.md) 기준으로 명시하고, benchmark/eval claim 은 [`docs/reviews/ai-review-checklists.md`](docs/reviews/ai-review-checklists.md)의 Benchmark Validity Audit 대상
 - **Shipping 경로는 commit-0 에 확정.** `ship-pr` skill (수동 게이트, ADR 예약 + stacked 안전) vs `make ship-arm` (Stop-hook 자동 ship) 둘은 mutually exclusive — 동시 활성화 금지
 - 5축 ↔ 4-pillar 매핑 전체: [`docs/agent-utilization.md`](docs/agent-utilization.md). `self-review-quarterly` skill 이 해당 표 기준으로 채점
 - **측정·감사 skill.** `retrieval-eval` (4-phase retrieval 측정), `eval-framework-progressive-audit` (5-phase 프레임워크 감사), `adr-portfolio-signals` (ADR→시니어 시그널 매핑) — 해당 범위 작업 시 우선 호출

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 ## 여기서 시작
 
 - [`docs/engineering-governance.md`](docs/engineering-governance.md) — 워크플로 맵
+- [`docs/operations/ai-engineering-operating-system.md`](docs/operations/ai-engineering-operating-system.md) — AI-agent 역할(role) / task queue / plan / review / eval evidence 운영 모델
+- [`tasks/queue.md`](tasks/queue.md) — 세션 간 이어지는 persistent task queue
+- [`docs/evaluation/surface-map.md`](docs/evaluation/surface-map.md) — smoke / synthetic benchmark / private real-eval claim 경계
+- [`docs/reviews/ai-review-checklists.md`](docs/reviews/ai-review-checklists.md) — normal / adversarial / benchmark / regression review 체크리스트
 - [`docs/adr/README.md`](docs/adr/README.md) — 결정 인덱스
 - [`docs/multi-agent-ownership.md`](docs/multi-agent-ownership.md) — 여러 agent 가 병행 작업할 때 조율 모델
 - [`docs/audits/`](docs/audits/) — Phase 3/4/5 eval-framework 감사 + failure inspection (retrieval-miss / verifier-false-negative / variance-source)
@@ -53,6 +57,8 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 
 - **non-trivial 변경 전 Plan subagent.** >1 파일 또는 >50 LOC, 또는 plan mode 진입 시 Plan subagent 우선. 오타/단일 라인만 예외
 - **읽기 다발 시 Explore subagent.** Read ≥5회 누적 또는 단일 파일 >200줄 → Explore 위임
+- **장기 작업은 queue + plan.** multi-session, load-bearing, eval/benchmark, 또는 >1 파일/>50 LOC 작업은 [`tasks/queue.md`](tasks/queue.md)에 상태를 남기고 [`docs/plans/TEMPLATE.md`](docs/plans/TEMPLATE.md) 기반 plan doc 를 사용. context loss 전후 handoff 는 [`docs/operations/long-session-workflow.md`](docs/operations/long-session-workflow.md) 형식으로 남김
+- **Eval/benchmark claim 은 surface 먼저.** smoke / synthetic benchmark / private real-eval 중 어느 표면인지 [`docs/evaluation/surface-map.md`](docs/evaluation/surface-map.md) 기준으로 명시하고, benchmark/eval claim 은 [`docs/reviews/ai-review-checklists.md`](docs/reviews/ai-review-checklists.md)의 Benchmark Validity Audit 대상
 - **Shipping 경로는 commit-0 에 확정.** `ship-pr` skill (수동 게이트, ADR 예약 + stacked 안전) vs `make ship-arm` (Stop-hook 자동 ship) 둘은 mutually exclusive — 동시 활성화 금지
 - 5축 ↔ 4-pillar 매핑 전체: [`docs/agent-utilization.md`](docs/agent-utilization.md). `self-review-quarterly` skill 이 해당 표 기준으로 채점
 - **측정·감사 skill.** `retrieval-eval` (4-phase retrieval 측정), `eval-framework-progressive-audit` (5-phase 프레임워크 감사), `adr-portfolio-signals` (ADR→시니어 시그널 매핑) — 해당 범위 작업 시 우선 호출

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ python3 scripts/check_latency_slo.py --config eval/config.yaml --summary reports
 
 | 목적 | 링크 |
 |---|---|
+| AI-agent 장기 작업 운영 모델 | [`docs/operations/ai-engineering-operating-system.md`](docs/operations/ai-engineering-operating-system.md) |
+| Persistent task queue | [`tasks/queue.md`](tasks/queue.md) |
+| Eval surface / claim boundary | [`docs/evaluation/surface-map.md`](docs/evaluation/surface-map.md) |
 | ADR 인덱스 (77개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |
 | 분석 변형 결과 + benchmarking + latency 비교 | [`docs/benchmarking.md`](docs/benchmarking.md) / [`docs/eval/ablation-results.md`](docs/eval/ablation-results.md) |
 | 설계 배경 (한국 RFP 적응 5가지) | [`docs/design-background.md`](docs/design-background.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 - **[1-페이지 아키텍처 심층 분석](./architecture-deep-dive.md)** — 파이프라인 / ADR 매핑 / 측정 highlight 한 페이지 요약
 - [엔지니어링 거버넌스(워크플로 맵)](./engineering-governance.md)
+- [AI Engineering Operating System](operations/ai-engineering-operating-system.md) — 장기 AI-agent task / plan / review / eval evidence 운영 모델
+- [Persistent Task Queue](../tasks/queue.md) — 세션 간 이어지는 작업 상태
+- [AI Review Checklists](reviews/ai-review-checklists.md)
+- [Evaluation Surface Map](evaluation/surface-map.md)
 - [Architecture Decision Records](./adr/README.md)
 - [벤치마킹](./benchmarking.md)
 - [검색(retrieval) 강화 마일스톤](retrieval/retrieval-hardening.md)

--- a/docs/engineering-governance.md
+++ b/docs/engineering-governance.md
@@ -7,10 +7,11 @@
 | 관심사 | 단일 출처 | 비고 |
 |---|---|---|
 | 코딩 & 리뷰 규칙 | [`CLAUDE.md`](../CLAUDE.md) | Pre-PR 체크리스트, 금지 shortcut, 성능 기대치 |
+| AI-agent 운영 모델 | [`docs/operations/ai-engineering-operating-system.md`](./operations/ai-engineering-operating-system.md), [`tasks/queue.md`](../tasks/queue.md) | 역할(role), persistent task queue, plan doc, review/eval handoff |
 | Multi-agent 조율 | [`docs/multi-agent-ownership.md`](./multi-agent-ownership.md) | 7-way 소유권, `rag_core.py` lock holder, 병행 작업 충돌 해결 |
 | Load-bearing 결정 | [`docs/adr/`](./adr/README.md) | 결정 당 짧은 파일 1개, status 추적 |
 | 동작 계약 | [ADR 0003](./adr/0003-structured-answer-citation-contract.md), [`docs/agentic/answer-policy.md`](./agentic/answer-policy.md) | 답변 JSON shape, `schema_version`, status 값 |
-| Eval 표면 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`eval/config.yaml`](../eval/config.yaml), `eval/*.example.yaml` | 공개 fixture smoke는 commit 가능, private/internal eval은 local-only |
+| Eval 표면 | [ADR 0005](./adr/0005-eval-split-public-synthetic-private-local.md), [`docs/evaluation/surface-map.md`](./evaluation/surface-map.md), [`eval/config.yaml`](../eval/config.yaml), `eval/*.example.yaml` | 공개 fixture smoke는 commit 가능, private/internal eval은 local-only |
 | Reviewer 메트릭 | `reports/eval_summary.json`, private/internal aggregate docs | PR eval 델타 워크플로가 fixture smoke + latency diff를 PR 코멘트에 upsert |
 | 실패 분석 | [`docs/real-data/real-data-failure-taxonomy.md`](./real-data/real-data-failure-taxonomy.md), [`docs/real-data/failure-cases.md`](./real-data/failure-cases.md) | 우선순위 백로그의 원천 |
 | API 데모 | [`docs/operations/api-demo.md`](./operations/api-demo.md), `api/main.py` | reviewer 놀이터, 측정 기준 아님 |
@@ -22,15 +23,17 @@ non-trivial 변경의 체크리스트 (사람·AI 공용):
 
 1. **Issue 열기 또는 픽업 (필수, ADR 0007).** 실패 taxonomy + 우선순위 백로그가 1차 source. [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/) 사용. 브랜치+PR 은 이 issue 번호 참조 필수 — 컨벤션 체크 (CI) 가 merge 차단
 2. **ADR 필요한지 판단.** [`docs/adr/README.md`](./adr/README.md) 기준 사용. 대부분 불필요, 모호하면 issue 에 질문
-3. **기존 코드 점검.** 읽은 파일, 재사용 함수, 놀란 점 명시
-4. **Branch + worktree (병렬 시).** `<type>/issue-<N>[-<slug>]` (ADR 0007) — 예: `feat/issue-79-hybrid-retrieval`. Claude Code 기본 worktree 명 (`claude/<auto>`) 은 PR 전 rename (`git branch -m feat/issue-<N>-<slug>`)
-5. **변경 + 테스트.** 재사용 우선, one concern per PR. 동작 변경 무 테스트 = 사고. 회귀는 `tests/test_*_regression.py`
-6. **Eval 로컬 실행 (해당 시).** `make eval` 공개 fixture smoke. 실제 성능 변경은 private/internal eval aggregate와 비교
-7. **Push + PR.** PR body 는 [`.github/pull_request_template.md`](../.github/pull_request_template.md) 채움
-8. **CI 검증.** 3개 체크 (모든 PR): `Pytest` + `Eval delta vs base` + `Validate branch name + issue link` (ADR 0007, required status check)
-9. **리뷰 응답.** 리뷰 중 scope 추가 금지 — follow-up issue
-10. **Merge.** Squash-merge, 브랜치 삭제, worktree 정리
-11. **문서 갱신** (reviewer 가 알아야 할 변경 시): 평가 경계, private/internal aggregate evidence, ADR status, taxonomy entry
+3. **Task queue / plan 판단.** multi-session, load-bearing, eval/benchmark, 또는 >1 파일/>50 LOC 작업은 [`tasks/queue.md`](../tasks/queue.md)에 task를 남기고 [`docs/plans/TEMPLATE.md`](./plans/TEMPLATE.md) 기반 plan doc를 작성
+4. **기존 코드 점검.** 읽은 파일, 재사용 함수, 놀란 점 명시
+5. **Branch + worktree (병렬 시).** `<type>/issue-<N>[-<slug>]` (ADR 0007) — 예: `feat/issue-79-hybrid-retrieval`. Claude Code 기본 worktree 명 (`claude/<auto>`) 은 PR 전 rename (`git branch -m feat/issue-<N>-<slug>`)
+6. **변경 + 테스트.** 재사용 우선, one concern per PR. 동작 변경 무 테스트 = 사고. 회귀는 `tests/test_*_regression.py`
+7. **Eval 로컬 실행 (해당 시).** `make eval` 공개 fixture smoke. 실제 성능 변경은 private/internal eval aggregate와 비교. Claim boundary는 [`docs/evaluation/surface-map.md`](./evaluation/surface-map.md) 기준
+8. **Review checklist 선택.** 일반 review 외에 load-bearing은 deep review, eval/benchmark claim은 benchmark auditor checklist ([`docs/reviews/ai-review-checklists.md`](./reviews/ai-review-checklists.md))를 적용
+9. **Push + PR.** PR body 는 [`.github/pull_request_template.md`](../.github/pull_request_template.md) 채움
+10. **CI 검증.** 3개 체크 (모든 PR): `Pytest` + `Eval delta vs base` + `Validate branch name + issue link` (ADR 0007, required status check)
+11. **리뷰 응답.** 리뷰 중 scope 추가 금지 — follow-up issue
+12. **Merge.** Squash-merge, 브랜치 삭제, worktree 정리
+13. **문서/queue 갱신** (reviewer 가 알아야 할 변경 시): task status, 평가 경계, private/internal aggregate evidence, ADR status, taxonomy entry
 
 ## Milestones & 이슈 lifecycle
 

--- a/docs/evaluation/surface-map.md
+++ b/docs/evaluation/surface-map.md
@@ -1,0 +1,103 @@
+# Evaluation Surface Map
+
+이 문서는 BidMate-DocAgent의 평가(evaluation) 표면(surface)을 구분한다.
+핵심 원칙은 [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)다:
+public fixture smoke는 wiring과 regression을 확인하고, 실제 성능(performance)
+주장은 private/internal eval aggregate에서만 후보가 된다.
+
+## Surface Summary
+
+| Surface | 데이터 | 목적 | 대표 명령 | Commit boundary | 허용 claim |
+|---|---|---|---|---|---|
+| Public fixture smoke | `eval/fixtures/smoke_rfp/raw/`, `eval/config.yaml` | CI wiring, schema, deterministic regression, latency SLO | `make smoke`, `make harness-smoke`, `python3 eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml` | raw run은 local/generated, small fixture는 commit 가능 | "eval harness가 동작한다", "regression guard 통과" |
+| Public synthetic benchmark | `data/eval/benchmark/`, `configs/eval/benchmark_naive_rag_v1.yaml` | controlled failure discovery, ablation setup | `python3 eval/naive_rag/validate_benchmark_dataset.py --config configs/eval/benchmark_naive_rag_v1.yaml --report reports/benchmark/naive_rag_v1_validation.json`, `python3 -m eval.naive_rag.benchmark --config configs/eval/benchmark_naive_rag_v1.yaml` | synthetic corpus/config/gold는 public; generated run artifacts는 local | "synthetic v1에서 failure mode X 관측" |
+| Private real-eval | `eval/real_config.local.yaml`, private corpus/index, `reports/real100/` local outputs | real RFP aggregate evidence, hardcase stress, paired delta | `make real-eval-check`, `make real-eval`, `make real-eval-semantic`, `make real-eval-delta` | raw/per-case local-only; allowlisted aggregate-only artifact만 commit | "private aggregate에서 delta X, provenance Y" |
+| PR fixture eval | `.github/workflows/pr-eval.yml` | PR마다 public fixture delta와 tests 검증 | GitHub Actions `PR Eval Delta` | PR comment/check only | "CI smoke delta passed/failed" |
+| Slow tests | `pytest -m slow`, `.github/workflows/slow-tests.yml` | real-model/full-corpus risk 확인 | `PYTEST_ADDOPTS="-m slow" bash scripts/test.sh` | generated outputs local | "slow gate passed on date/SHA" |
+
+## Allowed And Disallowed Claims
+
+### Public Fixture Smoke
+
+허용:
+
+- `reports/eval_summary.json` schema가 유지된다.
+- smoke fixture에서 특정 regression이 재현/수정됐다.
+- latency SLO check가 통과/실패했다.
+
+금지:
+
+- "RAG quality improved" 같은 real-world 성능 주장.
+- public fixture accuracy/recall을 portfolio headline metric으로 확대.
+- smoke fixture delta만으로 load-bearing behavior safety를 주장.
+
+### Public Synthetic Benchmark
+
+허용:
+
+- synthetic corpus에서 특정 distractor/failure mode를 드러냈다.
+- 같은 synthetic dataset/config/index에서 A/B 비교가 재현된다.
+- benchmark validator가 leakage/gold-evidence 계약을 검증했다.
+
+금지:
+
+- synthetic benchmark 점수를 실제 RFP 성능으로 주장.
+- gold evidence provenance 없이 `expected_terms` 기반 metric을 benchmark claim으로 사용.
+- synthetic-only success로 private real-eval regression risk를 닫는 것.
+
+### Private Real-Eval
+
+허용:
+
+- aggregate-only result를 기반으로 한 hardcase stress claim.
+- dataset/config/index/provenance/command가 함께 있는 paired delta.
+- private/non-public임을 명시한 reviewer evidence.
+
+금지:
+
+- raw private question, answer, evidence, filename, exact local path, doc/chunk id 노출.
+- provenance 없는 headline metric.
+- 같은 config/index가 아닌 run끼리 직접 비교.
+
+## Required Evidence By Claim Type
+
+| Claim type | Required evidence |
+|---|---|
+| Regression fixed | failing-before/passing-after test or replay command, affected failure mode |
+| Benchmark improved | dataset id, config path, index provenance, command, metric with CI when available, artifact path |
+| Retrieval improved | `chunk_recall@k`, MRR/nDCG, same corpus/index build rules, semantic backend provenance if dense/hybrid |
+| Answer quality improved | answer metric semantics, abstention/citation guardrails, private aggregate if real-world claim |
+| Latency improved | timed region, warm/cold split, stage latency, same hardware/process caveat |
+| Privacy-safe report | aggregate-only proof, forbidden fields absent, commit allowlist path |
+
+## Critical Warnings
+
+- `reports/eval_summary.json` is usually public fixture smoke output. It is not private real-eval evidence.
+- `reports/real100/eval_summary.json` is local/private and gitignored. Do not commit it.
+- `artifacts/runs/*/metrics/eval_summary.json` belongs to a harness run. Compare only after checking
+  dataset/config/index/provenance.
+- `make real-eval` uses the deterministic offline hashing path unless overridden. It is useful for
+  repeatable private eval plumbing, but semantic dense/hybrid retrieval quality claims require
+  `make real-eval-semantic` or equivalent semantic index provenance.
+- CI green means non-slow tests plus fixture smoke gate passed. It does not mean private real-eval passed.
+
+## Benchmark Auditor Checklist
+
+Before accepting an eval/benchmark claim, verify:
+
+- surface is classified as smoke, synthetic benchmark, or private real-eval.
+- dataset/config/index/provenance are named.
+- command is reproducible or the private/non-public boundary is explicit.
+- metric semantics match the wording.
+- CI/smoke result is not used as real-world performance proof.
+- synthetic result is not used as private real-eval substitute.
+- private aggregate has no raw case content or raw IDs.
+- regression guardrails are reported, not only headline improvements.
+
+## Related Docs
+
+- [Benchmarking](../benchmarking.md)
+- [Eval Dataset Spec](../eval/eval-dataset-spec.md)
+- [Synthetic Naive RAG Benchmark v1 Design](./synthetic_benchmark_v1_design.md)
+- [Private Real-Eval Workflow](./private_real_eval_workflow.md)
+- [Pre-Improvement Readiness Checklist](./pre_improvement_readiness_checklist.md)

--- a/docs/operations/ai-engineering-operating-system.md
+++ b/docs/operations/ai-engineering-operating-system.md
@@ -1,0 +1,293 @@
+# AI Engineering Operating System
+
+이 문서는 BidMate-DocAgent에서 장기 AI-agent 작업을 운영하는 최소 운영체계다.
+기존 규칙의 단일 출처(source of truth)는 계속 [`CLAUDE.md`](../../CLAUDE.md),
+[`docs/engineering-governance.md`](../engineering-governance.md),
+[`docs/adr/README.md`](../adr/README.md)다. 이 문서는 새 규칙을 크게 추가하지
+않고, 역할(role) -> 태스크(task) -> 계획(plan) -> 구현(implementation) ->
+검토(review) -> 평가(evaluation) 근거(evidence)를 한 흐름으로 연결한다.
+
+## Repository Audit
+
+### 현재 강점
+
+- RFP 문서 인텔리전스라는 도메인 경계가 명확하다. 범용 AI 실험장이 아니라
+  ingestion -> 청킹(chunking) -> 검색(retrieval) -> 재순위(reranking) ->
+  근거(evidence) -> 답변(answer) -> 평가(evaluation) 파이프라인이다.
+- ADR 0001/0003/0005 등 핵심 계약(contract)이 살아 있고,
+  [`scripts/_governance.py`](../../scripts/_governance.py)가 load-bearing path와
+  여러 governance gate의 단일 출처다.
+- CI는 `pytest`, public fixture smoke eval, latency SLO, branch/issue convention,
+  baseline provenance, PR §5b real-data delta를 분리해서 검증한다.
+- private real-eval은 raw data/per-case output을 커밋하지 않고 aggregate-only
+  산출물만 허용하는 경계가 있다.
+- [`docs/audits/`](../audits/)와 [`docs/self-review/`](../self-review/)는
+  측정이 틀릴 수 있음을 문서화해 과대주장(over-claim)을 줄인다.
+
+### 현재 약점
+
+- AI-agent가 "지금 무엇을 해야 하는가"를 읽을 persistent task queue가 없다.
+- 계획(plan) 문서가 worktree/session 밖으로 안정적으로 남지 않아 context
+  compaction 이후 같은 결정을 다시 탐색한다.
+- reviewer checklist가 PR 템플릿, ADR, audit 문서에 흩어져 있어 리뷰어 역할을
+  맡은 agent가 무엇을 공격적으로 확인해야 하는지 즉시 알기 어렵다.
+- `reports/eval_summary.json`, `reports/real100/eval_summary.json`,
+  `artifacts/runs/*/metrics/eval_summary.json`가 모두 존재할 수 있어 잘못된
+  산출물을 비교할 위험이 있다.
+- `benchmark`, `real-eval`, `smoke`라는 말이 여러 실행 표면(surface)에 걸쳐
+  쓰여 장기 agent가 매번 의미를 재구성해야 한다.
+
+### Workflow Bottlenecks
+
+- 장기 작업의 Definition of Ready가 issue/ADR/문서에 분산되어 있다.
+- 구현자(implementer)가 plan 없이 큰 범위를 건드리면 `rag_core.py`, `eval/`,
+  benchmark 문서가 drift하기 쉽다.
+- 리뷰어(reviewer)는 "테스트 통과"와 "claim validity"를 분리해 검토해야 하지만,
+  현재 시작점이 명확하지 않다.
+- benchmark auditor 역할이 암묵적이라 synthetic-only success나 metric inflation을
+  초기에 차단하기 어렵다.
+
+### Likely Failure Modes
+
+- Public fixture smoke 결과를 성능(performance) 주장으로 확대한다.
+- Synthetic benchmark 결과를 real-world RFP 성능처럼 표현한다.
+- `make real-eval`의 deterministic hashing 경로를 dense/hybrid 검색 품질 근거로
+  오해한다. Semantic retrieval claim은 `make real-eval-semantic` 또는 명시적
+  semantic index provenance가 필요하다.
+- `naive_baseline`, answer dict schema, ADR 0005 privacy boundary 같은 invariant를
+  작은 refactor 안에서 조용히 바꾼다.
+- AI-agent가 새 abstraction을 만들지만 기존 helper/contract를 재사용하지 않는다.
+- Long session에서 ADR 번호, PR base, private artifact 위치, pending eval 상태가
+  사라져 같은 결정을 반복한다.
+
+### Minimum Viable Intervention
+
+최소 운영체계는 다음 네 가지다.
+
+1. [`tasks/queue.md`](../../tasks/queue.md): 세션을 넘어 읽히는 작은 task queue.
+2. [`docs/plans/TEMPLATE.md`](../plans/TEMPLATE.md): 큰 작업을 self-contained하게
+   만드는 plan doc 형식.
+3. [`docs/reviews/ai-review-checklists.md`](../reviews/ai-review-checklists.md):
+   normal/adversarial/benchmark/regression/docs review 체크리스트.
+4. [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md): smoke,
+   synthetic benchmark, private real-eval의 claim boundary.
+
+이 네 가지가 없으면 미래 agent는 다음 질문에 답하기 어렵다: 다음 작업은 무엇인가,
+내 역할은 무엇인가, 어떤 plan을 따라야 하는가, 어떤 근거를 남겨야 하는가,
+어떤 claim이 허용되는가, 어떤 checklist가 내 작업을 검토할 것인가.
+
+## Source Of Truth Map
+
+| 관심사 | 단일 출처 | 이 문서의 역할 |
+|---|---|---|
+| repo-wide agent 규칙 | [`CLAUDE.md`](../../CLAUDE.md), [`AGENTS.md`](../../AGENTS.md) | 긴 작업 시작 시 어디를 읽을지 연결 |
+| engineering lifecycle | [`docs/engineering-governance.md`](../engineering-governance.md) | lifecycle에 task/plan/review artifact 추가 |
+| multi-agent ownership | [`docs/multi-agent-ownership.md`](../multi-agent-ownership.md) | 역할(role)과 파일 소유권(owner)을 연결 |
+| load-bearing path | [`scripts/_governance.py`](../../scripts/_governance.py) | task/plan의 validation 기대치로 참조 |
+| eval split | [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md), [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md) | claim 허용/금지 정책을 운영 레벨로 노출 |
+| active task state | [`tasks/queue.md`](../../tasks/queue.md) | 세션 간 handoff 상태 저장 |
+| large-work plan | [`docs/plans/`](../plans/) | context loss 후 이어서 구현 가능한 설계 단위 |
+| review gate | [`docs/reviews/ai-review-checklists.md`](../reviews/ai-review-checklists.md) | reviewer/deep reviewer/benchmark auditor가 사용할 기준 |
+
+## Definition Of The Minimum Viable Operating System
+
+Minimum viable operating system은 다음 조건을 만족하면 충분하다.
+
+- Agent가 [`tasks/queue.md`](../../tasks/queue.md)를 읽고 다음 실행 가능한 task를
+  찾을 수 있다.
+- Task가 큰 범위면 [`docs/plans/TEMPLATE.md`](../plans/TEMPLATE.md)를 따른 plan
+  doc가 있고, plan이 acceptance criteria와 validation command를 포함한다.
+- Implementer는 task와 plan의 scope/non-goals 밖으로 나가지 않는다.
+- Reviewer는 [`docs/reviews/ai-review-checklists.md`](../reviews/ai-review-checklists.md)의
+  checklist로 test pass theater, fake abstraction, benchmark contamination,
+  unverifiable claim을 공격적으로 확인한다.
+- Evaluation 관련 claim은 [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md)의
+  surface별 허용 claim을 따른다.
+- Long session은 [`docs/operations/long-session-workflow.md`](./long-session-workflow.md)의
+  handoff block을 남긴다.
+
+## Agent Role Model
+
+| Role | 책임 | 입력 | 출력 | 하지 말아야 할 것 | Handoff |
+|---|---|---|---|---|---|
+| Planner | self-contained work를 정의하고 scope를 줄인다 | issue/idea, audits, ADR, current queue | task entry, plan doc, acceptance criteria | 구현 시작, 성능 claim 작성 | queue row + plan link + validation expectations |
+| Implementer | plan 범위 안에서 변경하고 evidence를 남긴다 | ready task, plan doc, repo rules | code/docs patch, tests, local validation summary | plan 없이 load-bearing 변경, scope creep, unrelated refactor | changed files + commands + residual risk |
+| Reviewer | diff가 task/plan/contract를 만족하는지 확인한다 | PR/diff, plan, validation output | findings, required fixes, approve/needs-work verdict | 새 기능 구현, benchmark claim 검증 생략 | checklist 결과 + blocking/non-blocking findings |
+| Deep Reviewer | architecture drift와 hidden coupling을 찾는다 | large/load-bearing diff, ADR, module map | architecture findings, required ADR/test changes | 단순 style review에 머무르기 | risk-ranked findings with file refs |
+| Benchmark Auditor | benchmark/eval validity와 claim boundary를 검증한다 | eval config, dataset/provenance, reports, PR claims | allowed/disallowed claim verdict, missing evidence | synthetic-only 성공을 real claim으로 승인 | surface classification + evidence table |
+| Maintainer | merge readiness와 repo coherence를 결정한다 | task, plan, reviews, CI, eval evidence | merge-ready decision, follow-up issues | 모든 구현 세부를 직접 소유하기 | final acceptance or explicit follow-up |
+
+## Work Lifecycle
+
+```text
+idea / issue
+  -> task queue entry
+  -> plan doc when required
+  -> ready task
+  -> implementation
+  -> local validation
+  -> review
+  -> deep review / benchmark audit when required
+  -> merge-ready evidence
+  -> done
+```
+
+### Planning Required
+
+Plan doc가 필요한 경우:
+
+- >1 파일 또는 >50 LOC가 예상되는 non-trivial 변경.
+- `rag_core.py`, `rag_retrieval.py`, `rag_verifier.py`, `rag_answer.py`,
+  `rag_query.py`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`,
+  `docs/adr/`, `scripts/build_index.py` 등 load-bearing path 변경.
+- 새 eval surface, benchmark, metric, scorer, dataset, artifact를 추가하거나
+  기존 claim boundary를 바꾸는 작업.
+- ADR threshold에 닿을 가능성이 있는 기준선(baseline), answer schema, eval split,
+  privacy boundary 변경.
+- 여러 AI-agent 또는 여러 worktree가 같은 목표를 나눠 수행하는 작업.
+
+Plan doc를 생략할 수 있는 경우:
+
+- 오타, broken link, 단일 문서의 짧은 clarification.
+- 테스트 expectation의 명백한 mechanical update.
+- artifact 경로나 README 링크처럼 동작/평가 claim이 변하지 않는 1-file 문서 정리.
+
+Plan을 생략해도 task entry에는 validation command와 evidence required를 적는다.
+
+### Review Escalation
+
+Benchmark Auditor가 필수인 경우:
+
+- `eval/`, `benchmarks/`, `harness/`, `configs/eval/`, `reports/real100/`,
+  `docs/evaluation/`, `docs/eval/`의 claim-bearing 변경.
+- 성능 개선, regression, benchmark, accuracy, recall, nDCG, latency, cost frontier,
+  hardcase 결과를 PR 본문이나 docs에 언급하는 변경.
+- synthetic benchmark 또는 private real-eval aggregate를 생성/수정하는 변경.
+
+Deep Reviewer가 필수인 경우:
+
+- load-bearing path 변경.
+- answer dict schema, pipeline preset, baseline, retrieval backend default,
+  scoring semantics, privacy boundary 변경.
+- 하나의 PR이 여러 ownership role을 건드리는 경우.
+
+### Merge-Ready Evidence
+
+Merge-ready evidence는 최소한 다음을 포함한다.
+
+- 관련 task id와 plan link.
+- 변경 파일 목록과 scope/non-goals 확인.
+- 실행한 validation command와 실제 결과.
+- load-bearing 변경이면 PR §5b real-data delta 또는 "검색/검증 path 동작 변화 없음"
+  같은 명시적 escape.
+- eval/benchmark claim이면 dataset/config/index/provenance/command/result artifact.
+- reviewer checklist 결과와 남은 risk.
+
+## Task Queue Usage
+
+Queue는 [`tasks/queue.md`](../../tasks/queue.md)가 canonical이다. 상태(status)는
+`backlog`, `ready`, `running`, `blocked`, `review`, `done`만 사용한다.
+
+운영 규칙:
+
+- Planner는 backlog task를 ready로 옮길 때 acceptance criteria와 validation command를
+  비워두지 않는다.
+- Implementer는 시작 시 status를 `running`으로 바꾸고 owner role을 명시한다.
+- Review 요청 전 status는 `review`가 되고 evidence required 항목이 채워져야 한다.
+- 완료 후 status는 `done`이 되며 PR/commit/evidence link가 남아야 한다.
+- Queue는 GitHub issue를 대체하지 않는다. 세션 간 운영 상태와 AI-agent handoff를
+  작게 저장하는 repo-local index다.
+
+## Plan Doc Usage
+
+Plan doc는 [`docs/plans/TEMPLATE.md`](../plans/TEMPLATE.md)를 복사해서 작성한다.
+파일명은 `docs/plans/<task-id>-<slug>.md` 형식이 좋다.
+
+Plan은 다음을 반드시 포함한다.
+
+- 문제(problem)와 현재 동작(current behavior).
+- 원하는 동작(desired behavior)과 non-goals.
+- architecture impact와 affected interfaces.
+- task breakdown.
+- acceptance criteria.
+- validation strategy.
+- rollback strategy.
+- failure modes.
+- eval/benchmark impact.
+- reviewer notes.
+
+좋은 plan은 새 AI session이 읽고 바로 이어서 구현할 수 있어야 한다. "조사 필요",
+"적절히 수정"처럼 검증 불가능한 문장은 plan의 핵심 항목으로 쓰지 않는다.
+
+## Reviewer System
+
+리뷰는 "테스트가 통과했는가"가 아니라 "claim이 검증 가능한가"를 확인한다.
+체크리스트는 [`docs/reviews/ai-review-checklists.md`](../reviews/ai-review-checklists.md)를
+사용한다.
+
+기본 원칙:
+
+- Normal review는 scope, tests, dead code, duplicated logic, contract drift를 본다.
+- Adversarial review는 AI-agent failure mode를 일부러 찾는다.
+- Benchmark audit는 dataset/config/provenance/metric semantics/claim wording을 본다.
+- Regression review는 이전 failure mode가 다시 열렸는지 본다.
+- Documentation/governance review는 source-of-truth drift와 stale links를 본다.
+
+## Evaluation Governance
+
+세 평가 표면(surface)을 섞지 않는다.
+
+| Surface | 허용 claim | 금지 claim |
+|---|---|---|
+| Public fixture smoke | wiring, schema, deterministic regression, latency budget | real-world model quality, production performance |
+| Synthetic benchmark | controlled failure discovery, ablation setup, reproducible comparison within synthetic data | real RFP performance, customer/procurement quality |
+| Private real-eval | aggregate-only real-world evidence, hardcase stress, paired delta | raw case disclosure, unreproducible headline without provenance |
+
+세부 정책은 [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md)를 따른다.
+
+## Long-Session Workflow
+
+Long session은 중간 handoff를 필수 산출물로 본다. 세션 종료, context compaction,
+review 요청, blocking 상태 전환 시 [`docs/operations/long-session-workflow.md`](./long-session-workflow.md)의
+handoff block을 남긴다.
+
+최소 handoff:
+
+- branch/worktree/issue/PR/base.
+- active role.
+- task id와 plan link.
+- touched surfaces.
+- decisions made.
+- commands run and results.
+- next safe command.
+- pending review/eval/ADR risks.
+
+## Migration Strategy
+
+기존 문서를 대체하지 않는다.
+
+1. `CLAUDE.md`와 `AGENTS.md`는 짧은 pointer만 추가한다.
+2. 새 작업부터 `tasks/queue.md`와 plan doc를 사용한다.
+3. 기존 open PR/issue를 모두 이 시스템으로 retro-fit하지 않는다.
+4. eval/benchmark claim이 있는 새 PR부터 Benchmark Auditor checklist를 적용한다.
+5. 불편한 항목만 automation으로 승격한다. 처음부터 새 CI gate를 만들지 않는다.
+
+## Incremental Rollout
+
+| 단계 | 적용 범위 | 성공 신호 |
+|---|---|---|
+| 1 | 새 multi-session 작업에 queue + plan 사용 | context loss 후 재개 가능 |
+| 2 | eval/benchmark PR에 benchmark audit checklist 사용 | synthetic/real claim 혼동 감소 |
+| 3 | load-bearing PR에 deep review checklist 명시 | architecture drift 발견률 증가 |
+| 4 | 반복 누락 항목만 hook/CI로 자동화 | 문서 규칙이 실제 gate로 승격 |
+
+## Risks And Tradeoffs
+
+- 문서가 늘어나는 비용이 있다. 그래서 task queue, plan, review, eval map만 최소로
+  추가하고, 새 code automation은 만들지 않는다.
+- Queue가 GitHub issue와 중복될 수 있다. Queue는 issue tracker가 아니라 AI-agent
+  handoff index로 한정한다.
+- Checklist가 형식적으로 채워질 위험이 있다. Reviewer는 checklist의 "N/A" 사유가
+  검증 가능한지 확인해야 한다.
+- Private real-eval은 로컬 산출물이라 외부 reviewer가 raw 재현을 할 수 없다.
+  따라서 aggregate-only provenance와 claim wording을 더 엄격히 유지한다.

--- a/docs/operations/long-session-workflow.md
+++ b/docs/operations/long-session-workflow.md
@@ -1,0 +1,134 @@
+# Long-Session AI Workflow
+
+이 문서는 multi-day 또는 multi-week AI-agent 작업을 context loss 없이 이어가기 위한
+운영 절차다. 목표는 agent가 같은 결정을 재탐색하지 않고, architecture consistency와
+eval validity를 유지하며, reviewer가 검증 가능한 근거(evidence)를 받게 하는 것이다.
+
+## When To Use
+
+다음 중 하나면 long-session workflow를 사용한다.
+
+- 작업이 하루를 넘기거나 여러 Codex/Claude 세션으로 나뉜다.
+- `tasks/queue.md`의 task가 `running`, `blocked`, `review` 상태로 남는다.
+- plan doc가 필요한 범위다.
+- load-bearing path, eval/benchmark, ADR, private real-eval evidence가 관련된다.
+- 여러 worktree 또는 여러 agent가 같은 목표를 나눠 맡는다.
+
+## Start Checklist
+
+1. [`CLAUDE.md`](../../CLAUDE.md)와 현재 task entry를 읽는다.
+2. [`tasks/queue.md`](../../tasks/queue.md)에서 task status와 owner role을 확인한다.
+3. plan doc가 있으면 먼저 읽고, 없는데 필요한 범위면 구현 전에 만든다.
+4. `git status --short --branch`로 worktree 상태를 확인한다.
+5. 관련 ADR과 eval surface를 확인한다.
+6. 다음 safe command를 정하고 실행한다.
+
+## Context Preservation Rules
+
+- 중요한 결정은 채팅 transcript에만 두지 않는다. plan doc 또는 task queue에 남긴다.
+- "나중에 해야 함"은 queue의 acceptance criteria, blocked reason, next action으로
+  옮긴다.
+- 성능 claim은 raw memory가 아니라 dataset/config/provenance/command/result artifact로
+  남긴다.
+- Private raw question, answer, evidence, doc/chunk id, exact local path는 handoff에
+  쓰지 않는다.
+- ADR 번호, PR base, stacked dependency, private artifact 위치는 handoff마다 갱신한다.
+
+## Handoff Template
+
+세션 종료, context compaction 전, blocked 전환, review 요청 전에 아래 block을 남긴다.
+위치는 task entry 하단 또는 plan doc의 "Session Handoff" 섹션이다.
+
+```markdown
+## Session Handoff — YYYY-MM-DD HH:MM TZ
+
+- Role:
+- Branch / worktree:
+- Issue / PR:
+- Task:
+- Plan:
+- Current status:
+- Files touched:
+- Decisions made:
+- Commands run:
+- Results:
+- Eval surface:
+- Evidence artifacts:
+- Blockers:
+- Next safe command:
+- Reviewer focus:
+- Risks:
+```
+
+## Branch And Worktree Guidance
+
+- 한 worktree는 한 task 또는 한 PR concern에 묶는다.
+- Stacked PR이면 base branch와 upstream PR 번호를 handoff에 적는다.
+- ADR 작성 전 `python scripts/_governance.py --next-adr-number`와
+  `gh pr list --search "ADR" --state open --json number,title,headRefName`를 확인한다.
+- `reports/eval_summary.json`류 산출물을 비교하기 전 dataset/config/index/provenance를
+  handoff에 적는다.
+- 고정 `/tmp/<name>` output path를 쓰지 않는다. 필요하면 `mktemp`를 사용한다.
+
+## Issue Batching
+
+Batching은 같은 failure mode 또는 같은 measurement surface 안에서만 한다.
+
+허용:
+
+- 하나의 benchmark hardening plan 아래 validator, docs, regression test를 나눈다.
+- retrieval measurement surface를 추가하고 그 산출 report를 같은 PR에 포함한다.
+
+금지:
+
+- eval scorer 변경과 retrieval algorithm 변경을 같은 PR에 섞는다.
+- ADR status 변경과 unrelated product fix를 묶는다.
+- private real-eval aggregate 업데이트와 README narrative rewrite를 한 concern처럼 처리한다.
+
+## ADR Usage
+
+ADR은 큰 문서가 아니라 load-bearing decision의 고정점이다. 다음이면 ADR을 고려한다.
+
+- baseline/pipeline/answer contract/eval surface를 제거, 교체, 의미 변경한다.
+- 새 measurement surface를 도입해 reviewer가 의존할 artifact가 생긴다.
+- 두 선택지 중 하나를 택했고, 나중에 그 trade-off를 방어해야 한다.
+
+Routine bug fix, typo, small refactor는 ADR 없이 PR 설명에 남긴다.
+
+## Preventing Rediscovery
+
+장기 agent가 같은 결정을 반복하지 않게 하려면:
+
+- task entry에 "Decisions already made"를 유지한다.
+- plan doc에는 rejected alternatives를 적는다.
+- eval surface는 [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md)를 링크한다.
+- reviewer가 지적한 non-blocking risk는 follow-up task로 분리한다.
+- 막힌 이유는 "blocked" 상태와 unblock command로 적는다.
+
+## Continuation Prompt
+
+새 AI-agent 세션을 시작할 때는 아래처럼 넘긴다.
+
+```text
+Role: Implementer
+Repo: BidMate-DocAgent
+Task: <task id and title>
+Read first:
+- CLAUDE.md
+- tasks/queue.md entry <id>
+- docs/plans/<plan>.md
+- docs/evaluation/surface-map.md if eval/benchmark is touched
+Continue from the latest Session Handoff.
+Do not expand scope beyond acceptance criteria.
+Before final response, update the task status and evidence.
+```
+
+## Done Criteria
+
+Long-session task는 다음이 모두 충족되어야 done이다.
+
+- queue status가 `done`이고 PR/commit/evidence 링크가 있다.
+- plan acceptance criteria가 충족되거나 명시적으로 revised되었다.
+- validation commands가 실제 실행 결과와 함께 기록됐다.
+- reviewer/deep reviewer/benchmark auditor가 필요한 경우 checklist 결과가 있다.
+- 남은 위험이 follow-up task 또는 PR note로 분리됐다.

--- a/docs/plans/EXAMPLE-benchmark-hardening.md
+++ b/docs/plans/EXAMPLE-benchmark-hardening.md
@@ -1,0 +1,129 @@
+# Plan: T-2026-0001 Benchmark Hardening Against Synthetic Contamination
+
+- Status: example
+- Owner role: Planner
+- Related task: [`tasks/examples/benchmark-hardening.md`](../../tasks/examples/benchmark-hardening.md)
+- Related issue / PR: example only
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+## Problem Statement
+
+The public synthetic Naive RAG benchmark is useful for failure discovery, but it
+can become misleading if the benchmark index reads question/gold/expected-answer
+fields or if benchmark wording is used as real-world performance evidence.
+
+## Current Behavior
+
+Synthetic benchmark assets live under `data/eval/benchmark/` and
+`configs/eval/benchmark_naive_rag_v1.yaml`. The design doc states that the index
+must be built only from frozen corpus chunks and must not read questions, gold
+evidence, expected answers, or expected terms. The claim boundary is documented,
+but future agents can still weaken it by adding convenience code or docs that
+blur smoke, synthetic benchmark, and private real-eval.
+
+## Desired Behavior
+
+Benchmark runs should remain useful for controlled synthetic failure discovery
+without becoming evidence for real RFP performance. The benchmark validation path
+should make contamination and over-claiming harder to miss.
+
+## Scope
+
+- Add or verify checks that benchmark index build reads only corpus chunks.
+- Add reviewer-facing documentation that benchmark claims are synthetic-only.
+- Add regression tests for validator behavior if code changes are needed.
+
+## Non-Goals
+
+- Do not improve retrieval, reranking, answer generation, or verifier behavior.
+- Do not change private real-eval scoring.
+- Do not add a new benchmark dataset.
+- Do not claim product-quality improvement.
+
+## Constraints
+
+- ADR 0005 privacy and public/private split remain unchanged.
+- `naive_baseline` remains the control.
+- Public synthetic data may be committed; generated run artifacts remain local.
+- Any claim-bearing doc must link to [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md).
+
+## Architecture Impact
+
+- Affected modules: `eval/naive_rag/validate_benchmark_dataset.py`,
+  `eval/naive_rag/build_benchmark_index.py`, docs under `docs/evaluation/`.
+- Affected contracts: synthetic benchmark v1 input separation and claim boundary.
+- Load-bearing paths: `eval/` if validator or runner changes.
+- ADR impact: no new ADR unless a new measurement surface or claim contract is created.
+
+## Affected Interfaces
+
+- CLI: benchmark validation and index build commands.
+- Output artifacts: validation report under `reports/benchmark/`.
+- Docs: benchmark design/results wording.
+- Tests: focused validator/index-build regression tests.
+
+## Task Breakdown
+
+1. Inspect benchmark index builder inputs and confirm it does not parse questions/gold.
+2. Add regression coverage if the invariant is not already tested.
+3. Tighten docs so synthetic result wording cannot be read as private real-eval evidence.
+4. Run validation and focused tests.
+
+## Acceptance Criteria
+
+- [ ] Benchmark index builder reads `corpus_chunks_v1.jsonl` only.
+- [ ] Validator catches missing/invalid explicit gold evidence and leakage warnings remain visible.
+- [ ] Docs state that synthetic benchmark supports failure discovery, not real-world claims.
+- [ ] Review checklist identifies benchmark auditor as required.
+
+## Validation Strategy
+
+```bash
+python3 eval/naive_rag/validate_benchmark_dataset.py \
+  --config configs/eval/benchmark_naive_rag_v1.yaml \
+  --report reports/benchmark/naive_rag_v1_validation.json
+
+python3 -m eval.naive_rag.build_benchmark_index \
+  --corpus data/eval/benchmark/corpus_chunks_v1.jsonl \
+  --output data/eval/benchmark/index_v1
+
+python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
+python3 scripts/check_doc_links.py --check-all
+```
+
+Expected evidence:
+
+- validation report path and summary counts.
+- focused pytest result.
+- no real-world performance claim in changed docs.
+
+## Rollback Strategy
+
+Revert validator/test/doc changes. Do not delete benchmark data unless the plan
+explicitly changes dataset versioning.
+
+## Failure Modes
+
+- Index builder accidentally reads gold labels and inflates retrieval metrics.
+- Docs imply synthetic benchmark performance generalizes to private RFPs.
+- Validation report is generated but not reviewed.
+- New tests assert implementation details instead of contamination boundary.
+
+## Observability
+
+- Validation report: leakage warnings, dataset counts, gold evidence summary.
+- Test result: benchmark input separation and schema checks.
+- Review output: Benchmark Auditor verdict.
+
+## Eval / Benchmark Impact
+
+- Surface: public synthetic benchmark.
+- Allowed claim: benchmark hardening improved contamination resistance.
+- Disallowed claim: RAG model quality improved on real RFPs.
+- Benchmark auditor required: yes.
+
+## Reviewer Notes
+
+Attack the claim wording first. Then inspect whether any code path can read
+questions, expected answers, expected terms, or gold evidence during index build.

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -1,0 +1,121 @@
+# Plan: <task-id> <title>
+
+- Status: proposed
+- Owner role: Planner
+- Related task: `tasks/queue.md::<task-id>`
+- Related issue / PR:
+- Created:
+- Last updated:
+
+## Problem Statement
+
+What concrete failure, bottleneck, or missing capability does this plan address?
+
+## Current Behavior
+
+Describe the current code/docs/eval workflow. Include relevant files, commands,
+ADR, and observed failure modes.
+
+## Desired Behavior
+
+Describe the smallest useful end state. This must be testable.
+
+## Scope
+
+- In scope:
+- In scope:
+
+## Non-Goals
+
+- Out of scope:
+- Out of scope:
+
+## Constraints
+
+- Architecture constraints:
+- Eval/privacy constraints:
+- Compatibility constraints:
+- Tooling/CI constraints:
+
+## Architecture Impact
+
+- Affected modules:
+- Affected contracts:
+- Load-bearing paths:
+- ADR impact:
+
+## Affected Interfaces
+
+- CLI/API/config:
+- Output artifacts:
+- Docs:
+- Tests:
+
+## Task Breakdown
+
+1. Step:
+2. Step:
+3. Step:
+
+## Acceptance Criteria
+
+- [ ] Criterion:
+- [ ] Criterion:
+- [ ] Criterion:
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+# command
+```
+
+Expected evidence:
+
+- Test/eval output:
+- Artifact:
+- Reviewer check:
+
+## Rollback Strategy
+
+How to revert safely if the change creates regression or invalidates evaluation.
+
+## Failure Modes
+
+- Failure mode:
+- Failure mode:
+
+## Observability
+
+What logs, reports, metrics, traces, or artifacts will show whether the change
+works or fails?
+
+## Eval / Benchmark Impact
+
+- Surface: public fixture smoke / public synthetic benchmark / private real-eval / none
+- Allowed claim:
+- Disallowed claim:
+- Benchmark auditor required: yes/no
+
+## Reviewer Notes
+
+What should the reviewer attack first?
+
+## Session Handoff
+
+```markdown
+## Session Handoff — YYYY-MM-DD HH:MM TZ
+
+- Role:
+- Branch / worktree:
+- Issue / PR:
+- Task:
+- Current status:
+- Files touched:
+- Decisions made:
+- Commands run:
+- Results:
+- Next safe command:
+- Risks:
+```

--- a/docs/reviews/ai-review-checklists.md
+++ b/docs/reviews/ai-review-checklists.md
@@ -1,0 +1,86 @@
+# AI Review Checklists
+
+이 문서는 AI-agent가 만든 변경을 검토할 때 사용하는 reviewer checklist다.
+목표는 단순 test pass가 아니라 architecture drift, benchmark contamination,
+unverifiable claim, regression risk를 잡는 것이다.
+
+## Normal Code Review
+
+- Scope가 task/plan의 goal과 acceptance criteria에 묶여 있는가?
+- unrelated refactor, formatting churn, drive-by cleanup이 섞이지 않았는가?
+- 기존 helper/API/ADR contract를 재사용했는가?
+- dead code, unused config, orphaned docs가 생기지 않았는가?
+- duplicated logic이 기존 module과 분기하지 않는가?
+- behavior change에 regression test 또는 focused validation이 있는가?
+- answer dict schema, `naive_baseline`, eval split 등 invariant가 조용히 바뀌지 않았는가?
+- validation command가 실제 실행됐고 결과가 보고됐는가?
+
+## Adversarial Review
+
+AI-agent failure mode를 일부러 찾는다.
+
+- 테스트가 통과하지만 실제 path가 실행되지 않는 superficial test pass인가?
+- abstraction이 문제를 줄이지 않고 이름만 늘렸는가?
+- "future-proof" code가 현재 요구보다 넓은 surface를 여는가?
+- hidden coupling이 생겨 다른 preset/API/eval runner가 같은 값을 다르게 해석하는가?
+- fallback이 silent degrade를 만들지 않는가?
+- error handling이 실패를 숨기고 metric을 좋게 보이게 하지 않는가?
+- PR 설명의 claim이 diff와 validation evidence보다 강하지 않은가?
+- generated artifact가 source-of-truth처럼 쓰이는가?
+
+## Benchmark Validity Audit
+
+다음 중 하나라도 있으면 이 checklist를 사용한다: `eval/`, `benchmarks/`,
+`harness/`, `configs/eval/`, `reports/real100/`, `docs/evaluation/`, metric claim.
+
+- Surface가 public fixture smoke, public synthetic benchmark, private real-eval 중 어디인지 명시됐는가?
+- Dataset/config/index/provenance/command가 함께 제시됐는가?
+- Synthetic benchmark 결과를 real-world performance claim으로 쓰지 않았는가?
+- Smoke test가 wiring/regression 이상의 의미로 해석되지 않았는가?
+- Private result는 aggregate-only이고 raw question/answer/evidence/doc id/chunk id를 노출하지 않는가?
+- Metric denominator, skipped cases, `None` semantics, confidence interval이 claim wording과 맞는가?
+- Baseline과 treatment가 같은 corpus/index/config 조건에서 비교됐는가?
+- `make real-eval` hashing 경로로 semantic dense/hybrid retrieval claim을 만들지 않았는가?
+- 개선 metric과 guardrail metric이 함께 보고됐는가?
+- Benchmark contamination 가능성: index build가 questions/gold/expected answer를 읽지 않는가?
+
+## Regression Review
+
+- 이 변경이 과거 incident를 다시 열 수 있는가? 특히 #69 intended-abstention regression,
+  ADR 번호 collision, doc dead link, private artifact leak, baseline provenance drift.
+- 기존 regression test가 이 변경의 위험을 실제로 커버하는가?
+- Public fixture smoke로 잡히지 않는 private real-eval risk가 있는가?
+- Failure category count, abstention, citation precision, latency 같은 guardrail이 악화될 수 있는가?
+- Slow test 또는 real-model test가 필요한데 생략됐는가?
+- Rollback path가 명확한가?
+
+## Documentation / Governance Review
+
+- 새 문서가 기존 source of truth를 대체한다고 암시하지 않는가?
+- `CLAUDE.md`, `AGENTS.md`, `docs/engineering-governance.md`, ADR, README 사이에 drift가 생기지 않았는가?
+- Links가 상대 경로 기준으로 유효한가? `make check-doc-links` 또는 `python scripts/check_doc_links.py --check-all`를 실행했는가?
+- 새 eval/benchmark 문서가 [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md)의 claim boundary를 따르는가?
+- 새 plan/task/review 문서가 실제로 다음 agent가 실행 가능한 수준인가?
+- "N/A"가 필요한 곳에 사유가 있고, 사유가 검증 가능한가?
+
+## Review Output Format
+
+리뷰 결과는 findings를 먼저 쓴다.
+
+```markdown
+## Findings
+
+- [blocking] <file/path>:<line> — 문제와 영향. 필요한 수정.
+- [non-blocking] <file/path>:<line> — follow-up 권고.
+
+## Evidence Checked
+
+- Task:
+- Plan:
+- Commands:
+- Eval surface:
+
+## Verdict
+
+Approve / Needs changes / Needs benchmark audit / Needs deep review
+```

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,47 @@
+# Task Queue
+
+이 디렉터리는 AI-agent가 세션을 넘어 이어서 작업할 수 있도록 유지하는 작은
+repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다음 작업이
+무엇인지, 어떤 역할(role)로 수행해야 하는지, 어떤 evidence가 필요한지"를
+빠르게 읽게 하는 것이다.
+
+## Files
+
+- [`queue.md`](queue.md): active task queue. 상태(status)는 여기서 관리한다.
+- [`TEMPLATE.md`](TEMPLATE.md): 새 task 작성 템플릿.
+- [`examples/`](examples/): realistic example task. 실제 backlog가 아니라 운영 예시다.
+
+## Status
+
+| Status | Meaning |
+|---|---|
+| `backlog` | 아직 ready가 아니다. goal은 있으나 acceptance/evidence가 부족할 수 있다. |
+| `ready` | 바로 시작 가능하다. scope, non-goals, acceptance, validation이 있다. |
+| `running` | agent가 실행 중이다. owner role과 latest handoff가 있어야 한다. |
+| `blocked` | external decision, missing data, failed validation 등으로 멈췄다. |
+| `review` | 구현은 끝났고 reviewer/deep reviewer/benchmark auditor 검토가 필요하다. |
+| `done` | evidence와 PR/commit/link가 남아 완료됐다. |
+
+## Operating Rules
+
+- 새 multi-session 작업은 `queue.md`에 task entry를 남긴다.
+- 큰 작업은 [`docs/plans/TEMPLATE.md`](../docs/plans/TEMPLATE.md)를 복사해 plan doc를 만든다.
+- Eval/benchmark task는 [`docs/evaluation/surface-map.md`](../docs/evaluation/surface-map.md)의
+  surface와 allowed claim을 적는다.
+- Review 요청 전 [`docs/reviews/ai-review-checklists.md`](../docs/reviews/ai-review-checklists.md)의
+  필요한 checklist를 선택한다.
+- 완료 후 task entry에 validation command와 evidence link를 남긴다.
+
+## Minimal Entry
+
+```markdown
+## T-YYYY-NNNN — Title
+
+- Status:
+- Owner role:
+- Goal:
+- Plan:
+- Acceptance criteria:
+- Validation commands:
+- Evidence required:
+```

--- a/tasks/TEMPLATE.md
+++ b/tasks/TEMPLATE.md
@@ -1,0 +1,74 @@
+# <task-id> — <title>
+
+- Status: backlog
+- Owner role:
+- Related issue:
+- Related PR:
+- Related plan:
+- Created:
+- Last updated:
+
+## Goal
+
+One sentence describing the desired outcome.
+
+## Context
+
+Relevant ADRs, docs, code paths, incidents, reports, or prior decisions.
+
+## Scope
+
+- In scope:
+- In scope:
+
+## Non-Goals
+
+- Out of scope:
+- Out of scope:
+
+## Acceptance Criteria
+
+- [ ] Criterion:
+- [ ] Criterion:
+- [ ] Criterion:
+
+## Validation Commands
+
+```bash
+# command
+```
+
+## Evidence Required
+
+- Test/eval output:
+- Artifact:
+- Review checklist:
+- PR/commit:
+
+## Failure Conditions
+
+- Stop if:
+- Stop if:
+
+## Related Links
+
+- Plan:
+- Issue:
+- PR:
+- ADR:
+- Report:
+
+## Session Handoff
+
+```markdown
+## Session Handoff — YYYY-MM-DD HH:MM TZ
+
+- Role:
+- Branch / worktree:
+- Current status:
+- Decisions made:
+- Commands run:
+- Results:
+- Next safe command:
+- Risks:
+```

--- a/tasks/examples/benchmark-hardening.md
+++ b/tasks/examples/benchmark-hardening.md
@@ -1,0 +1,59 @@
+# T-EXAMPLE-001 — Benchmark hardening against synthetic contamination
+
+- Status: example
+- Owner role: Benchmark Auditor
+- Related issue: example only
+- Related PR: example only
+- Related plan: [`docs/plans/EXAMPLE-benchmark-hardening.md`](../../docs/plans/EXAMPLE-benchmark-hardening.md)
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+## Goal
+
+Ensure the public synthetic benchmark cannot accidentally use question/gold data
+during index build and cannot be reported as private real-eval performance.
+
+## Context
+
+Synthetic benchmark assets live under `data/eval/benchmark/` and are documented
+in [`docs/evaluation/synthetic_benchmark_v1_design.md`](../../docs/evaluation/synthetic_benchmark_v1_design.md).
+The benchmark is useful for failure discovery, not real RFP quality claims.
+
+## Scope
+
+- Inspect benchmark dataset validation and index build input boundaries.
+- Add focused regression coverage if the boundary is not already enforced.
+- Tighten claim wording in docs if needed.
+
+## Non-Goals
+
+- No retrieval or answer quality improvements.
+- No private real-eval changes.
+- No new benchmark corpus.
+
+## Acceptance Criteria
+
+- [ ] Index build reads corpus chunks only.
+- [ ] Gold evidence remains explicit and not derived from `expected_terms`.
+- [ ] Docs state synthetic-only claim boundary.
+- [ ] Benchmark Auditor signs off.
+
+## Validation Commands
+
+```bash
+python3 eval/naive_rag/validate_benchmark_dataset.py \
+  --config configs/eval/benchmark_naive_rag_v1.yaml \
+  --report reports/benchmark/naive_rag_v1_validation.json
+python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
+```
+
+## Evidence Required
+
+- Validation report summary.
+- Focused pytest result.
+- Checklist result from [`docs/reviews/ai-review-checklists.md`](../../docs/reviews/ai-review-checklists.md).
+
+## Failure Conditions
+
+- Stop if benchmark scoring semantics need to change.
+- Stop if the task starts optimizing model quality instead of hardening validity.

--- a/tasks/examples/eval-regression-safety.md
+++ b/tasks/examples/eval-regression-safety.md
@@ -1,0 +1,58 @@
+# T-EXAMPLE-002 — Eval regression safety surface separation
+
+- Status: example
+- Owner role: Reviewer
+- Related issue: example only
+- Related PR: example only
+- Related plan: TBD
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+## Goal
+
+Ensure future PRs do not use public fixture smoke, public synthetic benchmark,
+and private real-eval artifacts interchangeably when claiming regression safety.
+
+## Context
+
+This repo has several files named `eval_summary.json` across smoke, harness,
+benchmark, and private real-eval flows. The safe interpretation rules are in
+[`docs/evaluation/surface-map.md`](../../docs/evaluation/surface-map.md).
+
+## Scope
+
+- Confirm docs and PR template tell agents which artifact they are reading.
+- Confirm private raw artifacts remain local-only.
+- Add doc/test guard only if a concrete ambiguity exists.
+
+## Non-Goals
+
+- No scoring changes.
+- No private data inspection.
+- No new CI dependency on private real-eval.
+
+## Acceptance Criteria
+
+- [ ] Smoke result is described as regression/wiring only.
+- [ ] Synthetic result is described as controlled benchmark only.
+- [ ] Private result is aggregate-only and marked private/non-public.
+- [ ] Incompatible `eval_summary.json` comparisons are called out.
+
+## Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all
+python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
+```
+
+## Evidence Required
+
+- Doc link check output.
+- Focused pytest output.
+- Reviewer note confirming no unsupported performance claim.
+
+## Failure Conditions
+
+- Stop if raw private questions, answers, evidence, doc IDs, chunk IDs, or exact
+  local paths would be needed.
+- Stop if metric semantics are being changed; create a new plan and benchmark audit.

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -1,0 +1,124 @@
+# Persistent Task Queue
+
+이 queue는 장기 AI-agent 작업의 operational state를 저장한다. 실제 GitHub issue와
+PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/examples/`에 있고,
+아래 queue에는 현재 운영체계 도입 이후 실제로 수행할 수 있는 seed task만 둔다.
+
+## T-2026-0001 — Benchmark hardening against synthetic contamination
+
+- Status: backlog
+- Owner role: Planner -> Benchmark Auditor -> Implementer
+- Related issue: TBD
+- Related PR: TBD
+- Related plan: [`docs/plans/EXAMPLE-benchmark-hardening.md`](../docs/plans/EXAMPLE-benchmark-hardening.md)
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+### Goal
+
+Prevent public synthetic benchmark results from being inflated by leakage,
+contaminated index inputs, or over-claiming.
+
+### Context
+
+- Surface: public synthetic benchmark.
+- Relevant docs: [`docs/evaluation/surface-map.md`](../docs/evaluation/surface-map.md),
+  [`docs/evaluation/synthetic_benchmark_v1_design.md`](../docs/evaluation/synthetic_benchmark_v1_design.md).
+- Primary risk: synthetic-only success being read as real RFP performance.
+
+### Scope
+
+- Inspect benchmark validator and index builder input boundaries.
+- Add focused tests or docs only if a concrete gap is found.
+- Keep changes out of retrieval/answer production behavior.
+
+### Non-Goals
+
+- Do not improve benchmark score.
+- Do not change private real-eval.
+- Do not introduce a new benchmark dataset.
+
+### Acceptance Criteria
+
+- [ ] Benchmark index build is documented/tested as corpus-only.
+- [ ] Benchmark claim wording is synthetic-only and links to the surface map.
+- [ ] Benchmark Auditor checklist is satisfied.
+
+### Validation Commands
+
+```bash
+python3 eval/naive_rag/validate_benchmark_dataset.py \
+  --config configs/eval/benchmark_naive_rag_v1.yaml \
+  --report reports/benchmark/naive_rag_v1_validation.json
+
+python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
+```
+
+### Evidence Required
+
+- Validation report summary.
+- Focused pytest output.
+- Review note confirming no real-world performance claim.
+
+### Failure Conditions
+
+- Stop if index build reads questions/gold/expected answers.
+- Stop if the task requires changing scoring semantics; that needs a new plan.
+
+## T-2026-0002 — Eval regression safety surface separation
+
+- Status: backlog
+- Owner role: Planner -> Implementer -> Reviewer
+- Related issue: TBD
+- Related PR: TBD
+- Related plan: TBD
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+### Goal
+
+Make it harder for future agents to conflate public fixture smoke,
+public synthetic benchmark, and private real-eval artifacts when reporting
+regression evidence.
+
+### Context
+
+- Surface: eval governance.
+- Relevant docs: [`docs/evaluation/surface-map.md`](../docs/evaluation/surface-map.md),
+  [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md).
+- Primary risk: comparing incompatible `eval_summary.json` files.
+
+### Scope
+
+- Add docs/tests only around artifact naming, provenance, or checklist gaps.
+- Verify existing doc links and PR template wording.
+
+### Non-Goals
+
+- Do not change eval scoring.
+- Do not run or expose private raw eval data.
+- Do not make private real-eval a CI requirement.
+
+### Acceptance Criteria
+
+- [ ] Future agents can identify which `eval_summary.json` they are reading.
+- [ ] Smoke/synthetic/private claims are explicitly separated.
+- [ ] Reviewer checklist catches incompatible artifact comparisons.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all
+python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
+```
+
+### Evidence Required
+
+- Doc link check output.
+- Focused pytest output.
+- Reviewer note confirming claim boundary clarity.
+
+### Failure Conditions
+
+- Stop if proposed changes require private raw artifact inspection.
+- Stop if this expands into metric semantics; create a separate plan.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

AI-agent가 장기 작업을 수행할 때 task queue, plan doc, reviewer checklist, eval surface policy, long-session handoff를 한 흐름으로 읽을 수 있도록 최소 운영 모델을 추가했습니다.

Closes #1477

## 2. 영향 파일

- docs/operations/ai-engineering-operating-system.md
- docs/operations/long-session-workflow.md
- docs/evaluation/surface-map.md
- docs/reviews/ai-review-checklists.md
- docs/plans/TEMPLATE.md
- docs/plans/EXAMPLE-benchmark-hardening.md
- tasks/README.md
- tasks/TEMPLATE.md
- tasks/queue.md
- tasks/examples/benchmark-hardening.md
- tasks/examples/eval-regression-safety.md
- CLAUDE.md / AGENTS.md / README.md / docs/README.md / docs/engineering-governance.md pointer updates

## 3. 리스크

주요 리스크는 문서 증가로 인한 process bloat와 기존 source of truth drift입니다. 이를 줄이기 위해 기존 governance/ADR 문서를 대체하지 않고 pointer와 얇은 운영 레이어만 추가했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all` — pass, 195 markdown files scanned
- `python3 -m pytest tests/test_doc_links.py tests/test_governance.py -q` — pass
- `python3 -m pytest tests/test_eval_artifact_privacy_regression.py tests/test_private_real_eval_artifacts.py -q` — pass
- `git diff --check` — pass
- `make check-branch` — pass
- `bash scripts/test.sh` — pass, 2495 passed, 16 skipped, 69 deselected, 251 subtests passed

## 5. Eval 영향

Docs/governance-only change입니다. Product code, eval scoring, benchmark runner, dataset, report generation behavior는 변경하지 않았습니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

## 6. 하위 호환

하위 호환 영향 없음. 기존 ADR, CLAUDE.md, engineering governance를 대체하지 않고 새 문서로 연결만 추가했습니다.

## 7. 범위 외

- Product code 변경
- Benchmark/eval 동작 변경
- 새 CI gate 추가
- Private real-eval 실행 또는 aggregate 업데이트
