### PR TITLE
chore: add failure case html board

### DIFF
--- a/docs/operations/failure-mode-harden-process.md
+++ b/docs/operations/failure-mode-harden-process.md
@@ -44,7 +44,7 @@ in-test `test_ceilings_are_monotone_sane` 은 역전(천장 < 현재 rate)만 �
 |---|---|---|
 | classifier | `eval/scorers/failure_classifier.py` | 7-category first-match-wins 라벨 (ADR 0059) |
 | classifier lock | `tests/test_failure_classifier.py` | ordering 을 고정해 Finding #1 이 `verifier_false_negative` 로 유지되게 함 |
-| dashboard | `scripts/render_failure_distribution.py` | distribution + ADR 0059 계약 ✓ 렌더 (supply 2) |
+| dashboard | `scripts/render_failure_distribution.py` | distribution + ADR 0059 계약 ✓ 렌더 (Markdown/aggregate JSON + local HTML board) |
 | **regression gate** | `tests/test_failure_rate_regression.py` | **커밋된 baseline 의 래칫 천장 (ADR 0062)** |
 | **ratchet gate** | `scripts/check_branch_and_issue.py --check-ceiling-ratchet` | **base 대비 ceiling 상향/제거를 `[ALLOW_REGRESSION]` 없이 차단 (CI, issue #1150)** |
 | baseline | `reports/real100/baseline.aggregate.json` | 게이트가 읽는 커밋된 aggregate (ADR 0005 경계) |
@@ -71,7 +71,8 @@ in-test `test_ceilings_are_monotone_sane` 은 역전(천장 < 현재 rate)만 �
 
 4. **대시보드가 렌더하는지 검증한다.**
    `scripts/render_failure_distribution.py` 를 재실행한다; 새 카테고리가
-   `reports/real100/failure_distribution.md` 에 나타난다.
+   `reports/real100/failure_distribution.md` 와 local-only
+   `reports/real100/failure_distribution.html` 에 나타난다.
 
 ## fix 이후 천장 조이기
 

--- a/docs/plans/T-2026-0007-failure-case-board.md
+++ b/docs/plans/T-2026-0007-failure-case-board.md
@@ -1,0 +1,113 @@
+# Plan: T-2026-0007 Failure Case Board
+
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0007`
+- Related issue / PR: [#1510](https://github.com/hskim-solv/BidMate-DocAgent/issues/1510) / PR TBD
+- Related ADR: N/A - no decision-level change
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+## Problem Statement
+
+`scripts/render_failure_distribution.py` already emits a Markdown dashboard and
+aggregate JSON, but the human-facing failure triage view is still dense. Reviewers
+need a local HTML board that highlights total failures, dominant categories,
+the ADR 0075 contract, refusal-axis counts, and populated slice tables without
+changing classifier semantics or exposing private per-case data.
+
+## Desired Behavior
+
+Running the failure distribution renderer writes the existing committable
+Markdown and aggregate JSON plus a local `reports/real100/failure_distribution.html`
+file. The HTML is deterministic, dependency-free, and aggregate-only.
+
+## Constraints
+
+- Scope: reviewer tooling only.
+- Architecture: reuse `build_aggregate()` and keep `eval.scorers.failure_classifier`
+  as the single source of truth.
+- Compatibility: keep existing Markdown and aggregate JSON paths unchanged.
+- Privacy: render only counts and fail-closed enum buckets; escape HTML.
+- Non-goals: no classifier, retrieval, verifier, answer, eval scoring, or private
+  data changes.
+
+## Affected Interfaces
+
+- CLI: add `--out-html`, defaulting to `reports/real100/failure_distribution.html`;
+  `--out-html ""` disables HTML output.
+- Output artifacts: local ignored HTML board alongside committed Markdown/JSON.
+- Tests: extend renderer tests for HTML sections, contract warning, escaping,
+  disable behavior, and no private string leakage.
+
+## Data / Eval Impact
+
+- Surface: private real-eval aggregate viewer.
+- Data boundary: aggregate-only private output under ADR 0005.
+- Allowed claim: renderer now has a local human-readable failure case board.
+- Disallowed claim: no model quality, retrieval, verifier, or failure-rate
+  improvement claim.
+- Baseline/control affected: no.
+- Benchmark/eval auditor required: no.
+
+## Task Breakdown
+
+1. Add a small shared HTML report shell for local deterministic reports.
+2. Add HTML rendering and CLI output to `scripts/render_failure_distribution.py`.
+3. Add tests for HTML rendering, privacy, and disabled output.
+4. Document that the failure dashboard now has a local HTML view.
+
+## Acceptance Criteria
+
+- [x] Renderer emits Markdown, aggregate JSON, and local HTML by default.
+- [x] HTML output can be disabled with `--out-html ""`.
+- [x] HTML escapes dynamic text and does not leak raw query/doc strings.
+- [x] Existing Markdown/JSON behavior and schema stay unchanged.
+- [x] Workflow docs mention the HTML dashboard.
+
+## Validation Strategy
+
+Commands run:
+
+```bash
+python3 -m py_compile scripts/html_report.py scripts/render_failure_distribution.py
+python3 -m pytest -q tests/test_render_failure_distribution.py
+git diff --check
+```
+
+Expected evidence:
+
+- Focused test suite passes.
+- Generated HTML is local-only and ignored by git.
+- No real-eval performance claim is made.
+
+## Rollback Strategy
+
+Revert the helper, renderer, tests, docs, queue entry, and this plan. Generated
+`reports/real100/failure_distribution.html` artifacts are local ignored files
+and can be deleted without affecting committed evidence.
+
+## Reviewer Notes
+
+Attack privacy first: HTML must not leak raw query text, answer text, doc id,
+or chunk id. Then verify that `failure_distribution.md` and
+`failure_distribution.aggregate.json` remain the evidence artifacts.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Branch / worktree: chore/issue-1510-failure-case-board / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Issue / PR: #1510 / PR TBD
+- Task: T-2026-0007
+- Current status: implementation complete, validation passing.
+- Files touched: scripts/html_report.py, scripts/render_failure_distribution.py, tests/test_render_failure_distribution.py, docs/operations/failure-mode-harden-process.md, tasks/queue.md, docs/plans/T-2026-0007-failure-case-board.md
+- Decisions made: local self-contained HTML, no JS/dependencies, aggregate-only report shell.
+- Commands run: python3 -m py_compile scripts/html_report.py scripts/render_failure_distribution.py; python3 -m pytest -q tests/test_render_failure_distribution.py; git diff --check
+- Results: pass.
+- Next safe command: python3 -m pytest -q tests/test_render_failure_distribution.py
+- Open questions: none.
+- Risks: reviewer may prefer refactoring `ai_next_actions` to the shared shell in a later PR.
+```

--- a/scripts/html_report.py
+++ b/scripts/html_report.py
@@ -1,0 +1,218 @@
+"""Small helpers for self-contained local HTML reports.
+
+These helpers intentionally stay presentation-only: callers pass already
+aggregate-safe values, and all public text cells are escaped at the boundary.
+"""
+from __future__ import annotations
+
+from html import escape
+from typing import Sequence
+
+
+def html_text(value: object) -> str:
+    """Escape text for HTML element content and attributes."""
+    return escape(str(value), quote=True)
+
+
+def _tone_class(tone: str) -> str:
+    if tone in {"ok", "warn", "danger", "accent", "neutral"}:
+        return tone
+    return "neutral"
+
+
+def render_badge(label: object, *, tone: str = "neutral") -> str:
+    return (
+        f'<span class="badge {_tone_class(tone)}">'
+        f"{html_text(label)}</span>"
+    )
+
+
+def render_status_card(
+    label: object,
+    value: object,
+    *,
+    detail: object = "",
+    tone: str = "neutral",
+) -> str:
+    detail_html = f"<small>{html_text(detail)}</small>" if detail else ""
+    return (
+        f'<article class="status-card {_tone_class(tone)}">'
+        f"<span>{html_text(label)}</span>"
+        f"<strong>{html_text(value)}</strong>"
+        f"{detail_html}</article>"
+    )
+
+
+def render_table(
+    headers: Sequence[object],
+    rows: Sequence[Sequence[object]],
+    *,
+    empty_message: object = "No rows",
+) -> str:
+    header_html = "".join(f"<th>{html_text(header)}</th>" for header in headers)
+    if not rows:
+        body_html = (
+            f'<tr><td class="empty" colspan="{len(headers)}">'
+            f"{html_text(empty_message)}</td></tr>"
+        )
+    else:
+        body_html = "\n".join(
+            "<tr>"
+            + "".join(f"<td>{html_text(cell)}</td>" for cell in row)
+            + "</tr>"
+            for row in rows
+        )
+    return (
+        "<table>"
+        f"<thead><tr>{header_html}</tr></thead>"
+        f"<tbody>{body_html}</tbody>"
+        "</table>"
+    )
+
+
+def render_document(
+    *,
+    title: object,
+    subtitle: object,
+    body: str,
+    footer: object,
+) -> str:
+    """Wrap prebuilt report sections in a deterministic, dependency-free shell."""
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html_text(title)}</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --text: #1d2430;
+      --muted: #5b6575;
+      --line: #d9dee7;
+      --ok: #176f4d;
+      --warn: #986400;
+      --danger: #b42318;
+      --accent: #2459a7;
+      --neutral: #667085;
+      --table-stripe: #fbfcfe;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+    main {{
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 20px 48px;
+    }}
+    header {{
+      margin-bottom: 24px;
+    }}
+    h1, h2, h3, p {{ margin: 0; }}
+    h1 {{ font-size: 30px; line-height: 1.15; }}
+    h2 {{ font-size: 18px; margin-bottom: 12px; }}
+    h3 {{ font-size: 16px; margin: 18px 0 8px; }}
+    .subtitle {{ color: var(--muted); margin-top: 6px; max-width: 780px; }}
+    .grid {{
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 20px;
+    }}
+    .status-card, .panel {{
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: 0 1px 2px rgba(18, 24, 31, 0.04);
+    }}
+    .status-card {{
+      min-height: 96px;
+      padding: 14px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      border-top: 4px solid var(--neutral);
+    }}
+    .status-card span {{
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+    }}
+    .status-card strong {{ font-size: 20px; overflow-wrap: anywhere; }}
+    .status-card small {{ color: var(--muted); overflow-wrap: anywhere; }}
+    .ok {{ border-top-color: var(--ok); }}
+    .warn {{ border-top-color: var(--warn); }}
+    .danger {{ border-top-color: var(--danger); }}
+    .accent {{ border-top-color: var(--accent); }}
+    .panel {{ padding: 18px; margin-bottom: 16px; }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+    }}
+    th, td {{
+      text-align: left;
+      border-top: 1px solid var(--line);
+      padding: 10px 8px;
+      vertical-align: top;
+    }}
+    tbody tr:nth-child(even) {{ background: var(--table-stripe); }}
+    thead th {{
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+    }}
+    code {{
+      background: #eef1f5;
+      border-radius: 5px;
+      padding: 2px 5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }}
+    .badge {{
+      display: inline-block;
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--neutral);
+      border-radius: 6px;
+      padding: 3px 7px;
+      background: #fff;
+      white-space: nowrap;
+    }}
+    .badge.ok {{ border-left-color: var(--ok); }}
+    .badge.warn {{ border-left-color: var(--warn); }}
+    .badge.danger {{ border-left-color: var(--danger); }}
+    .badge.accent {{ border-left-color: var(--accent); }}
+    .empty {{ color: var(--muted); text-align: center; }}
+    .note {{ color: var(--muted); margin-bottom: 12px; }}
+    .stack {{
+      display: grid;
+      gap: 16px;
+    }}
+    footer {{ color: var(--muted); margin-top: 18px; font-size: 13px; }}
+    @media (max-width: 900px) {{
+      .grid {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }}
+    }}
+    @media (max-width: 560px) {{
+      main {{ padding: 22px 12px 36px; }}
+      .grid {{ grid-template-columns: 1fr; }}
+      th, td {{ padding: 8px 4px; }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>{html_text(title)}</h1>
+      <p class="subtitle">{html_text(subtitle)}</p>
+    </header>
+    {body}
+    <footer>{html_text(footer)}</footer>
+  </main>
+</body>
+</html>
+"""

--- a/scripts/render_failure_distribution.py
+++ b/scripts/render_failure_distribution.py
@@ -3,7 +3,8 @@
 
 Reads ``reports/real100/eval_summary.json`` (gitignored, local-only) and
 emits a committable markdown + aggregate JSON pair under
-``reports/real100/failure_distribution.{md,aggregate.json}``.
+``reports/real100/failure_distribution.{md,aggregate.json}`` plus a local
+human-readable HTML board at ``reports/real100/failure_distribution.html``.
 
 The data this renderer surfaces was introduced by ADR 0059 and normalized by
 ADR 0075 — top-level ``failure_category_counts: dict[str, int]`` with a
@@ -42,6 +43,7 @@ CLI::
     python3 scripts/render_failure_distribution.py
     python3 scripts/render_failure_distribution.py --summary path/to/eval_summary.json
     python3 scripts/render_failure_distribution.py --out-md X.md --out-json Y.json
+    python3 scripts/render_failure_distribution.py --out-html X.html
 
 Exit codes::
 
@@ -68,12 +70,20 @@ from eval.scorers.failure_classifier import (  # noqa: E402
     FAILURE_CATEGORIES,
     classify_failure,
 )
+from scripts.html_report import (  # noqa: E402
+    html_text,
+    render_badge,
+    render_document,
+    render_status_card,
+    render_table,
+)
 
 DEFAULT_SUMMARY = ROOT / "reports" / "real100" / "eval_summary.json"
 DEFAULT_OUT_MD = ROOT / "reports" / "real100" / "failure_distribution.md"
 DEFAULT_OUT_JSON = (
     ROOT / "reports" / "real100" / "failure_distribution.aggregate.json"
 )
+DEFAULT_OUT_HTML = ROOT / "reports" / "real100" / "failure_distribution.html"
 
 # Single source of truth for the normalized taxonomy is
 # ``eval.scorers.failure_classifier.FAILURE_CATEGORIES`` (imported above) —
@@ -424,6 +434,117 @@ def render_markdown(aggregate: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_html(aggregate: dict[str, Any]) -> str:
+    """Render the aggregate dict as a local human-readable HTML board."""
+    counts = aggregate["failure_category_counts"]
+    pcts = aggregate["failure_category_percent_of_failed"]
+    outcomes = aggregate["abstention_outcomes"]
+    total_failures = aggregate["total_failures"]
+    num_predictions = aggregate["num_predictions"]
+    finding = aggregate["finding_1_contract"]
+    slice_counts = aggregate.get("slice_counts") or {}
+
+    ranked = sorted(SAFE_CATEGORIES, key=lambda c: counts[c], reverse=True)
+    top_category = ranked[0] if ranked else "unknown"
+    failure_rate = 100.0 * total_failures / max(1, num_predictions)
+    nonzero_slice_count = sum(
+        1 for category in SAFE_CATEGORIES if slice_counts.get(category, {}).get("n", 0) > 0
+    )
+    slice_status = "case_results" if nonzero_slice_count > 0 else "zeroed"
+
+    cards = [
+        render_status_card(
+            "Total failures",
+            f"{total_failures} / {num_predictions}",
+            detail=f"{failure_rate:.1f}% of cases",
+            tone="warn" if total_failures else "ok",
+        ),
+        render_status_card(
+            "Top category",
+            top_category,
+            detail=f"{counts[top_category]} failures, {pcts[top_category]:.2f}% of failed",
+            tone="accent" if counts[top_category] else "ok",
+        ),
+        render_status_card(
+            "ADR 0075 contract",
+            "PASS" if finding["match"] else "FAIL",
+            detail=(
+                f"verifier_false_negative={finding['verifier_false_negative']} / "
+                f"incorrect_answer={finding['incorrect_answer']}"
+            ),
+            tone="ok" if finding["match"] else "danger",
+        ),
+        render_status_card(
+            "Slice source",
+            slice_status,
+            detail=f"{nonzero_slice_count} populated category slice(s)",
+            tone="accent" if nonzero_slice_count else "neutral",
+        ),
+    ]
+
+    composition_rows = [
+        [rank, category, counts[category], f"{pcts[category]:.2f}%"]
+        for rank, category in enumerate(ranked, start=1)
+    ]
+    outcome_rows = [[key, outcomes[key]] for key in SAFE_OUTCOME_KEYS]
+
+    contract_badge = render_badge(
+        "PASS" if finding["match"] else "FAIL",
+        tone="ok" if finding["match"] else "danger",
+    )
+    contract_text = (
+        "First-match-wins ordering is intact."
+        if finding["match"]
+        else (
+            "CONTRACT VIOLATED: verifier_false_negative diverges from "
+            "abstention_outcomes.incorrect_answer."
+        )
+    )
+
+    body_sections = [
+        f'<section class="grid">{"".join(cards)}</section>',
+        '<section class="panel"><h2>Composition</h2>'
+        '<p class="note">% of failures uses failed cases as the denominator.</p>'
+        + render_table(
+            ["Rank", "Category", "Count", "% of failures"],
+            composition_rows,
+        )
+        + "</section>",
+        '<section class="panel"><h2>ADR 0075 First-match Contract</h2>'
+        f'<p class="note">{contract_badge} {html_text(contract_text)}</p>'
+        + render_table(
+            ["Field", "Count"],
+            [
+                [
+                    "failure_category_counts.verifier_false_negative",
+                    finding["verifier_false_negative"],
+                ],
+                ["abstention_outcomes.incorrect_answer", finding["incorrect_answer"]],
+            ],
+        )
+        + "</section>",
+        '<section class="panel"><h2>Refusal-axis Cross-reference</h2>'
+        '<p class="note">PR #464 3-bin refusal-axis counts overlaid on the normalized surface.</p>'
+        + render_table(["Bin", "Count"], outcome_rows)
+        + "</section>",
+        _render_slice_html(aggregate),
+    ]
+
+    return render_document(
+        title=f"Failure-mode distribution (real100, n={num_predictions})",
+        subtitle=(
+            "Aggregate-only reviewer board generated from "
+            "reports/real100/eval_summary.json. No per-case query text, answer text, "
+            "doc id, or chunk id is emitted."
+        ),
+        body="\n".join(body_sections),
+        footer=(
+            "Local workflow artifact. The committable evidence remains "
+            "failure_distribution.md and failure_distribution.aggregate.json."
+        ),
+    )
+
+
 def _render_dim_table(title: str, dim: dict[str, int]) -> list[str]:
     """One sub-table for a single slice dimension (bucket → count)."""
     out = [f"**{title}**", "", "| bucket | count |", "|---|---:|"]
@@ -489,6 +610,50 @@ def _render_slice_markdown(aggregate: dict[str, Any]) -> list[str]:
     return lines
 
 
+def _render_slice_html(aggregate: dict[str, Any]) -> str:
+    """Per-category slice panels for the HTML report."""
+    slice_counts = aggregate.get("slice_counts") or {}
+    ranked = sorted(
+        (c for c in SAFE_CATEGORIES if slice_counts.get(c, {}).get("n", 0) > 0),
+        key=lambda c: slice_counts[c]["n"],
+        reverse=True,
+    )
+    if not ranked:
+        return (
+            '<section class="panel"><h2>Per-category Slices</h2>'
+            '<p class="note">No case_results in the source summary. The slice block '
+            "is zeroed; regenerate from a post-#1239 real-eval run for populated "
+            "slice tables.</p></section>"
+        )
+
+    panels: list[str] = [
+        '<section class="panel"><h2>Per-category Slices</h2>'
+        '<p class="note">Counts re-derived from case_results via '
+        "eval.scorers.failure_classifier.classify_failure. Values are counts or "
+        "fail-closed enum buckets only.</p>"
+    ]
+    for category in ranked:
+        payload = slice_counts[category]
+        panels.append(
+            f"<h3>{html_text(category)} (n={html_text(payload['n'])})</h3>"
+        )
+        for title, key in (
+            ("query_type", "query_type"),
+            ("hardcase_categories (multi-tag)", "hardcase_categories"),
+            ("evidence cardinality", "evidence_cardinality"),
+            ("expected_doc coverage", "expected_doc_coverage"),
+            ("retry_count", "retry_count"),
+            ("query specificity", "query_specificity"),
+            ("aux signals (True count)", "aux_true"),
+        ):
+            dim = payload[key]
+            rows = [[bucket, count] for bucket, count in dim.items()]
+            panels.append(f"<h3>{html_text(title)}</h3>")
+            panels.append(render_table(["Bucket", "Count"], rows))
+    panels.append("</section>")
+    return "\n".join(panels)
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Render failure-mode distribution dashboard.",
@@ -511,6 +676,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_OUT_JSON,
         help=f"Aggregate JSON output path (default: {DEFAULT_OUT_JSON})",
     )
+    parser.add_argument(
+        "--out-html",
+        default=str(DEFAULT_OUT_HTML),
+        help=(
+            "Optional human-readable HTML output path "
+            f"(default: {DEFAULT_OUT_HTML}). Pass an empty string to skip."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -527,12 +700,19 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Failed to build aggregate: {exc}", file=sys.stderr)
         return 1
     markdown = render_markdown(aggregate)
+    out_html = Path(args.out_html) if args.out_html else None
+    html_report = render_html(aggregate) if out_html is not None else None
     args.out_md.parent.mkdir(parents=True, exist_ok=True)
     args.out_md.write_text(markdown)
     args.out_json.parent.mkdir(parents=True, exist_ok=True)
     args.out_json.write_text(json.dumps(aggregate, indent=2, sort_keys=True) + "\n")
+    if out_html is not None and html_report is not None:
+        out_html.parent.mkdir(parents=True, exist_ok=True)
+        out_html.write_text(html_report)
     print(f"[OK] Wrote {args.out_md}")
     print(f"[OK] Wrote {args.out_json}")
+    if out_html is not None:
+        print(f"[OK] Wrote {out_html}")
     return 0
 
 

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -16,6 +16,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 3 | `T-2026-0003` | `review` | Implementer -> Reviewer | auto-ship Stage 5 Desktop main fast-forward sync 구현됨. |
 | 4 | `T-2026-0004` | `review` | Implementer -> Reviewer | HWP -> PDF -> PyMuPDF4LLM opt-in loader 구현됨. |
 | 5 | `T-2026-0006` | `review` | Implementer -> Reviewer | `ai_next_actions` human-readable HTML review surface 구현됨. |
+| 6 | `T-2026-0007` | `review` | Implementer -> Reviewer | failure distribution local HTML board 구현됨. |
 
 ## Examples
 
@@ -480,4 +481,94 @@ make check-branch
 - Open risks: reviewer should inspect whether the inline HTML/CSS is acceptable for a local-only generated report.
 - Next safe command: python3 -m pytest -q tests/test_ai_next_actions.py
 - Reviewer focus: privacy-safe rendering, deterministic output, and no evidence over-claim.
+```
+
+## T-2026-0007 — Human-readable failure case board
+
+- ID: T-2026-0007
+- Title: Human-readable failure case board
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+### Goal
+
+Give reviewers a compact local HTML view of failure-mode distribution and
+per-category slices without replacing the committed Markdown/aggregate JSON
+evidence.
+
+### Context
+
+- Surface: private real-eval aggregate viewer.
+- Relevant docs: [`docs/operations/failure-mode-harden-process.md`](../docs/operations/failure-mode-harden-process.md),
+  [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md),
+  [ADR 0075](../docs/adr/0075-normalized-failure-taxonomy.md).
+- Primary risk: raw private query/doc strings leaking into a human-facing local
+  report, or HTML being mistaken for model-quality evidence.
+
+### Scope
+
+- Add `reports/real100/failure_distribution.html` as a generated local artifact.
+- Keep `reports/real100/failure_distribution.md` and
+  `reports/real100/failure_distribution.aggregate.json` behavior unchanged.
+- Add a small shared HTML report shell for future local report surfaces.
+
+### Non-Goals
+
+- Do not change failure classifier ordering, taxonomy, eval scoring, retrieval,
+  verifier, answer generation, or private raw data.
+- Do not introduce JavaScript, external services, or runtime dependencies.
+- Do not publish local HTML artifacts.
+
+### Acceptance Criteria
+
+- [x] Renderer emits Markdown, aggregate JSON, and self-contained HTML by default.
+- [x] HTML output can be disabled with `--out-html ""`.
+- [x] HTML escapes dynamic text and does not leak raw query/doc strings.
+- [x] Existing aggregate schema remains unchanged.
+- [x] Workflow docs mention the local HTML dashboard.
+
+### Validation Commands
+
+```bash
+python3 -m py_compile scripts/html_report.py scripts/render_failure_distribution.py
+python3 -m pytest -q tests/test_render_failure_distribution.py
+python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0007-failure-case-board.md tasks/queue.md docs/operations/failure-mode-harden-process.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Doc-link check output.
+- Note that no real-eval performance claim is made.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0007-failure-case-board.md`](../docs/plans/T-2026-0007-failure-case-board.md)
+- Issue: [#1510](https://github.com/hskim-solv/BidMate-DocAgent/issues/1510)
+- PR: TBD
+- ADR: N/A
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1510-failure-case-board / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Task: T-2026-0007
+- Plan: docs/plans/T-2026-0007-failure-case-board.md
+- Current status: HTML failure board implemented on top of scripts/render_failure_distribution.py.
+- Files touched: scripts/html_report.py, scripts/render_failure_distribution.py, tests/test_render_failure_distribution.py, docs/operations/failure-mode-harden-process.md, tasks/queue.md, docs/plans/T-2026-0007-failure-case-board.md
+- Decisions made: Generate a self-contained local HTML file next to the existing Markdown/aggregate JSON output; keep source-of-truth classification in build_aggregate and failure_classifier.
+- Commands run: python3 -m py_compile scripts/html_report.py scripts/render_failure_distribution.py; python3 -m pytest -q tests/test_render_failure_distribution.py; git diff --check
+- Results: pass.
+- Eval surface: private real-eval aggregate viewer only.
+- Open risks: reviewer should inspect whether a later PR should migrate ai_next_actions HTML to the shared shell.
+- Next safe command: python3 -m pytest -q tests/test_render_failure_distribution.py
+- Reviewer focus: privacy-safe rendering, aggregate-only data boundary, and no evidence over-claim.
 ```

--- a/tests/test_render_failure_distribution.py
+++ b/tests/test_render_failure_distribution.py
@@ -16,6 +16,7 @@ from scripts.render_failure_distribution import (
     SAFE_OUTCOME_KEYS,
     build_aggregate,
     main,
+    render_html,
     render_markdown,
 )
 
@@ -225,10 +226,57 @@ class TestMarkdownRender(unittest.TestCase):
         self.assertIn("CONTRACT VIOLATED", md)
 
 
-class TestEndToEndCLI(unittest.TestCase):
-    """Main writes both artifacts to disk."""
+class TestHtmlRender(unittest.TestCase):
+    """HTML surface is reviewer-readable while staying aggregate-only."""
 
-    def test_writes_md_and_json(self) -> None:
+    def test_html_has_all_required_sections(self) -> None:
+        counts = {category: 0 for category in SAFE_CATEGORIES}
+        counts["retrieval_miss"] = 84
+        counts["verifier_false_negative"] = 65
+        outcomes = {key: 0 for key in SAFE_OUTCOME_KEYS}
+        outcomes["incorrect_answer"] = 65
+        agg = build_aggregate(
+            _summary(
+                num_predictions=221,
+                counts=counts,
+                outcomes=outcomes,
+                case_results=[_retrieval_miss_case(), _vfn_case()],
+            )
+        )
+        html = render_html(agg)
+        self.assertIn("<!doctype html>", html)
+        self.assertIn("Failure-mode distribution (real100, n=221)", html)
+        self.assertIn("Total failures", html)
+        self.assertIn("ADR 0075 First-match Contract", html)
+        self.assertIn("Refusal-axis Cross-reference", html)
+        self.assertIn("Per-category Slices", html)
+        self.assertIn("retrieval_miss", html)
+
+    def test_html_flags_contract_violation(self) -> None:
+        counts = {category: 0 for category in SAFE_CATEGORIES}
+        counts["verifier_false_negative"] = 60
+        outcomes = {key: 0 for key in SAFE_OUTCOME_KEYS}
+        outcomes["incorrect_answer"] = 65
+        html = render_html(build_aggregate(_summary(counts=counts, outcomes=outcomes)))
+        self.assertIn("FAIL", html)
+        self.assertIn("CONTRACT VIOLATED", html)
+
+    def test_html_escapes_dynamic_text(self) -> None:
+        counts = {category: 0 for category in SAFE_CATEGORIES}
+        counts["verifier_false_negative"] = 1
+        outcomes = {key: 0 for key in SAFE_OUTCOME_KEYS}
+        outcomes["incorrect_answer"] = 1
+        agg = build_aggregate(_summary(counts=counts, outcomes=outcomes))
+        agg["finding_1_contract"]["incorrect_answer"] = "<script>alert(1)</script>"
+        html = render_html(agg)
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", html)
+
+
+class TestEndToEndCLI(unittest.TestCase):
+    """Main writes artifacts to disk."""
+
+    def test_writes_md_json_and_html(self) -> None:
         counts = {category: 0 for category in SAFE_CATEGORIES}
         counts["retrieval_miss"] = 84
         counts["verifier_false_negative"] = 65
@@ -239,6 +287,7 @@ class TestEndToEndCLI(unittest.TestCase):
             summary_path = tmp_path / "eval_summary.json"
             md_path = tmp_path / "failure_distribution.md"
             json_path = tmp_path / "failure_distribution.aggregate.json"
+            html_path = tmp_path / "failure_distribution.html"
             summary_path.write_text(
                 json.dumps(_summary(counts=counts, outcomes=outcomes))
             )
@@ -250,14 +299,43 @@ class TestEndToEndCLI(unittest.TestCase):
                     str(md_path),
                     "--out-json",
                     str(json_path),
+                    "--out-html",
+                    str(html_path),
                 ]
             )
             self.assertEqual(exit_code, 0)
             self.assertTrue(md_path.exists())
             self.assertTrue(json_path.exists())
+            self.assertTrue(html_path.exists())
             written = json.loads(json_path.read_text())
             self.assertEqual(written["total_failures"], 149)
             self.assertTrue(written["finding_1_contract"]["match"])
+            self.assertIn("Failure-mode distribution", html_path.read_text())
+
+    def test_out_html_empty_disables_html(self) -> None:
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            summary_path = tmp_path / "eval_summary.json"
+            md_path = tmp_path / "failure_distribution.md"
+            json_path = tmp_path / "failure_distribution.aggregate.json"
+            html_path = tmp_path / "failure_distribution.html"
+            summary_path.write_text(json.dumps(_summary()))
+            exit_code = main(
+                [
+                    "--summary",
+                    str(summary_path),
+                    "--out-md",
+                    str(md_path),
+                    "--out-json",
+                    str(json_path),
+                    "--out-html",
+                    "",
+                ]
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(md_path.exists())
+            self.assertTrue(json_path.exists())
+            self.assertFalse(html_path.exists())
 
     def test_missing_summary_returns_nonzero(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -270,6 +348,8 @@ class TestEndToEndCLI(unittest.TestCase):
                     str(tmp_path / "x.md"),
                     "--out-json",
                     str(tmp_path / "x.json"),
+                    "--out-html",
+                    str(tmp_path / "x.html"),
                 ]
             )
             self.assertEqual(exit_code, 1)
@@ -422,6 +502,25 @@ class TestSliceNoPrivateLeak(unittest.TestCase):
         self.assertNotIn(secret_query, md)
         self.assertNotIn(secret_doc, md)
         self.assertIn("Per-category slices", md)
+
+    def test_html_has_no_private_strings(self) -> None:
+        secret_query = "비밀쿼리텍스트 얼마"
+        secret_doc = "secret-doc-id-zzz"
+        agg = build_aggregate(
+            _summary(
+                case_results=[
+                    _vfn_case(
+                        query=secret_query,
+                        evidence_doc_ids=[secret_doc],
+                        expected_doc_ids=[secret_doc],
+                    )
+                ]
+            )
+        )
+        html = render_html(agg)
+        self.assertNotIn(secret_query, html)
+        self.assertNotIn(secret_doc, html)
+        self.assertIn("Per-category Slices", html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1510

Failure-mode distribution을 사람이 빠르게 훑을 수 있도록 local-only HTML board를 추가합니다. 기존 `failure_distribution.md`와 `failure_distribution.aggregate.json`은 그대로 evidence artifact로 유지하고, HTML은 aggregate-only reviewer view로만 둡니다. 이 PR은 #1509 위에 stacked 되어 있습니다.

## 2. 영향 파일

- `scripts/html_report.py` — self-contained local HTML report shell helper
- `scripts/render_failure_distribution.py` — `--out-html` CLI와 HTML renderer 추가
- `tests/test_render_failure_distribution.py` — HTML section, contract warning, escaping, disabled output, private string non-leakage 테스트
- `docs/operations/failure-mode-harden-process.md` — failure dashboard HTML view 문서화
- `docs/plans/T-2026-0007-failure-case-board.md` — plan/handoff
- `tasks/queue.md` — T-2026-0007 queue entry

## 3. 리스크

가장 큰 리스크는 HTML이 raw query/doc id 같은 private per-case 문자열을 노출하거나, local status board가 eval evidence로 오해되는 것입니다. renderer는 기존 aggregate/slice counts만 읽고 HTML boundary에서 escaping하며, 테스트로 private marker 부재와 escaping을 검증했습니다.

## 4. 테스트

- `python3 -m py_compile scripts/html_report.py scripts/render_failure_distribution.py`
- `python3 -m pytest -q tests/test_render_failure_distribution.py`
- `python3 -m pytest -q tests/test_ai_next_actions.py tests/test_agent_loop.py::test_next_from_prs_writes_sanitized_agent_loop_outputs tests/test_render_failure_distribution.py`
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0007-failure-case-board.md tasks/queue.md docs/operations/failure-mode-harden-process.md`
- `git diff --check`
- `make check-branch`
- Browser verification over local HTTP: title rendered, 4 status cards present, ADR 0075 section present, `script` tag count = 0.

## 5. Eval 영향

No RAG/eval scoring behavior change. This is reviewer tooling over existing aggregate outputs only.

### 5b. Real-data delta

N/A — no load-bearing path changed and no retrieval/verifier/answer/eval scoring behavior changed. Real-data delta was not run; this PR makes no performance or readiness claim.

## 6. 하위 호환

Existing CLI outputs remain unchanged: Markdown and aggregate JSON still write to the same default paths. New `--out-html` defaults to `reports/real100/failure_distribution.html`; `--out-html ""` disables HTML generation.

## 7. 범위 외

- No classifier taxonomy/order change.
- No eval summary schema change.
- No retrieval/chunking/verifier/answer behavior change.
- `ai_next_actions` can be migrated to the shared HTML shell later if desired; not included here to keep this stacked PR focused.
