### PR TITLE
chore: add ADR decision map html board

### DIFF
--- a/docs/plans/T-2026-0009-adr-decision-map.md
+++ b/docs/plans/T-2026-0009-adr-decision-map.md
@@ -1,0 +1,110 @@
+# Plan: T-2026-0009 ADR Decision Map
+
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0009`
+- Related issue / PR: [#1516](https://github.com/hskim-solv/BidMate-DocAgent/issues/1516) / PR TBD
+- Related ADR: N/A - no decision-level change
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+## Problem Statement
+
+`docs/adr/README.md` is the source of truth for load-bearing decisions, but the
+index is optimized for archival completeness rather than quick human scanning.
+Reviewers need a local HTML map that shows status mix, decision areas, recent
+ADRs, proposed ADRs, and superseded decisions without editing ADR content or
+claiming to replace the source markdown.
+
+## Desired Behavior
+
+Running `scripts/render_adr_decision_map.py` writes
+`reports/adr_decision_map.html`. The page is self-contained, deterministic, and
+generated only from `docs/adr/README.md`.
+
+## Constraints
+
+- Scope: reviewer/navigation tooling only.
+- Architecture: parse ADR README rows; do not edit ADR files or reserve numbers.
+- Compatibility: no changes to ADR status, numbering, or README content.
+- Privacy: no private data involved.
+- Non-goals: no ADR creation, no status promotion, no lifecycle enforcement.
+
+## Affected Interfaces
+
+- CLI: add `scripts/render_adr_decision_map.py`.
+- Output artifacts: local ignored `reports/adr_decision_map.html`.
+- Tests: add parser/rendering/escaping tests.
+
+## Data / Eval Impact
+
+- Surface: none.
+- Data boundary: public repository docs only.
+- Allowed claim: ADR index has a local human-readable navigation board.
+- Disallowed claim: HTML is not the ADR source of truth and does not change
+  decision status.
+- Baseline/control affected: no.
+- Benchmark/eval auditor required: no.
+
+## Task Breakdown
+
+1. Add ADR README row parser and status/area summarizer.
+2. Render local HTML using the shared report shell.
+3. Add tests for canonical row parsing, status counts, and HTML escaping.
+4. Record plan and queue state.
+
+## Acceptance Criteria
+
+- [x] Renderer emits a local self-contained HTML board.
+- [x] HTML includes status mix, decision areas, recent ADRs, proposed ADRs, and
+  superseded decisions.
+- [x] Tests verify parser behavior and escaping.
+- [x] ADR files and `docs/adr/README.md` remain unmodified.
+
+## Validation Strategy
+
+Commands run:
+
+```bash
+python3 scripts/render_adr_decision_map.py
+python3 -m py_compile scripts/render_adr_decision_map.py scripts/html_report.py
+python3 -m pytest -q tests/test_render_adr_decision_map.py
+git diff --check
+```
+
+Expected evidence:
+
+- Focused test suite passes.
+- Generated HTML is local-only and ignored by git.
+- No ADR source file changed.
+
+## Rollback Strategy
+
+Revert the renderer, tests, queue entry, and this plan. Generated
+`reports/adr_decision_map.html` artifacts are local ignored files and can be
+deleted without affecting ADR records.
+
+## Reviewer Notes
+
+Attack source-of-truth wording first: the HTML must not be mistaken for an ADR
+registry replacement. Then inspect the row parser against README pipe-table
+format and escaping of title/status text.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Branch / worktree: chore/issue-1516-adr-decision-map / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Issue / PR: #1516 / PR TBD
+- Task: T-2026-0009
+- Current status: implementation complete, focused validation passing.
+- Files touched: scripts/render_adr_decision_map.py, tests/test_render_adr_decision_map.py, tasks/queue.md, docs/plans/T-2026-0009-adr-decision-map.md
+- Decisions made: local self-contained HTML generated from docs/adr/README.md only.
+- Commands run: python3 scripts/render_adr_decision_map.py; python3 -m py_compile scripts/render_adr_decision_map.py scripts/html_report.py; python3 -m pytest -q tests/test_render_adr_decision_map.py; git diff --check
+- Results: pass.
+- Next safe command: python3 -m pytest -q tests/test_render_adr_decision_map.py
+- Open questions: none.
+- Risks: keyword-based area classification is navigation-only and should not become governance logic.
+```

--- a/scripts/render_adr_decision_map.py
+++ b/scripts/render_adr_decision_map.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Render a local HTML board for ADR navigation.
+
+Reads ``docs/adr/README.md`` only and emits a local, ignored HTML map. This is
+presentation tooling: it never edits ADR files, reserves numbers, or changes
+decision status.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.html_report import render_document, render_status_card, render_table
+
+DEFAULT_ADR_README = ROOT / "docs" / "adr" / "README.md"
+DEFAULT_OUT_HTML = ROOT / "reports" / "adr_decision_map.html"
+
+ADR_ROW_RE = re.compile(
+    r"^\| \[(?P<number>\d{4})\]\((?P<link>\./[^)]+\.md)\) \| "
+    r"(?P<status>.*?) \| (?P<title>.*) \|$"
+)
+
+
+@dataclass(frozen=True)
+class AdrEntry:
+    number: int
+    link: str
+    status: str
+    title: str
+    area: str
+
+
+def _clean(text: str) -> str:
+    return re.sub(r"\s+", " ", text.replace("\\|", "|")).strip()
+
+
+def _status_family(status: str) -> str:
+    lowered = status.lower()
+    if "superseded" in lowered:
+        return "superseded"
+    if "deprecated" in lowered:
+        return "deprecated"
+    if "accepted" in lowered:
+        return "accepted"
+    if "proposed" in lowered:
+        return "proposed"
+    return "other"
+
+
+def _area_for(entry_text: str) -> str:
+    text = entry_text.lower()
+    if any(key in text for key in ("eval", "real", "benchmark", "metric", "judge")):
+        return "eval / measurement"
+    if any(key in text for key in ("retrieval", "embedding", "rerank", "bm25", "chunk")):
+        return "retrieval"
+    if any(key in text for key in ("hwp", "pdf", "parser", "ingestion", "page")):
+        return "ingestion"
+    if any(key in text for key in ("agent", "langgraph", "workflow", "codex")):
+        return "agent workflow"
+    if any(key in text for key in ("governance", "branch", "pr", "hook")):
+        return "governance"
+    if any(key in text for key in ("answer", "citation", "verifier", "evidence")):
+        return "answer / evidence"
+    if any(key in text for key in ("security", "injection", "pii")):
+        return "security"
+    return "foundation / other"
+
+
+def parse_adr_index(markdown: str) -> list[AdrEntry]:
+    entries: list[AdrEntry] = []
+    for line in markdown.splitlines():
+        match = ADR_ROW_RE.match(line)
+        if not match:
+            continue
+        status = _clean(match.group("status"))
+        title = _clean(match.group("title"))
+        link = _clean(match.group("link"))
+        entries.append(
+            AdrEntry(
+                number=int(match.group("number")),
+                link=link,
+                status=status,
+                title=title,
+                area=_area_for(f"{link} {status} {title}"),
+            )
+        )
+    return entries
+
+
+def build_board(entries: Iterable[AdrEntry]) -> dict[str, object]:
+    ordered = sorted(entries, key=lambda item: item.number)
+    status_counts = Counter(_status_family(item.status) for item in ordered)
+    area_counts = Counter(item.area for item in ordered)
+    proposed = [item for item in ordered if _status_family(item.status) == "proposed"]
+    superseded = [item for item in ordered if _status_family(item.status) == "superseded"]
+    accepted = [item for item in ordered if _status_family(item.status) == "accepted"]
+    return {
+        "total": len(ordered),
+        "latest": ordered[-1].number if ordered else None,
+        "status_counts": dict(sorted(status_counts.items())),
+        "area_counts": dict(area_counts.most_common()),
+        "recent": list(reversed(ordered[-12:])),
+        "proposed": proposed,
+        "superseded": superseded,
+        "accepted_count": len(accepted),
+    }
+
+
+def _entry_rows(entries: Iterable[AdrEntry]) -> list[list[object]]:
+    return [
+        [
+            f"{entry.number:04d}",
+            entry.status,
+            entry.area,
+            entry.title,
+            entry.link,
+        ]
+        for entry in entries
+    ]
+
+
+def render_html(board: dict[str, object]) -> str:
+    status_counts = board.get("status_counts")
+    if not isinstance(status_counts, dict):
+        status_counts = {}
+    area_counts = board.get("area_counts")
+    if not isinstance(area_counts, dict):
+        area_counts = {}
+    recent = board.get("recent")
+    proposed = board.get("proposed")
+    superseded = board.get("superseded")
+    recent_entries = [item for item in recent if isinstance(item, AdrEntry)] if isinstance(recent, list) else []
+    proposed_entries = [item for item in proposed if isinstance(item, AdrEntry)] if isinstance(proposed, list) else []
+    superseded_entries = [item for item in superseded if isinstance(item, AdrEntry)] if isinstance(superseded, list) else []
+
+    total = board.get("total", 0)
+    latest = board.get("latest")
+    cards = [
+        render_status_card("Total ADRs", total, detail="indexed decisions", tone="accent"),
+        render_status_card("Latest ADR", f"{latest:04d}" if isinstance(latest, int) else "-", tone="neutral"),
+        render_status_card("Accepted", status_counts.get("accepted", 0), tone="ok"),
+        render_status_card("Proposed", status_counts.get("proposed", 0), tone="warn"),
+    ]
+    status_rows = [[key, value] for key, value in sorted(status_counts.items())]
+    area_rows = [[key, value] for key, value in area_counts.items()]
+
+    body = "\n".join(
+        [
+            f'<section class="grid">{"".join(cards)}</section>',
+            '<section class="panel"><h2>Status Mix</h2>'
+            + render_table(["Status", "Count"], status_rows)
+            + "</section>",
+            '<section class="panel"><h2>Decision Areas</h2>'
+            '<p class="note">Keyword-based map for navigation only; ADR files remain the source of truth.</p>'
+            + render_table(["Area", "Count"], area_rows)
+            + "</section>",
+            '<section class="panel"><h2>Recent ADRs</h2>'
+            + render_table(
+                ["ADR", "Status", "Area", "Title", "Link"],
+                _entry_rows(recent_entries),
+            )
+            + "</section>",
+            '<section class="panel"><h2>Open Proposed Decisions</h2>'
+            + render_table(
+                ["ADR", "Status", "Area", "Title", "Link"],
+                _entry_rows(proposed_entries),
+                empty_message="No proposed ADRs",
+            )
+            + "</section>",
+            '<section class="panel"><h2>Superseded / Retired Decisions</h2>'
+            + render_table(
+                ["ADR", "Status", "Area", "Title", "Link"],
+                _entry_rows(superseded_entries),
+                empty_message="No superseded ADRs",
+            )
+            + "</section>",
+        ]
+    )
+    return render_document(
+        title="ADR Decision Map",
+        subtitle=(
+            "Local human-readable navigation view generated from docs/adr/README.md. "
+            "This page does not reserve ADR numbers or change decision status."
+        ),
+        body=body,
+        footer=(
+            "Local workflow artifact. ADR markdown files and docs/adr/README.md "
+            "remain the source of truth."
+        ),
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--adr-readme", type=Path, default=DEFAULT_ADR_README)
+    parser.add_argument("--out-html", type=Path, default=DEFAULT_OUT_HTML)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.adr_readme.exists():
+        print(f"ADR README not found: {args.adr_readme}", file=sys.stderr)
+        return 1
+    entries = parse_adr_index(args.adr_readme.read_text(encoding="utf-8"))
+    board = build_board(entries)
+    args.out_html.parent.mkdir(parents=True, exist_ok=True)
+    args.out_html.write_text(render_html(board), encoding="utf-8")
+    print(f"[OK] Wrote {args.out_html}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -18,6 +18,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 5 | `T-2026-0006` | `review` | Implementer -> Reviewer | `ai_next_actions` human-readable HTML review surface 구현됨. |
 | 6 | `T-2026-0007` | `review` | Implementer -> Reviewer | failure distribution local HTML board 구현됨. |
 | 7 | `T-2026-0008` | `review` | Implementer -> Reviewer | chunking diagnostics local HTML board 구현됨. |
+| 8 | `T-2026-0009` | `review` | Implementer -> Reviewer | ADR decision map local HTML board 구현됨. |
 
 ## Examples
 
@@ -662,4 +663,92 @@ make check-branch
 - Open risks: reviewer should inspect claim wording and whether additional slices belong in a separate follow-up.
 - Next safe command: python3 -m pytest -q tests/test_render_chunking_diagnostics_board.py
 - Reviewer focus: claim boundary, aggregate-only rendering, and no default behavior change.
+```
+
+## T-2026-0009 — Human-readable ADR decision map
+
+- ID: T-2026-0009
+- Title: Human-readable ADR decision map
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+### Goal
+
+Give reviewers a compact local HTML map of ADR status mix, decision areas,
+recent ADRs, proposed ADRs, and superseded decisions without editing ADR source
+files.
+
+### Context
+
+- Surface: ADR navigation/reviewer tooling.
+- Relevant docs: [`docs/adr/README.md`](../docs/adr/README.md).
+- Primary risk: a generated HTML view being mistaken for the ADR source of
+  truth, or keyword-based area grouping being treated as governance logic.
+
+### Scope
+
+- Add `reports/adr_decision_map.html` as a generated local artifact.
+- Parse existing `docs/adr/README.md` rows.
+- Keep ADR files, statuses, numbering, and README content unchanged.
+
+### Non-Goals
+
+- Do not create or edit ADRs.
+- Do not reserve ADR numbers.
+- Do not promote/demote statuses or enforce lifecycle policy.
+- Do not introduce JavaScript, external services, or runtime dependencies.
+
+### Acceptance Criteria
+
+- [x] Renderer emits a self-contained local HTML board.
+- [x] HTML includes status mix, decision areas, recent ADRs, proposed ADRs, and
+  superseded decisions.
+- [x] Tests verify canonical row parsing, status counts, and escaping.
+- [x] ADR source files remain unmodified.
+
+### Validation Commands
+
+```bash
+python3 scripts/render_adr_decision_map.py
+python3 -m py_compile scripts/render_adr_decision_map.py scripts/html_report.py
+python3 -m pytest -q tests/test_render_adr_decision_map.py
+python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0009-adr-decision-map.md tasks/queue.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Doc-link check output.
+- Note that `docs/adr/README.md` and ADR files are unchanged.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0009-adr-decision-map.md`](../docs/plans/T-2026-0009-adr-decision-map.md)
+- Issue: [#1516](https://github.com/hskim-solv/BidMate-DocAgent/issues/1516)
+- PR: TBD
+- ADR: N/A
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1516-adr-decision-map / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Task: T-2026-0009
+- Plan: docs/plans/T-2026-0009-adr-decision-map.md
+- Current status: HTML ADR decision map implemented.
+- Files touched: scripts/render_adr_decision_map.py, tests/test_render_adr_decision_map.py, tasks/queue.md, docs/plans/T-2026-0009-adr-decision-map.md
+- Decisions made: Generate a self-contained local HTML file from docs/adr/README.md only; keep ADR source files unchanged.
+- Commands run: python3 scripts/render_adr_decision_map.py; python3 -m py_compile scripts/render_adr_decision_map.py scripts/html_report.py; python3 -m pytest -q tests/test_render_adr_decision_map.py; git diff --check
+- Results: pass.
+- Eval surface: none.
+- Open risks: reviewer should inspect that area grouping is navigation-only.
+- Next safe command: python3 -m pytest -q tests/test_render_adr_decision_map.py
+- Reviewer focus: source-of-truth wording, parser robustness, and escaping.
 ```

--- a/tests/test_render_adr_decision_map.py
+++ b/tests/test_render_adr_decision_map.py
@@ -1,0 +1,69 @@
+"""Regression guard for the local ADR decision map renderer."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.render_adr_decision_map import build_board, main, parse_adr_index, render_html
+
+
+ADR_README = """# ADRs
+
+## Index
+
+| # | Status | Title |
+|---|---|---|
+| [0001](./0001-preserve-naive-baseline.md) | accepted | agentic baseline |
+| [0005](./0005-eval-split-public-synthetic-private-local.md) | accepted | Eval split |
+| [0059](./0059-failure-mode-classifier-as-measurement-surface.md) | superseded | failure classifier |
+| [0069](./0069-retrieval-aggregate-and-citation-coverage-surface.md) | proposed | retrieval aggregate |
+| [0078](./0078-pymupdf4llm-canonical-page-citation.md) | accepted | HWP/PDF citation |
+"""
+
+
+def test_parse_adr_index_reads_canonical_rows() -> None:
+    entries = parse_adr_index(ADR_README)
+
+    assert [entry.number for entry in entries] == [1, 5, 59, 69, 78]
+    assert entries[1].area == "eval / measurement"
+    assert entries[3].status == "proposed"
+    assert entries[4].area == "ingestion"
+
+
+def test_build_board_counts_status_and_recent() -> None:
+    board = build_board(parse_adr_index(ADR_README))
+
+    assert board["total"] == 5
+    assert board["latest"] == 78
+    assert board["status_counts"]["accepted"] == 3
+    assert board["status_counts"]["proposed"] == 1
+    assert board["status_counts"]["superseded"] == 1
+    assert board["proposed"][0].number == 69
+
+
+def test_html_has_sections_and_escapes_title() -> None:
+    entries = parse_adr_index(
+        ADR_README
+        + "| [0099](./0099-x.md) | proposed | <script>alert(1)</script> |\n"
+    )
+    html = render_html(build_board(entries))
+
+    assert "<!doctype html>" in html
+    assert "ADR Decision Map" in html
+    assert "Status Mix" in html
+    assert "Decision Areas" in html
+    assert "Recent ADRs" in html
+    assert "Open Proposed Decisions" in html
+    assert "<script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+
+def test_cli_writes_html(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    out = tmp_path / "adr.html"
+    readme.write_text(ADR_README, encoding="utf-8")
+
+    rc = main(["--adr-readme", str(readme), "--out-html", str(out)])
+
+    assert rc == 0
+    assert out.exists()
+    assert "ADR Decision Map" in out.read_text(encoding="utf-8")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1516

ADR index를 사람이 빠르게 훑을 수 있도록 local-only HTML decision map을 추가합니다. `docs/adr/README.md`를 읽어 status mix, decision areas, recent ADRs, proposed ADRs, superseded decisions를 렌더합니다. ADR 파일, 번호, status, README 내용은 변경하지 않습니다.

## 2. 영향 파일

- `scripts/render_adr_decision_map.py` — ADR README 기반 local HTML renderer 추가
- `tests/test_render_adr_decision_map.py` — canonical row parsing, status counts, escaping 테스트
- `docs/plans/T-2026-0009-adr-decision-map.md` — plan/handoff
- `tasks/queue.md` — T-2026-0009 queue entry

## 3. 리스크

가장 큰 리스크는 HTML이 ADR source of truth처럼 오해되거나, keyword-based area grouping이 governance logic처럼 쓰이는 것입니다. PR/plan/HTML footer에서 local navigation artifact임을 명시했고, ADR source files는 수정하지 않았습니다.

## 4. 테스트

- `python3 scripts/render_adr_decision_map.py`
- `python3 -m py_compile scripts/render_adr_decision_map.py scripts/html_report.py`
- `python3 -m pytest -q tests/test_render_adr_decision_map.py`
- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0009-adr-decision-map.md tasks/queue.md`
- `git diff --check`
- `make check-branch`
- Browser verification over local HTTP: title rendered, 4 status cards present, core sections present, `script` tag count = 0.

## 5. Eval 영향

All `N/A` — docs/navigation tooling only. No RAG, retrieval, verifier, answer, ingestion, eval, or benchmark behavior changes.

### 5b. Real-data delta

N/A — no load-bearing runtime/eval path changed. Real-data delta was not run; this PR makes no performance, readiness, or decision-status claim.

## 6. 하위 호환

No existing CLI/report output changes. New local command only: `python3 scripts/render_adr_decision_map.py`, which writes ignored `reports/adr_decision_map.html`.

## 7. 범위 외

- No ADR creation or status changes.
- No ADR number reservation.
- No lifecycle enforcement changes.
- No edits to `docs/adr/README.md` or ADR files.
