### PR TITLE
fix: make ship-start labels fail-soft

### DIFF
--- a/scripts/claude-hooks/_ship_start.py
+++ b/scripts/claude-hooks/_ship_start.py
@@ -63,15 +63,45 @@ def ensure_clean_worktree() -> None:
         )
 
 
+def split_labels(labels: str | None) -> list[str]:
+    if not labels:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in labels.split(","):
+        label = raw.strip()
+        if not label or label in seen:
+            continue
+        seen.add(label)
+        out.append(label)
+    return out
+
+
+def apply_issue_labels(issue_number: int, labels: list[str]) -> None:
+    for label in labels:
+        result = run(
+            ["gh", "issue", "edit", str(issue_number), "--add-label", label],
+            check=False,
+        )
+        if result.returncode == 0:
+            continue
+        detail = (result.stderr or result.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        print(
+            f"ship-start: warning — could not add label {label!r}{suffix}",
+            file=sys.stderr,
+        )
+
+
 def create_issue(title: str, body: str, labels: str | None) -> tuple[int, str]:
     cmd = ["gh", "issue", "create", "--title", title, "--body", body]
-    if labels:
-        cmd.extend(["--label", labels])
     url = run(cmd).stdout.strip()
     m = ISSUE_URL_RE.search(url)
     if not m:
         raise SystemExit(f"ship-start: could not parse issue number from gh output: {url!r}")
-    return int(m.group(1)), url
+    issue_number = int(m.group(1))
+    apply_issue_labels(issue_number, split_labels(labels))
+    return issue_number, url
 
 
 def main() -> int:

--- a/tests/test_ship_start_review_gate.py
+++ b/tests/test_ship_start_review_gate.py
@@ -31,6 +31,14 @@ def test_ship_start_allows_eval_type() -> None:
     assert "eval" in ship_start.ALLOWED_TYPES
 
 
+def test_ship_start_splits_labels() -> None:
+    assert ship_start.split_labels("enhancement, rag, enhancement,,evaluation") == [
+        "enhancement",
+        "rag",
+        "evaluation",
+    ]
+
+
 def test_ship_start_creates_issue_then_switches_branch(monkeypatch, capsys) -> None:
     calls: list[list[str]] = []
 
@@ -72,6 +80,60 @@ def test_ship_start_creates_issue_then_switches_branch(monkeypatch, capsys) -> N
         "origin/main",
     ] in calls
     assert "created https://github.com/hskim-solv/BidMate-DocAgent/issues/1410" in capsys.readouterr().out
+
+
+def test_ship_start_label_failure_warns_without_aborting(monkeypatch, capsys) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *, check=True):
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="")
+        if cmd[:3] == ["gh", "issue", "create"]:
+            assert "--label" not in cmd
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="https://github.com/hskim-solv/BidMate-DocAgent/issues/1495\n",
+            )
+        if cmd[:3] == ["gh", "issue", "edit"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                1,
+                stdout="",
+                stderr="could not find label",
+            )
+        if cmd[:3] == ["git", "switch", "-c"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(ship_start, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "_ship_start.py",
+            "--title",
+            "Harden ship-start label handling",
+            "--type",
+            "fix",
+            "--labels",
+            "enhancement,rag",
+            "--no-fetch",
+        ],
+    )
+
+    assert ship_start.main() == 0
+    assert [
+        "git",
+        "switch",
+        "-c",
+        "fix/issue-1495-harden-ship-start-label-handling",
+        "origin/main",
+    ] in calls
+    stderr = capsys.readouterr().err
+    assert "could not add label 'enhancement'" in stderr
+    assert "could not add label 'rag'" in stderr
 
 
 def test_review_gate_passes_when_open_and_no_review_blockers(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make ship-start`가 optional label 조합 중 하나라도 GitHub에 없으면 `gh issue create --label ...` 단계에서 issue/branch 생성 자체를 중단했습니다. Issue를 먼저 label 없이 만들고, label은 이후 개별 `gh issue edit --add-label`로 fail-soft 적용하게 바꿔 front door가 label taxonomy drift에 막히지 않게 했습니다.

Closes #1495

## 2. 영향 파일

- `scripts/claude-hooks/_ship_start.py` — issue 생성과 label 적용 분리, label split/dedupe, label 적용 실패 경고 처리
- `tests/test_ship_start_review_gate.py` — label split 및 label 실패 시 branch 생성 지속 regression test 추가

## 3. 리스크

가장 큰 리스크는 valid label이 더 이상 적용되지 않는 회귀입니다. `apply_issue_labels()`가 split된 label을 개별 `gh issue edit --add-label`로 호출하도록 단위 테스트에서 command flow를 고정했고, issue 생성 명령에는 `--label`이 없음을 검증했습니다.

## 4. 테스트

- `python3 -m pytest tests/test_ship_start_review_gate.py -q`
- `python3 -m py_compile scripts/claude-hooks/_ship_start.py`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All N/A — developer tooling front door 변경이며 RAG runtime, retrieval, answer, eval scorer 동작 변화 없음.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Load-bearing path 미변경이므로 `make real-eval-delta`는 실행하지 않았습니다.

## 6. 하위 호환

CLI flag는 그대로 유지합니다. `--labels`는 계속 comma-separated string을 받지만, 이제 issue 생성 성공을 label 적용 성공에 의존하지 않습니다. Answer-contract `schema_version` 변경 없음.

## 7. 범위 외

- GitHub label taxonomy 정리 또는 label 자동 생성은 범위 밖입니다.
- stale/orphan worktree cleanup은 push hook 경고로 관측됐지만 이 PR 범위 밖입니다.
