### PR TITLE
chore: Auto-sync Desktop main after auto-ship merge (#1482)

### DIFF
--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -51,6 +51,7 @@ make ship-start TITLE="자동화 범위 설명" TYPE=chore SLUG=short-slug
 | `DRY_RUN` | `0` | `1` 일 때, 모든 mutating 명령이 실행 대신 `.claude/.ship-dryrun.log` 로 echo 된다. |
 | `CROSS_OWNER` | _(empty)_ | `ack` 은 multi-agent lock 검사([`docs/multi-agent-ownership.md`](../multi-agent-ownership.md))를 우회한다. |
 | `STACKED` | _(empty)_ | `ack` 은 heterogeneous-prefix 거부를 우회한다(아래 [Stacked-PR 규율](#stacked-pr-discipline-tier-7) 참조). |
+| `BIDMATE_DESKTOP_REPO` | `/Users/hskim/Desktop/projects/BidMate-DocAgent` | Stage 5 merge 직후 fast-forward 동기화할 canonical Desktop checkout. |
 
 `make ship-disarm` 은 arm 파일과 pid 파일을 제거한다. `make ship-status`
 는 사람이 읽을 수 있는 요약을 출력한다.
@@ -161,9 +162,12 @@ GitHub review-fix 루프를 실행해 코멘트를 처리하고, fix 커밋을 p
 
 `gh pr merge <N> --squash --admin` (의도적으로 `--delete-branch` **없음** — issue #1283).
 머지 후 상태가 `MERGED` 인지 검증한다(아니면 검사를 위해 arm 파일을 그대로 둔다).
-그런 다음 `git push origin --delete <branch>` 로 **원격 브랜치를 삭제**하고,
-`git checkout main && git pull --ff-only`, 로컬 브랜치 삭제, `S5_OK` 라인을
-`.claude/.ship-history.log` 에 기록, arm 파일 제거.
+그런 다음 [`scripts/sync_desktop_main.py`](../../scripts/sync_desktop_main.py)로
+canonical Desktop checkout의 `main`을 `origin/main`에 맞게 fast-forward 한다.
+이 동기화는 fail-soft다: 대상이 없거나 dirty/divergent 상태면 로그만 남기고
+merge 성공을 되돌리지 않는다. 이어서 `git push origin --delete <branch>` 로
+**원격 브랜치를 삭제**하고, `git checkout main && git pull --ff-only`, 로컬 브랜치
+삭제, `S5_OK` 라인을 `.claude/.ship-history.log` 에 기록, arm 파일 제거.
 
 `--delete-branch` 를 쓰지 않는 이유: gh 의 `--delete-branch` 는 원격 삭제를
 로컬 checkout-to-default + 로컬 브랜치 삭제와 한 명령에 묶는다. 이 repo 는

--- a/docs/plans/T-2026-0003-desktop-main-auto-sync.md
+++ b/docs/plans/T-2026-0003-desktop-main-auto-sync.md
@@ -1,0 +1,41 @@
+# Plan: T-2026-0003 Desktop Main Auto Sync After Auto-Ship Merge
+
+- Status: review
+- Owner role: Implementer
+- Related task: `tasks/queue.md::T-2026-0003`
+- Related issue / PR: [#1482](https://github.com/hskim-solv/BidMate-DocAgent/issues/1482) / PR TBD
+- Related ADR: N/A - developer tooling only
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+## Problem Statement
+
+After auto-ship merges a PR, the canonical Desktop checkout can remain behind
+GitHub `main`. That stale main causes follow-up worktrees to start from an old
+base unless the operator remembers a manual `git pull --ff-only`.
+
+## Desired Behavior
+
+Auto-ship Stage 5 runs a fail-soft fast-forward sync for
+`/Users/hskim/Desktop/projects/BidMate-DocAgent` immediately after a successful
+merge. The sync never resets or discards local work.
+
+## Constraints
+
+- Only fast-forward `main`.
+- Skip when the target repo is missing, dirty, or divergent.
+- Do not block a successful merge if the Desktop sync cannot run safely.
+- Keep this as developer tooling; no eval or runtime behavior changes.
+
+## Validation Strategy
+
+```bash
+python3 -m pytest tests/test_sync_desktop_main.py -q
+python3 -m py_compile scripts/sync_desktop_main.py
+git diff --check
+```
+
+## Reviewer Notes
+
+Attack safety first: this must not run `reset`, discard local changes, or make
+merge success depend on a local Desktop checkout.

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -430,6 +430,14 @@ stage_5_merge() {
     fi
   fi
 
+  local desktop_repo="${BIDMATE_DESKTOP_REPO:-/Users/hskim/Desktop/projects/BidMate-DocAgent}"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "s5" "[dry-run] python3 scripts/sync_desktop_main.py --repo '$desktop_repo'"
+  else
+    python3 scripts/sync_desktop_main.py --repo "$desktop_repo" || \
+      log "s5" "desktop main sync skipped/non-fatal; run manually if needed"
+  fi
+
   # Worktree-safe remote-branch deletion (replaces gh's --delete-branch; #1283).
   mut git push origin --delete "$ARM_BRANCH" 2>/dev/null || \
     log "s5" "remote branch delete non-fatal: $ARM_BRANCH may already be gone"

--- a/scripts/sync_desktop_main.py
+++ b/scripts/sync_desktop_main.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Fail-soft sync for the canonical Desktop checkout's main branch.
+
+Auto-ship calls this after a successful merge so the long-lived Desktop clone
+does not lag behind GitHub main. The script never resets or discards local
+work: it only fast-forwards `main` when that is safe.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import sys
+
+
+DEFAULT_REPO = Path("/Users/hskim/Desktop/projects/BidMate-DocAgent")
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    status: str
+    reason: str
+    exit_code: int
+
+
+def _run_git(repo: Path, args: list[str], *, check: bool = False) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return result
+
+
+def _git_stdout(repo: Path, args: list[str]) -> str:
+    return _run_git(repo, args, check=True).stdout.strip()
+
+
+def _skip(reason: str) -> SyncResult:
+    return SyncResult("skipped", reason, 2)
+
+
+def sync_desktop_main(repo: Path, *, remote: str = "origin", branch: str = "main") -> SyncResult:
+    repo = repo.expanduser()
+    if not repo.exists():
+        return _skip(f"repo not found: {repo}")
+    if _run_git(repo, ["rev-parse", "--git-dir"]).returncode != 0:
+        return _skip(f"not a git repository: {repo}")
+
+    fetch = _run_git(repo, ["fetch", remote, branch])
+    if fetch.returncode != 0:
+        return _skip(f"fetch failed: {(fetch.stderr or fetch.stdout).strip()}")
+
+    remote_ref = f"{remote}/{branch}"
+    if _run_git(repo, ["rev-parse", "--verify", branch]).returncode != 0:
+        return _skip(f"local branch missing: {branch}")
+    if _run_git(repo, ["rev-parse", "--verify", remote_ref]).returncode != 0:
+        return _skip(f"remote branch missing: {remote_ref}")
+
+    local_sha = _git_stdout(repo, ["rev-parse", branch])
+    remote_sha = _git_stdout(repo, ["rev-parse", remote_ref])
+    if local_sha == remote_sha:
+        return SyncResult("ok", f"{branch} already matches {remote_ref}", 0)
+
+    ancestor = _run_git(repo, ["merge-base", "--is-ancestor", branch, remote_ref])
+    if ancestor.returncode != 0:
+        return _skip(f"{branch} is not an ancestor of {remote_ref}; refusing non-ff sync")
+
+    current_branch = _git_stdout(repo, ["branch", "--show-current"])
+    if current_branch == branch:
+        dirty = _git_stdout(repo, ["status", "--porcelain"])
+        if dirty:
+            return _skip(f"{repo} has local changes on {branch}; refusing pull")
+        merge = _run_git(repo, ["merge", "--ff-only", remote_ref])
+        if merge.returncode != 0:
+            return _skip(f"ff merge failed: {(merge.stderr or merge.stdout).strip()}")
+        return SyncResult("synced", f"{branch} fast-forwarded to {remote_ref}", 0)
+
+    update = _run_git(repo, ["branch", "--force", branch, remote_ref])
+    if update.returncode != 0:
+        return _skip(f"branch update failed: {(update.stderr or update.stdout).strip()}")
+    return SyncResult("synced", f"{branch} ref fast-forwarded to {remote_ref}", 0)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fast-forward the Desktop checkout main to origin/main.")
+    parser.add_argument("--repo", default=str(DEFAULT_REPO), help="Canonical Desktop checkout path.")
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--branch", default="main")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = sync_desktop_main(Path(args.repo), remote=args.remote, branch=args.branch)
+    except Exception as exc:
+        print(f"[desktop-main-sync] skipped: {exc}", file=sys.stderr)
+        return 2
+    stream = sys.stderr if result.exit_code else sys.stdout
+    print(f"[desktop-main-sync] {result.status}: {result.reason}", file=stream)
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -11,8 +11,9 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 
 | Order | ID | Status | Owner role | Why ready / not ready |
 |---:|---|---|---|---|
-| 1 | `T-2026-0001` | `review` | Implementer -> Benchmark Auditor -> Reviewer | corpus-only benchmark index boundary report와 focused tests 추가됨. |
-| 2 | `T-2026-0002` | `review` | Implementer -> Reviewer | eval summary surface label + opt-in mismatch gate와 focused tests 추가됨. |
+| 1 | `T-2026-0001` | `done` | Implementer -> Benchmark Auditor -> Reviewer | merged in PR #1481. |
+| 2 | `T-2026-0002` | `done` | Implementer -> Reviewer | merged in PR #1481. |
+| 3 | `T-2026-0003` | `review` | Implementer -> Reviewer | auto-ship Stage 5 Desktop main fast-forward sync 구현됨. |
 
 ## Examples
 
@@ -23,7 +24,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 
 - ID: T-2026-0001
 - Title: Benchmark hardening against synthetic contamination
-- Status: review
+- Status: done
 - Owner role: Implementer -> Benchmark Auditor -> Reviewer
 - Created: 2026-05-25
 - Last updated: 2026-05-25
@@ -56,7 +57,7 @@ contaminated index inputs, or over-claiming.
 
 - [x] Benchmark index build is documented/tested as corpus-only.
 - [x] Benchmark claim wording is synthetic-only and links to the surface map.
-- [ ] Benchmark Auditor checklist is satisfied.
+- [x] Benchmark Auditor checklist is satisfied.
 
 ### Validation Commands
 
@@ -83,7 +84,7 @@ python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
 
 - Plan: [`docs/plans/T-2026-0001-benchmark-contamination-guard.md`](../docs/plans/T-2026-0001-benchmark-contamination-guard.md)
 - Issue: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480)
-- PR: TBD
+- PR: [#1481](https://github.com/hskim-solv/BidMate-DocAgent/pull/1481)
 - ADR: [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md)
 - Report: TBD
 
@@ -106,21 +107,21 @@ python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
 ## Session Handoff — 2026-05-25 18:49 KST
 
 - Role: Implementer
-- Lifecycle stage: review
+- Lifecycle stage: done
 - Branch / worktree: fix/issue-1480-benchmark-eval-surface-guards / /Users/hskim/.codex/worktrees/cd0b/BidMate-DocAgent
 - Task: T-2026-0001
 - Plan: docs/plans/T-2026-0001-benchmark-contamination-guard.md
-- Current status: corpus-only index boundary report and regression tests added.
+- Current status: merged in PR #1481.
 - Files touched: eval/naive_rag/validate_benchmark_dataset.py, tests/test_naive_rag_benchmark_v1.py
 - Decisions made: Additive validator report only; no benchmark scoring or retrieval behavior change.
 - Commands run: python3 eval/naive_rag/validate_benchmark_dataset.py --config configs/eval/benchmark_naive_rag_v1.yaml --report reports/benchmark/naive_rag_v1_validation.json; python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q; python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py scripts/compare_eval.py; git diff --check
-- Results: pass; validation report index_build_boundary.status=pass.
+- Results: pass; validation report index_build_boundary.status=pass; PR #1481 merged.
 - Validation evidence: reports/benchmark/naive_rag_v1_validation.json generated locally.
 - Eval surface: public synthetic benchmark.
 - Evidence artifacts: local validation JSON only.
-- Open risks: Benchmark Auditor still needs to confirm no real-world performance claim is implied.
-- Next action: Review diff and benchmark validity checklist.
-- Next safe command: python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
+- Open risks: none for this task; follow-up benchmark expansion remains separate.
+- Next action: N/A
+- Next safe command: N/A
 - Reviewer focus: corpus-only proof, prohibited label fields, no metric semantics change.
 ```
 
@@ -128,7 +129,7 @@ python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
 
 - ID: T-2026-0002
 - Title: Eval regression safety surface separation
-- Status: review
+- Status: done
 - Owner role: Implementer -> Reviewer
 - Created: 2026-05-25
 - Last updated: 2026-05-25
@@ -161,7 +162,7 @@ regression evidence.
 
 - [x] Future agents can identify which `eval_summary.json` they are reading.
 - [x] Smoke/synthetic/private claims are explicitly separated.
-- [ ] Reviewer checklist catches incompatible artifact comparisons.
+- [x] Reviewer checklist catches incompatible artifact comparisons.
 
 ### Validation Commands
 
@@ -185,7 +186,7 @@ python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
 
 - Plan: [`docs/plans/T-2026-0002-eval-artifact-surface-guard.md`](../docs/plans/T-2026-0002-eval-artifact-surface-guard.md)
 - Issue: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480)
-- PR: TBD
+- PR: [#1481](https://github.com/hskim-solv/BidMate-DocAgent/pull/1481)
 - ADR: [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md)
 - Report: TBD
 
@@ -208,20 +209,100 @@ python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
 ## Session Handoff — 2026-05-25 18:49 KST
 
 - Role: Implementer
-- Lifecycle stage: review
+- Lifecycle stage: done
 - Branch / worktree: fix/issue-1480-benchmark-eval-surface-guards / /Users/hskim/.codex/worktrees/cd0b/BidMate-DocAgent
 - Task: T-2026-0002
 - Plan: docs/plans/T-2026-0002-eval-artifact-surface-guard.md
-- Current status: compare_eval surface labels and opt-in surface mismatch gate added.
+- Current status: merged in PR #1481.
 - Files touched: scripts/compare_eval.py, tests/test_compare_eval_regression_gate.py
 - Decisions made: Unknown surfaces remain visible but non-blocking by default to preserve PR eval compatibility.
 - Commands run: python3 -m pytest tests/test_compare_eval_regression_gate.py -q; python3 scripts/check_doc_links.py --check-all; python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q; python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py scripts/compare_eval.py; git diff --check
-- Results: pass.
-- Validation evidence: focused tests and doc link check.
+- Results: pass; PR #1481 merged.
+- Validation evidence: focused tests, doc link check, PR Eval Delta.
 - Eval surface: eval governance; no benchmark metric semantics changed.
 - Evidence artifacts: none committed.
 - Open risks: Reviewer should decide whether CI should enable --fail-on-surface-mismatch later.
-- Next action: Review diff and normal/governance checklist.
-- Next safe command: python3 -m pytest tests/test_compare_eval_regression_gate.py -q
+- Next action: no action; follow-up CI wiring would be a separate task.
+- Next safe command: N/A
 - Reviewer focus: backward-compatible output shape, no private raw data dependency, no incompatible surface overclaim.
+```
+
+## T-2026-0003 — Desktop main auto-sync after auto-ship merge
+
+- ID: T-2026-0003
+- Title: Desktop main auto-sync after auto-ship merge
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+### Goal
+
+After a successful auto-ship merge, make the canonical Desktop checkout's
+`main` match GitHub `origin/main` without requiring a manual pull.
+
+### Context
+
+- Surface: developer tooling / auto-ship.
+- Relevant docs: [`docs/operations/auto-ship.md`](../docs/operations/auto-ship.md).
+- Primary risk: stale Desktop `main` causing follow-up work to branch from an old base.
+
+### Scope
+
+- Add a fail-soft sync helper.
+- Call it from auto-ship Stage 5 after merge success.
+- Add focused temp-repo tests.
+
+### Non-Goals
+
+- Do not reset or discard local Desktop work.
+- Do not make Desktop sync a merge blocker.
+- Do not alter eval/runtime behavior.
+
+### Acceptance Criteria
+
+- [x] Clean Desktop `main` fast-forwards to `origin/main`.
+- [x] Dirty or divergent Desktop `main` is skipped.
+- [x] Auto-ship Stage 5 invokes the helper after merge success.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_sync_desktop_main.py -q
+python3 -m py_compile scripts/sync_desktop_main.py
+git diff --check
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Manual note that Desktop main was synced after #1481 merge.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0003-desktop-main-auto-sync.md`](../docs/plans/T-2026-0003-desktop-main-auto-sync.md)
+- Issue: [#1482](https://github.com/hskim-solv/BidMate-DocAgent/issues/1482)
+- PR: TBD
+- ADR: N/A
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-25 19:20 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1482-desktop-main-sync / /Users/hskim/.codex/worktrees/cd0b/BidMate-DocAgent
+- Task: T-2026-0003
+- Plan: docs/plans/T-2026-0003-desktop-main-auto-sync.md
+- Current status: fail-soft sync helper and Stage 5 hook added.
+- Files touched: scripts/sync_desktop_main.py, scripts/claude-hooks/stop-ship.sh, tests/test_sync_desktop_main.py, docs/operations/auto-ship.md, tasks/queue.md
+- Decisions made: dirty/divergent/missing Desktop repo skips; merge remains successful.
+- Commands run: python3 -m pytest tests/test_sync_desktop_main.py -q; python3 -m py_compile scripts/sync_desktop_main.py; bash -n scripts/claude-hooks/stop-ship.sh; python3 scripts/check_doc_links.py --check-all; git diff --check; python3 scripts/sync_desktop_main.py --repo /Users/hskim/Desktop/projects/BidMate-DocAgent
+- Results: pass; Desktop main already matches origin/main after manual fast-forward.
+- Eval surface: none.
+- Open risks: Reviewer should verify branch update cannot discard local work.
+- Next action: Run validation and ship.
+- Next safe command: python3 -m pytest tests/test_sync_desktop_main.py -q
+- Reviewer focus: no reset/destructive behavior, fail-soft Stage 5 behavior.
 ```

--- a/tests/test_sync_desktop_main.py
+++ b/tests/test_sync_desktop_main.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+from scripts.sync_desktop_main import sync_desktop_main
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    )
+
+
+def _sha(repo: Path, ref: str) -> str:
+    return _git(repo, "rev-parse", ref).stdout.strip()
+
+
+def _setup_remote_and_desktop(tmp_path: Path) -> tuple[Path, Path, Path]:
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    desktop = tmp_path / "desktop"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "clone", str(origin), str(seed)], check=True, capture_output=True, text=True)
+    _git(seed, "switch", "-c", "main")
+    (seed / "README.md").write_text("one\n", encoding="utf-8")
+    _git(seed, "add", "README.md")
+    _git(seed, "commit", "-m", "init")
+    _git(seed, "push", "-u", "origin", "main")
+    subprocess.run(["git", "clone", str(origin), str(desktop)], check=True, capture_output=True, text=True)
+    _git(desktop, "switch", "main")
+    return origin, seed, desktop
+
+
+def _push_remote_commit(seed: Path, text: str = "two\n") -> str:
+    (seed / "README.md").write_text(text, encoding="utf-8")
+    _git(seed, "add", "README.md")
+    _git(seed, "commit", "-m", "remote update")
+    _git(seed, "push", "origin", "main")
+    return _sha(seed, "HEAD")
+
+
+def test_sync_fast_forwards_clean_desktop_main(tmp_path: Path) -> None:
+    _origin, seed, desktop = _setup_remote_and_desktop(tmp_path)
+    remote_sha = _push_remote_commit(seed)
+
+    result = sync_desktop_main(desktop)
+
+    assert result.exit_code == 0
+    assert result.status == "synced"
+    assert _sha(desktop, "main") == remote_sha
+    assert _sha(desktop, "origin/main") == remote_sha
+
+
+def test_sync_updates_main_ref_when_desktop_is_on_feature_branch(tmp_path: Path) -> None:
+    _origin, seed, desktop = _setup_remote_and_desktop(tmp_path)
+    _git(desktop, "switch", "-c", "feature")
+    remote_sha = _push_remote_commit(seed)
+
+    result = sync_desktop_main(desktop)
+
+    assert result.exit_code == 0
+    assert _git(desktop, "branch", "--show-current").stdout.strip() == "feature"
+    assert _sha(desktop, "main") == remote_sha
+
+
+def test_sync_skips_dirty_desktop_main(tmp_path: Path) -> None:
+    _origin, seed, desktop = _setup_remote_and_desktop(tmp_path)
+    old_sha = _sha(desktop, "main")
+    _push_remote_commit(seed)
+    (desktop / "local.txt").write_text("dirty\n", encoding="utf-8")
+
+    result = sync_desktop_main(desktop)
+
+    assert result.exit_code == 2
+    assert result.status == "skipped"
+    assert "local changes" in result.reason
+    assert _sha(desktop, "main") == old_sha
+
+
+def test_sync_skips_divergent_desktop_main(tmp_path: Path) -> None:
+    _origin, seed, desktop = _setup_remote_and_desktop(tmp_path)
+    _push_remote_commit(seed, "remote\n")
+    (desktop / "README.md").write_text("local\n", encoding="utf-8")
+    _git(desktop, "add", "README.md")
+    _git(desktop, "commit", "-m", "local update")
+    local_sha = _sha(desktop, "main")
+
+    result = sync_desktop_main(desktop)
+
+    assert result.exit_code == 2
+    assert result.status == "skipped"
+    assert "not an ancestor" in result.reason
+    assert _sha(desktop, "main") == local_sha
+
+
+def test_stop_ship_stage_5_invokes_desktop_sync() -> None:
+    text = (REPO_ROOT / "scripts" / "claude-hooks" / "stop-ship.sh").read_text(encoding="utf-8")
+    assert "scripts/sync_desktop_main.py" in text
+    assert "BIDMATE_DESKTOP_REPO" in text


### PR DESCRIPTION
## 1. What changed and why

chore: Auto-sync Desktop main after auto-ship merge (#1482)

Closes #1482

🤖 Auto-shipped by scripts/claude-hooks/stop-ship.sh

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #1482

## 2. Files affected

- `docs/operations/auto-ship.md`
- `docs/plans/T-2026-0003-desktop-main-auto-sync.md`
- `scripts/claude-hooks/stop-ship.sh`
- `scripts/sync_desktop_main.py`
- `tasks/queue.md`
- `tests/test_sync_desktop_main.py`

## 3. Risks

Auto-generated PR; no load-bearing paths changed.

## 4. Tests

Local test run not captured by dispatcher.

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (no load-bearing path changed)

## 6. Backward compatibility

No public-API change detected.

## 7. Out of scope

N/A — single-concern auto-shipped PR.

---

Manual continuation after auto-ship push upstream mismatch. Auto-ship Stage 1 ran bash scripts/test.sh and reached commit successfully before Stage 2 push failed due upstream mismatch; push and PR creation continued manually.
