### PR TITLE
Add priority HTML review boards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ RFP 문서 이해를 위한 DocAgent 시스템. **입찰/RFP 문서 인텔리전
 
 - **사용자가 한국어로 쓰면 한국어로 응답.** 영어 프롬프트 또는 "respond in English" 명시 시만 영어. 코드·식별자·커밋 메시지·파일/디렉터리명은 영문 유지
 - **2-3줄 TL;DR 후 상세.** 한 턴에 한 결정 — 여러 PR/issue/branch 를 한 메시지에 묶지 않음
+- **AI가 이어받을 문서는 Markdown, 사람이 검토할 문서는 HTML.** 세션 handoff, plan, queue, reviewer 근거의 source-of-truth 는 `md`로 남긴다. 사람이 훑는 dashboard/review board 는 `html`로 렌더링한다. 둘 다 필요하면 `md`를 canonical 기록, `html`을 generated human view 로 병행한다.
 
 ## 자율성 & 승인
 

--- a/docs/plans/T-2026-0010-priority-html-review-boards.md
+++ b/docs/plans/T-2026-0010-priority-html-review-boards.md
@@ -1,0 +1,161 @@
+# Plan: T-2026-0010 Priority HTML Review Boards
+
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0010`
+- Related issue / PR: [#1518](https://github.com/hskim-solv/BidMate-DocAgent/issues/1518)
+- Related ADR: N/A - no decision-level change
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+## Problem Statement
+
+Several reviewer-critical aggregate surfaces exist only as JSON/Markdown
+artifacts. That makes it easy for a reviewer to miss which decision surface to
+inspect next, especially across private real-eval history, retrieval sweeps,
+difficulty slices, verifier false negatives, parser readiness, and benchmark
+claim boundaries.
+
+## Current Behavior
+
+Existing scripts render focused Markdown/HTML boards for some surfaces, but the
+six priority surfaces are still spread across:
+
+- `reports/real100/history/*.aggregate.json`
+- `reports/retrieval/hybrid_sweep_summary.aggregate.json`
+- `reports/real100/embedding_ablation_retrieval.aggregate.json`
+- `reports/real100/difficulty_profile.aggregate.json`
+- `reports/real100/verifier_false_negative_overlap.aggregate.json`
+- `reports/private_real_eval_summary.redacted.json`
+- benchmark/evaluation governance docs
+
+## Desired Behavior
+
+A single local script renders six self-contained HTML boards:
+
+1. Real100 eval history timeline
+2. Retrieval decision board
+3. Difficulty profile board
+4. Verifier / VFN overlap board
+5. Parser / page citation readiness board
+6. Benchmark validity board
+
+The durable AI handoff remains Markdown (`tasks/queue.md` and this plan), while
+the human review surface is HTML. If a future surface needs both, Markdown is
+the canonical source-of-truth and HTML is the generated human view.
+
+## Constraints
+
+- Scope constraints: presentation tooling and local HTML artifacts only.
+- Architecture constraints: do not change RAG runtime, parser runtime, scoring,
+  or benchmark semantics.
+- Compatibility constraints: missing source artifacts should degrade to empty
+  tables rather than failing unrelated boards.
+- Eval/privacy constraints: aggregate-only and redacted inputs; no private raw
+  document or per-case payload reads.
+- Tooling/CI constraints: use focused renderer tests and existing HTML helpers.
+- Non-goals: no new ADR, no new eval run, no performance claim.
+
+## Architecture Impact
+
+- Affected modules or docs: `CLAUDE.md`,
+  `scripts/render_priority_review_boards.py`, focused tests, task queue/plan
+  docs.
+- Affected contracts or invariants: none.
+- Load-bearing paths: no runtime load-bearing path changes.
+- ADR required: no, because this adds presentation artifacts only.
+- Backward compatibility expectation: additive CLI only.
+
+## Affected Interfaces
+
+- CLI/API/config: new local script CLI with optional `--root` and `--out-dir`.
+- Input data: existing aggregate JSON and Markdown docs.
+- Output artifacts: local HTML files under `reports/`.
+- Docs/review surfaces: task queue and plan.
+- Tests/eval entrypoints: focused pytest for renderer behavior.
+
+## Data / Eval Impact
+
+- Surface: private real-eval aggregate, public synthetic benchmark docs, none for runtime.
+- Data boundary: aggregate-only private output plus repository docs.
+- Allowed claim: local reviewer visibility over existing artifacts.
+- Disallowed claim: metric improvement, production readiness, or new real-eval result.
+- Baseline or control affected: no.
+- Benchmark/eval auditor required: no, because no scoring semantics change.
+
+## Task Breakdown
+
+1. Add the renderer script and six board outputs.
+2. Add focused tests for escaping, output count, and path redaction behavior.
+3. Generate the local HTML files and verify them through a local server.
+
+## Acceptance Criteria
+
+- [x] One command writes all six HTML boards.
+- [x] Tests cover escaping and aggregate-only path handling.
+- [x] Generated boards render locally without requiring file URL access.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 -m pytest tests/test_render_priority_review_boards.py -q
+python3 scripts/render_priority_review_boards.py
+git diff --check
+```
+
+Expected evidence:
+
+- Test/eval output: focused pytest passes.
+- Generated or updated artifact: six local HTML files under `reports/`.
+- Reviewer checklist or manual inspection: browser smoke via local HTTP server
+  confirms all six titles, status cards, and tables load.
+- Explicitly not validated, with reason: no real-eval run, because this does not
+  change eval/runtime behavior.
+
+## Rollback Strategy
+
+Revert the script, tests, task queue entry, and plan. Generated HTML files are
+local presentation artifacts and can be regenerated or removed without touching
+source aggregate JSON.
+
+## Failure Modes
+
+- Failure mode: raw private paths or case text leaks into HTML.
+- Detection signal: tests and review of source inputs; renderer reads only
+  aggregate/redacted paths.
+- Stop condition or fallback: stop if a desired board requires raw private cases.
+
+## Observability
+
+- `reports/real100/eval_history_timeline.html`
+- `reports/retrieval/retrieval_decision_board.html`
+- `reports/real100/difficulty_profile.html`
+- `reports/real100/verifier_overlap.html`
+- `reports/parser_page_citation_readiness.html`
+- `reports/benchmark_validity.html`
+
+## Reviewer Notes
+
+Attack privacy boundary and claim wording first. The HTML boards should help
+navigation only; they must not imply a fresh benchmark/eval run.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Branch / worktree: chore/issue-1518-priority-html-boards / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Issue / PR: #1518 / TBD
+- Task: T-2026-0010
+- Current status: review
+- Files touched: CLAUDE.md, tasks/queue.md, docs/plans/T-2026-0010-priority-html-review-boards.md, scripts/render_priority_review_boards.py, tests/test_render_priority_review_boards.py
+- Decisions made: Keep all six boards in one presentation-only renderer.
+- Commands run: gh issue create; git switch; python3 -m pytest tests/test_render_priority_review_boards.py -q; python3 scripts/render_priority_review_boards.py; git diff --check; python3 scripts/check_doc_links.py --check-all; browser smoke via http://127.0.0.1:8765
+- Results: issue and branch created; focused tests, doc links, diff check, and browser smoke pass.
+- Next safe command: gh pr create
+- Open questions: none
+- Risks: generated HTML files are local ignored artifacts; renderer and markdown source-of-truth are committed.
+```

--- a/scripts/render_priority_review_boards.py
+++ b/scripts/render_priority_review_boards.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python3
+"""Render local HTML reviewer boards for priority eval/governance surfaces.
+
+The boards intentionally read only aggregate-safe JSON and repository docs.
+They do not run retrieval, re-score evals, inspect private raw cases, or change
+runtime behavior.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.html_report import render_document, render_status_card, render_table
+
+DEFAULT_OUTPUTS = {
+    "eval_history": Path("reports/real100/eval_history_timeline.html"),
+    "retrieval_decision": Path("reports/retrieval/retrieval_decision_board.html"),
+    "difficulty_profile": Path("reports/real100/difficulty_profile.html"),
+    "verifier_overlap": Path("reports/real100/verifier_overlap.html"),
+    "parser_readiness": Path("reports/parser_page_citation_readiness.html"),
+    "benchmark_validity": Path("reports/benchmark_validity.html"),
+}
+
+FLAT_OUTPUT_NAMES = {
+    "eval_history": "eval_history_timeline.html",
+    "retrieval_decision": "retrieval_decision_board.html",
+    "difficulty_profile": "difficulty_profile.html",
+    "verifier_overlap": "verifier_overlap.html",
+    "parser_readiness": "parser_page_citation_readiness.html",
+    "benchmark_validity": "benchmark_validity.html",
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_sequence(value: Any) -> Sequence[Any]:
+    return value if isinstance(value, Sequence) and not isinstance(value, (str, bytes)) else []
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _cell(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value)
+
+
+def _pct(value: Any) -> str:
+    number = _number(value)
+    if number is None:
+        return "-"
+    return f"{number * 100:.1f}%"
+
+
+def _pct_already(value: Any) -> str:
+    number = _number(value)
+    if number is None:
+        return "-"
+    return f"{number:.1f}%"
+
+
+def _metric_mean(metric: Any) -> str:
+    metric_map = _as_mapping(metric)
+    if "mean" in metric_map:
+        return _pct(metric_map.get("mean"))
+    return _pct(metric)
+
+
+def _delta(value: Any) -> str:
+    number = _number(value)
+    if number is None:
+        return "-"
+    if abs(number) < 1 and "e" not in str(value).lower():
+        return f"{number:+.3f}"
+    return f"{number:+.2f}"
+
+
+def _top_counter_rows(counter: Mapping[str, Any], *, limit: int = 10) -> list[list[Any]]:
+    rows = sorted(counter.items(), key=lambda item: _number(item[1]) or 0, reverse=True)
+    return [[key, value] for key, value in rows[:limit]]
+
+
+def _panel(title: str, content: str, note: str = "") -> str:
+    note_html = f'<p class="note">{note}</p>' if note else ""
+    return f'<section class="panel"><h2>{title}</h2>{note_html}{content}</section>'
+
+
+def _source_panel(root: Path, paths: Sequence[Path]) -> str:
+    rows = [[_rel(path, root), "present" if path.exists() else "missing"] for path in paths]
+    return _panel(
+        "Sources",
+        render_table(["Artifact", "Status"], rows),
+        "All source paths are repository-relative; private raw case payloads are not read.",
+    )
+
+
+def _history_entries(root: Path) -> list[tuple[Path, dict[str, Any]]]:
+    history_dir = root / "reports" / "real100" / "history"
+    return [(path, _load_json(path)) for path in sorted(history_dir.glob("*.aggregate.json"))]
+
+
+def render_eval_history(root: Path) -> str:
+    entries = _history_entries(root)
+    rows: list[list[Any]] = []
+    for path, data in entries:
+        stem_parts = path.stem.replace(".aggregate", "").split("_", 1)
+        run_id = stem_parts[0]
+        commit = stem_parts[1] if len(stem_parts) > 1 else "-"
+        failure_counts = _as_mapping(data.get("failure_category_counts"))
+        top_failure = "-"
+        if failure_counts:
+            top_key, top_value = max(failure_counts.items(), key=lambda item: _number(item[1]) or 0)
+            top_failure = f"{top_key}: {top_value}"
+        rows.append(
+            [
+                run_id,
+                commit,
+                data.get("pipeline"),
+                data.get("num_predictions"),
+                _pct(data.get("accuracy")),
+                _pct(data.get("abstention")),
+                _pct(data.get("citation_precision")),
+                _pct(data.get("groundedness")),
+                top_failure,
+            ]
+        )
+
+    latest = entries[-1][1] if entries else {}
+    cards = [
+        render_status_card("History runs", len(entries), detail="aggregate snapshots", tone="accent"),
+        render_status_card("Latest accuracy", _pct(latest.get("accuracy")), tone="neutral"),
+        render_status_card("Latest abstention", _pct(latest.get("abstention")), tone="warn"),
+        render_status_card("Latest N", latest.get("num_predictions", "-"), tone="neutral"),
+    ]
+    body = "\n".join(
+        [
+            f'<section class="grid">{"".join(cards)}</section>',
+            _panel(
+                "Timeline",
+                render_table(
+                    [
+                        "Run",
+                        "Commit",
+                        "Pipeline",
+                        "N",
+                        "Accuracy",
+                        "Abstention",
+                        "Citation precision",
+                        "Groundedness",
+                        "Top failure",
+                    ],
+                    rows,
+                    empty_message="No history aggregate files found",
+                ),
+                "Use this to spot run-to-run drift before reading individual reports.",
+            ),
+            _source_panel(root, [path for path, _ in entries]),
+        ]
+    )
+    return render_document(
+        title="Real100 Eval History Timeline",
+        subtitle="Chronological, aggregate-only view of private real-eval snapshots.",
+        body=body,
+        footer="Generated from reports/real100/history/*.aggregate.json only.",
+    )
+
+
+def _metric_from_nested(data: Mapping[str, Any], *keys: str) -> Any:
+    current: Any = data
+    for key in keys:
+        current = _as_mapping(current).get(key)
+    return current
+
+
+def render_retrieval_decision(root: Path) -> str:
+    hybrid_path = root / "reports" / "retrieval" / "hybrid_sweep_summary.aggregate.json"
+    embedding_path = root / "reports" / "real100" / "embedding_ablation_retrieval.aggregate.json"
+    phase3_path = root / "reports" / "retrieval" / "phase3_mode_20260518T032404Z" / "deltas.json"
+    coverage_path = root / "reports" / "retrieval" / "phase4_metadata_20260520T032829Z_kordoc" / "coverage.json"
+    hybrid = _load_json(hybrid_path)
+    embedding = _load_json(embedding_path)
+    phase3 = _load_json(phase3_path)
+    coverage = _load_json(coverage_path)
+
+    decision = _as_mapping(hybrid.get("decision"))
+    baseline = _as_mapping(hybrid.get("baseline"))
+    baseline_metrics = _as_mapping(baseline.get("metrics"))
+    variants = _as_sequence(hybrid.get("variants"))
+    variant_rows = []
+    for variant in variants[:12]:
+        variant_map = _as_mapping(variant)
+        deltas = _as_mapping(variant_map.get("deltas_vs_dense"))
+        variant_rows.append(
+            [
+                variant_map.get("name"),
+                variant_map.get("primary_classification"),
+                _delta(deltas.get("recall_at_10")),
+                _delta(deltas.get("recall_at_5")),
+                _delta(deltas.get("mrr_at_5")),
+                _delta(deltas.get("ndcg_at_5")),
+                _delta(deltas.get("latency_p50_ms")),
+                _delta(deltas.get("latency_p95_ms")),
+            ]
+        )
+
+    model_rows = []
+    for model_name, model_info in _as_mapping(embedding.get("models")).items():
+        full = _as_mapping(_metric_from_nested(_as_mapping(model_info), "ablations", "full"))
+        model_rows.append(
+            [
+                model_name,
+                _as_mapping(model_info).get("hf_id"),
+                _metric_mean(full.get("chunk_recall_at_10")),
+                _metric_mean(full.get("chunk_recall_at_5")),
+                _metric_mean(full.get("chunk_mrr")),
+                _metric_mean(full.get("chunk_ndcg_at_10")),
+            ]
+        )
+
+    phase3_rows = [
+        [
+            name,
+            _delta(_as_mapping(metrics).get("chunk_recall@10")),
+            _delta(_as_mapping(metrics).get("chunk_recall@5")),
+            _delta(_as_mapping(metrics).get("mrr")),
+            _delta(_as_mapping(metrics).get("ndcg@10")),
+        ]
+        for name, metrics in phase3.items()
+    ]
+    coverage_rows = [
+        [
+            bucket,
+            stats.get("n"),
+            _pct_already(stats.get("pct")),
+            stats.get("gold_present"),
+            stats.get("gold_size_median"),
+        ]
+        for bucket, stats in _as_mapping(_as_mapping(coverage.get("stats")).get("buckets")).items()
+        if isinstance(stats, Mapping)
+    ]
+
+    cards = [
+        render_status_card("Hybrid decision", decision.get("final", "-"), detail="current sweep outcome", tone="warn"),
+        render_status_card("Winner found", _cell(decision.get("winner_found")), tone="danger" if not decision.get("winner_found") else "ok"),
+        render_status_card("Candidates", decision.get("candidate_count", "-"), detail="hybrid variants", tone="neutral"),
+        render_status_card("Dense recall@10", _pct(baseline_metrics.get("recall_at_10")), detail=baseline.get("name", ""), tone="accent"),
+    ]
+    body = "\n".join(
+        [
+            f'<section class="grid">{"".join(cards)}</section>',
+            _panel(
+                "Hybrid Sweep Candidates",
+                render_table(
+                    ["Variant", "Classification", "dRecall@10", "dRecall@5", "dMRR@5", "dNDCG@5", "dP50 ms", "dP95 ms"],
+                    variant_rows,
+                    empty_message="No hybrid variants found",
+                ),
+                "Deltas are versus the dense baseline in the aggregate sweep summary.",
+            ),
+            _panel(
+                "Embedding Ablation Full Retrieval Rows",
+                render_table(
+                    ["Model", "HF id", "Recall@10", "Recall@5", "MRR", "NDCG@10"],
+                    model_rows,
+                    empty_message="No embedding ablation aggregate found",
+                ),
+            ),
+            _panel(
+                "Mode Deltas",
+                render_table(["Variant", "dRecall@10", "dRecall@5", "dMRR", "dNDCG@10"], phase3_rows),
+                "Phase 3 mode deltas help separate backend choice from query/page metadata work.",
+            ),
+            _panel(
+                "Query Metadata Coverage",
+                render_table(["Bucket", "N", "Share", "Gold present", "Gold size median"], coverage_rows),
+            ),
+            _source_panel(root, [hybrid_path, embedding_path, phase3_path, coverage_path]),
+        ]
+    )
+    return render_document(
+        title="Retrieval Decision Board",
+        subtitle="One-page aggregate view for dense, hybrid, embedding, mode, and metadata retrieval decisions.",
+        body=body,
+        footer="Generated from aggregate retrieval artifacts only; no retrieval run is executed.",
+    )
+
+
+def render_difficulty_profile(root: Path) -> str:
+    path = root / "reports" / "real100" / "difficulty_profile.aggregate.json"
+    data = _load_json(path)
+    population = _as_mapping(data.get("population"))
+    outcomes = _as_mapping(data.get("overall_outcomes"))
+    conclusions = _as_mapping(data.get("conclusions"))
+    next_improvement = _as_mapping(conclusions.get("next_improvement"))
+    cards = [
+        render_status_card("Cases", population.get("num_cases", "-"), detail="profile population", tone="accent"),
+        render_status_card("Answerable", population.get("answerable_count", "-"), tone="neutral"),
+        render_status_card("Failure rate", _pct(outcomes.get("failure_rate")), detail=f"{outcomes.get('failed_count', '-')} failed", tone="warn"),
+        render_status_card("Next lever", next_improvement.get("recommended_next", "-"), tone="accent"),
+    ]
+
+    dominant_rows = [
+        [item.get("axis"), item.get("bucket"), item.get("failed_count"), _pct(item.get("share_of_all_failures"))]
+        for item in _as_sequence(conclusions.get("dominant_failure_slices"))
+        if isinstance(item, Mapping)
+    ]
+    lever_rows = [
+        [item.get("lever"), item.get("signal_count")]
+        for item in _as_sequence(next_improvement.get("ranked_signals"))
+        if isinstance(item, Mapping)
+    ]
+    axis_rows = []
+    for axis, buckets in _as_mapping(data.get("difficulty_axes")).items():
+        for bucket, stats in _as_mapping(buckets).items():
+            metrics = _as_mapping(_as_mapping(stats).get("metrics"))
+            axis_rows.append(
+                [
+                    axis,
+                    bucket,
+                    _as_mapping(stats).get("n"),
+                    _as_mapping(stats).get("failed_count"),
+                    _pct(_as_mapping(stats).get("failure_rate")),
+                    _metric_mean(metrics.get("recall_at_10")),
+                    _metric_mean(metrics.get("citation_precision")),
+                ]
+            )
+
+    body = "\n".join(
+        [
+            f'<section class="grid">{"".join(cards)}</section>',
+            _panel(
+                "Dominant Failure Slices",
+                render_table(["Axis", "Bucket", "Failed count", "Share of failures"], dominant_rows),
+                _cell(conclusions.get("interpretation")),
+            ),
+            _panel("Ranked Improvement Levers", render_table(["Lever", "Signal count"], lever_rows)),
+            _panel(
+                "Difficulty Axis Detail",
+                render_table(
+                    ["Axis", "Bucket", "N", "Failed", "Failure rate", "Recall@10", "Citation precision"],
+                    axis_rows,
+                ),
+            ),
+            _source_panel(root, [path]),
+        ]
+    )
+    return render_document(
+        title="Difficulty Profile Board",
+        subtitle="Private real-eval difficulty slices as aggregate counts and rates.",
+        body=body,
+        footer="Generated from reports/real100/difficulty_profile.aggregate.json only.",
+    )
+
+
+def render_verifier_overlap(root: Path) -> str:
+    path = root / "reports" / "real100" / "verifier_false_negative_overlap.aggregate.json"
+    data = _load_json(path)
+    vfn = _as_mapping(data.get("verifier_false_negative"))
+    inputs = _as_mapping(vfn.get("decision_inputs"))
+    overlap = _as_mapping(vfn.get("overlap"))
+    slices = _as_mapping(vfn.get("slices"))
+    cards = [
+        render_status_card("VFN total", vfn.get("total", "-"), detail=f"N={data.get('num_predictions', '-')}", tone="accent"),
+        render_status_card("Decision", vfn.get("decision", "-"), tone="warn"),
+        render_status_card("Retrieval fault signal", _pct(inputs.get("retrieval_fault_signal_rate")), tone="danger"),
+        render_status_card("Citation missing", _pct(inputs.get("citation_missing_rate")), tone="danger"),
+    ]
+    overlap_rows = []
+    for name, value in overlap.items():
+        value_map = _as_mapping(value)
+        if value_map:
+            count = value_map.get("count")
+            detail = ", ".join(f"{key}={val}" for key, val in _as_mapping(value_map.get("components")).items())
+            if not detail:
+                detail = ", ".join(f"{key}={val}" for key, val in _as_mapping(value_map.get("buckets")).items())
+            overlap_rows.append([name, count, detail or "-"])
+    pair_rows = _top_counter_rows(_as_mapping(_as_mapping(overlap.get("pairwise_intersections")).copy()), limit=20)
+    slice_rows = []
+    for slice_name, bucket_counts in slices.items():
+        for bucket, count in _as_mapping(bucket_counts).items():
+            slice_rows.append([slice_name, bucket, count])
+
+    body = "\n".join(
+        [
+            f'<section class="grid">{"".join(cards)}</section>',
+            _panel("Overlap Components", render_table(["Component", "Count", "Detail"], overlap_rows)),
+            _panel("Pairwise Intersections", render_table(["Intersection", "Count"], pair_rows)),
+            _panel("VFN Slices", render_table(["Slice", "Bucket", "Count"], slice_rows)),
+            _source_panel(root, [path]),
+        ]
+    )
+    return render_document(
+        title="Verifier / VFN Overlap Board",
+        subtitle="Aggregate overlap view for verifier false negatives and retrieval/citation fault signals.",
+        body=body,
+        footer="Generated from verifier_false_negative_overlap.aggregate.json only.",
+    )
+
+
+def render_parser_readiness(root: Path) -> str:
+    summary_path = root / "reports" / "private_real_eval_summary.redacted.json"
+    contract_path = root / "docs" / "evaluation" / "page_aware_parser_contract.md"
+    recovery_path = root / "docs" / "evaluation" / "page_metadata_recovery_plan.md"
+    hwp_path = root / "docs" / "hwp" / "hwp-eval-closure.md"
+    adr_path = root / "docs" / "adr" / "0078-pymupdf4llm-canonical-page-citation.md"
+    fixture_dir = root / "eval" / "fixtures" / "page_aware_parser_contract"
+    fixtures = sorted(fixture_dir.glob("*.json"))
+    summary = _load_json(summary_path)
+    failures = _as_mapping(summary.get("failure_type_counts"))
+    parser_failure_rows = [
+        [key, failures.get(key)]
+        for key in sorted(failures)
+        if key.startswith("parsing_failure.") or key.startswith("citation_failure.")
+    ]
+    readiness_rows = [
+        ["Page-aware parser contract", _cell(bool(_read_text(contract_path))), _rel(contract_path, root)],
+        ["Page metadata recovery plan", _cell(bool(_read_text(recovery_path))), _rel(recovery_path, root)],
+        ["HWP eval closure note", _cell(bool(_read_text(hwp_path))), _rel(hwp_path, root)],
+        ["Canonical page citation ADR", _cell(bool(_read_text(adr_path))), _rel(adr_path, root)],
+        ["Parser contract fixtures", len(fixtures), _rel(fixture_dir, root)],
+    ]
+    cards = [
+        render_status_card("Contract fixtures", len(fixtures), tone="accent"),
+        render_status_card("page_metadata_missing", failures.get("parsing_failure.page_metadata_missing", "-"), tone="neutral"),
+        render_status_card("missing_page_number", failures.get("citation_failure.missing_page_number", "-"), tone="neutral"),
+        render_status_card("Raw private cases read", "0", detail="redacted aggregate only", tone="ok"),
+    ]
+    body = "\n".join(
+        [
+            f'<section class="grid">{"".join(cards)}</section>',
+            _panel(
+                "Readiness Checklist",
+                render_table(["Surface", "Current signal", "Source"], readiness_rows),
+                "This is a readiness board, not a fresh parser evaluation.",
+            ),
+            _panel(
+                "Redacted Parser / Citation Failure Counters",
+                render_table(["Counter", "Count"], parser_failure_rows),
+            ),
+            _source_panel(root, [summary_path, contract_path, recovery_path, hwp_path, adr_path] + fixtures),
+        ]
+    )
+    return render_document(
+        title="Parser / Page Citation Readiness Board",
+        subtitle="Contract and redacted-counter view for page-aware parser and citation readiness.",
+        body=body,
+        footer="Generated without reading private raw documents or per-case payloads.",
+    )
+
+
+def _count_jsonl(path: Path) -> int:
+    if not path.exists():
+        return 0
+    return sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+
+
+def render_benchmark_validity(root: Path) -> str:
+    surface_path = root / "docs" / "evaluation" / "surface-map.md"
+    synthetic_path = root / "docs" / "evaluation" / "synthetic_benchmark_v1_design.md"
+    results_path = root / "docs" / "evaluation" / "naive_rag_benchmark_v1_results.md"
+    registry_path = root / "benchmarks" / "registry.json"
+    difficulty_path = root / "reports" / "real100" / "difficulty_profile.aggregate.json"
+    summary_path = root / "reports" / "private_real_eval_summary.redacted.json"
+    question_path = root / "data" / "eval" / "benchmark" / "rag_questions_v1.jsonl"
+    corpus_dir = root / "data" / "eval" / "benchmark" / "corpus"
+
+    difficulty = _load_json(difficulty_path)
+    summary = _load_json(summary_path)
+    conclusions = _as_mapping(difficulty.get("conclusions"))
+    claim_readiness = _as_mapping(summary.get("claim_readiness"))
+    synthetic_docs = sorted(corpus_dir.glob("*.json"))
+    cards = [
+        render_status_card("Private claim status", claim_readiness.get("status", "-"), tone="accent"),
+        render_status_card("Benchmark validity", conclusions.get("benchmark_validity", "-"), tone="ok"),
+        render_status_card("Invalid signal rate", _pct(conclusions.get("invalid_signal_rate")), tone="ok"),
+        render_status_card("Synthetic questions", _count_jsonl(question_path), detail=f"{len(synthetic_docs)} corpus docs", tone="neutral"),
+    ]
+    claim_rows = [
+        [
+            "Public fixture smoke",
+            "CI/regression sanity",
+            "pass/fail and contract regression",
+            "real-world RFP quality claim",
+        ],
+        [
+            "Public synthetic benchmark",
+            "benchmark method and contamination checks",
+            "synthetic-only score comparison",
+            "private real-eval or production performance claim",
+        ],
+        [
+            "Private real-eval aggregate",
+            "aggregate local reviewer evidence",
+            "aggregate trend/caveated claim readiness",
+            "raw private document or per-case disclosure",
+        ],
+    ]
+    limitation_rows = [[item] for item in _as_sequence(summary.get("known_limitations"))]
+    if not limitation_rows:
+        limitation_rows = [["No known_limitations list in redacted summary"]]
+    source_rows = [
+        ["Surface map", _cell(bool(_read_text(surface_path))), _rel(surface_path, root)],
+        ["Synthetic benchmark design", _cell(bool(_read_text(synthetic_path))), _rel(synthetic_path, root)],
+        ["Synthetic benchmark results", _cell(bool(_read_text(results_path))), _rel(results_path, root)],
+        ["Benchmark registry", _cell(registry_path.exists()), _rel(registry_path, root)],
+        ["Private redacted summary", _cell(summary_path.exists()), _rel(summary_path, root)],
+        ["Difficulty profile aggregate", _cell(difficulty_path.exists()), _rel(difficulty_path, root)],
+    ]
+    body = "\n".join(
+        [
+            f'<section class="grid">{"".join(cards)}</section>',
+            _panel(
+                "Claim Surface Boundaries",
+                render_table(["Surface", "Purpose", "Allowed claim", "Disallowed claim"], claim_rows),
+                "This board makes over-claiming visible before PR review.",
+            ),
+            _panel("Known Limitations", render_table(["Limitation"], limitation_rows)),
+            _panel("Validity Source Inventory", render_table(["Source", "Present", "Path"], source_rows)),
+            _source_panel(root, [surface_path, synthetic_path, results_path, registry_path, difficulty_path, summary_path, question_path]),
+        ]
+    )
+    return render_document(
+        title="Benchmark Validity Board",
+        subtitle="Reviewer map for benchmark surfaces, allowed claims, and aggregate validity signals.",
+        body=body,
+        footer="Generated from docs, public synthetic benchmark files, and redacted/aggregate reports.",
+    )
+
+
+def output_paths(root: Path, out_dir: Path | None) -> dict[str, Path]:
+    if out_dir is not None:
+        return {key: out_dir / name for key, name in FLAT_OUTPUT_NAMES.items()}
+    return {key: root / rel_path for key, rel_path in DEFAULT_OUTPUTS.items()}
+
+
+def render_all(root: Path, out_dir: Path | None = None) -> dict[Path, str]:
+    paths = output_paths(root, out_dir)
+    return {
+        paths["eval_history"]: render_eval_history(root),
+        paths["retrieval_decision"]: render_retrieval_decision(root),
+        paths["difficulty_profile"]: render_difficulty_profile(root),
+        paths["verifier_overlap"]: render_verifier_overlap(root),
+        paths["parser_readiness"]: render_parser_readiness(root),
+        paths["benchmark_validity"]: render_benchmark_validity(root),
+    }
+
+
+def write_all(root: Path, out_dir: Path | None = None) -> list[Path]:
+    written: list[Path] = []
+    for path, html in render_all(root, out_dir).items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(html, encoding="utf-8")
+        written.append(path)
+    return written
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="repository root")
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="optional flat output directory for all six HTML boards",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    root = args.root.resolve()
+    out_dir = args.out_dir.resolve() if args.out_dir else None
+    written = write_all(root, out_dir)
+    for path in written:
+        print(f"[OK] Wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -20,11 +20,104 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 7 | `T-2026-0007` | `review` | Implementer -> Reviewer | failure distribution local HTML board 구현됨. |
 | 8 | `T-2026-0008` | `review` | Implementer -> Reviewer | chunking diagnostics local HTML board 구현됨. |
 | 9 | `T-2026-0009` | `review` | Implementer -> Reviewer | ADR decision map local HTML board 구현됨. |
+| 10 | `T-2026-0010` | `review` | Implementer -> Reviewer | priority aggregate HTML review boards implemented; issue #1518 / branch `chore/issue-1518-priority-html-boards`. |
 
 ## Examples
 
 - [`tasks/examples/benchmark-hardening.md`](examples/benchmark-hardening.md): benchmark hardening task 작성 예시.
 - [`tasks/examples/eval-regression-safety.md`](examples/eval-regression-safety.md): eval regression safety task 작성 예시.
+
+## T-2026-0010 — Priority HTML review boards
+
+- ID: T-2026-0010
+- Title: Priority HTML review boards
+- Status: review
+- Owner role: Implementer -> Reviewer
+- Created: 2026-05-26
+- Last updated: 2026-05-26
+
+### Goal
+
+Render the next six aggregate reviewer surfaces as local HTML boards so a human
+can inspect current eval/retrieval/governance signals without opening several
+JSON and Markdown files.
+
+### Context
+
+- Surface: private real-eval aggregate / public synthetic benchmark docs /
+  reviewer workflow.
+- Relevant docs: [`docs/evaluation/surface-map.md`](../docs/evaluation/surface-map.md),
+  [`docs/plans/T-2026-0010-priority-html-review-boards.md`](../docs/plans/T-2026-0010-priority-html-review-boards.md).
+- Primary risk: HTML summaries accidentally implying a fresh eval run or
+  exposing private raw data.
+
+### Scope
+
+- Add a local renderer for six HTML boards.
+- Use existing aggregate/redacted JSON and docs only.
+- Add focused renderer tests.
+- Preserve the operating convention that AI handoff/source-of-truth stays in
+  Markdown while human review boards are rendered as HTML.
+
+### Non-Goals
+
+- Do not change RAG runtime, parser runtime, retrieval behavior, or eval scoring.
+- Do not read private raw documents or per-case payloads.
+- Do not claim performance improvement.
+
+### Acceptance Criteria
+
+- [x] One command writes all six local HTML boards.
+- [x] Tests prove escaping and repository-relative source paths.
+- [x] Generated HTML is manually smoke-checked through a local HTTP server.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_render_priority_review_boards.py -q
+python3 scripts/render_priority_review_boards.py
+git diff --check
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Generated HTML paths.
+- Browser smoke result.
+
+### Failure Conditions
+
+- Stop if a board needs raw private data.
+- Stop if the board would introduce a new benchmark/eval claim.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0010-priority-html-review-boards.md`](../docs/plans/T-2026-0010-priority-html-review-boards.md)
+- Issue: [#1518](https://github.com/hskim-solv/BidMate-DocAgent/issues/1518)
+- PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-26 00:00 KST
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1518-priority-html-boards / /Users/hskim/.codex/worktrees/8ed1/BidMate-DocAgent
+- Task: T-2026-0010
+- Plan: docs/plans/T-2026-0010-priority-html-review-boards.md
+- Current status: implemented and validated; PR pending.
+- Files touched: CLAUDE.md, tasks/queue.md, docs/plans/T-2026-0010-priority-html-review-boards.md, scripts/render_priority_review_boards.py, tests/test_render_priority_review_boards.py
+- Decisions made: presentation-only renderer; aggregate/redacted inputs only.
+- Commands run: gh issue create; git switch; python3 -m pytest tests/test_render_priority_review_boards.py -q; python3 scripts/render_priority_review_boards.py; git diff --check; python3 scripts/check_doc_links.py --check-all; browser smoke via http://127.0.0.1:8765
+- Results: six HTML boards generated locally; focused tests, doc links, diff check, and browser smoke pass.
+- Validation evidence: local HTTP browser smoke confirmed all six board titles/cards/tables.
+- Eval surface: aggregate-only private real-eval plus public docs.
+- Open risks: generated HTML files remain ignored local artifacts; script regenerates them.
+- Next action: open PR.
+- Next safe command: gh pr create
+- Reviewer focus: privacy boundary, over-claiming, escaping.
+```
 
 ## T-2026-0001 — Benchmark hardening against synthetic contamination
 

--- a/tests/test_render_priority_review_boards.py
+++ b/tests/test_render_priority_review_boards.py
@@ -1,0 +1,180 @@
+"""Regression guards for the priority local HTML review boards."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.render_priority_review_boards import main, render_all, render_eval_history
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _fixture_repo(root: Path) -> None:
+    _write_json(
+        root / "reports/real100/history/20260101T000000Z_deadbeef.aggregate.json",
+        {
+            "pipeline": "agentic_full",
+            "num_predictions": 2,
+            "accuracy": 0.5,
+            "abstention": 0.25,
+            "citation_precision": 0.75,
+            "groundedness": 1.0,
+            "failure_category_counts": {"retrieval_miss": 1},
+        },
+    )
+    _write_json(
+        root / "reports/retrieval/hybrid_sweep_summary.aggregate.json",
+        {
+            "baseline": {"name": "dense", "metrics": {"recall_at_10": 0.2}},
+            "decision": {
+                "final": "keep dense <script>alert(1)</script>",
+                "winner_found": False,
+                "candidate_count": 1,
+            },
+            "variants": [
+                {
+                    "name": "hybrid",
+                    "primary_classification": "ranking_regression",
+                    "deltas_vs_dense": {
+                        "recall_at_10": -0.1,
+                        "recall_at_5": 0.0,
+                        "mrr_at_5": -0.2,
+                        "ndcg_at_5": -0.3,
+                        "latency_p50_ms": 10,
+                        "latency_p95_ms": 20,
+                    },
+                }
+            ],
+        },
+    )
+    _write_json(
+        root / "reports/real100/embedding_ablation_retrieval.aggregate.json",
+        {
+            "models": {
+                "MiniLM": {
+                    "hf_id": "model",
+                    "ablations": {
+                        "full": {
+                            "chunk_recall_at_10": {"mean": 0.2},
+                            "chunk_recall_at_5": {"mean": 0.1},
+                            "chunk_mrr": {"mean": 0.3},
+                            "chunk_ndcg_at_10": {"mean": 0.4},
+                        }
+                    },
+                }
+            }
+        },
+    )
+    _write_json(root / "reports/retrieval/phase3_mode_20260518T032404Z/deltas.json", {"hybrid": {"chunk_recall@10": 0.1}})
+    _write_json(
+        root / "reports/retrieval/phase4_metadata_20260520T032829Z_kordoc/coverage.json",
+        {"stats": {"buckets": {"content_query": {"n": 2, "pct": 50.0, "gold_present": 1, "gold_size_median": 3}}}},
+    )
+    _write_json(
+        root / "reports/real100/difficulty_profile.aggregate.json",
+        {
+            "population": {"num_cases": 2, "answerable_count": 1},
+            "overall_outcomes": {"failure_rate": 0.5, "failed_count": 1},
+            "conclusions": {
+                "interpretation": "hard benchmark",
+                "benchmark_validity": "hard_benchmark_not_invalid",
+                "invalid_signal_rate": 0.0,
+                "dominant_failure_slices": [{"axis": "answerability", "bucket": "answerable", "failed_count": 1}],
+                "next_improvement": {"recommended_next": "page_metadata_recovery", "ranked_signals": [{"lever": "page", "signal_count": 2}]},
+            },
+            "difficulty_axes": {
+                "answerability": {
+                    "answerable": {
+                        "n": 1,
+                        "failed_count": 1,
+                        "failure_rate": 1.0,
+                        "metrics": {"recall_at_10": {"mean": 0.2}},
+                    }
+                }
+            },
+        },
+    )
+    _write_json(
+        root / "reports/real100/verifier_false_negative_overlap.aggregate.json",
+        {
+            "num_predictions": 2,
+            "verifier_false_negative": {
+                "total": 1,
+                "decision": "mixed",
+                "decision_inputs": {"retrieval_fault_signal_rate": 0.5, "citation_missing_rate": 1.0},
+                "overlap": {
+                    "retrieval_fault_signal": {"count": 1, "components": {"expected_doc_missing": 1}},
+                    "pairwise_intersections": {"retrieval_fault_signal+citation_missing": 1},
+                },
+                "slices": {"query_type": {"abstention": 1}},
+            },
+        },
+    )
+    _write_json(
+        root / "reports/private_real_eval_summary.redacted.json",
+        {
+            "claim_readiness": {"status": "claim-ready"},
+            "known_limitations": ["aggregate only"],
+            "failure_type_counts": {
+                "parsing_failure.page_metadata_missing": 0,
+                "citation_failure.missing_page_number": 0,
+            },
+        },
+    )
+    _write_text(root / "docs/evaluation/page_aware_parser_contract.md", "contract")
+    _write_text(root / "docs/evaluation/page_metadata_recovery_plan.md", "plan")
+    _write_text(root / "docs/hwp/hwp-eval-closure.md", "closure")
+    _write_text(root / "docs/adr/0078-pymupdf4llm-canonical-page-citation.md", "adr")
+    _write_text(root / "docs/evaluation/surface-map.md", "surface")
+    _write_text(root / "docs/evaluation/synthetic_benchmark_v1_design.md", "synthetic")
+    _write_text(root / "docs/evaluation/naive_rag_benchmark_v1_results.md", "results")
+    _write_json(root / "benchmarks/registry.json", {"suites": []})
+    _write_text(root / "data/eval/benchmark/rag_questions_v1.jsonl", "{}\n{}\n")
+    _write_json(root / "data/eval/benchmark/corpus/doc.json", {"doc": "public synthetic"})
+    _write_json(root / "eval/fixtures/page_aware_parser_contract/valid_sections.json", {"ok": True})
+
+
+def test_render_all_returns_six_escaped_documents(tmp_path: Path) -> None:
+    _fixture_repo(tmp_path)
+
+    docs = render_all(tmp_path, tmp_path / "out")
+
+    assert len(docs) == 6
+    joined = "\n".join(docs.values())
+    assert "Real100 Eval History Timeline" in joined
+    assert "Retrieval Decision Board" in joined
+    assert "Difficulty Profile Board" in joined
+    assert "Verifier / VFN Overlap Board" in joined
+    assert "Parser / Page Citation Readiness Board" in joined
+    assert "Benchmark Validity Board" in joined
+    assert "<script>" not in joined
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in joined
+
+
+def test_eval_history_does_not_expose_absolute_root_path(tmp_path: Path) -> None:
+    _fixture_repo(tmp_path)
+
+    html = render_eval_history(tmp_path)
+
+    assert str(tmp_path) not in html
+    assert "reports/real100/history/20260101T000000Z_deadbeef.aggregate.json" in html
+
+
+def test_cli_writes_six_flat_html_files(tmp_path: Path) -> None:
+    _fixture_repo(tmp_path)
+    out_dir = tmp_path / "html"
+
+    rc = main(["--root", str(tmp_path), "--out-dir", str(out_dir)])
+
+    assert rc == 0
+    outputs = sorted(out_dir.glob("*.html"))
+    assert len(outputs) == 6
+    assert any("Benchmark Validity Board" in path.read_text(encoding="utf-8") for path in outputs)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1518

기존 aggregate JSON/Markdown에 흩어진 6개 우선 review surface를 사람용 HTML board로 렌더링하는 로컬 스크립트를 추가했습니다. AI handoff/source-of-truth는 Markdown, human reviewer dashboard는 HTML이라는 운영 원칙도 `CLAUDE.md`와 task plan에 명시했습니다.

## 2. 영향 파일

- `CLAUDE.md` — AI용 Markdown / 사람용 HTML 산출물 원칙 추가.
- `scripts/render_priority_review_boards.py` — 6개 HTML board renderer 추가.
- `tests/test_render_priority_review_boards.py` — escaping, output count, repository-relative path guard.
- `docs/plans/T-2026-0010-priority-html-review-boards.md` — implementation plan and validation evidence.
- `tasks/queue.md` — T-2026-0010 queue entry/status.

Load-bearing path 변경 없음.

## 3. 리스크

가장 큰 리스크는 HTML summary가 fresh eval/performance claim처럼 읽히거나 private raw data/path를 노출하는 것입니다. Renderer는 aggregate/redacted JSON과 repo docs만 읽고, tests + browser smoke에서 HTML escaping과 `/Users/hskim...` 절대경로 미노출을 확인했습니다.

## 4. 테스트

- `python3 -m pytest tests/test_render_priority_review_boards.py -q`
- `python3 -m py_compile scripts/render_priority_review_boards.py`
- `python3 scripts/render_priority_review_boards.py`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`
- `make check-branch`
- Browser smoke via `http://127.0.0.1:8765`: all six board titles/cards/tables loaded; raw `<script>` not present.

## 5. Eval 영향

All `N/A`: presentation-only local renderer and documentation update. RAG runtime, parser runtime, retrieval behavior, scoring, benchmark semantics are unchanged.

### 5b. Real-data delta

N/A — no load-bearing path changed. 검색/검증 path 동작 변화 없음. No real-eval run was performed and this PR makes no performance claim.

## 6. 하위 호환

Backward compatible. Adds a new CLI script with optional `--root` and `--out-dir`; no existing CLI/API/schema/answer contract changes.

## 7. 범위 외

- Generated HTML files remain local ignored artifacts and are regenerated by `python3 scripts/render_priority_review_boards.py`.
- No new eval run, new benchmark surface, ADR, or metric claim.
- 7-15 candidate HTML boards are intentionally deferred for prioritization.
