### PR TITLE
chore: automate offline online run manifest

### DIFF
--- a/docs/evaluation/agent-gated-rfp-eval-loop.md
+++ b/docs/evaluation/agent-gated-rfp-eval-loop.md
@@ -77,7 +77,7 @@ metric suite다.
 | Milestone | Smallest next PR | Evidence required |
 |---|---|---|
 | v0-a metric inventory | 현재 private real-eval aggregate에 이미 있는 metric과 없는 metric을 [표로 분류한다](./v0-metric-suite-inventory.md). | aggregate-only inventory, no performance claim |
-| v0-b offline/online run manifest | offline/online 실행 환경, provider/model, payload class, egress mode를 같은 schema로 기록한다. | manifest schema + privacy test |
+| v0-b offline/online run manifest | offline/online 실행 환경, provider/model, payload class, egress mode를 [같은 schema](./offline-online-run-manifest.md)로 기록한다. | manifest schema + privacy test |
 | v0-c metric suite report | `scripts/render_v0_metric_suite_report.py`로 retrieval, grounding, citation, comparison, abstention, numeric/date/condition, judge agreement를 한 report shell에 모은다. | private real-eval aggregate + provenance |
 | v1 failure sensitivity | 세 개 이상의 RFP failure mode에 대해 metric이 실제로 움직이는지 확인한다. | before/after or historical failure replay |
 | v2 agreement calibration | human 또는 approved judge signal과 suite metric의 agreement를 측정한다. | agreement aggregate, no raw private text |

--- a/docs/evaluation/offline-online-run-manifest.md
+++ b/docs/evaluation/offline-online-run-manifest.md
@@ -1,0 +1,114 @@
+# Offline/Online Run Manifest
+
+이 manifest는 ADR 0079의 v0-b milestone을 위한 실행 환경 provenance다. 목적은
+offline과 online 평가(evaluation)를 같은 schema로 기록해, metric aggregate가
+어떤 환경과 payload boundary에서 생성됐는지 review할 수 있게 하는 것이다.
+
+이 문서는 성능(performance) 주장을 만들지 않는다. Private real-eval 원문,
+질문, 답변, 근거(evidence), `doc_id`, `chunk_id`, filename, exact local path는
+manifest에 쓰지 않는다.
+
+## Command
+
+```bash
+python3 scripts/agent_loop.py eval-run-manifest \
+  --mode offline \
+  --payload-class none \
+  --egress-mode none \
+  --provider local \
+  --model local-judge-v1 \
+  --judge-backend local-llm
+```
+
+```bash
+python3 scripts/agent_loop.py eval-run-manifest \
+  --mode online \
+  --payload-class private-raw \
+  --egress-mode private-raw \
+  --provider openai \
+  --model gpt-example \
+  --judge-backend external-judge
+```
+
+Default output:
+
+```text
+reports/agent_loop/offline_online_run_manifest.json
+```
+
+`eval/run_eval.py` also records the same `environment`, `model`, `payload`, and
+`privacy` sections inside `run_manifest`. A config may provide an optional
+top-level block:
+
+```yaml
+run_environment:
+  mode: offline
+  provider: local
+  model: local-judge-v1
+  judge_backend: local-llm
+  hardware: local-gpu
+  payload_class: none
+  private_data_egress: none
+```
+
+The same values can be overridden for ad hoc runs with:
+
+```text
+BIDMATE_EVAL_ENVIRONMENT
+BIDMATE_EVAL_PROVIDER
+BIDMATE_EVAL_MODEL
+BIDMATE_EVAL_JUDGE_BACKEND
+BIDMATE_EVAL_HARDWARE
+BIDMATE_EVAL_PAYLOAD_CLASS
+BIDMATE_EVAL_PRIVATE_DATA_EGRESS
+```
+
+## Schema
+
+Top-level fields:
+
+| field | purpose |
+|---|---|
+| `schema_version` | Manifest schema version. Current value: `1`. |
+| `generated_at` | UTC generation timestamp. |
+| `git_head` | Current git commit. |
+| `branch` | Current git branch. |
+| `environment` | Offline/online execution mode and network assumptions. |
+| `model` | Provider/model/judge backend provenance. |
+| `payload` | Payload class and private-data egress mode. |
+| `provenance` | Surface, case family, config digest, and sanitized source command. |
+| `cost_latency` | Optional online cost/latency scalars. |
+| `privacy` | Commit-safety booleans. |
+
+`environment` fields:
+
+| field | offline | online |
+|---|---|---|
+| `mode` | `offline` | `online` |
+| `network` | `closed` | `non-closed` |
+| `external_api_allowed` | `false` | `true` |
+| `external_api_used` | derived from provider | derived from provider |
+| `hardware` | sanitized scalar | sanitized scalar |
+
+`payload.private_data_egress` values:
+
+| value | meaning |
+|---|---|
+| `none` | No private data leaves the execution environment. Required for offline. |
+| `metadata-only` | Only coarse metadata/provenance leaves the environment. |
+| `public-only` | Only public fixture or synthetic public payload leaves the environment. |
+| `private-raw` | Private raw payload egress is intentionally allowed and recorded. |
+
+## Privacy Contract
+
+- Offline manifests must set `private_data_egress` to `none`.
+- Online manifests must record provider and model.
+- Config paths are not serialized. Only `config_sha256` is recorded.
+- Source commands are sanitized before serialization.
+- Manifest generation fails if exact local paths or raw private fields are present.
+
+## Claim Boundary
+
+This manifest is provenance evidence only. It supports later v0-c report review,
+but it is not a private real-eval result, benchmark lift, regression fix, or RFP
+quality claim.

--- a/docs/evaluation/v0-metric-suite-inventory.md
+++ b/docs/evaluation/v0-metric-suite-inventory.md
@@ -58,7 +58,7 @@ supplies aggregate κ/ρ evidence.
 
 | Milestone | Follow-up |
 |---|---|
-| v0-b offline/online run manifest | Reuse the metric family list here and add run-environment provenance fields for each aggregate source. |
+| v0-b offline/online run manifest | Reuse the metric family list here and add [run-environment provenance](./offline-online-run-manifest.md) fields for each aggregate source. |
 | v0-c metric suite report | Use `scripts/render_v0_metric_suite_report.py` to render one report shell that includes all present families and explicitly marks data-dependent partial families. |
 | v1 failure sensitivity | Use this inventory to pick at least three failure modes with observable metric movement. |
 | v2 agreement calibration | Promote human/judge agreement from partial to present with private-label aggregate evidence. |

--- a/docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md
+++ b/docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md
@@ -3,7 +3,7 @@
 - Status: review
 - Owner role: Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0017`
-- Related issue / PR: [#1542](https://github.com/hskim-solv/BidMate-DocAgent/issues/1542) / N/A
+- Related issue / PR: [#1542](https://github.com/hskim-solv/BidMate-DocAgent/issues/1542) / [#1545](https://github.com/hskim-solv/BidMate-DocAgent/pull/1545)
 - Related ADR: [ADR 0079](../adr/0079-agent-gated-offline-online-rfp-eval-loop.md)
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -146,7 +146,7 @@ must not be reviewed as a performance or metric improvement.
 - Role: Maintainer
 - Branch / worktree: chore/issue-1542-offline-online-manifest / /Users/hskim/.codex/worktrees/1542/BidMate-DocAgent
 - Task: T-2026-0017
-- Issue / PR: #1542 / N/A
+- Issue / PR: #1542 / #1545
 - Current status: implementation validated; ready for PR review
 - Files touched: eval/run_eval.py, scripts/agent_loop.py, scripts/run_real_eval_delta.py, docs/evaluation/offline-online-run-manifest.md, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/evaluation/v0-metric-suite-inventory.md, docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md, tasks/queue.md, tests/test_agent_loop.py, tests/test_eval_metrics.py, tests/test_run_manifest_versioning_regression.py, tests/test_run_real_eval_delta.py
 - Commands run: python3 -m pytest tests/test_agent_loop.py tests/test_run_manifest_versioning_regression.py tests/test_eval_metrics.py tests/test_run_real_eval_delta.py -q; python3 -m py_compile scripts/agent_loop.py eval/run_eval.py scripts/run_real_eval_delta.py; python3 scripts/agent_loop.py eval-run-manifest --mode offline --payload-class none --egress-mode none --provider local --model local-judge-v1 --judge-backend local-llm; python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/offline-online-run-manifest.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md tasks/queue.md; git diff --check; make check-branch; python3 scripts/_governance.py --check-eval-privacy

--- a/docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md
+++ b/docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md
@@ -1,0 +1,161 @@
+# Plan: T-2026-0017 v0-b offline/online run manifest
+
+- Status: review
+- Owner role: Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0017`
+- Related issue / PR: [#1542](https://github.com/hskim-solv/BidMate-DocAgent/issues/1542) / N/A
+- Related ADR: [ADR 0079](../adr/0079-agent-gated-offline-online-rfp-eval-loop.md)
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+## Problem Statement
+
+ADR 0079 defines v0 as producing metric-suite aggregates across offline and
+online environments, but current run manifests do not consistently record the
+offline/online execution axis, provider/model provenance, payload class, and
+private-data egress mode.
+
+Without this, later metric reports can compare numbers without enough context to
+review privacy boundary or environment compatibility.
+
+## Current Behavior
+
+`eval/run_eval.py::compute_run_manifest` records git/config/index/chunking
+provenance. `scripts/agent_loop.py manifest` records generated artifact
+freshness. Neither one separately automates the ADR 0079 offline/online
+execution environment contract.
+
+## Desired Behavior
+
+`eval/run_eval.py` records the v0-b offline/online environment block inside
+`run_manifest`, and `scripts/agent_loop.py eval-run-manifest` can write a
+standalone privacy-safe manifest artifact for review and handoff.
+
+## Constraints
+
+- Scope constraints: additive manifest fields only.
+- Architecture constraints: do not change RAG runtime, scoring, ranking, or eval
+  metric formulas.
+- Compatibility constraints: existing `run_manifest` keys remain present.
+- Eval/privacy constraints: aggregate/provenance only; no raw private content or
+  exact local paths.
+- Tooling/CI constraints: keep tests deterministic and offline.
+- Non-goals: do not run private real-eval and do not make a performance claim.
+
+## Architecture Impact
+
+- Affected modules or docs: `eval/run_eval.py`, `scripts/agent_loop.py`,
+  `scripts/run_real_eval_delta.py`, tests, eval docs, queue.
+- Affected contracts or invariants: `run_manifest` gains additive sections;
+  real-eval aggregate extraction whitelists those sections.
+- Load-bearing paths: `eval/run_eval.py`, `scripts/run_real_eval_delta.py`.
+- ADR required: no; implements accepted ADR 0079 milestone.
+- Backward compatibility expectation: existing consumers can ignore the new
+  nested sections.
+
+## Affected Interfaces
+
+- CLI/API/config: new `scripts/agent_loop.py eval-run-manifest`; optional
+  `run_environment` config block and env overrides for eval runs.
+- Input data: no private raw data read beyond hashing existing config files.
+- Output artifacts: `reports/agent_loop/offline_online_run_manifest.json` and
+  additive `run_manifest` sections.
+- Docs/review surfaces: v0-b schema doc and milestone links.
+- Tests/eval entrypoints: focused unit tests for manifest schema and privacy.
+
+## Data / Eval Impact
+
+- Surface: private real-eval provenance / eval harness plumbing.
+- Data boundary: aggregate-only private output; no data touched.
+- Allowed claim: manifest/provenance automation works.
+- Disallowed claim: no benchmark, metric, regression, or RFP quality claim.
+- Baseline or control affected: no; scoring and retrieval behavior unchanged.
+- Benchmark/eval auditor required: yes, because manifest fields are eval
+  provenance.
+
+## Task Breakdown
+
+1. Add run-environment provenance to `compute_run_manifest`.
+2. Add a standalone `eval-run-manifest` CLI for handoff/report artifacts.
+3. Whitelist the new scalar manifest sections in real-eval aggregate extraction.
+4. Add focused schema and privacy tests.
+5. Update v0-b docs and queue state.
+
+## Acceptance Criteria
+
+- [x] Offline and online manifest examples share the same section schema.
+- [x] Offline manifests force `private_data_egress=none`.
+- [x] Online manifests record provider/model/payload class/egress mode.
+- [x] Config paths are not serialized in committed manifest fields.
+- [x] Privacy tests cover raw private text and exact local path redaction.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 -m pytest tests/test_agent_loop.py tests/test_run_manifest_versioning_regression.py tests/test_eval_metrics.py tests/test_run_real_eval_delta.py -q
+python3 -m py_compile scripts/agent_loop.py eval/run_eval.py scripts/run_real_eval_delta.py
+python3 scripts/agent_loop.py eval-run-manifest --mode offline --payload-class none --egress-mode none --provider local --model local-judge-v1 --judge-backend local-llm
+python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/offline-online-run-manifest.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md tasks/queue.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: focused pytest and py_compile pass.
+- Generated or updated artifact: local `reports/agent_loop/offline_online_run_manifest.json`.
+- Reviewer checklist or manual inspection: no raw private content and no
+  performance claim.
+- Explicitly not validated, with reason: private real-eval not run; this is
+  manifest plumbing only.
+
+## Rollback Strategy
+
+Revert the PR. Do not delete local private eval outputs or ignored real-eval
+artifacts during rollback.
+
+## Failure Modes
+
+- Failure mode: online manifests omit provider/model.
+- Detection signal: `eval-run-manifest` validation raises `ValueError`.
+- Stop condition or fallback: keep the PR draft and fix schema input handling.
+
+- Failure mode: committed aggregate extraction leaks path-like manifest fields.
+- Detection signal: `tests/test_run_real_eval_delta.py` privacy assertions fail.
+- Stop condition or fallback: tighten the whitelist.
+
+## Observability
+
+- `run_manifest.environment`, `run_manifest.model`, `run_manifest.payload`, and
+  `run_manifest.privacy` in eval summaries.
+- `reports/agent_loop/offline_online_run_manifest.json` for standalone handoff.
+- Focused pytest coverage.
+
+## Reviewer Notes
+
+Attack privacy boundary, schema compatibility, and claim wording first. This PR
+must not be reviewed as a performance or metric improvement.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-27 KST
+
+- Role: Maintainer
+- Branch / worktree: chore/issue-1542-offline-online-manifest / /Users/hskim/.codex/worktrees/1542/BidMate-DocAgent
+- Task: T-2026-0017
+- Issue / PR: #1542 / N/A
+- Current status: implementation validated; ready for PR review
+- Files touched: eval/run_eval.py, scripts/agent_loop.py, scripts/run_real_eval_delta.py, docs/evaluation/offline-online-run-manifest.md, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/evaluation/v0-metric-suite-inventory.md, docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md, tasks/queue.md, tests/test_agent_loop.py, tests/test_eval_metrics.py, tests/test_run_manifest_versioning_regression.py, tests/test_run_real_eval_delta.py
+- Commands run: python3 -m pytest tests/test_agent_loop.py tests/test_run_manifest_versioning_regression.py tests/test_eval_metrics.py tests/test_run_real_eval_delta.py -q; python3 -m py_compile scripts/agent_loop.py eval/run_eval.py scripts/run_real_eval_delta.py; python3 scripts/agent_loop.py eval-run-manifest --mode offline --payload-class none --egress-mode none --provider local --model local-judge-v1 --judge-backend local-llm; python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/offline-online-run-manifest.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md tasks/queue.md; git diff --check; make check-branch; python3 scripts/_governance.py --check-eval-privacy
+- Results: passed
+- Validation evidence: focused pytest, py_compile, manifest CLI smoke, targeted doc link check, diff whitespace check, branch/issue check, eval privacy check
+- Blockers: none known
+- Open risks: review nested manifest whitelist and no-claim wording
+- Next action: run focused validation
+- Next safe command: python3 -m pytest tests/test_agent_loop.py tests/test_run_manifest_versioning_regression.py tests/test_eval_metrics.py tests/test_run_real_eval_delta.py -q
+- Reviewer focus: privacy-safe scalar whitelist, backward-compatible manifest fields, no performance claim
+- Eval surface: provenance plumbing only; no private real-eval run
+```

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
-from typing import Any
+from typing import Any, Mapping
 
 import yaml
 
@@ -56,6 +56,25 @@ DEFAULT_ABLATION_RUNS = [
         "pipeline": DEFAULT_CLI_PIPELINE_NAME,
     }
 ]
+RUN_ENVIRONMENT_MODES = {"offline", "online"}
+RUN_PAYLOAD_CLASSES = {
+    "none",
+    "aggregate-only",
+    "metadata-only",
+    "public-fixture",
+    "private-raw",
+}
+RUN_EGRESS_MODES = {"none", "metadata-only", "public-only", "private-raw"}
+LOCAL_PROVIDER_VALUES = {"local", "none", "stub", "offline", "unknown"}
+ABSOLUTE_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:/Users|/private|/var/folders|/Volumes)/[^\s)`'\"]+"
+)
+PRIVATE_INLINE_VALUE_RE = re.compile(
+    r"\b(?P<label>(?:raw\s+)?(?:question|answer|evidence)|doc[_ -]?id|"
+    r"chunk[_ -]?id|file\s*name|filename)\b"
+    r"\s*[:=]\s*(?P<value>[^\n;,]+)",
+    re.IGNORECASE,
+)
 
 
 def _git(*args: str) -> str:
@@ -75,6 +94,7 @@ def _git(*args: str) -> str:
 def compute_run_manifest(
     config_path: Path,
     index: dict[str, Any] | None = None,
+    run_environment: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the run_manifest block pinned to git commit + config bytes + UTC time.
 
@@ -105,6 +125,7 @@ def compute_run_manifest(
     chunker_version = chunking_meta.get("chunker_version")
     if not chunker_version and chunking_strategy:
         chunker_version = f"chunker.{chunking_strategy}.v1"
+    environment_block = build_run_environment_manifest(run_environment)
     return {
         "git_commit": commit,
         "git_dirty": dirty,
@@ -119,7 +140,86 @@ def compute_run_manifest(
         "chunker_version": chunker_version,
         "chunk_max_chars": chunking_meta.get("max_chars"),
         "chunk_overlap_sentences": chunking_meta.get("overlap_sentences"),
+        **environment_block,
     }
+
+
+def build_run_environment_manifest(run_environment: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Return the ADR 0079 offline/online execution provenance block.
+
+    The block is intentionally scalar and aggregate-only. It records execution
+    assumptions, not raw prompts, answers, evidence, case IDs, filenames, or
+    local paths.
+    """
+    source = dict(run_environment or {})
+    mode = _manifest_choice(
+        os.environ.get("BIDMATE_EVAL_ENVIRONMENT") or source.get("mode"),
+        default="offline",
+        choices=RUN_ENVIRONMENT_MODES,
+    )
+    provider = _manifest_scalar(
+        os.environ.get("BIDMATE_EVAL_PROVIDER") or source.get("provider"),
+        default="local" if mode == "offline" else "unknown",
+    )
+    model = _manifest_scalar(
+        os.environ.get("BIDMATE_EVAL_MODEL") or source.get("model"),
+        default="unknown",
+    )
+    judge_backend = _manifest_scalar(
+        os.environ.get("BIDMATE_EVAL_JUDGE_BACKEND") or source.get("judge_backend"),
+        default="unknown",
+    )
+    hardware = _manifest_scalar(
+        os.environ.get("BIDMATE_EVAL_HARDWARE") or source.get("hardware"),
+        default="unknown",
+    )
+    payload_class = _manifest_choice(
+        os.environ.get("BIDMATE_EVAL_PAYLOAD_CLASS") or source.get("payload_class"),
+        default="none",
+        choices=RUN_PAYLOAD_CLASSES,
+    )
+    egress_mode = _manifest_choice(
+        os.environ.get("BIDMATE_EVAL_PRIVATE_DATA_EGRESS")
+        or source.get("private_data_egress"),
+        default="none",
+        choices=RUN_EGRESS_MODES,
+    )
+    return {
+        "environment": {
+            "mode": mode,
+            "network": "closed" if mode == "offline" else "non-closed",
+            "external_api_allowed": mode == "online",
+            "external_api_used": provider.lower() not in LOCAL_PROVIDER_VALUES,
+            "hardware": hardware,
+        },
+        "model": {
+            "provider": provider,
+            "model": model,
+            "judge_backend": judge_backend,
+        },
+        "payload": {
+            "payload_class": payload_class,
+            "private_data_egress": "none" if mode == "offline" else egress_mode,
+        },
+        "privacy": {
+            "raw_private_content_committed": False,
+            "exact_local_paths_committed": False,
+        },
+    }
+
+
+def _manifest_choice(value: Any, *, default: str, choices: set[str]) -> str:
+    cleaned = _manifest_scalar(value, default=default).lower()
+    return cleaned if cleaned in choices else default
+
+
+def _manifest_scalar(value: Any, *, default: str) -> str:
+    text = str(value if value is not None else default).strip()
+    if not text:
+        text = default
+    text = ABSOLUTE_LOCAL_PATH_RE.sub("[redacted-local-path]", text)
+    text = PRIVATE_INLINE_VALUE_RE.sub(lambda match: f"{match.group('label')}: [redacted-private-value]", text)
+    return text or default
 
 
 def parse_args() -> argparse.Namespace:
@@ -1585,7 +1685,13 @@ def main() -> int:
     summary = {
         "mode": "rag",
         "provenance": build_provenance(),
-        "run_manifest": compute_run_manifest(config_path, index),
+        "run_manifest": compute_run_manifest(
+            config_path,
+            index,
+            config.get("run_environment")
+            if isinstance(config.get("run_environment"), dict)
+            else None,
+        ),
         "config": args.config,
         "index_dir": args.index_dir,
         "index_citation_metadata_coverage": index_citation_metadata_coverage(index),

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -90,6 +90,7 @@ DEFAULT_ARCHITECTURE_BRIEF = DEFAULT_REPORT_DIR / "architecture_brief.md"
 DEFAULT_SHIP_SIMULATION = DEFAULT_REPORT_DIR / "ship_simulation.md"
 DEFAULT_GATE_BRIEF = DEFAULT_REPORT_DIR / "gate_brief.md"
 DEFAULT_MANIFEST = DEFAULT_REPORT_DIR / "manifest.json"
+DEFAULT_EVAL_RUN_MANIFEST = DEFAULT_REPORT_DIR / "offline_online_run_manifest.json"
 DEFAULT_PR_BODY_CHECK = DEFAULT_REPORT_DIR / "pr_body_check.md"
 DEFAULT_CI_INGEST = DEFAULT_REPORT_DIR / "ci_ingest.md"
 DEFAULT_CI_FOLLOWUPS_DIR = DEFAULT_REPORT_DIR / "ci_followups"
@@ -192,6 +193,16 @@ EVAL_SURFACE_SIGNALS = (
     "synthetic benchmark",
     "performance claim",
 )
+EVAL_RUN_MODES = ("offline", "online")
+EVAL_RUN_PAYLOAD_CLASSES = (
+    "none",
+    "aggregate-only",
+    "metadata-only",
+    "public-fixture",
+    "private-raw",
+)
+EVAL_RUN_EGRESS_MODES = ("none", "metadata-only", "public-only", "private-raw")
+LOCAL_PROVIDER_VALUES = {"local", "none", "stub", "offline", "unknown"}
 
 FORBIDDEN_DYNAMIC_LABELS = {
     "raw question",
@@ -4982,6 +4993,180 @@ def _changed_files_hash(changed_files: Sequence[str], *, repo_root: Path) -> str
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
+def write_eval_run_manifest(
+    *,
+    mode: str,
+    provider: str | None = None,
+    model: str | None = None,
+    payload_class: str,
+    egress_mode: str,
+    surface: str = "private-real-eval",
+    case_family: str = "private-real-eval",
+    judge_backend: str | None = None,
+    hardware: str | None = None,
+    source_command: str = "manual",
+    config: Path | None = None,
+    cost_usd: float | None = None,
+    latency_ms: float | None = None,
+    out: Path = DEFAULT_EVAL_RUN_MANIFEST,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, dict[str, object]]:
+    manifest = build_eval_run_manifest(
+        mode=mode,
+        provider=provider,
+        model=model,
+        payload_class=payload_class,
+        egress_mode=egress_mode,
+        surface=surface,
+        case_family=case_family,
+        judge_backend=judge_backend,
+        hardware=hardware,
+        source_command=source_command,
+        config=config,
+        cost_usd=cost_usd,
+        latency_ms=latency_ms,
+        repo_root=repo_root,
+    )
+    _validate_eval_run_manifest(manifest)
+    out = _default_output(
+        out,
+        DEFAULT_EVAL_RUN_MANIFEST,
+        "offline_online_run_manifest.json",
+        repo_root=repo_root,
+    )
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return safe_out, manifest
+
+
+def build_eval_run_manifest(
+    *,
+    mode: str,
+    provider: str | None,
+    model: str | None,
+    payload_class: str,
+    egress_mode: str,
+    surface: str,
+    case_family: str,
+    judge_backend: str | None,
+    hardware: str | None,
+    source_command: str,
+    config: Path | None,
+    cost_usd: float | None,
+    latency_ms: float | None,
+    repo_root: Path,
+) -> dict[str, object]:
+    safe_mode = _require_choice("mode", mode, EVAL_RUN_MODES)
+    safe_payload = _require_choice("payload_class", payload_class, EVAL_RUN_PAYLOAD_CLASSES)
+    safe_egress = _require_choice("egress_mode", egress_mode, EVAL_RUN_EGRESS_MODES)
+    safe_provider = _manifest_scalar(provider, default="local" if safe_mode == "offline" else "unknown")
+    safe_model = _manifest_scalar(model, default="unknown")
+    safe_judge_backend = _manifest_scalar(judge_backend, default="unknown")
+    safe_hardware = _manifest_scalar(hardware, default="unknown")
+    config_sha = _config_sha256_16(config)
+
+    manifest: dict[str, object] = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "git_head": _current_git_head(repo_root) or "unknown",
+        "branch": _current_branch(repo_root) or "unknown",
+        "environment": {
+            "mode": safe_mode,
+            "network": "closed" if safe_mode == "offline" else "non-closed",
+            "external_api_allowed": safe_mode == "online",
+            "external_api_used": safe_provider.lower() not in LOCAL_PROVIDER_VALUES,
+            "hardware": safe_hardware,
+        },
+        "model": {
+            "provider": safe_provider,
+            "model": safe_model,
+            "judge_backend": safe_judge_backend,
+        },
+        "payload": {
+            "payload_class": safe_payload,
+            "private_data_egress": safe_egress,
+        },
+        "provenance": {
+            "surface": _manifest_scalar(surface, default="private-real-eval"),
+            "case_family": _manifest_scalar(case_family, default="private-real-eval"),
+            "config_sha256": config_sha,
+            "config_present": bool(config and config.exists()),
+            "source_command": _sanitize_command_text(source_command),
+        },
+        "cost_latency": {
+            "cost_usd": cost_usd,
+            "latency_ms": latency_ms,
+        },
+        "privacy": {
+            "raw_private_content_committed": False,
+            "exact_local_paths_committed": False,
+            "committable": True,
+        },
+    }
+    _validate_eval_run_manifest(manifest)
+    return manifest
+
+
+def _require_choice(label: str, value: str, choices: Sequence[str]) -> str:
+    cleaned = _sanitize_inline_text(str(value or "").strip().lower())
+    if cleaned not in choices:
+        raise ValueError(f"{label} must be one of: {', '.join(choices)}")
+    return cleaned
+
+
+def _manifest_scalar(value: str | None, *, default: str) -> str:
+    cleaned = _sanitize_inline_text(str(value or default).strip())
+    return cleaned or default
+
+
+def _config_sha256_16(config: Path | None) -> str:
+    if config is None:
+        return "unknown"
+    try:
+        if not config.exists() or not config.is_file():
+            return "missing"
+        return hashlib.sha256(config.read_bytes()).hexdigest()[:16]
+    except OSError:
+        return "unreadable"
+
+
+def _validate_eval_run_manifest(manifest: dict[str, object]) -> None:
+    environment = manifest.get("environment")
+    model = manifest.get("model")
+    payload = manifest.get("payload")
+    provenance = manifest.get("provenance")
+    privacy = manifest.get("privacy")
+    if not all(isinstance(section, dict) for section in (environment, model, payload, provenance, privacy)):
+        raise ValueError("eval run manifest requires environment, model, payload, provenance, and privacy sections")
+
+    mode = str(environment.get("mode") or "")
+    provider = str(model.get("provider") or "").strip()
+    model_id = str(model.get("model") or "").strip()
+    egress = str(payload.get("private_data_egress") or "")
+    if mode == "offline":
+        if environment.get("external_api_allowed") is not False:
+            raise ValueError("offline eval run manifest must set external_api_allowed=false")
+        if egress != "none":
+            raise ValueError("offline eval run manifest must set private_data_egress=none")
+    elif mode == "online":
+        if not provider or provider == "unknown":
+            raise ValueError("online eval run manifest requires provider")
+        if not model_id or model_id == "unknown":
+            raise ValueError("online eval run manifest requires model")
+    else:
+        raise ValueError("eval run manifest mode must be offline or online")
+
+    if privacy.get("raw_private_content_committed") is not False:
+        raise ValueError("eval run manifest must not commit raw private content")
+    if privacy.get("exact_local_paths_committed") is not False:
+        raise ValueError("eval run manifest must not commit exact local paths")
+
+    rendered = json.dumps(manifest, ensure_ascii=False, sort_keys=True)
+    if ABSOLUTE_LOCAL_PATH_RE.search(rendered) or _privacy_audit_text(rendered):
+        raise ValueError("eval run manifest contains private raw values or exact local paths")
+
+
 def _manifest_freshness(
     *,
     changed_files: Sequence[str],
@@ -7399,13 +7584,14 @@ def render_automation_coverage() -> str:
         ("13", "validation history ledger", "validate --record-history, validation-history"),
         ("14", "privacy regression corpus", "privacy-regression, privacy-audit-output"),
         ("15", "claim policy engine", "claim-policy, claim-audit"),
-        ("16", "architecture decision detector", "architecture-decision, architecture-brief, adr-reserve"),
-        ("17", "PR corpus workset planner", "pr-scan, next-from-prs, batch-plan, workset-recommend, continue-loop"),
-        ("18", "auto-pass strict profiles", "auto-pass-check --profile ..."),
-        ("19", "conservative remote execution", "human-gated-exec --confirm-human-approved"),
-        ("20", "existing auto-ship bridge", "auto-ship-prepare, auto-ship-plan, ship-simulate, ship-command-pack"),
-        ("21", "conservative issue cleanup", "issue-scan, maintenance-plan, human-gated-exec --action issue-close"),
-        ("22", "role-separated subagent dispatch", "role-dispatch --batch"),
+        ("16", "offline/online eval run manifest", "eval-run-manifest"),
+        ("17", "architecture decision detector", "architecture-decision, architecture-brief, adr-reserve"),
+        ("18", "PR corpus workset planner", "pr-scan, next-from-prs, batch-plan, workset-recommend, continue-loop"),
+        ("19", "auto-pass strict profiles", "auto-pass-check --profile ..."),
+        ("20", "conservative remote execution", "human-gated-exec --confirm-human-approved"),
+        ("21", "existing auto-ship bridge", "auto-ship-prepare, auto-ship-plan, ship-simulate, ship-command-pack"),
+        ("22", "conservative issue cleanup", "issue-scan, maintenance-plan, human-gated-exec --action issue-close"),
+        ("23", "role-separated subagent dispatch", "role-dispatch --batch"),
     )
     lines = [
         "# Agent Loop Automation Coverage",
@@ -8410,6 +8596,7 @@ Automation points:
 - review-patch-plan: generate review triage plus safe patch proposal together.
 - patch-proposal: render dry-run whitespace-only patch proposal for public-safe files.
 - manifest: write input-hash freshness metadata for generated artifacts.
+- eval-run-manifest: write privacy-safe offline/online eval execution provenance.
 - artifact-freshness: alias around stale/manifest freshness checks.
 - validation-history: summarize local JSONL validation history.
 - workset-recommend: recommend serial, parallel-safe, review-only, and agent-gated task sets.
@@ -9004,6 +9191,25 @@ def build_parser() -> argparse.ArgumentParser:
     manifest.add_argument("--source-command", dest="manifest_command", default="manual")
     manifest.add_argument("--output", action="append", type=Path, default=[])
     manifest.add_argument("--out", type=Path, default=DEFAULT_MANIFEST)
+
+    eval_manifest = sub.add_parser(
+        "eval-run-manifest",
+        help="Write a privacy-safe offline/online eval run manifest.",
+    )
+    eval_manifest.add_argument("--mode", required=True, choices=EVAL_RUN_MODES)
+    eval_manifest.add_argument("--surface", default="private-real-eval")
+    eval_manifest.add_argument("--case-family", default="private-real-eval")
+    eval_manifest.add_argument("--provider")
+    eval_manifest.add_argument("--model")
+    eval_manifest.add_argument("--judge-backend")
+    eval_manifest.add_argument("--payload-class", required=True, choices=EVAL_RUN_PAYLOAD_CLASSES)
+    eval_manifest.add_argument("--egress-mode", required=True, choices=EVAL_RUN_EGRESS_MODES)
+    eval_manifest.add_argument("--hardware")
+    eval_manifest.add_argument("--source-command", default="manual")
+    eval_manifest.add_argument("--config", type=Path)
+    eval_manifest.add_argument("--cost-usd", type=float)
+    eval_manifest.add_argument("--latency-ms", type=float)
+    eval_manifest.add_argument("--out", type=Path, default=DEFAULT_EVAL_RUN_MANIFEST)
 
     pr_check = sub.add_parser("pr-body-check", help="Validate a PR body draft before PR creation.")
     pr_check.add_argument("--body", type=Path, default=DEFAULT_PR_BODY)
@@ -9695,6 +9901,25 @@ def main(argv: list[str] | None = None) -> int:
                 changed_files=files,
                 command=args.manifest_command,
                 outputs=args.output,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "eval-run-manifest":
+            out, _ = write_eval_run_manifest(
+                mode=args.mode,
+                surface=args.surface,
+                case_family=args.case_family,
+                provider=args.provider,
+                model=args.model,
+                judge_backend=args.judge_backend,
+                payload_class=args.payload_class,
+                egress_mode=args.egress_mode,
+                hardware=args.hardware,
+                source_command=args.source_command,
+                config=args.config,
+                cost_usd=args.cost_usd,
+                latency_ms=args.latency_ms,
                 out=args.out,
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -274,8 +275,29 @@ SAFE_RETRY_EFFECTIVENESS_CI_KEYS = ("recovery_rate", "residual_failure_rate")
 
 # Sub-keys whitelisted from `run_manifest`. ``config_path`` is dropped
 # (filesystem layout is not committable); ``config_sha256`` is the
-# canonical config identifier.
+# canonical config identifier. Nested offline/online provenance fields are
+# scalar-only and contain no case payload or exact local path.
 SAFE_RUN_MANIFEST_KEYS = ("git_commit", "git_dirty", "config_sha256", "generated_at")
+SAFE_RUN_MANIFEST_NESTED_KEYS = {
+    "environment": (
+        "mode",
+        "network",
+        "external_api_allowed",
+        "external_api_used",
+        "hardware",
+    ),
+    "model": ("provider", "model", "judge_backend"),
+    "payload": ("payload_class", "private_data_egress"),
+    "privacy": ("raw_private_content_committed", "exact_local_paths_committed"),
+}
+ABSOLUTE_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:/Users|/private|/var/folders|/Volumes)/[^\s)`'\"]+"
+)
+PRIVATE_INLINE_VALUE_RE = re.compile(
+    r"\b(?:(?:raw\s+)?(?:question|answer|evidence)|doc[_ -]?id|"
+    r"chunk[_ -]?id|file\s*name|filename)\s*[:=]\s*[^\n;,]+",
+    re.IGNORECASE,
+)
 
 # Per-slice subkeys extracted from `by_query_type`.
 SAFE_SLICE_METRICS = (
@@ -538,12 +560,24 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                 out[key] = ci_out
         elif key == "run_manifest" and isinstance(value, dict):
             # Drop config_path (filesystem layout, not committable).
-            # Keep git_commit / git_dirty / config_sha256 / generated_at.
-            out[key] = {
-                sub: value.get(sub)
+            # Keep reproducibility fields and scalar offline/online provenance.
+            manifest_out = {
+                sub: _safe_run_manifest_value(value.get(sub))
                 for sub in SAFE_RUN_MANIFEST_KEYS
                 if value.get(sub) is not None
             }
+            for section, allowed in SAFE_RUN_MANIFEST_NESTED_KEYS.items():
+                raw_section = value.get(section)
+                if not isinstance(raw_section, dict):
+                    continue
+                section_out = {
+                    sub: _safe_run_manifest_value(raw_section.get(sub))
+                    for sub in allowed
+                    if raw_section.get(sub) is not None
+                }
+                if section_out:
+                    manifest_out[section] = section_out
+            out[key] = manifest_out
         elif key == "judge_ragas" and isinstance(value, dict):
             ragas: dict[str, Any] = {}
             for metric in SAFE_JUDGE_RAGAS_METRIC_KEYS:
@@ -726,6 +760,17 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
 
     _assert_no_forbidden(out)
     return out
+
+
+def _safe_run_manifest_value(value: Any) -> Any:
+    if isinstance(value, (bool, int, float)) or value is None:
+        return value
+    text = str(value)
+    if ABSOLUTE_LOCAL_PATH_RE.search(text):
+        return "[redacted-local-path]"
+    if PRIVATE_INLINE_VALUE_RE.search(text):
+        return "[redacted-private-value]"
+    return text
 
 
 def _assert_no_forbidden(obj: Any, path: str = "") -> None:

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -27,10 +27,11 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 14 | `T-2026-0014` | `done` | Maintainer -> Reviewer | merged in PR #1532. |
 | 15 | `T-2026-0015` | `done` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1536. |
 | 16 | `T-2026-0016` | `review` | Maintainer -> Reviewer | overlap preflight implemented; PR #1543. |
-| 17 | `T-2026-0018` | `review` | Maintainer -> Reviewer | issue #1547 implemented; draft PR #1548. |
-| 18 | `T-2026-0019` | `review` | Maintainer -> CI Reviewer -> Reviewer | local implementation ready on issue #1549 branch. |
-| 19 | `T-2026-0020` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1544; v0 metric-suite report implementation ready for review. |
-| 20 | `T-2026-0021` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 implemented; draft PR #1552. |
+| 17 | `T-2026-0017` | `review` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | v0-b manifest automation ready for review; PR #1545. |
+| 18 | `T-2026-0018` | `review` | Maintainer -> Reviewer | issue #1547 implemented; draft PR #1548. |
+| 19 | `T-2026-0019` | `review` | Maintainer -> CI Reviewer -> Reviewer | local implementation ready on issue #1549 branch. |
+| 20 | `T-2026-0020` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1544; v0 metric-suite report implementation ready for review. |
+| 21 | `T-2026-0021` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 implemented; draft PR #1552. |
 
 ## Examples
 
@@ -122,6 +123,91 @@ make check-branch
 - Results: passed
 - Next safe command: git diff --stat
 - Reviewer focus: false-clear risk, report-only behavior, GitHub/Git failures fail closed.
+```
+
+## T-2026-0017 — v0-b offline/online run manifest
+
+- ID: T-2026-0017
+- Title: v0-b offline/online run manifest
+- Status: review
+- Owner role: Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Close the v0-b milestone from the agent-gated RFP eval loop by automating a
+privacy-safe offline/online run manifest for eval provenance.
+
+### Scope
+
+- Add offline/online environment sections to `eval/run_eval.py` `run_manifest`.
+- Add `scripts/agent_loop.py eval-run-manifest` for standalone handoff artifacts.
+- Preserve only safe scalar manifest sections in real-eval aggregate extraction.
+- Document the schema and link it from v0-b docs.
+
+### Non-Goals
+
+- Do not run private real-eval.
+- Do not change retrieval, scoring, ranking, or answer behavior.
+- Do not make a benchmark, metric, regression, or RFP quality claim.
+
+### Acceptance Criteria
+
+- [x] Offline and online manifest examples share one section schema.
+- [x] Offline manifests force `private_data_egress=none`.
+- [x] Online manifests record provider/model/payload class/egress mode.
+- [x] Privacy tests prevent raw private text and exact local path leakage.
+- [x] Existing run manifest reproducibility fields remain present.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_agent_loop.py tests/test_run_manifest_versioning_regression.py tests/test_eval_metrics.py tests/test_run_real_eval_delta.py -q
+python3 -m py_compile scripts/agent_loop.py eval/run_eval.py scripts/run_real_eval_delta.py
+python3 scripts/agent_loop.py eval-run-manifest --mode offline --payload-class none --egress-mode none --provider local --model local-judge-v1 --judge-backend local-llm
+python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/offline-online-run-manifest.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md tasks/queue.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest and py_compile output.
+- CLI-generated manifest artifact.
+- Targeted doc link check.
+- Branch/issue convention check.
+
+### Failure Conditions
+
+- Stop if committed manifest output includes raw private question, answer,
+  evidence, `doc_id`, `chunk_id`, filename, or exact local path.
+- Stop if wording implies performance improvement or private real-eval success.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md`](../docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md)
+- Issue: [#1542](https://github.com/hskim-solv/BidMate-DocAgent/issues/1542)
+- PR: [#1545](https://github.com/hskim-solv/BidMate-DocAgent/pull/1545)
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-27 KST
+
+- Role: Maintainer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1542-offline-online-manifest / /Users/hskim/.codex/worktrees/1542/BidMate-DocAgent
+- Issue / PR: #1542 / #1545
+- Task: T-2026-0017
+- Current status: implementation validated; draft PR #1545 open.
+- Files touched: eval/run_eval.py, scripts/agent_loop.py, scripts/run_real_eval_delta.py, docs/evaluation/offline-online-run-manifest.md, docs/evaluation/agent-gated-rfp-eval-loop.md, docs/evaluation/v0-metric-suite-inventory.md, docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md, tasks/queue.md, tests/test_agent_loop.py, tests/test_eval_metrics.py, tests/test_run_manifest_versioning_regression.py, tests/test_run_real_eval_delta.py
+- Decisions made: use additive `run_manifest` sections plus standalone `eval-run-manifest`; keep private real-eval unrun and no performance claim.
+- Eval surface: provenance plumbing only; no metric claim.
+- Commands run: python3 -m pytest tests/test_agent_loop.py tests/test_run_manifest_versioning_regression.py tests/test_eval_metrics.py tests/test_run_real_eval_delta.py -q; python3 -m py_compile scripts/agent_loop.py eval/run_eval.py scripts/run_real_eval_delta.py; python3 scripts/agent_loop.py eval-run-manifest --mode offline --payload-class none --egress-mode none --provider local --model local-judge-v1 --judge-backend local-llm; python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/offline-online-run-manifest.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md tasks/queue.md; git diff --check; make check-branch; python3 scripts/_governance.py --check-eval-privacy.
+- Results: passed.
+- Next safe command: git diff --stat
+- Reviewer focus: privacy-safe scalar whitelist, backward-compatible manifest fields, no performance claim.
 ```
 
 ## T-2026-0018 — Codex-runnable auto-ship

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 import subprocess
 
+import pytest
+
 from scripts import agent_loop
 
 
@@ -1899,6 +1901,104 @@ question: PRIVATE RAW QUERY
     assert patch_out == repo / "reports" / "agent_loop" / "patch_proposal.diff"
     assert "-print('x')  " in patch
     assert "+print('x')" in patch
+
+
+def test_eval_run_manifest_records_offline_online_schema_without_private_leaks(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    config = repo / "eval" / "real_config.local.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("question: PRIVATE RAW QUERY\nanswer: PRIVATE RAW ANSWER\n", encoding="utf-8")
+
+    offline_out, offline = agent_loop.write_eval_run_manifest(
+        mode="offline",
+        provider="local",
+        model="local-judge-v1",
+        judge_backend="local-llm",
+        payload_class="none",
+        egress_mode="none",
+        hardware="/Users/example/private/gpu-host",
+        source_command=(
+            "python3 scripts/run_private_real_eval.py "
+            "--config /Users/example/private/real_config.local.yaml "
+            "--question 'PRIVATE RAW QUERY'"
+        ),
+        config=config,
+        repo_root=repo,
+    )
+    online_out, online = agent_loop.write_eval_run_manifest(
+        mode="online",
+        provider="openai",
+        model="gpt-fixture",
+        judge_backend="external-judge",
+        payload_class="private-raw",
+        egress_mode="private-raw",
+        surface="private-real-eval",
+        case_family="real100-v2",
+        cost_usd=1.25,
+        latency_ms=1250.0,
+        repo_root=repo,
+    )
+
+    assert offline_out == repo / "reports" / "agent_loop" / "offline_online_run_manifest.json"
+    assert online_out == offline_out
+    assert set(offline) == set(online)
+    assert set(offline["environment"]) == set(online["environment"])  # type: ignore[arg-type]
+    assert set(offline["model"]) == set(online["model"])  # type: ignore[arg-type]
+    assert set(offline["payload"]) == set(online["payload"])  # type: ignore[arg-type]
+    assert offline["environment"]["mode"] == "offline"  # type: ignore[index]
+    assert offline["environment"]["external_api_allowed"] is False  # type: ignore[index]
+    assert offline["payload"]["private_data_egress"] == "none"  # type: ignore[index]
+    assert online["environment"]["mode"] == "online"  # type: ignore[index]
+    assert online["environment"]["external_api_allowed"] is True  # type: ignore[index]
+    assert online["model"]["provider"] == "openai"  # type: ignore[index]
+    assert online["payload"]["private_data_egress"] == "private-raw"  # type: ignore[index]
+    assert online["provenance"]["config_sha256"] == "unknown"  # type: ignore[index]
+    assert offline["provenance"]["config_sha256"] != "unknown"  # type: ignore[index]
+
+    rendered = json.dumps([offline, online], ensure_ascii=False, sort_keys=True)
+    assert "PRIVATE RAW QUERY" not in rendered
+    assert "PRIVATE RAW ANSWER" not in rendered
+    assert "/Users/example" not in rendered
+    assert "real_config.local.yaml" not in rendered
+
+
+def test_eval_run_manifest_fails_closed_for_invalid_egress_and_online_provider(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    with pytest.raises(ValueError, match="private_data_egress=none"):
+        agent_loop.build_eval_run_manifest(
+            mode="offline",
+            provider="local",
+            model="local-judge-v1",
+            payload_class="private-raw",
+            egress_mode="private-raw",
+            surface="private-real-eval",
+            case_family="real100-v2",
+            judge_backend="local-llm",
+            hardware=None,
+            source_command="manual",
+            config=None,
+            cost_usd=None,
+            latency_ms=None,
+            repo_root=repo,
+        )
+
+    with pytest.raises(ValueError, match="online eval run manifest requires provider"):
+        agent_loop.build_eval_run_manifest(
+            mode="online",
+            provider=None,
+            model="gpt-fixture",
+            payload_class="metadata-only",
+            egress_mode="metadata-only",
+            surface="private-real-eval",
+            case_family="real100-v2",
+            judge_backend="external-judge",
+            hardware=None,
+            source_command="manual",
+            config=None,
+            cost_usd=None,
+            latency_ms=None,
+            repo_root=repo,
+        )
 
 
 def test_adr_html_context_ship_commands_and_apply_queue_plan(tmp_path: Path) -> None:

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -564,6 +564,10 @@ class RunManifestTest(unittest.TestCase):
         self.assertIn("config_path", manifest)
         self.assertIn("config_sha256", manifest)
         self.assertIn("generated_at", manifest)
+        self.assertIn("environment", manifest)
+        self.assertIn("model", manifest)
+        self.assertIn("payload", manifest)
+        self.assertIn("privacy", manifest)
         # Generated timestamp ends with Z (UTC) per spec.
         self.assertTrue(manifest["generated_at"].endswith("Z"))
         # SHA is truncated 16-char hex.

--- a/tests/test_run_manifest_versioning_regression.py
+++ b/tests/test_run_manifest_versioning_regression.py
@@ -51,6 +51,8 @@ class RunManifestVersioningTest(unittest.TestCase):
         # existing reproducibility fields are untouched
         self.assertIn("git_commit", manifest)
         self.assertIn("config_sha256", manifest)
+        self.assertEqual(manifest["environment"]["mode"], "offline")
+        self.assertEqual(manifest["payload"]["private_data_egress"], "none")
 
     def test_missing_index_is_none(self) -> None:
         manifest = compute_run_manifest(CONFIG_PATH)
@@ -70,6 +72,31 @@ class RunManifestVersioningTest(unittest.TestCase):
             {"build": {"chunking": {"requested_strategy": "section"}}},
         )
         self.assertEqual(manifest["chunker_version"], "chunker.section.v1")
+
+    def test_offline_online_environment_block_is_privacy_safe(self) -> None:
+        manifest = compute_run_manifest(
+            CONFIG_PATH,
+            run_environment={
+                "mode": "online",
+                "provider": "openai",
+                "model": "gpt-fixture",
+                "judge_backend": "external-judge",
+                "hardware": "/Users/example/private/gpu-host",
+                "payload_class": "private-raw",
+                "private_data_egress": "private-raw",
+            },
+        )
+        self.assertEqual(manifest["environment"]["mode"], "online")
+        self.assertEqual(manifest["environment"]["network"], "non-closed")
+        self.assertTrue(manifest["environment"]["external_api_allowed"])
+        self.assertTrue(manifest["environment"]["external_api_used"])
+        self.assertEqual(manifest["environment"]["hardware"], "[redacted-local-path]")
+        self.assertEqual(manifest["model"]["provider"], "openai")
+        self.assertEqual(manifest["model"]["model"], "gpt-fixture")
+        self.assertEqual(manifest["payload"]["payload_class"], "private-raw")
+        self.assertEqual(manifest["payload"]["private_data_egress"], "private-raw")
+        self.assertFalse(manifest["privacy"]["raw_private_content_committed"])
+        self.assertFalse(manifest["privacy"]["exact_local_paths_committed"])
 
 
 if __name__ == "__main__":

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -381,12 +381,36 @@ class ExtractAggregateTest(unittest.TestCase):
                 "config_path": "/Users/hskim/private/real_config.local.yaml",
                 "config_sha256": "0123456789abcdef",
                 "generated_at": "2026-05-11T10:30:00Z",
+                "environment": {
+                    "mode": "online",
+                    "network": "non-closed",
+                    "external_api_allowed": True,
+                    "external_api_used": True,
+                    "hardware": "/Users/hskim/private/gpu-host",
+                },
+                "model": {
+                    "provider": "openai",
+                    "model": "gpt-fixture",
+                    "judge_backend": "external-judge",
+                },
+                "payload": {
+                    "payload_class": "private-raw",
+                    "private_data_egress": "private-raw",
+                },
+                "privacy": {
+                    "raw_private_content_committed": False,
+                    "exact_local_paths_committed": False,
+                },
             },
         }
         agg = extract_aggregate(summary)
         manifest = agg["run_manifest"]
         self.assertEqual("abc123def456", manifest["git_commit"])
         self.assertEqual("0123456789abcdef", manifest["config_sha256"])
+        self.assertEqual("online", manifest["environment"]["mode"])
+        self.assertEqual("[redacted-local-path]", manifest["environment"]["hardware"])
+        self.assertEqual("private-raw", manifest["payload"]["private_data_egress"])
+        self.assertFalse(manifest["privacy"]["raw_private_content_committed"])
         self.assertNotIn("config_path", manifest)
         # The dropped path should not appear anywhere in the serialized output.
         self.assertNotIn("hskim", json.dumps(agg))


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Automate the v0-b offline/online run manifest so eval summaries and agent-loop handoff artifacts record environment mode, provider/model, payload class, private-data egress mode, and privacy-safe provenance with one schema. Closes #1542

## 2. 영향 파일

- Load-bearing: `eval/run_eval.py` adds additive `run_manifest.environment`, `run_manifest.model`, `run_manifest.payload`, and `run_manifest.privacy` sections.
- `scripts/run_real_eval_delta.py` preserves only safe scalar nested manifest fields in committable aggregate extraction.
- `scripts/agent_loop.py` adds `eval-run-manifest` for standalone review/handoff artifacts.
- Docs/queue/tests: v0-b schema doc, plan/queue entry, focused manifest/privacy tests.

## 3. 리스크

Main risks are manifest schema drift, accidental private raw value/path leakage, and load-bearing eval provenance changes being mistaken for metric behavior changes. The implementation keeps fields additive, sanitizes/redacts local paths and private raw labels, and does not touch retrieval, scoring, ranking, ingestion, or answer behavior.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py tests/test_run_manifest_versioning_regression.py tests/test_eval_metrics.py tests/test_run_real_eval_delta.py -q`
- `python3 -m py_compile scripts/agent_loop.py eval/run_eval.py scripts/run_real_eval_delta.py`
- `python3 scripts/agent_loop.py eval-run-manifest --mode offline --payload-class none --egress-mode none --provider local --model local-judge-v1 --judge-backend local-llm`
- `python3 scripts/check_doc_links.py --check-all --paths docs/evaluation/agent-gated-rfp-eval-loop.md docs/evaluation/offline-online-run-manifest.md docs/evaluation/v0-metric-suite-inventory.md docs/plans/T-2026-0017-v0-b-offline-online-run-manifest.md tasks/queue.md`
- `python3 scripts/_governance.py --check-eval-privacy`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

Eval output schema gains additive provenance fields only. No metric formula, retrieval path, verifier path, scoring path, ingestion path, or answer generation behavior changes.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

`make real-eval` / `make real-eval-delta` was not run because this PR records run-environment provenance only and makes no benchmark, metric, regression, or RFP quality claim.

## 6. 하위 호환

Existing `run_manifest` reproducibility fields remain present. Consumers that do not read the new nested sections can ignore them. The new `eval-run-manifest` CLI is additive.

## 7. 범위 외

- Private real-eval execution.
- Online egress policy changes.
- Metric suite report rendering for v0-c.
- Any performance or quality claim.
