### PR TITLE
chore: align agent gate surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | **무엇을 (what)** | RFP 문서용 citation-grounded **extractive** RAG — 외부 LLM 호출 없이 retrieved evidence 에서 claim 추출 + citation 잠금 ([ADR 0003](docs/adr/0003-structured-answer-citation-contract.md)) |
 | **왜 어려운지 (why hard)** | 한국어 공공/B2B RFP 는 길고 noisy 하며, 기관·사업명이 유사해 문서 간 비교·요건 추출이 구조적으로 어렵다 |
 | **무엇을 엔지니어링 (engineered)** | 메타데이터 우선 검색 ([ADR 0002](docs/adr/0002-metadata-first-retrieval.md)) + [comparison-aware balanced top-k](#핵심-기술-기여--comparison-aware-balanced-top-k) + verifier/retry + 근거 불충분 시 보류(abstention) |
-| **어떻게 평가 (evaluated)** | baseline 보존 ablation ([ADR 0001](docs/adr/0001-preserve-naive-baseline.md)) + 공개 fixture smoke / private internal eval 분리 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)) + PR 마다 회귀 게이트 ([pr-eval.yml](.github/workflows/pr-eval.yml)) + 78 ADR |
+| **어떻게 평가 (evaluated)** | baseline 보존 ablation ([ADR 0001](docs/adr/0001-preserve-naive-baseline.md)) + 공개 fixture smoke / private internal eval 분리 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)) + PR 마다 회귀 게이트 ([pr-eval.yml](.github/workflows/pr-eval.yml)) + 79 ADR |
 | **어떻게 실행 (run it)** | `make index && make demo`, 또는 [5분 quickstart](#실행-5분-quickstart) · [Colab](https://colab.research.google.com/github/hskim-solv/BidMate-DocAgent/blob/main/demo/bidmate_quickstart.ipynb) · [Live demo](https://bidmate-docagent-demo.fly.dev/) |
 
 > **Portfolio signal**: 외부 LLM API 를 호출하는 RAG 데모가 아니라, RFP 도메인의 실패 모드를 직접 정의하고 그것을 막는 평가·CI·provenance 게이트를 **소유(system ownership)** 한 사례. 리뷰어용 진입점 → [모듈 맵](docs/architecture/module-map.md) · [실패 모드 케이스 스터디](docs/case-studies/failure-modes.md) · [면접 피치](docs/portfolio-pitch.md).
@@ -25,7 +25,7 @@
 
 <details><summary><b>측정 상세 (over-claim 가드 — 펼치기)</b></summary>
 
-> **측정**: 공개 가능한 작은 fixture는 `make smoke`와 PR CI에서 평가 harness, metrics schema, latency SLO가 깨지지 않는지 확인하는 용도다. 실제 성능 수치는 private/internal eval set aggregate로 관리하며, 비공개 real-eval (100-doc RFP, n=221 hardcase, [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md))은 hardcase 스트레스와 distinguishing-power 분석에 사용한다. Goodhart 폐루프 ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) 첫 측정 발견 → [ADR 0054](docs/adr/0054-conditional-on-answer-scorer-semantics.md) scorer 정정 → CI-aware 판정, [reports/real100/distinguishing_power.md](reports/real100/distinguishing_power.md)). 공개 fixture smoke + private/internal eval 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 78개 설계 결정 (ADR).
+> **측정**: 공개 가능한 작은 fixture는 `make smoke`와 PR CI에서 평가 harness, metrics schema, latency SLO가 깨지지 않는지 확인하는 용도다. 실제 성능 수치는 private/internal eval set aggregate로 관리하며, 비공개 real-eval (100-doc RFP, n=221 hardcase, [ADR 0052](docs/adr/0052-real-eval-hardcase-expansion-to-200.md))은 hardcase 스트레스와 distinguishing-power 분석에 사용한다. Goodhart 폐루프 ([ADR 0053](docs/adr/0053-distinguishing-power-floor-ablations.md) 첫 측정 발견 → [ADR 0054](docs/adr/0054-conditional-on-answer-scorer-semantics.md) scorer 정정 → CI-aware 판정, [reports/real100/distinguishing_power.md](reports/real100/distinguishing_power.md)). 공개 fixture smoke + private/internal eval 분리 평가 ([ADR 0005](docs/adr/0005-eval-split-public-synthetic-private-local.md)), 79개 설계 결정 (ADR).
 
 </details>
 
@@ -185,7 +185,7 @@ python3 scripts/check_latency_slo.py --config eval/config.yaml --summary reports
 | AI-agent 장기 작업 운영 모델 | [`docs/operations/ai-engineering-operating-system.md`](docs/operations/ai-engineering-operating-system.md) |
 | Persistent task queue | [`tasks/queue.md`](tasks/queue.md) |
 | Eval surface / claim boundary | [`docs/evaluation/surface-map.md`](docs/evaluation/surface-map.md) |
-| ADR 인덱스 (78개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |
+| ADR 인덱스 (79개 결정) | [`docs/adr/README.md`](docs/adr/README.md) |
 | 분석 변형 결과 + benchmarking + latency 비교 | [`docs/benchmarking.md`](docs/benchmarking.md) / [`docs/eval/ablation-results.md`](docs/eval/ablation-results.md) |
 | 설계 배경 (한국 RFP 적응 5가지) | [`docs/design-background.md`](docs/design-background.md) |
 | 답변 출력 정책 + Evidence boundary + Baseline policy | [`docs/agentic/answer-policy.md`](docs/agentic/answer-policy.md) |

--- a/docs/evaluation/agent-gated-rfp-eval-loop.md
+++ b/docs/evaluation/agent-gated-rfp-eval-loop.md
@@ -72,9 +72,19 @@ metric suite다.
 | v2 | human/judge agreement가 기준선보다 높고, regression fixture에서 민감하게 반응한다. |
 | operating | 최근 변경 N회에서 false pass가 없고, 새 failure는 follow-up metric 또는 ratchet으로 흡수된다. |
 
+## Next Milestones
+
+| Milestone | Smallest next PR | Evidence required |
+|---|---|---|
+| v0-a metric inventory | 현재 private real-eval aggregate에 이미 있는 metric과 없는 metric을 표로 분류한다. | aggregate-only inventory, no performance claim |
+| v0-b offline/online run manifest | offline/online 실행 환경, provider/model, payload class, egress mode를 같은 schema로 기록한다. | manifest schema + privacy test |
+| v0-c metric suite report | retrieval, grounding, citation, comparison, abstention, numeric/date/condition, judge agreement를 한 report shell에 모은다. | private real-eval aggregate + provenance |
+| v1 failure sensitivity | 세 개 이상의 RFP failure mode에 대해 metric이 실제로 움직이는지 확인한다. | before/after or historical failure replay |
+| v2 agreement calibration | human 또는 approved judge signal과 suite metric의 agreement를 측정한다. | agreement aggregate, no raw private text |
+
 ## Agent Gate
 
-Human gate 대신 Codex는 보수적 agent gate를 집행한다.
+기존 human gate 자리에 Codex는 보수적 agent gate를 집행한다.
 
 - 애매하면 `draft`, `no performance claim`, `follow-up issue`, `fail closed`를 고른다.
 - Private real-eval은 claim-bearing loop의 필수 표면으로 둔다.
@@ -85,6 +95,25 @@ Human gate 대신 Codex는 보수적 agent gate를 집행한다.
   audit trail, dependent check, rollback note를 남긴다.
 - CLI에 남아 있는 `human-gated-*` 이름은 legacy compatibility 이름이다. 의미는
   "explicit conservative gate acknowledgment"로 해석한다.
+
+## Role Dispatch Policy
+
+역할(role) 분리는 `role-dispatch` report로 먼저 산출한다. 이 report는 Codex
+서브에이전트(subagent)를 실제 실행하지 않고, root session이 어떤 역할을 병렬
+또는 직렬로 보낼지 정하는 prompt source다.
+
+- 기본 체인: `Planner -> Implementer -> Reviewer`.
+- Eval/benchmark 표면: `Benchmark Auditor`를 자동 추가한다.
+- Private-data / real-eval 표면: `Privacy Auditor`와 `Benchmark Auditor`를 자동
+  추가한다.
+- Product runtime / ADR 표면: `Deep Reviewer`를 자동 추가한다.
+- 병렬 실행은 read-only 역할 또는 disjoint write scope일 때만 허용한다.
+- 같은 파일을 쓰는 역할은 직렬화한다.
+- 최대 12개 role subagent, depth 2(`root session -> role subagents`)를 넘기지
+  않는다.
+- Private real-eval 해석, benchmark/performance claim, remote mutation 실행은
+  서브에이전트에 위임하지 않는다. 서브에이전트는 evidence와 recommendation만
+  남기고, root session이 최종 agent gate를 집행한다.
 
 ## Related
 

--- a/docs/plans/T-2026-0014-agent-gate-surface-alignment.md
+++ b/docs/plans/T-2026-0014-agent-gate-surface-alignment.md
@@ -1,0 +1,144 @@
+# Plan: T-2026-0014 Agent gate surface alignment
+
+- Status: review
+- Owner role: Maintainer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0014`
+- Related issue / PR: Issue #1531 / PR #1532
+- Related ADR: ADR 0079
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+## Problem Statement
+
+After ADR 0079, several visible agent-loop surfaces still read as if routine
+progress depends on manual human gates. That weakens the intended conservative
+agent-gate operating model and leaves subagent role separation as an informal
+practice rather than a repeatable planning surface.
+
+## Current Behavior
+
+`scripts/agent_loop.py` already has many local, read-only or gated command
+surfaces, but the map, coverage report, command help, and generated briefs mix
+legacy human-gate wording with the new policy. The eval policy has ADR 0079
+semantics but lacks a concrete role-dispatch rule for Codex subagents.
+
+## Desired Behavior
+
+The loop should present conservative agent gates as the default decision model,
+keep legacy command/flag names for compatibility, and expose `role-dispatch` as
+a report-only plan for up to 12 role subagents with depth 2.
+
+## Constraints
+
+- Scope constraints: wording and local report tooling only.
+- Architecture constraints: no replacement of the existing shipping pipeline.
+- Compatibility constraints: keep `human-gated-exec` and `--confirm-human-approved`.
+- Eval/privacy constraints: no private real-eval run and no performance claim.
+- Tooling/CI constraints: focused agent-loop tests plus doc/link/branch checks.
+- Non-goals: no remote mutation behavior change.
+
+## Architecture Impact
+
+- Affected modules or docs: `scripts/agent_loop.py`, `tests/test_agent_loop.py`,
+  `docs/evaluation/agent-gated-rfp-eval-loop.md`, `tasks/queue.md`.
+- Affected contracts or invariants: legacy command and flag names remain stable.
+- Load-bearing paths: none.
+- ADR required: no; this implements ADR 0079 wording and tooling surfaces.
+- Backward compatibility expectation: existing CLI command names continue to work.
+
+## Affected Interfaces
+
+- CLI/API/config: adds `python3 scripts/agent_loop.py role-dispatch`.
+- Input data: optional changed-file list, `--from-git`, PR changed files, owner role.
+- Output artifacts: `reports/agent_loop/role_dispatch.md`.
+- Docs/review surfaces: eval policy and task queue handoff.
+- Tests/eval entrypoints: `tests/test_agent_loop.py`.
+
+## Data / Eval Impact
+
+- Surface: none.
+- Data boundary: no data touched.
+- Allowed claim: governance/tooling surfaces now align with ADR 0079.
+- Disallowed claim: no RFP QA, benchmark, private real-eval, or performance claim.
+- Baseline or control affected: no.
+- Benchmark/eval auditor required: no, but benchmark/privacy auditor roles are
+  included in generated dispatch plans when the changed-file surface requires it.
+
+## Task Breakdown
+
+1. Align visible agent-loop wording with conservative agent gates.
+2. Add `role-dispatch` report generation and CLI wiring.
+3. Document role dispatch policy and update queue handoff evidence.
+4. Add focused tests for map, coverage, and role-dispatch behavior.
+
+## Acceptance Criteria
+
+- [x] Loop map, gate brief, coverage report, and command help use agent-gate wording.
+- [x] `role-dispatch` renders max-12, depth-2 subagent dispatch cards without execution side effects.
+- [x] Eval policy documents role-dispatch rules and non-delegated decisions.
+- [x] Focused validation passes.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+python3 -m py_compile scripts/agent_loop.py
+python3 scripts/agent_loop.py role-dispatch --owner-role "Implementer -> Benchmark Auditor -> Reviewer" --from-git
+python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md tasks/queue.md docs/plans/T-2026-0014-agent-gate-surface-alignment.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: focused pytest return code 0.
+- Generated or updated artifact: `reports/agent_loop/role_dispatch.md`.
+- Reviewer checklist or manual inspection: legacy command names unchanged.
+- Explicitly not validated: private real-eval, because this change makes no metric claim.
+
+## Rollback Strategy
+
+Revert the wording and `role-dispatch` additions in one PR. Do not delete
+existing generated reports; they are local evidence artifacts and ignored by the
+tracked source tree.
+
+## Failure Modes
+
+- Failure mode: text implies remote mutation can happen without explicit command/flag.
+- Detection signal: tests or reviewer finds missing confirmation wording.
+- Stop condition or fallback: keep legacy names and fail closed to draft/no-claim.
+
+## Observability
+
+- `reports/agent_loop/role_dispatch.md`
+- `reports/agent_loop/automation_coverage.md`
+- `python3 -m pytest tests/test_agent_loop.py -q`
+- `python3 scripts/check_doc_links.py --check-all --paths ...`
+
+## Reviewer Notes
+
+Attack compatibility first: command names, confirmation flags, and remote
+mutation semantics must not change. Then check that subagent dispatch remains a
+planning report rather than hidden execution, and that no performance claim is
+introduced.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-27 KST
+
+- Role: Maintainer
+- Branch / worktree: chore/issue-1531-agent-gate-surfaces / /Users/hskim/.codex/worktrees/1c21/BidMate-DocAgent
+- Issue / PR: #1531 / PR #1532
+- Task: T-2026-0014
+- Current status: implementation complete; focused validation passed once.
+- Files touched: scripts/agent_loop.py, tests/test_agent_loop.py, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/plans/T-2026-0014-agent-gate-surface-alignment.md, tasks/queue.md
+- Decisions made: role dispatch is report-only; root session keeps final gate and remote mutation decisions.
+- Commands run: focused pytest, py_compile, role-dispatch, doc links, git diff --check, make check-branch
+- Results: passed
+- Next safe command: git diff --stat
+- Open questions: none
+- Risks: reviewer should confirm legacy wording is clear enough for compatibility.
+```

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -114,6 +114,7 @@ DEFAULT_ARCHITECTURE_DECISION = DEFAULT_REPORT_DIR / "architecture_decision.md"
 DEFAULT_WORKSET_RECOMMENDATION = DEFAULT_REPORT_DIR / "workset_recommendation.md"
 DEFAULT_DEPENDENCY_GRAPH = DEFAULT_REPORT_DIR / "dependency_graph.md"
 DEFAULT_AUTOMATION_COVERAGE = DEFAULT_REPORT_DIR / "automation_coverage.md"
+DEFAULT_ROLE_DISPATCH = DEFAULT_REPORT_DIR / "role_dispatch.md"
 DEFAULT_HUMAN_GATED_EXEC = DEFAULT_REPORT_DIR / "human_gated_exec.md"
 DEFAULT_AUTO_SHIP_PLAN = DEFAULT_REPORT_DIR / "auto_ship_plan.md"
 DEFAULT_AUTO_SHIP_PREPARE = DEFAULT_REPORT_DIR / "auto_ship_prepare.md"
@@ -636,8 +637,8 @@ BidMate operating mode:
 - Stay within the existing task queue, plan doc, review checklist, and eval surface map.
 - Do not create a new governance system or replace the operating model.
 - Do not auto-merge, auto-push, auto-close PRs, delete branches, or force-push.
-- Human approval is required for merge/close/push/delete/force-push, benchmark claims,
-  private real-eval decisions, and architecture tradeoff decisions.
+- Conservative agent gate evidence is required for merge/close/push/delete/force-push,
+  benchmark claims, private real-eval decisions, and architecture tradeoff decisions.
 
 Session-time-maxing loop:
 1. Inspect the existing repo workflow and relevant scripts.
@@ -646,7 +647,7 @@ Session-time-maxing loop:
 4. Add focused tests.
 5. Run focused validation and fix in-scope failures.
 6. Stop only when the scoped MVP is implemented and validated, or when blocked by
-   missing repo evidence or human approval.
+   missing repo evidence or an unresolved conservative agent gate.
 
 Required reads:
 {required_reads}
@@ -1714,7 +1715,7 @@ def _lane_for_brief(brief: dict[str, str]) -> tuple[str, str]:
         "architecture tradeoff",
     )
     if classification in {"needs_private_delta", "close_superseded"} or any(term in haystack for term in manual_terms):
-        return "manual-gated", "requires human approval or private/PR decision"
+        return "manual-gated", "requires conservative agent-gate evidence or private/PR decision"
     if classification in {"blocked", "failed_experiment"}:
         return "serial", "resolve before dependent implementation or claims"
     if classification == "ready_for_review" or "review " in haystack:
@@ -1728,14 +1729,14 @@ def render_batch_plan(briefs: Sequence[BriefSummary], *, tasks_dir: Path, repo_r
         "serial": "Set A - Serial Blockers",
         "parallel-safe": "Set B - Parallel Safe Candidates",
         "review-only": "Set C - Review-Only Passes",
-        "manual-gated": "Set D - Manual Gates",
+        "manual-gated": "Set D - Agent Gates",
     }
     lines = [
         "# Agent Loop Batch Plan",
         "",
         f"- Source briefs: `{_display_path(_repo_path(tasks_dir, repo_root), repo_root=repo_root)}`",
         "- This is a local planning artifact. It does not edit `tasks/queue.md`, plans, branches, PRs, or GitHub state.",
-        "- Execute at most one serial lane item at a time; parallel-safe items can be assigned independently after human scope review.",
+        "- Execute at most one serial lane item at a time; parallel-safe items can be assigned independently after conservative agent-gate scope review.",
         "",
         "## Lane Summary",
         "",
@@ -1773,10 +1774,10 @@ def render_batch_plan(briefs: Sequence[BriefSummary], *, tasks_dir: Path, repo_r
             )
     lines.extend(
         [
-            "## Human Stop Points",
+            "## Agent Gate Stop Points",
             "",
             "- Applying any draft to `tasks/queue.md` or `docs/plans/*.md`.",
-            "- Any push, PR create/merge/close, branch delete, or force-push.",
+            "- Any push, PR create/merge/close, branch delete, or force-push without explicit confirmation command/flag.",
             "- Benchmark/performance/private real-eval claims.",
             "- Architecture tradeoff decisions.",
             "",
@@ -1940,7 +1941,7 @@ def render_review_followup_task(
 
 ## Goal
 
-Address the reviewer finding with the smallest scoped change, or document why human approval is required.
+Address the reviewer finding with the smallest scoped change, or document why conservative agent-gate evidence is still missing.
 
 ## Finding
 
@@ -1949,7 +1950,7 @@ Address the reviewer finding with the smallest scoped change, or document why hu
 ## Constraints
 
 - Do not auto-merge, auto-push, create/close/merge PRs, delete branches, or force-push.
-- Do not make benchmark, performance, private real-eval, or architecture tradeoff claims without human approval.
+- Do not make benchmark, performance, private real-eval, or architecture tradeoff claims without ADR 0079 agent-gate evidence.
 - Do not expose raw private question, answer, evidence, doc_id, chunk_id, filenames, or exact local paths.
 
 ## Expected Evidence
@@ -2062,7 +2063,7 @@ def render_promote_draft(
 - Result: dry-run only; no tracked files were modified.
 - Queue target: `{target_queue}`
 - Plan target: `{target_plan}`
-- Manual approval required before applying these changes.
+- Conservative gate acknowledgment required before applying these changes.
 
 ## Queue Diff
 
@@ -3310,7 +3311,7 @@ def render_approval_packet(
     lines.extend(
         [
             "",
-            "## Human Approval Required Before",
+            "## Conservative Agent Gate Required Before",
             "",
             "- Applying queue/plan drafts to tracked docs.",
             "- Running push, PR create/merge/close, branch delete, or force-push.",
@@ -3383,7 +3384,7 @@ def render_queue_plan_patch(
     return _sanitize_dynamic_text(
         "\n".join(
             [
-                "# Agent-loop queue/plan patch proposal. Dry-run only; do not apply without human approval.",
+                "# Agent-loop queue/plan patch proposal. Dry-run only; do not apply without conservative gate acknowledgment.",
                 queue_diff,
                 plan_diff,
                 "",
@@ -3434,7 +3435,7 @@ def render_pr_body(
     file_block = "\n".join(f"- `{_display_path(path)}`" for path in files) if files else "- N/A"
     validation_block = "\n".join(f"- Suggested, not yet run: `{_sanitize_command_text(command)}`" for command in validation)
     five_b = (
-        "Load-bearing or eval surface touched. Human reviewer must verify aggregate-only §5b evidence or a truthful no-behavior-change attestation before PR is marked ready."
+        "Load-bearing or eval surface touched. Conservative reviewer evidence must verify aggregate-only §5b evidence or a truthful no-behavior-change attestation before PR is marked ready."
         if load_bearing
         else "N/A - no load-bearing path detected by changed-file surface; reviewer should still confirm."
     )
@@ -3454,7 +3455,7 @@ Closes #{issue_number or '<ISSUE_NUMBER>'}
 
 ## 3. 리스크
 
-- Human-gated decisions remain outside this CLI: push, PR create/merge/close, branch delete, force-push, private real-eval decisions, benchmark/performance claims, and architecture tradeoffs.
+- Conservative-agent-gated decisions remain outside this CLI: push, PR create/merge/close, branch delete, force-push, private real-eval decisions, benchmark/performance claims, and architecture tradeoffs.
 - Disallowed claims to avoid:
 {chr(10).join(f'  - {claim}' for claim in surface.disallowed_claims)}
 
@@ -3562,7 +3563,7 @@ def render_review_plan(findings: Sequence[ReviewFinding], *, sources: Sequence[s
         "# Review Plan",
         "",
         "- This is a triage artifact. It does not auto-fix, push, create/merge/close PRs, delete branches, or force-push.",
-        "- Privacy, benchmark, and architecture findings stay human-gated.",
+        "- Privacy, benchmark, and architecture findings stay conservative-agent-gated.",
         "",
         "## Sources",
         "",
@@ -4077,9 +4078,9 @@ def build_auto_ship_plan(
     else:
         decision = "arm-ready-auto-ship"
     human_gates = (
-        "Running `make ship-arm` is a shipping approval: the existing Stop hook may commit, push, create a PR, wait for CI/review, merge, and delete the remote branch when its gates pass.",
-        "Ready auto-merge remains a human shipping decision; use `DRAFT=true` when review or claim risk remains.",
-        "Private real-eval mode and benchmark/performance claim wording require human approval before using `REAL_EVAL=auto` or `REAL_EVAL=async` as evidence.",
+        "Running `make ship-arm` is a conservative shipping gate: the existing Stop hook may commit, push, create a PR, wait for CI/review, merge, and delete the remote branch when its gates pass.",
+        "Ready auto-merge remains an agent-gated shipping decision; use `DRAFT=true` when review or claim risk remains.",
+        "Private real-eval mode and benchmark/performance claim wording require ADR 0079 evidence before using `REAL_EVAL=auto` or `REAL_EVAL=async` as evidence.",
         "Architecture tradeoffs and ADR decisions are not decided by this plan.",
     )
     return AutoShipPlan(
@@ -4164,7 +4165,7 @@ def render_auto_ship_plan(
     if plan.surface.disallowed_claims:
         lines.extend(["", "## Disallowed Claims", ""])
         lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.surface.disallowed_claims)
-    lines.extend(["", "## Human Gates", ""])
+    lines.extend(["", "## Agent Gates", ""])
     lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in plan.human_gates)
     lines.extend(["", "## Changed Files", ""])
     normalized_paths: set[str] = set()
@@ -4471,7 +4472,8 @@ def render_gate_brief(
     rendered = render_decision_brief(points, repo_root=repo_root)
     return (
         f"# Gate Brief: {gate}\n\n"
-        "- Human gates are decision points, not automation failures.\n"
+        "- Conservative agent gates are policy decisions, not automation failures.\n"
+        "- ADR 0079 delegates routine gate decisions to Codex with draft/no-claim/follow-up/fail-closed defaults.\n"
         "- This command explains options and does not execute the gated action.\n\n"
         + rendered.split("\n", 1)[1]
     )
@@ -4834,7 +4836,7 @@ def render_ci_followup_task(finding: CIFinding, *, index: int) -> str:
 
 ## Goal
 
-Resolve the CI signal with the smallest local change, or document why human approval is required.
+Resolve the CI signal with the smallest local change, or document why conservative agent-gate evidence is still missing.
 
 ## Expected Evidence
 
@@ -4918,9 +4920,9 @@ def render_stacked_risk(*, branch: str, items: Sequence[dict[str, object]]) -> s
     lines.extend(
         [
             "",
-            "## Human Gate",
+            "## Agent Gate",
             "",
-            "- Branch deletion, PR merge, PR close, and force-push still require explicit human approval.",
+            "- Branch deletion, PR merge, PR close, and force-push still require conservative agent-gate evidence.",
             "- If dependents exist, do not delete the branch until child PRs are rebased or intentionally retained.",
             "",
         ]
@@ -5410,9 +5412,9 @@ def render_adr_reservation(*, number: int, title: str, draft_path: Path) -> str:
 - Suggested ADR number: `{number:04d}`
 - Suggested final path: `{final_path}`
 - Draft artifact: `{_display_path(draft_path.as_posix())}`
-- This command does not create or modify `docs/adr/`; human approval is required before reserving or committing an ADR.
+- This command does not create or modify `docs/adr/`; ADR 0079 agent-gate evidence is required before reserving or committing an ADR.
 
-## Human Checks
+## Agent Gate Checks
 
 - Confirm no open PR already reserves ADR `{number:04d}`.
 - Confirm this is a load-bearing decision, new measurement surface, or durable architecture tradeoff.
@@ -5520,7 +5522,7 @@ def render_ship_command_pack(*, pr: str | None, branch: str | None, repo_root: P
     lines = [
         "# Ship Command Pack",
         "",
-        "- Command suggestions only. Choose one shipping path after explicit approval.",
+        "- Command suggestions only. Choose one shipping path after the conservative agent gate passes.",
         "- This command did not push, create/merge/close PRs, delete branches, or force-push.",
         "",
         "## Safe Local Checks",
@@ -5538,22 +5540,22 @@ def render_ship_command_pack(*, pr: str | None, branch: str | None, repo_root: P
         "",
         "```bash",
         "# plan only: python3 scripts/agent_loop.py auto-ship-plan --from-git --draft --dry-run",
-        "# after approval, arm the single end-to-end Stop-hook pipeline:",
+        "# after the conservative agent gate passes, arm the single end-to-end Stop-hook pipeline:",
         "# make ship-arm REAL_EVAL=skip DRAFT=true DRY_RUN=1",
         "```",
         "",
         "## Manual Fallback Commands",
         "",
-        "Use these action-by-action commands only when the end-to-end `make ship-arm` path is not appropriate.",
+        "Use these action-by-action commands only when the end-to-end `make ship-arm` path is not appropriate. The command name is legacy; ADR 0079 treats it as conservative agent-gate acknowledgment, but the explicit confirmation flag is still required.",
         "",
         "```bash",
-        f"# create PR after approval: python3 scripts/agent_loop.py human-gated-exec --action pr-create --branch {shell_branch} --body reports/agent_loop/pr_body.md --confirm-human-approved",
+        f"# create PR after agent gate: python3 scripts/agent_loop.py human-gated-exec --action pr-create --branch {shell_branch} --body reports/agent_loop/pr_body.md --confirm-human-approved",
         f"# review gate before merge/close/delete: make ship-review-gate PR={safe_pr}",
-        f"# push after approval: python3 scripts/agent_loop.py human-gated-exec --action push --branch {shell_branch} --confirm-human-approved",
-        f"# merge after approval: python3 scripts/agent_loop.py human-gated-exec --action pr-merge --pr {safe_pr} --confirm-review-gate-passed --confirm-human-approved",
-        f"# close after approval: python3 scripts/agent_loop.py human-gated-exec --action pr-close --pr {safe_pr} --confirm-review-gate-passed --confirm-human-approved",
-        f"# delete remote branch after dependent check and approval: python3 scripts/agent_loop.py human-gated-exec --action branch-delete --branch {shell_branch} --confirm-dependents-reviewed --confirm-human-approved",
-        f"# force-with-lease after explicit approval: python3 scripts/agent_loop.py human-gated-exec --action force-push --branch {shell_branch} --confirm-force-with-lease --confirm-human-approved",
+        f"# push after agent gate: python3 scripts/agent_loop.py human-gated-exec --action push --branch {shell_branch} --confirm-human-approved",
+        f"# merge after agent gate: python3 scripts/agent_loop.py human-gated-exec --action pr-merge --pr {safe_pr} --confirm-review-gate-passed --confirm-human-approved",
+        f"# close after agent gate: python3 scripts/agent_loop.py human-gated-exec --action pr-close --pr {safe_pr} --confirm-review-gate-passed --confirm-human-approved",
+        f"# delete remote branch after dependent check and agent gate: python3 scripts/agent_loop.py human-gated-exec --action branch-delete --branch {shell_branch} --confirm-dependents-reviewed --confirm-human-approved",
+        f"# force-with-lease after explicit agent gate: python3 scripts/agent_loop.py human-gated-exec --action force-push --branch {shell_branch} --confirm-force-with-lease --confirm-human-approved",
         "```",
         "",
         "## Required Before Destructive Actions",
@@ -5755,9 +5757,9 @@ def _validate_branch_name(branch: str | None, *, allow_protected: bool = False) 
 
 def render_human_gated_exec(plan: HumanGatedExecPlan) -> str:
     lines = [
-        "# Human-Gated Execution",
+        "# Conservative Remote Execution",
         "",
-        "- This command exists only for explicit human-approved execution of already gated operations.",
+        "- `human-gated-exec` is a legacy command name for explicit conservative agent-gate execution of already gated operations.",
         "- It never bypasses review, claim, private real-eval, architecture, or dependency decisions.",
         f"- Action: `{plan.action}`",
         f"- Mode: `{'dry-run' if plan.dry_run else 'execute'}`",
@@ -6402,7 +6404,7 @@ def render_schedule_config() -> str:
     return """# Agent Loop Scheduled Status Recipe
 
 - Recipe only. This command does not install cron jobs, create Codex app automations, push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.
-- Keep scheduled jobs read-only/report-only unless a human explicitly changes the policy.
+- Keep scheduled jobs read-only/report-only unless the conservative agent gate explicitly changes the policy.
 
 ## Safe Refresh Commands
 
@@ -6413,7 +6415,7 @@ python3 scripts/agent_loop.py stale-reports --from-git --out reports/agent_loop/
 python3 scripts/agent_loop.py privacy-audit-output --path reports/agent_loop --out reports/agent_loop/privacy_audit.md
 ```
 
-## Human Gate
+## Agent Gate
 
 - Ask before installing a recurring runner.
 - Do not schedule `validate` with private real-eval inputs.
@@ -6585,11 +6587,14 @@ def render_claim_policy(*, surface: SurfaceReport, findings: Sequence[ClaimFindi
         f"- Required reviewer: `{surface.reviewer_type}`",
         f"- Source: `{_sanitize_dynamic_text(source)}`",
         "",
-        "## Allowed Without Extra Human Claim Approval",
+        "## Allowed Without Extra Agent-Gate Claim Approval",
         "",
         "- Local orchestration, docs, or CI-helper wording that does not claim product quality, benchmark lift, private real-eval success, latency improvement, or production behavior.",
         "",
         "## Disallowed Or Human-Gated Claims",
+        "",
+        "- Legacy heading retained for MCP/report consumers; ADR 0079 interprets these as agent-gated claims.",
+        "- Current label: Disallowed Or Agent-Gated Claims.",
         "",
     ]
     lines.extend(f"- {claim}" for claim in surface.disallowed_claims)
@@ -6697,7 +6702,7 @@ def render_workset_recommendation(*, batch: Path | None, tasks_dir: Path, max_it
     lines.extend(_render_workset_section("Set A - serial unblocker", serial, "Run one item first; it likely gates downstream work."))
     lines.extend(_render_workset_section("Set B - parallel candidates", parallel, "Can be delegated after checking file overlap and claim surface."))
     lines.extend(_render_workset_section("Set C - review-only passes", review, "Use adversarial review without implementation mutation."))
-    lines.extend(_render_workset_section("Set D - manual-gated", manual, "Prepare decision briefs; do not automate the gated action."))
+    lines.extend(_render_workset_section("Set D - agent-gated", manual, "Prepare decision briefs; do not automate the gated action."))
     lines.extend(["", "## Next Safe Command", "", "```bash", "python3 scripts/agent_loop.py decision-brief --gate task", "```", ""])
     return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
 
@@ -6751,9 +6756,9 @@ def render_dependency_graph(*, branch: str, items: Sequence[dict[str, object]]) 
         [
             "```",
             "",
-            "## Human Gate",
+            "## Agent Gate",
             "",
-            "- If dependents exist, branch deletion and merge cleanup require explicit human approval.",
+            "- If dependents exist, branch deletion and merge cleanup require conservative agent-gate evidence.",
             "",
         ]
     )
@@ -6793,9 +6798,10 @@ def render_automation_coverage() -> str:
         ("16", "architecture decision detector", "architecture-decision, architecture-brief, adr-reserve"),
         ("17", "next work-set recommender", "workset-recommend, batch-plan"),
         ("18", "auto-pass strict profiles", "auto-pass-check --profile ..."),
-        ("19", "human-approved remote execution", "human-gated-exec --confirm-human-approved"),
+        ("19", "conservative remote execution", "human-gated-exec --confirm-human-approved"),
         ("20", "existing auto-ship bridge", "auto-ship-prepare, auto-ship-plan, ship-simulate, ship-command-pack"),
         ("21", "conservative issue cleanup", "issue-scan, maintenance-plan, human-gated-exec --action issue-close"),
+        ("22", "role-separated subagent dispatch", "role-dispatch"),
     )
     lines = [
         "# Agent Loop Automation Coverage",
@@ -6809,16 +6815,176 @@ def render_automation_coverage() -> str:
     lines.extend(
         [
             "",
-            "## Still Human-Gated",
+            "## Still Agent-Gated",
             "",
             "- Queue/plan actual tracked-doc application unless `--confirm-human-approved` is explicit.",
-            "- Running existing `make ship-arm` remains a shipping approval; `auto-ship-plan` only prepares a plan.",
+            "- Running existing `make ship-arm` remains a conservative shipping gate; `auto-ship-plan` only prepares a plan.",
             "- Push, PR create/merge/close, issue close, branch delete, force-push require `human-gated-exec --confirm-human-approved` plus action-specific gates.",
-            "- Private real-eval decisions, benchmark/performance claims, architecture tradeoffs.",
+            "- Private real-eval decisions, benchmark/performance claims, and architecture tradeoffs follow ADR 0079 defaults.",
+            "- Role dispatch is report-only; it does not execute subagents or remote mutations.",
             "",
         ]
     )
     return "\n".join(lines)
+
+
+def write_role_dispatch(
+    *,
+    changed_files: Sequence[str] = (),
+    owner_role: str | None = None,
+    out: Path = DEFAULT_ROLE_DISPATCH,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    rendered = render_role_dispatch(changed_files=changed_files, owner_role=owner_role, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_ROLE_DISPATCH, "role_dispatch.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def _role_dispatch_chain(owner_role: str | None, surface: SurfaceReport) -> list[str]:
+    raw_roles = re.split(r"\s*(?:->|\+|,)\s*", owner_role or "Planner -> Implementer -> Reviewer")
+    roles = [_sanitize_inline_text(role).strip() for role in raw_roles if role.strip()]
+    if not roles:
+        roles = ["Planner", "Implementer", "Reviewer"]
+
+    reviewer_roles: list[str] = []
+    if "Benchmark Auditor" in surface.reviewer_type:
+        reviewer_roles.append("Benchmark Auditor")
+    if "Privacy Auditor" in surface.reviewer_type:
+        reviewer_roles.append("Privacy Auditor")
+    if surface.reviewer_type == "Deep Reviewer":
+        reviewer_roles.append("Deep Reviewer")
+    if surface.surface == "ci-validation":
+        reviewer_roles.append("CI Reviewer")
+    if surface.surface == "docs-only":
+        reviewer_roles.append("Documentation Reviewer")
+
+    insertion_index = max(len(roles) - 1, 0)
+    for role in reviewer_roles:
+        if role not in roles:
+            roles.insert(insertion_index, role)
+            insertion_index += 1
+    if "Reviewer" not in roles and "Deep Reviewer" not in roles:
+        roles.append("Reviewer")
+
+    deduped: list[str] = []
+    for role in roles:
+        if role not in deduped:
+            deduped.append(role)
+    return deduped[:12]
+
+
+def _role_dispatch_card(role: str, *, changed_files: Sequence[str], surface: SurfaceReport) -> tuple[str, str, str, str]:
+    files = ", ".join(changed_files) if changed_files else "current changed-file set"
+    if role in {"Explorer", "Reviewer", "Benchmark Auditor", "Deep Reviewer", "Privacy Auditor", "CI Reviewer", "Documentation Reviewer"}:
+        write_scope = "read-only/report-only"
+        parallel_rule = "parallel allowed with other read-only roles"
+    else:
+        write_scope = "assigned files only; avoid same-file overlap"
+        parallel_rule = "parallel only when file ownership is disjoint"
+
+    if role == "Benchmark Auditor":
+        responsibility = f"Audit eval/benchmark validity for `{surface.surface}`."
+        guardrail = "No metric or performance claim without private real-eval aggregate and provenance."
+    elif role == "Privacy Auditor":
+        responsibility = "Check payload class, private raw-value leakage, and egress assumptions."
+        guardrail = "Report aggregate-only evidence; do not include private RFP text."
+    elif role == "Deep Reviewer":
+        responsibility = "Review load-bearing architecture, ADR consistency, and regression risk."
+        guardrail = "Block hidden contract changes or unratified architecture shifts."
+    elif role == "CI Reviewer":
+        responsibility = "Summarize CI failures and map them to focused local validation."
+        guardrail = "Do not re-run or mutate CI from the dispatch report."
+    elif role == "Documentation Reviewer":
+        responsibility = "Check doc links, terminology consistency, and governance wording."
+        guardrail = "Keep compatibility names explicit when legacy commands remain."
+    elif role == "Reviewer":
+        responsibility = "Review final diff, tests, and handoff evidence."
+        guardrail = "Findings should cite files and lines; advisory comments stay advisory unless evidence-backed."
+    elif role == "Planner":
+        responsibility = f"Split `{files}` into serial, parallel, review, and gate lanes."
+        guardrail = "No implementation until scope, rollback, and validation evidence are named."
+    elif role in {"Implementer", "Worker"}:
+        responsibility = f"Implement the assigned slice for `{files}`."
+        guardrail = "Keep edits surgical and add behavior tests for behavior changes."
+    elif role == "Maintainer":
+        responsibility = "Own integration, compatibility, validation, and shipping evidence."
+        guardrail = "Remote mutation still requires action-specific gate checks and explicit confirmation."
+    else:
+        responsibility = f"Handle the `{role}` slice for `{files}`."
+        guardrail = "Stay within assigned scope and emit evidence before requesting integration."
+    return responsibility, write_scope, guardrail, parallel_rule
+
+
+def render_role_dispatch(
+    *,
+    changed_files: Sequence[str] = (),
+    owner_role: str | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> str:
+    normalized_files = tuple(_normalize_changed_file(path, repo_root=repo_root) for path in changed_files)
+    normalized_files = tuple(path for path in normalized_files if path)
+    surface = classify_changed_files(normalized_files)
+    roles = _role_dispatch_chain(owner_role, surface)
+    owner = _sanitize_inline_text(owner_role or "Planner -> Implementer -> Reviewer")
+
+    lines = [
+        "# Role Dispatch Plan",
+        "",
+        "- Report-only dispatch plan. It does not spawn subagents, edit files, push, merge, close issues/PRs, or call external services.",
+        "- Supports up to 12 role subagents with depth 2 maximum: root session -> role subagents only.",
+        "- Root session keeps integration, validation, commit, PR, merge, remote mutation, and conservative agent-gate decisions.",
+        "",
+        "## Inputs",
+        "",
+        f"- Owner role: `{owner}`",
+        f"- Surface: `{surface.surface}`",
+        f"- Surface confidence: `{surface.confidence}`",
+        f"- Reviewer type: `{surface.reviewer_type}`",
+    ]
+    if normalized_files:
+        lines.append("- Changed files:")
+        lines.extend(f"  - `{_sanitize_inline_text(path)}`" for path in normalized_files)
+    else:
+        lines.append("- Changed files: `none supplied`")
+
+    lines.extend(
+        [
+            "",
+            "## Dispatch Cards",
+            "",
+            "| Role | Responsibility | Write scope | Validation / guardrail | Parallel rule |",
+            "|---|---|---|---|---|",
+        ]
+    )
+    for role in roles:
+        responsibility, write_scope, guardrail, parallel_rule = _role_dispatch_card(
+            role, changed_files=normalized_files, surface=surface
+        )
+        lines.append(
+            "| "
+            + " | ".join(
+                _sanitize_dynamic_text(item).replace("\n", " ")
+                for item in (role, responsibility, write_scope, guardrail, parallel_rule)
+            )
+            + " |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Dispatch Policy",
+            "",
+            "- Run read-only roles in parallel when useful; serialize any role that writes the same file.",
+            "- Prefer sidecar reports from reviewers/auditors; the root session applies or rejects findings.",
+            "- Do not delegate private real-eval interpretation, benchmark/performance claims, or remote mutation execution.",
+            "- Use the plan as the prompt source for Codex subagents; actual subagent execution remains outside this report.",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
 
 
 def write_loop_state(
@@ -7064,7 +7230,7 @@ def _task_decision_point(task: TaskEntry, *, repo_root: Path) -> DecisionPoint:
                 ),
                 evidence_needed=("Multiple surfaces, missing validation, or unclear owner role.",),
                 next_safe_command="python3 scripts/agent_loop.py map",
-                manual_approval="Human scope judgment required.",
+                manual_approval="Conservative agent scope judgment required.",
             ),
         ),
     )
@@ -7112,20 +7278,20 @@ def _batch_decision_point(batch_path: Path, *, repo_root: Path) -> DecisionPoint
                     "Improves throughput when candidates touch independent surfaces.",
                     "Raises coordination cost and can create merge conflicts if independence is misclassified.",
                 ),
-                evidence_needed=("No shared files, shared PR source, or manual-gated claim surface.",),
+                evidence_needed=("No shared files, shared PR source, or agent-gated claim surface.",),
                 next_safe_command="python3 scripts/agent_loop.py batch-plan",
-                manual_approval="Human should confirm independence before parallel execution.",
+                manual_approval="Conservative agent gate should confirm independence before parallel execution.",
             ),
             DecisionOption(
-                label="Hold manual-gated items",
+                label="Hold agent-gated items",
                 recommended=manual_count > 0,
                 severity="high" if manual_count else "low",
                 reversibility="high",
                 tradeoffs=(
                     "Prevents accidental benchmark/private/PR state claims or destructive actions.",
-                    "May leave shipping or cleanup work waiting on a human decision.",
+                    "May leave shipping or cleanup work waiting on stronger evidence.",
                 ),
-                evidence_needed=("Reviewer-readable evidence and explicit human approval.",),
+                evidence_needed=("Reviewer-readable evidence and conservative agent-gate acknowledgment.",),
                 next_safe_command="python3 scripts/agent_loop.py decision-brief --gate claim --from-git",
                 manual_approval="Required for private eval, benchmark claims, push/PR/merge/close/delete.",
             ),
@@ -7152,7 +7318,7 @@ def _review_followup_decision_point(path: Path, *, repo_root: Path) -> DecisionP
         f"Review followups: `{_display_path(_repo_path(path, repo_root), repo_root=repo_root)}`",
         f"Parsed follow-up count: `{parsed}`",
         f"Blocking/P0/P1 findings: `{blocking}`",
-        f"Manual-gated findings: `{manual}`",
+        f"Agent-gated findings: `{manual}`",
     )
     return DecisionPoint(
         gate="review-findings",
@@ -7196,7 +7362,7 @@ def _review_followup_decision_point(path: Path, *, repo_root: Path) -> DecisionP
                 ),
                 evidence_needed=("File/line evidence, contract citation, or test output supporting the decision.",),
                 next_safe_command="python3 scripts/agent_loop.py render-prompt --task <TASK_ID>",
-                manual_approval="Human reviewer should approve rejected findings.",
+                manual_approval="Conservative reviewer evidence required before rejecting findings.",
             ),
         ),
     )
@@ -7259,7 +7425,7 @@ def _claim_decision_point(changed_files: Sequence[str], *, repo_root: Path) -> D
                 ),
                 evidence_needed=(
                     "Aggregate-only private delta, no raw question/answer/evidence/doc_id/chunk_id/filename/local path.",
-                    "Human approval of claim wording.",
+                    "ADR 0079 agent-gate evidence for claim wording.",
                 ),
                 next_safe_command="python3 scripts/_governance.py --check-eval-privacy",
                 manual_approval="Required for private real-eval decisions and claims.",
@@ -7316,7 +7482,7 @@ def _ship_decision_point(*, pr: str | None, changed_files: Sequence[str]) -> Dec
                     "Can finish or clean up work quickly.",
                     "Most irreversible path; stacked PRs, unresolved review, or branch deletion can lose coordination state.",
                 ),
-                evidence_needed=("CI state, unresolved review status, stacked dependent check, explicit human approval.",),
+                evidence_needed=("CI state, unresolved review status, stacked dependent check, conservative agent-gate acknowledgment.",),
                 next_safe_command="make ship-review-gate PR=<N>",
                 manual_approval="Required for merge, close, delete, and force-push decisions.",
             ),
@@ -7377,7 +7543,7 @@ def render_decision_brief(points: Sequence[DecisionPoint], *, repo_root: Path = 
                     "",
                     f"- Severity: `{option.severity}`",
                     f"- Reversibility: `{option.reversibility}`",
-                    f"- Manual approval: {option.manual_approval}",
+                    f"- Gate acknowledgment: {option.manual_approval}",
                     "- Trade-offs:",
                 ]
             )
@@ -7407,12 +7573,12 @@ flowchart TD
   A --> MCP["agent-loop-mcp: expose safe local loop tools to MCP clients"]
   MCP --> D
   B --> C["next-from-prs: generate next-action report and task briefs"]
-  C --> D["batch-plan: group serial, parallel, review, and manual-gated lanes"]
+  C --> D["batch-plan: group serial, parallel, review, and agent-gated lanes"]
   D --> E["decision-brief: explain options, trade-offs, severity, and safe commands"]
   E --> F["draft-task: generate queue and plan drafts"]
   F --> G["promote-draft: dry-run queue/plan diff only"]
-  G --> H{"Human gate: accept task scope and plan?"}
-  H -->|approved| I["render-prompt: copy-paste Codex session prompt"]
+  G --> H{"Agent gate: accept task scope and plan?"}
+  H -->|policy accepted| I["render-prompt: copy-paste Codex session prompt"]
   I --> J["Codex implementation session"]
   J --> K["suggest-validation or validate: focused safe local checks"]
   K --> VH["validation-history: local JSONL evidence ledger"]
@@ -7440,13 +7606,15 @@ flowchart TD
   ASP --> STACK["dependency-graph and stacked-risk before merge/delete cleanup"]
   RP --> PATCH["review-patch-plan and patch-proposal: dry-run safe patch"]
   ARCH --> ADR["adr-reserve: draft-only ADR reservation"]
-  C --> WORKSET["workset-recommend: serial/parallel/review/manual sets"]
+  C --> WORKSET["workset-recommend: serial/parallel/review/agent-gated sets"]
+  WORKSET --> ROLE["role-dispatch: role-separated subagent dispatch plan (max 12, depth 2)"]
   A --> INT["integration-pack and scheduled-status recipes"]
   INT --> MCP
   ISS --> F
-  Q --> R{"Human gate: review, claims, merge, close issue/PR, push, delete?"}
-  R -->|end-to-end approved| SHIP["make ship-arm: approved single end-to-end ship pipeline"]
-  R -->|manual fallback approved| EXEC["human-gated-exec: action-by-action remote mutation fallback"]
+  ROLE --> F
+  Q --> R{"Agent gate: review, claims, merge, close issue/PR, push, delete?"}
+  R -->|policy passes| SHIP["make ship-arm: conservative single end-to-end ship pipeline"]
+  R -->|fallback policy passes| EXEC["human-gated-exec: legacy-named conservative remote mutation fallback"]
   SHIP --> S["Existing ship workflow"]
   EXEC --> S["Manual fallback workflow"]
   R -->|more work| A
@@ -7458,13 +7626,13 @@ Automation points:
 - maintenance-plan: generate issue cleanup, queue migration, worktree cleanup, and branch deletion gate recommendations without executing them.
 - next-from-prs: deterministic wrapper around `scripts/ai_next_actions.py`.
 - pr-health: group exported PR state into CI, review, stale, draft, blocked, and ready lanes.
-- batch-plan: group local task briefs into serial, parallel-safe, review-only, and manual-gated lanes.
-- decision-brief: explain human-gate options, trade-offs, severity, reversibility, evidence, and next safe commands.
+- batch-plan: group local task briefs into serial, parallel-safe, review-only, and agent-gated lanes.
+- decision-brief: explain agent-gate options, trade-offs, severity, reversibility, evidence, and next safe commands.
 - draft-task: local queue/plan drafts under `reports/agent_loop/`.
 - promote-draft: local dry-run diff for queue/plan promotion; no tracked files are changed.
 - propose-queue-plan: dry-run queue/plan patch proposal; no tracked files are changed.
 - gate-status: summarize the current stop point and next safe command.
-- gate-brief: explain one human gate with options, trade-offs, severity, reversibility, and evidence.
+- gate-brief: explain one conservative agent gate with options, trade-offs, severity, reversibility, and evidence.
 - claim-audit: audit risky claim wording against eval/privacy surface classification.
 - claim-policy: render allowed/disallowed claim boundaries for the current surface.
 - privacy-audit-output: scan generated local artifacts for private raw values.
@@ -7483,8 +7651,8 @@ Automation points:
 - ship-simulate: predict auto-ship stop points without push/PR/merge/close/delete.
 - auto-ship-prepare: prepare or create a local ADR 0007 branch for the primary `make ship-arm` pipeline; branch creation requires `--confirm-human-approved`.
 - auto-ship-plan: render a readiness-backed bridge to the primary `make ship-arm` Stop-hook pipeline without arming it.
-- ship-command-pack: render human-gated ship commands without executing them.
-- human-gated-exec: execute push/PR create/merge/close, issue close, remote branch delete, or force-with-lease only as an action-by-action fallback with `--confirm-human-approved` and action-specific gates.
+- ship-command-pack: render conservative shipping commands without executing them.
+- human-gated-exec: legacy command name for conservative remote mutation fallback; executes push/PR create/merge/close, issue close, remote branch delete, or force-with-lease only with `--confirm-human-approved` and action-specific gates.
 - dependency-graph: render stacked PR graph without merge/delete mutation.
 - stacked-risk: detect dependent PR risk before merge/delete cleanup.
 - pr-body-check: verify `Closes`, §5b, claim, and privacy boundaries before PR creation.
@@ -7495,7 +7663,8 @@ Automation points:
 - manifest: write input-hash freshness metadata for generated artifacts.
 - artifact-freshness: alias around stale/manifest freshness checks.
 - validation-history: summarize local JSONL validation history.
-- workset-recommend: recommend serial, parallel-safe, review-only, and manual-gated task sets.
+- workset-recommend: recommend serial, parallel-safe, review-only, and agent-gated task sets.
+- role-dispatch: render role-separated subagent dispatch cards with max 12 and depth 2; report-only, does not spawn subagents.
 - automation-coverage: map implemented automation candidates to command surfaces.
 - auto-pass-check: fail-closed low-risk gate check; named strict profiles require high-confidence docs/CI/tooling surfaces and passed validation.
 - loop-state: write machine-readable current loop state JSON.
@@ -7511,13 +7680,14 @@ Automation points:
 - agent-loop-mcp: stdio MCP adapter for external coding agents and desktop clients; exposes local read/report tools, not shipping mutations.
 - agent-loop-artifacts.yml: PR-time informational GitHub Actions artifact generation.
 
-Human intervention points:
-- Apply a draft to `tasks/queue.md` or `docs/plans/*.md`.
+Conservative agent gate policy:
+- Apply queue/plan drafts only when scope, evidence, and rollback notes are present.
 - Create or switch the local shipping branch when detached HEAD or protected branch state is detected.
-- Decide architecture tradeoffs, benchmark/performance claims, or private real-eval meaning.
-- Push, create/merge/close PRs, close issues, delete branches, or force-push.
-- Prefer `make ship-arm` for approved end-to-end shipping; use `human-gated-exec` only as a manual fallback after explicit approval and action-specific preflight.
-- Approve reviewer findings and shipping path.
+- Decide architecture tradeoffs, benchmark/performance claims, and private real-eval meaning under ADR 0079; ambiguous cases default to draft, no claim, follow-up issue, or fail-closed.
+- Push, create/merge/close PRs, close issues, delete branches, or force-push only after the action-specific evidence checks pass and the existing explicit confirmation command/flag is used.
+- Prefer `make ship-arm` for policy-passing end-to-end shipping; use `human-gated-exec` only as a legacy-named manual fallback after action-specific preflight.
+- Treat informational reviews as advisory unless they produce unresolved review threads, requested changes, or concrete failing evidence.
+- Treat role dispatch as a planning surface only; it does not execute subagents or remote mutations.
 """
 
 
@@ -7658,7 +7828,7 @@ def _render_task_drafts(
 ## Out of Scope
 
 - Auto-merge, auto-push, PR creation/close/merge, branch deletion, or force-push.
-- Benchmark, performance, private real-eval, or architecture tradeoff decisions without human approval.
+- Benchmark, performance, private real-eval, or architecture tradeoff decisions without ADR 0079 agent-gate evidence.
 - Raw private question, answer, evidence, doc_id, chunk_id, filenames, or exact local paths.
 
 ## Surface / Claim Boundary
@@ -7870,7 +8040,7 @@ def build_parser() -> argparse.ArgumentParser:
     followup.add_argument("--out", type=Path, default=DEFAULT_REVIEW_FOLLOWUPS)
     followup.add_argument("--tasks-dir", type=Path, default=DEFAULT_REVIEW_FOLLOWUPS_DIR)
 
-    decision = sub.add_parser("decision-brief", help="Explain human-gate options, trade-offs, and risks.")
+    decision = sub.add_parser("decision-brief", help="Explain conservative agent-gate options, trade-offs, and risks.")
     decision.add_argument("--task")
     decision.add_argument("--batch", type=Path)
     decision.add_argument("--review-followups", type=Path)
@@ -7885,7 +8055,7 @@ def build_parser() -> argparse.ArgumentParser:
     promote.add_argument("--plan-draft", type=Path, default=DEFAULT_PLAN_DRAFT)
     promote.add_argument("--out", type=Path, default=DEFAULT_PROMOTE_DRAFT)
 
-    gate_status = sub.add_parser("gate-status", help="Summarize the current human gate and next safe command.")
+    gate_status = sub.add_parser("gate-status", help="Summarize the current conservative agent gate and next safe command.")
     gate_status.add_argument("--task")
     gate_status.add_argument("--batch", type=Path)
     gate_status.add_argument("--review-followups", type=Path)
@@ -8035,7 +8205,7 @@ def build_parser() -> argparse.ArgumentParser:
     auto_ship_prepare.add_argument("--no-dry-run", dest="dry_run", action="store_false", help="Recommend DRY_RUN=0 for the next ship-arm command.")
     auto_ship_prepare.add_argument("--out", type=Path, default=DEFAULT_AUTO_SHIP_PREPARE)
 
-    gate_brief = sub.add_parser("gate-brief", help="Explain a specific human gate with options and trade-offs.")
+    gate_brief = sub.add_parser("gate-brief", help="Explain a specific conservative agent gate with options and trade-offs.")
     gate_brief.add_argument("--gate", required=True, choices=sorted(GATE_BRIEF_CHOICES))
     gate_brief.add_argument("--task")
     gate_brief.add_argument("--changed-files", type=Path)
@@ -8089,12 +8259,12 @@ def build_parser() -> argparse.ArgumentParser:
     html_dash.add_argument("--pr")
     html_dash.add_argument("--out", type=Path, default=DEFAULT_DASHBOARD_HTML)
 
-    ship_cmds = sub.add_parser("ship-command-pack", help="Render human-gated shipping command suggestions.")
+    ship_cmds = sub.add_parser("ship-command-pack", help="Render conservative shipping command suggestions.")
     ship_cmds.add_argument("--pr")
     ship_cmds.add_argument("--branch")
     ship_cmds.add_argument("--out", type=Path, default=DEFAULT_SHIP_COMMANDS)
 
-    apply_qp = sub.add_parser("apply-queue-plan", help="Apply queue/plan drafts only with explicit human approval.")
+    apply_qp = sub.add_parser("apply-queue-plan", help="Apply queue/plan drafts only with explicit conservative gate acknowledgment.")
     apply_qp.add_argument("--queue-draft", type=Path, default=DEFAULT_QUEUE_DRAFT)
     apply_qp.add_argument("--plan-draft", type=Path, default=DEFAULT_PLAN_DRAFT)
     apply_qp.add_argument("--confirm-human-approved", action="store_true")
@@ -8178,7 +8348,7 @@ def build_parser() -> argparse.ArgumentParser:
     arch_decision.add_argument("--pr")
     arch_decision.add_argument("--out", type=Path, default=DEFAULT_ARCHITECTURE_DECISION)
 
-    workset = sub.add_parser("workset-recommend", help="Recommend serial/parallel/review/manual worksets.")
+    workset = sub.add_parser("workset-recommend", help="Recommend serial/parallel/review/agent-gated worksets.")
     workset.add_argument("--batch", type=Path)
     workset.add_argument("--tasks-dir", type=Path, default=DEFAULT_CODEX_TASKS_DIR)
     workset.add_argument("--max-items", type=int, default=12)
@@ -8187,7 +8357,14 @@ def build_parser() -> argparse.ArgumentParser:
     coverage = sub.add_parser("automation-coverage", help="Render coverage map for implemented automation candidates.")
     coverage.add_argument("--out", type=Path, default=DEFAULT_AUTOMATION_COVERAGE)
 
-    gated = sub.add_parser("human-gated-exec", help="Execute approved remote mutations only after explicit human approval.")
+    role_dispatch = sub.add_parser("role-dispatch", help="Render role-separated Codex subagent dispatch plan.")
+    role_dispatch.add_argument("--owner-role")
+    role_dispatch.add_argument("--changed-files", type=Path)
+    role_dispatch.add_argument("--from-git", action="store_true")
+    role_dispatch.add_argument("--pr")
+    role_dispatch.add_argument("--out", type=Path, default=DEFAULT_ROLE_DISPATCH)
+
+    gated = sub.add_parser("human-gated-exec", help="Legacy-named conservative remote mutation executor after explicit gate acknowledgment.")
     gated.add_argument("--action", required=True, choices=sorted(HUMAN_GATED_ACTIONS))
     gated.add_argument("--confirm-human-approved", action="store_true")
     gated.add_argument("--dry-run", action="store_true")
@@ -8214,7 +8391,7 @@ def build_parser() -> argparse.ArgumentParser:
     loop_state.add_argument("--pr")
     loop_state.add_argument("--out", type=Path, default=DEFAULT_LOOP_STATE)
 
-    sub.add_parser("map", help="Print the agent-loop automation map and human gates.")
+    sub.add_parser("map", help="Print the agent-loop automation map and conservative agent gates.")
 
     sub.add_parser("next", help="Recommend the next ready/backlog queue task.")
     return parser
@@ -8924,6 +9101,20 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.command == "automation-coverage":
             out, _ = write_automation_coverage(out=args.out)
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "role-dispatch":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=args.pr,
+                repo_root=ROOT_DIR,
+            )
+            out, _ = write_role_dispatch(
+                changed_files=files,
+                owner_role=args.owner_role,
+                out=args.out,
+            )
             sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
             return 0
         if args.command == "human-gated-exec":

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -23,18 +23,107 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 10 | `T-2026-0010` | `done` | Implementer -> Reviewer | merged in PR #1519. |
 | 11 | `T-2026-0011` | `done` | Implementer -> Reviewer | merged in PR #1521. |
 | 12 | `T-2026-0012` | `done` | Implementer -> Reviewer | merged in PR #1523. |
-| 13 | `T-2026-0013` | `review` | Maintainer -> Reviewer | policy docs implemented; PR pending. |
+| 13 | `T-2026-0013` | `done` | Maintainer -> Reviewer | merged in PR #1530. |
+| 14 | `T-2026-0014` | `review` | Maintainer -> Reviewer | agent gate surfaces and role dispatch aligned; PR #1532. |
 
 ## Examples
 
 - [`tasks/examples/benchmark-hardening.md`](examples/benchmark-hardening.md): benchmark hardening task 작성 예시.
 - [`tasks/examples/eval-regression-safety.md`](examples/eval-regression-safety.md): eval regression safety task 작성 예시.
 
+## T-2026-0014 — Agent gate surface alignment
+
+- ID: T-2026-0014
+- Title: Agent gate surface alignment
+- Status: review
+- Owner role: Maintainer -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Make the visible agent-loop surfaces match ADR 0079 so the loop reads as a
+conservative agent-gated operating system rather than a workflow waiting for
+manual human gates.
+
+### Scope
+
+- Update `scripts/agent_loop.py` map, gate brief, automation coverage, CLI help,
+  and ship command pack wording.
+- Keep legacy `human-gated-exec` command and `--confirm-human-approved` flag names
+  for compatibility.
+- Add concrete v0/v1/v2 metric-loop milestones to the agent-gated eval policy.
+- Add a report-only `role-dispatch` command for Codex subagent role separation
+  with max 12 roles and depth 2.
+
+### Non-Goals
+
+- Do not change remote mutation behavior.
+- Do not rename CLI flags or commands.
+- Do not run private real-eval.
+
+### Acceptance Criteria
+
+- [x] Loop map says `Agent gate` and explains legacy command naming.
+- [x] Gate brief references ADR 0079 conservative defaults.
+- [x] Metric-loop next milestones are visible in the eval policy.
+- [x] Focused tests cover the wording shift.
+- [x] Role dispatch plan is visible in the loop map, automation coverage, docs,
+  and tests.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+python3 -m py_compile scripts/agent_loop.py
+python3 scripts/agent_loop.py role-dispatch --owner-role "Implementer -> Benchmark Auditor -> Reviewer" --from-git
+python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md tasks/queue.md docs/plans/T-2026-0014-agent-gate-surface-alignment.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Py compile output.
+- Targeted doc link check.
+
+### Failure Conditions
+
+- Stop if compatibility command names change.
+- Stop if text implies performance evidence without private real-eval aggregate.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0014-agent-gate-surface-alignment.md`](../docs/plans/T-2026-0014-agent-gate-surface-alignment.md)
+- Issue: [#1531](https://github.com/hskim-solv/BidMate-DocAgent/issues/1531)
+- PR: [#1532](https://github.com/hskim-solv/BidMate-DocAgent/pull/1532)
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-27 KST
+
+- Role: Maintainer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1531-agent-gate-surfaces / /Users/hskim/.codex/worktrees/1c21/BidMate-DocAgent
+- Issue / PR: #1531 / PR #1532
+- Task: T-2026-0014
+- Current status: implementation complete; focused validation passed once.
+- Files touched: scripts/agent_loop.py, tests/test_agent_loop.py, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/plans/T-2026-0014-agent-gate-surface-alignment.md, tasks/queue.md
+- Decisions made: keep legacy command names but make visible policy say conservative agent gate; add report-only role dispatch for Codex subagents.
+- Eval surface: governance/tooling only; no metric claim.
+- Commands run: python3 -m pytest tests/test_agent_loop.py -q; python3 -m py_compile scripts/agent_loop.py; python3 scripts/agent_loop.py role-dispatch --owner-role "Implementer -> Benchmark Auditor -> Reviewer" --from-git; python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md tasks/queue.md docs/plans/T-2026-0014-agent-gate-surface-alignment.md; git diff --check; make check-branch.
+- Results: passed.
+- Next safe command: git diff --stat
+- Reviewer focus: compatibility, no hidden remote mutation change, no subagent execution side effect, no performance claim.
+```
+
 ## T-2026-0013 — Agent-gated offline/online RFP eval loop
 
 - ID: T-2026-0013
 - Title: Agent-gated offline/online RFP eval loop
-- Status: review
+- Status: done
 - Owner role: Maintainer -> Reviewer
 - Created: 2026-05-26
 - Last updated: 2026-05-26
@@ -94,7 +183,7 @@ make check-branch
 
 - Plan: [`docs/plans/T-2026-0013-agent-gated-rfp-eval-loop.md`](../docs/plans/T-2026-0013-agent-gated-rfp-eval-loop.md)
 - Issue: [#1529](https://github.com/hskim-solv/BidMate-DocAgent/issues/1529)
-- PR: TBD
+- PR: [#1530](https://github.com/hskim-solv/BidMate-DocAgent/pull/1530)
 
 ### Handoff Notes
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -748,7 +748,8 @@ make real-eval-delta
     assert queue_path.read_text(encoding="utf-8") == "original queue\n"
     assert "Set A - Serial Blockers" in rendered
     assert "Set B - Parallel Safe Candidates" in rendered
-    assert "Set D - Manual Gates" in rendered
+    assert "Set D - Agent Gates" in rendered
+    assert "Agent Gate Stop Points" in rendered
     assert "PRIVATE RAW QUERY" not in rendered
     assert "private.pdf" not in rendered
     payload = json.loads(json_out.read_text(encoding="utf-8"))
@@ -910,7 +911,7 @@ def test_decision_brief_task_gate_uses_task_context(tmp_path: Path) -> None:
     assert "T-2026-9999" in rendered
     assert "Keep as draft and inspect scope" in rendered
     assert "Promote draft to queue/plan" in rendered
-    assert "Manual approval" in rendered
+    assert "Gate acknowledgment" in rendered
 
 
 def test_decision_brief_rejects_unsafe_output_path(tmp_path: Path) -> None:
@@ -1245,11 +1246,12 @@ def test_loop_state_writes_machine_readable_safe_state(tmp_path: Path) -> None:
     assert payload["validation_suggestions"][-1] == "git diff --check"
 
 
-def test_loop_map_marks_human_gates_and_safe_automation() -> None:
+def test_loop_map_marks_agent_gates_and_safe_automation() -> None:
     rendered = agent_loop.render_loop_map()
 
     assert "flowchart TD" in rendered
-    assert "Human gate" in rendered
+    assert "Agent gate" in rendered
+    assert "Conservative agent gate policy" in rendered
     assert "pr-scan" in rendered
     assert "batch-plan" in rendered
     assert "decision-brief" in rendered
@@ -1262,11 +1264,15 @@ def test_loop_map_marks_human_gates_and_safe_automation() -> None:
     assert "review-followup" in rendered
     assert "agent-loop-mcp" in rendered
     assert "read-only `gh pr list`" in rendered
-    assert "Human intervention points" in rendered
     assert "force-push" in rendered
-    assert "make ship-arm: approved single end-to-end ship pipeline" in rendered
-    assert "human-gated-exec: action-by-action remote mutation fallback" in rendered
-    assert "Prefer `make ship-arm` for approved end-to-end shipping" in rendered
+    assert "make ship-arm: conservative single end-to-end ship pipeline" in rendered
+    assert "human-gated-exec: legacy-named conservative remote mutation fallback" in rendered
+    assert "Prefer `make ship-arm` for policy-passing end-to-end shipping" in rendered
+    assert "informational reviews as advisory" in rendered
+    assert "role-dispatch" in rendered
+    assert "max 12" in rendered
+    assert "depth 2" in rendered
+    assert "does not execute subagents or remote mutations" in rendered
 
 
 def test_ship_command_pack_separates_primary_ship_path_from_manual_fallback(tmp_path: Path) -> None:
@@ -1280,8 +1286,9 @@ def test_ship_command_pack_separates_primary_ship_path_from_manual_fallback(tmp_
 
     assert "## Primary End-to-End Ship Path" in rendered
     assert "## Manual Fallback Commands" in rendered
-    assert "Choose one shipping path after explicit approval" in rendered
-    assert "action-by-action commands only when the end-to-end `make ship-arm` path is not appropriate" in rendered
+    assert "Choose one shipping path after the conservative agent gate passes" in rendered
+    assert "ADR 0079 treats it as conservative agent-gate acknowledgment" in rendered
+    assert "explicit confirmation flag is still required" in rendered
     assert "# make ship-arm REAL_EVAL=skip DRAFT=true DRY_RUN=1" in rendered
     assert "--action pr-create" in rendered
 
@@ -1476,7 +1483,9 @@ python3 -m pytest tests/test_agent_loop.py -q
     assert arch_out == repo / "reports" / "agent_loop" / "architecture_brief.md"
     assert "ADR likely" in arch
     assert gate_out == repo / "reports" / "agent_loop" / "gate_brief.md"
-    assert "Human gates are decision points" in gate
+    assert "Conservative agent gates are policy decisions" in gate
+    assert "ADR 0079 delegates routine gate decisions" in gate
+    assert "Manual approval:" not in gate
     assert stale_out == repo / "reports" / "agent_loop" / "stale_reports.md"
     assert "old.md" in stale
     assert "dry-run" in stale
@@ -1699,6 +1708,11 @@ N/A - no load-bearing path.
     integration_out, integration = agent_loop.write_integration_pack(repo_root=repo)
     schedule_out, schedule = agent_loop.write_schedule_config(repo_root=repo)
     coverage_out, coverage = agent_loop.write_automation_coverage(repo_root=repo)
+    role_out, role_dispatch = agent_loop.write_role_dispatch(
+        changed_files=["eval/naive_rag/benchmark.py"],
+        owner_role="Implementer -> Reviewer",
+        repo_root=repo,
+    )
 
     assert threads_out == repo / "reports" / "agent_loop" / "review_threads.md"
     assert "Unresolved count: `1`" in threads_report
@@ -1717,7 +1731,7 @@ N/A - no load-bearing path.
     assert "Result: `pass`" in privacy
     assert claim_out == repo / "reports" / "agent_loop" / "claim_policy.md"
     assert claim_rc == 0
-    assert "Disallowed Or Human-Gated Claims" in claim
+    assert "Disallowed Or Agent-Gated Claims" in claim
     assert arch_out == repo / "reports" / "agent_loop" / "architecture_decision.md"
     assert "human-architecture-review-required" in arch
     assert integration_out == repo / "reports" / "agent_loop" / "integration_pack.md"
@@ -1726,6 +1740,44 @@ N/A - no load-bearing path.
     assert "does not install cron jobs" in schedule
     assert coverage_out == repo / "reports" / "agent_loop" / "automation_coverage.md"
     assert "auto-pass strict profiles" in coverage
+    assert "Still Agent-Gated" in coverage
+    assert "conservative remote execution" in coverage
+    assert "ADR 0079 defaults" in coverage
+    assert "role-separated subagent dispatch" in coverage
+    assert "does not execute subagents or remote mutations" in coverage
+    assert role_out == repo / "reports" / "agent_loop" / "role_dispatch.md"
+    assert "Role Dispatch Plan" in role_dispatch
+    assert "Benchmark Auditor" in role_dispatch
+    assert "depth 2 maximum" in role_dispatch
+    assert "does not spawn subagents" in role_dispatch
+
+
+def test_role_dispatch_adds_surface_auditors_without_executing_subagents(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+
+    default_rendered = agent_loop.render_role_dispatch(changed_files=["docs/readme.md"], repo_root=repo)
+    rendered = agent_loop.render_role_dispatch(
+        changed_files=["reports/real100/eval_summary.json", "docs/adr/0079-agent-gated-offline-online-rfp-eval-loop.md"],
+        owner_role="Planner -> Implementer -> Reviewer",
+        repo_root=repo,
+    )
+
+    assert "Owner role: `Planner -> Implementer -> Reviewer`" in default_rendered
+    assert "Planner" in default_rendered
+    assert "Implementer" in default_rendered
+    assert "Reviewer" in default_rendered
+    assert "Role Dispatch Plan" in rendered
+    assert "Planner" in rendered
+    assert "Implementer" in rendered
+    assert "Benchmark Auditor" in rendered
+    assert "Privacy Auditor" in rendered
+    assert "Reviewer" in rendered
+    assert "read-only/report-only" in rendered
+    assert "assigned files only" in rendered
+    assert "up to 12 role subagents" in rendered
+    assert "depth 2 maximum: root session -> role subagents only" in rendered
+    assert "does not spawn subagents" in rendered
+    assert "Do not delegate private real-eval interpretation" in rendered
 
 
 def test_dependency_graph_workset_and_strict_profiles_are_fail_closed(tmp_path: Path) -> None:

--- a/tests/test_agent_loop_mcp.py
+++ b/tests/test_agent_loop_mcp.py
@@ -317,7 +317,7 @@ def test_mcp_new_reports_are_read_centered_and_redacted() -> None:
     assert "Planning artifact only" in maintenance
     assert "performance claim language detected" in approval
     assert "PRIVATE RAW QUERY" not in approval
-    assert "Disallowed Or Human-Gated Claims" in policy
+    assert "Disallowed Or Agent-Gated Claims" in policy
     assert "Result: `pass`" in privacy
     assert "existing auto-ship bridge" in coverage
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Align visible agent-loop surfaces with ADR 0079 so routine workflow decisions read as conservative agent gates instead of manual human gates. Add a report-only `role-dispatch` command that turns changed-file surface + owner role into Codex subagent dispatch cards with max 12 roles and depth 2.

Closes #1531

## 2. 영향 파일

- `scripts/agent_loop.py` - agent-gate wording, `role-dispatch` renderer/CLI, automation coverage/map updates.
- `tests/test_agent_loop.py` - focused coverage for loop map, coverage report, and role dispatch behavior.
- `tests/test_agent_loop_mcp.py` - MCP report wording expectation updated to agent-gated claim policy.
- `docs/evaluation/agent-gated-rfp-eval-loop.md` - next milestones and role dispatch policy.
- `docs/plans/T-2026-0014-agent-gate-surface-alignment.md` - plan/handoff evidence.
- `tasks/queue.md` - task status and validation evidence.
- `README.md` - sync ADR count from 78 to 79 after ADR 0079 landed on main.

## 3. 리스크

Main risk is accidentally changing remote mutation semantics while changing wording. The implementation keeps legacy `human-gated-exec` and `--confirm-human-approved` names, and states that role dispatch is report-only and does not spawn subagents or mutate remote state.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q` (return code 0)
- `python3 -m pytest tests/test_agent_loop_mcp.py::test_mcp_new_reports_are_read_centered_and_redacted tests/test_governance_readme_adr_count.py::test_repo_readme_adr_count_today -q` (return code 0)
- `python3 -m py_compile scripts/agent_loop.py`
- `python3 scripts/agent_loop.py role-dispatch --owner-role "Implementer -> Benchmark Auditor -> Reviewer" --from-git`
- `python3 scripts/check_doc_links.py --check-all --paths README.md docs/evaluation/agent-gated-rfp-eval-loop.md tasks/queue.md docs/plans/T-2026-0014-agent-gate-surface-alignment.md`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

Governance/tooling only. No RFP QA behavior, retrieval, grounding, citation, abstention, comparison, benchmark, or latency claim is made.

### 5b. Real-data delta

N/A - no load-bearing RAG, ingestion, eval runtime, API, ADR, or index-builder behavior changed. Private real-eval was not run; this PR makes no performance or private real-eval claim.

## 6. 하위 호환

Existing CLI command and flag names remain compatible, including `human-gated-exec` and `--confirm-human-approved`. New `role-dispatch` only writes a local report artifact.

## 7. 범위 외

- No private real-eval execution.
- No remote mutation behavior change.
- No actual Codex subagent spawning from the repo command; the command emits a dispatch plan for the root session to use.