### PR TITLE
chore: sync T-2026-0015 lifecycle stage

### DIFF
--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -187,7 +187,7 @@ make check-branch
 ## Session Handoff — 2026-05-27 KST
 
 - Role: Maintainer
-- Lifecycle stage: review
+- Lifecycle stage: done
 - Branch / worktree: docs/issue-1535-v0-metric-inventory / /Users/hskim/.codex/worktrees/43e3/BidMate-DocAgent
 - Issue / PR: #1535 / PR #1536
 - Task: T-2026-0015


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

T-2026-0015 handoff의 lifecycle stage를 이미 merge된 실제 상태와 맞춥니다.

Closes #1539

## 2. 영향 파일

- tasks/queue.md

## 3. 리스크

단일 queue metadata 라인 변경입니다. 링크, whitespace, branch/issue convention을 확인했습니다.

## 4. 테스트

- python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md
- git diff --check
- make check-branch

## 5. Eval 영향

All N/A — RAG/runtime/eval behavior 변경 없음.

### 5b. Real-data delta

N/A — load-bearing path 변경 없음. 검색(retrieval)/검증(verification) path 동작 변화 없음.

## 6. 하위 호환

N/A — 계약(contract), schema, CLI flag 변경 없음.

## 7. 범위 외

Queue lifecycle stage 동기화 외 변경은 포함하지 않았습니다.