### PR TITLE
chore: Preserve private-path autoship artifacts (#1504)

### DIFF
--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -111,6 +111,11 @@ Stop hook 은 모든 Claude 턴마다 발화한다. 지배적 케이스는 no-op
    `data/files/`, `data/data_list.{csv,xlsx}`, `eval/*.local.yaml`,
    `reports/real*/`. pre-commit hook (`.githooks/pre-commit`)이
    2차 게이트다; 이 필터는 그것들을 제안하는 것을 막을 뿐이다.
+   제외된 untracked private-path 파일은
+   [`_ship_private_preserve.py`](../../scripts/claude-hooks/_ship_private_preserve.py)
+   가 `SHIP_PRIVATE_PRESERVE_ROOT` 로 지정한 canonical local checkout 의
+   같은 상대 경로로 이동한다. 이 변수가 없으면 이동하지 않고 skip한다.
+   tracked 수정 파일은 삭제 위험 때문에 이동하지 않는다.
 2. [`_ship_lock_check.py`](../../scripts/claude-hooks/_ship_lock_check.py)
    를 통한 **multi-agent lock 검사**.
    cross-owner 편집은 `CROSS_OWNER=ack` 가 아니면 abort 한다.

--- a/scripts/claude-hooks/README.md
+++ b/scripts/claude-hooks/README.md
@@ -53,6 +53,7 @@ Claude Code 의 PreToolUse / Stop / UserPromptSubmit 훅 모음. `.claude/settin
 - `_self_review.py` — `make hook-fires-weekly` + `/self-review-quarterly` 의 raw signal collector
 - `_ship_arm.py` — `make ship-arm` 의 arm-file 생성 로직
 - `_ship_lock_check.py` — ship 표면 lock 검사 (PR6 후 본격 활용 예정)
+- `_ship_private_preserve.py` — auto-ship private-path 필터가 제외한 untracked 산출물을 canonical local checkout 으로 이동
 - `_ship_pr_body.py` — stop-ship 의 PR body 빌드 헬퍼
 
 ## Telemetry 포맷

--- a/scripts/claude-hooks/_ship_private_preserve.py
+++ b/scripts/claude-hooks/_ship_private_preserve.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Preserve untracked private-path files skipped by auto-ship staging.
+
+``stop-ship.sh`` deliberately refuses to stage paths such as ``reports/real*/``
+and private data directories. This helper prevents generated aggregate files
+from being stranded in short-lived worktrees by moving untracked skipped files
+to the operator's canonical local checkout.
+
+Tracked modifications are never moved: moving them would delete a tracked file
+from the active worktree. Those stay in place for the operator to handle.
+"""
+from __future__ import annotations
+
+import argparse
+import filecmp
+import os
+from pathlib import Path
+import shutil
+import sys
+from typing import Iterable
+
+
+def _safe_relative_path(raw: str) -> Path:
+    path = Path(raw)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"unsafe relative path: {raw!r}")
+    return path
+
+
+def _same_file_content(source: Path, dest: Path) -> bool:
+    return source.is_file() and dest.is_file() and filecmp.cmp(source, dest, shallow=False)
+
+
+def _conflict_dest(dest: Path) -> Path:
+    suffix = f".ship-preserved-{os.getpid()}"
+    candidate = dest.with_name(dest.name + suffix)
+    idx = 1
+    while candidate.exists():
+        candidate = dest.with_name(f"{dest.name}{suffix}-{idx}")
+        idx += 1
+    return candidate
+
+
+def _preserve_root_from_env() -> Path | None:
+    configured = (
+        os.environ.get("SHIP_PRIVATE_PRESERVE_ROOT")
+        or os.environ.get("BIDMATE_PRIVATE_PRESERVE_ROOT")
+    )
+    return Path(configured) if configured else None
+
+
+def preserve_one(
+    *,
+    repo_root: Path,
+    preserve_root: Path,
+    status: str,
+    relpath: str,
+    dry_run: bool = False,
+) -> str:
+    rel = _safe_relative_path(relpath)
+    if status != "??":
+        return f"skip tracked-status {status} {rel}"
+
+    source = repo_root / rel
+    if not source.exists():
+        return f"skip missing {rel}"
+
+    resolved_repo = repo_root.resolve()
+    resolved_preserve = preserve_root.resolve()
+    if resolved_repo == resolved_preserve:
+        return f"skip same-root {rel}"
+
+    dest = preserve_root / rel
+    final_dest = dest
+    if dest.exists():
+        if _same_file_content(source, dest):
+            if not dry_run:
+                source.unlink()
+            return f"dedupe {rel}"
+        final_dest = _conflict_dest(dest)
+
+    if dry_run:
+        return f"dry-run move {rel} -> {final_dest}"
+
+    final_dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(source), str(final_dest))
+    return f"moved {rel} -> {final_dest}"
+
+
+def _records(lines: Iterable[str]) -> Iterable[tuple[str, str]]:
+    for line in lines:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        if "\t" not in line:
+            yield line[:2], line[3:]
+            continue
+        status, relpath = line.split("\t", 1)
+        yield status, relpath
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--preserve-root", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    configured_root = args.preserve_root or _preserve_root_from_env()
+    if configured_root is None:
+        print(
+            "ship-private-preserve: skip; SHIP_PRIVATE_PRESERVE_ROOT is not set",
+            file=sys.stderr,
+        )
+        return 0
+
+    preserve_root = configured_root.resolve()
+    if not preserve_root.exists():
+        print(f"ship-private-preserve: skip missing preserve root {preserve_root}", file=sys.stderr)
+        return 0
+
+    for status, relpath in _records(sys.stdin):
+        try:
+            message = preserve_one(
+                repo_root=repo_root,
+                preserve_root=preserve_root,
+                status=status,
+                relpath=relpath,
+                dry_run=args.dry_run,
+            )
+        except (OSError, ValueError) as exc:
+            print(f"ship-private-preserve: failed {relpath}: {exc}", file=sys.stderr)
+            continue
+        print(f"ship-private-preserve: {message}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -207,16 +207,37 @@ stage_1_commit() {
   # When adding new private paths, update HERE; load-bearing entries do
   # not belong in this exclusion.
   local files=()
+  local private_records=()
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
+    local status="${line:0:2}"
     local path="${line:3}"
     case "$path" in
-      data/files/*|data/data_list.csv|data/data_list.xlsx) continue ;;
-      eval/*.local.yaml) continue ;;
-      reports/real*/*) continue ;;
+      data/files/*|data/data_list.csv|data/data_list.xlsx)
+        private_records+=("${status}"$'\t'"${path}")
+        continue
+        ;;
+      eval/*.local.yaml)
+        private_records+=("${status}"$'\t'"${path}")
+        continue
+        ;;
+      reports/real*/*)
+        private_records+=("${status}"$'\t'"${path}")
+        continue
+        ;;
     esac
     files+=("$path")
   done <<< "$porcelain"
+
+  if [[ ${#private_records[@]} -gt 0 ]]; then
+    local preserve_args=("--repo-root" ".")
+    if [[ "$DRY_RUN" == "1" ]]; then
+      preserve_args+=("--dry-run")
+    fi
+    printf '%s\n' "${private_records[@]}" | \
+      python3 scripts/claude-hooks/_ship_private_preserve.py "${preserve_args[@]}" || \
+      log "s1" "private-path preserve helper failed; continuing without staging private paths"
+  fi
 
   if [[ ${#files[@]} -eq 0 ]]; then
     abort_disarm "s1" "no eligible files to stage (all matched private paths)"

--- a/tests/test_ship_private_preserve.py
+++ b/tests/test_ship_private_preserve.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER = REPO_ROOT / "scripts" / "claude-hooks" / "_ship_private_preserve.py"
+SPEC = importlib.util.spec_from_file_location("_ship_private_preserve", HELPER)
+assert SPEC is not None and SPEC.loader is not None
+preserve = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(preserve)
+
+
+def test_preserve_moves_untracked_private_report_to_canonical_checkout(tmp_path: Path) -> None:
+    repo = tmp_path / "worktree"
+    canonical = tmp_path / "main-checkout"
+    source = repo / "reports" / "real100" / "strategy.aggregate.json"
+    source.parent.mkdir(parents=True)
+    source.write_text('{"ok": true}\n', encoding="utf-8")
+    canonical.mkdir()
+
+    message = preserve.preserve_one(
+        repo_root=repo,
+        preserve_root=canonical,
+        status="??",
+        relpath="reports/real100/strategy.aggregate.json",
+    )
+
+    assert message.startswith("moved reports/real100/strategy.aggregate.json")
+    assert not source.exists()
+    assert (canonical / "reports" / "real100" / "strategy.aggregate.json").read_text(
+        encoding="utf-8"
+    ) == '{"ok": true}\n'
+
+
+def test_preserve_dedupes_identical_existing_file(tmp_path: Path) -> None:
+    repo = tmp_path / "worktree"
+    canonical = tmp_path / "main-checkout"
+    source = repo / "reports" / "real100" / "same.aggregate.json"
+    dest = canonical / "reports" / "real100" / "same.aggregate.json"
+    source.parent.mkdir(parents=True)
+    dest.parent.mkdir(parents=True)
+    source.write_text('{"same": true}\n', encoding="utf-8")
+    dest.write_text('{"same": true}\n', encoding="utf-8")
+
+    message = preserve.preserve_one(
+        repo_root=repo,
+        preserve_root=canonical,
+        status="??",
+        relpath="reports/real100/same.aggregate.json",
+    )
+
+    assert message == "dedupe reports/real100/same.aggregate.json"
+    assert not source.exists()
+    assert dest.read_text(encoding="utf-8") == '{"same": true}\n'
+
+
+def test_preserve_uses_conflict_name_when_destination_differs(tmp_path: Path) -> None:
+    repo = tmp_path / "worktree"
+    canonical = tmp_path / "main-checkout"
+    source = repo / "reports" / "real100" / "conflict.aggregate.json"
+    dest = canonical / "reports" / "real100" / "conflict.aggregate.json"
+    source.parent.mkdir(parents=True)
+    dest.parent.mkdir(parents=True)
+    source.write_text('{"new": true}\n', encoding="utf-8")
+    dest.write_text('{"old": true}\n', encoding="utf-8")
+
+    message = preserve.preserve_one(
+        repo_root=repo,
+        preserve_root=canonical,
+        status="??",
+        relpath="reports/real100/conflict.aggregate.json",
+    )
+
+    assert message.startswith("moved reports/real100/conflict.aggregate.json")
+    assert not source.exists()
+    assert dest.read_text(encoding="utf-8") == '{"old": true}\n'
+    conflicts = list(dest.parent.glob("conflict.aggregate.json.ship-preserved-*"))
+    assert len(conflicts) == 1
+    assert conflicts[0].read_text(encoding="utf-8") == '{"new": true}\n'
+
+
+def test_preserve_does_not_move_tracked_private_modification(tmp_path: Path) -> None:
+    repo = tmp_path / "worktree"
+    canonical = tmp_path / "main-checkout"
+    source = repo / "reports" / "real100" / "tracked.aggregate.json"
+    source.parent.mkdir(parents=True)
+    source.write_text('{"tracked": true}\n', encoding="utf-8")
+    canonical.mkdir()
+
+    message = preserve.preserve_one(
+        repo_root=repo,
+        preserve_root=canonical,
+        status=" M",
+        relpath="reports/real100/tracked.aggregate.json",
+    )
+
+    assert message == "skip tracked-status  M reports/real100/tracked.aggregate.json"
+    assert source.exists()
+    assert not (canonical / "reports" / "real100" / "tracked.aggregate.json").exists()
+
+
+def test_preserve_rejects_unsafe_relative_path(tmp_path: Path) -> None:
+    try:
+        preserve.preserve_one(
+            repo_root=tmp_path / "repo",
+            preserve_root=tmp_path / "main",
+            status="??",
+            relpath="../secret.txt",
+        )
+    except ValueError as exc:
+        assert "unsafe relative path" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected unsafe relative path to fail")
+
+
+def test_cli_without_preserve_root_skips_safely(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("SHIP_PRIVATE_PRESERVE_ROOT", raising=False)
+    monkeypatch.delenv("BIDMATE_PRIVATE_PRESERVE_ROOT", raising=False)
+    repo = tmp_path / "worktree"
+    source = repo / "reports" / "real100" / "skip.aggregate.json"
+    source.parent.mkdir(parents=True)
+    source.write_text('{"skip": true}\n', encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(HELPER),
+            "--repo-root",
+            str(repo),
+        ],
+        input="??\treports/real100/skip.aggregate.json\n",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "SHIP_PRIVATE_PRESERVE_ROOT is not set" in result.stderr
+    assert source.exists()


### PR DESCRIPTION
## 1. What changed and why

chore: Preserve private-path autoship artifacts (#1504)

Closes #1504

🤖 Auto-shipped by scripts/claude-hooks/stop-ship.sh

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #1504

## 2. Files affected

- `docs/operations/auto-ship.md`
- `scripts/claude-hooks/README.md`
- `scripts/claude-hooks/_ship_private_preserve.py`
- `scripts/claude-hooks/stop-ship.sh`
- `tests/test_ship_private_preserve.py`

## 3. Risks

Auto-generated PR; no load-bearing paths changed.

## 4. Tests

Local test run not captured by dispatcher.

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (no load-bearing path changed)

## 6. Backward compatibility

No public-API change detected.

## 7. Out of scope

N/A — single-concern auto-shipped PR.
