### PR TITLE
fix: Harden benchmark and eval artifact surface guards (#1480)

### DIFF
--- a/docs/plans/T-2026-0001-benchmark-contamination-guard.md
+++ b/docs/plans/T-2026-0001-benchmark-contamination-guard.md
@@ -1,0 +1,50 @@
+# Plan: T-2026-0001 Benchmark Contamination Guard
+
+- Status: review
+- Owner role: Implementer
+- Related task: `tasks/queue.md::T-2026-0001`
+- Related issue / PR: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480) / PR TBD
+- Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+## Problem Statement
+
+The public synthetic benchmark already uses explicit gold evidence, but the
+validator report did not expose a machine-readable proof that the benchmark
+index build is corpus-only. Future benchmark claims need reviewer-visible
+evidence that questions, expected answers, and gold labels are not index input.
+
+## Desired Behavior
+
+`validate_benchmark_dataset.py` reports an `index_build_boundary` block showing
+that `index_build.input_path` equals `corpus_path`, the command builds from
+`--corpus`, and corpus chunk rows contain no query/gold label fields.
+
+## Constraints
+
+- Do not change benchmark scoring semantics.
+- Do not change retrieval, verifier, answer, or private real-eval behavior.
+- Keep the surface classified as public synthetic benchmark only.
+
+## Architecture Impact
+
+- Affected modules: benchmark dataset validator and focused benchmark tests.
+- Load-bearing paths: `eval/`.
+- ADR required: no, this hardens an existing surface without changing its meaning.
+- Backward compatibility: additive report fields only.
+
+## Validation Strategy
+
+```bash
+python3 eval/naive_rag/validate_benchmark_dataset.py \
+  --config configs/eval/benchmark_naive_rag_v1.yaml \
+  --report reports/benchmark/naive_rag_v1_validation.json
+
+python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
+```
+
+## Reviewer Notes
+
+Attack the corpus-only proof first: the validator must fail if `index_build`
+points at questions/gold input or if corpus chunks carry label fields.

--- a/docs/plans/T-2026-0002-eval-artifact-surface-guard.md
+++ b/docs/plans/T-2026-0002-eval-artifact-surface-guard.md
@@ -1,0 +1,48 @@
+# Plan: T-2026-0002 Eval Artifact Surface Guard
+
+- Status: review
+- Owner role: Implementer
+- Related task: `tasks/queue.md::T-2026-0002`
+- Related issue / PR: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480) / PR TBD
+- Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+## Problem Statement
+
+Multiple files named `eval_summary.json` exist across public fixture smoke,
+public synthetic benchmark, private real-eval, and harness runs. The default
+delta comparator did not identify the surface being compared, so incompatible
+artifact comparisons could look legitimate.
+
+## Desired Behavior
+
+`scripts/compare_eval.py` renders best-effort surface labels for base/head
+summaries and offers an opt-in fail-closed gate for mismatched known surfaces.
+Unknown surfaces remain non-blocking but visible.
+
+## Constraints
+
+- Do not change metric calculation or regression thresholds.
+- Do not require private raw data or make private real-eval a CI dependency.
+- Keep existing PR fixture smoke workflow backward compatible.
+
+## Architecture Impact
+
+- Affected modules: eval delta comparator and focused CLI tests.
+- Load-bearing paths: none directly, but this is eval governance tooling.
+- ADR required: no, this enforces existing ADR 0005 surface separation.
+- Backward compatibility: default compare remains non-blocking for unknown or matching surfaces.
+
+## Validation Strategy
+
+```bash
+python3 -m pytest tests/test_compare_eval_regression_gate.py -q
+python3 scripts/check_doc_links.py --check-all
+python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
+```
+
+## Reviewer Notes
+
+Attack claim boundary wording first: smoke, synthetic benchmark, private
+real-eval, and harness summaries must not be silently treated as interchangeable.

--- a/eval/naive_rag/validate_benchmark_dataset.py
+++ b/eval/naive_rag/validate_benchmark_dataset.py
@@ -12,6 +12,7 @@ from collections import Counter, defaultdict
 import json
 from pathlib import Path
 import re
+import shlex
 import sys
 from typing import Any
 
@@ -27,6 +28,7 @@ from rag_indexing import (  # noqa: E402
     build_chunk_records,
     load_raw_documents,
 )
+from eval.naive_rag.build_benchmark_index import PROHIBITED_CORPUS_FIELDS  # noqa: E402
 
 
 MIN_TOTAL_QUESTIONS = 50
@@ -55,6 +57,13 @@ TOKEN_RE = re.compile(r"[A-Za-z0-9]+|[가-힣]{2,}")
 def repo_path(value: str | Path) -> Path:
     path = Path(value)
     return path if path.is_absolute() else ROOT_DIR / path
+
+
+def display_path(value: Path) -> str:
+    try:
+        return str(value.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(value)
 
 
 def compact_text(value: str) -> str:
@@ -176,6 +185,100 @@ def has_korean_and_latin(text: str) -> bool:
     return bool(re.search(r"[가-힣]", text)) and bool(re.search(r"[A-Za-z]", text))
 
 
+def command_corpus_args(command: str) -> list[str]:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return []
+
+    values: list[str] = []
+    idx = 0
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token == "--corpus":
+            if idx + 1 < len(tokens):
+                values.append(tokens[idx + 1])
+                idx += 2
+                continue
+            values.append("")
+        elif token.startswith("--corpus="):
+            values.append(token.split("=", 1)[1])
+        idx += 1
+    return values
+
+
+def index_build_boundary_report(
+    config: dict[str, Any],
+    *,
+    corpus_path: Path,
+    questions_path: Path,
+    gold_path: Path,
+    corpus_chunks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    build_config = config.get("index_build") if isinstance(config.get("index_build"), dict) else {}
+    raw_input_path = str(build_config.get("input_path") or "").strip()
+    input_path = repo_path(raw_input_path) if raw_input_path else None
+    command = str(build_config.get("command") or "").strip()
+    raw_corpus_path = str(config.get("corpus_path") or "").strip()
+    raw_questions_path = str(config.get("questions_path") or "").strip()
+    raw_gold_path = str(config.get("gold_evidence_path") or "").strip()
+    corpus_args = command_corpus_args(command)
+    normalized_corpus_args = [repo_path(value) for value in corpus_args]
+
+    prohibited_rows = [
+        {
+            "row": idx,
+            "fields": sorted(PROHIBITED_CORPUS_FIELDS & set(row)),
+        }
+        for idx, row in enumerate(corpus_chunks, start=1)
+        if PROHIBITED_CORPUS_FIELDS & set(row)
+    ]
+    prohibited_fields = sorted({field for row in prohibited_rows for field in row["fields"]})
+    question_gold_tokens = {
+        token
+        for token in {
+            raw_questions_path,
+            raw_gold_path,
+            display_path(questions_path),
+            display_path(gold_path),
+        }
+        if token
+    }
+    command_refs = sorted(token for token in question_gold_tokens if token in command)
+    command_uses_corpus = len(normalized_corpus_args) == 1 and normalized_corpus_args[0] == corpus_path
+    input_matches_corpus = input_path == corpus_path if input_path is not None else False
+
+    errors: list[str] = []
+    if not raw_input_path:
+        errors.append("index_build.input_path must be set to corpus_path")
+    elif not input_matches_corpus:
+        errors.append("index_build.input_path must match corpus_path")
+    if str(build_config.get("input_kind") or "") != "corpus_chunks_jsonl":
+        errors.append("index_build.input_kind must be corpus_chunks_jsonl")
+    if not command_uses_corpus:
+        errors.append("index_build.command must pass exactly one --corpus argument matching corpus_path")
+    if command_refs:
+        errors.append("index_build.command must not reference questions_path or gold_evidence_path")
+    if prohibited_rows:
+        errors.append("corpus_path rows must not contain query/gold label fields")
+
+    return {
+        "status": "pass" if not errors else "fail",
+        "surface": "public_synthetic_benchmark",
+        "input_kind": str(build_config.get("input_kind") or ""),
+        "allowed_input_path": display_path(corpus_path),
+        "configured_input_path": display_path(input_path) if input_path is not None else "",
+        "input_matches_corpus_path": input_matches_corpus,
+        "command_uses_corpus_path": command_uses_corpus,
+        "command_corpus_args": [display_path(path) for path in normalized_corpus_args],
+        "command_references_question_or_gold_paths": bool(command_refs),
+        "command_reference_matches": command_refs,
+        "corpus_rows_with_query_or_gold_fields": len(prohibited_rows),
+        "prohibited_corpus_fields_detected": prohibited_fields,
+        "errors": errors,
+    }
+
+
 def validate_dataset(config_path: Path) -> dict[str, Any]:
     config_path = repo_path(config_path)
     config = load_config(config_path)
@@ -235,6 +338,14 @@ def validate_dataset(config_path: Path) -> dict[str, Any]:
     if raw_chunk_ids != corpus_chunk_ids:
         errors.append("corpus_path chunk ids must match configured corpus_dir chunking output")
     chunk_by_id = {str(chunk.get("chunk_id") or ""): chunk for chunk in corpus_chunks}
+    index_boundary = index_build_boundary_report(
+        config,
+        corpus_path=corpus_path,
+        questions_path=questions_path,
+        gold_path=gold_path,
+        corpus_chunks=corpus_chunks,
+    )
+    errors.extend(index_boundary["errors"])
 
     answerable = [row for row in questions if bool(row.get("answerable", True))]
     unanswerable = [row for row in questions if not bool(row.get("answerable", True))]
@@ -380,7 +491,7 @@ def validate_dataset(config_path: Path) -> dict[str, Any]:
     page_gold_count = sum(1 for item in gold_evidence if item.get("page") is not None)
     page_chunk_count = sum(1 for chunk in corpus_chunks if chunk.get("page_span"))
     summary = {
-        "config_path": str(config_path.relative_to(ROOT_DIR)),
+        "config_path": display_path(config_path),
         "errors": errors,
         "warnings": warnings,
         "dataset_summary": {
@@ -390,10 +501,11 @@ def validate_dataset(config_path: Path) -> dict[str, Any]:
             "answerable_count": len(answerable),
             "unanswerable_count": len(unanswerable),
             "chunk_count_top_k_ratio": round(chunk_top_k_ratio, 3),
-            "corpus_path": str(corpus_path.relative_to(ROOT_DIR)) if corpus_path.is_absolute() else str(corpus_path),
+            "corpus_path": display_path(corpus_path),
             "chunking_strategy": chunking_strategy,
             "chunking": chunking_diagnostics,
         },
+        "index_build_boundary": index_boundary,
         "question_type_distribution": dict(sorted(type_counts.items())),
         "difficulty_distribution": dict(sorted(Counter(row.get("difficulty") for row in questions).items())),
         "gold_evidence_summary": {

--- a/scripts/compare_eval.py
+++ b/scripts/compare_eval.py
@@ -55,6 +55,15 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     ap.add_argument(
+        "--fail-on-surface-mismatch",
+        action="store_true",
+        help=(
+            "Exit 2 when the compared eval_summary.json files are classified "
+            "as different evaluation surfaces. Unknown surfaces are rendered "
+            "but do not fail the gate."
+        ),
+    )
+    ap.add_argument(
         "--regression-threshold",
         type=float,
         default=DEFAULT_REGRESSION_THRESHOLD,
@@ -92,6 +101,45 @@ def parse_args() -> argparse.Namespace:
 
 def _env_flag(name: str) -> bool:
     return (os.environ.get(name) or "").strip().lower() in ("1", "true", "yes", "y")
+
+
+def classify_eval_surface(summary: dict, *, path: str | Path | None = None) -> str:
+    """Best-effort eval surface classification for reviewer-visible output.
+
+    The classifier is intentionally conservative: unknown summaries are labeled
+    as unknown instead of being coerced into a claim-bearing surface.
+    """
+    benchmark_type = str(summary.get("benchmark_type") or summary.get("eval_type") or "").strip().lower()
+    if benchmark_type == "private_real_eval":
+        return "private_real_eval"
+    if benchmark_type == "naive_rag_benchmark":
+        return "public_synthetic_benchmark"
+    if benchmark_type == "public_fixture_smoke_regression":
+        return "public_fixture_smoke"
+
+    if path is not None:
+        normalized = Path(path).as_posix()
+        relativeish = normalized.lstrip("./")
+        if (
+            relativeish.startswith("reports/real")
+            or "/reports/real" in relativeish
+        ) and relativeish.endswith("/eval_summary.json"):
+            return "private_real_eval"
+        if relativeish == "reports/eval_summary.json" or relativeish.endswith("/reports/eval_summary.json"):
+            return "public_fixture_smoke"
+        if (
+            relativeish.startswith("artifacts/runs/")
+            or "/artifacts/runs/" in relativeish
+        ) and relativeish.endswith("/metrics/eval_summary.json"):
+            return "harness_run"
+
+    return "unknown_eval_summary"
+
+
+def surfaces_compatible(base_surface: str, head_surface: str) -> bool:
+    if base_surface.startswith("unknown") or head_surface.startswith("unknown"):
+        return True
+    return base_surface == head_surface
 
 
 def _render_gate_block(regressions: list[dict], *, allow: bool) -> list[str]:
@@ -195,6 +243,9 @@ def main() -> int:
     args = parse_args()
     base = json.loads(Path(args.base).read_text(encoding="utf-8"))
     head = json.loads(Path(args.head).read_text(encoding="utf-8"))
+    base_surface = classify_eval_surface(base, path=args.base)
+    head_surface = classify_eval_surface(head, path=args.head)
+    surface_mismatch = not surfaces_compatible(base_surface, head_surface)
 
     lines: list[str] = []
     lines.append(f"### {args.title}")
@@ -206,10 +257,17 @@ def main() -> int:
         f"- pipeline: `{head.get('pipeline', '?')}` "
         f"(primary run: `{head.get('primary_run', '?')}`)"
     )
+    lines.append(f"- surface: base=`{base_surface}` · head=`{head_surface}`")
     lines.append(
         f"- cases: base={base.get('num_predictions', '?')} · "
         f"head={head.get('num_predictions', '?')}"
     )
+    if surface_mismatch:
+        lines.append(
+            "> ⚠️ Surface mismatch: compare smoke, synthetic benchmark, "
+            "private real-eval, and harness artifacts only with matching "
+            "dataset/config/index provenance."
+        )
     lines.append("")
     n_min = min_num_predictions(base, head)
     lines.append("| metric | main | PR | Δ |")
@@ -236,6 +294,8 @@ def main() -> int:
 
     print("\n".join(lines))
 
+    if surface_mismatch and args.fail_on_surface_mismatch:
+        return 2
     if regressions and not args.allow_regression:
         return 1
     return 0

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -11,8 +11,8 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 
 | Order | ID | Status | Owner role | Why ready / not ready |
 |---:|---|---|---|---|
-| 1 | `T-2026-0001` | `ready` | Planner -> Benchmark Auditor -> Implementer | synthetic benchmark contamination 방지 범위, validation command, evidence가 명확하다. |
-| 2 | `T-2026-0002` | `ready` | Planner -> Implementer -> Reviewer | smoke/synthetic/private real-eval 분리 기준과 regression evidence가 명확하다. |
+| 1 | `T-2026-0001` | `review` | Implementer -> Benchmark Auditor -> Reviewer | corpus-only benchmark index boundary report와 focused tests 추가됨. |
+| 2 | `T-2026-0002` | `review` | Implementer -> Reviewer | eval summary surface label + opt-in mismatch gate와 focused tests 추가됨. |
 
 ## Examples
 
@@ -23,8 +23,8 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 
 - ID: T-2026-0001
 - Title: Benchmark hardening against synthetic contamination
-- Status: ready
-- Owner role: Planner -> Benchmark Auditor -> Implementer
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Reviewer
 - Created: 2026-05-25
 - Last updated: 2026-05-25
 
@@ -54,8 +54,8 @@ contaminated index inputs, or over-claiming.
 
 ### Acceptance Criteria
 
-- [ ] Benchmark index build is documented/tested as corpus-only.
-- [ ] Benchmark claim wording is synthetic-only and links to the surface map.
+- [x] Benchmark index build is documented/tested as corpus-only.
+- [x] Benchmark claim wording is synthetic-only and links to the surface map.
 - [ ] Benchmark Auditor checklist is satisfied.
 
 ### Validation Commands
@@ -81,8 +81,8 @@ python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
 
 ### Related Plan / Issue / PR Links
 
-- Plan: [`docs/plans/EXAMPLE-benchmark-hardening.md`](../docs/plans/EXAMPLE-benchmark-hardening.md)
-- Issue: TBD
+- Plan: [`docs/plans/T-2026-0001-benchmark-contamination-guard.md`](../docs/plans/T-2026-0001-benchmark-contamination-guard.md)
+- Issue: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480)
 - PR: TBD
 - ADR: [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md)
 - Report: TBD
@@ -102,12 +102,34 @@ python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
 - Risks: Scope creep into scoring semantics or unsupported real-eval claims.
 ```
 
+```markdown
+## Session Handoff — 2026-05-25 18:49 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: fix/issue-1480-benchmark-eval-surface-guards / /Users/hskim/.codex/worktrees/cd0b/BidMate-DocAgent
+- Task: T-2026-0001
+- Plan: docs/plans/T-2026-0001-benchmark-contamination-guard.md
+- Current status: corpus-only index boundary report and regression tests added.
+- Files touched: eval/naive_rag/validate_benchmark_dataset.py, tests/test_naive_rag_benchmark_v1.py
+- Decisions made: Additive validator report only; no benchmark scoring or retrieval behavior change.
+- Commands run: python3 eval/naive_rag/validate_benchmark_dataset.py --config configs/eval/benchmark_naive_rag_v1.yaml --report reports/benchmark/naive_rag_v1_validation.json; python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q; python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py scripts/compare_eval.py; git diff --check
+- Results: pass; validation report index_build_boundary.status=pass.
+- Validation evidence: reports/benchmark/naive_rag_v1_validation.json generated locally.
+- Eval surface: public synthetic benchmark.
+- Evidence artifacts: local validation JSON only.
+- Open risks: Benchmark Auditor still needs to confirm no real-world performance claim is implied.
+- Next action: Review diff and benchmark validity checklist.
+- Next safe command: python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
+- Reviewer focus: corpus-only proof, prohibited label fields, no metric semantics change.
+```
+
 ## T-2026-0002 — Eval regression safety surface separation
 
 - ID: T-2026-0002
 - Title: Eval regression safety surface separation
-- Status: ready
-- Owner role: Planner -> Implementer -> Reviewer
+- Status: review
+- Owner role: Implementer -> Reviewer
 - Created: 2026-05-25
 - Last updated: 2026-05-25
 
@@ -137,8 +159,8 @@ regression evidence.
 
 ### Acceptance Criteria
 
-- [ ] Future agents can identify which `eval_summary.json` they are reading.
-- [ ] Smoke/synthetic/private claims are explicitly separated.
+- [x] Future agents can identify which `eval_summary.json` they are reading.
+- [x] Smoke/synthetic/private claims are explicitly separated.
 - [ ] Reviewer checklist catches incompatible artifact comparisons.
 
 ### Validation Commands
@@ -161,8 +183,8 @@ python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
 
 ### Related Plan / Issue / PR Links
 
-- Plan: TBD
-- Issue: TBD
+- Plan: [`docs/plans/T-2026-0002-eval-artifact-surface-guard.md`](../docs/plans/T-2026-0002-eval-artifact-surface-guard.md)
+- Issue: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480)
 - PR: TBD
 - ADR: [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md)
 - Report: TBD
@@ -180,4 +202,26 @@ python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
 - Results: Task is ready when an implementer can prove artifact provenance or document manual validation.
 - Next safe command: inspect eval artifact docs and existing regression tests.
 - Risks: Accidentally requiring private raw data or comparing incompatible summaries.
+```
+
+```markdown
+## Session Handoff — 2026-05-25 18:49 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: fix/issue-1480-benchmark-eval-surface-guards / /Users/hskim/.codex/worktrees/cd0b/BidMate-DocAgent
+- Task: T-2026-0002
+- Plan: docs/plans/T-2026-0002-eval-artifact-surface-guard.md
+- Current status: compare_eval surface labels and opt-in surface mismatch gate added.
+- Files touched: scripts/compare_eval.py, tests/test_compare_eval_regression_gate.py
+- Decisions made: Unknown surfaces remain visible but non-blocking by default to preserve PR eval compatibility.
+- Commands run: python3 -m pytest tests/test_compare_eval_regression_gate.py -q; python3 scripts/check_doc_links.py --check-all; python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q; python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py scripts/compare_eval.py; git diff --check
+- Results: pass.
+- Validation evidence: focused tests and doc link check.
+- Eval surface: eval governance; no benchmark metric semantics changed.
+- Evidence artifacts: none committed.
+- Open risks: Reviewer should decide whether CI should enable --fail-on-surface-mismatch later.
+- Next action: Review diff and normal/governance checklist.
+- Next safe command: python3 -m pytest tests/test_compare_eval_regression_gate.py -q
+- Reviewer focus: backward-compatible output shape, no private raw data dependency, no incompatible surface overclaim.
 ```

--- a/tests/test_compare_eval_regression_gate.py
+++ b/tests/test_compare_eval_regression_gate.py
@@ -35,6 +35,7 @@ from _eval_delta import (  # noqa: E402
     min_num_predictions,
     silence_threshold,
 )
+from compare_eval import classify_eval_surface  # noqa: E402
 
 
 def _base_summary() -> dict:
@@ -211,6 +212,26 @@ class AbstentionOutcomeRegressionTest(unittest.TestCase):
         self.assertEqual(detect_abstention_outcome_regressions(base, head), [])
 
 
+class EvalSurfaceClassificationTest(unittest.TestCase):
+    def test_classifies_repo_relative_public_smoke_path(self) -> None:
+        self.assertEqual(
+            classify_eval_surface({}, path="reports/eval_summary.json"),
+            "public_fixture_smoke",
+        )
+
+    def test_classifies_repo_relative_private_real_eval_path(self) -> None:
+        self.assertEqual(
+            classify_eval_surface({}, path="reports/real100/eval_summary.json"),
+            "private_real_eval",
+        )
+
+    def test_classifies_repo_relative_harness_path(self) -> None:
+        self.assertEqual(
+            classify_eval_surface({}, path="artifacts/runs/run-1/metrics/eval_summary.json"),
+            "harness_run",
+        )
+
+
 class CompareEvalCliGateTest(unittest.TestCase):
     """Exit-code contract for the workflow.
 
@@ -261,6 +282,54 @@ class CompareEvalCliGateTest(unittest.TestCase):
             )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("### Test\n\n> Scope: public fixture smoke only.", result.stdout)
+
+    def test_surface_classification_renders_in_default_output(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            result = self._run(Path(td), _base_summary(), _base_summary())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("- surface: base=`unknown_eval_summary` · head=`unknown_eval_summary`", result.stdout)
+
+    def test_surface_mismatch_warning_is_non_blocking_by_default(self) -> None:
+        import tempfile
+        base = dict(_base_summary(), benchmark_type="private_real_eval")
+        head = dict(_base_summary(), benchmark_type="naive_rag_benchmark")
+        with tempfile.TemporaryDirectory() as td:
+            result = self._run(Path(td), base, head, regression_threshold=0)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("base=`private_real_eval` · head=`public_synthetic_benchmark`", result.stdout)
+        self.assertIn("Surface mismatch", result.stdout)
+
+    def test_surface_mismatch_can_fail_closed(self) -> None:
+        import tempfile
+        base = dict(_base_summary(), benchmark_type="private_real_eval")
+        head = dict(_base_summary(), benchmark_type="naive_rag_benchmark")
+        with tempfile.TemporaryDirectory() as td:
+            result = self._run(
+                Path(td),
+                base,
+                head,
+                regression_threshold=0,
+                fail_on_surface_mismatch=True,
+            )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("Surface mismatch", result.stdout)
+
+    def test_unknown_surface_does_not_fail_closed_against_known_surface(self) -> None:
+        import tempfile
+        base = _base_summary()
+        head = dict(_base_summary(), benchmark_type="private_real_eval")
+        with tempfile.TemporaryDirectory() as td:
+            result = self._run(
+                Path(td),
+                base,
+                head,
+                regression_threshold=0,
+                fail_on_surface_mismatch=True,
+            )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("base=`unknown_eval_summary` · head=`private_real_eval`", result.stdout)
+        self.assertNotIn("Surface mismatch", result.stdout)
 
     def test_regression_exits_one(self) -> None:
         import tempfile

--- a/tests/test_naive_rag_benchmark_v1.py
+++ b/tests/test_naive_rag_benchmark_v1.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -90,6 +91,96 @@ def test_benchmark_dataset_validator_reports_counts() -> None:
     assert dataset["answerable_count"] == 40
     assert dataset["unanswerable_count"] == 15
     assert summary["gold_evidence_summary"]["num_evidence_records"] == 47
+
+
+def test_benchmark_dataset_validator_reports_corpus_only_index_boundary() -> None:
+    summary = validate_dataset(BENCHMARK_CONFIG)
+    boundary = summary["index_build_boundary"]
+
+    assert summary["errors"] == []
+    assert boundary["status"] == "pass"
+    assert boundary["surface"] == "public_synthetic_benchmark"
+    assert boundary["input_kind"] == "corpus_chunks_jsonl"
+    assert boundary["allowed_input_path"] == "data/eval/benchmark/corpus_chunks_v1.jsonl"
+    assert boundary["configured_input_path"] == "data/eval/benchmark/corpus_chunks_v1.jsonl"
+    assert boundary["input_matches_corpus_path"] is True
+    assert boundary["command_uses_corpus_path"] is True
+    assert boundary["command_references_question_or_gold_paths"] is False
+    assert boundary["corpus_rows_with_query_or_gold_fields"] == 0
+    assert boundary["prohibited_corpus_fields_detected"] == []
+
+
+def test_benchmark_dataset_validator_rejects_index_build_from_questions(tmp_path: Path) -> None:
+    config = _yaml(BENCHMARK_CONFIG)
+    config["index_build"]["input_path"] = config["questions_path"]
+    config_path = tmp_path / "benchmark_naive_rag_v1.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    summary = validate_dataset(config_path)
+
+    assert summary["index_build_boundary"]["status"] == "fail"
+    assert "index_build.input_path must match corpus_path" in summary["errors"]
+
+
+def test_benchmark_dataset_validator_parses_actual_corpus_arg(tmp_path: Path) -> None:
+    config = _yaml(BENCHMARK_CONFIG)
+    config["index_build"]["command"] = (
+        "python3 -m eval.naive_rag.build_benchmark_index "
+        f"--corpus {config['questions_path']} "
+        f"--note {config['corpus_path']} "
+        "--output data/eval/benchmark/index_v1"
+    )
+    config_path = tmp_path / "benchmark_naive_rag_v1.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    summary = validate_dataset(config_path)
+
+    assert summary["index_build_boundary"]["status"] == "fail"
+    assert summary["index_build_boundary"]["command_uses_corpus_path"] is False
+    assert summary["index_build_boundary"]["command_corpus_args"] == [
+        "data/eval/benchmark/rag_questions_v1.jsonl"
+    ]
+    assert (
+        "index_build.command must pass exactly one --corpus argument matching corpus_path"
+        in summary["errors"]
+    )
+
+
+def test_benchmark_dataset_validator_rejects_label_fields_in_corpus_chunks(tmp_path: Path) -> None:
+    source = ROOT / "data" / "eval" / "benchmark" / "corpus_chunks_v1.jsonl"
+    rows = [json.loads(line) for line in source.read_text(encoding="utf-8").splitlines()]
+    rows[0]["expected_answer"] = "leaked label"
+    contaminated = tmp_path / "corpus_chunks_v1.jsonl"
+    contaminated.write_text(
+        "\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+    config = _yaml(BENCHMARK_CONFIG)
+    config["corpus_path"] = str(contaminated)
+    config["index_build"]["input_path"] = str(contaminated)
+    config["index_build"]["command"] = (
+        "python3 -m eval.naive_rag.build_benchmark_index "
+        f"--corpus {contaminated} --output data/eval/benchmark/index_v1"
+    )
+    config_path = tmp_path / "benchmark_naive_rag_v1.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    summary = validate_dataset(config_path)
+    boundary = summary["index_build_boundary"]
+
+    assert boundary["status"] == "fail"
+    assert boundary["corpus_rows_with_query_or_gold_fields"] == 1
+    assert boundary["prohibited_corpus_fields_detected"] == ["expected_answer"]
+    assert "corpus_path rows must not contain query/gold label fields" in summary["errors"]
 
 
 def test_benchmark_index_can_be_built_from_corpus_chunks_v1(tmp_path: Path) -> None:


### PR DESCRIPTION
## 1. What changed and why

fix: Harden benchmark and eval artifact surface guards (#1480)

Closes #1480

🤖 Auto-shipped by scripts/claude-hooks/stop-ship.sh

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #1480

## 2. Files affected

- `docs/plans/T-2026-0001-benchmark-contamination-guard.md`
- `docs/plans/T-2026-0002-eval-artifact-surface-guard.md`
- `eval/naive_rag/validate_benchmark_dataset.py` (load-bearing)
- `scripts/compare_eval.py`
- `tasks/queue.md`
- `tests/test_compare_eval_regression_gate.py`
- `tests/test_naive_rag_benchmark_v1.py`

## 3. Risks

Auto-generated PR. Test coverage: see §4. Reviewer should focus on the 1 load-bearing path(s) listed above.

## 4. Tests

Local test run not captured by dispatcher.

## 5. Eval impact

See §5b (load-bearing change touched).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (REAL_EVAL=skip)

## 6. Backward compatibility

No public-API change detected.

## 7. Out of scope

N/A — single-concern auto-shipped PR.

---

Manual continuation after auto-ship push upstream mismatch. Auto-ship Stage 1 ran bash scripts/test.sh and reached commit successfully before Stage 2 push failed due upstream mismatch; push and PR creation continued manually.
