### PR TITLE
fix: Harden synthetic benchmark integrity

### DIFF
--- a/docs/plans/T-2026-0001-benchmark-contamination-guard.md
+++ b/docs/plans/T-2026-0001-benchmark-contamination-guard.md
@@ -1,9 +1,9 @@
 # Plan: T-2026-0001 Benchmark Contamination Guard
 
-- Status: review
+- Status: done
 - Owner role: Implementer
 - Related task: `tasks/queue.md::T-2026-0001`
-- Related issue / PR: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480) / PR TBD
+- Related issue / PR: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480) / [#1481](https://github.com/hskim-solv/BidMate-DocAgent/pull/1481)
 - Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
 - Created: 2026-05-25
 - Last updated: 2026-05-25

--- a/docs/plans/T-2026-0001-benchmark-integrity-followup.md
+++ b/docs/plans/T-2026-0001-benchmark-integrity-followup.md
@@ -1,0 +1,179 @@
+# Plan: T-2026-0001 Benchmark Integrity Follow-up
+
+- Status: review
+- Owner role: Implementer
+- Related task: `tasks/queue.md::T-2026-0001`
+- Related issue / PR: [#1485](https://github.com/hskim-solv/BidMate-DocAgent/issues/1485) / PR TBD
+- Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
+- Created: 2026-05-25
+- Last updated: 2026-05-25
+
+## Problem Statement
+
+T-2026-0001 already added corpus-only index boundary checks. The remaining risk
+inside the same benchmark-integrity surface is that a future benchmark config can
+look syntactically valid while missing claim-boundary metadata or accidentally
+pointing benchmark paths at public smoke fixture assets.
+
+## Current Behavior
+
+`eval/naive_rag/validate_benchmark_dataset.py` validates benchmark type,
+version, `not_ci_smoke`, corpus/gold evidence consistency, leakage heuristics,
+and corpus-only index build boundaries. It does not yet make required
+`dataset_metadata` fields a validator contract, and it does not explicitly fail
+when benchmark paths point at smoke fixture paths such as `data/index` or
+`data/eval/rag_questions.jsonl`.
+
+## Desired Behavior
+
+The benchmark validator fails with clear errors when:
+
+- required public synthetic benchmark metadata is missing or misclassified.
+- benchmark corpus/index/question/gold paths reuse public fixture smoke assets.
+- index build output configuration drifts away from benchmark `index_dir`.
+
+The benchmark runner also refuses a stale or contaminated `index.json` whose
+recorded corpus provenance does not match the configured benchmark corpus.
+
+## Constraints
+
+- Scope constraints: only benchmark integrity validation and focused tests.
+- Architecture constraints: no retrieval, scoring, or answer-generation changes.
+- Compatibility constraints: additive validation/report fields only.
+- Eval/privacy constraints: public synthetic benchmark only; no private data.
+- Tooling/CI constraints: focused pytest and py_compile should cover the change.
+- Non-goals: no benchmark score improvement, no metric semantics change, no new dataset.
+
+## Architecture Impact
+
+- Affected modules or docs: `eval/naive_rag/validate_benchmark_dataset.py`,
+  `eval/naive_rag/benchmark.py`, `tests/test_naive_rag_benchmark_v1.py`,
+  this plan, and task handoff.
+- Affected contracts or invariants: benchmark config validity only.
+- Load-bearing paths: `eval/`.
+- ADR required: no, this hardens an existing surface without changing its meaning.
+- Backward compatibility expectation: existing valid v1 config remains valid.
+
+## Affected Interfaces
+
+- CLI/API/config: `validate_benchmark_dataset.py --config ...` may now reject
+  incomplete or smoke-contaminated benchmark configs.
+- Input data: no dataset content changes.
+- Output artifacts: validation JSON gains benchmark metadata/path boundary blocks.
+- Docs/review surfaces: Benchmark Validity Audit gets machine-readable evidence.
+- Tests/eval entrypoints: focused benchmark tests.
+
+## Data / Eval Impact
+
+- Surface: public synthetic benchmark.
+- Data boundary: public synthetic benchmark config and fixture paths only.
+- Allowed claim: validator hardens synthetic benchmark contamination checks.
+- Disallowed claim: any real-world RFP performance claim.
+- Baseline or control affected: no, benchmark retrieval and metrics are unchanged.
+- Benchmark/eval auditor required: yes.
+
+## Task Breakdown
+
+1. Add validator checks for required `dataset_metadata` and public synthetic surface classification.
+2. Add validator checks that benchmark paths do not reuse public fixture smoke paths.
+3. Add validator checks that `index_build.output_dir` and command `--output` match `index_dir`.
+4. Add runner checks for loaded index provenance before benchmark execution.
+5. Add focused regression tests for missing metadata, smoke path contamination, output drift, and stale index provenance.
+6. Run focused validation and record handoff evidence.
+
+## Acceptance Criteria
+
+- [x] Valid benchmark config still passes validation.
+- [x] Validator fails when `dataset_metadata.privacy` or claim-boundary fields are missing or wrong.
+- [x] Validator fails when benchmark paths point at smoke fixture assets.
+- [x] Validator fails when `index_build.output_dir` or command `--output` drifts away from `index_dir`.
+- [x] Benchmark runner fails before query execution when `index.json` provenance does not match `corpus_path`.
+- [x] Benchmark runner fails when `index.json` chunk ids/order/metadata/text are stale relative to `corpus_path`.
+- [x] Validator normalizes smoke fixture paths and rejects smoke paths embedded in `index_build.command`.
+- [x] Focused pytest and py_compile pass.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 eval/naive_rag/validate_benchmark_dataset.py --config configs/eval/benchmark_naive_rag_v1.yaml --report reports/benchmark/naive_rag_v1_validation.json
+python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q
+python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py eval/naive_rag/build_benchmark_index.py eval/naive_rag/benchmark.py
+git diff --check
+```
+
+Expected evidence:
+
+- Test/eval output: validator pass and focused pytest pass.
+- Generated or updated artifact: local validation JSON under `reports/benchmark/`.
+- Reviewer checklist or manual inspection: Benchmark Validity Audit.
+- Explicitly not validated, with reason: private real-eval is out of scope.
+
+## Rollback Strategy
+
+Revert validator and focused test changes. Do not delete benchmark dataset files
+or generated local reports unless they were created by this session and remain
+untracked.
+
+## Failure Modes
+
+- Failure mode: guard rejects the existing valid benchmark config.
+- Detection signal: validator CLI or focused pytest fails.
+- Stop condition or fallback: fix only if failure is in the new guard; otherwise
+  stop and record the blocker.
+
+## Observability
+
+- `reports/benchmark/naive_rag_v1_validation.json` exposes metadata/path/output boundary checks.
+- `tests/test_naive_rag_benchmark_v1.py` covers valid and contaminated configs.
+
+## Reviewer Notes
+
+Attack claim-boundary drift first: the validator should not allow a benchmark
+config that is missing synthetic-only metadata or that reuses smoke fixture
+paths.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-25 19:45 KST
+
+- Role: Implementer
+- Branch / worktree: started on fix/issue-1480-benchmark-integrity-followup; current branch observed as dev/multi-chunk-evidence-first-step / /Users/hskim/.codex/worktrees/cd0b/BidMate-DocAgent
+- Issue / PR: #1485 / PR TBD
+- Task: T-2026-0001 benchmark integrity follow-up
+- Current status: implementation complete; local validation passed; ready for review.
+- Files touched: docs/plans/T-2026-0001-benchmark-integrity-followup.md, eval/naive_rag/validate_benchmark_dataset.py, eval/naive_rag/benchmark.py, tests/test_naive_rag_benchmark_v1.py
+- Decisions made: keep this as additive benchmark integrity validation; do not change retrieval, scoring, or answer semantics.
+- Commands run: python3 eval/naive_rag/validate_benchmark_dataset.py --config configs/eval/benchmark_naive_rag_v1.yaml --report reports/benchmark/naive_rag_v1_validation.json; python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q; python3 -m pytest tests/test_naive_rag_benchmark_v1.py tests/test_synthetic_benchmark_dataset.py -q; python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py eval/naive_rag/build_benchmark_index.py eval/naive_rag/benchmark.py; git diff --check; git diff --check -- docs/plans/T-2026-0001-benchmark-integrity-followup.md eval/naive_rag/validate_benchmark_dataset.py eval/naive_rag/benchmark.py tests/test_naive_rag_benchmark_v1.py
+- Results: pass. Validation report shows benchmark_metadata.status=pass, smoke_fixture_path_boundary.status=pass, index_build_boundary.status=pass, command_writes_index_dir=True. Adversarial reviewer findings on stale index content and path/command smoke bypass were addressed with focused tests. Benchmark auditor also flagged unrelated `multi_chunk_evidence_profile` metric surface in the current worktree diff; it remains outside this follow-up scope and should not be included in a benchmark-integrity-only PR.
+- Next safe command: python3 -m pytest tests/test_naive_rag_benchmark_v1.py tests/test_synthetic_benchmark_dataset.py -q
+- Open questions: none for this checkpoint.
+- Risks: worktree contains unrelated local changes in tasks/queue.md, scripts/compare_eval.py, visual_ingestion.py, related tests, docs/plans/T-2026-0002-eval-artifact-surface-guard.md, docs/plans/T-2026-0004-visual-ingestion-page-metadata-contract-guard.md, and docs/plans/T-2026-0005-multi-chunk-evidence-regression-guard.md. `eval/naive_rag/benchmark.py` and `tests/test_naive_rag_benchmark_v1.py` also contain unrelated `multi_chunk_evidence_profile` metric changes; keep review/commit scope limited to the integrity guard lines or split that metric work into its own task/plan.
+```
+
+```markdown
+## Session Handoff - 2026-05-25 22:30 KST
+
+- Role: Maintainer + Integration Reviewer
+- Lifecycle stage: review
+- Branch / worktree: fix/issue-1485-benchmark-integrity-followup / /Users/hskim/.codex/worktrees/1485/BidMate-DocAgent
+- Base branch: main
+- Issue / PR: #1485 / PR TBD
+- Task: T-2026-0001 benchmark integrity follow-up
+- Plan: docs/plans/T-2026-0001-benchmark-integrity-followup.md
+- Current status: integration review tightened benchmark index provenance comparison after Benchmark Auditor found metadata drift could pass.
+- Files touched: eval/naive_rag/benchmark.py, tests/test_naive_rag_benchmark_v1.py, docs/plans/T-2026-0001-benchmark-integrity-followup.md
+- Decisions made: compare full corpus/index chunk dicts while excluding volatile `embedding` and `embedding_idx`; keep this as validation-only with no retrieval/scoring behavior change.
+- Commands run: python3 eval/naive_rag/validate_benchmark_dataset.py --config configs/eval/benchmark_naive_rag_v1.yaml --report reports/benchmark/naive_rag_v1_validation.json; python3 -m pytest -q tests/test_naive_rag_benchmark_v1.py tests/test_synthetic_benchmark_dataset.py; python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_naive_rag_benchmark_v1.py; python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py eval/naive_rag/build_benchmark_index.py eval/naive_rag/benchmark.py scripts/compare_eval.py scripts/run_real_eval_delta.py scripts/render_difficulty_profile.py visual_ingestion.py parser_page_metadata_contract.py scripts/page_metadata_recovery_audit.py ingestion.py rag_indexing.py; git diff --check
+- Results: all listed commands exited 0; validator report status remained pass with the existing lexical leakage warning.
+- Validation evidence: focused pytest, validator CLI, py_compile, diff check.
+- Eval surface: public synthetic benchmark.
+- Evidence artifacts: local reports/benchmark/naive_rag_v1_validation.json only.
+- Blockers: none for this checkpoint.
+- Open risks: stale embedding sidecar with identical chunk metadata is not recomputed in this guard; do not claim full contamination proof beyond corpus/index metadata boundary.
+- Next action: review and publish draft PR for issue #1485.
+- Next safe command: python3 -m pytest -q tests/test_naive_rag_benchmark_v1.py tests/test_synthetic_benchmark_dataset.py
+- Reviewer focus: full chunk provenance comparison, no metric semantics change, public synthetic-only claim wording.
+```

--- a/eval/naive_rag/benchmark.py
+++ b/eval/naive_rag/benchmark.py
@@ -13,7 +13,10 @@ ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from eval.naive_rag.build_benchmark_index import load_corpus_chunks  # noqa: E402
+from eval.naive_rag.build_benchmark_index import (  # noqa: E402
+    PROHIBITED_CORPUS_FIELDS,
+    load_corpus_chunks,
+)
 from eval.naive_rag.metrics import (  # noqa: E402
     BENCHMARK_CITATION_PAGE_METRIC_KEYS,
     BENCHMARK_LATENCY_METRIC_KEYS,
@@ -51,6 +54,15 @@ REQUIRED_OUTPUTS = (
 GOLD_DERIVED_FIELDS = frozenset(
     {"expected_terms", "required_terms", "derived_from_expected_terms"}
 )
+EXPECTED_INDEX_LEAKAGE_GUARD = "query_and_gold_label_files_not_read"
+
+
+def _chunk_for_provenance_comparison(chunk: dict[str, Any]) -> dict[str, Any]:
+    """Normalize volatile index-only fields before corpus/index comparison."""
+    normalized = dict(chunk)
+    normalized.pop("embedding", None)
+    normalized.pop("embedding_idx", None)
+    return normalized
 
 
 def load_benchmark_config(path: Path) -> dict[str, Any]:
@@ -101,6 +113,65 @@ def assert_explicit_gold_evidence(
                 raise ValueError(f"{qid}: unanswerable question must not have gold evidence")
             if expected_ids:
                 raise ValueError(f"{qid}: unanswerable question must have empty expected_evidence_ids")
+
+
+def assert_benchmark_index_provenance(
+    *,
+    index: dict[str, Any],
+    index_dir: Path,
+    corpus_path: Path,
+    corpus_chunks: list[dict[str, Any]],
+) -> None:
+    build = index.get("build") if isinstance(index.get("build"), dict) else {}
+    errors: list[str] = []
+    expected_corpus_path = _relative(corpus_path)
+
+    if build.get("input_kind") != "corpus_chunks_jsonl":
+        errors.append("index.build.input_kind must be corpus_chunks_jsonl")
+    if build.get("source_corpus_path") != expected_corpus_path:
+        errors.append(
+            "index.build.source_corpus_path must match benchmark config corpus_path "
+            f"({expected_corpus_path})"
+        )
+    if build.get("leakage_guard") != EXPECTED_INDEX_LEAKAGE_GUARD:
+        errors.append(f"index.build.leakage_guard must be {EXPECTED_INDEX_LEAKAGE_GUARD}")
+
+    try:
+        num_chunks = int(build.get("num_chunks"))
+    except (TypeError, ValueError):
+        num_chunks = -1
+    if num_chunks != len(corpus_chunks):
+        errors.append(
+            "index.build.num_chunks must match corpus_path chunk count "
+            f"({len(corpus_chunks)})"
+        )
+
+    index_chunks = index.get("chunks") if isinstance(index.get("chunks"), list) else []
+    contaminated_rows = [
+        idx
+        for idx, chunk in enumerate(index_chunks, start=1)
+        if isinstance(chunk, dict) and PROHIBITED_CORPUS_FIELDS & set(chunk)
+    ]
+    if contaminated_rows:
+        errors.append("index chunks must not contain query/gold label fields")
+
+    comparable_index_chunks = [
+        _chunk_for_provenance_comparison(chunk)
+        for chunk in index_chunks
+        if isinstance(chunk, dict)
+    ]
+    comparable_corpus_chunks = [
+        _chunk_for_provenance_comparison(chunk)
+        for chunk in corpus_chunks
+    ]
+    if comparable_index_chunks != comparable_corpus_chunks:
+        errors.append("index chunks must match corpus_path chunk ids, order, metadata, and text")
+
+    if errors:
+        raise ValueError(
+            f"Benchmark index provenance mismatch in {_relative(index_dir)}:\n- "
+            + "\n- ".join(errors)
+        )
 
 
 def _pages_from_span(value: Any) -> set[int]:
@@ -421,6 +492,12 @@ def run_from_config(
     corpus_chunks = load_corpus_chunks(corpus_path)
     index_load_start = time.perf_counter()
     index = load_index(index_dir)
+    assert_benchmark_index_provenance(
+        index=index,
+        index_dir=index_dir,
+        corpus_path=corpus_path,
+        corpus_chunks=corpus_chunks,
+    )
     index_load_ms = (time.perf_counter() - index_load_start) * 1000
     pipeline = config["pipeline"]
 

--- a/eval/naive_rag/validate_benchmark_dataset.py
+++ b/eval/naive_rag/validate_benchmark_dataset.py
@@ -37,6 +37,21 @@ MIN_UNANSWERABLE = 15
 MIN_DISTRACTOR_SENSITIVE = 8
 MIN_CHUNK_TOP_K_RATIO = 3.0
 SATURATION_WARNING_RATIO = 5.0
+EXPECTED_DATASET_ID = "synthetic_naive_rag_benchmark_v1"
+EXPECTED_PRIVACY = "public_synthetic"
+SMOKE_FIXTURE_PATHS = {
+    "index_dir": ("data/index",),
+    "index_build.output_dir": ("data/index",),
+    "questions_path": ("data/eval/rag_questions.jsonl",),
+    "gold_evidence_path": ("data/eval/gold_evidence.jsonl",),
+    "corpus_dir": ("eval/fixtures/smoke_rfp/raw",),
+    "corpus_path": ("eval/fixtures/smoke_rfp/raw",),
+    "index_build.input_path": (
+        "data/eval/rag_questions.jsonl",
+        "data/eval/gold_evidence.jsonl",
+        "eval/fixtures/smoke_rfp/raw",
+    ),
+}
 
 QUESTION_TYPE_MINIMUMS = {
     "exact_fact": 10,
@@ -59,11 +74,26 @@ def repo_path(value: str | Path) -> Path:
     return path if path.is_absolute() else ROOT_DIR / path
 
 
+def normalized_repo_path(value: str | Path) -> Path:
+    return repo_path(value).resolve(strict=False)
+
+
 def display_path(value: Path) -> str:
+    value = value.resolve(strict=False)
     try:
-        return str(value.relative_to(ROOT_DIR))
+        return str(value.relative_to(ROOT_DIR.resolve(strict=False)))
     except ValueError:
         return str(value)
+
+
+def is_relative_to(path: Path, parent: Path) -> bool:
+    path = path.resolve(strict=False)
+    parent = parent.resolve(strict=False)
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
 
 
 def compact_text(value: str) -> str:
@@ -185,7 +215,7 @@ def has_korean_and_latin(text: str) -> bool:
     return bool(re.search(r"[가-힣]", text)) and bool(re.search(r"[A-Za-z]", text))
 
 
-def command_corpus_args(command: str) -> list[str]:
+def command_option_values(command: str, option: str) -> list[str]:
     try:
         tokens = shlex.split(command)
     except ValueError:
@@ -195,35 +225,203 @@ def command_corpus_args(command: str) -> list[str]:
     idx = 0
     while idx < len(tokens):
         token = tokens[idx]
-        if token == "--corpus":
+        if token == option:
             if idx + 1 < len(tokens):
                 values.append(tokens[idx + 1])
                 idx += 2
                 continue
             values.append("")
-        elif token.startswith("--corpus="):
+        elif token.startswith(f"{option}="):
             values.append(token.split("=", 1)[1])
         idx += 1
     return values
+
+
+def command_corpus_args(command: str) -> list[str]:
+    return command_option_values(command, "--corpus")
+
+
+def command_output_args(command: str) -> list[str]:
+    return command_option_values(command, "--output")
+
+
+def benchmark_metadata_report(config: dict[str, Any]) -> dict[str, Any]:
+    metadata = config.get("dataset_metadata") if isinstance(config.get("dataset_metadata"), dict) else {}
+    errors: list[str] = []
+    dataset_id = str(metadata.get("dataset_id") or "").strip()
+    privacy = str(metadata.get("privacy") or "").strip()
+    intended_use = str(metadata.get("intended_use") or "").strip()
+    not_for_claims = str(metadata.get("not_for_claims") or "").strip()
+
+    if dataset_id != EXPECTED_DATASET_ID:
+        errors.append(f"dataset_metadata.dataset_id must be {EXPECTED_DATASET_ID}")
+    if privacy != EXPECTED_PRIVACY:
+        errors.append(f"dataset_metadata.privacy must be {EXPECTED_PRIVACY}")
+    if not intended_use:
+        errors.append("dataset_metadata.intended_use must describe public synthetic benchmark use")
+    if not not_for_claims:
+        errors.append("dataset_metadata.not_for_claims must describe disallowed real-world claims")
+    elif "private real-eval" not in not_for_claims.lower():
+        errors.append("dataset_metadata.not_for_claims must name private real-eval as required evidence")
+
+    numeric_requirements = {
+        "minimum_questions": MIN_TOTAL_QUESTIONS,
+        "minimum_answerable": MIN_ANSWERABLE,
+        "minimum_unanswerable": MIN_UNANSWERABLE,
+        "minimum_chunk_to_top_k_ratio": MIN_CHUNK_TOP_K_RATIO,
+    }
+    numeric_values: dict[str, float | None] = {}
+    for key, minimum in numeric_requirements.items():
+        raw_value = metadata.get(key)
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError):
+            value = None
+        numeric_values[key] = value
+        if value is None or value < float(minimum):
+            errors.append(f"dataset_metadata.{key} must be >= {minimum}")
+
+    warning_raw = metadata.get("saturation_warning_chunk_to_top_k_ratio")
+    try:
+        warning_ratio = float(warning_raw)
+    except (TypeError, ValueError):
+        warning_ratio = None
+    numeric_values["saturation_warning_chunk_to_top_k_ratio"] = warning_ratio
+    minimum_ratio = numeric_values["minimum_chunk_to_top_k_ratio"]
+    if warning_ratio is None or (
+        minimum_ratio is not None and warning_ratio < minimum_ratio
+    ):
+        errors.append(
+            "dataset_metadata.saturation_warning_chunk_to_top_k_ratio "
+            "must be >= minimum_chunk_to_top_k_ratio"
+        )
+
+    return {
+        "status": "pass" if not errors else "fail",
+        "surface": "public_synthetic_benchmark" if privacy == EXPECTED_PRIVACY else "invalid",
+        "dataset_id": dataset_id,
+        "privacy": privacy,
+        "intended_use_present": bool(intended_use),
+        "not_for_claims_present": bool(not_for_claims),
+        "not_for_claims_mentions_private_real_eval": "private real-eval" in not_for_claims.lower(),
+        "minimums": numeric_values,
+        "errors": errors,
+    }
+
+
+def smoke_fixture_path_report(config: dict[str, Any]) -> dict[str, Any]:
+    build_config = config.get("index_build") if isinstance(config.get("index_build"), dict) else {}
+    raw_paths = {
+        "corpus_dir": str(config.get("corpus_dir") or "").strip(),
+        "corpus_path": str(config.get("corpus_path") or "").strip(),
+        "index_dir": str(config.get("index_dir") or "").strip(),
+        "questions_path": str(config.get("questions_path") or "").strip(),
+        "gold_evidence_path": str(config.get("gold_evidence_path") or "").strip(),
+        "index_build.input_path": str(build_config.get("input_path") or "").strip(),
+        "index_build.output_dir": str(build_config.get("output_dir") or "").strip(),
+    }
+    blocked_paths = {
+        field: tuple(normalized_repo_path(path) for path in blocked)
+        for field, blocked in SMOKE_FIXTURE_PATHS.items()
+    }
+    all_blocked_paths = sorted(
+        {
+            path
+            for blocked in SMOKE_FIXTURE_PATHS.values()
+            for path in blocked
+        }
+    )
+    all_blocked_normalized = tuple(normalized_repo_path(path) for path in all_blocked_paths)
+
+    matches: list[dict[str, str]] = []
+    seen_matches: set[tuple[str, str, str]] = set()
+
+    def add_match(field: str, configured_path: str, blocked_smoke_path: str) -> None:
+        key = (field, configured_path, blocked_smoke_path)
+        if key in seen_matches:
+            return
+        seen_matches.add(key)
+        matches.append(
+            {
+                "field": field,
+                "configured_path": configured_path,
+                "blocked_smoke_path": blocked_smoke_path,
+            }
+        )
+
+    for field, raw_path in raw_paths.items():
+        if not raw_path:
+            continue
+        candidate = normalized_repo_path(raw_path)
+        for blocked in blocked_paths.get(field, ()):
+            if candidate == blocked or is_relative_to(candidate, blocked):
+                add_match(
+                    field,
+                    display_path(candidate),
+                    display_path(blocked),
+                )
+
+    command = str(build_config.get("command") or "").strip()
+    if command:
+        try:
+            command_tokens = shlex.split(command)
+        except ValueError:
+            command_tokens = command.split()
+        for token in command_tokens:
+            values = [token]
+            if "=" in token:
+                values.append(token.split("=", 1)[1])
+            for value in values:
+                candidate = normalized_repo_path(value)
+                for raw_blocked, blocked in zip(all_blocked_paths, all_blocked_normalized, strict=True):
+                    if (
+                        value == raw_blocked
+                        or raw_blocked in token
+                        or candidate == blocked
+                        or is_relative_to(candidate, blocked)
+                    ):
+                        add_match(
+                            "index_build.command",
+                            value,
+                            display_path(blocked),
+                        )
+                        break
+
+    errors = []
+    if matches:
+        fields = ", ".join(sorted({match["field"] for match in matches}))
+        errors.append(f"benchmark paths must not point at public fixture smoke assets: {fields}")
+
+    return {
+        "status": "pass" if not errors else "fail",
+        "surface": "public_synthetic_benchmark",
+        "smoke_fixture_path_matches": matches,
+        "errors": errors,
+    }
 
 
 def index_build_boundary_report(
     config: dict[str, Any],
     *,
     corpus_path: Path,
+    index_dir: Path,
     questions_path: Path,
     gold_path: Path,
     corpus_chunks: list[dict[str, Any]],
 ) -> dict[str, Any]:
     build_config = config.get("index_build") if isinstance(config.get("index_build"), dict) else {}
     raw_input_path = str(build_config.get("input_path") or "").strip()
-    input_path = repo_path(raw_input_path) if raw_input_path else None
+    input_path = normalized_repo_path(raw_input_path) if raw_input_path else None
+    raw_output_dir = str(build_config.get("output_dir") or "").strip()
+    output_dir = normalized_repo_path(raw_output_dir) if raw_output_dir else None
     command = str(build_config.get("command") or "").strip()
     raw_corpus_path = str(config.get("corpus_path") or "").strip()
     raw_questions_path = str(config.get("questions_path") or "").strip()
     raw_gold_path = str(config.get("gold_evidence_path") or "").strip()
     corpus_args = command_corpus_args(command)
-    normalized_corpus_args = [repo_path(value) for value in corpus_args]
+    normalized_corpus_args = [normalized_repo_path(value) for value in corpus_args]
+    output_args = command_output_args(command)
+    normalized_output_args = [normalized_repo_path(value) for value in output_args]
 
     prohibited_rows = [
         {
@@ -245,18 +443,32 @@ def index_build_boundary_report(
         if token
     }
     command_refs = sorted(token for token in question_gold_tokens if token in command)
-    command_uses_corpus = len(normalized_corpus_args) == 1 and normalized_corpus_args[0] == corpus_path
-    input_matches_corpus = input_path == corpus_path if input_path is not None else False
+    normalized_corpus_path = corpus_path.resolve(strict=False)
+    normalized_index_dir = index_dir.resolve(strict=False)
+    command_uses_corpus = (
+        len(normalized_corpus_args) == 1 and normalized_corpus_args[0] == normalized_corpus_path
+    )
+    command_writes_index_dir = (
+        len(normalized_output_args) == 1 and normalized_output_args[0] == normalized_index_dir
+    )
+    input_matches_corpus = input_path == normalized_corpus_path if input_path is not None else False
+    output_matches_index_dir = output_dir == normalized_index_dir if output_dir is not None else False
 
     errors: list[str] = []
     if not raw_input_path:
         errors.append("index_build.input_path must be set to corpus_path")
     elif not input_matches_corpus:
         errors.append("index_build.input_path must match corpus_path")
+    if not raw_output_dir:
+        errors.append("index_build.output_dir must be set to index_dir")
+    elif not output_matches_index_dir:
+        errors.append("index_build.output_dir must match index_dir")
     if str(build_config.get("input_kind") or "") != "corpus_chunks_jsonl":
         errors.append("index_build.input_kind must be corpus_chunks_jsonl")
     if not command_uses_corpus:
         errors.append("index_build.command must pass exactly one --corpus argument matching corpus_path")
+    if not command_writes_index_dir:
+        errors.append("index_build.command must pass exactly one --output argument matching index_dir")
     if command_refs:
         errors.append("index_build.command must not reference questions_path or gold_evidence_path")
     if prohibited_rows:
@@ -268,9 +480,14 @@ def index_build_boundary_report(
         "input_kind": str(build_config.get("input_kind") or ""),
         "allowed_input_path": display_path(corpus_path),
         "configured_input_path": display_path(input_path) if input_path is not None else "",
+        "allowed_output_dir": display_path(index_dir),
+        "configured_output_dir": display_path(output_dir) if output_dir is not None else "",
         "input_matches_corpus_path": input_matches_corpus,
+        "output_matches_index_dir": output_matches_index_dir,
         "command_uses_corpus_path": command_uses_corpus,
+        "command_writes_index_dir": command_writes_index_dir,
         "command_corpus_args": [display_path(path) for path in normalized_corpus_args],
+        "command_output_args": [display_path(path) for path in normalized_output_args],
         "command_references_question_or_gold_paths": bool(command_refs),
         "command_reference_matches": command_refs,
         "corpus_rows_with_query_or_gold_fields": len(prohibited_rows),
@@ -292,8 +509,14 @@ def validate_dataset(config_path: Path) -> dict[str, Any]:
     if config.get("not_ci_smoke") is not True:
         errors.append("config.not_ci_smoke must be true")
 
+    metadata_boundary = benchmark_metadata_report(config)
+    errors.extend(metadata_boundary["errors"])
+    path_boundary = smoke_fixture_path_report(config)
+    errors.extend(path_boundary["errors"])
+
     corpus_dir = repo_path(config.get("corpus_dir") or "")
     corpus_path = repo_path(config.get("corpus_path") or "")
+    index_dir = repo_path(config.get("index_dir") or "")
     questions_path = repo_path(config.get("questions_path") or "")
     gold_path = repo_path(config.get("gold_evidence_path") or "")
 
@@ -341,6 +564,7 @@ def validate_dataset(config_path: Path) -> dict[str, Any]:
     index_boundary = index_build_boundary_report(
         config,
         corpus_path=corpus_path,
+        index_dir=index_dir,
         questions_path=questions_path,
         gold_path=gold_path,
         corpus_chunks=corpus_chunks,
@@ -505,6 +729,8 @@ def validate_dataset(config_path: Path) -> dict[str, Any]:
             "chunking_strategy": chunking_strategy,
             "chunking": chunking_diagnostics,
         },
+        "benchmark_metadata": metadata_boundary,
+        "smoke_fixture_path_boundary": path_boundary,
         "index_build_boundary": index_boundary,
         "question_type_distribution": dict(sorted(type_counts.items())),
         "difficulty_distribution": dict(sorted(Counter(row.get("difficulty") for row in questions).items())),

--- a/tests/test_naive_rag_benchmark_v1.py
+++ b/tests/test_naive_rag_benchmark_v1.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import pytest
 import yaml
 
-from eval.naive_rag.benchmark import REQUIRED_OUTPUTS, run_from_config as run_benchmark_from_config
+from eval.naive_rag.benchmark import (
+    REQUIRED_OUTPUTS,
+    run_from_config as run_benchmark_from_config,
+)
 from eval.naive_rag.build_benchmark_index import build_benchmark_index
 from eval.naive_rag.run_eval import load_contract_config
 from eval.naive_rag.validate_benchmark_dataset import validate_dataset
@@ -25,6 +28,10 @@ def _write_temp_benchmark_config(tmp_path: Path, *, index_dir: Path) -> Path:
     config = _yaml(BENCHMARK_CONFIG)
     config["index_dir"] = str(index_dir)
     config["output_root"] = str(tmp_path / "runs")
+    return _write_config(tmp_path, config)
+
+
+def _write_config(tmp_path: Path, config: dict) -> Path:
     config_path = tmp_path / "benchmark_naive_rag_v1.yaml"
     config_path.write_text(
         yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
@@ -93,6 +100,19 @@ def test_benchmark_dataset_validator_reports_counts() -> None:
     assert summary["gold_evidence_summary"]["num_evidence_records"] == 47
 
 
+def test_benchmark_dataset_validator_reports_metadata_and_smoke_boundaries() -> None:
+    summary = validate_dataset(BENCHMARK_CONFIG)
+
+    assert summary["errors"] == []
+    assert summary["benchmark_metadata"]["status"] == "pass"
+    assert summary["benchmark_metadata"]["surface"] == "public_synthetic_benchmark"
+    assert summary["benchmark_metadata"]["dataset_id"] == "synthetic_naive_rag_benchmark_v1"
+    assert summary["benchmark_metadata"]["privacy"] == "public_synthetic"
+    assert summary["benchmark_metadata"]["not_for_claims_mentions_private_real_eval"] is True
+    assert summary["smoke_fixture_path_boundary"]["status"] == "pass"
+    assert summary["smoke_fixture_path_boundary"]["smoke_fixture_path_matches"] == []
+
+
 def test_benchmark_dataset_validator_reports_corpus_only_index_boundary() -> None:
     summary = validate_dataset(BENCHMARK_CONFIG)
     boundary = summary["index_build_boundary"]
@@ -103,21 +123,131 @@ def test_benchmark_dataset_validator_reports_corpus_only_index_boundary() -> Non
     assert boundary["input_kind"] == "corpus_chunks_jsonl"
     assert boundary["allowed_input_path"] == "data/eval/benchmark/corpus_chunks_v1.jsonl"
     assert boundary["configured_input_path"] == "data/eval/benchmark/corpus_chunks_v1.jsonl"
+    assert boundary["allowed_output_dir"] == "data/eval/benchmark/index_v1"
+    assert boundary["configured_output_dir"] == "data/eval/benchmark/index_v1"
     assert boundary["input_matches_corpus_path"] is True
+    assert boundary["output_matches_index_dir"] is True
     assert boundary["command_uses_corpus_path"] is True
+    assert boundary["command_writes_index_dir"] is True
     assert boundary["command_references_question_or_gold_paths"] is False
     assert boundary["corpus_rows_with_query_or_gold_fields"] == 0
     assert boundary["prohibited_corpus_fields_detected"] == []
 
 
+def test_benchmark_dataset_validator_rejects_missing_claim_boundary_metadata(tmp_path: Path) -> None:
+    config = _yaml(BENCHMARK_CONFIG)
+    del config["dataset_metadata"]["not_for_claims"]
+    config["dataset_metadata"]["privacy"] = "public_fixture"
+    config_path = _write_config(tmp_path, config)
+
+    summary = validate_dataset(config_path)
+
+    assert summary["benchmark_metadata"]["status"] == "fail"
+    assert summary["benchmark_metadata"]["surface"] == "invalid"
+    assert "dataset_metadata.privacy must be public_synthetic" in summary["errors"]
+    assert (
+        "dataset_metadata.not_for_claims must describe disallowed real-world claims"
+        in summary["errors"]
+    )
+
+
+def test_benchmark_dataset_validator_rejects_smoke_fixture_paths(tmp_path: Path) -> None:
+    config = _yaml(BENCHMARK_CONFIG)
+    config["index_dir"] = "data/index"
+    config["index_build"]["output_dir"] = "data/index"
+    config["index_build"]["command"] = (
+        "python3 -m eval.naive_rag.build_benchmark_index "
+        f"--corpus {config['corpus_path']} --output data/index"
+    )
+    config_path = _write_config(tmp_path, config)
+
+    summary = validate_dataset(config_path)
+
+    assert summary["smoke_fixture_path_boundary"]["status"] == "fail"
+    assert {
+        (match["field"], match["configured_path"], match["blocked_smoke_path"])
+        for match in summary["smoke_fixture_path_boundary"]["smoke_fixture_path_matches"]
+    } >= {
+        ("index_dir", "data/index", "data/index"),
+        ("index_build.output_dir", "data/index", "data/index"),
+        ("index_build.command", "data/index", "data/index"),
+    }
+    assert (
+        "benchmark paths must not point at public fixture smoke assets: "
+        "index_build.command, index_build.output_dir, index_dir"
+    ) in summary["errors"]
+
+
+def test_benchmark_dataset_validator_normalizes_smoke_fixture_paths(tmp_path: Path) -> None:
+    config = _yaml(BENCHMARK_CONFIG)
+    config["index_dir"] = "data/not_smoke/../index"
+    config["index_build"]["output_dir"] = "data/not_smoke/../index"
+    config["index_build"]["command"] = (
+        "python3 -m eval.naive_rag.build_benchmark_index "
+        f"--corpus {config['corpus_path']} --output data/not_smoke/../index"
+    )
+    config_path = _write_config(tmp_path, config)
+
+    summary = validate_dataset(config_path)
+
+    assert summary["smoke_fixture_path_boundary"]["status"] == "fail"
+    assert {
+        (match["field"], match["blocked_smoke_path"])
+        for match in summary["smoke_fixture_path_boundary"]["smoke_fixture_path_matches"]
+    } >= {
+        ("index_dir", "data/index"),
+        ("index_build.output_dir", "data/index"),
+        ("index_build.command", "data/index"),
+    }
+
+
+def test_benchmark_dataset_validator_rejects_smoke_path_in_index_command(tmp_path: Path) -> None:
+    config = _yaml(BENCHMARK_CONFIG)
+    config["index_build"]["command"] = (
+        "python3 -m eval.naive_rag.build_benchmark_index "
+        f"--corpus {config['corpus_path']} "
+        "--output data/eval/benchmark/index_v1 "
+        "--note data/eval/rag_questions.jsonl"
+    )
+    config_path = _write_config(tmp_path, config)
+
+    summary = validate_dataset(config_path)
+
+    assert summary["smoke_fixture_path_boundary"]["status"] == "fail"
+    assert {
+        (match["field"], match["configured_path"], match["blocked_smoke_path"])
+        for match in summary["smoke_fixture_path_boundary"]["smoke_fixture_path_matches"]
+    } == {
+        ("index_build.command", "data/eval/rag_questions.jsonl", "data/eval/rag_questions.jsonl")
+    }
+
+
+def test_benchmark_dataset_validator_rejects_index_output_drift(tmp_path: Path) -> None:
+    config = _yaml(BENCHMARK_CONFIG)
+    config["index_build"]["output_dir"] = "data/eval/benchmark/index_drift"
+    config["index_build"]["command"] = (
+        "python3 -m eval.naive_rag.build_benchmark_index "
+        f"--corpus {config['corpus_path']} --output data/eval/benchmark/index_drift"
+    )
+    config_path = _write_config(tmp_path, config)
+
+    summary = validate_dataset(config_path)
+    boundary = summary["index_build_boundary"]
+
+    assert boundary["status"] == "fail"
+    assert boundary["output_matches_index_dir"] is False
+    assert boundary["command_writes_index_dir"] is False
+    assert "index_build.output_dir must match index_dir" in summary["errors"]
+    assert (
+        "index_build.command must pass exactly one --output argument matching index_dir"
+        in summary["errors"]
+    )
+
+
 def test_benchmark_dataset_validator_rejects_index_build_from_questions(tmp_path: Path) -> None:
     config = _yaml(BENCHMARK_CONFIG)
     config["index_build"]["input_path"] = config["questions_path"]
-    config_path = tmp_path / "benchmark_naive_rag_v1.yaml"
-    config_path.write_text(
-        yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
-        encoding="utf-8",
-    )
+    config_path = _write_config(tmp_path, config)
 
     summary = validate_dataset(config_path)
 
@@ -133,11 +263,7 @@ def test_benchmark_dataset_validator_parses_actual_corpus_arg(tmp_path: Path) ->
         f"--note {config['corpus_path']} "
         "--output data/eval/benchmark/index_v1"
     )
-    config_path = tmp_path / "benchmark_naive_rag_v1.yaml"
-    config_path.write_text(
-        yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
-        encoding="utf-8",
-    )
+    config_path = _write_config(tmp_path, config)
 
     summary = validate_dataset(config_path)
 
@@ -168,11 +294,7 @@ def test_benchmark_dataset_validator_rejects_label_fields_in_corpus_chunks(tmp_p
         "python3 -m eval.naive_rag.build_benchmark_index "
         f"--corpus {contaminated} --output data/eval/benchmark/index_v1"
     )
-    config_path = tmp_path / "benchmark_naive_rag_v1.yaml"
-    config_path.write_text(
-        yaml.safe_dump(config, allow_unicode=True, sort_keys=False),
-        encoding="utf-8",
-    )
+    config_path = _write_config(tmp_path, config)
 
     summary = validate_dataset(config_path)
     boundary = summary["index_build_boundary"]
@@ -218,6 +340,54 @@ def test_benchmark_runner_fails_when_index_v1_is_missing(tmp_path: Path) -> None
     config_path = _write_temp_benchmark_config(tmp_path, index_dir=tmp_path / "missing_index_v1")
 
     with pytest.raises(FileNotFoundError, match="Build it with"):
+        run_benchmark_from_config(config_path)
+
+
+def test_benchmark_runner_rejects_index_with_mismatched_source_corpus_path(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index_v1"
+    build_benchmark_index(
+        ROOT / "data" / "eval" / "benchmark" / "corpus_chunks_v1.jsonl",
+        index_dir,
+    )
+    index_path = index_dir / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["build"]["source_corpus_path"] = "data/eval/benchmark/rag_questions_v1.jsonl"
+    index_path.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding="utf-8")
+    config_path = _write_temp_benchmark_config(tmp_path, index_dir=index_dir)
+
+    with pytest.raises(ValueError, match="source_corpus_path"):
+        run_benchmark_from_config(config_path)
+
+
+def test_benchmark_runner_rejects_index_with_stale_chunk_content(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index_v1"
+    build_benchmark_index(
+        ROOT / "data" / "eval" / "benchmark" / "corpus_chunks_v1.jsonl",
+        index_dir,
+    )
+    index_path = index_dir / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["chunks"][0]["text"] = "stale corpus chunk text"
+    index_path.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding="utf-8")
+    config_path = _write_temp_benchmark_config(tmp_path, index_dir=index_dir)
+
+    with pytest.raises(ValueError, match="chunk ids, order, metadata, and text"):
+        run_benchmark_from_config(config_path)
+
+
+def test_benchmark_runner_rejects_index_with_stale_chunk_metadata(tmp_path: Path) -> None:
+    index_dir = tmp_path / "index_v1"
+    build_benchmark_index(
+        ROOT / "data" / "eval" / "benchmark" / "corpus_chunks_v1.jsonl",
+        index_dir,
+    )
+    index_path = index_dir / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["chunks"][0]["metadata"] = {"stale": True}
+    index_path.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding="utf-8")
+    config_path = _write_temp_benchmark_config(tmp_path, index_dir=index_dir)
+
+    with pytest.raises(ValueError, match="chunk ids, order, metadata, and text"):
         run_benchmark_from_config(config_path)
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Public synthetic Naive RAG benchmark가 syntactically valid config처럼 보이면서도 claim-boundary metadata가 빠지거나 public fixture smoke asset을 재사용하는 경우를 더 빨리 잡도록 benchmark integrity guard를 강화했습니다.

구체적으로 `validate_benchmark_dataset.py`가 required `dataset_metadata`, smoke fixture path boundary, `index_build.output_dir`/`--output` drift를 검사하고, benchmark runner가 `index.json`의 corpus provenance와 chunk payload가 configured `corpus_path`와 맞는지 query 실행 전에 검증합니다.

Closes #1485

## 2. 영향 파일

- `eval/naive_rag/validate_benchmark_dataset.py` — load-bearing eval validator. Metadata/path/output boundary report 추가.
- `eval/naive_rag/benchmark.py` — load-bearing public synthetic benchmark runner. Stale/contaminated benchmark index provenance guard 추가.
- `tests/test_naive_rag_benchmark_v1.py` — missing metadata, smoke path contamination, output drift, stale index provenance regression coverage 추가.
- `docs/plans/T-2026-0001-benchmark-integrity-followup.md` — execution plan/handoff.
- `docs/plans/T-2026-0001-benchmark-contamination-guard.md` — previously merged #1481 plan status 정리.

## 3. 리스크

- Existing valid benchmark config가 너무 엄격한 validator 때문에 실패할 수 있음. Focused validator CLI와 benchmark tests로 현재 config pass를 확인했습니다.
- Stale index guard는 chunk JSON payload drift를 잡지만 embedding sidecar 재계산 여부까지 증명하지는 않습니다. 따라서 claim은 corpus/index metadata boundary hardening으로 제한합니다.
- Retrieval ranking, answer generation, verifier, benchmark scoring semantics는 변경하지 않았습니다.

## 4. 테스트

- `python3 eval/naive_rag/validate_benchmark_dataset.py --config configs/eval/benchmark_naive_rag_v1.yaml --report reports/benchmark/naive_rag_v1_validation.json`
- `python3 -m pytest -q tests/test_naive_rag_benchmark_v1.py tests/test_synthetic_benchmark_dataset.py`
- `python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py eval/naive_rag/build_benchmark_index.py eval/naive_rag/benchmark.py`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`

## 5. Eval 영향

Surface: public synthetic benchmark.

Allowed claim: the synthetic benchmark validator/runner now rejects missing claim-boundary metadata, smoke fixture path reuse, output drift, and stale benchmark index payloads before benchmark results can be interpreted.

Disallowed claim: no real-world RFP performance improvement, no private real-eval improvement, no retrieval quality improvement.

### 5b. Real-data delta

| 항목 | 값 |
|---|---|
| real eval 실행 | 미실행 |
| 사유 | 이 PR은 public synthetic benchmark validator/runner guard만 강화합니다. Private real-eval path, retrieval ranking, verifier, answer generation, benchmark scoring semantics는 변경하지 않습니다. |
| 성능 claim | 없음 |
| known warning | Validator CLI는 기존 lexical leakage warning 21건을 계속 출력합니다. 이는 기존 dataset review signal이며 이번 PR의 성능 claim이 아닙니다. |

검색/검증/답변 path 동작 변화 없음. Public synthetic benchmark guard만 강화합니다.

## 6. 하위 호환

Existing valid v1 benchmark config는 계속 통과합니다. 다만 contaminated or stale benchmark config/index는 이제 benchmark 실행 전 fail-fast합니다.

## 7. 범위 외

- retrieval behavior 변경
- answer/verifier/prompt 변경
- benchmark score/metric semantics 변경
- private real-eval 실행 또는 성능 claim
- multi-chunk evidence profile reporting
