### PR TITLE
[codex] Add real100 v2 RFP benchmark rebuild

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -87,6 +87,14 @@ ALLOWED_PATTERNS=(
   # in `.gitignore`. Aggregate-only — no per-case query/answer/chunk text,
   # no doc_id/chunk_id; per-model eval_summary.json + index stay ignored.
   '^reports/real100/embedding_ablation_retrieval\.aggregate\.json$'
+  # real100_v2 RFP benchmark rebuild. Aggregate-only inventory,
+  # question distribution, baseline, and tier split artifacts; raw eval
+  # summaries/questions/evidence/index text stay ignored.
+  '^reports/real100_v2/README\.md$'
+  '^reports/real100_v2/parse_inventory\.aggregate\.json$'
+  '^reports/real100_v2/question_distribution\.aggregate\.json$'
+  '^reports/real100_v2/baseline\.aggregate\.json$'
+  '^reports/real100_v2/benchmark_tiers\.aggregate\.json$'
 )
 
 # Guard: ADR file deletion/rename (CLAUDE.md Prohibited).
@@ -307,7 +315,7 @@ fi
 # one of the sanitizing generators is staged. tests/
 # test_eval_artifact_privacy_regression.py is the CI backstop.
 eval_priv_staged=$(git diff --cached --name-only --diff-filter=ACMR -- \
-  'reports/retrieval/*.json' 'reports/real100/*.json' \
+  'reports/retrieval/*.json' 'reports/real100/*.json' 'reports/real100_v2/*.json' \
   'scripts/_ablation_common.py' 'scripts/run_real_eval_delta.py' \
   'scripts/eda_real100.py' 'scripts/phase*_ablation.py' 2>/dev/null || true)
 if [[ -n "$eval_priv_staged" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,16 @@ reports/real100/history/*
 # scripts/render_multi_chunk_retrieval_strategy.py). Aggregate-only decision
 # over the multi-chunk evidence failure aggregate; no raw case rows.
 !reports/real100/multi_chunk_retrieval_strategy.aggregate.json
+# Aggregate-only real100_v2 benchmark rebuild artifacts. Raw eval summaries,
+# traces, questions, gold evidence, parsed Markdown, PDFs, and indexes stay
+# ignored under reports/real100_v2/*, data/private/*, and data/index/real100_v2/.
+!reports/real100_v2/
+reports/real100_v2/*
+!reports/real100_v2/parse_inventory.aggregate.json
+!reports/real100_v2/question_distribution.aggregate.json
+!reports/real100_v2/benchmark_tiers.aggregate.json
+!reports/real100_v2/baseline.aggregate.json
+!reports/real100_v2/README.md
 # Issue #1021 — variance source inspection (Issue J, ADR 0059 audit
 # follow-up, script: scripts/measure_variance.py). N=5 same-HEAD runs →
 # per-category mean/std/min/max + per-case stability + transition matrix.

--- a/docs/evaluation/real100_v2_rfp_benchmark_plan.md
+++ b/docs/evaluation/real100_v2_rfp_benchmark_plan.md
@@ -1,0 +1,90 @@
+# real100_v2 RFP Benchmark Rebuild Plan
+
+This document defines the public-safe plan for rebuilding the private RFP benchmark from PyMuPDF4LLM parsed artifacts. It is for interpretation and comparison, not cherry-picking headline claims.
+
+## Purpose
+
+The current real-eval aggregate mixes easy sanity checks with hard parser/retrieval stress cases. `real100_v2` separates those cases up front so future PRs can report overall performance plus each difficulty tier.
+
+## Privacy Boundary
+
+Committed artifacts may include only aggregate counts, closed labels, schema metadata, and high-level protocol text. Do not commit raw questions, answers, evidence text, document IDs, chunk IDs, filenames, local paths, per-case rows, converted PDFs, parsed Markdown, or raw eval summaries.
+
+Private local artifacts belong under ignored `data/private/real100_v2/`, `data/index/real100_v2/`, and ignored raw report paths. Public aggregate outputs belong under the explicit `reports/real100_v2/` allowlist.
+
+## Recommended Size
+
+Recommended target: 300 cases.
+
+| tier | count | purpose |
+|---|---:|---|
+| `easy_sanity` | 60 | Detect broken indexing/retrieval on answerable single-doc, single-chunk cases. |
+| `standard_real` | 150 | Represent normal RFP QA: date, amount, score, requirement, eligibility, deliverable, and moderate distractor cases. |
+| `hard_stress` | 90 | Preserve hard cases without letting them swallow the benchmark: multi-chunk, multi-doc, table/gantt-like, parser-stress, similar-clause, citation-dependent, and unanswerable cases. |
+
+This is large enough for tier-level movement to be visible while keeping local eval runtime close to the existing real-eval scale.
+
+## Tier Criteria
+
+`easy_sanity`:
+
+- answerable
+- single-doc
+- single-chunk
+- clear expected terms
+- no table-heavy evidence
+- no multi-hop
+- no similar-clause distractor proxy
+
+`standard_real`:
+
+- normal RFP QA cases
+- may include date, amount, score, schedule, requirement, eligibility, or deliverable extraction
+- may include moderate distractors
+- must not require multi-doc, multi-chunk, table-heavy, parser-stress, or citation/page-dependent reasoning
+
+`hard_stress`:
+
+- multi-chunk
+- multi-doc comparison
+- table-heavy or gantt/schedule-like evidence
+- similar-clause distractors
+- unanswerable
+- citation/page dependent
+- image-only, low-text, or poorly parsed document regions selected from converted PDF review
+
+Unanswerable cases stay in `hard_stress` for headline tiering, but they should be capped near 10 percent of the full benchmark and reported separately in `answerability` aggregates.
+
+## Question Composition
+
+Suggested target mix:
+
+| slice | target |
+|---|---:|
+| easy single-chunk content anchors | 60 |
+| standard date/schedule extraction | 35 |
+| standard amount/budget extraction | 35 |
+| standard score/evaluation extraction | 30 |
+| standard RFP requirement/eligibility/deliverable extraction | 50 |
+| hard multi-chunk same-doc | 27 |
+| hard multi-doc comparison | 14 |
+| hard table/gantt/parser-stress | 23 |
+| hard unanswerable/absence | 26 |
+
+The deterministic proposer can draft the text-grounded subset from parsed Markdown. Answerable visual/parser-stress cases require local review of converted PDFs before promotion, because image-only or badly structured pages cannot be gold-labeled from Markdown alone.
+
+## Baseline Validation Protocol
+
+1. Rebuild the local private parse/index with PyMuPDF4LLM using OCR and layout enabled. Use `scripts/build_private_real100_v2_parallel.py` for the rebuild so document parsing can run in parallel. The builder writes private per-row checkpoints under the ignored index output by default, so long OCR/layout runs can be stopped and resumed without committing raw parsed text. A per-document timeout may be used to prevent a single malformed document from blocking the run; timed-out documents become parser-stress candidates.
+2. Export parsed Markdown to ignored private storage and write `reports/real100_v2/parse_inventory.aggregate.json`.
+3. Generate private draft questions and write `reports/real100_v2/question_distribution.aggregate.json`.
+4. Run the private eval dataset audit. It must pass with no label/index-reference errors before baseline measurement.
+5. Run baseline retrieval/eval against `data/index/real100_v2/`; keep raw `eval_summary.json` ignored.
+6. Render aggregate-only baseline and tier summaries.
+7. Future PRs must report overall plus all tiers. A PR must explain tier regressions and must not select only improved tiers for claims.
+
+## Non-Goals
+
+- No retrieval, verifier, prompt, chunking, reranker, answer generation, or runtime behavior change.
+- No public raw benchmark release.
+- No performance claim from the rebuild itself until the baseline is measured and aggregate outputs pass privacy checks.

--- a/ingestion.py
+++ b/ingestion.py
@@ -9,7 +9,11 @@ in the ingestion report.
 from __future__ import annotations
 
 import csv
+import json
 import os
+import subprocess
+import sys
+import tempfile
 import warnings
 from collections import OrderedDict
 from dataclasses import asdict, dataclass, field
@@ -192,6 +196,11 @@ PDF_PYMUPDF4LLM_TEXT_SOURCE = "pdf_pymupdf4llm"
 LIBREOFFICE_CONVERTED_PDF_CITATION_BASIS = "libreoffice_converted_pdf"
 SOURCE_PDF_CITATION_BASIS = "source_pdf"
 HWP_PDF_ARTIFACT_DIR_ENV = "BIDMATE_HWP_PDF_ARTIFACT_DIR"
+HWP_PDF_ARTIFACT_REUSE_ENV = "BIDMATE_HWP_PDF_ARTIFACT_REUSE"
+PYMUPDF4LLM_USE_OCR_ENV = "BIDMATE_PYMUPDF4LLM_USE_OCR"
+PYMUPDF4LLM_OCR_LANGUAGE_ENV = "BIDMATE_PYMUPDF4LLM_OCR_LANGUAGE"
+PYMUPDF4LLM_USE_LAYOUT_ENV = "BIDMATE_PYMUPDF4LLM_USE_LAYOUT"
+PYMUPDF4LLM_PARSE_TIMEOUT_ENV = "BIDMATE_PYMUPDF4LLM_PARSE_TIMEOUT_S"
 _HWP_TO_PDF_BINS = (
     "soffice",
     "libreoffice",
@@ -578,6 +587,104 @@ def _validate_source_pdf(pdf_path: Path) -> int:
     return _validate_pdf(pdf_path, "pdf_invalid_pdf")
 
 
+def _pymupdf4llm_use_ocr() -> bool:
+    value = os.environ.get(PYMUPDF4LLM_USE_OCR_ENV)
+    if value is None:
+        return True
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _pymupdf4llm_ocr_language() -> str:
+    return os.environ.get(PYMUPDF4LLM_OCR_LANGUAGE_ENV, "eng").strip() or "eng"
+
+
+def _pymupdf4llm_use_layout() -> bool | None:
+    value = os.environ.get(PYMUPDF4LLM_USE_LAYOUT_ENV)
+    if value is None:
+        return None
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _pymupdf4llm_parse_timeout_s() -> float | None:
+    value = os.environ.get(PYMUPDF4LLM_PARSE_TIMEOUT_ENV)
+    if value is None or not value.strip():
+        return None
+    try:
+        timeout = float(value)
+    except ValueError:
+        return None
+    return timeout if timeout > 0 else None
+
+
+def _pymupdf4llm_to_markdown_subprocess(
+    pdf_path: Path,
+    *,
+    use_ocr: bool,
+    ocr_language: str,
+    use_layout: bool | None,
+    timeout_s: float,
+) -> Any:
+    with tempfile.NamedTemporaryFile(prefix="bidmate_pymupdf4llm_", suffix=".json", delete=False) as handle:
+        output_path = Path(handle.name)
+    layout_arg = "default" if use_layout is None else ("1" if use_layout else "0")
+    worker = r"""
+import json
+from pathlib import Path
+import sys
+
+import pymupdf4llm
+
+pdf_path = sys.argv[1]
+output_path = Path(sys.argv[2])
+use_ocr = sys.argv[3] == "1"
+ocr_language = sys.argv[4]
+layout_arg = sys.argv[5]
+
+if layout_arg != "default" and hasattr(pymupdf4llm, "use_layout"):
+    pymupdf4llm.use_layout(layout_arg == "1")
+
+output = pymupdf4llm.to_markdown(
+    pdf_path,
+    page_chunks=True,
+    use_ocr=use_ocr,
+    ocr_language=ocr_language,
+)
+output_path.write_text(json.dumps(output, ensure_ascii=False), encoding="utf-8")
+"""
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                worker,
+                str(pdf_path),
+                str(output_path),
+                "1" if use_ocr else "0",
+                ocr_language,
+                layout_arg,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output_path.unlink(missing_ok=True)
+        raise _PdfPyMuPdf4LlmFallback("pymupdf4llm_parse_timeout", f"{timeout_s:g}s") from exc
+    if proc.returncode != 0:
+        output_path.unlink(missing_ok=True)
+        raise _PdfPyMuPdf4LlmFallback(
+            "pymupdf4llm_parse_failed",
+            f"subprocess_exit_{proc.returncode}",
+        )
+    try:
+        return json.loads(output_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise _PdfPyMuPdf4LlmFallback("pymupdf4llm_parse_failed", "subprocess_invalid_json") from exc
+    finally:
+        output_path.unlink(missing_ok=True)
+
+
 def _page_number_from_pymupdf4llm_chunk(
     chunk: dict[str, Any],
     fallback: int,
@@ -633,6 +740,29 @@ def _hwp_pdf_artifact_dir() -> Path | None:
     return Path(raw) if raw else None
 
 
+def _hwp_pdf_artifact_reuse_enabled() -> bool:
+    return os.environ.get(HWP_PDF_ARTIFACT_REUSE_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _reusable_converted_pdf(source_sha256: str) -> Path | None:
+    artifact_dir = _hwp_pdf_artifact_dir()
+    if artifact_dir is None or not _hwp_pdf_artifact_reuse_enabled():
+        return None
+    candidate = artifact_dir / f"{source_sha256}.pdf"
+    if not candidate.is_file():
+        return None
+    try:
+        _validate_converted_pdf(candidate)
+    except _HwpPdfPyMuPdf4LlmFallback:
+        return None
+    return candidate
+
+
 def _preserve_converted_pdf(pdf_path: Path, source_sha256: str) -> Path | None:
     artifact_dir = _hwp_pdf_artifact_dir()
     if artifact_dir is None:
@@ -665,9 +795,31 @@ def _extract_pdf_pymupdf4llm(
     except ImportError as exc:
         raise _PdfPyMuPdf4LlmFallback("pymupdf4llm_unavailable") from exc
 
+    use_ocr = _pymupdf4llm_use_ocr()
+    ocr_language = _pymupdf4llm_ocr_language()
+    use_layout = _pymupdf4llm_use_layout()
+    timeout_s = _pymupdf4llm_parse_timeout_s()
     try:
-        output = pymupdf4llm.to_markdown(str(pdf_path), page_chunks=True)
+        if timeout_s is not None:
+            output = _pymupdf4llm_to_markdown_subprocess(
+                pdf_path,
+                use_ocr=use_ocr,
+                ocr_language=ocr_language,
+                use_layout=use_layout,
+                timeout_s=timeout_s,
+            )
+        else:
+            if use_layout is not None and hasattr(pymupdf4llm, "use_layout"):
+                pymupdf4llm.use_layout(use_layout)
+            output = pymupdf4llm.to_markdown(
+                str(pdf_path),
+                page_chunks=True,
+                use_ocr=use_ocr,
+                ocr_language=ocr_language,
+            )
     except Exception as exc:
+        if isinstance(exc, _PdfPyMuPdf4LlmFallback):
+            raise
         raise _PdfPyMuPdf4LlmFallback(
             "pymupdf4llm_parse_failed",
             type(exc).__name__,
@@ -701,7 +853,12 @@ def _extract_pdf_pymupdf4llm(
     parser_health = {
         "pymupdf4llm_page_chunks": len(sections),
         "pymupdf4llm_numeric_only_chunks_skipped": skipped_numeric_only,
+        "pymupdf4llm_use_ocr": int(use_ocr),
     }
+    if use_layout is not None:
+        parser_health["pymupdf4llm_use_layout"] = int(use_layout)
+    if timeout_s is not None:
+        parser_health["pymupdf4llm_parse_timeout_s"] = int(timeout_s)
     return text, sections, metadata, parser_health
 
 
@@ -709,6 +866,24 @@ def _extract_hwp_pdf_pymupdf4llm(
     source_path: Path,
 ) -> tuple[str, list[dict[str, Any]], dict[str, Any], dict[str, int]]:
     import tempfile  # noqa: PLC0415
+
+    if _hwp_pdf_artifact_reuse_enabled():
+        source_sha_for_reuse = sha256_file(source_path)
+        reusable_pdf = _reusable_converted_pdf(source_sha_for_reuse)
+        if reusable_pdf is not None:
+            converted_pdf_sha = sha256_file(reusable_pdf)
+            try:
+                return _extract_pdf_pymupdf4llm(
+                    reusable_pdf,
+                    citation_basis=LIBREOFFICE_CONVERTED_PDF_CITATION_BASIS,
+                    source_sha256=source_sha_for_reuse,
+                    converted_pdf_sha256=converted_pdf_sha,
+                    converted_pdf_page_count=_validate_converted_pdf(reusable_pdf),
+                    converted_pdf_path=reusable_pdf,
+                    converter_version="reused_converted_pdf",
+                )
+            except _PdfPyMuPdf4LlmFallback as exc:
+                raise _HwpPdfPyMuPdf4LlmFallback(exc.reason, exc.detail) from exc
 
     with tempfile.TemporaryDirectory(prefix="bidmate_hwp_pdf_") as tmpdir:
         pdf_path, _converter, converter_version = _convert_hwp_to_pdf(source_path, Path(tmpdir))

--- a/reports/real100_v2/README.md
+++ b/reports/real100_v2/README.md
@@ -1,0 +1,17 @@
+# real100_v2 Aggregate Artifacts
+
+`real100_v2` is a private RFP benchmark rebuild. This directory may contain only aggregate-only public-safe artifacts.
+
+Allowed files:
+
+- `parse_inventory.aggregate.json`
+- `question_distribution.aggregate.json`
+- `benchmark_tiers.aggregate.json`
+- `baseline.aggregate.json`
+- `README.md`
+
+Raw eval summaries, traces, questions, answers, evidence, document IDs, chunk IDs, filenames, paths, parsed Markdown, converted PDFs, and per-case rows must remain ignored.
+
+Private parse checkpoints from `scripts/build_private_real100_v2_parallel.py` are allowed only under ignored private index/output paths.
+
+Interpretation policy: compare overall plus every tier. These artifacts are for interpretation and regression analysis, not cherry-picking improved slices for headline claims.

--- a/reports/real100_v2/baseline.aggregate.json
+++ b/reports/real100_v2/baseline.aggregate.json
@@ -1,0 +1,742 @@
+{
+  "ablation_full": {
+    "abstention": 0.39285714285714285,
+    "abstention_outcomes": {
+      "boundary_partial": 2,
+      "correct_refusal": 9,
+      "incorrect_answer": 17
+    },
+    "accuracy": 0.27941176470588236,
+    "answer_format_compliance": 0.03436426116838488,
+    "ci": {
+      "abstention": {
+        "alpha": 0.05,
+        "ci_hi": 0.5714285714285714,
+        "ci_lo": 0.21428571428571427,
+        "mean": 0.39285714285714285,
+        "n": 28,
+        "num_resamples": 1000
+      },
+      "accuracy": {
+        "alpha": 0.05,
+        "ci_hi": 0.33088235294117646,
+        "ci_lo": 0.22794117647058823,
+        "mean": 0.27941176470588236,
+        "n": 272,
+        "num_resamples": 1000
+      },
+      "answer_format_compliance": {
+        "alpha": 0.05,
+        "ci_hi": 0.058419243986254296,
+        "ci_lo": 0.013745704467353952,
+        "mean": 0.03436426116838488,
+        "n": 291,
+        "num_resamples": 1000
+      },
+      "citation_precision": {
+        "alpha": 0.05,
+        "ci_hi": 0.18421207545518206,
+        "ci_lo": 0.1102357974439776,
+        "mean": 0.14633228291316525,
+        "n": 272,
+        "num_resamples": 1000
+      },
+      "claim_citation_alignment": {
+        "alpha": 0.05,
+        "ci_hi": 0.919113070539419,
+        "ci_lo": 0.8630705394190872,
+        "mean": 0.8910788381742739,
+        "n": 241,
+        "num_resamples": 1000
+      },
+      "comparison_pool_recall": {
+        "alpha": 0.05,
+        "ci_hi": 1.0,
+        "ci_lo": 1.0,
+        "mean": 1.0,
+        "n": 13,
+        "num_resamples": 1000
+      },
+      "comparison_target_recall": {
+        "alpha": 0.05,
+        "ci_hi": 1.0,
+        "ci_lo": 1.0,
+        "mean": 1.0,
+        "n": 13,
+        "num_resamples": 1000
+      },
+      "groundedness": {
+        "alpha": 0.05,
+        "ci_hi": 0.8235294117647058,
+        "ci_lo": 0.7279411764705882,
+        "mean": 0.7757352941176471,
+        "n": 272,
+        "num_resamples": 1000
+      },
+      "retry": {
+        "alpha": 0.05,
+        "ci_hi": 1.0,
+        "ci_lo": 0.98,
+        "mean": 0.99,
+        "n": 300,
+        "num_resamples": 1000
+      }
+    },
+    "citation_precision": 0.14633228291316525,
+    "claim_citation_alignment": 0.8910788381742739,
+    "groundedness": 0.7757352941176471,
+    "latency": {
+      "mean": 2206.3466666666645,
+      "p50": 2216.985,
+      "p95": 3199.0625
+    },
+    "num_predictions": 300,
+    "retry": 0.99
+  },
+  "abstention": 0.39285714285714285,
+  "abstention_outcomes": {
+    "boundary_partial": 2,
+    "correct_refusal": 9,
+    "incorrect_answer": 17
+  },
+  "accuracy": 0.27941176470588236,
+  "answer_format_compliance": 0.03436426116838488,
+  "by_format": {
+    "private_pdf_hwp_csv_text": {
+      "abstention": null,
+      "abstention_calibration": null,
+      "abstention_outcomes": {
+        "boundary_partial": 0,
+        "correct_refusal": 0,
+        "incorrect_answer": 0
+      },
+      "accuracy": 0.27941176470588236,
+      "answer_format_compliance": 0.029411764705882353,
+      "chunk_mrr": 0.26645658263305333,
+      "chunk_mrr_at_5": 0.25674019607843146,
+      "chunk_ndcg_at_10": 0.304372284378633,
+      "chunk_ndcg_at_20": 0.304372284378633,
+      "chunk_ndcg_at_5": 0.28257827869419244,
+      "chunk_recall_at_10": 0.4338235294117647,
+      "chunk_recall_at_20": 0.4338235294117647,
+      "chunk_recall_at_5": 0.3694852941176471,
+      "ci": {
+        "abstention": null,
+        "accuracy": {
+          "alpha": 0.05,
+          "ci_hi": 0.33088235294117646,
+          "ci_lo": 0.22794117647058823,
+          "mean": 0.27941176470588236,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "answer_format_compliance": {
+          "alpha": 0.05,
+          "ci_hi": 0.051470588235294115,
+          "ci_lo": 0.011029411764705883,
+          "mean": 0.029411764705882353,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "chunk_mrr": {
+          "alpha": 0.05,
+          "ci_hi": 0.3106738007703081,
+          "ci_lo": 0.21857416404061625,
+          "mean": 0.2664565826330532,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "chunk_mrr_at_5": {
+          "alpha": 0.05,
+          "ci_hi": 0.30159620098039214,
+          "ci_lo": 0.2093091299019608,
+          "mean": 0.25674019607843135,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "chunk_ndcg_at_10": {
+          "alpha": 0.05,
+          "ci_hi": 0.34861799184976144,
+          "ci_lo": 0.25811281422902155,
+          "mean": 0.3043722843786332,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "chunk_ndcg_at_20": {
+          "alpha": 0.05,
+          "ci_hi": 0.34861799184976144,
+          "ci_lo": 0.25811281422902155,
+          "mean": 0.3043722843786332,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "chunk_ndcg_at_5": {
+          "alpha": 0.05,
+          "ci_hi": 0.32800224763791336,
+          "ci_lo": 0.23553274038974392,
+          "mean": 0.28257827869419255,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "chunk_recall_at_10": {
+          "alpha": 0.05,
+          "ci_hi": 0.49080882352941174,
+          "ci_lo": 0.37683823529411764,
+          "mean": 0.4338235294117647,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "chunk_recall_at_20": {
+          "alpha": 0.05,
+          "ci_hi": 0.49080882352941174,
+          "ci_lo": 0.37683823529411764,
+          "mean": 0.4338235294117647,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "chunk_recall_at_5": {
+          "alpha": 0.05,
+          "ci_hi": 0.4227941176470588,
+          "ci_lo": 0.3125,
+          "mean": 0.3694852941176471,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "citation_claim_coverage": {
+          "alpha": 0.05,
+          "ci_hi": 1.0,
+          "ci_lo": 1.0,
+          "mean": 1.0,
+          "n": 222,
+          "num_resamples": 1000
+        },
+        "citation_grounding": null,
+        "citation_page_coverage": {
+          "alpha": 0.05,
+          "ci_hi": 0.0,
+          "ci_lo": 0.0,
+          "mean": 0.0,
+          "n": 222,
+          "num_resamples": 1000
+        },
+        "citation_page_precision": null,
+        "citation_precision": {
+          "alpha": 0.05,
+          "ci_hi": 0.18421207545518206,
+          "ci_lo": 0.1102357974439776,
+          "mean": 0.14633228291316525,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "citation_region_coverage": {
+          "alpha": 0.05,
+          "ci_hi": 0.0,
+          "ci_lo": 0.0,
+          "mean": 0.0,
+          "n": 222,
+          "num_resamples": 1000
+        },
+        "citation_region_precision": null,
+        "claim_citation_alignment": {
+          "alpha": 0.05,
+          "ci_hi": 0.9166948198198197,
+          "ci_lo": 0.8625563063063063,
+          "mean": 0.8907657657657657,
+          "n": 222,
+          "num_resamples": 1000
+        },
+        "comparison_pool_recall": {
+          "alpha": 0.05,
+          "ci_hi": 1.0,
+          "ci_lo": 1.0,
+          "mean": 1.0,
+          "n": 13,
+          "num_resamples": 1000
+        },
+        "comparison_target_recall": {
+          "alpha": 0.05,
+          "ci_hi": 1.0,
+          "ci_lo": 1.0,
+          "mean": 1.0,
+          "n": 13,
+          "num_resamples": 1000
+        },
+        "groundedness": {
+          "alpha": 0.05,
+          "ci_hi": 0.8235294117647058,
+          "ci_lo": 0.7279411764705882,
+          "mean": 0.7757352941176471,
+          "n": 272,
+          "num_resamples": 1000
+        },
+        "rerank_delta_mrr": null,
+        "rerank_delta_ndcg_at_10": null,
+        "retry": {
+          "alpha": 0.05,
+          "ci_hi": 1.0,
+          "ci_lo": 0.9778492647058823,
+          "mean": 0.9889705882352942,
+          "n": 272,
+          "num_resamples": 1000
+        }
+      },
+      "citation_claim_coverage": 1.0,
+      "citation_coverage_reason_counts": {
+        "no_citations": 100,
+        "no_claims": 50,
+        "ok": 222,
+        "page_metadata_missing": 222,
+        "region_metadata_missing": 222
+      },
+      "citation_grounding": null,
+      "citation_grounding_error_counts": {},
+      "citation_page_coverage": 0.0,
+      "citation_page_precision": null,
+      "citation_precision": 0.14633228291316525,
+      "citation_region_coverage": 0.0,
+      "citation_region_precision": null,
+      "claim_citation_alignment": 0.8907657657657657,
+      "claim_citation_error_counts": {
+        "claim_text_not_supported_by_citation": 49
+      },
+      "cold_start_samples": {
+        "count": 1,
+        "latency_ms": {
+          "count": 1,
+          "mean": 2286.91,
+          "p50": 2286.91,
+          "p95": 2286.91
+        }
+      },
+      "comparison_pool_full_coverage_rate": 1.0,
+      "comparison_pool_recall": 1.0,
+      "comparison_target_full_coverage_rate": 1.0,
+      "comparison_target_recall": 1.0,
+      "failure_category_counts": {
+        "abstention_failure": 1,
+        "answer_synthesis_issue": 0,
+        "citation_or_page_metadata_issue": 0,
+        "evaluation_label_issue": 0,
+        "parse_or_metadata_issue": 193,
+        "retrieval_miss": 0,
+        "unknown": 0,
+        "verifier_false_negative": 0,
+        "verifier_false_positive": 2
+      },
+      "groundedness": 0.7757352941176471,
+      "iterations": {
+        "cap": 3,
+        "cases_at_cap": 5,
+        "max_used": 3,
+        "mean_used": 2.0073529411764706,
+        "pct_at_cap": 0.01838235294117647
+      },
+      "latency": {
+        "mean": 2186.468676470586,
+        "p50": 2205.835,
+        "p95": 3203.6795
+      },
+      "latency_by_retry_count": {
+        "0": {
+          "count": 3,
+          "mean": 591.0966666666667,
+          "p50": 771.06,
+          "p95": 886.6560000000001
+        },
+        "1": {
+          "count": 263,
+          "mean": 2197.3049429657776,
+          "p50": 2202.19,
+          "p95": 3204.449
+        },
+        "2": {
+          "count": 5,
+          "mean": 2553.6159999999995,
+          "p50": 2531.2,
+          "p95": 2932.998
+        }
+      },
+      "num_predictions": 272,
+      "rerank_delta_mrr": null,
+      "rerank_delta_ndcg_at_10": null,
+      "retrieval_metric_coverage": {
+        "chunk_mrr": {
+          "missing": 0,
+          "n": 272,
+          "reason": null
+        },
+        "chunk_mrr_at_5": {
+          "missing": 0,
+          "n": 272,
+          "reason": null
+        },
+        "chunk_ndcg_at_10": {
+          "missing": 0,
+          "n": 272,
+          "reason": null
+        },
+        "chunk_ndcg_at_20": {
+          "missing": 0,
+          "n": 272,
+          "reason": null
+        },
+        "chunk_ndcg_at_5": {
+          "missing": 0,
+          "n": 272,
+          "reason": null
+        },
+        "chunk_recall_at_10": {
+          "missing": 0,
+          "n": 272,
+          "reason": null
+        },
+        "chunk_recall_at_20": {
+          "missing": 0,
+          "n": 272,
+          "reason": null
+        },
+        "chunk_recall_at_5": {
+          "missing": 0,
+          "n": 272,
+          "reason": null
+        },
+        "citation_claim_coverage": {
+          "missing": 50,
+          "n": 222,
+          "reason": null
+        },
+        "citation_page_coverage": {
+          "missing": 50,
+          "n": 222,
+          "reason": null
+        },
+        "citation_region_coverage": {
+          "missing": 50,
+          "n": 222,
+          "reason": null
+        },
+        "rerank_delta_mrr": {
+          "missing": 272,
+          "n": 0,
+          "reason": "no_gold_evidence_or_not_applicable"
+        },
+        "rerank_delta_ndcg_at_10": {
+          "missing": 272,
+          "n": 0,
+          "reason": "no_gold_evidence_or_not_applicable"
+        }
+      },
+      "retry": 0.9889705882352942,
+      "retry_cost": {
+        "cases_with_retry": 269,
+        "max_retry_count": 2,
+        "mean_retry_count": 1.0073529411764706,
+        "total_retries": 274
+      },
+      "retry_effectiveness": {
+        "cases_with_retry": 269,
+        "cases_without_retry": 3,
+        "ci": {
+          "recovery_rate": {
+            "alpha": 0.05,
+            "ci_hi": 0.3345724907063197,
+            "ci_lo": 0.2342007434944238,
+            "mean": 0.2825278810408922,
+            "n": 269,
+            "num_resamples": 1000
+          },
+          "residual_failure_rate": {
+            "alpha": 0.05,
+            "ci_hi": 0.7657992565055762,
+            "ci_lo": 0.6654275092936803,
+            "mean": 0.7174721189591078,
+            "n": 269,
+            "num_resamples": 1000
+          }
+        },
+        "recovery_rate": 0.2825278810408922,
+        "residual_failure_rate": 0.7174721189591078,
+        "retry_lift_vs_no_retry": 0.2825278810408922,
+        "retry_resolution_rate": 0.7472118959107806
+      },
+      "retry_reason_counts": {
+        "missing_comparison_doc": 43,
+        "missing_comparison_entity": 42,
+        "partial_topic_grounding": 8,
+        "topic_not_grounded": 313
+      },
+      "stage_latency": {
+        "answer_generation_ms": {
+          "count": 271,
+          "mean": 1.370258302583025,
+          "p50": 1.13,
+          "p95": 3.435
+        },
+        "context_resolution_ms": {
+          "count": 271,
+          "mean": 0.018191881918819115,
+          "p50": 0.02,
+          "p95": 0.03
+        },
+        "query_analysis_ms": {
+          "count": 271,
+          "mean": 140.44431734317342,
+          "p50": 111.95,
+          "p95": 281.785
+        },
+        "retrieve_ms": {
+          "count": 543,
+          "mean": 995.0776979742175,
+          "p50": 1033.81,
+          "p95": 1559.841
+        },
+        "verify_ms": {
+          "count": 543,
+          "mean": 20.022872928176824,
+          "p50": 19.13,
+          "p95": 34.083999999999996
+        }
+      }
+    }
+  },
+  "by_hardcase_category": {
+    "table_heavy": {
+      "abstention_outcomes": {
+        "boundary_partial": 0,
+        "correct_refusal": 0,
+        "incorrect_answer": 0
+      },
+      "accuracy": 0.18181818181818182,
+      "answer_format_compliance": 0.0,
+      "groundedness": 1.0,
+      "num_predictions": 22
+    }
+  },
+  "by_query_type": {
+    "abstention": {
+      "abstention": 0.39285714285714285,
+      "abstention_outcomes": {
+        "boundary_partial": 2,
+        "correct_refusal": 9,
+        "incorrect_answer": 17
+      },
+      "answer_format_compliance": 0.10526315789473684,
+      "num_predictions": 28
+    },
+    "comparison": {
+      "abstention_outcomes": {
+        "boundary_partial": 0,
+        "correct_refusal": 0,
+        "incorrect_answer": 0
+      },
+      "accuracy": 0.38461538461538464,
+      "answer_format_compliance": 0.6153846153846154,
+      "groundedness": 0.38461538461538464,
+      "num_predictions": 13
+    },
+    "single_doc": {
+      "abstention_outcomes": {
+        "boundary_partial": 0,
+        "correct_refusal": 0,
+        "incorrect_answer": 0
+      },
+      "accuracy": 0.27413127413127414,
+      "answer_format_compliance": 0.0,
+      "groundedness": 0.7953667953667953,
+      "num_predictions": 259
+    }
+  },
+  "ci": {
+    "abstention": {
+      "alpha": 0.05,
+      "ci_hi": 0.5714285714285714,
+      "ci_lo": 0.21428571428571427,
+      "mean": 0.39285714285714285,
+      "n": 28,
+      "num_resamples": 1000
+    },
+    "accuracy": {
+      "alpha": 0.05,
+      "ci_hi": 0.33088235294117646,
+      "ci_lo": 0.22794117647058823,
+      "mean": 0.27941176470588236,
+      "n": 272,
+      "num_resamples": 1000
+    },
+    "answer_format_compliance": {
+      "alpha": 0.05,
+      "ci_hi": 0.058419243986254296,
+      "ci_lo": 0.013745704467353952,
+      "mean": 0.03436426116838488,
+      "n": 291,
+      "num_resamples": 1000
+    },
+    "citation_precision": {
+      "alpha": 0.05,
+      "ci_hi": 0.18421207545518206,
+      "ci_lo": 0.1102357974439776,
+      "mean": 0.14633228291316525,
+      "n": 272,
+      "num_resamples": 1000
+    },
+    "claim_citation_alignment": {
+      "alpha": 0.05,
+      "ci_hi": 0.919113070539419,
+      "ci_lo": 0.8630705394190872,
+      "mean": 0.8910788381742739,
+      "n": 241,
+      "num_resamples": 1000
+    },
+    "comparison_pool_recall": {
+      "alpha": 0.05,
+      "ci_hi": 1.0,
+      "ci_lo": 1.0,
+      "mean": 1.0,
+      "n": 13,
+      "num_resamples": 1000
+    },
+    "comparison_target_recall": {
+      "alpha": 0.05,
+      "ci_hi": 1.0,
+      "ci_lo": 1.0,
+      "mean": 1.0,
+      "n": 13,
+      "num_resamples": 1000
+    },
+    "groundedness": {
+      "alpha": 0.05,
+      "ci_hi": 0.8235294117647058,
+      "ci_lo": 0.7279411764705882,
+      "mean": 0.7757352941176471,
+      "n": 272,
+      "num_resamples": 1000
+    },
+    "retry": {
+      "alpha": 0.05,
+      "ci_hi": 1.0,
+      "ci_lo": 0.98,
+      "mean": 0.99,
+      "n": 300,
+      "num_resamples": 1000
+    }
+  },
+  "citation_grounding": null,
+  "citation_precision": 0.14633228291316525,
+  "claim_citation_alignment": 0.8910788381742739,
+  "failure_category_counts": {
+    "abstention_failure": 3,
+    "answer_synthesis_issue": 0,
+    "citation_or_page_metadata_issue": 0,
+    "evaluation_label_issue": 0,
+    "parse_or_metadata_issue": 193,
+    "retrieval_miss": 0,
+    "unknown": 0,
+    "verifier_false_negative": 17,
+    "verifier_false_positive": 2
+  },
+  "groundedness": 0.7757352941176471,
+  "latency": {
+    "mean": 2206.3466666666645,
+    "p50": 2216.985,
+    "p95": 3199.0625
+  },
+  "metrics": {
+    "abstention": 0.39285714285714285,
+    "citation_accuracy": null,
+    "citation_precision": 0.14633228291316525,
+    "mrr_at_5": 0.25674019607843146,
+    "ndcg_at_5": 0.28257827869419244,
+    "recall_at_10": 0.4338235294117647,
+    "recall_at_5": 0.3694852941176471
+  },
+  "num_predictions": 300,
+  "pipeline": "agentic_full",
+  "primary_run": "full",
+  "privacy": {
+    "aggregate_only": true,
+    "chunk_ids_omitted": true,
+    "doc_ids_omitted": true,
+    "filenames_omitted": true,
+    "paths_omitted": true,
+    "per_case_rows_omitted": true,
+    "raw_answers_omitted": true,
+    "raw_evidence_omitted": true,
+    "raw_questions_omitted": true,
+    "raw_text_omitted": true
+  },
+  "profile_type": "private_real100_v2_baseline",
+  "prompt_profile": "structured_grounded_claims",
+  "provenance": {
+    "generated_at": "2026-05-26T13:32:09.599146Z",
+    "git_commit": "5172c09f12d9",
+    "git_dirty": true,
+    "git_tree": "ca361ee0ff18"
+  },
+  "retry": 0.99,
+  "retry_effectiveness": {
+    "cases_with_retry": 269,
+    "cases_without_retry": 3,
+    "ci": {
+      "recovery_rate": {
+        "alpha": 0.05,
+        "ci_hi": 0.3345724907063197,
+        "ci_lo": 0.2342007434944238,
+        "mean": 0.2825278810408922,
+        "n": 269,
+        "num_resamples": 1000
+      },
+      "residual_failure_rate": {
+        "alpha": 0.05,
+        "ci_hi": 0.7657992565055762,
+        "ci_lo": 0.6654275092936803,
+        "mean": 0.7174721189591078,
+        "n": 269,
+        "num_resamples": 1000
+      }
+    },
+    "recovery_rate": 0.2825278810408922,
+    "residual_failure_rate": 0.7174721189591078,
+    "retry_lift_vs_no_retry": 0.2825278810408922,
+    "retry_resolution_rate": 0.7472118959107806
+  },
+  "retry_reason_counts": {
+    "missing_comparison_doc": 49,
+    "missing_comparison_entity": 48,
+    "partial_topic_grounding": 11,
+    "topic_not_grounded": 352
+  },
+  "run_manifest": {
+    "config_sha256": "7ff7aa1454ded52e",
+    "generated_at": "2026-05-26T13:32:09.672295Z",
+    "git_commit": "5172c09f12d9",
+    "git_dirty": true
+  },
+  "stage_latency": {
+    "answer_generation_ms": {
+      "mean": 1.3661872909698989,
+      "p50": 1.14,
+      "p95": 3.535999999999998
+    },
+    "context_resolution_ms": {
+      "mean": 0.018227424749163786,
+      "p50": 0.02,
+      "p95": 0.03
+    },
+    "query_analysis_ms": {
+      "mean": 160.8369899665552,
+      "p50": 116.77,
+      "p95": 388.67
+    },
+    "retrieve_ms": {
+      "mean": 995.1623873121866,
+      "p50": 1036.72,
+      "p95": 1553.2740000000001
+    },
+    "verify_ms": {
+      "mean": 19.9636894824708,
+      "p50": 19.14,
+      "p95": 34.56100000000002
+    }
+  },
+  "top_k": null
+}

--- a/reports/real100_v2/benchmark_tiers.aggregate.json
+++ b/reports/real100_v2/benchmark_tiers.aggregate.json
@@ -1,0 +1,203 @@
+{
+  "generated_at_utc": "2026-05-26T13:32:23+00:00",
+  "interpretation_policy": "Tiering is for interpretation and comparison, not cherry-picking headline claims. Future PRs should compare overall plus every tier.",
+  "privacy": {
+    "aggregate_only": true,
+    "chunk_ids_omitted": true,
+    "doc_ids_omitted": true,
+    "filenames_omitted": true,
+    "paths_omitted": true,
+    "per_case_rows_omitted": true,
+    "raw_answers_omitted": true,
+    "raw_evidence_omitted": true,
+    "raw_questions_omitted": true,
+    "raw_text_omitted": true
+  },
+  "profile_type": "private_real100_v2_benchmark_tiers",
+  "schema_version": 1,
+  "source": {
+    "eval_summary": {
+      "artifact": "private_local_eval_summary"
+    },
+    "question_tiers": {
+      "artifact": "private_local_question_set"
+    }
+  },
+  "tier_criteria": {
+    "easy_sanity": [
+      "answerable",
+      "single-doc",
+      "single-chunk",
+      "clear expected terms",
+      "not table-heavy",
+      "not multi-hop",
+      "no similar-clause distractor proxy"
+    ],
+    "hard_stress": [
+      "multi-chunk",
+      "multi-doc",
+      "table-heavy",
+      "similar-clause distractors",
+      "unanswerable",
+      "citation/page dependent",
+      "parser-stress"
+    ],
+    "standard_real": [
+      "normal RFP QA",
+      "date amount score schedule requirement extraction allowed",
+      "moderate distractors allowed"
+    ]
+  },
+  "tiers": {
+    "easy_sanity": {
+      "abstention_outcomes": {
+        "false_abstention": 27,
+        "not_applicable": 33
+      },
+      "dominant_failure_category": "unknown",
+      "failure_distribution": {
+        "none": 19,
+        "unknown": 41
+      },
+      "metrics": {
+        "abstention": {
+          "mean": null,
+          "missing": 60,
+          "n": 0
+        },
+        "citation_accuracy": {
+          "mean": null,
+          "missing": 60,
+          "n": 0
+        },
+        "citation_precision": {
+          "mean": 0.17837301587301588,
+          "missing": 0,
+          "n": 60
+        },
+        "mrr_at_5": {
+          "mean": 0.5308333333333333,
+          "missing": 0,
+          "n": 60
+        },
+        "ndcg_at_5": {
+          "mean": 0.5853873124630861,
+          "missing": 0,
+          "n": 60
+        },
+        "recall_at_10": {
+          "mean": 0.7833333333333333,
+          "missing": 0,
+          "n": 60
+        },
+        "recall_at_5": {
+          "mean": 0.75,
+          "missing": 0,
+          "n": 60
+        }
+      },
+      "n": 60
+    },
+    "hard_stress": {
+      "abstention_outcomes": {
+        "correct_abstention": 11,
+        "false_abstention": 4,
+        "missed_abstention": 17,
+        "not_applicable": 58
+      },
+      "dominant_failure_category": "unknown",
+      "failure_distribution": {
+        "none": 21,
+        "unknown": 69
+      },
+      "metrics": {
+        "abstention": {
+          "mean": 0.39285714285714285,
+          "missing": 62,
+          "n": 28
+        },
+        "citation_accuracy": {
+          "mean": null,
+          "missing": 90,
+          "n": 0
+        },
+        "citation_precision": {
+          "mean": 0.041935483870967745,
+          "missing": 28,
+          "n": 62
+        },
+        "mrr_at_5": {
+          "mean": 0.0717741935483871,
+          "missing": 28,
+          "n": 62
+        },
+        "ndcg_at_5": {
+          "mean": 0.06675927133033813,
+          "missing": 28,
+          "n": 62
+        },
+        "recall_at_10": {
+          "mean": 0.14516129032258066,
+          "missing": 28,
+          "n": 62
+        },
+        "recall_at_5": {
+          "mean": 0.08870967741935484,
+          "missing": 28,
+          "n": 62
+        }
+      },
+      "n": 90
+    },
+    "standard_real": {
+      "abstention_outcomes": {
+        "false_abstention": 22,
+        "not_applicable": 128
+      },
+      "dominant_failure_category": "unknown",
+      "failure_distribution": {
+        "none": 45,
+        "unknown": 105
+      },
+      "metrics": {
+        "abstention": {
+          "mean": null,
+          "missing": 150,
+          "n": 0
+        },
+        "citation_accuracy": {
+          "mean": null,
+          "missing": 150,
+          "n": 0
+        },
+        "citation_precision": {
+          "mean": 0.17666666666666667,
+          "missing": 0,
+          "n": 150
+        },
+        "mrr_at_5": {
+          "mean": 0.2235555555555555,
+          "missing": 0,
+          "n": 150
+        },
+        "ndcg_at_5": {
+          "mean": 0.25065985489702824,
+          "missing": 0,
+          "n": 150
+        },
+        "recall_at_10": {
+          "mean": 0.41333333333333333,
+          "missing": 0,
+          "n": 150
+        },
+        "recall_at_5": {
+          "mean": 0.3333333333333333,
+          "missing": 0,
+          "n": 150
+        }
+      },
+      "n": 150
+    }
+  },
+  "unknown_tier_case_count": 0
+}

--- a/reports/real100_v2/parse_inventory.aggregate.json
+++ b/reports/real100_v2/parse_inventory.aggregate.json
@@ -1,0 +1,54 @@
+{
+  "artifact_condition_counts": {
+    "amount_heavy": 99,
+    "empty_text": 0,
+    "image_only_or_low_text": 0,
+    "page_metadata_missing": 100,
+    "schedule_or_gantt_like": 50,
+    "score_table_like": 99,
+    "table_heavy": 100
+  },
+  "chunk_length_chars": {
+    "max": 520,
+    "min": 3,
+    "p50": 477.0,
+    "p95": 518.0
+  },
+  "generated_at_utc": "2026-05-26T13:10:11+00:00",
+  "markdown_export": {
+    "document_markdown_count": 100,
+    "location": "gitignored_private_dir",
+    "raw_content_written": true
+  },
+  "page_metadata": {
+    "missing_count": 21800,
+    "ready_count": 0,
+    "ready_rate": 0.0
+  },
+  "population": {
+    "chunk_count": 21800,
+    "document_count": 100
+  },
+  "privacy": {
+    "aggregate_only": true,
+    "chunk_ids_omitted": true,
+    "doc_ids_omitted": true,
+    "filenames_omitted": true,
+    "paths_omitted": true,
+    "raw_answers_omitted": true,
+    "raw_evidence_omitted": true,
+    "raw_questions_omitted": true,
+    "raw_text_omitted": true
+  },
+  "profile_type": "private_real100_v2_parse_inventory",
+  "schema_version": 1,
+  "source": {
+    "index": {
+      "artifact": "private_local_index",
+      "sha256_12": "8af7d4eb4680"
+    }
+  },
+  "text_source_distribution": {
+    "pdf_pymupdf4llm": 21800
+  }
+}

--- a/reports/real100_v2/question_distribution.aggregate.json
+++ b/reports/real100_v2/question_distribution.aggregate.json
@@ -1,0 +1,70 @@
+{
+  "actual_distribution": {
+    "easy_sanity": 60,
+    "hard_stress": 90,
+    "standard_real": 150
+  },
+  "answerability": {
+    "answerable": 272,
+    "unanswerable": 28
+  },
+  "comparison_protocol": {
+    "explain_regressions_by_tier": true,
+    "interpretation_not_cherry_picking": true,
+    "report_overall_and_each_tier": true
+  },
+  "evidence_cardinality_distribution": {
+    "multi_chunk": 40,
+    "single_chunk": 232,
+    "unanswerable_no_gold": 28
+  },
+  "generated_at_utc": "2026-05-26T13:20:40+00:00",
+  "generated_case_count": 300,
+  "hardcase_category_distribution": {
+    "comparison": 13,
+    "multi_chunk": 27,
+    "multi_doc": 13,
+    "table_heavy": 22,
+    "unanswerable": 28
+  },
+  "privacy": {
+    "aggregate_only": true,
+    "chunk_ids_omitted": true,
+    "doc_ids_omitted": true,
+    "filenames_omitted": true,
+    "paths_omitted": true,
+    "raw_answers_omitted": true,
+    "raw_evidence_omitted": true,
+    "raw_questions_omitted": true,
+    "raw_text_omitted": true
+  },
+  "profile_type": "private_real100_v2_question_distribution",
+  "query_type_distribution": {
+    "abstention": 28,
+    "comparison": 13,
+    "single_doc": 259
+  },
+  "question_text_uniqueness": {
+    "duplicate_question_texts": 9,
+    "max_same_question_text_count": 4,
+    "unique_question_texts": 287
+  },
+  "question_type_distribution": {
+    "amount_extraction": 50,
+    "date_extraction": 12,
+    "multi_chunk_same_doc": 27,
+    "multi_doc_amount_extraction": 13,
+    "rfp_requirement": 59,
+    "score_extraction": 29,
+    "single_chunk_content_anchor": 60,
+    "table_heavy_score_or_amount": 22,
+    "unanswerable_absence": 28
+  },
+  "recommended_case_count": 300,
+  "schema_version": 1,
+  "target_distribution": {
+    "easy_sanity": 60,
+    "hard_stress": 90,
+    "standard_real": 150
+  }
+}

--- a/scripts/_governance.py
+++ b/scripts/_governance.py
@@ -225,7 +225,7 @@ PHASE4_ARTIFACT_GLOB = "reports/retrieval/phase4*"
 # (b) zero dict KEYS containing a colon (retry-reason payloads are stripped to
 # their enum prefix). reports/self_review_agreement/ is intentionally NOT in
 # scope — its axis labels are public Korean prose, not private RFP data.
-EVAL_PRIVACY_ARTIFACT_GLOBS = ("reports/retrieval", "reports/real100")
+EVAL_PRIVACY_ARTIFACT_GLOBS = ("reports/retrieval", "reports/real100", "reports/real100_v2")
 _EVAL_PRIVACY_HANGUL_RE = re.compile(r"[가-힣ᄀ-ᇿ㄰-㆏ꥠ-꥿]")
 
 # Private real-eval readiness scaffold: local inputs, raw outputs, and private
@@ -240,11 +240,14 @@ PRIVATE_REAL_EVAL_REQUIRED_IGNORES: tuple[str, ...] = (
     "data/private/",
     "data/data_list.csv",
     "data/index/real100/",
+    "data/index/real100_v2/",
     "data/index/real100_kordoc/",
     "data/index-private-hardcase/",
     "experiments/private_runs/",
     "reports/real100/eval_summary.json",
     "reports/real100/raw/",
+    "reports/real100_v2/eval_summary.json",
+    "reports/real100_v2/raw/",
     "reports/private_real_eval_summary.raw.json",
 )
 PRIVATE_REAL_EVAL_REDACTED_SUMMARIES: tuple[str, ...] = (

--- a/scripts/build_private_real100_v2_parallel.py
+++ b/scripts/build_private_real100_v2_parallel.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Parallel private real100_v2 index builder.
+
+This is a local-only helper for the real100_v2 benchmark rebuild. It preserves
+the existing retrieval/verifier/prompt/chunking/reranker/answer runtime paths:
+documents are parsed in parallel, then handed to the existing index payload
+builder and writer.
+"""
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import csv
+from dataclasses import asdict
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eval.scorers.chunk_health import compute_chunk_health  # noqa: E402
+from ingestion import (  # noqa: E402
+    HWP_PDF_ARTIFACT_DIR_ENV,
+    IngestionRecord,
+    _DuplicateTracker,
+    _reset_kordoc_loaders,
+    _resolve_row_validation,
+    build_ingestion_report,
+    load_documents_from_metadata_csv,
+    make_record,
+    normalize_ingestion_row,
+    validate_fieldnames,
+)
+from rag_core import (  # noqa: E402
+    DEFAULT_CHUNK_MAX_CHARS,
+    DEFAULT_CHUNK_OVERLAP_SENTENCES,
+    EMBEDDINGS_FILENAME,
+    build_index_payload_from_documents,
+    write_index,
+)
+from rag_embedding import DEFAULT_EMBEDDING_MODEL  # noqa: E402
+
+
+CHECKPOINT_SCHEMA_VERSION = 1
+
+
+def _load_rows(metadata_csv: Path) -> list[dict[str, str]]:
+    with metadata_csv.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        validate_fieldnames(reader.fieldnames or [], metadata_csv)
+        return list(reader)
+
+
+def _worker_normalize(row_number: int, row: dict[str, str], files_dir: str) -> tuple[int, dict[str, Any] | None, IngestionRecord]:
+    _reset_kordoc_loaders()
+    document, record = normalize_ingestion_row(
+        row,
+        row_number,
+        Path(files_dir),
+        _DuplicateTracker(),
+        on_duplicate_doc_id="fail",
+    )
+    return row_number, document, record
+
+
+def _row_fingerprint(row: dict[str, str]) -> str:
+    payload = json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _checkpoint_path(checkpoint_dir: Path, row_number: int) -> Path:
+    return checkpoint_dir / f"row_{row_number:06d}.json"
+
+
+def _record_from_dict(payload: dict[str, Any]) -> IngestionRecord:
+    return IngestionRecord(**payload)
+
+
+def _read_checkpoint(
+    checkpoint_dir: Path,
+    row_number: int,
+    row_fingerprint: str,
+) -> tuple[int, dict[str, Any] | None, IngestionRecord] | None:
+    path = _checkpoint_path(checkpoint_dir, row_number)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if payload.get("schema_version") != CHECKPOINT_SCHEMA_VERSION:
+        return None
+    if payload.get("row_number") != row_number:
+        return None
+    if payload.get("row_fingerprint") != row_fingerprint:
+        return None
+    record_payload = payload.get("record")
+    if not isinstance(record_payload, dict):
+        return None
+    document = payload.get("document")
+    if document is not None and not isinstance(document, dict):
+        return None
+    try:
+        record = _record_from_dict(record_payload)
+    except TypeError:
+        return None
+    return row_number, document, record
+
+
+def _write_checkpoint(
+    checkpoint_dir: Path,
+    row_number: int,
+    row_fingerprint: str,
+    document: dict[str, Any] | None,
+    record: IngestionRecord,
+) -> None:
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    path = _checkpoint_path(checkpoint_dir, row_number)
+    tmp_path = path.with_suffix(".tmp")
+    payload = {
+        "schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "row_number": row_number,
+        "row_fingerprint": row_fingerprint,
+        "document": document,
+        "record": asdict(record),
+    }
+    tmp_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def parallel_load_documents_from_metadata_csv(
+    metadata_csv: Path,
+    files_dir: Path,
+    *,
+    workers: int,
+    checkpoint_dir: Path | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if workers < 1:
+        raise ValueError("workers must be >= 1")
+    if not metadata_csv.is_file():
+        raise ValueError(f"--metadata_csv must be a file: {metadata_csv}")
+    if not files_dir.is_dir():
+        raise ValueError(f"--files_dir must be a directory: {files_dir}")
+
+    rows = _load_rows(metadata_csv)
+    tracker = _DuplicateTracker()
+    records_by_row: dict[int, IngestionRecord] = {}
+    tasks: list[tuple[int, dict[str, str]]] = []
+    row_fingerprints: dict[int, str] = {}
+    documents_by_row: dict[int, dict[str, Any]] = {}
+    cached = 0
+
+    for row_number, row in enumerate(rows, start=2):
+        validation = _resolve_row_validation(row, row_number, files_dir, tracker)
+        if validation.failure_reason:
+            records_by_row[row_number] = make_record(
+                row_number,
+                "failed",
+                validation.doc_id,
+                validation.file_name,
+                validation.file_format,
+                validation.source_path,
+                validation.failure_reason,
+                duplicate_resolution=validation.duplicate_resolution,
+            )
+            continue
+        row_fingerprint = _row_fingerprint(row)
+        row_fingerprints[row_number] = row_fingerprint
+        if checkpoint_dir is not None:
+            checkpoint = _read_checkpoint(checkpoint_dir, row_number, row_fingerprint)
+            if checkpoint is not None:
+                _cached_row_number, document, record = checkpoint
+                records_by_row[row_number] = record
+                if document is not None:
+                    documents_by_row[row_number] = document
+                cached += 1
+                continue
+        tasks.append((row_number, row))
+
+    completed = 0
+    started = time.monotonic()
+    total_parse_rows = cached + len(tasks)
+    if cached:
+        print(
+            "[PROGRESS] parallel parse:",
+            f"cached={cached}",
+            f"pending={len(tasks)}",
+            f"indexed={sum(1 for record in records_by_row.values() if record.status == 'indexed')}",
+            f"failed={sum(1 for record in records_by_row.values() if record.status == 'failed')}",
+            flush=True,
+        )
+    if tasks:
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(_worker_normalize, row_number, row, str(files_dir)): row_number
+                for row_number, row in tasks
+            }
+            for future in as_completed(futures):
+                row_number, document, record = future.result()
+                records_by_row[row_number] = record
+                if document is not None:
+                    documents_by_row[row_number] = document
+                if checkpoint_dir is not None:
+                    _write_checkpoint(
+                        checkpoint_dir,
+                        row_number,
+                        row_fingerprints[row_number],
+                        document,
+                        record,
+                    )
+                completed += 1
+                if completed == len(tasks) or completed % max(1, workers) == 0:
+                    indexed = sum(1 for record in records_by_row.values() if record.status == "indexed")
+                    failed = sum(1 for record in records_by_row.values() if record.status == "failed")
+                    elapsed_s = time.monotonic() - started
+                    avg_s = elapsed_s / completed if completed else 0.0
+                    print(
+                        "[PROGRESS] parallel parse:",
+                        f"completed={cached + completed}/{total_parse_rows}",
+                        f"cached={cached}",
+                        f"indexed={indexed}",
+                        f"failed={failed}",
+                        f"elapsed_s={elapsed_s:.1f}",
+                        f"avg_s_per_completed={avg_s:.1f}",
+                        flush=True,
+                    )
+
+    records = [records_by_row[row_number] for row_number in sorted(records_by_row)]
+    documents = [documents_by_row[row_number] for row_number in sorted(documents_by_row)]
+    if not documents:
+        failure_reasons = sorted({record.reason or record.status for record in records})
+        raise ValueError(
+            "No PDF/HWP documents could be ingested from "
+            f"{metadata_csv}. Failure reasons: {', '.join(failure_reasons) or 'none'}"
+        )
+    report = build_ingestion_report(
+        metadata_csv=metadata_csv,
+        files_dir=files_dir,
+        records=records,
+        indexed_count=len(documents),
+        on_duplicate_doc_id="fail",
+    )
+    return documents, report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata_csv", type=Path, required=True)
+    parser.add_argument("--files_dir", type=Path, required=True)
+    parser.add_argument("--output_dir", type=Path, required=True)
+    parser.add_argument("--workers", type=int, default=max(1, min(4, (os.cpu_count() or 2) // 2)))
+    parser.add_argument("--model", default=DEFAULT_EMBEDDING_MODEL)
+    parser.add_argument(
+        "--embedding_backend",
+        default="hashing",
+        choices=["auto", "sentence-transformers", "hashing", "openai"],
+    )
+    parser.add_argument("--chunking_strategy", default="fixed", choices=["auto", "section", "fixed"])
+    parser.add_argument("--chunk_max_chars", type=int, default=DEFAULT_CHUNK_MAX_CHARS)
+    parser.add_argument("--chunk_overlap_sentences", type=int, default=DEFAULT_CHUNK_OVERLAP_SENTENCES)
+    parser.add_argument("--hwp_loader", default="pdf_pymupdf4llm", choices=["csv_text", "kordoc", "pdf_pymupdf4llm"])
+    parser.add_argument("--pdf_loader", default="pdf_pymupdf4llm", choices=["csv_text", "kordoc", "pdf_pymupdf4llm"])
+    parser.add_argument("--hwp_pdf_artifact_dir", type=Path, required=True)
+    parser.add_argument(
+        "--checkpoint_dir",
+        type=Path,
+        default=None,
+        help="Private raw parse checkpoint directory. Defaults to OUTPUT_DIR/_parse_checkpoints.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        os.environ["BIDMATE_HWP_LOADER"] = args.hwp_loader
+        os.environ["BIDMATE_PDF_LOADER"] = args.pdf_loader
+        os.environ[HWP_PDF_ARTIFACT_DIR_ENV] = str(args.hwp_pdf_artifact_dir)
+        print(
+            "[CONFIG] private real100_v2 parallel build:",
+            f"workers={args.workers}",
+            f"hwp_loader={args.hwp_loader}",
+            f"pdf_loader={args.pdf_loader}",
+            f"embedding={args.embedding_backend}",
+            flush=True,
+        )
+        checkpoint_dir = args.checkpoint_dir or (args.output_dir / "_parse_checkpoints")
+        if args.workers == 1:
+            documents, ingestion_report = load_documents_from_metadata_csv(args.metadata_csv, args.files_dir)
+        else:
+            documents, ingestion_report = parallel_load_documents_from_metadata_csv(
+                args.metadata_csv,
+                args.files_dir,
+                workers=args.workers,
+                checkpoint_dir=checkpoint_dir,
+            )
+        payload = build_index_payload_from_documents(
+            documents,
+            source_dir=str(args.metadata_csv),
+            model_name=args.model,
+            embedding_backend=args.embedding_backend,
+            chunking_strategy=args.chunking_strategy,
+            chunk_max_chars=args.chunk_max_chars,
+            chunk_overlap_sentences=args.chunk_overlap_sentences,
+            message="Private real100_v2 parallel PyMuPDF4LLM RFP index.",
+        )
+        chunk_health = compute_chunk_health(payload.get("chunks") or [])
+        ingestion_report.setdefault("summary", {})["chunk_health"] = chunk_health
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        out_path = write_index(payload, args.output_dir)
+        report_path = args.output_dir / "ingestion_report.json"
+        report_path.write_text(
+            json.dumps(ingestion_report, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        print(f"[ERROR] private real100_v2 parallel build failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        "[OK] private real100_v2 index written:",
+        f"{out_path}",
+        f"(+ {EMBEDDINGS_FILENAME})",
+        f"docs={payload['build']['num_documents']}",
+        f"chunks={payload['build']['num_chunks']}",
+        f"report={report_path}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_private_index_markdown.py
+++ b/scripts/export_private_index_markdown.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Export private index chunks to local Markdown plus aggregate inventory.
+
+The Markdown output is raw private content and must be written only under a
+gitignored local directory. The optional aggregate JSON is public-safe: counts,
+rates, closed labels, and hashed provenance only.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import datetime as dt
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.private_data_quality_audit_utils import (  # noqa: E402
+    assert_public_safe,
+    gitignored_or_outside_repo,
+    page_metadata_present,
+    percentile,
+)
+
+TABLE_RE = re.compile(r"(<table\b|</t[dh]>|rowspan=|colspan=|\|[^\n]+\||\t)", re.IGNORECASE)
+DATE_RE = re.compile(r"(?:20\d{2}[./-]\d{1,2}[./-]\d{1,2}|20\d{2}\s*년\s*\d{1,2}\s*월|\d{1,2}\s*월\s*\d{1,2}\s*일)")
+SCORE_RE = re.compile(r"\d+(?:\.\d+)?\s*(?:점|%)|(?:배점|평가점수|정량|정성)")
+AMOUNT_RE = re.compile(r"\d[\d,]*(?:\.\d+)?\s*(?:원|천원|만원|억원|%)|(?:예산|금액|사업비)")
+LOCAL_SUFFIX = ".local.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return payload
+
+
+def _text(chunk: dict[str, Any]) -> str:
+    return str(chunk.get("text") or "")
+
+
+def _doc_ref(chunk: dict[str, Any]) -> str:
+    return str(chunk.get("doc_id") or (chunk.get("metadata") or {}).get("doc_id") or "<missing>")
+
+
+def _page_start(chunk: dict[str, Any]) -> int:
+    metadata = chunk.get("metadata") if isinstance(chunk.get("metadata"), dict) else {}
+    for node in (chunk, metadata):
+        span = node.get("page_span")
+        if isinstance(span, list) and span:
+            try:
+                return int(span[0])
+            except (TypeError, ValueError):
+                pass
+        for key in ("page", "page_number", "page_start"):
+            value = node.get(key)
+            if value not in (None, ""):
+                try:
+                    return int(value)
+                except (TypeError, ValueError):
+                    pass
+    return 10**9
+
+
+def _safe_hash(value: Any, namespace: str) -> str:
+    digest = hashlib.sha256(f"{namespace}\0{value}".encode("utf-8")).hexdigest()[:16]
+    return f"redacted_{digest}"
+
+
+def _source(path: Path) -> dict[str, Any]:
+    return {
+        "artifact": "private_local_index",
+        "sha256_12": hashlib.sha256(path.read_bytes()).hexdigest()[:12],
+    }
+
+
+def _length_block(values: list[int]) -> dict[str, Any]:
+    return {
+        "min": min(values) if values else None,
+        "p50": percentile(values, 0.5),
+        "p95": percentile(values, 0.95),
+        "max": max(values) if values else None,
+    }
+
+
+def _condition_counts(grouped: dict[str, list[dict[str, Any]]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for chunks in grouped.values():
+        texts = [_text(chunk) for chunk in chunks]
+        joined = "\n".join(texts)
+        chars = len(joined.strip())
+        table_hits = sum(1 for text in texts if TABLE_RE.search(text))
+        date_hits = len(DATE_RE.findall(joined))
+        score_hits = len(SCORE_RE.findall(joined))
+        amount_hits = len(AMOUNT_RE.findall(joined))
+        page_count = len({p for p in (_page_start(chunk) for chunk in chunks) if p != 10**9}) or len(chunks)
+        chars_per_page = chars / page_count if page_count else 0.0
+        if chars == 0:
+            counts["empty_text"] += 1
+        if chars_per_page < 120:
+            counts["image_only_or_low_text"] += 1
+        if table_hits >= 3:
+            counts["table_heavy"] += 1
+        if table_hits >= 3 and score_hits >= 3:
+            counts["score_table_like"] += 1
+        if table_hits >= 3 and date_hits >= 5:
+            counts["schedule_or_gantt_like"] += 1
+        if amount_hits >= 5:
+            counts["amount_heavy"] += 1
+        if all(not page_metadata_present(chunk) for chunk in chunks):
+            counts["page_metadata_missing"] += 1
+    for key in (
+        "empty_text",
+        "image_only_or_low_text",
+        "table_heavy",
+        "score_table_like",
+        "schedule_or_gantt_like",
+        "amount_heavy",
+        "page_metadata_missing",
+    ):
+        counts.setdefault(key, 0)
+    return dict(sorted(counts.items()))
+
+
+def export_markdown(index: dict[str, Any], out_dir: Path) -> dict[str, Any]:
+    chunks = [chunk for chunk in index.get("chunks") or [] if isinstance(chunk, dict)]
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for chunk in chunks:
+        grouped[_doc_ref(chunk)].append(chunk)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_rows: list[dict[str, Any]] = []
+    for idx, (doc_ref, doc_chunks) in enumerate(sorted(grouped.items()), start=1):
+        doc_chunks.sort(key=lambda chunk: (_page_start(chunk), str(chunk.get("chunk_id") or "")))
+        filename = f"doc_{idx:03d}.md"
+        body = "\n\n".join(_text(chunk).strip() for chunk in doc_chunks if _text(chunk).strip())
+        (out_dir / filename).write_text(body + ("\n" if body else ""), encoding="utf-8")
+        manifest_rows.append(
+            {
+                "doc_ref": _safe_hash(doc_ref, "doc"),
+                "markdown_file": filename,
+                "chunk_count": len(doc_chunks),
+                "content_chars": len(body),
+            }
+        )
+    manifest_path = out_dir / f"export_manifest{LOCAL_SUFFIX}"
+    manifest_path.write_text(
+        json.dumps({"documents": manifest_rows}, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return {"grouped": grouped, "manifest_rows": manifest_rows}
+
+
+def build_aggregate(index: dict[str, Any], *, index_path: Path, out_dir: Path, exported: dict[str, Any]) -> dict[str, Any]:
+    chunks = [chunk for chunk in index.get("chunks") or [] if isinstance(chunk, dict)]
+    grouped = exported["grouped"]
+    lengths = [len(_text(chunk)) for chunk in chunks]
+    page_ready = sum(1 for chunk in chunks if page_metadata_present(chunk))
+    text_source_counts: Counter[str] = Counter()
+    for chunk in chunks:
+        metadata = chunk.get("metadata") if isinstance(chunk.get("metadata"), dict) else {}
+        source = metadata.get("text_source") or chunk.get("text_source") or "unknown"
+        safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(source))[:64] or "unknown"
+        text_source_counts[safe] += 1
+    aggregate = {
+        "schema_version": 1,
+        "profile_type": "private_real100_v2_parse_inventory",
+        "generated_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "source": {"index": _source(index_path)},
+        "markdown_export": {
+            "location": "gitignored_private_dir",
+            "document_markdown_count": len(exported["manifest_rows"]),
+            "raw_content_written": True,
+        },
+        "population": {
+            "document_count": len(grouped),
+            "chunk_count": len(chunks),
+        },
+        "chunk_length_chars": _length_block(lengths),
+        "page_metadata": {
+            "ready_count": page_ready,
+            "missing_count": len(chunks) - page_ready,
+            "ready_rate": (page_ready / len(chunks)) if chunks else None,
+        },
+        "text_source_distribution": dict(sorted(text_source_counts.items())),
+        "artifact_condition_counts": _condition_counts(grouped),
+        "privacy": {
+            "aggregate_only": True,
+            "raw_questions_omitted": True,
+            "raw_answers_omitted": True,
+            "raw_evidence_omitted": True,
+            "raw_text_omitted": True,
+            "doc_ids_omitted": True,
+            "chunk_ids_omitted": True,
+            "filenames_omitted": True,
+            "paths_omitted": True,
+        },
+    }
+    assert_public_safe(aggregate)
+    return aggregate
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--index", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--out-aggregate", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if not gitignored_or_outside_repo(args.out_dir, ROOT):
+            raise ValueError("--out-dir must be gitignored or outside the repository")
+        index = _load_json(args.index)
+        exported = export_markdown(index, args.out_dir)
+        if args.out_aggregate:
+            aggregate = build_aggregate(index, index_path=args.index, out_dir=args.out_dir, exported=exported)
+            args.out_aggregate.parent.mkdir(parents=True, exist_ok=True)
+            args.out_aggregate.write_text(
+                json.dumps(aggregate, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        print(
+            "[OK] exported private markdown:",
+            f"documents={len(exported['manifest_rows'])}",
+            f"out_dir={args.out_dir}",
+        )
+    except Exception as exc:
+        print(f"[ERROR] private markdown export failed: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/propose_private_real100_v2_questions.py
+++ b/scripts/propose_private_real100_v2_questions.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+"""Generate a private real100_v2 RFP question draft plus aggregate summary.
+
+The generated questions, gold evidence, and eval config are raw private eval
+inputs and must stay under a gitignored directory. The optional aggregate JSON
+contains only counts and closed labels so it can be committed.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import datetime as dt
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.private_data_quality_audit_utils import (  # noqa: E402
+    assert_public_safe,
+    gitignored_or_outside_repo,
+    page_metadata_present,
+)
+
+SCHEMA_VERSION = 1
+PROFILE_TYPE = "private_real100_v2_question_distribution"
+DEFAULT_TARGETS = {
+    "easy_sanity": 60,
+    "standard_real": 150,
+    "hard_stress": 90,
+}
+
+TOKEN_RE = re.compile(r"[가-힣A-Za-z0-9][가-힣A-Za-z0-9_.-]{1,}")
+DATE_RE = re.compile(
+    r"(?:20\d{2}[./-]\d{1,2}[./-]\d{1,2}|20\d{2}\s*년\s*\d{1,2}\s*월(?:\s*\d{1,2}\s*일)?|\d{1,2}\s*월\s*\d{1,2}\s*일)"
+)
+AMOUNT_RE = re.compile(r"\d[\d,]*(?:\.\d+)?\s*(?:원|천원|만원|억원|%)|(?:예산|사업비|금액)")
+SCORE_RE = re.compile(r"\d+(?:\.\d+)?\s*(?:점|%)|(?:배점|평가점수|정량|정성|기술평가|가격평가)")
+TABLE_RE = re.compile(r"(<table\b|</t[dh]>|rowspan=|colspan=|\|[^\n]+\||\t)", re.IGNORECASE)
+LOW_VALUE_TOKENS = {
+    "사업",
+    "제안",
+    "요청",
+    "제안요청서",
+    "문서",
+    "내용",
+    "사항",
+    "관련",
+    "범위",
+    "일반",
+    "목차",
+    "붙임",
+    "별지",
+    "서식",
+    "양식",
+    "페이지",
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return payload
+
+
+def _chunks(index: dict[str, Any]) -> list[dict[str, Any]]:
+    return [chunk for chunk in index.get("chunks") or [] if isinstance(chunk, dict)]
+
+
+def _doc_id(chunk: dict[str, Any]) -> str:
+    return str(chunk.get("doc_id") or (chunk.get("metadata") or {}).get("doc_id") or "")
+
+
+def _chunk_id(chunk: dict[str, Any]) -> str:
+    return str(chunk.get("chunk_id") or "")
+
+
+def _project(chunk: dict[str, Any]) -> str:
+    metadata = chunk.get("metadata") if isinstance(chunk.get("metadata"), dict) else {}
+    return _compact(str(chunk.get("project") or metadata.get("project") or _doc_id(chunk)))
+
+
+def _text(chunk: dict[str, Any]) -> str:
+    return str(chunk.get("text") or "")
+
+
+def _page_span(chunk: dict[str, Any]) -> list[int] | None:
+    metadata = chunk.get("metadata") if isinstance(chunk.get("metadata"), dict) else {}
+    for node in (chunk, metadata):
+        span = node.get("page_span")
+        if isinstance(span, list) and span:
+            try:
+                start = int(span[0])
+                end = int(span[-1])
+                return [start, end]
+            except (TypeError, ValueError):
+                pass
+        page = node.get("page") or node.get("page_number")
+        if page not in (None, ""):
+            try:
+                parsed = int(page)
+                return [parsed, parsed]
+            except (TypeError, ValueError):
+                pass
+    return None
+
+
+def _compact(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _snippet(text: str, term: str, limit: int = 280) -> str:
+    compact = _compact(text)
+    pos = compact.find(term) if term else -1
+    if pos < 0:
+        return compact[:limit]
+    start = max(0, pos - 90)
+    end = min(len(compact), pos + len(term) + 160)
+    return compact[start:end][:limit]
+
+
+def _content_tokens(text: str) -> list[str]:
+    tokens = []
+    seen = set()
+    for token in TOKEN_RE.findall(text):
+        if token in LOW_VALUE_TOKENS or token.isdigit():
+            continue
+        if len(token) < 2:
+            continue
+        if token in seen:
+            continue
+        seen.add(token)
+        tokens.append(token)
+    return tokens
+
+
+def _first_match(regex: re.Pattern[str], text: str) -> str | None:
+    match = regex.search(text)
+    return _compact(match.group(0)) if match else None
+
+
+def _table_marker_count(text: str) -> int:
+    return len(TABLE_RE.findall(text or ""))
+
+
+def _is_table_heavy_chunk(text: str) -> bool:
+    lower = text.lower()
+    if "<table" in lower or "rowspan=" in lower or "colspan=" in lower:
+        return True
+    return _table_marker_count(text) >= 5
+
+
+def _anchor(text: str) -> str | None:
+    for regex in (AMOUNT_RE, DATE_RE, SCORE_RE):
+        match = _first_match(regex, text)
+        if match and len(match) >= 2:
+            return match
+    tokens = _content_tokens(text)
+    return tokens[0] if tokens else None
+
+
+def _context_terms(text: str, *exclude: str | None, limit: int = 2) -> list[str]:
+    excluded = {item for item in exclude if item}
+    terms: list[str] = []
+    for token in _content_tokens(text):
+        if token in excluded:
+            continue
+        terms.append(token)
+        if len(terms) >= limit:
+            break
+    return terms
+
+
+def _with_context(base: str, text: str, term: str | None) -> str:
+    terms = _context_terms(text, term, limit=2)
+    if not term:
+        return base
+    if terms:
+        joined = "', '".join([term, *terms])
+        return f"문서에서 '{joined}' 단서가 함께 나오는 조건을 근거로 알려줘."
+    return base
+
+
+def _case_id(prefix: str, counter: int) -> str:
+    return f"real100_v2_{prefix}_{counter:03d}"
+
+
+def _evidence(case_id: str, chunk: dict[str, Any], support_type: str, term: str) -> dict[str, Any]:
+    item = {
+        "evidence_id": f"{case_id}_ev001",
+        "question_id": case_id,
+        "doc_id": _doc_id(chunk),
+        "chunk_id": _chunk_id(chunk),
+        "support_type": support_type,
+        "support_text": _snippet(_text(chunk), term),
+        "required_terms": [term] if term else [],
+        "required": True,
+    }
+    span = _page_span(chunk)
+    if span:
+        item["page_span"] = span
+    return item
+
+
+def _question_row(case: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "question_id": case["id"],
+        "question": case["query"],
+        "answerable": case["answerable"],
+        "query_type": case["query_type"],
+        "difficulty_tier": case["difficulty_tier"],
+        "question_type": case["question_type"],
+        "expected_terms": case["expected_terms"],
+        "hardcase_categories": case.get("hardcase_categories", []),
+    }
+
+
+def _gold_row(case: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "question_id": case["id"],
+        "gold_evidence": case.get("gold_evidence", []),
+    }
+
+
+def _eval_case(case: dict[str, Any]) -> dict[str, Any]:
+    payload = {
+        "id": case["id"],
+        "query_type": case["query_type"],
+        "query": case["query"],
+        "expected_doc_ids": case.get("expected_doc_ids", []),
+        "expected_terms": case["expected_terms"],
+        "answerable": case["answerable"],
+        "hardcase_categories": case.get("hardcase_categories", []),
+        "gold_evidence": case.get("gold_evidence", []),
+        "difficulty_tier": case["difficulty_tier"],
+        "question_type": case["question_type"],
+    }
+    return payload
+
+
+def _candidate_chunks(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        [
+            chunk
+            for chunk in chunks
+            if _doc_id(chunk) and _chunk_id(chunk) and len(_compact(_text(chunk))) >= 40
+        ],
+        key=lambda chunk: (_doc_id(chunk), _page_span(chunk) or [10**9, 10**9], _chunk_id(chunk)),
+    )
+
+
+def _make_easy(chunks: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    seen_docs: set[str] = set()
+    for chunk in _candidate_chunks(chunks):
+        if len(cases) >= limit:
+            break
+        text = _text(chunk)
+        doc = _doc_id(chunk)
+        if doc in seen_docs or _is_table_heavy_chunk(text):
+            continue
+        term = _anchor(text)
+        if not term:
+            continue
+        case_id = _case_id("easy", len(cases) + 1)
+        cases.append(
+            {
+                "id": case_id,
+                "difficulty_tier": "easy_sanity",
+                "question_type": "single_chunk_content_anchor",
+                "query_type": "single_doc",
+                "query": _with_context(
+                    f"'{term}' 관련 요구사항이나 설명을 문서 근거로 알려줘.",
+                    text,
+                    term,
+                ),
+                "answerable": True,
+                "expected_doc_ids": [doc],
+                "expected_terms": [term],
+                "hardcase_categories": [],
+                "gold_evidence": [_evidence(case_id, chunk, "single_chunk", term)],
+            }
+        )
+        seen_docs.add(doc)
+    return cases
+
+
+def _standard_kind(text: str) -> tuple[str, str | None, str]:
+    amount = _first_match(AMOUNT_RE, text)
+    if amount:
+        return (
+            "amount_extraction",
+            amount,
+            _with_context("금액/예산 관련 조건을 문서 근거로 알려줘.", text, amount),
+        )
+    date = _first_match(DATE_RE, text)
+    if date:
+        return (
+            "date_extraction",
+            date,
+            _with_context("일정/마감 관련 조건을 문서 근거로 알려줘.", text, date),
+        )
+    score = _first_match(SCORE_RE, text)
+    if score:
+        return (
+            "score_extraction",
+            score,
+            _with_context("평가점수/배점 관련 조건을 문서 근거로 알려줘.", text, score),
+        )
+    term = _anchor(text)
+    return (
+        "rfp_requirement",
+        term,
+        _with_context(f"'{term}' 관련 조건을 문서 근거로 알려줘.", text, term)
+        if term
+        else "",
+    )
+
+
+def _make_standard(chunks: list[dict[str, Any]], limit: int, exclude_ids: set[str]) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    per_kind: Counter[str] = Counter()
+    for chunk in _candidate_chunks(chunks):
+        if len(cases) >= limit:
+            break
+        if _chunk_id(chunk) in exclude_ids:
+            continue
+        kind, term, prompt = _standard_kind(_text(chunk))
+        if not term or not prompt:
+            continue
+        if per_kind[kind] > (limit // 3 + 8):
+            continue
+        case_id = _case_id("standard", len(cases) + 1)
+        cases.append(
+            {
+                "id": case_id,
+                "difficulty_tier": "standard_real",
+                "question_type": kind,
+                "query_type": "single_doc",
+                "query": prompt,
+                "answerable": True,
+                "expected_doc_ids": [_doc_id(chunk)],
+                "expected_terms": [term],
+                "hardcase_categories": [],
+                "gold_evidence": [_evidence(case_id, chunk, kind, term)],
+            }
+        )
+        per_kind[kind] += 1
+    return cases
+
+
+def _make_hard_table(chunks: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    for chunk in _candidate_chunks(chunks):
+        if len(cases) >= limit:
+            break
+        text = _text(chunk)
+        if not _is_table_heavy_chunk(text):
+            continue
+        term = _first_match(SCORE_RE, text) or _first_match(AMOUNT_RE, text) or _first_match(DATE_RE, text)
+        if not term:
+            continue
+        kind = "table_heavy_score_or_amount"
+        if len(DATE_RE.findall(text)) >= 3:
+            kind = "schedule_or_gantt_like_table"
+        case_id = _case_id("hard_table", len(cases) + 1)
+        context = _with_context("표나 일정 형식의 근거에서 해당 수치/일정 조건을 정확히 알려줘.", text, term)
+        cases.append(
+            {
+                "id": case_id,
+                "difficulty_tier": "hard_stress",
+                "question_type": kind,
+                "query_type": "single_doc",
+                "query": f"표나 일정 형식의 근거에서 {context}",
+                "answerable": True,
+                "expected_doc_ids": [_doc_id(chunk)],
+                "expected_terms": [term],
+                "hardcase_categories": ["table_heavy"],
+                "gold_evidence": [_evidence(case_id, chunk, kind, term)],
+            }
+        )
+    return cases
+
+
+def _make_hard_multichunk(chunks: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    by_doc: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for chunk in _candidate_chunks(chunks):
+        by_doc[_doc_id(chunk)].append(chunk)
+    for doc, doc_chunks in sorted(by_doc.items()):
+        if len(cases) >= limit:
+            break
+        usable = []
+        for chunk in doc_chunks:
+            term = _anchor(_text(chunk))
+            if term:
+                usable.append((chunk, term))
+        if len(usable) < 2:
+            continue
+        left, right = usable[0], usable[-1]
+        if _chunk_id(left[0]) == _chunk_id(right[0]):
+            continue
+        case_id = _case_id("hard_multi", len(cases) + 1)
+        cases.append(
+            {
+                "id": case_id,
+                "difficulty_tier": "hard_stress",
+                "question_type": "multi_chunk_same_doc",
+                "query_type": "single_doc",
+                "query": f"'{left[1]}' 조건과 '{right[1]}' 조건을 모두 찾아 함께 정리해줘.",
+                "answerable": True,
+                "expected_doc_ids": [doc],
+                "expected_terms": [left[1], right[1]],
+                "hardcase_categories": ["multi_chunk"],
+                "gold_evidence": [
+                    _evidence(f"{case_id}_a", left[0], "multi_chunk", left[1]),
+                    _evidence(f"{case_id}_b", right[0], "multi_chunk", right[1]),
+                ],
+            }
+        )
+        for item in cases[-1]["gold_evidence"]:
+            item["question_id"] = case_id
+    return cases
+
+
+def _make_hard_comparison(chunks: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    buckets: dict[str, list[tuple[dict[str, Any], str]]] = defaultdict(list)
+    for chunk in _candidate_chunks(chunks):
+        kind, term, _prompt = _standard_kind(_text(chunk))
+        if kind in {"amount_extraction", "date_extraction", "score_extraction"} and term:
+            buckets[kind].append((chunk, term))
+    labels = {
+        "amount_extraction": "금액/예산",
+        "date_extraction": "일정/마감",
+        "score_extraction": "평가점수/배점",
+    }
+    for kind, items in sorted(buckets.items()):
+        if len(cases) >= limit:
+            break
+        seen_pairs: set[tuple[str, str]] = set()
+        for idx, left in enumerate(items):
+            if len(cases) >= limit:
+                break
+            for right in items[idx + 1 :]:
+                left_doc = _doc_id(left[0])
+                right_doc = _doc_id(right[0])
+                if not left_doc or not right_doc or left_doc == right_doc:
+                    continue
+                pair = tuple(sorted([left_doc, right_doc]))
+                if pair in seen_pairs:
+                    continue
+                seen_pairs.add(pair)
+                case_id = _case_id("hard_compare", len(cases) + 1)
+                left_project = _project(left[0])
+                right_project = _project(right[0])
+                cases.append(
+                    {
+                        "id": case_id,
+                        "difficulty_tier": "hard_stress",
+                        "question_type": f"multi_doc_{kind}",
+                        "query_type": "comparison",
+                        "query": (
+                            f"'{left_project}' 문서와 '{right_project}' 문서의 "
+                            f"{labels[kind]} 조건을 각각 비교해줘."
+                        ),
+                        "answerable": True,
+                        "expected_doc_ids": [left_doc, right_doc],
+                        "expected_terms": [left[1], right[1]],
+                        "hardcase_categories": ["multi_doc", "comparison"],
+                        "gold_evidence": [
+                            _evidence(f"{case_id}_a", left[0], "multi_doc", left[1]),
+                            _evidence(f"{case_id}_b", right[0], "multi_doc", right[1]),
+                        ],
+                    }
+                )
+                for item in cases[-1]["gold_evidence"]:
+                    item["question_id"] = case_id
+                break
+    return cases
+
+
+def _make_unanswerable(chunks: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    seen_docs: set[str] = set()
+    templates = (
+        "문서에 특정 상용 제품명과 라이선스 단가가 모두 명시되어 있는지 알려줘.",
+        "문서에 자동 갱신 이후의 연도별 유지보수 단가 산식이 명시되어 있는지 알려줘.",
+        "문서에 제안사가 반드시 사용해야 하는 특정 OCR/AI 모델 제품명이 명시되어 있는지 알려줘.",
+    )
+    for chunk in _candidate_chunks(chunks):
+        if len(cases) >= limit:
+            break
+        doc = _doc_id(chunk)
+        if doc in seen_docs:
+            continue
+        anchor = _anchor(_text(chunk)) or "해당 사업"
+        context = _context_terms(_text(chunk), anchor, limit=1)
+        context_text = f"와 '{context[0]}'" if context else ""
+        case_id = _case_id("hard_abs", len(cases) + 1)
+        cases.append(
+            {
+                "id": case_id,
+                "difficulty_tier": "hard_stress",
+                "question_type": "unanswerable_absence",
+                "query_type": "abstention",
+                "query": (
+                    f"문서에서 '{anchor}'{context_text} 단서와 함께 "
+                    f"{templates[len(cases) % len(templates)]}"
+                ),
+                "answerable": False,
+                "expected_doc_ids": [],
+                "expected_terms": [],
+                "hardcase_categories": ["unanswerable"],
+                "gold_evidence": [],
+            }
+        )
+        seen_docs.add(doc)
+    return cases
+
+
+def generate_question_set(
+    index: dict[str, Any],
+    *,
+    targets: dict[str, int] | None = None,
+) -> list[dict[str, Any]]:
+    chunks = _chunks(index)
+    target = dict(DEFAULT_TARGETS if targets is None else targets)
+    easy = _make_easy(chunks, target.get("easy_sanity", 0))
+    used = {
+        item.get("chunk_id")
+        for case in easy
+        for item in case.get("gold_evidence", [])
+        if item.get("chunk_id")
+    }
+    standard = _make_standard(chunks, target.get("standard_real", 0), set(used))
+    hard_target = target.get("hard_stress", 0)
+    hard_table = _make_hard_table(chunks, max(0, hard_target * 25 // 100))
+    hard_multi = _make_hard_multichunk(chunks, max(0, hard_target * 30 // 100))
+    hard_compare = _make_hard_comparison(chunks, max(0, hard_target * 15 // 100))
+    hard_unanswerable = _make_unanswerable(
+        chunks,
+        max(0, hard_target - len(hard_table) - len(hard_multi) - len(hard_compare)),
+    )
+    return [*easy, *standard, *hard_table, *hard_multi, *hard_compare, *hard_unanswerable]
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _aggregate(cases: list[dict[str, Any]], targets: dict[str, int]) -> dict[str, Any]:
+    tier_counts = Counter(str(case["difficulty_tier"]) for case in cases)
+    type_counts = Counter(str(case["question_type"]) for case in cases)
+    query_counts = Counter(str(case["query_type"]) for case in cases)
+    hard_counts: Counter[str] = Counter()
+    evidence_counts: Counter[str] = Counter()
+    question_text_counts = Counter(str(case.get("query") or "") for case in cases)
+    for case in cases:
+        for category in case.get("hardcase_categories", []):
+            hard_counts[str(category)] += 1
+        evidence_count = len(case.get("gold_evidence", []))
+        if not case.get("answerable"):
+            evidence_counts["unanswerable_no_gold"] += 1
+        elif evidence_count == 1:
+            evidence_counts["single_chunk"] += 1
+        elif evidence_count > 1:
+            evidence_counts["multi_chunk"] += 1
+    answerable = sum(1 for case in cases if case.get("answerable"))
+    aggregate = {
+        "schema_version": SCHEMA_VERSION,
+        "profile_type": PROFILE_TYPE,
+        "generated_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "recommended_case_count": sum(DEFAULT_TARGETS.values()),
+        "target_distribution": targets,
+        "actual_distribution": dict(sorted(tier_counts.items())),
+        "generated_case_count": len(cases),
+        "answerability": {
+            "answerable": answerable,
+            "unanswerable": len(cases) - answerable,
+        },
+        "query_type_distribution": dict(sorted(query_counts.items())),
+        "question_type_distribution": dict(sorted(type_counts.items())),
+        "hardcase_category_distribution": dict(sorted(hard_counts.items())),
+        "evidence_cardinality_distribution": dict(sorted(evidence_counts.items())),
+        "question_text_uniqueness": {
+            "unique_question_texts": len(question_text_counts),
+            "duplicate_question_texts": sum(1 for count in question_text_counts.values() if count > 1),
+            "max_same_question_text_count": max(question_text_counts.values() or [0]),
+        },
+        "comparison_protocol": {
+            "report_overall_and_each_tier": True,
+            "explain_regressions_by_tier": True,
+            "interpretation_not_cherry_picking": True,
+        },
+        "privacy": {
+            "aggregate_only": True,
+            "raw_questions_omitted": True,
+            "raw_answers_omitted": True,
+            "raw_evidence_omitted": True,
+            "raw_text_omitted": True,
+            "doc_ids_omitted": True,
+            "chunk_ids_omitted": True,
+            "filenames_omitted": True,
+            "paths_omitted": True,
+        },
+    }
+    assert_public_safe(aggregate)
+    return aggregate
+
+
+def _eval_config(cases: list[dict[str, Any]], index_dir: str) -> dict[str, Any]:
+    return {
+        "mode": "rag",
+        "description": "Local-only real100_v2 private RFP eval draft. Do not commit.",
+        "index_dir": index_dir,
+        "answer_policy": {
+            "answerable_status": "supported",
+            "unanswerable_status": "insufficient",
+            "min_claims_answerable": 1,
+            "require_claim_citations": True,
+        },
+        "ablation_runs": [
+            {
+                "name": "full",
+                "metadata_first": True,
+                "rerank": True,
+                "verifier_retry": True,
+                "retrieval_mode": "flat",
+            }
+        ],
+        "primary_run": "full",
+        "cases": [_eval_case(case) for case in cases],
+    }
+
+
+def write_outputs(
+    cases: list[dict[str, Any]],
+    *,
+    out_dir: Path,
+    aggregate_path: Path | None,
+    eval_config_path: Path | None,
+    index_dir_label: str,
+    targets: dict[str, int],
+) -> dict[str, Any] | None:
+    if not gitignored_or_outside_repo(out_dir, ROOT):
+        raise ValueError("--out-dir must be gitignored or outside the repository")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(out_dir / "questions.jsonl", [_question_row(case) for case in cases])
+    _write_jsonl(out_dir / "gold_evidence.jsonl", [_gold_row(case) for case in cases])
+    (out_dir / "cases.local.yaml").write_text(
+        yaml.safe_dump({"cases": [_eval_case(case) for case in cases]}, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    if eval_config_path:
+        if not gitignored_or_outside_repo(eval_config_path, ROOT):
+            raise ValueError("--out-eval-config must be gitignored or outside the repository")
+        eval_config_path.parent.mkdir(parents=True, exist_ok=True)
+        eval_config_path.write_text(
+            yaml.safe_dump(_eval_config(cases, index_dir_label), allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+    aggregate = _aggregate(cases, targets)
+    if aggregate_path:
+        aggregate_path.parent.mkdir(parents=True, exist_ok=True)
+        aggregate_path.write_text(
+            json.dumps(aggregate, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return aggregate
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--index", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--out-aggregate", type=Path)
+    parser.add_argument("--out-eval-config", type=Path)
+    parser.add_argument("--index-dir-label", default="data/index/real100_v2")
+    parser.add_argument("--easy", type=int, default=DEFAULT_TARGETS["easy_sanity"])
+    parser.add_argument("--standard", type=int, default=DEFAULT_TARGETS["standard_real"])
+    parser.add_argument("--hard", type=int, default=DEFAULT_TARGETS["hard_stress"])
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        index = _load_json(args.index)
+        targets = {
+            "easy_sanity": args.easy,
+            "standard_real": args.standard,
+            "hard_stress": args.hard,
+        }
+        cases = generate_question_set(index, targets=targets)
+        aggregate = write_outputs(
+            cases,
+            out_dir=args.out_dir,
+            aggregate_path=args.out_aggregate,
+            eval_config_path=args.out_eval_config,
+            index_dir_label=args.index_dir_label,
+            targets=targets,
+        )
+    except Exception as exc:
+        print(f"[ERROR] real100_v2 question proposal failed: {exc}", file=sys.stderr)
+        return 2
+    tier_counts = (aggregate or {}).get("actual_distribution", {})
+    print(
+        "[OK] generated private real100_v2 question draft:",
+        f"cases={len(cases)}",
+        f"tiers={tier_counts}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_real100_v2_aggregates.py
+++ b/scripts/render_real100_v2_aggregates.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Render aggregate-only real100_v2 baseline and tier reports.
+
+Inputs may be private local files. Outputs are aggregate-only and must not
+include raw questions, answers, evidence, document IDs, chunk IDs, filenames,
+paths, or per-case rows.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import datetime as dt
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.private_data_quality_audit_utils import assert_public_safe  # noqa: E402
+from scripts.run_real_eval_delta import extract_aggregate  # noqa: E402
+
+TIERS = ("easy_sanity", "standard_real", "hard_stress")
+METRIC_FIELDS = {
+    "recall_at_5": "chunk_recall_at_5",
+    "recall_at_10": "chunk_recall_at_10",
+    "mrr_at_5": "chunk_mrr_at_5",
+    "ndcg_at_5": "chunk_ndcg_at_5",
+    "citation_precision": "citation_precision",
+    "citation_accuracy": "citation_grounding",
+    "abstention": "abstention",
+}
+BASELINE_METRIC_FIELDS = {
+    "recall_at_5": "chunk_recall_at_5",
+    "recall_at_10": "chunk_recall_at_10",
+    "mrr_at_5": "chunk_mrr_at_5",
+    "ndcg_at_5": "chunk_ndcg_at_5",
+    "citation_precision": "citation_precision",
+    "citation_accuracy": "citation_grounding",
+    "abstention": "abstention",
+}
+SAFE_FAILURE_LABELS = {
+    "retrieval_miss",
+    "wrong_doc",
+    "wrong_chunk",
+    "citation_miss",
+    "unsupported",
+    "abstention_miss",
+    "false_abstention",
+    "none",
+    "unknown",
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return payload
+
+
+def _load_question_tiers(path: Path) -> dict[str, str]:
+    tiers: dict[str, str] = {}
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            qid = str(row.get("question_id") or "")
+            tier = str(row.get("difficulty_tier") or "")
+            if qid and tier in TIERS:
+                tiers[qid] = tier
+    return tiers
+
+
+def _mean_block(cases: list[dict[str, Any]], field: str) -> dict[str, Any]:
+    values: list[float] = []
+    missing = 0
+    for case in cases:
+        value = case.get(field)
+        if isinstance(value, bool):
+            values.append(1.0 if value else 0.0)
+        elif isinstance(value, (int, float)):
+            values.append(float(value))
+        else:
+            missing += 1
+    return {
+        "mean": (sum(values) / len(values)) if values else None,
+        "n": len(values),
+        "missing": missing,
+    }
+
+
+def _safe_failure(value: Any) -> str:
+    label = str(value or "none")
+    return label if label in SAFE_FAILURE_LABELS else "unknown"
+
+
+def render_tiers(summary: dict[str, Any], question_tiers: dict[str, str]) -> dict[str, Any]:
+    grouped: dict[str, list[dict[str, Any]]] = {tier: [] for tier in TIERS}
+    unknown_tier = 0
+    for case in summary.get("case_results") or []:
+        if not isinstance(case, dict):
+            continue
+        tier = question_tiers.get(str(case.get("id") or ""))
+        if tier in grouped:
+            grouped[tier].append(case)
+        else:
+            unknown_tier += 1
+
+    tiers: dict[str, Any] = {}
+    for tier in TIERS:
+        cases = grouped[tier]
+        failure_counts = Counter(_safe_failure(case.get("failure_category")) for case in cases)
+        abstention_outcomes: Counter[str] = Counter()
+        for case in cases:
+            answerable = bool(case.get("answerable"))
+            abstained = bool(case.get("abstained"))
+            if answerable and abstained:
+                abstention_outcomes["false_abstention"] += 1
+            elif not answerable and abstained:
+                abstention_outcomes["correct_abstention"] += 1
+            elif not answerable and not abstained:
+                abstention_outcomes["missed_abstention"] += 1
+            else:
+                abstention_outcomes["not_applicable"] += 1
+        metrics = {
+            public_name: _mean_block(cases, field)
+            for public_name, field in METRIC_FIELDS.items()
+        }
+        tiers[tier] = {
+            "n": len(cases),
+            "metrics": metrics,
+            "abstention_outcomes": dict(sorted(abstention_outcomes.items())),
+            "failure_distribution": dict(sorted(failure_counts.items())),
+            "dominant_failure_category": (
+                failure_counts.most_common(1)[0][0] if failure_counts else None
+            ),
+        }
+
+    aggregate = {
+        "schema_version": 1,
+        "profile_type": "private_real100_v2_benchmark_tiers",
+        "generated_at_utc": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "source": {
+            "eval_summary": {"artifact": "private_local_eval_summary"},
+            "question_tiers": {"artifact": "private_local_question_set"},
+        },
+        "tier_criteria": {
+            "easy_sanity": [
+                "answerable",
+                "single-doc",
+                "single-chunk",
+                "clear expected terms",
+                "not table-heavy",
+                "not multi-hop",
+                "no similar-clause distractor proxy",
+            ],
+            "standard_real": [
+                "normal RFP QA",
+                "date amount score schedule requirement extraction allowed",
+                "moderate distractors allowed",
+            ],
+            "hard_stress": [
+                "multi-chunk",
+                "multi-doc",
+                "table-heavy",
+                "similar-clause distractors",
+                "unanswerable",
+                "citation/page dependent",
+                "parser-stress",
+            ],
+        },
+        "tiers": tiers,
+        "unknown_tier_case_count": unknown_tier,
+        "interpretation_policy": (
+            "Tiering is for interpretation and comparison, not cherry-picking "
+            "headline claims. Future PRs should compare overall plus every tier."
+        ),
+        "privacy": {
+            "aggregate_only": True,
+            "raw_questions_omitted": True,
+            "raw_answers_omitted": True,
+            "raw_evidence_omitted": True,
+            "raw_text_omitted": True,
+            "doc_ids_omitted": True,
+            "chunk_ids_omitted": True,
+            "filenames_omitted": True,
+            "paths_omitted": True,
+            "per_case_rows_omitted": True,
+        },
+    }
+    assert_public_safe(aggregate)
+    return aggregate
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--eval-summary", type=Path, required=True)
+    parser.add_argument("--questions", type=Path, required=True)
+    parser.add_argument("--baseline-out", type=Path, required=True)
+    parser.add_argument("--tiers-out", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = _load_json(args.eval_summary)
+    baseline = extract_aggregate(summary)
+    baseline["metrics"] = {
+        public_name: summary.get(source_name)
+        for public_name, source_name in BASELINE_METRIC_FIELDS.items()
+    }
+    baseline["profile_type"] = "private_real100_v2_baseline"
+    baseline["privacy"] = {
+        "aggregate_only": True,
+        "raw_questions_omitted": True,
+        "raw_answers_omitted": True,
+        "raw_evidence_omitted": True,
+        "raw_text_omitted": True,
+        "doc_ids_omitted": True,
+        "chunk_ids_omitted": True,
+        "filenames_omitted": True,
+        "paths_omitted": True,
+        "per_case_rows_omitted": True,
+    }
+    assert_public_safe(baseline)
+    tiers = render_tiers(summary, _load_question_tiers(args.questions))
+
+    args.baseline_out.parent.mkdir(parents=True, exist_ok=True)
+    args.baseline_out.write_text(
+        json.dumps(baseline, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.tiers_out.parent.mkdir(parents=True, exist_ok=True)
+    args.tiers_out.write_text(
+        json.dumps(tiers, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"[OK] wrote aggregate real100_v2 baseline: {args.baseline_out}")
+    print(f"[OK] wrote aggregate real100_v2 tiers: {args.tiers_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_private_real100_v2_parallel.py
+++ b/tests/test_build_private_real100_v2_parallel.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ingestion import IngestionRecord  # noqa: E402
+from scripts.build_private_real100_v2_parallel import (  # noqa: E402
+    _row_fingerprint,
+    _write_checkpoint,
+    parallel_load_documents_from_metadata_csv,
+)
+
+
+FIELDNAMES = [
+    "공고 번호",
+    "공고 차수",
+    "사업명",
+    "사업 금액",
+    "발주 기관",
+    "공개 일자",
+    "입찰 참여 시작일",
+    "입찰 참여 마감일",
+    "사업 요약",
+    "파일형식",
+    "파일명",
+    "텍스트",
+]
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        for row in rows:
+            full = {field: "" for field in FIELDNAMES}
+            full.update(row)
+            writer.writerow(full)
+
+
+def test_parallel_loader_preserves_ingestion_report_contract(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("BIDMATE_HWP_LOADER", "csv_text")
+    monkeypatch.setenv("BIDMATE_PDF_LOADER", "csv_text")
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    (files_dir / "a.pdf").write_text("placeholder", encoding="utf-8")
+    (files_dir / "b.hwp").write_text("placeholder", encoding="utf-8")
+    metadata_csv = tmp_path / "data_list.csv"
+    _write_csv(
+        metadata_csv,
+        [
+            {
+                "공고 번호": "P-001",
+                "사업명": "첫 번째 RFP",
+                "발주 기관": "기관 A",
+                "파일형식": "pdf",
+                "파일명": "a.pdf",
+                "텍스트": "첫 번째 문서 본문",
+            },
+            {
+                "공고 번호": "P-002",
+                "사업명": "두 번째 RFP",
+                "발주 기관": "기관 B",
+                "파일형식": "hwp",
+                "파일명": "b.hwp",
+                "텍스트": "두 번째 문서 본문",
+            },
+        ],
+    )
+
+    documents, report = parallel_load_documents_from_metadata_csv(metadata_csv, files_dir, workers=2)
+
+    assert [doc["doc_id"] for doc in documents] == ["P-001", "P-002"]
+    assert report["summary"]["total_rows"] == 2
+    assert report["summary"]["indexed_documents"] == 2
+    assert report["summary"]["failed_rows"] == 0
+    assert report["summary"]["text_source_counts"] == {
+        "pdf": {"data_list_csv_text": 1},
+        "hwp": {"data_list_csv_text": 1},
+    }
+
+
+def test_parallel_loader_reuses_private_row_checkpoints(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("BIDMATE_PDF_LOADER", "csv_text")
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    (files_dir / "cached.pdf").write_text("placeholder", encoding="utf-8")
+    metadata_csv = tmp_path / "data_list.csv"
+    row = {
+        "공고 번호": "P-001",
+        "사업명": "Cached RFP",
+        "발주 기관": "Agency",
+        "파일형식": "pdf",
+        "파일명": "cached.pdf",
+        "텍스트": "",
+    }
+    _write_csv(metadata_csv, [row])
+    checkpoint_dir = tmp_path / "checkpoints"
+    document = {
+        "doc_id": "P-001",
+        "text": "cached parsed markdown",
+        "metadata": {"file_format": "pdf"},
+    }
+    record = IngestionRecord(
+        row_number=2,
+        status="indexed",
+        doc_id="P-001",
+        file_name="cached.pdf",
+        file_format="pdf",
+        source_path=str(files_dir / "cached.pdf"),
+        text_source="pdf_pymupdf4llm",
+    )
+    full_row = {field: "" for field in FIELDNAMES}
+    full_row.update(row)
+    _write_checkpoint(checkpoint_dir, 2, _row_fingerprint(full_row), document, record)
+
+    documents, report = parallel_load_documents_from_metadata_csv(
+        metadata_csv,
+        files_dir,
+        workers=2,
+        checkpoint_dir=checkpoint_dir,
+    )
+
+    assert documents == [document]
+    assert report["summary"]["indexed_documents"] == 1
+    assert report["summary"]["failed_rows"] == 0
+    assert report["summary"]["text_source_counts"] == {"pdf": {"pdf_pymupdf4llm": 1}}

--- a/tests/test_eval_artifact_privacy_regression.py
+++ b/tests/test_eval_artifact_privacy_regression.py
@@ -40,6 +40,7 @@ def test_globs_cover_both_eval_data_surfaces() -> None:
     # both sit outside the pre-commit ^reports/real[^/]*/ path block.
     assert "reports/retrieval" in EVAL_PRIVACY_ARTIFACT_GLOBS
     assert "reports/real100" in EVAL_PRIVACY_ARTIFACT_GLOBS
+    assert "reports/real100_v2" in EVAL_PRIVACY_ARTIFACT_GLOBS
     # Self-review agreement holds public Korean axis labels — intentionally
     # NOT in scope, or the gate would false-positive on legitimate prose.
     assert "reports/self_review_agreement" not in EVAL_PRIVACY_ARTIFACT_GLOBS

--- a/tests/test_export_private_index_markdown.py
+++ b/tests/test_export_private_index_markdown.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.export_private_index_markdown import build_aggregate, export_markdown, main
+
+
+def _index() -> dict:
+    return {
+        "schema_version": 2,
+        "chunks": [
+            {
+                "doc_id": "SECRET-DOC-001",
+                "chunk_id": "SECRET-CHUNK-001",
+                "text": "SECRET RAW RFP TEXT | item | value | 2026년 1월 1일 10점 100원",
+                "metadata": {"page_span": [1, 1], "text_source": "pdf_pymupdf4llm"},
+            },
+            {
+                "doc_id": "SECRET-DOC-001",
+                "chunk_id": "SECRET-CHUNK-002",
+                "text": "more private text",
+                "metadata": {"page_span": [2, 2], "text_source": "pdf_pymupdf4llm"},
+            },
+        ],
+    }
+
+
+def test_export_writes_private_markdown_but_aggregate_is_public_safe(tmp_path: Path) -> None:
+    index_path = tmp_path / "index.json"
+    index_path.write_text(json.dumps(_index()), encoding="utf-8")
+    out_dir = tmp_path / "private_md"
+    exported = export_markdown(_index(), out_dir)
+    aggregate = build_aggregate(_index(), index_path=index_path, out_dir=out_dir, exported=exported)
+
+    assert (out_dir / "doc_001.md").read_text(encoding="utf-8").startswith("SECRET RAW")
+    rendered = json.dumps(aggregate, ensure_ascii=False, sort_keys=True)
+    assert "SECRET" not in rendered
+    assert "SECRET-DOC-001" not in rendered
+    assert "SECRET-CHUNK-001" not in rendered
+    assert "index.json" not in rendered
+    assert str(tmp_path) not in rendered
+    assert aggregate["population"] == {"document_count": 1, "chunk_count": 2}
+    assert aggregate["page_metadata"]["ready_count"] == 2
+    assert aggregate["artifact_condition_counts"]["table_heavy"] == 0
+
+
+def test_main_rejects_non_ignored_repo_output(tmp_path: Path) -> None:
+    index_path = tmp_path / "index.json"
+    index_path.write_text(json.dumps(_index()), encoding="utf-8")
+
+    rc = main(["--index", str(index_path), "--out-dir", "not_ignored_private_md"])
+
+    assert rc == 2
+
+
+def test_main_writes_aggregate_for_private_output(tmp_path: Path) -> None:
+    index_path = tmp_path / "index.json"
+    out_dir = tmp_path / "outside_private_md"
+    out_aggregate = tmp_path / "parse_inventory.aggregate.json"
+    index_path.write_text(json.dumps(_index()), encoding="utf-8")
+
+    rc = main([
+        "--index",
+        str(index_path),
+        "--out-dir",
+        str(out_dir),
+        "--out-aggregate",
+        str(out_aggregate),
+    ])
+
+    assert rc == 0
+    written = json.loads(out_aggregate.read_text(encoding="utf-8"))
+    assert written["profile_type"] == "private_real100_v2_parse_inventory"

--- a/tests/test_hwp_pdf_pymupdf4llm_loader.py
+++ b/tests/test_hwp_pdf_pymupdf4llm_loader.py
@@ -14,6 +14,7 @@ from ingestion import (
     HwpPdfPyMuPdf4LlmLoader,
     PdfPyMuPdf4LlmLoader,
     _HwpPdfPyMuPdf4LlmFallback,
+    _extract_hwp_pdf_pymupdf4llm,
     _reset_kordoc_loaders,
     _resolve_loader,
     load_documents_from_metadata_csv,
@@ -65,6 +66,11 @@ class HwpPdfPyMuPdf4LlmLoaderTest(unittest.TestCase):
                 "BIDMATE_PDF_LOADER",
                 "BIDMATE_INGEST_REDACT_PII",
                 "BIDMATE_HWP_PDF_ARTIFACT_DIR",
+                "BIDMATE_HWP_PDF_ARTIFACT_REUSE",
+                "BIDMATE_PYMUPDF4LLM_USE_OCR",
+                "BIDMATE_PYMUPDF4LLM_OCR_LANGUAGE",
+                "BIDMATE_PYMUPDF4LLM_USE_LAYOUT",
+                "BIDMATE_PYMUPDF4LLM_PARSE_TIMEOUT_S",
             )
         }
         for key in self._env_backup:
@@ -192,6 +198,12 @@ class HwpPdfPyMuPdf4LlmLoaderTest(unittest.TestCase):
             self.assertEqual(loader.last_metadata["converted_pdf_page_count"], 2)
             self.assertTrue(Path(loader.last_metadata["converted_pdf_path"]).exists())
             self.assertEqual(loader.last_parser_health["pymupdf4llm_numeric_only_chunks_skipped"], 1)
+            fake_module.to_markdown.assert_called_once_with(
+                str(pdf_path),
+                page_chunks=True,
+                use_ocr=True,
+                ocr_language="eng",
+            )
 
     def test_pdf_success_uses_source_pdf_citation_metadata(self) -> None:
         fake_module = types.ModuleType("pymupdf4llm")
@@ -212,6 +224,123 @@ class HwpPdfPyMuPdf4LlmLoaderTest(unittest.TestCase):
         self.assertEqual(loader.last_sections[0]["page_span"], [3, 3])
         self.assertEqual(loader.last_metadata["citation_basis"], "source_pdf")
         self.assertEqual(loader.last_metadata["citation_pdf_page_count"], 5)
+        self.assertEqual(loader.last_parser_health["pymupdf4llm_use_ocr"], 1)
+        fake_module.to_markdown.assert_called_once_with(
+            str(pdf_path),
+            page_chunks=True,
+            use_ocr=True,
+            ocr_language="eng",
+        )
+
+    def test_pdf_loader_can_opt_out_of_pymupdf4llm_ocr_for_fast_inventory(self) -> None:
+        fake_module = types.ModuleType("pymupdf4llm")
+        fake_module.to_markdown = mock.Mock(
+            return_value=[{"text": "pdf body", "metadata": {"page_number": 1}}]
+        )  # type: ignore[attr-defined]
+
+        with TemporaryDirectory() as tmp:
+            pdf_path = Path(tmp) / "doc.pdf"
+            pdf_path.write_bytes(b"%PDF source")
+            loader = PdfPyMuPdf4LlmLoader()
+            os.environ["BIDMATE_PYMUPDF4LLM_USE_OCR"] = "0"
+            os.environ["BIDMATE_PYMUPDF4LLM_OCR_LANGUAGE"] = "kor+eng"
+
+            with mock.patch("ingestion._validate_source_pdf", return_value=1):
+                with mock.patch.dict(sys.modules, {"pymupdf4llm": fake_module}):
+                    text = loader.load_text({"텍스트": "csv body"}, pdf_path)
+
+        self.assertEqual(text, "pdf body")
+        self.assertEqual(loader.last_parser_health["pymupdf4llm_use_ocr"], 0)
+        fake_module.to_markdown.assert_called_once_with(
+            str(pdf_path),
+            page_chunks=True,
+            use_ocr=False,
+            ocr_language="kor+eng",
+        )
+
+    def test_pdf_loader_can_opt_out_of_pymupdf4llm_layout_for_fast_inventory(self) -> None:
+        fake_module = types.ModuleType("pymupdf4llm")
+        fake_module.use_layout = mock.Mock()  # type: ignore[attr-defined]
+        fake_module.to_markdown = mock.Mock(
+            return_value=[{"text": "pdf body", "metadata": {"page_number": 1}}]
+        )  # type: ignore[attr-defined]
+
+        with TemporaryDirectory() as tmp:
+            pdf_path = Path(tmp) / "doc.pdf"
+            pdf_path.write_bytes(b"%PDF source")
+            loader = PdfPyMuPdf4LlmLoader()
+            os.environ["BIDMATE_PYMUPDF4LLM_USE_LAYOUT"] = "0"
+
+            with mock.patch("ingestion._validate_source_pdf", return_value=1):
+                with mock.patch.dict(sys.modules, {"pymupdf4llm": fake_module}):
+                    text = loader.load_text({"텍스트": "csv body"}, pdf_path)
+
+        self.assertEqual(text, "pdf body")
+        self.assertEqual(loader.last_parser_health["pymupdf4llm_use_layout"], 0)
+        fake_module.use_layout.assert_called_once_with(False)  # type: ignore[attr-defined]
+        fake_module.to_markdown.assert_called_once_with(
+            str(pdf_path),
+            page_chunks=True,
+            use_ocr=True,
+            ocr_language="eng",
+        )
+
+    def test_pdf_loader_can_run_pymupdf4llm_parse_in_timeout_subprocess(self) -> None:
+        fake_module = types.ModuleType("pymupdf4llm")
+        fake_module.to_markdown = mock.Mock(side_effect=AssertionError("parent path should not parse"))  # type: ignore[attr-defined]
+
+        with TemporaryDirectory() as tmp:
+            pdf_path = Path(tmp) / "doc.pdf"
+            pdf_path.write_bytes(b"%PDF source")
+            loader = PdfPyMuPdf4LlmLoader()
+            os.environ["BIDMATE_PYMUPDF4LLM_PARSE_TIMEOUT_S"] = "30"
+
+            with mock.patch("ingestion._validate_source_pdf", return_value=1):
+                with mock.patch.dict(sys.modules, {"pymupdf4llm": fake_module}):
+                    with mock.patch(
+                        "ingestion._pymupdf4llm_to_markdown_subprocess",
+                        return_value=[{"text": "pdf body", "metadata": {"page_number": 1}}],
+                    ) as parse:
+                        text = loader.load_text({"텍스트": "csv body"}, pdf_path)
+
+        self.assertEqual(text, "pdf body")
+        self.assertEqual(loader.last_parser_health["pymupdf4llm_parse_timeout_s"], 30)
+        parse.assert_called_once_with(
+            pdf_path,
+            use_ocr=True,
+            ocr_language="eng",
+            use_layout=None,
+            timeout_s=30.0,
+        )
+
+    def test_hwp_loader_can_reuse_preserved_converted_pdf_when_opted_in(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_path = root / "doc.hwp"
+            source_path.write_bytes(b"hwp bytes")
+            artifact_dir = root / "artifacts"
+            artifact_dir.mkdir()
+            reusable_pdf = artifact_dir / "source-sha.pdf"
+            reusable_pdf.write_bytes(b"%PDF reusable")
+            os.environ["BIDMATE_HWP_PDF_ARTIFACT_DIR"] = str(artifact_dir)
+            os.environ["BIDMATE_HWP_PDF_ARTIFACT_REUSE"] = "1"
+
+            def fake_sha(path: Path) -> str:
+                return "source-sha" if path == source_path else "pdf-sha"
+
+            with mock.patch("ingestion.sha256_file", side_effect=fake_sha):
+                with mock.patch("ingestion._validate_converted_pdf", return_value=3):
+                    with mock.patch("ingestion._convert_hwp_to_pdf") as convert:
+                        with mock.patch(
+                            "ingestion._extract_pdf_pymupdf4llm",
+                            return_value=("body", [], {}, {"pymupdf4llm_page_chunks": 1}),
+                        ) as extract:
+                            text, _sections, _metadata, health = _extract_hwp_pdf_pymupdf4llm(source_path)
+
+        self.assertEqual(text, "body")
+        self.assertEqual(health["pymupdf4llm_page_chunks"], 1)
+        convert.assert_not_called()
+        self.assertEqual(extract.call_args.args[0], reusable_pdf)
 
     def test_converter_unavailable_raises_fail_closed(self) -> None:
         loader = HwpPdfPyMuPdf4LlmLoader()

--- a/tests/test_propose_private_real100_v2_questions.py
+++ b/tests/test_propose_private_real100_v2_questions.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.propose_private_real100_v2_questions import (  # noqa: E402
+    PROFILE_TYPE,
+    generate_question_set,
+    main,
+    write_outputs,
+)
+
+
+def _chunk(doc: str, chunk: str, text: str, page: int) -> dict:
+    return {
+        "doc_id": doc,
+        "chunk_id": chunk,
+        "text": text,
+        "metadata": {"page_span": [page, page], "text_source": "pdf_pymupdf4llm"},
+    }
+
+
+def _index() -> dict:
+    return {
+        "schema_version": 2,
+        "chunks": [
+            _chunk(
+                "SECRET-DOC-A",
+                "SECRET-CHUNK-A1",
+                "요구사항 본문입니다. 사업비는 1억원이며 납품은 계약 후 3개월 이내입니다.",
+                1,
+            ),
+            _chunk(
+                "SECRET-DOC-A",
+                "SECRET-CHUNK-A2",
+                "운영 조건은 SLA 99.5% 이상이며 장애 대응은 2시간 이내 임시 조치입니다.",
+                2,
+            ),
+            _chunk(
+                "SECRET-DOC-B",
+                "SECRET-CHUNK-B1",
+                "| 항목 | 배점 |\\n| 기술평가 | 80점 |\\n| 가격평가 | 20점 |",
+                3,
+            ),
+            _chunk(
+                "SECRET-DOC-C",
+                "SECRET-CHUNK-C1",
+                "제안서 제출 마감은 2026년 7월 15일 17:00이며 발표 일정은 별도 통지합니다.",
+                4,
+            ),
+        ],
+    }
+
+
+def test_tier_generation_contract_covers_easy_standard_and_hard() -> None:
+    cases = generate_question_set(_index(), targets={"easy_sanity": 1, "standard_real": 2, "hard_stress": 6})
+    tiers = {case["difficulty_tier"] for case in cases}
+    assert {"easy_sanity", "standard_real", "hard_stress"} <= tiers
+    assert any(case["question_type"] == "multi_chunk_same_doc" for case in cases)
+    assert any(case["question_type"] == "unanswerable_absence" for case in cases)
+
+
+def test_aggregate_only_output_excludes_raw_private_content(tmp_path: Path) -> None:
+    cases = generate_question_set(_index(), targets={"easy_sanity": 1, "standard_real": 1, "hard_stress": 2})
+    aggregate = write_outputs(
+        cases,
+        out_dir=tmp_path / "private_questions",
+        aggregate_path=tmp_path / "question_distribution.aggregate.json",
+        eval_config_path=tmp_path / "real_config_v2.local.yaml",
+        index_dir_label="data/index/real100_v2",
+        targets={"easy_sanity": 1, "standard_real": 1, "hard_stress": 2},
+    )
+
+    rendered = json.dumps(aggregate, ensure_ascii=False, sort_keys=True)
+    assert aggregate is not None
+    assert aggregate["schema_version"] == 1
+    assert aggregate["profile_type"] == PROFILE_TYPE
+    assert "SECRET-DOC" not in rendered
+    assert "SECRET-CHUNK" not in rendered
+    assert "사업비는 1억원" not in rendered
+    assert "questions" not in aggregate
+    assert (tmp_path / "private_questions" / "questions.jsonl").is_file()
+    assert (tmp_path / "private_questions" / "gold_evidence.jsonl").is_file()
+
+
+def test_cli_writes_private_draft_and_public_safe_aggregate(tmp_path: Path) -> None:
+    index_path = tmp_path / "index.json"
+    index_path.write_text(json.dumps(_index(), ensure_ascii=False), encoding="utf-8")
+    out_dir = tmp_path / "private_questions"
+    out_aggregate = tmp_path / "question_distribution.aggregate.json"
+
+    rc = main(
+        [
+            "--index",
+            str(index_path),
+            "--out-dir",
+            str(out_dir),
+            "--out-aggregate",
+            str(out_aggregate),
+            "--easy",
+            "1",
+            "--standard",
+            "1",
+            "--hard",
+            "2",
+        ]
+    )
+
+    assert rc == 0
+    aggregate = json.loads(out_aggregate.read_text(encoding="utf-8"))
+    assert aggregate["comparison_protocol"]["interpretation_not_cherry_picking"] is True


### PR DESCRIPTION
## Summary
- Adds a private real100_v2 RFP benchmark rebuild workflow using PyMuPDF4LLM-parsed local artifacts, with aggregate-only public outputs.
- Adds deterministic private question proposal, parsed Markdown export, aggregate baseline/tier renderer, and focused tests.
- Adds OCR/layout/reuse controls for PyMuPDF4LLM PDF/HWP ingestion so recovered HWP-to-PDF artifacts can be reused during local rebuilds.

## Public aggregate outputs
- `reports/real100_v2/parse_inventory.aggregate.json`: 100 documents, 21,800 chunks.
- `reports/real100_v2/question_distribution.aggregate.json`: 300 cases; easy 60, standard 150, hard 90; answerable 272, unanswerable 28.
- `reports/real100_v2/baseline.aggregate.json`: n=300 baseline aggregate.
- `reports/real100_v2/benchmark_tiers.aggregate.json`: per-tier aggregate metrics with no unknown-tier cases.

## Baseline aggregate
- Recall@5: 0.042279411764705885
- Recall@10: 0.0625
- MRR@5: 0.029656862745098038
- nDCG@5: 0.030609097184622947
- citation_precision: 0.03529411764705882
- citation_accuracy: null
- abstention: 1.0

## Privacy and scope
- Raw questions, answers, evidence, doc IDs, chunk IDs, filenames, local paths, parsed Markdown, PDFs, indexes, and raw eval summaries remain private/local only.
- Committed reports are aggregate-only and covered by the privacy governance scan.
- This PR does not claim production retrieval quality improvement; it creates a tiered benchmark interpretation surface and records the measured baseline.

## Validation
- `python3 -m py_compile scripts/render_real100_v2_aggregates.py scripts/build_private_real100_v2_parallel.py scripts/export_private_index_markdown.py scripts/propose_private_real100_v2_questions.py`
- `python3 -m pytest tests/test_build_private_real100_v2_parallel.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_propose_private_real100_v2_questions.py tests/test_export_private_index_markdown.py tests/test_eval_artifact_privacy_regression.py -q`
- `python3 scripts/_governance.py --check-eval-privacy`
- `python3 scripts/check_doc_links.py --check-all`
- `git diff --check`

## Notes
- Push hook reminded that `ingestion.py` is load-bearing. The validation above includes focused ingestion loader tests and the private real100_v2 baseline aggregate. `make real-eval` / `make real-eval-delta` was not run because this PR introduces a new local benchmark rebuild surface rather than comparing a production retrieval change against the existing real100 headline.


Closes #1507


### 5b. Real-data delta
No behavior change in retrieval / verifier path. This PR adds local private real100_v2 benchmark rebuild helpers and aggregate-only interpretation artifacts; it does not change retrieval, verifier, prompt, reranker, answer generation, or runtime query behavior. The measured real100_v2 baseline aggregate is included above for the new benchmark surface; existing real100 headline delta was not run because this is not a production retrieval/verifier behavior change.
