### PR TITLE
chore: add agent overlap preflight

### DIFF
--- a/docs/operations/ai-codex-workflow.md
+++ b/docs/operations/ai-codex-workflow.md
@@ -60,6 +60,23 @@ HTML은 로컬 상태판이며 PR 증거(evidence)가 아니다. PR에 인용할
 HTML 자체가 아니라 source aggregate artifact, 실행 command, diff, ADR/source-of-truth
 일치 여부다.
 
+## Overlap Preflight
+
+Codex가 파일을 편집하기 전에 같은 issue/branch/PR/worktree가 이미 진행 중인지
+확인한다. 이 check는 report-only이며 branch switch, push, PR 생성/머지/닫기,
+issue close, branch delete를 실행하지 않는다.
+
+```bash
+python3 scripts/agent_loop.py overlap-preflight \
+  --issue <N> \
+  --branch <type>/issue-<N>-<slug>
+```
+
+`blocked`이면 현재 작업을 시작하지 않는다. 예: 같은 issue의 open PR이 있거나,
+다른 worktree가 같은 issue branch를 소유하거나, 현재 checkout이 detached/stale인
+경우다. `warn`이면 branch/PR history를 사람이 볼 수 있는 report로 확인한 뒤
+진행한다.
+
 ## Classification Contract
 
 Planner는 다음 순서로 active work를 분류한다.

--- a/docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md
+++ b/docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md
@@ -1,0 +1,69 @@
+# Plan: T-2026-0016 Agent worktree overlap preflight
+
+- Status: review
+- Owner role: Maintainer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0016`
+- Related issue / PR: Issue #1541 / PR TBD
+- Related ADR: ADR 0007; ADR 0079
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+## Problem Statement
+
+Codex sessions can start from stale detached worktrees or duplicate an issue that
+another worktree, branch, or PR already owns. The existing `preflight` command
+checks handoff, surface, and validation, but it does not prove that starting the
+work is non-overlapping.
+
+## Desired Behavior
+
+Before editing files, an agent can run a read-only overlap preflight for a target
+issue and ADR 0007 branch. It should block duplicate or stale starts and write a
+local report under `reports/agent_loop/`.
+
+## Constraints
+
+- Report-only command; no tracked file, branch, PR, issue, or remote mutation.
+- Fail closed when GitHub issue or PR state cannot be read.
+- Treat detached or stale checkout state as a blocker.
+- Treat remote branch leftovers as warnings unless an open/merged PR proves the
+  work is active or completed.
+
+## Implementation Summary
+
+1. Add `overlap-preflight` to `scripts/agent_loop.py`.
+2. Inspect `git worktree list --porcelain`, local issue branches, remote heads,
+   open PRs, branch PR history, issue state, current branch, and `origin/main`
+   freshness.
+3. Return `blocked`, `warn`, or `clear` and render Markdown plus optional JSON.
+4. Add regression tests for duplicate worktree, open PR, closed/merged history,
+   detached/stale checkout, and clear state.
+5. Document start-of-task usage in `tasks/README.md` and
+   `docs/operations/ai-codex-workflow.md`.
+
+## Acceptance Criteria
+
+- [x] Same issue branch in another worktree blocks.
+- [x] Same issue open PR blocks.
+- [x] Closed issue with merged branch history blocks as completed.
+- [x] Detached or stale current checkout blocks.
+- [x] Clean ADR 0007 branch/issue with no overlap reports clear.
+- [x] Start-of-task docs mention overlap preflight.
+
+## Validation
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+python3 -m py_compile scripts/agent_loop.py
+python3 scripts/agent_loop.py overlap-preflight --issue 1541 --branch chore/issue-1541-overlap-preflight
+python3 scripts/check_doc_links.py --check-all --paths tasks/README.md docs/operations/ai-codex-workflow.md docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md tasks/queue.md
+git diff --check
+make check-branch
+```
+
+## Reviewer Notes
+
+Focus on false-clear risk: if the command cannot prove issue, PR, worktree, or
+freshness state, it should block or warn instead of returning clear. Also verify
+that the command writes only ignored report artifacts.
+

--- a/docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md
+++ b/docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md
@@ -3,7 +3,7 @@
 - Status: review
 - Owner role: Maintainer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0016`
-- Related issue / PR: Issue #1541 / PR TBD
+- Related issue / PR: Issue #1541 / PR #1543
 - Related ADR: ADR 0007; ADR 0079
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -66,4 +66,3 @@ make check-branch
 Focus on false-clear risk: if the command cannot prove issue, PR, worktree, or
 freshness state, it should block or warn instead of returning clear. Also verify
 that the command writes only ignored report artifacts.
-

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1584,7 +1584,13 @@ def build_overlap_preflight(*, issue: str, branch: str, repo_root: Path = ROOT_D
     elif any(str(pr.get("state") or "").upper() == "CLOSED" for pr in branch_prs):
         warnings.append("target branch has closed PR history; inspect before reusing the branch")
 
-    worktrees = tuple(_git_worktree_entries(repo_root))
+    worktree_state_proven = True
+    try:
+        worktrees = tuple(_git_worktree_entries(repo_root))
+    except ValueError as exc:
+        blockers.append(str(exc))
+        worktrees = ()
+        worktree_state_proven = False
     current_path = repo_root.resolve()
     overlapping_worktrees = [
         item
@@ -1593,7 +1599,7 @@ def build_overlap_preflight(*, issue: str, branch: str, repo_root: Path = ROOT_D
     ]
     if overlapping_worktrees:
         blockers.append("another worktree already owns an issue branch for the target issue")
-    else:
+    elif worktree_state_proven:
         evidence.append("no other worktree owns the target issue")
 
     local_issue_branches = sorted(_local_issue_branches(repo_root).get(safe_issue, set()))
@@ -5314,8 +5320,11 @@ def _git_worktree_entries(repo_root: Path) -> tuple[WorktreeSnapshot, ...]:
             check=True,
             text=True,
         )
-    except (OSError, subprocess.CalledProcessError):
-        return ()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        message = "git worktree list failed; worktree state could not be proven"
+        if isinstance(exc, subprocess.CalledProcessError) and exc.stderr:
+            message += f": {_sanitize_inline_text(exc.stderr)}"
+        raise ValueError(message) from exc
     entries: list[WorktreeSnapshot] = []
     path = ""
     head = ""
@@ -5349,7 +5358,11 @@ def _git_worktree_entries(repo_root: Path) -> tuple[WorktreeSnapshot, ...]:
 
 def _worktree_issue_branches(repo_root: Path) -> dict[str, set[str]]:
     found: dict[str, set[str]] = {}
-    for item in _git_worktree_entries(repo_root):
+    try:
+        worktrees = _git_worktree_entries(repo_root)
+    except ValueError:
+        return found
+    for item in worktrees:
         issue = _issue_from_branch(item.branch)
         if issue:
             found.setdefault(issue, set()).add(item.branch)

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -115,6 +115,7 @@ DEFAULT_WORKSET_RECOMMENDATION = DEFAULT_REPORT_DIR / "workset_recommendation.md
 DEFAULT_DEPENDENCY_GRAPH = DEFAULT_REPORT_DIR / "dependency_graph.md"
 DEFAULT_AUTOMATION_COVERAGE = DEFAULT_REPORT_DIR / "automation_coverage.md"
 DEFAULT_ROLE_DISPATCH = DEFAULT_REPORT_DIR / "role_dispatch.md"
+DEFAULT_OVERLAP_PREFLIGHT = DEFAULT_REPORT_DIR / "overlap_preflight.md"
 DEFAULT_HUMAN_GATED_EXEC = DEFAULT_REPORT_DIR / "human_gated_exec.md"
 DEFAULT_AUTO_SHIP_PLAN = DEFAULT_REPORT_DIR / "auto_ship_plan.md"
 DEFAULT_AUTO_SHIP_PREPARE = DEFAULT_REPORT_DIR / "auto_ship_prepare.md"
@@ -412,6 +413,30 @@ class MaintenancePlan:
     issues: tuple[IssueTriageItem, ...]
     worktree_actions: tuple[str, ...]
     queue_task_briefs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorktreeSnapshot:
+    path: str
+    branch: str
+    head: str
+
+
+@dataclass(frozen=True)
+class OverlapPreflightReport:
+    issue: str
+    branch: str
+    result: str
+    current_branch: str
+    current_head: str
+    origin_main: str
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    evidence: tuple[str, ...]
+    open_prs: tuple[str, ...]
+    branch_prs: tuple[str, ...]
+    worktrees: tuple[WorktreeSnapshot, ...]
+    remote_branches: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -1459,6 +1484,216 @@ def render_preflight(
             ]
         )
     return (0 if handoff.ok else 1), "\n".join(lines) + "\n"
+
+
+def write_overlap_preflight(
+    *,
+    issue: str,
+    branch: str,
+    out: Path = DEFAULT_OVERLAP_PREFLIGHT,
+    json_out: Path | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, Path | None, OverlapPreflightReport, str]:
+    report = build_overlap_preflight(issue=issue, branch=branch, repo_root=repo_root)
+    rendered = render_overlap_preflight(report, repo_root=repo_root)
+    out = _default_output(out, DEFAULT_OVERLAP_PREFLIGHT, "overlap_preflight.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    safe_json: Path | None = None
+    if json_out is not None:
+        safe_json = _safe_output_path(json_out, repo_root=repo_root)
+        safe_json.parent.mkdir(parents=True, exist_ok=True)
+        safe_json.write_text(json.dumps(_overlap_preflight_json(report), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return safe_out, safe_json, report, rendered
+
+
+def build_overlap_preflight(*, issue: str, branch: str, repo_root: Path = ROOT_DIR) -> OverlapPreflightReport:
+    safe_issue = _validate_issue_selector(issue)
+    safe_branch = _validate_branch_name(branch)
+    blockers: list[str] = []
+    warnings: list[str] = []
+    evidence: list[str] = []
+
+    branch_issue = _issue_from_branch(safe_branch)
+    if branch_issue != safe_issue:
+        blockers.append("target branch issue number does not match --issue")
+    elif not re.match(r"^[a-z][a-z0-9_-]*/issue-\d+", safe_branch):
+        blockers.append("target branch does not match ADR 0007 `<type>/issue-<N>` convention")
+    else:
+        evidence.append("target branch follows ADR 0007 and matches the requested issue")
+
+    current_branch = _current_branch(repo_root) or "unknown"
+    current_head = _git_ref("HEAD", repo_root=repo_root) or "unknown"
+    origin_main = _git_ref("origin/main", repo_root=repo_root) or "unknown"
+    evidence.append(f"current branch={current_branch}")
+    evidence.append(f"current head={current_head}")
+    if origin_main != "unknown":
+        evidence.append(f"origin/main={origin_main}")
+    else:
+        warnings.append("origin/main could not be resolved; freshness could not be proven")
+
+    current_issue = _issue_from_branch(current_branch)
+    if current_branch == "HEAD":
+        blockers.append("current checkout is detached HEAD; switch to latest main or the target issue branch before editing")
+    elif current_issue and current_issue != safe_issue:
+        blockers.append(f"current branch belongs to issue #{current_issue}, not issue #{safe_issue}")
+    elif current_issue == safe_issue and current_branch != safe_branch:
+        warnings.append(f"current branch is a different branch for issue #{safe_issue}: `{current_branch}`")
+
+    if origin_main != "unknown" and current_branch != "HEAD":
+        if current_head == origin_main:
+            evidence.append("current checkout is exactly at origin/main")
+        elif _git_is_ancestor("origin/main", "HEAD", repo_root=repo_root):
+            evidence.append("current checkout contains origin/main")
+        else:
+            blockers.append("current checkout does not contain origin/main; refresh from latest main before editing")
+
+    try:
+        issue_info = _issue_info(safe_issue, repo_root=repo_root)
+    except ValueError as exc:
+        blockers.append(str(exc))
+        issue_info = {}
+    if str(issue_info.get("state") or "").upper() == "CLOSED":
+        blockers.append(f"issue #{safe_issue} is closed; treat this as completed unless a follow-up issue is opened")
+    elif issue_info:
+        evidence.append(f"issue #{safe_issue} is {str(issue_info.get('state') or 'unknown').lower()}")
+
+    try:
+        open_prs = _open_pr_items(repo_root=repo_root)
+    except ValueError as exc:
+        blockers.append(str(exc))
+        open_prs = []
+    matching_open_prs = tuple(_pr_label(pr) for pr in open_prs if _pr_matches_issue_or_branch(pr, issue=safe_issue, branch=safe_branch))
+    if matching_open_prs:
+        blockers.append("open PR already exists for the target issue or branch")
+    else:
+        evidence.append("no open PR matched the target issue or branch")
+
+    try:
+        branch_prs = _branch_pr_items(safe_branch, repo_root=repo_root)
+    except ValueError as exc:
+        blockers.append(str(exc))
+        branch_prs = []
+    matching_branch_prs = tuple(_pr_label(pr) for pr in branch_prs)
+    if any(_pr_is_merged(pr) for pr in branch_prs):
+        blockers.append("target branch already has a merged PR; treat this issue branch as completed")
+    elif branch_prs:
+        warnings.append("target branch has closed PR history; inspect before reusing the branch")
+
+    worktrees = tuple(_git_worktree_entries(repo_root))
+    current_path = repo_root.resolve()
+    overlapping_worktrees = [
+        item
+        for item in worktrees
+        if Path(item.path).resolve() != current_path and _issue_from_branch(item.branch) == safe_issue
+    ]
+    if overlapping_worktrees:
+        blockers.append("another worktree already owns an issue branch for the target issue")
+    else:
+        evidence.append("no other worktree owns the target issue")
+
+    local_issue_branches = sorted(_local_issue_branches(repo_root).get(safe_issue, set()))
+    unexpected_local = [item for item in local_issue_branches if item not in {safe_branch, current_branch}]
+    if unexpected_local:
+        warnings.append("other local branches exist for the target issue: " + ", ".join(f"`{item}`" for item in unexpected_local))
+
+    try:
+        remote_issue_branches = tuple(sorted(_remote_issue_branches(safe_issue, repo_root=repo_root)))
+    except ValueError as exc:
+        warnings.append(str(exc))
+        remote_issue_branches = ()
+    if safe_branch in remote_issue_branches:
+        warnings.append("remote branch already exists for the target branch; inspect before pushing")
+    remote_other = [item for item in remote_issue_branches if item != safe_branch]
+    if remote_other:
+        warnings.append("other remote branches exist for the target issue: " + ", ".join(f"`{item}`" for item in remote_other))
+    if not remote_issue_branches:
+        evidence.append("no remote branch matched the target issue")
+
+    result = "blocked" if blockers else ("warn" if warnings else "clear")
+    return OverlapPreflightReport(
+        issue=safe_issue,
+        branch=safe_branch,
+        result=result,
+        current_branch=current_branch,
+        current_head=current_head,
+        origin_main=origin_main,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        evidence=tuple(_dedupe_preserve_order(evidence)),
+        open_prs=matching_open_prs,
+        branch_prs=matching_branch_prs,
+        worktrees=worktrees,
+        remote_branches=remote_issue_branches,
+    )
+
+
+def render_overlap_preflight(report: OverlapPreflightReport, *, repo_root: Path = ROOT_DIR) -> str:
+    lines = [
+        "# Agent Worktree Overlap Preflight",
+        "",
+        "- Read-only start-of-task check. It does not edit tracked files, switch branches, push, create/merge/close PRs, close issues, delete branches, or force-push.",
+        f"- Result: `{report.result}`",
+        f"- Issue: `#{report.issue}`",
+        f"- Target branch: `{report.branch}`",
+        f"- Current branch: `{report.current_branch}`",
+        f"- Current head: `{report.current_head}`",
+        f"- origin/main: `{report.origin_main}`",
+        "",
+        "## Blockers",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.blockers) if report.blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.warnings) if report.warnings else lines.append("- None")
+    lines.extend(["", "## Evidence", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.evidence) if report.evidence else lines.append("- None")
+    lines.extend(["", "## Matching PRs", ""])
+    if report.open_prs or report.branch_prs:
+        for label in (*report.open_prs, *report.branch_prs):
+            lines.append(f"- {_sanitize_dynamic_text(label)}")
+    else:
+        lines.append("- None")
+    lines.extend(["", "## Worktrees", ""])
+    for item in report.worktrees:
+        lines.append(
+            f"- `{_display_path(_repo_path(Path(item.path), repo_root), repo_root=repo_root)}` "
+            f"branch=`{_sanitize_inline_text(item.branch)}` head=`{_sanitize_inline_text(item.head)}`"
+        )
+    if not report.worktrees:
+        lines.append("- None")
+    lines.extend(["", "## Remote Branches", ""])
+    lines.extend(f"- `{_sanitize_inline_text(item)}`" for item in report.remote_branches) if report.remote_branches else lines.append("- None")
+    next_command = "python3 scripts/agent_loop.py overlap-preflight --issue <N> --branch <type>/issue-<N>-<slug>"
+    if report.result == "clear":
+        next_command = "git status --short --branch" if report.current_branch == report.branch else f"git switch -c {shlex.quote(report.branch)}"
+    elif report.result == "warn":
+        next_command = f"python3 scripts/agent_loop.py branch-issue-hygiene --branch {shlex.quote(report.branch)}"
+    lines.extend(["", "## Next Safe Command", "", "```bash", next_command, "```", ""])
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def _overlap_preflight_json(report: OverlapPreflightReport) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "issue": report.issue,
+        "branch": report.branch,
+        "result": report.result,
+        "current_branch": report.current_branch,
+        "current_head": report.current_head,
+        "origin_main": report.origin_main,
+        "blockers": list(report.blockers),
+        "warnings": list(report.warnings),
+        "evidence": list(report.evidence),
+        "open_prs": list(report.open_prs),
+        "branch_prs": list(report.branch_prs),
+        "worktrees": [
+            {"path": _sanitize_dynamic_text(item.path), "branch": item.branch, "head": item.head}
+            for item in report.worktrees
+        ],
+        "remote_branches": list(report.remote_branches),
+    }
 
 
 def scan_pr_state(
@@ -5068,7 +5303,7 @@ def _local_issue_branches(repo_root: Path) -> dict[str, set[str]]:
     return found
 
 
-def _worktree_issue_branches(repo_root: Path) -> dict[str, set[str]]:
+def _git_worktree_entries(repo_root: Path) -> tuple[WorktreeSnapshot, ...]:
     try:
         result = subprocess.run(
             ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
@@ -5077,16 +5312,160 @@ def _worktree_issue_branches(repo_root: Path) -> dict[str, set[str]]:
             text=True,
         )
     except (OSError, subprocess.CalledProcessError):
-        return {}
-    found: dict[str, set[str]] = {}
-    for line in result.stdout.splitlines():
-        if not line.startswith("branch refs/heads/"):
+        return ()
+    entries: list[WorktreeSnapshot] = []
+    path = ""
+    head = ""
+    branch = "HEAD"
+
+    def flush() -> None:
+        nonlocal path, head, branch
+        if path:
+            entries.append(WorktreeSnapshot(path=path, branch=branch, head=head or "unknown"))
+        path = ""
+        head = ""
+        branch = "HEAD"
+
+    for raw in [*result.stdout.splitlines(), ""]:
+        line = raw.strip()
+        if not line:
+            flush()
             continue
-        branch = line.removeprefix("branch refs/heads/")
-        issue = _issue_from_branch(branch)
+        if line.startswith("worktree "):
+            if path:
+                flush()
+            path = line.removeprefix("worktree ")
+        elif line.startswith("HEAD "):
+            head = line.removeprefix("HEAD ")
+        elif line.startswith("branch refs/heads/"):
+            branch = line.removeprefix("branch refs/heads/")
+        elif line == "detached":
+            branch = "HEAD"
+    return tuple(entries)
+
+
+def _worktree_issue_branches(repo_root: Path) -> dict[str, set[str]]:
+    found: dict[str, set[str]] = {}
+    for item in _git_worktree_entries(repo_root):
+        issue = _issue_from_branch(item.branch)
         if issue:
-            found.setdefault(issue, set()).add(branch)
+            found.setdefault(issue, set()).add(item.branch)
     return found
+
+
+def _remote_issue_branches(issue: str, *, repo_root: Path) -> set[str]:
+    safe_issue = _validate_issue_selector(issue)
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-remote", "--heads", "origin"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("could not read remote branch state") from exc
+    found: set[str] = set()
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) != 2 or not parts[1].startswith("refs/heads/"):
+            continue
+        branch = parts[1].removeprefix("refs/heads/")
+        if _issue_from_branch(branch) == safe_issue:
+            found.add(branch)
+    return found
+
+
+def _git_ref(ref: str, *, repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short", ref],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def _git_is_ancestor(ancestor: str, descendant: str, *, repo_root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", ancestor, descendant],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _issue_info(issue: str, *, repo_root: Path) -> dict[str, object]:
+    safe_issue = _validate_issue_selector(issue)
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", safe_issue, "--json", "number,title,state,url,closedAt"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(f"could not read issue #{safe_issue} state") from exc
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise ValueError("gh issue view JSON must be an object")
+    return payload
+
+
+def _open_pr_items(*, repo_root: Path) -> list[dict[str, object]]:
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--json", "number,title,url,headRefName,state,mergedAt"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("could not read open PR state") from exc
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, list):
+        raise ValueError("gh pr list JSON must be an array")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _branch_pr_items(branch: str, *, repo_root: Path) -> list[dict[str, object]]:
+    safe_branch = _validate_branch_name(branch)
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--state", "all", "--head", safe_branch, "--json", "number,title,url,headRefName,state,mergedAt"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(f"could not read PR history for branch {safe_branch}") from exc
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, list):
+        raise ValueError("gh pr list JSON must be an array")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _pr_matches_issue_or_branch(pr: dict[str, object], *, issue: str, branch: str) -> bool:
+    head = str(pr.get("headRefName") or "")
+    return head == branch or _issue_from_branch(head) == issue
+
+
+def _pr_is_merged(pr: dict[str, object]) -> bool:
+    return str(pr.get("state") or "").upper() == "MERGED" or bool(pr.get("mergedAt"))
+
+
+def _pr_label(pr: dict[str, object]) -> str:
+    number = _sanitize_inline_text(str(pr.get("number") or "N/A"))
+    title = _sanitize_inline_text(str(pr.get("title") or "Untitled PR"))
+    head = _sanitize_inline_text(str(pr.get("headRefName") or "unknown"))
+    state = _sanitize_inline_text(str(pr.get("state") or "unknown"))
+    return f"#{number} {title} head=`{head}` state=`{state}`"
 
 
 def _issue_label_names(labels: object) -> list[str]:
@@ -7623,6 +8002,7 @@ flowchart TD
 Automation points:
 - pr-scan: read-only `gh pr list` JSON export.
 - issue-scan: read-only `gh issue list` JSON export plus conservative close/queue/in-flight/manual classification.
+- overlap-preflight: read-only start-of-task check for issue, branch, PR, worktree, remote branch, and freshness overlap.
 - maintenance-plan: generate issue cleanup, queue migration, worktree cleanup, and branch deletion gate recommendations without executing them.
 - next-from-prs: deterministic wrapper around `scripts/ai_next_actions.py`.
 - pr-health: group exported PR state into CI, review, stale, draft, blocked, and ready lanes.
@@ -7676,7 +8056,7 @@ Automation points:
 - review-followup: parse reviewer findings into local follow-up task briefs.
 - review-ingest: normalize local or PR review text into review-followup briefs.
 - safe-fix: dry-run/apply whitespace-only local fixes for supported public-safe text files.
-- render-prompt, status, preflight, classify-surface, suggest-validation, validate, handoff-check, review-prompt.
+- render-prompt, status, preflight, overlap-preflight, classify-surface, suggest-validation, validate, handoff-check, review-prompt.
 - agent-loop-mcp: stdio MCP adapter for external coding agents and desktop clients; exposes local read/report tools, not shipping mutations.
 - agent-loop-artifacts.yml: PR-time informational GitHub Actions artifact generation.
 
@@ -7979,6 +8359,12 @@ def build_parser() -> argparse.ArgumentParser:
     preflight.add_argument("--from-git", action="store_true")
     preflight.add_argument("--pr")
     preflight.add_argument("--write-prompts", action="store_true")
+
+    overlap = sub.add_parser("overlap-preflight", help="Check issue/branch/worktree overlap before editing.")
+    overlap.add_argument("--issue", required=True)
+    overlap.add_argument("--branch", required=True)
+    overlap.add_argument("--out", type=Path, default=DEFAULT_OVERLAP_PREFLIGHT)
+    overlap.add_argument("--json-out", type=Path)
 
     pr_scan = sub.add_parser("pr-scan", help="Export read-only PR state for planning.")
     pr_scan.add_argument("--out", type=Path, default=DEFAULT_PR_STATE)
@@ -8486,6 +8872,18 @@ def main(argv: list[str] | None = None) -> int:
             stream = sys.stdout if rc == 0 else sys.stderr
             stream.write(rendered)
             return rc
+        if args.command == "overlap-preflight":
+            out, json_out, report, _ = write_overlap_preflight(
+                issue=args.issue,
+                branch=args.branch,
+                out=args.out,
+                json_out=args.json_out,
+            )
+            if json_out is None:
+                sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            else:
+                sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)} and {_repo_path(json_out, ROOT_DIR)}\n")
+            return 1 if report.result == "blocked" else 0
         if args.command == "pr-scan":
             out = scan_pr_state(
                 out=args.out,

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1504,7 +1504,10 @@ def write_overlap_preflight(
     if json_out is not None:
         safe_json = _safe_output_path(json_out, repo_root=repo_root)
         safe_json.parent.mkdir(parents=True, exist_ok=True)
-        safe_json.write_text(json.dumps(_overlap_preflight_json(report), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        safe_json.write_text(
+            json.dumps(_overlap_preflight_json(report, repo_root=repo_root), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     return safe_out, safe_json, report, rendered
 
 
@@ -1578,7 +1581,7 @@ def build_overlap_preflight(*, issue: str, branch: str, repo_root: Path = ROOT_D
     matching_branch_prs = tuple(_pr_label(pr) for pr in branch_prs)
     if any(_pr_is_merged(pr) for pr in branch_prs):
         blockers.append("target branch already has a merged PR; treat this issue branch as completed")
-    elif branch_prs:
+    elif any(str(pr.get("state") or "").upper() == "CLOSED" for pr in branch_prs):
         warnings.append("target branch has closed PR history; inspect before reusing the branch")
 
     worktrees = tuple(_git_worktree_entries(repo_root))
@@ -1651,7 +1654,7 @@ def render_overlap_preflight(report: OverlapPreflightReport, *, repo_root: Path 
     lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in report.evidence) if report.evidence else lines.append("- None")
     lines.extend(["", "## Matching PRs", ""])
     if report.open_prs or report.branch_prs:
-        for label in (*report.open_prs, *report.branch_prs):
+        for label in _dedupe_preserve_order([*report.open_prs, *report.branch_prs]):
             lines.append(f"- {_sanitize_dynamic_text(label)}")
     else:
         lines.append("- None")
@@ -1674,7 +1677,7 @@ def render_overlap_preflight(report: OverlapPreflightReport, *, repo_root: Path 
     return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
 
 
-def _overlap_preflight_json(report: OverlapPreflightReport) -> dict[str, object]:
+def _overlap_preflight_json(report: OverlapPreflightReport, *, repo_root: Path = ROOT_DIR) -> dict[str, object]:
     return {
         "schema_version": 1,
         "issue": report.issue,
@@ -1689,7 +1692,7 @@ def _overlap_preflight_json(report: OverlapPreflightReport) -> dict[str, object]
         "open_prs": list(report.open_prs),
         "branch_prs": list(report.branch_prs),
         "worktrees": [
-            {"path": _sanitize_dynamic_text(item.path), "branch": item.branch, "head": item.head}
+            {"path": _display_path(item.path, repo_root=repo_root), "branch": item.branch, "head": item.head}
             for item in report.worktrees
         ],
         "remote_branches": list(report.remote_branches),

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -30,8 +30,9 @@ repo-local task queue다. GitHub issue를 대체하지 않는다. 목적은 "다
 1. `tasks/queue.md`를 연다.
 2. `Ready Order`에서 status가 `ready`인 첫 task를 고른다.
 3. task의 `Scope`, `Non-Goals`, `Evidence Required`, `Failure Conditions`를 먼저 읽는다.
-4. 시작 시 status를 `running`으로 바꾸고 `Handoff Notes`에 branch/worktree와 첫 명령을 남긴다.
-5. 끝나면 status를 `review` 또는 `done`으로 바꾸고 validation output, artifact, PR/commit link를 남긴다.
+4. 파일을 편집하기 전에 `python3 scripts/agent_loop.py overlap-preflight --issue <N> --branch <type>/issue-<N>-<slug>`로 같은 issue/branch/PR/worktree가 이미 진행 중인지 확인한다.
+5. 시작 시 status를 `running`으로 바꾸고 `Handoff Notes`에 branch/worktree와 첫 명령을 남긴다.
+6. 끝나면 status를 `review` 또는 `done`으로 바꾸고 validation output, artifact, PR/commit link를 남긴다.
 
 `backlog` task는 missing decision이나 validation이 남아 있다는 뜻이다. agent는
 `backlog`를 임의로 실행하지 말고 ready 조건을 먼저 채운다.

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -26,7 +26,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 13 | `T-2026-0013` | `done` | Maintainer -> Reviewer | merged in PR #1530. |
 | 14 | `T-2026-0014` | `done` | Maintainer -> Reviewer | merged in PR #1532. |
 | 15 | `T-2026-0015` | `done` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1536. |
-| 16 | `T-2026-0016` | `review` | Maintainer -> Reviewer | overlap preflight implemented; issue #1541. |
+| 16 | `T-2026-0016` | `review` | Maintainer -> Reviewer | overlap preflight implemented; PR #1543. |
 
 ## Examples
 
@@ -98,7 +98,7 @@ make check-branch
 
 - Plan: [`docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md`](../docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md)
 - Issue: [#1541](https://github.com/hskim-solv/BidMate-DocAgent/issues/1541)
-- PR: TBD
+- PR: [#1543](https://github.com/hskim-solv/BidMate-DocAgent/pull/1543)
 
 ### Handoff Notes
 
@@ -108,9 +108,9 @@ make check-branch
 - Role: Maintainer
 - Lifecycle stage: review
 - Branch / worktree: chore/issue-1541-overlap-preflight / /Users/hskim/.codex/worktrees/43e3/BidMate-DocAgent
-- Issue / PR: #1541 / PR TBD
+- Issue / PR: #1541 / PR #1543
 - Task: T-2026-0016
-- Current status: overlap preflight implemented; focused validation passed.
+- Current status: overlap preflight implemented; focused validation passed; PR #1543 open.
 - Files touched: scripts/agent_loop.py, tests/test_agent_loop.py, tasks/README.md, docs/operations/ai-codex-workflow.md, docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md, tasks/queue.md
 - Decisions made: keep this as a local report-only pre-edit check, not a CI gate.
 - Eval surface: workflow/tooling only; no metric or performance claim.

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -26,11 +26,99 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 13 | `T-2026-0013` | `done` | Maintainer -> Reviewer | merged in PR #1530. |
 | 14 | `T-2026-0014` | `done` | Maintainer -> Reviewer | merged in PR #1532. |
 | 15 | `T-2026-0015` | `done` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1536. |
+| 16 | `T-2026-0016` | `review` | Maintainer -> Reviewer | overlap preflight implemented; issue #1541. |
 
 ## Examples
 
 - [`tasks/examples/benchmark-hardening.md`](examples/benchmark-hardening.md): benchmark hardening task 작성 예시.
 - [`tasks/examples/eval-regression-safety.md`](examples/eval-regression-safety.md): eval regression safety task 작성 예시.
+
+## T-2026-0016 — Agent worktree overlap preflight
+
+- ID: T-2026-0016
+- Title: Agent worktree overlap preflight
+- Status: review
+- Owner role: Maintainer -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Prevent duplicate Codex sessions from starting on an issue, branch, PR, or
+worktree that is already in flight.
+
+### Scope
+
+- Add `overlap-preflight` to `scripts/agent_loop.py`.
+- Check issue state, target branch, open PRs, branch PR history, local worktrees,
+  remote branch leftovers, and current checkout freshness.
+- Write local report artifacts under `reports/agent_loop/`.
+- Document that agents should run overlap preflight before editing files.
+
+### Non-Goals
+
+- Do not add a CI gate.
+- Do not switch branches, push, create/merge/close PRs, close issues, or delete branches.
+- Do not change RAG runtime or eval behavior.
+
+### Acceptance Criteria
+
+- [x] Same issue branch in another worktree blocks.
+- [x] Same issue open PR blocks.
+- [x] Closed issue with merged branch history blocks as completed.
+- [x] Detached or stale current checkout blocks.
+- [x] Clean ADR 0007 branch/issue with no overlap reports clear.
+- [x] Start-of-task docs mention overlap preflight.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_agent_loop.py -q
+python3 -m py_compile scripts/agent_loop.py
+python3 scripts/agent_loop.py overlap-preflight --issue 1541 --branch chore/issue-1541-overlap-preflight
+python3 scripts/check_doc_links.py --check-all --paths tasks/README.md docs/operations/ai-codex-workflow.md docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md tasks/queue.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Py compile output.
+- Overlap preflight smoke output.
+- Targeted doc link check output.
+- Diff whitespace and branch checks.
+
+### Failure Conditions
+
+- Stop if the command mutates tracked docs, branches, PRs, issues, or remote state.
+- Stop if a blocked overlap returns clear.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md`](../docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md)
+- Issue: [#1541](https://github.com/hskim-solv/BidMate-DocAgent/issues/1541)
+- PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-27 KST
+
+- Role: Maintainer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1541-overlap-preflight / /Users/hskim/.codex/worktrees/43e3/BidMate-DocAgent
+- Issue / PR: #1541 / PR TBD
+- Task: T-2026-0016
+- Current status: overlap preflight implemented; focused validation passed.
+- Files touched: scripts/agent_loop.py, tests/test_agent_loop.py, tasks/README.md, docs/operations/ai-codex-workflow.md, docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md, tasks/queue.md
+- Decisions made: keep this as a local report-only pre-edit check, not a CI gate.
+- Eval surface: workflow/tooling only; no metric or performance claim.
+- Commands run: python3 -m pytest tests/test_agent_loop.py -q; python3 -m py_compile scripts/agent_loop.py; python3 scripts/agent_loop.py overlap-preflight --issue 1541 --branch chore/issue-1541-overlap-preflight; python3 scripts/check_doc_links.py --check-all --paths tasks/README.md docs/operations/ai-codex-workflow.md docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md tasks/queue.md; git diff --check; make check-branch
+- Results: passed
+- Next safe command: git diff --stat
+- Reviewer focus: false-clear risk, report-only behavior, GitHub/Git failures fail closed.
+```
 
 ## T-2026-0014 — Agent gate surface alignment
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -672,6 +672,23 @@ def test_overlap_preflight_blocks_detached_or_stale_checkout(monkeypatch, tmp_pa
     assert any("does not contain origin/main" in blocker for blocker in stale.blockers)
 
 
+def test_overlap_preflight_blocks_when_worktree_inspection_fails(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    _stub_overlap_environment(monkeypatch, repo, branch=branch)
+
+    def fail_worktrees(repo_root: Path) -> tuple[agent_loop.WorktreeSnapshot, ...]:
+        raise ValueError("git worktree list failed; worktree state could not be proven")
+
+    monkeypatch.setattr(agent_loop, "_git_worktree_entries", fail_worktrees)
+
+    report = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+
+    assert report.result == "blocked"
+    assert any("worktree state could not be proven" in blocker for blocker in report.blockers)
+    assert not any("no other worktree owns the target issue" in item for item in report.evidence)
+
+
 def test_overlap_preflight_writes_markdown_and_optional_json(monkeypatch, tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     branch = "chore/issue-1541-overlap-preflight"

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -617,6 +617,20 @@ def test_overlap_preflight_blocks_same_issue_open_pr(monkeypatch, tmp_path: Path
     assert report.open_prs == ("#9 Overlap PR head=`docs/issue-1541-existing` state=`OPEN`",)
 
 
+def test_overlap_preflight_dedupes_exact_open_branch_pr(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    pr = {"number": 9, "title": "Overlap PR", "headRefName": branch, "state": "OPEN"}
+    _stub_overlap_environment(monkeypatch, repo, branch=branch, open_prs=[pr], branch_prs=[pr])
+
+    report = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+    rendered = agent_loop.render_overlap_preflight(report, repo_root=repo)
+
+    assert report.result == "blocked"
+    assert not any("closed PR history" in warning for warning in report.warnings)
+    assert rendered.count("#9 Overlap PR") == 1
+
+
 def test_overlap_preflight_blocks_closed_issue_with_merged_branch_history(monkeypatch, tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     branch = "chore/issue-1541-overlap-preflight"

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -528,6 +528,158 @@ def test_preflight_wires_handoff_surface_and_validation(tmp_path: Path) -> None:
     assert "git diff --check" in rendered
 
 
+def _stub_overlap_environment(
+    monkeypatch,
+    repo: Path,
+    *,
+    issue: str = "1541",
+    branch: str = "chore/issue-1541-overlap-preflight",
+    current_branch: str | None = None,
+    head: str = "abc1234",
+    origin_main: str = "abc1234",
+    contains_origin: bool = True,
+    worktrees: tuple[agent_loop.WorktreeSnapshot, ...] | None = None,
+    open_prs: list[dict[str, object]] | None = None,
+    branch_prs: list[dict[str, object]] | None = None,
+    issue_state: str = "OPEN",
+    remote_branches: set[str] | None = None,
+) -> None:
+    current = branch if current_branch is None else current_branch
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: current)
+    monkeypatch.setattr(agent_loop, "_git_ref", lambda ref, *, repo_root: head if ref == "HEAD" else origin_main)
+    monkeypatch.setattr(agent_loop, "_git_is_ancestor", lambda ancestor, descendant, *, repo_root: contains_origin)
+    monkeypatch.setattr(
+        agent_loop,
+        "_git_worktree_entries",
+        lambda repo_root: worktrees
+        if worktrees is not None
+        else (agent_loop.WorktreeSnapshot(path=str(repo), branch=current, head=head),),
+    )
+    monkeypatch.setattr(agent_loop, "_local_issue_branches", lambda repo_root: {issue: {branch}})
+    monkeypatch.setattr(agent_loop, "_remote_issue_branches", lambda selected_issue, *, repo_root: remote_branches or set())
+    monkeypatch.setattr(agent_loop, "_open_pr_items", lambda *, repo_root: open_prs or [])
+    monkeypatch.setattr(agent_loop, "_branch_pr_items", lambda selected_branch, *, repo_root: branch_prs or [])
+    monkeypatch.setattr(
+        agent_loop,
+        "_issue_info",
+        lambda selected_issue, *, repo_root: {
+            "number": int(selected_issue),
+            "title": "Overlap preflight fixture",
+            "state": issue_state,
+            "url": f"https://example.test/{selected_issue}",
+        },
+    )
+
+
+def test_overlap_preflight_clear_when_no_issue_branch_pr_or_worktree_overlap(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    _stub_overlap_environment(monkeypatch, repo, branch=branch)
+
+    report = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+    rendered = agent_loop.render_overlap_preflight(report, repo_root=repo)
+
+    assert report.result == "clear"
+    assert not report.blockers
+    assert "Result: `clear`" in rendered
+    assert "git status --short --branch" in rendered
+
+
+def test_overlap_preflight_blocks_same_issue_branch_in_another_worktree(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    worktrees = (
+        agent_loop.WorktreeSnapshot(path=str(repo), branch=branch, head="abc1234"),
+        agent_loop.WorktreeSnapshot(path=str(tmp_path / "other"), branch="docs/issue-1541-existing", head="def5678"),
+    )
+    _stub_overlap_environment(monkeypatch, repo, branch=branch, worktrees=worktrees)
+
+    report = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+
+    assert report.result == "blocked"
+    assert any("another worktree" in blocker for blocker in report.blockers)
+
+
+def test_overlap_preflight_blocks_same_issue_open_pr(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    _stub_overlap_environment(
+        monkeypatch,
+        repo,
+        branch=branch,
+        open_prs=[{"number": 9, "title": "Overlap PR", "headRefName": "docs/issue-1541-existing", "state": "OPEN"}],
+    )
+
+    report = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+
+    assert report.result == "blocked"
+    assert any("open PR" in blocker for blocker in report.blockers)
+    assert report.open_prs == ("#9 Overlap PR head=`docs/issue-1541-existing` state=`OPEN`",)
+
+
+def test_overlap_preflight_blocks_closed_issue_with_merged_branch_history(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    _stub_overlap_environment(
+        monkeypatch,
+        repo,
+        branch=branch,
+        issue_state="CLOSED",
+        branch_prs=[{"number": 10, "title": "Merged work", "headRefName": branch, "state": "MERGED", "mergedAt": "2026-05-27T00:00:00Z"}],
+    )
+
+    report = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+
+    assert report.result == "blocked"
+    assert any("closed" in blocker for blocker in report.blockers)
+    assert any("merged PR" in blocker for blocker in report.blockers)
+
+
+def test_overlap_preflight_blocks_detached_or_stale_checkout(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    _stub_overlap_environment(monkeypatch, repo, branch=branch, current_branch="HEAD")
+
+    detached = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+
+    _stub_overlap_environment(
+        monkeypatch,
+        repo,
+        branch=branch,
+        head="old1111",
+        origin_main="new2222",
+        contains_origin=False,
+    )
+    stale = agent_loop.build_overlap_preflight(issue="1541", branch=branch, repo_root=repo)
+
+    assert detached.result == "blocked"
+    assert any("detached HEAD" in blocker for blocker in detached.blockers)
+    assert stale.result == "blocked"
+    assert any("does not contain origin/main" in blocker for blocker in stale.blockers)
+
+
+def test_overlap_preflight_writes_markdown_and_optional_json(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    branch = "chore/issue-1541-overlap-preflight"
+    _stub_overlap_environment(monkeypatch, repo, branch=branch)
+
+    out, json_out, report, _ = agent_loop.write_overlap_preflight(
+        issue="1541",
+        branch=branch,
+        out=Path("reports/agent_loop/overlap_preflight.md"),
+        json_out=Path("reports/agent_loop/overlap_preflight.json"),
+        repo_root=repo,
+    )
+
+    assert report.result == "clear"
+    assert out == repo / "reports" / "agent_loop" / "overlap_preflight.md"
+    assert json_out == repo / "reports" / "agent_loop" / "overlap_preflight.json"
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["result"] == "clear"
+    assert payload["issue"] == "1541"
+    assert str(repo) not in json_out.read_text(encoding="utf-8")
+
+
 def test_pr_selector_rejects_gh_option_like_values() -> None:
     for value in ("--repo=other/repo", "-R", "12\n--repo=other/repo", "abc"):
         try:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

작업 시작 전 같은 issue/branch/PR/worktree가 이미 진행 중인지 확인하는 read-only overlap preflight를 agent loop에 추가합니다. 이번 #1535/#1539 흐름처럼 stale detached worktree나 다른 세션과 겹치는 상황을 파일 편집 전에 차단하는 목적입니다.

Closes #1541

## 2. 영향 파일

- scripts/agent_loop.py
- tests/test_agent_loop.py
- tasks/README.md
- docs/operations/ai-codex-workflow.md
- docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md
- tasks/queue.md

## 3. 리스크

주요 리스크는 false-clear입니다. 그래서 GitHub issue/PR state를 읽지 못하면 blocker로 처리하고, detached/stale checkout, same issue open PR, other worktree owner, merged branch history를 모두 blocked로 고정했습니다. Remote branch leftover는 inspect-needed warning입니다.

## 4. 테스트

- python3 -m pytest tests/test_agent_loop.py -q
- python3 -m py_compile scripts/agent_loop.py
- python3 scripts/agent_loop.py overlap-preflight --issue 1541 --branch chore/issue-1541-overlap-preflight
- python3 scripts/check_doc_links.py --check-all --paths tasks/README.md docs/operations/ai-codex-workflow.md docs/plans/T-2026-0016-agent-worktree-overlap-preflight.md tasks/queue.md
- git diff --check
- make check-branch

## 5. Eval 영향

Workflow/tooling change only. RAG runtime, retrieval, verifier, ingestion, eval runner, scorer behavior 변경 없음. 성능 주장(performance claim) 없음.

### 5b. Real-data delta

N/A — load-bearing path 변경 없음. Private real-eval 실행하지 않음.

## 6. 하위 호환

기존 preflight 명령은 그대로 유지합니다. 새 명령은 report-only additive CLI입니다.

## 7. 범위 외

CI gate 승격, worktree cleanup 실행, branch switch, push/PR/merge/close/delete 자동 실행은 범위 밖입니다.