### PR TITLE
chore: add chunking diagnostics html board

### DIFF
--- a/docs/plans/T-2026-0008-chunking-diagnostics-board.md
+++ b/docs/plans/T-2026-0008-chunking-diagnostics-board.md
@@ -1,0 +1,115 @@
+# Plan: T-2026-0008 Chunking Diagnostics Board
+
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0008`
+- Related issue / PR: [#1514](https://github.com/hskim-solv/BidMate-DocAgent/issues/1514) / PR TBD
+- Related ADR: N/A - no decision-level change
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+## Problem Statement
+
+Chunking evidence is spread across Phase 2 retrieval reports, real100 corpus EDA,
+and multi-chunk evidence failure aggregates. That is enough for agent workflows
+but slow for human review. Reviewers need one local HTML board that shows the
+chunking ablation shape, corpus chunk health, and multi-chunk evidence failure
+signals without changing retrieval or chunking behavior.
+
+## Desired Behavior
+
+Running `scripts/render_chunking_diagnostics_board.py` writes a local
+`reports/retrieval/chunking_diagnostics.html` file. The page is self-contained,
+deterministic, and aggregate-only.
+
+## Constraints
+
+- Scope: reviewer tooling only.
+- Architecture: read existing committed aggregate artifacts; do not create a new
+  eval surface or runtime path.
+- Compatibility: no changes to existing report files or metrics.
+- Privacy: emit only aggregate metrics/counts; never render case ids, query text,
+  doc ids, chunk ids, or raw text.
+- Non-goals: no chunking winner claim, default change, retrieval change, verifier
+  change, answer change, or eval scoring change.
+
+## Affected Interfaces
+
+- CLI: add `scripts/render_chunking_diagnostics_board.py`.
+- Output artifacts: local ignored `reports/retrieval/chunking_diagnostics.html`.
+- Tests: add focused renderer tests for aggregate metric calculation and privacy.
+- Docs: mention the local board in chunking diagnostics docs.
+
+## Data / Eval Impact
+
+- Surface: private real-eval aggregate viewer plus existing Phase 2 retrieval
+  aggregate report.
+- Data boundary: aggregate-only private output under ADR 0005.
+- Allowed claim: chunking diagnostics now have a local human-readable board.
+- Disallowed claim: no chunking variant is promoted and no RAG quality improvement
+  is claimed.
+- Baseline/control affected: no.
+- Benchmark/eval auditor required: no.
+
+## Task Breakdown
+
+1. Add a renderer that combines Phase 2 chunking aggregate files, EDA aggregate,
+   and multi-chunk evidence aggregate.
+2. Add HTML rendering using the shared local report shell.
+3. Add tests for aggregate-only rendering and CLI output.
+4. Document the local board and validation commands.
+
+## Acceptance Criteria
+
+- [x] Renderer emits a local self-contained HTML board.
+- [x] HTML includes chunking variants, recall@10 deltas, chunk health, and
+  multi-chunk retrieval outcome counts.
+- [x] Tests verify private case ids are not rendered.
+- [x] Existing retrieval/chunking/eval behavior is unchanged.
+
+## Validation Strategy
+
+Commands run:
+
+```bash
+python3 -m py_compile scripts/render_chunking_diagnostics_board.py scripts/html_report.py
+python3 -m pytest -q tests/test_render_chunking_diagnostics_board.py
+git diff --check
+```
+
+Expected evidence:
+
+- Focused test suite passes.
+- Generated HTML is local-only and ignored by git.
+- No real-eval performance or default-change claim is made.
+
+## Rollback Strategy
+
+Revert the renderer, tests, docs, queue entry, and this plan. Generated
+`reports/retrieval/chunking_diagnostics.html` artifacts are local ignored files
+and can be deleted without affecting committed evidence.
+
+## Reviewer Notes
+
+Attack claim wording first: the board must say the current Phase 2 chunking
+ablation is diagnostic, not a winner declaration. Then inspect privacy: no
+case ids, query text, doc ids, chunk ids, or raw text should render.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Branch / worktree: chore/issue-1514-chunking-diagnostics-board / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Issue / PR: #1514 / PR TBD
+- Task: T-2026-0008
+- Current status: implementation complete, focused validation passing.
+- Files touched: scripts/render_chunking_diagnostics_board.py, tests/test_render_chunking_diagnostics_board.py, docs/retrieval/chunking-diagnostics.md, tasks/queue.md, docs/plans/T-2026-0008-chunking-diagnostics-board.md
+- Decisions made: local self-contained HTML, no JS/dependencies, aggregate-only board.
+- Commands run: python3 -m py_compile scripts/render_chunking_diagnostics_board.py scripts/html_report.py; python3 -m pytest -q tests/test_render_chunking_diagnostics_board.py; git diff --check
+- Results: pass.
+- Next safe command: python3 -m pytest -q tests/test_render_chunking_diagnostics_board.py
+- Open questions: none.
+- Risks: reviewer may want additional retrieval aggregate slices later; keep them separate.
+```

--- a/docs/retrieval/chunking-diagnostics.md
+++ b/docs/retrieval/chunking-diagnostics.md
@@ -49,6 +49,10 @@ python3 scripts/build_index.py \
 - 기본 flat retrieval은 naive baseline과 agentic full pipeline 모두의 기본 retrieval mode다.
 - hierarchical retrieval은 긴 section이 여러 child chunk로 나뉠 때 주변 문맥을 함께 확인하는 실험 옵션이다.
 - 품질 비교는 `reports/eval_summary.json`의 `hierarchical` ablation run과 fixed/auto 임시 인덱스 평가 결과를 함께 본다.
+- 사람용 local board가 필요하면 `python3 scripts/render_chunking_diagnostics_board.py`를 실행해
+  `reports/retrieval/chunking_diagnostics.html`을 본다. 이 HTML은 Phase 2
+  chunking ablation, real100 chunk health, multi-chunk evidence failure aggregate를
+  한 화면에 모으는 reviewer view이며, chunking winner나 성능 개선 claim이 아니다.
 
 ## Chunk-boundary probe set (issue #73)
 

--- a/scripts/render_chunking_diagnostics_board.py
+++ b/scripts/render_chunking_diagnostics_board.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Render a local HTML board for chunking and multi-chunk diagnostics.
+
+This is a reviewer-facing view over existing aggregate or aggregate-derived
+artifacts. It does not change retrieval, verifier, prompt, chunking, reranker,
+answer, or eval runtime behavior.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.html_report import render_document, render_status_card, render_table
+
+DEFAULT_PHASE2_DIR = ROOT / "reports" / "retrieval" / "phase2_chunking_20260518-0740"
+DEFAULT_EDA = ROOT / "reports" / "real100" / "eda.aggregate.json"
+DEFAULT_MULTI_CHUNK = (
+    ROOT / "reports" / "real100" / "multi_chunk_evidence_failures.aggregate.json"
+)
+DEFAULT_OUT_HTML = ROOT / "reports" / "retrieval" / "chunking_diagnostics.html"
+
+METRICS: tuple[str, ...] = ("chunk_recall@5", "chunk_recall@10", "mrr", "ndcg@10")
+
+
+def _load_json(path: Path) -> Any:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _rows(value: Any) -> list[dict[str, Any]]:
+    return [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+
+
+def _num(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _fmt(value: Any, digits: int = 3) -> str:
+    num = _num(value)
+    if num is None:
+        return "-"
+    return f"{num:.{digits}f}"
+
+
+def _pct(value: Any) -> str:
+    num = _num(value)
+    if num is None:
+        return "-"
+    return f"{100.0 * num:.1f}%"
+
+
+def _rate(numerator: Any, denominator: Any) -> float | None:
+    num = _num(numerator)
+    den = _num(denominator)
+    if num is None or den is None or den <= 0:
+        return None
+    return num / den
+
+
+def _metric_mean(per_case: list[dict[str, Any]], metric: str) -> tuple[float | None, int]:
+    values = [_num(case.get(metric)) for case in per_case]
+    clean = [value for value in values if value is not None]
+    if not clean:
+        return None, 0
+    return sum(clean) / len(clean), len(clean)
+
+
+def _significance(delta: dict[str, Any]) -> str:
+    lo = _num(delta.get("ci_lo"))
+    hi = _num(delta.get("ci_hi"))
+    if lo is None or hi is None:
+        return "n/a"
+    if lo > 0:
+        return "positive"
+    if hi < 0:
+        return "negative"
+    return "not significant"
+
+
+def build_board(
+    *,
+    specs: list[dict[str, Any]],
+    raw_results: dict[str, Any],
+    deltas: dict[str, Any],
+    eda: dict[str, Any],
+    multi_chunk: dict[str, Any],
+) -> dict[str, Any]:
+    """Build an aggregate-only payload for HTML rendering."""
+    variants: list[dict[str, Any]] = []
+    for spec in specs:
+        name = str(spec.get("name") or "")
+        raw = _mapping(raw_results.get(name))
+        per_case = _rows(raw.get("per_case"))
+        metric_summary = {
+            metric: {
+                "mean": mean,
+                "n": n,
+            }
+            for metric in METRICS
+            for mean, n in [_metric_mean(per_case, metric)]
+        }
+        variants.append(
+            {
+                "name": name,
+                "chunking_strategy": str(spec.get("chunking_strategy") or ""),
+                "chunk_max_chars": spec.get("chunk_max_chars"),
+                "chunk_overlap_sentences": spec.get("chunk_overlap_sentences"),
+                "num_documents": spec.get("num_documents"),
+                "num_chunks": spec.get("num_chunks"),
+                "section_detection_rate": spec.get("section_detection_rate"),
+                "heuristic_engagement_rate": spec.get("heuristic_engagement_rate"),
+                "latency_ms": _mapping(raw.get("latency_ms")),
+                "metrics": metric_summary,
+            }
+        )
+
+    current = next((item for item in variants if item["name"] == "current"), None)
+    recall10_ranked = sorted(
+        variants,
+        key=lambda item: (
+            _num(_mapping(item.get("metrics")).get("chunk_recall@10", {}).get("mean"))
+            or -1.0
+        ),
+        reverse=True,
+    )
+    best_recall10 = recall10_ranked[0] if recall10_ranked else None
+    recall10_deltas = {
+        name: _mapping(_mapping(payload).get("chunk_recall@10"))
+        for name, payload in deltas.items()
+    }
+    chunk_health = _mapping(
+        _mapping(_mapping(eda.get("axis2_chunk_health")).get("corpus_chunk_health"))
+    )
+    per_doc_chunk_count = _mapping(
+        _mapping(eda.get("axis2_chunk_health")).get("per_doc_chunk_count")
+    )
+    population = _mapping(multi_chunk.get("population"))
+    return {
+        "schema_version": 1,
+        "variants": variants,
+        "current": current,
+        "best_recall10": best_recall10,
+        "recall10_deltas": recall10_deltas,
+        "chunk_health": chunk_health,
+        "per_doc_chunk_count": per_doc_chunk_count,
+        "multi_chunk": {
+            "population": population,
+            "retrieval_outcome_by_k": _mapping(multi_chunk.get("retrieval_outcome_by_k")),
+            "evidence_split": _mapping(multi_chunk.get("evidence_split")),
+            "expected_impact": _mapping(multi_chunk.get("expected_impact")),
+            "candidate_pool_expansion": _mapping(
+                multi_chunk.get("candidate_pool_expansion")
+            ),
+            "top10_failure_rate": _rate(
+                population.get("multi_chunk_top10_evidence_failures"),
+                population.get("multi_chunk_gold_cases"),
+            ),
+        },
+    }
+
+
+def render_html(board: dict[str, Any]) -> str:
+    variants = _rows(board.get("variants"))
+    current = _mapping(board.get("current"))
+    best = _mapping(board.get("best_recall10"))
+    chunk_health = _mapping(board.get("chunk_health"))
+    multi = _mapping(board.get("multi_chunk"))
+    population = _mapping(multi.get("population"))
+
+    best_name = best.get("name") or "-"
+    best_recall = _mapping(_mapping(best.get("metrics")).get("chunk_recall@10")).get(
+        "mean"
+    )
+    current_chunks = current.get("num_chunks")
+    top10_failure_rate = multi.get("top10_failure_rate")
+
+    cards = [
+        render_status_card(
+            "Current chunks",
+            current_chunks if current_chunks is not None else "-",
+            detail=f"{current.get('chunking_strategy', '-')} / max {current.get('chunk_max_chars', '-')}",
+            tone="accent",
+        ),
+        render_status_card(
+            "Best recall@10",
+            f"{best_name} {_fmt(best_recall)}",
+            detail="phase2 chunking ablation, overall mean",
+            tone="warn",
+        ),
+        render_status_card(
+            "Mid-sentence cuts",
+            _pct(chunk_health.get("mid_sentence_cut_ratio")),
+            detail="EDA snapshot, aggregate only",
+            tone="warn",
+        ),
+        render_status_card(
+            "Multi-chunk top10 failures",
+            _pct(top10_failure_rate),
+            detail=(
+                f"{population.get('multi_chunk_top10_evidence_failures', '-')} / "
+                f"{population.get('multi_chunk_gold_cases', '-')} gold cases"
+            ),
+            tone="danger",
+        ),
+    ]
+
+    variant_rows = []
+    for item in variants:
+        metrics = _mapping(item.get("metrics"))
+        latency = _mapping(item.get("latency_ms"))
+        variant_rows.append(
+            [
+                item.get("name"),
+                item.get("chunking_strategy"),
+                item.get("chunk_max_chars"),
+                item.get("num_chunks"),
+                _pct(item.get("section_detection_rate")),
+                _fmt(_mapping(metrics.get("chunk_recall@10")).get("mean")),
+                _fmt(_mapping(metrics.get("mrr")).get("mean")),
+                _fmt(_mapping(metrics.get("ndcg@10")).get("mean")),
+                _fmt(latency.get("p50")),
+                _fmt(latency.get("p95")),
+            ]
+        )
+
+    delta_rows = []
+    for name, delta in _mapping(board.get("recall10_deltas")).items():
+        delta_rows.append(
+            [
+                name,
+                _fmt(delta.get("mean_current")),
+                _fmt(delta.get("mean_other")),
+                _fmt(delta.get("mean_diff")),
+                f"{_fmt(delta.get('ci_lo'))} to {_fmt(delta.get('ci_hi'))}",
+                _significance(delta),
+            ]
+        )
+
+    health_rows = [
+        ["total_chunks", chunk_health.get("total_chunks")],
+        ["empty_chunks", chunk_health.get("empty_chunks")],
+        ["near_empty_chunks", chunk_health.get("near_empty_chunks")],
+        ["mean_length", _fmt(_mapping(chunk_health.get("length_chars")).get("mean"))],
+        ["p95_length", _fmt(_mapping(chunk_health.get("length_chars")).get("p95"))],
+        ["mid_sentence_cut_ratio", _pct(chunk_health.get("mid_sentence_cut_ratio"))],
+        ["chunks_per_doc_mean", _fmt(_mapping(board.get("per_doc_chunk_count")).get("mean"))],
+        ["chunks_per_doc_p95", _fmt(_mapping(board.get("per_doc_chunk_count")).get("p95"))],
+    ]
+
+    outcome_rows = []
+    for k, outcomes in sorted(_mapping(multi.get("retrieval_outcome_by_k")).items()):
+        mapped = _mapping(outcomes)
+        outcome_rows.append(
+            [
+                f"top{k}",
+                mapped.get("all_gold_retrieved", 0),
+                mapped.get("partial_gold_retrieved", 0),
+                mapped.get("no_gold_retrieved", 0),
+                mapped.get("not_observable", 0),
+            ]
+        )
+
+    body = "\n".join(
+        [
+            f'<section class="grid">{"".join(cards)}</section>',
+            '<section class="panel"><h2>Chunking Variants</h2>'
+            '<p class="note">Metrics are aggregate means over eligible cases; no per-case id or text is emitted.</p>'
+            + render_table(
+                [
+                    "Variant",
+                    "Strategy",
+                    "Max chars",
+                    "Chunks",
+                    "Section detect",
+                    "Recall@10",
+                    "MRR",
+                    "nDCG@10",
+                    "p50 ms",
+                    "p95 ms",
+                ],
+                variant_rows,
+            )
+            + "</section>",
+            '<section class="panel"><h2>Recall@10 Delta vs Current</h2>'
+            '<p class="note">Positive means the variant improved over current. CI crossing zero is not claim-ready.</p>'
+            + render_table(
+                ["Variant", "Current", "Variant", "Delta", "95% CI", "Signal"],
+                delta_rows,
+            )
+            + "</section>",
+            '<section class="panel"><h2>Chunk Health Snapshot</h2>'
+            + render_table(["Metric", "Value"], health_rows)
+            + "</section>",
+            '<section class="panel"><h2>Multi-chunk Evidence Retrieval</h2>'
+            '<p class="note">Counts come from multi_chunk_evidence_failures.aggregate.json.</p>'
+            + render_table(
+                [
+                    "K",
+                    "All gold",
+                    "Partial gold",
+                    "No gold",
+                    "Not observable",
+                ],
+                outcome_rows,
+            )
+            + "</section>",
+        ]
+    )
+    return render_document(
+        title="Chunking Diagnostics Board",
+        subtitle=(
+            "Local aggregate-only view of Phase 2 chunking ablation, corpus chunk "
+            "health, and multi-chunk evidence failure diagnostics."
+        ),
+        body=body,
+        footer=(
+            "Local workflow artifact. This board does not claim a chunking winner "
+            "or any RAG quality improvement."
+        ),
+    )
+
+
+def load_board(phase2_dir: Path, eda_path: Path, multi_chunk_path: Path) -> dict[str, Any]:
+    return build_board(
+        specs=_rows(_load_json(phase2_dir / "chunking_specs.json")),
+        raw_results=_mapping(_load_json(phase2_dir / "raw_results.json")),
+        deltas=_mapping(_load_json(phase2_dir / "deltas.json")),
+        eda=_mapping(_load_json(eda_path)),
+        multi_chunk=_mapping(_load_json(multi_chunk_path)),
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--phase2-dir", type=Path, default=DEFAULT_PHASE2_DIR)
+    parser.add_argument("--eda", type=Path, default=DEFAULT_EDA)
+    parser.add_argument("--multi-chunk", type=Path, default=DEFAULT_MULTI_CHUNK)
+    parser.add_argument("--out-html", type=Path, default=DEFAULT_OUT_HTML)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        board = load_board(args.phase2_dir, args.eda, args.multi_chunk)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Failed to build chunking diagnostics board: {exc}", file=sys.stderr)
+        return 1
+    args.out_html.parent.mkdir(parents=True, exist_ok=True)
+    args.out_html.write_text(render_html(board), encoding="utf-8")
+    print(f"[OK] Wrote {args.out_html}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -17,6 +17,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 4 | `T-2026-0004` | `review` | Implementer -> Reviewer | HWP -> PDF -> PyMuPDF4LLM opt-in loader 구현됨. |
 | 5 | `T-2026-0006` | `review` | Implementer -> Reviewer | `ai_next_actions` human-readable HTML review surface 구현됨. |
 | 6 | `T-2026-0007` | `review` | Implementer -> Reviewer | failure distribution local HTML board 구현됨. |
+| 7 | `T-2026-0008` | `review` | Implementer -> Reviewer | chunking diagnostics local HTML board 구현됨. |
 
 ## Examples
 
@@ -571,4 +572,94 @@ make check-branch
 - Open risks: reviewer should inspect whether a later PR should migrate ai_next_actions HTML to the shared shell.
 - Next safe command: python3 -m pytest -q tests/test_render_failure_distribution.py
 - Reviewer focus: privacy-safe rendering, aggregate-only data boundary, and no evidence over-claim.
+```
+
+## T-2026-0008 — Human-readable chunking diagnostics board
+
+- ID: T-2026-0008
+- Title: Human-readable chunking diagnostics board
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+### Goal
+
+Give reviewers a compact local HTML view of Phase 2 chunking ablation, real100
+chunk health, and multi-chunk evidence failure diagnostics without changing
+retrieval or chunking behavior.
+
+### Context
+
+- Surface: private real-eval aggregate viewer plus existing Phase 2 retrieval
+  aggregate report.
+- Relevant docs: [`docs/retrieval/chunking-diagnostics.md`](../docs/retrieval/chunking-diagnostics.md),
+  [ADR 0005](../docs/adr/0005-eval-split-public-synthetic-private-local.md),
+  [ADR 0076](../docs/adr/0076-multi-chunk-evidence-failure-analysis-surface.md).
+- Primary risk: a diagnostic board being mistaken for a chunking winner claim,
+  or per-case identifiers/text leaking into local HTML.
+
+### Scope
+
+- Add `reports/retrieval/chunking_diagnostics.html` as a generated local artifact.
+- Read existing aggregate or aggregate-derived artifacts only.
+- Keep Phase 2 report files and real100 aggregate files unchanged.
+
+### Non-Goals
+
+- Do not change chunking defaults, retrieval, verifier, answer generation, eval
+  scoring, or private raw data.
+- Do not introduce JavaScript, external services, or runtime dependencies.
+- Do not publish local HTML artifacts.
+
+### Acceptance Criteria
+
+- [x] Renderer emits a self-contained local HTML board.
+- [x] HTML includes chunking variants, recall@10 deltas, chunk health, and
+  multi-chunk retrieval outcome counts.
+- [x] HTML does not render private case ids from per-case inputs.
+- [x] Existing retrieval/chunking/eval behavior remains unchanged.
+
+### Validation Commands
+
+```bash
+python3 -m py_compile scripts/render_chunking_diagnostics_board.py scripts/html_report.py
+python3 -m pytest -q tests/test_render_chunking_diagnostics_board.py
+python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0008-chunking-diagnostics-board.md tasks/queue.md docs/retrieval/chunking-diagnostics.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Doc-link check output.
+- Note that no chunking winner or RAG quality claim is made.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0008-chunking-diagnostics-board.md`](../docs/plans/T-2026-0008-chunking-diagnostics-board.md)
+- Issue: [#1514](https://github.com/hskim-solv/BidMate-DocAgent/issues/1514)
+- PR: TBD
+- ADR: N/A
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1514-chunking-diagnostics-board / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Task: T-2026-0008
+- Plan: docs/plans/T-2026-0008-chunking-diagnostics-board.md
+- Current status: HTML chunking diagnostics board implemented.
+- Files touched: scripts/render_chunking_diagnostics_board.py, tests/test_render_chunking_diagnostics_board.py, docs/retrieval/chunking-diagnostics.md, tasks/queue.md, docs/plans/T-2026-0008-chunking-diagnostics-board.md
+- Decisions made: Generate a self-contained local HTML file from existing aggregate artifacts; do not claim a chunking winner.
+- Commands run: python3 -m py_compile scripts/render_chunking_diagnostics_board.py scripts/html_report.py; python3 -m pytest -q tests/test_render_chunking_diagnostics_board.py; git diff --check
+- Results: pass.
+- Eval surface: private real-eval aggregate viewer plus existing Phase 2 retrieval aggregate report.
+- Open risks: reviewer should inspect claim wording and whether additional slices belong in a separate follow-up.
+- Next safe command: python3 -m pytest -q tests/test_render_chunking_diagnostics_board.py
+- Reviewer focus: claim boundary, aggregate-only rendering, and no default behavior change.
 ```

--- a/tests/test_render_chunking_diagnostics_board.py
+++ b/tests/test_render_chunking_diagnostics_board.py
@@ -1,0 +1,188 @@
+"""Regression guard for the local chunking diagnostics HTML board."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.render_chunking_diagnostics_board import build_board, main, render_html
+
+
+def _specs() -> list[dict[str, object]]:
+    return [
+        {
+            "name": "current",
+            "chunking_strategy": "fixed",
+            "chunk_max_chars": 520,
+            "chunk_overlap_sentences": 1,
+            "num_documents": 2,
+            "num_chunks": 20,
+            "section_detection_rate": 0.0,
+        },
+        {
+            "name": "larger",
+            "chunking_strategy": "fixed",
+            "chunk_max_chars": 1040,
+            "chunk_overlap_sentences": 1,
+            "num_documents": 2,
+            "num_chunks": 10,
+            "section_detection_rate": 0.0,
+        },
+    ]
+
+
+def _raw_results() -> dict[str, object]:
+    return {
+        "current": {
+            "latency_ms": {"p50": 10.0, "p95": 20.0},
+            "per_case": [
+                {
+                    "qid": "PRIVATE_CASE_A",
+                    "chunk_recall@5": 0.5,
+                    "chunk_recall@10": 0.5,
+                    "mrr": 0.25,
+                    "ndcg@10": 0.3,
+                },
+                {
+                    "qid": "PRIVATE_CASE_B",
+                    "chunk_recall@5": None,
+                    "chunk_recall@10": None,
+                    "mrr": None,
+                    "ndcg@10": None,
+                },
+            ],
+        },
+        "larger": {
+            "latency_ms": {"p50": 8.0, "p95": 12.0},
+            "per_case": [
+                {
+                    "qid": "PRIVATE_CASE_A",
+                    "chunk_recall@5": 1.0,
+                    "chunk_recall@10": 1.0,
+                    "mrr": 0.5,
+                    "ndcg@10": 0.6,
+                }
+            ],
+        },
+    }
+
+
+def _deltas() -> dict[str, object]:
+    return {
+        "larger": {
+            "chunk_recall@10": {
+                "mean_current": 0.5,
+                "mean_other": 1.0,
+                "mean_diff": 0.5,
+                "ci_lo": -0.1,
+                "ci_hi": 0.9,
+            }
+        }
+    }
+
+
+def _eda() -> dict[str, object]:
+    return {
+        "axis2_chunk_health": {
+            "corpus_chunk_health": {
+                "total_chunks": 30,
+                "empty_chunks": 0,
+                "near_empty_chunks": 1,
+                "length_chars": {"mean": 430.0, "p95": 517.0},
+                "mid_sentence_cut_ratio": 0.25,
+            },
+            "per_doc_chunk_count": {"mean": 15.0, "p95": 18.0},
+        }
+    }
+
+
+def _multi_chunk() -> dict[str, object]:
+    return {
+        "population": {
+            "num_predictions": 2,
+            "multi_chunk_gold_cases": 2,
+            "multi_chunk_top10_evidence_failures": 1,
+        },
+        "retrieval_outcome_by_k": {
+            "5": {
+                "all_gold_retrieved": 1,
+                "partial_gold_retrieved": 0,
+                "no_gold_retrieved": 1,
+                "not_observable": 0,
+            },
+            "10": {
+                "all_gold_retrieved": 1,
+                "partial_gold_retrieved": 0,
+                "no_gold_retrieved": 1,
+                "not_observable": 0,
+            },
+        },
+        "evidence_split": {},
+        "expected_impact": {},
+        "candidate_pool_expansion": {},
+    }
+
+
+def test_build_board_uses_aggregate_metrics_only() -> None:
+    board = build_board(
+        specs=_specs(),
+        raw_results=_raw_results(),
+        deltas=_deltas(),
+        eda=_eda(),
+        multi_chunk=_multi_chunk(),
+    )
+
+    assert board["current"]["num_chunks"] == 20
+    assert board["best_recall10"]["name"] == "larger"
+    assert board["multi_chunk"]["top10_failure_rate"] == 0.5
+    assert board["variants"][0]["metrics"]["chunk_recall@10"]["mean"] == 0.5
+
+
+def test_html_has_required_sections_and_no_private_case_ids() -> None:
+    board = build_board(
+        specs=_specs(),
+        raw_results=_raw_results(),
+        deltas=_deltas(),
+        eda=_eda(),
+        multi_chunk=_multi_chunk(),
+    )
+    html = render_html(board)
+
+    assert "<!doctype html>" in html
+    assert "Chunking Diagnostics Board" in html
+    assert "Chunking Variants" in html
+    assert "Recall@10 Delta vs Current" in html
+    assert "Chunk Health Snapshot" in html
+    assert "Multi-chunk Evidence Retrieval" in html
+    assert "PRIVATE_CASE_A" not in html
+    assert "PRIVATE_CASE_B" not in html
+    assert "<script" not in html
+
+
+def test_cli_writes_html(tmp_path: Path) -> None:
+    phase2 = tmp_path / "phase2"
+    phase2.mkdir()
+    (phase2 / "chunking_specs.json").write_text(json.dumps(_specs()), encoding="utf-8")
+    (phase2 / "raw_results.json").write_text(json.dumps(_raw_results()), encoding="utf-8")
+    (phase2 / "deltas.json").write_text(json.dumps(_deltas()), encoding="utf-8")
+    eda = tmp_path / "eda.aggregate.json"
+    multi = tmp_path / "multi.aggregate.json"
+    out = tmp_path / "chunking.html"
+    eda.write_text(json.dumps(_eda()), encoding="utf-8")
+    multi.write_text(json.dumps(_multi_chunk()), encoding="utf-8")
+
+    rc = main(
+        [
+            "--phase2-dir",
+            str(phase2),
+            "--eda",
+            str(eda),
+            "--multi-chunk",
+            str(multi),
+            "--out-html",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    assert out.exists()
+    assert "Chunking Diagnostics Board" in out.read_text(encoding="utf-8")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1514

Chunking diagnostics를 사람이 빠르게 볼 수 있도록 local-only HTML board를 추가합니다. 기존 Phase 2 chunking ablation report, real100 EDA aggregate, multi-chunk evidence failure aggregate를 읽어 하나의 reviewer view로 렌더합니다. 이 PR은 chunking winner나 RAG 성능 개선을 주장하지 않습니다.

## 2. 영향 파일

- `scripts/render_chunking_diagnostics_board.py` — aggregate-only HTML renderer 추가
- `tests/test_render_chunking_diagnostics_board.py` — metric aggregation, CLI output, private case id non-leakage 테스트
- `docs/retrieval/chunking-diagnostics.md` — local board 사용 위치 문서화
- `docs/plans/T-2026-0008-chunking-diagnostics-board.md` — plan/handoff
- `tasks/queue.md` — T-2026-0008 queue entry

## 3. 리스크

가장 큰 리스크는 diagnostic board가 chunking winner claim으로 읽히거나, per-case id/text가 HTML에 노출되는 것입니다. Renderer는 per-case 입력을 평균 계산에만 쓰고 HTML에는 aggregate metric/count만 렌더합니다. 테스트와 browser check로 private marker와 script 실행 표면이 없음을 확인했습니다.

## 4. 테스트

- `python3 -m py_compile scripts/render_chunking_diagnostics_board.py scripts/html_report.py`
- `python3 -m pytest -q tests/test_render_chunking_diagnostics_board.py`
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0008-chunking-diagnostics-board.md tasks/queue.md docs/retrieval/chunking-diagnostics.md`
- `git diff --check`
- `make check-branch`
- Browser verification over local HTTP: title rendered, 4 status cards present, core sections present, `script` tag count = 0.

## 5. Eval 영향

No retrieval/chunking/eval scoring behavior change. This is reviewer tooling over existing aggregate artifacts only.

### 5b. Real-data delta

N/A — no load-bearing path changed and no retrieval/verifier/answer/eval scoring behavior changed. Real-data delta was not run; this PR makes no performance, default-change, or chunking-winner claim.

## 6. 하위 호환

No existing CLI/report output changes. New local command only: `python3 scripts/render_chunking_diagnostics_board.py`, which writes ignored `reports/retrieval/chunking_diagnostics.html`.

## 7. 범위 외

- No chunking default change.
- No retrieval, verifier, reranker, answer, or eval scoring change.
- No new metric surface or committed aggregate output.
- ADR decision map HTML remains separate follow-up scope.
