### PR TITLE
chore: sync T-2026-0015 merged state

### DIFF
--- a/docs/plans/T-2026-0015-v0-metric-suite-inventory.md
+++ b/docs/plans/T-2026-0015-v0-metric-suite-inventory.md
@@ -1,9 +1,9 @@
 # Plan: T-2026-0015 v0 metric suite inventory
 
-- Status: review
+- Status: done
 - Owner role: Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0015`
-- Related issue / PR: Issue #1535 / PR TBD
+- Related issue / PR: Issue #1535 / PR #1536
 - Related ADR: ADR 0079; ADR 0005; ADR 0016
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -127,9 +127,9 @@ does not claim performance movement.
 
 - Role: Maintainer
 - Branch / worktree: docs/issue-1535-v0-metric-inventory / /Users/hskim/.codex/worktrees/43e3/BidMate-DocAgent
-- Issue / PR: #1535 / PR TBD
+- Issue / PR: #1535 / PR #1536
 - Task: T-2026-0015
-- Current status: inventory implemented; focused validation passed.
+- Current status: merged in PR #1536.
 - Files touched: docs/evaluation/v0-metric-suite-inventory.md, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/plans/T-2026-0015-v0-metric-suite-inventory.md, tasks/queue.md
 - Decisions made: classify grounding, comparison coverage, abstention calibration, numeric/date/condition, and human/judge agreement as partial where current artifacts expose only a narrower metric, null field, labels, or tooling rather than full canonical coverage.
 - Commands run: python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0015-v0-metric-suite-inventory.md tasks/queue.md; git diff --check; make check-branch

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -25,7 +25,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 12 | `T-2026-0012` | `done` | Implementer -> Reviewer | merged in PR #1523. |
 | 13 | `T-2026-0013` | `done` | Maintainer -> Reviewer | merged in PR #1530. |
 | 14 | `T-2026-0014` | `done` | Maintainer -> Reviewer | merged in PR #1532. |
-| 15 | `T-2026-0015` | `review` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | v0-a metric inventory implemented; issue #1535. |
+| 15 | `T-2026-0015` | `done` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1536. |
 
 ## Examples
 
@@ -125,7 +125,7 @@ make check-branch
 
 - ID: T-2026-0015
 - Title: v0 metric suite inventory
-- Status: review
+- Status: done
 - Owner role: Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -179,7 +179,7 @@ make check-branch
 
 - Plan: [`docs/plans/T-2026-0015-v0-metric-suite-inventory.md`](../docs/plans/T-2026-0015-v0-metric-suite-inventory.md)
 - Issue: [#1535](https://github.com/hskim-solv/BidMate-DocAgent/issues/1535)
-- PR: TBD
+- PR: [#1536](https://github.com/hskim-solv/BidMate-DocAgent/pull/1536)
 
 ### Handoff Notes
 
@@ -189,9 +189,9 @@ make check-branch
 - Role: Maintainer
 - Lifecycle stage: review
 - Branch / worktree: docs/issue-1535-v0-metric-inventory / /Users/hskim/.codex/worktrees/43e3/BidMate-DocAgent
-- Issue / PR: #1535 / PR TBD
+- Issue / PR: #1535 / PR #1536
 - Task: T-2026-0015
-- Current status: inventory implemented; focused validation passed.
+- Current status: merged in PR #1536.
 - Files touched: docs/evaluation/v0-metric-suite-inventory.md, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/plans/T-2026-0015-v0-metric-suite-inventory.md, tasks/queue.md
 - Decisions made: treat grounding, comparison coverage, abstention calibration, numeric/date/condition accuracy, and human/judge agreement as partial where current artifacts expose only a narrower metric, null field, labels, or tooling.
 - Eval surface: aggregate-only private real-eval inventory; no metric claim.


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

T-2026-0015가 PR #1536으로 merge된 상태와 persistent task queue / plan 상태를 맞춥니다.

Closes #1537

## 2. 영향 파일

- docs/plans/T-2026-0015-v0-metric-suite-inventory.md
- tasks/queue.md

## 3. 리스크

Queue/plan metadata만 바꾸는 문서 변경입니다. 링크와 branch/issue convention을 확인했습니다.

## 4. 테스트

- python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0015-v0-metric-suite-inventory.md tasks/queue.md
- git diff --check
- make check-branch

## 5. Eval 영향

All N/A — RAG/runtime/eval behavior 변경 없음.

### 5b. Real-data delta

N/A — load-bearing path 변경 없음. 검색(retrieval)/검증(verification) path 동작 변화 없음.

## 6. 하위 호환

N/A — 계약(contract), schema, CLI flag 변경 없음.

## 7. 범위 외

Private real-eval은 실행하지 않았습니다. Queue/plan 상태 동기화 외 변경은 포함하지 않았습니다.