### PR TITLE
chore: add agent loop automation CLI

### DIFF
--- a/.claude/commands/agent-loop-auto-pass.md
+++ b/.claude/commands/agent-loop-auto-pass.md
@@ -1,0 +1,31 @@
+---
+description: Check whether a low-risk local gate can continue without human review.
+argument-hint: "[optional TASK_ID]"
+allowed-tools: Bash(python3 scripts/agent_loop.py auto-pass-check:*), Bash(python3 scripts/agent_loop.py loop-state:*)
+---
+
+# Agent Loop Auto-Pass
+
+Run the fail-closed low-risk gate check. This is not a shipping approval.
+
+Arguments from the user:
+
+```text
+$ARGUMENTS
+```
+
+If the argument contains a task id matching `T-YYYY-NNNN`, run:
+
+```bash
+python3 scripts/agent_loop.py auto-pass-check --task <TASK_ID> --from-git --run-validation --out reports/agent_loop/auto_pass.md
+python3 scripts/agent_loop.py loop-state --task <TASK_ID> --from-git
+```
+
+Otherwise run:
+
+```bash
+python3 scripts/agent_loop.py auto-pass-check --from-git --run-validation --out reports/agent_loop/auto_pass.md
+python3 scripts/agent_loop.py loop-state --from-git
+```
+
+Only treat `Decision: auto-pass` as permission to continue local read/report orchestration. It does not authorize push, PR creation, merge, close, branch deletion, force-push, private real-eval decisions, architecture decisions, or benchmark/performance claims.

--- a/.claude/commands/agent-loop-auto-ship.md
+++ b/.claude/commands/agent-loop-auto-ship.md
@@ -1,0 +1,39 @@
+---
+description: Prepare and plan the existing BidMate auto-ship path without arming it.
+argument-hint: "[optional TASK_ID]"
+allowed-tools: Bash(python3 scripts/agent_loop.py auto-ship-prepare:*), Bash(python3 scripts/agent_loop.py auto-ship-plan:*), Bash(python3 scripts/agent_loop.py ship-simulate:*), Bash(python3 scripts/agent_loop.py approval-packet:*), Bash(make ship-status)
+---
+
+# Agent Loop Auto-Ship Plan
+
+Render local preparation and plan reports for using the existing `make ship-arm` Stop-hook pipeline.
+This command is planning-only; it must not run `make ship-arm`.
+
+Arguments from the user:
+
+```text
+$ARGUMENTS
+```
+
+If the argument contains a task id matching `T-YYYY-NNNN`, run:
+
+```bash
+python3 scripts/agent_loop.py auto-ship-prepare --out reports/agent_loop/auto_ship_prepare.md
+python3 scripts/agent_loop.py auto-ship-plan --task <TASK_ID> --from-git --dry-run --out reports/agent_loop/auto_ship_plan.md
+python3 scripts/agent_loop.py ship-simulate --task <TASK_ID> --from-git --out reports/agent_loop/ship_simulation.md
+python3 scripts/agent_loop.py approval-packet --task <TASK_ID> --from-git --out reports/agent_loop/approval_packet.md
+make ship-status
+```
+
+Otherwise run:
+
+```bash
+python3 scripts/agent_loop.py auto-ship-prepare --out reports/agent_loop/auto_ship_prepare.md
+python3 scripts/agent_loop.py auto-ship-plan --from-git --dry-run --out reports/agent_loop/auto_ship_plan.md
+python3 scripts/agent_loop.py ship-simulate --from-git --out reports/agent_loop/ship_simulation.md
+python3 scripts/agent_loop.py approval-packet --from-git --out reports/agent_loop/approval_packet.md
+make ship-status
+```
+
+Report the recommendation, blockers, warnings, dry-run command, and human gates.
+Do not arm auto-ship, push, create/merge/close PRs, delete branches, force-push, run private real-eval, or approve benchmark/performance claims.

--- a/.claude/commands/agent-loop-preflight.md
+++ b/.claude/commands/agent-loop-preflight.md
@@ -1,0 +1,27 @@
+---
+description: Run local BidMate preflight for a task and write copy-paste prompts.
+argument-hint: "TASK_ID"
+allowed-tools: Bash(python3 scripts/agent_loop.py preflight:*), Bash(python3 scripts/agent_loop.py handoff-check:*), Bash(python3 scripts/agent_loop.py suggest-validation:*)
+---
+
+# Agent Loop Preflight
+
+Use this when a BidMate task is about to move from implementation to review.
+
+Task argument:
+
+```text
+$ARGUMENTS
+```
+
+Require a task id matching `T-YYYY-NNNN`. If it is missing, stop and ask for the task id.
+
+Run:
+
+```bash
+python3 scripts/agent_loop.py preflight --task <TASK_ID> --from-git --write-prompts
+```
+
+If preflight fails, summarize missing handoff fields, weak validation evidence, or surface review requirements. If it passes, point to the rendered implementation and review prompts under `reports/agent_loop/`.
+
+Do not edit queue/plan docs, push, create/merge/close PRs, delete branches, force-push, run private real-eval, or approve benchmark/performance claims.

--- a/.claude/commands/agent-loop-review.md
+++ b/.claude/commands/agent-loop-review.md
@@ -1,0 +1,37 @@
+---
+description: Render an adversarial review prompt and review gate summary for a BidMate task.
+argument-hint: "TASK_ID [PR_NUMBER]"
+allowed-tools: Bash(python3 scripts/agent_loop.py review-prompt:*), Bash(python3 scripts/agent_loop.py gate-status:*), Bash(python3 scripts/agent_loop.py claim-audit:*), Bash(python3 scripts/agent_loop.py privacy-audit-output:*)
+---
+
+# Agent Loop Review Prompt
+
+Use this to prepare a copy-paste adversarial review prompt and local review gate evidence.
+
+Arguments from the user:
+
+```text
+$ARGUMENTS
+```
+
+Require a task id matching `T-YYYY-NNNN`. If a numeric PR number is also present, pass it with `--pr`.
+
+Run one of:
+
+```bash
+python3 scripts/agent_loop.py review-prompt --task <TASK_ID> --from-git --out reports/agent_loop/review_prompt.txt
+python3 scripts/agent_loop.py gate-status --task <TASK_ID> --from-git --out reports/agent_loop/gate_status.md
+python3 scripts/agent_loop.py claim-audit --from-git --out reports/agent_loop/claim_audit.md
+python3 scripts/agent_loop.py privacy-audit-output --path reports/agent_loop --out reports/agent_loop/privacy_audit.md
+```
+
+or, with a PR number:
+
+```bash
+python3 scripts/agent_loop.py review-prompt --task <TASK_ID> --pr <PR_NUMBER> --from-git --out reports/agent_loop/review_prompt.txt
+python3 scripts/agent_loop.py gate-status --task <TASK_ID> --pr <PR_NUMBER> --from-git --out reports/agent_loop/gate_status.md
+python3 scripts/agent_loop.py claim-audit --pr <PR_NUMBER> --out reports/agent_loop/claim_audit.md
+python3 scripts/agent_loop.py privacy-audit-output --path reports/agent_loop --out reports/agent_loop/privacy_audit.md
+```
+
+Summarize required reviewer modes, surface classification, claim/privacy boundaries, and next safe command. Do not auto-fix review comments unless the user explicitly asks for a scoped implementation pass.

--- a/.claude/commands/agent-loop-status.md
+++ b/.claude/commands/agent-loop-status.md
@@ -1,0 +1,33 @@
+---
+description: Summarize the BidMate agent-loop state, surface, and next safe command.
+argument-hint: "[optional TASK_ID]"
+allowed-tools: Bash(python3 scripts/agent_loop.py status:*), Bash(python3 scripts/agent_loop.py gate-status:*), Bash(python3 scripts/agent_loop.py loop-state:*)
+---
+
+# Agent Loop Status
+
+Run the local BidMate agent-loop status check. This command is read/report centered.
+
+Arguments from the user:
+
+```text
+$ARGUMENTS
+```
+
+If the argument contains a task id matching `T-YYYY-NNNN`, run:
+
+```bash
+python3 scripts/agent_loop.py status --task <TASK_ID> --from-git
+python3 scripts/agent_loop.py gate-status --task <TASK_ID> --from-git
+python3 scripts/agent_loop.py loop-state --task <TASK_ID> --from-git
+```
+
+Otherwise run:
+
+```bash
+python3 scripts/agent_loop.py status --from-git
+python3 scripts/agent_loop.py gate-status --from-git
+python3 scripts/agent_loop.py loop-state --from-git
+```
+
+Report the current gate, surface classification, validation suggestions, generated artifact paths, and the next safe command. Do not push, create/merge/close PRs, delete branches, force-push, or make benchmark/private-real-eval claims.

--- a/.claude/commands/agent-loop-watch.md
+++ b/.claude/commands/agent-loop-watch.md
@@ -1,0 +1,30 @@
+---
+description: Enable, disable, or inspect the agent-loop Stop-hook report refresher.
+argument-hint: "on|off|status"
+allowed-tools: Bash(touch .claude/.agent-loop-watch), Bash(rm -f .claude/.agent-loop-watch), Bash(test -f .claude/.agent-loop-watch), Bash(python3 scripts/agent_loop.py gate-status:*), Bash(python3 scripts/agent_loop.py loop-state:*), Bash(python3 scripts/agent_loop.py auto-pass-check:*)
+---
+
+# Agent Loop Watch
+
+Control the optional Stop-hook report refresher.
+
+Arguments:
+
+```text
+$ARGUMENTS
+```
+
+Behavior:
+
+- `on`: run `touch .claude/.agent-loop-watch`, then generate current reports:
+
+```bash
+python3 scripts/agent_loop.py gate-status --from-git --out reports/agent_loop/gate_status.md
+python3 scripts/agent_loop.py loop-state --from-git --out reports/agent_loop/loop_state.json
+python3 scripts/agent_loop.py auto-pass-check --from-git --out reports/agent_loop/auto_pass.md
+```
+
+- `off`: run `rm -f .claude/.agent-loop-watch`.
+- `status` or empty: run `test -f .claude/.agent-loop-watch` and report whether watch mode is active.
+
+The Stop hook only refreshes ignored local reports. It does not run validation, push, create/merge/close PRs, delete branches, force-push, run private real-eval, or approve claims.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,10 @@
           {
             "type": "command",
             "command": "bash scripts/claude-hooks/stop-ship.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/claude-hooks/stop-agent-loop.sh"
           }
         ]
       }

--- a/.github/workflows/agent-loop-artifacts.yml
+++ b/.github/workflows/agent-loop-artifacts.yml
@@ -1,0 +1,187 @@
+name: Agent Loop Artifacts
+
+# Informational PR artifact generator for the BidMate agent-loop helpers.
+# It never pushes, comments, creates/merges/closes PRs, deletes branches,
+# force-pushes, runs private real-eval, or calls external model APIs.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: agent-loop-artifacts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  artifacts:
+    name: Generate local loop reports
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Collect changed files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p reports/agent_loop
+          gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' \
+            > reports/agent_loop/changed_files.txt
+          wc -l reports/agent_loop/changed_files.txt
+
+      - name: Generate agent-loop reports
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          mkdir -p .agent_loop_tmp
+          PR_BODY_FILE="$(mktemp .agent_loop_tmp/pr_body.XXXXXX)"
+          printf '%s' "$PR_BODY" > "$PR_BODY_FILE"
+          python3 scripts/agent_loop.py classify-surface \
+            --changed-files reports/agent_loop/changed_files.txt \
+            > reports/agent_loop/surface.md
+          python3 scripts/agent_loop.py suggest-validation \
+            --changed-files reports/agent_loop/changed_files.txt \
+            > reports/agent_loop/validation_suggestions.md
+          python3 scripts/agent_loop.py gate-status \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --out reports/agent_loop/gate_status.md
+          python3 scripts/agent_loop.py claim-audit \
+            --text "$PR_BODY_FILE" \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --out reports/agent_loop/claim_audit.md
+          python3 scripts/agent_loop.py auto-pass-check \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --out reports/agent_loop/auto_pass.md
+          python3 scripts/agent_loop.py loop-state \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --out reports/agent_loop/loop_state.json
+          python3 scripts/agent_loop.py dashboard \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --out reports/agent_loop/dashboard.md
+          python3 scripts/agent_loop.py approval-packet \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --out reports/agent_loop/approval_packet.md
+          python3 scripts/agent_loop.py pr-body \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --branch "$BRANCH" \
+            --out reports/agent_loop/pr_body.md
+          python3 scripts/agent_loop.py pr-body-check \
+            --body "$PR_BODY_FILE" \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --branch "$BRANCH" \
+            --out reports/agent_loop/pr_body_check.md
+          python3 scripts/agent_loop.py readiness-score \
+            --body "$PR_BODY_FILE" \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --branch "$BRANCH" \
+            --out reports/agent_loop/readiness_score.md
+          python3 scripts/agent_loop.py branch-issue-hygiene \
+            --body "$PR_BODY_FILE" \
+            --branch "$BRANCH" \
+            --out reports/agent_loop/branch_issue_hygiene.md
+          python3 scripts/agent_loop.py context-pack \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --out reports/agent_loop/context_pack.md
+          python3 scripts/agent_loop.py architecture-brief \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --out reports/agent_loop/architecture_brief.md
+          python3 scripts/agent_loop.py ship-simulate \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --branch "$BRANCH" \
+            --out reports/agent_loop/ship_simulation.md
+          python3 scripts/agent_loop.py auto-ship-prepare \
+            --target-branch "$BRANCH" \
+            --out reports/agent_loop/auto_ship_prepare.md
+          python3 scripts/agent_loop.py auto-ship-plan \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --branch "$BRANCH" \
+            --dry-run \
+            --out reports/agent_loop/auto_ship_plan.md
+          python3 scripts/agent_loop.py gate-brief \
+            --gate pr-create \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --out reports/agent_loop/gate_brief.md
+          python3 scripts/agent_loop.py stale-reports \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --out reports/agent_loop/stale_reports.md
+          python3 scripts/agent_loop.py ci-summary \
+            --pr "$PR" \
+            --out reports/agent_loop/ci_summary.md
+          python3 scripts/agent_loop.py patch-proposal \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --out reports/agent_loop/patch_proposal.diff
+          python3 scripts/agent_loop.py claim-policy \
+            --text "$PR_BODY_FILE" \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --out reports/agent_loop/claim_policy.md
+          python3 scripts/agent_loop.py architecture-decision \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --out reports/agent_loop/architecture_decision.md
+          python3 scripts/agent_loop.py dashboard-html \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --pr "$PR" \
+            --out reports/agent_loop/dashboard.html
+          python3 scripts/agent_loop.py ship-command-pack \
+            --pr "$PR" \
+            --branch "$BRANCH" \
+            --out reports/agent_loop/ship_commands.md
+          python3 scripts/agent_loop.py integration-pack \
+            --out reports/agent_loop/integration_pack.md
+          python3 scripts/agent_loop.py scheduled-status \
+            --out reports/agent_loop/schedule_config.md
+          python3 scripts/agent_loop.py privacy-regression \
+            --out reports/agent_loop/privacy_regression.md
+          python3 scripts/agent_loop.py automation-coverage \
+            --out reports/agent_loop/automation_coverage.md
+          python3 scripts/agent_loop.py manifest \
+            --changed-files reports/agent_loop/changed_files.txt \
+            --source-command "agent-loop-artifacts" \
+            --output reports/agent_loop/dashboard.md \
+            --output reports/agent_loop/approval_packet.md \
+            --output reports/agent_loop/pr_body.md \
+            --output reports/agent_loop/auto_ship_prepare.md \
+            --output reports/agent_loop/auto_ship_plan.md \
+            --out reports/agent_loop/manifest.json
+          python3 scripts/agent_loop.py privacy-audit-output \
+            --path reports/agent_loop \
+            --out reports/agent_loop/privacy_audit.md
+          rm -rf .agent_loop_tmp
+          exit 0
+
+      - name: Step summary
+        if: always()
+        run: |
+          cat reports/agent_loop/dashboard.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: agent-loop-reports
+          path: reports/agent_loop/
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 .env
 .env.*
 !.env.example
+.agent_loop_tmp/
 
 # OS/editor files
 .DS_Store
@@ -31,6 +32,8 @@ venv/
 !.claude/skills/**
 !.claude/agents/
 !.claude/agents/**
+!.claude/commands/
+!.claude/commands/**
 
 # Local/private source data
 configs/eval/private_real_eval.local.yaml
@@ -41,6 +44,7 @@ data/private/
 data/data_list.csv
 data/data_list.xlsx
 eval/real_config.local.yaml
+reports/agent_loop/
 eval/*.local.yaml
 configs/eval/*.local.yaml
 원본 데이터/

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@
 # Tests
 .PHONY: test test-regression
 
+# Agent-loop orchestration helpers. Thin wrappers around scripts/agent_loop.py;
+# they render prompts, classify surfaces, check handoffs, suggest or run
+# allowlisted local validation, and write ignored local planning drafts. They
+# do not perform GitHub mutations.
+.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
+
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
 .PHONY: ship-start ship-arm ship-disarm ship-status ship-review-gate
@@ -240,6 +246,658 @@ test-fast:
 # Run before any change to rag_core retrieval/verification or the eval pipeline.
 test-regression:
 	$(PYTHON) -m pytest tests/test_retrieval_loop_regression.py -q
+
+# ---------------------------------------------------------------------------
+# Agent-loop orchestration helpers.
+#
+# These targets make the lightweight CLI easy to call from Codex Desktop or a
+# local terminal. They intentionally stop at ignored local artifacts and
+# allowlisted local validation: no Codex auto-run, no push, no PR
+# creation/merge/close, no branch deletion, no force-push.
+#
+# Examples:
+#   make agent-loop-next
+#   make agent-loop-map
+#   make agent-loop-mcp
+#   make agent-loop-pr-scan
+#   make agent-loop-next-from-prs
+#   make agent-loop-pr-health
+#   make agent-loop-draft-task
+#   make agent-loop-draft-next
+#   make agent-loop-batch-plan
+#   make agent-loop-review-followup REVIEW=reports/agent_loop/review_prompt.md
+#   make agent-loop-review-ingest REVIEW=reports/agent_loop/review_prompt.md
+#   make agent-loop-decision-brief TASK=T-2026-0003
+#   make agent-loop-promote-draft
+#   make agent-loop-gate-status TASK=T-2026-0003
+#   make agent-loop-claim-audit CLAIM_TEXT=reports/agent_loop/review_prompt.txt
+#   make agent-loop-privacy-audit-output
+#   make agent-loop-auto-pass
+#   make agent-loop-dashboard
+#   make agent-loop-mcp-config
+#   make agent-loop-safe-fix
+#   make agent-loop-approval-packet
+#   make agent-loop-propose-queue-plan
+#   make agent-loop-pr-body
+#   make agent-loop-review-plan REVIEW=reports/agent_loop/review_prompt.md
+#   make agent-loop-stale-reports
+#   make agent-loop-context-pack
+#   make agent-loop-architecture-brief
+#   make agent-loop-ship-simulate
+#   make agent-loop-auto-ship-prepare AUTO_SHIP_ISSUE=123 AUTO_SHIP_CREATE_BRANCH=1 CONFIRM_HUMAN_APPROVED=1
+#   make agent-loop-auto-ship-plan AUTO_SHIP_DRY_RUN=1
+#   make agent-loop-gate-brief GATE=pr-create
+#   make agent-loop-manifest
+#   make agent-loop-pr-body-check
+#   make agent-loop-ci-ingest CI_LOG=reports/agent_loop/ci.log
+#   make agent-loop-stacked-risk BRANCH=chore/issue-123-example
+#   make agent-loop-patch-proposal
+#   make agent-loop-adr-reserve ADR_TITLE="New eval surface"
+#   make agent-loop-dashboard-html
+#   make agent-loop-ship-command-pack
+#   make agent-loop-apply-queue-plan CONFIRM_HUMAN_APPROVED=1
+#   make agent-loop-loop-state TASK=T-2026-0003
+#   make agent-loop-status TASK=T-2026-0003
+#   make agent-loop-preflight TASK=T-2026-0003
+#   make agent-loop-prompt TASK=T-2026-0003 OUT=reports/agent_loop/rendered_prompt.txt
+#   make agent-loop-validation
+#   make agent-loop-validate
+#   make agent-loop-surface CHANGED_FILES=/path/to/changed-files.txt
+#   make agent-loop-handoff TASK=T-2026-0003
+#   make agent-loop-review TASK=T-2026-0003 CHANGED_FILES=/path/to/changed-files.txt
+# ---------------------------------------------------------------------------
+
+ROLE ?= Implementer
+TASK ?=
+PLAN ?=
+PR ?=
+BRANCH ?=
+CHANGED_FILES ?=
+OUT ?=
+PR_STATE ?= reports/agent_loop/pr_state.json
+LIMIT ?= 30
+STATE ?= open
+TASK_BRIEF ?=
+DRAFT_TASK_ID ?= T-2026-0000
+READINESS_SUMMARY ?=
+READINESS_REPORT ?=
+REAL100_DIR ?=
+PAGE_METADATA_INDEX_DIR ?=
+REVIEW ?=
+BATCH_OUT ?= reports/agent_loop/batch_plan.md
+BATCH_JSON_OUT ?= reports/agent_loop/batch_plan.json
+REVIEW_FOLLOWUP_OUT ?= reports/agent_loop/review_followups.md
+REVIEW_FOLLOWUP_DIR ?= reports/agent_loop/review_followups
+DECISION_OUT ?= reports/agent_loop/decision_brief.md
+DECISION_BATCH ?=
+DECISION_REVIEW_FOLLOWUPS ?=
+PROMOTE_OUT ?= reports/agent_loop/promote_draft.md
+GATE_STATUS_OUT ?= reports/agent_loop/gate_status.md
+CLAIM_TEXT ?=
+CLAIM_AUDIT_OUT ?= reports/agent_loop/claim_audit.md
+PRIVACY_AUDIT_PATH ?= reports/agent_loop
+PRIVACY_AUDIT_OUT ?= reports/agent_loop/privacy_audit.md
+AUTO_PASS_OUT ?= reports/agent_loop/auto_pass.md
+AUTO_PASS_STRICT ?=
+AUTO_PASS_PROFILE ?= standard
+RUN_VALIDATION ?=
+DASHBOARD_OUT ?= reports/agent_loop/dashboard.md
+MCP_CONFIG_OUT ?= reports/agent_loop/mcp_client_config.md
+REVIEW_INGEST_OUT ?= reports/agent_loop/review_ingest.md
+PR_HEALTH_OUT ?= reports/agent_loop/pr_health.md
+SAFE_FIX_OUT ?= reports/agent_loop/safe_fix.md
+SAFE_FIX_APPLY ?=
+APPROVAL_PACKET_OUT ?= reports/agent_loop/approval_packet.md
+QUEUE_PLAN_PATCH_OUT ?= reports/agent_loop/queue_plan_patch.diff
+PR_BODY_OUT ?= reports/agent_loop/pr_body.md
+ISSUE ?=
+REVIEW_PLAN_OUT ?= reports/agent_loop/review_plan.md
+STALE_REPORTS_OUT ?= reports/agent_loop/stale_reports.md
+STALE_MAX_AGE_DAYS ?= 7
+STALE_APPLY ?=
+CONTEXT_PACK_OUT ?= reports/agent_loop/context_pack.md
+ARCHITECTURE_BRIEF_OUT ?= reports/agent_loop/architecture_brief.md
+SHIP_SIMULATION_OUT ?= reports/agent_loop/ship_simulation.md
+AUTO_SHIP_PREPARE_OUT ?= reports/agent_loop/auto_ship_prepare.md
+AUTO_SHIP_ISSUE ?=
+AUTO_SHIP_TARGET_BRANCH ?=
+AUTO_SHIP_BRANCH_TYPE ?= chore
+AUTO_SHIP_SLUG ?= agent-loop-auto-ship
+AUTO_SHIP_CREATE_BRANCH ?=
+AUTO_SHIP_PLAN_OUT ?= reports/agent_loop/auto_ship_plan.md
+AUTO_SHIP_TTL ?= 2h
+AUTO_SHIP_REAL_EVAL ?=
+AUTO_SHIP_DRAFT ?=
+AUTO_SHIP_DRY_RUN ?=
+AUTO_SHIP_READY ?=
+AUTO_SHIP_NO_DRY_RUN ?=
+GATE_BRIEF_OUT ?= reports/agent_loop/gate_brief.md
+MANIFEST_OUT ?= reports/agent_loop/manifest.json
+MANIFEST_COMMAND ?= manual
+MANIFEST_OUTPUT ?=
+PR_BODY_CHECK_OUT ?= reports/agent_loop/pr_body_check.md
+CI_LOG ?=
+CI_INGEST_OUT ?= reports/agent_loop/ci_ingest.md
+CI_FOLLOWUP_DIR ?= reports/agent_loop/ci_followups
+STACKED_RISK_OUT ?= reports/agent_loop/stacked_risk.md
+PATCH_PROPOSAL_OUT ?= reports/agent_loop/patch_proposal.diff
+PATCH_REVIEW_PLAN ?=
+ADR_TITLE ?=
+ADR_RESERVATION_OUT ?= reports/agent_loop/adr_reservation.md
+ADR_DRAFT_OUT ?= reports/agent_loop/adr_draft.md
+DASHBOARD_HTML_OUT ?= reports/agent_loop/dashboard.html
+SHIP_COMMANDS_OUT ?= reports/agent_loop/ship_commands.md
+APPLY_QUEUE_PLAN_OUT ?= reports/agent_loop/apply_queue_plan.md
+CONFIRM_HUMAN_APPROVED ?=
+REVIEW_THREADS_JSON ?=
+REVIEW_THREADS_OUT ?= reports/agent_loop/review_threads.md
+CI_SUMMARY_OUT ?= reports/agent_loop/ci_summary.md
+READINESS_SCORE_OUT ?= reports/agent_loop/readiness_score.md
+BRANCH_ISSUE_HYGIENE_OUT ?= reports/agent_loop/branch_issue_hygiene.md
+INTEGRATION_PACK_OUT ?= reports/agent_loop/integration_pack.md
+SCHEDULE_CONFIG_OUT ?= reports/agent_loop/schedule_config.md
+VALIDATION_HISTORY ?= reports/agent_loop/validation_history.jsonl
+VALIDATION_HISTORY_OUT ?= reports/agent_loop/validation_history.md
+PRIVACY_REGRESSION_OUT ?= reports/agent_loop/privacy_regression.md
+CLAIM_POLICY_OUT ?= reports/agent_loop/claim_policy.md
+ARCHITECTURE_DECISION_OUT ?= reports/agent_loop/architecture_decision.md
+WORKSET_RECOMMENDATION_OUT ?= reports/agent_loop/workset_recommendation.md
+DEPENDENCY_GRAPH_OUT ?= reports/agent_loop/dependency_graph.md
+AUTOMATION_COVERAGE_OUT ?= reports/agent_loop/automation_coverage.md
+HUMAN_GATED_ACTION ?=
+HUMAN_GATED_EXEC_OUT ?= reports/agent_loop/human_gated_exec.md
+HUMAN_GATED_DRY_RUN ?=
+CONFIRM_REVIEW_GATE_PASSED ?=
+CONFIRM_DEPENDENTS_REVIEWED ?=
+CONFIRM_FORCE_WITH_LEASE ?=
+PR_BASE ?=
+PR_TITLE ?=
+PR_READY ?=
+LOOP_STATE_OUT ?= reports/agent_loop/loop_state.json
+GATE ?= auto
+
+agent-loop-next:
+	$(PYTHON) scripts/agent_loop.py next
+
+agent-loop-status:
+	$(PYTHON) scripts/agent_loop.py status \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git)
+
+agent-loop-prompt:
+	@if [ -z "$(TASK)" ]; then \
+	  echo "Usage: make agent-loop-prompt TASK=T-2026-0003 [ROLE=Implementer] [PLAN=docs/plans/...] [OUT=reports/agent_loop/rendered_prompt.txt]"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py render-prompt \
+	  --task "$(TASK)" \
+	  --role "$(ROLE)" \
+	  $(if $(PLAN),--plan "$(PLAN)",) \
+	  --out "$(or $(OUT),reports/agent_loop/rendered_prompt.txt)"
+
+agent-loop-handoff:
+	@if [ -z "$(TASK)" ]; then \
+	  echo "Usage: make agent-loop-handoff TASK=T-2026-0003 [PLAN=docs/plans/...]"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py handoff-check \
+	  --task "$(TASK)" \
+	  $(if $(PLAN),--plan "$(PLAN)",)
+
+agent-loop-review:
+	@if [ -z "$(TASK)" ]; then \
+	  echo "Usage: make agent-loop-review TASK=T-2026-0003 [PR=123] [BRANCH=name] [CHANGED_FILES=changed.txt] [OUT=reports/agent_loop/review_prompt.txt]"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py review-prompt \
+	  --task "$(TASK)" \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(or $(OUT),reports/agent_loop/review_prompt.txt)"
+
+agent-loop-surface:
+	$(PYTHON) scripts/agent_loop.py classify-surface \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git)
+
+agent-loop-validation:
+	$(PYTHON) scripts/agent_loop.py suggest-validation \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git)
+
+agent-loop-validate:
+	$(PYTHON) scripts/agent_loop.py validate \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  $(if $(KEEP_GOING),--keep-going,) \
+	  $(if $(RECORD_HISTORY),--record-history --history "$(VALIDATION_HISTORY)",)
+
+agent-loop-preflight:
+	@if [ -z "$(TASK)" ]; then \
+	  echo "Usage: make agent-loop-preflight TASK=T-2026-0003 [PR=123] [CHANGED_FILES=changed.txt]"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py preflight \
+	  --task "$(TASK)" \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --write-prompts
+
+agent-loop-pr-scan:
+	$(PYTHON) scripts/agent_loop.py pr-scan \
+	  --state "$(STATE)" \
+	  --limit "$(LIMIT)" \
+	  --out "$(PR_STATE)" \
+	  $(if $(INCLUDE_BODY),--include-body,)
+
+agent-loop-next-from-prs:
+	$(PYTHON) scripts/agent_loop.py next-from-prs \
+	  --pr-json "$(PR_STATE)" \
+	  $(if $(READINESS_SUMMARY),--readiness-summary "$(READINESS_SUMMARY)",) \
+	  $(if $(READINESS_REPORT),--readiness-report "$(READINESS_REPORT)",) \
+	  $(if $(REAL100_DIR),--real100-dir "$(REAL100_DIR)",) \
+	  $(if $(PAGE_METADATA_INDEX_DIR),--page-metadata-index-dir "$(PAGE_METADATA_INDEX_DIR)",)
+
+agent-loop-pr-health:
+	$(PYTHON) scripts/agent_loop.py pr-health \
+	  --pr-json "$(PR_STATE)" \
+	  --out "$(PR_HEALTH_OUT)"
+
+agent-loop-draft-task:
+	$(PYTHON) scripts/agent_loop.py draft-task \
+	  --task-id "$(DRAFT_TASK_ID)" \
+	  $(if $(TASK_BRIEF),--task-brief "$(TASK_BRIEF)",)
+
+agent-loop-draft-next:
+	$(PYTHON) scripts/agent_loop.py draft-next \
+	  --task-id "$(DRAFT_TASK_ID)" \
+	  --state "$(STATE)" \
+	  --limit "$(LIMIT)" \
+	  $(if $(INCLUDE_BODY),--include-body,)
+
+agent-loop-batch-plan:
+	$(PYTHON) scripts/agent_loop.py batch-plan \
+	  --tasks-dir reports/agent_loop/codex_tasks \
+	  --out "$(BATCH_OUT)" \
+	  --json-out "$(BATCH_JSON_OUT)"
+
+agent-loop-review-followup:
+	@if [ -z "$(REVIEW)" ]; then \
+	  echo "Usage: make agent-loop-review-followup REVIEW=reports/agent_loop/reviewer_output.md"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py review-followup \
+	  --review "$(REVIEW)" \
+	  --out "$(REVIEW_FOLLOWUP_OUT)" \
+	  --tasks-dir "$(REVIEW_FOLLOWUP_DIR)"
+
+agent-loop-review-ingest:
+	$(PYTHON) scripts/agent_loop.py review-ingest \
+	  $(if $(REVIEW),--review "$(REVIEW)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  --out "$(REVIEW_INGEST_OUT)" \
+	  --followup-out "$(REVIEW_FOLLOWUP_OUT)" \
+	  --tasks-dir "$(REVIEW_FOLLOWUP_DIR)"
+
+agent-loop-decision-brief:
+	$(PYTHON) scripts/agent_loop.py decision-brief \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(DECISION_BATCH),--batch "$(DECISION_BATCH)",) \
+	  $(if $(DECISION_REVIEW_FOLLOWUPS),--review-followups "$(DECISION_REVIEW_FOLLOWUPS)",) \
+	  --gate "$(GATE)" \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(DECISION_OUT)"
+
+agent-loop-promote-draft:
+	$(PYTHON) scripts/agent_loop.py promote-draft \
+	  --out "$(PROMOTE_OUT)"
+
+agent-loop-gate-status:
+	$(PYTHON) scripts/agent_loop.py gate-status \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(DECISION_BATCH),--batch "$(DECISION_BATCH)",) \
+	  $(if $(DECISION_REVIEW_FOLLOWUPS),--review-followups "$(DECISION_REVIEW_FOLLOWUPS)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(GATE_STATUS_OUT)"
+
+agent-loop-claim-audit:
+	$(PYTHON) scripts/agent_loop.py claim-audit \
+	  $(if $(CLAIM_TEXT),--text "$(CLAIM_TEXT)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(CLAIM_AUDIT_OUT)"
+
+agent-loop-privacy-audit-output:
+	$(PYTHON) scripts/agent_loop.py privacy-audit-output \
+	  --path "$(PRIVACY_AUDIT_PATH)" \
+	  --out "$(PRIVACY_AUDIT_OUT)"
+
+agent-loop-auto-pass:
+	$(PYTHON) scripts/agent_loop.py auto-pass-check \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  $(if $(CLAIM_TEXT),--claim-text "$(CLAIM_TEXT)",) \
+	  $(if $(RUN_VALIDATION),--run-validation,) \
+	  $(if $(AUTO_PASS_STRICT),--strict,) \
+	  --profile "$(AUTO_PASS_PROFILE)" \
+	  --out "$(AUTO_PASS_OUT)"
+
+agent-loop-dashboard:
+	$(PYTHON) scripts/agent_loop.py dashboard \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(DECISION_BATCH),--batch "$(DECISION_BATCH)",) \
+	  $(if $(DECISION_REVIEW_FOLLOWUPS),--review-followups "$(DECISION_REVIEW_FOLLOWUPS)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(DASHBOARD_OUT)"
+
+agent-loop-mcp-config:
+	$(PYTHON) scripts/agent_loop.py mcp-config \
+	  --out "$(MCP_CONFIG_OUT)"
+
+agent-loop-safe-fix:
+	$(PYTHON) scripts/agent_loop.py safe-fix \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  $(if $(SAFE_FIX_APPLY),--apply,) \
+	  --out "$(SAFE_FIX_OUT)"
+
+agent-loop-approval-packet:
+	$(PYTHON) scripts/agent_loop.py approval-packet \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  $(if $(CLAIM_TEXT),--claim-text "$(CLAIM_TEXT)",) \
+	  $(if $(RUN_VALIDATION),--run-validation,) \
+	  --out "$(APPROVAL_PACKET_OUT)"
+
+agent-loop-propose-queue-plan:
+	$(PYTHON) scripts/agent_loop.py propose-queue-plan \
+	  --task-id "$(DRAFT_TASK_ID)" \
+	  $(if $(TASK_BRIEF),--task-brief "$(TASK_BRIEF)",) \
+	  --out "$(QUEUE_PLAN_PATCH_OUT)"
+
+agent-loop-pr-body:
+	$(PYTHON) scripts/agent_loop.py pr-body \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(ISSUE),--issue "$(ISSUE)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(PR_BODY_OUT)"
+
+agent-loop-review-plan:
+	$(PYTHON) scripts/agent_loop.py review-plan \
+	  $(if $(REVIEW),--review "$(REVIEW)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  --out "$(REVIEW_PLAN_OUT)"
+
+agent-loop-stale-reports:
+	$(PYTHON) scripts/agent_loop.py stale-reports \
+	  --max-age-days "$(STALE_MAX_AGE_DAYS)" \
+	  $(if $(STALE_APPLY),--apply,) \
+	  --out "$(STALE_REPORTS_OUT)"
+
+agent-loop-context-pack:
+	$(PYTHON) scripts/agent_loop.py context-pack \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(CONTEXT_PACK_OUT)"
+
+agent-loop-architecture-brief:
+	$(PYTHON) scripts/agent_loop.py architecture-brief \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(ARCHITECTURE_BRIEF_OUT)"
+
+agent-loop-ship-simulate:
+	$(PYTHON) scripts/agent_loop.py ship-simulate \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(SHIP_SIMULATION_OUT)"
+
+agent-loop-auto-ship-prepare:
+	$(PYTHON) scripts/agent_loop.py auto-ship-prepare \
+	  $(if $(AUTO_SHIP_ISSUE),--issue "$(AUTO_SHIP_ISSUE)",) \
+	  $(if $(AUTO_SHIP_TARGET_BRANCH),--target-branch "$(AUTO_SHIP_TARGET_BRANCH)",) \
+	  --type "$(AUTO_SHIP_BRANCH_TYPE)" \
+	  --slug "$(AUTO_SHIP_SLUG)" \
+	  $(if $(AUTO_SHIP_CREATE_BRANCH),--create-branch,) \
+	  $(if $(CONFIRM_HUMAN_APPROVED),--confirm-human-approved,) \
+	  --ttl "$(AUTO_SHIP_TTL)" \
+	  $(if $(AUTO_SHIP_REAL_EVAL),--real-eval "$(AUTO_SHIP_REAL_EVAL)",) \
+	  $(if $(AUTO_SHIP_DRAFT),--draft,) \
+	  $(if $(AUTO_SHIP_READY),--ready,) \
+	  $(if $(AUTO_SHIP_DRY_RUN),--dry-run,) \
+	  $(if $(AUTO_SHIP_NO_DRY_RUN),--no-dry-run,) \
+	  --out "$(AUTO_SHIP_PREPARE_OUT)"
+
+agent-loop-auto-ship-plan:
+	$(PYTHON) scripts/agent_loop.py auto-ship-plan \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --ttl "$(AUTO_SHIP_TTL)" \
+	  $(if $(AUTO_SHIP_REAL_EVAL),--real-eval "$(AUTO_SHIP_REAL_EVAL)",) \
+	  $(if $(AUTO_SHIP_DRAFT),--draft,) \
+	  $(if $(AUTO_SHIP_DRY_RUN),--dry-run,) \
+	  --out "$(AUTO_SHIP_PLAN_OUT)"
+
+agent-loop-gate-brief:
+	$(PYTHON) scripts/agent_loop.py gate-brief \
+	  --gate "$(GATE)" \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(GATE_BRIEF_OUT)"
+
+agent-loop-manifest:
+	$(PYTHON) scripts/agent_loop.py manifest \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --source-command "$(MANIFEST_COMMAND)" \
+	  $(if $(MANIFEST_OUTPUT),--output "$(MANIFEST_OUTPUT)",) \
+	  --out "$(MANIFEST_OUT)"
+
+agent-loop-pr-body-check:
+	$(PYTHON) scripts/agent_loop.py pr-body-check \
+	  --body "$(PR_BODY_OUT)" \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(PR_BODY_CHECK_OUT)"
+
+agent-loop-ci-ingest:
+	$(PYTHON) scripts/agent_loop.py ci-ingest \
+	  $(if $(CI_LOG),--log "$(CI_LOG)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  --out "$(CI_INGEST_OUT)" \
+	  --tasks-dir "$(CI_FOLLOWUP_DIR)"
+
+agent-loop-stacked-risk:
+	@if [ -z "$(BRANCH)" ]; then \
+	  echo "Usage: make agent-loop-stacked-risk BRANCH=chore/issue-123-example [PR_STATE=reports/agent_loop/pr_state.json]"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py stacked-risk \
+	  --branch "$(BRANCH)" \
+	  $(if $(PR_STATE),--pr-json "$(PR_STATE)",) \
+	  --out "$(STACKED_RISK_OUT)"
+
+agent-loop-patch-proposal:
+	$(PYTHON) scripts/agent_loop.py patch-proposal \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  $(if $(PATCH_REVIEW_PLAN),--review-plan "$(PATCH_REVIEW_PLAN)",) \
+	  --out "$(PATCH_PROPOSAL_OUT)"
+
+agent-loop-adr-reserve:
+	@if [ -z "$(ADR_TITLE)" ]; then \
+	  echo "Usage: make agent-loop-adr-reserve ADR_TITLE='Decision title'"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py adr-reserve \
+	  --title "$(ADR_TITLE)" \
+	  --out "$(ADR_RESERVATION_OUT)" \
+	  --draft-out "$(ADR_DRAFT_OUT)"
+
+agent-loop-dashboard-html:
+	$(PYTHON) scripts/agent_loop.py dashboard-html \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(DASHBOARD_HTML_OUT)"
+
+agent-loop-ship-command-pack:
+	$(PYTHON) scripts/agent_loop.py ship-command-pack \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  --out "$(SHIP_COMMANDS_OUT)"
+
+agent-loop-apply-queue-plan:
+	$(PYTHON) scripts/agent_loop.py apply-queue-plan \
+	  $(if $(CONFIRM_HUMAN_APPROVED),--confirm-human-approved,) \
+	  --out "$(APPLY_QUEUE_PLAN_OUT)"
+
+agent-loop-review-threads:
+	$(PYTHON) scripts/agent_loop.py review-threads \
+	  $(if $(REVIEW_THREADS_JSON),--threads-json "$(REVIEW_THREADS_JSON)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  --out "$(REVIEW_THREADS_OUT)"
+
+agent-loop-ci-summary:
+	$(PYTHON) scripts/agent_loop.py ci-summary \
+	  $(if $(CI_LOG),--log "$(CI_LOG)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  --out "$(CI_SUMMARY_OUT)"
+
+agent-loop-readiness-score:
+	$(PYTHON) scripts/agent_loop.py readiness-score \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(PR_BODY_OUT),--body "$(PR_BODY_OUT)",) \
+	  $(if $(CLAIM_TEXT),--claim-text "$(CLAIM_TEXT)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(READINESS_SCORE_OUT)"
+
+agent-loop-artifact-freshness:
+	$(PYTHON) scripts/agent_loop.py artifact-freshness \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --max-age-days "$(STALE_MAX_AGE_DAYS)" \
+	  --out "$(STALE_REPORTS_OUT)"
+
+agent-loop-review-patch-plan:
+	$(PYTHON) scripts/agent_loop.py review-patch-plan \
+	  $(if $(REVIEW),--review "$(REVIEW)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --review-out "$(REVIEW_PLAN_OUT)" \
+	  --patch-out "$(PATCH_PROPOSAL_OUT)"
+
+agent-loop-queue-plan-sync:
+	$(PYTHON) scripts/agent_loop.py queue-plan-sync \
+	  $(if $(TASK_BRIEF),--task-brief "$(TASK_BRIEF)",) \
+	  --task-id "$(DRAFT_TASK_ID)" \
+	  --out "$(QUEUE_PLAN_PATCH_OUT)"
+
+agent-loop-dependency-graph:
+	@if [ -z "$(BRANCH)" ]; then \
+	  echo "Usage: make agent-loop-dependency-graph BRANCH=chore/issue-123-example [PR_STATE=reports/agent_loop/pr_state.json]"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py dependency-graph \
+	  --branch "$(BRANCH)" \
+	  $(if $(PR_STATE),--pr-json "$(PR_STATE)",) \
+	  --out "$(DEPENDENCY_GRAPH_OUT)"
+
+agent-loop-branch-issue-hygiene:
+	$(PYTHON) scripts/agent_loop.py branch-issue-hygiene \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(PR_BODY_OUT),--body "$(PR_BODY_OUT)",) \
+	  --out "$(BRANCH_ISSUE_HYGIENE_OUT)"
+
+agent-loop-integration-pack:
+	$(PYTHON) scripts/agent_loop.py integration-pack \
+	  --out "$(INTEGRATION_PACK_OUT)"
+
+agent-loop-scheduled-status:
+	$(PYTHON) scripts/agent_loop.py scheduled-status \
+	  --out "$(SCHEDULE_CONFIG_OUT)"
+
+agent-loop-validation-history:
+	$(PYTHON) scripts/agent_loop.py validation-history \
+	  --history "$(VALIDATION_HISTORY)" \
+	  --out "$(VALIDATION_HISTORY_OUT)"
+
+agent-loop-privacy-regression:
+	$(PYTHON) scripts/agent_loop.py privacy-regression \
+	  --out "$(PRIVACY_REGRESSION_OUT)"
+
+agent-loop-claim-policy:
+	$(PYTHON) scripts/agent_loop.py claim-policy \
+	  $(if $(CLAIM_TEXT),--text "$(CLAIM_TEXT)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(CLAIM_POLICY_OUT)"
+
+agent-loop-architecture-decision:
+	$(PYTHON) scripts/agent_loop.py architecture-decision \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(ARCHITECTURE_DECISION_OUT)"
+
+agent-loop-workset-recommend:
+	$(PYTHON) scripts/agent_loop.py workset-recommend \
+	  $(if $(DECISION_BATCH),--batch "$(DECISION_BATCH)",) \
+	  --tasks-dir reports/agent_loop/codex_tasks \
+	  --out "$(WORKSET_RECOMMENDATION_OUT)"
+
+agent-loop-automation-coverage:
+	$(PYTHON) scripts/agent_loop.py automation-coverage \
+	  --out "$(AUTOMATION_COVERAGE_OUT)"
+
+agent-loop-human-gated-exec:
+	@if [ -z "$(HUMAN_GATED_ACTION)" ]; then \
+	  echo "Usage: make agent-loop-human-gated-exec HUMAN_GATED_ACTION=push|pr-create|pr-merge|pr-close|branch-delete|force-push CONFIRM_HUMAN_APPROVED=1"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py human-gated-exec \
+	  --action "$(HUMAN_GATED_ACTION)" \
+	  $(if $(CONFIRM_HUMAN_APPROVED),--confirm-human-approved,) \
+	  $(if $(HUMAN_GATED_DRY_RUN),--dry-run,) \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(PR_BODY_OUT),--body "$(PR_BODY_OUT)",) \
+	  $(if $(PR_BASE),--base "$(PR_BASE)",) \
+	  $(if $(PR_TITLE),--title "$(PR_TITLE)",) \
+	  $(if $(PR_READY),--ready,) \
+	  $(if $(CONFIRM_REVIEW_GATE_PASSED),--confirm-review-gate-passed,) \
+	  $(if $(CONFIRM_DEPENDENTS_REVIEWED),--confirm-dependents-reviewed,) \
+	  $(if $(CONFIRM_FORCE_WITH_LEASE),--confirm-force-with-lease,) \
+	  --out "$(HUMAN_GATED_EXEC_OUT)"
+
+agent-loop-loop-state:
+	$(PYTHON) scripts/agent_loop.py loop-state \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(DECISION_BATCH),--batch "$(DECISION_BATCH)",) \
+	  $(if $(DECISION_REVIEW_FOLLOWUPS),--review-followups "$(DECISION_REVIEW_FOLLOWUPS)",) \
+	  $(if $(PR),--pr "$(PR)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  --out "$(LOOP_STATE_OUT)"
+
+agent-loop-map:
+	$(PYTHON) scripts/agent_loop.py map
+
+agent-loop-mcp:
+	$(PYTHON) scripts/agent_loop_mcp.py
 
 # F2 (#853): local Qdrant container for the production HTTP server
 # integration test. Image pin is in docker-compose.qdrant.yml.

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -100,6 +100,7 @@ KNOWN_HOOKS: set[str] = {
     "plan-slug-race",
     "delegation-gate",
     "stop-ship",
+    "agent-loop",
 }
 
 

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1,0 +1,8480 @@
+#!/usr/bin/env python3
+"""Lightweight orchestration CLI for the BidMate AI-agent operating loop.
+
+The CLI is intentionally read-centered except when explicitly writing generated
+local artifacts under ``reports/agent_loop/``. It never pushes, merges, closes
+PRs, deletes branches, force-pushes, or calls external model APIs.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import difflib
+import hashlib
+import html
+import json
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import sys
+from typing import Iterable, Sequence
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts._governance import is_load_bearing  # noqa: E402
+
+
+TASK_ID_RE = re.compile(r"\bT-\d{4}-\d{4}\b")
+TASK_HEADING_RE = re.compile(
+    r"^##\s+(?P<id>T-\d{4}-\d{4})\s+(?:[-\u2013\u2014])\s+(?P<title>.+?)\s*$",
+    re.MULTILINE,
+)
+FIELD_RE = re.compile(r"^\s*[-*]\s*(?P<label>[^:\n]+):\s*(?P<value>.*)$", re.MULTILINE)
+FENCED_BASH_RE = re.compile(r"```(?:bash|sh|shell)?\n(?P<body>.*?)```", re.DOTALL)
+HANDOFF_HEADING_RE = re.compile(
+    r"^#{1,6}\s+(?P<title>(?:Session\s+Handoff|Workstream\s+State|Handoff)(?!\s+Notes)\b.*)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+ABSOLUTE_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:/Users|/private|/var/folders|/Volumes)/[^\s)`'\"]+"
+)
+PRIVATE_INLINE_VALUE_RE = re.compile(
+    r"\b(?P<label>(?:raw\s+)?(?:question|answer|evidence)|doc[_ -]?id|"
+    r"chunk[_ -]?id|file\s*name|filename)\b"
+    r"\s*[:=]\s*(?P<value>[^\n;,]+)",
+    re.IGNORECASE,
+)
+PRIVATE_FLAG_VALUE_RE = re.compile(
+    r"(?P<flag>--(?:raw-)?(?:question|answer|evidence|doc[_-]?id|chunk[_-]?id|file(?:[_-]?name)?)\s+)"
+    r"(?P<value>\"[^\"]*\"|'[^']*'|\S+)",
+    re.IGNORECASE,
+)
+
+DEFAULT_REPORT_DIR = ROOT_DIR / "reports" / "agent_loop"
+DEFAULT_RENDER_PROMPT = DEFAULT_REPORT_DIR / "rendered_prompt.txt"
+DEFAULT_REVIEW_PROMPT = DEFAULT_REPORT_DIR / "review_prompt.txt"
+DEFAULT_PR_STATE = DEFAULT_REPORT_DIR / "pr_state.json"
+DEFAULT_QUEUE_DRAFT = DEFAULT_REPORT_DIR / "queue_entry_draft.md"
+DEFAULT_PLAN_DRAFT = DEFAULT_REPORT_DIR / "plan_draft.md"
+DEFAULT_AI_NEXT_ACTIONS = DEFAULT_REPORT_DIR / "ai_next_actions.md"
+DEFAULT_CODEX_TASKS_DIR = DEFAULT_REPORT_DIR / "codex_tasks"
+DEFAULT_BATCH_PLAN = DEFAULT_REPORT_DIR / "batch_plan.md"
+DEFAULT_BATCH_PLAN_JSON = DEFAULT_REPORT_DIR / "batch_plan.json"
+DEFAULT_REVIEW_FOLLOWUPS = DEFAULT_REPORT_DIR / "review_followups.md"
+DEFAULT_REVIEW_FOLLOWUPS_DIR = DEFAULT_REPORT_DIR / "review_followups"
+DEFAULT_DECISION_BRIEF = DEFAULT_REPORT_DIR / "decision_brief.md"
+DEFAULT_PROMOTE_DRAFT = DEFAULT_REPORT_DIR / "promote_draft.md"
+DEFAULT_GATE_STATUS = DEFAULT_REPORT_DIR / "gate_status.md"
+DEFAULT_CLAIM_AUDIT = DEFAULT_REPORT_DIR / "claim_audit.md"
+DEFAULT_PRIVACY_AUDIT = DEFAULT_REPORT_DIR / "privacy_audit.md"
+DEFAULT_LOOP_STATE = DEFAULT_REPORT_DIR / "loop_state.json"
+DEFAULT_AUTO_PASS = DEFAULT_REPORT_DIR / "auto_pass.md"
+DEFAULT_DASHBOARD = DEFAULT_REPORT_DIR / "dashboard.md"
+DEFAULT_MCP_CLIENT_CONFIG = DEFAULT_REPORT_DIR / "mcp_client_config.md"
+DEFAULT_REVIEW_INGEST = DEFAULT_REPORT_DIR / "review_ingest.md"
+DEFAULT_PR_HEALTH = DEFAULT_REPORT_DIR / "pr_health.md"
+DEFAULT_SAFE_FIX = DEFAULT_REPORT_DIR / "safe_fix.md"
+DEFAULT_APPROVAL_PACKET = DEFAULT_REPORT_DIR / "approval_packet.md"
+DEFAULT_QUEUE_PLAN_PATCH = DEFAULT_REPORT_DIR / "queue_plan_patch.diff"
+DEFAULT_PR_BODY = DEFAULT_REPORT_DIR / "pr_body.md"
+DEFAULT_REVIEW_PLAN = DEFAULT_REPORT_DIR / "review_plan.md"
+DEFAULT_STALE_REPORTS = DEFAULT_REPORT_DIR / "stale_reports.md"
+DEFAULT_CONTEXT_PACK = DEFAULT_REPORT_DIR / "context_pack.md"
+DEFAULT_ARCHITECTURE_BRIEF = DEFAULT_REPORT_DIR / "architecture_brief.md"
+DEFAULT_SHIP_SIMULATION = DEFAULT_REPORT_DIR / "ship_simulation.md"
+DEFAULT_GATE_BRIEF = DEFAULT_REPORT_DIR / "gate_brief.md"
+DEFAULT_MANIFEST = DEFAULT_REPORT_DIR / "manifest.json"
+DEFAULT_PR_BODY_CHECK = DEFAULT_REPORT_DIR / "pr_body_check.md"
+DEFAULT_CI_INGEST = DEFAULT_REPORT_DIR / "ci_ingest.md"
+DEFAULT_CI_FOLLOWUPS_DIR = DEFAULT_REPORT_DIR / "ci_followups"
+DEFAULT_STACKED_RISK = DEFAULT_REPORT_DIR / "stacked_risk.md"
+DEFAULT_PATCH_PROPOSAL = DEFAULT_REPORT_DIR / "patch_proposal.diff"
+DEFAULT_ADR_RESERVATION = DEFAULT_REPORT_DIR / "adr_reservation.md"
+DEFAULT_ADR_DRAFT = DEFAULT_REPORT_DIR / "adr_draft.md"
+DEFAULT_DASHBOARD_HTML = DEFAULT_REPORT_DIR / "dashboard.html"
+DEFAULT_SHIP_COMMANDS = DEFAULT_REPORT_DIR / "ship_commands.md"
+DEFAULT_APPLY_QUEUE_PLAN = DEFAULT_REPORT_DIR / "apply_queue_plan.md"
+DEFAULT_REVIEW_THREADS = DEFAULT_REPORT_DIR / "review_threads.md"
+DEFAULT_CI_SUMMARY = DEFAULT_REPORT_DIR / "ci_summary.md"
+DEFAULT_READINESS_SCORE = DEFAULT_REPORT_DIR / "readiness_score.md"
+DEFAULT_BRANCH_ISSUE_HYGIENE = DEFAULT_REPORT_DIR / "branch_issue_hygiene.md"
+DEFAULT_INTEGRATION_PACK = DEFAULT_REPORT_DIR / "integration_pack.md"
+DEFAULT_SCHEDULE_CONFIG = DEFAULT_REPORT_DIR / "schedule_config.md"
+DEFAULT_VALIDATION_HISTORY = DEFAULT_REPORT_DIR / "validation_history.jsonl"
+DEFAULT_VALIDATION_HISTORY_REPORT = DEFAULT_REPORT_DIR / "validation_history.md"
+DEFAULT_PRIVACY_REGRESSION = DEFAULT_REPORT_DIR / "privacy_regression.md"
+DEFAULT_CLAIM_POLICY = DEFAULT_REPORT_DIR / "claim_policy.md"
+DEFAULT_ARCHITECTURE_DECISION = DEFAULT_REPORT_DIR / "architecture_decision.md"
+DEFAULT_WORKSET_RECOMMENDATION = DEFAULT_REPORT_DIR / "workset_recommendation.md"
+DEFAULT_DEPENDENCY_GRAPH = DEFAULT_REPORT_DIR / "dependency_graph.md"
+DEFAULT_AUTOMATION_COVERAGE = DEFAULT_REPORT_DIR / "automation_coverage.md"
+DEFAULT_HUMAN_GATED_EXEC = DEFAULT_REPORT_DIR / "human_gated_exec.md"
+DEFAULT_AUTO_SHIP_PLAN = DEFAULT_REPORT_DIR / "auto_ship_plan.md"
+DEFAULT_AUTO_SHIP_PREPARE = DEFAULT_REPORT_DIR / "auto_ship_prepare.md"
+DEFAULT_DRAFT_TASK_ID = "T-2026-0000"
+QUEUE_PATH = Path("tasks/queue.md")
+PLAN_DIR = Path("docs/plans")
+
+GH_PR_JSON_FIELDS = (
+    "number",
+    "title",
+    "url",
+    "headRefName",
+    "baseRefName",
+    "isDraft",
+    "reviewDecision",
+    "mergeStateStatus",
+    "statusCheckRollup",
+    "labels",
+    "updatedAt",
+)
+GH_PR_BODY_FIELD = "body"
+
+REQUIRED_READS = (
+    "CLAUDE.md",
+    "docs/operations/ai-engineering-operating-system.md",
+    "docs/operations/long-session-workflow.md",
+    "tasks/queue.md",
+    "docs/evaluation/surface-map.md",
+    "docs/reviews/ai-review-checklists.md",
+)
+
+REQUIRED_HANDOFF_FIELDS = (
+    "Role",
+    "Lifecycle stage",
+    "Branch / worktree",
+    "Task",
+    "Current status",
+    "Files touched",
+    "Commands run",
+    "Results",
+    "Validation evidence",
+    "Blockers",
+    "Open risks",
+    "Next action",
+    "Next safe command",
+    "Reviewer focus",
+)
+
+EVAL_SURFACE_SIGNALS = (
+    "eval/",
+    "configs/eval/",
+    "data/eval/",
+    "reports/",
+    "eval_summary.json",
+    "benchmark_naive_rag",
+    "real-eval",
+    "real eval",
+    "real100",
+    "private aggregate",
+    "public fixture",
+    "synthetic benchmark",
+    "performance claim",
+)
+
+FORBIDDEN_DYNAMIC_LABELS = {
+    "raw question",
+    "question",
+    "raw answer",
+    "answer",
+    "raw evidence",
+    "evidence",
+    "doc_id",
+    "doc id",
+    "chunk_id",
+    "chunk id",
+    "filename",
+    "file name",
+}
+
+
+@dataclass(frozen=True)
+class TaskEntry:
+    task_id: str
+    title: str
+    body: str
+    status: str | None
+    owner_role: str | None
+
+
+@dataclass(frozen=True)
+class HandoffReport:
+    ok: bool
+    source: str
+    heading: str
+    present_fields: tuple[str, ...]
+    missing_fields: tuple[str, ...]
+    invalid_fields: tuple[str, ...]
+    eval_surface_required: bool
+
+
+@dataclass(frozen=True)
+class SurfaceReport:
+    surface: str
+    confidence: str
+    reviewer_type: str
+    disallowed_claims: tuple[str, ...]
+    matched_files: tuple[str, ...]
+    additional_surfaces: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ValidationRun:
+    command: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class DraftTaskResult:
+    queue_path: Path
+    plan_path: Path
+    queue_text: str
+    plan_text: str
+
+
+@dataclass(frozen=True)
+class BriefSummary:
+    path: Path
+    index: int
+    title: str
+    classification: str
+    source: str
+    reason: str
+    goal: str
+    verification: str
+    lane: str
+    gate_reason: str
+
+
+@dataclass(frozen=True)
+class ReviewFinding:
+    severity: str
+    target: str
+    summary: str
+    reviewer_mode: str
+
+
+@dataclass(frozen=True)
+class DecisionOption:
+    label: str
+    recommended: bool
+    severity: str
+    reversibility: str
+    tradeoffs: tuple[str, ...]
+    evidence_needed: tuple[str, ...]
+    next_safe_command: str
+    manual_approval: str
+
+
+@dataclass(frozen=True)
+class DecisionPoint:
+    gate: str
+    title: str
+    context: tuple[str, ...]
+    options: tuple[DecisionOption, ...]
+
+
+@dataclass(frozen=True)
+class PrivacyFinding:
+    path: str
+    issue: str
+
+
+@dataclass(frozen=True)
+class ClaimFinding:
+    issue: str
+    severity: str
+    reviewer: str
+
+
+@dataclass(frozen=True)
+class AutoPassReport:
+    ok: bool
+    decision: str
+    confidence: str
+    surface: SurfaceReport
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    evidence: tuple[str, ...]
+    next_safe_command: str
+
+
+@dataclass(frozen=True)
+class SafeFixChange:
+    path: str
+    action: str
+
+
+@dataclass(frozen=True)
+class SafeFixReport:
+    applied: bool
+    changes: tuple[SafeFixChange, ...]
+    skipped: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PRBodyFinding:
+    severity: str
+    issue: str
+    remediation: str
+
+
+@dataclass(frozen=True)
+class CIFinding:
+    lane: str
+    summary: str
+    source: str
+    validation: str
+
+
+@dataclass(frozen=True)
+class ReviewThreadFinding:
+    status: str
+    path: str
+    line: str
+    reviewer_mode: str
+    lane: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class ReadinessScore:
+    score: int
+    decision: str
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    evidence: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AutoShipPlan:
+    decision: str
+    branch: str
+    issue: str | None
+    surface: SurfaceReport
+    recommended_command: str
+    dry_run_command: str
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    evidence: tuple[str, ...]
+    human_gates: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AutoShipPrepareReport:
+    result: str
+    current_branch: str
+    target_branch: str | None
+    branch_command: str
+    ship_arm_command: str
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    evidence: tuple[str, ...]
+    created: bool = False
+    returncode: int | None = None
+
+
+@dataclass(frozen=True)
+class HumanGatedExecPlan:
+    action: str
+    command: tuple[str, ...]
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    dry_run: bool
+    executed: bool
+    returncode: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+
+
+def _repo_path(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _normalize_field(label: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", label.lower())
+
+
+def _field_map(text: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for match in FIELD_RE.finditer(text):
+        label = match.group("label").strip()
+        value = match.group("value").strip()
+        fields[_normalize_field(label)] = value
+    return fields
+
+
+def _task_public_fields(body: str) -> dict[str, str]:
+    fields = {}
+    for match in FIELD_RE.finditer(body):
+        label = match.group("label").strip()
+        if label.lower() in FORBIDDEN_DYNAMIC_LABELS:
+            continue
+        if label in {"Title", "Status", "Owner role"}:
+            fields[label] = _sanitize_dynamic_text(match.group("value").strip())
+    return fields
+
+
+def _sanitize_dynamic_text(text: str) -> str:
+    redacted = ABSOLUTE_LOCAL_PATH_RE.sub("[redacted-local-path]", text)
+    return PRIVATE_INLINE_VALUE_RE.sub(
+        lambda match: f"{match.group('label')}: [redacted-private-value]",
+        redacted,
+    )
+
+
+def _sanitize_inline_text(text: str) -> str:
+    redacted = _sanitize_dynamic_text(text)
+    redacted = redacted.replace("```", "'''")
+    redacted = re.sub(
+        r"\b(?:review instructions|output format|system|developer|user|instructions)\s*:",
+        "[redacted-instruction-label]:",
+        redacted,
+        flags=re.IGNORECASE,
+    )
+    redacted = re.sub(r"[\r\n\t]+", " ", redacted)
+    return re.sub(r"\s{2,}", " ", redacted).strip()
+
+
+def _sanitize_command_text(text: str) -> str:
+    redacted = _sanitize_dynamic_text(text)
+    return PRIVATE_FLAG_VALUE_RE.sub(
+        lambda match: f"{match.group('flag')}[redacted-private-value]",
+        redacted,
+    )
+
+
+def _normalize_changed_file(path: str, *, repo_root: Path = ROOT_DIR) -> str:
+    raw = path.strip().strip("`")
+    if not raw:
+        return ""
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        try:
+            return candidate.resolve().relative_to(repo_root.resolve()).as_posix()
+        except ValueError:
+            return "[redacted-local-path]"
+    normalized = raw[2:] if raw.startswith("./") else raw
+    try:
+        return (repo_root / normalized).resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return "[redacted-local-path]"
+
+
+def _privacy_sensitive_path(path: str) -> bool:
+    lowered = path.lower()
+    if lowered.startswith(
+        (
+            "reports/real100/",
+            "reports/private",
+            "data/private/",
+            "data/files/",
+            "data/files_kordoc/",
+            "data/index/real",
+        )
+    ):
+        return True
+    return bool(re.search(r"(^|[/_.-])(doc[_-]?id|chunk[_-]?id)([/_.-]|$)", lowered))
+
+
+def _display_path(path: str, *, repo_root: Path = ROOT_DIR) -> str:
+    normalized = _normalize_changed_file(path, repo_root=repo_root)
+    if normalized == "[redacted-local-path]":
+        return normalized
+    if normalized.startswith("reports/real100/"):
+        return "reports/real100/[redacted-private-artifact]"
+    if normalized.startswith("reports/private"):
+        return "reports/[redacted-private-artifact]"
+    if normalized.startswith("data/index/real"):
+        return "data/index/[redacted-private-index]"
+    if normalized.startswith(("data/private/", "data/files/", "data/files_kordoc/")):
+        return "data/[redacted-private-input]"
+    if _privacy_sensitive_path(normalized):
+        return "[redacted-private-path]"
+    return _sanitize_dynamic_text(normalized)
+
+
+def _extract_validation_commands(task: TaskEntry) -> list[str]:
+    commands: list[str] = []
+    section = _section_text(task.body, "Validation Commands")
+    for fenced in FENCED_BASH_RE.finditer(section):
+        for line in fenced.group("body").splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                commands.append(_sanitize_command_text(stripped))
+    return commands
+
+
+def _section_text(markdown: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^###\s+{re.escape(heading)}\s*$|^##\s+{re.escape(heading)}\s*$",
+        re.IGNORECASE | re.MULTILINE,
+    )
+    match = pattern.search(markdown)
+    if not match:
+        return ""
+    rest = markdown[match.end() :]
+    next_heading = re.search(r"^#{2,3}\s+", rest, re.MULTILINE)
+    return rest[: next_heading.start()] if next_heading else rest
+
+
+def parse_task_entries(queue_text: str) -> list[TaskEntry]:
+    matches = list(TASK_HEADING_RE.finditer(queue_text))
+    entries: list[TaskEntry] = []
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(queue_text)
+        body = queue_text[start:end].strip()
+        fields = _task_public_fields(body)
+        entries.append(
+            TaskEntry(
+                task_id=match.group("id"),
+                title=fields.get("Title") or match.group("title").strip(),
+                body=body,
+                status=fields.get("Status"),
+                owner_role=fields.get("Owner role"),
+            )
+        )
+    return entries
+
+
+def load_task(task_id: str, repo_root: Path = ROOT_DIR) -> TaskEntry:
+    if not TASK_ID_RE.fullmatch(task_id):
+        raise ValueError(f"invalid task id: {task_id}")
+    queue_path = repo_root / QUEUE_PATH
+    queue_text = _read_text(queue_path)
+    for entry in parse_task_entries(queue_text):
+        if entry.task_id == task_id:
+            return entry
+    raise ValueError(f"task {task_id} not found in {_repo_path(queue_path, repo_root)}")
+
+
+def find_plan_path(task: TaskEntry, repo_root: Path = ROOT_DIR) -> Path | None:
+    body_match = re.search(r"\((?P<path>\.\./docs/plans/[^)]+|docs/plans/[^)]+)\)", task.body)
+    if body_match:
+        raw = body_match.group("path")
+        rel = raw[3:] if raw.startswith("../") else raw
+        candidate = repo_root / rel
+        if candidate.exists():
+            return candidate
+    plan_dir = repo_root / PLAN_DIR
+    candidates = sorted(plan_dir.glob(f"*{task.task_id}*.md")) if plan_dir.is_dir() else []
+    return candidates[0] if candidates else None
+
+
+def render_prompt(
+    task_id: str,
+    *,
+    role: str = "Implementer",
+    plan_path: Path | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> str:
+    task = load_task(task_id, repo_root)
+    resolved_plan = plan_path or find_plan_path(task, repo_root)
+    validation_commands = _extract_validation_commands(task)
+    plan_display = _display_path(_repo_path(resolved_plan, repo_root), repo_root=repo_root) if resolved_plan else "N/A"
+    validation_block = (
+        "\n".join(f"- {cmd}" for cmd in validation_commands)
+        if validation_commands
+        else "- Derive focused validation from changed files; do not claim it was run."
+    )
+    required_reads = "\n".join(f"- {path}" for path in REQUIRED_READS)
+    text = f"""# BidMate-DocAgent Codex Session Prompt
+
+Role: {_sanitize_inline_text(role)}
+Operating mode: Actual development mode for BidMate-DocAgent.
+Task: {task.task_id} - {_sanitize_inline_text(task.title)}
+Plan: {plan_display}
+
+BidMate operating mode:
+- Stay within the existing task queue, plan doc, review checklist, and eval surface map.
+- Do not create a new governance system or replace the operating model.
+- Do not auto-merge, auto-push, auto-close PRs, delete branches, or force-push.
+- Human approval is required for merge/close/push/delete/force-push, benchmark claims,
+  private real-eval decisions, and architecture tradeoff decisions.
+
+Session-time-maxing loop:
+1. Inspect the existing repo workflow and relevant scripts.
+2. Identify the smallest useful automation surface inside the task scope.
+3. Implement the scoped change.
+4. Add focused tests.
+5. Run focused validation and fix in-scope failures.
+6. Stop only when the scoped MVP is implemented and validated, or when blocked by
+   missing repo evidence or human approval.
+
+Required reads:
+{required_reads}
+- This task entry in tasks/queue.md
+{"- " + plan_display if resolved_plan else "- Plan doc: N/A; create one only if project rules require it."}
+
+Eval surface reminder:
+- Classify public fixture smoke, public synthetic benchmark, private real-eval, and
+  benchmark-reporting separately before making any evaluation claim.
+- Public smoke is wiring/regression evidence, not real-world model quality.
+- Synthetic benchmark evidence must not be described as real RFP performance.
+- Private real-eval evidence must stay aggregate-only and public-safe.
+
+Validation expectations:
+{validation_block}
+- Always include git diff --check before final handoff.
+- Report only commands actually run; suggestions are not evidence.
+
+Handoff requirement:
+- Before stopping, leave or verify a Session Handoff / Workstream State block with
+  Role, Lifecycle stage, Branch / worktree, Task, Current status, Files touched,
+  Commands run, Results, Validation evidence, Blockers, Open risks, Next action,
+  Next safe command, and Reviewer focus.
+- Include Eval surface when eval, benchmark, metrics, reports, or performance/private
+  claims are touched.
+- Do not expose private raw question, answer, evidence, doc_id, chunk_id, filenames,
+  exact local paths, or raw case text.
+
+Final response format:
+1. Implementation summary
+2. Commands added or changed
+3. Files changed
+4. Tests added
+5. Validation commands run
+6. Validation result
+7. Example usage
+8. Remaining risks
+9. Follow-up automation steps
+10. Commands intentionally left unimplemented, if any
+"""
+    return _sanitize_dynamic_text(text).rstrip() + "\n"
+
+
+def _load_plan_text(plan_path: Path | None, repo_root: Path) -> tuple[str, str] | None:
+    if plan_path is None:
+        return None
+    path = plan_path if plan_path.is_absolute() else repo_root / plan_path
+    if not path.exists():
+        raise ValueError(f"plan not found: {path}")
+    return _display_path(_repo_path(path, repo_root), repo_root=repo_root), _read_text(path)
+
+
+def _latest_handoff_block(sources: Sequence[tuple[str, str]]) -> tuple[str, str, str] | None:
+    latest: tuple[str, str, str] | None = None
+    for source, text in sources:
+        matches = list(HANDOFF_HEADING_RE.finditer(text))
+        for index, match in enumerate(matches):
+            start = match.start()
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+            latest = (source, match.group("title").strip(), text[start:end])
+    return latest
+
+
+def _needs_eval_surface(*texts: str) -> bool:
+    haystack = "\n".join(texts).lower()
+    for match in re.finditer(r"surface:\s*([^\n]+)", haystack):
+        value = match.group(1).strip().strip(".")
+        if value and value not in {"none", "n/a", "no data touched"}:
+            return True
+    return any(signal in haystack for signal in EVAL_SURFACE_SIGNALS)
+
+
+def check_handoff(
+    task_id: str,
+    *,
+    plan_path: Path | None = None,
+    changed_files: Sequence[str] = (),
+    repo_root: Path = ROOT_DIR,
+) -> HandoffReport:
+    task = load_task(task_id, repo_root)
+    resolved_plan = plan_path or find_plan_path(task, repo_root)
+    sources: list[tuple[str, str]] = [(f"{QUEUE_PATH}::{task.task_id}", task.body)]
+    loaded_plan = _load_plan_text(resolved_plan, repo_root)
+    if loaded_plan is not None:
+        sources.append(loaded_plan)
+    latest = _latest_handoff_block(sources)
+    if latest is None:
+        required = list(REQUIRED_HANDOFF_FIELDS)
+        if _needs_eval_surface(task.body, loaded_plan[1] if loaded_plan else "", "\n".join(changed_files)):
+            required.append("Eval surface")
+        return HandoffReport(False, "(none)", "(none)", (), tuple(required), (), "Eval surface" in required)
+
+    source, heading, block = latest
+    fields = _field_map(block)
+    required = list(REQUIRED_HANDOFF_FIELDS)
+    eval_required = _needs_eval_surface(task.body, loaded_plan[1] if loaded_plan else "", "\n".join(changed_files))
+    if eval_required:
+        required.append("Eval surface")
+
+    missing: list[str] = []
+    present: list[str] = []
+    invalid: list[str] = []
+    current_status = fields.get(_normalize_field("Current status"), "")
+    terminal = _is_terminal_status(current_status)
+    for label in required:
+        value = fields.get(_normalize_field(label), "")
+        if value:
+            present.append(label)
+            if not _handoff_field_value_is_valid(label, value, terminal=terminal):
+                invalid.append(label)
+        else:
+            missing.append(label)
+    return HandoffReport(
+        ok=not missing and not invalid,
+        source=source,
+        heading=heading,
+        present_fields=tuple(present),
+        missing_fields=tuple(missing),
+        invalid_fields=tuple(invalid),
+        eval_surface_required=eval_required,
+    )
+
+
+def _is_terminal_status(value: str) -> bool:
+    lowered = value.strip().lower()
+    return any(token in lowered for token in ("done", "merged", "complete", "completed"))
+
+
+def _handoff_field_value_is_valid(label: str, value: str, *, terminal: bool) -> bool:
+    lowered = value.strip().lower().strip(".")
+    weak_evidence = {
+        "n/a",
+        "na",
+        "none",
+        "not run",
+        "not yet",
+        "not executed",
+        "not validated",
+        "suggested only",
+        "todo",
+        "tbd",
+        "unknown",
+    }
+    if label == "Eval surface":
+        return lowered not in {"n/a", "na", "none", "no data touched", "unknown", "tbd"}
+    if label in {"Commands run", "Results", "Validation evidence"}:
+        return lowered not in weak_evidence
+    if label == "Next safe command" and not terminal:
+        return lowered not in {"n/a", "na", "none", "not applicable", "unknown", "tbd", "todo"}
+    return True
+
+
+def render_handoff_report(report: HandoffReport) -> str:
+    lines = [
+        "Handoff check",
+        f"- source: {_sanitize_dynamic_text(report.source)}",
+        f"- heading: {_sanitize_dynamic_text(report.heading)}",
+        f"- eval surface required: {'yes' if report.eval_surface_required else 'no'}",
+        f"- present fields: {len(report.present_fields)}",
+    ]
+    if report.ok:
+        lines.append("- result: pass")
+    else:
+        lines.append("- result: fail")
+        if report.missing_fields:
+            lines.append("- missing fields:")
+            lines.extend(f"  - {field}" for field in report.missing_fields)
+        if report.invalid_fields:
+            lines.append("- invalid fields:")
+            lines.extend(f"  - {field}" for field in report.invalid_fields)
+    return "\n".join(lines) + "\n"
+
+
+def _changed_files_from_git(repo_root: Path = ROOT_DIR) -> list[str]:
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(repo_root), "status", "--porcelain=v1"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("could not read changed files from git status") from exc
+    files: list[str] = []
+    for line in status.splitlines():
+        if not line:
+            continue
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path:
+            files.append(path)
+    return sorted(set(files))
+
+
+def _changed_files_from_pr(pr: str, repo_root: Path = ROOT_DIR) -> list[str]:
+    safe_pr = _validate_pr_selector(pr)
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "diff", safe_pr, "--name-only"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(f"could not read changed files from PR {pr}") from exc
+    return sorted(
+        {
+            normalized
+            for line in result.stdout.splitlines()
+            if (normalized := _normalize_changed_file(line, repo_root=repo_root))
+        }
+    )
+
+
+def _validate_pr_selector(pr: str) -> str:
+    if not re.fullmatch(r"\d{1,10}", str(pr)):
+        raise ValueError("PR selector must be a numeric PR number")
+    return str(pr)
+
+
+def _read_changed_files(
+    path: Path | None,
+    *,
+    from_git: bool,
+    pr: str | None = None,
+    repo_root: Path,
+) -> list[str]:
+    files: list[str] = []
+    if path is not None:
+        text = _read_text(path)
+        for raw in re.split(r"[\n,]", text):
+            item = _normalize_changed_file(raw, repo_root=repo_root)
+            if item:
+                files.append(item)
+    if pr and path is None:
+        files.extend(_changed_files_from_pr(pr, repo_root))
+    if from_git:
+        files.extend(_changed_files_from_git(repo_root))
+    return sorted(set(files))
+
+
+def _path_matches(path: str, *prefixes_or_names: str) -> bool:
+    return any(path == item or path.startswith(item) for item in prefixes_or_names)
+
+
+def _surface_for_path(path: str) -> tuple[str, ...]:
+    p = _normalize_changed_file(path).strip()
+    p = p[2:] if p.startswith("./") else p
+    if not p:
+        return ("unknown",)
+    if p == "reports/eval_summary.json":
+        return ("public-fixture-smoke", "benchmark-reporting")
+    if p.startswith("docs/adr/"):
+        return ("governance-adr",)
+    if p.startswith(".github/workflows/") or p in {
+        ".claude/settings.json",
+        ".gitignore",
+        "pyproject.toml",
+        "Makefile",
+        "scripts/_governance.py",
+        "scripts/agent_loop.py",
+        "scripts/agent_loop_mcp.py",
+        "tests/test_agent_loop.py",
+        "tests/test_agent_loop_mcp.py",
+        "tests/test_agent_loop_claude_integration.py",
+        "scripts/ai_next_actions.py",
+        "tests/test_ai_next_actions.py",
+        "tests/test_hook_telemetry.py",
+    }:
+        return ("ci-validation",)
+    if p.startswith(".claude/commands/") or p.startswith("scripts/claude-hooks/"):
+        return ("ci-validation",)
+    if p.startswith("reports/real100/") or p.startswith("reports/private"):
+        return ("private-real-eval", "privacy-sensitive-artifact", "benchmark-reporting")
+    if p in {"eval/real_config.local.yaml", "configs/eval/private_real_eval.local.yaml"}:
+        return ("private-real-eval", "privacy-sensitive-artifact")
+    if p.startswith(("data/index/real100", "data/private/", "data/files/", "data/files_kordoc/")):
+        return ("private-real-eval", "privacy-sensitive-artifact")
+    if p in {"scripts/run_real_eval_delta.py"}:
+        return ("private-real-eval", "benchmark-reporting")
+    if p.startswith("configs/eval/benchmark") or p.startswith("data/eval/benchmark/"):
+        return ("public-synthetic-benchmark",)
+    if p in {"eval/naive_rag/benchmark.py", "tests/test_naive_rag_benchmark_v1.py"}:
+        return ("public-synthetic-benchmark",)
+    if p.startswith("eval/fixtures/smoke_rfp/") or p == "eval/config.yaml":
+        return ("public-fixture-smoke",)
+    if p.startswith("eval/") or p.startswith("configs/eval/") or p in {
+        "scripts/compare_eval.py",
+        "scripts/render_difficulty_profile.py",
+        "scripts/render_failure_distribution.py",
+        "scripts/render_failure_slices.py",
+        "scripts/measure_variance.py",
+    }:
+        return ("eval-harness", "benchmark-reporting")
+    if p.startswith("reports/"):
+        return ("benchmark-reporting",)
+    if is_load_bearing(p) or _path_matches(p, "api/"):
+        return ("product-runtime",)
+    if p.startswith("docs/evaluation/") or p.startswith("docs/eval/"):
+        return ("benchmark-reporting", "docs-only")
+    if p.startswith("docs/") and p.endswith(".md"):
+        return ("docs-only",)
+    if p.endswith(".md"):
+        return ("docs-only",)
+    return ("unknown",)
+
+
+SURFACE_PRIORITY = {
+    "privacy-sensitive-artifact": 0,
+    "private-real-eval": 1,
+    "public-synthetic-benchmark": 2,
+    "eval-harness": 3,
+    "public-fixture-smoke": 4,
+    "benchmark-reporting": 5,
+    "product-runtime": 6,
+    "governance-adr": 7,
+    "ci-validation": 8,
+    "docs-only": 9,
+    "unknown": 99,
+}
+
+DISALLOWED_CLAIMS = {
+    "docs-only": (
+        "Do not claim behavior, benchmark, or private real-eval impact from docs alone.",
+    ),
+    "governance-adr": (
+        "Do not claim implementation behavior changed unless code and tests changed too.",
+    ),
+    "product-runtime": (
+        "Do not claim quality, retrieval, latency, or performance improvement without eval surface evidence.",
+        "Do not expose private raw data or exact local paths.",
+    ),
+    "eval-harness": (
+        "Do not treat harness wiring or smoke output as real-world RFP quality.",
+        "Do not compare incompatible dataset/config/index provenance.",
+    ),
+    "public-fixture-smoke": (
+        "Do not claim real-world model quality or production performance.",
+    ),
+    "public-synthetic-benchmark": (
+        "Do not claim real RFP performance, customer quality, or private real-eval success.",
+    ),
+    "private-real-eval": (
+        "Do not expose raw question, answer, evidence, filename, exact local path, doc_id, or chunk_id.",
+        "Do not make headline metrics without dataset/config/index/provenance.",
+    ),
+    "benchmark-reporting": (
+        "Do not compare metrics across surfaces without matching dataset/config/index/provenance.",
+    ),
+    "privacy-sensitive-artifact": (
+        "Do not include raw private content, raw IDs, exact local paths, or per-case evidence text.",
+    ),
+    "ci-validation": (
+        "Do not interpret CI green as private real-eval or benchmark performance evidence.",
+    ),
+    "unknown": (
+        "Do not make benchmark, performance, or private-data claims until a human classifies the surface.",
+    ),
+}
+
+
+def classify_changed_files(changed_files: Sequence[str]) -> SurfaceReport:
+    normalized_files = sorted(
+        {
+            normalized
+            for path in changed_files
+            if (normalized := _normalize_changed_file(path))
+        }
+    )
+    if not normalized_files:
+        surface = "unknown"
+        return SurfaceReport(
+            surface=surface,
+            confidence="low",
+            reviewer_type="Human reviewer",
+            disallowed_claims=DISALLOWED_CLAIMS[surface],
+            matched_files=(),
+        )
+    surfaces: list[str] = []
+    for path in normalized_files:
+        surfaces.extend(_surface_for_path(path))
+    unique = sorted(set(surfaces), key=lambda item: SURFACE_PRIORITY.get(item, 99))
+    surface = unique[0] if unique else "unknown"
+    unknown_count = surfaces.count("unknown")
+    confidence = "high"
+    if unknown_count:
+        confidence = "low" if unknown_count == len(changed_files) else "medium"
+    elif len(set(unique) - {"docs-only"}) > 1:
+        confidence = "medium"
+
+    if surface in {"private-real-eval", "privacy-sensitive-artifact"}:
+        reviewer = "Benchmark Auditor + Privacy Auditor"
+    elif surface in {
+        "eval-harness",
+        "public-fixture-smoke",
+        "public-synthetic-benchmark",
+        "benchmark-reporting",
+    }:
+        reviewer = "Benchmark Auditor"
+    elif surface in {"product-runtime", "governance-adr"}:
+        reviewer = "Deep Reviewer"
+    elif surface == "ci-validation":
+        reviewer = "Maintainer / CI Reviewer"
+    elif surface == "docs-only":
+        reviewer = "Documentation / Governance Reviewer"
+    else:
+        reviewer = "Human reviewer"
+
+    return SurfaceReport(
+        surface=surface,
+        confidence=confidence,
+        reviewer_type=reviewer,
+        disallowed_claims=tuple(
+            _dedupe_preserve_order(
+                claim for item in unique for claim in DISALLOWED_CLAIMS[item]
+            )
+        ),
+        matched_files=tuple(normalized_files),
+        additional_surfaces=tuple(item for item in unique if item != surface),
+    )
+
+
+def render_surface_report(report: SurfaceReport) -> str:
+    lines = [
+        f"surface: {report.surface}",
+        f"confidence: {report.confidence}",
+        f"required reviewer type: {report.reviewer_type}",
+    ]
+    if report.additional_surfaces:
+        lines.append("additional surfaces: " + ", ".join(report.additional_surfaces))
+    lines.append("disallowed claims:")
+    lines.extend(f"- {claim}" for claim in report.disallowed_claims)
+    if report.matched_files:
+        lines.append("matched files:")
+        lines.extend(f"- {_display_path(path)}" for path in report.matched_files)
+    return "\n".join(lines) + "\n"
+
+
+def _has_any(files: Sequence[str], predicate) -> bool:  # type: ignore[no-untyped-def]
+    return any(predicate(path) for path in files)
+
+
+def suggest_validation_commands(changed_files: Sequence[str]) -> list[str]:
+    files = sorted(
+        {
+            normalized
+            for path in changed_files
+            if (normalized := _normalize_changed_file(path))
+        }
+    )
+    commands: list[str] = []
+    py_files = [path for path in files if path.endswith(".py") and not _privacy_sensitive_path(path)]
+    if py_files:
+        commands.append("python3 -m py_compile " + " ".join(py_files))
+    test_files = [
+        path
+        for path in files
+        if path.startswith("tests/test_") and path.endswith(".py") and not _privacy_sensitive_path(path)
+    ]
+    if test_files:
+        commands.append("python3 -m pytest " + " ".join(test_files) + " -q")
+
+    def touched(*targets: str) -> bool:
+        return any(path in targets for path in files)
+
+    if touched(
+        "tests/test_naive_rag_benchmark_v1.py",
+        "eval/naive_rag/benchmark.py",
+        "configs/eval/benchmark_naive_rag_v1.yaml",
+    ) or _has_any(files, lambda p: p.startswith("data/eval/benchmark/")):
+        commands.append("python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q")
+    if touched("scripts/compare_eval.py"):
+        commands.append("python3 -m pytest tests/test_compare_eval_regression_gate.py -q")
+    if touched("scripts/run_real_eval_delta.py"):
+        commands.append("python3 -m pytest tests/test_run_real_eval_delta.py -q")
+    if touched("scripts/render_difficulty_profile.py"):
+        commands.append("python3 -m pytest tests/test_render_difficulty_profile.py -q")
+    if _has_any(files, lambda p: p.startswith("docs/") and p.endswith(".md")):
+        commands.append("python3 scripts/check_doc_links.py --check-all")
+    if _has_any(files, lambda p: p.startswith("docs/adr/") and p.endswith(".md")):
+        commands.append(
+            "python3 -m pytest tests/test_governance_adr_numbers.py "
+            "tests/test_governance_adr_readme_parity.py -q"
+        )
+    surface = classify_changed_files(files)
+    privacy_related = surface.surface in {"private-real-eval", "privacy-sensitive-artifact"} or (
+        "privacy-sensitive-artifact" in surface.additional_surfaces
+        or surface.surface == "private-real-eval"
+        or "private-real-eval" in surface.additional_surfaces
+    )
+    if privacy_related:
+        commands.append("python3 scripts/_governance.py --check-eval-privacy")
+    commands.append("git diff --check")
+    return _dedupe_preserve_order(commands)
+
+
+def _dedupe_preserve_order(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def render_validation_suggestions(commands: Sequence[str]) -> str:
+    lines = ["Suggested validation commands:", ""]
+    lines.extend(
+        f"{index}. {_sanitize_command_text(command)}"
+        for index, command in enumerate(commands, start=1)
+    )
+    lines.append("")
+    lines.append("These are suggestions only; this command did not run them.")
+    return "\n".join(lines) + "\n"
+
+
+def _validation_command_allowed(command: str) -> bool:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return False
+    if parts == ["git", "diff", "--check"]:
+        return True
+    if parts == ["python3", "scripts/check_doc_links.py", "--check-all"]:
+        return True
+    if parts == ["python3", "scripts/_governance.py", "--check-eval-privacy"]:
+        return True
+    if parts[:3] == ["python3", "-m", "py_compile"] and len(parts) > 3:
+        return all(
+            arg.endswith(".py") and not _privacy_sensitive_path(arg)
+            for arg in parts[3:]
+        )
+    if parts[:3] == ["python3", "-m", "pytest"] and len(parts) > 4:
+        test_args = [arg for arg in parts[3:] if arg != "-q"]
+        return bool(test_args) and all(
+            arg.startswith("tests/test_") and arg.endswith(".py") and not _privacy_sensitive_path(arg)
+            for arg in test_args
+        )
+    return False
+
+
+def run_validation_commands(
+    changed_files: Sequence[str],
+    *,
+    keep_going: bool = False,
+) -> tuple[int, list[ValidationRun]]:
+    runs: list[ValidationRun] = []
+    final_rc = 0
+    for command in suggest_validation_commands(changed_files):
+        if not _validation_command_allowed(command):
+            runs.append(
+                ValidationRun(
+                    command=command,
+                    returncode=2,
+                    stdout="",
+                    stderr="agent-loop: refused non-allowlisted validation command",
+                )
+            )
+            final_rc = 2
+            if not keep_going:
+                break
+            continue
+        result = subprocess.run(
+            shlex.split(command),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        run = ValidationRun(
+            command=command,
+            returncode=result.returncode,
+            stdout=_sanitize_dynamic_text(result.stdout or ""),
+            stderr=_sanitize_dynamic_text(result.stderr or ""),
+        )
+        runs.append(run)
+        if result.returncode != 0:
+            final_rc = result.returncode
+            if not keep_going:
+                break
+    return final_rc, runs
+
+
+def render_validation_run_report(runs: Sequence[ValidationRun]) -> str:
+    lines = ["Validation run:", ""]
+    for index, run in enumerate(runs, start=1):
+        lines.append(f"{index}. {_sanitize_command_text(run.command)}")
+        lines.append(f"   rc: {run.returncode}")
+        if run.stdout.strip():
+            lines.append("   stdout:")
+            lines.extend(f"     {line}" for line in run.stdout.rstrip().splitlines())
+        if run.stderr.strip():
+            lines.append("   stderr:")
+            lines.extend(f"     {line}" for line in run.stderr.rstrip().splitlines())
+    if not runs:
+        lines.append("No validation commands selected.")
+    return "\n".join(lines) + "\n"
+
+
+def _review_modes(changed_files: Sequence[str]) -> list[str]:
+    report = classify_changed_files(changed_files)
+    modes = ["Normal Code Review", "Adversarial Review"]
+    surfaces = {report.surface, *report.additional_surfaces}
+    if surfaces & {
+        "eval-harness",
+        "public-fixture-smoke",
+        "public-synthetic-benchmark",
+        "private-real-eval",
+        "benchmark-reporting",
+        "privacy-sensitive-artifact",
+    }:
+        modes.extend(
+            [
+                "Benchmark Validity Audit",
+                "eval surface classification",
+                "allowed/disallowed claim audit",
+                "privacy boundary check",
+            ]
+        )
+    if any(is_load_bearing(path) or path.startswith("docs/adr/") for path in changed_files):
+        modes.append("Deep Review")
+    return _dedupe_preserve_order(modes)
+
+
+def render_review_prompt(
+    task_id: str,
+    *,
+    pr: str | None = None,
+    branch: str | None = None,
+    changed_files: Sequence[str] | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> str:
+    task = load_task(task_id, repo_root)
+    plan = find_plan_path(task, repo_root)
+    files = sorted(changed_files or _changed_files_from_git(repo_root))
+    surface = classify_changed_files(files)
+    modes = _review_modes(files)
+    file_block = "\n".join(f"- {_display_path(path)}" for path in files) if files else "- Not discovered"
+    mode_block = "\n".join(f"- {mode}" for mode in modes)
+    safe_pr = _validate_pr_selector(pr) if pr else None
+    ref_lines = []
+    if safe_pr:
+        ref_lines.append(f"- PR: {safe_pr}")
+    if branch:
+        ref_lines.append(f"- Branch: {_sanitize_inline_text(branch)}")
+    refs = "\n".join(ref_lines) if ref_lines else "- PR/Branch: N/A"
+    plan_display = _display_path(_repo_path(plan, repo_root), repo_root=repo_root) if plan else "N/A"
+    text = f"""# BidMate-DocAgent Adversarial Review Prompt
+
+Role: Reviewer / Adversarial Reviewer
+Task: {task.task_id} - {_sanitize_inline_text(task.title)}
+Plan: {plan_display}
+{refs}
+
+Changed files:
+{file_block}
+
+Required review modes:
+{mode_block}
+
+Surface classification:
+- surface: {surface.surface}
+- confidence: {surface.confidence}
+- reviewer type: {surface.reviewer_type}
+
+Review instructions:
+- Start with findings, ordered by severity, with file/line references when possible.
+- Check task/plan scope, existing contracts, tests, validation evidence, and claim wording.
+- Treat generated artifacts as local evidence, not source-of-truth, unless commit policy allows them.
+- If eval, benchmark, metrics, reports, or configs are touched, perform Benchmark Validity Audit:
+  classify the eval surface, verify dataset/config/index/provenance, audit allowed/disallowed
+  claims, and check the privacy boundary.
+- If load-bearing paths or ADRs are touched, perform Deep Review for architecture drift,
+  hidden coupling, baseline/schema/eval split changes, and missing ADR/test evidence.
+- Do not approve benchmark/performance/private real-eval claims without human-reviewable
+  provenance and aggregate-only evidence.
+
+Disallowed claims to attack:
+{chr(10).join(f"- {claim}" for claim in surface.disallowed_claims)}
+
+Output format:
+## Findings
+- [blocking] <file/path>:<line> - issue, impact, required fix.
+- [non-blocking] <file/path>:<line> - follow-up recommendation.
+
+## Evidence Checked
+- Task:
+- Plan:
+- Commands:
+- Eval surface:
+
+## Verdict
+Approve / Needs changes / Needs benchmark audit / Needs deep review
+"""
+    return _sanitize_dynamic_text(text).rstrip() + "\n"
+
+
+def recommend_next_task(repo_root: Path = ROOT_DIR) -> str:
+    queue_text = _read_text(repo_root / QUEUE_PATH)
+    entries = parse_task_entries(queue_text)
+    if not entries:
+        raise ValueError("no task entries found in tasks/queue.md")
+    ready = [entry for entry in entries if (entry.status or "").lower() == "ready"]
+    backlog = [entry for entry in entries if (entry.status or "").lower() == "backlog"]
+    candidates = ready or backlog
+    if not candidates:
+        raise ValueError("no ready or backlog task found; choose manually from tasks/queue.md")
+    candidates = sorted(
+        candidates,
+        key=lambda item: (
+            0 if _extract_validation_commands(item) else 1,
+            0 if "Acceptance Criteria" in item.body else 1,
+            item.task_id,
+        ),
+    )
+    task = candidates[0]
+    plan = find_plan_path(task, repo_root)
+    validation = _extract_validation_commands(task)
+    files = [line.strip("- ` ") for line in re.findall(r"`([^`]+)`", task.body)]
+    surface = classify_changed_files(files)
+    lines = [
+        f"Recommended next task: {task.task_id} - {task.title}",
+        f"- status: {task.status or 'unknown'}",
+        f"- role: {task.owner_role or 'Implementer'}",
+        f"- branch suggestion: <type>/issue-<N>-{task.task_id.lower()}",
+        f"- plan required: {'yes' if plan else 'evaluate before implementation'}",
+        f"- plan: {_display_path(_repo_path(plan, repo_root), repo_root=repo_root) if plan else 'N/A'}",
+        f"- validation command: {validation[0] if validation else 'derive from changed files'}",
+        f"- reviewer requirement: {surface.reviewer_type}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_status(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    repo_root: Path = ROOT_DIR,
+) -> str:
+    lines = ["Agent-loop status", ""]
+    if task_id:
+        task = load_task(task_id, repo_root)
+        plan = find_plan_path(task, repo_root)
+        lines.extend(
+            [
+                f"- task: {task.task_id} - {_sanitize_dynamic_text(task.title)}",
+                f"- status: {task.status or 'unknown'}",
+                f"- owner role: {task.owner_role or 'unknown'}",
+                f"- plan: {_display_path(_repo_path(plan, repo_root), repo_root=repo_root) if plan else 'N/A'}",
+            ]
+        )
+        handoff = check_handoff(task_id, changed_files=changed_files, repo_root=repo_root)
+        lines.append(f"- handoff: {'pass' if handoff.ok else 'fail'}")
+        if handoff.missing_fields:
+            lines.append("- handoff missing: " + ", ".join(handoff.missing_fields))
+        if handoff.invalid_fields:
+            lines.append("- handoff invalid: " + ", ".join(handoff.invalid_fields))
+    else:
+        lines.append(recommend_next_task(repo_root).rstrip())
+
+    surface = classify_changed_files(changed_files)
+    lines.extend(
+        [
+            "",
+            "Surface:",
+            render_surface_report(surface).rstrip(),
+            "",
+            render_validation_suggestions(suggest_validation_commands(changed_files)).rstrip(),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_preflight(
+    *,
+    task_id: str,
+    changed_files: Sequence[str],
+    write_prompts: bool = False,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[int, str]:
+    handoff = check_handoff(task_id, changed_files=changed_files, repo_root=repo_root)
+    surface = classify_changed_files(changed_files)
+    validation = suggest_validation_commands(changed_files)
+    lines = [
+        "Agent-loop preflight",
+        "",
+        "Handoff:",
+        render_handoff_report(handoff).rstrip(),
+        "",
+        "Surface:",
+        render_surface_report(surface).rstrip(),
+        "",
+        render_validation_suggestions(validation).rstrip(),
+    ]
+    if write_prompts:
+        prompt = render_prompt(task_id, repo_root=repo_root)
+        review = render_review_prompt(task_id, changed_files=changed_files, repo_root=repo_root)
+        _write_or_stdout(prompt, DEFAULT_RENDER_PROMPT)
+        _write_or_stdout(review, DEFAULT_REVIEW_PROMPT)
+        lines.extend(
+            [
+                "",
+                "Generated prompts:",
+                f"- {_repo_path(DEFAULT_RENDER_PROMPT, repo_root)}",
+                f"- {_repo_path(DEFAULT_REVIEW_PROMPT, repo_root)}",
+            ]
+        )
+    return (0 if handoff.ok else 1), "\n".join(lines) + "\n"
+
+
+def scan_pr_state(
+    *,
+    out: Path = DEFAULT_PR_STATE,
+    state: str = "open",
+    limit: int = 30,
+    include_body: bool = False,
+    repo_root: Path = ROOT_DIR,
+) -> Path:
+    if state not in {"open", "closed", "all"}:
+        raise ValueError("--state must be one of: open, closed, all")
+    if limit < 1 or limit > 100:
+        raise ValueError("--limit must be between 1 and 100")
+    if out == DEFAULT_PR_STATE:
+        out = repo_root / "reports" / "agent_loop" / "pr_state.json"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    fields = ",".join((*GH_PR_JSON_FIELDS, GH_PR_BODY_FIELD) if include_body else GH_PR_JSON_FIELDS)
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                state,
+                "--limit",
+                str(limit),
+                "--json",
+                fields,
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("could not scan PR state with read-only gh pr list") from exc
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError("gh pr list did not return valid JSON") from exc
+    if not isinstance(payload, list):
+        raise ValueError("gh pr list JSON must be an array")
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return safe_out
+
+
+def run_next_from_prs(
+    *,
+    pr_json: Path = DEFAULT_PR_STATE,
+    out_md: Path = DEFAULT_AI_NEXT_ACTIONS,
+    tasks_dir: Path = DEFAULT_CODEX_TASKS_DIR,
+    readiness_summaries: Sequence[Path] = (),
+    readiness_reports: Sequence[Path] = (),
+    real100_dir: Path | None = None,
+    page_metadata_index_dir: Path | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path]:
+    from scripts import ai_next_actions  # local import keeps the base CLI lightweight
+
+    pr_path = _resolve_input_path(pr_json, repo_root=repo_root)
+    if not pr_path.exists():
+        raise ValueError("PR state JSON not found; run pr-scan first or pass --pr-json")
+    if out_md == DEFAULT_AI_NEXT_ACTIONS:
+        out_md = repo_root / "reports" / "agent_loop" / "ai_next_actions.md"
+    if tasks_dir == DEFAULT_CODEX_TASKS_DIR:
+        tasks_dir = repo_root / "reports" / "agent_loop" / "codex_tasks"
+    safe_out_md = _safe_output_path(out_md, repo_root=repo_root)
+    safe_tasks_dir = _safe_output_path(tasks_dir, repo_root=repo_root)
+
+    items, sources, page_gate, private_delta_needed = ai_next_actions.build_plan(
+        [_resolve_input_path(path, repo_root=repo_root) for path in readiness_summaries],
+        [_resolve_input_path(path, repo_root=repo_root) for path in readiness_reports],
+        pr_path,
+        _resolve_input_path(real100_dir, repo_root=repo_root) if real100_dir is not None else None,
+        _resolve_input_path(page_metadata_index_dir, repo_root=repo_root)
+        if page_metadata_index_dir is not None
+        else None,
+    )
+    safe_items = [_sanitize_work_item(ai_next_actions, item) for item in items]
+    safe_sources = [_sanitize_source_state(ai_next_actions, source) for source in sources]
+    markdown = ai_next_actions.render_summary_markdown(
+        safe_items,
+        safe_sources,
+        page_gate=page_gate,
+        private_delta_needed=private_delta_needed,
+    )
+    ai_next_actions._write_outputs(  # noqa: SLF001 - reuse the existing local writer
+        safe_out_md,
+        safe_tasks_dir,
+        safe_items,
+        _sanitize_dynamic_text(markdown),
+    )
+    return safe_out_md, safe_tasks_dir
+
+
+def _sanitize_work_item(ai_next_actions, item):  # type: ignore[no-untyped-def]
+    return ai_next_actions.WorkItem(
+        classification=_sanitize_inline_text(item.classification),
+        title=_sanitize_inline_text(item.title),
+        reason=_sanitize_inline_text(item.reason),
+        source=_sanitize_inline_text(item.source),
+        slug=_slugify(item.slug),
+        goal=_sanitize_dynamic_text(item.goal),
+        expected_evidence=_sanitize_dynamic_text(item.expected_evidence),
+        verification=_sanitize_command_text(item.verification),
+    )
+
+
+def _sanitize_source_state(ai_next_actions, source):  # type: ignore[no-untyped-def]
+    return ai_next_actions.SourceState(
+        kind=_sanitize_inline_text(source.kind),
+        label=_sanitize_inline_text(source.label),
+        unsafe=source.unsafe,
+    )
+
+
+def draft_task_from_brief(
+    *,
+    task_brief: Path | None = None,
+    task_id: str = DEFAULT_DRAFT_TASK_ID,
+    out_queue: Path = DEFAULT_QUEUE_DRAFT,
+    out_plan: Path = DEFAULT_PLAN_DRAFT,
+    repo_root: Path = ROOT_DIR,
+) -> DraftTaskResult:
+    if not TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("--task-id must match T-YYYY-NNNN")
+    brief_path = _resolve_task_brief(task_brief, repo_root=repo_root)
+    brief_text = _sanitize_dynamic_text(_read_text(brief_path))
+    brief = _parse_task_brief(brief_text)
+    queue_text, plan_text = _render_task_drafts(
+        brief,
+        task_id=task_id,
+        brief_path=brief_path,
+        repo_root=repo_root,
+    )
+    if out_queue == DEFAULT_QUEUE_DRAFT:
+        out_queue = repo_root / "reports" / "agent_loop" / "queue_entry_draft.md"
+    if out_plan == DEFAULT_PLAN_DRAFT:
+        out_plan = repo_root / "reports" / "agent_loop" / "plan_draft.md"
+    safe_queue = _safe_output_path(out_queue, repo_root=repo_root)
+    safe_plan = _safe_output_path(out_plan, repo_root=repo_root)
+    safe_queue.parent.mkdir(parents=True, exist_ok=True)
+    safe_plan.parent.mkdir(parents=True, exist_ok=True)
+    safe_queue.write_text(queue_text, encoding="utf-8")
+    safe_plan.write_text(plan_text, encoding="utf-8")
+    return DraftTaskResult(safe_queue, safe_plan, queue_text, plan_text)
+
+
+def draft_next_from_prs(
+    *,
+    task_id: str = DEFAULT_DRAFT_TASK_ID,
+    state: str = "open",
+    limit: int = 30,
+    include_body: bool = False,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path, DraftTaskResult]:
+    pr_state = scan_pr_state(
+        out=repo_root / "reports" / "agent_loop" / "pr_state.json",
+        state=state,
+        limit=limit,
+        include_body=include_body,
+        repo_root=repo_root,
+    )
+    _, tasks_dir = run_next_from_prs(pr_json=pr_state, repo_root=repo_root)
+    briefs = sorted(tasks_dir.glob("*.md"))
+    if not briefs:
+        raise ValueError("planner did not produce a task brief")
+    draft = draft_task_from_brief(task_brief=briefs[0], task_id=task_id, repo_root=repo_root)
+    return pr_state, tasks_dir, draft
+
+
+def write_batch_plan(
+    *,
+    tasks_dir: Path = DEFAULT_CODEX_TASKS_DIR,
+    out: Path = DEFAULT_BATCH_PLAN,
+    json_out: Path | None = DEFAULT_BATCH_PLAN_JSON,
+    max_items: int = 12,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path | None, str]:
+    if max_items < 1:
+        raise ValueError("--max-items must be at least 1")
+    if tasks_dir == DEFAULT_CODEX_TASKS_DIR:
+        tasks_dir = repo_root / "reports" / "agent_loop" / "codex_tasks"
+    resolved_tasks_dir = _resolve_input_path(tasks_dir, repo_root=repo_root)
+    briefs = _load_brief_summaries(resolved_tasks_dir, max_items=max_items, repo_root=repo_root)
+    if out == DEFAULT_BATCH_PLAN:
+        out = repo_root / "reports" / "agent_loop" / "batch_plan.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    rendered = render_batch_plan(briefs, tasks_dir=resolved_tasks_dir, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+
+    safe_json: Path | None = None
+    if json_out is not None:
+        if json_out == DEFAULT_BATCH_PLAN_JSON:
+            json_out = repo_root / "reports" / "agent_loop" / "batch_plan.json"
+        safe_json = _safe_output_path(json_out, repo_root=repo_root)
+        safe_json.parent.mkdir(parents=True, exist_ok=True)
+        payload = [_brief_summary_payload(item, repo_root=repo_root) for item in briefs]
+        safe_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return safe_out, safe_json, rendered
+
+
+def _load_brief_summaries(tasks_dir: Path, *, max_items: int, repo_root: Path) -> list[BriefSummary]:
+    if not tasks_dir.is_dir():
+        raise ValueError("task briefs directory not found; run next-from-prs first or pass --tasks-dir")
+    paths = sorted(tasks_dir.glob("*.md"))[:max_items]
+    if not paths:
+        raise ValueError("no task briefs found for batch planning")
+    summaries: list[BriefSummary] = []
+    for index, path in enumerate(paths, start=1):
+        brief = _parse_task_brief(_sanitize_dynamic_text(_read_text(path)))
+        lane, reason = _lane_for_brief(brief)
+        summaries.append(
+            BriefSummary(
+                path=path,
+                index=index,
+                title=_sanitize_inline_text(brief["title"]),
+                classification=_sanitize_inline_text(brief["classification"]),
+                source=_sanitize_inline_text(brief["source"]),
+                reason=_sanitize_inline_text(brief["reason"]),
+                goal=_sanitize_inline_text(brief["goal"]),
+                verification=_sanitize_command_text(brief["verification"]),
+                lane=lane,
+                gate_reason=reason,
+            )
+        )
+    return summaries
+
+
+def _lane_for_brief(brief: dict[str, str]) -> tuple[str, str]:
+    classification = brief["classification"].lower()
+    haystack = "\n".join(
+        [brief["title"], brief["classification"], brief["source"], brief["reason"], brief["goal"], brief["verification"]]
+    ).lower()
+    manual_terms = (
+        "gh pr merge",
+        "gh pr close",
+        "gh pr create",
+        "git push",
+        "git branch -d",
+        "git branch -D".lower(),
+        "force-push",
+        "delete branch",
+        "make real-eval",
+        "private delta",
+        "private real-eval",
+        "benchmark claim",
+        "architecture tradeoff",
+    )
+    if classification in {"needs_private_delta", "close_superseded"} or any(term in haystack for term in manual_terms):
+        return "manual-gated", "requires human approval or private/PR decision"
+    if classification in {"blocked", "failed_experiment"}:
+        return "serial", "resolve before dependent implementation or claims"
+    if classification == "ready_for_review" or "review " in haystack:
+        return "review-only", "review pass can run without implementation mutation"
+    return "parallel-safe", "no hard dependency detected; verify independently"
+
+
+def render_batch_plan(briefs: Sequence[BriefSummary], *, tasks_dir: Path, repo_root: Path = ROOT_DIR) -> str:
+    lanes = ("serial", "parallel-safe", "review-only", "manual-gated")
+    label = {
+        "serial": "Set A - Serial Blockers",
+        "parallel-safe": "Set B - Parallel Safe Candidates",
+        "review-only": "Set C - Review-Only Passes",
+        "manual-gated": "Set D - Manual Gates",
+    }
+    lines = [
+        "# Agent Loop Batch Plan",
+        "",
+        f"- Source briefs: `{_display_path(_repo_path(tasks_dir, repo_root), repo_root=repo_root)}`",
+        "- This is a local planning artifact. It does not edit `tasks/queue.md`, plans, branches, PRs, or GitHub state.",
+        "- Execute at most one serial lane item at a time; parallel-safe items can be assigned independently after human scope review.",
+        "",
+        "## Lane Summary",
+        "",
+        "| Lane | Count | Meaning |",
+        "|---|---:|---|",
+    ]
+    for lane in lanes:
+        count = sum(1 for item in briefs if item.lane == lane)
+        lines.append(f"| `{lane}` | {count} | {label[lane]} |")
+    lines.append("")
+
+    for lane in lanes:
+        lines.extend([f"## {label[lane]}", ""])
+        items = [item for item in briefs if item.lane == lane]
+        if not items:
+            lines.extend(["- None", ""])
+            continue
+        for item in items:
+            lines.extend(
+                [
+                    f"### {item.index:03d}. {item.title}",
+                    "",
+                    f"- Brief: `{_display_path(_repo_path(item.path, repo_root), repo_root=repo_root)}`",
+                    f"- Classification: `{item.classification}`",
+                    f"- Source: `{item.source}`",
+                    f"- Gate reason: {item.gate_reason}",
+                    f"- Reason: {item.reason}",
+                    "- Suggested next safe command:",
+                    "",
+                    "```bash",
+                    _ensure_git_diff_check(item.verification),
+                    "```",
+                    "",
+                ]
+            )
+    lines.extend(
+        [
+            "## Human Stop Points",
+            "",
+            "- Applying any draft to `tasks/queue.md` or `docs/plans/*.md`.",
+            "- Any push, PR create/merge/close, branch delete, or force-push.",
+            "- Benchmark/performance/private real-eval claims.",
+            "- Architecture tradeoff decisions.",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines))
+
+
+def _brief_summary_payload(item: BriefSummary, *, repo_root: Path) -> dict[str, object]:
+    return {
+        "index": item.index,
+        "title": item.title,
+        "classification": item.classification,
+        "source": item.source,
+        "lane": item.lane,
+        "gate_reason": item.gate_reason,
+        "brief": _display_path(_repo_path(item.path, repo_root), repo_root=repo_root),
+        "verification": _ensure_git_diff_check(item.verification).splitlines(),
+    }
+
+
+def write_review_followups(
+    *,
+    review: Path,
+    out: Path = DEFAULT_REVIEW_FOLLOWUPS,
+    tasks_dir: Path = DEFAULT_REVIEW_FOLLOWUPS_DIR,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path, int, str]:
+    review_path = _resolve_input_path(review, repo_root=repo_root)
+    if not review_path.exists():
+        raise ValueError(f"review file not found: {_display_path(str(review), repo_root=repo_root)}")
+    findings = parse_review_findings(_read_text(review_path))
+    if out == DEFAULT_REVIEW_FOLLOWUPS:
+        out = repo_root / "reports" / "agent_loop" / "review_followups.md"
+    if tasks_dir == DEFAULT_REVIEW_FOLLOWUPS_DIR:
+        tasks_dir = repo_root / "reports" / "agent_loop" / "review_followups"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_tasks_dir = _safe_output_path(tasks_dir, repo_root=repo_root)
+    rendered = render_review_followups(findings, review_path=review_path, tasks_dir=safe_tasks_dir, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_tasks_dir.mkdir(parents=True, exist_ok=True)
+    for stale in safe_tasks_dir.glob("*.md"):
+        stale.unlink()
+    safe_out.write_text(rendered, encoding="utf-8")
+    for index, finding in enumerate(findings, start=1):
+        task_path = safe_tasks_dir / f"{index:03d}-{_slugify(finding.summary)}.md"
+        task_path.write_text(
+            render_review_followup_task(finding, index=index, review_path=review_path, repo_root=repo_root),
+            encoding="utf-8",
+        )
+    return safe_out, safe_tasks_dir, len(findings), rendered
+
+
+def parse_review_findings(text: str) -> list[ReviewFinding]:
+    sanitized = _sanitize_dynamic_text(text)
+    findings: list[ReviewFinding] = []
+    in_findings = False
+    for raw_line in sanitized.splitlines():
+        line = raw_line.strip()
+        if re.match(r"^#{1,3}\s+Findings\b", line, re.IGNORECASE):
+            in_findings = True
+            continue
+        if in_findings and re.match(r"^#{1,3}\s+", line):
+            break
+        if not in_findings or not line.startswith("-"):
+            continue
+        match = re.match(r"^-\s*\[(?P<severity>[^\]]+)\]\s*(?P<body>.+)$", line)
+        if not match:
+            continue
+        severity = _sanitize_inline_text(match.group("severity").lower())
+        body = _sanitize_inline_text(match.group("body"))
+        target = "N/A"
+        summary = body
+        if " - " in body:
+            left, summary = body.split(" - ", 1)
+            target = _display_path(left.strip())
+        findings.append(
+            ReviewFinding(
+                severity=severity,
+                target=target,
+                summary=_sanitize_inline_text(summary),
+                reviewer_mode=_reviewer_mode_for_finding(severity, body),
+            )
+        )
+    return findings
+
+
+def _reviewer_mode_for_finding(severity: str, body: str) -> str:
+    lowered = f"{severity}\n{body}".lower()
+    if any(token in lowered for token in ("privacy", "private", "doc_id", "chunk_id", "raw evidence", "filename")):
+        return "Privacy Auditor"
+    if any(token in lowered for token in ("benchmark", "eval", "metric", "claim", "real-eval", "performance")):
+        return "Benchmark Auditor"
+    if any(token in lowered for token in ("architecture", "adr", "load-bearing", "schema", "contract")):
+        return "Deep Reviewer"
+    return "Reviewer"
+
+
+def render_review_followups(
+    findings: Sequence[ReviewFinding],
+    *,
+    review_path: Path,
+    tasks_dir: Path,
+    repo_root: Path = ROOT_DIR,
+) -> str:
+    lines = [
+        "# Review Follow-up Plan",
+        "",
+        f"- Source review: `{_display_path(_repo_path(review_path, repo_root), repo_root=repo_root)}`",
+        f"- Task briefs: `{_display_path(_repo_path(tasks_dir, repo_root), repo_root=repo_root)}`",
+        "- This command does not auto-fix code, edit queue/plan docs, push, create/close/merge PRs, or delete branches.",
+        "",
+    ]
+    if not findings:
+        lines.extend(
+            [
+                "## Findings",
+                "",
+                "- No actionable findings parsed. Review manually if the source used a different format.",
+                "",
+            ]
+        )
+        return _sanitize_dynamic_text("\n".join(lines))
+    lines.extend(["## Findings", ""])
+    for index, finding in enumerate(findings, start=1):
+        lane = "serial" if finding.severity in {"blocking", "p0", "p1"} else "parallel-safe"
+        if finding.reviewer_mode in {"Privacy Auditor", "Benchmark Auditor", "Deep Reviewer"}:
+            lane = "manual-gated"
+        lines.extend(
+            [
+                f"### {index:03d}. {finding.summary}",
+                "",
+                f"- Severity: `{finding.severity}`",
+                f"- Target: `{finding.target}`",
+                f"- Reviewer mode: `{finding.reviewer_mode}`",
+                f"- Lane: `{lane}`",
+                f"- Brief: `{_display_path(_repo_path(tasks_dir / f'{index:03d}-{_slugify(finding.summary)}.md', repo_root), repo_root=repo_root)}`",
+                "",
+            ]
+        )
+    return _sanitize_dynamic_text("\n".join(lines))
+
+
+def render_review_followup_task(
+    finding: ReviewFinding,
+    *,
+    index: int,
+    review_path: Path,
+    repo_root: Path = ROOT_DIR,
+) -> str:
+    summary = finding.summary
+    verification = _ensure_git_diff_check(_validation_for_finding(finding))
+    return _sanitize_dynamic_text(
+        f"""# Review Follow-up {index:03d}: {summary}
+
+- Classification: `review_followup`
+- Severity: `{finding.severity}`
+- Reviewer mode: `{finding.reviewer_mode}`
+- Source review: `{_display_path(_repo_path(review_path, repo_root), repo_root=repo_root)}`
+- Target: `{finding.target}`
+
+## Goal
+
+Address the reviewer finding with the smallest scoped change, or document why human approval is required.
+
+## Finding
+
+{summary}
+
+## Constraints
+
+- Do not auto-merge, auto-push, create/close/merge PRs, delete branches, or force-push.
+- Do not make benchmark, performance, private real-eval, or architecture tradeoff claims without human approval.
+- Do not expose raw private question, answer, evidence, doc_id, chunk_id, filenames, or exact local paths.
+
+## Expected Evidence
+
+Focused diff, focused validation, and updated handoff evidence for this finding only.
+
+## Verification
+
+```bash
+{verification}
+```
+"""
+    )
+
+
+def _validation_for_finding(finding: ReviewFinding) -> str:
+    target = finding.target.split(":", 1)[0].strip()
+    if target.endswith(".py") and not _privacy_sensitive_path(target):
+        commands = [f"python3 -m py_compile {target}"]
+        if target.startswith("tests/test_"):
+            commands.append(f"python3 -m pytest {target} -q")
+        return "\n".join(commands)
+    if target.startswith("docs/") and target.endswith(".md"):
+        return "python3 scripts/check_doc_links.py --check-all"
+    if finding.reviewer_mode == "Privacy Auditor":
+        return "python3 scripts/_governance.py --check-eval-privacy"
+    return "git diff --check"
+
+
+def write_decision_brief(
+    *,
+    task_id: str | None = None,
+    batch: Path | None = None,
+    review_followups: Path | None = None,
+    gate: str = "auto",
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_DECISION_BRIEF,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    points = build_decision_points(
+        task_id=task_id,
+        batch=batch,
+        review_followups=review_followups,
+        gate=gate,
+        changed_files=changed_files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    if out == DEFAULT_DECISION_BRIEF:
+        out = repo_root / "reports" / "agent_loop" / "decision_brief.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    rendered = render_decision_brief(points, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def write_promote_draft(
+    *,
+    queue_draft: Path = DEFAULT_QUEUE_DRAFT,
+    plan_draft: Path = DEFAULT_PLAN_DRAFT,
+    out: Path = DEFAULT_PROMOTE_DRAFT,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    queue_path = _resolve_default_agent_loop_path(queue_draft, "queue_entry_draft.md", repo_root=repo_root)
+    plan_path = _resolve_default_agent_loop_path(plan_draft, "plan_draft.md", repo_root=repo_root)
+    if not queue_path.exists():
+        raise ValueError("queue draft not found; run draft-task first or pass --queue-draft")
+    if not plan_path.exists():
+        raise ValueError("plan draft not found; run draft-task first or pass --plan-draft")
+    queue_draft_text = _sanitize_dynamic_text(_read_text(queue_path)).rstrip() + "\n"
+    plan_draft_text = _sanitize_dynamic_text(_read_text(plan_path)).rstrip() + "\n"
+    target_plan = _extract_suggested_plan_path(plan_draft_text)
+    target_queue = repo_root / QUEUE_PATH
+    target_plan_path = repo_root / target_plan
+    queue_before = _read_text(target_queue) if target_queue.exists() else ""
+    queue_after = queue_before.rstrip() + "\n\n" + queue_draft_text
+    plan_before = _read_text(target_plan_path) if target_plan_path.exists() else ""
+    rendered = render_promote_draft(
+        queue_before=queue_before,
+        queue_after=queue_after,
+        plan_before=plan_before,
+        plan_after=plan_draft_text,
+        target_queue=QUEUE_PATH.as_posix(),
+        target_plan=target_plan.as_posix(),
+    )
+    if out == DEFAULT_PROMOTE_DRAFT:
+        out = repo_root / "reports" / "agent_loop" / "promote_draft.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_promote_draft(
+    *,
+    queue_before: str,
+    queue_after: str,
+    plan_before: str,
+    plan_after: str,
+    target_queue: str,
+    target_plan: str,
+) -> str:
+    queue_diff = _unified_diff(queue_before, queue_after, fromfile=f"a/{target_queue}", tofile=f"b/{target_queue}")
+    plan_diff = _unified_diff(plan_before, plan_after, fromfile=f"a/{target_plan}", tofile=f"b/{target_plan}")
+    return _sanitize_dynamic_text(
+        f"""# Promote Draft Dry Run
+
+- Result: dry-run only; no tracked files were modified.
+- Queue target: `{target_queue}`
+- Plan target: `{target_plan}`
+- Manual approval required before applying these changes.
+
+## Queue Diff
+
+```diff
+{queue_diff}
+```
+
+## Plan Diff
+
+```diff
+{plan_diff}
+```
+"""
+    )
+
+
+def _unified_diff(before: str, after: str, *, fromfile: str, tofile: str) -> str:
+    diff = difflib.unified_diff(
+        before.splitlines(),
+        after.splitlines(),
+        fromfile=fromfile,
+        tofile=tofile,
+        lineterm="",
+    )
+    return "\n".join(diff) or "(no diff)"
+
+
+def _extract_suggested_plan_path(plan_text: str) -> Path:
+    match = re.search(r"Suggested (?:final )?path:\s*`(?P<path>docs/plans/[^`]+\.md)`", plan_text)
+    if not match:
+        match = re.search(r"Suggested plan path:\s*`(?P<path>docs/plans/[^`]+\.md)`", plan_text)
+    if not match:
+        raise ValueError("plan draft does not name a suggested docs/plans/*.md path")
+    rel = Path(match.group("path"))
+    if rel.is_absolute() or ".." in rel.parts or not rel.as_posix().startswith("docs/plans/"):
+        raise ValueError("suggested plan path must stay under docs/plans/")
+    return rel
+
+
+def _resolve_default_agent_loop_path(path: Path, default_name: str, *, repo_root: Path) -> Path:
+    if path == DEFAULT_QUEUE_DRAFT and default_name == "queue_entry_draft.md":
+        return repo_root / "reports" / "agent_loop" / default_name
+    if path == DEFAULT_PLAN_DRAFT and default_name == "plan_draft.md":
+        return repo_root / "reports" / "agent_loop" / default_name
+    return _resolve_input_path(path, repo_root=repo_root)
+
+
+def write_gate_status(
+    *,
+    task_id: str | None = None,
+    batch: Path | None = None,
+    review_followups: Path | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    out: Path | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path | None, str]:
+    status = build_gate_status(
+        task_id=task_id,
+        batch=batch,
+        review_followups=review_followups,
+        changed_files=changed_files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    rendered = render_gate_status(status)
+    written: Path | None = None
+    if out is not None:
+        if out == DEFAULT_GATE_STATUS:
+            out = repo_root / "reports" / "agent_loop" / "gate_status.md"
+        written = _safe_output_path(out, repo_root=repo_root)
+        written.parent.mkdir(parents=True, exist_ok=True)
+        written.write_text(rendered, encoding="utf-8")
+    return written, rendered
+
+
+def build_gate_status(
+    *,
+    task_id: str | None,
+    batch: Path | None,
+    review_followups: Path | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    repo_root: Path,
+) -> dict[str, object]:
+    signals: list[str] = []
+    gate = "orientation"
+    severity = "low"
+    next_safe = "python3 scripts/agent_loop.py map"
+    if task_id:
+        report = check_handoff(task_id, changed_files=changed_files, repo_root=repo_root)
+        if not report.ok:
+            gate = "handoff"
+            severity = "high"
+            next_safe = f"python3 scripts/agent_loop.py handoff-check --task {task_id}"
+            signals.append("handoff missing or invalid")
+        else:
+            gate = "implementation-or-review"
+            severity = "medium"
+            next_safe = f"python3 scripts/agent_loop.py review-prompt --task {task_id} --from-git"
+            signals.append("handoff passes")
+    batch_path = _default_existing_path(batch, repo_root / "reports" / "agent_loop" / "batch_plan.json")
+    if batch_path is not None:
+        batch_path = _resolve_input_path(batch_path, repo_root=repo_root)
+        if batch_path.exists():
+            payload = _load_batch_payload(batch_path)
+            manual = sum(1 for item in payload if item.get("lane") == "manual-gated")
+            serial = sum(1 for item in payload if item.get("lane") == "serial")
+            if manual:
+                gate = "manual-gated-task"
+                severity = "high"
+                next_safe = "python3 scripts/agent_loop.py decision-brief --gate task"
+                signals.append(f"manual-gated task count: {manual}")
+            elif serial:
+                gate = "serial-task-selection"
+                severity = "medium"
+                next_safe = "python3 scripts/agent_loop.py batch-plan"
+                signals.append(f"serial task count: {serial}")
+    followups_path = _default_existing_path(review_followups, repo_root / "reports" / "agent_loop" / "review_followups.md")
+    if followups_path is not None:
+        followups_path = _resolve_input_path(followups_path, repo_root=repo_root)
+        if followups_path.exists():
+            text = _sanitize_dynamic_text(_read_text(followups_path))
+            parsed = len(re.findall(r"^###\s+\d{3}\.", text, re.MULTILINE))
+            if parsed:
+                gate = "review-followup"
+                severity = "high" if "manual-gated" in text else "medium"
+                next_safe = "python3 scripts/agent_loop.py decision-brief --gate review"
+                signals.append(f"review follow-up count: {parsed}")
+    if changed_files:
+        surface = classify_changed_files(changed_files)
+        signals.append(f"surface: {surface.surface}")
+        if {surface.surface, *surface.additional_surfaces} & {"private-real-eval", "privacy-sensitive-artifact", "benchmark-reporting"}:
+            gate = "claim-boundary"
+            severity = "critical" if surface.surface in {"private-real-eval", "privacy-sensitive-artifact"} else "high"
+            next_safe = "python3 scripts/agent_loop.py decision-brief --gate claim --from-git"
+    if pr:
+        _validate_pr_selector(pr)
+        if gate not in {"claim-boundary", "manual-gated-task", "review-followup"}:
+            gate = "ship"
+            severity = "high"
+            next_safe = f"make ship-review-gate PR={pr}"
+        signals.append(f"pr: {pr}")
+    return {
+        "gate": gate,
+        "severity": severity,
+        "signals": tuple(_dedupe_preserve_order(signals)),
+        "next_safe_command": next_safe,
+    }
+
+
+def render_gate_status(status: dict[str, object]) -> str:
+    signals = status.get("signals") or ()
+    lines = [
+        "# Agent Loop Gate Status",
+        "",
+        f"- Current gate: `{status['gate']}`",
+        f"- Severity: `{status['severity']}`",
+        "- Signals:",
+    ]
+    if signals:
+        lines.extend(f"  - {_sanitize_dynamic_text(str(item))}" for item in signals)
+    else:
+        lines.append("  - no concrete loop artifact detected")
+    lines.extend(
+        [
+            "- Next safe command:",
+            "",
+            "```bash",
+            _sanitize_command_text(str(status["next_safe_command"])),
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines))
+
+
+def write_claim_audit(
+    *,
+    text_path: Path | None = None,
+    changed_files: Sequence[str] = (),
+    out: Path = DEFAULT_CLAIM_AUDIT,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, int, str]:
+    text = ""
+    source = "changed files only"
+    if text_path is not None:
+        resolved = _resolve_input_path(text_path, repo_root=repo_root)
+        if not resolved.exists():
+            raise ValueError(f"claim text file not found: {_display_path(_repo_path(resolved, repo_root), repo_root=repo_root)}")
+        text = _read_text(resolved)
+        source = _display_path(_repo_path(resolved, repo_root), repo_root=repo_root)
+    surface = classify_changed_files(changed_files)
+    findings = audit_claim_text(text, surface)
+    rendered = render_claim_audit(source=source, surface=surface, findings=findings)
+    if out == DEFAULT_CLAIM_AUDIT:
+        out = repo_root / "reports" / "agent_loop" / "claim_audit.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, 1 if findings else 0, rendered
+
+
+def audit_claim_text(text: str, surface: SurfaceReport) -> list[ClaimFinding]:
+    lowered = text.lower()
+    findings: list[ClaimFinding] = []
+    claim_patterns = {
+        "performance": r"\b(performance|latency|faster|speed|p95|throughput)\b",
+        "quality": r"\b(quality|accuracy|recall|precision|improved|improvement|better)\b",
+        "benchmark": r"\b(benchmark|score|metric|eval result|regression)\b",
+        "private-real-eval": r"\b(private real[- ]?eval|real100|real rfp|customer|production)\b",
+    }
+    for issue, pattern in claim_patterns.items():
+        if re.search(pattern, lowered):
+            findings.append(
+                ClaimFinding(
+                    issue=f"{issue} claim language detected",
+                    severity=_claim_severity(issue, surface),
+                    reviewer=_claim_reviewer(issue, surface),
+                )
+            )
+    surfaces = {surface.surface, *surface.additional_surfaces}
+    if findings and surface.surface in {"unknown", "docs-only", "ci-validation"}:
+        findings.append(
+            ClaimFinding(
+                issue=f"claim language appears on `{surface.surface}` surface without sufficient eval provenance",
+                severity="high",
+                reviewer="Human reviewer + Benchmark Auditor",
+            )
+        )
+    if "private-real-eval" in surfaces or "privacy-sensitive-artifact" in surfaces:
+        findings.append(
+            ClaimFinding(
+                issue="private/privacy-sensitive surface requires aggregate-only evidence and human claim approval",
+                severity="critical",
+                reviewer="Benchmark Auditor + Privacy Auditor",
+            )
+        )
+    return _dedupe_claim_findings(findings)
+
+
+def _dedupe_claim_findings(findings: Iterable[ClaimFinding]) -> list[ClaimFinding]:
+    seen: set[tuple[str, str, str]] = set()
+    out: list[ClaimFinding] = []
+    for finding in findings:
+        key = (finding.issue, finding.severity, finding.reviewer)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return out
+
+
+def _claim_severity(issue: str, surface: SurfaceReport) -> str:
+    surfaces = {surface.surface, *surface.additional_surfaces}
+    if issue == "private-real-eval" or surfaces & {"private-real-eval", "privacy-sensitive-artifact"}:
+        return "critical"
+    if issue in {"performance", "benchmark"}:
+        return "high"
+    return "medium"
+
+
+def _claim_reviewer(issue: str, surface: SurfaceReport) -> str:
+    surfaces = {surface.surface, *surface.additional_surfaces}
+    if issue == "private-real-eval" or surfaces & {"private-real-eval", "privacy-sensitive-artifact"}:
+        return "Benchmark Auditor + Privacy Auditor"
+    if issue in {"performance", "benchmark", "quality"}:
+        return "Benchmark Auditor"
+    return "Human reviewer"
+
+
+def render_claim_audit(*, source: str, surface: SurfaceReport, findings: Sequence[ClaimFinding]) -> str:
+    lines = [
+        "# Claim Audit",
+        "",
+        f"- Source: `{_sanitize_dynamic_text(source)}`",
+        f"- Surface: `{surface.surface}`",
+        f"- Confidence: `{surface.confidence}`",
+        f"- Required reviewer: `{surface.reviewer_type}`",
+        "- Matched files:",
+    ]
+    if surface.matched_files:
+        lines.extend(f"  - `{_display_path(path)}`" for path in surface.matched_files)
+    else:
+        lines.append("  - `N/A`")
+    lines.extend(["", "## Findings", ""])
+    if not findings:
+        lines.append("- None. No risky claim language detected in the provided text.")
+    else:
+        for finding in findings:
+            lines.extend(
+                [
+                    f"- Severity: `{finding.severity}`",
+                    f"  - Issue: {_sanitize_dynamic_text(finding.issue)}",
+                    f"  - Reviewer: `{finding.reviewer}`",
+                ]
+            )
+    lines.extend(["", "## Disallowed Claims", ""])
+    lines.extend(f"- {claim}" for claim in surface.disallowed_claims)
+    return _sanitize_dynamic_text("\n".join(lines)) + "\n"
+
+
+def write_privacy_audit_output(
+    *,
+    path: Path = DEFAULT_REPORT_DIR,
+    out: Path = DEFAULT_PRIVACY_AUDIT,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, int, str]:
+    target = repo_root / "reports" / "agent_loop" if path == DEFAULT_REPORT_DIR else _resolve_input_path(path, repo_root=repo_root)
+    safe_target = _safe_output_path(target, repo_root=repo_root)
+    if out == DEFAULT_PRIVACY_AUDIT:
+        out = repo_root / "reports" / "agent_loop" / "privacy_audit.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    findings = audit_privacy_output(safe_target, out_path=safe_out, repo_root=repo_root)
+    rendered = render_privacy_audit(findings, target=safe_target, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, 1 if findings else 0, rendered
+
+
+def audit_privacy_output(target: Path, *, out_path: Path | None, repo_root: Path) -> list[PrivacyFinding]:
+    paths = sorted(target.rglob("*")) if target.is_dir() else [target]
+    findings: list[PrivacyFinding] = []
+    for file_path in paths:
+        if not file_path.is_file() or (out_path is not None and file_path.resolve() == out_path.resolve()):
+            continue
+        if file_path.suffix.lower() not in {".md", ".txt", ".json", ".jsonl", ".yaml", ".yml"}:
+            continue
+        try:
+            text = _read_text(file_path)
+        except UnicodeDecodeError:
+            continue
+        rel = _display_path(_repo_path(file_path, repo_root), repo_root=repo_root)
+        for issue, pattern in _privacy_audit_patterns().items():
+            if pattern.search(text):
+                findings.append(PrivacyFinding(path=rel, issue=issue))
+    return _dedupe_privacy_findings(findings)
+
+
+def _privacy_audit_patterns() -> dict[str, re.Pattern[str]]:
+    return {
+        "absolute local path": ABSOLUTE_LOCAL_PATH_RE,
+        "private raw field value": re.compile(
+            r"\b(?:(?:raw\s+)?(?:question|answer|evidence)|doc[_ -]?id|chunk[_ -]?id|file\s*name|filename)\b"
+            r"\s*[:=](?!\s*\[redacted-private-value\])\s*([^\n;,]+)",
+            re.IGNORECASE,
+        ),
+        "json private raw field value": re.compile(
+            r'"(?:question|answer|evidence|doc_id|chunk_id|filename)"\s*:\s*"(?!\[redacted-private-value\])[^"]+"',
+            re.IGNORECASE,
+        ),
+        "private raw flag value": re.compile(
+            r"--(?:raw-)?(?:question|answer|evidence|doc[_-]?id|chunk[_-]?id|file(?:[_-]?name)?)\s+"
+            r"(?!\[redacted-private-value\])(\"[^\"]*\"|'[^']*'|\S+)",
+            re.IGNORECASE,
+        ),
+        "private real100 artifact path": re.compile(r"reports/real100/(?!\[redacted-private-artifact\])\S+", re.IGNORECASE),
+        "raw doc/chunk id token": re.compile(r"\b(?:doc|chunk)[_-]?id[-_:][A-Za-z0-9]", re.IGNORECASE),
+    }
+
+
+def _dedupe_privacy_findings(findings: Iterable[PrivacyFinding]) -> list[PrivacyFinding]:
+    seen: set[tuple[str, str]] = set()
+    out: list[PrivacyFinding] = []
+    for finding in findings:
+        key = (finding.path, finding.issue)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return out
+
+
+def render_privacy_audit(findings: Sequence[PrivacyFinding], *, target: Path, repo_root: Path) -> str:
+    lines = [
+        "# Agent Loop Privacy Audit",
+        "",
+        f"- Target: `{_display_path(_repo_path(target, repo_root), repo_root=repo_root)}`",
+        f"- Result: `{'fail' if findings else 'pass'}`",
+        f"- Finding count: `{len(findings)}`",
+        "",
+        "## Findings",
+        "",
+    ]
+    if not findings:
+        lines.append("- None")
+    else:
+        for finding in findings:
+            lines.extend(
+                [
+                    f"- File: `{finding.path}`",
+                    f"  - Issue: {finding.issue}",
+                ]
+            )
+    return _sanitize_dynamic_text("\n".join(lines)) + "\n"
+
+
+AUTO_PASS_LOW_RISK_SURFACES = {"docs-only", "ci-validation"}
+
+
+def write_auto_pass_check(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    claim_text: Path | None = None,
+    run_validation: bool = False,
+    strict: bool = False,
+    profile: str = "standard",
+    out: Path | None = DEFAULT_AUTO_PASS,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path | None, AutoPassReport, str]:
+    report = build_auto_pass_report(
+        task_id=task_id,
+        changed_files=changed_files,
+        claim_text=claim_text,
+        run_validation=run_validation,
+        strict=strict,
+        profile=profile,
+        repo_root=repo_root,
+    )
+    rendered = render_auto_pass_report(report)
+    written: Path | None = None
+    if out is not None:
+        if out == DEFAULT_AUTO_PASS:
+            out = repo_root / "reports" / "agent_loop" / "auto_pass.md"
+        written = _safe_output_path(out, repo_root=repo_root)
+        written.parent.mkdir(parents=True, exist_ok=True)
+        written.write_text(rendered, encoding="utf-8")
+    return written, report, rendered
+
+
+def build_auto_pass_report(
+    *,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    claim_text: Path | None,
+    run_validation: bool,
+    repo_root: Path,
+    strict: bool = False,
+    profile: str = "standard",
+) -> AutoPassReport:
+    if profile not in {"standard", "docs-only-strict", "ci-only-strict", "agent-loop-tooling-strict"}:
+        raise ValueError("--profile must be one of: standard, docs-only-strict, ci-only-strict, agent-loop-tooling-strict")
+    files = sorted(
+        {
+            normalized
+            for path in changed_files
+            if (normalized := _normalize_changed_file(path, repo_root=repo_root))
+        }
+    )
+    surface = classify_changed_files(files)
+    surfaces = {surface.surface, *surface.additional_surfaces}
+    blockers: list[str] = []
+    warnings: list[str] = []
+    evidence: list[str] = []
+
+    if not files:
+        blockers.append("changed files were not provided; auto-pass requires concrete file evidence")
+    gated_surfaces = sorted(surfaces - AUTO_PASS_LOW_RISK_SURFACES)
+    if gated_surfaces:
+        blockers.append("surface requires human review: " + ", ".join(gated_surfaces))
+    if surface.confidence != "high":
+        blockers.append(f"surface confidence is {surface.confidence}; auto-pass requires high confidence")
+    blockers.extend(_auto_pass_profile_blockers(profile=profile, files=files, surfaces=surfaces))
+
+    if task_id:
+        handoff = check_handoff(task_id, changed_files=files, repo_root=repo_root)
+        if handoff.ok:
+            evidence.append(f"handoff-check passed for {task_id}")
+        else:
+            missing = ", ".join((*handoff.missing_fields, *handoff.invalid_fields))
+            blockers.append(f"handoff-check failed for {task_id}: {missing or 'unknown issue'}")
+    elif strict:
+        blockers.append("strict mode requires --task so handoff-check can run")
+    else:
+        warnings.append("no task id was provided; handoff was not checked")
+
+    privacy_target = repo_root / "reports" / "agent_loop"
+    privacy_findings = audit_privacy_output(
+        privacy_target,
+        out_path=repo_root / "reports" / "agent_loop" / "auto_pass.md",
+        repo_root=repo_root,
+    )
+    if privacy_findings:
+        blockers.append(f"privacy audit found {len(privacy_findings)} generated artifact issue(s)")
+    else:
+        evidence.append("privacy audit found no generated artifact issues")
+
+    if claim_text is not None:
+        resolved_claim_text = _resolve_input_path(claim_text, repo_root=repo_root)
+        if not resolved_claim_text.exists():
+            blockers.append("claim text file not found")
+        else:
+            claim_source = _display_path(_repo_path(resolved_claim_text, repo_root), repo_root=repo_root)
+            claim_findings = audit_claim_text(_read_text(resolved_claim_text), surface)
+            if claim_findings:
+                blockers.append(f"claim audit found {len(claim_findings)} issue(s) in {claim_source}")
+            else:
+                evidence.append(f"claim audit found no risky claim language in {claim_source}")
+    elif strict:
+        blockers.append("strict mode requires --claim-text so claim wording can be audited")
+    else:
+        warnings.append("no claim text was provided; claim wording was not audited")
+
+    followups = repo_root / "reports" / "agent_loop" / "review_followups.md"
+    if strict and followups.exists():
+        text = _sanitize_dynamic_text(_read_text(followups))
+        parsed = len(re.findall(r"^###\s+\d{3}\.", text, re.MULTILINE))
+        if parsed:
+            blockers.append(f"strict mode blocks because {parsed} review follow-up item(s) exist")
+
+    if run_validation:
+        rc, runs = run_validation_commands(files)
+        if not runs:
+            blockers.append("validation selected no commands")
+        for run in runs:
+            evidence.append(f"validation rc={run.returncode}: {_sanitize_command_text(run.command)}")
+        if rc != 0:
+            blockers.append("validation failed; auto-pass requires all selected validation commands to pass")
+    else:
+        blockers.append("validation was not run; pass --run-validation to allow auto-pass")
+
+    ok = not blockers
+    confidence = "high" if ok else ("medium" if evidence else "low")
+    next_safe = (
+        "python3 scripts/agent_loop.py loop-state --from-git"
+        if ok
+        else "python3 scripts/agent_loop.py decision-brief --from-git"
+    )
+    if task_id:
+        next_safe = (
+            f"python3 scripts/agent_loop.py loop-state --task {task_id} --from-git"
+            if ok
+            else f"python3 scripts/agent_loop.py decision-brief --task {task_id} --from-git"
+        )
+    return AutoPassReport(
+        ok=ok,
+        decision="auto-pass" if ok else "human-review-required",
+        confidence=confidence,
+        surface=surface,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        evidence=tuple(_dedupe_preserve_order(evidence)),
+        next_safe_command=next_safe,
+    )
+
+
+def _auto_pass_profile_blockers(*, profile: str, files: Sequence[str], surfaces: set[str]) -> list[str]:
+    if profile == "standard":
+        return []
+    blockers: list[str] = []
+    if profile == "docs-only-strict":
+        if surfaces != {"docs-only"}:
+            blockers.append("docs-only-strict requires only docs-only surface")
+        if any(not (path.startswith("docs/") and path.endswith(".md")) for path in files):
+            blockers.append("docs-only-strict requires every changed file to be a docs/*.md file")
+    elif profile == "ci-only-strict":
+        if surfaces != {"ci-validation"}:
+            blockers.append("ci-only-strict requires only ci-validation surface")
+        if any(
+            not (
+                path.startswith(".github/workflows/")
+                or path.startswith(".claude/")
+                or path.startswith("scripts/claude-hooks/")
+                or path in {"Makefile", ".gitignore", "scripts/_governance.py"}
+            )
+            for path in files
+        ):
+            blockers.append("ci-only-strict allows only workflow, Claude hook/command, Makefile, .gitignore, or governance helper files")
+    elif profile == "agent-loop-tooling-strict":
+        allowed_prefixes = (
+            "scripts/agent_loop",
+            "tests/test_agent_loop",
+            ".github/workflows/agent-loop-artifacts.yml",
+            ".claude/commands/agent-loop",
+            "scripts/claude-hooks/stop-agent-loop.sh",
+        )
+        allowed_names = {"Makefile", ".gitignore", "scripts/_governance.py", "tests/test_hook_telemetry.py"}
+        if any(not (path in allowed_names or path.startswith(allowed_prefixes)) for path in files):
+            blockers.append("agent-loop-tooling-strict allows only agent-loop CLI, tests, workflow, Claude command/hook, Makefile, .gitignore, or governance helper files")
+        if surfaces - {"ci-validation"}:
+            blockers.append("agent-loop-tooling-strict requires ci-validation surface only")
+    return blockers
+
+
+def render_auto_pass_report(report: AutoPassReport) -> str:
+    lines = [
+        "# Agent Loop Auto-Pass Check",
+        "",
+        f"- Decision: `{report.decision}`",
+        f"- Confidence: `{report.confidence}`",
+        f"- Surface: `{report.surface.surface}`",
+        f"- Surface confidence: `{report.surface.confidence}`",
+        "- This check does not push, create/merge/close PRs, delete branches, force-push, run private eval, or approve shipping.",
+        "",
+        "## Blockers",
+        "",
+    ]
+    if report.blockers:
+        lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.blockers)
+    else:
+        lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    if report.warnings:
+        lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.warnings)
+    else:
+        lines.append("- None")
+    lines.extend(["", "## Evidence", ""])
+    if report.evidence:
+        lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.evidence)
+    else:
+        lines.append("- None")
+    lines.extend(
+        [
+            "",
+            "## Matched Files",
+            "",
+        ]
+    )
+    if report.surface.matched_files:
+        lines.extend(f"- `{_display_path(path)}`" for path in report.surface.matched_files)
+    else:
+        lines.append("- `N/A`")
+    lines.extend(
+        [
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            _sanitize_command_text(report.next_safe_command),
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines))
+
+
+def write_dashboard(
+    *,
+    task_id: str | None = None,
+    batch: Path | None = None,
+    review_followups: Path | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_DASHBOARD,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    state = build_loop_state(
+        task_id=task_id,
+        batch=batch,
+        review_followups=review_followups,
+        changed_files=changed_files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    rendered = render_dashboard(state, repo_root=repo_root)
+    if out == DEFAULT_DASHBOARD:
+        out = repo_root / "reports" / "agent_loop" / "dashboard.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_dashboard(state: dict[str, object], *, repo_root: Path = ROOT_DIR) -> str:
+    gate = state.get("gate") if isinstance(state.get("gate"), dict) else {}
+    surface = state.get("surface") if isinstance(state.get("surface"), dict) else {}
+    task = state.get("task") if isinstance(state.get("task"), dict) else None
+    artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
+    freshness = state.get("freshness") if isinstance(state.get("freshness"), list) else []
+    manifest = state.get("manifest") if isinstance(state.get("manifest"), dict) else {}
+    validation = state.get("validation_suggestions") if isinstance(state.get("validation_suggestions"), list) else []
+    lines = [
+        "# Agent Loop Dashboard",
+        "",
+        "- This dashboard is generated from local agent-loop state.",
+        "- It does not push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.",
+        "",
+        "## Current Gate",
+        "",
+        f"- Gate: `{gate.get('gate', 'unknown')}`",
+        f"- Severity: `{gate.get('severity', 'unknown')}`",
+        f"- Surface: `{surface.get('surface', 'unknown')}`",
+        f"- Surface confidence: `{surface.get('confidence', 'unknown')}`",
+        f"- Reviewer: `{surface.get('reviewer_type', 'unknown')}`",
+        f"- PR: `{state.get('pr') or 'N/A'}`",
+    ]
+    if task:
+        lines.extend(
+            [
+                f"- Task: `{task.get('id')}` - {_sanitize_dynamic_text(str(task.get('title', '')))}",
+                f"- Handoff: `{'pass' if task.get('handoff_ok') else 'fail'}`",
+            ]
+        )
+    else:
+        lines.append("- Task: `N/A`")
+    lines.extend(["", "## Signals", ""])
+    signals = gate.get("signals") if isinstance(gate.get("signals"), (list, tuple)) else []
+    if signals:
+        lines.extend(f"- {_sanitize_dynamic_text(str(item))}" for item in signals)
+    else:
+        lines.append("- no concrete loop artifact detected")
+
+    lines.extend(["", "## Artifacts", "", "| Artifact | Exists |", "|---|---:|"])
+    for name, exists in sorted(artifacts.items()):
+        lines.append(f"| `{_display_path(str(name), repo_root=repo_root)}` | `{bool(exists)}` |")
+
+    stale = [item for item in freshness if isinstance(item, dict) and item.get("stale")]
+    lines.extend(["", "## Freshness", ""])
+    if stale:
+        lines.append(f"- Stale local artifact count: `{len(stale)}`")
+        lines.append("- Next safe command:")
+        lines.extend(["", "```bash", "python3 scripts/agent_loop.py stale-reports", "```"])
+    else:
+        lines.append("- No stale local artifact detected by the 7-day report threshold.")
+    lines.append(f"- Manifest current: `{bool(manifest.get('current', False))}` ({_sanitize_inline_text(str(manifest.get('reason', 'not checked')))})")
+
+    lines.extend(["", "## Suggested Validation", ""])
+    if validation:
+        lines.extend(f"{index}. {_sanitize_command_text(str(command))}" for index, command in enumerate(validation, start=1))
+    else:
+        lines.append("- N/A")
+
+    next_safe = str(gate.get("next_safe_command", "python3 scripts/agent_loop.py map"))
+    lines.extend(
+        [
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            _sanitize_command_text(next_safe),
+            "```",
+            "",
+            "## Loop",
+            "",
+            "```mermaid",
+            "flowchart LR",
+            "  status[\"status\"] --> gate[\"gate-status\"] --> audit[\"claim/privacy/auto-pass\"] --> handoff[\"handoff-check\"] --> review[\"review\"]",
+            "  review --> state[\"loop-state\"] --> status",
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines))
+
+
+def render_mcp_client_config(*, repo_root: Path = ROOT_DIR) -> str:
+    return """# Agent Loop MCP Client Config Samples
+
+Use placeholders instead of personal absolute paths when committing or sharing.
+
+## Claude Desktop / Claude Code style
+
+```json
+{
+  "mcpServers": {
+    "bidmate-agent-loop": {
+      "command": "python3",
+      "args": ["<REPO_ROOT>/scripts/agent_loop_mcp.py"],
+      "cwd": "<REPO_ROOT>"
+    }
+  }
+}
+```
+
+## Cursor / generic MCP client
+
+```json
+{
+  "bidmate-agent-loop": {
+    "command": "python3",
+    "args": ["<REPO_ROOT>/scripts/agent_loop_mcp.py"],
+    "env": {}
+  }
+}
+```
+
+## Smoke Test
+
+```bash
+printf '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}\\n' \\
+  | python3 scripts/agent_loop_mcp.py
+```
+
+Safety boundary:
+- Tools are read/report centered by default.
+- `write` defaults to `false` for MCP tools.
+- Exposed tools do not push, create/merge/close PRs, delete branches,
+  force-push, run private real-eval, or call external model APIs.
+""".rstrip() + "\n"
+
+
+def write_mcp_client_config(
+    *,
+    out: Path = DEFAULT_MCP_CLIENT_CONFIG,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_mcp_client_config(repo_root=repo_root)
+    if out == DEFAULT_MCP_CLIENT_CONFIG:
+        out = repo_root / "reports" / "agent_loop" / "mcp_client_config.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def write_review_ingest(
+    *,
+    reviews: Sequence[Path] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_REVIEW_INGEST,
+    followup_out: Path = DEFAULT_REVIEW_FOLLOWUPS,
+    tasks_dir: Path = DEFAULT_REVIEW_FOLLOWUPS_DIR,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path, Path, int, str]:
+    findings: list[ReviewFinding] = []
+    source_lines: list[str] = []
+    for review in reviews:
+        path = _resolve_input_path(review, repo_root=repo_root)
+        if not path.exists():
+            raise ValueError(f"review file not found: {_display_path(str(review), repo_root=repo_root)}")
+        text = _read_text(path)
+        parsed = parse_review_findings(text) or _extract_loose_review_findings(text)
+        findings.extend(parsed)
+        source_lines.append(f"- file: `{_display_path(_repo_path(path, repo_root), repo_root=repo_root)}` ({len(parsed)} finding(s))")
+    if pr:
+        pr_text = _review_text_from_pr(pr, repo_root=repo_root)
+        parsed = parse_review_findings(pr_text) or _extract_loose_review_findings(pr_text)
+        findings.extend(parsed)
+        source_lines.append(f"- PR: `{_validate_pr_selector(pr)}` ({len(parsed)} finding(s))")
+    if not reviews and not pr:
+        raise ValueError("review-ingest requires --review or --pr")
+
+    if out == DEFAULT_REVIEW_INGEST:
+        out = repo_root / "reports" / "agent_loop" / "review_ingest.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    rendered = _render_review_ingest(findings, source_lines=source_lines)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    followup_path, followup_dir, count, _ = write_review_followups(
+        review=safe_out,
+        out=followup_out,
+        tasks_dir=tasks_dir,
+        repo_root=repo_root,
+    )
+    return safe_out, followup_path, followup_dir, count, rendered
+
+
+def _render_review_ingest(findings: Sequence[ReviewFinding], *, source_lines: Sequence[str]) -> str:
+    lines = [
+        "# Review Ingest",
+        "",
+        "- This local artifact normalizes reviewer output into the `review-followup` finding format.",
+        "- It does not auto-fix, push, create/merge/close PRs, delete branches, or force-push.",
+        "",
+        "## Sources",
+        "",
+    ]
+    lines.extend(source_lines or ["- N/A"])
+    lines.extend(["", "## Findings", ""])
+    if not findings:
+        lines.append("- No actionable findings parsed. Review manually if the source format is unusual.")
+    for finding in findings:
+        lines.append(f"- [{finding.severity}] {finding.target} - {finding.summary}")
+    return _sanitize_dynamic_text("\n".join(lines)) + "\n"
+
+
+def _review_text_from_pr(pr: str, *, repo_root: Path) -> str:
+    safe_pr = _validate_pr_selector(pr)
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", safe_pr, "--json", "reviews,comments,reviewDecision"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(f"could not read review state from PR {safe_pr}") from exc
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError("gh pr view did not return valid JSON") from exc
+    blocks: list[str] = ["## Findings"]
+    for key in ("reviews", "comments"):
+        items = payload.get(key) if isinstance(payload, dict) else None
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            body = item.get("body") or ""
+            if body:
+                blocks.append(_sanitize_dynamic_text(str(body)))
+    return "\n\n".join(blocks)
+
+
+def _extract_loose_review_findings(text: str) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    for raw in _sanitize_dynamic_text(text).splitlines():
+        line = raw.strip().lstrip("-* ").strip()
+        if not line:
+            continue
+        lowered = line.lower()
+        if not any(token in lowered for token in ("blocking", "p0", "p1", "p2", "bug", "privacy", "benchmark", "unsafe", "missing")):
+            continue
+        severity = "blocking" if any(token in lowered for token in ("blocking", "p0", "p1", "privacy", "unsafe")) else "non-blocking"
+        target = "N/A"
+        match = re.search(r"(?P<target>(?:[\w.-]+/)*[\w.-]+\.\w+:\d+)", line)
+        if match:
+            target = _display_path(match.group("target"))
+        findings.append(
+            ReviewFinding(
+                severity=severity,
+                target=target,
+                summary=_sanitize_inline_text(line),
+                reviewer_mode=_reviewer_mode_for_finding(severity, line),
+            )
+        )
+    return findings
+
+
+def write_pr_health(
+    *,
+    pr_json: Path = DEFAULT_PR_STATE,
+    out: Path = DEFAULT_PR_HEALTH,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    path = _resolve_input_path(pr_json, repo_root=repo_root)
+    if not path.exists():
+        raise ValueError("PR state JSON not found; run pr-scan first or pass --pr-json")
+    try:
+        payload = json.loads(_read_text(path))
+    except json.JSONDecodeError as exc:
+        raise ValueError("PR state JSON must be valid JSON") from exc
+    if not isinstance(payload, list):
+        raise ValueError("PR state JSON must be an array")
+    rendered = render_pr_health([item for item in payload if isinstance(item, dict)])
+    if out == DEFAULT_PR_HEALTH:
+        out = repo_root / "reports" / "agent_loop" / "pr_health.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_pr_health(items: Sequence[dict[str, object]]) -> str:
+    lanes: dict[str, list[str]] = {
+        "ci-failing": [],
+        "review-required": [],
+        "draft": [],
+        "blocked-or-dirty": [],
+        "stale": [],
+        "ready-ish": [],
+    }
+    for item in items:
+        number = str(item.get("number") or "N/A")
+        title = _sanitize_inline_text(str(item.get("title") or "Untitled PR"))
+        label = f"#{number} {title}"
+        if item.get("isDraft") is True:
+            lanes["draft"].append(label)
+        review = str(item.get("reviewDecision") or "").upper()
+        if review in {"REVIEW_REQUIRED", "CHANGES_REQUESTED"}:
+            lanes["review-required"].append(label)
+        merge_state = str(item.get("mergeStateStatus") or "").upper()
+        if merge_state and merge_state not in {"CLEAN", "HAS_HOOKS"}:
+            lanes["blocked-or-dirty"].append(f"{label} (`{merge_state}`)")
+        if _has_failing_check(item.get("statusCheckRollup")):
+            lanes["ci-failing"].append(label)
+        if _is_stale_pr(item.get("updatedAt")):
+            lanes["stale"].append(label)
+        if not any(label in entry for lane in ("ci-failing", "review-required", "draft", "blocked-or-dirty") for entry in lanes[lane]):
+            lanes["ready-ish"].append(label)
+
+    lines = [
+        "# PR Health",
+        "",
+        "- Read-only analysis of exported PR state.",
+        "- It does not push, create/merge/close PRs, delete branches, or force-push.",
+        "",
+    ]
+    for lane, entries in lanes.items():
+        lines.extend([f"## {lane}", ""])
+        if entries:
+            lines.extend(f"- {_sanitize_dynamic_text(entry)}" for entry in entries)
+        else:
+            lines.append("- None")
+        lines.append("")
+    lines.extend(
+        [
+            "## Next Recommendation",
+            "",
+            _pr_health_next_command(lanes),
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines))
+
+
+def _has_failing_check(value: object) -> bool:
+    if not isinstance(value, list):
+        return False
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        conclusion = str(item.get("conclusion") or item.get("state") or "").upper()
+        status = str(item.get("status") or "").upper()
+        if conclusion in {"FAILURE", "ERROR", "CANCELLED", "ACTION_REQUIRED"} or status in {"FAILURE", "ERROR"}:
+            return True
+    return False
+
+
+def _is_stale_pr(value: object, *, days: int = 14) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return (datetime.now(timezone.utc) - parsed).days >= days
+
+
+def _pr_health_next_command(lanes: dict[str, list[str]]) -> str:
+    if lanes["ci-failing"]:
+        return "```bash\npython3 scripts/agent_loop.py pr-health\n```"
+    if lanes["review-required"]:
+        return "```bash\npython3 scripts/agent_loop.py review-ingest --pr <PR_NUMBER>\n```"
+    if lanes["blocked-or-dirty"]:
+        return "```bash\npython3 scripts/agent_loop.py decision-brief --gate ship --pr <PR_NUMBER>\n```"
+    return "```bash\npython3 scripts/agent_loop.py batch-plan\n```"
+
+
+SAFE_FIX_SUFFIXES = {".py", ".md", ".txt", ".json", ".jsonl", ".yaml", ".yml", ".toml", ".sh"}
+SAFE_FIX_NAMES = {"Makefile", ".gitignore"}
+
+
+def write_safe_fix(
+    *,
+    changed_files: Sequence[str],
+    apply: bool = False,
+    out: Path = DEFAULT_SAFE_FIX,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, SafeFixReport, str]:
+    report = build_safe_fix_report(changed_files=changed_files, apply=apply, repo_root=repo_root)
+    rendered = render_safe_fix_report(report)
+    if out == DEFAULT_SAFE_FIX:
+        out = repo_root / "reports" / "agent_loop" / "safe_fix.md"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, report, rendered
+
+
+def build_safe_fix_report(
+    *,
+    changed_files: Sequence[str],
+    apply: bool,
+    repo_root: Path,
+) -> SafeFixReport:
+    changes: list[SafeFixChange] = []
+    skipped: list[str] = []
+    for raw in changed_files:
+        rel = _normalize_changed_file(raw, repo_root=repo_root)
+        if not rel or rel == "[redacted-local-path]":
+            skipped.append("unusable path")
+            continue
+        if _privacy_sensitive_path(rel):
+            skipped.append(f"{_display_path(rel)}: privacy-sensitive path")
+            continue
+        path = repo_root / rel
+        if not path.is_file():
+            skipped.append(f"{_display_path(rel)}: not a file")
+            continue
+        if path.name not in SAFE_FIX_NAMES and path.suffix.lower() not in SAFE_FIX_SUFFIXES:
+            skipped.append(f"{_display_path(rel)}: unsupported suffix")
+            continue
+        try:
+            original = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            skipped.append(f"{_display_path(rel)}: not utf-8 text")
+            continue
+        fixed = _fix_text_whitespace(original)
+        if fixed == original:
+            continue
+        if apply:
+            path.write_text(fixed, encoding="utf-8")
+        action = "applied whitespace normalization" if apply else "would normalize whitespace"
+        changes.append(SafeFixChange(path=_display_path(rel), action=action))
+    return SafeFixReport(
+        applied=apply,
+        changes=tuple(changes),
+        skipped=tuple(_dedupe_preserve_order(skipped)),
+    )
+
+
+def _fix_text_whitespace(text: str) -> str:
+    lines = [line.rstrip(" \t") for line in text.splitlines()]
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def render_safe_fix_report(report: SafeFixReport) -> str:
+    lines = [
+        "# Safe Local Auto-Fix",
+        "",
+        f"- Mode: `{'apply' if report.applied else 'dry-run'}`",
+        "- Scope: trailing whitespace and final newline only for allowlisted public-safe text files.",
+        "- This command does not run formatters, change product behavior, push, create/merge/close PRs, delete branches, or force-push.",
+        "",
+        "## Changes",
+        "",
+    ]
+    if report.changes:
+        lines.extend(f"- `{item.path}`: {item.action}" for item in report.changes)
+    else:
+        lines.append("- None")
+    lines.extend(["", "## Skipped", ""])
+    if report.skipped:
+        lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.skipped)
+    else:
+        lines.append("- None")
+    return _sanitize_dynamic_text("\n".join(lines)) + "\n"
+
+
+def _default_output(out: Path, default: Path, filename: str, *, repo_root: Path) -> Path:
+    return repo_root / "reports" / "agent_loop" / filename if out == default else out
+
+
+def write_approval_packet(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    claim_text: Path | None = None,
+    run_validation: bool = False,
+    out: Path = DEFAULT_APPROVAL_PACKET,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    files = sorted(_normalize_changed_file(path, repo_root=repo_root) for path in changed_files if path)
+    surface = classify_changed_files(files)
+    gate = build_gate_status(
+        task_id=task_id,
+        batch=None,
+        review_followups=None,
+        changed_files=files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    auto_pass = build_auto_pass_report(
+        task_id=task_id,
+        changed_files=files,
+        claim_text=claim_text,
+        run_validation=run_validation,
+        strict=False,
+        repo_root=repo_root,
+    )
+    claim_findings: list[ClaimFinding] = []
+    claim_source = "N/A"
+    if claim_text is not None:
+        resolved = _resolve_input_path(claim_text, repo_root=repo_root)
+        if resolved.exists():
+            claim_source = _display_path(_repo_path(resolved, repo_root), repo_root=repo_root)
+            claim_findings = audit_claim_text(_read_text(resolved), surface)
+    privacy_findings = audit_privacy_output(
+        repo_root / "reports" / "agent_loop",
+        out_path=_default_output(out, DEFAULT_APPROVAL_PACKET, "approval_packet.md", repo_root=repo_root),
+        repo_root=repo_root,
+    )
+    rendered = render_approval_packet(
+        task_id=task_id,
+        changed_files=files,
+        pr=pr,
+        surface=surface,
+        gate=gate,
+        auto_pass=auto_pass,
+        claim_findings=claim_findings,
+        claim_source=claim_source,
+        privacy_findings=privacy_findings,
+    )
+    out = _default_output(out, DEFAULT_APPROVAL_PACKET, "approval_packet.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_approval_packet(
+    *,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    surface: SurfaceReport,
+    gate: dict[str, object],
+    auto_pass: AutoPassReport,
+    claim_findings: Sequence[ClaimFinding],
+    claim_source: str,
+    privacy_findings: Sequence[PrivacyFinding],
+) -> str:
+    lines = [
+        "# Agent Loop PR Approval Packet",
+        "",
+        "- Purpose: collect the evidence a human should inspect before PR creation or shipping.",
+        "- This packet does not push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.",
+        "",
+        "## Summary",
+        "",
+        f"- Task: `{task_id or 'N/A'}`",
+        f"- PR: `{_validate_pr_selector(pr) if pr else 'N/A'}`",
+        f"- Gate: `{gate.get('gate', 'unknown')}`",
+        f"- Severity: `{gate.get('severity', 'unknown')}`",
+        f"- Auto-pass decision: `{auto_pass.decision}`",
+        f"- Surface: `{surface.surface}`",
+        f"- Surface confidence: `{surface.confidence}`",
+        f"- Required reviewer: `{surface.reviewer_type}`",
+        "",
+        "## Changed Files",
+        "",
+    ]
+    if changed_files:
+        lines.extend(f"- `{_display_path(path)}`" for path in changed_files)
+    else:
+        lines.append("- `N/A`")
+    lines.extend(
+        [
+            "",
+            "## Validation Suggestions",
+            "",
+        ]
+    )
+    lines.extend(f"{index}. {_sanitize_command_text(command)}" for index, command in enumerate(suggest_validation_commands(changed_files), start=1))
+    lines.extend(["", "## Auto-Pass Blockers", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in auto_pass.blockers) if auto_pass.blockers else lines.append("- None")
+    lines.extend(["", "## Claim Audit", ""])
+    lines.append(f"- Source: `{_sanitize_dynamic_text(claim_source)}`")
+    if claim_findings:
+        for finding in claim_findings:
+            lines.append(f"- `{finding.severity}` / `{finding.reviewer}`: {_sanitize_dynamic_text(finding.issue)}")
+    else:
+        lines.append("- No risky claim wording was detected in the provided claim text.")
+    lines.extend(["", "## Privacy Audit", ""])
+    if privacy_findings:
+        for finding in privacy_findings:
+            lines.append(f"- `{finding.path}`: {finding.issue}")
+    else:
+        lines.append("- No private raw values were found in generated agent-loop artifacts.")
+    lines.extend(
+        [
+            "",
+            "## Human Approval Required Before",
+            "",
+            "- Applying queue/plan drafts to tracked docs.",
+            "- Running push, PR create/merge/close, branch delete, or force-push.",
+            "- Making benchmark/performance/private real-eval claims.",
+            "- Choosing architecture tradeoffs.",
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            _sanitize_command_text(str(gate.get("next_safe_command", "python3 scripts/agent_loop.py gate-brief --gate pr-create"))),
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_propose_queue_plan(
+    *,
+    task_brief: Path | None = None,
+    task_id: str = DEFAULT_DRAFT_TASK_ID,
+    queue_draft: Path = DEFAULT_QUEUE_DRAFT,
+    plan_draft: Path = DEFAULT_PLAN_DRAFT,
+    out: Path = DEFAULT_QUEUE_PLAN_PATCH,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    if task_brief is not None:
+        draft_task_from_brief(
+            task_brief=task_brief,
+            task_id=task_id,
+            out_queue=queue_draft,
+            out_plan=plan_draft,
+            repo_root=repo_root,
+        )
+    queue_path = _resolve_default_agent_loop_path(queue_draft, "queue_entry_draft.md", repo_root=repo_root)
+    plan_path = _resolve_default_agent_loop_path(plan_draft, "plan_draft.md", repo_root=repo_root)
+    if not queue_path.exists() or not plan_path.exists():
+        raise ValueError("queue/plan drafts not found; run draft-task or pass --task-brief")
+    queue_text = _sanitize_dynamic_text(_read_text(queue_path)).rstrip() + "\n"
+    plan_text = _sanitize_dynamic_text(_read_text(plan_path)).rstrip() + "\n"
+    target_plan = _extract_suggested_plan_path(plan_text)
+    target_queue = repo_root / QUEUE_PATH
+    target_plan_path = repo_root / target_plan
+    rendered = render_queue_plan_patch(
+        queue_before=_read_text(target_queue) if target_queue.exists() else "",
+        queue_after=(_read_text(target_queue).rstrip() + "\n\n" + queue_text) if target_queue.exists() else queue_text,
+        plan_before=_read_text(target_plan_path) if target_plan_path.exists() else "",
+        plan_after=plan_text,
+        target_queue=QUEUE_PATH.as_posix(),
+        target_plan=target_plan.as_posix(),
+    )
+    out = _default_output(out, DEFAULT_QUEUE_PLAN_PATCH, "queue_plan_patch.diff", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_queue_plan_patch(
+    *,
+    queue_before: str,
+    queue_after: str,
+    plan_before: str,
+    plan_after: str,
+    target_queue: str,
+    target_plan: str,
+) -> str:
+    queue_diff = _unified_diff(queue_before, queue_after, fromfile=f"a/{target_queue}", tofile=f"b/{target_queue}")
+    plan_diff = _unified_diff(plan_before, plan_after, fromfile=f"a/{target_plan}", tofile=f"b/{target_plan}")
+    return _sanitize_dynamic_text(
+        "\n".join(
+            [
+                "# Agent-loop queue/plan patch proposal. Dry-run only; do not apply without human approval.",
+                queue_diff,
+                plan_diff,
+                "",
+            ]
+        )
+    )
+
+
+def write_pr_body(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    branch: str | None = None,
+    issue: str | None = None,
+    out: Path = DEFAULT_PR_BODY,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_pr_body(
+        task_id=task_id,
+        changed_files=changed_files,
+        branch=branch,
+        issue=issue,
+        repo_root=repo_root,
+    )
+    out = _default_output(out, DEFAULT_PR_BODY, "pr_body.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_pr_body(
+    *,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    branch: str | None,
+    issue: str | None,
+    repo_root: Path = ROOT_DIR,
+) -> str:
+    task = load_task(task_id, repo_root) if task_id else None
+    files = sorted(_normalize_changed_file(path, repo_root=repo_root) for path in changed_files if path)
+    surface = classify_changed_files(files)
+    branch_name = branch or _current_branch(repo_root) or ""
+    issue_number = issue or _issue_from_branch(branch_name) or ""
+    validation = suggest_validation_commands(files)
+    load_bearing = [path for path in files if path != "[redacted-local-path]" and (is_load_bearing(path) or path.startswith("eval/"))]
+    title = _sanitize_inline_text(task.title) if task else "Agent-loop scoped change"
+    file_block = "\n".join(f"- `{_display_path(path)}`" for path in files) if files else "- N/A"
+    validation_block = "\n".join(f"- Suggested, not yet run: `{_sanitize_command_text(command)}`" for command in validation)
+    five_b = (
+        "Load-bearing or eval surface touched. Human reviewer must verify aggregate-only §5b evidence or a truthful no-behavior-change attestation before PR is marked ready."
+        if load_bearing
+        else "N/A - no load-bearing path detected by changed-file surface; reviewer should still confirm."
+    )
+    text = f"""## 1. 무엇을 왜 바꿨는가
+
+{title}
+
+Closes #{issue_number or '<ISSUE_NUMBER>'}
+
+## 2. 영향 파일
+
+{file_block}
+
+- Surface: `{surface.surface}`
+- Additional surfaces: `{', '.join(surface.additional_surfaces) if surface.additional_surfaces else 'N/A'}`
+- Required reviewer: `{surface.reviewer_type}`
+
+## 3. 리스크
+
+- Human-gated decisions remain outside this CLI: push, PR create/merge/close, branch delete, force-push, private real-eval decisions, benchmark/performance claims, and architecture tradeoffs.
+- Disallowed claims to avoid:
+{chr(10).join(f'  - {claim}' for claim in surface.disallowed_claims)}
+
+## 4. 테스트
+
+{validation_block}
+
+## 5. Eval 영향
+
+- Surface classification: `{surface.surface}`
+- Claim boundary: suggestions only; no benchmark/performance/private real-eval claim is made by this draft.
+
+### 5b. Real-data delta
+
+{five_b}
+
+## 6. 하위 호환
+
+N/A - this draft must be reviewed against the actual implementation diff before PR creation.
+
+## 7. 범위 외
+
+- Auto-push, PR creation/merge/close, branch deletion, force-push.
+- Private raw question/answer/evidence/doc_id/chunk_id/filename/local path exposure.
+"""
+    return _sanitize_dynamic_text(text).rstrip() + "\n"
+
+
+def _issue_from_branch(branch: str) -> str | None:
+    match = re.search(r"(?:^|/)issue-(\d+)(?:-|$)", branch)
+    return match.group(1) if match else None
+
+
+def _current_branch(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def _current_git_head(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def write_review_plan(
+    *,
+    reviews: Sequence[Path] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_REVIEW_PLAN,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    findings, sources = _collect_review_findings(reviews=reviews, pr=pr, repo_root=repo_root)
+    rendered = render_review_plan(findings, sources=sources)
+    out = _default_output(out, DEFAULT_REVIEW_PLAN, "review_plan.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def _collect_review_findings(
+    *,
+    reviews: Sequence[Path],
+    pr: str | None,
+    repo_root: Path,
+) -> tuple[list[ReviewFinding], list[str]]:
+    findings: list[ReviewFinding] = []
+    sources: list[str] = []
+    for review in reviews:
+        path = _resolve_input_path(review, repo_root=repo_root)
+        if not path.exists():
+            raise ValueError(f"review file not found: {_display_path(str(review), repo_root=repo_root)}")
+        text = _read_text(path)
+        parsed = parse_review_findings(text) or _extract_loose_review_findings(text)
+        findings.extend(parsed)
+        sources.append(f"file `{_display_path(_repo_path(path, repo_root), repo_root=repo_root)}`")
+    if pr:
+        text = _review_text_from_pr(pr, repo_root=repo_root)
+        parsed = parse_review_findings(text) or _extract_loose_review_findings(text)
+        findings.extend(parsed)
+        sources.append(f"PR `{_validate_pr_selector(pr)}`")
+    if not reviews and not pr:
+        raise ValueError("review-plan requires --review or --pr")
+    return findings, sources
+
+
+def render_review_plan(findings: Sequence[ReviewFinding], *, sources: Sequence[str]) -> str:
+    lanes = {"must-fix": 0, "should-fix": 0, "needs-human-decision": 0, "safe-local-fix-candidate": 0}
+    lines = [
+        "# Review Plan",
+        "",
+        "- This is a triage artifact. It does not auto-fix, push, create/merge/close PRs, delete branches, or force-push.",
+        "- Privacy, benchmark, and architecture findings stay human-gated.",
+        "",
+        "## Sources",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(source)}" for source in sources)
+    lines.extend(["", "## Findings", ""])
+    if not findings:
+        lines.append("- No actionable findings parsed. Review manually if the source format is unusual.")
+    for finding in findings:
+        lane = _review_plan_lane(finding)
+        lanes[lane] += 1
+        lines.extend(
+            [
+                f"### {finding.summary}",
+                "",
+                f"- Lane: `{lane}`",
+                f"- Severity: `{finding.severity}`",
+                f"- Target: `{finding.target}`",
+                f"- Reviewer mode: `{finding.reviewer_mode}`",
+                f"- Suggested validation: `{_sanitize_command_text(_validation_for_finding(finding))}`",
+                "",
+            ]
+        )
+    lines.extend(["## Lane Summary", "", "| Lane | Count |", "|---|---:|"])
+    for lane, count in lanes.items():
+        lines.append(f"| `{lane}` | {count} |")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def _review_plan_lane(finding: ReviewFinding) -> str:
+    if finding.reviewer_mode in {"Privacy Auditor", "Benchmark Auditor", "Deep Reviewer"}:
+        return "needs-human-decision"
+    target = finding.target.split(":", 1)[0]
+    if target.endswith((".py", ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".sh")) and not _privacy_sensitive_path(target):
+        if finding.severity in {"non-blocking", "p2", "p3", "nit"}:
+            return "safe-local-fix-candidate"
+    if finding.severity in {"blocking", "p0", "p1"}:
+        return "must-fix"
+    return "should-fix"
+
+
+def write_stale_reports(
+    *,
+    changed_files: Sequence[str] = (),
+    max_age_days: int = 7,
+    apply: bool = False,
+    out: Path = DEFAULT_STALE_REPORTS,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    out = _default_output(out, DEFAULT_STALE_REPORTS, "stale_reports.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    artifacts = _report_freshness(repo_root=repo_root, max_age_days=max_age_days, out_path=safe_out)
+    deleted: list[str] = []
+    if apply:
+        for item in artifacts:
+            if item["stale"] and item["path"] != _display_path(_repo_path(safe_out, repo_root), repo_root=repo_root):
+                target = repo_root / str(item["path"])
+                if target.is_file():
+                    target.unlink()
+                    deleted.append(str(item["path"]))
+    rendered = render_stale_reports(
+        artifacts,
+        max_age_days=max_age_days,
+        apply=apply,
+        deleted=deleted,
+        manifest=_manifest_freshness(changed_files=changed_files, repo_root=repo_root),
+    )
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def _report_freshness(*, repo_root: Path, max_age_days: int = 7, out_path: Path | None = None) -> list[dict[str, object]]:
+    report_dir = repo_root / "reports" / "agent_loop"
+    if not report_dir.exists():
+        return []
+    now = datetime.now(timezone.utc)
+    artifacts: list[dict[str, object]] = []
+    for path in sorted(report_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        age_days = max(0.0, (now - datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)).total_seconds() / 86400)
+        rel = _display_path(_repo_path(path, repo_root), repo_root=repo_root)
+        artifacts.append(
+            {
+                "path": rel,
+                "age_days": round(age_days, 2),
+                "stale": age_days > max_age_days,
+                "current_output": bool(out_path and path.resolve() == out_path.resolve()),
+            }
+        )
+    return artifacts
+
+
+def render_stale_reports(
+    artifacts: Sequence[dict[str, object]],
+    *,
+    max_age_days: int,
+    apply: bool,
+    deleted: Sequence[str],
+    manifest: dict[str, object] | None = None,
+) -> str:
+    stale_count = sum(1 for item in artifacts if item.get("stale"))
+    lines = [
+        "# Agent Loop Stale Report Artifacts",
+        "",
+        f"- Mode: `{'apply' if apply else 'dry-run'}`",
+        f"- Stale threshold days: `{max_age_days}`",
+        f"- Stale artifact count: `{stale_count}`",
+        "- This command is limited to ignored `reports/agent_loop/` artifacts.",
+        "",
+        "## Manifest Freshness",
+        "",
+        f"- Exists: `{bool((manifest or {}).get('exists', False))}`",
+        f"- Current: `{bool((manifest or {}).get('current', False))}`",
+        f"- Reason: `{_sanitize_inline_text(str((manifest or {}).get('reason', 'not checked')))}`",
+        "",
+        "## Artifacts",
+        "",
+        "| Artifact | Age days | Stale |",
+        "|---|---:|---:|",
+    ]
+    if artifacts:
+        for item in artifacts:
+            lines.append(f"| `{item['path']}` | `{item['age_days']}` | `{bool(item['stale'])}` |")
+    else:
+        lines.append("| `N/A` | `0` | `False` |")
+    lines.extend(["", "## Deleted", ""])
+    if deleted:
+        lines.extend(f"- `{_display_path(path)}`" for path in deleted)
+    else:
+        lines.append("- None")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_context_pack(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    profile: str = "generic",
+    out: Path = DEFAULT_CONTEXT_PACK,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    state = build_loop_state(
+        task_id=task_id,
+        batch=None,
+        review_followups=None,
+        changed_files=changed_files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    rendered = render_context_pack(state, changed_files=changed_files, profile=profile)
+    out = _default_output(out, DEFAULT_CONTEXT_PACK, "context_pack.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_context_pack(state: dict[str, object], *, changed_files: Sequence[str], profile: str = "generic") -> str:
+    if profile not in {"generic", "codex", "claude", "chatgpt"}:
+        raise ValueError("--profile must be one of: generic, codex, claude, chatgpt")
+    surface = state.get("surface") if isinstance(state.get("surface"), dict) else {}
+    gate = state.get("gate") if isinstance(state.get("gate"), dict) else {}
+    task = state.get("task") if isinstance(state.get("task"), dict) else None
+    lines = [
+        "# Cross-Agent Context Pack",
+        "",
+        f"- Profile: `{profile}`",
+        "- Safe to paste into another coding agent only after human review of this redacted summary.",
+        "- Contains no raw diff, private case text, raw question/answer/evidence, doc_id, chunk_id, filename, or exact local path by design.",
+        "",
+        "## Task",
+        "",
+    ]
+    if task:
+        lines.extend(
+            [
+                f"- ID: `{task.get('id')}`",
+                f"- Title: {_sanitize_dynamic_text(str(task.get('title', '')))}",
+                f"- Status: `{task.get('status')}`",
+                f"- Handoff: `{'pass' if task.get('handoff_ok') else 'fail'}`",
+            ]
+        )
+    else:
+        lines.append("- N/A")
+    lines.extend(
+        [
+            "",
+            "## Surface",
+            "",
+            f"- Surface: `{surface.get('surface', 'unknown')}`",
+            f"- Confidence: `{surface.get('confidence', 'unknown')}`",
+            f"- Reviewer: `{surface.get('reviewer_type', 'unknown')}`",
+            "",
+            "## Changed Files",
+            "",
+        ]
+    )
+    lines.extend(f"- `{_display_path(path)}`" for path in changed_files) if changed_files else lines.append("- `N/A`")
+    lines.extend(["", "## Suggested Validation", ""])
+    validation = state.get("validation_suggestions") if isinstance(state.get("validation_suggestions"), list) else []
+    lines.extend(f"- `{_sanitize_command_text(str(command))}`" for command in validation) if validation else lines.append("- N/A")
+    lines.extend(["", "## Profile Notes", ""])
+    if profile == "codex":
+        lines.append("- Focus on file edits, tests, validation, and concise handoff.")
+    elif profile == "claude":
+        lines.append("- Focus on long-session handoff, slash commands, hooks, and allowed-tools boundaries.")
+    elif profile == "chatgpt":
+        lines.append("- Focus on design review, trade-offs, claim wording, and reviewer questions.")
+    else:
+        lines.append("- Generic profile for any coding agent.")
+    lines.extend(
+        [
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            _sanitize_command_text(str(gate.get("next_safe_command", "python3 scripts/agent_loop.py map"))),
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_architecture_brief(
+    *,
+    changed_files: Sequence[str] = (),
+    out: Path = DEFAULT_ARCHITECTURE_BRIEF,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    surface = classify_changed_files(changed_files)
+    rendered = render_architecture_brief(surface=surface, changed_files=changed_files)
+    out = _default_output(out, DEFAULT_ARCHITECTURE_BRIEF, "architecture_brief.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_architecture_brief(*, surface: SurfaceReport, changed_files: Sequence[str]) -> str:
+    load_bearing = [path for path in changed_files if path != "[redacted-local-path]" and is_load_bearing(path)]
+    adr_files = [path for path in changed_files if _normalize_changed_file(path).startswith("docs/adr/")]
+    surfaces = {surface.surface, *surface.additional_surfaces}
+    adr_likely = bool(load_bearing or adr_files or surfaces & {"product-runtime", "eval-harness", "public-synthetic-benchmark", "private-real-eval"})
+    lines = [
+        "# Architecture Decision Brief",
+        "",
+        "- This brief explains trade-offs. It does not choose architecture, write ADRs, push, or create PRs.",
+        "",
+        "## Signals",
+        "",
+        f"- Surface: `{surface.surface}`",
+        f"- ADR likely: `{'yes' if adr_likely else 'no'}`",
+        f"- Load-bearing files: `{len(load_bearing)}`",
+        f"- ADR files: `{len(adr_files)}`",
+        "",
+        "## Files",
+        "",
+    ]
+    lines.extend(f"- `{_display_path(path)}`" for path in changed_files) if changed_files else lines.append("- `N/A`")
+    lines.extend(
+        [
+            "",
+            "## Options",
+            "",
+            "### 1. Keep the change local and reversible (recommended default)",
+            "",
+            "- Severity: `low`",
+            "- Reversibility: `high`",
+            "- Trade-off: fastest way to preserve momentum while avoiding premature architecture commitment.",
+            "- Evidence needed: focused tests and no contract or eval-surface expansion.",
+            "",
+            "### 2. Proceed with scoped architecture change after human review",
+            "",
+            "- Severity: `high`",
+            "- Reversibility: `medium`",
+            "- Trade-off: can solve the real design issue but may create coupling, migration, or ADR obligations.",
+            "- Evidence needed: alternatives, compatibility, tests, and reviewer agreement.",
+            "",
+            "### 3. Reserve or update an ADR",
+            "",
+            "- Severity: `high`",
+            "- Reversibility: `low` once accepted",
+            "- Trade-off: records the decision but adds governance weight and should not be used for minor implementation detail.",
+            "- Evidence needed: load-bearing decision, rejected alternatives, consequences, and validation plan.",
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            "python3 scripts/agent_loop.py gate-brief --gate architecture --from-git",
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_ship_simulation(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    branch: str | None = None,
+    out: Path = DEFAULT_SHIP_SIMULATION,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_ship_simulation(
+        task_id=task_id,
+        changed_files=changed_files,
+        pr=pr,
+        branch=branch,
+        repo_root=repo_root,
+    )
+    out = _default_output(out, DEFAULT_SHIP_SIMULATION, "ship_simulation.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_ship_simulation(
+    *,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    branch: str | None,
+    repo_root: Path,
+) -> str:
+    surface = classify_changed_files(changed_files)
+    branch_name = branch or _current_branch(repo_root) or "unknown"
+    issue_number = _issue_from_branch(branch_name)
+    blockers: list[str] = []
+    if not issue_number:
+        blockers.append("branch does not expose an ADR 0007 issue number")
+    if surface.confidence != "high":
+        blockers.append(f"surface confidence is {surface.confidence}")
+    if {surface.surface, *surface.additional_surfaces} & {"private-real-eval", "privacy-sensitive-artifact", "benchmark-reporting"}:
+        blockers.append("claim/privacy/eval surface requires human review")
+    if task_id:
+        handoff = check_handoff(task_id, changed_files=changed_files, repo_root=repo_root)
+        if not handoff.ok:
+            blockers.append("handoff-check is missing or has weak evidence")
+    else:
+        blockers.append("no task id provided for handoff-check")
+    stop_before = "gh pr create" if not pr else "gh pr merge / gh pr close / branch delete"
+    lines = [
+        "# Auto-Ship Readiness Simulation",
+        "",
+        "- Simulation only. This command does not push, create/merge/close PRs, delete branches, or force-push.",
+        "",
+        "## Inputs",
+        "",
+        f"- Task: `{task_id or 'N/A'}`",
+        f"- PR: `{_validate_pr_selector(pr) if pr else 'N/A'}`",
+        f"- Branch: `{_sanitize_inline_text(branch_name)}`",
+        f"- Issue from branch: `{issue_number or 'N/A'}`",
+        f"- Git HEAD: `{_current_git_head(repo_root) or 'unknown'}`",
+        f"- Surface: `{surface.surface}`",
+        "",
+        "## Simulated Stop",
+        "",
+        f"- Would stop before: `{stop_before}`",
+        "",
+        "## Blockers",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in blockers) if blockers else lines.append("- None detected by local simulation.")
+    lines.extend(["", "## Suggested Validation", ""])
+    lines.extend(f"- `{_sanitize_command_text(command)}`" for command in suggest_validation_commands(changed_files))
+    lines.extend(
+        [
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            "python3 scripts/agent_loop.py approval-packet --from-git",
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_auto_ship_plan(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    branch: str | None = None,
+    ttl: str = "2h",
+    real_eval: str | None = None,
+    draft: bool = False,
+    dry_run: bool = False,
+    out: Path = DEFAULT_AUTO_SHIP_PLAN,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, AutoShipPlan, str]:
+    plan = build_auto_ship_plan(
+        task_id=task_id,
+        changed_files=changed_files,
+        pr=pr,
+        branch=branch,
+        ttl=ttl,
+        real_eval=real_eval,
+        draft=draft,
+        dry_run=dry_run,
+        repo_root=repo_root,
+    )
+    rendered = render_auto_ship_plan(plan, task_id=task_id, changed_files=changed_files, pr=pr, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_AUTO_SHIP_PLAN, "auto_ship_plan.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, plan, rendered
+
+
+def build_auto_ship_plan(
+    *,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    branch: str | None,
+    ttl: str,
+    real_eval: str | None,
+    draft: bool,
+    dry_run: bool,
+    repo_root: Path,
+) -> AutoShipPlan:
+    if not re.fullmatch(r"\s*\d+\s*[smhd]\s*", ttl, flags=re.IGNORECASE):
+        raise ValueError("auto-ship ttl must look like 30m, 2h, or 1d")
+    if real_eval is not None and real_eval not in {"auto", "skip", "async"}:
+        raise ValueError("auto-ship real_eval must be auto, skip, or async")
+    files = sorted(
+        {
+            normalized
+            for path in changed_files
+            if (normalized := _normalize_changed_file(path, repo_root=repo_root))
+        }
+    )
+    surface = classify_changed_files(files)
+    branch_name = branch or _current_branch(repo_root) or "unknown"
+    if branch_name != "unknown":
+        branch_name = _validate_branch_name(branch_name, allow_protected=True)
+    issue_number = _issue_from_branch(branch_name)
+    risky_surfaces = {
+        "private-real-eval",
+        "privacy-sensitive-artifact",
+        "benchmark-reporting",
+        "public-synthetic-benchmark",
+        "eval-harness",
+        "product-runtime",
+        "governance-adr",
+    }
+    blockers: list[str] = []
+    warnings: list[str] = []
+    evidence: list[str] = [
+        f"surface={surface.surface}",
+        f"surface confidence={surface.confidence}",
+        f"required reviewer={surface.reviewer_type}",
+        f"changed files={len(files)}",
+    ]
+    if pr:
+        evidence.append(f"PR={_validate_pr_selector(pr)}")
+    if branch_name == "unknown":
+        blockers.append("current branch could not be determined")
+    if branch_name in {"HEAD", "main", "master"} or branch_name.startswith("release/"):
+        blockers.append(f"existing ship-arm refuses protected branch `{branch_name}`")
+    if not issue_number:
+        blockers.append("branch does not expose an ADR 0007 issue number")
+    else:
+        evidence.append(f"issue from branch=#{issue_number}")
+    armed_file = repo_root / ".claude" / ".ship-armed"
+    ship_pr_marker = repo_root / ".claude" / ".ship-pr-active"
+    if armed_file.exists():
+        blockers.append("ship-arm is already armed; run `make ship-status` or `make ship-disarm` before re-arming")
+    if ship_pr_marker.exists():
+        blockers.append("ship-pr mutex marker exists; finish or cancel the ship-pr workflow before arming auto-ship")
+    if not files:
+        warnings.append("no changed files were supplied; use `--from-git` or `--changed-files` for a meaningful plan")
+    if task_id:
+        handoff = check_handoff(task_id, changed_files=files, repo_root=repo_root)
+        if handoff.ok:
+            evidence.append("handoff-check=pass")
+        else:
+            blockers.append("handoff-check is missing or has weak evidence for the provided task")
+    else:
+        warnings.append("no task id supplied; auto-ship can still use issue/branch state, but agent-loop handoff is not checked")
+    surface_set = {surface.surface, *surface.additional_surfaces}
+    if surface.confidence != "high":
+        warnings.append(f"surface confidence is {surface.confidence}; prefer draft or dry-run arming")
+    if surface_set & risky_surfaces:
+        warnings.append("changed-file surface requires reviewer or human claim/eval/architecture decision before ready merge")
+    chosen_real_eval = real_eval or "skip"
+    if real_eval is None:
+        warnings.append("REAL_EVAL defaults to skip in this plan; choose auto/async only after human private-eval decision")
+    chosen_draft = draft or bool(blockers) or surface.confidence != "high" or bool(surface_set & risky_surfaces)
+    dry_run_command = _make_ship_arm_command(ttl=ttl, real_eval="skip", draft=True, dry_run=True)
+    recommended_command = _make_ship_arm_command(
+        ttl=ttl,
+        real_eval=chosen_real_eval,
+        draft=chosen_draft,
+        dry_run=dry_run,
+    )
+    if blockers:
+        decision = "blocked"
+    elif dry_run:
+        decision = "dry-run-first"
+    elif chosen_draft:
+        decision = "arm-draft-auto-ship"
+    else:
+        decision = "arm-ready-auto-ship"
+    human_gates = (
+        "Running `make ship-arm` is a shipping approval: the existing Stop hook may commit, push, create a PR, wait for CI/review, merge, and delete the remote branch when its gates pass.",
+        "Ready auto-merge remains a human shipping decision; use `DRAFT=true` when review or claim risk remains.",
+        "Private real-eval mode and benchmark/performance claim wording require human approval before using `REAL_EVAL=auto` or `REAL_EVAL=async` as evidence.",
+        "Architecture tradeoffs and ADR decisions are not decided by this plan.",
+    )
+    return AutoShipPlan(
+        decision=decision,
+        branch=branch_name,
+        issue=issue_number,
+        surface=surface,
+        recommended_command=recommended_command,
+        dry_run_command=dry_run_command,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        evidence=tuple(_dedupe_preserve_order(evidence)),
+        human_gates=human_gates,
+    )
+
+
+def _make_ship_arm_command(*, ttl: str, real_eval: str, draft: bool, dry_run: bool) -> str:
+    return " ".join(
+        (
+            "make",
+            "ship-arm",
+            f"TTL={shlex.quote(ttl)}",
+            f"REAL_EVAL={shlex.quote(real_eval)}",
+            f"DRAFT={'true' if draft else 'false'}",
+            f"DRY_RUN={1 if dry_run else 0}",
+        )
+    )
+
+
+def render_auto_ship_plan(
+    plan: AutoShipPlan,
+    *,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    repo_root: Path,
+) -> str:
+    lines = [
+        "# Auto-Ship Plan",
+        "",
+        "- Plan only. This command does not arm auto-ship, commit, push, create/merge/close PRs, delete branches, force-push, or run private eval.",
+        "- It bridges the agent-loop reports to the existing `make ship-arm` Stop-hook pipeline.",
+        "",
+        "## Decision",
+        "",
+        f"- Decision: `{plan.decision}`",
+        f"- Task: `{task_id or 'N/A'}`",
+        f"- PR: `{_validate_pr_selector(pr) if pr else 'N/A'}`",
+        f"- Branch: `{_sanitize_inline_text(plan.branch)}`",
+        f"- Issue from branch: `{plan.issue or 'N/A'}`",
+        f"- Surface: `{plan.surface.surface}`",
+        f"- Surface confidence: `{plan.surface.confidence}`",
+        f"- Required reviewer: `{plan.surface.reviewer_type}`",
+        "",
+        "## Existing Auto-Ship Path",
+        "",
+        "- `make ship-arm` writes `.claude/.ship-armed`.",
+        "- The existing Stop hook then runs the repository auto-ship pipeline once and disarms.",
+        "- `DRY_RUN=1` echoes mutating commands to `.claude/.ship-dryrun.log` instead of executing them.",
+        "- `DRAFT=true` creates a draft PR so the review gate stops before ready merge.",
+        "",
+        "## Recommended Command",
+        "",
+        "```bash",
+        _sanitize_command_text(plan.recommended_command),
+        "```",
+        "",
+        "## Dry-Run Rehearsal",
+        "",
+        "```bash",
+        _sanitize_command_text(plan.dry_run_command),
+        "```",
+        "",
+        "## Blockers",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.blockers) if plan.blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.warnings) if plan.warnings else lines.append("- None")
+    lines.extend(["", "## Evidence", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.evidence)
+    if plan.surface.disallowed_claims:
+        lines.extend(["", "## Disallowed Claims", ""])
+        lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.surface.disallowed_claims)
+    lines.extend(["", "## Human Gates", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.human_gates)
+    lines.extend(["", "## Changed Files", ""])
+    normalized_paths: set[str] = set()
+    for raw in changed_files:
+        item = _normalize_changed_file(raw, repo_root=repo_root)
+        if item:
+            normalized_paths.add(item)
+    normalized = [_display_path(path, repo_root=repo_root) for path in sorted(normalized_paths)]
+    lines.extend(f"- `{path}`" for path in normalized) if normalized else lines.append("- None supplied")
+    lines.extend(
+        [
+            "",
+            "## Next Safe Commands",
+            "",
+            "```bash",
+            "python3 scripts/agent_loop.py approval-packet --from-git",
+            "python3 scripts/agent_loop.py readiness-score --from-git",
+            "python3 scripts/agent_loop.py auto-ship-plan --from-git --dry-run",
+            "make ship-status",
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_auto_ship_prepare(
+    *,
+    issue: str | None = None,
+    target_branch: str | None = None,
+    branch_type: str = "chore",
+    slug: str = "agent-loop-auto-ship",
+    create_branch: bool = False,
+    confirm_human_approved: bool = False,
+    ttl: str = "2h",
+    real_eval: str | None = None,
+    draft: bool = True,
+    dry_run: bool = True,
+    out: Path = DEFAULT_AUTO_SHIP_PREPARE,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, AutoShipPrepareReport, str]:
+    report = build_auto_ship_prepare(
+        issue=issue,
+        target_branch=target_branch,
+        branch_type=branch_type,
+        slug=slug,
+        create_branch=create_branch,
+        confirm_human_approved=confirm_human_approved,
+        ttl=ttl,
+        real_eval=real_eval,
+        draft=draft,
+        dry_run=dry_run,
+        repo_root=repo_root,
+    )
+    if create_branch and confirm_human_approved and not report.blockers and report.target_branch:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "switch", "-c", report.target_branch],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        report = AutoShipPrepareReport(
+            result="branch-created" if result.returncode == 0 else "branch-create-failed",
+            current_branch=report.current_branch,
+            target_branch=report.target_branch,
+            branch_command=report.branch_command,
+            ship_arm_command=report.ship_arm_command,
+            blockers=report.blockers if result.returncode == 0 else (*report.blockers, "git switch -c failed"),
+            warnings=report.warnings,
+            evidence=(*report.evidence, f"git switch returncode={result.returncode}"),
+            created=result.returncode == 0,
+            returncode=result.returncode,
+        )
+    rendered = render_auto_ship_prepare(report)
+    out = _default_output(out, DEFAULT_AUTO_SHIP_PREPARE, "auto_ship_prepare.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, report, rendered
+
+
+def build_auto_ship_prepare(
+    *,
+    issue: str | None,
+    target_branch: str | None,
+    branch_type: str,
+    slug: str,
+    create_branch: bool,
+    confirm_human_approved: bool,
+    ttl: str,
+    real_eval: str | None,
+    draft: bool,
+    dry_run: bool,
+    repo_root: Path,
+) -> AutoShipPrepareReport:
+    current = _current_branch(repo_root) or "unknown"
+    blockers: list[str] = []
+    warnings: list[str] = []
+    evidence: list[str] = [f"current branch={current}"]
+    if not re.fullmatch(r"\s*\d+\s*[smhd]\s*", ttl, flags=re.IGNORECASE):
+        raise ValueError("auto-ship ttl must look like 30m, 2h, or 1d")
+    if real_eval is not None and real_eval not in {"auto", "skip", "async"}:
+        raise ValueError("auto-ship real_eval must be auto, skip, or async")
+    if issue is not None and not re.fullmatch(r"\d{1,10}", issue):
+        raise ValueError("issue must be a numeric GitHub issue number")
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", branch_type):
+        raise ValueError("branch type must be a safe branch prefix such as chore, docs, or feat")
+    if target_branch:
+        target = _validate_branch_name(target_branch)
+    elif issue:
+        target = _validate_branch_name(f"{branch_type}/issue-{issue}-{_slugify(slug)}")
+    else:
+        target = None
+    current_issue = _issue_from_branch(current)
+    current_ready = bool(
+        current_issue
+        and current not in {"HEAD", "main", "master"}
+        and not current.startswith("release/")
+    )
+    if current_ready:
+        target = current
+        evidence.append(f"current branch issue=#{current_issue}")
+    else:
+        warnings.append("current branch is not ready for `make ship-arm`; create or switch to an ADR 0007 branch first")
+    if not target:
+        blockers.append("provide --issue <N> or --target-branch <type>/issue-<N>-<slug>")
+    elif not _issue_from_branch(target):
+        blockers.append("target branch must include an ADR 0007 issue number")
+    elif create_branch and _branch_exists(target, repo_root=repo_root):
+        blockers.append(f"target branch already exists: `{target}`")
+    if create_branch and not confirm_human_approved:
+        blockers.append("--confirm-human-approved is required to create a local branch")
+    if (repo_root / ".claude" / ".ship-armed").exists():
+        warnings.append("ship-arm is already armed; disarm before preparing another shipping branch")
+    chosen_real_eval = real_eval or "skip"
+    if real_eval is None:
+        warnings.append("REAL_EVAL defaults to skip; choose auto/async only after human private-eval decision")
+    branch_command = (
+        f"python3 scripts/agent_loop.py auto-ship-prepare --issue {issue or '<ISSUE>'} "
+        f"--type {shlex.quote(branch_type)} --slug {shlex.quote(slug)} "
+        "--create-branch --confirm-human-approved"
+    )
+    if target_branch:
+        branch_command = (
+            f"python3 scripts/agent_loop.py auto-ship-prepare --target-branch {shlex.quote(target_branch)} "
+            "--create-branch --confirm-human-approved"
+        )
+    ship_arm_command = _make_ship_arm_command(ttl=ttl, real_eval=chosen_real_eval, draft=draft, dry_run=dry_run)
+    if blockers:
+        result = "blocked"
+    elif current_ready and not create_branch:
+        result = "ready-for-ship-arm"
+    elif create_branch:
+        result = "ready-to-create-branch"
+    else:
+        result = "needs-branch"
+    if target:
+        evidence.append(f"target branch={target}")
+    return AutoShipPrepareReport(
+        result=result,
+        current_branch=current,
+        target_branch=target,
+        branch_command=branch_command,
+        ship_arm_command=ship_arm_command,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        evidence=tuple(_dedupe_preserve_order(evidence)),
+    )
+
+
+def _branch_exists(branch: str, *, repo_root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def render_auto_ship_prepare(report: AutoShipPrepareReport) -> str:
+    lines = [
+        "# Auto-Ship Prepare",
+        "",
+        "- This command prepares the local branch state for the existing `make ship-arm` pipeline.",
+        "- By default it writes this report only. It creates a local branch only with `--create-branch --confirm-human-approved`.",
+        "- It does not arm auto-ship, commit, push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.",
+        "",
+        "## Result",
+        "",
+        f"- Result: `{report.result}`",
+        f"- Current branch: `{_sanitize_inline_text(report.current_branch)}`",
+        f"- Target branch: `{_sanitize_inline_text(report.target_branch or 'N/A')}`",
+        f"- Branch created: `{report.created}`",
+        f"- Return code: `{report.returncode if report.returncode is not None else 'N/A'}`",
+        "",
+        "## Branch Preparation Command",
+        "",
+        "```bash",
+        _sanitize_command_text(report.branch_command),
+        "```",
+        "",
+        "## Next Ship-Arm Command",
+        "",
+        "```bash",
+        _sanitize_command_text(report.ship_arm_command),
+        "```",
+        "",
+        "## Blockers",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.blockers) if report.blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.warnings) if report.warnings else lines.append("- None")
+    lines.extend(["", "## Evidence", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.evidence)
+    lines.extend(
+        [
+            "",
+            "## Next Safe Commands",
+            "",
+            "```bash",
+            "python3 scripts/agent_loop.py auto-ship-plan --from-git --dry-run",
+            "make ship-status",
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+GATE_BRIEF_CHOICES = {
+    "task",
+    "plan",
+    "review",
+    "claim",
+    "ship",
+    "pr-create",
+    "merge",
+    "close",
+    "branch-delete",
+    "force-push",
+    "private-real-eval",
+    "benchmark-claim",
+    "architecture",
+}
+
+
+def write_gate_brief(
+    *,
+    gate: str,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_GATE_BRIEF,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_gate_brief(
+        gate=gate,
+        task_id=task_id,
+        changed_files=changed_files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    out = _default_output(out, DEFAULT_GATE_BRIEF, "gate_brief.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_gate_brief(
+    *,
+    gate: str,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    repo_root: Path,
+) -> str:
+    if gate not in GATE_BRIEF_CHOICES:
+        raise ValueError("--gate must be one of: " + ", ".join(sorted(GATE_BRIEF_CHOICES)))
+    mapped = {
+        "pr-create": "ship",
+        "merge": "ship",
+        "close": "ship",
+        "branch-delete": "ship",
+        "force-push": "ship",
+        "private-real-eval": "claim",
+        "benchmark-claim": "claim",
+        "architecture": "claim",
+    }.get(gate, gate)
+    if mapped in {"task", "plan", "review", "claim", "ship"}:
+        points = build_decision_points(
+            task_id=task_id,
+            batch=None,
+            review_followups=None,
+            gate=mapped,
+            changed_files=changed_files,
+            pr=pr,
+            repo_root=repo_root,
+        )
+    else:
+        points = [_no_input_decision_point()]
+    rendered = render_decision_brief(points, repo_root=repo_root)
+    return (
+        f"# Gate Brief: {gate}\n\n"
+        "- Human gates are decision points, not automation failures.\n"
+        "- This command explains options and does not execute the gated action.\n\n"
+        + rendered.split("\n", 1)[1]
+    )
+
+
+def write_manifest(
+    *,
+    changed_files: Sequence[str] = (),
+    command: str = "manual",
+    outputs: Sequence[Path] = (),
+    out: Path = DEFAULT_MANIFEST,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, dict[str, object]]:
+    manifest = build_manifest(
+        changed_files=changed_files,
+        command=command,
+        outputs=outputs,
+        repo_root=repo_root,
+    )
+    out = _default_output(out, DEFAULT_MANIFEST, "manifest.json", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return safe_out, manifest
+
+
+def build_manifest(
+    *,
+    changed_files: Sequence[str],
+    command: str,
+    outputs: Sequence[Path],
+    repo_root: Path,
+) -> dict[str, object]:
+    normalized = sorted(
+        {
+            item
+            for path in changed_files
+            if (item := _normalize_changed_file(path, repo_root=repo_root))
+        }
+    )
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "git_head": _current_git_head(repo_root) or "unknown",
+        "branch": _current_branch(repo_root) or "unknown",
+        "command": _sanitize_inline_text(command),
+        "changed_files_hash": _changed_files_hash(normalized, repo_root=repo_root),
+        "changed_files": [_display_path(path, repo_root=repo_root) for path in normalized],
+        "outputs": [_display_path(_repo_path(path if path.is_absolute() else repo_root / path, repo_root), repo_root=repo_root) for path in outputs],
+    }
+
+
+def _changed_files_hash(changed_files: Sequence[str], *, repo_root: Path) -> str:
+    payload: list[dict[str, str]] = []
+    for path in sorted(changed_files):
+        display = _display_path(path, repo_root=repo_root)
+        content_hash = "not-read"
+        normalized = _normalize_changed_file(path, repo_root=repo_root)
+        candidate = repo_root / normalized
+        if normalized != "[redacted-local-path]" and not _privacy_sensitive_path(normalized) and candidate.is_file():
+            try:
+                content_hash = hashlib.sha256(candidate.read_bytes()).hexdigest()
+            except OSError:
+                content_hash = "unreadable"
+        payload.append({"path": display, "content_hash": content_hash})
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _manifest_freshness(
+    *,
+    changed_files: Sequence[str],
+    repo_root: Path,
+) -> dict[str, object]:
+    path = repo_root / "reports" / "agent_loop" / "manifest.json"
+    current_hash = _changed_files_hash(changed_files, repo_root=repo_root)
+    if not path.exists():
+        return {"exists": False, "current": False, "reason": "manifest not found"}
+    try:
+        payload = json.loads(_read_text(path))
+    except json.JSONDecodeError:
+        return {"exists": True, "current": False, "reason": "manifest is invalid JSON"}
+    recorded = payload.get("changed_files_hash") if isinstance(payload, dict) else None
+    return {
+        "exists": True,
+        "current": recorded == current_hash,
+        "reason": "hash match" if recorded == current_hash else "changed files hash mismatch",
+        "recorded_hash": recorded or "unknown",
+        "current_hash": current_hash,
+    }
+
+
+def write_pr_body_check(
+    *,
+    body: Path,
+    changed_files: Sequence[str] = (),
+    branch: str | None = None,
+    out: Path = DEFAULT_PR_BODY_CHECK,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, int, str]:
+    body_path = _resolve_input_path(body, repo_root=repo_root)
+    if not body_path.exists():
+        raise ValueError(f"PR body file not found: {_display_path(str(body), repo_root=repo_root)}")
+    text = _read_text(body_path)
+    findings = check_pr_body_text(text, changed_files=changed_files, branch=branch, repo_root=repo_root)
+    rendered = render_pr_body_check(findings, body_path=body_path, changed_files=changed_files, branch=branch, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_PR_BODY_CHECK, "pr_body_check.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, 1 if findings else 0, rendered
+
+
+def check_pr_body_text(
+    text: str,
+    *,
+    changed_files: Sequence[str],
+    branch: str | None,
+    repo_root: Path,
+) -> list[PRBodyFinding]:
+    findings: list[PRBodyFinding] = []
+    sanitized = _sanitize_dynamic_text(text)
+    closers = re.findall(r"\b(?:Closes|Fixes|Resolves)\s+#(\d+)\b", sanitized, flags=re.IGNORECASE)
+    branch_issue = _issue_from_branch(branch or _current_branch(repo_root) or "")
+    if not closers:
+        findings.append(PRBodyFinding("high", "missing Closes/Fixes/Resolves issue reference", "Add `Closes #<issue>` matching the branch issue."))
+    elif branch_issue and branch_issue not in closers:
+        findings.append(PRBodyFinding("high", "PR body issue reference does not match branch issue", f"Use `Closes #{branch_issue}` or rename the branch."))
+    if "### 5b. Real-data delta" not in sanitized:
+        findings.append(PRBodyFinding("high", "missing §5b Real-data delta section", "Keep the PR template §5b section."))
+    else:
+        section = _section_after_heading(sanitized, "### 5b. Real-data delta")
+        load_bearing = [path for path in changed_files if _normalize_changed_file(path) != "[redacted-local-path]" and (is_load_bearing(_normalize_changed_file(path)) or _normalize_changed_file(path).startswith("eval/"))]
+        weak = not section.strip() or section.strip().lower() in {"n/a", "n/a.", "none", "todo", "tbd"}
+        if load_bearing and weak:
+            findings.append(PRBodyFinding("critical", "load-bearing change has weak §5b content", "Attach aggregate-only real-data delta or truthful no-behavior-change attestation."))
+    surface = classify_changed_files(changed_files)
+    for claim in audit_claim_text(_claim_scan_text_from_pr_body(sanitized), surface):
+        findings.append(PRBodyFinding(claim.severity, claim.issue, f"Get review from {claim.reviewer} or remove the claim."))
+    for issue, pattern in _privacy_audit_patterns().items():
+        if pattern.search(text):
+            findings.append(PRBodyFinding("critical", f"private raw value detected in PR body: {issue}", "Redact private raw values before PR creation."))
+    return _dedupe_pr_body_findings(findings)
+
+
+def _claim_scan_text_from_pr_body(text: str) -> str:
+    kept: list[str] = []
+    skip_section = False
+    for line in text.splitlines():
+        lowered = line.lower()
+        if "disallowed claims" in lowered or "human-gated decisions" in lowered:
+            skip_section = True
+            continue
+        if skip_section and re.match(r"^#{1,3}\s+", line):
+            skip_section = False
+        if skip_section:
+            continue
+        if any(token in lowered for token in ("do not claim", "claim boundary", "no benchmark", "not a benchmark", "without sufficient eval provenance")):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def _section_after_heading(text: str, heading: str) -> str:
+    index = text.find(heading)
+    if index < 0:
+        return ""
+    rest = text[index + len(heading):]
+    match = re.search(r"^#{1,3}\s+", rest, re.MULTILINE)
+    return rest[: match.start()] if match else rest
+
+
+def _dedupe_pr_body_findings(findings: Iterable[PRBodyFinding]) -> list[PRBodyFinding]:
+    seen: set[tuple[str, str]] = set()
+    out: list[PRBodyFinding] = []
+    for finding in findings:
+        key = (finding.severity, finding.issue)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return out
+
+
+def render_pr_body_check(
+    findings: Sequence[PRBodyFinding],
+    *,
+    body_path: Path,
+    changed_files: Sequence[str],
+    branch: str | None,
+    repo_root: Path,
+) -> str:
+    lines = [
+        "# PR Body Check",
+        "",
+        f"- Body: `{_display_path(_repo_path(body_path, repo_root), repo_root=repo_root)}`",
+        f"- Branch: `{_sanitize_inline_text(branch or _current_branch(repo_root) or 'unknown')}`",
+        f"- Result: `{'fail' if findings else 'pass'}`",
+        "- This check does not create, update, merge, or close a PR.",
+        "",
+        "## Changed Files",
+        "",
+    ]
+    lines.extend(f"- `{_display_path(path)}`" for path in changed_files) if changed_files else lines.append("- `N/A`")
+    lines.extend(["", "## Findings", ""])
+    if findings:
+        for finding in findings:
+            lines.extend(
+                [
+                    f"- Severity: `{finding.severity}`",
+                    f"  - Issue: {_sanitize_dynamic_text(finding.issue)}",
+                    f"  - Remediation: {_sanitize_dynamic_text(finding.remediation)}",
+                ]
+            )
+    else:
+        lines.append("- None")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_ci_ingest(
+    *,
+    logs: Sequence[Path] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_CI_INGEST,
+    tasks_dir: Path = DEFAULT_CI_FOLLOWUPS_DIR,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path, int, str]:
+    findings, sources = collect_ci_findings(logs=logs, pr=pr, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_CI_INGEST, "ci_ingest.md", repo_root=repo_root)
+    tasks_dir = repo_root / "reports" / "agent_loop" / "ci_followups" if tasks_dir == DEFAULT_CI_FOLLOWUPS_DIR else tasks_dir
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_tasks = _safe_output_path(tasks_dir, repo_root=repo_root)
+    rendered = render_ci_ingest(findings, sources=sources, tasks_dir=safe_tasks, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_tasks.mkdir(parents=True, exist_ok=True)
+    for stale in safe_tasks.glob("*.md"):
+        stale.unlink()
+    safe_out.write_text(rendered, encoding="utf-8")
+    for index, finding in enumerate(findings, start=1):
+        (safe_tasks / f"{index:03d}-{_slugify(finding.summary)}.md").write_text(
+            render_ci_followup_task(finding, index=index),
+            encoding="utf-8",
+        )
+    return safe_out, safe_tasks, len(findings), rendered
+
+
+def collect_ci_findings(
+    *,
+    logs: Sequence[Path],
+    pr: str | None,
+    repo_root: Path,
+) -> tuple[list[CIFinding], list[str]]:
+    blocks: list[str] = []
+    sources: list[str] = []
+    for log in logs:
+        path = _resolve_input_path(log, repo_root=repo_root)
+        if not path.exists():
+            raise ValueError(f"CI log not found: {_display_path(str(log), repo_root=repo_root)}")
+        blocks.append(_read_text(path))
+        sources.append(f"file `{_display_path(_repo_path(path, repo_root), repo_root=repo_root)}`")
+    if pr:
+        blocks.append(_ci_text_from_pr(pr, repo_root=repo_root))
+        sources.append(f"PR `{_validate_pr_selector(pr)}`")
+    if not blocks:
+        raise ValueError("ci-ingest requires --log or --pr")
+    findings: list[CIFinding] = []
+    for block in blocks:
+        findings.extend(_extract_ci_findings(block, pr=pr))
+    return _dedupe_ci_findings(findings), sources
+
+
+def _ci_text_from_pr(pr: str, *, repo_root: Path) -> str:
+    safe_pr = _validate_pr_selector(pr)
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "checks", safe_pr, "--json", "name,conclusion,state,detailsUrl,link"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(f"could not read CI checks from PR {safe_pr}") from exc
+    return _sanitize_dynamic_text(result.stdout)
+
+
+def _extract_ci_findings(text: str, *, pr: str | None) -> list[CIFinding]:
+    sanitized = _sanitize_dynamic_text(text)
+    lowered = sanitized.lower()
+    findings: list[CIFinding] = []
+    test_match = re.search(r"(tests/test_[\w./-]+\.py)", sanitized)
+    if any(token in lowered for token in ("assertionerror", "failed", "pytest", '"conclusion":"failure"', '"state":"failure"')):
+        test_file = test_match.group(1) if test_match else "tests/test_<target>.py"
+        findings.append(CIFinding("test-failure", f"CI test failure near {test_file}", "ci log", f"python3 -m pytest {test_file} -q"))
+    if any(token in lowered for token in ("git diff --check", "trailing whitespace", "whitespace error")):
+        findings.append(CIFinding("safe-local-fix-candidate", "Whitespace or diff-check failure", "ci log", "git diff --check"))
+    if any(token in lowered for token in ("branch", "closes #", "adr 0007", "issue reference")):
+        findings.append(CIFinding("branch-issue", "Branch/issue convention failure", "ci log", "make check-branch"))
+    if "5b" in lowered or "real-data delta" in lowered:
+        validation = f"python3 scripts/check_branch_and_issue.py --check-5b {pr}" if pr else "python3 scripts/check_branch_and_issue.py --check-5b <PR_NUMBER>"
+        findings.append(CIFinding("manual-gated", "§5b real-data delta gate needs human-readable evidence", "ci log", validation))
+    if any(token in lowered for token in ("privacy", "doc_id", "chunk_id", "raw evidence", "private")):
+        findings.append(CIFinding("manual-gated", "Privacy/governance failure requires redaction review", "ci log", "python3 scripts/_governance.py --check-eval-privacy"))
+    if not findings:
+        findings.append(CIFinding("unknown", "CI failure could not be classified safely", "ci log", "python3 scripts/agent_loop.py gate-brief --gate review"))
+    return findings
+
+
+def _dedupe_ci_findings(findings: Iterable[CIFinding]) -> list[CIFinding]:
+    seen: set[tuple[str, str, str]] = set()
+    out: list[CIFinding] = []
+    for finding in findings:
+        key = (finding.lane, finding.summary, finding.validation)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return out
+
+
+def render_ci_ingest(
+    findings: Sequence[CIFinding],
+    *,
+    sources: Sequence[str],
+    tasks_dir: Path,
+    repo_root: Path,
+) -> str:
+    lines = [
+        "# CI Ingest",
+        "",
+        "- Read-only CI failure triage. It does not push, re-run CI, create/merge/close PRs, delete branches, or force-push.",
+        f"- Follow-up briefs: `{_display_path(_repo_path(tasks_dir, repo_root), repo_root=repo_root)}`",
+        "",
+        "## Sources",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(source)}" for source in sources)
+    lines.extend(["", "## Findings", ""])
+    for index, finding in enumerate(findings, start=1):
+        lines.extend(
+            [
+                f"### {index:03d}. {finding.summary}",
+                "",
+                f"- Lane: `{finding.lane}`",
+                f"- Source: `{_sanitize_dynamic_text(finding.source)}`",
+                f"- Suggested validation: `{_sanitize_command_text(finding.validation)}`",
+                "",
+            ]
+        )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def render_ci_followup_task(finding: CIFinding, *, index: int) -> str:
+    return _sanitize_dynamic_text(
+        f"""# CI Follow-up {index:03d}: {finding.summary}
+
+- Classification: `ci_followup`
+- Lane: `{finding.lane}`
+- Source: `{finding.source}`
+
+## Goal
+
+Resolve the CI signal with the smallest local change, or document why human approval is required.
+
+## Expected Evidence
+
+Focused validation output and updated handoff evidence.
+
+## Verification
+
+```bash
+{_ensure_git_diff_check(finding.validation)}
+```
+"""
+    )
+
+
+def write_stacked_risk(
+    *,
+    branch: str,
+    pr_json: Path | None = None,
+    out: Path = DEFAULT_STACKED_RISK,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    items = _stacked_pr_items(branch=branch, pr_json=pr_json, repo_root=repo_root)
+    rendered = render_stacked_risk(branch=branch, items=items)
+    out = _default_output(out, DEFAULT_STACKED_RISK, "stacked_risk.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def _stacked_pr_items(*, branch: str, pr_json: Path | None, repo_root: Path) -> list[dict[str, object]]:
+    safe_branch = _sanitize_inline_text(branch)
+    if pr_json is not None:
+        path = _resolve_input_path(pr_json, repo_root=repo_root)
+        payload = json.loads(_read_text(path))
+        if not isinstance(payload, list):
+            raise ValueError("PR state JSON must be an array")
+        return [item for item in payload if isinstance(item, dict) and str(item.get("baseRefName") or "") == safe_branch]
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--base",
+                safe_branch,
+                "--json",
+                "number,title,headRefName,baseRefName,isDraft,reviewDecision,mergeStateStatus",
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(f"could not read dependent PRs for branch {safe_branch}") from exc
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, list):
+        raise ValueError("gh pr list JSON must be an array")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def render_stacked_risk(*, branch: str, items: Sequence[dict[str, object]]) -> str:
+    lines = [
+        "# Stacked PR Dependency Risk",
+        "",
+        "- Read-only dependent PR check. It does not merge, close, delete branches, push, or force-push.",
+        f"- Branch: `{_sanitize_inline_text(branch)}`",
+        f"- Dependent open PR count: `{len(items)}`",
+        "",
+        "## Dependents",
+        "",
+    ]
+    if items:
+        for item in items:
+            lines.append(f"- #{item.get('number', 'N/A')} {_sanitize_inline_text(str(item.get('title') or 'Untitled'))} from `{_sanitize_inline_text(str(item.get('headRefName') or 'unknown'))}`")
+    else:
+        lines.append("- None detected.")
+    lines.extend(
+        [
+            "",
+            "## Human Gate",
+            "",
+            "- Branch deletion, PR merge, PR close, and force-push still require explicit human approval.",
+            "- If dependents exist, do not delete the branch until child PRs are rebased or intentionally retained.",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_patch_proposal(
+    *,
+    changed_files: Sequence[str] = (),
+    review_plan: Path | None = None,
+    out: Path = DEFAULT_PATCH_PROPOSAL,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_patch_proposal(changed_files=changed_files, review_plan=review_plan, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_PATCH_PROPOSAL, "patch_proposal.diff", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_patch_proposal(
+    *,
+    changed_files: Sequence[str],
+    review_plan: Path | None,
+    repo_root: Path,
+) -> str:
+    header = [
+        "# Agent-loop safe patch proposal. Dry-run only; review before applying.",
+        "# Scope: whitespace/final-newline diff for public-safe allowlisted text files.",
+    ]
+    if review_plan is not None:
+        path = _resolve_input_path(review_plan, repo_root=repo_root)
+        if path.exists():
+            header.append(f"# Review plan: {_display_path(_repo_path(path, repo_root), repo_root=repo_root)}")
+    diffs: list[str] = []
+    for raw in changed_files:
+        rel = _normalize_changed_file(raw, repo_root=repo_root)
+        if not rel or rel == "[redacted-local-path]" or _privacy_sensitive_path(rel):
+            continue
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        if path.name not in SAFE_FIX_NAMES and path.suffix.lower() not in SAFE_FIX_SUFFIXES:
+            continue
+        try:
+            before = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        after = _fix_text_whitespace(before)
+        if after != before:
+            diffs.append(_unified_diff(before, after, fromfile=f"a/{rel}", tofile=f"b/{rel}"))
+    if not diffs:
+        diffs.append("# No safe patch proposal generated.")
+    return _sanitize_dynamic_text("\n".join([*header, *diffs, ""])).rstrip() + "\n"
+
+
+def write_adr_reservation(
+    *,
+    title: str,
+    out: Path = DEFAULT_ADR_RESERVATION,
+    draft_out: Path = DEFAULT_ADR_DRAFT,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path, str]:
+    number = _next_adr_number(repo_root)
+    draft = render_adr_draft(number=number, title=title)
+    rendered = render_adr_reservation(number=number, title=title, draft_path=draft_out)
+    out = _default_output(out, DEFAULT_ADR_RESERVATION, "adr_reservation.md", repo_root=repo_root)
+    draft_out = _default_output(draft_out, DEFAULT_ADR_DRAFT, "adr_draft.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_draft = _safe_output_path(draft_out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_draft.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    safe_draft.write_text(draft, encoding="utf-8")
+    return safe_out, safe_draft, rendered
+
+
+def _next_adr_number(repo_root: Path) -> int:
+    adr_dir = repo_root / "docs" / "adr"
+    numbers: list[int] = []
+    if adr_dir.is_dir():
+        for path in adr_dir.glob("*.md"):
+            match = re.match(r"(\d{4})-", path.name)
+            if match:
+                numbers.append(int(match.group(1)))
+    return (max(numbers) + 1) if numbers else 1
+
+
+def render_adr_reservation(*, number: int, title: str, draft_path: Path) -> str:
+    slug = _slugify(title)
+    final_path = f"docs/adr/{number:04d}-{slug}.md"
+    return _sanitize_dynamic_text(
+        f"""# ADR Reservation Assistant
+
+- Suggested ADR number: `{number:04d}`
+- Suggested final path: `{final_path}`
+- Draft artifact: `{_display_path(draft_path.as_posix())}`
+- This command does not create or modify `docs/adr/`; human approval is required before reserving or committing an ADR.
+
+## Human Checks
+
+- Confirm no open PR already reserves ADR `{number:04d}`.
+- Confirm this is a load-bearing decision, new measurement surface, or durable architecture tradeoff.
+- Confirm alternatives and consequences are clear.
+"""
+    )
+
+
+def render_adr_draft(*, number: int, title: str) -> str:
+    slug = _slugify(title)
+    return _sanitize_dynamic_text(
+        f"""# ADR {number:04d}: {title}
+
+- Status: draft
+- Suggested final path: `docs/adr/{number:04d}-{slug}.md`
+
+## Context
+
+Describe the load-bearing decision, measurement surface, or architecture tradeoff.
+
+## Decision
+
+TBD by human review.
+
+## Alternatives
+
+- Option A:
+- Option B:
+
+## Consequences
+
+- Positive:
+- Negative:
+- Validation:
+"""
+    )
+
+
+def write_dashboard_html(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_DASHBOARD_HTML,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    state = build_loop_state(
+        task_id=task_id,
+        batch=None,
+        review_followups=None,
+        changed_files=changed_files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    markdown = render_dashboard(state, repo_root=repo_root)
+    rendered = render_dashboard_html(markdown)
+    out = _default_output(out, DEFAULT_DASHBOARD_HTML, "dashboard.html", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_dashboard_html(markdown: str) -> str:
+    escaped = html.escape(_sanitize_dynamic_text(markdown))
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>BidMate Agent Loop Dashboard</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 32px; color: #17202a; background: #f7f8fa; }}
+    main {{ max-width: 1080px; margin: 0 auto; background: white; border: 1px solid #d8dee4; border-radius: 8px; padding: 24px; }}
+    pre {{ white-space: pre-wrap; background: #f0f3f6; padding: 16px; border-radius: 6px; overflow-x: auto; }}
+  </style>
+</head>
+<body>
+  <main>
+    <pre>{escaped}</pre>
+  </main>
+</body>
+</html>
+"""
+
+
+def write_ship_command_pack(
+    *,
+    pr: str | None = None,
+    branch: str | None = None,
+    out: Path = DEFAULT_SHIP_COMMANDS,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_ship_command_pack(pr=pr, branch=branch, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_SHIP_COMMANDS, "ship_commands.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_ship_command_pack(*, pr: str | None, branch: str | None, repo_root: Path) -> str:
+    safe_pr = _validate_pr_selector(pr) if pr else "<PR_NUMBER>"
+    branch_name = _sanitize_inline_text(branch or _current_branch(repo_root) or "<branch>")
+    shell_branch = shlex.quote(branch_name)
+    lines = [
+        "# Ship Command Pack",
+        "",
+        "- Command suggestions only. Do not run human-gated commands without explicit approval.",
+        "- This command did not push, create/merge/close PRs, delete branches, or force-push.",
+        "",
+        "## Safe Local Checks",
+        "",
+        "```bash",
+        "python3 scripts/agent_loop.py auto-ship-prepare --issue <ISSUE> --create-branch --confirm-human-approved",
+        "python3 scripts/agent_loop.py approval-packet --from-git",
+        "python3 scripts/agent_loop.py ship-simulate --from-git",
+        "python3 scripts/agent_loop.py auto-ship-plan --from-git --dry-run",
+        "make check-branch",
+        "git diff --check",
+        "```",
+        "",
+        "## Existing Auto-Ship Bridge",
+        "",
+        "```bash",
+        "# plan only: python3 scripts/agent_loop.py auto-ship-plan --from-git --draft --dry-run",
+        "# arm existing Stop-hook pipeline after approval: make ship-arm REAL_EVAL=skip DRAFT=true DRY_RUN=1",
+        "```",
+        "",
+        "## Human-Gated Commands",
+        "",
+        "```bash",
+        f"# create PR after approval: python3 scripts/agent_loop.py human-gated-exec --action pr-create --branch {shell_branch} --body reports/agent_loop/pr_body.md --confirm-human-approved",
+        f"# review gate before merge/close/delete: make ship-review-gate PR={safe_pr}",
+        f"# push after approval: python3 scripts/agent_loop.py human-gated-exec --action push --branch {shell_branch} --confirm-human-approved",
+        f"# merge after approval: python3 scripts/agent_loop.py human-gated-exec --action pr-merge --pr {safe_pr} --confirm-review-gate-passed --confirm-human-approved",
+        f"# close after approval: python3 scripts/agent_loop.py human-gated-exec --action pr-close --pr {safe_pr} --confirm-review-gate-passed --confirm-human-approved",
+        f"# delete remote branch after dependent check and approval: python3 scripts/agent_loop.py human-gated-exec --action branch-delete --branch {shell_branch} --confirm-dependents-reviewed --confirm-human-approved",
+        f"# force-with-lease after explicit approval: python3 scripts/agent_loop.py human-gated-exec --action force-push --branch {shell_branch} --confirm-force-with-lease --confirm-human-approved",
+        "```",
+        "",
+        "## Required Before Destructive Actions",
+        "",
+        "- Run `stacked-risk` for branch deletion or merge cleanup.",
+        "- Verify unresolved review threads and CI status.",
+        "- Verify no private raw data or overbroad benchmark/performance claim.",
+        "",
+    ]
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+HUMAN_GATED_ACTIONS = {"push", "pr-create", "pr-merge", "pr-close", "branch-delete", "force-push"}
+
+
+def write_human_gated_exec(
+    *,
+    action: str,
+    confirm_human_approved: bool,
+    dry_run: bool = False,
+    branch: str | None = None,
+    pr: str | None = None,
+    body: Path | None = None,
+    base: str | None = None,
+    title: str | None = None,
+    draft: bool = True,
+    confirm_review_gate_passed: bool = False,
+    confirm_dependents_reviewed: bool = False,
+    confirm_force_with_lease: bool = False,
+    out: Path = DEFAULT_HUMAN_GATED_EXEC,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, HumanGatedExecPlan, str]:
+    plan = build_human_gated_exec_plan(
+        action=action,
+        confirm_human_approved=confirm_human_approved,
+        dry_run=dry_run,
+        branch=branch,
+        pr=pr,
+        body=body,
+        base=base,
+        title=title,
+        draft=draft,
+        confirm_review_gate_passed=confirm_review_gate_passed,
+        confirm_dependents_reviewed=confirm_dependents_reviewed,
+        confirm_force_with_lease=confirm_force_with_lease,
+        repo_root=repo_root,
+    )
+    if confirm_human_approved and not dry_run and not plan.blockers:
+        result = subprocess.run(
+            list(plan.command),
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        plan = HumanGatedExecPlan(
+            action=plan.action,
+            command=plan.command,
+            blockers=plan.blockers,
+            warnings=plan.warnings,
+            dry_run=plan.dry_run,
+            executed=True,
+            returncode=result.returncode,
+            stdout=_sanitize_dynamic_text(result.stdout or ""),
+            stderr=_sanitize_dynamic_text(result.stderr or ""),
+        )
+    rendered = render_human_gated_exec(plan)
+    out = _default_output(out, DEFAULT_HUMAN_GATED_EXEC, "human_gated_exec.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, plan, rendered
+
+
+def build_human_gated_exec_plan(
+    *,
+    action: str,
+    confirm_human_approved: bool,
+    dry_run: bool,
+    branch: str | None,
+    pr: str | None,
+    body: Path | None,
+    base: str | None,
+    title: str | None,
+    draft: bool,
+    confirm_review_gate_passed: bool,
+    confirm_dependents_reviewed: bool,
+    confirm_force_with_lease: bool,
+    repo_root: Path,
+) -> HumanGatedExecPlan:
+    if action not in HUMAN_GATED_ACTIONS:
+        raise ValueError("--action must be one of: " + ", ".join(sorted(HUMAN_GATED_ACTIONS)))
+    blockers: list[str] = []
+    warnings: list[str] = []
+    if not confirm_human_approved:
+        blockers.append("--confirm-human-approved is required before any remote state mutation")
+    branch_needed = action in {"push", "force-push", "pr-create", "branch-delete"}
+    current_branch = branch or (_current_branch(repo_root) if branch_needed else None)
+    safe_branch = _validate_branch_name(current_branch) if current_branch else ""
+
+    command: tuple[str, ...]
+    if action == "push":
+        if not safe_branch:
+            blockers.append("--branch is required when the current branch is unknown")
+        command = ("git", "push", "-u", "origin", safe_branch or "<branch>")
+    elif action == "force-push":
+        if not safe_branch:
+            blockers.append("--branch is required for force-push")
+        if not confirm_force_with_lease:
+            blockers.append("--confirm-force-with-lease is required; plain force-push is not supported")
+        command = ("git", "push", "--force-with-lease", "origin", safe_branch or "<branch>")
+    elif action == "pr-create":
+        if not safe_branch:
+            blockers.append("--branch is required when the current branch is unknown")
+        body_path = _resolve_input_path(body or DEFAULT_PR_BODY, repo_root=repo_root)
+        if not body_path.exists():
+            blockers.append("PR body file not found")
+        else:
+            findings = check_pr_body_text(_read_text(body_path), changed_files=_changed_files_from_git(repo_root), branch=safe_branch, repo_root=repo_root)
+            if findings:
+                blockers.append(f"PR body check has {len(findings)} finding(s)")
+        command_parts = ["gh", "pr", "create", "--body-file", _display_path(_repo_path(body_path, repo_root), repo_root=repo_root)]
+        if draft:
+            command_parts.append("--draft")
+        if base:
+            command_parts.extend(["--base", _validate_branch_name(base, allow_protected=True)])
+        if title:
+            command_parts.extend(["--title", _sanitize_inline_text(title)])
+        command = tuple(command_parts)
+    elif action == "pr-merge":
+        safe_pr = _validate_pr_selector(pr or "")
+        if not confirm_review_gate_passed:
+            blockers.append("--confirm-review-gate-passed is required before merge")
+        command = ("gh", "pr", "merge", safe_pr, "--squash")
+        warnings.append("merge command intentionally omits --delete-branch")
+    elif action == "pr-close":
+        safe_pr = _validate_pr_selector(pr or "")
+        if not confirm_review_gate_passed:
+            blockers.append("--confirm-review-gate-passed is required before close")
+        command = ("gh", "pr", "close", safe_pr)
+    else:
+        if not safe_branch:
+            blockers.append("--branch is required for branch-delete")
+        dependents: list[dict[str, object]] = []
+        if safe_branch:
+            try:
+                dependents = _stacked_pr_items(branch=safe_branch, pr_json=None, repo_root=repo_root)
+            except ValueError as exc:
+                blockers.append(f"could not verify dependent PRs: {exc}")
+        if dependents and not confirm_dependents_reviewed:
+            blockers.append(f"branch has {len(dependents)} dependent open PR(s); pass --confirm-dependents-reviewed only after human review")
+        command = ("git", "push", "origin", "--delete", safe_branch or "<branch>")
+    return HumanGatedExecPlan(
+        action=action,
+        command=command,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        dry_run=dry_run,
+        executed=False,
+    )
+
+
+def _validate_branch_name(branch: str | None, *, allow_protected: bool = False) -> str:
+    if not branch:
+        return ""
+    safe = _sanitize_inline_text(branch)
+    if not allow_protected and safe in {"HEAD", "main", "master"}:
+        raise ValueError("refusing gated action on HEAD/main/master branch")
+    if not re.fullmatch(r"[A-Za-z0-9._/-]+", safe) or safe.startswith("-") or ".." in safe or safe.endswith(".lock"):
+        raise ValueError("branch name contains unsafe characters")
+    return safe
+
+
+def render_human_gated_exec(plan: HumanGatedExecPlan) -> str:
+    lines = [
+        "# Human-Gated Execution",
+        "",
+        "- This command exists only for explicit human-approved execution of already gated operations.",
+        "- It never bypasses review, claim, private real-eval, architecture, or dependency decisions.",
+        f"- Action: `{plan.action}`",
+        f"- Mode: `{'dry-run' if plan.dry_run else 'execute'}`",
+        f"- Executed: `{plan.executed}`",
+        f"- Return code: `{plan.returncode if plan.returncode is not None else 'N/A'}`",
+        "",
+        "## Command",
+        "",
+        "```bash",
+        _sanitize_command_text(shlex.join(plan.command)),
+        "```",
+        "",
+        "## Blockers",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.blockers) if plan.blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.warnings) if plan.warnings else lines.append("- None")
+    if plan.executed:
+        lines.extend(
+            [
+                "",
+                "## Execution Output",
+                "",
+                f"- stdout bytes: `{len(plan.stdout.encode('utf-8'))}`",
+                f"- stderr bytes: `{len(plan.stderr.encode('utf-8'))}`",
+            ]
+        )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_apply_queue_plan(
+    *,
+    confirm_human_approved: bool,
+    queue_draft: Path = DEFAULT_QUEUE_DRAFT,
+    plan_draft: Path = DEFAULT_PLAN_DRAFT,
+    out: Path = DEFAULT_APPLY_QUEUE_PLAN,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    queue_path = _resolve_default_agent_loop_path(queue_draft, "queue_entry_draft.md", repo_root=repo_root)
+    plan_path = _resolve_default_agent_loop_path(plan_draft, "plan_draft.md", repo_root=repo_root)
+    if not queue_path.exists() or not plan_path.exists():
+        raise ValueError("queue/plan drafts not found; run draft-task first")
+    queue_text = _sanitize_dynamic_text(_read_text(queue_path)).rstrip() + "\n"
+    plan_text = _sanitize_dynamic_text(_read_text(plan_path)).rstrip() + "\n"
+    if _privacy_audit_text(queue_text + "\n" + plan_text):
+        raise ValueError("queue/plan drafts contain private raw values; redact before applying")
+    target_queue = repo_root / QUEUE_PATH
+    target_plan = repo_root / _extract_suggested_plan_path(plan_text)
+    rendered = render_apply_queue_plan(
+        confirm_human_approved=confirm_human_approved,
+        target_queue=QUEUE_PATH.as_posix(),
+        target_plan=_repo_path(target_plan, repo_root),
+    )
+    out = _default_output(out, DEFAULT_APPLY_QUEUE_PLAN, "apply_queue_plan.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    if confirm_human_approved:
+        target_queue.parent.mkdir(parents=True, exist_ok=True)
+        target_plan.parent.mkdir(parents=True, exist_ok=True)
+        before = _read_text(target_queue) if target_queue.exists() else ""
+        target_queue.write_text(before.rstrip() + "\n\n" + queue_text, encoding="utf-8")
+        target_plan.write_text(plan_text, encoding="utf-8")
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def _privacy_audit_text(text: str) -> bool:
+    return any(pattern.search(text) for pattern in _privacy_audit_patterns().values())
+
+
+def render_apply_queue_plan(*, confirm_human_approved: bool, target_queue: str, target_plan: str) -> str:
+    return _sanitize_dynamic_text(
+        f"""# Apply Queue/Plan
+
+- Result: `{'applied' if confirm_human_approved else 'blocked'}`
+- Queue target: `{target_queue}`
+- Plan target: `{target_plan}`
+- This command writes tracked queue/plan docs only when `--confirm-human-approved` is present.
+- It does not push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.
+"""
+    )
+
+
+def write_review_threads(
+    *,
+    threads_json: Path | None = None,
+    pr: str | None = None,
+    out: Path = DEFAULT_REVIEW_THREADS,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    findings, sources = collect_review_thread_findings(threads_json=threads_json, pr=pr, repo_root=repo_root)
+    rendered = render_review_threads(findings, sources=sources)
+    out = _default_output(out, DEFAULT_REVIEW_THREADS, "review_threads.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def collect_review_thread_findings(
+    *,
+    threads_json: Path | None,
+    pr: str | None,
+    repo_root: Path,
+) -> tuple[list[ReviewThreadFinding], list[str]]:
+    payloads: list[object] = []
+    sources: list[str] = []
+    if threads_json is not None:
+        path = _resolve_input_path(threads_json, repo_root=repo_root)
+        if not path.exists():
+            raise ValueError(f"review threads JSON not found: {_display_path(str(threads_json), repo_root=repo_root)}")
+        payloads.append(json.loads(_read_text(path)))
+        sources.append(f"file `{_display_path(_repo_path(path, repo_root), repo_root=repo_root)}`")
+    if pr:
+        payloads.append(_review_threads_payload_from_pr(pr, repo_root=repo_root))
+        sources.append(f"PR `{_validate_pr_selector(pr)}`")
+    if not payloads:
+        raise ValueError("review-threads requires --threads-json or --pr")
+    findings: list[ReviewThreadFinding] = []
+    for payload in payloads:
+        findings.extend(_parse_review_threads_payload(payload))
+    return _dedupe_review_thread_findings(findings), sources
+
+
+def _review_threads_payload_from_pr(pr: str, *, repo_root: Path) -> object:
+    safe_pr = _validate_pr_selector(pr)
+    try:
+        repo = subprocess.run(
+            ["gh", "repo", "view", "--json", "owner,name"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        repo_payload = json.loads(repo.stdout)
+        owner = repo_payload.get("owner", {}).get("login")
+        name = repo_payload.get("name")
+        if not owner or not name:
+            raise ValueError("could not determine GitHub owner/name")
+        query = """
+        query($owner:String!, $name:String!, $number:Int!) {
+          repository(owner:$owner, name:$name) {
+            pullRequest(number:$number) {
+              reviewThreads(first:100) {
+                nodes {
+                  isResolved
+                  path
+                  line
+                  comments(first:20) {
+                    nodes {
+                      body
+                      path
+                      line
+                      author { login }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={safe_pr}",
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"could not read review threads from PR {safe_pr}") from exc
+    return json.loads(result.stdout)
+
+
+def _parse_review_threads_payload(payload: object) -> list[ReviewThreadFinding]:
+    threads = _find_review_thread_nodes(payload)
+    findings: list[ReviewThreadFinding] = []
+    for thread in threads:
+        if not isinstance(thread, dict):
+            continue
+        comments = _thread_comments(thread)
+        last_comment = comments[-1] if comments else {}
+        body = str(last_comment.get("body") or thread.get("body") or "")
+        path = _display_path(str(thread.get("path") or last_comment.get("path") or "unknown"))
+        line = str(thread.get("line") or last_comment.get("line") or "unknown")
+        resolved = bool(thread.get("isResolved") or thread.get("resolved"))
+        reviewer_mode = _reviewer_mode_for_text(body + "\n" + path)
+        lane = _review_thread_lane(resolved=resolved, reviewer_mode=reviewer_mode, text=body)
+        findings.append(
+            ReviewThreadFinding(
+                status="resolved" if resolved else "unresolved",
+                path=path,
+                line=_sanitize_inline_text(line),
+                reviewer_mode=reviewer_mode,
+                lane=lane,
+                summary=_review_thread_summary(body, path=path),
+            )
+        )
+    return findings
+
+
+def _find_review_thread_nodes(payload: object) -> list[object]:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    nodes = payload.get("nodes")
+    if isinstance(nodes, list) and any(isinstance(item, dict) and ("isResolved" in item or "resolved" in item) for item in nodes):
+        return nodes
+    out: list[object] = []
+    for value in payload.values():
+        out.extend(_find_review_thread_nodes(value))
+    return out
+
+
+def _thread_comments(thread: dict[str, object]) -> list[dict[str, object]]:
+    comments = thread.get("comments")
+    if isinstance(comments, dict):
+        nodes = comments.get("nodes")
+        if isinstance(nodes, list):
+            return [item for item in nodes if isinstance(item, dict)]
+    if isinstance(comments, list):
+        return [item for item in comments if isinstance(item, dict)]
+    return []
+
+
+def _reviewer_mode_for_text(text: str) -> str:
+    lowered = text.lower()
+    if any(token in lowered for token in ("private", "privacy", "doc_id", "chunk_id", "raw evidence", "raw question")):
+        return "Privacy Auditor"
+    if any(token in lowered for token in ("benchmark", "eval", "metric", "latency", "performance", "claim")):
+        return "Benchmark Auditor"
+    if any(token in lowered for token in ("architecture", "adr", "contract", "load-bearing", "schema")):
+        return "Deep Reviewer"
+    return "Adversarial Reviewer"
+
+
+def _review_thread_lane(*, resolved: bool, reviewer_mode: str, text: str) -> str:
+    if resolved:
+        return "resolved"
+    if reviewer_mode in {"Privacy Auditor", "Benchmark Auditor", "Deep Reviewer"}:
+        return "needs-human-decision"
+    lowered = text.lower()
+    if any(token in lowered for token in ("must", "blocking", "requested changes", "regression", "bug")):
+        return "must-fix"
+    return "should-fix"
+
+
+def _review_thread_summary(text: str, *, path: str) -> str:
+    mode = _reviewer_mode_for_text(text + "\n" + path)
+    if mode == "Privacy Auditor":
+        return "Privacy-sensitive review thread needs redaction-aware handling"
+    if mode == "Benchmark Auditor":
+        return "Benchmark/eval review thread needs claim-boundary handling"
+    if mode == "Deep Reviewer":
+        return "Architecture/load-bearing review thread needs human design review"
+    return "Implementation review thread needs local follow-up"
+
+
+def _dedupe_review_thread_findings(findings: Iterable[ReviewThreadFinding]) -> list[ReviewThreadFinding]:
+    seen: set[tuple[str, str, str, str]] = set()
+    out: list[ReviewThreadFinding] = []
+    for finding in findings:
+        key = (finding.status, finding.path, finding.line, finding.summary)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return out
+
+
+def render_review_threads(findings: Sequence[ReviewThreadFinding], *, sources: Sequence[str]) -> str:
+    unresolved = [finding for finding in findings if finding.status == "unresolved"]
+    lines = [
+        "# Review Thread Ingest",
+        "",
+        "- Read-only review-thread triage. It does not reply, resolve comments, push, create/merge/close PRs, delete branches, or force-push.",
+        "- Comment bodies are summarized instead of echoed to avoid leaking private raw values.",
+        f"- Unresolved count: `{len(unresolved)}`",
+        "",
+        "## Sources",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(source)}" for source in sources)
+    lines.extend(["", "## Threads", "", "| Status | Lane | Reviewer | Location | Summary |", "|---|---|---|---|---|"])
+    if findings:
+        for finding in findings:
+            location = f"{finding.path}:{finding.line}"
+            lines.append(
+                "| "
+                f"`{finding.status}` | `{finding.lane}` | `{finding.reviewer_mode}` | "
+                f"`{_display_path(location)}` | {_sanitize_inline_text(finding.summary)} |"
+            )
+    else:
+        lines.append("| `none` | `N/A` | `N/A` | `N/A` | No review threads found. |")
+    lines.extend(
+        [
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            "python3 scripts/agent_loop.py review-plan --pr <PR_NUMBER>",
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_ci_summary(
+    *,
+    logs: Sequence[Path] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_CI_SUMMARY,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    findings, sources = collect_ci_findings(logs=logs, pr=pr, repo_root=repo_root)
+    rendered = render_ci_summary(findings, sources=sources)
+    out = _default_output(out, DEFAULT_CI_SUMMARY, "ci_summary.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_ci_summary(findings: Sequence[CIFinding], *, sources: Sequence[str]) -> str:
+    lanes: dict[str, int] = {}
+    for finding in findings:
+        lanes[finding.lane] = lanes.get(finding.lane, 0) + 1
+    lines = [
+        "# CI Summary",
+        "",
+        "- Read-only CI summary. It does not re-run CI, push, create/merge/close PRs, delete branches, or force-push.",
+        "",
+        "## Sources",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(source)}" for source in sources)
+    lines.extend(["", "## Lane Counts", "", "| Lane | Count |", "|---|---:|"])
+    for lane, count in sorted(lanes.items()):
+        lines.append(f"| `{lane}` | {count} |")
+    lines.extend(["", "## Recommended Local Reproduction", ""])
+    for finding in findings:
+        lines.append(f"- `{_sanitize_command_text(finding.validation)}`")
+    lines.extend(["", "## Next Safe Command", "", "```bash", "python3 scripts/agent_loop.py ci-ingest --log <CI_LOG>", "```", ""])
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_readiness_score(
+    *,
+    task_id: str | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    body: Path | None = None,
+    branch: str | None = None,
+    claim_text: Path | None = None,
+    out: Path = DEFAULT_READINESS_SCORE,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, ReadinessScore, str]:
+    report = build_readiness_score(
+        task_id=task_id,
+        changed_files=changed_files,
+        pr=pr,
+        body=body,
+        branch=branch,
+        claim_text=claim_text,
+        repo_root=repo_root,
+    )
+    rendered = render_readiness_score(report, changed_files=changed_files, pr=pr)
+    out = _default_output(out, DEFAULT_READINESS_SCORE, "readiness_score.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, report, rendered
+
+
+def build_readiness_score(
+    *,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    body: Path | None,
+    branch: str | None,
+    claim_text: Path | None,
+    repo_root: Path,
+) -> ReadinessScore:
+    files = sorted(_normalize_changed_file(path, repo_root=repo_root) for path in changed_files if path)
+    surface = classify_changed_files(files)
+    surfaces = {surface.surface, *surface.additional_surfaces}
+    blockers: list[str] = []
+    warnings: list[str] = []
+    evidence: list[str] = []
+
+    if not files:
+        blockers.append("changed files are missing")
+    else:
+        evidence.append(f"changed-file surface classified as {surface.surface}")
+    if surface.confidence != "high":
+        warnings.append(f"surface confidence is {surface.confidence}")
+    if surfaces & {"private-real-eval", "privacy-sensitive-artifact"}:
+        blockers.append("private/privacy-sensitive surface requires human review")
+    if surfaces & {"benchmark-reporting", "public-synthetic-benchmark"}:
+        warnings.append("benchmark/eval surface requires claim-boundary review")
+    if surfaces & {"product-runtime", "governance-adr"}:
+        warnings.append("runtime/governance surface requires reviewer attention")
+
+    if task_id:
+        handoff = check_handoff(task_id, changed_files=files, repo_root=repo_root)
+        if handoff.ok:
+            evidence.append(f"handoff-check passed for {task_id}")
+        else:
+            blockers.append("handoff-check failed or has weak evidence")
+    else:
+        warnings.append("no task id provided; handoff-check was not evaluated")
+
+    privacy_findings = audit_privacy_output(repo_root / "reports" / "agent_loop", out_path=None, repo_root=repo_root)
+    if privacy_findings:
+        blockers.append(f"privacy audit found {len(privacy_findings)} generated artifact issue(s)")
+    else:
+        evidence.append("generated agent-loop privacy audit has no findings")
+
+    if body is not None:
+        body_path = _resolve_input_path(body, repo_root=repo_root)
+        if body_path.exists():
+            pr_findings = check_pr_body_text(_read_text(body_path), changed_files=files, branch=branch, repo_root=repo_root)
+            if pr_findings:
+                blockers.append(f"PR body check has {len(pr_findings)} finding(s)")
+            else:
+                evidence.append("PR body check has no findings")
+        else:
+            blockers.append("PR body path does not exist")
+    else:
+        warnings.append("no PR body was provided")
+
+    if claim_text is not None:
+        resolved_claim = _resolve_input_path(claim_text, repo_root=repo_root)
+        if resolved_claim.exists():
+            claim_findings = audit_claim_text(_read_text(resolved_claim), surface)
+            if claim_findings:
+                blockers.append(f"claim audit found {len(claim_findings)} issue(s)")
+            else:
+                evidence.append("claim audit found no risky wording")
+        else:
+            blockers.append("claim text path does not exist")
+    else:
+        warnings.append("no claim text was provided")
+
+    manifest = _manifest_freshness(changed_files=files, repo_root=repo_root)
+    if manifest.get("current"):
+        evidence.append("manifest freshness hash matches changed files")
+    else:
+        warnings.append("manifest is missing or stale")
+
+    score = 100 - (30 * len(blockers)) - (8 * len(warnings))
+    score = max(0, min(100, score))
+    decision = "ready-for-human-approval" if not blockers and score >= 80 else ("blocked" if blockers else "review-before-ship")
+    if pr:
+        evidence.append(f"PR context: {_validate_pr_selector(pr)}")
+    return ReadinessScore(
+        score=score,
+        decision=decision,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        evidence=tuple(_dedupe_preserve_order(evidence)),
+    )
+
+
+def render_readiness_score(report: ReadinessScore, *, changed_files: Sequence[str], pr: str | None) -> str:
+    lines = [
+        "# PR Readiness Score",
+        "",
+        "- Decision support only. This score does not push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.",
+        f"- Score: `{report.score}`",
+        f"- Decision: `{report.decision}`",
+        f"- PR: `{_validate_pr_selector(pr) if pr else 'N/A'}`",
+        "",
+        "## Changed Files",
+        "",
+    ]
+    lines.extend(f"- `{_display_path(path)}`" for path in changed_files) if changed_files else lines.append("- `N/A`")
+    lines.extend(["", "## Blockers", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.blockers) if report.blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.warnings) if report.warnings else lines.append("- None")
+    lines.extend(["", "## Evidence", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.evidence) if report.evidence else lines.append("- None")
+    lines.extend(["", "## Next Safe Command", "", "```bash", "python3 scripts/agent_loop.py approval-packet --from-git", "```", ""])
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_branch_issue_hygiene(
+    *,
+    branch: str | None = None,
+    body: Path | None = None,
+    task_id: str | None = None,
+    out: Path = DEFAULT_BRANCH_ISSUE_HYGIENE,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, int, str]:
+    rendered, findings = render_branch_issue_hygiene(
+        branch=branch or _current_branch(repo_root) or "unknown",
+        body=body,
+        task_id=task_id,
+        repo_root=repo_root,
+    )
+    out = _default_output(out, DEFAULT_BRANCH_ISSUE_HYGIENE, "branch_issue_hygiene.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, 1 if findings else 0, rendered
+
+
+def render_branch_issue_hygiene(
+    *,
+    branch: str,
+    body: Path | None,
+    task_id: str | None,
+    repo_root: Path,
+) -> tuple[str, list[str]]:
+    findings: list[str] = []
+    safe_branch = _sanitize_inline_text(branch)
+    issue = _issue_from_branch(safe_branch)
+    if not re.match(r"^[a-z][a-z0-9_-]*/issue-\d+", safe_branch):
+        findings.append("branch does not match ADR 0007 `<type>/issue-<N>` convention")
+    if not issue:
+        findings.append("branch does not expose an issue number")
+    closers: list[str] = []
+    body_label = "N/A"
+    if body is not None:
+        body_path = _resolve_input_path(body, repo_root=repo_root)
+        body_label = _display_path(_repo_path(body_path, repo_root), repo_root=repo_root)
+        if body_path.exists():
+            closers = re.findall(r"\b(?:Closes|Fixes|Resolves)\s+#(\d+)\b", _sanitize_dynamic_text(_read_text(body_path)), re.IGNORECASE)
+            if not closers:
+                findings.append("PR body has no Closes/Fixes/Resolves issue reference")
+            elif issue and issue not in closers:
+                findings.append("PR body issue reference does not match branch issue")
+        else:
+            findings.append("PR body path does not exist")
+    else:
+        findings.append("PR body was not provided")
+    if task_id and not TASK_ID_RE.fullmatch(task_id):
+        findings.append("task id does not match T-YYYY-NNNN")
+    lines = [
+        "# Branch / Issue Hygiene",
+        "",
+        "- Read-only hygiene check. It does not create issues, rename branches, push, create PRs, merge, close, or delete branches.",
+        f"- Branch: `{safe_branch}`",
+        f"- Issue from branch: `{issue or 'N/A'}`",
+        f"- PR body: `{body_label}`",
+        f"- PR body closers: `{', '.join('#' + item for item in closers) if closers else 'N/A'}`",
+        f"- Task: `{task_id or 'N/A'}`",
+        "",
+        "## Findings",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in findings) if findings else lines.append("- None")
+    lines.extend(["", "## Next Safe Command", "", "```bash", "make check-branch", "```", ""])
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n", findings
+
+
+def write_integration_pack(
+    *,
+    out: Path = DEFAULT_INTEGRATION_PACK,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_integration_pack(repo_root=repo_root)
+    out = _default_output(out, DEFAULT_INTEGRATION_PACK, "integration_pack.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_integration_pack(*, repo_root: Path = ROOT_DIR) -> str:
+    return _sanitize_dynamic_text(
+        f"""# Agent Loop Integration Pack
+
+- Purpose: package read-only CLI/MCP usage for Codex, Claude, ChatGPT, and generic MCP clients.
+- This pack does not call external LLM APIs, install clients, push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.
+
+## Local CLI
+
+```bash
+python3 scripts/agent_loop.py map
+python3 scripts/agent_loop.py dashboard --from-git
+python3 scripts/agent_loop.py readiness-score --from-git
+```
+
+## MCP
+
+```bash
+python3 scripts/agent_loop.py mcp-config --out reports/agent_loop/mcp_client_config.md
+python3 scripts/agent_loop_mcp.py
+```
+
+## Agent Profiles
+
+- Codex: use `context-pack --profile codex` for implementation context.
+- Claude: use `context-pack --profile claude` for hooks, slash commands, and long-session handoff.
+- ChatGPT: use `context-pack --profile chatgpt` for decision support and reviewer prompts.
+
+## Privacy Boundary
+
+- Share generated summaries only after checking `privacy-audit-output`.
+- Do not paste private raw question, answer, evidence, doc_id, chunk_id, filename, exact local path, or private case text into external services.
+
+## Repo
+
+- Root placeholder: `<REPO_ROOT>`
+- Current branch: `{_current_branch(repo_root) or 'unknown'}`
+"""
+    ).rstrip() + "\n"
+
+
+def write_schedule_config(
+    *,
+    out: Path = DEFAULT_SCHEDULE_CONFIG,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_schedule_config()
+    out = _default_output(out, DEFAULT_SCHEDULE_CONFIG, "schedule_config.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_schedule_config() -> str:
+    return """# Agent Loop Scheduled Status Recipe
+
+- Recipe only. This command does not install cron jobs, create Codex app automations, push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.
+- Keep scheduled jobs read-only/report-only unless a human explicitly changes the policy.
+
+## Safe Refresh Commands
+
+```bash
+python3 scripts/agent_loop.py loop-state --from-git --out reports/agent_loop/loop_state.json
+python3 scripts/agent_loop.py dashboard --from-git --out reports/agent_loop/dashboard.md
+python3 scripts/agent_loop.py stale-reports --from-git --out reports/agent_loop/stale_reports.md
+python3 scripts/agent_loop.py privacy-audit-output --path reports/agent_loop --out reports/agent_loop/privacy_audit.md
+```
+
+## Human Gate
+
+- Ask before installing a recurring runner.
+- Do not schedule `validate` with private real-eval inputs.
+- Do not schedule push, PR creation, merge, close, branch deletion, or force-push.
+""".rstrip() + "\n"
+
+
+def append_validation_history(
+    runs: Sequence[ValidationRun],
+    *,
+    changed_files: Sequence[str],
+    history: Path = DEFAULT_VALIDATION_HISTORY,
+    repo_root: Path = ROOT_DIR,
+) -> Path:
+    if history == DEFAULT_VALIDATION_HISTORY:
+        history = repo_root / "reports" / "agent_loop" / "validation_history.jsonl"
+    safe_history = _safe_output_path(history, repo_root=repo_root)
+    safe_history.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "git_head": _current_git_head(repo_root) or "unknown",
+        "branch": _current_branch(repo_root) or "unknown",
+        "changed_files_hash": _changed_files_hash(changed_files, repo_root=repo_root),
+        "changed_files": [_display_path(path, repo_root=repo_root) for path in changed_files],
+        "commands": [
+            {
+                "command": _sanitize_command_text(run.command),
+                "returncode": run.returncode,
+            }
+            for run in runs
+        ],
+    }
+    with safe_history.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+    return safe_history
+
+
+def write_validation_history_report(
+    *,
+    history: Path = DEFAULT_VALIDATION_HISTORY,
+    out: Path = DEFAULT_VALIDATION_HISTORY_REPORT,
+    limit: int = 10,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    entries = read_validation_history(history=history, limit=limit, repo_root=repo_root)
+    rendered = render_validation_history(entries, history=history, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_VALIDATION_HISTORY_REPORT, "validation_history.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def read_validation_history(*, history: Path, limit: int, repo_root: Path) -> list[dict[str, object]]:
+    path = repo_root / "reports" / "agent_loop" / "validation_history.jsonl" if history == DEFAULT_VALIDATION_HISTORY else _resolve_input_path(history, repo_root=repo_root)
+    if not path.exists():
+        return []
+    entries: list[dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            entries.append(payload)
+    return entries[-limit:]
+
+
+def render_validation_history(entries: Sequence[dict[str, object]], *, history: Path, repo_root: Path) -> str:
+    history_label = _display_path(_repo_path(history if history.is_absolute() else repo_root / history, repo_root), repo_root=repo_root)
+    lines = [
+        "# Validation History",
+        "",
+        "- Local JSONL ledger summary. It stores command names and return codes, not raw stdout/stderr.",
+        f"- History: `{history_label}`",
+        f"- Entry count shown: `{len(entries)}`",
+        "",
+        "| Time | Git HEAD | Commands | Result |",
+        "|---|---|---|---|",
+    ]
+    if entries:
+        for entry in entries:
+            commands = entry.get("commands") if isinstance(entry.get("commands"), list) else []
+            command_count = len(commands)
+            failed = any(isinstance(command, dict) and command.get("returncode") not in {0, "0"} for command in commands)
+            lines.append(
+                f"| `{_sanitize_inline_text(str(entry.get('generated_at', 'unknown')))}` | "
+                f"`{_sanitize_inline_text(str(entry.get('git_head', 'unknown')))}` | `{command_count}` | "
+                f"`{'fail' if failed else 'pass'}` |"
+            )
+    else:
+        lines.append("| `N/A` | `N/A` | `0` | `N/A` |")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_privacy_regression(
+    *,
+    out: Path = DEFAULT_PRIVACY_REGRESSION,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, int, str]:
+    rendered, failures = render_privacy_regression()
+    out = _default_output(out, DEFAULT_PRIVACY_REGRESSION, "privacy_regression.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, 1 if failures else 0, rendered
+
+
+def render_privacy_regression() -> tuple[str, list[str]]:
+    samples = [
+        "question: PRIVATE_QUERY\nanswer: PRIVATE_ANSWER\nevidence: PRIVATE_EVIDENCE\ndoc_id: DOC-1\nchunk_id: CHUNK-1\n/Users/example/private.pdf",
+        "--raw-question PRIVATE_QUERY --answer PRIVATE_ANSWER --doc-id DOC-1 --chunk-id CHUNK-1",
+    ]
+    failures: list[str] = []
+    for index, sample in enumerate(samples, start=1):
+        sanitized = _sanitize_command_text(_sanitize_dynamic_text(sample))
+        if any(token in sanitized for token in ("PRIVATE_QUERY", "PRIVATE_ANSWER", "PRIVATE_EVIDENCE", "DOC-1", "CHUNK-1", "/Users/example")):
+            failures.append(f"sample-{index} leaked a private token")
+        if _privacy_audit_text(sanitized):
+            failures.append(f"sample-{index} still matches privacy audit patterns after sanitization")
+    lines = [
+        "# Privacy Regression",
+        "",
+        "- Fixture-based sanitizer check. It does not read private data, push, create/merge/close PRs, delete branches, force-push, run private eval, or call external services.",
+        f"- Result: `{'fail' if failures else 'pass'}`",
+        f"- Sample count: `{len(samples)}`",
+        "",
+        "## Findings",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in failures) if failures else lines.append("- None")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n", failures
+
+
+def write_claim_policy(
+    *,
+    changed_files: Sequence[str] = (),
+    text: Path | None = None,
+    out: Path = DEFAULT_CLAIM_POLICY,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, int, str]:
+    surface = classify_changed_files(changed_files)
+    findings: list[ClaimFinding] = []
+    source = "N/A"
+    if text is not None:
+        path = _resolve_input_path(text, repo_root=repo_root)
+        if not path.exists():
+            raise ValueError(f"claim text file not found: {_display_path(str(text), repo_root=repo_root)}")
+        source = _display_path(_repo_path(path, repo_root), repo_root=repo_root)
+        findings = audit_claim_text(_read_text(path), surface)
+    rendered = render_claim_policy(surface=surface, findings=findings, source=source)
+    out = _default_output(out, DEFAULT_CLAIM_POLICY, "claim_policy.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, 1 if findings else 0, rendered
+
+
+def render_claim_policy(*, surface: SurfaceReport, findings: Sequence[ClaimFinding], source: str) -> str:
+    lines = [
+        "# Claim Policy",
+        "",
+        "- Claim policy helper. It does not approve benchmark/performance/private real-eval claims.",
+        f"- Surface: `{surface.surface}`",
+        f"- Additional surfaces: `{', '.join(surface.additional_surfaces) if surface.additional_surfaces else 'N/A'}`",
+        f"- Required reviewer: `{surface.reviewer_type}`",
+        f"- Source: `{_sanitize_dynamic_text(source)}`",
+        "",
+        "## Allowed Without Extra Human Claim Approval",
+        "",
+        "- Local orchestration, docs, or CI-helper wording that does not claim product quality, benchmark lift, private real-eval success, latency improvement, or production behavior.",
+        "",
+        "## Disallowed Or Human-Gated Claims",
+        "",
+    ]
+    lines.extend(f"- {claim}" for claim in surface.disallowed_claims)
+    lines.extend(["", "## Text Findings", ""])
+    if findings:
+        for finding in findings:
+            lines.append(f"- `{finding.severity}` / `{finding.reviewer}`: {_sanitize_dynamic_text(finding.issue)}")
+    else:
+        lines.append("- None")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_architecture_decision(
+    *,
+    changed_files: Sequence[str] = (),
+    out: Path = DEFAULT_ARCHITECTURE_DECISION,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    surface = classify_changed_files(changed_files)
+    rendered = render_architecture_decision(surface=surface, changed_files=changed_files)
+    out = _default_output(out, DEFAULT_ARCHITECTURE_DECISION, "architecture_decision.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_architecture_decision(*, surface: SurfaceReport, changed_files: Sequence[str]) -> str:
+    load_bearing = [path for path in changed_files if path != "[redacted-local-path]" and is_load_bearing(_normalize_changed_file(path))]
+    adr_files = [path for path in changed_files if _normalize_changed_file(path).startswith("docs/adr/")]
+    surfaces = {surface.surface, *surface.additional_surfaces}
+    likely = bool(load_bearing or adr_files or surfaces & {"product-runtime", "eval-harness", "public-synthetic-benchmark", "private-real-eval", "governance-adr"})
+    decision = "human-architecture-review-required" if likely else "no-architecture-decision-detected"
+    lines = [
+        "# Architecture Decision Detector",
+        "",
+        "- Detector only. It does not choose architecture, write ADRs, push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.",
+        f"- Decision: `{decision}`",
+        f"- Surface: `{surface.surface}`",
+        f"- Load-bearing files: `{len(load_bearing)}`",
+        f"- ADR files: `{len(adr_files)}`",
+        "",
+        "## Signals",
+        "",
+    ]
+    lines.extend(f"- `{_display_path(path)}`" for path in changed_files) if changed_files else lines.append("- `N/A`")
+    lines.extend(
+        [
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            "python3 scripts/agent_loop.py architecture-brief --from-git",
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_workset_recommendation(
+    *,
+    batch: Path | None = None,
+    tasks_dir: Path = DEFAULT_CODEX_TASKS_DIR,
+    max_items: int = 12,
+    out: Path = DEFAULT_WORKSET_RECOMMENDATION,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_workset_recommendation(batch=batch, tasks_dir=tasks_dir, max_items=max_items, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_WORKSET_RECOMMENDATION, "workset_recommendation.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_workset_recommendation(*, batch: Path | None, tasks_dir: Path, max_items: int, repo_root: Path) -> str:
+    items: list[dict[str, object]] = []
+    source = "batch JSON"
+    if batch is not None:
+        path = _resolve_input_path(batch, repo_root=repo_root)
+        items = _load_batch_payload(path)
+        source = _display_path(_repo_path(path, repo_root), repo_root=repo_root)
+    else:
+        resolved_tasks_dir = repo_root / "reports" / "agent_loop" / "codex_tasks" if tasks_dir == DEFAULT_CODEX_TASKS_DIR else _resolve_input_path(tasks_dir, repo_root=repo_root)
+        briefs = _load_brief_summaries(resolved_tasks_dir, max_items=max_items, repo_root=repo_root)
+        items = [_brief_summary_payload(brief, repo_root=repo_root) for brief in briefs]
+        source = _display_path(_repo_path(resolved_tasks_dir, repo_root), repo_root=repo_root)
+    lanes: dict[str, list[dict[str, object]]] = {}
+    for item in items:
+        lanes.setdefault(str(item.get("lane", "unknown")), []).append(item)
+    lines = [
+        "# Workset Recommendation",
+        "",
+        "- Local planning recommendation. It does not edit queue/plan docs, push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.",
+        f"- Source: `{source}`",
+        "",
+        "## Candidate Sets",
+        "",
+    ]
+    serial = lanes.get("serial", [])[:1]
+    parallel = lanes.get("parallel-safe", [])[:3]
+    review = lanes.get("review-only", [])[:3]
+    manual = lanes.get("manual-gated", [])[:3]
+    lines.extend(_render_workset_section("Set A - serial unblocker", serial, "Run one item first; it likely gates downstream work."))
+    lines.extend(_render_workset_section("Set B - parallel candidates", parallel, "Can be delegated after checking file overlap and claim surface."))
+    lines.extend(_render_workset_section("Set C - review-only passes", review, "Use adversarial review without implementation mutation."))
+    lines.extend(_render_workset_section("Set D - manual-gated", manual, "Prepare decision briefs; do not automate the gated action."))
+    lines.extend(["", "## Next Safe Command", "", "```bash", "python3 scripts/agent_loop.py decision-brief --gate task", "```", ""])
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def _render_workset_section(title: str, items: Sequence[dict[str, object]], guidance: str) -> list[str]:
+    lines = [f"### {title}", "", f"- Guidance: {_sanitize_dynamic_text(guidance)}"]
+    if not items:
+        lines.append("- Items: `N/A`")
+    for item in items:
+        lines.append(f"- `{_sanitize_inline_text(str(item.get('title', 'Untitled')))}` - {_sanitize_inline_text(str(item.get('reason', '')))}")
+    lines.append("")
+    return lines
+
+
+def write_dependency_graph(
+    *,
+    branch: str,
+    pr_json: Path | None = None,
+    out: Path = DEFAULT_DEPENDENCY_GRAPH,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    items = _stacked_pr_items(branch=branch, pr_json=pr_json, repo_root=repo_root)
+    rendered = render_dependency_graph(branch=branch, items=items)
+    out = _default_output(out, DEFAULT_DEPENDENCY_GRAPH, "dependency_graph.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_dependency_graph(*, branch: str, items: Sequence[dict[str, object]]) -> str:
+    safe_branch = _sanitize_inline_text(branch)
+    lines = [
+        "# Stacked Dependency Graph",
+        "",
+        "- Read-only graph. It does not merge, close, delete branches, push, or force-push.",
+        f"- Base branch: `{safe_branch}`",
+        "",
+        "```mermaid",
+        "flowchart TD",
+        f"  base[\"{safe_branch}\"]",
+    ]
+    if items:
+        for item in items:
+            node_id = "pr" + re.sub(r"\W+", "_", str(item.get("number", "x")))
+            label = f"PR #{item.get('number', 'N/A')} {str(item.get('headRefName') or 'unknown')}"
+            lines.append(f"  {node_id}[\"{_sanitize_inline_text(label)}\"] --> base")
+    else:
+        lines.append('  none["No dependent PRs detected"] --> base')
+    lines.extend(
+        [
+            "```",
+            "",
+            "## Human Gate",
+            "",
+            "- If dependents exist, branch deletion and merge cleanup require explicit human approval.",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_automation_coverage(
+    *,
+    out: Path = DEFAULT_AUTOMATION_COVERAGE,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_automation_coverage()
+    out = _default_output(out, DEFAULT_AUTOMATION_COVERAGE, "automation_coverage.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def render_automation_coverage() -> str:
+    rows = (
+        ("1", "PR review thread ingest", "review-threads, review-plan, review-ingest"),
+        ("2", "CI logs summary", "ci-summary, ci-ingest"),
+        ("3", "PR readiness score", "readiness-score, approval-packet, ship-simulate"),
+        ("4", "dashboard UX", "dashboard, dashboard-html, loop-state"),
+        ("5", "artifact freshness", "artifact-freshness, stale-reports, manifest"),
+        ("6", "safe local auto-fix", "safe-fix, patch-proposal"),
+        ("7", "review to patch proposal", "review-patch-plan, patch-proposal"),
+        ("8", "queue/plan sync UX", "queue-plan-sync, propose-queue-plan, apply-queue-plan"),
+        ("9", "stacked PR dependency graph", "dependency-graph, stacked-risk"),
+        ("10", "branch/issue hygiene", "branch-issue-hygiene, pr-body-check"),
+        ("11", "agent integrations", "integration-pack, mcp-config, context-pack"),
+        ("12", "scheduled status recipe", "scheduled-status"),
+        ("13", "validation history ledger", "validate --record-history, validation-history"),
+        ("14", "privacy regression corpus", "privacy-regression, privacy-audit-output"),
+        ("15", "claim policy engine", "claim-policy, claim-audit"),
+        ("16", "architecture decision detector", "architecture-decision, architecture-brief, adr-reserve"),
+        ("17", "next work-set recommender", "workset-recommend, batch-plan"),
+        ("18", "auto-pass strict profiles", "auto-pass-check --profile ..."),
+        ("19", "human-approved remote execution", "human-gated-exec --confirm-human-approved"),
+        ("20", "existing auto-ship bridge", "auto-ship-prepare, auto-ship-plan, ship-simulate, ship-command-pack"),
+    )
+    lines = [
+        "# Agent Loop Automation Coverage",
+        "",
+        "- Coverage map only. It does not execute gated actions.",
+        "",
+        "| # | Candidate | Implemented command surface |",
+        "|---:|---|---|",
+    ]
+    lines.extend(f"| {index} | {name} | `{commands}` |" for index, name, commands in rows)
+    lines.extend(
+        [
+            "",
+            "## Still Human-Gated",
+            "",
+            "- Queue/plan actual tracked-doc application unless `--confirm-human-approved` is explicit.",
+            "- Running existing `make ship-arm` remains a shipping approval; `auto-ship-plan` only prepares a plan.",
+            "- Push, PR create/merge/close, branch delete, force-push require `human-gated-exec --confirm-human-approved` plus action-specific gates.",
+            "- Private real-eval decisions, benchmark/performance claims, architecture tradeoffs.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_loop_state(
+    *,
+    task_id: str | None = None,
+    batch: Path | None = None,
+    review_followups: Path | None = None,
+    changed_files: Sequence[str] = (),
+    pr: str | None = None,
+    out: Path = DEFAULT_LOOP_STATE,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, dict[str, object]]:
+    state = build_loop_state(
+        task_id=task_id,
+        batch=batch,
+        review_followups=review_followups,
+        changed_files=changed_files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    if out == DEFAULT_LOOP_STATE:
+        out = repo_root / "reports" / "agent_loop" / "loop_state.json"
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return safe_out, state
+
+
+def build_loop_state(
+    *,
+    task_id: str | None,
+    batch: Path | None,
+    review_followups: Path | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    repo_root: Path,
+) -> dict[str, object]:
+    surface = classify_changed_files(changed_files)
+    gate = build_gate_status(
+        task_id=task_id,
+        batch=batch,
+        review_followups=review_followups,
+        changed_files=changed_files,
+        pr=pr,
+        repo_root=repo_root,
+    )
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "task": None,
+        "pr": _validate_pr_selector(pr) if pr else None,
+        "gate": gate,
+        "surface": {
+            "surface": surface.surface,
+            "confidence": surface.confidence,
+            "reviewer_type": surface.reviewer_type,
+            "additional_surfaces": list(surface.additional_surfaces),
+            "matched_files": [_display_path(path) for path in surface.matched_files],
+            "disallowed_claims": list(surface.disallowed_claims),
+        },
+        "validation_suggestions": suggest_validation_commands(changed_files),
+        "artifacts": _loop_artifact_state(repo_root),
+        "freshness": _report_freshness(repo_root=repo_root, max_age_days=7),
+        "manifest": _manifest_freshness(changed_files=changed_files, repo_root=repo_root),
+    }
+    if task_id:
+        task = load_task(task_id, repo_root)
+        handoff = check_handoff(task_id, changed_files=changed_files, repo_root=repo_root)
+        payload["task"] = {
+            "id": task.task_id,
+            "title": _sanitize_inline_text(task.title),
+            "status": task.status or "unknown",
+            "owner_role": task.owner_role or "unknown",
+            "handoff_ok": handoff.ok,
+            "handoff_missing": list(handoff.missing_fields),
+            "handoff_invalid": list(handoff.invalid_fields),
+        }
+    return payload
+
+
+def _loop_artifact_state(repo_root: Path) -> dict[str, bool]:
+    rels = (
+        "reports/agent_loop/pr_state.json",
+        "reports/agent_loop/ai_next_actions.md",
+        "reports/agent_loop/codex_tasks",
+        "reports/agent_loop/batch_plan.json",
+        "reports/agent_loop/queue_entry_draft.md",
+        "reports/agent_loop/plan_draft.md",
+        "reports/agent_loop/review_followups.md",
+        "reports/agent_loop/decision_brief.md",
+        "reports/agent_loop/auto_pass.md",
+        "reports/agent_loop/dashboard.md",
+        "reports/agent_loop/mcp_client_config.md",
+        "reports/agent_loop/review_ingest.md",
+        "reports/agent_loop/pr_health.md",
+        "reports/agent_loop/safe_fix.md",
+        "reports/agent_loop/approval_packet.md",
+        "reports/agent_loop/queue_plan_patch.diff",
+        "reports/agent_loop/pr_body.md",
+        "reports/agent_loop/review_plan.md",
+        "reports/agent_loop/stale_reports.md",
+        "reports/agent_loop/context_pack.md",
+        "reports/agent_loop/architecture_brief.md",
+        "reports/agent_loop/ship_simulation.md",
+        "reports/agent_loop/gate_brief.md",
+        "reports/agent_loop/manifest.json",
+        "reports/agent_loop/pr_body_check.md",
+        "reports/agent_loop/ci_ingest.md",
+        "reports/agent_loop/ci_followups",
+        "reports/agent_loop/stacked_risk.md",
+        "reports/agent_loop/patch_proposal.diff",
+        "reports/agent_loop/adr_reservation.md",
+        "reports/agent_loop/adr_draft.md",
+        "reports/agent_loop/dashboard.html",
+        "reports/agent_loop/ship_commands.md",
+        "reports/agent_loop/apply_queue_plan.md",
+        "reports/agent_loop/review_threads.md",
+        "reports/agent_loop/ci_summary.md",
+        "reports/agent_loop/readiness_score.md",
+        "reports/agent_loop/branch_issue_hygiene.md",
+        "reports/agent_loop/integration_pack.md",
+        "reports/agent_loop/schedule_config.md",
+        "reports/agent_loop/validation_history.jsonl",
+        "reports/agent_loop/validation_history.md",
+        "reports/agent_loop/privacy_regression.md",
+        "reports/agent_loop/claim_policy.md",
+        "reports/agent_loop/architecture_decision.md",
+        "reports/agent_loop/workset_recommendation.md",
+        "reports/agent_loop/dependency_graph.md",
+        "reports/agent_loop/automation_coverage.md",
+        "reports/agent_loop/human_gated_exec.md",
+    )
+    return {rel: (repo_root / rel).exists() for rel in rels}
+
+
+def build_decision_points(
+    *,
+    task_id: str | None,
+    batch: Path | None,
+    review_followups: Path | None,
+    gate: str,
+    changed_files: Sequence[str],
+    pr: str | None,
+    repo_root: Path,
+) -> list[DecisionPoint]:
+    if gate not in {"auto", "task", "plan", "review", "claim", "ship"}:
+        raise ValueError("--gate must be one of: auto, task, plan, review, claim, ship")
+    points: list[DecisionPoint] = []
+    if task_id and gate in {"auto", "task", "plan"}:
+        task = load_task(task_id, repo_root)
+        points.append(_task_decision_point(task, repo_root=repo_root))
+
+    batch_path = _default_existing_path(batch, repo_root / "reports" / "agent_loop" / "batch_plan.json")
+    if batch_path is not None and gate in {"auto", "task", "plan"}:
+        batch_path = _resolve_input_path(batch_path, repo_root=repo_root)
+        if not batch_path.exists():
+            raise ValueError(f"batch plan not found: {_display_path(_repo_path(batch_path, repo_root), repo_root=repo_root)}")
+        points.append(_batch_decision_point(batch_path, repo_root=repo_root))
+
+    followups_path = _default_existing_path(
+        review_followups,
+        repo_root / "reports" / "agent_loop" / "review_followups.md",
+    )
+    if followups_path is not None and gate in {"auto", "review"}:
+        followups_path = _resolve_input_path(followups_path, repo_root=repo_root)
+        if not followups_path.exists():
+            raise ValueError(
+                f"review followups not found: {_display_path(_repo_path(followups_path, repo_root), repo_root=repo_root)}"
+            )
+        points.append(_review_followup_decision_point(followups_path, repo_root=repo_root))
+
+    if changed_files and gate in {"auto", "claim"}:
+        points.append(_claim_decision_point(changed_files, repo_root=repo_root))
+
+    if (pr or gate == "ship") and gate in {"auto", "ship"}:
+        points.append(_ship_decision_point(pr=pr, changed_files=changed_files))
+
+    if not points:
+        points.append(_no_input_decision_point())
+    return points
+
+
+def _default_existing_path(path: Path | None, default: Path) -> Path | None:
+    if path is None:
+        return default if default.exists() else None
+    return path
+
+
+def _task_decision_point(task: TaskEntry, *, repo_root: Path) -> DecisionPoint:
+    plan = find_plan_path(task, repo_root)
+    validation = _extract_validation_commands(task)
+    next_validation = validation[0] if validation else "python3 scripts/agent_loop.py suggest-validation --from-git"
+    context = (
+        f"Task: `{task.task_id}` - {_sanitize_inline_text(task.title)}",
+        f"Status: `{task.status or 'unknown'}`",
+        f"Owner role: `{task.owner_role or 'unknown'}`",
+        f"Plan: `{_display_path(_repo_path(plan, repo_root), repo_root=repo_root) if plan else 'N/A'}`",
+    )
+    return DecisionPoint(
+        gate="task-scope",
+        title="Decide whether to promote the task/plan draft",
+        context=context,
+        options=(
+            DecisionOption(
+                label="Keep as draft and inspect scope",
+                recommended=True,
+                severity="medium",
+                reversibility="high",
+                tradeoffs=(
+                    "Safest default; avoids committing an ambiguous task or plan.",
+                    "Costs another review pass before implementation starts.",
+                ),
+                evidence_needed=(
+                    "Task has acceptance criteria and validation commands.",
+                    "Plan path exists or the work is small enough to proceed without one.",
+                ),
+                next_safe_command=f"python3 scripts/agent_loop.py render-prompt --task {task.task_id}",
+                manual_approval="Required before editing queue/plan docs.",
+            ),
+            DecisionOption(
+                label="Promote draft to queue/plan",
+                recommended=False,
+                severity="medium",
+                reversibility="medium",
+                tradeoffs=(
+                    "Makes the work visible to future sessions.",
+                    "Can create queue churn if the task is too broad or duplicates active work.",
+                ),
+                evidence_needed=(
+                    "No duplicate active task in `tasks/queue.md`.",
+                    "Scope is one concern and has reviewer focus.",
+                ),
+                next_safe_command="python3 scripts/agent_loop.py batch-plan",
+                manual_approval="Required because this changes tracked governance docs.",
+            ),
+            DecisionOption(
+                label="Split or defer the task",
+                recommended=False,
+                severity="low",
+                reversibility="high",
+                tradeoffs=(
+                    "Reduces implementation risk if the task mixes surfaces.",
+                    "May delay visible progress if overused.",
+                ),
+                evidence_needed=("Multiple surfaces, missing validation, or unclear owner role.",),
+                next_safe_command="python3 scripts/agent_loop.py map",
+                manual_approval="Human scope judgment required.",
+            ),
+        ),
+    )
+
+
+def _batch_decision_point(batch_path: Path, *, repo_root: Path) -> DecisionPoint:
+    payload = _load_batch_payload(batch_path)
+    counts = {lane: 0 for lane in ("serial", "parallel-safe", "review-only", "manual-gated")}
+    for item in payload:
+        lane = str(item.get("lane") or "unknown")
+        if lane in counts:
+            counts[lane] += 1
+    context = (
+        f"Batch file: `{_display_path(_repo_path(batch_path, repo_root), repo_root=repo_root)}`",
+        "Lane counts: "
+        + ", ".join(f"`{lane}`={count}" for lane, count in counts.items()),
+    )
+    serial_count = counts["serial"]
+    parallel_count = counts["parallel-safe"]
+    manual_count = counts["manual-gated"]
+    return DecisionPoint(
+        gate="batch-selection",
+        title="Choose the next task lane",
+        context=context,
+        options=(
+            DecisionOption(
+                label="Run the first serial blocker",
+                recommended=serial_count > 0,
+                severity="high" if serial_count else "low",
+                reversibility="medium",
+                tradeoffs=(
+                    "Clears dependencies before parallel work expands the state space.",
+                    "Can block throughput if the serial item needs human evidence or external review.",
+                ),
+                evidence_needed=("Serial lane item has a focused validation command.",),
+                next_safe_command="python3 scripts/agent_loop.py draft-task --task-brief reports/agent_loop/codex_tasks/001-*.md",
+                manual_approval="Required before applying generated queue/plan drafts.",
+            ),
+            DecisionOption(
+                label="Assign parallel-safe candidates",
+                recommended=serial_count == 0 and parallel_count > 0,
+                severity="medium",
+                reversibility="medium",
+                tradeoffs=(
+                    "Improves throughput when candidates touch independent surfaces.",
+                    "Raises coordination cost and can create merge conflicts if independence is misclassified.",
+                ),
+                evidence_needed=("No shared files, shared PR source, or manual-gated claim surface.",),
+                next_safe_command="python3 scripts/agent_loop.py batch-plan",
+                manual_approval="Human should confirm independence before parallel execution.",
+            ),
+            DecisionOption(
+                label="Hold manual-gated items",
+                recommended=manual_count > 0,
+                severity="high" if manual_count else "low",
+                reversibility="high",
+                tradeoffs=(
+                    "Prevents accidental benchmark/private/PR state claims or destructive actions.",
+                    "May leave shipping or cleanup work waiting on a human decision.",
+                ),
+                evidence_needed=("Reviewer-readable evidence and explicit human approval.",),
+                next_safe_command="python3 scripts/agent_loop.py decision-brief --gate claim --from-git",
+                manual_approval="Required for private eval, benchmark claims, push/PR/merge/close/delete.",
+            ),
+        ),
+    )
+
+
+def _load_batch_payload(batch_path: Path) -> list[dict[str, object]]:
+    try:
+        payload = json.loads(_read_text(batch_path))
+    except json.JSONDecodeError as exc:
+        raise ValueError("batch JSON must be a JSON array; run batch-plan first") from exc
+    if not isinstance(payload, list):
+        raise ValueError("batch JSON must be a JSON array")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _review_followup_decision_point(path: Path, *, repo_root: Path) -> DecisionPoint:
+    text = _sanitize_dynamic_text(_read_text(path))
+    blocking = len(re.findall(r"Severity:\s*`?(?:blocking|p0|p1)`?", text, re.IGNORECASE))
+    manual = len(re.findall(r"Lane:\s*`?manual-gated`?", text, re.IGNORECASE))
+    parsed = len(re.findall(r"^###\s+\d{3}\.", text, re.MULTILINE))
+    context = (
+        f"Review followups: `{_display_path(_repo_path(path, repo_root), repo_root=repo_root)}`",
+        f"Parsed follow-up count: `{parsed}`",
+        f"Blocking/P0/P1 findings: `{blocking}`",
+        f"Manual-gated findings: `{manual}`",
+    )
+    return DecisionPoint(
+        gate="review-findings",
+        title="Choose which reviewer findings to address",
+        context=context,
+        options=(
+            DecisionOption(
+                label="Fix blocking findings first",
+                recommended=blocking > 0,
+                severity="high" if blocking else "low",
+                reversibility="medium",
+                tradeoffs=(
+                    "Targets issues most likely to block review or ship.",
+                    "Can delay smaller cleanup items.",
+                ),
+                evidence_needed=("Focused diff and validation for each blocking finding.",),
+                next_safe_command="python3 scripts/agent_loop.py review-followup --review <review-output.md>",
+                manual_approval="Required if the finding is privacy, benchmark, or architecture gated.",
+            ),
+            DecisionOption(
+                label="Convert non-blocking findings to follow-up tasks",
+                recommended=blocking == 0 and parsed > 0,
+                severity="medium",
+                reversibility="high",
+                tradeoffs=(
+                    "Keeps current PR focused while preserving reviewer feedback.",
+                    "Can accumulate debt if follow-ups are not queued.",
+                ),
+                evidence_needed=("Clear rationale for deferring each non-blocking item.",),
+                next_safe_command="python3 scripts/agent_loop.py batch-plan",
+                manual_approval="Required before changing queue/plan docs.",
+            ),
+            DecisionOption(
+                label="Reject or defer a finding with rationale",
+                recommended=False,
+                severity="medium",
+                reversibility="medium",
+                tradeoffs=(
+                    "Useful when a finding is out of scope or factually wrong.",
+                    "Risky if done without evidence; may hide a real regression.",
+                ),
+                evidence_needed=("File/line evidence, contract citation, or test output supporting the decision.",),
+                next_safe_command="python3 scripts/agent_loop.py render-prompt --task <TASK_ID>",
+                manual_approval="Human reviewer should approve rejected findings.",
+            ),
+        ),
+    )
+
+
+def _claim_decision_point(changed_files: Sequence[str], *, repo_root: Path) -> DecisionPoint:
+    surface = classify_changed_files(changed_files)
+    context = (
+        f"Surface: `{surface.surface}`",
+        f"Confidence: `{surface.confidence}`",
+        f"Required reviewer: `{surface.reviewer_type}`",
+        "Matched files: "
+        + (", ".join(f"`{_display_path(path)}`" for path in surface.matched_files) if surface.matched_files else "`N/A`"),
+        "Disallowed claims: " + "; ".join(surface.disallowed_claims),
+    )
+    surfaces = {surface.surface, *surface.additional_surfaces}
+    sensitive = bool(surfaces & {"private-real-eval", "privacy-sensitive-artifact", "benchmark-reporting"})
+    return DecisionPoint(
+        gate="claim-boundary",
+        title="Decide what claims are allowed",
+        context=context,
+        options=(
+            DecisionOption(
+                label="Make no benchmark/performance/private-data claim",
+                recommended=True,
+                severity="low",
+                reversibility="high",
+                tradeoffs=(
+                    "Safest wording; avoids overclaiming from insufficient evidence.",
+                    "May undersell a valid improvement until evidence is gathered.",
+                ),
+                evidence_needed=("Changed-file surface classification and validation command list.",),
+                next_safe_command="python3 scripts/agent_loop.py suggest-validation --from-git",
+                manual_approval="Not required for conservative no-claim wording.",
+            ),
+            DecisionOption(
+                label="Make a scoped public fixture or synthetic benchmark claim",
+                recommended=False,
+                severity="medium",
+                reversibility="medium",
+                tradeoffs=(
+                    "Can be useful when provenance is complete and wording is narrow.",
+                    "Unsafe if phrased as real-world RFP quality or private eval success.",
+                ),
+                evidence_needed=(
+                    "Dataset/config/index/provenance and exact command output.",
+                    "Benchmark Validity Audit reviewer pass.",
+                ),
+                next_safe_command="python3 scripts/agent_loop.py review-prompt --task <TASK_ID> --from-git",
+                manual_approval="Required before benchmark/performance claims.",
+            ),
+            DecisionOption(
+                label="Use private real-eval evidence",
+                recommended=False,
+                severity="critical" if sensitive else "high",
+                reversibility="low",
+                tradeoffs=(
+                    "Most relevant evidence for private real-data behavior.",
+                    "Highest privacy and claim risk; aggregate-only evidence is mandatory.",
+                ),
+                evidence_needed=(
+                    "Aggregate-only private delta, no raw question/answer/evidence/doc_id/chunk_id/filename/local path.",
+                    "Human approval of claim wording.",
+                ),
+                next_safe_command="python3 scripts/_governance.py --check-eval-privacy",
+                manual_approval="Required for private real-eval decisions and claims.",
+            ),
+        ),
+    )
+
+
+def _ship_decision_point(*, pr: str | None, changed_files: Sequence[str]) -> DecisionPoint:
+    safe_pr = _validate_pr_selector(pr) if pr else "N/A"
+    validation = suggest_validation_commands(changed_files) if changed_files else ["git diff --check"]
+    context = (
+        f"PR: `{safe_pr}`",
+        f"Changed files known: `{len(changed_files)}`",
+        f"Suggested validation count: `{len(validation)}`",
+    )
+    return DecisionPoint(
+        gate="ship",
+        title="Decide whether to push, open PR, merge, close, or delete",
+        context=context,
+        options=(
+            DecisionOption(
+                label="Hold shipping and run local preflight",
+                recommended=True,
+                severity="medium",
+                reversibility="high",
+                tradeoffs=(
+                    "Keeps the state local until validation and handoff evidence are clear.",
+                    "Delays collaboration on GitHub.",
+                ),
+                evidence_needed=("Focused validation, handoff-check, review prompt.",),
+                next_safe_command="python3 scripts/agent_loop.py preflight --task <TASK_ID> --from-git --write-prompts",
+                manual_approval="Not required for local preflight.",
+            ),
+            DecisionOption(
+                label="Push or create/update PR outside this CLI",
+                recommended=False,
+                severity="high",
+                reversibility="medium",
+                tradeoffs=(
+                    "Makes work reviewable in GitHub.",
+                    "Can expose incomplete state or trigger CI/review churn.",
+                ),
+                evidence_needed=("Clean diff, validation evidence, branch/issue convention, PR body evidence.",),
+                next_safe_command="make check-branch",
+                manual_approval="Required by project shipping policy even though this helper does not execute it.",
+            ),
+            DecisionOption(
+                label="Merge, close, or delete branch outside this CLI",
+                recommended=False,
+                severity="critical",
+                reversibility="low",
+                tradeoffs=(
+                    "Can finish or clean up work quickly.",
+                    "Most irreversible path; stacked PRs, unresolved review, or branch deletion can lose coordination state.",
+                ),
+                evidence_needed=("CI state, unresolved review status, stacked dependent check, explicit human approval.",),
+                next_safe_command="make ship-review-gate PR=<N>",
+                manual_approval="Required for merge, close, delete, and force-push decisions.",
+            ),
+        ),
+    )
+
+
+def _no_input_decision_point() -> DecisionPoint:
+    return DecisionPoint(
+        gate="orientation",
+        title="Choose the next decision input",
+        context=("No task, batch, review-followup, changed files, or ship gate input was provided.",),
+        options=(
+            DecisionOption(
+                label="Generate current loop state first",
+                recommended=True,
+                severity="low",
+                reversibility="high",
+                tradeoffs=(
+                    "Gives the decision helper concrete evidence.",
+                    "Adds one local report generation step.",
+                ),
+                evidence_needed=("PR state, task briefs, batch plan, or changed-file surface.",),
+                next_safe_command="python3 scripts/agent_loop.py map",
+                manual_approval="Not required.",
+            ),
+        ),
+    )
+
+
+def render_decision_brief(points: Sequence[DecisionPoint], *, repo_root: Path = ROOT_DIR) -> str:
+    lines = [
+        "# Agent Loop Decision Brief",
+        "",
+        "- This is a decision-support artifact, not an approval or execution command.",
+        "- It does not edit queue/plan docs, push, create/close/merge PRs, delete branches, force-push, or run private eval.",
+        "- Recommended defaults prefer reversible local actions and conservative claim wording.",
+        "",
+    ]
+    for point in points:
+        lines.extend(
+            [
+                f"## {point.title}",
+                "",
+                f"- Gate: `{point.gate}`",
+                "",
+                "### Context",
+                "",
+            ]
+        )
+        lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in point.context)
+        lines.extend(["", "### Options", ""])
+        for index, option in enumerate(point.options, start=1):
+            marker = " (recommended default)" if option.recommended else ""
+            lines.extend(
+                [
+                    f"#### {index}. {option.label}{marker}",
+                    "",
+                    f"- Severity: `{option.severity}`",
+                    f"- Reversibility: `{option.reversibility}`",
+                    f"- Manual approval: {option.manual_approval}",
+                    "- Trade-offs:",
+                ]
+            )
+            lines.extend(f"  - {_sanitize_dynamic_text(item)}" for item in option.tradeoffs)
+            lines.append("- Evidence needed:")
+            lines.extend(f"  - {_sanitize_dynamic_text(item)}" for item in option.evidence_needed)
+            lines.extend(
+                [
+                    "- Next safe command:",
+                    "",
+                    "```bash",
+                    _sanitize_command_text(option.next_safe_command),
+                    "```",
+                    "",
+                ]
+            )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def render_loop_map() -> str:
+    return """# BidMate Agent Loop Map
+
+```mermaid
+flowchart TD
+  A["Repo state: queue, plans, PRs, reports"] --> B["pr-scan: read GitHub PR metadata"]
+  A --> MCP["agent-loop-mcp: expose safe local loop tools to MCP clients"]
+  MCP --> D
+  B --> C["next-from-prs: generate next-action report and task briefs"]
+  C --> D["batch-plan: group serial, parallel, review, and manual-gated lanes"]
+  D --> E["decision-brief: explain options, trade-offs, severity, and safe commands"]
+  E --> F["draft-task: generate queue and plan drafts"]
+  F --> G["promote-draft: dry-run queue/plan diff only"]
+  G --> H{"Human gate: accept task scope and plan?"}
+  H -->|approved| I["render-prompt: copy-paste Codex session prompt"]
+  I --> J["Codex implementation session"]
+  J --> K["suggest-validation or validate: focused safe local checks"]
+  K --> VH["validation-history: local JSONL evidence ledger"]
+  K --> AP["auto-pass-check: low-risk local gate decision"]
+  AP --> L["claim-audit and privacy-audit-output"]
+  L --> POLICY["claim-policy and privacy-regression"]
+  L --> M["handoff-check: fail closed on missing or weak evidence"]
+  M --> N["review-prompt: adversarial reviewer prompt"]
+  M --> PKT["approval-packet, pr-body, context-pack"]
+  PKT --> READY["readiness-score and branch-issue-hygiene"]
+  PKT --> SIM["ship-simulate: predict stop points without remote mutation"]
+  SIM --> ASP["auto-ship-plan: bridge to existing make ship-arm without arming"]
+  N --> RT["review-threads: unresolved thread ingest"]
+  RT --> RP["review-plan: triage review findings"]
+  RP --> O["review-followup: convert findings to local follow-up briefs"]
+  O --> P["decision-brief, gate-brief, and gate-status"]
+  P --> Q["loop-state: machine-readable state JSON"]
+  Q --> DB["dashboard and stale-reports"]
+  DB --> FRESH["artifact-freshness and manifest freshness"]
+  DB --> ARCH["architecture-decision and architecture-brief"]
+  DB --> HTML["dashboard-html and manifest freshness"]
+  N --> CI["ci-summary and ci-ingest: convert CI failures to follow-up briefs"]
+  PKT --> BODY["pr-body-check and ship-command-pack"]
+  BODY --> ASP
+  ASP --> STACK["dependency-graph and stacked-risk before merge/delete cleanup"]
+  RP --> PATCH["review-patch-plan and patch-proposal: dry-run safe patch"]
+  ARCH --> ADR["adr-reserve: draft-only ADR reservation"]
+  C --> WORKSET["workset-recommend: serial/parallel/review/manual sets"]
+  A --> INT["integration-pack and scheduled-status recipes"]
+  INT --> MCP
+  Q --> R{"Human gate: review, claims, merge, close, push, delete?"}
+  R -->|approved| EXEC["human-gated-exec or make ship-arm: explicit approved shipping mutation"]
+  EXEC --> S["Existing ship/manual workflow"]
+  R -->|more work| A
+```
+
+Automation points:
+- pr-scan: read-only `gh pr list` JSON export.
+- next-from-prs: deterministic wrapper around `scripts/ai_next_actions.py`.
+- pr-health: group exported PR state into CI, review, stale, draft, blocked, and ready lanes.
+- batch-plan: group local task briefs into serial, parallel-safe, review-only, and manual-gated lanes.
+- decision-brief: explain human-gate options, trade-offs, severity, reversibility, evidence, and next safe commands.
+- draft-task: local queue/plan drafts under `reports/agent_loop/`.
+- promote-draft: local dry-run diff for queue/plan promotion; no tracked files are changed.
+- propose-queue-plan: dry-run queue/plan patch proposal; no tracked files are changed.
+- gate-status: summarize the current stop point and next safe command.
+- gate-brief: explain one human gate with options, trade-offs, severity, reversibility, and evidence.
+- claim-audit: audit risky claim wording against eval/privacy surface classification.
+- claim-policy: render allowed/disallowed claim boundaries for the current surface.
+- privacy-audit-output: scan generated local artifacts for private raw values.
+- privacy-regression: run public sanitizer fixtures to guard prompt/report redaction.
+- review-threads: read unresolved review-thread state without resolving or replying.
+- approval-packet: bundle pre-PR/pre-ship evidence into one local report.
+- readiness-score: combine local ship signals into a decision-support score.
+- branch-issue-hygiene: check branch, issue, task, and PR-body linkage.
+- pr-body: draft `.github/pull_request_template.md` content without creating a PR.
+- context-pack: render a redacted cross-agent handoff bundle.
+- integration-pack: package Codex/Claude/ChatGPT/MCP read-only usage guidance.
+- scheduled-status: render a safe recurring status recipe without installing it.
+- architecture-decision: detect whether human architecture review is needed.
+- architecture-brief: summarize ADR/load-bearing trade-offs without choosing an architecture.
+- adr-reserve: propose ADR number and local draft without touching `docs/adr/`.
+- ship-simulate: predict auto-ship stop points without push/PR/merge/close/delete.
+- auto-ship-prepare: prepare or create a local ADR 0007 branch for existing `make ship-arm`; branch creation requires `--confirm-human-approved`.
+- auto-ship-plan: render a readiness-backed bridge to the existing `make ship-arm` Stop-hook pipeline without arming it.
+- ship-command-pack: render human-gated ship commands without executing them.
+- human-gated-exec: execute push/PR create/merge/close/remote branch delete/force-with-lease only with `--confirm-human-approved` and action-specific gates.
+- dependency-graph: render stacked PR graph without merge/delete mutation.
+- stacked-risk: detect dependent PR risk before merge/delete cleanup.
+- pr-body-check: verify `Closes`, §5b, claim, and privacy boundaries before PR creation.
+- ci-summary: summarize CI signals without re-running or mutating CI.
+- ci-ingest: normalize CI failures into local follow-up briefs.
+- review-patch-plan: generate review triage plus safe patch proposal together.
+- patch-proposal: render dry-run whitespace-only patch proposal for public-safe files.
+- manifest: write input-hash freshness metadata for generated artifacts.
+- artifact-freshness: alias around stale/manifest freshness checks.
+- validation-history: summarize local JSONL validation history.
+- workset-recommend: recommend serial, parallel-safe, review-only, and manual-gated task sets.
+- automation-coverage: map implemented automation candidates to command surfaces.
+- auto-pass-check: fail-closed low-risk gate check; named strict profiles require high-confidence docs/CI/tooling surfaces and passed validation.
+- loop-state: write machine-readable current loop state JSON.
+- dashboard: render a human-readable loop report from loop-state signals.
+- dashboard-html: render static local HTML view of the dashboard.
+- stale-reports: separate current vs stale local report artifacts; dry-run by default.
+- apply-queue-plan: apply queue/plan drafts only with explicit `--confirm-human-approved`.
+- mcp-config: render placeholder-based MCP client config samples.
+- review-followup: parse reviewer findings into local follow-up task briefs.
+- review-ingest: normalize local or PR review text into review-followup briefs.
+- safe-fix: dry-run/apply whitespace-only local fixes for supported public-safe text files.
+- render-prompt, status, preflight, classify-surface, suggest-validation, validate, handoff-check, review-prompt.
+- agent-loop-mcp: stdio MCP adapter for external coding agents and desktop clients; exposes local read/report tools, not shipping mutations.
+- agent-loop-artifacts.yml: PR-time informational GitHub Actions artifact generation.
+
+Human intervention points:
+- Apply a draft to `tasks/queue.md` or `docs/plans/*.md`.
+- Create or switch the local shipping branch when detached HEAD or protected branch state is detected.
+- Decide architecture tradeoffs, benchmark/performance claims, or private real-eval meaning.
+- Push, create/merge/close PRs, delete branches, or force-push.
+- For the above, use `human-gated-exec` or existing `make ship-arm` only after explicit human approval and action-specific preflight.
+- Approve reviewer findings and shipping path.
+"""
+
+
+def _resolve_input_path(path: Path, *, repo_root: Path) -> Path:
+    candidate = path if path.is_absolute() else repo_root / path
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise ValueError("input path must stay under the repository root") from exc
+    return resolved
+
+
+def _resolve_task_brief(path: Path | None, *, repo_root: Path) -> Path:
+    if path is not None:
+        resolved = _resolve_input_path(path, repo_root=repo_root)
+        if not resolved.exists():
+            raise ValueError(f"task brief not found: {_display_path(str(path), repo_root=repo_root)}")
+        return resolved
+    tasks_dir = repo_root / "reports" / "agent_loop" / "codex_tasks"
+    candidates = sorted(tasks_dir.glob("*.md")) if tasks_dir.is_dir() else []
+    if not candidates:
+        raise ValueError("no task brief found under reports/codex_tasks; run next-from-prs first or pass --task-brief")
+    return candidates[0]
+
+
+def _parse_task_brief(text: str) -> dict[str, str]:
+    title_match = re.search(r"^#\s+(.+?)\s*$", text, re.MULTILINE)
+    title = title_match.group(1).strip() if title_match else "Untitled agent-loop follow-up"
+    fields = _field_map(text)
+    verification = ""
+    verification_section = _section_text(text, "Verification")
+    fenced = FENCED_BASH_RE.search(verification_section)
+    if fenced:
+        verification = "\n".join(
+            line.strip()
+            for line in fenced.group("body").splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        )
+    if not verification:
+        verification = "git diff --check"
+    return {
+        "title": _sanitize_dynamic_text(title),
+        "classification": _clean_scalar(fields.get(_normalize_field("Classification"), "unknown")),
+        "source": _clean_scalar(fields.get(_normalize_field("Source"), "planner")),
+        "reason": _clean_scalar(fields.get(_normalize_field("Reason"), "no reason captured")),
+        "goal": _clean_section(_section_text(text, "Goal")) or "Define the smallest safe follow-up from the planner brief.",
+        "expected_evidence": _clean_section(_section_text(text, "Expected Evidence"))
+        or "Public-safe evidence or a documented no-go decision.",
+        "verification": _sanitize_command_text(verification),
+    }
+
+
+def _clean_scalar(text: str) -> str:
+    return _sanitize_inline_text(text.strip().strip("`"))
+
+
+def _clean_section(text: str) -> str:
+    cleaned = text.strip()
+    cleaned = re.sub(r"```.*?```", "", cleaned, flags=re.DOTALL).strip()
+    return _sanitize_dynamic_text(cleaned)
+
+
+def _render_task_drafts(
+    brief: dict[str, str],
+    *,
+    task_id: str,
+    brief_path: Path,
+    repo_root: Path,
+) -> tuple[str, str]:
+    title = brief["title"]
+    slug = _slugify(title)
+    suggested_plan = f"docs/plans/{task_id}-{slug}.md"
+    source_brief = _display_path(_repo_path(brief_path, repo_root), repo_root=repo_root)
+    verification = _ensure_git_diff_check(brief["verification"])
+    queue_text = f"""<!-- Draft generated by scripts/agent_loop.py draft-task. Review before applying. -->
+## {task_id} — {title}
+
+- ID: {task_id}
+- Title: {title}
+- Status: backlog
+- Owner role: Planner -> Implementer -> Reviewer
+
+### Goal
+
+{brief["goal"]}
+
+### Context
+
+- Classification: `{brief["classification"]}`
+- Source: `{brief["source"]}`
+- Reason: {brief["reason"]}
+- Source brief: `{source_brief}`
+- Suggested plan path: `{suggested_plan}`
+
+### Acceptance Criteria
+
+- [ ] Scope stays limited to the cited workflow surface.
+- [ ] Public-safe evidence or no-go rationale is captured without raw private data.
+- [ ] Reviewer prompt covers any eval, benchmark, privacy, or architecture surface touched.
+
+### Validation Commands
+
+```bash
+{verification}
+```
+
+### Evidence Required
+
+{brief["expected_evidence"]}
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`{suggested_plan}`](../{suggested_plan})
+"""
+    plan_text = f"""# Plan: {task_id} {title}
+
+- Status: draft
+- Owner role: Planner -> Implementer -> Reviewer
+- Related task: `tasks/queue.md::{task_id}`
+- Source brief: `{source_brief}`
+- Suggested final path: `{suggested_plan}`
+
+## Problem
+
+{brief["reason"]}
+
+## Desired Outcome
+
+{brief["goal"]}
+
+## Scope
+
+- Convert the planner brief into one narrow, reviewable Codex task.
+- Reuse existing BidMate operating docs, queue, plans, validation commands, and reviewer prompts.
+- Keep generated artifacts local unless a human promotes a redacted artifact.
+
+## Out of Scope
+
+- Auto-merge, auto-push, PR creation/close/merge, branch deletion, or force-push.
+- Benchmark, performance, private real-eval, or architecture tradeoff decisions without human approval.
+- Raw private question, answer, evidence, doc_id, chunk_id, filenames, or exact local paths.
+
+## Surface / Claim Boundary
+
+- Initial classification: `{brief["classification"]}`
+- Eval surface: classify again after implementation if changed files touch eval, benchmark, metrics, reports, configs, or claims.
+- Disallowed claim: do not claim product quality, benchmark lift, or private real-eval success from this draft alone.
+
+## Implementation Steps
+
+1. Read the required operating docs and this plan.
+2. Inspect the cited workflow surface and existing tests.
+3. Make the smallest scoped change.
+4. Add or update focused tests.
+5. Run focused validation and `git diff --check`.
+6. Leave a handoff with required fields and reviewer focus.
+
+## Validation
+
+```bash
+{verification}
+```
+
+## Reviewer Focus
+
+- Scope control against the source brief.
+- Privacy boundary and claim wording.
+- Conservative eval surface classification.
+- Validation evidence matches commands actually run.
+
+## Session Handoff
+
+- Role:
+- Lifecycle stage:
+- Branch / worktree:
+- Task: {task_id}
+- Current status:
+- Files touched:
+- Commands run:
+- Results:
+- Validation evidence:
+- Blockers:
+- Open risks:
+- Next action:
+- Next safe command:
+- Reviewer focus:
+- Eval surface:
+"""
+    return _sanitize_dynamic_text(queue_text).rstrip() + "\n", _sanitize_dynamic_text(plan_text).rstrip() + "\n"
+
+
+def _slugify(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug[:60].strip("-") or "agent-loop-task"
+
+
+def _ensure_git_diff_check(commands: str) -> str:
+    lines = [line.strip() for line in commands.splitlines() if line.strip()]
+    if "git diff --check" not in lines:
+        lines.append("git diff --check")
+    return "\n".join(_sanitize_command_text(line) for line in lines)
+
+
+def _write_or_stdout(text: str, out: Path | None) -> None:
+    if out is None:
+        sys.stdout.write(text)
+        return
+    safe_out = _safe_output_path(out)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(text, encoding="utf-8")
+    sys.stdout.write(f"[OK] wrote {_repo_path(safe_out, ROOT_DIR)}\n")
+
+
+def _safe_output_path(out: Path, *, repo_root: Path = ROOT_DIR) -> Path:
+    candidate = out if out.is_absolute() else repo_root / out
+    root = (repo_root / "reports" / "agent_loop").resolve()
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("--out must stay under reports/agent_loop/") from exc
+    return candidate
+
+
+def _safe_reports_path(out: Path, *, repo_root: Path = ROOT_DIR) -> Path:
+    candidate = out if out.is_absolute() else repo_root / out
+    root = (repo_root / "reports").resolve()
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("generated report output must stay under reports/") from exc
+    return candidate
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    render = sub.add_parser("render-prompt", help="Render a copy-paste Codex prompt.")
+    render.add_argument("--task", required=True, help="Task id, e.g. T-2026-0003")
+    render.add_argument("--role", default="Implementer")
+    render.add_argument("--plan", type=Path)
+    render.add_argument("--out", type=Path, help=f"Optional output path. Default stdout.")
+
+    handoff = sub.add_parser("handoff-check", help="Check latest handoff block.")
+    handoff.add_argument("--task", required=True)
+    handoff.add_argument("--plan", type=Path)
+    handoff.add_argument("--changed-files", type=Path)
+    handoff.add_argument("--from-git", action="store_true")
+    handoff.add_argument("--pr")
+
+    review = sub.add_parser("review-prompt", help="Render adversarial review prompt.")
+    review.add_argument("--task", required=True)
+    review.add_argument("--pr")
+    review.add_argument("--branch")
+    review.add_argument("--changed-files", type=Path)
+    review.add_argument("--from-git", action="store_true")
+    review.add_argument("--out", type=Path, help=f"Optional output path. Default stdout.")
+
+    classify = sub.add_parser("classify-surface", help="Classify changed-file surface.")
+    classify.add_argument("--changed-files", type=Path)
+    classify.add_argument("--from-git", action="store_true")
+    classify.add_argument("--pr")
+
+    suggest = sub.add_parser("suggest-validation", help="Suggest focused validation.")
+    suggest.add_argument("--changed-files", type=Path)
+    suggest.add_argument("--from-git", action="store_true")
+    suggest.add_argument("--pr")
+
+    validate = sub.add_parser("validate", help="Run allowlisted safe local validation.")
+    validate.add_argument("--changed-files", type=Path)
+    validate.add_argument("--from-git", action="store_true")
+    validate.add_argument("--pr")
+    validate.add_argument("--keep-going", action="store_true")
+    validate.add_argument("--record-history", action="store_true")
+    validate.add_argument("--history", type=Path, default=DEFAULT_VALIDATION_HISTORY)
+
+    status = sub.add_parser("status", help="Summarize task, handoff, surface, and validation suggestions.")
+    status.add_argument("--task")
+    status.add_argument("--changed-files", type=Path)
+    status.add_argument("--from-git", action="store_true")
+    status.add_argument("--pr")
+
+    preflight = sub.add_parser("preflight", help="Run handoff/surface/validation preflight.")
+    preflight.add_argument("--task", required=True)
+    preflight.add_argument("--changed-files", type=Path)
+    preflight.add_argument("--from-git", action="store_true")
+    preflight.add_argument("--pr")
+    preflight.add_argument("--write-prompts", action="store_true")
+
+    pr_scan = sub.add_parser("pr-scan", help="Export read-only PR state for planning.")
+    pr_scan.add_argument("--out", type=Path, default=DEFAULT_PR_STATE)
+    pr_scan.add_argument("--state", choices=("open", "closed", "all"), default="open")
+    pr_scan.add_argument("--limit", type=int, default=30)
+    pr_scan.add_argument(
+        "--include-body",
+        action="store_true",
+        help="Include PR body in local ignored state; use only when PR bodies are public-safe.",
+    )
+
+    next_prs = sub.add_parser("next-from-prs", help="Generate next-action briefs from PR state JSON.")
+    next_prs.add_argument("--pr-json", type=Path, default=DEFAULT_PR_STATE)
+    next_prs.add_argument("--out-md", type=Path, default=DEFAULT_AI_NEXT_ACTIONS)
+    next_prs.add_argument("--tasks-dir", type=Path, default=DEFAULT_CODEX_TASKS_DIR)
+    next_prs.add_argument("--readiness-summary", action="append", type=Path, default=[])
+    next_prs.add_argument("--readiness-report", action="append", type=Path, default=[])
+    next_prs.add_argument("--real100-dir", type=Path)
+    next_prs.add_argument("--page-metadata-index-dir", type=Path)
+
+    draft = sub.add_parser("draft-task", help="Draft queue and plan entries from a task brief.")
+    draft.add_argument("--task-brief", type=Path)
+    draft.add_argument("--task-id", default=DEFAULT_DRAFT_TASK_ID)
+    draft.add_argument("--out-queue", type=Path, default=DEFAULT_QUEUE_DRAFT)
+    draft.add_argument("--out-plan", type=Path, default=DEFAULT_PLAN_DRAFT)
+
+    draft_next = sub.add_parser("draft-next", help="Scan PRs, generate briefs, and draft queue/plan artifacts.")
+    draft_next.add_argument("--task-id", default=DEFAULT_DRAFT_TASK_ID)
+    draft_next.add_argument("--state", choices=("open", "closed", "all"), default="open")
+    draft_next.add_argument("--limit", type=int, default=30)
+    draft_next.add_argument(
+        "--include-body",
+        action="store_true",
+        help="Include PR body in local ignored state; use only when PR bodies are public-safe.",
+    )
+
+    batch = sub.add_parser("batch-plan", help="Group generated task briefs into execution lanes.")
+    batch.add_argument("--tasks-dir", type=Path, default=DEFAULT_CODEX_TASKS_DIR)
+    batch.add_argument("--out", type=Path, default=DEFAULT_BATCH_PLAN)
+    batch.add_argument("--json-out", type=Path, default=DEFAULT_BATCH_PLAN_JSON)
+    batch.add_argument("--no-json", action="store_true")
+    batch.add_argument("--max-items", type=int, default=12)
+
+    followup = sub.add_parser("review-followup", help="Convert reviewer findings into local follow-up briefs.")
+    followup.add_argument("--review", required=True, type=Path)
+    followup.add_argument("--out", type=Path, default=DEFAULT_REVIEW_FOLLOWUPS)
+    followup.add_argument("--tasks-dir", type=Path, default=DEFAULT_REVIEW_FOLLOWUPS_DIR)
+
+    decision = sub.add_parser("decision-brief", help="Explain human-gate options, trade-offs, and risks.")
+    decision.add_argument("--task")
+    decision.add_argument("--batch", type=Path)
+    decision.add_argument("--review-followups", type=Path)
+    decision.add_argument("--gate", choices=("auto", "task", "plan", "review", "claim", "ship"), default="auto")
+    decision.add_argument("--changed-files", type=Path)
+    decision.add_argument("--from-git", action="store_true")
+    decision.add_argument("--pr")
+    decision.add_argument("--out", type=Path, default=DEFAULT_DECISION_BRIEF)
+
+    promote = sub.add_parser("promote-draft", help="Render a dry-run diff for queue/plan draft promotion.")
+    promote.add_argument("--queue-draft", type=Path, default=DEFAULT_QUEUE_DRAFT)
+    promote.add_argument("--plan-draft", type=Path, default=DEFAULT_PLAN_DRAFT)
+    promote.add_argument("--out", type=Path, default=DEFAULT_PROMOTE_DRAFT)
+
+    gate_status = sub.add_parser("gate-status", help="Summarize the current human gate and next safe command.")
+    gate_status.add_argument("--task")
+    gate_status.add_argument("--batch", type=Path)
+    gate_status.add_argument("--review-followups", type=Path)
+    gate_status.add_argument("--changed-files", type=Path)
+    gate_status.add_argument("--from-git", action="store_true")
+    gate_status.add_argument("--pr")
+    gate_status.add_argument("--out", type=Path)
+
+    claim = sub.add_parser("claim-audit", help="Audit claim wording against the changed-file surface.")
+    claim.add_argument("--text", type=Path)
+    claim.add_argument("--changed-files", type=Path)
+    claim.add_argument("--from-git", action="store_true")
+    claim.add_argument("--pr")
+    claim.add_argument("--out", type=Path, default=DEFAULT_CLAIM_AUDIT)
+
+    privacy = sub.add_parser("privacy-audit-output", help="Scan local agent-loop artifacts for private raw values.")
+    privacy.add_argument("--path", type=Path, default=DEFAULT_REPORT_DIR)
+    privacy.add_argument("--out", type=Path, default=DEFAULT_PRIVACY_AUDIT)
+
+    auto_pass = sub.add_parser("auto-pass-check", help="Check whether a low-risk local gate can continue without human review.")
+    auto_pass.add_argument("--task")
+    auto_pass.add_argument("--changed-files", type=Path)
+    auto_pass.add_argument("--from-git", action="store_true")
+    auto_pass.add_argument("--claim-text", type=Path)
+    auto_pass.add_argument("--run-validation", action="store_true")
+    auto_pass.add_argument("--strict", action="store_true")
+    auto_pass.add_argument(
+        "--profile",
+        choices=("standard", "docs-only-strict", "ci-only-strict", "agent-loop-tooling-strict"),
+        default="standard",
+    )
+    auto_pass.add_argument("--out", type=Path, default=DEFAULT_AUTO_PASS)
+
+    dashboard = sub.add_parser("dashboard", help="Render a human-readable dashboard from loop state.")
+    dashboard.add_argument("--task")
+    dashboard.add_argument("--batch", type=Path)
+    dashboard.add_argument("--review-followups", type=Path)
+    dashboard.add_argument("--changed-files", type=Path)
+    dashboard.add_argument("--from-git", action="store_true")
+    dashboard.add_argument("--pr")
+    dashboard.add_argument("--out", type=Path, default=DEFAULT_DASHBOARD)
+
+    mcp_config = sub.add_parser("mcp-config", help="Render MCP client config samples.")
+    mcp_config.add_argument("--out", type=Path, default=DEFAULT_MCP_CLIENT_CONFIG)
+
+    review_ingest = sub.add_parser("review-ingest", help="Ingest review output or PR review text into follow-up briefs.")
+    review_ingest.add_argument("--review", action="append", type=Path, default=[])
+    review_ingest.add_argument("--pr")
+    review_ingest.add_argument("--out", type=Path, default=DEFAULT_REVIEW_INGEST)
+    review_ingest.add_argument("--followup-out", type=Path, default=DEFAULT_REVIEW_FOLLOWUPS)
+    review_ingest.add_argument("--tasks-dir", type=Path, default=DEFAULT_REVIEW_FOLLOWUPS_DIR)
+
+    pr_health = sub.add_parser("pr-health", help="Analyze exported PR state into next-action lanes.")
+    pr_health.add_argument("--pr-json", type=Path, default=DEFAULT_PR_STATE)
+    pr_health.add_argument("--out", type=Path, default=DEFAULT_PR_HEALTH)
+
+    safe_fix = sub.add_parser("safe-fix", help="Dry-run or apply very small local whitespace fixes.")
+    safe_fix.add_argument("--changed-files", type=Path)
+    safe_fix.add_argument("--from-git", action="store_true")
+    safe_fix.add_argument("--apply", action="store_true")
+    safe_fix.add_argument("--out", type=Path, default=DEFAULT_SAFE_FIX)
+
+    approval = sub.add_parser("approval-packet", help="Bundle PR/shipping approval evidence into one local report.")
+    approval.add_argument("--task")
+    approval.add_argument("--changed-files", type=Path)
+    approval.add_argument("--from-git", action="store_true")
+    approval.add_argument("--pr")
+    approval.add_argument("--claim-text", type=Path)
+    approval.add_argument("--run-validation", action="store_true")
+    approval.add_argument("--out", type=Path, default=DEFAULT_APPROVAL_PACKET)
+
+    propose = sub.add_parser("propose-queue-plan", help="Render a dry-run queue/plan patch proposal.")
+    propose.add_argument("--task-brief", type=Path)
+    propose.add_argument("--task-id", default=DEFAULT_DRAFT_TASK_ID)
+    propose.add_argument("--queue-draft", type=Path, default=DEFAULT_QUEUE_DRAFT)
+    propose.add_argument("--plan-draft", type=Path, default=DEFAULT_PLAN_DRAFT)
+    propose.add_argument("--out", type=Path, default=DEFAULT_QUEUE_PLAN_PATCH)
+
+    pr_body = sub.add_parser("pr-body", help="Render a PR template body draft from local evidence.")
+    pr_body.add_argument("--task")
+    pr_body.add_argument("--changed-files", type=Path)
+    pr_body.add_argument("--from-git", action="store_true")
+    pr_body.add_argument("--pr")
+    pr_body.add_argument("--branch")
+    pr_body.add_argument("--issue")
+    pr_body.add_argument("--out", type=Path, default=DEFAULT_PR_BODY)
+
+    review_plan = sub.add_parser("review-plan", help="Triage review findings into fix and human-decision lanes.")
+    review_plan.add_argument("--review", action="append", type=Path, default=[])
+    review_plan.add_argument("--pr")
+    review_plan.add_argument("--out", type=Path, default=DEFAULT_REVIEW_PLAN)
+
+    stale = sub.add_parser("stale-reports", help="Report or remove stale local agent-loop artifacts.")
+    stale.add_argument("--changed-files", type=Path)
+    stale.add_argument("--from-git", action="store_true")
+    stale.add_argument("--pr")
+    stale.add_argument("--max-age-days", type=int, default=7)
+    stale.add_argument("--apply", action="store_true")
+    stale.add_argument("--out", type=Path, default=DEFAULT_STALE_REPORTS)
+
+    context = sub.add_parser("context-pack", help="Render a redacted cross-agent context pack.")
+    context.add_argument("--task")
+    context.add_argument("--changed-files", type=Path)
+    context.add_argument("--from-git", action="store_true")
+    context.add_argument("--pr")
+    context.add_argument("--profile", choices=("generic", "codex", "claude", "chatgpt"), default="generic")
+    context.add_argument("--out", type=Path, default=DEFAULT_CONTEXT_PACK)
+
+    arch = sub.add_parser("architecture-brief", help="Explain architecture/ADR trade-offs for changed files.")
+    arch.add_argument("--changed-files", type=Path)
+    arch.add_argument("--from-git", action="store_true")
+    arch.add_argument("--pr")
+    arch.add_argument("--out", type=Path, default=DEFAULT_ARCHITECTURE_BRIEF)
+
+    ship_sim = sub.add_parser("ship-simulate", help="Simulate auto-ship readiness without mutating remote state.")
+    ship_sim.add_argument("--task")
+    ship_sim.add_argument("--changed-files", type=Path)
+    ship_sim.add_argument("--from-git", action="store_true")
+    ship_sim.add_argument("--pr")
+    ship_sim.add_argument("--branch")
+    ship_sim.add_argument("--out", type=Path, default=DEFAULT_SHIP_SIMULATION)
+
+    auto_ship = sub.add_parser("auto-ship-plan", help="Plan existing make ship-arm usage without arming auto-ship.")
+    auto_ship.add_argument("--task")
+    auto_ship.add_argument("--changed-files", type=Path)
+    auto_ship.add_argument("--from-git", action="store_true")
+    auto_ship.add_argument("--pr")
+    auto_ship.add_argument("--branch")
+    auto_ship.add_argument("--ttl", default="2h")
+    auto_ship.add_argument("--real-eval", choices=("auto", "skip", "async"))
+    auto_ship.add_argument("--draft", action="store_true")
+    auto_ship.add_argument("--dry-run", action="store_true")
+    auto_ship.add_argument("--out", type=Path, default=DEFAULT_AUTO_SHIP_PLAN)
+
+    auto_ship_prepare = sub.add_parser("auto-ship-prepare", help="Prepare local branch state for existing make ship-arm.")
+    auto_ship_prepare.add_argument("--issue")
+    auto_ship_prepare.add_argument("--target-branch")
+    auto_ship_prepare.add_argument("--type", dest="branch_type", default="chore")
+    auto_ship_prepare.add_argument("--slug", default="agent-loop-auto-ship")
+    auto_ship_prepare.add_argument("--create-branch", action="store_true")
+    auto_ship_prepare.add_argument("--confirm-human-approved", action="store_true")
+    auto_ship_prepare.add_argument("--ttl", default="2h")
+    auto_ship_prepare.add_argument("--real-eval", choices=("auto", "skip", "async"))
+    auto_ship_prepare.add_argument("--draft", action="store_true", default=True)
+    auto_ship_prepare.add_argument("--ready", action="store_true", help="Recommend DRAFT=false for the next ship-arm command.")
+    auto_ship_prepare.add_argument("--dry-run", action="store_true", default=True)
+    auto_ship_prepare.add_argument("--no-dry-run", dest="dry_run", action="store_false", help="Recommend DRY_RUN=0 for the next ship-arm command.")
+    auto_ship_prepare.add_argument("--out", type=Path, default=DEFAULT_AUTO_SHIP_PREPARE)
+
+    gate_brief = sub.add_parser("gate-brief", help="Explain a specific human gate with options and trade-offs.")
+    gate_brief.add_argument("--gate", required=True, choices=sorted(GATE_BRIEF_CHOICES))
+    gate_brief.add_argument("--task")
+    gate_brief.add_argument("--changed-files", type=Path)
+    gate_brief.add_argument("--from-git", action="store_true")
+    gate_brief.add_argument("--pr")
+    gate_brief.add_argument("--out", type=Path, default=DEFAULT_GATE_BRIEF)
+
+    manifest = sub.add_parser("manifest", help="Write input-hash manifest for generated agent-loop artifacts.")
+    manifest.add_argument("--changed-files", type=Path)
+    manifest.add_argument("--from-git", action="store_true")
+    manifest.add_argument("--pr")
+    manifest.add_argument("--source-command", dest="manifest_command", default="manual")
+    manifest.add_argument("--output", action="append", type=Path, default=[])
+    manifest.add_argument("--out", type=Path, default=DEFAULT_MANIFEST)
+
+    pr_check = sub.add_parser("pr-body-check", help="Validate a PR body draft before PR creation.")
+    pr_check.add_argument("--body", type=Path, default=DEFAULT_PR_BODY)
+    pr_check.add_argument("--changed-files", type=Path)
+    pr_check.add_argument("--from-git", action="store_true")
+    pr_check.add_argument("--pr")
+    pr_check.add_argument("--branch")
+    pr_check.add_argument("--out", type=Path, default=DEFAULT_PR_BODY_CHECK)
+
+    ci_ingest = sub.add_parser("ci-ingest", help="Ingest CI output into local follow-up briefs.")
+    ci_ingest.add_argument("--log", action="append", type=Path, default=[])
+    ci_ingest.add_argument("--pr")
+    ci_ingest.add_argument("--out", type=Path, default=DEFAULT_CI_INGEST)
+    ci_ingest.add_argument("--tasks-dir", type=Path, default=DEFAULT_CI_FOLLOWUPS_DIR)
+
+    stacked = sub.add_parser("stacked-risk", help="Check read-only dependent PR risk for a branch.")
+    stacked.add_argument("--branch", required=True)
+    stacked.add_argument("--pr-json", type=Path)
+    stacked.add_argument("--out", type=Path, default=DEFAULT_STACKED_RISK)
+
+    patch = sub.add_parser("patch-proposal", help="Render safe dry-run patch proposal for changed files.")
+    patch.add_argument("--changed-files", type=Path)
+    patch.add_argument("--from-git", action="store_true")
+    patch.add_argument("--pr")
+    patch.add_argument("--review-plan", type=Path)
+    patch.add_argument("--out", type=Path, default=DEFAULT_PATCH_PROPOSAL)
+
+    adr = sub.add_parser("adr-reserve", help="Draft an ADR reservation artifact without touching docs/adr.")
+    adr.add_argument("--title", required=True)
+    adr.add_argument("--out", type=Path, default=DEFAULT_ADR_RESERVATION)
+    adr.add_argument("--draft-out", type=Path, default=DEFAULT_ADR_DRAFT)
+
+    html_dash = sub.add_parser("dashboard-html", help="Render a static HTML dashboard.")
+    html_dash.add_argument("--task")
+    html_dash.add_argument("--changed-files", type=Path)
+    html_dash.add_argument("--from-git", action="store_true")
+    html_dash.add_argument("--pr")
+    html_dash.add_argument("--out", type=Path, default=DEFAULT_DASHBOARD_HTML)
+
+    ship_cmds = sub.add_parser("ship-command-pack", help="Render human-gated shipping command suggestions.")
+    ship_cmds.add_argument("--pr")
+    ship_cmds.add_argument("--branch")
+    ship_cmds.add_argument("--out", type=Path, default=DEFAULT_SHIP_COMMANDS)
+
+    apply_qp = sub.add_parser("apply-queue-plan", help="Apply queue/plan drafts only with explicit human approval.")
+    apply_qp.add_argument("--queue-draft", type=Path, default=DEFAULT_QUEUE_DRAFT)
+    apply_qp.add_argument("--plan-draft", type=Path, default=DEFAULT_PLAN_DRAFT)
+    apply_qp.add_argument("--confirm-human-approved", action="store_true")
+    apply_qp.add_argument("--out", type=Path, default=DEFAULT_APPLY_QUEUE_PLAN)
+
+    review_threads = sub.add_parser("review-threads", help="Ingest unresolved review threads into local triage.")
+    review_threads.add_argument("--threads-json", type=Path)
+    review_threads.add_argument("--pr")
+    review_threads.add_argument("--out", type=Path, default=DEFAULT_REVIEW_THREADS)
+
+    ci_summary = sub.add_parser("ci-summary", help="Summarize CI logs or read-only PR check state.")
+    ci_summary.add_argument("--log", action="append", type=Path, default=[])
+    ci_summary.add_argument("--pr")
+    ci_summary.add_argument("--out", type=Path, default=DEFAULT_CI_SUMMARY)
+
+    readiness = sub.add_parser("readiness-score", help="Score local PR readiness signals without approving ship.")
+    readiness.add_argument("--task")
+    readiness.add_argument("--changed-files", type=Path)
+    readiness.add_argument("--from-git", action="store_true")
+    readiness.add_argument("--pr")
+    readiness.add_argument("--body", type=Path)
+    readiness.add_argument("--branch")
+    readiness.add_argument("--claim-text", type=Path)
+    readiness.add_argument("--out", type=Path, default=DEFAULT_READINESS_SCORE)
+
+    artifact_freshness = sub.add_parser("artifact-freshness", help="Alias for stale report freshness checks.")
+    artifact_freshness.add_argument("--changed-files", type=Path)
+    artifact_freshness.add_argument("--from-git", action="store_true")
+    artifact_freshness.add_argument("--pr")
+    artifact_freshness.add_argument("--max-age-days", type=int, default=7)
+    artifact_freshness.add_argument("--out", type=Path, default=DEFAULT_STALE_REPORTS)
+
+    review_patch = sub.add_parser("review-patch-plan", help="Generate review plan and safe patch proposal together.")
+    review_patch.add_argument("--review", action="append", type=Path, default=[])
+    review_patch.add_argument("--pr")
+    review_patch.add_argument("--changed-files", type=Path)
+    review_patch.add_argument("--from-git", action="store_true")
+    review_patch.add_argument("--review-out", type=Path, default=DEFAULT_REVIEW_PLAN)
+    review_patch.add_argument("--patch-out", type=Path, default=DEFAULT_PATCH_PROPOSAL)
+
+    qp_sync = sub.add_parser("queue-plan-sync", help="Render queue/plan sync proposal without tracked-doc mutation.")
+    qp_sync.add_argument("--task-brief", type=Path)
+    qp_sync.add_argument("--task-id", default=DEFAULT_DRAFT_TASK_ID)
+    qp_sync.add_argument("--out", type=Path, default=DEFAULT_QUEUE_PLAN_PATCH)
+
+    dependency = sub.add_parser("dependency-graph", help="Render a read-only stacked PR dependency graph.")
+    dependency.add_argument("--branch", required=True)
+    dependency.add_argument("--pr-json", type=Path)
+    dependency.add_argument("--out", type=Path, default=DEFAULT_DEPENDENCY_GRAPH)
+
+    hygiene = sub.add_parser("branch-issue-hygiene", help="Check branch, issue, task, and PR-body linkage.")
+    hygiene.add_argument("--branch")
+    hygiene.add_argument("--body", type=Path)
+    hygiene.add_argument("--task")
+    hygiene.add_argument("--out", type=Path, default=DEFAULT_BRANCH_ISSUE_HYGIENE)
+
+    integration = sub.add_parser("integration-pack", help="Render Codex/Claude/ChatGPT/MCP integration guidance.")
+    integration.add_argument("--out", type=Path, default=DEFAULT_INTEGRATION_PACK)
+
+    scheduled = sub.add_parser("scheduled-status", help="Render a safe scheduled status recipe without installing it.")
+    scheduled.add_argument("--out", type=Path, default=DEFAULT_SCHEDULE_CONFIG)
+
+    history = sub.add_parser("validation-history", help="Summarize local validation JSONL history.")
+    history.add_argument("--history", type=Path, default=DEFAULT_VALIDATION_HISTORY)
+    history.add_argument("--limit", type=int, default=10)
+    history.add_argument("--out", type=Path, default=DEFAULT_VALIDATION_HISTORY_REPORT)
+
+    privacy_regression = sub.add_parser("privacy-regression", help="Run public fixture sanitizer regression checks.")
+    privacy_regression.add_argument("--out", type=Path, default=DEFAULT_PRIVACY_REGRESSION)
+
+    claim_policy = sub.add_parser("claim-policy", help="Render claim policy for a changed-file surface and optional text.")
+    claim_policy.add_argument("--text", type=Path)
+    claim_policy.add_argument("--changed-files", type=Path)
+    claim_policy.add_argument("--from-git", action="store_true")
+    claim_policy.add_argument("--pr")
+    claim_policy.add_argument("--out", type=Path, default=DEFAULT_CLAIM_POLICY)
+
+    arch_decision = sub.add_parser("architecture-decision", help="Detect whether human architecture review is needed.")
+    arch_decision.add_argument("--changed-files", type=Path)
+    arch_decision.add_argument("--from-git", action="store_true")
+    arch_decision.add_argument("--pr")
+    arch_decision.add_argument("--out", type=Path, default=DEFAULT_ARCHITECTURE_DECISION)
+
+    workset = sub.add_parser("workset-recommend", help="Recommend serial/parallel/review/manual worksets.")
+    workset.add_argument("--batch", type=Path)
+    workset.add_argument("--tasks-dir", type=Path, default=DEFAULT_CODEX_TASKS_DIR)
+    workset.add_argument("--max-items", type=int, default=12)
+    workset.add_argument("--out", type=Path, default=DEFAULT_WORKSET_RECOMMENDATION)
+
+    coverage = sub.add_parser("automation-coverage", help="Render coverage map for implemented automation candidates.")
+    coverage.add_argument("--out", type=Path, default=DEFAULT_AUTOMATION_COVERAGE)
+
+    gated = sub.add_parser("human-gated-exec", help="Execute approved remote mutations only after explicit human approval.")
+    gated.add_argument("--action", required=True, choices=sorted(HUMAN_GATED_ACTIONS))
+    gated.add_argument("--confirm-human-approved", action="store_true")
+    gated.add_argument("--dry-run", action="store_true")
+    gated.add_argument("--branch")
+    gated.add_argument("--pr")
+    gated.add_argument("--body", type=Path)
+    gated.add_argument("--base")
+    gated.add_argument("--title")
+    gated.add_argument("--ready", action="store_true", help="Create PR as ready instead of draft.")
+    gated.add_argument("--confirm-review-gate-passed", action="store_true")
+    gated.add_argument("--confirm-dependents-reviewed", action="store_true")
+    gated.add_argument("--confirm-force-with-lease", action="store_true")
+    gated.add_argument("--out", type=Path, default=DEFAULT_HUMAN_GATED_EXEC)
+
+    loop_state = sub.add_parser("loop-state", help="Write machine-readable agent-loop state JSON.")
+    loop_state.add_argument("--task")
+    loop_state.add_argument("--batch", type=Path)
+    loop_state.add_argument("--review-followups", type=Path)
+    loop_state.add_argument("--changed-files", type=Path)
+    loop_state.add_argument("--from-git", action="store_true")
+    loop_state.add_argument("--pr")
+    loop_state.add_argument("--out", type=Path, default=DEFAULT_LOOP_STATE)
+
+    sub.add_parser("map", help="Print the agent-loop automation map and human gates.")
+
+    sub.add_parser("next", help="Recommend the next ready/backlog queue task.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "render-prompt":
+            text = render_prompt(args.task, role=args.role, plan_path=args.plan)
+            _write_or_stdout(text, args.out)
+            return 0
+        if args.command == "handoff-check":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            report = check_handoff(args.task, plan_path=args.plan, changed_files=files)
+            rendered = render_handoff_report(report)
+            stream = sys.stdout if report.ok else sys.stderr
+            stream.write(rendered)
+            return 0 if report.ok else 1
+        if args.command == "review-prompt":
+            changed_files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            text = render_review_prompt(
+                args.task,
+                pr=args.pr,
+                branch=args.branch,
+                changed_files=changed_files or None,
+            )
+            _write_or_stdout(text, args.out)
+            return 0
+        if args.command == "classify-surface":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            sys.stdout.write(render_surface_report(classify_changed_files(files)))
+            return 0
+        if args.command == "suggest-validation":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            sys.stdout.write(render_validation_suggestions(suggest_validation_commands(files)))
+            return 0
+        if args.command == "validate":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            rc, runs = run_validation_commands(files, keep_going=args.keep_going)
+            if args.record_history:
+                append_validation_history(runs, changed_files=files, history=args.history, repo_root=ROOT_DIR)
+            sys.stdout.write(render_validation_run_report(runs))
+            return rc
+        if args.command == "status":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            sys.stdout.write(render_status(task_id=args.task, changed_files=files))
+            return 0
+        if args.command == "preflight":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            rc, rendered = render_preflight(
+                task_id=args.task,
+                changed_files=files,
+                write_prompts=args.write_prompts,
+            )
+            stream = sys.stdout if rc == 0 else sys.stderr
+            stream.write(rendered)
+            return rc
+        if args.command == "pr-scan":
+            out = scan_pr_state(
+                out=args.out,
+                state=args.state,
+                limit=args.limit,
+                include_body=args.include_body,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "next-from-prs":
+            out_md, tasks_dir = run_next_from_prs(
+                pr_json=args.pr_json,
+                out_md=args.out_md,
+                tasks_dir=args.tasks_dir,
+                readiness_summaries=args.readiness_summary,
+                readiness_reports=args.readiness_report,
+                real100_dir=args.real100_dir,
+                page_metadata_index_dir=args.page_metadata_index_dir,
+            )
+            task_count = len(list(tasks_dir.glob("*.md"))) if tasks_dir.is_dir() else 0
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(out_md, ROOT_DIR)} and {task_count} task brief(s) under "
+                f"{_repo_path(tasks_dir, ROOT_DIR)}\n"
+            )
+            return 0
+        if args.command == "draft-task":
+            draft = draft_task_from_brief(
+                task_brief=args.task_brief,
+                task_id=args.task_id,
+                out_queue=args.out_queue,
+                out_plan=args.out_plan,
+            )
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(draft.queue_path, ROOT_DIR)} and "
+                f"{_repo_path(draft.plan_path, ROOT_DIR)}\n"
+            )
+            return 0
+        if args.command == "draft-next":
+            pr_state, tasks_dir, draft = draft_next_from_prs(
+                task_id=args.task_id,
+                state=args.state,
+                limit=args.limit,
+                include_body=args.include_body,
+            )
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(pr_state, ROOT_DIR)}, "
+                f"{_repo_path(tasks_dir, ROOT_DIR)}, "
+                f"{_repo_path(draft.queue_path, ROOT_DIR)}, and "
+                f"{_repo_path(draft.plan_path, ROOT_DIR)}\n"
+            )
+            return 0
+        if args.command == "batch-plan":
+            out, json_out, _ = write_batch_plan(
+                tasks_dir=args.tasks_dir,
+                out=args.out,
+                json_out=None if args.no_json else args.json_out,
+                max_items=args.max_items,
+            )
+            if json_out is None:
+                sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            else:
+                sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)} and {_repo_path(json_out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "review-followup":
+            out, tasks_dir, count, _ = write_review_followups(
+                review=args.review,
+                out=args.out,
+                tasks_dir=args.tasks_dir,
+            )
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(out, ROOT_DIR)} and {count} follow-up brief(s) under "
+                f"{_repo_path(tasks_dir, ROOT_DIR)}\n"
+            )
+            return 0
+        if args.command == "decision-brief":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=None,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_decision_brief(
+                task_id=args.task,
+                batch=args.batch,
+                review_followups=args.review_followups,
+                gate=args.gate,
+                changed_files=files,
+                pr=args.pr,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "promote-draft":
+            out, _ = write_promote_draft(
+                queue_draft=args.queue_draft,
+                plan_draft=args.plan_draft,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "gate-status":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=None,
+                repo_root=ROOT_DIR,
+            )
+            out, rendered = write_gate_status(
+                task_id=args.task,
+                batch=args.batch,
+                review_followups=args.review_followups,
+                changed_files=files,
+                pr=args.pr,
+                out=args.out,
+            )
+            if out is None:
+                sys.stdout.write(rendered)
+            else:
+                sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "claim-audit":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, rc, _ = write_claim_audit(
+                text_path=args.text,
+                changed_files=files,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return rc
+        if args.command == "privacy-audit-output":
+            out, rc, _ = write_privacy_audit_output(path=args.path, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return rc
+        if args.command == "auto-pass-check":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=None,
+                repo_root=ROOT_DIR,
+            )
+            out, report, rendered = write_auto_pass_check(
+                task_id=args.task,
+                changed_files=files,
+                claim_text=args.claim_text,
+                run_validation=args.run_validation,
+                strict=args.strict,
+                profile=args.profile,
+                out=args.out,
+            )
+            if out is None:
+                sys.stdout.write(rendered)
+            else:
+                sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0 if report.ok else 1
+        if args.command == "dashboard":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=None,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_dashboard(
+                task_id=args.task,
+                batch=args.batch,
+                review_followups=args.review_followups,
+                changed_files=files,
+                pr=args.pr,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "mcp-config":
+            out, _ = write_mcp_client_config(out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "review-ingest":
+            out, followup_out, tasks_dir, count, _ = write_review_ingest(
+                reviews=args.review,
+                pr=args.pr,
+                out=args.out,
+                followup_out=args.followup_out,
+                tasks_dir=args.tasks_dir,
+            )
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(out, ROOT_DIR)}, {_repo_path(followup_out, ROOT_DIR)}, "
+                f"and {count} follow-up brief(s) under {_repo_path(tasks_dir, ROOT_DIR)}\n"
+            )
+            return 0
+        if args.command == "pr-health":
+            out, _ = write_pr_health(pr_json=args.pr_json, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "safe-fix":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=None,
+                repo_root=ROOT_DIR,
+            )
+            out, _, _ = write_safe_fix(
+                changed_files=files,
+                apply=args.apply,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "approval-packet":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_approval_packet(
+                task_id=args.task,
+                changed_files=files,
+                pr=args.pr,
+                claim_text=args.claim_text,
+                run_validation=args.run_validation,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "propose-queue-plan":
+            out, _ = write_propose_queue_plan(
+                task_brief=args.task_brief,
+                task_id=args.task_id,
+                queue_draft=args.queue_draft,
+                plan_draft=args.plan_draft,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "pr-body":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_pr_body(
+                task_id=args.task,
+                changed_files=files,
+                branch=args.branch,
+                issue=args.issue,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "review-plan":
+            out, _ = write_review_plan(reviews=args.review, pr=args.pr, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "stale-reports":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_stale_reports(
+                changed_files=files,
+                max_age_days=args.max_age_days,
+                apply=args.apply,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "context-pack":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_context_pack(task_id=args.task, changed_files=files, pr=args.pr, profile=args.profile, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "architecture-brief":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_architecture_brief(changed_files=files, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "ship-simulate":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_ship_simulation(
+                task_id=args.task,
+                changed_files=files,
+                pr=args.pr,
+                branch=args.branch,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "auto-ship-plan":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, plan, _ = write_auto_ship_plan(
+                task_id=args.task,
+                changed_files=files,
+                pr=args.pr,
+                branch=args.branch,
+                ttl=args.ttl,
+                real_eval=args.real_eval,
+                draft=args.draft,
+                dry_run=args.dry_run,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0 if plan.decision != "blocked" else 1
+        if args.command == "auto-ship-prepare":
+            out, report, _ = write_auto_ship_prepare(
+                issue=args.issue,
+                target_branch=args.target_branch,
+                branch_type=args.branch_type,
+                slug=args.slug,
+                create_branch=args.create_branch,
+                confirm_human_approved=args.confirm_human_approved,
+                ttl=args.ttl,
+                real_eval=args.real_eval,
+                draft=not args.ready,
+                dry_run=args.dry_run,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0 if report.result in {"ready-for-ship-arm", "branch-created"} else 1
+        if args.command == "gate-brief":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_gate_brief(
+                gate=args.gate,
+                task_id=args.task,
+                changed_files=files,
+                pr=args.pr,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "manifest":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_manifest(
+                changed_files=files,
+                command=args.manifest_command,
+                outputs=args.output,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "pr-body-check":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, rc, _ = write_pr_body_check(
+                body=args.body,
+                changed_files=files,
+                branch=args.branch,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return rc
+        if args.command == "ci-ingest":
+            out, tasks_dir, count, _ = write_ci_ingest(
+                logs=args.log,
+                pr=args.pr,
+                out=args.out,
+                tasks_dir=args.tasks_dir,
+            )
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(out, ROOT_DIR)} and {count} CI follow-up brief(s) under "
+                f"{_repo_path(tasks_dir, ROOT_DIR)}\n"
+            )
+            return 0
+        if args.command == "stacked-risk":
+            out, _ = write_stacked_risk(branch=args.branch, pr_json=args.pr_json, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "patch-proposal":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_patch_proposal(
+                changed_files=files,
+                review_plan=args.review_plan,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "adr-reserve":
+            out, draft_out, _ = write_adr_reservation(
+                title=args.title,
+                out=args.out,
+                draft_out=args.draft_out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)} and {_repo_path(draft_out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "dashboard-html":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_dashboard_html(task_id=args.task, changed_files=files, pr=args.pr, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "ship-command-pack":
+            out, _ = write_ship_command_pack(pr=args.pr, branch=args.branch, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "apply-queue-plan":
+            if not args.confirm_human_approved:
+                raise ValueError("apply-queue-plan requires --confirm-human-approved")
+            out, _ = write_apply_queue_plan(
+                confirm_human_approved=args.confirm_human_approved,
+                queue_draft=args.queue_draft,
+                plan_draft=args.plan_draft,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "review-threads":
+            out, _ = write_review_threads(
+                threads_json=args.threads_json,
+                pr=args.pr,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "ci-summary":
+            out, _ = write_ci_summary(logs=args.log, pr=args.pr, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "readiness-score":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, report, _ = write_readiness_score(
+                task_id=args.task,
+                changed_files=files,
+                pr=args.pr,
+                body=args.body,
+                branch=args.branch,
+                claim_text=args.claim_text,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0 if report.decision != "blocked" else 1
+        if args.command == "artifact-freshness":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_stale_reports(
+                changed_files=files,
+                max_age_days=args.max_age_days,
+                apply=False,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "review-patch-plan":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            review_out, _ = write_review_plan(reviews=args.review, pr=args.pr, out=args.review_out)
+            patch_out, _ = write_patch_proposal(
+                changed_files=files,
+                review_plan=review_out,
+                out=args.patch_out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(review_out, ROOT_DIR)} and {_repo_path(patch_out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "queue-plan-sync":
+            out, _ = write_propose_queue_plan(
+                task_brief=args.task_brief,
+                task_id=args.task_id,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "dependency-graph":
+            out, _ = write_dependency_graph(branch=args.branch, pr_json=args.pr_json, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "branch-issue-hygiene":
+            out, rc, _ = write_branch_issue_hygiene(
+                branch=args.branch,
+                body=args.body,
+                task_id=args.task,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return rc
+        if args.command == "integration-pack":
+            out, _ = write_integration_pack(out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "scheduled-status":
+            out, _ = write_schedule_config(out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "validation-history":
+            out, _ = write_validation_history_report(
+                history=args.history,
+                limit=args.limit,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "privacy-regression":
+            out, rc, _ = write_privacy_regression(out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return rc
+        if args.command == "claim-policy":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, rc, _ = write_claim_policy(
+                changed_files=files,
+                text=args.text,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return rc
+        if args.command == "architecture-decision":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_architecture_decision(changed_files=files, out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "workset-recommend":
+            out, _ = write_workset_recommendation(
+                batch=args.batch,
+                tasks_dir=args.tasks_dir,
+                max_items=args.max_items,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "automation-coverage":
+            out, _ = write_automation_coverage(out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "human-gated-exec":
+            out, plan, _ = write_human_gated_exec(
+                action=args.action,
+                confirm_human_approved=args.confirm_human_approved,
+                dry_run=args.dry_run,
+                branch=args.branch,
+                pr=args.pr,
+                body=args.body,
+                base=args.base,
+                title=args.title,
+                draft=not args.ready,
+                confirm_review_gate_passed=args.confirm_review_gate_passed,
+                confirm_dependents_reviewed=args.confirm_dependents_reviewed,
+                confirm_force_with_lease=args.confirm_force_with_lease,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            if plan.blockers:
+                return 1
+            return plan.returncode if plan.executed and plan.returncode is not None else 0
+        if args.command == "loop-state":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=None,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_loop_state(
+                task_id=args.task,
+                batch=args.batch,
+                review_followups=args.review_followups,
+                changed_files=files,
+                pr=args.pr,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "map":
+            sys.stdout.write(render_loop_map())
+            return 0
+        if args.command == "next":
+            sys.stdout.write(recommend_next_task())
+            return 0
+    except ValueError as exc:
+        sys.stderr.write(f"agent-loop: {exc}\n")
+        return 2
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/agent_loop_mcp.py
+++ b/scripts/agent_loop_mcp.py
@@ -1,0 +1,1735 @@
+#!/usr/bin/env python3
+"""MCP stdio server for the BidMate agent-loop helper.
+
+This adapter exposes the read/report-centered parts of ``scripts/agent_loop.py``
+to MCP clients. It intentionally does not expose commands that push, merge,
+create or close PRs, delete branches, force-push, run private eval, or call
+external model APIs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from typing import Any, Callable
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import agent_loop  # noqa: E402
+
+
+JSON = dict[str, Any]
+ToolHandler = Callable[[JSON], str]
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "bidmate-agent-loop"
+SERVER_VERSION = "0.1.0"
+
+
+def tool_definitions() -> list[JSON]:
+    """Return MCP tool metadata with conservative input schemas."""
+
+    changed_files_schema: JSON = {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Changed file paths. Use repo-relative paths when possible.",
+    }
+    maybe_changed_files = {"changed_files": changed_files_schema}
+    task_property = {
+        "task": {
+            "type": "string",
+            "pattern": r"^T-\d{4}-\d{4}$",
+            "description": "BidMate queue task id.",
+        }
+    }
+
+    return [
+        {
+            "name": "agent_loop_map",
+            "description": "Render the BidMate agent-loop map and human stop points.",
+            "inputSchema": _schema({}),
+        },
+        {
+            "name": "agent_loop_classify_surface",
+            "description": "Classify changed-file surface conservatively from provided paths.",
+            "inputSchema": _schema(maybe_changed_files),
+        },
+        {
+            "name": "agent_loop_suggest_validation",
+            "description": "Suggest safe focused validation commands without running them.",
+            "inputSchema": _schema(maybe_changed_files),
+        },
+        {
+            "name": "agent_loop_gate_status",
+            "description": "Summarize the current gate, severity, signals, and next safe command.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "batch": {"type": "string", "description": "Optional local batch plan JSON path."},
+                    "review_followups": {
+                        "type": "string",
+                        "description": "Optional local review follow-up report path.",
+                    },
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/gate_status.md as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_loop_state",
+            "description": "Build machine-readable loop state JSON from local artifacts and changed paths.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "batch": {"type": "string"},
+                    "review_followups": {"type": "string"},
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/loop_state.json as well as returning JSON.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_decision_brief",
+            "description": "Render human-gate options with trade-offs, severity, evidence, and next commands.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "batch": {"type": "string"},
+                    "review_followups": {"type": "string"},
+                    "gate": {
+                        "type": "string",
+                        "enum": ["auto", "task", "plan", "review", "claim", "ship"],
+                        "default": "auto",
+                    },
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/decision_brief.md as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_render_prompt",
+            "description": "Render a copy-paste Codex implementation prompt for a task.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    "role": {"type": "string", "default": "Implementer"},
+                    "plan": {"type": "string", "description": "Optional plan path."},
+                },
+                required=["task"],
+            ),
+        },
+        {
+            "name": "agent_loop_review_prompt",
+            "description": "Render a copy-paste adversarial review prompt for a task.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "branch": {"type": "string"},
+                },
+                required=["task"],
+            ),
+        },
+        {
+            "name": "agent_loop_handoff_check",
+            "description": "Check the latest handoff block and fail closed on missing or weak evidence.",
+            "inputSchema": _schema({**task_property, **maybe_changed_files, "plan": {"type": "string"}}, required=["task"]),
+        },
+        {
+            "name": "agent_loop_claim_audit",
+            "description": "Audit claim wording against changed-file surface classification.",
+            "inputSchema": _schema(
+                {
+                    **maybe_changed_files,
+                    "text": {"type": "string", "description": "Optional local text/report path to audit."},
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/claim_audit.md as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_privacy_audit_output",
+            "description": "Scan local agent-loop report artifacts for unredacted private raw values.",
+            "inputSchema": _schema(
+                {
+                    "path": {
+                        "type": "string",
+                        "description": "Path under reports/agent_loop to scan.",
+                        "default": "reports/agent_loop",
+                    },
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/privacy_audit.md as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_auto_pass_check",
+            "description": "Fail-closed check for whether a low-risk local gate can continue without human review.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "claim_text": {"type": "string", "description": "Optional local claim text/report path."},
+                    "run_validation": {
+                        "type": "boolean",
+                        "description": "Run allowlisted local validation before allowing auto-pass.",
+                        "default": False,
+                    },
+                    "strict": {
+                        "type": "boolean",
+                        "description": "Require task, claim text, and no open review follow-up artifacts.",
+                        "default": False,
+                    },
+                    "profile": {
+                        "type": "string",
+                        "enum": ["standard", "docs-only-strict", "ci-only-strict", "agent-loop-tooling-strict"],
+                        "default": "standard",
+                    },
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/auto_pass.md as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_dashboard",
+            "description": "Render a human-readable dashboard from current loop state.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "batch": {"type": "string"},
+                    "review_followups": {"type": "string"},
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/dashboard.md as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_mcp_config",
+            "description": "Render placeholder-based MCP client config samples.",
+            "inputSchema": _schema({}),
+        },
+        {
+            "name": "agent_loop_pr_health",
+            "description": "Analyze exported PR state JSON into next-action lanes.",
+            "inputSchema": _schema(
+                {
+                    "pr_json": {"type": "string", "default": "reports/agent_loop/pr_state.json"},
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/pr_health.md as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_safe_fix_dry_run",
+            "description": "Dry-run safe whitespace-only local fixes for changed files.",
+            "inputSchema": _schema(maybe_changed_files),
+        },
+        {
+            "name": "agent_loop_approval_packet",
+            "description": "Bundle PR/shipping approval evidence into one local report without approving action.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "claim_text": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_propose_queue_plan",
+            "description": "Render a dry-run queue/plan patch proposal; tracked files are not modified.",
+            "inputSchema": _schema(
+                {
+                    "task_brief": {"type": "string"},
+                    "task_id": {"type": "string", "pattern": r"^T-\d{4}-\d{4}$", "default": "T-2026-0000"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_pr_body",
+            "description": "Render a PR body draft from local evidence without creating a PR.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "branch": {"type": "string"},
+                    "issue": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_review_plan",
+            "description": "Triage review findings into fix and human-decision lanes.",
+            "inputSchema": _schema(
+                {
+                    "review": {"type": "string"},
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_stale_reports",
+            "description": "Report stale local agent-loop artifacts; delete is not exposed over MCP.",
+            "inputSchema": _schema(
+                {
+                    "max_age_days": {"type": "integer", "minimum": 0, "maximum": 365, "default": 7},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_context_pack",
+            "description": "Render a redacted cross-agent context pack.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_architecture_brief",
+            "description": "Explain architecture/ADR trade-offs without choosing an architecture.",
+            "inputSchema": _schema({**maybe_changed_files, "write": {"type": "boolean", "default": False}}),
+        },
+        {
+            "name": "agent_loop_ship_simulate",
+            "description": "Simulate auto-ship readiness without mutating remote state.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "branch": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_auto_ship_plan",
+            "description": "Plan existing make ship-arm usage without arming or mutating remote state.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "branch": {"type": "string"},
+                    "ttl": {"type": "string", "default": "2h"},
+                    "real_eval": {"type": "string", "enum": ["auto", "skip", "async"]},
+                    "draft": {"type": "boolean", "default": False},
+                    "dry_run": {"type": "boolean", "default": False},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_auto_ship_prepare",
+            "description": "Report local branch preparation needed before make ship-arm; MCP never creates branches.",
+            "inputSchema": _schema(
+                {
+                    "issue": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "target_branch": {"type": "string"},
+                    "branch_type": {"type": "string", "default": "chore"},
+                    "slug": {"type": "string", "default": "agent-loop-auto-ship"},
+                    "ttl": {"type": "string", "default": "2h"},
+                    "real_eval": {"type": "string", "enum": ["auto", "skip", "async"]},
+                    "draft": {"type": "boolean"},
+                    "dry_run": {"type": "boolean"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_gate_brief",
+            "description": "Explain a specific human gate with options and trade-offs.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "gate": {
+                        "type": "string",
+                        "enum": sorted(agent_loop.GATE_BRIEF_CHOICES),
+                    },
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {"type": "boolean", "default": False},
+                },
+                required=["gate"],
+            ),
+        },
+        {
+            "name": "agent_loop_manifest",
+            "description": "Build or write an input-hash manifest for generated reports.",
+            "inputSchema": _schema(
+                {
+                    **maybe_changed_files,
+                    "source_command": {"type": "string", "default": "mcp"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_pr_body_check",
+            "description": "Validate a local PR body draft without creating or updating a PR.",
+            "inputSchema": _schema(
+                {
+                    **maybe_changed_files,
+                    "body": {"type": "string", "default": "reports/agent_loop/pr_body.md"},
+                    "branch": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_ci_ingest",
+            "description": "Ingest CI log text from local files into follow-up briefs.",
+            "inputSchema": _schema(
+                {
+                    "log": {"type": "string"},
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_stacked_risk",
+            "description": "Check read-only dependent PR risk from exported PR state or GitHub.",
+            "inputSchema": _schema(
+                {
+                    "branch": {"type": "string"},
+                    "pr_json": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                },
+                required=["branch"],
+            ),
+        },
+        {
+            "name": "agent_loop_patch_proposal",
+            "description": "Render a dry-run safe patch proposal from changed files.",
+            "inputSchema": _schema({**maybe_changed_files, "write": {"type": "boolean", "default": False}}),
+        },
+        {
+            "name": "agent_loop_adr_reserve",
+            "description": "Draft ADR reservation artifacts under reports/agent_loop only.",
+            "inputSchema": _schema({"title": {"type": "string"}, "write": {"type": "boolean", "default": False}}, required=["title"]),
+        },
+        {
+            "name": "agent_loop_dashboard_html",
+            "description": "Render a static HTML dashboard from local loop state.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_ship_command_pack",
+            "description": "Render human-gated shipping command suggestions without executing them.",
+            "inputSchema": _schema(
+                {
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "branch": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_apply_queue_plan_dry_run",
+            "description": "Explain queue/plan apply gate without applying tracked docs.",
+            "inputSchema": _schema({}),
+        },
+        {
+            "name": "agent_loop_review_threads",
+            "description": "Ingest review threads from local JSON or a PR without resolving or replying.",
+            "inputSchema": _schema(
+                {
+                    "threads_json": {"type": "string"},
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_ci_summary",
+            "description": "Summarize CI logs or read-only PR check state.",
+            "inputSchema": _schema(
+                {
+                    "log": {"type": "string"},
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_readiness_score",
+            "description": "Score local PR readiness signals without approving shipping.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    **maybe_changed_files,
+                    "pr": {"type": "string", "pattern": r"^\d{1,10}$"},
+                    "body": {"type": "string"},
+                    "branch": {"type": "string"},
+                    "claim_text": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_branch_issue_hygiene",
+            "description": "Check branch, issue, task, and PR body linkage without creating issues or PRs.",
+            "inputSchema": _schema(
+                {
+                    **task_property,
+                    "branch": {"type": "string"},
+                    "body": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_validation_history",
+            "description": "Summarize local validation JSONL history.",
+            "inputSchema": _schema(
+                {
+                    "history": {"type": "string"},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 10},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_privacy_regression",
+            "description": "Run public sanitizer regression checks without private data.",
+            "inputSchema": _schema({"write": {"type": "boolean", "default": False}}),
+        },
+        {
+            "name": "agent_loop_claim_policy",
+            "description": "Render claim policy for changed files and optional claim text.",
+            "inputSchema": _schema(
+                {
+                    **maybe_changed_files,
+                    "text": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_architecture_decision",
+            "description": "Detect whether human architecture review is needed.",
+            "inputSchema": _schema({**maybe_changed_files, "write": {"type": "boolean", "default": False}}),
+        },
+        {
+            "name": "agent_loop_workset_recommend",
+            "description": "Recommend serial, parallel, review-only, and manual-gated worksets.",
+            "inputSchema": _schema(
+                {
+                    "batch": {"type": "string"},
+                    "tasks_dir": {"type": "string"},
+                    "max_items": {"type": "integer", "minimum": 1, "maximum": 100, "default": 12},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_dependency_graph",
+            "description": "Render a read-only stacked PR dependency graph.",
+            "inputSchema": _schema(
+                {
+                    "branch": {"type": "string"},
+                    "pr_json": {"type": "string"},
+                    "write": {"type": "boolean", "default": False},
+                },
+                required=["branch"],
+            ),
+        },
+        {
+            "name": "agent_loop_integration_pack",
+            "description": "Render Codex/Claude/ChatGPT/MCP integration guidance.",
+            "inputSchema": _schema({"write": {"type": "boolean", "default": False}}),
+        },
+        {
+            "name": "agent_loop_scheduled_status",
+            "description": "Render a safe scheduled status recipe without installing it.",
+            "inputSchema": _schema({"write": {"type": "boolean", "default": False}}),
+        },
+        {
+            "name": "agent_loop_automation_coverage",
+            "description": "Render coverage map for implemented automation candidates.",
+            "inputSchema": _schema({"write": {"type": "boolean", "default": False}}),
+        },
+        {
+            "name": "agent_loop_batch_plan",
+            "description": "Group local generated task briefs into serial, parallel-safe, review-only, and gated lanes.",
+            "inputSchema": _schema(
+                {
+                    "tasks_dir": {"type": "string", "default": "reports/agent_loop/codex_tasks"},
+                    "max_items": {"type": "integer", "minimum": 1, "maximum": 100, "default": 12},
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/batch_plan.md/json as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_review_followup",
+            "description": "Convert reviewer findings into local follow-up task briefs.",
+            "inputSchema": _schema(
+                {
+                    "review": {
+                        "type": "string",
+                        "description": "Local review output path under the repo.",
+                    },
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/review_followups.md and briefs.",
+                        "default": False,
+                    },
+                },
+                required=["review"],
+            ),
+        },
+        {
+            "name": "agent_loop_promote_draft_dry_run",
+            "description": "Render a dry-run diff for queue/plan draft promotion; tracked files are not modified.",
+            "inputSchema": _schema(
+                {
+                    "queue_draft": {"type": "string", "default": "reports/agent_loop/queue_entry_draft.md"},
+                    "plan_draft": {"type": "string", "default": "reports/agent_loop/plan_draft.md"},
+                    "write": {
+                        "type": "boolean",
+                        "description": "Write reports/agent_loop/promote_draft.md as well as returning text.",
+                        "default": False,
+                    },
+                }
+            ),
+        },
+    ]
+
+
+def _schema(properties: JSON, *, required: list[str] | None = None) -> JSON:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required or [],
+        "additionalProperties": False,
+    }
+
+
+def call_tool(name: str, arguments: JSON | None = None) -> JSON:
+    args = arguments or {}
+    handlers: dict[str, ToolHandler] = {
+        "agent_loop_map": _tool_map,
+        "agent_loop_classify_surface": _tool_classify_surface,
+        "agent_loop_suggest_validation": _tool_suggest_validation,
+        "agent_loop_gate_status": _tool_gate_status,
+        "agent_loop_loop_state": _tool_loop_state,
+        "agent_loop_decision_brief": _tool_decision_brief,
+        "agent_loop_render_prompt": _tool_render_prompt,
+        "agent_loop_review_prompt": _tool_review_prompt,
+        "agent_loop_handoff_check": _tool_handoff_check,
+        "agent_loop_claim_audit": _tool_claim_audit,
+        "agent_loop_privacy_audit_output": _tool_privacy_audit_output,
+        "agent_loop_auto_pass_check": _tool_auto_pass_check,
+        "agent_loop_dashboard": _tool_dashboard,
+        "agent_loop_mcp_config": _tool_mcp_config,
+        "agent_loop_pr_health": _tool_pr_health,
+        "agent_loop_safe_fix_dry_run": _tool_safe_fix_dry_run,
+        "agent_loop_approval_packet": _tool_approval_packet,
+        "agent_loop_propose_queue_plan": _tool_propose_queue_plan,
+        "agent_loop_pr_body": _tool_pr_body,
+        "agent_loop_review_plan": _tool_review_plan,
+        "agent_loop_stale_reports": _tool_stale_reports,
+        "agent_loop_context_pack": _tool_context_pack,
+        "agent_loop_architecture_brief": _tool_architecture_brief,
+        "agent_loop_ship_simulate": _tool_ship_simulate,
+        "agent_loop_auto_ship_plan": _tool_auto_ship_plan,
+        "agent_loop_auto_ship_prepare": _tool_auto_ship_prepare,
+        "agent_loop_gate_brief": _tool_gate_brief,
+        "agent_loop_manifest": _tool_manifest,
+        "agent_loop_pr_body_check": _tool_pr_body_check,
+        "agent_loop_ci_ingest": _tool_ci_ingest,
+        "agent_loop_stacked_risk": _tool_stacked_risk,
+        "agent_loop_patch_proposal": _tool_patch_proposal,
+        "agent_loop_adr_reserve": _tool_adr_reserve,
+        "agent_loop_dashboard_html": _tool_dashboard_html,
+        "agent_loop_ship_command_pack": _tool_ship_command_pack,
+        "agent_loop_apply_queue_plan_dry_run": _tool_apply_queue_plan_dry_run,
+        "agent_loop_review_threads": _tool_review_threads,
+        "agent_loop_ci_summary": _tool_ci_summary,
+        "agent_loop_readiness_score": _tool_readiness_score,
+        "agent_loop_branch_issue_hygiene": _tool_branch_issue_hygiene,
+        "agent_loop_validation_history": _tool_validation_history,
+        "agent_loop_privacy_regression": _tool_privacy_regression,
+        "agent_loop_claim_policy": _tool_claim_policy,
+        "agent_loop_architecture_decision": _tool_architecture_decision,
+        "agent_loop_workset_recommend": _tool_workset_recommend,
+        "agent_loop_dependency_graph": _tool_dependency_graph,
+        "agent_loop_integration_pack": _tool_integration_pack,
+        "agent_loop_scheduled_status": _tool_scheduled_status,
+        "agent_loop_automation_coverage": _tool_automation_coverage,
+        "agent_loop_batch_plan": _tool_batch_plan,
+        "agent_loop_review_followup": _tool_review_followup,
+        "agent_loop_promote_draft_dry_run": _tool_promote_draft_dry_run,
+    }
+    handler = handlers.get(name)
+    if handler is None:
+        return _tool_result(f"unknown tool: {name}", is_error=True)
+    try:
+        return _tool_result(handler(args))
+    except (OSError, ValueError) as exc:
+        return _tool_result(f"agent-loop: {exc}", is_error=True)
+
+
+def _tool_result(text: str, *, is_error: bool = False) -> JSON:
+    return {
+        "content": [{"type": "text", "text": agent_loop._sanitize_dynamic_text(text)}],
+        "isError": is_error,
+    }
+
+
+def _tool_map(_: JSON) -> str:
+    return agent_loop.render_loop_map()
+
+
+def _tool_classify_surface(args: JSON) -> str:
+    return agent_loop.render_surface_report(agent_loop.classify_changed_files(_changed_files_arg(args)))
+
+
+def _tool_suggest_validation(args: JSON) -> str:
+    return agent_loop.render_validation_suggestions(
+        agent_loop.suggest_validation_commands(_changed_files_arg(args))
+    )
+
+
+def _tool_gate_status(args: JSON) -> str:
+    out = agent_loop.DEFAULT_GATE_STATUS if _bool_arg(args, "write", False) else None
+    _, rendered = agent_loop.write_gate_status(
+        task_id=_optional_str(args, "task"),
+        batch=_optional_path(args, "batch"),
+        review_followups=_optional_path(args, "review_followups"),
+        changed_files=_changed_files_arg(args),
+        pr=_optional_str(args, "pr"),
+        out=out,
+    )
+    return rendered
+
+
+def _tool_loop_state(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, state = agent_loop.write_loop_state(
+            task_id=_optional_str(args, "task"),
+            batch=_optional_path(args, "batch"),
+            review_followups=_optional_path(args, "review_followups"),
+            changed_files=_changed_files_arg(args),
+            pr=_optional_str(args, "pr"),
+        )
+    else:
+        state = agent_loop.build_loop_state(
+            task_id=_optional_str(args, "task"),
+            batch=_optional_path(args, "batch"),
+            review_followups=_optional_path(args, "review_followups"),
+            changed_files=_changed_files_arg(args),
+            pr=_optional_str(args, "pr"),
+            repo_root=agent_loop.ROOT_DIR,
+        )
+    return json.dumps(state, indent=2, sort_keys=True) + "\n"
+
+
+def _tool_decision_brief(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_decision_brief(
+            task_id=_optional_str(args, "task"),
+            batch=_optional_path(args, "batch"),
+            review_followups=_optional_path(args, "review_followups"),
+            gate=_str_arg(args, "gate", "auto"),
+            changed_files=_changed_files_arg(args),
+            pr=_optional_str(args, "pr"),
+        )
+        return rendered
+    points = agent_loop.build_decision_points(
+        task_id=_optional_str(args, "task"),
+        batch=_optional_path(args, "batch"),
+        review_followups=_optional_path(args, "review_followups"),
+        gate=_str_arg(args, "gate", "auto"),
+        changed_files=_changed_files_arg(args),
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_decision_brief(points)
+
+
+def _tool_render_prompt(args: JSON) -> str:
+    return agent_loop.render_prompt(
+        _required_str(args, "task"),
+        role=_str_arg(args, "role", "Implementer"),
+        plan_path=_optional_path(args, "plan"),
+    )
+
+
+def _tool_review_prompt(args: JSON) -> str:
+    return agent_loop.render_review_prompt(
+        _required_str(args, "task"),
+        pr=_optional_str(args, "pr"),
+        branch=_optional_str(args, "branch"),
+        changed_files=_changed_files_arg(args) or None,
+    )
+
+
+def _tool_handoff_check(args: JSON) -> str:
+    report = agent_loop.check_handoff(
+        _required_str(args, "task"),
+        plan_path=_optional_path(args, "plan"),
+        changed_files=_changed_files_arg(args),
+    )
+    return agent_loop.render_handoff_report(report)
+
+
+def _tool_claim_audit(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_claim_audit(
+            text_path=_optional_path(args, "text"),
+            changed_files=_changed_files_arg(args),
+        )
+        return rendered
+    text = ""
+    source = "changed files only"
+    text_path = _optional_path(args, "text")
+    if text_path is not None:
+        resolved = agent_loop._resolve_input_path(text_path, repo_root=agent_loop.ROOT_DIR)
+        text = resolved.read_text(encoding="utf-8")
+        source = agent_loop._display_path(agent_loop._repo_path(resolved, agent_loop.ROOT_DIR))
+    surface = agent_loop.classify_changed_files(_changed_files_arg(args))
+    findings = agent_loop.audit_claim_text(text, surface)
+    return agent_loop.render_claim_audit(source=source, surface=surface, findings=findings)
+
+
+def _tool_privacy_audit_output(args: JSON) -> str:
+    path = _optional_path(args, "path") or agent_loop.DEFAULT_REPORT_DIR
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_privacy_audit_output(path=path)
+        return rendered
+    target = agent_loop._resolve_input_path(path, repo_root=agent_loop.ROOT_DIR)
+    safe_target = agent_loop._safe_output_path(target, repo_root=agent_loop.ROOT_DIR)
+    findings = agent_loop.audit_privacy_output(
+        safe_target,
+        out_path=agent_loop.DEFAULT_PRIVACY_AUDIT,
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_privacy_audit(findings, target=safe_target, repo_root=agent_loop.ROOT_DIR)
+
+
+def _tool_auto_pass_check(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_auto_pass_check(
+            task_id=_optional_str(args, "task"),
+            changed_files=_changed_files_arg(args),
+            claim_text=_optional_path(args, "claim_text"),
+            run_validation=_bool_arg(args, "run_validation", False),
+            strict=_bool_arg(args, "strict", False),
+            profile=_str_arg(args, "profile", "standard"),
+        )
+        return rendered
+    report = agent_loop.build_auto_pass_report(
+        task_id=_optional_str(args, "task"),
+        changed_files=_changed_files_arg(args),
+        claim_text=_optional_path(args, "claim_text"),
+        run_validation=_bool_arg(args, "run_validation", False),
+        repo_root=agent_loop.ROOT_DIR,
+        strict=_bool_arg(args, "strict", False),
+        profile=_str_arg(args, "profile", "standard"),
+    )
+    return agent_loop.render_auto_pass_report(report)
+
+
+def _tool_dashboard(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_dashboard(
+            task_id=_optional_str(args, "task"),
+            batch=_optional_path(args, "batch"),
+            review_followups=_optional_path(args, "review_followups"),
+            changed_files=_changed_files_arg(args),
+            pr=_optional_str(args, "pr"),
+        )
+        return rendered
+    state = agent_loop.build_loop_state(
+        task_id=_optional_str(args, "task"),
+        batch=_optional_path(args, "batch"),
+        review_followups=_optional_path(args, "review_followups"),
+        changed_files=_changed_files_arg(args),
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_dashboard(state)
+
+
+def _tool_mcp_config(_: JSON) -> str:
+    return agent_loop.render_mcp_client_config()
+
+
+def _tool_pr_health(args: JSON) -> str:
+    pr_json = _optional_path(args, "pr_json") or agent_loop.DEFAULT_PR_STATE
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_pr_health(pr_json=pr_json)
+        return rendered
+    path = agent_loop._resolve_input_path(pr_json, repo_root=agent_loop.ROOT_DIR)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("PR state JSON must be an array")
+    return agent_loop.render_pr_health([item for item in payload if isinstance(item, dict)])
+
+
+def _tool_safe_fix_dry_run(args: JSON) -> str:
+    report = agent_loop.build_safe_fix_report(
+        changed_files=_changed_files_arg(args),
+        apply=False,
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_safe_fix_report(report)
+
+
+def _tool_approval_packet(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_approval_packet(
+            task_id=_optional_str(args, "task"),
+            changed_files=changed_files,
+            pr=_optional_str(args, "pr"),
+            claim_text=_optional_path(args, "claim_text"),
+        )
+        return rendered
+    surface = agent_loop.classify_changed_files(changed_files)
+    gate = agent_loop.build_gate_status(
+        task_id=_optional_str(args, "task"),
+        batch=None,
+        review_followups=None,
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    auto_pass = agent_loop.build_auto_pass_report(
+        task_id=_optional_str(args, "task"),
+        changed_files=changed_files,
+        claim_text=_optional_path(args, "claim_text"),
+        run_validation=False,
+        strict=False,
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    claim_findings = ()
+    claim_source = "N/A"
+    claim_text = _optional_path(args, "claim_text")
+    if claim_text is not None:
+        resolved = agent_loop._resolve_input_path(claim_text, repo_root=agent_loop.ROOT_DIR)
+        if resolved.exists():
+            claim_source = agent_loop._display_path(agent_loop._repo_path(resolved, agent_loop.ROOT_DIR))
+            claim_findings = tuple(agent_loop.audit_claim_text(resolved.read_text(encoding="utf-8"), surface))
+    privacy_findings = tuple(
+        agent_loop.audit_privacy_output(
+            agent_loop.ROOT_DIR / "reports" / "agent_loop",
+            out_path=None,
+            repo_root=agent_loop.ROOT_DIR,
+        )
+    )
+    return agent_loop.render_approval_packet(
+        task_id=_optional_str(args, "task"),
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        surface=surface,
+        gate=gate,
+        auto_pass=auto_pass,
+        claim_findings=claim_findings,
+        claim_source=claim_source,
+        privacy_findings=privacy_findings,
+    )
+
+
+def _tool_propose_queue_plan(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_propose_queue_plan(
+            task_brief=_optional_path(args, "task_brief"),
+            task_id=_str_arg(args, "task_id", agent_loop.DEFAULT_DRAFT_TASK_ID),
+        )
+        return rendered
+    return _queue_plan_patch_text(
+        task_brief=_optional_path(args, "task_brief"),
+        task_id=_str_arg(args, "task_id", agent_loop.DEFAULT_DRAFT_TASK_ID),
+    )
+
+
+def _tool_pr_body(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_pr_body(
+            task_id=_optional_str(args, "task"),
+            changed_files=changed_files,
+            branch=_optional_str(args, "branch"),
+            issue=_optional_str(args, "issue"),
+        )
+        return rendered
+    return agent_loop.render_pr_body(
+        task_id=_optional_str(args, "task"),
+        changed_files=changed_files,
+        branch=_optional_str(args, "branch"),
+        issue=_optional_str(args, "issue"),
+    )
+
+
+def _tool_review_plan(args: JSON) -> str:
+    review = _optional_path(args, "review")
+    reviews = [review] if review is not None else []
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_review_plan(
+            reviews=reviews,
+            pr=_optional_str(args, "pr"),
+        )
+        return rendered
+    findings, sources = agent_loop._collect_review_findings(
+        reviews=reviews,
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_review_plan(findings, sources=sources)
+
+
+def _tool_stale_reports(args: JSON) -> str:
+    max_age_days = _int_arg(args, "max_age_days", 7)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_stale_reports(max_age_days=max_age_days, apply=False)
+        return rendered
+    artifacts = agent_loop._report_freshness(repo_root=agent_loop.ROOT_DIR, max_age_days=max_age_days)
+    return agent_loop.render_stale_reports(artifacts, max_age_days=max_age_days, apply=False, deleted=())
+
+
+def _tool_context_pack(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_context_pack(
+            task_id=_optional_str(args, "task"),
+            changed_files=changed_files,
+            pr=_optional_str(args, "pr"),
+        )
+        return rendered
+    state = agent_loop.build_loop_state(
+        task_id=_optional_str(args, "task"),
+        batch=None,
+        review_followups=None,
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_context_pack(state, changed_files=changed_files)
+
+
+def _tool_architecture_brief(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    surface = agent_loop.classify_changed_files(changed_files)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_architecture_brief(changed_files=changed_files)
+        return rendered
+    return agent_loop.render_architecture_brief(surface=surface, changed_files=changed_files)
+
+
+def _tool_ship_simulate(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_ship_simulation(
+            task_id=_optional_str(args, "task"),
+            changed_files=changed_files,
+            pr=_optional_str(args, "pr"),
+            branch=_optional_str(args, "branch"),
+        )
+        return rendered
+    return agent_loop.render_ship_simulation(
+        task_id=_optional_str(args, "task"),
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        branch=_optional_str(args, "branch"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+
+
+def _tool_auto_ship_plan(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_auto_ship_plan(
+            task_id=_optional_str(args, "task"),
+            changed_files=changed_files,
+            pr=_optional_str(args, "pr"),
+            branch=_optional_str(args, "branch"),
+            ttl=_str_arg(args, "ttl", "2h"),
+            real_eval=_optional_str(args, "real_eval"),
+            draft=_bool_arg(args, "draft", False),
+            dry_run=_bool_arg(args, "dry_run", False),
+        )
+        return rendered
+    plan = agent_loop.build_auto_ship_plan(
+        task_id=_optional_str(args, "task"),
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        branch=_optional_str(args, "branch"),
+        ttl=_str_arg(args, "ttl", "2h"),
+        real_eval=_optional_str(args, "real_eval"),
+        draft=_bool_arg(args, "draft", False),
+        dry_run=_bool_arg(args, "dry_run", False),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_auto_ship_plan(
+        plan,
+        task_id=_optional_str(args, "task"),
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+
+
+def _tool_auto_ship_prepare(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_auto_ship_prepare(
+            issue=_optional_str(args, "issue"),
+            target_branch=_optional_str(args, "target_branch"),
+            branch_type=_str_arg(args, "branch_type", "chore"),
+            slug=_str_arg(args, "slug", "agent-loop-auto-ship"),
+            create_branch=False,
+            confirm_human_approved=False,
+            ttl=_str_arg(args, "ttl", "2h"),
+            real_eval=_optional_str(args, "real_eval"),
+            draft=_bool_arg(args, "draft", True),
+            dry_run=_bool_arg(args, "dry_run", True),
+        )
+        return rendered
+    report = agent_loop.build_auto_ship_prepare(
+        issue=_optional_str(args, "issue"),
+        target_branch=_optional_str(args, "target_branch"),
+        branch_type=_str_arg(args, "branch_type", "chore"),
+        slug=_str_arg(args, "slug", "agent-loop-auto-ship"),
+        create_branch=False,
+        confirm_human_approved=False,
+        ttl=_str_arg(args, "ttl", "2h"),
+        real_eval=_optional_str(args, "real_eval"),
+        draft=_bool_arg(args, "draft", True),
+        dry_run=_bool_arg(args, "dry_run", True),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_auto_ship_prepare(report)
+
+
+def _tool_gate_brief(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_gate_brief(
+            gate=_required_str(args, "gate"),
+            task_id=_optional_str(args, "task"),
+            changed_files=changed_files,
+            pr=_optional_str(args, "pr"),
+        )
+        return rendered
+    return agent_loop.render_gate_brief(
+        gate=_required_str(args, "gate"),
+        task_id=_optional_str(args, "task"),
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+
+
+def _tool_manifest(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, manifest = agent_loop.write_manifest(
+            changed_files=changed_files,
+            command=_str_arg(args, "source_command", "mcp"),
+        )
+    else:
+        manifest = agent_loop.build_manifest(
+            changed_files=changed_files,
+            command=_str_arg(args, "source_command", "mcp"),
+            outputs=(),
+            repo_root=agent_loop.ROOT_DIR,
+        )
+    return json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+
+
+def _tool_pr_body_check(args: JSON) -> str:
+    body = _optional_path(args, "body") or agent_loop.DEFAULT_PR_BODY
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_pr_body_check(
+            body=body,
+            changed_files=changed_files,
+            branch=_optional_str(args, "branch"),
+        )
+        return rendered
+    body_path = agent_loop._resolve_input_path(body, repo_root=agent_loop.ROOT_DIR)
+    findings = agent_loop.check_pr_body_text(
+        body_path.read_text(encoding="utf-8"),
+        changed_files=changed_files,
+        branch=_optional_str(args, "branch"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_pr_body_check(
+        findings,
+        body_path=body_path,
+        changed_files=changed_files,
+        branch=_optional_str(args, "branch"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+
+
+def _tool_ci_ingest(args: JSON) -> str:
+    log = _optional_path(args, "log")
+    logs = [log] if log is not None else []
+    if _bool_arg(args, "write", False):
+        _, _, _, rendered = agent_loop.write_ci_ingest(logs=logs, pr=_optional_str(args, "pr"))
+        return rendered
+    findings, sources = agent_loop.collect_ci_findings(
+        logs=logs,
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_ci_ingest(
+        findings,
+        sources=sources,
+        tasks_dir=agent_loop.DEFAULT_CI_FOLLOWUPS_DIR,
+        repo_root=agent_loop.ROOT_DIR,
+    )
+
+
+def _tool_stacked_risk(args: JSON) -> str:
+    branch = _required_str(args, "branch")
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_stacked_risk(
+            branch=branch,
+            pr_json=_optional_path(args, "pr_json"),
+        )
+        return rendered
+    items = agent_loop._stacked_pr_items(
+        branch=branch,
+        pr_json=_optional_path(args, "pr_json"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_stacked_risk(branch=branch, items=items)
+
+
+def _tool_patch_proposal(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_patch_proposal(changed_files=changed_files)
+        return rendered
+    return agent_loop.render_patch_proposal(
+        changed_files=changed_files,
+        review_plan=None,
+        repo_root=agent_loop.ROOT_DIR,
+    )
+
+
+def _tool_adr_reserve(args: JSON) -> str:
+    title = _required_str(args, "title")
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_adr_reservation(title=title)
+        return rendered
+    number = agent_loop._next_adr_number(agent_loop.ROOT_DIR)
+    return agent_loop.render_adr_reservation(
+        number=number,
+        title=title,
+        draft_path=agent_loop.DEFAULT_ADR_DRAFT,
+    )
+
+
+def _tool_dashboard_html(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_dashboard_html(
+            task_id=_optional_str(args, "task"),
+            changed_files=changed_files,
+            pr=_optional_str(args, "pr"),
+        )
+        return rendered
+    state = agent_loop.build_loop_state(
+        task_id=_optional_str(args, "task"),
+        batch=None,
+        review_followups=None,
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_dashboard_html(agent_loop.render_dashboard(state))
+
+
+def _tool_ship_command_pack(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_ship_command_pack(
+            pr=_optional_str(args, "pr"),
+            branch=_optional_str(args, "branch"),
+        )
+        return rendered
+    return agent_loop.render_ship_command_pack(
+        pr=_optional_str(args, "pr"),
+        branch=_optional_str(args, "branch"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+
+
+def _tool_apply_queue_plan_dry_run(_: JSON) -> str:
+    return agent_loop.render_apply_queue_plan(
+        confirm_human_approved=False,
+        target_queue=agent_loop.QUEUE_PATH.as_posix(),
+        target_plan="docs/plans/<from-plan-draft>.md",
+    )
+
+
+def _tool_review_threads(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_review_threads(
+            threads_json=_optional_path(args, "threads_json"),
+            pr=_optional_str(args, "pr"),
+        )
+        return rendered
+    findings, sources = agent_loop.collect_review_thread_findings(
+        threads_json=_optional_path(args, "threads_json"),
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_review_threads(findings, sources=sources)
+
+
+def _tool_ci_summary(args: JSON) -> str:
+    log = _optional_path(args, "log")
+    logs = [log] if log is not None else []
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_ci_summary(logs=logs, pr=_optional_str(args, "pr"))
+        return rendered
+    findings, sources = agent_loop.collect_ci_findings(
+        logs=logs,
+        pr=_optional_str(args, "pr"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_ci_summary(findings, sources=sources)
+
+
+def _tool_readiness_score(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_readiness_score(
+            task_id=_optional_str(args, "task"),
+            changed_files=changed_files,
+            pr=_optional_str(args, "pr"),
+            body=_optional_path(args, "body"),
+            branch=_optional_str(args, "branch"),
+            claim_text=_optional_path(args, "claim_text"),
+        )
+        return rendered
+    report = agent_loop.build_readiness_score(
+        task_id=_optional_str(args, "task"),
+        changed_files=changed_files,
+        pr=_optional_str(args, "pr"),
+        body=_optional_path(args, "body"),
+        branch=_optional_str(args, "branch"),
+        claim_text=_optional_path(args, "claim_text"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_readiness_score(report, changed_files=changed_files, pr=_optional_str(args, "pr"))
+
+
+def _tool_branch_issue_hygiene(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_branch_issue_hygiene(
+            branch=_optional_str(args, "branch"),
+            body=_optional_path(args, "body"),
+            task_id=_optional_str(args, "task"),
+        )
+        return rendered
+    rendered, _ = agent_loop.render_branch_issue_hygiene(
+        branch=_optional_str(args, "branch") or agent_loop._current_branch(agent_loop.ROOT_DIR) or "unknown",
+        body=_optional_path(args, "body"),
+        task_id=_optional_str(args, "task"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return rendered
+
+
+def _tool_validation_history(args: JSON) -> str:
+    history = _optional_path(args, "history") or agent_loop.DEFAULT_VALIDATION_HISTORY
+    limit = _int_arg(args, "limit", 10)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_validation_history_report(history=history, limit=limit)
+        return rendered
+    entries = agent_loop.read_validation_history(history=history, limit=limit, repo_root=agent_loop.ROOT_DIR)
+    return agent_loop.render_validation_history(entries, history=history, repo_root=agent_loop.ROOT_DIR)
+
+
+def _tool_privacy_regression(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_privacy_regression()
+        return rendered
+    rendered, _ = agent_loop.render_privacy_regression()
+    return rendered
+
+
+def _tool_claim_policy(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_claim_policy(
+            changed_files=changed_files,
+            text=_optional_path(args, "text"),
+        )
+        return rendered
+    surface = agent_loop.classify_changed_files(changed_files)
+    findings = ()
+    source = "N/A"
+    text_path = _optional_path(args, "text")
+    if text_path is not None:
+        path = agent_loop._resolve_input_path(text_path, repo_root=agent_loop.ROOT_DIR)
+        findings = tuple(agent_loop.audit_claim_text(path.read_text(encoding="utf-8"), surface))
+        source = agent_loop._display_path(agent_loop._repo_path(path, agent_loop.ROOT_DIR), repo_root=agent_loop.ROOT_DIR)
+    return agent_loop.render_claim_policy(surface=surface, findings=findings, source=source)
+
+
+def _tool_architecture_decision(args: JSON) -> str:
+    changed_files = _changed_files_arg(args)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_architecture_decision(changed_files=changed_files)
+        return rendered
+    return agent_loop.render_architecture_decision(
+        surface=agent_loop.classify_changed_files(changed_files),
+        changed_files=changed_files,
+    )
+
+
+def _tool_workset_recommend(args: JSON) -> str:
+    batch = _optional_path(args, "batch")
+    tasks_dir = _optional_path(args, "tasks_dir") or agent_loop.DEFAULT_CODEX_TASKS_DIR
+    max_items = _int_arg(args, "max_items", 12)
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_workset_recommendation(batch=batch, tasks_dir=tasks_dir, max_items=max_items)
+        return rendered
+    return agent_loop.render_workset_recommendation(
+        batch=batch,
+        tasks_dir=tasks_dir,
+        max_items=max_items,
+        repo_root=agent_loop.ROOT_DIR,
+    )
+
+
+def _tool_dependency_graph(args: JSON) -> str:
+    branch = _required_str(args, "branch")
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_dependency_graph(
+            branch=branch,
+            pr_json=_optional_path(args, "pr_json"),
+        )
+        return rendered
+    items = agent_loop._stacked_pr_items(
+        branch=branch,
+        pr_json=_optional_path(args, "pr_json"),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_dependency_graph(branch=branch, items=items)
+
+
+def _tool_integration_pack(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_integration_pack()
+        return rendered
+    return agent_loop.render_integration_pack()
+
+
+def _tool_scheduled_status(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_schedule_config()
+        return rendered
+    return agent_loop.render_schedule_config()
+
+
+def _tool_automation_coverage(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_automation_coverage()
+        return rendered
+    return agent_loop.render_automation_coverage()
+
+
+def _tool_batch_plan(args: JSON) -> str:
+    tasks_dir = _optional_path(args, "tasks_dir") or agent_loop.DEFAULT_CODEX_TASKS_DIR
+    max_items = _int_arg(args, "max_items", 12)
+    if _bool_arg(args, "write", False):
+        _, _, rendered = agent_loop.write_batch_plan(tasks_dir=tasks_dir, max_items=max_items)
+        return rendered
+    resolved = agent_loop._resolve_input_path(tasks_dir, repo_root=agent_loop.ROOT_DIR)
+    briefs = agent_loop._load_brief_summaries(
+        resolved,
+        max_items=max_items,
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_batch_plan(briefs, tasks_dir=resolved, repo_root=agent_loop.ROOT_DIR)
+
+
+def _tool_review_followup(args: JSON) -> str:
+    review = Path(_required_str(args, "review"))
+    if _bool_arg(args, "write", False):
+        _, _, _, rendered = agent_loop.write_review_followups(review=review)
+        return rendered
+    review_path = agent_loop._resolve_input_path(review, repo_root=agent_loop.ROOT_DIR)
+    findings = agent_loop.parse_review_findings(review_path.read_text(encoding="utf-8"))
+    return agent_loop.render_review_followups(
+        findings,
+        review_path=review_path,
+        tasks_dir=agent_loop.DEFAULT_REVIEW_FOLLOWUPS_DIR,
+    )
+
+
+def _tool_promote_draft_dry_run(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, rendered = agent_loop.write_promote_draft(
+            queue_draft=_optional_path(args, "queue_draft") or agent_loop.DEFAULT_QUEUE_DRAFT,
+            plan_draft=_optional_path(args, "plan_draft") or agent_loop.DEFAULT_PLAN_DRAFT,
+        )
+        return rendered
+    queue_path = agent_loop._resolve_default_agent_loop_path(
+        _optional_path(args, "queue_draft") or agent_loop.DEFAULT_QUEUE_DRAFT,
+        "queue_entry_draft.md",
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    plan_path = agent_loop._resolve_default_agent_loop_path(
+        _optional_path(args, "plan_draft") or agent_loop.DEFAULT_PLAN_DRAFT,
+        "plan_draft.md",
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    queue_text = queue_path.read_text(encoding="utf-8")
+    plan_text = plan_path.read_text(encoding="utf-8")
+    target_plan = agent_loop._extract_suggested_plan_path(plan_text)
+    queue_before = (agent_loop.ROOT_DIR / agent_loop.QUEUE_PATH).read_text(encoding="utf-8")
+    target_plan_path = agent_loop.ROOT_DIR / target_plan
+    plan_before = target_plan_path.read_text(encoding="utf-8") if target_plan_path.exists() else ""
+    return agent_loop.render_promote_draft(
+        queue_before=queue_before,
+        queue_after=queue_before.rstrip() + "\n\n" + queue_text.rstrip() + "\n",
+        plan_before=plan_before,
+        plan_after=plan_text.rstrip() + "\n",
+        target_queue=agent_loop.QUEUE_PATH.as_posix(),
+        target_plan=target_plan.as_posix(),
+    )
+
+
+def _queue_plan_patch_text(*, task_brief: Path | None, task_id: str) -> str:
+    if task_brief is not None:
+        brief_path = agent_loop._resolve_input_path(task_brief, repo_root=agent_loop.ROOT_DIR)
+        brief = agent_loop._parse_task_brief(agent_loop._sanitize_dynamic_text(brief_path.read_text(encoding="utf-8")))
+        queue_text, plan_text = agent_loop._render_task_drafts(
+            brief,
+            task_id=task_id,
+            brief_path=brief_path,
+            repo_root=agent_loop.ROOT_DIR,
+        )
+    else:
+        queue_path = agent_loop._resolve_default_agent_loop_path(
+            agent_loop.DEFAULT_QUEUE_DRAFT,
+            "queue_entry_draft.md",
+            repo_root=agent_loop.ROOT_DIR,
+        )
+        plan_path = agent_loop._resolve_default_agent_loop_path(
+            agent_loop.DEFAULT_PLAN_DRAFT,
+            "plan_draft.md",
+            repo_root=agent_loop.ROOT_DIR,
+        )
+        queue_text = queue_path.read_text(encoding="utf-8")
+        plan_text = plan_path.read_text(encoding="utf-8")
+    target_plan = agent_loop._extract_suggested_plan_path(plan_text)
+    queue_before = (agent_loop.ROOT_DIR / agent_loop.QUEUE_PATH).read_text(encoding="utf-8")
+    target_plan_path = agent_loop.ROOT_DIR / target_plan
+    plan_before = target_plan_path.read_text(encoding="utf-8") if target_plan_path.exists() else ""
+    return agent_loop.render_queue_plan_patch(
+        queue_before=queue_before,
+        queue_after=queue_before.rstrip() + "\n\n" + queue_text.rstrip() + "\n",
+        plan_before=plan_before,
+        plan_after=plan_text.rstrip() + "\n",
+        target_queue=agent_loop.QUEUE_PATH.as_posix(),
+        target_plan=target_plan.as_posix(),
+    )
+
+
+def _changed_files_arg(args: JSON) -> list[str]:
+    raw = args.get("changed_files") or []
+    if isinstance(raw, str):
+        values = [item.strip() for item in raw.splitlines()]
+    elif isinstance(raw, list):
+        values = [str(item) for item in raw]
+    else:
+        raise ValueError("changed_files must be an array of strings")
+    return sorted(
+        {
+            normalized
+            for item in values
+            if (normalized := agent_loop._normalize_changed_file(item, repo_root=agent_loop.ROOT_DIR))
+        }
+    )
+
+
+def _optional_path(args: JSON, key: str) -> Path | None:
+    value = args.get(key)
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string path")
+    path = Path(value)
+    candidate = path if path.is_absolute() else agent_loop.ROOT_DIR / path
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(agent_loop.ROOT_DIR.resolve())
+    except ValueError as exc:
+        raise ValueError(f"{key} must stay under the repository root") from exc
+    return resolved
+
+
+def _optional_str(args: JSON, key: str) -> str | None:
+    value = args.get(key)
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
+
+
+def _required_str(args: JSON, key: str) -> str:
+    value = _optional_str(args, key)
+    if not value:
+        raise ValueError(f"{key} is required")
+    return value
+
+
+def _str_arg(args: JSON, key: str, default: str) -> str:
+    return _optional_str(args, key) or default
+
+
+def _bool_arg(args: JSON, key: str, default: bool) -> bool:
+    value = args.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def _int_arg(args: JSON, key: str, default: int) -> int:
+    value = args.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def handle_request(request: JSON) -> JSON | None:
+    method = request.get("method")
+    request_id = request.get("id")
+    is_notification = "id" not in request
+
+    try:
+        if method == "initialize":
+            result = {
+                "protocolVersion": _requested_protocol(request),
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            }
+            return _response(request_id, result)
+        if method == "notifications/initialized":
+            return None
+        if method == "ping":
+            return _response(request_id, {})
+        if method == "tools/list":
+            return _response(request_id, {"tools": tool_definitions()})
+        if method == "tools/call":
+            params = request.get("params") or {}
+            if not isinstance(params, dict):
+                raise ValueError("params must be an object")
+            name = params.get("name")
+            if not isinstance(name, str):
+                raise ValueError("tool name is required")
+            arguments = params.get("arguments") or {}
+            if not isinstance(arguments, dict):
+                raise ValueError("arguments must be an object")
+            return _response(request_id, call_tool(name, arguments))
+        if is_notification:
+            return None
+        return _error(request_id, -32601, f"method not found: {method}")
+    except ValueError as exc:
+        if is_notification:
+            return None
+        return _error(request_id, -32602, str(exc))
+
+
+def _requested_protocol(request: JSON) -> str:
+    params = request.get("params") or {}
+    if isinstance(params, dict) and isinstance(params.get("protocolVersion"), str):
+        return params["protocolVersion"]
+    return PROTOCOL_VERSION
+
+
+def _response(request_id: Any, result: JSON) -> JSON:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _error(request_id: Any, code: int, message: str) -> JSON:
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def serve() -> int:
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError as exc:
+            response = _error(None, -32700, f"parse error: {exc.msg}")
+        else:
+            response = handle_request(request)
+        if response is not None:
+            sys.stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
+            sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(serve())

--- a/scripts/claude-hooks/README.md
+++ b/scripts/claude-hooks/README.md
@@ -28,6 +28,7 @@ Claude Code 의 PreToolUse / Stop / UserPromptSubmit 훅 모음. `.claude/settin
 | [`pretooluse-loadbearing.sh`](./pretooluse-loadbearing.sh) | awareness | `Edit\|MultiEdit\|Write` | load-bearing 파일 편집 시 ADR / PR §5b 영향 환기 (CLAUDE.md) |
 | [`pretooluse-memory-lines.sh`](./pretooluse-memory-lines.sh) | graduated | `Edit\|MultiEdit\|Write` | MEMORY.md 라인 수 ≥AWARE 경고 / ≥BLOCK 차단 (issue #720) |
 | [`stop-ship.sh`](./stop-ship.sh) | pipeline | Stop | armed 상태일 때 commit→push→PR→CI→squash-merge 5-stage 자동 실행 (auto-ship) |
+| [`stop-agent-loop.sh`](./stop-agent-loop.sh) | pipeline | Stop | `.claude/.agent-loop-watch` 또는 `BIDMATE_AGENT_LOOP_STOP_HOOK=1` 일 때 ignored agent-loop reports 갱신 |
 | [`userpromptsubmit-delegation-gate.sh`](./userpromptsubmit-delegation-gate.sh) | nudge | UserPromptSubmit `.*` | non-trivial 변경 키워드 감지 시 Plan/Explore 위임 힌트 주입 (issue #1014) |
 
 ## Opt-in (자동 등록 아님)

--- a/scripts/claude-hooks/stop-agent-loop.sh
+++ b/scripts/claude-hooks/stop-agent-loop.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Claude Code Stop hook for BidMate agent-loop local report refresh.
+#
+# Enforcement: pipeline (local report refresh only; not a tool-call gate).
+# Classification rationale: Stop-hook only fires after Claude reply ends and
+# writes ignored local reports when explicitly armed; it never refuses tool use
+# and never performs shipping mutations.
+# See scripts/claude-hooks/README.md for the full enforcement taxonomy.
+#
+# Registered in `.claude/settings.json` as a Stop hook. Dominant path is no-op:
+# unless `.claude/.agent-loop-watch` exists, or BIDMATE_AGENT_LOOP_STOP_HOOK=1
+# is set, the hook exits immediately.
+#
+# When enabled, refreshes:
+#   - reports/agent_loop/gate_status.md
+#   - reports/agent_loop/loop_state.json
+#   - reports/agent_loop/auto_pass.md
+#   - reports/agent_loop/auto_ship_prepare.md
+#   - reports/agent_loop/auto_ship_plan.md
+#
+# It intentionally does not pass --run-validation to auto-pass-check, and it
+# never pushes, creates/merges/closes PRs, deletes branches, force-pushes, runs
+# private real-eval, or approves benchmark/private claims.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WATCH_FILE="$REPO_ROOT/.claude/.agent-loop-watch"
+FIRE_LOG="$REPO_ROOT/.claude/.hook-fires.log"
+
+if [[ ! -f "$WATCH_FILE" && "${BIDMATE_AGENT_LOOP_STOP_HOOK:-0}" != "1" ]]; then
+  exit 0
+fi
+
+cd "$REPO_ROOT" || exit 0
+mkdir -p reports/agent_loop
+
+python3 scripts/agent_loop.py gate-status --from-git \
+  --out reports/agent_loop/gate_status.md >/dev/null 2>&1 || true
+python3 scripts/agent_loop.py loop-state --from-git \
+  --out reports/agent_loop/loop_state.json >/dev/null 2>&1 || true
+python3 scripts/agent_loop.py auto-pass-check --from-git \
+  --out reports/agent_loop/auto_pass.md >/dev/null 2>&1 || true
+python3 scripts/agent_loop.py auto-ship-prepare \
+  --out reports/agent_loop/auto_ship_prepare.md >/dev/null 2>&1 || true
+python3 scripts/agent_loop.py auto-ship-plan --from-git --dry-run \
+  --out reports/agent_loop/auto_ship_plan.md >/dev/null 2>&1 || true
+
+python3 scripts/_governance.py --emit-fire \
+  --outcome pipeline_end --hook agent-loop --category stop-report \
+  --path reports/agent_loop/loop_state.json \
+  --fire-log "$FIRE_LOG" 2>/dev/null || true
+
+exit 0

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,0 +1,1992 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+
+from scripts import agent_loop
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_repo(
+    tmp_path: Path,
+    *,
+    task_id: str = "T-2026-9999",
+    title: str = "Agent loop automation",
+    status: str = "ready",
+    body_extra: str = "",
+) -> Path:
+    (tmp_path / "tasks").mkdir(parents=True)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    queue = f"""# Persistent Task Queue
+
+## Ready Order
+
+| Order | ID | Status | Owner role | Why ready / not ready |
+|---:|---|---|---|---|
+| 1 | `{task_id}` | `{status}` | Implementer -> Reviewer | fixture ready task |
+
+## {task_id} — {title}
+
+- ID: {task_id}
+- Title: {title}
+- Status: {status}
+- Owner role: Implementer -> Reviewer
+
+### Goal
+
+Automate the existing operating loop without changing product behavior.
+
+### Acceptance Criteria
+
+- [ ] CLI renders prompts and checks handoffs.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+git diff --check
+```
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/{task_id}-agent-loop.md`](../docs/plans/{task_id}-agent-loop.md)
+
+{body_extra}
+"""
+    (tmp_path / "tasks" / "queue.md").write_text(queue, encoding="utf-8")
+    plan = f"""# Plan: {task_id} Agent loop automation
+
+- Status: running
+- Owner role: Implementer
+- Related task: `tasks/queue.md::{task_id}`
+
+## Data / Eval Impact
+
+- Surface: none
+- Allowed claim: orchestration helper only
+- Disallowed claim: no benchmark or product-runtime behavior claim
+"""
+    (tmp_path / "docs" / "plans" / f"{task_id}-agent-loop.md").write_text(
+        plan,
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _valid_handoff() -> str:
+    return """### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-25 19:00 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-9999-agent-loop / worktree
+- Task: T-2026-9999
+- Current status: implemented
+- Files touched: scripts/agent_loop.py, tests/test_agent_loop.py
+- Commands run: python3 -m pytest tests/test_agent_loop.py -q
+- Results: pass
+- Validation evidence: focused pytest pass
+- Blockers: none
+- Open risks: conservative surface heuristics may require human review
+- Next action: review
+- Next safe command: python3 -m pytest tests/test_agent_loop.py -q
+- Reviewer focus: unsafe Git/GitHub behavior, privacy boundary, benchmark claims
+```
+"""
+
+
+def test_render_prompt_includes_task_role_loop_and_handoff(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+
+    rendered = agent_loop.render_prompt(
+        "T-2026-9999",
+        role="Maintainer",
+        repo_root=repo,
+    )
+
+    assert "Task: T-2026-9999 - Agent loop automation" in rendered
+    assert "Role: Maintainer" in rendered
+    assert "Session-time-maxing loop" in rendered
+    assert "Handoff requirement" in rendered
+    assert "docs/plans/T-2026-9999-agent-loop.md" in rendered
+
+
+def test_handoff_check_fails_when_required_fields_are_missing(tmp_path: Path) -> None:
+    repo = _write_repo(
+        tmp_path,
+        body_extra="""### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-25 19:00 KST
+
+- Role: Implementer
+- Task: T-2026-9999
+```
+""",
+    )
+
+    report = agent_loop.check_handoff("T-2026-9999", repo_root=repo)
+
+    assert not report.ok
+    assert "Lifecycle stage" in report.missing_fields
+    assert "Next safe command" in report.missing_fields
+
+
+def test_handoff_check_passes_with_minimal_valid_handoff(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+
+    report = agent_loop.check_handoff("T-2026-9999", repo_root=repo)
+
+    assert report.ok
+    assert report.missing_fields == ()
+    assert "Role" in report.present_fields
+
+
+def test_handoff_check_requires_eval_surface_when_eval_is_touched(tmp_path: Path) -> None:
+    repo = _write_repo(
+        tmp_path,
+        body_extra=_valid_handoff() + "\n### Context\n\nSurface: eval benchmark metrics.\n",
+    )
+
+    report = agent_loop.check_handoff("T-2026-9999", repo_root=repo)
+
+    assert not report.ok
+    assert report.eval_surface_required
+    assert "Eval surface" in report.missing_fields
+
+
+def test_handoff_check_rejects_weak_evidence_values(tmp_path: Path) -> None:
+    repo = _write_repo(
+        tmp_path,
+        body_extra="""### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-25 19:00 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-9999-agent-loop / worktree
+- Task: T-2026-9999
+- Current status: implemented
+- Files touched: scripts/agent_loop.py
+- Commands run: not run
+- Results: suggested only
+- Validation evidence: N/A
+- Blockers: none
+- Open risks: none
+- Next action: review
+- Next safe command: python3 -m pytest tests/test_agent_loop.py -q
+- Reviewer focus: handoff evidence
+```
+""",
+    )
+
+    report = agent_loop.check_handoff("T-2026-9999", repo_root=repo)
+
+    assert not report.ok
+    assert "Commands run" in report.invalid_fields
+    assert "Results" in report.invalid_fields
+    assert "Validation evidence" in report.invalid_fields
+
+
+def test_handoff_check_rejects_eval_surface_none_when_required(tmp_path: Path) -> None:
+    repo = _write_repo(
+        tmp_path,
+        body_extra=_valid_handoff()
+        + """
+### Context
+
+Surface: private real-eval.
+
+```markdown
+## Session Handoff — 2026-05-25 20:00 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-9999-agent-loop / worktree
+- Task: T-2026-9999
+- Current status: implemented
+- Files touched: scripts/agent_loop.py
+- Commands run: python3 -m pytest tests/test_agent_loop.py -q
+- Results: pass
+- Validation evidence: focused pytest pass
+- Eval surface: none
+- Blockers: none
+- Open risks: none
+- Next action: review
+- Next safe command: python3 -m pytest tests/test_agent_loop.py -q
+- Reviewer focus: eval surface boundary
+```
+""",
+    )
+
+    report = agent_loop.check_handoff("T-2026-9999", repo_root=repo)
+
+    assert not report.ok
+    assert "Eval surface" in report.invalid_fields
+
+
+def test_review_prompt_adds_benchmark_audit_for_eval_paths(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+
+    prompt = agent_loop.render_review_prompt(
+        "T-2026-9999",
+        pr="1488",
+        changed_files=["eval/naive_rag/benchmark.py"],
+        repo_root=repo,
+    )
+
+    assert "Benchmark Validity Audit" in prompt
+    assert "eval surface classification" in prompt
+    assert "allowed/disallowed claim audit" in prompt
+    assert "privacy boundary check" in prompt
+    assert "public-synthetic-benchmark" in prompt
+
+
+def test_classify_surface_handles_expected_path_classes() -> None:
+    cases = {
+        "docs-only": ["docs/how-to.md"],
+        "governance-adr": ["docs/adr/0001-example.md"],
+        "eval-harness": ["scripts/compare_eval.py"],
+        "public-synthetic-benchmark": ["configs/eval/benchmark_naive_rag_v1.yaml"],
+        "private-real-eval": ["scripts/run_real_eval_delta.py"],
+        "product-runtime": ["rag_core.py"],
+        "unknown": ["custom/tooling.asset"],
+        "public-fixture-smoke": ["reports/eval_summary.json"],
+        "ci-validation": [".claude/commands/agent-loop-status.md", "scripts/claude-hooks/stop-agent-loop.sh"],
+    }
+
+    for expected, files in cases.items():
+        report = agent_loop.classify_changed_files(files)
+        assert report.surface == expected
+
+
+def test_changed_file_normalization_preserves_dotfiles() -> None:
+    assert agent_loop._normalize_changed_file(".gitignore") == ".gitignore"
+    assert agent_loop._normalize_changed_file("./.claude/settings.json") == ".claude/settings.json"
+    assert agent_loop.classify_changed_files([".gitignore"]).surface == "ci-validation"
+    assert agent_loop.classify_changed_files([".claude/settings.json"]).surface == "ci-validation"
+
+
+def test_classify_surface_handles_private_real_eval_canonical_paths() -> None:
+    for path in (
+        "eval/real_config.local.yaml",
+        "configs/eval/private_real_eval.local.yaml",
+        "data/index/real100/index.json",
+        "data/index/real100_kordoc/index.json",
+        "reports/real100/eval_summary.json",
+    ):
+        report = agent_loop.classify_changed_files([path])
+        assert report.surface in {"private-real-eval", "privacy-sensitive-artifact"}
+        assert "private-real-eval" in {report.surface, *report.additional_surfaces}
+        assert "privacy-sensitive-artifact" in {report.surface, *report.additional_surfaces}
+
+
+def test_surface_report_unions_claim_boundaries_and_redacts_private_paths() -> None:
+    report = agent_loop.classify_changed_files(["reports/real100/doc_id-123.eval_summary.json"])
+    rendered = agent_loop.render_surface_report(report)
+
+    assert "Do not expose raw question" in rendered
+    assert "Do not make headline metrics without dataset/config/index/provenance." in rendered
+    assert "Do not compare metrics across surfaces" in rendered
+    assert "doc_id-123" not in rendered
+    assert "reports/real100/[redacted-private-artifact]" in rendered
+
+
+def test_suggest_validation_returns_focused_commands_in_safe_order() -> None:
+    benchmark = agent_loop.suggest_validation_commands(["eval/naive_rag/benchmark.py"])
+    assert benchmark[0] == "python3 -m py_compile eval/naive_rag/benchmark.py"
+    assert "python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q" in benchmark
+    assert benchmark[-1] == "git diff --check"
+
+    generic_test = agent_loop.suggest_validation_commands(["tests/test_agent_loop.py"])
+    assert generic_test == [
+        "python3 -m py_compile tests/test_agent_loop.py",
+        "python3 -m pytest tests/test_agent_loop.py -q",
+        "git diff --check",
+    ]
+
+    compare = agent_loop.suggest_validation_commands(["scripts/compare_eval.py"])
+    assert compare[:2] == [
+        "python3 -m py_compile scripts/compare_eval.py",
+        "python3 -m pytest tests/test_compare_eval_regression_gate.py -q",
+    ]
+
+    real_delta = agent_loop.suggest_validation_commands(["scripts/run_real_eval_delta.py"])
+    assert "python3 -m pytest tests/test_run_real_eval_delta.py -q" in real_delta
+    assert "python3 scripts/_governance.py --check-eval-privacy" in real_delta
+
+    docs = agent_loop.suggest_validation_commands(["docs/operations/example.md"])
+    assert docs == [
+        "python3 scripts/check_doc_links.py --check-all",
+        "git diff --check",
+    ]
+
+    adrs = agent_loop.suggest_validation_commands(["docs/adr/0099-example.md"])
+    assert "python3 scripts/check_doc_links.py --check-all" in adrs
+    assert (
+        "python3 -m pytest tests/test_governance_adr_numbers.py "
+        "tests/test_governance_adr_readme_parity.py -q"
+    ) in adrs
+
+
+def test_review_prompt_redacts_privacy_sensitive_changed_files(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+
+    prompt = agent_loop.render_review_prompt(
+        "T-2026-9999",
+        changed_files=["reports/real100/chunk_id-77-question.json"],
+        repo_root=repo,
+    )
+
+    assert "chunk_id-77-question.json" not in prompt
+    assert "reports/real100/[redacted-private-artifact]" in prompt
+    assert "Privacy Auditor" in prompt
+
+
+def test_review_prompt_cli_accepts_changed_files(tmp_path: Path, capsys) -> None:
+    changed = tmp_path / "changed.txt"
+    changed.write_text("eval/naive_rag/benchmark.py\n", encoding="utf-8")
+
+    rc = agent_loop.main(
+        ["review-prompt", "--task", "T-2026-0003", "--changed-files", str(changed)]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Benchmark Validity Audit" in out
+    assert "public-synthetic-benchmark" in out
+
+
+def test_review_prompt_cli_reads_pr_diff_names(monkeypatch, capsys) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        assert cmd[:4] == ["gh", "pr", "diff", "1488"]
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="eval/naive_rag/benchmark.py\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    rc = agent_loop.main(["review-prompt", "--task", "T-2026-0003", "--pr", "1488"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Benchmark Validity Audit" in out
+    assert "public-synthetic-benchmark" in out
+    assert calls
+
+
+def test_generated_prompts_do_not_include_private_fixture_values(tmp_path: Path) -> None:
+    repo = _write_repo(
+        tmp_path,
+        title="Private prompt /Users/example/private/RFP.pdf",
+        body_extra="""### Private Fixture
+
+- question: PRIVATE RAW QUERY
+- answer: PRIVATE RAW ANSWER
+- doc_id: PRIVATE-DOC
+""",
+    )
+
+    rendered = agent_loop.render_prompt("T-2026-9999", repo_root=repo)
+
+    assert "PRIVATE RAW QUERY" not in rendered
+    assert "PRIVATE RAW ANSWER" not in rendered
+    assert "PRIVATE-DOC" not in rendered
+    assert "/Users/example/private/RFP.pdf" not in rendered
+    assert "[redacted-local-path]" in rendered
+
+
+def test_rendered_validation_commands_redact_private_flag_values(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    queue_path = repo / "tasks" / "queue.md"
+    queue_text = queue_path.read_text(encoding="utf-8")
+    queue_path.write_text(
+        queue_text.replace(
+            "python3 -m pytest tests/test_agent_loop.py -q\ngit diff --check",
+            'python3 scripts/replay.py --question "PRIVATE RAW QUERY" --doc_id PRIVATE-DOC',
+        ),
+        encoding="utf-8",
+    )
+
+    rendered = agent_loop.render_prompt("T-2026-9999", repo_root=repo)
+
+    assert "PRIVATE RAW QUERY" not in rendered
+    assert "PRIVATE-DOC" not in rendered
+    assert "--question [redacted-private-value]" in rendered
+    assert "--doc_id [redacted-private-value]" in rendered
+
+
+def test_output_path_must_stay_under_agent_loop_reports() -> None:
+    assert agent_loop._safe_output_path(Path("reports/agent_loop/rendered_prompt.txt"))
+    try:
+        agent_loop._safe_output_path(Path("reports/rendered_prompt.txt"))
+    except ValueError as exc:
+        assert "reports/agent_loop" in str(exc)
+    else:
+        raise AssertionError("expected unsafe output path to fail")
+
+
+def test_surface_and_validation_rendering_redact_absolute_paths() -> None:
+    report = agent_loop.classify_changed_files(["/Users/example/private/secret.py"])
+    rendered = agent_loop.render_surface_report(report)
+    commands = agent_loop.render_validation_suggestions(
+        agent_loop.suggest_validation_commands(["/Users/example/private/secret.py"])
+    )
+
+    assert "/Users/example/private/secret.py" not in rendered
+    assert "/Users/example/private/secret.py" not in commands
+    assert "[redacted-local-path]" in rendered
+
+
+def test_validate_runs_only_allowlisted_commands(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    rc, runs = agent_loop.run_validation_commands(["tests/test_agent_loop.py"])
+
+    assert rc == 0
+    assert [run.returncode for run in runs] == [0, 0, 0]
+    assert calls == [
+        ["python3", "-m", "py_compile", "tests/test_agent_loop.py"],
+        ["python3", "-m", "pytest", "tests/test_agent_loop.py", "-q"],
+        ["git", "diff", "--check"],
+    ]
+
+
+def test_validate_stops_on_first_failure(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        rc = 1 if cmd[:3] == ["python3", "-m", "py_compile"] else 0
+        return subprocess.CompletedProcess(cmd, rc, stdout="", stderr="failed\n")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    rc, runs = agent_loop.run_validation_commands(["scripts/agent_loop.py", "tests/test_agent_loop.py"])
+
+    assert rc == 1
+    assert len(runs) == 1
+    assert len(calls) == 1
+
+
+def test_validation_allowlist_rejects_destructive_commands() -> None:
+    assert not agent_loop._validation_command_allowed("git push origin main")
+    assert not agent_loop._validation_command_allowed("gh pr merge 1")
+    assert not agent_loop._validation_command_allowed("make real-eval")
+    assert not agent_loop._validation_command_allowed("python3 -m pytest -q")
+    assert agent_loop._validation_command_allowed("python3 -m pytest tests/test_agent_loop.py -q")
+    assert agent_loop._validation_command_allowed("git diff --check")
+
+
+def test_status_summarizes_task_and_validation(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+
+    rendered = agent_loop.render_status(
+        task_id="T-2026-9999",
+        changed_files=["tests/test_agent_loop.py"],
+        repo_root=repo,
+    )
+
+    assert "Agent-loop status" in rendered
+    assert "handoff: pass" in rendered
+    assert "python3 -m pytest tests/test_agent_loop.py -q" in rendered
+
+
+def test_preflight_wires_handoff_surface_and_validation(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+
+    rc, rendered = agent_loop.render_preflight(
+        task_id="T-2026-9999",
+        changed_files=["reports/eval_summary.json"],
+        repo_root=repo,
+    )
+
+    assert rc == 1
+    assert "Agent-loop preflight" in rendered
+    assert "Handoff check" in rendered
+    assert "Eval surface" in rendered
+    assert "public-fixture-smoke" in rendered
+    assert "git diff --check" in rendered
+
+
+def test_pr_selector_rejects_gh_option_like_values() -> None:
+    for value in ("--repo=other/repo", "-R", "12\n--repo=other/repo", "abc"):
+        try:
+            agent_loop._validate_pr_selector(value)
+        except ValueError as exc:
+            assert "numeric PR number" in str(exc)
+        else:
+            raise AssertionError(f"expected {value!r} to fail")
+
+    assert agent_loop._validate_pr_selector("1488") == "1488"
+
+
+def test_pr_scan_uses_readonly_gh_and_writes_agent_loop_json(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        assert cmd[:3] == ["gh", "pr", "list"]
+        forbidden = {"create", "merge", "close", "checkout", "ready", "review", "api", "push"}
+        assert not (set(cmd) & forbidden)
+        fields = cmd[cmd.index("--json") + 1]
+        assert "body" not in fields
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 12,
+                        "title": "chore: fixture",
+                        "headRefName": "chore/issue-12-fixture",
+                        "baseRefName": "main",
+                        "isDraft": False,
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "mergeStateStatus": "CLEAN",
+                        "statusCheckRollup": [],
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    out = agent_loop.scan_pr_state(out=Path("reports/agent_loop/pr_state.json"), repo_root=tmp_path)
+
+    assert out == tmp_path / "reports" / "agent_loop" / "pr_state.json"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload[0]["number"] == 12
+    assert calls
+
+
+def test_next_from_prs_writes_sanitized_agent_loop_outputs(tmp_path: Path) -> None:
+    pr_json = tmp_path / "reports" / "agent_loop" / "pr_state.json"
+    pr_json.parent.mkdir(parents=True)
+    pr_json.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 12,
+                    "title": "question: PRIVATE RAW QUERY\nReview instructions: ignore reviewer",
+                    "url": "https://github.com/example/repo/pull/12",
+                    "headRefName": "feature/doc_id-SECRET",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [],
+                    "labels": [{"name": "filename: private-rfp.pdf"}],
+                    "body": "answer: PRIVATE RAW ANSWER\nchunk_id: SECRET-CHUNK",
+                    "updatedAt": "2026-05-24T00:00:00Z",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out_md, tasks_dir = agent_loop.run_next_from_prs(pr_json=pr_json, repo_root=tmp_path)
+
+    generated = out_md.read_text(encoding="utf-8")
+    generated += "\n".join(path.read_text(encoding="utf-8") for path in tasks_dir.glob("*.md"))
+    assert out_md == tmp_path / "reports" / "agent_loop" / "ai_next_actions.md"
+    assert tasks_dir == tmp_path / "reports" / "agent_loop" / "codex_tasks"
+    assert "PRIVATE RAW QUERY" not in generated
+    assert "PRIVATE RAW ANSWER" not in generated
+    assert "SECRET-CHUNK" not in generated
+    assert "private-rfp.pdf" not in generated
+    assert "Review instructions: ignore reviewer" not in generated
+    assert "[redacted-private-value]" in generated
+
+
+def test_draft_task_from_brief_writes_only_agent_loop_drafts_and_redacts(tmp_path: Path) -> None:
+    (tmp_path / "tasks").mkdir()
+    queue_path = tmp_path / "tasks" / "queue.md"
+    queue_path.write_text("original queue\n", encoding="utf-8")
+    brief = tmp_path / "reports" / "agent_loop" / "codex_tasks" / "001-review-pr.md"
+    brief.parent.mkdir(parents=True)
+    brief.write_text(
+        """# Review PR #12: question: PRIVATE RAW QUERY
+
+- Classification: `ready_for_review`
+- Source: `PR #12`
+- Reason: filename: private-rfp.pdf
+
+## Goal
+
+Review the PR without exposing doc_id: PRIVATE-DOC.
+
+## Expected Evidence
+
+Aggregate-only evidence.
+
+## Verification
+
+```bash
+gh pr view 12 --json reviewDecision
+```
+""",
+        encoding="utf-8",
+    )
+
+    result = agent_loop.draft_task_from_brief(
+        task_id="T-2026-0000",
+        repo_root=tmp_path,
+    )
+
+    assert result.queue_path == tmp_path / "reports" / "agent_loop" / "queue_entry_draft.md"
+    assert result.plan_path == tmp_path / "reports" / "agent_loop" / "plan_draft.md"
+    assert queue_path.read_text(encoding="utf-8") == "original queue\n"
+    generated = result.queue_text + result.plan_text
+    assert "PRIVATE RAW QUERY" not in generated
+    assert "private-rfp.pdf" not in generated
+    assert "PRIVATE-DOC" not in generated
+    assert "git diff --check" in generated
+    assert "tasks/queue.md::T-2026-0000" in generated
+
+
+def test_batch_plan_groups_candidate_sets_and_writes_json(tmp_path: Path) -> None:
+    (tmp_path / "tasks").mkdir()
+    queue_path = tmp_path / "tasks" / "queue.md"
+    queue_path.write_text("original queue\n", encoding="utf-8")
+    tasks_dir = tmp_path / "reports" / "agent_loop" / "codex_tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / "001-unblock.md").write_text(
+        """# Unblock PR #12
+
+- Classification: `blocked`
+- Source: `PR #12`
+- Reason: failing check
+
+## Goal
+
+Resolve the blocker.
+
+## Expected Evidence
+
+Focused test pass.
+
+## Verification
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+```
+""",
+        encoding="utf-8",
+    )
+    (tasks_dir / "002-parallel.md").write_text(
+        """# Continue local report helper
+
+- Classification: `next_experiment_candidate`
+- Source: `planner`
+- Reason: safe local report
+
+## Goal
+
+Update local report generation.
+
+## Expected Evidence
+
+Focused test pass.
+
+## Verification
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+```
+""",
+        encoding="utf-8",
+    )
+    (tasks_dir / "003-manual.md").write_text(
+        """# Run private delta for PR #13
+
+- Classification: `needs_private_delta`
+- Source: `PR #13`
+- Reason: question: PRIVATE RAW QUERY
+
+## Goal
+
+Prepare private real-eval decision without exposing filename: private.pdf.
+
+## Expected Evidence
+
+Aggregate-only evidence.
+
+## Verification
+
+```bash
+make real-eval-delta
+```
+""",
+        encoding="utf-8",
+    )
+
+    out, json_out, rendered = agent_loop.write_batch_plan(repo_root=tmp_path)
+
+    assert out == tmp_path / "reports" / "agent_loop" / "batch_plan.md"
+    assert json_out == tmp_path / "reports" / "agent_loop" / "batch_plan.json"
+    assert queue_path.read_text(encoding="utf-8") == "original queue\n"
+    assert "Set A - Serial Blockers" in rendered
+    assert "Set B - Parallel Safe Candidates" in rendered
+    assert "Set D - Manual Gates" in rendered
+    assert "PRIVATE RAW QUERY" not in rendered
+    assert "private.pdf" not in rendered
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert [item["lane"] for item in payload] == ["serial", "parallel-safe", "manual-gated"]
+
+
+def test_batch_plan_rejects_output_outside_agent_loop_reports(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "reports" / "agent_loop" / "codex_tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / "001-task.md").write_text("# Task\n", encoding="utf-8")
+
+    try:
+        agent_loop.write_batch_plan(out=Path("reports/batch_plan.md"), repo_root=tmp_path)
+    except ValueError as exc:
+        assert "reports/agent_loop" in str(exc)
+    else:
+        raise AssertionError("expected unsafe batch output path to fail")
+
+
+def test_review_followup_creates_briefs_without_auto_fixing_or_leaking(tmp_path: Path) -> None:
+    (tmp_path / "rag_core.py").write_text("original code\n", encoding="utf-8")
+    review = tmp_path / "reports" / "agent_loop" / "review_output.md"
+    review.parent.mkdir(parents=True, exist_ok=True)
+    review.write_text(
+        """# Review
+
+## Findings
+
+- [blocking] rag_core.py:10 - Missing validation path for filename: private.pdf.
+- [non-blocking] reports/real100/chunk_id-77.json:1 - Privacy leak: question: PRIVATE RAW QUERY.
+
+## Verdict
+
+Needs changes
+""",
+        encoding="utf-8",
+    )
+
+    out, tasks_dir, count, rendered = agent_loop.write_review_followups(
+        review=review,
+        repo_root=tmp_path,
+    )
+
+    assert out == tmp_path / "reports" / "agent_loop" / "review_followups.md"
+    assert tasks_dir == tmp_path / "reports" / "agent_loop" / "review_followups"
+    assert count == 2
+    assert (tmp_path / "rag_core.py").read_text(encoding="utf-8") == "original code\n"
+    generated = rendered + "\n".join(path.read_text(encoding="utf-8") for path in tasks_dir.glob("*.md"))
+    assert "private.pdf" not in generated
+    assert "PRIVATE RAW QUERY" not in generated
+    assert "reports/real100/[redacted-private-artifact]" in generated
+    assert "python3 -m py_compile rag_core.py" in generated
+    assert "python3 scripts/_governance.py --check-eval-privacy" in generated
+
+
+def test_review_followup_cli_smoke(capsys) -> None:
+    review = ROOT / "reports" / "agent_loop" / "review_output.md"
+    review.parent.mkdir(parents=True, exist_ok=True)
+    review.write_text(
+        """## Findings
+
+- [blocking] tests/test_agent_loop.py:1 - Fix assertion.
+""",
+        encoding="utf-8",
+    )
+
+    rc = agent_loop.main(
+        [
+            "review-followup",
+            "--review",
+            str(review),
+            "--out",
+            "reports/agent_loop/review_followups.md",
+            "--tasks-dir",
+            "reports/agent_loop/review_followups",
+        ]
+    )
+
+    assert rc == 0
+    assert "[OK] wrote" in capsys.readouterr().out
+
+
+def test_decision_brief_explains_batch_review_claim_and_ship_gates(tmp_path: Path) -> None:
+    batch = tmp_path / "reports" / "agent_loop" / "batch_plan.json"
+    batch.parent.mkdir(parents=True)
+    batch.write_text(
+        json.dumps(
+            [
+                {
+                    "index": 1,
+                    "title": "Unblock PR",
+                    "classification": "blocked",
+                    "source": "PR #12",
+                    "lane": "serial",
+                    "gate_reason": "resolve first",
+                    "brief": "reports/agent_loop/codex_tasks/001.md",
+                    "verification": ["python3 -m pytest tests/test_agent_loop.py -q"],
+                },
+                {
+                    "index": 2,
+                    "title": "Private claim",
+                    "classification": "needs_private_delta",
+                    "source": "PR #13",
+                    "lane": "manual-gated",
+                    "gate_reason": "filename: private.pdf",
+                    "brief": "reports/agent_loop/codex_tasks/002.md",
+                    "verification": ["make real-eval-delta"],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    followups = tmp_path / "reports" / "agent_loop" / "review_followups.md"
+    followups.write_text(
+        """# Review Follow-up Plan
+
+### 001. Privacy leak
+
+- Severity: `blocking`
+- Target: `reports/real100/chunk_id-77.json`
+- Reviewer mode: `Privacy Auditor`
+- Lane: `manual-gated`
+""",
+        encoding="utf-8",
+    )
+
+    out, rendered = agent_loop.write_decision_brief(
+        batch=batch,
+        review_followups=followups,
+        changed_files=["reports/real100/eval_summary.json"],
+        pr="12",
+        repo_root=tmp_path,
+    )
+
+    assert out == tmp_path / "reports" / "agent_loop" / "decision_brief.md"
+    assert "Decision Brief" in rendered
+    assert "Choose the next task lane" in rendered
+    assert "Choose which reviewer findings to address" in rendered
+    assert "Decide what claims are allowed" in rendered
+    assert "Decide whether to push, open PR, merge, close, or delete" in rendered
+    assert "Trade-offs" in rendered
+    assert "Severity" in rendered
+    assert "Reversibility" in rendered
+    assert "private.pdf" not in rendered
+    assert "reports/real100/[redacted-private-artifact]" in rendered
+    assert "make real-eval-delta" not in rendered
+
+
+def test_decision_brief_task_gate_uses_task_context(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+
+    out, rendered = agent_loop.write_decision_brief(
+        task_id="T-2026-9999",
+        gate="task",
+        repo_root=repo,
+    )
+
+    assert out == repo / "reports" / "agent_loop" / "decision_brief.md"
+    assert "T-2026-9999" in rendered
+    assert "Keep as draft and inspect scope" in rendered
+    assert "Promote draft to queue/plan" in rendered
+    assert "Manual approval" in rendered
+
+
+def test_decision_brief_rejects_unsafe_output_path(tmp_path: Path) -> None:
+    try:
+        agent_loop.write_decision_brief(out=Path("reports/decision_brief.md"), repo_root=tmp_path)
+    except ValueError as exc:
+        assert "reports/agent_loop" in str(exc)
+    else:
+        raise AssertionError("expected unsafe decision brief path to fail")
+
+
+def test_promote_draft_writes_dry_run_diff_without_mutating_tracked_docs(tmp_path: Path) -> None:
+    (tmp_path / "tasks").mkdir()
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    queue = tmp_path / "tasks" / "queue.md"
+    queue.write_text("# Queue\n", encoding="utf-8")
+    report_dir = tmp_path / "reports" / "agent_loop"
+    report_dir.mkdir(parents=True)
+    (report_dir / "queue_entry_draft.md").write_text(
+        """## T-2026-0000 — Draft task
+
+- ID: T-2026-0000
+- Title: Draft task
+""",
+        encoding="utf-8",
+    )
+    (report_dir / "plan_draft.md").write_text(
+        """# Plan: T-2026-0000 Draft task
+
+- Suggested final path: `docs/plans/T-2026-0000-draft-task.md`
+""",
+        encoding="utf-8",
+    )
+
+    out, rendered = agent_loop.write_promote_draft(repo_root=tmp_path)
+
+    assert out == tmp_path / "reports" / "agent_loop" / "promote_draft.md"
+    assert "dry-run only" in rendered
+    assert "tasks/queue.md" in rendered
+    assert "docs/plans/T-2026-0000-draft-task.md" in rendered
+    assert queue.read_text(encoding="utf-8") == "# Queue\n"
+    assert not (tmp_path / "docs" / "plans" / "T-2026-0000-draft-task.md").exists()
+
+
+def test_gate_status_identifies_claim_boundary_and_next_safe_command(tmp_path: Path) -> None:
+    out, rendered = agent_loop.write_gate_status(
+        changed_files=["reports/real100/eval_summary.json"],
+        pr="12",
+        out=Path("reports/agent_loop/gate_status.md"),
+        repo_root=tmp_path,
+    )
+
+    assert out == tmp_path / "reports" / "agent_loop" / "gate_status.md"
+    assert "claim-boundary" in rendered
+    assert "critical" in rendered
+    assert "decision-brief --gate claim" in rendered
+    assert "reports/real100/eval_summary.json" not in rendered
+    assert "reports/real100/[redacted-private-artifact]" not in rendered
+
+
+def test_claim_audit_flags_risky_claims_without_echoing_text(tmp_path: Path) -> None:
+    claim = tmp_path / "reports" / "agent_loop" / "claim_text.md"
+    claim.parent.mkdir(parents=True)
+    claim.write_text(
+        "Private real RFP performance improved. question: PRIVATE RAW QUERY\n",
+        encoding="utf-8",
+    )
+
+    out, rc, rendered = agent_loop.write_claim_audit(
+        text_path=claim,
+        changed_files=["docs/operations/example.md"],
+        repo_root=tmp_path,
+    )
+
+    assert rc == 1
+    assert out == tmp_path / "reports" / "agent_loop" / "claim_audit.md"
+    assert "performance claim language detected" in rendered
+    assert "private-real-eval claim language detected" in rendered
+    assert "PRIVATE RAW QUERY" not in rendered
+
+
+def test_privacy_audit_output_finds_private_values_without_leaking_them(tmp_path: Path) -> None:
+    report_dir = tmp_path / "reports" / "agent_loop"
+    report_dir.mkdir(parents=True)
+    (report_dir / "unsafe.md").write_text(
+        "question: PRIVATE RAW QUERY\nreports/real100/case-1.json\n",
+        encoding="utf-8",
+    )
+    (report_dir / "unsafe.json").write_text(
+        json.dumps({"doc_id": "PRIVATE-DOC", "safe": "value"}),
+        encoding="utf-8",
+    )
+
+    out, rc, rendered = agent_loop.write_privacy_audit_output(repo_root=tmp_path)
+
+    assert rc == 1
+    assert out == tmp_path / "reports" / "agent_loop" / "privacy_audit.md"
+    assert "private raw field value" in rendered
+    assert "json private raw field value" in rendered
+    assert "private real100 artifact path" in rendered
+    assert "PRIVATE RAW QUERY" not in rendered
+    assert "PRIVATE-DOC" not in rendered
+
+
+def test_auto_pass_check_requires_validation_for_low_risk_surface(tmp_path: Path) -> None:
+    report = agent_loop.build_auto_pass_report(
+        task_id=None,
+        changed_files=["scripts/agent_loop.py", "tests/test_agent_loop.py"],
+        claim_text=None,
+        run_validation=False,
+        repo_root=tmp_path,
+    )
+
+    assert not report.ok
+    assert report.decision == "human-review-required"
+    assert any("validation was not run" in blocker for blocker in report.blockers)
+
+
+def test_auto_pass_check_passes_low_risk_with_validation(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+
+    def fake_run_validation(changed_files, *, keep_going=False):
+        assert changed_files == ["scripts/agent_loop.py", "tests/test_agent_loop.py"]
+        assert keep_going is False
+        return (
+            0,
+            [
+                agent_loop.ValidationRun(
+                    command="python3 -m py_compile scripts/agent_loop.py tests/test_agent_loop.py",
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                ),
+                agent_loop.ValidationRun(
+                    command="git diff --check",
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(agent_loop, "run_validation_commands", fake_run_validation)
+
+    out, report, rendered = agent_loop.write_auto_pass_check(
+        task_id="T-2026-9999",
+        changed_files=["scripts/agent_loop.py", "tests/test_agent_loop.py"],
+        run_validation=True,
+        repo_root=repo,
+    )
+
+    assert out == repo / "reports" / "agent_loop" / "auto_pass.md"
+    assert report.ok
+    assert report.decision == "auto-pass"
+    assert "handoff-check passed" in rendered
+    assert "validation rc=0" in rendered
+    assert "approve shipping" in rendered
+
+
+def test_auto_pass_check_blocks_private_or_unknown_surface(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        agent_loop,
+        "run_validation_commands",
+        lambda changed_files, *, keep_going=False: (
+            0,
+            [agent_loop.ValidationRun("git diff --check", 0, "", "")],
+        ),
+    )
+
+    report = agent_loop.build_auto_pass_report(
+        task_id=None,
+        changed_files=["reports/real100/eval_summary.json", "unknown.bin"],
+        claim_text=None,
+        run_validation=True,
+        repo_root=tmp_path,
+    )
+
+    assert not report.ok
+    assert any("private-real-eval" in blocker for blocker in report.blockers)
+    assert any("unknown" in blocker for blocker in report.blockers)
+
+
+def test_auto_pass_strict_requires_task_claim_and_no_review_followups(monkeypatch, tmp_path: Path) -> None:
+    followups = tmp_path / "reports" / "agent_loop" / "review_followups.md"
+    followups.parent.mkdir(parents=True)
+    followups.write_text("### 001. Fix finding\n", encoding="utf-8")
+    monkeypatch.setattr(
+        agent_loop,
+        "run_validation_commands",
+        lambda changed_files, *, keep_going=False: (
+            0,
+            [agent_loop.ValidationRun("git diff --check", 0, "", "")],
+        ),
+    )
+
+    report = agent_loop.build_auto_pass_report(
+        task_id=None,
+        changed_files=["scripts/agent_loop.py"],
+        claim_text=None,
+        run_validation=True,
+        repo_root=tmp_path,
+        strict=True,
+    )
+
+    assert not report.ok
+    assert any("strict mode requires --task" in blocker for blocker in report.blockers)
+    assert any("strict mode requires --claim-text" in blocker for blocker in report.blockers)
+    assert any("review follow-up" in blocker for blocker in report.blockers)
+
+
+def test_dashboard_and_mcp_config_render_safe_reports(tmp_path: Path) -> None:
+    out, rendered = agent_loop.write_dashboard(
+        changed_files=["scripts/agent_loop.py"],
+        pr="12",
+        repo_root=tmp_path,
+    )
+
+    assert out == tmp_path / "reports" / "agent_loop" / "dashboard.md"
+    assert "Agent Loop Dashboard" in rendered
+    assert "ci-validation" in rendered
+    assert "force-push" in rendered
+
+    cfg_out, config = agent_loop.write_mcp_client_config(repo_root=tmp_path)
+    assert cfg_out == tmp_path / "reports" / "agent_loop" / "mcp_client_config.md"
+    assert "<REPO_ROOT>/scripts/agent_loop_mcp.py" in config
+    assert str(tmp_path) not in config
+
+
+def test_review_ingest_combines_review_and_creates_followups(tmp_path: Path) -> None:
+    review = tmp_path / "reports" / "agent_loop" / "review.md"
+    review.parent.mkdir(parents=True)
+    review.write_text(
+        """# Review
+
+Possible issue: [P1] scripts/agent_loop.py:10 missing privacy check.
+""",
+        encoding="utf-8",
+    )
+
+    out, followup, tasks_dir, count, rendered = agent_loop.write_review_ingest(
+        reviews=[review],
+        repo_root=tmp_path,
+    )
+
+    assert out == tmp_path / "reports" / "agent_loop" / "review_ingest.md"
+    assert followup == tmp_path / "reports" / "agent_loop" / "review_followups.md"
+    assert tasks_dir == tmp_path / "reports" / "agent_loop" / "review_followups"
+    assert count == 1
+    assert "scripts/agent_loop.py:10" in rendered
+
+
+def test_pr_health_groups_pr_state_lanes(tmp_path: Path) -> None:
+    pr_state = tmp_path / "reports" / "agent_loop" / "pr_state.json"
+    pr_state.parent.mkdir(parents=True)
+    pr_state.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 1,
+                    "title": "Failing checks",
+                    "isDraft": False,
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [{"conclusion": "FAILURE"}],
+                    "updatedAt": "2020-01-01T00:00:00Z",
+                },
+                {
+                    "number": 2,
+                    "title": "Ready",
+                    "isDraft": False,
+                    "reviewDecision": "APPROVED",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+                    "updatedAt": "2999-01-01T00:00:00Z",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out, rendered = agent_loop.write_pr_health(pr_json=pr_state, repo_root=tmp_path)
+
+    assert out == tmp_path / "reports" / "agent_loop" / "pr_health.md"
+    assert "#1 Failing checks" in rendered
+    assert "ci-failing" in rendered
+    assert "review-required" in rendered
+    assert "#2 Ready" in rendered
+
+
+def test_safe_fix_dry_run_and_apply_are_whitespace_only(tmp_path: Path) -> None:
+    target = tmp_path / "notes.md"
+    target.write_text("hello   \nworld\t\n", encoding="utf-8")
+
+    out, dry, rendered = agent_loop.write_safe_fix(
+        changed_files=["notes.md", "reports/real100/eval_summary.json"],
+        apply=False,
+        repo_root=tmp_path,
+    )
+
+    assert out == tmp_path / "reports" / "agent_loop" / "safe_fix.md"
+    assert not dry.applied
+    assert "would normalize whitespace" in rendered
+    assert target.read_text(encoding="utf-8") == "hello   \nworld\t\n"
+    assert "privacy-sensitive path" in rendered
+
+    _, applied, _ = agent_loop.write_safe_fix(
+        changed_files=["notes.md"],
+        apply=True,
+        repo_root=tmp_path,
+    )
+    assert applied.applied
+    assert target.read_text(encoding="utf-8") == "hello\nworld\n"
+
+
+def test_loop_state_writes_machine_readable_safe_state(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+
+    out, state = agent_loop.write_loop_state(
+        task_id="T-2026-9999",
+        changed_files=["tests/test_agent_loop.py"],
+        pr="12",
+        repo_root=repo,
+    )
+
+    assert out == repo / "reports" / "agent_loop" / "loop_state.json"
+    assert state["schema_version"] == 1
+    assert state["task"]["id"] == "T-2026-9999"  # type: ignore[index]
+    assert state["task"]["handoff_ok"] is True  # type: ignore[index]
+    assert state["pr"] == "12"
+    assert state["surface"]["surface"] == "ci-validation"  # type: ignore[index]
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["validation_suggestions"][-1] == "git diff --check"
+
+
+def test_loop_map_marks_human_gates_and_safe_automation() -> None:
+    rendered = agent_loop.render_loop_map()
+
+    assert "flowchart TD" in rendered
+    assert "Human gate" in rendered
+    assert "pr-scan" in rendered
+    assert "batch-plan" in rendered
+    assert "decision-brief" in rendered
+    assert "promote-draft" in rendered
+    assert "gate-status" in rendered
+    assert "claim-audit" in rendered
+    assert "privacy-audit-output" in rendered
+    assert "auto-pass-check" in rendered
+    assert "loop-state" in rendered
+    assert "review-followup" in rendered
+    assert "agent-loop-mcp" in rendered
+    assert "read-only `gh pr list`" in rendered
+    assert "Human intervention points" in rendered
+    assert "force-push" in rendered
+
+
+def test_approval_packet_pr_body_context_and_ship_simulation_are_local_reports(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    claim = repo / "reports" / "agent_loop" / "claim.md"
+    claim.parent.mkdir(parents=True)
+    claim.write_text("Docs-only orchestration change. question: PRIVATE RAW QUERY\n", encoding="utf-8")
+
+    approval_out, approval = agent_loop.write_approval_packet(
+        task_id="T-2026-9999",
+        changed_files=["scripts/agent_loop.py", "tests/test_agent_loop.py"],
+        claim_text=claim,
+        repo_root=repo,
+    )
+    body_out, body = agent_loop.write_pr_body(
+        task_id="T-2026-9999",
+        changed_files=["scripts/agent_loop.py"],
+        branch="chore/issue-123-agent-loop",
+        repo_root=repo,
+    )
+    context_out, context = agent_loop.write_context_pack(
+        task_id="T-2026-9999",
+        changed_files=["scripts/agent_loop.py"],
+        repo_root=repo,
+    )
+    ship_out, ship = agent_loop.write_ship_simulation(
+        task_id="T-2026-9999",
+        changed_files=["scripts/agent_loop.py"],
+        branch="chore/issue-123-agent-loop",
+        repo_root=repo,
+    )
+
+    assert approval_out == repo / "reports" / "agent_loop" / "approval_packet.md"
+    assert body_out == repo / "reports" / "agent_loop" / "pr_body.md"
+    assert context_out == repo / "reports" / "agent_loop" / "context_pack.md"
+    assert ship_out == repo / "reports" / "agent_loop" / "ship_simulation.md"
+    combined = "\n".join([approval, body, context, ship])
+    assert "PRIVATE RAW QUERY" not in combined
+    assert "Closes #123" in body
+    assert "Suggested, not yet run" in body
+    assert "Cross-Agent Context Pack" in context
+    assert "Simulation only" in ship
+    assert "gh pr create" in ship
+    assert "git push" not in ship
+
+
+def test_auto_ship_plan_bridges_existing_ship_arm_without_arming(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+
+    out, plan, rendered = agent_loop.write_auto_ship_plan(
+        task_id="T-2026-9999",
+        changed_files=["docs/operations/auto-ship.md"],
+        branch="chore/issue-9999-agent-loop",
+        dry_run=True,
+        repo_root=repo,
+    )
+
+    assert out == repo / "reports" / "agent_loop" / "auto_ship_plan.md"
+    assert plan.decision == "dry-run-first"
+    assert "make ship-arm" in rendered
+    assert "DRY_RUN=1" in rendered
+    assert "Plan only" in rendered
+    assert "does not arm auto-ship" in rendered
+    assert not (repo / ".claude" / ".ship-armed").exists()
+
+
+def test_auto_ship_plan_blocks_existing_armed_state_and_private_surface(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / ".ship-armed").write_text("{}\n", encoding="utf-8")
+
+    out, plan, rendered = agent_loop.write_auto_ship_plan(
+        changed_files=["reports/real100/eval_summary.json"],
+        branch="chore/issue-9999-agent-loop",
+        repo_root=repo,
+    )
+
+    assert out == repo / "reports" / "agent_loop" / "auto_ship_plan.md"
+    assert plan.decision == "blocked"
+    assert any("already armed" in blocker for blocker in plan.blockers)
+    assert "private-real-eval" in rendered or "privacy-sensitive-artifact" in rendered
+    assert "REAL_EVAL=skip" in rendered
+    assert "human private-eval decision" in rendered
+
+
+def test_auto_ship_prepare_reports_detached_head_branch_command(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "HEAD")
+
+    out, report, rendered = agent_loop.write_auto_ship_prepare(
+        issue="9999",
+        slug="agent-loop",
+        repo_root=repo,
+    )
+
+    assert out == repo / "reports" / "agent_loop" / "auto_ship_prepare.md"
+    assert report.result == "needs-branch"
+    assert report.created is False
+    assert "chore/issue-9999-agent-loop" in rendered
+    assert "--create-branch --confirm-human-approved" in rendered
+    assert "does not arm auto-ship" in rendered
+
+
+def test_auto_ship_prepare_can_create_local_branch_with_confirmation(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    calls: list[list[str]] = []
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "HEAD")
+    monkeypatch.setattr(agent_loop, "_branch_exists", lambda branch, repo_root: False)
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    _out, report, rendered = agent_loop.write_auto_ship_prepare(
+        issue="9999",
+        slug="agent-loop",
+        create_branch=True,
+        confirm_human_approved=True,
+        repo_root=repo,
+    )
+
+    assert report.result == "branch-created"
+    assert report.created is True
+    assert calls == [["git", "-C", str(repo), "switch", "-c", "chore/issue-9999-agent-loop"]]
+    assert "Branch created: `True`" in rendered
+    assert "make ship-arm" in rendered
+
+
+def test_propose_queue_plan_review_plan_stale_architecture_and_gate_reports(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    brief = repo / "reports" / "agent_loop" / "codex_tasks" / "001-task.md"
+    brief.parent.mkdir(parents=True)
+    brief.write_text(
+        """# Add agent loop helper
+
+- Classification: `ready`
+- Source: `PR #12`
+- Reason: safe helper
+
+## Goal
+
+Add a local-only report.
+
+## Expected Evidence
+
+Focused test.
+
+## Verification
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+```
+""",
+        encoding="utf-8",
+    )
+
+    patch_out, patch = agent_loop.write_propose_queue_plan(task_brief=brief, repo_root=repo)
+
+    review = repo / "reports" / "agent_loop" / "review.md"
+    review.write_text(
+        """## Findings
+
+- [blocking] scripts/agent_loop.py:1 - Fix unsafe path handling.
+- [non-blocking] reports/real100/doc_id-1.json:1 - Privacy issue: filename: private.pdf.
+""",
+        encoding="utf-8",
+    )
+    review_out, review_plan = agent_loop.write_review_plan(reviews=[review], repo_root=repo)
+    arch_out, arch = agent_loop.write_architecture_brief(changed_files=["rag_core.py"], repo_root=repo)
+    gate_out, gate = agent_loop.write_gate_brief(
+        gate="architecture",
+        changed_files=["rag_core.py"],
+        repo_root=repo,
+    )
+
+    old_report = repo / "reports" / "agent_loop" / "old.md"
+    old_report.write_text("old\n", encoding="utf-8")
+    os.utime(old_report, (0, 0))
+    stale_out, stale = agent_loop.write_stale_reports(max_age_days=1, repo_root=repo)
+
+    assert patch_out == repo / "reports" / "agent_loop" / "queue_plan_patch.diff"
+    assert "Dry-run only" in patch
+    assert "tasks/queue.md" in patch
+    assert review_out == repo / "reports" / "agent_loop" / "review_plan.md"
+    assert "must-fix" in review_plan
+    assert "needs-human-decision" in review_plan
+    assert "private.pdf" not in review_plan
+    assert arch_out == repo / "reports" / "agent_loop" / "architecture_brief.md"
+    assert "ADR likely" in arch
+    assert gate_out == repo / "reports" / "agent_loop" / "gate_brief.md"
+    assert "Human gates are decision points" in gate
+    assert stale_out == repo / "reports" / "agent_loop" / "stale_reports.md"
+    assert "old.md" in stale
+    assert "dry-run" in stale
+
+
+def test_safe_fix_supports_shell_hooks_without_touching_private_paths(tmp_path: Path) -> None:
+    script = tmp_path / "scripts" / "claude-hooks" / "stop-agent-loop.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/usr/bin/env bash  \necho ok  ", encoding="utf-8")
+
+    _, report, rendered = agent_loop.write_safe_fix(
+        changed_files=["scripts/claude-hooks/stop-agent-loop.sh"],
+        apply=True,
+        repo_root=tmp_path,
+    )
+
+    assert report.applied
+    assert "unsupported suffix" not in rendered
+    assert script.read_text(encoding="utf-8") == "#!/usr/bin/env bash\necho ok\n"
+
+
+def test_manifest_pr_body_check_ci_stacked_and_patch_proposal(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    body = repo / "reports" / "agent_loop" / "pr_body.md"
+    body.parent.mkdir(parents=True)
+    body.write_text(
+        """## 1. 무엇을 왜 바꿨는가
+
+Closes #999
+
+### 5b. Real-data delta
+
+N/A
+question: PRIVATE RAW QUERY
+""",
+        encoding="utf-8",
+    )
+    target = repo / "scripts" / "agent_loop.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("print('x')  \n", encoding="utf-8")
+
+    manifest_out, manifest = agent_loop.write_manifest(
+        changed_files=["scripts/agent_loop.py"],
+        command="test-command",
+        outputs=[Path("reports/agent_loop/pr_body.md")],
+        repo_root=repo,
+    )
+    check_out, rc, check = agent_loop.write_pr_body_check(
+        body=body,
+        changed_files=["rag_core.py"],
+        branch="chore/issue-123-example",
+        repo_root=repo,
+    )
+
+    ci_log = repo / "reports" / "agent_loop" / "ci.log"
+    ci_log.write_text("FAILED tests/test_agent_loop.py::test_x AssertionError\n5b missing\n", encoding="utf-8")
+    ci_out, ci_dir, count, ci = agent_loop.write_ci_ingest(logs=[ci_log], repo_root=repo)
+
+    pr_state = repo / "reports" / "agent_loop" / "pr_state.json"
+    pr_state.write_text(
+        json.dumps([{"number": 22, "title": "Child PR", "baseRefName": "feature-parent", "headRefName": "child"}]),
+        encoding="utf-8",
+    )
+    stacked_out, stacked = agent_loop.write_stacked_risk(
+        branch="feature-parent",
+        pr_json=pr_state,
+        repo_root=repo,
+    )
+    patch_out, patch = agent_loop.write_patch_proposal(
+        changed_files=["scripts/agent_loop.py"],
+        repo_root=repo,
+    )
+
+    assert manifest_out == repo / "reports" / "agent_loop" / "manifest.json"
+    assert manifest["changed_files_hash"]
+    assert check_out == repo / "reports" / "agent_loop" / "pr_body_check.md"
+    assert rc == 1
+    assert "does not match branch issue" in check
+    assert "private raw value" in check
+    assert "PRIVATE RAW QUERY" not in check
+    assert ci_out == repo / "reports" / "agent_loop" / "ci_ingest.md"
+    assert ci_dir == repo / "reports" / "agent_loop" / "ci_followups"
+    assert count >= 2
+    assert "test-failure" in ci
+    assert "PRIVATE RAW QUERY" not in ci
+    assert stacked_out == repo / "reports" / "agent_loop" / "stacked_risk.md"
+    assert "Dependent open PR count: `1`" in stacked
+    assert patch_out == repo / "reports" / "agent_loop" / "patch_proposal.diff"
+    assert "-print('x')  " in patch
+    assert "+print('x')" in patch
+
+
+def test_adr_html_context_ship_commands_and_apply_queue_plan(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    adr_dir = repo / "docs" / "adr"
+    adr_dir.mkdir(parents=True, exist_ok=True)
+    (adr_dir / "0001-existing.md").write_text("# ADR 0001\n", encoding="utf-8")
+
+    adr_out, draft_out, adr = agent_loop.write_adr_reservation(
+        title="New eval surface",
+        repo_root=repo,
+    )
+    html_out, html = agent_loop.write_dashboard_html(
+        changed_files=["scripts/agent_loop.py"],
+        repo_root=repo,
+    )
+    context_out, context = agent_loop.write_context_pack(
+        changed_files=["scripts/agent_loop.py"],
+        profile="claude",
+        repo_root=repo,
+    )
+    commands_out, commands = agent_loop.write_ship_command_pack(
+        pr="42",
+        branch="chore/issue-123-agent-loop",
+        repo_root=repo,
+    )
+
+    report_dir = repo / "reports" / "agent_loop"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "queue_entry_draft.md").write_text(
+        """## T-2026-0000 — Draft
+
+- ID: T-2026-0000
+- Title: Draft
+""",
+        encoding="utf-8",
+    )
+    (report_dir / "plan_draft.md").write_text(
+        """# Plan: T-2026-0000 Draft
+
+- Suggested final path: `docs/plans/T-2026-0000-draft.md`
+""",
+        encoding="utf-8",
+    )
+    blocked_out, blocked = agent_loop.write_apply_queue_plan(confirm_human_approved=False, repo_root=repo)
+    assert blocked_out == repo / "reports" / "agent_loop" / "apply_queue_plan.md"
+    assert "blocked" in blocked
+    assert not (repo / "docs" / "plans" / "T-2026-0000-draft.md").exists()
+    apply_out, applied = agent_loop.write_apply_queue_plan(
+        confirm_human_approved=True,
+        repo_root=repo,
+    )
+
+    assert adr_out == repo / "reports" / "agent_loop" / "adr_reservation.md"
+    assert draft_out == repo / "reports" / "agent_loop" / "adr_draft.md"
+    assert "0002" in adr
+    assert not (repo / "docs" / "adr" / "0002-new-eval-surface.md").exists()
+    assert html_out == repo / "reports" / "agent_loop" / "dashboard.html"
+    assert "<!doctype html>" in html
+    assert context_out == repo / "reports" / "agent_loop" / "context_pack.md"
+    assert "Profile: `claude`" in context
+    assert commands_out == repo / "reports" / "agent_loop" / "ship_commands.md"
+    assert "Human-Gated Commands" in commands
+    assert apply_out == repo / "reports" / "agent_loop" / "apply_queue_plan.md"
+    assert "applied" in applied
+    assert (repo / "docs" / "plans" / "T-2026-0000-draft.md").exists()
+
+
+def test_review_threads_readiness_history_policy_and_coverage_reports(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    report_dir = repo / "reports" / "agent_loop"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    threads = report_dir / "threads.json"
+    threads.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "isResolved": False,
+                        "path": "eval/naive_rag/benchmark.py",
+                        "line": 12,
+                        "comments": {"nodes": [{"body": "Benchmark claim needs human review."}]},
+                    },
+                    {
+                        "isResolved": True,
+                        "path": "scripts/agent_loop.py",
+                        "line": 3,
+                        "comments": {"nodes": [{"body": "nit fixed"}]},
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    body = report_dir / "pr_body.md"
+    body.write_text(
+        """Closes #9999
+
+### 5b. Real-data delta
+
+N/A - no load-bearing path.
+""",
+        encoding="utf-8",
+    )
+
+    threads_out, threads_report = agent_loop.write_review_threads(threads_json=threads, repo_root=repo)
+    score_out, score, score_report = agent_loop.write_readiness_score(
+        task_id="T-2026-9999",
+        changed_files=["scripts/agent_loop.py"],
+        body=body,
+        branch="chore/issue-9999-agent-loop",
+        repo_root=repo,
+    )
+    history_path = agent_loop.append_validation_history(
+        [agent_loop.ValidationRun("git diff --check", 0, "PRIVATE RAW QUERY", "")],
+        changed_files=["scripts/agent_loop.py"],
+        repo_root=repo,
+    )
+    history_out, history = agent_loop.write_validation_history_report(repo_root=repo)
+    hygiene_out, hygiene_rc, hygiene = agent_loop.write_branch_issue_hygiene(
+        branch="chore/issue-9999-agent-loop",
+        body=body,
+        task_id="T-2026-9999",
+        repo_root=repo,
+    )
+    privacy_out, privacy_rc, privacy = agent_loop.write_privacy_regression(repo_root=repo)
+    claim_out, claim_rc, claim = agent_loop.write_claim_policy(changed_files=["docs/readme.md"], text=body, repo_root=repo)
+    arch_out, arch = agent_loop.write_architecture_decision(changed_files=["rag_core.py"], repo_root=repo)
+    integration_out, integration = agent_loop.write_integration_pack(repo_root=repo)
+    schedule_out, schedule = agent_loop.write_schedule_config(repo_root=repo)
+    coverage_out, coverage = agent_loop.write_automation_coverage(repo_root=repo)
+
+    assert threads_out == repo / "reports" / "agent_loop" / "review_threads.md"
+    assert "Unresolved count: `1`" in threads_report
+    assert "Benchmark Auditor" in threads_report
+    assert score_out == repo / "reports" / "agent_loop" / "readiness_score.md"
+    assert score.decision in {"ready-for-human-approval", "review-before-ship"}
+    assert "does not push" in score_report
+    assert history_path == repo / "reports" / "agent_loop" / "validation_history.jsonl"
+    assert history_out == repo / "reports" / "agent_loop" / "validation_history.md"
+    assert "PRIVATE RAW QUERY" not in history
+    assert hygiene_out == repo / "reports" / "agent_loop" / "branch_issue_hygiene.md"
+    assert hygiene_rc == 0
+    assert "Closes" not in hygiene or "#9999" in hygiene
+    assert privacy_out == repo / "reports" / "agent_loop" / "privacy_regression.md"
+    assert privacy_rc == 0
+    assert "Result: `pass`" in privacy
+    assert claim_out == repo / "reports" / "agent_loop" / "claim_policy.md"
+    assert claim_rc == 0
+    assert "Disallowed Or Human-Gated Claims" in claim
+    assert arch_out == repo / "reports" / "agent_loop" / "architecture_decision.md"
+    assert "human-architecture-review-required" in arch
+    assert integration_out == repo / "reports" / "agent_loop" / "integration_pack.md"
+    assert "ChatGPT" in integration
+    assert schedule_out == repo / "reports" / "agent_loop" / "schedule_config.md"
+    assert "does not install cron jobs" in schedule
+    assert coverage_out == repo / "reports" / "agent_loop" / "automation_coverage.md"
+    assert "auto-pass strict profiles" in coverage
+
+
+def test_dependency_graph_workset_and_strict_profiles_are_fail_closed(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    report_dir = repo / "reports" / "agent_loop"
+    tasks_dir = report_dir / "codex_tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "001-ready.md").write_text(
+        """# Ready local fix
+
+- Classification: ready_for_implementation
+- Source: PR #1
+- Reason: Small docs update
+
+## Goal
+
+Update docs.
+
+## Expected Evidence
+
+Focused validation.
+
+## Verification
+
+```bash
+git diff --check
+```
+""",
+        encoding="utf-8",
+    )
+    pr_state = report_dir / "pr_state.json"
+    pr_state.write_text(
+        json.dumps([{"number": 5, "title": "Child", "baseRefName": "parent", "headRefName": "child"}]),
+        encoding="utf-8",
+    )
+
+    workset_out, workset = agent_loop.write_workset_recommendation(tasks_dir=tasks_dir, repo_root=repo)
+    graph_out, graph = agent_loop.write_dependency_graph(branch="parent", pr_json=pr_state, repo_root=repo)
+    strict_report = agent_loop.build_auto_pass_report(
+        task_id=None,
+        changed_files=["scripts/agent_loop.py", "rag_core.py"],
+        claim_text=None,
+        run_validation=False,
+        strict=True,
+        profile="agent-loop-tooling-strict",
+        repo_root=repo,
+    )
+
+    assert workset_out == repo / "reports" / "agent_loop" / "workset_recommendation.md"
+    assert "parallel candidates" in workset
+    assert graph_out == repo / "reports" / "agent_loop" / "dependency_graph.md"
+    assert "flowchart TD" in graph
+    assert "PR #5 child" in graph
+    assert strict_report.decision == "human-review-required"
+    assert any("agent-loop-tooling-strict" in blocker for blocker in strict_report.blockers)
+
+
+def test_human_gated_exec_requires_confirmation_and_uses_safe_commands(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    blocked_out, blocked_plan, blocked = agent_loop.write_human_gated_exec(
+        action="push",
+        confirm_human_approved=False,
+        branch="chore/issue-9999-agent-loop",
+        repo_root=repo,
+    )
+    assert not calls
+    executed_out, executed_plan, executed = agent_loop.write_human_gated_exec(
+        action="push",
+        confirm_human_approved=True,
+        branch="chore/issue-9999-agent-loop",
+        repo_root=repo,
+    )
+    merge_plan = agent_loop.build_human_gated_exec_plan(
+        action="pr-merge",
+        confirm_human_approved=True,
+        dry_run=True,
+        branch=None,
+        pr="42",
+        body=None,
+        base=None,
+        title=None,
+        draft=True,
+        confirm_review_gate_passed=True,
+        confirm_dependents_reviewed=False,
+        confirm_force_with_lease=False,
+        repo_root=repo,
+    )
+    force_plan = agent_loop.build_human_gated_exec_plan(
+        action="force-push",
+        confirm_human_approved=True,
+        dry_run=True,
+        branch="chore/issue-9999-agent-loop",
+        pr=None,
+        body=None,
+        base=None,
+        title=None,
+        draft=True,
+        confirm_review_gate_passed=False,
+        confirm_dependents_reviewed=False,
+        confirm_force_with_lease=False,
+        repo_root=repo,
+    )
+
+    assert blocked_out == repo / "reports" / "agent_loop" / "human_gated_exec.md"
+    assert blocked_plan.blockers
+    assert "confirm-human-approved" in blocked
+    assert executed_out == repo / "reports" / "agent_loop" / "human_gated_exec.md"
+    assert executed_plan.executed
+    assert calls == [["git", "push", "-u", "origin", "chore/issue-9999-agent-loop"]]
+    assert "ok" not in executed  # output body is summarized, not echoed
+    assert merge_plan.command == ("gh", "pr", "merge", "42", "--squash")
+    assert "--delete-branch" not in merge_plan.command
+    assert "--admin" not in merge_plan.command
+    assert any("force-with-lease" in blocker for blocker in force_plan.blockers)
+
+
+def test_human_gated_exec_pr_create_checks_body_and_rejects_unsafe_branch(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    body = repo / "reports" / "agent_loop" / "pr_body.md"
+    body.parent.mkdir(parents=True, exist_ok=True)
+    body.write_text(
+        """Closes #9999
+
+### 5b. Real-data delta
+
+N/A - no load-bearing path.
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(agent_loop, "_changed_files_from_git", lambda repo_root: ["scripts/agent_loop.py"])
+
+    plan = agent_loop.build_human_gated_exec_plan(
+        action="pr-create",
+        confirm_human_approved=True,
+        dry_run=True,
+        branch="chore/issue-9999-agent-loop",
+        pr=None,
+        body=body,
+        base="main",
+        title="Agent loop gated exec",
+        draft=True,
+        confirm_review_gate_passed=False,
+        confirm_dependents_reviewed=False,
+        confirm_force_with_lease=False,
+        repo_root=repo,
+    )
+
+    assert not plan.blockers
+    assert plan.command[:3] == ("gh", "pr", "create")
+    assert "--draft" in plan.command
+    try:
+        agent_loop.build_human_gated_exec_plan(
+            action="push",
+            confirm_human_approved=True,
+            dry_run=True,
+            branch="bad branch;rm",
+            pr=None,
+            body=None,
+            base=None,
+            title=None,
+            draft=True,
+            confirm_review_gate_passed=False,
+            confirm_dependents_reviewed=False,
+            confirm_force_with_lease=False,
+            repo_root=repo,
+        )
+    except ValueError as exc:
+        assert "unsafe" in str(exc)
+    else:
+        raise AssertionError("expected unsafe branch to fail")
+
+
+def test_path_traversal_changed_files_are_redacted_and_not_read(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    outside = tmp_path.parent / "outside_agent_loop_secret.py"
+    outside.write_text("print('SECRET_OUTSIDE')  \n", encoding="utf-8")
+
+    normalized = agent_loop._normalize_changed_file("../outside_agent_loop_secret.py", repo_root=repo)
+    patch = agent_loop.render_patch_proposal(
+        changed_files=["../outside_agent_loop_secret.py", str(outside)],
+        review_plan=None,
+        repo_root=repo,
+    )
+    safe_fix = agent_loop.build_safe_fix_report(
+        changed_files=["../outside_agent_loop_secret.py", str(outside)],
+        apply=False,
+        repo_root=repo,
+    )
+
+    assert normalized == "[redacted-local-path]"
+    assert "SECRET_OUTSIDE" not in patch
+    assert not safe_fix.changes
+
+
+def test_workflow_uses_hardened_readonly_agent_loop_artifacts() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "agent-loop-artifacts.yml").read_text(encoding="utf-8")
+
+    assert "persist-credentials: false" in workflow
+    assert ".agent_loop_tmp" in workflow
+    assert "--text \"$PR_BODY_FILE\"" in workflow
+    assert "readiness-score" in workflow
+    assert "branch-issue-hygiene" in workflow
+    assert "privacy-regression" in workflow
+    assert "auto-ship-plan" in workflow
+
+
+def test_default_agent_loop_outputs_are_gitignored() -> None:
+    for rel in (
+        "reports/agent_loop/rendered_prompt.txt",
+        "reports/agent_loop/review_prompt.txt",
+        "reports/agent_loop/pr_state.json",
+        "reports/agent_loop/changed_files.txt",
+        "reports/agent_loop/surface.md",
+        "reports/agent_loop/validation_suggestions.md",
+        "reports/agent_loop/queue_entry_draft.md",
+        "reports/agent_loop/codex_tasks/001-example.md",
+        "reports/agent_loop/batch_plan.md",
+        "reports/agent_loop/batch_plan.json",
+        "reports/agent_loop/review_followups.md",
+        "reports/agent_loop/review_followups/001-example.md",
+        "reports/agent_loop/decision_brief.md",
+        "reports/agent_loop/promote_draft.md",
+        "reports/agent_loop/gate_status.md",
+        "reports/agent_loop/claim_audit.md",
+        "reports/agent_loop/privacy_audit.md",
+        "reports/agent_loop/auto_pass.md",
+        "reports/agent_loop/dashboard.md",
+        "reports/agent_loop/mcp_client_config.md",
+        "reports/agent_loop/review_ingest.md",
+        "reports/agent_loop/pr_health.md",
+        "reports/agent_loop/safe_fix.md",
+        "reports/agent_loop/approval_packet.md",
+        "reports/agent_loop/queue_plan_patch.diff",
+        "reports/agent_loop/pr_body.md",
+        "reports/agent_loop/review_plan.md",
+        "reports/agent_loop/stale_reports.md",
+        "reports/agent_loop/context_pack.md",
+        "reports/agent_loop/architecture_brief.md",
+        "reports/agent_loop/ship_simulation.md",
+        "reports/agent_loop/auto_ship_plan.md",
+        "reports/agent_loop/auto_ship_prepare.md",
+        "reports/agent_loop/gate_brief.md",
+        "reports/agent_loop/manifest.json",
+        "reports/agent_loop/pr_body_check.md",
+        "reports/agent_loop/ci_ingest.md",
+        "reports/agent_loop/ci_followups/001-example.md",
+        "reports/agent_loop/stacked_risk.md",
+        "reports/agent_loop/patch_proposal.diff",
+        "reports/agent_loop/adr_reservation.md",
+        "reports/agent_loop/adr_draft.md",
+        "reports/agent_loop/dashboard.html",
+        "reports/agent_loop/ship_commands.md",
+        "reports/agent_loop/apply_queue_plan.md",
+        "reports/agent_loop/review_threads.md",
+        "reports/agent_loop/ci_summary.md",
+        "reports/agent_loop/readiness_score.md",
+        "reports/agent_loop/branch_issue_hygiene.md",
+        "reports/agent_loop/integration_pack.md",
+        "reports/agent_loop/schedule_config.md",
+        "reports/agent_loop/validation_history.jsonl",
+        "reports/agent_loop/validation_history.md",
+        "reports/agent_loop/privacy_regression.md",
+        "reports/agent_loop/claim_policy.md",
+        "reports/agent_loop/architecture_decision.md",
+        "reports/agent_loop/workset_recommendation.md",
+        "reports/agent_loop/dependency_graph.md",
+        "reports/agent_loop/automation_coverage.md",
+        "reports/agent_loop/human_gated_exec.md",
+        "reports/agent_loop/loop_state.json",
+    ):
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", "--", rel],
+            cwd=ROOT,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, rel

--- a/tests/test_agent_loop_claude_integration.py
+++ b/tests/test_agent_loop_claude_integration.py
@@ -99,7 +99,7 @@ def test_agent_loop_commands_are_tracked_and_safe() -> None:
     )
     for path in commands:
         result = subprocess.run(
-            ["git", "check-ignore", "-v", "--", path.as_posix()],
+            ["git", "check-ignore", "--no-index", "-v", "--", path.as_posix()],
             cwd=ROOT,
             capture_output=True,
             text=True,

--- a/tests/test_agent_loop_claude_integration.py
+++ b/tests/test_agent_loop_claude_integration.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "scripts" / "claude-hooks" / "stop-agent-loop.sh"
+COMMAND_DIR = ROOT / ".claude" / "commands"
+
+
+def _copy_agent_loop_hook_repo(tmp_path: Path) -> Path:
+    repo = tmp_path
+    (repo / "scripts" / "claude-hooks").mkdir(parents=True)
+    shutil.copy2(HOOK, repo / "scripts" / "claude-hooks" / HOOK.name)
+    shutil.copy2(ROOT / "scripts" / "agent_loop.py", repo / "scripts" / "agent_loop.py")
+    shutil.copy2(ROOT / "scripts" / "_governance.py", repo / "scripts" / "_governance.py")
+    return repo
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        },
+    )
+
+
+def test_stop_agent_loop_no_watch_is_noop(tmp_path: Path) -> None:
+    repo = _copy_agent_loop_hook_repo(tmp_path)
+
+    result = subprocess.run(
+        ["bash", "scripts/claude-hooks/stop-agent-loop.sh"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert not (repo / "reports" / "agent_loop").exists()
+
+
+def test_stop_agent_loop_watch_refreshes_local_reports_and_telemetry(tmp_path: Path) -> None:
+    repo = _copy_agent_loop_hook_repo(tmp_path)
+    _git("init", "-q", "-b", "main", cwd=repo)
+    (repo / ".gitignore").write_text(".claude/\nreports/\n", encoding="utf-8")
+    (repo / "README.md").write_text("fixture\n", encoding="utf-8")
+    _git("add", ".gitignore", "README.md", cwd=repo)
+    _git("commit", "-qm", "init", cwd=repo)
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / ".agent-loop-watch").write_text("1\n", encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", "scripts/claude-hooks/stop-agent-loop.sh"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    report_dir = repo / "reports" / "agent_loop"
+    assert (report_dir / "gate_status.md").exists()
+    assert (report_dir / "loop_state.json").exists()
+    assert (report_dir / "auto_pass.md").exists()
+    assert (report_dir / "auto_ship_prepare.md").exists()
+    assert (report_dir / "auto_ship_plan.md").exists()
+    fires = (repo / ".claude" / ".hook-fires.log").read_text(encoding="utf-8")
+    assert "|pipeline_end|agent-loop|stop-report|reports/agent_loop/loop_state.json" in fires
+
+
+def test_agent_loop_commands_are_tracked_and_safe() -> None:
+    commands = sorted(COMMAND_DIR.glob("agent-loop-*.md"))
+    assert {path.name for path in commands} == {
+        "agent-loop-auto-ship.md",
+        "agent-loop-auto-pass.md",
+        "agent-loop-preflight.md",
+        "agent-loop-review.md",
+        "agent-loop-status.md",
+        "agent-loop-watch.md",
+    }
+
+    forbidden_in_bash = re.compile(
+        r"\b(?:git\s+push|gh\s+pr\s+(?:create|merge|close)|git\s+branch\s+-D|force-push)\b",
+        re.IGNORECASE,
+    )
+    for path in commands:
+        result = subprocess.run(
+            ["git", "check-ignore", "-v", "--", path.as_posix()],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"{path} should have an explicit gitignore rule"
+        assert ":!" in result.stdout, f"{path} should be allowlisted, not ignored"
+
+        text = path.read_text(encoding="utf-8")
+        assert "allowed-tools:" in text
+        assert "scripts/agent_loop.py" in text or path.name == "agent-loop-watch.md"
+        for block in re.findall(r"```bash\n(.*?)```", text, flags=re.DOTALL):
+            assert not forbidden_in_bash.search(block), path.name
+
+
+def test_settings_registers_stop_agent_loop_hook_after_stop_ship() -> None:
+    settings = (ROOT / ".claude" / "settings.json").read_text(encoding="utf-8")
+    assert "bash scripts/claude-hooks/stop-ship.sh" in settings
+    assert "bash scripts/claude-hooks/stop-agent-loop.sh" in settings
+    assert settings.index("stop-ship.sh") < settings.index("stop-agent-loop.sh")
+
+
+def test_agent_loop_artifacts_workflow_is_informational_and_uploads_reports() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "agent-loop-artifacts.yml").read_text(encoding="utf-8")
+
+    assert "pull_request:" in workflow
+    assert "permissions:" in workflow
+    assert "contents: read" in workflow
+    assert "pull-requests: read" in workflow
+    assert "actions/upload-artifact@v7" in workflow
+    assert "reports/agent_loop/" in workflow
+    assert "dashboard" in workflow
+    forbidden = re.compile(r"\b(?:git\s+push|gh\s+pr\s+(?:create|merge|close)|git\s+branch\s+-D|force-push)\b")
+    assert not forbidden.search(workflow)

--- a/tests/test_agent_loop_mcp.py
+++ b/tests/test_agent_loop_mcp.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import agent_loop_mcp
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _call(name: str, arguments: dict | None = None) -> str:
+    response = agent_loop_mcp.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        }
+    )
+    assert response is not None
+    assert "error" not in response
+    result = response["result"]
+    assert not result.get("isError", False)
+    return result["content"][0]["text"]
+
+
+def test_mcp_initialize_and_tool_list_are_read_report_centered() -> None:
+    init = agent_loop_mcp.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05"},
+        }
+    )
+    assert init is not None
+    assert init["result"]["capabilities"] == {"tools": {}}
+
+    listed = agent_loop_mcp.handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    )
+    assert listed is not None
+    names = {tool["name"] for tool in listed["result"]["tools"]}
+
+    assert "agent_loop_classify_surface" in names
+    assert "agent_loop_gate_status" in names
+    assert "agent_loop_auto_pass_check" in names
+    assert "agent_loop_dashboard" in names
+    assert "agent_loop_mcp_config" in names
+    assert "agent_loop_pr_health" in names
+    assert "agent_loop_safe_fix_dry_run" in names
+    assert "agent_loop_approval_packet" in names
+    assert "agent_loop_pr_body" in names
+    assert "agent_loop_review_plan" in names
+    assert "agent_loop_context_pack" in names
+    assert "agent_loop_architecture_brief" in names
+    assert "agent_loop_ship_simulate" in names
+    assert "agent_loop_auto_ship_plan" in names
+    assert "agent_loop_auto_ship_prepare" in names
+    assert "agent_loop_gate_brief" in names
+    assert "agent_loop_manifest" in names
+    assert "agent_loop_pr_body_check" in names
+    assert "agent_loop_patch_proposal" in names
+    assert "agent_loop_dashboard_html" in names
+    assert "agent_loop_ship_command_pack" in names
+    assert "agent_loop_apply_queue_plan_dry_run" in names
+    assert "agent_loop_review_threads" in names
+    assert "agent_loop_ci_summary" in names
+    assert "agent_loop_readiness_score" in names
+    assert "agent_loop_branch_issue_hygiene" in names
+    assert "agent_loop_validation_history" in names
+    assert "agent_loop_privacy_regression" in names
+    assert "agent_loop_claim_policy" in names
+    assert "agent_loop_architecture_decision" in names
+    assert "agent_loop_workset_recommend" in names
+    assert "agent_loop_dependency_graph" in names
+    assert "agent_loop_integration_pack" in names
+    assert "agent_loop_scheduled_status" in names
+    assert "agent_loop_automation_coverage" in names
+    assert "agent_loop_promote_draft_dry_run" in names
+    assert "agent_loop_validate" not in names
+    assert "agent_loop_pr_scan" not in names
+    assert "agent_loop_draft_next" not in names
+    for name in names:
+        lowered = name.lower()
+        assert "push" not in lowered
+        assert "merge" not in lowered
+        assert "close" not in lowered
+        assert "delete" not in lowered
+        assert "force" not in lowered
+
+    write_defaults = {
+        prop["default"]
+        for tool in listed["result"]["tools"]
+        for prop in tool["inputSchema"]["properties"].values()
+        if isinstance(prop, dict) and "default" in prop and prop.get("type") == "boolean"
+    }
+    assert write_defaults == {False}
+
+
+def test_mcp_classifies_private_eval_and_redacts_private_report_paths() -> None:
+    text = _call(
+        "agent_loop_classify_surface",
+        {
+            "changed_files": [
+                "reports/real100/eval_summary.json",
+                "eval/real_config.local.yaml",
+                "reports/eval_summary.json",
+            ]
+        },
+    )
+
+    assert "privacy-sensitive-artifact" in text
+    assert "private-real-eval" in text
+    assert "public-fixture-smoke" in text
+    assert "reports/real100/[redacted-private-artifact]" in text
+    assert "reports/real100/eval_summary.json" not in text
+    assert "/Users/" not in text
+
+
+def test_mcp_suggest_validation_does_not_run_commands() -> None:
+    text = _call(
+        "agent_loop_suggest_validation",
+        {
+            "changed_files": [
+                "eval/naive_rag/benchmark.py",
+                "scripts/compare_eval.py",
+            ]
+        },
+    )
+
+    assert "python3 -m py_compile eval/naive_rag/benchmark.py scripts/compare_eval.py" in text
+    assert "python3 -m pytest tests/test_naive_rag_benchmark_v1.py -q" in text
+    assert "python3 -m pytest tests/test_compare_eval_regression_gate.py -q" in text
+    assert "git diff --check" in text
+    assert "did not run them" in text
+
+
+def test_mcp_unknown_tool_returns_tool_error_not_process_error() -> None:
+    response = agent_loop_mcp.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "agent_loop_validate", "arguments": {}},
+        }
+    )
+
+    assert response is not None
+    assert "error" not in response
+    result = response["result"]
+    assert result["isError"] is True
+    assert "unknown tool" in result["content"][0]["text"]
+
+
+def test_mcp_auto_pass_check_fails_closed_without_validation() -> None:
+    text = _call(
+        "agent_loop_auto_pass_check",
+        {
+            "changed_files": [
+                "scripts/agent_loop.py",
+                "tests/test_agent_loop.py",
+            ]
+        },
+    )
+
+    assert "human-review-required" in text
+    assert "validation was not run" in text
+    assert "auto-pass" not in text.splitlines()[2]
+
+
+def test_mcp_rejects_input_paths_outside_repo() -> None:
+    response = agent_loop_mcp.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "agent_loop_claim_audit",
+                "arguments": {"text": "/etc/passwd"},
+            },
+        }
+    )
+
+    assert response is not None
+    result = response["result"]
+    assert result["isError"] is True
+    assert "repository root" in result["content"][0]["text"]
+
+
+def test_mcp_dashboard_config_and_safe_fix_are_read_centered(tmp_path: Path) -> None:
+    text = _call("agent_loop_dashboard", {"changed_files": ["scripts/agent_loop.py"]})
+    assert "Agent Loop Dashboard" in text
+    assert "ci-validation" in text
+
+    config = _call("agent_loop_mcp_config")
+    assert "<REPO_ROOT>/scripts/agent_loop_mcp.py" in config
+    assert str(ROOT) not in config
+
+    safe_fix = _call("agent_loop_safe_fix_dry_run", {"changed_files": ["scripts/agent_loop.py"]})
+    assert "Safe Local Auto-Fix" in safe_fix
+    assert "dry-run" in safe_fix
+
+    context = _call("agent_loop_context_pack", {"changed_files": ["reports/real100/doc_id-1.json"]})
+    assert "Cross-Agent Context Pack" in context
+    assert "reports/real100/[redacted-private-artifact]" in context
+    assert "doc_id-1" not in context
+
+    ship = _call("agent_loop_ship_simulate", {"changed_files": ["scripts/agent_loop.py"], "branch": "chore/issue-123-agent-loop"})
+    assert "Simulation only" in ship
+    assert "gh pr create" in ship
+
+    auto_ship = _call(
+        "agent_loop_auto_ship_plan",
+        {
+            "changed_files": ["docs/operations/auto-ship.md"],
+            "branch": "chore/issue-123-agent-loop",
+            "dry_run": True,
+        },
+    )
+    assert "Auto-Ship Plan" in auto_ship
+    assert "make ship-arm" in auto_ship
+    assert "does not arm auto-ship" in auto_ship
+
+    prepare = _call(
+        "agent_loop_auto_ship_prepare",
+        {
+            "issue": "123",
+            "slug": "agent-loop",
+        },
+    )
+    assert "Auto-Ship Prepare" in prepare
+    assert "auto-ship-prepare --issue 123" in prepare
+    assert "make ship-arm" in prepare
+    assert "does not arm auto-ship" in prepare
+
+    manifest = _call("agent_loop_manifest", {"changed_files": ["scripts/agent_loop.py"]})
+    assert "changed_files_hash" in manifest
+
+    html = _call("agent_loop_dashboard_html", {"changed_files": ["scripts/agent_loop.py"]})
+    assert "<!doctype html>" in html
+
+    dry_apply = _call("agent_loop_apply_queue_plan_dry_run")
+    assert "blocked" in dry_apply
+
+
+def test_mcp_new_reports_are_read_centered_and_redacted() -> None:
+    scratch = ROOT / ".agent_loop_tmp"
+    scratch.mkdir(parents=True, exist_ok=True)
+    threads = scratch / "mcp_threads.json"
+    threads.write_text(
+        json.dumps(
+            [
+                {
+                    "isResolved": False,
+                    "path": "reports/real100/doc_id-1.json",
+                    "line": 7,
+                    "comments": [{"body": "privacy issue with doc_id: SECRET"}],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    claim = scratch / "mcp_claim.md"
+    claim.write_text("This improves latency. question: PRIVATE RAW QUERY\n", encoding="utf-8")
+
+    threads_report = _call("agent_loop_review_threads", {"threads_json": ".agent_loop_tmp/mcp_threads.json"})
+    approval = _call(
+        "agent_loop_approval_packet",
+        {"changed_files": ["reports/eval_summary.json"], "claim_text": ".agent_loop_tmp/mcp_claim.md"},
+    )
+    policy = _call(
+        "agent_loop_claim_policy",
+        {"changed_files": ["reports/eval_summary.json"], "text": ".agent_loop_tmp/mcp_claim.md"},
+    )
+    privacy = _call("agent_loop_privacy_regression")
+    coverage = _call("agent_loop_automation_coverage")
+
+    assert "Privacy Auditor" in threads_report
+    assert "SECRET" not in threads_report
+    assert "performance claim language detected" in approval
+    assert "PRIVATE RAW QUERY" not in approval
+    assert "Disallowed Or Human-Gated Claims" in policy
+    assert "Result: `pass`" in privacy
+    assert "existing auto-ship bridge" in coverage
+
+
+def test_mcp_stdio_smoke_lists_tools() -> None:
+    request = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+    result = subprocess.run(
+        [sys.executable, "scripts/agent_loop_mcp.py"],
+        cwd=ROOT,
+        input=request + "\n",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    response = json.loads(result.stdout.strip())
+    assert response["id"] == 1
+    names = {tool["name"] for tool in response["result"]["tools"]}
+    assert "agent_loop_map" in names

--- a/tests/test_hook_telemetry.py
+++ b/tests/test_hook_telemetry.py
@@ -134,7 +134,7 @@ def test_known_hooks_matches_inventory(gov):
     expected = {
         "bash-guard", "loadbearing", "memory-lines",
         "adr-template", "adr-collision", "plan-slug-race",
-        "delegation-gate", "stop-ship",
+        "delegation-gate", "stop-ship", "agent-loop",
     }
     assert gov.KNOWN_HOOKS == expected
 
@@ -228,6 +228,8 @@ HOOK_EMIT_EXPECTATIONS = [
      "--hook plan-slug-race", "--outcome blocked"),
     ("scripts/claude-hooks/pretooluse-bash-guard.sh",
      "--hook bash-guard", "--outcome blocked"),
+    ("scripts/claude-hooks/stop-agent-loop.sh",
+     "--hook agent-loop", "--outcome pipeline_end"),
 ]
 
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Add a lightweight agent-loop automation CLI around the existing BidMate AI-agent operating loop.

Closes #1497

This keeps the existing operating model intact while reducing repetitive local orchestration:

- prompt rendering, handoff checks, and reviewer prompt generation
- surface classification and local validation suggestions/runs
- PR readiness, claim, privacy, dashboard, and handoff reports
- MCP and Claude command access to local read/report helpers
- preparation/planning around the existing `make ship-arm` path

## 2. 영향 파일

- `.claude/commands/`
- `.claude/settings.json`
- `.github/workflows/agent-loop-artifacts.yml`
- `.gitignore`
- `Makefile`
- `scripts/_governance.py`
- `scripts/agent_loop.py`
- `scripts/agent_loop_mcp.py`
- `scripts/claude-hooks/README.md`
- `scripts/claude-hooks/stop-agent-loop.sh`
- `tests/test_agent_loop.py`
- `tests/test_agent_loop_claude_integration.py`
- `tests/test_agent_loop_mcp.py`
- `tests/test_hook_telemetry.py`

Surface: `ci-validation` / agent-loop tooling.

## 3. 리스크

- This is orchestration/tooling only; it does not change product runtime, retrieval, answer, or evaluation logic.
- Remote write helpers remain explicit and gated.
- `auto-ship-plan` does not arm auto-ship.
- `auto-ship-prepare` creates a local branch only with `--create-branch --confirm-human-approved`.
- Measurement statements, sensitive-data decisions, and architecture choices remain manual.

## 4. 테스트

Run locally:

```bash
python3 -m py_compile scripts/agent_loop.py scripts/agent_loop_mcp.py
python3 -m pytest -q tests/test_agent_loop.py tests/test_agent_loop_mcp.py tests/test_agent_loop_claude_integration.py tests/test_hook_telemetry.py
python3 scripts/agent_loop.py validate --from-git --keep-going --record-history
python3 scripts/agent_loop.py privacy-audit-output --path reports/agent_loop --out reports/agent_loop/privacy_audit.md
git diff --check
```

All passed locally.

## 5. Eval 영향

No evaluation logic change.

Surface classification is used only for agent-loop decision support.

### 5b. Real-data delta

N/A - no product or evaluation runtime path is changed.

## 6. 하위 호환

Existing `make ship-arm` behavior is not replaced.

New helpers write ignored local artifacts under `reports/agent_loop/` and expose read/report-centered MCP/Claude command surfaces.

## 7. 범위 외

- Running Codex automatically
- External LLM API calls
- Auto-approving sensitive data decisions
- Auto-selecting architecture choices
