### PR TITLE
chore: reduce duplicate agent-loop automation reports

### DIFF
--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -58,6 +58,12 @@ make ship-start TITLE="자동화 범위 설명" TYPE=chore SLUG=short-slug
 [`Makefile:289-339`](../Makefile) 와
 [`scripts/claude-hooks/_ship_arm.py`](../../scripts/claude-hooks/_ship_arm.py) 참조.
 
+`make ship-arm` 은 승인된 end-to-end shipping 경로다. Agent-loop 의
+`auto-ship-prepare` / `auto-ship-plan` 은 이 경로를 준비·설명하는 명시적
+planning command 이며, local Stop hook 의 lightweight status refresh 는 이
+auto-ship 준비 리포트를 자동 갱신하지 않는다. 개별 push / PR 생성 / 머지 /
+브랜치 삭제가 필요할 때만 `human-gated-exec` 를 수동 fallback 으로 사용한다.
+
 ## 파이프라인 개요
 
 ```

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -5097,7 +5097,7 @@ def render_ship_command_pack(*, pr: str | None, branch: str | None, repo_root: P
     lines = [
         "# Ship Command Pack",
         "",
-        "- Command suggestions only. Do not run human-gated commands without explicit approval.",
+        "- Command suggestions only. Choose one shipping path after explicit approval.",
         "- This command did not push, create/merge/close PRs, delete branches, or force-push.",
         "",
         "## Safe Local Checks",
@@ -5111,14 +5111,17 @@ def render_ship_command_pack(*, pr: str | None, branch: str | None, repo_root: P
         "git diff --check",
         "```",
         "",
-        "## Existing Auto-Ship Bridge",
+        "## Primary End-to-End Ship Path",
         "",
         "```bash",
         "# plan only: python3 scripts/agent_loop.py auto-ship-plan --from-git --draft --dry-run",
-        "# arm existing Stop-hook pipeline after approval: make ship-arm REAL_EVAL=skip DRAFT=true DRY_RUN=1",
+        "# after approval, arm the single end-to-end Stop-hook pipeline:",
+        "# make ship-arm REAL_EVAL=skip DRAFT=true DRY_RUN=1",
         "```",
         "",
-        "## Human-Gated Commands",
+        "## Manual Fallback Commands",
+        "",
+        "Use these action-by-action commands only when the end-to-end `make ship-arm` path is not appropriate.",
         "",
         "```bash",
         f"# create PR after approval: python3 scripts/agent_loop.py human-gated-exec --action pr-create --branch {shell_branch} --body reports/agent_loop/pr_body.md --confirm-human-approved",
@@ -6990,8 +6993,10 @@ flowchart TD
   A --> INT["integration-pack and scheduled-status recipes"]
   INT --> MCP
   Q --> R{"Human gate: review, claims, merge, close, push, delete?"}
-  R -->|approved| EXEC["human-gated-exec or make ship-arm: explicit approved shipping mutation"]
-  EXEC --> S["Existing ship/manual workflow"]
+  R -->|end-to-end approved| SHIP["make ship-arm: approved single end-to-end ship pipeline"]
+  R -->|manual fallback approved| EXEC["human-gated-exec: action-by-action remote mutation fallback"]
+  SHIP --> S["Existing ship workflow"]
+  EXEC --> S["Manual fallback workflow"]
   R -->|more work| A
 ```
 
@@ -7022,10 +7027,10 @@ Automation points:
 - architecture-brief: summarize ADR/load-bearing trade-offs without choosing an architecture.
 - adr-reserve: propose ADR number and local draft without touching `docs/adr/`.
 - ship-simulate: predict auto-ship stop points without push/PR/merge/close/delete.
-- auto-ship-prepare: prepare or create a local ADR 0007 branch for existing `make ship-arm`; branch creation requires `--confirm-human-approved`.
-- auto-ship-plan: render a readiness-backed bridge to the existing `make ship-arm` Stop-hook pipeline without arming it.
+- auto-ship-prepare: prepare or create a local ADR 0007 branch for the primary `make ship-arm` pipeline; branch creation requires `--confirm-human-approved`.
+- auto-ship-plan: render a readiness-backed bridge to the primary `make ship-arm` Stop-hook pipeline without arming it.
 - ship-command-pack: render human-gated ship commands without executing them.
-- human-gated-exec: execute push/PR create/merge/close/remote branch delete/force-with-lease only with `--confirm-human-approved` and action-specific gates.
+- human-gated-exec: execute push/PR create/merge/close/remote branch delete/force-with-lease only as an action-by-action fallback with `--confirm-human-approved` and action-specific gates.
 - dependency-graph: render stacked PR graph without merge/delete mutation.
 - stacked-risk: detect dependent PR risk before merge/delete cleanup.
 - pr-body-check: verify `Closes`, §5b, claim, and privacy boundaries before PR creation.
@@ -7057,7 +7062,7 @@ Human intervention points:
 - Create or switch the local shipping branch when detached HEAD or protected branch state is detected.
 - Decide architecture tradeoffs, benchmark/performance claims, or private real-eval meaning.
 - Push, create/merge/close PRs, delete branches, or force-push.
-- For the above, use `human-gated-exec` or existing `make ship-arm` only after explicit human approval and action-specific preflight.
+- Prefer `make ship-arm` for approved end-to-end shipping; use `human-gated-exec` only as a manual fallback after explicit approval and action-specific preflight.
 - Approve reviewer findings and shipping path.
 """
 

--- a/scripts/claude-hooks/README.md
+++ b/scripts/claude-hooks/README.md
@@ -28,7 +28,7 @@ Claude Code 의 PreToolUse / Stop / UserPromptSubmit 훅 모음. `.claude/settin
 | [`pretooluse-loadbearing.sh`](./pretooluse-loadbearing.sh) | awareness | `Edit\|MultiEdit\|Write` | load-bearing 파일 편집 시 ADR / PR §5b 영향 환기 (CLAUDE.md) |
 | [`pretooluse-memory-lines.sh`](./pretooluse-memory-lines.sh) | graduated | `Edit\|MultiEdit\|Write` | MEMORY.md 라인 수 ≥AWARE 경고 / ≥BLOCK 차단 (issue #720) |
 | [`stop-ship.sh`](./stop-ship.sh) | pipeline | Stop | armed 상태일 때 commit→push→PR→CI→squash-merge 5-stage 자동 실행 (auto-ship) |
-| [`stop-agent-loop.sh`](./stop-agent-loop.sh) | pipeline | Stop | `.claude/.agent-loop-watch` 또는 `BIDMATE_AGENT_LOOP_STOP_HOOK=1` 일 때 ignored agent-loop reports 갱신 |
+| [`stop-agent-loop.sh`](./stop-agent-loop.sh) | pipeline | Stop | `.claude/.agent-loop-watch` 또는 `BIDMATE_AGENT_LOOP_STOP_HOOK=1` 일 때 ignored agent-loop status reports (`gate_status`, `loop_state`, `auto_pass`) 갱신 |
 | [`userpromptsubmit-delegation-gate.sh`](./userpromptsubmit-delegation-gate.sh) | nudge | UserPromptSubmit `.*` | non-trivial 변경 키워드 감지 시 Plan/Explore 위임 힌트 주입 (issue #1014) |
 
 ## Opt-in (자동 등록 아님)

--- a/scripts/claude-hooks/stop-agent-loop.sh
+++ b/scripts/claude-hooks/stop-agent-loop.sh
@@ -1,26 +1,25 @@
 #!/usr/bin/env bash
-# Claude Code Stop hook for BidMate agent-loop local report refresh.
+# Claude Code Stop hook for BidMate agent-loop lightweight status refresh.
 #
 # Enforcement: pipeline (local report refresh only; not a tool-call gate).
 # Classification rationale: Stop-hook only fires after Claude reply ends and
-# writes ignored local reports when explicitly armed; it never refuses tool use
-# and never performs shipping mutations.
+# writes ignored local status reports when explicitly armed; it never refuses
+# tool use and never performs shipping mutations.
 # See scripts/claude-hooks/README.md for the full enforcement taxonomy.
 #
 # Registered in `.claude/settings.json` as a Stop hook. Dominant path is no-op:
 # unless `.claude/.agent-loop-watch` exists, or BIDMATE_AGENT_LOOP_STOP_HOOK=1
 # is set, the hook exits immediately.
 #
-# When enabled, refreshes:
+# When enabled, refreshes only status-oriented reports:
 #   - reports/agent_loop/gate_status.md
 #   - reports/agent_loop/loop_state.json
 #   - reports/agent_loop/auto_pass.md
-#   - reports/agent_loop/auto_ship_prepare.md
-#   - reports/agent_loop/auto_ship_plan.md
 #
 # It intentionally does not pass --run-validation to auto-pass-check, and it
-# never pushes, creates/merges/closes PRs, deletes branches, force-pushes, runs
-# private real-eval, or approves benchmark/private claims.
+# never renders auto-ship prepare/plan reports, pushes, creates/merges/closes
+# PRs, deletes branches, force-pushes, runs private real-eval, or approves
+# benchmark/private claims.
 
 set -u
 
@@ -41,10 +40,6 @@ python3 scripts/agent_loop.py loop-state --from-git \
   --out reports/agent_loop/loop_state.json >/dev/null 2>&1 || true
 python3 scripts/agent_loop.py auto-pass-check --from-git \
   --out reports/agent_loop/auto_pass.md >/dev/null 2>&1 || true
-python3 scripts/agent_loop.py auto-ship-prepare \
-  --out reports/agent_loop/auto_ship_prepare.md >/dev/null 2>&1 || true
-python3 scripts/agent_loop.py auto-ship-plan --from-git --dry-run \
-  --out reports/agent_loop/auto_ship_plan.md >/dev/null 2>&1 || true
 
 python3 scripts/_governance.py --emit-fire \
   --outcome pipeline_end --hook agent-loop --category stop-report \

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1264,6 +1264,26 @@ def test_loop_map_marks_human_gates_and_safe_automation() -> None:
     assert "read-only `gh pr list`" in rendered
     assert "Human intervention points" in rendered
     assert "force-push" in rendered
+    assert "make ship-arm: approved single end-to-end ship pipeline" in rendered
+    assert "human-gated-exec: action-by-action remote mutation fallback" in rendered
+    assert "Prefer `make ship-arm` for approved end-to-end shipping" in rendered
+
+
+def test_ship_command_pack_separates_primary_ship_path_from_manual_fallback(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+
+    rendered = agent_loop.render_ship_command_pack(
+        pr="12",
+        branch="chore/issue-9999-agent-loop",
+        repo_root=repo,
+    )
+
+    assert "## Primary End-to-End Ship Path" in rendered
+    assert "## Manual Fallback Commands" in rendered
+    assert "Choose one shipping path after explicit approval" in rendered
+    assert "action-by-action commands only when the end-to-end `make ship-arm` path is not appropriate" in rendered
+    assert "# make ship-arm REAL_EVAL=skip DRAFT=true DRY_RUN=1" in rendered
+    assert "--action pr-create" in rendered
 
 
 def test_approval_packet_pr_body_context_and_ship_simulation_are_local_reports(tmp_path: Path) -> None:
@@ -1609,7 +1629,8 @@ def test_adr_html_context_ship_commands_and_apply_queue_plan(tmp_path: Path) -> 
     assert context_out == repo / "reports" / "agent_loop" / "context_pack.md"
     assert "Profile: `claude`" in context
     assert commands_out == repo / "reports" / "agent_loop" / "ship_commands.md"
-    assert "Human-Gated Commands" in commands
+    assert "Primary End-to-End Ship Path" in commands
+    assert "Manual Fallback Commands" in commands
     assert apply_out == repo / "reports" / "agent_loop" / "apply_queue_plan.md"
     assert "applied" in applied
     assert (repo / "docs" / "plans" / "T-2026-0000-draft.md").exists()

--- a/tests/test_agent_loop_claude_integration.py
+++ b/tests/test_agent_loop_claude_integration.py
@@ -53,7 +53,7 @@ def test_stop_agent_loop_no_watch_is_noop(tmp_path: Path) -> None:
     assert not (repo / "reports" / "agent_loop").exists()
 
 
-def test_stop_agent_loop_watch_refreshes_local_reports_and_telemetry(tmp_path: Path) -> None:
+def test_stop_agent_loop_watch_refreshes_status_reports_and_telemetry(tmp_path: Path) -> None:
     repo = _copy_agent_loop_hook_repo(tmp_path)
     _git("init", "-q", "-b", "main", cwd=repo)
     (repo / ".gitignore").write_text(".claude/\nreports/\n", encoding="utf-8")
@@ -76,8 +76,8 @@ def test_stop_agent_loop_watch_refreshes_local_reports_and_telemetry(tmp_path: P
     assert (report_dir / "gate_status.md").exists()
     assert (report_dir / "loop_state.json").exists()
     assert (report_dir / "auto_pass.md").exists()
-    assert (report_dir / "auto_ship_prepare.md").exists()
-    assert (report_dir / "auto_ship_plan.md").exists()
+    assert not (report_dir / "auto_ship_prepare.md").exists()
+    assert not (report_dir / "auto_ship_plan.md").exists()
     fires = (repo / ".claude" / ".hook-fires.log").read_text(encoding="utf-8")
     assert "|pipeline_end|agent-loop|stop-report|reports/agent_loop/loop_state.json" in fires
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Agent-loop 자동화 중복을 보수적으로 줄였습니다. Stop hook watch refresh는 status report만 갱신하고, auto-ship prepare/plan report는 명시적 agent-loop-auto-ship command 또는 Make target에서만 생성되도록 경계를 분리했습니다. Shipping 안내도 `make ship-arm`은 end-to-end primary path, `human-gated-exec`는 action-by-action fallback으로 정리했습니다.

Closes #1512

## 2. 영향 파일

- `scripts/claude-hooks/stop-agent-loop.sh` — watch refresh 범위를 status report로 축소
- `scripts/agent_loop.py` — ship command pack / loop map 문구에서 primary path와 fallback 분리
- `scripts/claude-hooks/README.md`, `docs/operations/auto-ship.md` — 기존 운영 문서 amend
- `tests/test_agent_loop.py`, `tests/test_agent_loop_claude_integration.py` — 새 경계 회귀 테스트

## 3. 리스크

- Watch mode 사용자가 더 이상 Stop hook만으로 `auto_ship_prepare.md` / `auto_ship_plan.md`를 자동 갱신하지 못합니다. 의도된 변경이며, 명시적 `agent-loop-auto-ship` command나 Make target은 유지됩니다.
- Shipping 안내가 잘못 해석될 수 있는 리스크는 테스트에서 primary path와 fallback 문구를 고정해 낮췄습니다.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop_claude_integration.py tests/test_agent_loop.py::test_loop_map_marks_human_gates_and_safe_automation tests/test_agent_loop.py::test_ship_command_pack_separates_primary_ship_path_from_manual_fallback tests/test_agent_loop.py::test_workflow_uses_hardened_readonly_agent_loop_artifacts -q`
- `python3 -m pytest tests/test_ship_dispatcher_gates.py tests/test_ship_arm_mutex.py -q`
- `git diff --check`

## 5. Eval 영향

All `N/A` — RAG 검색(retrieval), 재순위(reranking), 검증(verification), 답변(answer), eval scoring 동작 변경 없음. Agent-loop 자동화 리포트 경계와 문구 정리만 포함합니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

## 6. 하위 호환

기존 CLI subcommand, Make target, workflow 이름은 유지됩니다. 변경되는 동작은 `.claude/.agent-loop-watch` 활성 Stop hook이 auto-ship prepare/plan report를 자동 갱신하지 않는 것뿐입니다. 명시적 command/Make target으로 같은 산출물을 계속 만들 수 있습니다.

## 7. 범위 외

- GitHub Actions 자동화 비활성화
- `make ship-arm` 또는 `human-gated-exec` 제거
- deploy/publish workflow 정책 변경
