### PR TITLE
fix: Render eval provenance in comparator

### DIFF
--- a/docs/plans/T-2026-0002-eval-artifact-surface-guard.md
+++ b/docs/plans/T-2026-0002-eval-artifact-surface-guard.md
@@ -3,7 +3,7 @@
 - Status: review
 - Owner role: Implementer
 - Related task: `tasks/queue.md::T-2026-0002`
-- Related issue / PR: [#1480](https://github.com/hskim-solv/BidMate-DocAgent/issues/1480) / PR TBD
+- Related issue / PR: [#1487](https://github.com/hskim-solv/BidMate-DocAgent/issues/1487) / PR TBD
 - Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
 - Created: 2026-05-25
 - Last updated: 2026-05-25
@@ -20,6 +20,10 @@ artifact comparisons could look legitimate.
 `scripts/compare_eval.py` renders best-effort surface labels for base/head
 summaries and offers an opt-in fail-closed gate for mismatched known surfaces.
 Unknown surfaces remain non-blocking but visible.
+
+Follow-up 01B also renders privacy-safe run/config/index/dataset provenance
+before the metric table. Missing provenance and comparable provenance mismatch
+are warned by default and can fail closed with opt-in CLI flags.
 
 ## Constraints
 
@@ -38,11 +42,65 @@ Unknown surfaces remain non-blocking but visible.
 
 ```bash
 python3 -m pytest tests/test_compare_eval_regression_gate.py -q
+python3 -m pytest -q tests/test_compare_eval_regression_gate.py tests/test_run_real_eval_delta.py tests/test_eval_artifact_privacy_regression.py tests/test_render_difficulty_profile.py
 python3 scripts/check_doc_links.py --check-all
-python3 -m pytest tests/test_eval_artifact_privacy_regression.py -q
+python3 -m py_compile scripts/compare_eval.py scripts/run_real_eval_delta.py scripts/render_difficulty_profile.py
+git diff --check
 ```
 
 ## Reviewer Notes
 
 Attack claim boundary wording first: smoke, synthetic benchmark, private
 real-eval, and harness summaries must not be silently treated as interchangeable.
+
+## Session Handoff
+
+```markdown
+## Session Handoff — 2026-05-25 19:46 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: fix/issue-1487-eval-provenance-comparator / /Users/hskim/.codex/worktrees/1487/BidMate-DocAgent
+- Base branch: main
+- Issue / PR: #1487 / PR TBD
+- Task: T-2026-0002 follow-up 01B
+- Plan: docs/plans/T-2026-0002-eval-artifact-surface-guard.md
+- Current status: compare_eval provenance rendering and opt-in strict gates implemented; adversarial review blockers addressed and re-review approved; focused validation passed.
+- Files touched: scripts/compare_eval.py, tests/test_compare_eval_regression_gate.py, docs/plans/T-2026-0002-eval-artifact-surface-guard.md
+- Decisions made: default comparator remains backward-compatible; missing/mismatched provenance is warning-only unless `--fail-on-missing-provenance` or `--fail-on-provenance-mismatch` is passed.
+- Commands run: python3 -m pytest tests/test_compare_eval_regression_gate.py -q; python3 -m py_compile scripts/compare_eval.py; python3 -m pytest -q tests/test_compare_eval_regression_gate.py tests/test_run_real_eval_delta.py tests/test_eval_artifact_privacy_regression.py tests/test_render_difficulty_profile.py; python3 -m py_compile scripts/compare_eval.py scripts/run_real_eval_delta.py scripts/render_difficulty_profile.py; python3 scripts/check_doc_links.py --check-all; git diff --check
+- Results: all listed commands exited 0.
+- Validation evidence: focused comparator regression suite plus private aggregate/privacy renderer suites.
+- Eval surface: PR fixture eval / eval governance comparator guard; no scoring semantics or benchmark metric changed.
+- Evidence artifacts: none.
+- Blockers: none.
+- Open risks: existing worktree has unrelated in-progress changes (`eval/naive_rag/*`, `visual_ingestion.py`, `tests/test_visual_ingestion.py`, `tests/test_naive_rag_benchmark_v1.py`, `tasks/queue.md`, and untracked plan docs); reviewer should isolate this follow-up diff when reviewing.
+- Next action: review the isolated T-2026-0002 follow-up diff.
+- Next safe command: python3 -m pytest -q tests/test_compare_eval_regression_gate.py tests/test_run_real_eval_delta.py tests/test_eval_artifact_privacy_regression.py tests/test_render_difficulty_profile.py
+- Reviewer focus: provenance rendering is privacy-safe, strict flags are opt-in, metric/regression exit-code semantics unchanged.
+```
+
+```markdown
+## Session Handoff — 2026-05-25 22:30 KST
+
+- Role: Maintainer + Integration Reviewer
+- Lifecycle stage: review
+- Branch / worktree: dev/multi-chunk-evidence-first-step / /Users/hskim/.codex/worktrees/cd0b/BidMate-DocAgent
+- Base branch: main
+- Issue / PR: #1480 / PR TBD
+- Task: T-2026-0002 follow-up 01B
+- Plan: docs/plans/T-2026-0002-eval-artifact-surface-guard.md
+- Current status: integration review addressed provenance fake-progress risks from Benchmark Auditor and Adversarial Reviewer.
+- Files touched: scripts/compare_eval.py, tests/test_compare_eval_regression_gate.py, docs/plans/T-2026-0002-eval-artifact-surface-guard.md
+- Decisions made: dataset count-only summaries no longer satisfy required dataset provenance; path-based config/index/dataset provenance includes a short path hash with basename redaction to detect same-basename mismatches without printing raw private paths.
+- Commands run: python3 -m pytest -q tests/test_compare_eval_regression_gate.py tests/test_run_real_eval_delta.py tests/test_eval_artifact_privacy_regression.py tests/test_render_difficulty_profile.py; python3 scripts/check_doc_links.py --check-all; python3 -m py_compile eval/naive_rag/validate_benchmark_dataset.py eval/naive_rag/build_benchmark_index.py eval/naive_rag/benchmark.py scripts/compare_eval.py scripts/run_real_eval_delta.py scripts/render_difficulty_profile.py visual_ingestion.py parser_page_metadata_contract.py scripts/page_metadata_recovery_audit.py ingestion.py rag_indexing.py; git diff --check
+- Results: all listed commands exited 0.
+- Validation evidence: focused comparator/privacy tests, doc link check, py_compile, diff check.
+- Eval surface: PR fixture eval / eval governance comparator guard.
+- Evidence artifacts: none.
+- Blockers: none for this checkpoint.
+- Open risks: comparator still cannot prove file content equality when only paths are available; exact comparability requires explicit sha/fingerprint fields.
+- Next action: review and publish draft PR for issue #1487.
+- Next safe command: python3 -m pytest -q tests/test_compare_eval_regression_gate.py tests/test_run_real_eval_delta.py tests/test_eval_artifact_privacy_regression.py tests/test_render_difficulty_profile.py
+- Reviewer focus: privacy-safe provenance rendering, fail-closed flags remain opt-in, no metric threshold/exit-code drift.
+```

--- a/scripts/compare_eval.py
+++ b/scripts/compare_eval.py
@@ -21,10 +21,12 @@ Regression gate:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _eval_delta import (  # noqa: E402
@@ -39,6 +41,28 @@ from _eval_delta import (  # noqa: E402
 
 DEFAULT_REGRESSION_THRESHOLD = 0.05
 ENV_ALLOW_REGRESSION = "ALLOW_REGRESSION"
+REQUIRED_PROVENANCE_FIELDS = ("run", "config", "index", "dataset")
+COMPARABLE_PROVENANCE_FIELDS = ("config", "index", "dataset")
+UNKNOWN_PROVENANCE_SENTINELS = {"unknown", "none", "null", "n/a", "na", "?"}
+DATASET_COUNT_ONLY_PREFIX = "counts_only: "
+PRIVATE_RELATIVE_PATH_PREFIXES = (
+    "data/private/",
+    "experiments/private",
+    "reports/real",
+)
+PRIVATE_PATH_SUFFIXES = {
+    ".bin",
+    ".csv",
+    ".json",
+    ".jsonl",
+    ".npy",
+    ".pkl",
+    ".pt",
+    ".safetensors",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -61,6 +85,24 @@ def parse_args() -> argparse.Namespace:
             "Exit 2 when the compared eval_summary.json files are classified "
             "as different evaluation surfaces. Unknown surfaces are rendered "
             "but do not fail the gate."
+        ),
+    )
+    ap.add_argument(
+        "--fail-on-missing-provenance",
+        action="store_true",
+        help=(
+            "Exit 2 when either eval_summary.json is missing run/config/index/"
+            "dataset provenance needed to interpret metric claims. Missing "
+            "provenance is always rendered before the metric table."
+        ),
+    )
+    ap.add_argument(
+        "--fail-on-provenance-mismatch",
+        action="store_true",
+        help=(
+            "Exit 2 when comparable config/index/dataset provenance is present "
+            "on both eval_summary.json files but differs. The run provenance "
+            "itself may differ across base/head and is not compared."
         ),
     )
     ap.add_argument(
@@ -140,6 +182,233 @@ def surfaces_compatible(base_surface: str, head_surface: str) -> bool:
     if base_surface.startswith("unknown") or head_surface.startswith("unknown"):
         return True
     return base_surface == head_surface
+
+
+def _present(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        text = value.strip()
+        return bool(text) and text.lower() not in UNKNOWN_PROVENANCE_SENTINELS
+    return True
+
+
+def _first_present(summary: dict, *paths: str) -> Any:
+    for path in paths:
+        value = get_path(summary, path)
+        if _present(value):
+            return value
+    return None
+
+
+def _short_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = " ".join(str(value or "").strip().split())
+    return text if text else "unknown"
+
+
+def _privacy_safe_scalar(value: Any) -> str:
+    text = _short_scalar(value)
+    if text == "unknown":
+        return text
+    if _looks_like_local_path(text) or _looks_like_private_relative_path(text):
+        return _basename_label(text)
+    return text
+
+
+def _looks_like_local_path(text: str) -> bool:
+    if text.startswith(("file://", "/", "~", "\\\\")):
+        return True
+    return len(text) >= 3 and text[1] == ":" and text[2] in ("\\", "/")
+
+
+def _looks_like_private_relative_path(text: str) -> bool:
+    normalized = text.replace("\\", "/")
+    if any(normalized.startswith(prefix) for prefix in PRIVATE_RELATIVE_PATH_PREFIXES):
+        return True
+    return "/" in normalized and Path(normalized).suffix.lower() in PRIVATE_PATH_SUFFIXES
+
+
+def _basename_label(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return "unknown"
+    if text.startswith("file://"):
+        text = text[len("file://"):]
+    if "\\" in text or (len(text) >= 2 and text[1] == ":"):
+        return PureWindowsPath(text).name or "path-present"
+    return Path(text).name or "path-present"
+
+
+def _path_provenance_label(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return "unknown"
+    return f"{_basename_label(text)}#{hashlib.sha256(text.encode('utf-8')).hexdigest()[:12]}"
+
+
+def eval_provenance_summary(summary: dict) -> dict[str, str]:
+    """Return privacy-safe provenance labels for reviewer-visible output.
+
+    Only aggregate metadata is read. Local filesystem paths are reduced to a
+    basename so the comparator can surface that provenance exists without
+    rendering private absolute paths.
+    """
+    git_commit = _first_present(
+        summary,
+        "provenance.git_commit",
+        "run_manifest.git_commit",
+    )
+    git_tree = _first_present(summary, "provenance.git_tree")
+    git_dirty = _first_present(summary, "provenance.git_dirty", "run_manifest.git_dirty")
+    generated_at = _first_present(
+        summary,
+        "provenance.generated_at",
+        "run_manifest.generated_at",
+        "generated_at",
+    )
+    run_bits: list[str] = []
+    if _present(git_commit):
+        run_bits.append(f"git={_short_scalar(git_commit)}")
+    if _present(git_tree):
+        run_bits.append(f"tree={_short_scalar(git_tree)}")
+    if _present(generated_at):
+        run_bits.append(f"generated={_short_scalar(generated_at)}")
+    if run_bits and _present(git_dirty):
+        run_bits.append(f"dirty={_short_scalar(git_dirty)}")
+
+    config_sha = _first_present(summary, "run_manifest.config_sha256", "config_sha256")
+    config_path = _first_present(summary, "run_manifest.config_path", "config_path")
+    if _present(config_sha):
+        config = f"sha={_short_scalar(config_sha)}"
+    elif _present(config_path):
+        config = f"path={_path_provenance_label(config_path)}"
+    else:
+        config = "unknown"
+
+    embedding_backend = _first_present(
+        summary,
+        "run_manifest.embedding_backend",
+        "index_provenance.embedding_backend",
+        "model_config.backend",
+        "embedding.backend",
+    )
+    embedding_model = _first_present(
+        summary,
+        "run_manifest.embedding_model_id",
+        "index_provenance.model",
+        "model_config.model",
+        "embedding.model",
+    )
+    index_dir = _first_present(summary, "index_dir")
+    if _present(embedding_backend) or _present(embedding_model):
+        index = (
+            f"embedding={_privacy_safe_scalar(embedding_backend)}/"
+            f"{_privacy_safe_scalar(embedding_model)}"
+        )
+    elif _present(index_dir):
+        index = f"path={_path_provenance_label(index_dir)}"
+    else:
+        index = "unknown"
+
+    dataset_source = summary.get("dataset")
+    if not isinstance(dataset_source, dict):
+        dataset_source = summary.get("dataset_summary")
+    dataset_bits: list[str] = []
+    dataset_identity_present = False
+    if isinstance(dataset_source, dict):
+        dataset_id = _first_present(
+            dataset_source,
+            "id",
+            "name",
+            "sha256",
+            "fingerprint",
+        )
+        if _present(dataset_id):
+            dataset_identity_present = True
+            dataset_bits.append(f"id={_privacy_safe_scalar(dataset_id)}")
+        for label, keys in (
+            ("questions", ("num_questions", "question_count", "n_questions")),
+            (
+                "docs",
+                ("num_documents", "num_docs", "document_count", "doc_count", "corpus_size"),
+            ),
+            ("chunks", ("num_chunks", "chunk_count", "n_chunks")),
+            ("answerable", ("answerable_count", "answerable_question_count")),
+            ("unanswerable", ("unanswerable_count", "unanswerable_question_count")),
+        ):
+            value = _first_present(dataset_source, *keys)
+            if isinstance(value, int):
+                dataset_bits.append(f"{label}={value}")
+    dataset_id = _first_present(
+        summary,
+        "dataset_id",
+        "dataset_sha256",
+        "dataset_hash",
+        "dataset_fingerprint",
+    )
+    dataset_path = _first_present(summary, "dataset_path", "questions_path", "corpus_path")
+    if _present(dataset_id) and not dataset_bits:
+        dataset_identity_present = True
+        dataset_bits.append(f"id={_privacy_safe_scalar(dataset_id)}")
+    elif _present(dataset_path):
+        dataset_identity_present = True
+        if not any(bit.startswith(("id=", "path=")) for bit in dataset_bits):
+            dataset_bits.insert(0, f"path={_path_provenance_label(dataset_path)}")
+
+    return {
+        "run": ", ".join(run_bits) if run_bits else "unknown",
+        "config": config,
+        "index": index,
+        "dataset": (
+            ", ".join(dataset_bits)
+            if dataset_identity_present
+            else (
+                DATASET_COUNT_ONLY_PREFIX + ", ".join(dataset_bits)
+                if dataset_bits
+                else "unknown"
+            )
+        ),
+    }
+
+
+def missing_required_provenance(summary: dict) -> list[str]:
+    provenance = eval_provenance_summary(summary)
+    return [
+        field
+        for field in REQUIRED_PROVENANCE_FIELDS
+        if provenance.get(field) == "unknown"
+        or (
+            field == "dataset"
+            and str(provenance.get(field) or "").startswith(DATASET_COUNT_ONLY_PREFIX)
+        )
+    ]
+
+
+def provenance_mismatches(base: dict, head: dict) -> dict[str, tuple[str, str]]:
+    base_provenance = eval_provenance_summary(base)
+    head_provenance = eval_provenance_summary(head)
+    out: dict[str, tuple[str, str]] = {}
+    for field in COMPARABLE_PROVENANCE_FIELDS:
+        base_value = base_provenance.get(field, "unknown")
+        head_value = head_provenance.get(field, "unknown")
+        if "unknown" in (base_value, head_value):
+            continue
+        if base_value != head_value:
+            out[field] = (base_value, head_value)
+    return out
+
+
+def _render_provenance(label: str, summary: dict) -> str:
+    provenance = eval_provenance_summary(summary)
+    return (
+        f"- provenance({label}): run=`{provenance['run']}` · "
+        f"config=`{provenance['config']}` · index=`{provenance['index']}` · "
+        f"dataset=`{provenance['dataset']}`"
+    )
 
 
 def _render_gate_block(regressions: list[dict], *, allow: bool) -> list[str]:
@@ -246,6 +515,10 @@ def main() -> int:
     base_surface = classify_eval_surface(base, path=args.base)
     head_surface = classify_eval_surface(head, path=args.head)
     surface_mismatch = not surfaces_compatible(base_surface, head_surface)
+    base_missing_provenance = missing_required_provenance(base)
+    head_missing_provenance = missing_required_provenance(head)
+    missing_provenance = bool(base_missing_provenance or head_missing_provenance)
+    mismatched_provenance = provenance_mismatches(base, head)
 
     lines: list[str] = []
     lines.append(f"### {args.title}")
@@ -258,6 +531,8 @@ def main() -> int:
         f"(primary run: `{head.get('primary_run', '?')}`)"
     )
     lines.append(f"- surface: base=`{base_surface}` · head=`{head_surface}`")
+    lines.append(_render_provenance("base", base))
+    lines.append(_render_provenance("head", head))
     lines.append(
         f"- cases: base={base.get('num_predictions', '?')} · "
         f"head={head.get('num_predictions', '?')}"
@@ -267,6 +542,33 @@ def main() -> int:
             "> ⚠️ Surface mismatch: compare smoke, synthetic benchmark, "
             "private real-eval, and harness artifacts only with matching "
             "dataset/config/index provenance."
+        )
+    if missing_provenance:
+        missing_bits = []
+        if base_missing_provenance:
+            missing_bits.append(
+                "base missing "
+                + ", ".join(f"`{field}`" for field in base_missing_provenance)
+            )
+        if head_missing_provenance:
+            missing_bits.append(
+                "head missing "
+                + ", ".join(f"`{field}`" for field in head_missing_provenance)
+            )
+        lines.append(
+            "> ⚠️ Missing provenance: " + "; ".join(missing_bits) + ". "
+            "Metric deltas should not be used as benchmark/performance claims "
+            "until run/config/index/dataset provenance is explicit."
+        )
+    if mismatched_provenance:
+        mismatch_bits = [
+            f"`{field}` base=`{base_value}` head=`{head_value}`"
+            for field, (base_value, head_value) in mismatched_provenance.items()
+        ]
+        lines.append(
+            "> ⚠️ Provenance mismatch: " + "; ".join(mismatch_bits) + ". "
+            "Treat metric deltas as non-comparable unless this is an intentional "
+            "config/index/dataset change."
         )
     lines.append("")
     n_min = min_num_predictions(base, head)
@@ -295,6 +597,10 @@ def main() -> int:
     print("\n".join(lines))
 
     if surface_mismatch and args.fail_on_surface_mismatch:
+        return 2
+    if missing_provenance and args.fail_on_missing_provenance:
+        return 2
+    if mismatched_provenance and args.fail_on_provenance_mismatch:
         return 2
     if regressions and not args.allow_regression:
         return 1

--- a/tests/test_compare_eval_regression_gate.py
+++ b/tests/test_compare_eval_regression_gate.py
@@ -17,6 +17,7 @@ What the gate must do:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -35,7 +36,11 @@ from _eval_delta import (  # noqa: E402
     min_num_predictions,
     silence_threshold,
 )
-from compare_eval import classify_eval_surface  # noqa: E402
+from compare_eval import (  # noqa: E402
+    classify_eval_surface,
+    missing_required_provenance,
+    provenance_mismatches,
+)
 
 
 def _base_summary() -> dict:
@@ -53,6 +58,38 @@ def _base_summary() -> dict:
         "retry": 0.20,
         "latency": {"p50": 200.0, "p95": 800.0},
     }
+
+
+def _provenanced_summary(**overrides: object) -> dict:
+    summary = dict(
+        _base_summary(),
+        benchmark_type="public_fixture_smoke_regression",
+        provenance={
+            "git_commit": "abc123def456",
+            "git_dirty": False,
+            "generated_at": "2026-05-25T00:00:00Z",
+        },
+        run_manifest={
+            "git_commit": "abc123def456",
+            "git_dirty": False,
+            "config_sha256": "cfg1111111111111",
+            "embedding_backend": "hashing",
+            "embedding_model_id": "hashing",
+            "generated_at": "2026-05-25T00:00:00Z",
+        },
+        dataset_summary={
+            "id": "public-fixture-smoke-v1",
+            "num_questions": 42,
+            "num_docs": 5,
+            "num_chunks": 100,
+        },
+    )
+    summary.update(overrides)
+    return summary
+
+
+def _path_label(value: str) -> str:
+    return f"{Path(value).name}#{hashlib.sha256(value.encode('utf-8')).hexdigest()[:12]}"
 
 
 class DetectRegressionsTest(unittest.TestCase):
@@ -232,6 +269,121 @@ class EvalSurfaceClassificationTest(unittest.TestCase):
         )
 
 
+class EvalProvenanceTest(unittest.TestCase):
+    def test_missing_required_provenance_reports_run_config_index(self) -> None:
+        self.assertEqual(
+            missing_required_provenance(_base_summary()),
+            ["run", "config", "index", "dataset"],
+        )
+
+    def test_unknown_sentinel_does_not_count_as_present_provenance(self) -> None:
+        summary = dict(
+            _base_summary(),
+            provenance={"git_commit": "unknown"},
+            run_manifest={
+                "config_sha256": "unknown",
+                "embedding_backend": "unknown",
+                "embedding_model_id": "unknown",
+            },
+            dataset={"id": "unknown"},
+        )
+        self.assertEqual(
+            missing_required_provenance(summary),
+            ["run", "config", "index", "dataset"],
+        )
+
+    def test_dataset_counts_without_identity_do_not_satisfy_required_provenance(self) -> None:
+        summary = _provenanced_summary(
+            dataset_summary={
+                "num_questions": 42,
+                "num_docs": 5,
+                "num_chunks": 100,
+            }
+        )
+
+        self.assertEqual(missing_required_provenance(summary), ["dataset"])
+
+    def test_provenance_mismatch_ignores_run_commit_but_compares_config_index_dataset(self) -> None:
+        base = _provenanced_summary(
+            provenance={
+                "git_commit": "basecommit",
+                "generated_at": "2026-05-25T00:00:00Z",
+            },
+            run_manifest={
+                "git_commit": "basecommit",
+                "config_sha256": "cfg-base",
+                "embedding_backend": "hashing",
+                "embedding_model_id": "hashing",
+            },
+        )
+        head = _provenanced_summary(
+            provenance={
+                "git_commit": "headcommit",
+                "generated_at": "2026-05-25T01:00:00Z",
+            },
+            run_manifest={
+                "git_commit": "headcommit",
+                "config_sha256": "cfg-head",
+                "embedding_backend": "sentence-transformers",
+                "embedding_model_id": "model-v2",
+            },
+            dataset_summary={
+                "id": "public-fixture-smoke-v2",
+                "num_questions": 41,
+                "num_docs": 5,
+                "num_chunks": 100,
+            },
+        )
+        mismatches = provenance_mismatches(base, head)
+        self.assertEqual(set(mismatches), {"config", "index", "dataset"})
+        self.assertNotIn("run", mismatches)
+
+    def test_dataset_aliases_participate_in_provenance_mismatch(self) -> None:
+        base = _provenanced_summary(
+            dataset_summary={
+                "id": "public-fixture-smoke-v1",
+                "question_count": 42,
+                "corpus_size": 5,
+                "chunk_count": 100,
+            }
+        )
+        head = _provenanced_summary(
+            dataset_summary={
+                "id": "public-fixture-smoke-v1",
+                "question_count": 42,
+                "corpus_size": 5,
+                "chunk_count": 101,
+            }
+        )
+        self.assertEqual(set(provenance_mismatches(base, head)), {"dataset"})
+
+    def test_same_basename_paths_still_participate_in_provenance_mismatch(self) -> None:
+        base = _provenanced_summary(
+            run_manifest={
+                "git_commit": "abc123def456",
+                "git_dirty": False,
+                "config_path": "/private/base/config.yaml",
+                "embedding_backend": "hashing",
+                "embedding_model_id": "hashing",
+            },
+        )
+        head = _provenanced_summary(
+            run_manifest={
+                "git_commit": "abc123def456",
+                "git_dirty": False,
+                "config_path": "/private/head/config.yaml",
+                "embedding_backend": "hashing",
+                "embedding_model_id": "hashing",
+            },
+        )
+
+        mismatches = provenance_mismatches(base, head)
+
+        self.assertEqual(set(mismatches), {"config"})
+        self.assertIn("config.yaml#", mismatches["config"][0])
+        self.assertIn("config.yaml#", mismatches["config"][1])
+
+
 class CompareEvalCliGateTest(unittest.TestCase):
     """Exit-code contract for the workflow.
 
@@ -314,6 +466,82 @@ class CompareEvalCliGateTest(unittest.TestCase):
             )
         self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
         self.assertIn("Surface mismatch", result.stdout)
+
+    def test_missing_provenance_can_fail_closed(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            result = self._run(
+                Path(td),
+                _base_summary(),
+                _base_summary(),
+                regression_threshold=0,
+                fail_on_missing_provenance=True,
+            )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("Missing provenance", result.stdout)
+        self.assertIn("base missing `run`, `config`, `index`, `dataset`", result.stdout)
+
+    def test_provenance_mismatch_can_fail_closed(self) -> None:
+        import tempfile
+        base = _provenanced_summary()
+        head = _provenanced_summary(
+            run_manifest={
+                "git_commit": "abc123def456",
+                "git_dirty": False,
+                "config_sha256": "cfg2222222222222",
+                "embedding_backend": "hashing",
+                "embedding_model_id": "hashing",
+                "generated_at": "2026-05-25T00:00:00Z",
+            }
+        )
+        with tempfile.TemporaryDirectory() as td:
+            result = self._run(
+                Path(td),
+                base,
+                head,
+                regression_threshold=0,
+                fail_on_provenance_mismatch=True,
+        )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("Provenance mismatch", result.stdout)
+        self.assertIn(
+            "`config` base=`sha=cfg1111111111111` "
+            "head=`sha=cfg2222222222222`",
+            result.stdout,
+        )
+
+    def test_provenance_renders_before_metric_table_and_redacts_paths(self) -> None:
+        import tempfile
+        base = dict(
+            _base_summary(),
+            provenance={"generated_at": "2026-05-25T00:00:00Z"},
+            run_manifest={
+                "config_path": "/Users/hskim/private/real_config.local.yaml",
+                "embedding_backend": "local",
+                "embedding_model_id": "data/private/model.bin",
+                "generated_at": "2026-05-25T00:00:00Z",
+            },
+            dataset_path="file:///Users/hskim/private/questions.jsonl",
+        )
+        head = dict(base)
+        with tempfile.TemporaryDirectory() as td:
+            result = self._run(Path(td), base, head, regression_threshold=0)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertLess(
+            result.stdout.index("- provenance(base):"),
+            result.stdout.index("| metric |"),
+        )
+        self.assertIn(
+            f"config=`path={_path_label('/Users/hskim/private/real_config.local.yaml')}`",
+            result.stdout,
+        )
+        self.assertIn("index=`embedding=local/model.bin`", result.stdout)
+        self.assertIn(
+            f"dataset=`path={_path_label('file:///Users/hskim/private/questions.jsonl')}`",
+            result.stdout,
+        )
+        self.assertNotIn("/Users/hskim/private", result.stdout)
+        self.assertNotIn("data/private", result.stdout)
 
     def test_unknown_surface_does_not_fail_closed_against_known_surface(self) -> None:
         import tempfile


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`eval_summary.json` 비교 결과가 metric table만 보여주면 서로 다른 dataset/config/index를 비교해도 claim-ready처럼 보일 수 있습니다. `scripts/compare_eval.py`에 privacy-safe provenance rendering을 추가해 base/head의 run/config/index/dataset provenance를 metric table 전에 노출하고, missing/mismatched provenance를 opt-in fail-closed로 처리할 수 있게 했습니다.

Closes #1487

## 2. 영향 파일

- `scripts/compare_eval.py` — comparator output에 provenance block, missing/mismatch warning, opt-in strict flags 추가.
- `tests/test_compare_eval_regression_gate.py` — missing provenance, same-basename path mismatch, redaction, strict flag regression tests 추가.
- `docs/plans/T-2026-0002-eval-artifact-surface-guard.md` — follow-up handoff 갱신.

## 3. 리스크

- Path-only provenance는 file content equality를 증명하지 않습니다. 그래서 exact comparability에는 explicit sha/fingerprint가 필요하다는 risk를 문서화했습니다.
- Basename만 출력하면 private path는 보호되지만 same-basename mismatch를 놓칠 수 있어, basename + short path hash를 사용했습니다.
- Default behavior는 warning-only입니다. CI/PR eval compatibility를 위해 strict gates는 opt-in flag로만 동작합니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_compare_eval_regression_gate.py tests/test_run_real_eval_delta.py tests/test_eval_artifact_privacy_regression.py tests/test_render_difficulty_profile.py`
- `python3 -m py_compile scripts/compare_eval.py scripts/run_real_eval_delta.py scripts/render_difficulty_profile.py`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`

## 5. Eval 영향

Surface: PR fixture eval / eval governance comparator guard.

Allowed claim: comparator now makes provenance risks visible and can fail closed when explicitly requested.

Disallowed claim: no metric quality improvement, no benchmark score improvement, no real-world performance claim.

### 5b. Real-data delta

| 항목 | 값 |
|---|---|
| real eval 실행 | 미실행 |
| 사유 | 이 PR은 aggregate comparator rendering/exit-code guard만 변경합니다. Retrieval, verifier, answer generation, metric calculation, regression threshold는 변경하지 않습니다. |
| 성능 claim | 없음 |
| private data boundary | Private raw question/answer/evidence/doc id/chunk id/path를 출력하지 않고 path는 basename + short hash로만 표시합니다. |

## 6. 하위 호환

Default comparator behavior remains warning-only for provenance issues. Existing regression gate thresholds and metric calculations are unchanged.

## 7. 범위 외

- metric calculation 변경
- CI에서 strict provenance flags 활성화
- private real-eval 실행
- benchmark scoring semantics 변경
