### PR TITLE
Eval-first RAG adapter hardening

### DIFF
--- a/data/index/index.json
+++ b/data/index/index.json
@@ -16,6 +16,9 @@
     "source_dir": "eval/fixtures/smoke_rfp/raw",
     "chunking": {
       "requested_strategy": "fixed",
+      "base_strategy": "fixed",
+      "contextual": false,
+      "chunker_version": "chunker.fixed.v1",
       "max_chars": 520,
       "overlap_sentences": 1,
       "num_parent_sections": 5,
@@ -28,6 +31,7 @@
           "doc_id": "rfp-agency-a-ai-quality",
           "requested_strategy": "fixed",
           "actual_strategy": "fixed",
+          "contextual": false,
           "num_input_sections": 3,
           "num_parent_sections": 1,
           "num_chunks": 1
@@ -36,6 +40,7 @@
           "doc_id": "rfp-agency-b-mlops-governance",
           "requested_strategy": "fixed",
           "actual_strategy": "fixed",
+          "contextual": false,
           "num_input_sections": 3,
           "num_parent_sections": 1,
           "num_chunks": 1
@@ -44,6 +49,7 @@
           "doc_id": "rfp-agency-d-spectrometer-probe",
           "requested_strategy": "fixed",
           "actual_strategy": "fixed",
+          "contextual": false,
           "num_input_sections": 2,
           "num_parent_sections": 1,
           "num_chunks": 2
@@ -52,6 +58,7 @@
           "doc_id": "rfp-agency-e-water-quality-main",
           "requested_strategy": "fixed",
           "actual_strategy": "fixed",
+          "contextual": false,
           "num_input_sections": 2,
           "num_parent_sections": 1,
           "num_chunks": 1
@@ -60,6 +67,7 @@
           "doc_id": "rfp-agency-e-water-quality-supplement",
           "requested_strategy": "fixed",
           "actual_strategy": "fixed",
+          "contextual": false,
           "num_input_sections": 2,
           "num_parent_sections": 1,
           "num_chunks": 1
@@ -280,6 +288,8 @@
       "chunk_seq_in_section": 1,
       "total_chunks_in_section": 1,
       "chunking_strategy": "fixed",
+      "chunker_version": "chunker.fixed.v1",
+      "contextual": false,
       "text": "사업 개요\n기관 A는 운영 중인 인공지능 모델의 품질관리 체계를 표준화하기 위해 AI 품질관리 플랫폼을 구축한다. 플랫폼은 모델 성능 저하 감지, 품질 지표 측정 자동화, 산출물 표준화를 포함한다. 측정 결과는 분기별 거버넌스 회의에서 검토한다. AI 요구사항 개요\n핵심 AI 요구사항은 모델 품질관리, 보안 통제, 로그 추적이다. 보안 통제는 관리자 권한 변경, 데이터 접근, 모델 배포 승인을 모두 기록해야 한다. 로그 추적은 감사 저장소에 1년 이상 보관하며 이상 접근은 운영자에게 즉시 알림으로 전달한다. 산출물 및 운영\n수행사는 운영 매뉴얼, 시험 결과서, 보안 통제 매트릭스, 교육 자료를 제출한다. 납품 기한은 계약 체결일로부터 6개월이며 인수 시험은 단계별로 진행한다.",
       "tokens": [
         "a",
@@ -411,6 +421,8 @@
       "chunk_seq_in_section": 1,
       "total_chunks_in_section": 1,
       "chunking_strategy": "fixed",
+      "chunker_version": "chunker.fixed.v1",
+      "contextual": false,
       "text": "사업 개요\n기관 B는 데이터 거버넌스와 MLOps 자동화를 결합한 운영 체계를 구축한다. 데이터 계보, 학습 파이프라인 배포, 모델 승인 이력, 배포 후 모니터링을 하나의 콘솔에서 관리해야 한다. AI 운영 요구사항\nMLOps 자동화는 실험 등록, 모델 버전 관리, 재학습 승인, 배포 롤백 기능을 포함한다. 품질관리 항목은 데이터 드리프트, 성능 저하, 배포 실패율이다. 데이터 거버넌스 항목은 소유자, 보존 기간, 접근 권한, 변경 이력으로 구분한다. 보안 및 감사\n모든 승인 이력은 감사 로그로 남겨야 하며 운영자는 월간 감사 리포트를 생성할 수 있어야 한다. 외부 연계 API는 토큰 기반 인증을 사용한다.",
       "tokens": [
         "b",
@@ -531,6 +543,8 @@
       "chunk_seq_in_section": 1,
       "total_chunks_in_section": 2,
       "chunking_strategy": "fixed",
+      "chunker_version": "chunker.fixed.v1",
+      "contextual": false,
       "text": "사업 개요\n기관 D는 분광기 시스템의 안정적 운영과 측정 결과 신뢰도 확보를 목표로 본 사업을 발주한다. 분광기 시스템은 라만 분광기와 형광 분광기 두 종류로 구성되며 각각의 측정 워크플로는 독립적으로 운영된다. 본 사업은 운영 자동화, 측정 품질 모니터링, 데이터 보관 표준화를 포괄한다. 사업 기간은 12개월이며 단계적 도입 방식을 채택한다. 1단계는 라만 분광기 운영 자동화이고 2단계는 형광 분광기 통합이다. 사업 종료 시점에는 통합 운영 콘솔이 구축되어 두 시스템을 단일 화면에서 관리할 수 있어야 한다. 운영 인력은 시프트제로 배치되며 야간 알람 처리 절차가 별도로 정의된다. 본 사업의 핵심 성공 지표는 측정 재현성 95퍼센트 이상이다. 운영 자동화는 측정 시작부터 결과 보고까지 전 과정을 포괄하며 수동 개입 없이 일상 운영이 가능해야 한다. 시스템 가용성은 99.5퍼센트 이상을 목표로 하며 정기 점검 시간은 가용성 산정에서 제외된다. 분광기 캘리브레이션 주기는 라만의 경우 매일이고 형광의 경우 주 단위이다.",
       "tokens": [
         "d",
@@ -697,6 +711,8 @@
       "chunk_seq_in_section": 2,
       "total_chunks_in_section": 2,
       "chunking_strategy": "fixed",
+      "chunker_version": "chunker.fixed.v1",
+      "contextual": false,
       "text": "분광기 캘리브레이션 주기는 라만의 경우 매일이고 형광의 경우 주 단위이다. 캘리브레이션 결과는 자동으로 품질 대시보드에 반영된다. 운영 데이터는 분기별로 외부 감사 대상이 되며 외부 감사를 위한 데이터 추출 기능이 별도로 요구된다. 운영 자동화 세부 요구사항\n운영 자동화는 측정 잡 스케줄링, 결과 검증, 이상 탐지, 보고서 생성의 네 단계로 나뉜다. 측정 잡 스케줄링은 우선순위 기반 큐 처리 방식을 채택하며 긴급 측정 요청은 진행 중 잡을 보존한 채 끼워 넣을 수 있어야 한다. 보고서는 5년간 보관되며 보관 위치는 사내 NAS와 클라우드 백업의 이중화 구조이다. 보고서 자동 생성 실패 시 운영자에게 즉시 알람이 전달된다.",
       "tokens": [
         "d",
@@ -823,6 +839,8 @@
       "chunk_seq_in_section": 1,
       "total_chunks_in_section": 1,
       "chunking_strategy": "fixed",
+      "chunker_version": "chunker.fixed.v1",
+      "contextual": false,
       "text": "사업 개요\n기관 E 수질 모니터링 본 사업은 광역 상수도 원수 수질 측정망의 본 운영을 다룬다. 본 사업은 측정 지점 운영, 데이터 수집, 정기 보고를 포함하며 12개월 단위로 갱신된다. 측정 항목\n본 사업에서 측정하는 항목은 탁도, pH, 잔류 염소, 대장균이며 측정 주기는 매시간이다. 측정 데이터는 본청 서버에 실시간 전송된다.",
       "tokens": [
         "e",
@@ -909,6 +927,8 @@
       "chunk_seq_in_section": 1,
       "total_chunks_in_section": 1,
       "chunking_strategy": "fixed",
+      "chunker_version": "chunker.fixed.v1",
+      "contextual": false,
       "text": "사업 개요\n기관 E 수질 모니터링 부속 사업은 본 사업과 별개로 비상시 긴급 측정 대응을 다룬다. 부속 사업은 비상 출동 인력 운영과 임시 측정 장비 배치를 포함한다. 사업 기간은 6개월이며 본 사업과 병행 진행한다. 비상 측정 절차\n비상 측정은 본 사업의 측정망에서 이상 수치가 감지되면 30분 내 출동해 추가 측정을 수행한다. 비상 측정 결과는 즉시 보고된다.",
       "tokens": [
         "e",

--- a/docs/plans/T-2026-0005-rag-eval-first-adapter-hardening.md
+++ b/docs/plans/T-2026-0005-rag-eval-first-adapter-hardening.md
@@ -1,0 +1,147 @@
+# Plan: T-2026-0005 Eval-first RAG adapter hardening
+
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0005`
+- Related issue / PR: issue #1493 / PR #1499
+- Related ADR: ADR 0001, ADR 0003, ADR 0005, ADR 0069, ADR 0074
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+## Problem Statement
+
+The repository already has the right flat RAG module split, but the next
+improvement wave still needs safer measurement and adapter seams before more
+providers or chunking variants are promoted. Without this work, future agents
+can add attractive components without a stable retrieval metric, versioned run
+manifest, or opt-in provider boundary.
+
+## Current Behavior
+
+`rag_indexing.py` supports `fixed`, `section`, and `auto` chunking. `rag_embedding.py`
+exposes `embed_texts()` directly. `eval/run_eval.py` aggregates chunk recall,
+MRR, nDCG, and citation coverage, while ADR 0069 explicitly leaves RAGAS
+context precision/recall as a separate opt-in judge surface.
+
+## Desired Behavior
+
+Add LLM-free context precision/recall over gold chunk ids, expose more
+index/version provenance in `run_manifest`, provide an `EmbeddingProvider`
+Protocol around existing embedding code, and add deterministic contextual
+chunking as an opt-in strategy. Defaults remain unchanged.
+
+## Constraints
+
+- Scope constraints: no `src/rag/*` tree; use existing flat modules.
+- Architecture constraints: provider-specific code stays behind adapters and lazy imports.
+- Compatibility constraints: no answer `schema_version` bump; no default pipeline changes.
+- Eval/privacy constraints: public fixture smoke proves wiring only; no private raw data.
+- Tooling/CI constraints: branch must satisfy ADR 0007 and PR template 5b.
+- Non-goals: late chunking, ColPali/ColQwen, GPT-VL full OCR, Self-RAG/Reflexion/CRAG defaults.
+
+## Architecture Impact
+
+- Affected modules or docs: `eval/scorers/*`, `eval/run_eval.py`, `rag_embedding.py`,
+  `rag_indexing.py`, `scripts/build_index.py`, tests, task/plan docs.
+- Affected contracts or invariants: additive eval summary and manifest fields only.
+- Load-bearing paths: `eval/`, `scripts/build_index.py`.
+- ADR required: no, this implements existing ADR direction and does not create a durable default change.
+- Backward compatibility expectation: existing configs and indexes keep loading; missing fields read as `None`.
+
+## Affected Interfaces
+
+- CLI/API/config: `scripts/build_index.py --chunking_strategy contextual` becomes valid.
+- Input data: unchanged.
+- Output artifacts: eval summary gains context metric keys and additional manifest fields.
+- Docs/review surfaces: task queue and plan document record scope.
+- Tests/eval entrypoints: focused unit tests plus optional `make smoke`.
+
+## Data / Eval Impact
+
+- Surface: public fixture smoke eval.
+- Data boundary: public fixture and aggregate-only eval summary fields.
+- Allowed claim: metric/manifest plumbing works and defaults are preserved.
+- Disallowed claim: real RFP quality improvement.
+- Baseline or control affected: no; `naive_baseline` remains dense/fixed/default.
+- Benchmark/eval auditor required: yes, because eval surface keys are added.
+
+## Task Breakdown
+
+1. Add task queue entry and this plan doc.
+2. Add context precision/recall scoring and aggregate plumbing.
+3. Extend run manifest and synthesis token/cost aggregate fields additively.
+4. Add embedding provider Protocol/factory around `embed_texts()`.
+5. Add deterministic contextual chunking strategy and CLI choice.
+6. Add focused regression tests and run validation commands.
+
+## Acceptance Criteria
+
+- [x] Context precision/recall keys appear in per-case and aggregate eval blocks.
+- [x] Run manifest includes index schema, embedding dimension, chunking strategy, and chunker version fields.
+- [x] `EmbeddingProvider` can embed documents/query and raises clear dimension mismatch errors.
+- [x] `contextual` chunking emits `contextual_prefix` without changing default chunking.
+- [x] Focused tests pass and branch convention check passes.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 -m pytest tests/test_chunk_metrics_regression.py tests/test_chunk_aggregate_regression.py tests/test_run_manifest_versioning_regression.py -q
+python3 -m pytest tests/test_embedding_provider_protocol.py tests/test_contextual_chunking_regression.py -q
+python3 -m pytest tests/test_vector_store_protocol.py tests/test_vector_store_qdrant.py -q
+make check-branch
+make smoke
+bash scripts/test.sh
+```
+
+Expected evidence:
+
+- Test/eval output: focused pytest pass.
+- Generated or updated artifact: public fixture `data/index/index.json` carries additive chunk version fields; no generated reports committed.
+- Reviewer checklist or manual inspection: confirm no default/provider behavior flip.
+- Explicitly not validated, with reason: private real-eval unless reviewer requires it for load-bearing risk.
+
+## Rollback Strategy
+
+Revert the implementation commit. No generated indexes or private reports need
+to be deleted. Existing indexes without the new manifest fields remain readable.
+
+## Failure Modes
+
+- Failure mode: context precision is confused with RAGAS judge precision.
+- Detection signal: docs/tests must name it LLM-free and gold-chunk based.
+- Stop condition or fallback: keep RAGAS under `judge_ragas` only.
+
+- Failure mode: contextual chunking changes default embeddings.
+- Detection signal: fixed/default tests or smoke output changes unexpectedly.
+- Stop condition or fallback: keep `contextual` opt-in only.
+
+## Observability
+
+`reports/eval_summary.json` aggregate keys, `run_manifest`, chunk diagnostics,
+and focused regression tests show whether the work is active and bounded.
+
+## Reviewer Notes
+
+Attack baseline preservation, answer contract drift, metric semantics, and
+provider boundary first. This PR should not claim quality improvement.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-26 12:36 KST
+
+- Role: Implementer
+- Branch / worktree: feat/issue-1493-rag-eval-first-adapter-hardening / /Users/hskim/.codex/worktrees/be41/BidMate-DocAgent
+- Issue / PR: #1493 / PR #1499
+- Task: T-2026-0005
+- Current status: review
+- Files touched: eval/scorers/*, eval/run_eval.py, rag_embedding.py, rag_indexing.py, scripts/build_index.py, data/index/index.json, tests, tasks/queue.md, this plan doc.
+- Decisions made: Keep flat layout, additive eval surfaces, opt-in contextual chunking, and existing embedding wrapper compatibility.
+- Commands run: focused pytest, vector store pytest, py_compile, git diff --check, make check-branch, make smoke, bash scripts/test.sh.
+- Results: pass; private real-eval not run.
+- Next safe command: review diff and open PR.
+- Open questions: none.
+- Risks: load-bearing eval/index changes require precise test coverage.
+```

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -98,14 +98,27 @@ def compute_run_manifest(
     except (FileNotFoundError, OSError):
         config_sha = "unknown"
     embedding_meta = (index or {}).get("embedding") or {}
+    build_meta = (index or {}).get("build") or {}
+    chunking_meta = build_meta.get("chunking") if isinstance(build_meta, dict) else {}
+    chunking_meta = chunking_meta if isinstance(chunking_meta, dict) else {}
+    chunking_strategy = chunking_meta.get("requested_strategy")
+    chunker_version = chunking_meta.get("chunker_version")
+    if not chunker_version and chunking_strategy:
+        chunker_version = f"chunker.{chunking_strategy}.v1"
     return {
         "git_commit": commit,
         "git_dirty": dirty,
         "config_path": str(config_path),
         "config_sha256": config_sha,
         "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "index_schema_version": (index or {}).get("schema_version"),
         "embedding_backend": embedding_meta.get("backend"),
         "embedding_model_id": embedding_meta.get("model"),
+        "embedding_dim": embedding_meta.get("dimension"),
+        "chunking_strategy": chunking_strategy,
+        "chunker_version": chunker_version,
+        "chunk_max_chars": chunking_meta.get("max_chars"),
+        "chunk_overlap_sentences": chunking_meta.get("overlap_sentences"),
     }
 
 
@@ -173,6 +186,8 @@ def normalize_run_config(run: dict[str, Any]) -> dict[str, Any]:
         # Issue #988 / ADR 0057 — bm25_backend metadata for measurement
         # surface. Default `okapi` keeps existing summaries byte-equal.
         "bm25_backend": str(config.get("bm25_backend", "okapi")),
+        "query_expansion": str(config.get("query_expansion", "identity")),
+        "reranker_backend": os.environ.get("BIDMATE_RERANK_BACKEND", "stub"),
         # P0-a (#1282) — eval-only oracle-evidence ceiling probe. Read from
         # the raw run dict, NOT resolve_pipeline_config, so it never enters
         # PIPELINE_CONFIG_KEYS / product code (ADR 0001 byte-identity). Empty
@@ -563,6 +578,8 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
     # None-skip convention of the answer-quality metrics above.
     retrieval_metric_keys = [
         *(f"chunk_recall_at_{k}" for k in CHUNK_METRIC_KS),
+        *(f"context_precision_at_{k}" for k in CHUNK_METRIC_KS),
+        *(f"context_recall_at_{k}" for k in CHUNK_METRIC_KS),
         "chunk_mrr_at_5",
         "chunk_mrr",
         "chunk_ndcg_at_5",
@@ -631,6 +648,23 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         for result in case_results
         for error in result.get("claim_citation_errors") or []
         if isinstance(error, dict) and error.get("code")
+    )
+    synthesis_tokens_in = [
+        int(r["tokens_in"]) for r in case_results if isinstance(r.get("tokens_in"), (int, float))
+    ]
+    synthesis_tokens_out = [
+        int(r["tokens_out"]) for r in case_results if isinstance(r.get("tokens_out"), (int, float))
+    ]
+    synthesis_costs = [
+        float(r["cost_estimate_usd"])
+        for r in case_results
+        if isinstance(r.get("cost_estimate_usd"), (int, float))
+    ]
+    cases_with_token_usage = sum(
+        1
+        for r in case_results
+        if isinstance(r.get("tokens_in"), (int, float))
+        or isinstance(r.get("tokens_out"), (int, float))
     )
 
     warm_results = [r for r in case_results if not bool(r.get("cold_start"))]
@@ -734,6 +768,18 @@ def metric_block(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         "citation_grounding_error_counts": dict(sorted(citation_grounding_error_counts.items())),
         "citation_coverage_reason_counts": dict(sorted(citation_coverage_reason_counts.items())),
         "claim_citation_error_counts": dict(sorted(claim_citation_error_counts.items())),
+        "synthesis_tokens": {
+            "tokens_in_total": sum(synthesis_tokens_in) if synthesis_tokens_in else None,
+            "tokens_out_total": sum(synthesis_tokens_out) if synthesis_tokens_out else None,
+            "cases_with_token_usage": cases_with_token_usage,
+        },
+        "synthesis_cost": {
+            "estimated_cost_usd_total": (
+                round(sum(synthesis_costs), 6) if synthesis_costs else None
+            ),
+            "estimated_cost_usd_mean": rate(synthesis_costs),
+            "cases_with_cost": len(synthesis_costs),
+        },
     }
     if comparison_recall_scores:
         block["comparison_target_recall"] = rate(comparison_recall_scores)
@@ -862,6 +908,11 @@ def summarize_run(
         # `full_bm25s` row's bm25s usage is visible alongside the parity
         # measurements in eval_summary.json.
         "bm25_backend": str(run_config.get("bm25_backend", "okapi")),
+        "query_expansion": str(run_config.get("query_expansion", "identity")),
+        "reranker_backend": str(
+            run_config.get("reranker_backend")
+            or os.environ.get("BIDMATE_RERANK_BACKEND", "stub")
+        ),
         **metric_block(case_results),
         "by_query_type": {},
         "by_slice": {},
@@ -1511,6 +1562,12 @@ def main() -> int:
         "chunk_recall_at_5": primary_summary.get("chunk_recall_at_5"),
         "chunk_recall_at_10": primary_summary.get("chunk_recall_at_10"),
         "chunk_recall_at_20": primary_summary.get("chunk_recall_at_20"),
+        "context_precision_at_5": primary_summary.get("context_precision_at_5"),
+        "context_precision_at_10": primary_summary.get("context_precision_at_10"),
+        "context_precision_at_20": primary_summary.get("context_precision_at_20"),
+        "context_recall_at_5": primary_summary.get("context_recall_at_5"),
+        "context_recall_at_10": primary_summary.get("context_recall_at_10"),
+        "context_recall_at_20": primary_summary.get("context_recall_at_20"),
         "chunk_mrr_at_5": primary_summary.get("chunk_mrr_at_5"),
         "chunk_mrr": primary_summary.get("chunk_mrr"),
         "chunk_ndcg_at_5": primary_summary.get("chunk_ndcg_at_5"),
@@ -1527,6 +1584,8 @@ def main() -> int:
         "ci": primary_summary.get("ci", {}),
         "latency": primary_summary["latency"],
         "stage_latency": primary_summary.get("stage_latency", {}),
+        "synthesis_tokens": primary_summary.get("synthesis_tokens", {}),
+        "synthesis_cost": primary_summary.get("synthesis_cost", {}),
         "latency_by_retry_count": primary_summary.get("latency_by_retry_count", {}),
         "cold_start_samples": primary_summary.get("cold_start_samples", {}),
         "retry": primary_summary["retry"],

--- a/eval/scorers/__init__.py
+++ b/eval/scorers/__init__.py
@@ -12,6 +12,8 @@ from eval.scorers.chunk_metrics import (
     chunk_mrr_at_k,
     chunk_ndcg_at_k,
     chunk_recall_at_k,
+    context_precision_at_k,
+    context_recall_at_k,
     derive_gold_evidence,
     derive_gold_chunk_ids,
 )
@@ -23,6 +25,8 @@ __all__ = [
     "chunk_mrr_at_k",
     "chunk_ndcg_at_k",
     "chunk_recall_at_k",
+    "context_precision_at_k",
+    "context_recall_at_k",
     "compute_chunk_health",
     "derive_gold_evidence",
     "derive_gold_chunk_ids",

--- a/eval/scorers/case.py
+++ b/eval/scorers/case.py
@@ -20,6 +20,8 @@ from eval.scorers.chunk_metrics import (
     chunk_mrr_at_k,
     chunk_ndcg_at_k,
     chunk_recall_at_k,
+    context_precision_at_k,
+    context_recall_at_k,
 )
 from eval.scorers.citation import score_citation_coverage, score_citation_grounding
 from eval.scorers.format import score_answer_format
@@ -175,6 +177,13 @@ def score_case(
         f"chunk_recall_at_{k}": chunk_recall_at_k(retrieved_chunk_ids, gold_for_chunks, k)
         for k in CHUNK_METRIC_KS
     }
+    for k in CHUNK_METRIC_KS:
+        chunk_metrics[f"context_precision_at_{k}"] = context_precision_at_k(
+            retrieved_chunk_ids, gold_for_chunks, k
+        )
+        chunk_metrics[f"context_recall_at_{k}"] = context_recall_at_k(
+            retrieved_chunk_ids, gold_for_chunks, k
+        )
     chunk_metrics["chunk_mrr_at_5"] = chunk_mrr_at_k(retrieved_chunk_ids, gold_for_chunks, 5)
     chunk_metrics["chunk_mrr"] = chunk_mrr(retrieved_chunk_ids, gold_for_chunks)
     chunk_metrics["chunk_ndcg_at_5"] = chunk_ndcg_at_k(retrieved_chunk_ids, gold_for_chunks, 5)

--- a/eval/scorers/chunk_metrics.py
+++ b/eval/scorers/chunk_metrics.py
@@ -1,4 +1,9 @@
-"""Chunk-level retrieval metrics: recall@k, MRR@k, nDCG@k."""
+"""Chunk-level retrieval metrics: recall@k, MRR@k, nDCG@k.
+
+The ``context_*`` helpers are deterministic, gold-chunk based retrieval
+metrics. They are intentionally separate from the opt-in RAGAS judge metrics
+that live under ``judge_ragas``.
+"""
 from __future__ import annotations
 
 import math
@@ -186,6 +191,23 @@ def chunk_recall_at_k(retrieved: list[str], gold: list[str], k: int) -> float | 
     head = retrieved[:k]
     hits = sum(1 for chunk_id in gold if chunk_id in head)
     return hits / len(gold)
+
+
+def context_precision_at_k(retrieved: list[str], gold: list[str], k: int) -> float | None:
+    if not gold:
+        return None
+    if not retrieved or k <= 0:
+        return 0.0
+    gold_set = set(gold)
+    head = _unique(retrieved[:k])
+    if not head:
+        return 0.0
+    hits = sum(1 for chunk_id in head if chunk_id in gold_set)
+    return hits / len(head)
+
+
+def context_recall_at_k(retrieved: list[str], gold: list[str], k: int) -> float | None:
+    return chunk_recall_at_k(retrieved, gold, k)
 
 
 def chunk_mrr_at_k(retrieved: list[str], gold: list[str], k: int) -> float | None:

--- a/rag_embedding.py
+++ b/rag_embedding.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import os
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
@@ -95,6 +95,80 @@ class EmbeddingResult:
     vectors: np.ndarray
     backend: str
     model: str
+
+
+@runtime_checkable
+class EmbeddingProvider(Protocol):
+    """Provider interface for embedding documents and queries.
+
+    The default implementation below delegates to ``embed_texts`` so existing
+    CLI/build behavior stays unchanged. Future providers should implement this
+    Protocol and keep network/API logic behind lazy imports plus ADR 0061 data
+    boundary checks.
+    """
+
+    def embed_documents(self, texts: list[str]) -> EmbeddingResult: ...
+
+    def embed_query(self, query: str) -> EmbeddingResult: ...
+
+
+class EmbedTextsProvider:
+    """EmbeddingProvider wrapper around the existing ``embed_texts`` function."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str = DEFAULT_EMBEDDING_MODEL,
+        backend: str = "auto",
+        local_only: bool = False,
+        expected_dimension: int | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self.backend = backend
+        self.local_only = local_only
+        self.expected_dimension = expected_dimension
+
+    def embed_documents(self, texts: list[str]) -> EmbeddingResult:
+        result = embed_texts(
+            texts,
+            model_name=self.model_name,
+            backend=self.backend,
+            local_only=self.local_only,
+        )
+        return ensure_embedding_dimension(result, self.expected_dimension)
+
+    def embed_query(self, query: str) -> EmbeddingResult:
+        return self.embed_documents([query])
+
+
+def ensure_embedding_dimension(
+    result: EmbeddingResult,
+    expected_dimension: int | None,
+) -> EmbeddingResult:
+    if expected_dimension is None:
+        return result
+    actual = int(result.vectors.shape[1]) if result.vectors.ndim == 2 else None
+    if actual != expected_dimension:
+        raise ValueError(
+            f"Embedding dimension mismatch for {result.backend}/{result.model}: "
+            f"expected {expected_dimension}, got {actual}."
+        )
+    return result
+
+
+def default_embedding_provider(
+    *,
+    model_name: str = DEFAULT_EMBEDDING_MODEL,
+    backend: str = "auto",
+    local_only: bool = False,
+    expected_dimension: int | None = None,
+) -> EmbeddingProvider:
+    return EmbedTextsProvider(
+        model_name=model_name,
+        backend=backend,
+        local_only=local_only,
+        expected_dimension=expected_dimension,
+    )
 
 
 def embed_texts(

--- a/rag_indexing.py
+++ b/rag_indexing.py
@@ -11,7 +11,8 @@ Public surface:
   ``normalize_text_document`` — read JSON/MD/TXT under the configured
   corpus directory and produce the normalized in-memory document shape.
 - ``validate_chunking_options`` / ``resolve_chunking_strategy`` —
-  guard rails around the ``auto`` / ``section`` / ``fixed`` choice.
+  guard rails around the ``auto`` / ``section`` / ``fixed`` /
+  opt-in ``contextual`` choice.
 - ``build_chunk_records`` / ``build_chunks`` / ``make_chunk`` —
   document → chunk records with section / parent_section_id /
   chunking diagnostics.
@@ -28,7 +29,7 @@ Constants:
 
 - ``DEFAULT_CHUNK_MAX_CHARS = 520`` — naive-baseline canonical value.
 - ``DEFAULT_CHUNK_OVERLAP_SENTENCES = 1`` — naive-baseline canonical.
-- ``VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}``.
+- ``VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed", "contextual"}``.
 - ``INDEX_FILENAME = "index.json"`` — the on-disk JSON shape.
 - ``INDEX_SCHEMA_VERSION = 2`` — current ``schema_version`` field.
 
@@ -76,7 +77,8 @@ from rag_vector_store import (
 
 DEFAULT_CHUNK_MAX_CHARS = 520
 DEFAULT_CHUNK_OVERLAP_SENTENCES = 1
-VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed"}
+CONTEXTUAL_CHUNKER_VERSION = "chunker.contextual_prefix.v1"
+VALID_CHUNKING_STRATEGIES = {"auto", "section", "fixed", "contextual"}
 
 INDEX_FILENAME = "index.json"
 INDEX_SCHEMA_VERSION = 2
@@ -184,10 +186,27 @@ def validate_chunking_options(
 
 
 def resolve_chunking_strategy(doc: dict[str, Any], requested_strategy: str) -> str:
+    if requested_strategy == "contextual":
+        requested_strategy = "auto"
     if requested_strategy == "auto":
         from rag_metadata_processing import document_has_section_structure
         return "section" if document_has_section_structure(doc) else "fixed"
     return requested_strategy
+
+
+def contextual_prefix(
+    doc: dict[str, Any],
+    parent_section: dict[str, Any],
+    chunk_seq_in_section: int,
+    total_chunks_in_section: int,
+) -> str:
+    section_path = parent_section.get("section_path") or [parent_section.get("section", "")]
+    section = " > ".join(str(part) for part in section_path if str(part).strip())
+    return (
+        f"Document title: {doc.get('title', '')}. "
+        f"Section path: {section or 'body'}. "
+        f"Chunk position: {chunk_seq_in_section} of {total_chunks_in_section}."
+    ).strip()
 
 
 def build_chunk_records(
@@ -197,6 +216,8 @@ def build_chunk_records(
     overlap_sentences: int = DEFAULT_CHUNK_OVERLAP_SENTENCES,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
     validate_chunking_options(chunking_strategy, max_chars, overlap_sentences)
+    contextual = chunking_strategy == "contextual"
+    base_strategy = "auto" if contextual else chunking_strategy
     chunks: list[dict[str, Any]] = []
     parent_sections: list[dict[str, Any]] = []
     strategy_counts = {"section": 0, "fixed": 0}
@@ -204,7 +225,7 @@ def build_chunk_records(
 
     for doc in documents:
         normalized_sections = normalize_document_sections(doc)
-        actual_strategy = resolve_chunking_strategy(doc, chunking_strategy)
+        actual_strategy = resolve_chunking_strategy(doc, base_strategy)
         parent_candidates = (
             normalized_sections
             if actual_strategy == "section"
@@ -228,6 +249,7 @@ def build_chunk_records(
                         chunk_seq_in_section,
                         total_chunks_in_section,
                         actual_strategy,
+                        contextual=contextual,
                     )
                 )
                 chunk_seq += 1
@@ -239,6 +261,7 @@ def build_chunk_records(
                 "doc_id": doc["doc_id"],
                 "requested_strategy": chunking_strategy,
                 "actual_strategy": actual_strategy,
+                "contextual": contextual,
                 "num_input_sections": len(normalized_sections),
                 "num_parent_sections": len(parent_candidates),
                 "num_chunks": doc_chunk_count,
@@ -251,6 +274,11 @@ def build_chunk_records(
     )
     diagnostics = {
         "requested_strategy": chunking_strategy,
+        "base_strategy": base_strategy,
+        "contextual": contextual,
+        "chunker_version": (
+            CONTEXTUAL_CHUNKER_VERSION if contextual else f"chunker.{chunking_strategy}.v1"
+        ),
         "max_chars": max_chars,
         "overlap_sentences": overlap_sentences,
         "num_parent_sections": len(parent_sections),
@@ -286,6 +314,8 @@ def make_chunk(
     chunk_seq_in_section: int,
     total_chunks_in_section: int,
     chunking_strategy: str,
+    *,
+    contextual: bool = False,
 ) -> dict[str, Any]:
     text = " ".join(sentences).strip()
     section_path = parent_section.get("section_path") or [parent_section.get("section", "")]
@@ -306,6 +336,10 @@ def make_chunk(
         "chunk_seq_in_section": chunk_seq_in_section,
         "total_chunks_in_section": total_chunks_in_section,
         "chunking_strategy": chunking_strategy,
+        "chunker_version": (
+            CONTEXTUAL_CHUNKER_VERSION if contextual else f"chunker.{chunking_strategy}.v1"
+        ),
+        "contextual": contextual,
         "text": text,
         "text_span_hash": text_span_hash(text),
         "tokens": tokenize(
@@ -316,6 +350,13 @@ def make_chunk(
         chunk["regions"] = regions
     if page_span:
         chunk["page_span"] = page_span
+    if contextual:
+        chunk["contextual_prefix"] = contextual_prefix(
+            doc,
+            parent_section,
+            chunk_seq_in_section,
+            total_chunks_in_section,
+        )
     return chunk
 
 
@@ -356,17 +397,18 @@ def build_index_payload_from_documents(
         chunking_strategy=chunking_strategy,
         overlap_sentences=chunk_overlap_sentences,
     )
-    embedding_inputs = [
-        " ".join(
-            [
-                chunk["title"],
-                chunk.get("agency", ""),
-                " > ".join(chunk.get("section_path") or [chunk["section"]]),
-                chunk["text"],
-            ]
-        )
-        for chunk in chunks
-    ]
+    embedding_inputs = []
+    for chunk in chunks:
+        embedding_parts = [
+            chunk["title"],
+            chunk.get("agency", ""),
+            " > ".join(chunk.get("section_path") or [chunk["section"]]),
+        ]
+        prefix = chunk.get("contextual_prefix")
+        if prefix:
+            embedding_parts.append(prefix)
+        embedding_parts.append(chunk["text"])
+        embedding_inputs.append(" ".join(embedding_parts))
     embedding_result = embed_texts(embedding_inputs, model_name=model_name, backend=embedding_backend)
     # M2 (#207): vectors live in a sidecar .npy. Chunks reference rows by
     # embedding_idx — inline lists were ~85% of the JSON file size and

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -87,8 +87,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--chunking_strategy",
         default="fixed",
-        choices=["auto", "section", "fixed"],
-        help="Chunking strategy. Default fixed is the naive baseline reference.",
+        choices=["auto", "section", "fixed", "contextual"],
+        help=(
+            "Chunking strategy. Default fixed is the naive baseline reference; "
+            "contextual is opt-in and prepends deterministic chunk context."
+        ),
     )
     parser.add_argument(
         "--chunk_max_chars",

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -15,6 +15,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 2 | `T-2026-0002` | `done` | Implementer -> Reviewer | merged in PR #1481. |
 | 3 | `T-2026-0003` | `review` | Implementer -> Reviewer | auto-ship Stage 5 Desktop main fast-forward sync 구현됨. |
 | 4 | `T-2026-0004` | `review` | Implementer -> Reviewer | HWP -> PDF -> PyMuPDF4LLM opt-in loader 구현됨. |
+| 5 | `T-2026-0005` | `review` | Implementer -> Benchmark Auditor -> Reviewer | implementation validated; issue #1493 / branch `feat/issue-1493-rag-eval-first-adapter-hardening`. |
 
 ## Examples
 
@@ -393,3 +394,78 @@ python3 -m py_compile ingestion.py scripts/build_index.py scripts/compare_hwp_ex
 - Next safe command: python3 -m pytest tests/test_ingestion_kordoc_regression.py tests/test_mixed_format_ingestion_regression.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_provenance_banner.py tests/test_run_eval_by_format_text_source.py -q
 - Reviewer focus: fail-closed parser policy, private path exclusion from answer citations, and page-citation-ready telemetry.
 ```
+
+## T-2026-0005 — Eval-first RAG adapter hardening
+
+- ID: T-2026-0005
+- Title: Eval-first RAG adapter hardening
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Reviewer
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+### Goal
+
+Implement the eval-first RAG hardening plan without creating a new `src/rag/*`
+tree or changing the `naive_baseline` / answer schema / ADR 0005 boundary.
+
+### Context
+
+- Surface: public fixture smoke eval + eval governance.
+- Relevant docs: [ADR 0001](../docs/adr/0001-preserve-naive-baseline.md),
+  [ADR 0003](../docs/adr/0003-structured-answer-citation-contract.md),
+  [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md),
+  [ADR 0069](../docs/adr/0069-retrieval-aggregate-and-citation-coverage-surface.md),
+  [ADR 0074](../docs/adr/0074-rfp-rag-stage-separation.md).
+- Primary risk: mixing measurement additions with default behavior changes.
+
+### Scope
+
+- Add LLM-free context precision/recall retrieval metrics.
+- Extend run/index version manifest fields additively.
+- Add `EmbeddingProvider` Protocol/factory around existing `rag_embedding.py`.
+- Add opt-in deterministic contextual chunking while preserving fixed/section defaults.
+- Keep Qdrant/pgvector and multimodal expansion as follow-up-only surfaces.
+
+### Non-Goals
+
+- Do not change `naive_baseline`.
+- Do not bump answer `schema_version`.
+- Do not make HyDE, Self-RAG, Reflexion, CRAG, ColPali, or GPT-VL default.
+- Do not send private data to external providers.
+
+### Acceptance Criteria
+
+- [x] `reports/eval_summary.json` can expose context precision/recall aggregates.
+- [x] `run_manifest` carries index/chunking/embedding version fields.
+- [x] Embedding provider swapping is tested with fake/local providers.
+- [x] Contextual chunking is opt-in and regression-tested.
+- [x] Focused tests and branch convention checks pass.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_chunk_metrics_regression.py tests/test_chunk_aggregate_regression.py tests/test_run_manifest_versioning_regression.py -q
+python3 -m pytest tests/test_embedding_provider_protocol.py tests/test_contextual_chunking_regression.py -q
+python3 -m pytest tests/test_vector_store_protocol.py tests/test_vector_store_qdrant.py -q
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Smoke/eval summary diff explanation.
+- Review note confirming baseline and answer contract unchanged.
+
+### Failure Conditions
+
+- Stop if the implementation requires changing answer dict shape.
+- Stop if external provider code would run by default.
+- Stop if public fixture smoke is used as a real-world quality claim.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0005-rag-eval-first-adapter-hardening.md`](../docs/plans/T-2026-0005-rag-eval-first-adapter-hardening.md)
+- Issue: [#1493](https://github.com/hskim-solv/BidMate-DocAgent/issues/1493)
+- PR: [#1499](https://github.com/hskim-solv/BidMate-DocAgent/pull/1499)
+- ADR: ADR 0001, ADR 0003, ADR 0005, ADR 0069, ADR 0074

--- a/tests/test_chunk_aggregate_regression.py
+++ b/tests/test_chunk_aggregate_regression.py
@@ -23,6 +23,8 @@ from eval.scorers.chunk_metrics import CHUNK_METRIC_KS  # noqa: E402
 
 CHUNK_AGG_KEYS = (
     *(f"chunk_recall_at_{k}" for k in CHUNK_METRIC_KS),
+    *(f"context_precision_at_{k}" for k in CHUNK_METRIC_KS),
+    *(f"context_recall_at_{k}" for k in CHUNK_METRIC_KS),
     "chunk_mrr_at_5",
     "chunk_mrr",
     "chunk_ndcg_at_5",
@@ -54,6 +56,12 @@ class ChunkAggregateTest(unittest.TestCase):
                 chunk_recall_at_5=1.0,
                 chunk_recall_at_10=1.0,
                 chunk_recall_at_20=1.0,
+                context_precision_at_5=1.0,
+                context_precision_at_10=1.0,
+                context_precision_at_20=1.0,
+                context_recall_at_5=1.0,
+                context_recall_at_10=1.0,
+                context_recall_at_20=1.0,
                 chunk_mrr_at_5=1.0,
                 chunk_mrr=1.0,
                 chunk_ndcg_at_5=1.0,
@@ -66,6 +74,12 @@ class ChunkAggregateTest(unittest.TestCase):
                 chunk_recall_at_5=0.0,
                 chunk_recall_at_10=0.0,
                 chunk_recall_at_20=0.0,
+                context_precision_at_5=0.0,
+                context_precision_at_10=0.0,
+                context_precision_at_20=0.0,
+                context_recall_at_5=0.0,
+                context_recall_at_10=0.0,
+                context_recall_at_20=0.0,
                 chunk_mrr_at_5=0.0,
                 chunk_mrr=0.0,
                 chunk_ndcg_at_5=0.0,
@@ -77,6 +91,8 @@ class ChunkAggregateTest(unittest.TestCase):
         ]
         block = metric_block(rows)
         self.assertAlmostEqual(block["chunk_recall_at_5"], 0.5)
+        self.assertAlmostEqual(block["context_precision_at_5"], 0.5)
+        self.assertAlmostEqual(block["context_recall_at_5"], 0.5)
         self.assertAlmostEqual(block["chunk_mrr_at_5"], 0.5)
         self.assertAlmostEqual(block["chunk_mrr"], 0.5)
         self.assertAlmostEqual(block["chunk_ndcg_at_5"], 0.5)
@@ -92,6 +108,8 @@ class ChunkAggregateTest(unittest.TestCase):
         rows = [
             _row(
                 chunk_recall_at_5=1.0,
+                context_precision_at_5=1.0,
+                context_recall_at_5=1.0,
                 chunk_mrr_at_5=1.0,
                 chunk_mrr=1.0,
                 chunk_ndcg_at_5=1.0,
@@ -102,6 +120,8 @@ class ChunkAggregateTest(unittest.TestCase):
             ),
             _row(
                 chunk_recall_at_5=None,
+                context_precision_at_5=None,
+                context_recall_at_5=None,
                 chunk_mrr_at_5=None,
                 chunk_mrr=None,
                 chunk_ndcg_at_5=None,
@@ -113,6 +133,8 @@ class ChunkAggregateTest(unittest.TestCase):
         ]
         block = metric_block(rows)
         self.assertEqual(block["chunk_recall_at_5"], 1.0)
+        self.assertEqual(block["context_precision_at_5"], 1.0)
+        self.assertEqual(block["context_recall_at_5"], 1.0)
         self.assertEqual(block["ci"]["chunk_recall_at_5"]["n"], 1)
         self.assertIsNone(block["rerank_delta_mrr"])
         self.assertIsNone(block["ci"]["rerank_delta_mrr"])
@@ -125,6 +147,18 @@ class ChunkAggregateTest(unittest.TestCase):
             self.assertIn(key, block)
             self.assertIsNone(block[key])
             self.assertIsNone(block["ci"][key])
+
+    def test_synthesis_token_and_cost_aggregates_are_additive(self) -> None:
+        block = metric_block([
+            _row(tokens_in=100, tokens_out=20, cost_estimate_usd=0.01),
+            _row(tokens_in=50, tokens_out=10, cost_estimate_usd=0.02),
+            _row(),
+        ])
+        self.assertEqual(block["synthesis_tokens"]["tokens_in_total"], 150)
+        self.assertEqual(block["synthesis_tokens"]["tokens_out_total"], 30)
+        self.assertEqual(block["synthesis_tokens"]["cases_with_token_usage"], 2)
+        self.assertEqual(block["synthesis_cost"]["estimated_cost_usd_total"], 0.03)
+        self.assertEqual(block["synthesis_cost"]["cases_with_cost"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_chunk_metrics_regression.py
+++ b/tests/test_chunk_metrics_regression.py
@@ -19,6 +19,8 @@ from eval.scorers import (  # noqa: E402
     chunk_mrr_at_k,
     chunk_ndcg_at_k,
     chunk_recall_at_k,
+    context_precision_at_k,
+    context_recall_at_k,
     derive_gold_evidence,
     derive_gold_chunk_ids,
 )
@@ -39,6 +41,19 @@ class ChunkMetricsTest(unittest.TestCase):
 
     def test_recall_at_k_returns_zero_for_empty_retrieved(self) -> None:
         self.assertEqual(chunk_recall_at_k([], ["c1"], 5), 0.0)
+
+    def test_context_precision_at_k_counts_gold_fraction_in_retrieved_head(self) -> None:
+        self.assertEqual(
+            context_precision_at_k(["c1", "c2", "c3"], ["c2", "c4"], 3),
+            1 / 3,
+        )
+        self.assertEqual(context_precision_at_k(["c1", "c2"], ["c2"], 1), 0.0)
+
+    def test_context_precision_at_k_returns_none_for_no_gold(self) -> None:
+        self.assertIsNone(context_precision_at_k(["c1", "c2"], [], 5))
+
+    def test_context_recall_at_k_matches_gold_coverage(self) -> None:
+        self.assertEqual(context_recall_at_k(["c1", "c2"], ["c2", "c3"], 5), 0.5)
 
     def test_mrr_rewards_earlier_hits(self) -> None:
         self.assertEqual(chunk_mrr(["c1", "c2"], ["c1"]), 1.0)
@@ -174,6 +189,8 @@ class ScoreCaseChunkMetrics20Test(unittest.TestCase):
         )
         result = score_case(self._CASE, pred, gold_chunk_ids=["doc-a::chunk-001"])
         self.assertIn("chunk_recall_at_20", result)
+        self.assertIn("context_precision_at_20", result)
+        self.assertIn("context_recall_at_20", result)
 
     def test_chunk_ndcg_at_20_present_in_output(self) -> None:
         pred = _minimal_prediction(
@@ -201,7 +218,9 @@ class ScoreCaseChunkMetrics20Test(unittest.TestCase):
         )
         result = score_case(self._CASE, pred, gold_chunk_ids=[gold_chunk_id])
         self.assertEqual(result["chunk_recall_at_20"], 1.0)
+        self.assertEqual(result["context_recall_at_20"], 1.0)
         self.assertEqual(result["chunk_recall_at_10"], 0.0)  # not in @10
+        self.assertEqual(result["context_recall_at_10"], 0.0)
 
     def test_chunk_recall_at_20_none_when_no_gold(self) -> None:
         pred = _minimal_prediction(retrieved_chunk_ids=["doc-a::chunk-001"])

--- a/tests/test_contextual_chunking_regression.py
+++ b/tests/test_contextual_chunking_regression.py
@@ -1,0 +1,88 @@
+"""Regression guards for opt-in deterministic contextual chunking."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import rag_indexing  # noqa: E402
+from rag_embedding import EmbeddingResult  # noqa: E402
+
+
+DOCUMENT = {
+    "doc_id": "doc-a",
+    "title": "RFP Alpha",
+    "agency": "Agency A",
+    "project": "Project A",
+    "metadata": {},
+    "source_path": "doc-a.txt",
+    "sections": [
+        {
+            "heading": "Security",
+            "section_path": ["Requirements", "Security"],
+            "text": "Access logs must be retained. Audit trails must be searchable.",
+        }
+    ],
+}
+
+
+def test_contextual_chunking_adds_prefix_without_changing_base_strategy() -> None:
+    chunks, _parents, diagnostics = rag_indexing.build_chunk_records(
+        [DOCUMENT],
+        chunking_strategy="contextual",
+        max_chars=1000,
+    )
+
+    assert diagnostics["requested_strategy"] == "contextual"
+    assert diagnostics["base_strategy"] == "auto"
+    assert diagnostics["contextual"] is True
+    assert diagnostics["chunker_version"] == rag_indexing.CONTEXTUAL_CHUNKER_VERSION
+    assert chunks[0]["chunking_strategy"] == "section"
+    assert chunks[0]["contextual"] is True
+    assert chunks[0]["chunker_version"] == rag_indexing.CONTEXTUAL_CHUNKER_VERSION
+    assert chunks[0]["contextual_prefix"].startswith("Document title: RFP Alpha.")
+    assert "Requirements > Security" in chunks[0]["contextual_prefix"]
+
+
+def test_default_fixed_chunking_has_no_contextual_prefix() -> None:
+    chunks, _parents, diagnostics = rag_indexing.build_chunk_records(
+        [DOCUMENT],
+        chunking_strategy="fixed",
+        max_chars=1000,
+    )
+
+    assert diagnostics["contextual"] is False
+    assert "contextual_prefix" not in chunks[0]
+    assert chunks[0]["contextual"] is False
+
+
+def test_contextual_prefix_participates_in_embedding_input(monkeypatch) -> None:
+    captured_inputs: list[str] = []
+
+    def fake_embed_texts(texts, model_name, backend):
+        captured_inputs.extend(texts)
+        return EmbeddingResult(
+            vectors=np.ones((len(texts), 4), dtype=np.float32),
+            backend="fake",
+            model="fake-model",
+        )
+
+    monkeypatch.setattr(rag_indexing, "embed_texts", fake_embed_texts)
+    payload = rag_indexing.build_index_payload_from_documents(
+        [DOCUMENT],
+        source_dir="fixtures",
+        embedding_backend="hashing",
+        chunking_strategy="contextual",
+        chunk_max_chars=1000,
+    )
+
+    assert payload["embedding"]["dimension"] == 4
+    assert captured_inputs
+    assert "Document title: RFP Alpha." in captured_inputs[0]
+    assert "Access logs must be retained" in captured_inputs[0]

--- a/tests/test_embedding_provider_protocol.py
+++ b/tests/test_embedding_provider_protocol.py
@@ -1,0 +1,53 @@
+"""Regression guards for the EmbeddingProvider Protocol interface."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_embedding import (  # noqa: E402
+    EmbeddingProvider,
+    EmbeddingResult,
+    default_embedding_provider,
+    ensure_embedding_dimension,
+)
+
+
+def test_default_embedding_provider_is_protocol_instance() -> None:
+    provider = default_embedding_provider(backend="hashing", expected_dimension=384)
+    assert isinstance(provider, EmbeddingProvider)
+
+    docs = provider.embed_documents(["alpha", "beta"])
+    query = provider.embed_query("alpha")
+
+    assert docs.backend == "hashing"
+    assert docs.vectors.shape == (2, 384)
+    assert query.vectors.shape == (1, 384)
+
+
+def test_embedding_dimension_mismatch_raises_explicit_error() -> None:
+    result = EmbeddingResult(
+        vectors=np.zeros((2, 3), dtype=np.float32),
+        backend="fake",
+        model="fake-model",
+    )
+
+    with pytest.raises(ValueError, match="Embedding dimension mismatch"):
+        ensure_embedding_dimension(result, 4)
+
+
+def test_embedding_dimension_match_returns_original_result() -> None:
+    result = EmbeddingResult(
+        vectors=np.zeros((1, 4), dtype=np.float32),
+        backend="fake",
+        model="fake-model",
+    )
+
+    assert ensure_embedding_dimension(result, 4) is result

--- a/tests/test_run_manifest_versioning_regression.py
+++ b/tests/test_run_manifest_versioning_regression.py
@@ -22,11 +22,32 @@ CONFIG_PATH = ROOT / "eval" / "config.yaml"
 
 
 class RunManifestVersioningTest(unittest.TestCase):
-    def test_embedding_fields_from_index(self) -> None:
-        index = {"embedding": {"backend": "hashing", "model": "hashing-384"}}
+    def test_version_fields_from_index(self) -> None:
+        index = {
+            "schema_version": 2,
+            "embedding": {
+                "backend": "hashing",
+                "model": "hashing-384",
+                "dimension": 384,
+            },
+            "build": {
+                "chunking": {
+                    "requested_strategy": "fixed",
+                    "chunker_version": "chunker.fixed.v1",
+                    "max_chars": 520,
+                    "overlap_sentences": 1,
+                }
+            },
+        }
         manifest = compute_run_manifest(CONFIG_PATH, index)
+        self.assertEqual(manifest["index_schema_version"], 2)
         self.assertEqual(manifest["embedding_backend"], "hashing")
         self.assertEqual(manifest["embedding_model_id"], "hashing-384")
+        self.assertEqual(manifest["embedding_dim"], 384)
+        self.assertEqual(manifest["chunking_strategy"], "fixed")
+        self.assertEqual(manifest["chunker_version"], "chunker.fixed.v1")
+        self.assertEqual(manifest["chunk_max_chars"], 520)
+        self.assertEqual(manifest["chunk_overlap_sentences"], 1)
         # existing reproducibility fields are untouched
         self.assertIn("git_commit", manifest)
         self.assertIn("config_sha256", manifest)
@@ -35,11 +56,20 @@ class RunManifestVersioningTest(unittest.TestCase):
         manifest = compute_run_manifest(CONFIG_PATH)
         self.assertIsNone(manifest["embedding_backend"])
         self.assertIsNone(manifest["embedding_model_id"])
+        self.assertIsNone(manifest["index_schema_version"])
+        self.assertIsNone(manifest["chunking_strategy"])
 
     def test_index_without_embedding_meta_is_none(self) -> None:
         manifest = compute_run_manifest(CONFIG_PATH, {"chunks": []})
         self.assertIsNone(manifest["embedding_backend"])
         self.assertIsNone(manifest["embedding_model_id"])
+
+    def test_chunker_version_derived_for_legacy_chunking_meta(self) -> None:
+        manifest = compute_run_manifest(
+            CONFIG_PATH,
+            {"build": {"chunking": {"requested_strategy": "section"}}},
+        )
+        self.assertEqual(manifest["chunker_version"], "chunker.section.v1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Eval-first RAG hardening plan의 1차 범위를 기존 flat module layout에 맞춰 구현했습니다. 새 `src/rag/*` 트리는 만들지 않고, gold chunk 기반 context precision/recall, run manifest version fields, `EmbeddingProvider` Protocol wrapper, opt-in deterministic contextual chunking을 추가했습니다. `naive_baseline`, answer `schema_version: 2`, ADR 0005 private boundary는 변경하지 않았습니다.

Closes #1493

## 2. 영향 파일

- Load-bearing: `eval/run_eval.py`, `eval/scorers/*`, `scripts/build_index.py`
- Supporting: `rag_embedding.py`, `rag_indexing.py`, `data/index/index.json`
- Tests: `tests/test_chunk_*`, `tests/test_run_manifest_versioning_regression.py`, `tests/test_contextual_chunking_regression.py`, `tests/test_embedding_provider_protocol.py`
- Docs/task: `tasks/queue.md`, `docs/plans/T-2026-0005-rag-eval-first-adapter-hardening.md`

## 3. 리스크

- Context precision/recall이 RAGAS judge metric으로 오해될 수 있어 LLM-free gold-chunk retrieval metric으로 별도 구현/문서화했습니다.
- `contextual` chunking이 default embedding input을 바꾸면 baseline drift가 생기므로 opt-in mode에서만 prefix를 embedding input에 넣도록 regression test를 추가했습니다.
- Provider abstraction이 외부 API 호출을 기본화하지 않도록 기존 `embed_texts()` wrapper만 추가하고 default backend 동작은 유지했습니다.

## 4. 테스트

- `python3 -m py_compile eval/run_eval.py eval/scorers/chunk_metrics.py eval/scorers/case.py rag_embedding.py rag_indexing.py scripts/build_index.py`
- `python3 -m pytest tests/test_chunk_metrics_regression.py tests/test_chunk_aggregate_regression.py tests/test_run_manifest_versioning_regression.py -q`
- `python3 -m pytest tests/test_embedding_provider_protocol.py tests/test_contextual_chunking_regression.py -q`
- `python3 -m pytest tests/test_vector_store_protocol.py tests/test_vector_store_qdrant.py -q`
- `git diff --check`
- `make check-branch`
- `python3 scripts/check_doc_links.py --check-all`
- `make smoke`
- `bash scripts/test.sh` — `2539 passed, 16 skipped, 69 deselected, 12 warnings, 251 subtests passed`

## 5. Eval 영향

Public fixture smoke passed. This PR adds measurement/versioning surfaces and an opt-in chunking strategy; it does not claim real-data quality improvement.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

`REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent make real-eval-check` passed. A full `make real-eval` was started for this PR but intentionally stopped because this change is additive measurement/versioning plus opt-in chunking, not a default retrieval/verifier behavior change. No completed current-run real-data delta is used as performance evidence in this PR.

## 6. 하위 호환

- Public answer dict contract unchanged; no `ANSWER_SCHEMA_VERSION` bump.
- Existing indexes without new manifest/chunker fields keep loading; missing fields resolve to `None` or derived legacy chunker version.
- Existing `rag_embedding.py::embed_texts()` callers remain compatible.
- `scripts/build_index.py --chunking_strategy contextual` is additive; default remains `fixed`.

## 7. 범위 외

- No Qdrant native hybrid/multi-vector change.
- No pgvector implementation.
- No Gemini/Voyage/local Korean provider implementation.
- No HyDE/Self-RAG/Reflexion/CRAG/ColPali/GPT-VL default promotion.

