### PR TITLE
docs: inventory v0 metric suite coverage

### DIFF
--- a/docs/evaluation/agent-gated-rfp-eval-loop.md
+++ b/docs/evaluation/agent-gated-rfp-eval-loop.md
@@ -76,7 +76,7 @@ metric suite다.
 
 | Milestone | Smallest next PR | Evidence required |
 |---|---|---|
-| v0-a metric inventory | 현재 private real-eval aggregate에 이미 있는 metric과 없는 metric을 표로 분류한다. | aggregate-only inventory, no performance claim |
+| v0-a metric inventory | 현재 private real-eval aggregate에 이미 있는 metric과 없는 metric을 [표로 분류한다](./v0-metric-suite-inventory.md). | aggregate-only inventory, no performance claim |
 | v0-b offline/online run manifest | offline/online 실행 환경, provider/model, payload class, egress mode를 같은 schema로 기록한다. | manifest schema + privacy test |
 | v0-c metric suite report | retrieval, grounding, citation, comparison, abstention, numeric/date/condition, judge agreement를 한 report shell에 모은다. | private real-eval aggregate + provenance |
 | v1 failure sensitivity | 세 개 이상의 RFP failure mode에 대해 metric이 실제로 움직이는지 확인한다. | before/after or historical failure replay |

--- a/docs/evaluation/v0-metric-suite-inventory.md
+++ b/docs/evaluation/v0-metric-suite-inventory.md
@@ -1,0 +1,58 @@
+# v0 Metric Suite Inventory
+
+This document closes the v0-a inventory milestone from the
+[Agent-Gated RFP Evaluation Loop](./agent-gated-rfp-eval-loop.md). It classifies
+which private real-eval aggregate surfaces already expose each metric family and
+which gaps remain before a v0 metric-suite report can claim coverage.
+
+This is an aggregate-only inventory. It is not a performance claim, does not run
+private real-eval, and does not compare deltas.
+
+## Status Vocabulary
+
+| Status | Meaning |
+|---|---|
+| Present | A committed aggregate-only private real-eval artifact already exposes the metric family with enough structure to include it in a v0 report shell. |
+| Partial | Related aggregate fields exist, but the current surface is too narrow, null, non-canonical, or missing a subdimension required by the metric family. |
+| Missing | No dedicated aggregate-only metric exists for the family. |
+
+## Inventory
+
+| Metric family | Status | Current aggregate evidence | Gap / smallest next step |
+|---|---|---|---|
+| Retrieval recall | Present | `reports/real100_v2/baseline.aggregate.json` exposes `chunk_recall_at_5`, `chunk_recall_at_10`, `chunk_recall_at_20`, `chunk_mrr`, and `chunk_ndcg_at_*` under aggregate slices. `reports/real100/embedding_ablation_retrieval.aggregate.json` is a retrieval-only aggregate surface. | v0-c should choose the canonical primary source and render retrieval metrics with dataset/config/index provenance. |
+| Grounding | Partial | `reports/real100_v2/baseline.aggregate.json` and `reports/real100/baseline.aggregate.json` expose answer-level `groundedness` with CI blocks. `eval/scorers/citation.py` also defines page/region `citation_grounding`, but the committed baseline aggregate keeps that field null. | v0-c should report answer-level groundedness as present, keep it separate from trajectory rationality, and leave page/region grounding marked partial until gold page/region metadata is populated. |
+| Citation precision | Present | `reports/real100_v2/baseline.aggregate.json` and `reports/real100/baseline.aggregate.json` expose `citation_precision`; `reports/private_real_eval_summary.redacted.json` also carries legacy citation aggregate fields. | v0-c should standardize on `citation_precision` naming and avoid mixing legacy `citation_accuracy` with the metric-suite label unless semantics are restated. |
+| Claim-citation alignment | Present | `reports/real100_v2/baseline.aggregate.json` and `reports/real100/baseline.aggregate.json` expose `claim_citation_alignment`; [Citation Grounding Evaluation](../eval/citation-grounding-eval.md) defines the report field. | v0-c should include claim-level error counts when available, but the core family is already measurable. |
+| Comparison coverage | Partial | Top-level CI blocks include `comparison_target_recall` and `comparison_pool_recall`, and `by_query_type` has a `comparison` slice. | The comparison slice does not yet expose per-target evidence/claim coverage in the report shell. Add a comparison-specific aggregate that reports target, evidence, and claim coverage with enough cases to interpret gaps. |
+| Abstention calibration | Partial | Aggregate files expose `abstention` and `abstention_outcomes`; some slices carry an `abstention_calibration` key. | `abstention_calibration` is not yet a populated canonical metric. Add an explicit calibration aggregate for answerable vs unanswerable cases, including correct refusal and incorrect-answer buckets. |
+| Numeric/date/condition accuracy | Partial | `reports/real100_v2/question_distribution.aggregate.json` classifies amount/date/score/question types, and `reports/real100/difficulty_profile.aggregate.json` exposes date-like and amount-like diagnostic slices. | There is no dedicated slot exactness metric for amount, date, eligibility, submission condition, or score fields. Add a field-level scorer before treating this family as present. |
+| Human/judge agreement | Partial | `eval/judges/judge_agreement.py` defines judge-human agreement aggregation, and ADR 0016 defines the private-label boundary. `reports/self_review_agreement/*.json` are committed agreement examples, but they are self-review governance artifacts rather than RFP QA metric-suite outputs. | Add a private real-eval agreement aggregate for an approved judge or human reviewer signal; keep per-case CSV labels local-only. |
+
+## v0 Readiness Verdict
+
+v0-a is complete because every metric family has been classified against current
+aggregate artifacts. The broader v0 exit condition is not complete yet:
+grounding page/region coverage, comparison coverage, abstention calibration,
+numeric/date/condition accuracy, and human/judge agreement still need follow-up
+metric work before the suite can be treated as fully adopted.
+
+## Privacy And Claim Boundary
+
+- Use only aggregate files committed under allowlisted report paths.
+- Do not commit raw private questions, answers, evidence text, document IDs,
+  chunk IDs, filenames, exact local paths, parsed Markdown, per-case rows, or raw
+  eval summaries.
+- Do not describe this inventory as an improvement, regression fix, or quality
+  result. It is a coverage map for the next metric-suite PRs.
+- Any future performance claim still requires private real-eval aggregate,
+  dataset/config/index provenance, and wording scoped to the measured surface.
+
+## Recommended Follow-Ups
+
+| Milestone | Follow-up |
+|---|---|
+| v0-b offline/online run manifest | Reuse the metric family list here and add run-environment provenance fields for each aggregate source. |
+| v0-c metric suite report | Render one report shell that includes all present families and explicitly marks partial or missing families. |
+| v1 failure sensitivity | Use this inventory to pick at least three failure modes with observable metric movement. |
+| v2 agreement calibration | Promote human/judge agreement from partial to present with private-label aggregate evidence. |

--- a/docs/plans/T-2026-0015-v0-metric-suite-inventory.md
+++ b/docs/plans/T-2026-0015-v0-metric-suite-inventory.md
@@ -1,0 +1,140 @@
+# Plan: T-2026-0015 v0 metric suite inventory
+
+- Status: review
+- Owner role: Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0015`
+- Related issue / PR: Issue #1535 / PR TBD
+- Related ADR: ADR 0079; ADR 0005; ADR 0016
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+## Problem Statement
+
+ADR 0079 and the agent-gated eval-loop policy define a v0-a milestone to
+inventory which metric families already exist in private real-eval aggregate
+surfaces. Without that inventory, the next metric-suite PRs can blur present
+metrics, partial proxies, and missing measurement work.
+
+## Current Behavior
+
+`docs/evaluation/agent-gated-rfp-eval-loop.md` lists the metric families and
+v0/v1/v2 milestones, but it does not classify current aggregate artifacts.
+Committed private real-eval aggregate files exist under `reports/real100/` and
+`reports/real100_v2/`, while raw private eval summaries and per-case rows remain
+local-only.
+
+## Desired Behavior
+
+The repo should have an aggregate-only v0-a inventory that classifies every
+metric family as present, partial, or missing, names the current source
+artifacts, and makes the follow-up work visible without making a performance
+claim.
+
+## Constraints
+
+- Scope constraints: docs and queue only.
+- Architecture constraints: no runtime, scorer, or eval runner behavior change.
+- Compatibility constraints: no command or schema rename.
+- Eval/privacy constraints: no private real-eval run; no raw private content; no performance claim.
+- Tooling/CI constraints: focused doc link and whitespace validation.
+- Non-goals: no metric implementation, no v0-c report shell, no private-data egress.
+
+## Architecture Impact
+
+- Affected modules or docs: `docs/evaluation/v0-metric-suite-inventory.md`,
+  `docs/evaluation/agent-gated-rfp-eval-loop.md`, `docs/plans/`, `tasks/queue.md`.
+- Affected contracts or invariants: none.
+- Load-bearing paths: none.
+- ADR required: no; this implements an ADR 0079 milestone without a new decision.
+- Backward compatibility expectation: existing eval artifacts and commands remain unchanged.
+
+## Affected Interfaces
+
+- CLI/API/config: none.
+- Input data: committed aggregate-only report artifacts.
+- Output artifacts: `docs/evaluation/v0-metric-suite-inventory.md`.
+- Docs/review surfaces: agent-gated eval-loop next milestones and task queue.
+- Tests/eval entrypoints: doc link check and diff whitespace check.
+
+## Data / Eval Impact
+
+- Surface: private real-eval aggregate inventory.
+- Data boundary: aggregate-only private output.
+- Allowed claim: v0-a inventory classifies current metric-family coverage.
+- Disallowed claim: no RFP QA quality, benchmark, private real-eval, or performance improvement claim.
+- Baseline or control affected: no, with reason: this is documentation only.
+- Benchmark/eval auditor required: yes, for metric-family classification and claim boundary.
+
+## Task Breakdown
+
+1. Add a v0 metric-suite inventory document.
+2. Link the v0-a milestone to that inventory from the agent-gated eval-loop policy.
+3. Add queue state and handoff evidence for issue #1535.
+4. Validate links, branch naming, and diff whitespace.
+
+## Acceptance Criteria
+
+- [x] Inventory covers retrieval, grounding, citation precision, claim-citation alignment, comparison coverage, abstention calibration, numeric/date/condition accuracy, and human/judge agreement.
+- [x] Each family is classified as present, partial, or missing with aggregate-only source paths.
+- [x] The document explicitly says it is not a performance claim and does not expose raw private content.
+- [x] Queue and plan link the work to issue #1535 and the v0-a milestone.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0015-v0-metric-suite-inventory.md tasks/queue.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: targeted doc link check passes.
+- Generated or updated artifact: v0 inventory doc.
+- Reviewer checklist or manual inspection: no raw private identifiers or performance wording.
+- Explicitly not validated: private real-eval, because this change makes no metric claim.
+
+## Rollback Strategy
+
+Revert the docs and queue changes in one PR. Do not delete existing aggregate
+reports; this PR only references them.
+
+## Failure Modes
+
+- Failure mode: inventory wording implies quality improvement.
+- Detection signal: reviewer finds performance-claim language without private real-eval delta.
+- Stop condition or fallback: replace claim wording with coverage-only language.
+
+## Observability
+
+- `docs/evaluation/v0-metric-suite-inventory.md`
+- `python3 scripts/check_doc_links.py --check-all --paths ...`
+- `git diff --check`
+- `make check-branch`
+
+## Reviewer Notes
+
+Attack the classification boundaries first: partial families should not be
+described as adopted metrics. Then check privacy wording and ensure the PR body
+does not claim performance movement.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-27 KST
+
+- Role: Maintainer
+- Branch / worktree: docs/issue-1535-v0-metric-inventory / /Users/hskim/.codex/worktrees/43e3/BidMate-DocAgent
+- Issue / PR: #1535 / PR TBD
+- Task: T-2026-0015
+- Current status: inventory implemented; focused validation passed.
+- Files touched: docs/evaluation/v0-metric-suite-inventory.md, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/plans/T-2026-0015-v0-metric-suite-inventory.md, tasks/queue.md
+- Decisions made: classify grounding, comparison coverage, abstention calibration, numeric/date/condition, and human/judge agreement as partial where current artifacts expose only a narrower metric, null field, labels, or tooling rather than full canonical coverage.
+- Commands run: python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0015-v0-metric-suite-inventory.md tasks/queue.md; git diff --check; make check-branch
+- Results: passed
+- Next safe command: git diff --stat
+- Open questions: none
+- Risks: reviewer should confirm partial/present boundaries and no-performance-claim wording.
+```

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -25,6 +25,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 12 | `T-2026-0012` | `done` | Implementer -> Reviewer | merged in PR #1523. |
 | 13 | `T-2026-0013` | `done` | Maintainer -> Reviewer | merged in PR #1530. |
 | 14 | `T-2026-0014` | `done` | Maintainer -> Reviewer | merged in PR #1532. |
+| 15 | `T-2026-0015` | `review` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | v0-a metric inventory implemented; issue #1535. |
 
 ## Examples
 
@@ -118,6 +119,86 @@ make check-branch
 - Next action: N/A; merged in PR #1532.
 - Next safe command: N/A
 - Reviewer focus: compatibility, no hidden remote mutation change, no subagent execution side effect, no performance claim.
+```
+
+## T-2026-0015 — v0 metric suite inventory
+
+- ID: T-2026-0015
+- Title: v0 metric suite inventory
+- Status: review
+- Owner role: Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Close the v0-a milestone from the agent-gated RFP eval loop by classifying
+which metric families already exist in committed private real-eval aggregate
+surfaces and which remain partial or missing.
+
+### Scope
+
+- Add `docs/evaluation/v0-metric-suite-inventory.md`.
+- Link the v0-a milestone from `docs/evaluation/agent-gated-rfp-eval-loop.md`.
+- Keep the inventory aggregate-only and explicitly non-claim-bearing.
+- Do not change eval runner, scorer, RAG runtime, or private data.
+
+### Non-Goals
+
+- Do not run private real-eval.
+- Do not implement new metrics.
+- Do not make a performance claim.
+
+### Acceptance Criteria
+
+- [x] Inventory covers all eight metric families in the agent-gated eval-loop policy.
+- [x] Each family is classified as present, partial, or missing with aggregate source paths.
+- [x] Privacy and no-performance-claim boundaries are explicit.
+- [x] Plan and queue reference issue #1535.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0015-v0-metric-suite-inventory.md tasks/queue.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Targeted doc link check output.
+- Diff whitespace output.
+- Branch/issue convention check.
+
+### Failure Conditions
+
+- Stop if wording implies RFP QA performance movement.
+- Stop if any raw private identifier, filename, local path, question, answer, or evidence text is introduced.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0015-v0-metric-suite-inventory.md`](../docs/plans/T-2026-0015-v0-metric-suite-inventory.md)
+- Issue: [#1535](https://github.com/hskim-solv/BidMate-DocAgent/issues/1535)
+- PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-27 KST
+
+- Role: Maintainer
+- Lifecycle stage: review
+- Branch / worktree: docs/issue-1535-v0-metric-inventory / /Users/hskim/.codex/worktrees/43e3/BidMate-DocAgent
+- Issue / PR: #1535 / PR TBD
+- Task: T-2026-0015
+- Current status: inventory implemented; focused validation passed.
+- Files touched: docs/evaluation/v0-metric-suite-inventory.md, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/plans/T-2026-0015-v0-metric-suite-inventory.md, tasks/queue.md
+- Decisions made: treat grounding, comparison coverage, abstention calibration, numeric/date/condition accuracy, and human/judge agreement as partial where current artifacts expose only a narrower metric, null field, labels, or tooling.
+- Eval surface: aggregate-only private real-eval inventory; no metric claim.
+- Commands run: python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0015-v0-metric-suite-inventory.md tasks/queue.md; git diff --check; make check-branch
+- Results: passed
+- Next safe command: git diff --stat
+- Reviewer focus: no raw private content, no performance claim, present/partial boundary.
 ```
 
 ## T-2026-0013 — Agent-gated offline/online RFP eval loop


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Agent-gated RFP eval loop의 v0-a milestone을 닫기 위해 현재 committed private real-eval aggregate에서 metric family별 present/partial coverage를 분류하는 inventory 문서를 추가합니다. 이 PR은 aggregate-only coverage map이며 성능 주장(performance claim)이 아닙니다.

Closes #1535

## 2. 영향 파일

- docs/evaluation/v0-metric-suite-inventory.md
- docs/evaluation/agent-gated-rfp-eval-loop.md
- docs/plans/T-2026-0015-v0-metric-suite-inventory.md
- tasks/queue.md

## 3. 리스크

주요 리스크는 partial metric을 adopted/present처럼 과장하거나 private raw identifier를 노출하는 것입니다. Grounding, comparison coverage, abstention calibration, numeric/date/condition accuracy, human/judge agreement는 보수적으로 partial로 표시했고, no-performance-claim / aggregate-only boundary를 명시했습니다.

## 4. 테스트

- python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0015-v0-metric-suite-inventory.md tasks/queue.md
- git diff --check
- make check-branch

## 5. Eval 영향

Aggregate-only metric inventory 문서 변경입니다. RAG runtime, retrieval, verifier, eval runner, ingestion, api 동작 변경 없음. Private real-eval은 실행하지 않았고 성능 주장은 하지 않습니다.

### 5b. Real-data delta

N/A — load-bearing path 변경 없음. 검색(retrieval)/검증(verification)/eval 실행 path 동작 변화 없음.

## 6. 하위 호환

N/A — schema, CLI flag, command, artifact format 변경 없음.

## 7. 범위 외

v0-b offline/online run manifest, v0-c metric suite report shell, 신규 scorer 구현, private real-eval 실행은 범위 밖입니다.