### PR TITLE
docs: refine AI operating system workflow

### DIFF
--- a/docs/operations/ai-engineering-operating-system.md
+++ b/docs/operations/ai-engineering-operating-system.md
@@ -26,11 +26,12 @@
 
 ### 현재 약점
 
-- AI-agent가 "지금 무엇을 해야 하는가"를 읽을 persistent task queue가 없다.
-- 계획(plan) 문서가 worktree/session 밖으로 안정적으로 남지 않아 context
-  compaction 이후 같은 결정을 다시 탐색한다.
+- AI-agent가 "지금 무엇을 해야 하는가"를 찾는 진입점이 GitHub issue, audit,
+  local TODO, PR review에 흩어져 있었다.
+- 계획(plan) 문서가 worktree/session 밖으로 항상 남지는 않아 context compaction
+  이후 같은 결정을 다시 탐색했다.
 - reviewer checklist가 PR 템플릿, ADR, audit 문서에 흩어져 있어 리뷰어 역할을
-  맡은 agent가 무엇을 공격적으로 확인해야 하는지 즉시 알기 어렵다.
+  맡은 agent가 무엇을 공격적으로 확인해야 하는지 즉시 알기 어려웠다.
 - `reports/eval_summary.json`, `reports/real100/eval_summary.json`,
   `artifacts/runs/*/metrics/eval_summary.json`가 모두 존재할 수 있어 잘못된
   산출물을 비교할 위험이 있다.
@@ -88,6 +89,19 @@
 | active task state | [`tasks/queue.md`](../../tasks/queue.md) | 세션 간 handoff 상태 저장 |
 | large-work plan | [`docs/plans/`](../plans/) | context loss 후 이어서 구현 가능한 설계 단위 |
 | review gate | [`docs/reviews/ai-review-checklists.md`](../reviews/ai-review-checklists.md) | reviewer/deep reviewer/benchmark auditor가 사용할 기준 |
+
+## Operating Questions
+
+| 질문 | 답하는 문서 |
+|---|---|
+| What should I work on next? | [`tasks/queue.md`](../../tasks/queue.md)의 `Ready Order` |
+| What role am I acting as? | 이 문서의 [Agent Role Model](#agent-role-model) |
+| What plan should I follow? | task의 plan link 또는 [`docs/plans/TEMPLATE.md`](../plans/TEMPLATE.md) |
+| What evidence must I produce? | task의 `Evidence Required`와 plan의 `Validation Strategy` |
+| What claims am I allowed to make? | [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md) |
+| What review checklist will be used? | [`docs/reviews/ai-review-checklists.md`](../reviews/ai-review-checklists.md) |
+| How do I continue after context loss? | [`docs/operations/long-session-workflow.md`](./long-session-workflow.md) |
+| How do I avoid corrupting evals? | ADR 0005, `surface-map.md`, Benchmark Validity Audit |
 
 ## Definition Of The Minimum Viable Operating System
 

--- a/docs/operations/long-session-workflow.md
+++ b/docs/operations/long-session-workflow.md
@@ -18,10 +18,12 @@ eval validity를 유지하며, reviewer가 검증 가능한 근거(evidence)를 
 
 1. [`CLAUDE.md`](../../CLAUDE.md)와 현재 task entry를 읽는다.
 2. [`tasks/queue.md`](../../tasks/queue.md)에서 task status와 owner role을 확인한다.
-3. plan doc가 있으면 먼저 읽고, 없는데 필요한 범위면 구현 전에 만든다.
-4. `git status --short --branch`로 worktree 상태를 확인한다.
-5. 관련 ADR과 eval surface를 확인한다.
-6. 다음 safe command를 정하고 실행한다.
+3. [`docs/operations/ai-engineering-operating-system.md`](./ai-engineering-operating-system.md)에서
+   role, evidence, review escalation을 확인한다.
+4. plan doc가 있으면 먼저 읽고, 없는데 필요한 범위면 구현 전에 만든다.
+5. `git status --short --branch`로 worktree 상태를 확인한다.
+6. 관련 ADR과 eval surface를 확인한다.
+7. 다음 safe command를 정하고 실행한다.
 
 ## Context Preservation Rules
 
@@ -43,7 +45,9 @@ eval validity를 유지하며, reviewer가 검증 가능한 근거(evidence)를 
 ## Session Handoff — YYYY-MM-DD HH:MM TZ
 
 - Role:
+- Lifecycle stage:
 - Branch / worktree:
+- Base branch:
 - Issue / PR:
 - Task:
 - Plan:
@@ -52,12 +56,14 @@ eval validity를 유지하며, reviewer가 검증 가능한 근거(evidence)를 
 - Decisions made:
 - Commands run:
 - Results:
+- Validation evidence:
 - Eval surface:
 - Evidence artifacts:
 - Blockers:
+- Open risks:
+- Next action:
 - Next safe command:
 - Reviewer focus:
-- Risks:
 ```
 
 ## Branch And Worktree Guidance
@@ -115,6 +121,7 @@ Repo: BidMate-DocAgent
 Task: <task id and title>
 Read first:
 - CLAUDE.md
+- docs/operations/ai-engineering-operating-system.md
 - tasks/queue.md entry <id>
 - docs/plans/<plan>.md
 - docs/evaluation/surface-map.md if eval/benchmark is touched

--- a/docs/plans/EXAMPLE-benchmark-hardening.md
+++ b/docs/plans/EXAMPLE-benchmark-hardening.md
@@ -1,9 +1,10 @@
 # Plan: T-2026-0001 Benchmark Hardening Against Synthetic Contamination
 
-- Status: example
+- Status: proposed
 - Owner role: Planner
 - Related task: [`tasks/examples/benchmark-hardening.md`](../../tasks/examples/benchmark-hardening.md)
 - Related issue / PR: example only
+- Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
 - Created: 2026-05-25
 - Last updated: 2026-05-25
 
@@ -28,40 +29,41 @@ Benchmark runs should remain useful for controlled synthetic failure discovery
 without becoming evidence for real RFP performance. The benchmark validation path
 should make contamination and over-claiming harder to miss.
 
-## Scope
-
-- Add or verify checks that benchmark index build reads only corpus chunks.
-- Add reviewer-facing documentation that benchmark claims are synthetic-only.
-- Add regression tests for validator behavior if code changes are needed.
-
-## Non-Goals
-
-- Do not improve retrieval, reranking, answer generation, or verifier behavior.
-- Do not change private real-eval scoring.
-- Do not add a new benchmark dataset.
-- Do not claim product-quality improvement.
-
 ## Constraints
 
-- ADR 0005 privacy and public/private split remain unchanged.
-- `naive_baseline` remains the control.
-- Public synthetic data may be committed; generated run artifacts remain local.
-- Any claim-bearing doc must link to [`docs/evaluation/surface-map.md`](../evaluation/surface-map.md).
+- Scope constraints: add or verify benchmark validity checks and claim wording only.
+- Architecture constraints: `naive_baseline` remains the control.
+- Compatibility constraints: existing benchmark config and public synthetic data stay valid.
+- Eval/privacy constraints: ADR 0005 privacy and public/private split remain unchanged.
+- Tooling/CI constraints: generated run artifacts remain local unless explicitly allowed.
+- Non-goals: do not improve retrieval, reranking, answer generation, verifier behavior,
+  private real-eval scoring, or product-quality claims.
 
 ## Architecture Impact
 
-- Affected modules: `eval/naive_rag/validate_benchmark_dataset.py`,
+- Affected modules or docs: `eval/naive_rag/validate_benchmark_dataset.py`,
   `eval/naive_rag/build_benchmark_index.py`, docs under `docs/evaluation/`.
-- Affected contracts: synthetic benchmark v1 input separation and claim boundary.
+- Affected contracts or invariants: synthetic benchmark v1 input separation and claim boundary.
 - Load-bearing paths: `eval/` if validator or runner changes.
-- ADR impact: no new ADR unless a new measurement surface or claim contract is created.
+- ADR required: no unless a new measurement surface or claim contract is created.
+- Backward compatibility expectation: existing benchmark corpus/config remains readable.
 
 ## Affected Interfaces
 
-- CLI: benchmark validation and index build commands.
+- CLI/API/config: benchmark validation and index build commands.
+- Input data: `data/eval/benchmark/corpus_chunks_v1.jsonl` only for index build.
 - Output artifacts: validation report under `reports/benchmark/`.
-- Docs: benchmark design/results wording.
-- Tests: focused validator/index-build regression tests.
+- Docs/review surfaces: benchmark design/results wording and Benchmark Auditor checklist.
+- Tests/eval entrypoints: focused validator/index-build regression tests.
+
+## Data / Eval Impact
+
+- Surface: public synthetic benchmark.
+- Data boundary: public synthetic corpus; generated run artifacts remain local.
+- Allowed claim: benchmark hardening improved contamination resistance.
+- Disallowed claim: RAG model quality improved on real RFPs.
+- Baseline or control affected: no; `naive_baseline` remains the control.
+- Benchmark/eval auditor required: yes.
 
 ## Task Breakdown
 
@@ -116,14 +118,26 @@ explicitly changes dataset versioning.
 - Test result: benchmark input separation and schema checks.
 - Review output: Benchmark Auditor verdict.
 
-## Eval / Benchmark Impact
-
-- Surface: public synthetic benchmark.
-- Allowed claim: benchmark hardening improved contamination resistance.
-- Disallowed claim: RAG model quality improved on real RFPs.
-- Benchmark auditor required: yes.
-
 ## Reviewer Notes
 
 Attack the claim wording first. Then inspect whether any code path can read
 questions, expected answers, expected terms, or gold evidence during index build.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-25 00:00 KST
+
+- Role: Planner
+- Branch / worktree: example only
+- Issue / PR: example only
+- Task: T-EXAMPLE-001
+- Current status: proposed example plan
+- Files touched: N/A
+- Decisions made: Treat this as benchmark validity hardening, not model improvement.
+- Commands run: None; example only.
+- Results: N/A
+- Next safe command: python3 eval/naive_rag/validate_benchmark_dataset.py --help
+- Open questions: whether a concrete validator gap exists.
+- Risks: unsupported real-world claim wording or benchmark leakage.
+```

--- a/docs/plans/EXAMPLE.md
+++ b/docs/plans/EXAMPLE.md
@@ -1,0 +1,156 @@
+# Plan: T-2026-0002 Evaluation Regression Safety for Claim-Bearing Runs
+
+- Status: proposed
+- Owner role: Evaluation Systems Designer
+- Related task: `tasks/queue.md::T-2026-0002` (example)
+- Related issue / PR: example only
+- Related ADR: `docs/adr/0005-eval-split-public-synthetic-private-local.md`, `docs/adr/0055-claim-validator-as-pr-gate.md`
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+## Problem Statement
+
+Claim-bearing evaluation work can regress quietly when a PR updates metrics,
+gold data, or report wording without preserving the baseline/control surface.
+The reviewer then has to rediscover which claims are supported by smoke tests,
+synthetic benchmarks, or private real-eval aggregates.
+
+## Current Behavior
+
+The repository separates public fixture smoke, public synthetic benchmark, and
+private real-eval surfaces. Claim validation exists for explicit PR-body metric
+claims, and ADRs define the public/private boundary. However, an AI session that
+joins midstream can still miss which commands produced the evidence, which
+artifact is allowed to support the claim, and which wording is disallowed.
+
+## Desired Behavior
+
+Every claim-bearing eval change should leave a compact execution trail: the
+surface, allowed claim, control or baseline, commands, artifacts, and reviewer
+attack points are visible before implementation and updated at handoff.
+
+## Constraints
+
+- Scope constraints: focus on documentation and process wiring; do not change
+  scoring code in this plan.
+- Architecture constraints: preserve existing answer contract and eval preset
+  names.
+- Compatibility constraints: existing CI and local eval commands continue to
+  work.
+- Eval/privacy constraints: private RFP data stays local; only aggregate
+  private results may be referenced.
+- Tooling/CI constraints: command examples must be runnable from repo root.
+- Non-goals: do not introduce a new metric, benchmark, or judge.
+
+## Architecture Impact
+
+- Affected modules or docs: eval operating docs, PR template wording, plan docs.
+- Affected contracts or invariants: claim-bearing evidence must identify its
+  eval surface and control.
+- Load-bearing paths: none unless eval config or scorer code changes in a
+  follow-up.
+- ADR required: no for process clarification; yes if a new claim gate or eval
+  surface is introduced.
+- Backward compatibility expectation: existing reports and PRs remain valid.
+
+## Affected Interfaces
+
+- CLI/API/config: no runtime interface change.
+- Input data: no new data input.
+- Output artifacts: evaluation summaries and validation reports are referenced,
+  not reformatted.
+- Docs/review surfaces: plan docs and reviewer notes.
+- Tests/eval entrypoints: existing smoke and eval commands only.
+
+## Data / Eval Impact
+
+- Surface: private real-eval for claim-bearing aggregate evidence; public
+  fixture smoke for reproducible sanity checks.
+- Data boundary: aggregate-only private output.
+- Allowed claim: "This change preserves or improves the measured aggregate on
+  the named eval surface under the listed command."
+- Disallowed claim: "This proves general real-world RFP quality" without the
+  private real-eval evidence and claim gate.
+- Baseline or control affected: no; any control change requires a separate ADR.
+- Benchmark/eval auditor required: yes for metric or claim wording changes.
+
+## Task Breakdown
+
+1. Identify the eval surface and existing control or baseline for the work.
+2. Record the exact command, config, index provenance, and expected output
+   artifact in the plan.
+3. Update docs or PR wording so allowed and disallowed claims are explicit.
+4. Run the lightweight validation commands and attach aggregate evidence.
+5. Add a handoff note with the next safe command and remaining reviewer risks.
+
+## Acceptance Criteria
+
+- [ ] The plan names the eval surface and disallowed claim before implementation.
+- [ ] The validation command and expected artifact path are reproducible from the
+  repo root.
+- [ ] Reviewer notes identify the first claim or data-boundary risk to attack.
+- [ ] Handoff notes are sufficient for a new session to resume without reading
+  the entire eval history.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+test -f docs/evaluation/surface-map.md
+test -f docs/adr/0055-claim-validator-as-pr-gate.md
+python3 scripts/check_doc_links.py --check-all
+```
+
+Expected evidence:
+
+- Test/eval output: doc-link check exits successfully.
+- Generated or updated artifact: N/A - this plan changes process docs only.
+- Reviewer checklist or manual inspection: reviewer confirms claim wording maps
+  to exactly one eval surface.
+- Explicitly not validated, with reason: private real-eval is not run for this
+  process-only example.
+
+## Rollback Strategy
+
+Revert the documentation or PR wording changes. Do not delete historical eval
+reports, ADRs, or private aggregate artifacts; they are evidence records, not
+temporary build output.
+
+## Failure Modes
+
+- Failure mode: public fixture smoke result is described as real-eval evidence.
+- Detection signal: reviewer cannot map the claim to a surface in
+  `docs/evaluation/surface-map.md`.
+- Stop condition or fallback: stop claim publication and rewrite the claim as a
+  smoke-only sanity result.
+
+## Observability
+
+- Plan fields: `Data / Eval Impact`, `Validation Strategy`, and `Reviewer Notes`.
+- PR evidence: command output, aggregate report path, and claim validator result.
+- Review artifact: selected eval/benchmark checklist and unresolved objections.
+
+## Reviewer Notes
+
+Attack claim wording first. Then verify that the named command, config, and
+artifact support the exact claim and do not imply a broader real-world result.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-25 15:30 KST
+
+- Role: Evaluation Systems Designer
+- Branch / worktree: example only
+- Issue / PR: N/A
+- Task: T-2026-0002
+- Current status: example plan complete
+- Files touched: docs/plans/EXAMPLE.md
+- Decisions made: no new eval surface; use existing claim boundary
+- Commands run: not run for example
+- Results: N/A
+- Next safe command: python3 scripts/check_doc_links.py --check-all
+- Open questions: whether a future PR should add CI enforcement
+- Risks: process docs can be ignored unless PR reviewers require them
+```

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,74 @@
+# Plan Documents
+
+Plan documents make larger AI-assisted work resumable across context
+compaction, session handoffs, and reviewer changes. A good plan is not a design
+essay; it is the smallest durable execution record that lets the next session
+continue without rediscovering the same repo context.
+
+Use [`TEMPLATE.md`](./TEMPLATE.md) for new plans. Use [`EXAMPLE.md`](./EXAMPLE.md)
+as a realistic reference.
+
+## When a Plan Is Required
+
+Create a plan document before implementation when a task has any of these
+properties:
+
+- Multi-day, multi-session, or likely to survive context compaction.
+- Changes more than one file or is expected to exceed roughly 50 LOC.
+- Touches load-bearing paths, repo governance, eval/benchmark surfaces, public
+  claims, or cross-agent workflow.
+- Changes behavior and validation cannot be captured by one focused test or one
+  obvious command.
+- Requires sequencing across planner, implementer, evaluator, and reviewer
+  roles.
+- Needs rollback instructions because a bad change could invalidate metrics,
+  break a contract, or confuse future agents.
+
+## When a Plan Can Be Skipped
+
+Skip the plan document when the task is small and locally obvious:
+
+- Typo fixes, link fixes, or formatting-only changes.
+- A single-line or single-file change with a direct validation command.
+- A small documentation clarification that does not create or change policy.
+- Mechanical updates where the PR description can fully capture context,
+  validation, and rollback.
+
+If the task starts small but reveals policy, eval, architecture, or handoff
+risk, stop and create a plan before expanding the scope.
+
+## How Plans Relate to Tasks and ADRs
+
+- `tasks/queue.md` is the compact cross-session task index.
+- `docs/plans/<task-id>-<slug>.md` is the execution record for large work.
+- [`docs/adr/`](../adr/README.md) is the canonical home for durable decisions.
+  Do not create a parallel root `adr/` tree in this repository.
+
+Plans answer "how will we execute and verify this work?" ADRs answer "which
+decision are future changes expected to respect?"
+
+## Required Plan Content
+
+Every plan must include:
+
+- Title, owner role, status, and links to related task/issue/PR/ADR.
+- Problem statement, current behavior, and desired behavior.
+- Constraints, architecture impact, affected interfaces, and data/eval impact.
+- Task breakdown, acceptance criteria, validation strategy, and rollback
+  strategy.
+- Failure modes, observability, reviewer notes, and handoff notes.
+
+Each field must affect execution, review, or maintenance. If a field is not
+applicable, write `N/A` plus the reason instead of leaving it blank.
+
+## Handoff Discipline
+
+Append a handoff note whenever a session pauses, context compacts, or ownership
+changes. The next session should learn:
+
+- What changed.
+- What was validated.
+- Which command is safe to run next.
+- Which risks or open questions remain.
+
+Do not use handoff notes as a diary. Keep them operational.

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -1,67 +1,74 @@
 # Plan: <task-id> <title>
 
-- Status: proposed
-- Owner role: Planner
-- Related task: `tasks/queue.md::<task-id>`
-- Related issue / PR:
-- Created:
-- Last updated:
+- Status: proposed | running | blocked | review | done
+- Owner role: <Planner | Implementer | Evaluator | Reviewer | other role>
+- Related task: `tasks/queue.md::<task-id>` | N/A
+- Related issue / PR: <links or N/A>
+- Related ADR: <links or "N/A - no decision-level change">
+- Created: YYYY-MM-DD
+- Last updated: YYYY-MM-DD
 
 ## Problem Statement
 
-What concrete failure, bottleneck, or missing capability does this plan address?
+State the concrete failure, bottleneck, missing capability, or coordination risk.
+Name the user-visible or reviewer-visible consequence if this plan is not done.
 
 ## Current Behavior
 
-Describe the current code/docs/eval workflow. Include relevant files, commands,
-ADR, and observed failure modes.
+Describe the current workflow or implementation enough for a new session to
+resume without rediscovery. Include relevant files, commands, docs, ADRs,
+observed outputs, and known failure modes.
 
 ## Desired Behavior
 
-Describe the smallest useful end state. This must be testable.
-
-## Scope
-
-- In scope:
-- In scope:
-
-## Non-Goals
-
-- Out of scope:
-- Out of scope:
+Describe the smallest useful end state. This must be observable through a
+command, artifact, review checklist, or explicit non-change claim.
 
 ## Constraints
 
+- Scope constraints:
 - Architecture constraints:
-- Eval/privacy constraints:
 - Compatibility constraints:
+- Eval/privacy constraints:
 - Tooling/CI constraints:
+- Non-goals:
 
 ## Architecture Impact
 
-- Affected modules:
-- Affected contracts:
+- Affected modules or docs:
+- Affected contracts or invariants:
 - Load-bearing paths:
-- ADR impact:
+- ADR required: yes/no, with reason:
+- Backward compatibility expectation:
 
 ## Affected Interfaces
 
 - CLI/API/config:
+- Input data:
 - Output artifacts:
-- Docs:
-- Tests:
+- Docs/review surfaces:
+- Tests/eval entrypoints:
+
+## Data / Eval Impact
+
+- Surface: public fixture smoke | public synthetic benchmark | private real-eval | none
+- Data boundary: public fixture | aggregate-only private output | no data touched | other:
+- Allowed claim:
+- Disallowed claim:
+- Baseline or control affected: yes/no, with reason:
+- Benchmark/eval auditor required: yes/no:
 
 ## Task Breakdown
 
-1. Step:
-2. Step:
-3. Step:
+1. <Actionable step and target file/surface>
+2. <Actionable step and target file/surface>
+3. <Actionable step and target file/surface>
 
 ## Acceptance Criteria
 
-- [ ] Criterion:
-- [ ] Criterion:
-- [ ] Criterion:
+- [ ] <Observable criterion tied to desired behavior>
+- [ ] <Contract or documentation criterion>
+- [ ] <Validation evidence criterion>
 
 ## Validation Strategy
 
@@ -74,38 +81,40 @@ Commands that must be run:
 Expected evidence:
 
 - Test/eval output:
-- Artifact:
-- Reviewer check:
+- Generated or updated artifact:
+- Reviewer checklist or manual inspection:
+- Explicitly not validated, with reason:
 
 ## Rollback Strategy
 
-How to revert safely if the change creates regression or invalidates evaluation.
+Explain how to revert safely if the change regresses behavior, invalidates an
+eval claim, or creates operational risk. Name any data/artifacts that must not
+be deleted during rollback.
 
 ## Failure Modes
 
 - Failure mode:
-- Failure mode:
+- Detection signal:
+- Stop condition or fallback:
 
 ## Observability
 
-What logs, reports, metrics, traces, or artifacts will show whether the change
-works or fails?
-
-## Eval / Benchmark Impact
-
-- Surface: public fixture smoke / public synthetic benchmark / private real-eval / none
-- Allowed claim:
-- Disallowed claim:
-- Benchmark auditor required: yes/no
+List the logs, reports, metrics, traces, CI checks, or review artifacts that
+show whether the work is succeeding or failing. Prefer stable paths and command
+outputs over narrative promises.
 
 ## Reviewer Notes
 
-What should the reviewer attack first?
+Tell the reviewer what to attack first: claim wording, contract drift,
+baseline preservation, data boundary, rollback path, missing tests, or another
+specific risk.
 
-## Session Handoff
+## Handoff Notes
+
+Update this section at every session boundary or context compaction.
 
 ```markdown
-## Session Handoff — YYYY-MM-DD HH:MM TZ
+## Session Handoff - YYYY-MM-DD HH:MM TZ
 
 - Role:
 - Branch / worktree:
@@ -117,5 +126,6 @@ What should the reviewer attack first?
 - Commands run:
 - Results:
 - Next safe command:
+- Open questions:
 - Risks:
 ```

--- a/docs/reviews/README.md
+++ b/docs/reviews/README.md
@@ -1,0 +1,24 @@
+# Reviewer System
+
+AI-agent PR의 reviewer system은 [`ai-review-checklists.md`](./ai-review-checklists.md)가
+단일 출처(source of truth)다. 이 README는 어떤 checklist를 고를지 알려주는 얇은
+라우터다.
+
+## Review Mode Routing
+
+| Mode | Required when |
+|---|---|
+| Normal Code Review | 모든 non-trivial 코드·설정·테스트·문서 변경 |
+| Adversarial Review | AI-agent 생성 PR, load-bearing path, 큰 refactor, claim-heavy PR |
+| Benchmark Validity Audit | `eval/`, benchmark, metric, leaderboard, README metric snapshot, performance claim, private aggregate 변경 |
+| Regression Review | bug fix, behavior change, RAG pipeline, verifier, answer contract, eval runner, 과거 incident 재발 가능 변경 |
+| Documentation / Governance Review | ADR, governance, review, task/process docs, claim boundary 문서, root docs reference 변경 |
+
+## Evidence Standard
+
+Reviewer는 PR 설명을 근거(evidence)로 취급하지 않는다. 승인 가능한 claim은 diff,
+실행된 command 결과, test/eval artifact, 관련 ADR/source-of-truth와의 일치 중
+하나로 뒷받침되어야 한다.
+
+근거가 없으면 claim은 없는 것으로 처리한다. green CI, synthetic-only success,
+깔끔한 agent 요약은 private real-eval 또는 architecture safety 증거가 아니다.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -13,6 +13,9 @@ repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다
 
 ## Status
 
+허용 status 값은 아래 6개뿐이다. 예시 파일도 실제 status 값은 이 목록 중 하나를
+사용한다.
+
 | Status | Meaning |
 |---|---|
 | `backlog` | 아직 ready가 아니다. goal은 있으나 acceptance/evidence가 부족할 수 있다. |
@@ -21,6 +24,36 @@ repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다
 | `blocked` | external decision, missing data, failed validation 등으로 멈췄다. |
 | `review` | 구현은 끝났고 reviewer/deep reviewer/benchmark auditor 검토가 필요하다. |
 | `done` | evidence와 PR/commit/link가 남아 완료됐다. |
+
+## How Agents Pick Work
+
+1. `tasks/queue.md`를 연다.
+2. `Ready Order`에서 status가 `ready`인 첫 task를 고른다.
+3. task의 `Scope`, `Non-Goals`, `Evidence Required`, `Failure Conditions`를 먼저 읽는다.
+4. 시작 시 status를 `running`으로 바꾸고 `Handoff Notes`에 branch/worktree와 첫 명령을 남긴다.
+5. 끝나면 status를 `review` 또는 `done`으로 바꾸고 validation output, artifact, PR/commit link를 남긴다.
+
+`backlog` task는 missing decision이나 validation이 남아 있다는 뜻이다. agent는
+`backlog`를 임의로 실행하지 말고 ready 조건을 먼저 채운다.
+
+## Required Task Schema
+
+모든 task는 아래 필드를 포함한다.
+
+- `ID`
+- `Title`
+- `Status`
+- `Owner role`
+- `Goal`
+- `Context`
+- `Scope`
+- `Non-Goals`
+- `Acceptance Criteria`
+- `Validation Commands`
+- `Evidence Required`
+- `Failure Conditions`
+- `Related Plan / Issue / PR Links`
+- `Handoff Notes`
 
 ## Operating Rules
 
@@ -31,17 +64,26 @@ repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다
 - Review 요청 전 [`docs/reviews/ai-review-checklists.md`](../docs/reviews/ai-review-checklists.md)의
   필요한 checklist를 선택한다.
 - 완료 후 task entry에 validation command와 evidence link를 남긴다.
+- 실패 조건(failure condition)에 닿으면 추측으로 계속하지 말고 status를 `blocked`로
+  바꾼 뒤 관측된 error와 다음 확인 명령을 남긴다.
 
 ## Minimal Entry
 
 ```markdown
 ## T-YYYY-NNNN — Title
 
+- ID:
+- Title:
 - Status:
 - Owner role:
 - Goal:
-- Plan:
-- Acceptance criteria:
-- Validation commands:
-- Evidence required:
+- Context:
+- Scope:
+- Non-Goals:
+- Acceptance Criteria:
+- Validation Commands:
+- Evidence Required:
+- Failure Conditions:
+- Related Plan / Issue / PR Links:
+- Handoff Notes:
 ```

--- a/tasks/TEMPLATE.md
+++ b/tasks/TEMPLATE.md
@@ -1,10 +1,9 @@
 # <task-id> — <title>
 
+- ID: <task-id>
+- Title: <title>
 - Status: backlog
 - Owner role:
-- Related issue:
-- Related PR:
-- Related plan:
 - Created:
 - Last updated:
 
@@ -50,7 +49,7 @@ Relevant ADRs, docs, code paths, incidents, reports, or prior decisions.
 - Stop if:
 - Stop if:
 
-## Related Links
+## Related Plan / Issue / PR Links
 
 - Plan:
 - Issue:
@@ -58,7 +57,7 @@ Relevant ADRs, docs, code paths, incidents, reports, or prior decisions.
 - ADR:
 - Report:
 
-## Session Handoff
+## Handoff Notes
 
 ```markdown
 ## Session Handoff — YYYY-MM-DD HH:MM TZ

--- a/tasks/examples/benchmark-hardening.md
+++ b/tasks/examples/benchmark-hardening.md
@@ -1,10 +1,9 @@
 # T-EXAMPLE-001 — Benchmark hardening against synthetic contamination
 
-- Status: example
+- ID: T-EXAMPLE-001
+- Title: Benchmark hardening against synthetic contamination
+- Status: ready
 - Owner role: Benchmark Auditor
-- Related issue: example only
-- Related PR: example only
-- Related plan: [`docs/plans/EXAMPLE-benchmark-hardening.md`](../../docs/plans/EXAMPLE-benchmark-hardening.md)
 - Created: 2026-05-25
 - Last updated: 2026-05-25
 
@@ -57,3 +56,26 @@ python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
 
 - Stop if benchmark scoring semantics need to change.
 - Stop if the task starts optimizing model quality instead of hardening validity.
+
+## Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/EXAMPLE-benchmark-hardening.md`](../../docs/plans/EXAMPLE-benchmark-hardening.md)
+- Issue: example only
+- PR: example only
+- ADR: [ADR 0005](../../docs/adr/0005-eval-split-public-synthetic-private-local.md)
+- Report: example only
+
+## Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-25 00:00 KST
+
+- Role: Benchmark Auditor
+- Branch / worktree: example only
+- Current status: ready
+- Decisions made: Separate synthetic benchmark claims from private real-eval claims.
+- Commands run: None; example task.
+- Results: N/A.
+- Next safe command: inspect benchmark dataset validator and index build inputs.
+- Risks: Metric inflation, benchmark leakage, or unsupported real-world quality claims.
+```

--- a/tasks/examples/eval-regression-safety.md
+++ b/tasks/examples/eval-regression-safety.md
@@ -1,10 +1,9 @@
 # T-EXAMPLE-002 — Eval regression safety surface separation
 
-- Status: example
+- ID: T-EXAMPLE-002
+- Title: Eval regression safety surface separation
+- Status: ready
 - Owner role: Reviewer
-- Related issue: example only
-- Related PR: example only
-- Related plan: TBD
 - Created: 2026-05-25
 - Last updated: 2026-05-25
 
@@ -56,3 +55,26 @@ python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
 - Stop if raw private questions, answers, evidence, doc IDs, chunk IDs, or exact
   local paths would be needed.
 - Stop if metric semantics are being changed; create a new plan and benchmark audit.
+
+## Related Plan / Issue / PR Links
+
+- Plan: example only
+- Issue: example only
+- PR: example only
+- ADR: [ADR 0005](../../docs/adr/0005-eval-split-public-synthetic-private-local.md)
+- Report: example only
+
+## Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-25 00:00 KST
+
+- Role: Reviewer
+- Branch / worktree: example only
+- Current status: ready
+- Decisions made: Regression evidence must name the surface before making a claim.
+- Commands run: None; example task.
+- Results: N/A.
+- Next safe command: inspect docs/evaluation/surface-map.md and current eval artifact references.
+- Risks: Incompatible eval_summary.json comparisons or accidental private artifact disclosure.
+```

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -4,13 +4,27 @@
 PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/examples/`에 있고,
 아래 queue에는 현재 운영체계 도입 이후 실제로 수행할 수 있는 seed task만 둔다.
 
+## Ready Order
+
+새 세션은 이 표에서 위에서부터 첫 `ready` task를 선택한다. `backlog`는 ready
+조건이 부족한 작업이고, `review`는 구현보다 검토가 우선이다.
+
+| Order | ID | Status | Owner role | Why ready / not ready |
+|---:|---|---|---|---|
+| 1 | `T-2026-0001` | `ready` | Planner -> Benchmark Auditor -> Implementer | synthetic benchmark contamination 방지 범위, validation command, evidence가 명확하다. |
+| 2 | `T-2026-0002` | `ready` | Planner -> Implementer -> Reviewer | smoke/synthetic/private real-eval 분리 기준과 regression evidence가 명확하다. |
+
+## Examples
+
+- [`tasks/examples/benchmark-hardening.md`](examples/benchmark-hardening.md): benchmark hardening task 작성 예시.
+- [`tasks/examples/eval-regression-safety.md`](examples/eval-regression-safety.md): eval regression safety task 작성 예시.
+
 ## T-2026-0001 — Benchmark hardening against synthetic contamination
 
-- Status: backlog
+- ID: T-2026-0001
+- Title: Benchmark hardening against synthetic contamination
+- Status: ready
 - Owner role: Planner -> Benchmark Auditor -> Implementer
-- Related issue: TBD
-- Related PR: TBD
-- Related plan: [`docs/plans/EXAMPLE-benchmark-hardening.md`](../docs/plans/EXAMPLE-benchmark-hardening.md)
 - Created: 2026-05-25
 - Last updated: 2026-05-25
 
@@ -65,13 +79,35 @@ python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
 - Stop if index build reads questions/gold/expected answers.
 - Stop if the task requires changing scoring semantics; that needs a new plan.
 
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/EXAMPLE-benchmark-hardening.md`](../docs/plans/EXAMPLE-benchmark-hardening.md)
+- Issue: TBD
+- PR: TBD
+- ADR: [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md)
+- Report: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-25 00:00 KST
+
+- Role: Task Queue Designer
+- Branch / worktree: TBD by implementer
+- Current status: ready
+- Decisions made: Treat this as benchmark validity hardening, not metric improvement.
+- Commands run: None yet.
+- Results: Task is ready when an implementer can run validation commands or document why a command is unavailable.
+- Next safe command: inspect benchmark validator and index build inputs.
+- Risks: Scope creep into scoring semantics or unsupported real-eval claims.
+```
+
 ## T-2026-0002 — Eval regression safety surface separation
 
-- Status: backlog
+- ID: T-2026-0002
+- Title: Eval regression safety surface separation
+- Status: ready
 - Owner role: Planner -> Implementer -> Reviewer
-- Related issue: TBD
-- Related PR: TBD
-- Related plan: TBD
 - Created: 2026-05-25
 - Last updated: 2026-05-25
 
@@ -122,3 +158,26 @@ python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
 
 - Stop if proposed changes require private raw artifact inspection.
 - Stop if this expands into metric semantics; create a separate plan.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD
+- Issue: TBD
+- PR: TBD
+- ADR: [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md)
+- Report: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-25 00:00 KST
+
+- Role: Task Queue Designer
+- Branch / worktree: TBD by implementer
+- Current status: ready
+- Decisions made: Treat smoke, synthetic benchmark, and private real-eval as separate evidence surfaces.
+- Commands run: None yet.
+- Results: Task is ready when an implementer can prove artifact provenance or document manual validation.
+- Next safe command: inspect eval artifact docs and existing regression tests.
+- Risks: Accidentally requiring private raw data or comparing incompatible summaries.
+```


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

#1478로 들어간 AI Engineering Operating System을 실제 다음 세션이 바로 사용할 수 있게 보강합니다. 운영 질문 라우터, plan/task schema, long-session handoff 필드, plan/review README를 추가해 role, plan, evidence, claim boundary를 더 빨리 찾게 합니다.

Closes #1477

## 2. 영향 파일

- `docs/operations/ai-engineering-operating-system.md`
- `docs/operations/long-session-workflow.md`
- `docs/plans/README.md`
- `docs/plans/EXAMPLE.md`
- `docs/plans/EXAMPLE-benchmark-hardening.md`
- `docs/plans/TEMPLATE.md`
- `docs/reviews/README.md`
- `tasks/README.md`
- `tasks/TEMPLATE.md`
- `tasks/examples/benchmark-hardening.md`
- `tasks/examples/eval-regression-safety.md`
- `tasks/queue.md`

Load-bearing paths: N/A - docs/task process only, no `rag_*`, `ingestion.py`, `visual_ingestion.py`, `eval/`, `api/`, `docs/adr/`, or `scripts/build_index.py` change.

## 3. 리스크

- Process docs가 과해져 future agent가 오히려 읽기 어렵게 될 수 있음. 이를 줄이기 위해 canonical 문서는 유지하고 README/예시/라우터 위주로 정리했습니다.
- Task seed가 실제 backlog처럼 오해될 수 있음. `Ready Order`, examples, scope/non-goals를 명시했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all` 통과: 211 markdown file(s), broken links/ADR refs/fragments 없음.
- `python3 -m pytest tests/test_doc_links.py -q` 통과.
- `make check-branch` 통과.
- `git diff --cached --check` 통과.

신규 동작 테스트: N/A - docs-only 운영 문서 정리이며 runtime behavior 변경 없음.

## 5. Eval 영향

All `N/A` - runtime/eval code, fixtures, scorer, benchmark runner 변경 없음. Public fixture smoke나 private real-eval 수치에 영향을 주지 않습니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Load-bearing path 변경 없음.

## 6. 하위 호환

기존 CLI/API/schema/answer contract 변경 없음. 기존 `tasks/queue.md`, `docs/plans/TEMPLATE.md` 형식을 더 엄격히 확장하지만 repo-internal process docs라 runtime 호환성 영향은 없습니다.

## 7. 범위 외

- 다른 eval/benchmark follow-up worktree의 미커밋 산출물 정리.
- 새 CI gate 또는 hook 추가.
- product code, eval implementation, private real-eval 실행.
