### PR TITLE
chore: add human review surface for AI next actions

### DIFF
--- a/docs/operations/ai-codex-workflow.md
+++ b/docs/operations/ai-codex-workflow.md
@@ -27,10 +27,30 @@ python3 scripts/ai_next_actions.py \
 ```
 
 - `reports/ai_next_actions.md`: 현재 상태와 최우선 Codex task
+- `reports/ai_next_actions.html`: 사람이 빠르게 보는 현재 상태판
 - `reports/codex_tasks/*.md`: Codex에게 넘길 scoped task briefs
 
 `reports/*`는 기본 gitignore 대상이므로 이 산출물은 로컬 workflow artifact다.
 committable evidence가 필요하면 별도 redacted aggregate 산출물로 승격해야 한다.
+
+## Human Review Surface
+
+`reports/ai_next_actions.html`은 agent용 Markdown을 사람이 읽는 review surface로
+투영한 정적 HTML이다. 같은 planner 결과에서 생성되므로 Markdown task brief와
+판단 순서가 다르면 안 된다.
+
+HTML 화면에서 먼저 볼 항목은 다음 네 가지다.
+
+| Area | What to decide |
+|---|---|
+| Top task | 지금 검토하거나 실행할 단일 작업 |
+| Page citation claim | page-level claim을 해도 되는지 여부 |
+| Private delta needed | load-bearing 변경의 private delta evidence 필요 여부 |
+| Privacy guard | 입력 artifact가 aggregate/redacted boundary를 지켰는지 여부 |
+
+HTML은 로컬 상태판이며 PR 증거(evidence)가 아니다. PR에 인용할 수 있는 것은
+HTML 자체가 아니라 source aggregate artifact, 실행 command, diff, ADR/source-of-truth
+일치 여부다.
 
 ## Classification Contract
 
@@ -38,10 +58,11 @@ Planner는 다음 순서로 active work를 분류한다.
 
 | Classification | Meaning |
 |---|---|
+| `failed_experiment` | NO-GO 또는 negative experiment 신호가 있다. |
+| `close_superseded` | stale/superseded draft PR을 active review 후보에서 제거해야 한다. |
 | `blocked` | readiness blocker, requested changes, merge blocker, failing check가 있다. |
 | `needs_private_delta` | private delta evidence가 필요한 PR 또는 load-bearing change가 있다. |
 | `ready_for_review` | blocker-free 상태라 reviewer handoff가 가능하다. |
-| `failed_experiment` | NO-GO 또는 negative experiment 신호가 있다. |
 | `next_experiment_candidate` | 위 신호가 없으므로 다음 측정 후보를 고른다. |
 
 Page citation claim은 readiness summary의 page metadata gate가 `NO-GO`이거나

--- a/docs/plans/T-2026-0006-human-review-surface.md
+++ b/docs/plans/T-2026-0006-human-review-surface.md
@@ -1,0 +1,109 @@
+# Plan: T-2026-0006 Human Review Surface
+
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0006`
+- Related issue / PR: [#1506](https://github.com/hskim-solv/BidMate-DocAgent/issues/1506) / PR TBD
+- Related ADR: N/A - no decision-level change
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+## Problem Statement
+
+`scripts/ai_next_actions.py` already turns PR/readiness/eval aggregate state into
+deterministic Markdown, but that output is still optimized for agents and task
+handoff. Human reviewers need a compact current-state page that surfaces the
+top task, blockers, private delta need, page-citation gate, and privacy guard
+without changing the planner's source-of-truth logic.
+
+## Desired Behavior
+
+Running the planner writes the existing Markdown task brief plus a local
+`reports/ai_next_actions.html` file. The HTML is self-contained, deterministic,
+and explicitly local-only; it is a status board, not PR evidence.
+
+## Constraints
+
+- Scope: workflow/reviewer tooling only.
+- Architecture: reuse the existing `WorkItem` and `SourceState` model.
+- Compatibility: keep existing Markdown and `reports/codex_tasks/*.md` outputs.
+- Privacy: render only existing aggregate/redacted strings and escape HTML.
+- Non-goals: no retrieval, verifier, answer, eval, private-data, or external API changes.
+
+## Affected Interfaces
+
+- CLI: add `--out-html`, defaulting to `reports/ai_next_actions.html`; `--out-html ""` disables HTML output.
+- Output artifacts: add local ignored `reports/ai_next_actions.html`.
+- Docs/review surfaces: document the HTML status board in workflow and review docs.
+
+## Data / Eval Impact
+
+- Surface: none.
+- Data boundary: aggregate-only or redacted local artifacts already accepted by the planner.
+- Allowed claim: planner now has a human-readable local status board.
+- Disallowed claim: the HTML is not eval evidence and does not prove performance or readiness.
+- Baseline/control affected: no.
+- Benchmark/eval auditor required: no.
+
+## Task Breakdown
+
+1. Add stdlib-only HTML rendering to `scripts/ai_next_actions.py`.
+2. Extend planner tests for determinism, privacy, escaping, gitignore coverage, and disabled HTML output.
+3. Update docs so reviewers know when to use the HTML and when to verify source evidence.
+
+## Acceptance Criteria
+
+- [x] Planner emits Markdown, task briefs, and self-contained HTML from the same work items.
+- [x] HTML escapes PR/user-provided text.
+- [x] Forbidden private readiness fields do not appear in generated Markdown, HTML, or task briefs.
+- [x] `--out-html ""` skips HTML generation.
+- [x] Review docs state that HTML is local status, not approval evidence.
+
+## Validation Strategy
+
+Commands run:
+
+```bash
+python3 -m py_compile scripts/ai_next_actions.py
+python3 -m pytest -q tests/test_ai_next_actions.py
+python3 scripts/check_doc_links.py --check-all
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Focused test suite passes.
+- Documentation links pass.
+- Browser visual check was attempted but `file://` navigation was blocked by the app URL policy; no browser workaround used.
+
+## Rollback Strategy
+
+Revert the script, tests, docs, queue entry, and this plan. Generated
+`reports/ai_next_actions.html` artifacts are ignored local files and can be
+deleted without affecting committed evidence.
+
+## Reviewer Notes
+
+Attack privacy-safe rendering first: HTML must not leak raw readiness fields or
+execute PR/user-provided text. Then verify output compatibility and no evidence
+over-claim.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Branch / worktree: chore/issue-1506-human-review-surface / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Issue / PR: #1506 / PR TBD
+- Task: T-2026-0006
+- Current status: implementation complete, validation passing.
+- Files touched: scripts/ai_next_actions.py, tests/test_ai_next_actions.py, docs/operations/ai-codex-workflow.md, docs/reviews/README.md, tasks/queue.md, docs/plans/T-2026-0006-human-review-surface.md
+- Decisions made: local self-contained HTML, no JS/dependencies, non-evidence status board.
+- Commands run: python3 -m py_compile scripts/ai_next_actions.py; python3 -m pytest -q tests/test_ai_next_actions.py; python3 scripts/check_doc_links.py --check-all; git diff --check; make check-branch
+- Results: pass; browser file:// visual check blocked by app policy.
+- Next safe command: python3 -m pytest -q tests/test_ai_next_actions.py
+- Open questions: none.
+- Risks: reviewer may prefer moving inline CSS to a separate committed template later.
+```

--- a/docs/reviews/README.md
+++ b/docs/reviews/README.md
@@ -22,3 +22,13 @@ Reviewer는 PR 설명을 근거(evidence)로 취급하지 않는다. 승인 가�
 
 근거가 없으면 claim은 없는 것으로 처리한다. green CI, synthetic-only success,
 깔끔한 agent 요약은 private real-eval 또는 architecture safety 증거가 아니다.
+
+## Fast Triage Surface
+
+현재 open PR, readiness aggregate, private delta 필요 여부를 먼저 좁힐 때는
+[`scripts/ai_next_actions.py`](../../scripts/ai_next_actions.py)가 생성하는
+`reports/ai_next_actions.html`을 본다. 사용법과 해석 기준은
+[`docs/operations/ai-codex-workflow.md`](../operations/ai-codex-workflow.md)에 둔다.
+
+이 HTML은 사람용 상태판이지 승인 근거(evidence)가 아니다. reviewer는 상태판이
+가리키는 source artifact와 command 결과를 따로 확인해야 한다.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1518,9 +1518,11 @@ def run_next_from_prs(
     )
     ai_next_actions._write_outputs(  # noqa: SLF001 - reuse the existing local writer
         safe_out_md,
+        None,
         safe_tasks_dir,
         safe_items,
         _sanitize_dynamic_text(markdown),
+        None,
     )
     return safe_out_md, safe_tasks_dir
 

--- a/scripts/ai_next_actions.py
+++ b/scripts/ai_next_actions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import html
 import json
 from pathlib import Path
 import re
@@ -23,6 +24,7 @@ from scripts._governance import find_redacted_summary_forbidden_fields
 
 
 DEFAULT_OUT_MD = ROOT_DIR / "reports" / "ai_next_actions.md"
+DEFAULT_OUT_HTML = ROOT_DIR / "reports" / "ai_next_actions.html"
 DEFAULT_TASKS_DIR = ROOT_DIR / "reports" / "codex_tasks"
 
 CLASSIFICATION_ORDER = {
@@ -658,6 +660,279 @@ def render_summary_markdown(
     return "\n".join(lines)
 
 
+def _html_text(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _classification_label(value: str) -> str:
+    return value.replace("_", " ")
+
+
+def _render_status_card(label: str, value: object, tone: str = "neutral") -> str:
+    return (
+        f'<section class="status-card {tone}">'
+        f"<span>{_html_text(label)}</span>"
+        f"<strong>{_html_text(value)}</strong>"
+        "</section>"
+    )
+
+
+def render_review_html(
+    items: Sequence[WorkItem],
+    sources: Sequence[SourceState],
+    *,
+    page_gate: str,
+    private_delta_needed: bool,
+) -> str:
+    top = items[0]
+    counts = _classification_counts(items)
+    blocked = counts["blocked"] > 0
+    privacy = _privacy_note(sources)
+    top_tone = top.classification.replace("_", "-")
+    cards = [
+        _render_status_card("Top task", _classification_label(top.classification), top_tone),
+        _render_status_card("Page citation claim", page_gate, "danger" if page_gate == "NO-GO" else "ok"),
+        _render_status_card("Private delta needed", private_delta_needed, "warn" if private_delta_needed else "ok"),
+        _render_status_card("Blocked", blocked, "danger" if blocked else "ok"),
+        _render_status_card("Privacy guard", privacy, "warn" if any(source.unsafe for source in sources) else "ok"),
+    ]
+    classification_rows = "\n".join(
+        "<tr>"
+        f"<th>{_html_text(name)}</th>"
+        f"<td>{counts[name]}</td>"
+        "</tr>"
+        for name in CLASSIFICATION_ORDER
+    )
+    follow_up_rows = "\n".join(
+        "<tr>"
+        f'<td><span class="badge {item.classification.replace("_", "-")}">'
+        f"{_html_text(_classification_label(item.classification))}</span></td>"
+        f"<td>{_html_text(item.title)}</td>"
+        f"<td>{_html_text(item.source)}</td>"
+        "</tr>"
+        for item in items[1:]
+    )
+    if not follow_up_rows:
+        follow_up_rows = '<tr><td colspan="3" class="empty">None</td></tr>'
+    sources_list = "\n".join(
+        "<li>"
+        f"<span>{_html_text(source.kind)}</span>"
+        f"<code>{_html_text(source.label)}</code>"
+        f"{' <strong>sanitized</strong>' if source.unsafe else ''}"
+        "</li>"
+        for source in sources
+    )
+    if not sources_list:
+        sources_list = '<li><span>planner</span><code>default</code></li>'
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AI Next Actions</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --text: #1d2430;
+      --muted: #5b6575;
+      --line: #d9dee7;
+      --ok: #176f4d;
+      --warn: #986400;
+      --danger: #b42318;
+      --accent: #2459a7;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+    main {{
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 20px 48px;
+    }}
+    header {{
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      align-items: end;
+      margin-bottom: 24px;
+    }}
+    h1, h2, h3, p {{ margin: 0; }}
+    h1 {{ font-size: 30px; line-height: 1.15; }}
+    h2 {{ font-size: 18px; margin-bottom: 12px; }}
+    h3 {{ font-size: 16px; margin-bottom: 8px; }}
+    .subtitle {{ color: var(--muted); margin-top: 6px; max-width: 760px; }}
+    .grid {{
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 20px;
+    }}
+    .status-card, .panel {{
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: 0 1px 2px rgba(18, 24, 31, 0.04);
+    }}
+    .status-card {{
+      min-height: 94px;
+      padding: 14px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      border-top: 4px solid var(--accent);
+    }}
+    .status-card span {{ color: var(--muted); font-size: 12px; text-transform: uppercase; }}
+    .status-card strong {{ font-size: 20px; overflow-wrap: anywhere; }}
+    .ok {{ border-top-color: var(--ok); }}
+    .warn, .needs-private-delta, .next-experiment-candidate {{ border-top-color: var(--warn); }}
+    .danger, .failed-experiment, .blocked {{ border-top-color: var(--danger); }}
+    .close-superseded {{ border-top-color: #6b5b95; }}
+    .ready-for-review {{ border-top-color: var(--ok); }}
+    .panel {{ padding: 18px; margin-bottom: 16px; }}
+    .task {{
+      display: grid;
+      grid-template-columns: 180px 1fr;
+      gap: 10px 18px;
+    }}
+    .task dt {{ color: var(--muted); }}
+    .task dd {{ margin: 0; overflow-wrap: anywhere; }}
+    code {{
+      background: #eef1f5;
+      border-radius: 5px;
+      padding: 2px 5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+    }}
+    th, td {{
+      text-align: left;
+      border-top: 1px solid var(--line);
+      padding: 10px 8px;
+      vertical-align: top;
+    }}
+    thead th {{ color: var(--muted); font-size: 12px; text-transform: uppercase; }}
+    .badge {{
+      display: inline-block;
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--accent);
+      border-radius: 6px;
+      padding: 3px 7px;
+      background: #fff;
+      white-space: nowrap;
+    }}
+    .badge.ok, .badge.ready-for-review {{ border-left-color: var(--ok); }}
+    .badge.warn, .badge.needs-private-delta, .badge.next-experiment-candidate {{ border-left-color: var(--warn); }}
+    .badge.danger, .badge.failed-experiment, .badge.blocked {{ border-left-color: var(--danger); }}
+    .badge.close-superseded {{ border-left-color: #6b5b95; }}
+    .empty {{ color: var(--muted); text-align: center; }}
+    .sources {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 8px;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }}
+    .sources li {{
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      padding: 10px;
+      background: #fbfcfe;
+      min-width: 0;
+    }}
+    .sources span {{
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      margin-bottom: 4px;
+      text-transform: uppercase;
+    }}
+    footer {{ color: var(--muted); margin-top: 18px; font-size: 13px; }}
+    @media (max-width: 900px) {{
+      header {{ display: block; }}
+      .grid {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }}
+      .task {{ grid-template-columns: 1fr; gap: 4px; }}
+    }}
+    @media (max-width: 560px) {{
+      main {{ padding: 22px 12px 36px; }}
+      .grid {{ grid-template-columns: 1fr; }}
+      th, td {{ padding: 8px 4px; }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>AI Next Actions</h1>
+        <p class="subtitle">Human-readable view of the deterministic Codex planner. Inputs are aggregate or redacted local artifacts.</p>
+      </div>
+    </header>
+    <section class="grid">
+      {"".join(cards)}
+    </section>
+    <section class="panel">
+      <h2>Recommended Task</h2>
+      <dl class="task">
+        <dt>Classification</dt>
+        <dd><span class="badge {top_tone}">{_html_text(_classification_label(top.classification))}</span></dd>
+        <dt>Task</dt>
+        <dd>{_html_text(top.title)}</dd>
+        <dt>Reason</dt>
+        <dd>{_html_text(top.reason)}</dd>
+        <dt>Source</dt>
+        <dd><code>{_html_text(top.source)}</code></dd>
+        <dt>Goal</dt>
+        <dd>{_html_text(top.goal)}</dd>
+        <dt>Expected evidence</dt>
+        <dd>{_html_text(top.expected_evidence)}</dd>
+        <dt>Verification</dt>
+        <dd><code>{_html_text(top.verification)}</code></dd>
+      </dl>
+    </section>
+    <section class="panel">
+      <h2>Active Work</h2>
+      <table>
+        <tbody>
+          {classification_rows}
+        </tbody>
+      </table>
+    </section>
+    <section class="panel">
+      <h2>Follow-up Candidates</h2>
+      <table>
+        <thead>
+          <tr><th>Classification</th><th>Task</th><th>Source</th></tr>
+        </thead>
+        <tbody>
+          {follow_up_rows}
+        </tbody>
+      </table>
+    </section>
+    <section class="panel">
+      <h2>Sources</h2>
+      <ul class="sources">
+        {sources_list}
+      </ul>
+    </section>
+    <footer>
+      Local workflow artifact. Do not treat this page as committable eval evidence unless the source aggregate artifact is separately reviewed.
+    </footer>
+  </main>
+</body>
+</html>
+"""
+
+
 def render_task_markdown(item: WorkItem) -> str:
     return "\n".join(
         [
@@ -691,12 +966,23 @@ def render_task_markdown(item: WorkItem) -> str:
     )
 
 
-def _write_outputs(out_md: Path, tasks_dir: Path, items: Sequence[WorkItem], markdown: str) -> None:
+def _write_outputs(
+    out_md: Path,
+    out_html: Path | None,
+    tasks_dir: Path,
+    items: Sequence[WorkItem],
+    markdown: str,
+    html_report: str | None,
+) -> None:
     out_md.parent.mkdir(parents=True, exist_ok=True)
+    if out_html is not None:
+        out_html.parent.mkdir(parents=True, exist_ok=True)
     tasks_dir.mkdir(parents=True, exist_ok=True)
     for stale in tasks_dir.glob("*.md"):
         stale.unlink()
     out_md.write_text(markdown, encoding="utf-8")
+    if out_html is not None and html_report is not None:
+        out_html.write_text(html_report, encoding="utf-8")
     for idx, item in enumerate(items, start=1):
         task_path = tasks_dir / f"{idx:03d}-{item.slug}.md"
         task_path.write_text(render_task_markdown(item), encoding="utf-8")
@@ -797,6 +1083,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional index directory to audit for page metadata recovery.",
     )
     parser.add_argument("--out-md", type=Path, default=DEFAULT_OUT_MD)
+    parser.add_argument(
+        "--out-html",
+        default=str(DEFAULT_OUT_HTML),
+        help="Optional human-readable HTML report path. Pass an empty string to skip.",
+    )
     parser.add_argument("--tasks-dir", type=Path, default=DEFAULT_TASKS_DIR)
     args = parser.parse_args(argv)
 
@@ -813,8 +1104,16 @@ def main(argv: list[str] | None = None) -> int:
         page_gate=page_gate,
         private_delta_needed=private_delta_needed,
     )
-    _write_outputs(args.out_md, args.tasks_dir, items, markdown)
-    print(f"[OK] wrote {args.out_md} and {len(items)} task file(s) under {args.tasks_dir}")
+    html_report = render_review_html(
+        items,
+        sources,
+        page_gate=page_gate,
+        private_delta_needed=private_delta_needed,
+    )
+    out_html = Path(args.out_html) if args.out_html else None
+    _write_outputs(args.out_md, out_html, args.tasks_dir, items, markdown, html_report)
+    html_message = f", {out_html}" if out_html is not None else ""
+    print(f"[OK] wrote {args.out_md}{html_message} and {len(items)} task file(s) under {args.tasks_dir}")
     return 0
 
 

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -15,6 +15,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 2 | `T-2026-0002` | `done` | Implementer -> Reviewer | merged in PR #1481. |
 | 3 | `T-2026-0003` | `review` | Implementer -> Reviewer | auto-ship Stage 5 Desktop main fast-forward sync 구현됨. |
 | 4 | `T-2026-0004` | `review` | Implementer -> Reviewer | HWP -> PDF -> PyMuPDF4LLM opt-in loader 구현됨. |
+| 5 | `T-2026-0006` | `review` | Implementer -> Reviewer | `ai_next_actions` human-readable HTML review surface 구현됨. |
 
 ## Examples
 
@@ -392,4 +393,91 @@ python3 -m py_compile ingestion.py scripts/build_index.py scripts/compare_hwp_ex
 - Open risks: actual HWP conversion quality still depends on local LibreOffice HWP filter setup.
 - Next safe command: python3 -m pytest tests/test_ingestion_kordoc_regression.py tests/test_mixed_format_ingestion_regression.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_provenance_banner.py tests/test_run_eval_by_format_text_source.py -q
 - Reviewer focus: fail-closed parser policy, private path exclusion from answer citations, and page-citation-ready telemetry.
+```
+
+## T-2026-0006 — Human-readable AI next actions review surface
+
+- ID: T-2026-0006
+- Title: Human-readable AI next actions review surface
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+### Goal
+
+Give human reviewers a compact local HTML status board for the deterministic
+AI next-action planner, without replacing the existing Markdown task briefs.
+
+### Context
+
+- Surface: workflow/reviewer tooling.
+- Relevant docs: [`docs/operations/ai-codex-workflow.md`](../docs/operations/ai-codex-workflow.md),
+  [`docs/reviews/README.md`](../docs/reviews/README.md).
+- Primary risk: dense agent-oriented Markdown being treated as sufficient for
+  human triage, or local generated HTML being mistaken for PR evidence.
+
+### Scope
+
+- Add `reports/ai_next_actions.html` as a generated local artifact.
+- Keep `reports/ai_next_actions.md` and `reports/codex_tasks/*.md` behavior.
+- Document that the HTML is a status board, not approval evidence.
+
+### Non-Goals
+
+- Do not change retrieval, verifier, answer, eval, or private-data behavior.
+- Do not introduce JavaScript, external services, or new runtime dependencies.
+- Do not publish local `reports/*` artifacts.
+
+### Acceptance Criteria
+
+- [x] Planner emits Markdown, task briefs, and self-contained HTML from one
+  deterministic work-item model.
+- [x] HTML escapes PR/user-provided text and does not leak forbidden private
+  readiness fields.
+- [x] HTML output can be disabled with `--out-html ""`.
+- [x] Reviewer docs explain how to use the local status board.
+
+### Validation Commands
+
+```bash
+python3 -m py_compile scripts/ai_next_actions.py
+python3 -m pytest -q tests/test_ai_next_actions.py
+python3 scripts/check_doc_links.py --check-all
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Doc-link check output.
+- Manual note if browser visual verification is unavailable.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0006-human-review-surface.md`](../docs/plans/T-2026-0006-human-review-surface.md)
+- Issue: [#1506](https://github.com/hskim-solv/BidMate-DocAgent/issues/1506)
+- PR: TBD
+- ADR: N/A
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1506-human-review-surface / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Task: T-2026-0006
+- Plan: docs/plans/T-2026-0006-human-review-surface.md
+- Current status: HTML review surface implemented on top of scripts/ai_next_actions.py.
+- Files touched: scripts/ai_next_actions.py, tests/test_ai_next_actions.py, docs/operations/ai-codex-workflow.md, docs/reviews/README.md, tasks/queue.md, docs/plans/T-2026-0006-human-review-surface.md
+- Decisions made: Generate a self-contained local HTML file next to the existing Markdown output; keep source-of-truth logic in WorkItem classification and keep HTML non-evidence.
+- Commands run: python3 -m py_compile scripts/ai_next_actions.py; python3 -m pytest -q tests/test_ai_next_actions.py; python3 scripts/check_doc_links.py --check-all; git diff --check; make check-branch
+- Results: pass, except browser file:// visual verification was blocked by app URL policy.
+- Eval surface: none.
+- Open risks: reviewer should inspect whether the inline HTML/CSS is acceptable for a local-only generated report.
+- Next safe command: python3 -m pytest -q tests/test_ai_next_actions.py
+- Reviewer focus: privacy-safe rendering, deterministic output, and no evidence over-claim.
 ```

--- a/tests/test_ai_next_actions.py
+++ b/tests/test_ai_next_actions.py
@@ -52,8 +52,11 @@ def _run(
     if page_metadata_index_dir is not None:
         args.extend(["--page-metadata-index-dir", str(page_metadata_index_dir)])
     out_md = tmp_path / "reports" / "ai_next_actions.md"
+    out_html = tmp_path / "reports" / "ai_next_actions.html"
     tasks_dir = tmp_path / "reports" / "codex_tasks"
-    rc = planner.main([*args, "--out-md", str(out_md), "--tasks-dir", str(tasks_dir)])
+    rc = planner.main(
+        [*args, "--out-md", str(out_md), "--out-html", str(out_html), "--tasks-dir", str(tasks_dir)]
+    )
     assert rc == 0
     tasks = {path.name: path.read_text(encoding="utf-8") for path in sorted(tasks_dir.glob("*.md"))}
     return out_md.read_text(encoding="utf-8"), tasks
@@ -292,7 +295,8 @@ def test_forbidden_private_keys_do_not_leak_to_generated_reports(tmp_path: Path)
     )
 
     md, tasks = _run(tmp_path, summary=unsafe)
-    generated = md + "\n".join(tasks.values())
+    html = (tmp_path / "reports" / "ai_next_actions.html").read_text(encoding="utf-8")
+    generated = md + html + "\n".join(tasks.values())
 
     assert "sanitized input contained forbidden fields" in generated
     assert "PRIVATE RAW QUERY" not in generated
@@ -315,13 +319,24 @@ def test_output_is_deterministic_from_fixture_inputs(tmp_path: Path) -> None:
 
     first_md, first_tasks = _run(tmp_path / "first", summary=summary, prs=prs)
     second_md, second_tasks = _run(tmp_path / "second", summary=summary, prs=prs)
+    first_html = (tmp_path / "first" / "reports" / "ai_next_actions.html").read_text(
+        encoding="utf-8"
+    )
+    second_html = (tmp_path / "second" / "reports" / "ai_next_actions.html").read_text(
+        encoding="utf-8"
+    )
 
     assert first_md == second_md
     assert first_tasks == second_tasks
+    assert first_html == second_html
 
 
 def test_default_outputs_are_gitignored() -> None:
-    for rel in ("reports/ai_next_actions.md", "reports/codex_tasks/001-example.md"):
+    for rel in (
+        "reports/ai_next_actions.md",
+        "reports/ai_next_actions.html",
+        "reports/codex_tasks/001-example.md",
+    ):
         result = subprocess.run(
             ["git", "check-ignore", "-q", "--", rel],
             cwd=ROOT,
@@ -329,6 +344,17 @@ def test_default_outputs_are_gitignored() -> None:
             check=False,
         )
         assert result.returncode == 0, rel
+
+
+def test_html_output_can_be_disabled(tmp_path: Path) -> None:
+    out_md = tmp_path / "reports" / "ai_next_actions.md"
+    tasks_dir = tmp_path / "reports" / "codex_tasks"
+
+    rc = planner.main(["--out-md", str(out_md), "--out-html", "", "--tasks-dir", str(tasks_dir)])
+
+    assert rc == 0
+    assert out_md.exists()
+    assert not (tmp_path / "reports" / "ai_next_actions.html").exists()
 
 
 def test_missing_required_pr_json_fields_fail_closed(tmp_path: Path) -> None:
@@ -348,3 +374,21 @@ def test_unstable_merge_state_is_blocked(tmp_path: Path) -> None:
     assert "Top task: `blocked` - Unblock PR #12" in md
     assert "merge state is UNSTABLE" in md
     assert any("Resolve review, merge, or CI blockers" in body for body in tasks.values())
+
+
+def test_html_report_escapes_pr_text(tmp_path: Path) -> None:
+    _run(
+        tmp_path,
+        summary=_summary(),
+        prs=[
+            _pr(
+                title="<script>alert('x')</script>",
+                body="No blocker.",
+            )
+        ],
+    )
+    html = (tmp_path / "reports" / "ai_next_actions.html").read_text(encoding="utf-8")
+
+    assert "<script>alert" not in html
+    assert "&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;" in html
+    assert "Human-readable view of the deterministic Codex planner" in html


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`scripts/ai_next_actions.py`의 deterministic planner 결과를 사람이 바로 훑을 수 있도록 `reports/ai_next_actions.html` 정적 상태판을 추가했습니다. 기존 Markdown task brief는 유지하고, HTML은 local-only status board이며 PR 증거(evidence)가 아님을 문서화했습니다.

Closes #1506

## 2. 영향 파일

- `scripts/ai_next_actions.py`: `--out-html` CLI와 self-contained HTML renderer 추가
- `tests/test_ai_next_actions.py`: HTML 생성, escape, privacy, determinism, disable 경로 검증
- `docs/operations/ai-codex-workflow.md`: human review surface 사용법과 classification 순서 정렬
- `docs/reviews/README.md`: fast triage surface pointer 추가
- `tasks/queue.md`, `docs/plans/T-2026-0006-human-review-surface.md`: T-2026-0006 운영 기록

## 3. 리스크

- 가장 큰 리스크는 PR 제목/body 같은 외부 텍스트가 HTML에서 escape되지 않거나, local HTML이 승인 근거(evidence)로 오해되는 것입니다.
- 이를 배제하기 위해 HTML escape 테스트, forbidden private field non-leak 테스트, docs 문구를 추가했습니다.

## 4. 테스트

```bash
python3 -m py_compile scripts/ai_next_actions.py
python3 -m pytest -q tests/test_ai_next_actions.py
python3 scripts/check_doc_links.py --check-all
python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0006-human-review-surface.md tasks/queue.md docs/operations/ai-codex-workflow.md docs/reviews/README.md
git diff --check
make check-branch
```

Browser visual check was attempted against the generated local `file://` HTML, but the Codex app URL policy blocked `file://` navigation. I did not work around that policy.

## 5. Eval 영향

All `N/A`: workflow/reviewer tooling only. 검색(retrieval), 재순위(reranking), 검증(verifier), 답변(answer), eval runner, benchmark metric behavior changed none.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Load-bearing path 변경이 아니며 private real-eval delta를 실행하지 않았습니다. 성능(performance) 주장은 없습니다.

## 6. 하위 호환

- 기존 기본 출력 `reports/ai_next_actions.md`와 `reports/codex_tasks/*.md` 유지.
- 새 기본 출력 `reports/ai_next_actions.html` 추가.
- `--out-html ""`로 HTML 생성을 끌 수 있습니다.

## 7. 범위 외

- GitHub Pages 공개 dashboard, JS 기반 UI, external service integration은 하지 않았습니다.
- 실제 open PR 상태를 자동 fetch하는 wrapper target은 별도 follow-up 범위입니다.
