### PR TITLE
chore: Summarize private hybrid sweep decision (#1502)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,8 @@ reports/figures/*
 # just qid + category + metric values, ADR 0005 boundary preserved.
 !reports/retrieval/
 reports/retrieval/*
+!reports/retrieval/hybrid_sweep_summary.md
+!reports/retrieval/hybrid_sweep_summary.aggregate.json
 !reports/retrieval/phase2_chunking_*/
 reports/retrieval/phase2_chunking_*/*
 !reports/retrieval/phase2_chunking_*/REPORT.md

--- a/docs/retrieval/hybrid_sweep_decision.md
+++ b/docs/retrieval/hybrid_sweep_decision.md
@@ -1,0 +1,47 @@
+# Hybrid Sweep Decision
+
+이 문서는 private hybrid BM25+dense RRF sweep의 winner/no-winner 판정 규칙을
+고정한다. 산출물은 aggregate-only이며 raw query, answer, evidence, doc_id,
+chunk_id, filename, local path를 포함하지 않는다.
+
+## Decision Surface
+
+- Input: local `aggregate.json` from the private hybrid sweep harness.
+- Public-safe outputs:
+  - `reports/retrieval/hybrid_sweep_summary.md`
+  - `reports/retrieval/hybrid_sweep_summary.aggregate.json`
+- Timestamped sweep run directories remain gitignored.
+- Retrieval, verifier, prompt, chunking, reranker, answer generation, and runtime
+  defaults are unchanged.
+
+## Winner Rule
+
+A hybrid variant is `winner_found` only when it has a material Recall@5 or
+Recall@10 gain against `full_dense_top20` and does not regress on all guardrails:
+
+- MRR@5 and nDCG@5 must not regress.
+- Citation precision or citation accuracy must not regress. If those are absent,
+  the citation guardrail aggregate must not worsen.
+- Latency p50 and p95 must remain within the configured tolerance.
+
+Recall@10-only gains are insufficient. For this DocAgent system, the right
+evidence must appear early enough for answer generation and citation selection;
+a recall gain that pushes gold evidence lower in rank can still reduce MRR@5,
+nDCG@5, and citation quality. If citation or latency also worsens, the hybrid
+variant is not a product improvement even if Recall@10 moves upward.
+
+## #1448 Reference
+
+PR #1448 remains `NO-GO`: its single hybrid arm improved Recall@10 slightly but
+regressed MRR@5, nDCG@5, citation accuracy, and latency. The sweep can overturn
+that only if a new candidate is classified as `winner_found`.
+
+## Final Decision Mapping
+
+- `winner_found` -> `promote selected hybrid variant`
+- all candidates missing required comparable metrics -> `mark hybrid as failed experiment`
+- otherwise -> `keep dense baseline and abandon hybrid for now`
+
+The other possible next-step choices, `run reranker after hybrid` and
+`run metadata/page-aware recovery first`, require separate evidence surfaces and
+are not selected by this summarizer.

--- a/reports/retrieval/hybrid_sweep_summary.aggregate.json
+++ b/reports/retrieval/hybrid_sweep_summary.aggregate.json
@@ -1,0 +1,1073 @@
+{
+  "artifact_type": "private_hybrid_sweep_decision_summary",
+  "baseline": {
+    "metrics": {
+      "citation_metric": null,
+      "citation_value": null,
+      "latency_p50_ms": 1318.55,
+      "latency_p95_ms": 3162.16,
+      "mrr_at_5": 0.4101694915254237,
+      "ndcg_at_5": 0.2673650847088794,
+      "recall_at_10": 0.25359818758849834,
+      "recall_at_5": 0.19497305668075882,
+      "retrieval_miss_count": 0,
+      "retrieval_miss_denominator": 221,
+      "retrieval_miss_rate": 0.0
+    },
+    "name": "full_dense_top20"
+  },
+  "decision": {
+    "candidate_count": 27,
+    "failed_candidate_count": 0,
+    "final": "keep dense baseline and abandon hybrid for now",
+    "selected_variant": "hybrid_bm25_dense_v1_k20_dense100_bm2520",
+    "winner_found": false
+  },
+  "notes": [
+    "Recall@10-only gains are insufficient when ranking, citation, or latency guardrails regress.",
+    "#1448 remains NO-GO unless a sweep winner is found."
+  ],
+  "privacy_boundary": "aggregate_only_no_raw_content_or_identifiers",
+  "reference": {
+    "dense_baseline": "full_dense_top20",
+    "pr_1448": {
+      "decision": "NO-GO",
+      "rule": "NO-GO unless a sweep candidate is classified as winner_found"
+    }
+  },
+  "schema_version": 1,
+  "thresholds": {
+    "latency_regression_ms": 10.0,
+    "latency_regression_ratio": 0.05,
+    "material_recall_delta": 0.005,
+    "metric_regression_tolerance": 0.001
+  },
+  "variants": [
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 452.81999999999994,
+        "latency_p95_ms": -564.0099999999998,
+        "mrr_at_5": -0.09096045197740105,
+        "ndcg_at_5": -0.04835109956481079,
+        "recall_at_10": 0.0026513691204420597,
+        "recall_at_5": -0.004632588447644553,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1771.37,
+        "latency_p95_ms": 2598.15,
+        "mrr_at_5": 0.31920903954802266,
+        "ndcg_at_5": 0.21901398514406858,
+        "recall_at_10": 0.2562495567089404,
+        "recall_at_5": 0.19034046823311426,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense20_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 20,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 790.4600000000003,
+        "latency_p95_ms": 46.470000000000255,
+        "mrr_at_5": -0.10296610169491521,
+        "ndcg_at_5": -0.06065846584134027,
+        "recall_at_10": -0.0049734835941414035,
+        "recall_at_5": -0.01691017603545153,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 2109.01,
+        "latency_p95_ms": 3208.63,
+        "mrr_at_5": 0.3072033898305085,
+        "ndcg_at_5": 0.2067066188675391,
+        "recall_at_10": 0.24862470399435693,
+        "recall_at_5": 0.1780628806453073,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense20_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 20,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 592.1000000000001,
+        "latency_p95_ms": -384.5799999999999,
+        "mrr_at_5": -0.10663841807909608,
+        "ndcg_at_5": -0.06143251667725899,
+        "recall_at_10": -0.006666258803865788,
+        "recall_at_5": -0.0160627184083329,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1910.65,
+        "latency_p95_ms": 2777.58,
+        "mrr_at_5": 0.3035310734463276,
+        "ndcg_at_5": 0.20593256803162038,
+        "recall_at_10": 0.24693192878463255,
+        "recall_at_5": 0.17891033827242592,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense20_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 20,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 1039.8700000000001,
+        "latency_p95_ms": 378.3900000000003,
+        "mrr_at_5": -0.11200564971751414,
+        "ndcg_at_5": -0.059230047163491395,
+        "recall_at_10": 0.0049975623933118385,
+        "recall_at_5": -0.011217182055543229,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 2358.42,
+        "latency_p95_ms": 3540.55,
+        "mrr_at_5": 0.29816384180790956,
+        "ndcg_at_5": 0.20813503754538798,
+        "recall_at_10": 0.2585957499818102,
+        "recall_at_5": 0.1837558746252156,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense50_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 50,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 1029.3999999999999,
+        "latency_p95_ms": 235.6800000000003,
+        "mrr_at_5": -0.12062146892655373,
+        "ndcg_at_5": -0.0695200877886814,
+        "recall_at_10": -0.0074452678461285615,
+        "recall_at_5": -0.026587040919114513,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 2347.95,
+        "latency_p95_ms": 3397.84,
+        "mrr_at_5": 0.28954802259886997,
+        "ndcg_at_5": 0.19784499692019797,
+        "recall_at_10": 0.24615291974236977,
+        "recall_at_5": 0.1683860157616443,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense50_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 50,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 1156.82,
+        "latency_p95_ms": 434.02,
+        "mrr_at_5": -0.12203389830508476,
+        "ndcg_at_5": -0.06932087922545027,
+        "recall_at_10": -0.00829272547324722,
+        "recall_at_5": -0.025739583291995882,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 2475.37,
+        "latency_p95_ms": 3596.18,
+        "mrr_at_5": 0.28813559322033894,
+        "ndcg_at_5": 0.1980442054834291,
+        "recall_at_10": 0.24530546211525112,
+        "recall_at_5": 0.16923347338876293,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense50_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 50,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "recall_only_gain",
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 296.30999999999995,
+        "latency_p95_ms": -849.2599999999998,
+        "mrr_at_5": -0.10805084745762716,
+        "ndcg_at_5": -0.05571780589961861,
+        "recall_at_10": 0.005802093245200646,
+        "recall_at_5": -0.0044210121237800715,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1614.86,
+        "latency_p95_ms": 2312.9,
+        "mrr_at_5": 0.30211864406779654,
+        "ndcg_at_5": 0.21164727880926076,
+        "recall_at_10": 0.259400280833699,
+        "recall_at_5": 0.19055204455697874,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense100_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 100,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "recall_only_gain"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 204.58000000000015,
+        "latency_p95_ms": -1127.7099999999998,
+        "mrr_at_5": -0.11596045197740107,
+        "ndcg_at_5": -0.06501484007287064,
+        "recall_at_10": -0.006291783853661526,
+        "recall_at_5": -0.01681620911438439,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1523.13,
+        "latency_p95_ms": 2034.45,
+        "mrr_at_5": 0.29420903954802263,
+        "ndcg_at_5": 0.20235024463600873,
+        "recall_at_10": 0.2473064037348368,
+        "recall_at_5": 0.17815684756637443,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense100_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 100,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 219.16000000000008,
+        "latency_p95_ms": -1131.31,
+        "mrr_at_5": -0.11737288135593221,
+        "ndcg_at_5": -0.06468967157463645,
+        "recall_at_10": -0.006291783853661526,
+        "recall_at_5": -0.01596875148726576,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1537.71,
+        "latency_p95_ms": 2030.85,
+        "mrr_at_5": 0.2927966101694915,
+        "ndcg_at_5": 0.20267541313424292,
+        "recall_at_10": 0.2473064037348368,
+        "recall_at_5": 0.17900430519349306,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k20_dense100_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 100,
+        "rrf_k": 20,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 178.6500000000001,
+        "latency_p95_ms": -1174.8799999999999,
+        "mrr_at_5": -0.08672316384180784,
+        "ndcg_at_5": -0.04729030345854737,
+        "recall_at_10": 0.0026513691204420597,
+        "recall_at_5": -0.004632588447644553,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1497.2,
+        "latency_p95_ms": 1987.28,
+        "mrr_at_5": 0.32344632768361586,
+        "ndcg_at_5": 0.220074781250332,
+        "recall_at_10": 0.2562495567089404,
+        "recall_at_5": 0.19034046823311426,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense20_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 20,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 196.44000000000005,
+        "latency_p95_ms": -1113.4299999999998,
+        "mrr_at_5": -0.10706214689265536,
+        "ndcg_at_5": -0.06422352477769383,
+        "recall_at_10": -0.0049734835941414035,
+        "recall_at_5": -0.020706079990253812,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1514.99,
+        "latency_p95_ms": 2048.73,
+        "mrr_at_5": 0.30310734463276834,
+        "ndcg_at_5": 0.20314155993118554,
+        "recall_at_10": 0.24862470399435693,
+        "recall_at_5": 0.174266976690505,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense20_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 20,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 182.86000000000013,
+        "latency_p95_ms": -1166.57,
+        "mrr_at_5": -0.1327683615819209,
+        "ndcg_at_5": -0.0763526732304968,
+        "recall_at_10": -0.009576167071893266,
+        "recall_at_5": -0.024416964209612563,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1501.41,
+        "latency_p95_ms": 1995.59,
+        "mrr_at_5": 0.2774011299435028,
+        "ndcg_at_5": 0.19101241147838258,
+        "recall_at_10": 0.24402202051660507,
+        "recall_at_5": 0.17055609247114625,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense20_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 20,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 236.80999999999995,
+        "latency_p95_ms": -1145.0099999999998,
+        "mrr_at_5": -0.1125706214689266,
+        "ndcg_at_5": -0.061644734876405094,
+        "recall_at_10": 0.0007602742577186294,
+        "recall_at_5": -0.016866899569667526,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1555.36,
+        "latency_p95_ms": 2017.15,
+        "mrr_at_5": 0.2975988700564971,
+        "ndcg_at_5": 0.20572034983247428,
+        "recall_at_10": 0.25435846184621697,
+        "recall_at_5": 0.1781061571110913,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense50_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 50,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "citation_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.008474576271186474,
+        "latency_p50_ms": 243.41000000000008,
+        "latency_p95_ms": -1091.52,
+        "mrr_at_5": -0.13446327683615816,
+        "ndcg_at_5": -0.08004245564939183,
+        "recall_at_10": -0.01686805433459304,
+        "recall_at_5": -0.03407218657669939,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1561.96,
+        "latency_p95_ms": 2070.64,
+        "mrr_at_5": 0.27570621468926554,
+        "ndcg_at_5": 0.18732262905948754,
+        "recall_at_10": 0.2367301332539053,
+        "recall_at_5": 0.16090087010405943,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense50_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 50,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "citation_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.050847457627118675,
+        "latency_p50_ms": 238.87000000000012,
+        "latency_p95_ms": -1104.5899999999997,
+        "mrr_at_5": -0.16186440677966102,
+        "ndcg_at_5": -0.09952032623016721,
+        "recall_at_10": -0.027091732719925432,
+        "recall_at_5": -0.05255437076944419,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1557.42,
+        "latency_p95_ms": 2057.57,
+        "mrr_at_5": 0.24830508474576268,
+        "ndcg_at_5": 0.16784475847871216,
+        "recall_at_10": 0.2265064548685729,
+        "recall_at_5": 0.14241868591131462,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense50_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 50,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 209.01,
+        "latency_p95_ms": -1129.29,
+        "mrr_at_5": -0.12033898305084745,
+        "ndcg_at_5": -0.06385362868118852,
+        "recall_at_10": 0.0013353347904062618,
+        "recall_at_5": -0.01333124031366928,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1527.56,
+        "latency_p95_ms": 2032.87,
+        "mrr_at_5": 0.28983050847457625,
+        "ndcg_at_5": 0.20351145602769086,
+        "recall_at_10": 0.2549335223789046,
+        "recall_at_5": 0.18164181636708954,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense100_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 100,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 251.5,
+        "latency_p95_ms": -1137.8999999999999,
+        "mrr_at_5": -0.1316384180790961,
+        "ndcg_at_5": -0.07498443278952793,
+        "recall_at_10": -0.003570827938619403,
+        "recall_at_5": -0.020055513694315907,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1570.05,
+        "latency_p95_ms": 2024.26,
+        "mrr_at_5": 0.2785310734463276,
+        "ndcg_at_5": 0.19238065191935144,
+        "recall_at_10": 0.25002735964987893,
+        "recall_at_5": 0.1749175429864429,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense100_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 100,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "citation_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.01694915254237289,
+        "latency_p50_ms": 236.23000000000002,
+        "latency_p95_ms": -1074.81,
+        "mrr_at_5": -0.15000000000000002,
+        "ndcg_at_5": -0.0906019009894326,
+        "recall_at_10": -0.015757154331158457,
+        "recall_at_5": -0.03695659754455238,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1554.78,
+        "latency_p95_ms": 2087.35,
+        "mrr_at_5": 0.2601694915254237,
+        "ndcg_at_5": 0.17676318371944677,
+        "recall_at_10": 0.23784103325733988,
+        "recall_at_5": 0.15801645913620643,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k60_dense100_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 100,
+        "rrf_k": 60,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 205.23000000000002,
+        "latency_p95_ms": -1111.3799999999997,
+        "mrr_at_5": -0.08813559322033898,
+        "ndcg_at_5": -0.04766662686615514,
+        "recall_at_10": 0.0026513691204420597,
+        "recall_at_5": -0.004632588447644553,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1523.78,
+        "latency_p95_ms": 2050.78,
+        "mrr_at_5": 0.3220338983050847,
+        "ndcg_at_5": 0.21969845784272424,
+        "recall_at_10": 0.2562495567089404,
+        "recall_at_5": 0.19034046823311426,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense20_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 20,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "latency_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": 183.98000000000002,
+        "latency_p95_ms": -1161.3899999999999,
+        "mrr_at_5": -0.10847457627118645,
+        "ndcg_at_5": -0.06459984818530165,
+        "recall_at_10": -0.0049734835941414035,
+        "recall_at_5": -0.020706079990253812,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1502.53,
+        "latency_p95_ms": 2000.77,
+        "mrr_at_5": 0.30169491525423725,
+        "ndcg_at_5": 0.20276523652357772,
+        "recall_at_10": 0.24862470399435693,
+        "recall_at_5": 0.174266976690505,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense20_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 20,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": -88.6099999999999,
+        "latency_p95_ms": -1493.5199999999998,
+        "mrr_at_5": -0.13418079096045205,
+        "ndcg_at_5": -0.07652974449578168,
+        "recall_at_10": -0.009576167071893266,
+        "recall_at_5": -0.024416964209612563,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1229.94,
+        "latency_p95_ms": 1668.64,
+        "mrr_at_5": 0.27598870056497166,
+        "ndcg_at_5": 0.1908353402130977,
+        "recall_at_10": 0.24402202051660507,
+        "recall_at_5": 0.17055609247114625,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense20_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 20,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": -71.52999999999997,
+        "latency_p95_ms": -1506.1999999999998,
+        "mrr_at_5": -0.1146892655367232,
+        "ndcg_at_5": -0.06222031042633577,
+        "recall_at_10": 0.0007602742577186294,
+        "recall_at_5": -0.016866899569667526,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1247.02,
+        "latency_p95_ms": 1655.96,
+        "mrr_at_5": 0.2954802259887005,
+        "ndcg_at_5": 0.2051447742825436,
+        "recall_at_10": 0.25435846184621697,
+        "recall_at_5": 0.1781061571110913,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense50_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 50,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "citation_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.008474576271186474,
+        "latency_p50_ms": -50.180000000000064,
+        "latency_p95_ms": -1457.7499999999998,
+        "mrr_at_5": -0.13658192090395477,
+        "ndcg_at_5": -0.08024170779171469,
+        "recall_at_10": -0.01686805433459304,
+        "recall_at_5": -0.03407218657669939,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1268.37,
+        "latency_p95_ms": 1704.41,
+        "mrr_at_5": 0.27358757062146893,
+        "ndcg_at_5": 0.18712337691716469,
+        "recall_at_10": 0.2367301332539053,
+        "recall_at_5": 0.16090087010405943,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense50_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 50,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "citation_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.05932203389830509,
+        "latency_p50_ms": -28.50999999999999,
+        "latency_p95_ms": -1487.8,
+        "mrr_at_5": -0.164406779661017,
+        "ndcg_at_5": -0.0996462861651703,
+        "recall_at_10": -0.029563484132354823,
+        "recall_at_5": -0.05255437076944419,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1290.04,
+        "latency_p95_ms": 1674.36,
+        "mrr_at_5": 0.2457627118644067,
+        "ndcg_at_5": 0.16771879854370908,
+        "recall_at_10": 0.2240347034561435,
+        "recall_at_5": 0.14241868591131462,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense50_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 50,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": -60.86999999999989,
+        "latency_p95_ms": -1486.11,
+        "mrr_at_5": -0.12429378531073448,
+        "ndcg_at_5": -0.06696066010324062,
+        "recall_at_10": 0.0013353347904062618,
+        "recall_at_5": -0.017568528449262544,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1257.68,
+        "latency_p95_ms": 1676.05,
+        "mrr_at_5": 0.2858757062146892,
+        "ndcg_at_5": 0.20040442460563876,
+        "recall_at_10": 0.2549335223789046,
+        "recall_at_5": 0.17740452823149627,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense100_bm2520",
+      "parameters": {
+        "bm25_pool": 20,
+        "dense_pool": 100,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.0,
+        "latency_p50_ms": -44.57999999999993,
+        "latency_p95_ms": -1479.36,
+        "mrr_at_5": -0.13615819209039548,
+        "ndcg_at_5": -0.07865073357846714,
+        "recall_at_10": -0.005393484967532669,
+        "recall_at_5": -0.02641144589770575,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1273.97,
+        "latency_p95_ms": 1682.8,
+        "mrr_at_5": 0.2740112994350282,
+        "ndcg_at_5": 0.18871435113041224,
+        "recall_at_10": 0.24820470262096567,
+        "recall_at_5": 0.16856161078305307,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense100_bm2550",
+      "parameters": {
+        "bm25_pool": 50,
+        "dense_pool": 100,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    },
+    {
+      "classifications": [
+        "ranking_regression",
+        "citation_regression"
+      ],
+      "deltas_vs_dense": {
+        "citation": 0.03389830508474578,
+        "latency_p50_ms": -77.88999999999987,
+        "latency_p95_ms": -1521.4899999999998,
+        "mrr_at_5": -0.16045197740112996,
+        "ndcg_at_5": -0.09654468437914557,
+        "recall_at_10": -0.01985093359941431,
+        "recall_at_5": -0.044356319200698324,
+        "retrieval_miss": 0
+      },
+      "metrics": {
+        "citation_metric": "citation_chunk_guardrail",
+        "citation_value": null,
+        "latency_p50_ms": 1240.66,
+        "latency_p95_ms": 1640.67,
+        "mrr_at_5": 0.24971751412429374,
+        "ndcg_at_5": 0.1708204003297338,
+        "recall_at_10": 0.23374725398908403,
+        "recall_at_5": 0.1506167374800605,
+        "retrieval_miss_count": 0,
+        "retrieval_miss_denominator": 221,
+        "retrieval_miss_rate": 0.0
+      },
+      "missing_metrics": [],
+      "name": "hybrid_bm25_dense_v1_k100_dense100_bm25100",
+      "parameters": {
+        "bm25_pool": 100,
+        "dense_pool": 100,
+        "rrf_k": 100,
+        "top_k": 20
+      },
+      "primary_classification": "ranking_regression"
+    }
+  ]
+}

--- a/reports/retrieval/hybrid_sweep_summary.md
+++ b/reports/retrieval/hybrid_sweep_summary.md
@@ -1,0 +1,55 @@
+# Hybrid Sweep Decision
+
+This report is aggregate-only. It contains no raw questions, answers, evidence text, document identifiers, chunk identifiers, filenames, or local paths.
+
+## Decision
+
+- Final decision: `keep dense baseline and abandon hybrid for now`
+- Selected variant: `hybrid_bm25_dense_v1_k20_dense100_bm2520`
+- #1448 reference: `NO-GO unless a sweep candidate is classified as winner_found`
+
+Recall@10-only gains are insufficient when MRR@5, nDCG@5, citation, or latency regresses because the system must retrieve the right evidence early, cite it correctly, and stay within the existing latency envelope.
+
+## Dense Baseline
+
+| Variant | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation | p50 ms | p95 ms | retrieval_miss |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| full_dense_top20 | 0.195 | 0.254 | 0.410 | 0.267 | - | 1318.5 | 3162.2 | 0 |
+
+## Hybrid Variants
+
+| Variant | k | Dense pool | BM25 pool | dR@5 | dR@10 | dMRR@5 | dnDCG@5 | dCitation | dP50 ms | dP95 ms | dMiss | Classification |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| hybrid_bm25_dense_v1_k20_dense20_bm2520 | 20 | 20 | 20 | -0.005 | +0.003 | -0.091 | -0.048 | 0.000 | +452.8 | -564.0 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k20_dense20_bm2550 | 20 | 20 | 50 | -0.017 | -0.005 | -0.103 | -0.061 | 0.000 | +790.5 | +46.5 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k20_dense20_bm25100 | 20 | 20 | 100 | -0.016 | -0.007 | -0.107 | -0.061 | 0.000 | +592.1 | -384.6 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k20_dense50_bm2520 | 20 | 50 | 20 | -0.011 | +0.005 | -0.112 | -0.059 | 0.000 | +1039.9 | +378.4 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k20_dense50_bm2550 | 20 | 50 | 50 | -0.027 | -0.007 | -0.121 | -0.070 | 0.000 | +1029.4 | +235.7 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k20_dense50_bm25100 | 20 | 50 | 100 | -0.026 | -0.008 | -0.122 | -0.069 | 0.000 | +1156.8 | +434.0 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k20_dense100_bm2520 | 20 | 100 | 20 | -0.004 | +0.006 | -0.108 | -0.056 | 0.000 | +296.3 | -849.3 | 0 | recall_only_gain, ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k20_dense100_bm2550 | 20 | 100 | 50 | -0.017 | -0.006 | -0.116 | -0.065 | 0.000 | +204.6 | -1127.7 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k20_dense100_bm25100 | 20 | 100 | 100 | -0.016 | -0.006 | -0.117 | -0.065 | 0.000 | +219.2 | -1131.3 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense20_bm2520 | 60 | 20 | 20 | -0.005 | +0.003 | -0.087 | -0.047 | 0.000 | +178.7 | -1174.9 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense20_bm2550 | 60 | 20 | 50 | -0.021 | -0.005 | -0.107 | -0.064 | 0.000 | +196.4 | -1113.4 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense20_bm25100 | 60 | 20 | 100 | -0.024 | -0.010 | -0.133 | -0.076 | 0.000 | +182.9 | -1166.6 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense50_bm2520 | 60 | 50 | 20 | -0.017 | +0.001 | -0.113 | -0.062 | 0.000 | +236.8 | -1145.0 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense50_bm2550 | 60 | 50 | 50 | -0.034 | -0.017 | -0.134 | -0.080 | +0.008 | +243.4 | -1091.5 | 0 | ranking_regression, citation_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense50_bm25100 | 60 | 50 | 100 | -0.053 | -0.027 | -0.162 | -0.100 | +0.051 | +238.9 | -1104.6 | 0 | ranking_regression, citation_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense100_bm2520 | 60 | 100 | 20 | -0.013 | +0.001 | -0.120 | -0.064 | 0.000 | +209.0 | -1129.3 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense100_bm2550 | 60 | 100 | 50 | -0.020 | -0.004 | -0.132 | -0.075 | 0.000 | +251.5 | -1137.9 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k60_dense100_bm25100 | 60 | 100 | 100 | -0.037 | -0.016 | -0.150 | -0.091 | +0.017 | +236.2 | -1074.8 | 0 | ranking_regression, citation_regression, latency_regression |
+| hybrid_bm25_dense_v1_k100_dense20_bm2520 | 100 | 20 | 20 | -0.005 | +0.003 | -0.088 | -0.048 | 0.000 | +205.2 | -1111.4 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k100_dense20_bm2550 | 100 | 20 | 50 | -0.021 | -0.005 | -0.108 | -0.065 | 0.000 | +184.0 | -1161.4 | 0 | ranking_regression, latency_regression |
+| hybrid_bm25_dense_v1_k100_dense20_bm25100 | 100 | 20 | 100 | -0.024 | -0.010 | -0.134 | -0.077 | 0.000 | -88.6 | -1493.5 | 0 | ranking_regression |
+| hybrid_bm25_dense_v1_k100_dense50_bm2520 | 100 | 50 | 20 | -0.017 | +0.001 | -0.115 | -0.062 | 0.000 | -71.5 | -1506.2 | 0 | ranking_regression |
+| hybrid_bm25_dense_v1_k100_dense50_bm2550 | 100 | 50 | 50 | -0.034 | -0.017 | -0.137 | -0.080 | +0.008 | -50.2 | -1457.7 | 0 | ranking_regression, citation_regression |
+| hybrid_bm25_dense_v1_k100_dense50_bm25100 | 100 | 50 | 100 | -0.053 | -0.030 | -0.164 | -0.100 | +0.059 | -28.5 | -1487.8 | 0 | ranking_regression, citation_regression |
+| hybrid_bm25_dense_v1_k100_dense100_bm2520 | 100 | 100 | 20 | -0.018 | +0.001 | -0.124 | -0.067 | 0.000 | -60.9 | -1486.1 | 0 | ranking_regression |
+| hybrid_bm25_dense_v1_k100_dense100_bm2550 | 100 | 100 | 50 | -0.026 | -0.005 | -0.136 | -0.079 | 0.000 | -44.6 | -1479.4 | 0 | ranking_regression |
+| hybrid_bm25_dense_v1_k100_dense100_bm25100 | 100 | 100 | 100 | -0.044 | -0.020 | -0.160 | -0.097 | +0.034 | -77.9 | -1521.5 | 0 | ranking_regression, citation_regression |
+
+## Notes
+
+- `winner_found` requires a material Recall@5 or Recall@10 gain and no MRR@5, nDCG@5, citation, or latency regression.
+- Missing required metrics are classified as `failed_experiment`; missing `retrieval_miss` is displayed as `-`, not zero.
+- Timestamped sweep outputs remain local and gitignored.

--- a/scripts/summarize_private_hybrid_sweep.py
+++ b/scripts/summarize_private_hybrid_sweep.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""Summarize private hybrid sweep aggregates into a public-safe decision.
+
+Reads ``reports/retrieval/hybrid_sweep_*/aggregate.json`` and writes a stable
+aggregate-only markdown + JSON pair. This is a read-only measurement consumer:
+it does not import retrieval runtime code or change retrieval/verifier behavior.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.run_private_hybrid_sweep import (  # noqa: E402
+    ABSOLUTE_LOCAL_PATH_RE,
+    FORBIDDEN_KEYS,
+    FORBIDDEN_PATH_FRAGMENTS,
+    assert_rendered_output_privacy_safe,
+    render_output_path,
+)
+
+DEFAULT_OUT_MD = ROOT / "reports" / "retrieval" / "hybrid_sweep_summary.md"
+DEFAULT_OUT_JSON = ROOT / "reports" / "retrieval" / "hybrid_sweep_summary.aggregate.json"
+
+MATERIAL_RECALL_DELTA = 0.005
+METRIC_REGRESSION_TOLERANCE = 0.001
+LATENCY_REGRESSION_RATIO = 0.05
+LATENCY_REGRESSION_MS = 10.0
+
+FINAL_DECISIONS = {
+    "promote selected hybrid variant",
+    "run reranker after hybrid",
+    "keep dense baseline and abandon hybrid for now",
+    "run metadata/page-aware recovery first",
+    "mark hybrid as failed experiment",
+}
+
+_PATH_LIKE_RE = re.compile(r"(^|[\s:=`'\"])(?:\.{0,2}/|[A-Za-z]:[\\/]|[^ \t\n]+[\\/][^ \t\n]+)")
+
+
+@dataclass(frozen=True)
+class NormalizedMetrics:
+    recall_at_5: float | None
+    recall_at_10: float | None
+    mrr_at_5: float | None
+    ndcg_at_5: float | None
+    citation_value: float | None
+    citation_metric: str | None
+    citation_guardrail_rates: dict[str, float]
+    latency_p50_ms: float | None
+    latency_p95_ms: float | None
+    retrieval_miss_count: int | None
+    retrieval_miss_rate: float | None
+    retrieval_miss_denominator: int | None
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--aggregate",
+        default=None,
+        help="Input aggregate.json. Defaults to newest reports/retrieval/hybrid_sweep_*/aggregate.json.",
+    )
+    parser.add_argument("--out-md", default=str(DEFAULT_OUT_MD))
+    parser.add_argument("--out-json", default=str(DEFAULT_OUT_JSON))
+    return parser.parse_args(argv)
+
+
+def newest_aggregate() -> Path:
+    candidates = sorted(
+        (ROOT / "reports" / "retrieval").glob("hybrid_sweep_*/aggregate.json"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        raise FileNotFoundError(
+            "No hybrid sweep aggregate found under reports/retrieval/hybrid_sweep_*/aggregate.json"
+        )
+    return candidates[0]
+
+
+def load_aggregate(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("hybrid sweep aggregate root must be an object")
+    return payload
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _metric(metrics: dict[str, Any], *aliases: str) -> float | None:
+    for key in aliases:
+        if key not in metrics:
+            continue
+        value = metrics.get(key)
+        direct = _number(value)
+        if direct is not None:
+            return direct
+        if isinstance(value, dict):
+            for nested_key in ("mean", "rate", "value"):
+                nested = _number(value.get(nested_key))
+                if nested is not None:
+                    return nested
+    return None
+
+
+def _latency(metrics: dict[str, Any]) -> tuple[float | None, float | None]:
+    block = metrics.get("latency_ms")
+    if not isinstance(block, dict):
+        block = metrics.get("latency")
+    if not isinstance(block, dict):
+        return (None, None)
+    p50 = _number(block.get("p50"))
+    if p50 is None:
+        p50 = _number(block.get("p50_ms"))
+    p95 = _number(block.get("p95"))
+    if p95 is None:
+        p95 = _number(block.get("p95_ms"))
+    return (p50, p95)
+
+
+def _citation_guardrail_rates(metrics: dict[str, Any]) -> dict[str, float]:
+    block = metrics.get("citation_chunk_guardrail")
+    if not isinstance(block, dict):
+        return {}
+    out: dict[str, float] = {}
+    for key in sorted(block):
+        value = block.get(key)
+        rate = None
+        if isinstance(value, dict):
+            rate = _number(value.get("rate"))
+        else:
+            rate = _number(value)
+        if rate is not None:
+            out[str(key)] = rate
+    return out
+
+
+def _retrieval_miss(metrics: dict[str, Any]) -> tuple[int | None, float | None, int | None]:
+    if "retrieval_miss" not in metrics:
+        return (None, None, None)
+    value = metrics.get("retrieval_miss")
+    if isinstance(value, dict):
+        count_raw = value.get("count")
+        denom_raw = value.get("denominator")
+        count = int(count_raw) if isinstance(count_raw, int) and not isinstance(count_raw, bool) else None
+        denominator = (
+            int(denom_raw)
+            if isinstance(denom_raw, int) and not isinstance(denom_raw, bool)
+            else None
+        )
+        return (count, _number(value.get("rate")), denominator)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return (int(value), None, None)
+    return (None, None, None)
+
+
+def normalize_metrics(variant: dict[str, Any]) -> NormalizedMetrics:
+    metrics = variant.get("metrics")
+    if not isinstance(metrics, dict):
+        metrics = {}
+    citation_metric = None
+    citation_value = _metric(metrics, "citation_precision")
+    if citation_value is not None:
+        citation_metric = "citation_precision"
+    else:
+        citation_value = _metric(metrics, "citation_accuracy")
+        if citation_value is not None:
+            citation_metric = "citation_accuracy"
+    p50, p95 = _latency(metrics)
+    miss_count, miss_rate, miss_denominator = _retrieval_miss(metrics)
+    return NormalizedMetrics(
+        recall_at_5=_metric(metrics, "recall_at_5", "chunk_recall_at_5", "Recall@5", "chunk_recall@5"),
+        recall_at_10=_metric(metrics, "recall_at_10", "chunk_recall_at_10", "Recall@10", "chunk_recall@10"),
+        mrr_at_5=_metric(metrics, "mrr_at_5", "chunk_mrr_at_5", "MRR@5"),
+        ndcg_at_5=_metric(metrics, "ndcg_at_5", "chunk_ndcg_at_5", "nDCG@5", "ndcg@5"),
+        citation_value=citation_value,
+        citation_metric=citation_metric,
+        citation_guardrail_rates=_citation_guardrail_rates(metrics),
+        latency_p50_ms=p50,
+        latency_p95_ms=p95,
+        retrieval_miss_count=miss_count,
+        retrieval_miss_rate=miss_rate,
+        retrieval_miss_denominator=miss_denominator,
+    )
+
+
+def _params(variant: dict[str, Any]) -> dict[str, Any]:
+    params = variant.get("parameters")
+    return params if isinstance(params, dict) else {}
+
+
+def _is_hybrid(variant: dict[str, Any]) -> bool:
+    name = str(variant.get("name") or "")
+    params = _params(variant)
+    return name.startswith("hybrid_") or params.get("retrieval_backend") == "hybrid"
+
+
+def _variant_sort_key(row: dict[str, Any]) -> tuple[int, int, int, str]:
+    params = _params(row.get("variant") or {})
+    return (
+        int(params.get("rrf_k") or 0),
+        int(params.get("dense_pool") or 0),
+        int(params.get("bm25_pool") or 0),
+        str(row.get("name") or ""),
+    )
+
+
+def _delta(candidate: float | None, baseline: float | None) -> float | None:
+    if candidate is None or baseline is None:
+        return None
+    return candidate - baseline
+
+
+def _latency_regressed(candidate: float | None, baseline: float | None) -> bool:
+    if candidate is None or baseline is None:
+        return False
+    tolerance = max(LATENCY_REGRESSION_MS, abs(baseline) * LATENCY_REGRESSION_RATIO)
+    return candidate > baseline + tolerance
+
+
+def _citation_comparison(candidate: NormalizedMetrics, baseline: NormalizedMetrics) -> tuple[str | None, float | None, bool]:
+    if (
+        candidate.citation_value is not None
+        and baseline.citation_value is not None
+        and candidate.citation_metric == baseline.citation_metric
+    ):
+        delta = candidate.citation_value - baseline.citation_value
+        return (candidate.citation_metric, delta, delta < -METRIC_REGRESSION_TOLERANCE)
+
+    shared = sorted(set(candidate.citation_guardrail_rates) & set(baseline.citation_guardrail_rates))
+    if shared:
+        max_delta = max(
+            candidate.citation_guardrail_rates[key] - baseline.citation_guardrail_rates[key]
+            for key in shared
+        )
+        return ("citation_chunk_guardrail", max_delta, max_delta > METRIC_REGRESSION_TOLERANCE)
+
+    return (None, None, False)
+
+
+def _retrieval_miss_delta(candidate: NormalizedMetrics, baseline: NormalizedMetrics) -> int | float | None:
+    if candidate.retrieval_miss_count is None or baseline.retrieval_miss_count is None:
+        return None
+    if (
+        candidate.retrieval_miss_denominator is not None
+        and baseline.retrieval_miss_denominator is not None
+        and candidate.retrieval_miss_denominator == baseline.retrieval_miss_denominator
+    ):
+        return candidate.retrieval_miss_count - baseline.retrieval_miss_count
+    if candidate.retrieval_miss_rate is not None and baseline.retrieval_miss_rate is not None:
+        return candidate.retrieval_miss_rate - baseline.retrieval_miss_rate
+    return None
+
+
+def classify_variant(variant: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    candidate_metrics = normalize_metrics(variant)
+    baseline_metrics = normalize_metrics(baseline)
+
+    required: list[tuple[str, Any]] = [
+        ("recall_at_5", candidate_metrics.recall_at_5),
+        ("recall_at_10", candidate_metrics.recall_at_10),
+        ("mrr_at_5", candidate_metrics.mrr_at_5),
+        ("ndcg_at_5", candidate_metrics.ndcg_at_5),
+        ("latency_p50_ms", candidate_metrics.latency_p50_ms),
+        ("latency_p95_ms", candidate_metrics.latency_p95_ms),
+        ("baseline_recall_at_5", baseline_metrics.recall_at_5),
+        ("baseline_recall_at_10", baseline_metrics.recall_at_10),
+        ("baseline_mrr_at_5", baseline_metrics.mrr_at_5),
+        ("baseline_ndcg_at_5", baseline_metrics.ndcg_at_5),
+        ("baseline_latency_p50_ms", baseline_metrics.latency_p50_ms),
+        ("baseline_latency_p95_ms", baseline_metrics.latency_p95_ms),
+    ]
+    missing = [key for key, value in required if value is None]
+    citation_metric, citation_delta, citation_regression = _citation_comparison(
+        candidate_metrics, baseline_metrics
+    )
+    if citation_metric is None:
+        missing.append("citation")
+
+    recall5_delta = _delta(candidate_metrics.recall_at_5, baseline_metrics.recall_at_5)
+    recall10_delta = _delta(candidate_metrics.recall_at_10, baseline_metrics.recall_at_10)
+    mrr5_delta = _delta(candidate_metrics.mrr_at_5, baseline_metrics.mrr_at_5)
+    ndcg5_delta = _delta(candidate_metrics.ndcg_at_5, baseline_metrics.ndcg_at_5)
+    latency_p50_delta = _delta(candidate_metrics.latency_p50_ms, baseline_metrics.latency_p50_ms)
+    latency_p95_delta = _delta(candidate_metrics.latency_p95_ms, baseline_metrics.latency_p95_ms)
+
+    if missing:
+        classifications = ["failed_experiment"]
+        primary = "failed_experiment"
+    else:
+        recall_gain = max(recall5_delta or 0.0, recall10_delta or 0.0) >= MATERIAL_RECALL_DELTA
+        ranking_regression = (
+            (mrr5_delta or 0.0) < -METRIC_REGRESSION_TOLERANCE
+            or (ndcg5_delta or 0.0) < -METRIC_REGRESSION_TOLERANCE
+        )
+        latency_regression = _latency_regressed(
+            candidate_metrics.latency_p50_ms, baseline_metrics.latency_p50_ms
+        ) or _latency_regressed(candidate_metrics.latency_p95_ms, baseline_metrics.latency_p95_ms)
+
+        classifications = []
+        if ranking_regression:
+            classifications.append("ranking_regression")
+        if citation_regression:
+            classifications.append("citation_regression")
+        if latency_regression:
+            classifications.append("latency_regression")
+
+        if recall_gain and not classifications:
+            classifications.insert(0, "winner_found")
+            primary = "winner_found"
+        elif recall_gain:
+            classifications.insert(0, "recall_only_gain")
+            primary = "recall_only_gain"
+        elif classifications:
+            primary = classifications[0]
+        else:
+            classifications.append("no_material_change")
+            primary = "no_material_change"
+
+    params = _params(variant)
+    return {
+        "name": str(variant.get("name") or ""),
+        "variant": variant,
+        "parameters": {
+            "rrf_k": params.get("rrf_k"),
+            "dense_pool": params.get("dense_pool"),
+            "bm25_pool": params.get("bm25_pool"),
+            "top_k": params.get("top_k"),
+        },
+        "metrics": {
+            "recall_at_5": candidate_metrics.recall_at_5,
+            "recall_at_10": candidate_metrics.recall_at_10,
+            "mrr_at_5": candidate_metrics.mrr_at_5,
+            "ndcg_at_5": candidate_metrics.ndcg_at_5,
+            "citation_metric": citation_metric or candidate_metrics.citation_metric,
+            "citation_value": candidate_metrics.citation_value,
+            "latency_p50_ms": candidate_metrics.latency_p50_ms,
+            "latency_p95_ms": candidate_metrics.latency_p95_ms,
+            "retrieval_miss_count": candidate_metrics.retrieval_miss_count,
+            "retrieval_miss_rate": candidate_metrics.retrieval_miss_rate,
+            "retrieval_miss_denominator": candidate_metrics.retrieval_miss_denominator,
+        },
+        "deltas_vs_dense": {
+            "recall_at_5": recall5_delta,
+            "recall_at_10": recall10_delta,
+            "mrr_at_5": mrr5_delta,
+            "ndcg_at_5": ndcg5_delta,
+            "citation": citation_delta,
+            "latency_p50_ms": latency_p50_delta,
+            "latency_p95_ms": latency_p95_delta,
+            "retrieval_miss": _retrieval_miss_delta(candidate_metrics, baseline_metrics),
+        },
+        "primary_classification": primary,
+        "classifications": classifications,
+        "missing_metrics": missing,
+    }
+
+
+def _candidate_score(row: dict[str, Any]) -> tuple[float, float, float, float, float, str]:
+    deltas = row.get("deltas_vs_dense") or {}
+    metrics = row.get("metrics") or {}
+    recall_gain = max(float(deltas.get("recall_at_5") or 0.0), float(deltas.get("recall_at_10") or 0.0))
+    ranking_delta = min(float(deltas.get("mrr_at_5") or 0.0), float(deltas.get("ndcg_at_5") or 0.0))
+    citation_delta = float(deltas.get("citation") or 0.0)
+    if metrics.get("citation_metric") == "citation_chunk_guardrail":
+        citation_delta = -citation_delta
+    latency = float(metrics.get("latency_p95_ms") or 0.0)
+    return (
+        recall_gain,
+        ranking_delta,
+        citation_delta,
+        -latency,
+        float(metrics.get("recall_at_10") or 0.0),
+        str(row.get("name") or ""),
+    )
+
+
+def build_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    assert_summary_privacy_safe(payload)
+    variants = payload.get("variants")
+    if not isinstance(variants, list):
+        raise ValueError("aggregate payload must contain variants[]")
+    baseline_name = str((payload.get("sweep") or {}).get("baseline") or "full_dense_top20")
+    baseline = next(
+        (row for row in variants if isinstance(row, dict) and row.get("name") == baseline_name),
+        None,
+    )
+    if baseline is None:
+        baseline = next(
+            (
+                row
+                for row in variants
+                if isinstance(row, dict)
+                and str(row.get("name") or "").startswith("full_dense")
+            ),
+            None,
+        )
+    if baseline is None:
+        raise ValueError("dense baseline variant not found")
+
+    candidate_rows = [
+        classify_variant(row, baseline)
+        for row in variants
+        if isinstance(row, dict) and row is not baseline and _is_hybrid(row)
+    ]
+    candidate_rows.sort(key=_variant_sort_key)
+    winners = [row for row in candidate_rows if row["primary_classification"] == "winner_found"]
+    failed = [row for row in candidate_rows if row["primary_classification"] == "failed_experiment"]
+    if winners:
+        selected = max(winners, key=_candidate_score)
+        final_decision = "promote selected hybrid variant"
+    elif candidate_rows and len(failed) == len(candidate_rows):
+        selected = None
+        final_decision = "mark hybrid as failed experiment"
+    else:
+        selected = max(
+            [row for row in candidate_rows if row["primary_classification"] != "failed_experiment"],
+            key=_candidate_score,
+            default=None,
+        )
+        final_decision = "keep dense baseline and abandon hybrid for now"
+
+    assert final_decision in FINAL_DECISIONS
+    baseline_metrics = normalize_metrics(baseline)
+    summary = {
+        "schema_version": 1,
+        "artifact_type": "private_hybrid_sweep_decision_summary",
+        "privacy_boundary": "aggregate_only_no_raw_content_or_identifiers",
+        "reference": {
+            "dense_baseline": str(baseline.get("name") or baseline_name),
+            "pr_1448": {
+                "decision": "NO-GO",
+                "rule": "NO-GO unless a sweep candidate is classified as winner_found",
+            },
+        },
+        "thresholds": {
+            "material_recall_delta": MATERIAL_RECALL_DELTA,
+            "metric_regression_tolerance": METRIC_REGRESSION_TOLERANCE,
+            "latency_regression_ratio": LATENCY_REGRESSION_RATIO,
+            "latency_regression_ms": LATENCY_REGRESSION_MS,
+        },
+        "baseline": {
+            "name": str(baseline.get("name") or baseline_name),
+            "metrics": {
+                "recall_at_5": baseline_metrics.recall_at_5,
+                "recall_at_10": baseline_metrics.recall_at_10,
+                "mrr_at_5": baseline_metrics.mrr_at_5,
+                "ndcg_at_5": baseline_metrics.ndcg_at_5,
+                "citation_metric": baseline_metrics.citation_metric,
+                "citation_value": baseline_metrics.citation_value,
+                "latency_p50_ms": baseline_metrics.latency_p50_ms,
+                "latency_p95_ms": baseline_metrics.latency_p95_ms,
+                "retrieval_miss_count": baseline_metrics.retrieval_miss_count,
+                "retrieval_miss_rate": baseline_metrics.retrieval_miss_rate,
+                "retrieval_miss_denominator": baseline_metrics.retrieval_miss_denominator,
+            },
+        },
+        "decision": {
+            "final": final_decision,
+            "selected_variant": selected.get("name") if selected else None,
+            "winner_found": bool(winners),
+            "candidate_count": len(candidate_rows),
+            "failed_candidate_count": len(failed),
+        },
+        "variants": [
+            {
+                key: value
+                for key, value in row.items()
+                if key != "variant"
+            }
+            for row in candidate_rows
+        ],
+        "notes": [
+            "Recall@10-only gains are insufficient when ranking, citation, or latency guardrails regress.",
+            "#1448 remains NO-GO unless a sweep winner is found.",
+        ],
+    }
+    assert_summary_privacy_safe(summary)
+    return summary
+
+
+def _fmt(value: Any, *, percent: bool = False, signed: bool = False) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, (int, float)):
+        if percent:
+            val = value * 100
+            prefix = "+" if signed and val > 0 else ""
+            return f"{prefix}{val:.2f}pp" if signed else f"{val:.2f}%"
+        prefix = "+" if signed and value > 0 else ""
+        return f"{prefix}{value:.3f}"
+    return str(value)
+
+
+def _fmt_ms(value: Any, *, signed: bool = False) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        prefix = "+" if signed and value > 0 else ""
+        return f"{prefix}{value:.1f}"
+    return str(value)
+
+
+def _fmt_count(value: Any) -> str:
+    if value is None:
+        return "-"
+    return str(value)
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    decision = summary["decision"]
+    baseline = summary["baseline"]
+    lines = [
+        "# Hybrid Sweep Decision",
+        "",
+        "This report is aggregate-only. It contains no raw questions, answers, evidence text, document identifiers, chunk identifiers, filenames, or local paths.",
+        "",
+        "## Decision",
+        "",
+        f"- Final decision: `{decision['final']}`",
+        f"- Selected variant: `{decision['selected_variant'] or '-'}`",
+        "- #1448 reference: `NO-GO unless a sweep candidate is classified as winner_found`",
+        "",
+        "Recall@10-only gains are insufficient when MRR@5, nDCG@5, citation, or latency regresses because the system must retrieve the right evidence early, cite it correctly, and stay within the existing latency envelope.",
+        "",
+        "## Dense Baseline",
+        "",
+        "| Variant | Recall@5 | Recall@10 | MRR@5 | nDCG@5 | Citation | p50 ms | p95 ms | retrieval_miss |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    base_metrics = baseline["metrics"]
+    lines.append(
+        "| {name} | {r5} | {r10} | {mrr} | {ndcg} | {citation} | {p50} | {p95} | {miss} |".format(
+            name=baseline["name"],
+            r5=_fmt(base_metrics.get("recall_at_5")),
+            r10=_fmt(base_metrics.get("recall_at_10")),
+            mrr=_fmt(base_metrics.get("mrr_at_5")),
+            ndcg=_fmt(base_metrics.get("ndcg_at_5")),
+            citation=_fmt(base_metrics.get("citation_value")),
+            p50=_fmt_ms(base_metrics.get("latency_p50_ms")),
+            p95=_fmt_ms(base_metrics.get("latency_p95_ms")),
+            miss=_fmt_count(base_metrics.get("retrieval_miss_count")),
+        )
+    )
+    lines.extend(
+        [
+            "",
+            "## Hybrid Variants",
+            "",
+            "| Variant | k | Dense pool | BM25 pool | dR@5 | dR@10 | dMRR@5 | dnDCG@5 | dCitation | dP50 ms | dP95 ms | dMiss | Classification |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for row in summary["variants"]:
+        params = row["parameters"]
+        deltas = row["deltas_vs_dense"]
+        lines.append(
+            "| {name} | {k} | {dense} | {bm25} | {dr5} | {dr10} | {dmrr} | {dndcg} | {dcit} | {dp50} | {dp95} | {dmiss} | {cls} |".format(
+                name=row["name"],
+                k=_fmt_count(params.get("rrf_k")),
+                dense=_fmt_count(params.get("dense_pool")),
+                bm25=_fmt_count(params.get("bm25_pool")),
+                dr5=_fmt(deltas.get("recall_at_5"), signed=True),
+                dr10=_fmt(deltas.get("recall_at_10"), signed=True),
+                dmrr=_fmt(deltas.get("mrr_at_5"), signed=True),
+                dndcg=_fmt(deltas.get("ndcg_at_5"), signed=True),
+                dcit=_fmt(deltas.get("citation"), signed=True),
+                dp50=_fmt_ms(deltas.get("latency_p50_ms"), signed=True),
+                dp95=_fmt_ms(deltas.get("latency_p95_ms"), signed=True),
+                dmiss=_fmt_count(deltas.get("retrieval_miss")),
+                cls=", ".join(row["classifications"]),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- `winner_found` requires a material Recall@5 or Recall@10 gain and no MRR@5, nDCG@5, citation, or latency regression.",
+            "- Missing required metrics are classified as `failed_experiment`; missing `retrieval_miss` is displayed as `-`, not zero.",
+            "- Timestamped sweep outputs remain local and gitignored.",
+            "",
+        ]
+    )
+    rendered = "\n".join(lines)
+    assert_summary_text_privacy_safe(rendered)
+    return rendered
+
+
+def assert_summary_privacy_safe(obj: Any) -> None:
+    hits: list[str] = []
+
+    def walk(node: Any, trail: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                key_text = str(key)
+                if key_text.lower() in FORBIDDEN_KEYS:
+                    hits.append(f"{trail}.{key_text}")
+                if "/" in key_text or "\\" in key_text or ":" in key_text:
+                    hits.append(f"{trail}.{key_text}:path_like_key")
+                walk(value, f"{trail}.{key_text}")
+        elif isinstance(node, list):
+            for idx, item in enumerate(node):
+                walk(item, f"{trail}[{idx}]")
+        elif isinstance(node, str):
+            for fragment in FORBIDDEN_PATH_FRAGMENTS:
+                if fragment in node:
+                    hits.append(f"{trail}:private_path_fragment")
+                    break
+            if ABSOLUTE_LOCAL_PATH_RE.search(node) or _PATH_LIKE_RE.search(node):
+                hits.append(f"{trail}:path_like_value")
+
+    walk(obj, "$")
+    if hits:
+        raise ValueError("summary artifact failed privacy guard: " + ", ".join(hits[:20]))
+
+
+def assert_summary_text_privacy_safe(text: str) -> None:
+    hits = [fragment for fragment in FORBIDDEN_PATH_FRAGMENTS if fragment in text]
+    if ABSOLUTE_LOCAL_PATH_RE.search(text):
+        hits.append("absolute_local_path")
+    if hits:
+        raise ValueError("summary markdown failed privacy guard: " + ", ".join(sorted(set(hits))))
+
+
+def write_summary(summary: dict[str, Any], out_md: Path, out_json: Path) -> None:
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    assert_summary_privacy_safe(summary)
+    out_json.write_text(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    out_md.write_text(render_markdown(summary), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    aggregate_path = Path(args.aggregate) if args.aggregate else newest_aggregate()
+    if not aggregate_path.is_absolute():
+        aggregate_path = ROOT / aggregate_path
+    payload = load_aggregate(aggregate_path)
+    summary = build_summary(payload)
+    out_md = Path(args.out_md)
+    out_json = Path(args.out_json)
+    if not out_md.is_absolute():
+        out_md = ROOT / out_md
+    if not out_json.is_absolute():
+        out_json = ROOT / out_json
+    write_summary(summary, out_md, out_json)
+    message = (
+        f"[OK] hybrid sweep summary written: {render_output_path(out_md)} "
+        f"and {render_output_path(out_json)}"
+    )
+    assert_rendered_output_privacy_safe(message)
+    print(message, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_private_hybrid_sweep_summary.py
+++ b/tests/test_private_hybrid_sweep_summary.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.summarize_private_hybrid_sweep import (  # noqa: E402
+    build_summary,
+    main,
+    render_markdown,
+)
+
+
+def _variant(
+    name: str,
+    *,
+    rrf_k: int | None = None,
+    dense_pool: int | None = None,
+    bm25_pool: int | None = None,
+    recall5: float | None = 0.50,
+    recall10: float | None = 0.60,
+    mrr5: float | None = 0.40,
+    ndcg5: float | None = 0.45,
+    citation: float | None = 0.70,
+    p50: float | None = 100.0,
+    p95: float | None = 200.0,
+    retrieval_miss: dict | None = None,
+) -> dict:
+    backend = "hybrid" if name.startswith("hybrid_") else "dense"
+    metrics: dict[str, object] = {
+        "recall_at_5": recall5,
+        "recall_at_10": recall10,
+        "mrr_at_5": mrr5,
+        "ndcg_at_5": ndcg5,
+        "latency_ms": {"p50": p50, "p95": p95, "count": 10},
+    }
+    if citation is not None:
+        metrics["citation_precision"] = citation
+    if retrieval_miss is not None:
+        metrics["retrieval_miss"] = retrieval_miss
+    return {
+        "name": name,
+        "parameters": {
+            "retrieval_backend": backend,
+            "rrf_k": rrf_k,
+            "dense_pool": dense_pool,
+            "bm25_pool": bm25_pool,
+            "top_k": 20,
+        },
+        "num_cases": 10,
+        "metrics": metrics,
+    }
+
+
+def _aggregate(*variants: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "artifact_type": "private_hybrid_retrieval_sweep_aggregate",
+        "privacy_boundary": "aggregate_only_no_raw_content_or_identifiers",
+        "sweep": {"baseline": "full_dense_top20", "candidate": "hybrid_bm25_dense_v1"},
+        "variants": [_variant("full_dense_top20"), *variants],
+    }
+
+
+def test_winner_selection_promotes_hybrid_variant() -> None:
+    payload = _aggregate(
+        _variant(
+            "hybrid_bm25_dense_v1_k60_dense50_bm2550",
+            rrf_k=60,
+            dense_pool=50,
+            bm25_pool=50,
+            recall5=0.51,
+            recall10=0.62,
+            mrr5=0.40,
+            ndcg5=0.45,
+            citation=0.701,
+            p50=102.0,
+            p95=205.0,
+        )
+    )
+
+    summary = build_summary(payload)
+
+    assert summary["decision"]["final"] == "promote selected hybrid variant"
+    assert summary["decision"]["selected_variant"] == "hybrid_bm25_dense_v1_k60_dense50_bm2550"
+    assert summary["variants"][0]["primary_classification"] == "winner_found"
+
+
+def test_recall_only_gain_with_regressions_keeps_dense_baseline() -> None:
+    payload = _aggregate(
+        _variant(
+            "hybrid_bm25_dense_v1_k60_dense50_bm2550",
+            rrf_k=60,
+            dense_pool=50,
+            bm25_pool=50,
+            recall5=0.50,
+            recall10=0.62,
+            mrr5=0.35,
+            ndcg5=0.40,
+            citation=0.60,
+            p50=120.0,
+            p95=230.0,
+        )
+    )
+
+    summary = build_summary(payload)
+    row = summary["variants"][0]
+
+    assert summary["decision"]["final"] == "keep dense baseline and abandon hybrid for now"
+    assert row["primary_classification"] == "recall_only_gain"
+    assert row["classifications"] == [
+        "recall_only_gain",
+        "ranking_regression",
+        "citation_regression",
+        "latency_regression",
+    ]
+
+
+def test_guardrail_citation_delta_is_inverted_for_selected_no_winner() -> None:
+    baseline = _variant("full_dense_top20", citation=None)
+    baseline["metrics"]["citation_chunk_guardrail"] = {
+        "citation_or_page_metadata_issue": {"count": 1, "rate": 0.10, "denominator": 10}
+    }
+    better_guardrail = _variant(
+        "hybrid_bm25_dense_v1_k20_dense20_bm2520",
+        rrf_k=20,
+        dense_pool=20,
+        bm25_pool=20,
+        citation=None,
+        recall10=0.62,
+        mrr5=0.35,
+        ndcg5=0.40,
+        p50=120.0,
+    )
+    better_guardrail["metrics"]["citation_chunk_guardrail"] = {
+        "citation_or_page_metadata_issue": {"count": 0, "rate": 0.00, "denominator": 10}
+    }
+    worse_guardrail = _variant(
+        "hybrid_bm25_dense_v1_k20_dense20_bm2550",
+        rrf_k=20,
+        dense_pool=20,
+        bm25_pool=50,
+        citation=None,
+        recall10=0.62,
+        mrr5=0.35,
+        ndcg5=0.40,
+        p50=120.0,
+    )
+    worse_guardrail["metrics"]["citation_chunk_guardrail"] = {
+        "citation_or_page_metadata_issue": {"count": 2, "rate": 0.20, "denominator": 10}
+    }
+    payload = {
+        "schema_version": 1,
+        "artifact_type": "private_hybrid_retrieval_sweep_aggregate",
+        "privacy_boundary": "aggregate_only_no_raw_content_or_identifiers",
+        "sweep": {"baseline": "full_dense_top20", "candidate": "hybrid_bm25_dense_v1"},
+        "variants": [baseline, worse_guardrail, better_guardrail],
+    }
+
+    summary = build_summary(payload)
+
+    assert summary["decision"]["final"] == "keep dense baseline and abandon hybrid for now"
+    assert summary["decision"]["selected_variant"] == "hybrid_bm25_dense_v1_k20_dense20_bm2520"
+    rows = {row["name"]: row for row in summary["variants"]}
+    assert rows["hybrid_bm25_dense_v1_k20_dense20_bm2520"]["deltas_vs_dense"]["citation"] == -0.10
+    assert rows["hybrid_bm25_dense_v1_k20_dense20_bm2550"]["deltas_vs_dense"]["citation"] == 0.10
+
+
+@pytest.mark.parametrize(
+    "leaky_payload",
+    [
+        {"variants": [_variant("full_dense_top20"), {"name": "hybrid_bad", "query": "raw private"}]},
+        {
+            "variants": [
+                _variant("full_dense_top20"),
+                {"name": "hybrid_bad", "metrics": {"doc_id": "private-doc"}},
+            ]
+        },
+        {
+            "variants": [
+                _variant("full_dense_top20"),
+                {"name": "hybrid_bad", "metrics": {"filename": "private.pdf", "evidence": []}},
+            ]
+        },
+        {
+            "variants": [
+                _variant("full_dense_top20"),
+                {"name": "hybrid_bad", "metrics": {"safe": "/Users/example/private.pdf"}},
+            ]
+        },
+    ],
+)
+def test_privacy_guard_rejects_raw_fields_and_paths(leaky_payload: dict) -> None:
+    leaky_payload.setdefault("sweep", {"baseline": "full_dense_top20"})
+    with pytest.raises(ValueError, match="privacy guard"):
+        build_summary(leaky_payload)
+
+
+def test_missing_required_metric_blocks_winner_instead_of_zero_fill() -> None:
+    payload = _aggregate(
+        _variant(
+            "hybrid_bm25_dense_v1_k20_dense20_bm2520",
+            rrf_k=20,
+            dense_pool=20,
+            bm25_pool=20,
+            recall10=0.80,
+            ndcg5=None,
+        )
+    )
+
+    summary = build_summary(payload)
+    row = summary["variants"][0]
+
+    assert row["primary_classification"] == "failed_experiment"
+    assert "ndcg_at_5" in row["missing_metrics"]
+    assert summary["decision"]["final"] == "mark hybrid as failed experiment"
+
+
+def test_retrieval_miss_explicit_zero_is_distinct_from_missing() -> None:
+    payload = _aggregate(
+        _variant(
+            "hybrid_bm25_dense_v1_k20_dense20_bm2520",
+            rrf_k=20,
+            dense_pool=20,
+            bm25_pool=20,
+            retrieval_miss={"count": 0, "rate": 0.0, "denominator": 10},
+        ),
+        _variant(
+            "hybrid_bm25_dense_v1_k60_dense20_bm2520",
+            rrf_k=60,
+            dense_pool=20,
+            bm25_pool=20,
+        ),
+    )
+    payload["variants"][0]["metrics"]["retrieval_miss"] = {
+        "count": 0,
+        "rate": 0.0,
+        "denominator": 10,
+    }
+
+    summary = build_summary(payload)
+    explicit = summary["variants"][0]
+    missing = summary["variants"][1]
+
+    assert explicit["metrics"]["retrieval_miss_count"] == 0
+    assert explicit["deltas_vs_dense"]["retrieval_miss"] == 0
+    assert missing["metrics"]["retrieval_miss_count"] is None
+    assert missing["deltas_vs_dense"]["retrieval_miss"] is None
+
+    md = render_markdown(summary)
+    assert "| hybrid_bm25_dense_v1_k20_dense20_bm2520 | 20 | 20 | 20 |" in md
+    assert "| hybrid_bm25_dense_v1_k60_dense20_bm2520 | 60 | 20 | 20 |" in md
+
+
+def test_markdown_table_rendering_is_stable_and_sorted() -> None:
+    payload = _aggregate(
+        _variant("hybrid_bm25_dense_v1_k60_dense20_bm2520", rrf_k=60, dense_pool=20, bm25_pool=20),
+        _variant("hybrid_bm25_dense_v1_k20_dense20_bm2520", rrf_k=20, dense_pool=20, bm25_pool=20),
+    )
+
+    summary = build_summary(payload)
+    first = render_markdown(summary)
+    second = render_markdown(summary)
+
+    assert first == second
+    table = first.split("## Hybrid Variants", 1)[1]
+    assert table.index("hybrid_bm25_dense_v1_k20_dense20_bm2520") < table.index(
+        "hybrid_bm25_dense_v1_k60_dense20_bm2520"
+    )
+    assert "| Variant | k | Dense pool | BM25 pool | dR@5 | dR@10 |" in first
+
+
+def test_main_writes_summary_artifacts_from_explicit_aggregate(tmp_path: Path) -> None:
+    aggregate_path = tmp_path / "aggregate.json"
+    out_md = tmp_path / "summary.md"
+    out_json = tmp_path / "summary.aggregate.json"
+    aggregate_path.write_text(
+        json.dumps(
+            _aggregate(
+                _variant(
+                    "hybrid_bm25_dense_v1_k60_dense50_bm2550",
+                    rrf_k=60,
+                    dense_pool=50,
+                    bm25_pool=50,
+                    recall10=0.62,
+                )
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    rc = main(["--aggregate", str(aggregate_path), "--out-md", str(out_md), "--out-json", str(out_json)])
+
+    assert rc == 0
+    assert out_md.exists()
+    assert out_json.exists()
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["artifact_type"] == "private_hybrid_sweep_decision_summary"


### PR DESCRIPTION
## 1. What changed and why

chore: Summarize private hybrid sweep decision (#1502)

Closes #1502

🤖 Auto-shipped by scripts/claude-hooks/stop-ship.sh

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #1502

## 2. Files affected

- `.gitignore`
- `docs/retrieval/hybrid_sweep_decision.md`
- `reports/retrieval/hybrid_sweep_summary.aggregate.json`
- `reports/retrieval/hybrid_sweep_summary.md`
- `scripts/summarize_private_hybrid_sweep.py`
- `tests/test_private_hybrid_sweep_summary.py`

## 3. Risks

Auto-generated PR; no load-bearing paths changed.

## 4. Tests

Local tests passed (bash scripts/test.sh).

## 5. Eval impact

All `·` (no behavior change in retrieval / verifier path).

### 5b. Real-data delta

No behavior change in retrieval / verifier path. (no load-bearing path changed)

## 6. Backward compatibility

No public-API change detected.

## 7. Out of scope

N/A — single-concern auto-shipped PR.
