### PR TITLE
chore: slim PR eval scope and cleanup worktrees

### DIFF
--- a/.githooks/_pre-push-worktree-hygiene.sh
+++ b/.githooks/_pre-push-worktree-hygiene.sh
@@ -172,6 +172,17 @@ _is_clean_worktree() {
   [[ -z "$untracked" ]]
 }
 
+_prune_if_requested() {
+  if [[ "$prune_after" == "1" ]]; then
+    if [[ "$dry_run" == "1" ]]; then
+      printf 'worktree cleanup: would run git worktree prune\n' >&2
+    else
+      git worktree prune >/dev/null 2>&1 || true
+      printf 'worktree cleanup: pruned stale worktree admin files.\n' >&2
+    fi
+  fi
+}
+
 _flush() {
   # detached (no branch line) → skip; main → skip (it's never an orphan);
   # current worktree → skip.
@@ -201,7 +212,12 @@ done < <(git worktree list --porcelain 2>/dev/null)
 # Flush the final block (porcelain may not end with a trailing blank line).
 _flush
 
-[[ -z "$orphans" ]] && exit 0
+if [[ -z "$orphans" ]]; then
+  if [[ "$clean_mode" == "1" ]]; then
+    _prune_if_requested
+  fi
+  exit 0
+fi
 
 if [[ "$clean_mode" == "1" ]]; then
   cat >&2 <<EOF
@@ -239,6 +255,7 @@ fi
 
 if [[ -z "$clean_orphans" ]]; then
   printf 'worktree cleanup: no clean orphan worktrees to remove.\n' >&2
+  _prune_if_requested
   exit 0
 fi
 
@@ -258,13 +275,6 @@ while IFS=$'\t' read -r orphan_path orphan_branch; do
   fi
 done <<< "$clean_orphans"
 
-if [[ "$prune_after" == "1" ]]; then
-  if [[ "$dry_run" == "1" ]]; then
-    printf 'worktree cleanup: would run git worktree prune\n' >&2
-  else
-    git worktree prune >/dev/null 2>&1 || true
-    printf 'worktree cleanup: pruned stale worktree admin files.\n' >&2
-  fi
-fi
+_prune_if_requested
 
 exit 0

--- a/.githooks/_pre-push-worktree-hygiene.sh
+++ b/.githooks/_pre-push-worktree-hygiene.sh
@@ -4,13 +4,16 @@
 # Sourced by `.githooks/pre-push`, also runnable standalone:
 #
 #     bash .githooks/_pre-push-worktree-hygiene.sh
+#     bash .githooks/_pre-push-worktree-hygiene.sh --clean --dry-run
+#     bash .githooks/_pre-push-worktree-hygiene.sh --clean --prune
 #
 # Detects worktrees whose checked-out branch is already merged into main
 # but were never removed. Stale worktrees accumulate and are the root
 # cause of the recurring "동시 worktree → ADR 번호 충돌" failure mode
 # CLAUDE.md keeps citing. Prints the exact `git worktree remove` command
-# for each orphan — never auto-removes (a worktree may hold un-pushed
-# work the merge check can't see). Soft-warn only: `exit 0` always.
+# for each orphan. Default pre-push mode never auto-removes. Standalone
+# `--clean` mode removes only clean orphan worktrees; dirty/untracked
+# worktrees are skipped. Soft-warn only: `exit 0` always.
 #
 # "Merged" is decided per branch by three OFFLINE signals (no network — every
 # push stays fast, like the other pre-push sub-hooks) plus one OPT-IN online
@@ -42,12 +45,42 @@
 
 set -u
 
-# Base ref, resolved once: prefer a local `main`, fall back to `origin/main`
-# for checkouts without a local main ref. No base → fresh clone → skip.
-if git rev-parse --verify -q refs/heads/main >/dev/null 2>&1; then
-  base_ref="main"
-elif git rev-parse --verify -q refs/remotes/origin/main >/dev/null 2>&1; then
+clean_mode=0
+dry_run=0
+prune_after=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --clean) clean_mode=1 ;;
+    --dry-run) clean_mode=1; dry_run=1 ;;
+    --prune) prune_after=1 ;;
+    -h|--help)
+      cat <<'EOF'
+Usage:
+  bash .githooks/_pre-push-worktree-hygiene.sh
+  bash .githooks/_pre-push-worktree-hygiene.sh --clean --dry-run
+  bash .githooks/_pre-push-worktree-hygiene.sh --clean --prune
+
+Default mode prints orphan worktree warnings only. --clean removes only clean
+orphan worktrees; dirty/untracked worktrees are skipped. No branches or remote
+refs are deleted.
+EOF
+      exit 0
+      ;;
+    *)
+      printf 'worktree hygiene: unknown option: %s\n' "$arg" >&2
+      exit 0
+      ;;
+  esac
+done
+
+# Base ref, resolved once: prefer `origin/main` so a stale local `main` does not
+# hide recently merged PRs. Fall back to local `main` for isolated test repos or
+# checkouts without a remote-tracking main. No base → fresh clone → skip.
+if git rev-parse --verify -q refs/remotes/origin/main >/dev/null 2>&1; then
   base_ref="origin/main"
+elif git rev-parse --verify -q refs/heads/main >/dev/null 2>&1; then
+  base_ref="main"
 else
   exit 0
 fi
@@ -124,8 +157,20 @@ _is_merged() {
 }
 
 orphans=""
+clean_orphans=""
+dirty_orphans=""
 cur_path=""
 cur_branch=""
+
+_is_clean_worktree() {
+  local path="$1"
+  [[ -d "$path" ]] || return 1
+  git -C "$path" diff --quiet --ignore-submodules -- 2>/dev/null || return 1
+  git -C "$path" diff --cached --quiet --ignore-submodules -- 2>/dev/null || return 1
+  local untracked
+  untracked=$(git -C "$path" ls-files --others --exclude-standard 2>/dev/null || true)
+  [[ -z "$untracked" ]]
+}
 
 _flush() {
   # detached (no branch line) → skip; main → skip (it's never an orphan);
@@ -133,6 +178,13 @@ _flush() {
   if [[ -n "$cur_branch" && "$cur_branch" != "main" && "$cur_path" != "$self_top" ]]; then
     if _is_merged "$cur_branch"; then
       orphans="${orphans}  git worktree remove \"${cur_path}\"   # branch '${cur_branch}' merged into main"$'\n'
+      if [[ "$clean_mode" == "1" ]]; then
+        if _is_clean_worktree "$cur_path"; then
+          clean_orphans="${clean_orphans}${cur_path}"$'\t'"${cur_branch}"$'\n'
+        else
+          dirty_orphans="${dirty_orphans}  skip dirty/untracked \"${cur_path}\"   # branch '${cur_branch}'"$'\n'
+        fi
+      fi
     fi
   fi
   cur_path=""
@@ -151,7 +203,15 @@ _flush
 
 [[ -z "$orphans" ]] && exit 0
 
-cat >&2 <<EOF
+if [[ "$clean_mode" == "1" ]]; then
+  cat >&2 <<EOF
+
+⚠️  Orphan worktrees detected — branch already merged into main:
+
+$(printf '%s' "$orphans")
+EOF
+else
+  cat >&2 <<EOF
 
 ⚠️  Orphan worktrees detected — branch already merged into main, but the
     worktree was never removed (not auto-removing):
@@ -163,5 +223,48 @@ $(printf '%s' "$orphans")
     "동시 worktree → ADR 번호 충돌" (CLAUDE.md). Push proceeds.
 
 EOF
+fi
+
+if [[ "$clean_mode" != "1" ]]; then
+  exit 0
+fi
+
+if [[ -n "$dirty_orphans" ]]; then
+  cat >&2 <<EOF
+Skipped worktrees with local changes:
+
+$(printf '%s' "$dirty_orphans")
+EOF
+fi
+
+if [[ -z "$clean_orphans" ]]; then
+  printf 'worktree cleanup: no clean orphan worktrees to remove.\n' >&2
+  exit 0
+fi
+
+while IFS=$'\t' read -r orphan_path orphan_branch; do
+  [[ -n "$orphan_path" ]] || continue
+  if [[ "$dry_run" == "1" ]]; then
+    printf 'worktree cleanup: would remove "%s"   # branch '\''%s'\''\n' \
+      "$orphan_path" "$orphan_branch" >&2
+  else
+    if git worktree remove "$orphan_path" >/dev/null 2>&1; then
+      printf 'worktree cleanup: removed "%s"   # branch '\''%s'\''\n' \
+        "$orphan_path" "$orphan_branch" >&2
+    else
+      printf 'worktree cleanup: failed to remove "%s"   # branch '\''%s'\''\n' \
+        "$orphan_path" "$orphan_branch" >&2
+    fi
+  fi
+done <<< "$clean_orphans"
+
+if [[ "$prune_after" == "1" ]]; then
+  if [[ "$dry_run" == "1" ]]; then
+    printf 'worktree cleanup: would run git worktree prune\n' >&2
+  else
+    git worktree prune >/dev/null 2>&1 || true
+    printf 'worktree cleanup: pruned stale worktree admin files.\n' >&2
+  fi
+fi
 
 exit 0

--- a/.github/workflows/pr-eval.yml
+++ b/.github/workflows/pr-eval.yml
@@ -42,6 +42,8 @@ jobs:
     # Per-shard coverage.xml uploads to Codecov with `shard-N` flags;
     # Codecov merges them server-side.
     name: Pytest (shard ${{ matrix.shard }})
+    needs: changes
+    if: needs.changes.outputs.pytest == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -139,37 +141,40 @@ jobs:
           fi
 
   changes:
-    # Decide whether this PR touches any path that can move the eval delta.
-    # docs/governance-only PRs (no runtime code) get eval-delta skipped to
-    # save runner-minutes. No checkout — the PR file list comes from the
-    # GitHub API (gh is preinstalled), so this job is seconds-cheap.
+    # Decide whether this PR touches paths that need full pytest and/or the
+    # fixture smoke eval. Docs/report-only PRs skip both to save runner-minutes.
+    # The classifier is tested in tests/test_pr_eval_change_scope.py so the
+    # path policy does not drift as an inline shell regex.
     # `main` carries no required status checks, so a skipped eval-delta does
-    # not leave the PR pending. pytest + baseline-provenance still always run.
-    name: Detect runtime-affecting changes
+    # not leave the PR pending. Baseline provenance still always runs.
+    name: Detect PR eval change scope
     runs-on: ubuntu-latest
     outputs:
-      runtime: ${{ steps.filter.outputs.runtime }}
+      runtime: ${{ steps.scope.outputs.runtime }}
+      pytest: ${{ steps.scope.outputs.pytest }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/pr_eval_change_scope.py
+          sparse-checkout-cone-mode: false
+
       - name: Classify changed files
-        id: filter
+        id: scope
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          mkdir -p reports
           files=$(gh api --paginate \
             "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
-          echo "Changed files:"; echo "$files"
-          # Any of: a .py module, the eval/ tree, smoke fixture corpus, requirements,
-          # the run-eval composite action, or this workflow → run eval-delta.
-          if echo "$files" | grep -qE \
-            '\.py$|^eval/|^eval/fixtures/smoke_rfp/raw/|^requirements.*\.txt$|^\.github/actions/run-eval/|^\.github/workflows/pr-eval\.yml$'; then
-            echo "runtime=true" >> "$GITHUB_OUTPUT"
-            echo "→ runtime-affecting; eval-delta will run."
-          else
-            echo "runtime=false" >> "$GITHUB_OUTPUT"
-            echo "→ docs/governance-only; eval-delta skipped."
-          fi
+          printf '%s\n' "$files" > reports/pr_eval_changed_files.txt
+          echo "Changed files:"
+          cat reports/pr_eval_changed_files.txt
+          python3 scripts/pr_eval_change_scope.py \
+            --changed-files reports/pr_eval_changed_files.txt \
+            --github-output "$GITHUB_OUTPUT"
 
   eval-delta:
     name: Fixture smoke eval vs base

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@
 
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
-.PHONY: ship-start ship-arm ship-disarm ship-status ship-review-gate
+.PHONY: ship-start ship-arm ship-disarm ship-status ship-review-gate worktree-cleanup-dry-run worktree-cleanup
 
 # Self-review (quarterly meta-feedback loop). Combines 4-axis portfolio
 # rubric + 5-axis Claude collaboration rubric. See SKILL at
@@ -1125,6 +1125,12 @@ ship-status:
 
 ship-review-gate:
 	@$(PYTHON) scripts/claude-hooks/_ship_review_gate.py $(if $(PR),--pr "$(PR)",)
+
+worktree-cleanup-dry-run:
+	@bash .githooks/_pre-push-worktree-hygiene.sh --clean --dry-run
+
+worktree-cleanup:
+	@bash .githooks/_pre-push-worktree-hygiene.sh --clean --prune
 
 # ---------------------------------------------------------------------------
 # Self-review quarterly: meta-feedback loop over the past quarter.

--- a/scripts/pr_eval_change_scope.py
+++ b/scripts/pr_eval_change_scope.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Classify PR changed files for the PR Eval Delta workflow.
+
+The workflow has two different costs:
+
+* pytest should run for code, tests, hooks, workflow, or tooling changes.
+* fixture smoke eval should only run for paths that can affect runtime/eval
+  behavior or the eval-delta workflow itself.
+
+Docs/report-only changes intentionally skip both, while baseline provenance and
+branch/issue checks remain handled by separate always-on workflows/jobs.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+RUNTIME_FILES = {
+    "ingestion.py",
+    "visual_ingestion.py",
+    "text_normalize.py",
+    "korean_lexicon.py",
+    "scripts/build_index.py",
+    "scripts/check_latency_slo.py",
+    "scripts/compare_eval.py",
+    "scripts/validate_claim.py",
+    ".github/workflows/pr-eval.yml",
+}
+
+RUNTIME_PREFIXES = (
+    "eval/",
+    "api/",
+    ".github/actions/run-eval/",
+)
+
+PYTEST_PREFIXES = (
+    "tests/",
+    "scripts/",
+    ".githooks/",
+    ".github/workflows/",
+    ".github/actions/",
+    ".claude/commands/",
+)
+
+PYTEST_FILES = {
+    "Makefile",
+    "pyproject.toml",
+    "pytest.ini",
+    "setup.cfg",
+    "requirements.txt",
+    "requirements-dev.txt",
+}
+
+REPORT_PREFIXES = (
+    "reports/",
+    "artifacts/",
+)
+
+DOC_PREFIXES = (
+    "docs/",
+)
+
+DOC_SUFFIXES = (
+    ".md",
+    ".txt",
+    ".rst",
+)
+
+
+@dataclass(frozen=True)
+class ChangeScope:
+    runtime: bool
+    pytest: bool
+    runtime_reasons: tuple[str, ...]
+    pytest_reasons: tuple[str, ...]
+
+
+def _normalize(path: str) -> str:
+    path = path.strip()
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def _is_rag_module(path: str) -> bool:
+    name = Path(path).name
+    return "/" not in path and name.startswith("rag_") and name.endswith(".py")
+
+
+def _is_requirements(path: str) -> bool:
+    name = Path(path).name
+    return name.startswith("requirements") and name.endswith(".txt")
+
+
+def _is_runtime_path(path: str) -> bool:
+    if path in RUNTIME_FILES or _is_rag_module(path) or _is_requirements(path):
+        return True
+    return any(path.startswith(prefix) for prefix in RUNTIME_PREFIXES)
+
+
+def _is_docs_or_reports_only_path(path: str) -> bool:
+    if path.startswith(DOC_PREFIXES):
+        return True
+    if path.startswith(REPORT_PREFIXES):
+        return True
+    return path.endswith(DOC_SUFFIXES)
+
+
+def _is_pytest_path(path: str) -> bool:
+    if _is_runtime_path(path):
+        return True
+    if path.endswith(".py"):
+        return True
+    if path in PYTEST_FILES or _is_requirements(path):
+        return True
+    return any(path.startswith(prefix) for prefix in PYTEST_PREFIXES)
+
+
+def classify(paths: Iterable[str]) -> ChangeScope:
+    changed = tuple(path for path in (_normalize(p) for p in paths) if path)
+    runtime_reasons: list[str] = []
+    pytest_reasons: list[str] = []
+
+    for path in changed:
+        if _is_runtime_path(path):
+            runtime_reasons.append(path)
+        if _is_pytest_path(path):
+            pytest_reasons.append(path)
+
+    if changed and not pytest_reasons:
+        non_docs_report = [path for path in changed if not _is_docs_or_reports_only_path(path)]
+        if non_docs_report:
+            pytest_reasons.extend(non_docs_report)
+
+    return ChangeScope(
+        runtime=bool(runtime_reasons),
+        pytest=bool(pytest_reasons),
+        runtime_reasons=tuple(runtime_reasons),
+        pytest_reasons=tuple(pytest_reasons),
+    )
+
+
+def _read_changed_files(path: str) -> list[str]:
+    if path == "-":
+        import sys
+
+        return sys.stdin.read().splitlines()
+    return Path(path).read_text(encoding="utf-8").splitlines()
+
+
+def _bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def render(scope: ChangeScope) -> str:
+    runtime_reason = ", ".join(scope.runtime_reasons) if scope.runtime_reasons else "none"
+    pytest_reason = ", ".join(scope.pytest_reasons) if scope.pytest_reasons else "none"
+    return "\n".join(
+        [
+            f"runtime={_bool(scope.runtime)}",
+            f"pytest={_bool(scope.pytest)}",
+            f"runtime_reason={runtime_reason}",
+            f"pytest_reason={pytest_reason}",
+        ]
+    )
+
+
+def write_github_output(path: str, scope: ChangeScope) -> None:
+    with Path(path).open("a", encoding="utf-8") as f:
+        f.write(f"runtime={_bool(scope.runtime)}\n")
+        f.write(f"pytest={_bool(scope.pytest)}\n")
+        f.write(
+            "runtime_reason="
+            f"{'; '.join(scope.runtime_reasons) if scope.runtime_reasons else 'none'}\n"
+        )
+        f.write(
+            "pytest_reason="
+            f"{'; '.join(scope.pytest_reasons) if scope.pytest_reasons else 'none'}\n"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        help="Path to newline-delimited changed file list, or '-' for stdin.",
+    )
+    parser.add_argument(
+        "--github-output",
+        help="Optional GitHub Actions output file path. Usually $GITHUB_OUTPUT.",
+    )
+    args = parser.parse_args(argv)
+
+    scope = classify(_read_changed_files(args.changed_files))
+    if args.github_output:
+        write_github_output(args.github_output, scope)
+    print(render(scope))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/pr_eval_change_scope.py
+++ b/scripts/pr_eval_change_scope.py
@@ -25,6 +25,7 @@ RUNTIME_FILES = {
     "text_normalize.py",
     "korean_lexicon.py",
     "scripts/build_index.py",
+    "scripts/_eval_delta.py",
     "scripts/check_latency_slo.py",
     "scripts/compare_eval.py",
     "scripts/validate_claim.py",

--- a/tests/test_hook_pre_push_worktree_hygiene.py
+++ b/tests/test_hook_pre_push_worktree_hygiene.py
@@ -14,6 +14,10 @@ Pins the soft-warn contract (always exit 0; warning only on stderr) for
   9. cherry walk capped by divergence (#1270)   → exit 0, walk skipped past cap
  10. aggregate cherry budget (#1251)             → exit 0, ≤budget walks run
  11. default budget never bites a small repo     → exit 0, all small branches flagged
+ 12. origin/main is preferred over stale local main
+ 13. --clean --dry-run does not remove candidates
+ 14. --clean removes clean orphan worktrees without deleting branches
+ 15. --clean skips dirty/untracked orphan worktrees
 
 Scenarios 5-8 are the #1163 fix: `git branch --merged` only lists ancestor
 tips, so squash-merges (this repo's default merge path) were a silent
@@ -79,10 +83,13 @@ class TestPrePushWorktreeHygiene(unittest.TestCase):
         return wt
 
     def _run_hook(
-        self, *, cwd: Path | None = None, env: dict[str, str] | None = None
+        self,
+        *args: str,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess:
         return subprocess.run(
-            ["bash", str(HOOK)],
+            ["bash", str(HOOK), *args],
             cwd=str(cwd or self.repo),
             capture_output=True,
             text=True,
@@ -255,6 +262,54 @@ class TestPrePushWorktreeHygiene(unittest.TestCase):
         r = self._run_hook(env=env)
         self.assertEqual(0, r.returncode, r.stderr)
         self.assertEqual("", r.stderr.strip(), r.stderr)
+
+    def test_origin_main_is_preferred_over_stale_local_main(self) -> None:
+        # Local main can lag behind the synced desktop/origin state. If the
+        # squash landed on origin/main only, the hook should still flag the
+        # orphan instead of trusting stale local main.
+        self._add_worktree("wt_remote", "feat-remote", extra_commit=True)
+        self._squash_merge("feat-remote")
+        remote_main = self._git("rev-parse", "main").stdout.strip()
+        self._git("update-ref", "refs/remotes/origin/main", remote_main)
+        self._git("reset", "--hard", "HEAD~1")
+
+        r = self._run_hook()
+
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertIn("feat-remote", r.stderr)
+        self.assertIn("wt_remote", r.stderr)
+
+    def test_clean_dry_run_does_not_remove_clean_orphan(self) -> None:
+        wt = self._add_worktree("wt_merged", "feat-merged", extra_commit=False)
+
+        r = self._run_hook("--clean", "--dry-run")
+
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertTrue(wt.exists())
+        self.assertIn("would remove", r.stderr)
+        self.assertIn("feat-merged", r.stderr)
+
+    def test_clean_removes_clean_orphan_without_deleting_branch(self) -> None:
+        wt = self._add_worktree("wt_merged", "feat-merged", extra_commit=False)
+
+        r = self._run_hook("--clean")
+
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertFalse(wt.exists())
+        self.assertIn("removed", r.stderr)
+        branch = self._git("show-ref", "--verify", "refs/heads/feat-merged")
+        self.assertEqual(0, branch.returncode, branch.stderr)
+
+    def test_clean_skips_dirty_orphan(self) -> None:
+        wt = self._add_worktree("wt_merged", "feat-merged", extra_commit=False)
+        (wt / "untracked.txt").write_text("local work\n", encoding="utf-8")
+
+        r = self._run_hook("--clean")
+
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertTrue(wt.exists())
+        self.assertIn("skip dirty/untracked", r.stderr)
+        self.assertIn("no clean orphan worktrees", r.stderr)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_hook_pre_push_worktree_hygiene.py
+++ b/tests/test_hook_pre_push_worktree_hygiene.py
@@ -18,6 +18,7 @@ Pins the soft-warn contract (always exit 0; warning only on stderr) for
  13. --clean --dry-run does not remove candidates
  14. --clean removes clean orphan worktrees without deleting branches
  15. --clean skips dirty/untracked orphan worktrees
+ 16. --clean --prune prunes even when there are no clean removals
 
 Scenarios 5-8 are the #1163 fix: `git branch --merged` only lists ancestor
 tips, so squash-merges (this repo's default merge path) were a silent
@@ -310,6 +311,18 @@ class TestPrePushWorktreeHygiene(unittest.TestCase):
         self.assertTrue(wt.exists())
         self.assertIn("skip dirty/untracked", r.stderr)
         self.assertIn("no clean orphan worktrees", r.stderr)
+
+    def test_clean_prune_runs_even_when_only_dirty_orphans_exist(self) -> None:
+        wt = self._add_worktree("wt_merged", "feat-merged", extra_commit=False)
+        (wt / "untracked.txt").write_text("local work\n", encoding="utf-8")
+
+        r = self._run_hook("--clean", "--prune")
+
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertTrue(wt.exists())
+        self.assertIn("skip dirty/untracked", r.stderr)
+        self.assertIn("no clean orphan worktrees", r.stderr)
+        self.assertIn("pruned stale worktree admin files", r.stderr)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_pr_eval_change_scope.py
+++ b/tests/test_pr_eval_change_scope.py
@@ -52,6 +52,13 @@ def test_pr_eval_workflow_runs_pytest_and_fixture_smoke() -> None:
     assert scope.runtime is True
 
 
+def test_eval_delta_helper_runs_pytest_and_fixture_smoke() -> None:
+    scope = classify(["scripts/_eval_delta.py"])
+
+    assert scope.pytest is True
+    assert scope.runtime is True
+
+
 def test_other_workflow_runs_pytest_but_skips_fixture_smoke() -> None:
     scope = classify([".github/workflows/agent-loop-artifacts.yml"])
 

--- a/tests/test_pr_eval_change_scope.py
+++ b/tests/test_pr_eval_change_scope.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from scripts.pr_eval_change_scope import classify
+
+
+def test_agent_loop_change_runs_pytest_but_skips_fixture_smoke() -> None:
+    scope = classify(["scripts/agent_loop.py"])
+
+    assert scope.pytest is True
+    assert scope.runtime is False
+
+
+def test_rag_module_runs_pytest_and_fixture_smoke() -> None:
+    scope = classify(["rag_core.py"])
+
+    assert scope.pytest is True
+    assert scope.runtime is True
+
+
+def test_docs_only_skips_pytest_and_fixture_smoke() -> None:
+    scope = classify(["docs/operations/auto-ship.md"])
+
+    assert scope.pytest is False
+    assert scope.runtime is False
+
+
+def test_report_only_skips_pytest_and_fixture_smoke() -> None:
+    scope = classify(["reports/real100/baseline.aggregate.json"])
+
+    assert scope.pytest is False
+    assert scope.runtime is False
+
+
+def test_eval_tree_runs_pytest_and_fixture_smoke() -> None:
+    scope = classify(["eval/naive_rag/benchmark.py"])
+
+    assert scope.pytest is True
+    assert scope.runtime is True
+
+
+def test_requirements_run_pytest_and_fixture_smoke() -> None:
+    scope = classify(["requirements-dev.txt"])
+
+    assert scope.pytest is True
+    assert scope.runtime is True
+
+
+def test_pr_eval_workflow_runs_pytest_and_fixture_smoke() -> None:
+    scope = classify([".github/workflows/pr-eval.yml"])
+
+    assert scope.pytest is True
+    assert scope.runtime is True
+
+
+def test_other_workflow_runs_pytest_but_skips_fixture_smoke() -> None:
+    scope = classify([".github/workflows/agent-loop-artifacts.yml"])
+
+    assert scope.pytest is True
+    assert scope.runtime is False
+
+
+def test_unknown_tooling_file_fails_toward_pytest_not_fixture_smoke() -> None:
+    scope = classify(["Dockerfile"])
+
+    assert scope.pytest is True
+    assert scope.runtime is False

--- a/tests/test_pr_gate_workflow_triggers_regression.py
+++ b/tests/test_pr_gate_workflow_triggers_regression.py
@@ -88,5 +88,17 @@ class FiveBGateStillWiredTest(unittest.TestCase):
         )
 
 
+class PrEvalChangeScopeWiringTest(unittest.TestCase):
+    """The balanced CI policy must stay in tested code, not inline regex."""
+
+    def test_pr_eval_uses_tested_change_scope_helper(self) -> None:
+        text = (WORKFLOWS / "pr-eval.yml").read_text(encoding="utf-8")
+
+        self.assertIn("scripts/pr_eval_change_scope.py", text)
+        self.assertIn("pytest: ${{ steps.scope.outputs.pytest }}", text)
+        self.assertIn("if: needs.changes.outputs.pytest == 'true'", text)
+        self.assertIn("if: needs.changes.outputs.runtime == 'true'", text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR-time CI에서 runtime/eval에 영향 없는 자동화 Python 변경까지 fixture smoke eval을 돌던 비용을 줄이고, pre-push orphan worktree 경고를 안전하게 정리할 수 있는 명시적 cleanup 경로를 추가합니다.

Closes #1500

## 2. 영향 파일

- .github/workflows/pr-eval.yml — changed-file scope job을 통해 pytest와 fixture smoke eval 실행 여부를 분리
- scripts/pr_eval_change_scope.py — PR changed files classifier
- .githooks/_pre-push-worktree-hygiene.sh / Makefile — clean orphan worktree dry-run/cleanup target 추가
- tests/test_pr_eval_change_scope.py, tests/test_hook_pre_push_worktree_hygiene.py, tests/test_pr_gate_workflow_triggers_regression.py — classifier, cleanup safety, workflow wiring regression tests

## 3. 리스크

가장 큰 리스크는 CI를 너무 느슨하게 만들어 runtime 회귀를 놓치는 것입니다. runtime/eval 표면은 rag_*.py, ingestion.py, visual_ingestion.py, text_normalize.py, korean_lexicon.py, eval/, api/, requirements, run-eval action, pr-eval workflow로 보수적으로 유지했고, unknown/tooling 변경은 pytest 쪽으로 fail-closed 처리했습니다.

## 4. 테스트

- PASS: python3 -m py_compile scripts/pr_eval_change_scope.py
- PASS: python3 -m pytest -q tests/test_pr_eval_change_scope.py tests/test_hook_pre_push_worktree_hygiene.py tests/test_pr_gate_workflow_triggers_regression.py
- PASS: make worktree-cleanup-dry-run
- PASS: git diff --check

## 5. Eval 영향

CI orchestration-only change. RAG 검색(retrieval), 재순위(reranking), 근거(evidence), 답변(answer), eval scorer behavior 변경 없음. Fixture smoke eval 실행 조건만 더 정확하게 분리합니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Load-bearing path 변경 없음. Private real-eval 판단 또는 benchmark/performance claim 없음.

## 6. 하위 호환

기존 pre-push 기본 동작은 soft-warn only 그대로입니다. 새 cleanup은 명시적으로 make worktree-cleanup 또는 --clean 옵션을 실행할 때만 동작하며 branch/remote ref는 삭제하지 않습니다.

## 7. 범위 외

- full pytest를 changed-file focused pytest로 대체하지 않음
- private real-eval 자동 판단 없음
- dirty/untracked worktree 자동 제거 없음
- branch/remote branch 삭제 없음