### PR TITLE
chore: add agent loop issue janitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@
 # they render prompts, classify surfaces, check handoffs, suggest or run
 # allowlisted local validation, and write ignored local planning drafts. They
 # do not perform GitHub mutations.
-.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
+.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-issue-scan agent-loop-maintenance-plan agent-loop-issue-close agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
 
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
@@ -260,6 +260,9 @@ test-regression:
 #   make agent-loop-map
 #   make agent-loop-mcp
 #   make agent-loop-pr-scan
+#   make agent-loop-issue-scan
+#   make agent-loop-maintenance-plan
+#   make agent-loop-issue-close ISSUE=123 COMMENT_FILE=reports/agent_loop/issue-close-123.md CONFIRM_HUMAN_APPROVED=1
 #   make agent-loop-next-from-prs
 #   make agent-loop-pr-health
 #   make agent-loop-draft-task
@@ -315,6 +318,12 @@ BRANCH ?=
 CHANGED_FILES ?=
 OUT ?=
 PR_STATE ?= reports/agent_loop/pr_state.json
+ISSUE_STATE ?= reports/agent_loop/issue_state.json
+ISSUE_TRIAGE_OUT ?= reports/agent_loop/issue_triage.md
+MAINTENANCE_PLAN_OUT ?= reports/agent_loop/maintenance_plan.md
+MAINTENANCE_PLAN_JSON ?= reports/agent_loop/maintenance_plan.json
+ISSUE_QUEUE_TASKS_DIR ?= reports/agent_loop/issue_queue_tasks
+COMMENT_FILE ?=
 LIMIT ?= 30
 STATE ?= open
 TASK_BRIEF ?=
@@ -617,6 +626,32 @@ agent-loop-propose-queue-plan:
 	  --task-id "$(DRAFT_TASK_ID)" \
 	  $(if $(TASK_BRIEF),--task-brief "$(TASK_BRIEF)",) \
 	  --out "$(QUEUE_PLAN_PATCH_OUT)"
+
+agent-loop-issue-scan:
+	$(PYTHON) scripts/agent_loop.py issue-scan \
+	  --limit "$(LIMIT)" \
+	  --out-json "$(ISSUE_STATE)" \
+	  --out "$(ISSUE_TRIAGE_OUT)"
+
+agent-loop-maintenance-plan:
+	$(PYTHON) scripts/agent_loop.py maintenance-plan \
+	  --limit "$(LIMIT)" \
+	  --out "$(MAINTENANCE_PLAN_OUT)" \
+	  --json-out "$(MAINTENANCE_PLAN_JSON)" \
+	  --tasks-dir "$(ISSUE_QUEUE_TASKS_DIR)"
+
+agent-loop-issue-close:
+	@if [ -z "$(ISSUE)" ] || [ -z "$(COMMENT_FILE)" ]; then \
+	  echo "Usage: make agent-loop-issue-close ISSUE=123 COMMENT_FILE=reports/agent_loop/issue-close-123.md CONFIRM_HUMAN_APPROVED=1"; \
+	  exit 1; \
+	fi
+	$(PYTHON) scripts/agent_loop.py human-gated-exec \
+	  --action issue-close \
+	  --issue "$(ISSUE)" \
+	  --comment-file "$(COMMENT_FILE)" \
+	  --triage-plan "$(MAINTENANCE_PLAN_JSON)" \
+	  $(if $(CONFIRM_HUMAN_APPROVED),--confirm-human-approved,) \
+	  --out "$(HUMAN_GATED_EXEC_OUT)"
 
 agent-loop-pr-body:
 	$(PYTHON) scripts/agent_loop.py pr-body \

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -117,6 +117,11 @@ DEFAULT_AUTOMATION_COVERAGE = DEFAULT_REPORT_DIR / "automation_coverage.md"
 DEFAULT_HUMAN_GATED_EXEC = DEFAULT_REPORT_DIR / "human_gated_exec.md"
 DEFAULT_AUTO_SHIP_PLAN = DEFAULT_REPORT_DIR / "auto_ship_plan.md"
 DEFAULT_AUTO_SHIP_PREPARE = DEFAULT_REPORT_DIR / "auto_ship_prepare.md"
+DEFAULT_ISSUE_STATE = DEFAULT_REPORT_DIR / "issue_state.json"
+DEFAULT_ISSUE_TRIAGE = DEFAULT_REPORT_DIR / "issue_triage.md"
+DEFAULT_ISSUE_QUEUE_TASKS_DIR = DEFAULT_REPORT_DIR / "issue_queue_tasks"
+DEFAULT_MAINTENANCE_PLAN = DEFAULT_REPORT_DIR / "maintenance_plan.md"
+DEFAULT_MAINTENANCE_PLAN_JSON = DEFAULT_REPORT_DIR / "maintenance_plan.json"
 DEFAULT_DRAFT_TASK_ID = "T-2026-0000"
 QUEUE_PATH = Path("tasks/queue.md")
 PLAN_DIR = Path("docs/plans")
@@ -135,6 +140,13 @@ GH_PR_JSON_FIELDS = (
     "updatedAt",
 )
 GH_PR_BODY_FIELD = "body"
+GH_ISSUE_JSON_FIELDS = (
+    "number",
+    "title",
+    "url",
+    "labels",
+    "updatedAt",
+)
 
 REQUIRED_READS = (
     "CLAUDE.md",
@@ -380,6 +392,25 @@ class AutoShipPrepareReport:
     evidence: tuple[str, ...]
     created: bool = False
     returncode: int | None = None
+
+
+@dataclass(frozen=True)
+class IssueTriageItem:
+    number: str
+    title: str
+    url: str
+    labels: tuple[str, ...]
+    updated_at: str
+    classification: str
+    evidence: tuple[str, ...]
+    recommended_actions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MaintenancePlan:
+    issues: tuple[IssueTriageItem, ...]
+    worktree_actions: tuple[str, ...]
+    queue_task_briefs: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -4897,6 +4928,396 @@ def render_stacked_risk(*, branch: str, items: Sequence[dict[str, object]]) -> s
     return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
 
 
+def write_issue_scan(
+    *,
+    issue_json: Path | None = None,
+    out_json: Path = DEFAULT_ISSUE_STATE,
+    out: Path = DEFAULT_ISSUE_TRIAGE,
+    limit: int = 200,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path, tuple[IssueTriageItem, ...], str]:
+    issues = _load_issue_state(issue_json=issue_json, limit=limit, repo_root=repo_root)
+    triage = build_issue_triage(issues=issues, repo_root=repo_root)
+    rendered = render_issue_triage(triage)
+    out_json = _default_output(out_json, DEFAULT_ISSUE_STATE, "issue_state.json", repo_root=repo_root)
+    out = _default_output(out, DEFAULT_ISSUE_TRIAGE, "issue_triage.md", repo_root=repo_root)
+    safe_json = _safe_output_path(out_json, repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_json.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_json.write_text(json.dumps([_triage_item_json(item) for item in triage], indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_json, safe_out, triage, rendered
+
+
+def _load_issue_state(*, issue_json: Path | None, limit: int, repo_root: Path) -> list[dict[str, object]]:
+    if issue_json is not None:
+        path = _resolve_input_path(issue_json, repo_root=repo_root)
+        payload = json.loads(_read_text(path))
+    else:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--state",
+                "open",
+                "--limit",
+                str(limit),
+                "--json",
+                ",".join(GH_ISSUE_JSON_FIELDS),
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        payload = json.loads(result.stdout)
+    if not isinstance(payload, list):
+        raise ValueError("issue state JSON must be an array")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def build_issue_triage(*, issues: Sequence[dict[str, object]], repo_root: Path = ROOT_DIR) -> tuple[IssueTriageItem, ...]:
+    queue_entries = _queue_entries_by_issue(repo_root)
+    local_branches = _local_issue_branches(repo_root)
+    worktree_branches = _worktree_issue_branches(repo_root)
+    items: list[IssueTriageItem] = []
+    for issue in issues:
+        number = _validate_issue_selector(str(issue.get("number") or ""))
+        title = _sanitize_inline_text(str(issue.get("title") or "Untitled issue"))
+        url = _sanitize_inline_text(str(issue.get("url") or ""))
+        labels = _issue_label_names(issue.get("labels"))
+        updated_at = _sanitize_inline_text(str(issue.get("updatedAt") or ""))
+        evidence: list[str] = []
+        actions: list[str] = []
+        queue_matches = queue_entries.get(number, [])
+        branch_matches = sorted(local_branches.get(number, set()) | worktree_branches.get(number, set()))
+        if queue_matches:
+            evidence.extend(queue_matches)
+        if branch_matches:
+            evidence.extend(f"local branch/worktree `{branch}` exists" for branch in branch_matches)
+
+        lowered = f"{title} {' '.join(labels)}".lower()
+        if branch_matches:
+            classification = "in_flight"
+            actions.append("Inspect the branch/worktree before closing; run branch-issue-hygiene and stacked-risk.")
+        elif any("queue done" in item for item in evidence) or _has_superseded_signal(lowered):
+            classification = "close_candidate"
+            if not evidence:
+                evidence.append("title/label contains an explicit superseded/archive signal")
+            actions.append(f"Prepare a close comment, then run human-gated-exec --action issue-close --issue {number}.")
+        elif queue_matches:
+            classification = "manual_review"
+            actions.append("Queue already references this issue but is not done; verify whether it should remain open.")
+        elif _manual_issue_signal(lowered):
+            classification = "manual_review"
+            evidence.append("manual/user-action/security/eval signal requires human review")
+            actions.append("Keep open until a human decides whether to archive, defer, or convert.")
+        else:
+            classification = "queue_candidate"
+            evidence.append("no local branch/worktree or done/superseded evidence found")
+            actions.append("Generate a queue/plan draft instead of closing.")
+        items.append(
+            IssueTriageItem(
+                number=number,
+                title=title,
+                url=url,
+                labels=tuple(labels),
+                updated_at=updated_at,
+                classification=classification,
+                evidence=tuple(_dedupe_preserve_order(evidence)),
+                recommended_actions=tuple(_dedupe_preserve_order(actions)),
+            )
+        )
+    return tuple(items)
+
+
+def _queue_entries_by_issue(repo_root: Path) -> dict[str, list[str]]:
+    queue_path = repo_root / QUEUE_PATH
+    if not queue_path.exists():
+        return {}
+    entries_by_issue: dict[str, list[str]] = {}
+    for entry in parse_task_entries(_read_text(queue_path)):
+        issues = set(re.findall(r"(?:issues/|#)(\d+)", entry.body))
+        for issue in issues:
+            status = (entry.status or "unknown").lower()
+            marker = "queue done" if status == "done" else f"queue {status}"
+            entries_by_issue.setdefault(issue, []).append(f"{marker}: `{entry.task_id}` {entry.title}")
+    return entries_by_issue
+
+
+def _local_issue_branches(repo_root: Path) -> dict[str, set[str]]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "branch", "--format=%(refname:short)"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return {}
+    found: dict[str, set[str]] = {}
+    for raw in result.stdout.splitlines():
+        branch = raw.strip()
+        issue = _issue_from_branch(branch)
+        if issue:
+            found.setdefault(issue, set()).add(branch)
+    return found
+
+
+def _worktree_issue_branches(repo_root: Path) -> dict[str, set[str]]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return {}
+    found: dict[str, set[str]] = {}
+    for line in result.stdout.splitlines():
+        if not line.startswith("branch refs/heads/"):
+            continue
+        branch = line.removeprefix("branch refs/heads/")
+        issue = _issue_from_branch(branch)
+        if issue:
+            found.setdefault(issue, set()).add(branch)
+    return found
+
+
+def _issue_label_names(labels: object) -> list[str]:
+    if not isinstance(labels, list):
+        return []
+    names: list[str] = []
+    for item in labels:
+        if isinstance(item, dict) and item.get("name"):
+            names.append(_sanitize_inline_text(str(item["name"])))
+    return names
+
+
+def _has_superseded_signal(text: str) -> bool:
+    return any(token in text for token in ("superseded", "obsolete", "archive", "closed by", "already done"))
+
+
+def _manual_issue_signal(text: str) -> bool:
+    return any(
+        token in text
+        for token in (
+            "confidential",
+            "security",
+            "privacy",
+            "purge",
+            "leak",
+            "real-eval",
+            "real eval",
+            "benchmark",
+            "user-action",
+            "operator-run",
+            "manual",
+        )
+    )
+
+
+def render_issue_triage(items: Sequence[IssueTriageItem]) -> str:
+    lines = [
+        "# Issue Triage",
+        "",
+        "- Conservative read-only issue cleanup scan.",
+        "- This report does not close issues, edit queue docs, delete branches, or remove worktrees.",
+        "- `close_candidate` means the issue has local done/superseded evidence; it still requires `human-gated-exec --action issue-close`.",
+        "",
+        "| Issue | Classification | Labels | Evidence | Recommended action |",
+        "|---:|---|---|---|---|",
+    ]
+    for item in items:
+        evidence = "<br>".join(_sanitize_dynamic_text(text) for text in item.evidence) or "N/A"
+        actions = "<br>".join(_sanitize_dynamic_text(text) for text in item.recommended_actions) or "N/A"
+        labels = ", ".join(item.labels) or "N/A"
+        issue = f"[#{item.number}]({item.url})" if item.url else f"#{item.number}"
+        lines.append(f"| {issue} | `{item.classification}` | {labels} | {evidence} | {actions} |")
+    lines.extend(["", "## Summary", ""])
+    counts: dict[str, int] = {}
+    for item in items:
+        counts[item.classification] = counts.get(item.classification, 0) + 1
+    for key in ("close_candidate", "queue_candidate", "in_flight", "manual_review"):
+        lines.append(f"- `{key}`: {counts.get(key, 0)}")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def write_maintenance_plan(
+    *,
+    issue_json: Path | None = None,
+    out: Path = DEFAULT_MAINTENANCE_PLAN,
+    json_out: Path = DEFAULT_MAINTENANCE_PLAN_JSON,
+    tasks_dir: Path = DEFAULT_ISSUE_QUEUE_TASKS_DIR,
+    limit: int = 200,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path, MaintenancePlan, str]:
+    issues = _load_issue_state(issue_json=issue_json, limit=limit, repo_root=repo_root)
+    triage = build_issue_triage(issues=issues, repo_root=repo_root)
+    safe_tasks_dir = _safe_output_path(_default_output(tasks_dir, DEFAULT_ISSUE_QUEUE_TASKS_DIR, "issue_queue_tasks", repo_root=repo_root), repo_root=repo_root)
+    safe_tasks_dir.mkdir(parents=True, exist_ok=True)
+    task_briefs = _write_issue_queue_briefs(triage, tasks_dir=safe_tasks_dir)
+    plan = MaintenancePlan(
+        issues=triage,
+        worktree_actions=tuple(_maintenance_worktree_actions(repo_root)),
+        queue_task_briefs=tuple(_repo_path(path, repo_root) for path in task_briefs),
+    )
+    rendered = render_maintenance_plan(plan)
+    out = _default_output(out, DEFAULT_MAINTENANCE_PLAN, "maintenance_plan.md", repo_root=repo_root)
+    json_out = _default_output(json_out, DEFAULT_MAINTENANCE_PLAN_JSON, "maintenance_plan.json", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_json = _safe_output_path(json_out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_json.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    safe_json.write_text(json.dumps(_maintenance_plan_json(plan), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return safe_out, safe_json, plan, rendered
+
+
+def _write_issue_queue_briefs(items: Sequence[IssueTriageItem], *, tasks_dir: Path) -> list[Path]:
+    paths: list[Path] = []
+    for index, item in enumerate([candidate for candidate in items if candidate.classification == "queue_candidate"], start=1):
+        slug = _slugify(f"issue-{item.number}-{item.title}")[:72]
+        path = tasks_dir / f"{index:03d}-{slug}.md"
+        labels = ", ".join(item.labels) or "N/A"
+        path.write_text(
+            _sanitize_dynamic_text(
+                f"""# Queue issue #{item.number}: {item.title}
+
+- Classification: `queue_candidate`
+- Source: `{item.url or '#' + item.number}`
+- Labels: {labels}
+- Reason: no branch/worktree or done/superseded evidence was found during conservative issue scan.
+
+## Goal
+
+Convert the issue into a scoped queue/backlog task, or document why it should remain open.
+
+## Expected Evidence
+
+Queue entry or explicit human no-go rationale. Do not close the issue from this draft alone.
+
+## Verification
+
+```bash
+git diff --check
+```
+"""
+            ).rstrip()
+            + "\n",
+            encoding="utf-8",
+        )
+        paths.append(path)
+    return paths
+
+
+def _maintenance_worktree_actions(repo_root: Path) -> list[str]:
+    actions = ["make worktree-cleanup-dry-run"]
+    try:
+        result = subprocess.run(
+            ["bash", ".githooks/_pre-push-worktree-hygiene.sh", "--clean", "--dry-run"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return actions
+    output = _sanitize_dynamic_text((result.stdout or "") + (result.stderr or "")).strip()
+    if output:
+        actions.append(output)
+    return actions
+
+
+def render_maintenance_plan(plan: MaintenancePlan) -> str:
+    close_items = [item for item in plan.issues if item.classification == "close_candidate"]
+    queue_items = [item for item in plan.issues if item.classification == "queue_candidate"]
+    in_flight = [item for item in plan.issues if item.classification == "in_flight"]
+    manual = [item for item in plan.issues if item.classification == "manual_review"]
+    lines = [
+        "# Agent Loop Maintenance Plan",
+        "",
+        "- Planning artifact only. It does not close issues, edit tracked queue docs, delete branches, or remove worktrees.",
+        "- Conservative policy: only `close_candidate` issues may be closed, and only through `human-gated-exec --action issue-close` with this plan as evidence.",
+        "",
+        "## Issue Lanes",
+        "",
+        f"- Close candidates: `{len(close_items)}`",
+        f"- Queue candidates: `{len(queue_items)}`",
+        f"- In-flight: `{len(in_flight)}`",
+        f"- Manual review: `{len(manual)}`",
+        "",
+        "## Close Candidate Commands",
+        "",
+    ]
+    if close_items:
+        for item in close_items:
+            lines.append(f"- `python3 scripts/agent_loop.py human-gated-exec --action issue-close --issue {item.number} --triage-plan reports/agent_loop/maintenance_plan.json --comment-file reports/agent_loop/issue-close-{item.number}.md --confirm-human-approved`")
+    else:
+        lines.append("- None.")
+    lines.extend(["", "## Queue Candidate Drafts", ""])
+    if plan.queue_task_briefs:
+        lines.extend(f"- `{path}`" for path in plan.queue_task_briefs)
+        lines.append("- Promote one draft with `python3 scripts/agent_loop.py queue-plan-sync --task-brief <path>` and then review `apply-queue-plan` output.")
+    else:
+        lines.append("- None.")
+    lines.extend(["", "## Branch / Worktree Cleanup", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(action)}" for action in plan.worktree_actions)
+    lines.extend(["", "## Remote Branch Cleanup Gate", ""])
+    lines.append("- Before deleting any remote branch, run `python3 scripts/agent_loop.py stacked-risk --branch <branch>` and then `human-gated-exec --action branch-delete` only after review.")
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def _triage_item_json(item: IssueTriageItem) -> dict[str, object]:
+    return {
+        "number": item.number,
+        "title": item.title,
+        "url": item.url,
+        "labels": list(item.labels),
+        "updatedAt": item.updated_at,
+        "classification": item.classification,
+        "evidence": list(item.evidence),
+        "recommended_actions": list(item.recommended_actions),
+    }
+
+
+def _maintenance_plan_json(plan: MaintenancePlan) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "issues": [_triage_item_json(item) for item in plan.issues],
+        "worktree_actions": list(plan.worktree_actions),
+        "queue_task_briefs": list(plan.queue_task_briefs),
+    }
+
+
+def _validate_issue_selector(issue: str) -> str:
+    safe = _sanitize_inline_text(issue.strip().lstrip("#"))
+    if not re.fullmatch(r"\d{1,10}", safe):
+        raise ValueError("issue selector must be a numeric issue number")
+    return safe
+
+
+def _issue_close_allowed(*, issue: str, triage_plan: Path | None, repo_root: Path) -> tuple[bool, str]:
+    if triage_plan is None:
+        return False, "--triage-plan is required for issue-close"
+    path = _resolve_input_path(triage_plan, repo_root=repo_root)
+    payload = json.loads(_read_text(path))
+    issues = payload.get("issues") if isinstance(payload, dict) else None
+    if not isinstance(issues, list):
+        return False, "triage plan JSON must contain an issues array"
+    for item in issues:
+        if not isinstance(item, dict) or str(item.get("number")) != issue:
+            continue
+        if item.get("classification") == "close_candidate":
+            return True, "triage plan marks issue as close_candidate"
+        return False, f"triage plan marks issue as {item.get('classification') or 'unknown'}"
+    return False, "issue is not present in triage plan"
+
+
 def write_patch_proposal(
     *,
     changed_files: Sequence[str] = (),
@@ -5145,7 +5566,7 @@ def render_ship_command_pack(*, pr: str | None, branch: str | None, repo_root: P
     return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
 
 
-HUMAN_GATED_ACTIONS = {"push", "pr-create", "pr-merge", "pr-close", "branch-delete", "force-push"}
+HUMAN_GATED_ACTIONS = {"push", "pr-create", "pr-merge", "pr-close", "branch-delete", "force-push", "issue-close"}
 
 
 def write_human_gated_exec(
@@ -5158,6 +5579,9 @@ def write_human_gated_exec(
     body: Path | None = None,
     base: str | None = None,
     title: str | None = None,
+    issue: str | None = None,
+    comment_file: Path | None = None,
+    triage_plan: Path | None = None,
     draft: bool = True,
     confirm_review_gate_passed: bool = False,
     confirm_dependents_reviewed: bool = False,
@@ -5174,6 +5598,9 @@ def write_human_gated_exec(
         body=body,
         base=base,
         title=title,
+        issue=issue,
+        comment_file=comment_file,
+        triage_plan=triage_plan,
         draft=draft,
         confirm_review_gate_passed=confirm_review_gate_passed,
         confirm_dependents_reviewed=confirm_dependents_reviewed,
@@ -5222,6 +5649,9 @@ def build_human_gated_exec_plan(
     confirm_dependents_reviewed: bool,
     confirm_force_with_lease: bool,
     repo_root: Path,
+    issue: str | None = None,
+    comment_file: Path | None = None,
+    triage_plan: Path | None = None,
 ) -> HumanGatedExecPlan:
     if action not in HUMAN_GATED_ACTIONS:
         raise ValueError("--action must be one of: " + ", ".join(sorted(HUMAN_GATED_ACTIONS)))
@@ -5273,6 +5703,23 @@ def build_human_gated_exec_plan(
         if not confirm_review_gate_passed:
             blockers.append("--confirm-review-gate-passed is required before close")
         command = ("gh", "pr", "close", safe_pr)
+    elif action == "issue-close":
+        safe_issue = _validate_issue_selector(issue or "")
+        allowed, reason = _issue_close_allowed(issue=safe_issue, triage_plan=triage_plan, repo_root=repo_root)
+        if not allowed:
+            blockers.append(reason)
+        if comment_file is None:
+            blockers.append("--comment-file is required for issue-close")
+            comment_text = "<comment-file>"
+        else:
+            comment_path = _resolve_input_path(comment_file, repo_root=repo_root)
+            if not comment_path.exists():
+                blockers.append("issue close comment file not found")
+                comment_text = "<comment-file>"
+            else:
+                comment_text = _sanitize_dynamic_text(_read_text(comment_path))
+        command = ("gh", "issue", "close", safe_issue, "--comment", comment_text)
+        warnings.append("issue-close is conservative: only close_candidate entries from a triage plan are allowed")
     else:
         if not safe_branch:
             blockers.append("--branch is required for branch-delete")
@@ -6348,6 +6795,7 @@ def render_automation_coverage() -> str:
         ("18", "auto-pass strict profiles", "auto-pass-check --profile ..."),
         ("19", "human-approved remote execution", "human-gated-exec --confirm-human-approved"),
         ("20", "existing auto-ship bridge", "auto-ship-prepare, auto-ship-plan, ship-simulate, ship-command-pack"),
+        ("21", "conservative issue cleanup", "issue-scan, maintenance-plan, human-gated-exec --action issue-close"),
     )
     lines = [
         "# Agent Loop Automation Coverage",
@@ -6365,7 +6813,7 @@ def render_automation_coverage() -> str:
             "",
             "- Queue/plan actual tracked-doc application unless `--confirm-human-approved` is explicit.",
             "- Running existing `make ship-arm` remains a shipping approval; `auto-ship-plan` only prepares a plan.",
-            "- Push, PR create/merge/close, branch delete, force-push require `human-gated-exec --confirm-human-approved` plus action-specific gates.",
+            "- Push, PR create/merge/close, issue close, branch delete, force-push require `human-gated-exec --confirm-human-approved` plus action-specific gates.",
             "- Private real-eval decisions, benchmark/performance claims, architecture tradeoffs.",
             "",
         ]
@@ -6955,6 +7403,7 @@ def render_loop_map() -> str:
 ```mermaid
 flowchart TD
   A["Repo state: queue, plans, PRs, reports"] --> B["pr-scan: read GitHub PR metadata"]
+  A --> ISS["issue-scan and maintenance-plan: conservative issue cleanup and queue migration"]
   A --> MCP["agent-loop-mcp: expose safe local loop tools to MCP clients"]
   MCP --> D
   B --> C["next-from-prs: generate next-action report and task briefs"]
@@ -6994,7 +7443,8 @@ flowchart TD
   C --> WORKSET["workset-recommend: serial/parallel/review/manual sets"]
   A --> INT["integration-pack and scheduled-status recipes"]
   INT --> MCP
-  Q --> R{"Human gate: review, claims, merge, close, push, delete?"}
+  ISS --> F
+  Q --> R{"Human gate: review, claims, merge, close issue/PR, push, delete?"}
   R -->|end-to-end approved| SHIP["make ship-arm: approved single end-to-end ship pipeline"]
   R -->|manual fallback approved| EXEC["human-gated-exec: action-by-action remote mutation fallback"]
   SHIP --> S["Existing ship workflow"]
@@ -7004,6 +7454,8 @@ flowchart TD
 
 Automation points:
 - pr-scan: read-only `gh pr list` JSON export.
+- issue-scan: read-only `gh issue list` JSON export plus conservative close/queue/in-flight/manual classification.
+- maintenance-plan: generate issue cleanup, queue migration, worktree cleanup, and branch deletion gate recommendations without executing them.
 - next-from-prs: deterministic wrapper around `scripts/ai_next_actions.py`.
 - pr-health: group exported PR state into CI, review, stale, draft, blocked, and ready lanes.
 - batch-plan: group local task briefs into serial, parallel-safe, review-only, and manual-gated lanes.
@@ -7032,7 +7484,7 @@ Automation points:
 - auto-ship-prepare: prepare or create a local ADR 0007 branch for the primary `make ship-arm` pipeline; branch creation requires `--confirm-human-approved`.
 - auto-ship-plan: render a readiness-backed bridge to the primary `make ship-arm` Stop-hook pipeline without arming it.
 - ship-command-pack: render human-gated ship commands without executing them.
-- human-gated-exec: execute push/PR create/merge/close/remote branch delete/force-with-lease only as an action-by-action fallback with `--confirm-human-approved` and action-specific gates.
+- human-gated-exec: execute push/PR create/merge/close, issue close, remote branch delete, or force-with-lease only as an action-by-action fallback with `--confirm-human-approved` and action-specific gates.
 - dependency-graph: render stacked PR graph without merge/delete mutation.
 - stacked-risk: detect dependent PR risk before merge/delete cleanup.
 - pr-body-check: verify `Closes`, §5b, claim, and privacy boundaries before PR creation.
@@ -7063,7 +7515,7 @@ Human intervention points:
 - Apply a draft to `tasks/queue.md` or `docs/plans/*.md`.
 - Create or switch the local shipping branch when detached HEAD or protected branch state is detected.
 - Decide architecture tradeoffs, benchmark/performance claims, or private real-eval meaning.
-- Push, create/merge/close PRs, delete branches, or force-push.
+- Push, create/merge/close PRs, close issues, delete branches, or force-push.
 - Prefer `make ship-arm` for approved end-to-end shipping; use `human-gated-exec` only as a manual fallback after explicit approval and action-specific preflight.
 - Approve reviewer findings and shipping path.
 """
@@ -7367,6 +7819,19 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Include PR body in local ignored state; use only when PR bodies are public-safe.",
     )
+
+    issue_scan = sub.add_parser("issue-scan", help="Conservatively classify open issues for cleanup or queue migration.")
+    issue_scan.add_argument("--issue-json", type=Path, help="Optional local issue state JSON for tests or offline scans.")
+    issue_scan.add_argument("--limit", type=int, default=200)
+    issue_scan.add_argument("--out-json", type=Path, default=DEFAULT_ISSUE_STATE)
+    issue_scan.add_argument("--out", type=Path, default=DEFAULT_ISSUE_TRIAGE)
+
+    maintenance = sub.add_parser("maintenance-plan", help="Plan conservative issue, queue, branch, and worktree cleanup.")
+    maintenance.add_argument("--issue-json", type=Path, help="Optional local issue state JSON for tests or offline scans.")
+    maintenance.add_argument("--limit", type=int, default=200)
+    maintenance.add_argument("--out", type=Path, default=DEFAULT_MAINTENANCE_PLAN)
+    maintenance.add_argument("--json-out", type=Path, default=DEFAULT_MAINTENANCE_PLAN_JSON)
+    maintenance.add_argument("--tasks-dir", type=Path, default=DEFAULT_ISSUE_QUEUE_TASKS_DIR)
 
     next_prs = sub.add_parser("next-from-prs", help="Generate next-action briefs from PR state JSON.")
     next_prs.add_argument("--pr-json", type=Path, default=DEFAULT_PR_STATE)
@@ -7731,6 +8196,9 @@ def build_parser() -> argparse.ArgumentParser:
     gated.add_argument("--body", type=Path)
     gated.add_argument("--base")
     gated.add_argument("--title")
+    gated.add_argument("--issue")
+    gated.add_argument("--comment-file", type=Path)
+    gated.add_argument("--triage-plan", type=Path)
     gated.add_argument("--ready", action="store_true", help="Create PR as ready instead of draft.")
     gated.add_argument("--confirm-review-gate-passed", action="store_true")
     gated.add_argument("--confirm-dependents-reviewed", action="store_true")
@@ -7849,6 +8317,31 @@ def main(argv: list[str] | None = None) -> int:
                 include_body=args.include_body,
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "issue-scan":
+            state_out, triage_out, triage, _ = write_issue_scan(
+                issue_json=args.issue_json,
+                out_json=args.out_json,
+                out=args.out,
+                limit=args.limit,
+            )
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(state_out, ROOT_DIR)} and {_repo_path(triage_out, ROOT_DIR)} "
+                f"for {len(triage)} issue(s)\n"
+            )
+            return 0
+        if args.command == "maintenance-plan":
+            out, json_out, plan, _ = write_maintenance_plan(
+                issue_json=args.issue_json,
+                out=args.out,
+                json_out=args.json_out,
+                tasks_dir=args.tasks_dir,
+                limit=args.limit,
+            )
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(out, ROOT_DIR)}, {_repo_path(json_out, ROOT_DIR)}, "
+                f"and {len(plan.queue_task_briefs)} queue brief(s)\n"
+            )
             return 0
         if args.command == "next-from-prs":
             out_md, tasks_dir = run_next_from_prs(
@@ -8443,6 +8936,9 @@ def main(argv: list[str] | None = None) -> int:
                 body=args.body,
                 base=args.base,
                 title=args.title,
+                issue=args.issue,
+                comment_file=args.comment_file,
+                triage_plan=args.triage_plan,
                 draft=not args.ready,
                 confirm_review_gate_passed=args.confirm_review_gate_passed,
                 confirm_dependents_reviewed=args.confirm_dependents_reviewed,

--- a/scripts/agent_loop_mcp.py
+++ b/scripts/agent_loop_mcp.py
@@ -257,6 +257,28 @@ def tool_definitions() -> list[JSON]:
             ),
         },
         {
+            "name": "agent_loop_issue_scan",
+            "description": "Read open issue state and conservatively classify cleanup versus queue migration lanes.",
+            "inputSchema": _schema(
+                {
+                    "issue_json": {"type": "string", "description": "Optional local issue state JSON path."},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 200},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
+            "name": "agent_loop_maintenance_plan",
+            "description": "Render conservative issue, queue, branch, and worktree maintenance plan without executing cleanup.",
+            "inputSchema": _schema(
+                {
+                    "issue_json": {"type": "string", "description": "Optional local issue state JSON path."},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 200},
+                    "write": {"type": "boolean", "default": False},
+                }
+            ),
+        },
+        {
             "name": "agent_loop_safe_fix_dry_run",
             "description": "Dry-run safe whitespace-only local fixes for changed files.",
             "inputSchema": _schema(maybe_changed_files),
@@ -682,6 +704,8 @@ def call_tool(name: str, arguments: JSON | None = None) -> JSON:
         "agent_loop_dashboard": _tool_dashboard,
         "agent_loop_mcp_config": _tool_mcp_config,
         "agent_loop_pr_health": _tool_pr_health,
+        "agent_loop_issue_scan": _tool_issue_scan,
+        "agent_loop_maintenance_plan": _tool_maintenance_plan,
         "agent_loop_safe_fix_dry_run": _tool_safe_fix_dry_run,
         "agent_loop_approval_packet": _tool_approval_packet,
         "agent_loop_propose_queue_plan": _tool_propose_queue_plan,
@@ -925,6 +949,42 @@ def _tool_pr_health(args: JSON) -> str:
     if not isinstance(payload, list):
         raise ValueError("PR state JSON must be an array")
     return agent_loop.render_pr_health([item for item in payload if isinstance(item, dict)])
+
+
+def _tool_issue_scan(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, _, _, rendered = agent_loop.write_issue_scan(
+            issue_json=_optional_path(args, "issue_json"),
+            limit=_int_arg(args, "limit", 200),
+        )
+        return rendered
+    issues = agent_loop._load_issue_state(
+        issue_json=_optional_path(args, "issue_json"),
+        limit=_int_arg(args, "limit", 200),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    return agent_loop.render_issue_triage(agent_loop.build_issue_triage(issues=issues, repo_root=agent_loop.ROOT_DIR))
+
+
+def _tool_maintenance_plan(args: JSON) -> str:
+    if _bool_arg(args, "write", False):
+        _, _, _, rendered = agent_loop.write_maintenance_plan(
+            issue_json=_optional_path(args, "issue_json"),
+            limit=_int_arg(args, "limit", 200),
+        )
+        return rendered
+    issues = agent_loop._load_issue_state(
+        issue_json=_optional_path(args, "issue_json"),
+        limit=_int_arg(args, "limit", 200),
+        repo_root=agent_loop.ROOT_DIR,
+    )
+    triage = agent_loop.build_issue_triage(issues=issues, repo_root=agent_loop.ROOT_DIR)
+    plan = agent_loop.MaintenancePlan(
+        issues=triage,
+        worktree_actions=("make worktree-cleanup-dry-run",),
+        queue_task_briefs=(),
+    )
+    return agent_loop.render_maintenance_plan(plan)
 
 
 def _tool_safe_fix_dry_run(args: JSON) -> str:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1783,6 +1783,142 @@ git diff --check
     assert any("agent-loop-tooling-strict" in blocker for blocker in strict_report.blockers)
 
 
+def test_issue_scan_classifies_conservatively_with_queue_and_branch_evidence(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(
+        tmp_path,
+        task_id="T-2026-0001",
+        status="done",
+        body_extra="- Issue: [#101](https://github.com/example/repo/issues/101)\n",
+    )
+    issues = [
+        {"number": 101, "title": "Completed cleanup", "labels": [], "url": "https://example.test/101"},
+        {"number": 102, "title": "Active branch work", "labels": [], "url": "https://example.test/102"},
+        {"number": 103, "title": "New backlog item", "labels": [], "url": "https://example.test/103"},
+        {"number": 104, "title": "fix(eval): benchmark needs judgment", "labels": [{"name": "eval"}], "url": "https://example.test/104"},
+    ]
+    monkeypatch.setattr(agent_loop, "_local_issue_branches", lambda repo_root: {"102": {"chore/issue-102-active"}})
+    monkeypatch.setattr(agent_loop, "_worktree_issue_branches", lambda repo_root: {})
+
+    triage = agent_loop.build_issue_triage(issues=issues, repo_root=repo)
+    by_number = {item.number: item for item in triage}
+
+    assert by_number["101"].classification == "close_candidate"
+    assert any("queue done" in evidence for evidence in by_number["101"].evidence)
+    assert by_number["102"].classification == "in_flight"
+    assert by_number["103"].classification == "queue_candidate"
+    assert by_number["104"].classification == "manual_review"
+
+
+def test_maintenance_plan_writes_queue_briefs_without_mutating_tracked_docs(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    issue_state = repo / "reports" / "agent_loop" / "issues.json"
+    issue_state.parent.mkdir(parents=True, exist_ok=True)
+    issue_state.write_text(
+        json.dumps(
+            [
+                {"number": 201, "title": "Backlog janitor item", "labels": [], "url": "https://example.test/201"},
+                {"number": 202, "title": "Already superseded cleanup", "labels": [{"name": "superseded"}], "url": "https://example.test/202"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(agent_loop, "_local_issue_branches", lambda repo_root: {})
+    monkeypatch.setattr(agent_loop, "_worktree_issue_branches", lambda repo_root: {})
+    monkeypatch.setattr(agent_loop, "_maintenance_worktree_actions", lambda repo_root: ["make worktree-cleanup-dry-run"])
+
+    out, json_out, plan, rendered = agent_loop.write_maintenance_plan(issue_json=issue_state, repo_root=repo)
+
+    assert out == repo / "reports" / "agent_loop" / "maintenance_plan.md"
+    assert json_out == repo / "reports" / "agent_loop" / "maintenance_plan.json"
+    assert len(plan.queue_task_briefs) == 1
+    assert (repo / plan.queue_task_briefs[0]).exists()
+    assert "human-gated-exec --action issue-close --issue 202" in rendered
+    assert not (repo / "tasks" / "queue.md").read_text(encoding="utf-8").startswith("Queue issue")
+
+
+def test_human_gated_issue_close_requires_triage_plan_comment_and_close_candidate(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    report_dir = repo / "reports" / "agent_loop"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    triage_plan = report_dir / "maintenance_plan.json"
+    triage_plan.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "issues": [
+                    {"number": "301", "classification": "close_candidate"},
+                    {"number": "302", "classification": "queue_candidate"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    comment = report_dir / "issue-close-301.md"
+    comment.write_text("Closing as superseded by merged work.", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    blocked = agent_loop.build_human_gated_exec_plan(
+        action="issue-close",
+        confirm_human_approved=True,
+        dry_run=True,
+        branch=None,
+        pr=None,
+        body=None,
+        base=None,
+        title=None,
+        issue="302",
+        comment_file=comment,
+        triage_plan=triage_plan,
+        draft=True,
+        confirm_review_gate_passed=False,
+        confirm_dependents_reviewed=False,
+        confirm_force_with_lease=False,
+        repo_root=repo,
+    )
+    executed_out, executed_plan, _ = agent_loop.write_human_gated_exec(
+        action="issue-close",
+        issue="301",
+        comment_file=comment,
+        triage_plan=triage_plan,
+        confirm_human_approved=True,
+        repo_root=repo,
+    )
+
+    assert any("queue_candidate" in blocker for blocker in blocked.blockers)
+    assert executed_out == repo / "reports" / "agent_loop" / "human_gated_exec.md"
+    assert executed_plan.command == ("gh", "issue", "close", "301", "--comment", "Closing as superseded by merged work.")
+    assert calls == [["gh", "issue", "close", "301", "--comment", "Closing as superseded by merged work."]]
+    try:
+        agent_loop.build_human_gated_exec_plan(
+            action="issue-close",
+            confirm_human_approved=True,
+            dry_run=True,
+            branch=None,
+            pr=None,
+            body=None,
+            base=None,
+            title=None,
+            issue="../301",
+            comment_file=comment,
+            triage_plan=triage_plan,
+            draft=True,
+            confirm_review_gate_passed=False,
+            confirm_dependents_reviewed=False,
+            confirm_force_with_lease=False,
+            repo_root=repo,
+        )
+    except ValueError as exc:
+        assert "issue selector" in str(exc)
+    else:
+        raise AssertionError("unsafe issue selector should be rejected")
+
+
 def test_human_gated_exec_requires_confirmation_and_uses_safe_commands(monkeypatch, tmp_path: Path) -> None:
     repo = _write_repo(tmp_path, body_extra=_valid_handoff())
     calls: list[list[str]] = []
@@ -1848,6 +1984,132 @@ def test_human_gated_exec_requires_confirmation_and_uses_safe_commands(monkeypat
     assert "--delete-branch" not in merge_plan.command
     assert "--admin" not in merge_plan.command
     assert any("force-with-lease" in blocker for blocker in force_plan.blockers)
+
+
+def test_issue_scan_and_maintenance_plan_are_conservative(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(
+        tmp_path,
+        task_id="T-2026-0012",
+        title="Merged cleanup",
+        status="done",
+        body_extra="- Issue: [#12](https://github.com/example/repo/issues/12)\n",
+    )
+    issue_json = repo / "reports" / "agent_loop" / "issues.json"
+    issue_json.parent.mkdir(parents=True, exist_ok=True)
+    issue_json.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 12,
+                    "title": "Already merged cleanup",
+                    "url": "https://github.com/example/repo/issues/12",
+                    "labels": [],
+                    "updatedAt": "2026-05-26T00:00:00Z",
+                },
+                {
+                    "number": 34,
+                    "title": "Add backlog cleanup",
+                    "url": "https://github.com/example/repo/issues/34",
+                    "labels": [{"name": "follow-up"}],
+                    "updatedAt": "2026-05-26T00:00:00Z",
+                },
+                {
+                    "number": 56,
+                    "title": "user-action: manual portfolio review",
+                    "url": "https://github.com/example/repo/issues/56",
+                    "labels": [{"name": "follow-up"}],
+                    "updatedAt": "2026-05-26T00:00:00Z",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(agent_loop, "_maintenance_worktree_actions", lambda repo_root: ["dry-run fixture"])
+
+    state_out, triage_out, triage, rendered = agent_loop.write_issue_scan(
+        issue_json=issue_json,
+        repo_root=repo,
+    )
+    plan_out, json_out, plan, plan_text = agent_loop.write_maintenance_plan(
+        issue_json=issue_json,
+        repo_root=repo,
+    )
+
+    classifications = {item.number: item.classification for item in triage}
+    assert classifications == {"12": "close_candidate", "34": "queue_candidate", "56": "manual_review"}
+    assert state_out == repo / "reports" / "agent_loop" / "issue_state.json"
+    assert triage_out == repo / "reports" / "agent_loop" / "issue_triage.md"
+    assert plan_out == repo / "reports" / "agent_loop" / "maintenance_plan.md"
+    assert json_out == repo / "reports" / "agent_loop" / "maintenance_plan.json"
+    assert len(plan.queue_task_briefs) == 1
+    assert "issue-34" in plan.queue_task_briefs[0]
+    assert "human-gated-exec --action issue-close --issue 12" in plan_text
+    assert "dry-run fixture" in plan_text
+    assert "close_candidate" in rendered
+
+
+def test_human_gated_issue_close_requires_triage_and_uses_gh_comment(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    report_dir = repo / "reports" / "agent_loop"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    triage_plan = report_dir / "maintenance_plan.json"
+    triage_plan.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "issues": [
+                    {"number": "12", "classification": "close_candidate"},
+                    {"number": "34", "classification": "manual_review"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    comment = report_dir / "issue-close-12.md"
+    comment.write_text("Closing because merged evidence is in the queue.\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="closed\n", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    blocked = agent_loop.build_human_gated_exec_plan(
+        action="issue-close",
+        confirm_human_approved=True,
+        dry_run=True,
+        branch=None,
+        pr=None,
+        body=None,
+        base=None,
+        title=None,
+        draft=True,
+        confirm_review_gate_passed=False,
+        confirm_dependents_reviewed=False,
+        confirm_force_with_lease=False,
+        repo_root=repo,
+        issue="34",
+        comment_file=comment,
+        triage_plan=triage_plan,
+    )
+    out, executed, rendered = agent_loop.write_human_gated_exec(
+        action="issue-close",
+        confirm_human_approved=True,
+        issue="12",
+        comment_file=comment,
+        triage_plan=triage_plan,
+        repo_root=repo,
+    )
+
+    assert any("manual_review" in blocker for blocker in blocked.blockers)
+    assert out == repo / "reports" / "agent_loop" / "human_gated_exec.md"
+    assert executed.executed
+    assert calls == [["gh", "issue", "close", "12", "--comment", "Closing because merged evidence is in the queue.\n"]]
+    assert "--comment-file" not in executed.command
+    assert executed.command[:4] == ("gh", "issue", "close", "12")
+    assert "--comment" in executed.command
+    assert "closed" not in rendered
 
 
 def test_human_gated_exec_pr_create_checks_body_and_rejects_unsafe_branch(monkeypatch, tmp_path: Path) -> None:
@@ -1945,6 +2207,11 @@ def test_default_agent_loop_outputs_are_gitignored() -> None:
         "reports/agent_loop/rendered_prompt.txt",
         "reports/agent_loop/review_prompt.txt",
         "reports/agent_loop/pr_state.json",
+        "reports/agent_loop/issue_state.json",
+        "reports/agent_loop/issue_triage.md",
+        "reports/agent_loop/issue_queue_tasks/001-example.md",
+        "reports/agent_loop/maintenance_plan.md",
+        "reports/agent_loop/maintenance_plan.json",
         "reports/agent_loop/changed_files.txt",
         "reports/agent_loop/surface.md",
         "reports/agent_loop/validation_suggestions.md",

--- a/tests/test_agent_loop_mcp.py
+++ b/tests/test_agent_loop_mcp.py
@@ -51,6 +51,8 @@ def test_mcp_initialize_and_tool_list_are_read_report_centered() -> None:
     assert "agent_loop_dashboard" in names
     assert "agent_loop_mcp_config" in names
     assert "agent_loop_pr_health" in names
+    assert "agent_loop_issue_scan" in names
+    assert "agent_loop_maintenance_plan" in names
     assert "agent_loop_safe_fix_dry_run" in names
     assert "agent_loop_approval_packet" in names
     assert "agent_loop_pr_body" in names
@@ -84,6 +86,7 @@ def test_mcp_initialize_and_tool_list_are_read_report_centered() -> None:
     assert "agent_loop_validate" not in names
     assert "agent_loop_pr_scan" not in names
     assert "agent_loop_draft_next" not in names
+    assert "agent_loop_issue_close" not in names
     for name in names:
         lowered = name.lower()
         assert "push" not in lowered
@@ -213,6 +216,16 @@ def test_mcp_dashboard_config_and_safe_fix_are_read_centered(tmp_path: Path) -> 
     assert "Simulation only" in ship
     assert "gh pr create" in ship
 
+    issue_json = ROOT / ".agent_loop_tmp" / "mcp_issues.json"
+    issue_json.parent.mkdir(parents=True, exist_ok=True)
+    issue_json.write_text('[{"number": 991, "title": "MCP backlog", "labels": [], "url": "https://example.test/991"}]', encoding="utf-8")
+    issue_scan = _call("agent_loop_issue_scan", {"issue_json": ".agent_loop_tmp/mcp_issues.json"})
+    assert "Issue Triage" in issue_scan
+    assert "queue_candidate" in issue_scan
+    maintenance = _call("agent_loop_maintenance_plan", {"issue_json": ".agent_loop_tmp/mcp_issues.json"})
+    assert "Agent Loop Maintenance Plan" in maintenance
+    assert "Planning artifact only" in maintenance
+
     auto_ship = _call(
         "agent_loop_auto_ship_plan",
         {
@@ -266,8 +279,25 @@ def test_mcp_new_reports_are_read_centered_and_redacted() -> None:
     )
     claim = scratch / "mcp_claim.md"
     claim.write_text("This improves latency. question: PRIVATE RAW QUERY\n", encoding="utf-8")
+    issues = scratch / "mcp_issues.json"
+    issues.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 999999,
+                    "title": "Backlog issue for MCP scan",
+                    "url": "https://github.com/example/repo/issues/999999",
+                    "labels": [{"name": "follow-up"}],
+                    "updatedAt": "2026-05-26T00:00:00Z",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     threads_report = _call("agent_loop_review_threads", {"threads_json": ".agent_loop_tmp/mcp_threads.json"})
+    issue_scan = _call("agent_loop_issue_scan", {"issue_json": ".agent_loop_tmp/mcp_issues.json"})
+    maintenance = _call("agent_loop_maintenance_plan", {"issue_json": ".agent_loop_tmp/mcp_issues.json"})
     approval = _call(
         "agent_loop_approval_packet",
         {"changed_files": ["reports/eval_summary.json"], "claim_text": ".agent_loop_tmp/mcp_claim.md"},
@@ -281,6 +311,10 @@ def test_mcp_new_reports_are_read_centered_and_redacted() -> None:
 
     assert "Privacy Auditor" in threads_report
     assert "SECRET" not in threads_report
+    assert "Issue Triage" in issue_scan
+    assert "queue_candidate" in issue_scan
+    assert "Agent Loop Maintenance Plan" in maintenance
+    assert "Planning artifact only" in maintenance
     assert "performance claim language detected" in approval
     assert "PRIVATE RAW QUERY" not in approval
     assert "Disallowed Or Human-Gated Claims" in policy


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

agent-loop automation에 보수적인 issue cleanup / maintenance planning 표면을 추가했습니다. 열린 issue를 `close_candidate`, `queue_candidate`, `in_flight`, `manual_review`로 분류하고, queue draft 및 worktree cleanup 권고를 local report로만 생성합니다. Issue close는 triage plan의 `close_candidate`와 comment file, human approval이 모두 있을 때만 `human-gated-exec`로 실행됩니다.

Closes #1527

## 2. 영향 파일

- `scripts/agent_loop.py` — `issue-scan`, `maintenance-plan`, `human-gated-exec --action issue-close` 추가.
- `scripts/agent_loop_mcp.py` — issue scan / maintenance plan MCP read-centered tools 추가.
- `Makefile` — agent-loop issue scan / maintenance plan / issue close wrapper 추가.
- `tests/test_agent_loop.py`, `tests/test_agent_loop_mcp.py` — conservative triage, maintenance plan, issue close gate, MCP 호출 검증.

Load-bearing path 변경 없음.

## 3. 리스크

가장 큰 리스크는 automation이 issue를 성급히 닫거나 worktree/branch를 삭제하는 것입니다. 구현은 기본적으로 report만 쓰고, issue close는 `close_candidate` triage evidence + comment file + `--confirm-human-approved`가 있어야 실행되도록 막았습니다. Worktree/branch cleanup은 권고만 출력하고 삭제하지 않습니다.

## 4. 테스트

- `python3 -m py_compile scripts/agent_loop.py scripts/agent_loop_mcp.py tests/test_agent_loop.py tests/test_agent_loop_mcp.py`
- `python3 -m pytest -q tests/test_agent_loop.py tests/test_agent_loop_mcp.py`
- `git diff --check`
- `make check-branch`
- `python3 scripts/check_doc_links.py --check-all`

## 5. Eval 영향

All `N/A`: RAG runtime, ingestion, retrieval, eval scoring, benchmark artifact를 변경하지 않았습니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Load-bearing path 변경 없음. Real-data delta 실행하지 않음; 성능 주장 없음.

## 6. 하위 호환

기존 agent-loop 명령은 유지됩니다. 새 명령과 Make target은 additive입니다. Issue close는 기존 `human-gated-exec`의 remote mutation gate에 새 action으로 추가되며, 기본 동작은 실행하지 않고 blocker/report를 생성합니다.

## 7. 범위 외

- 기존 orphan worktree 후보 6개는 삭제하지 않았습니다. 모두 dirty/untracked 상태라 별도 triage가 필요합니다.
- 실제 issue close 실행은 이 PR에서 수행하지 않습니다.
- Branch delete나 worktree remove 자동화는 추가하지 않았습니다.