### PR TITLE
chore: add Codex-runnable auto-ship

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@
 
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
-.PHONY: ship-start ship-arm ship-disarm ship-status ship-review-gate worktree-cleanup-dry-run worktree-cleanup
+.PHONY: ship-start ship-arm ship-run codex-ship ship-disarm ship-status ship-review-gate worktree-cleanup-dry-run worktree-cleanup
 
 # Self-review (quarterly meta-feedback loop). Combines 4-axis portfolio
 # rubric + 5-axis Claude collaboration rubric. See SKILL at
@@ -1108,6 +1108,7 @@ clean:
 #   make ship-arm                       # 2h TTL, auto §5b
 #   make ship-arm TTL=30m REAL_EVAL=skip
 #   make ship-arm DRY_RUN=1             # safe end-to-end test
+#   make ship-run DRY_RUN=1             # arm + immediately invoke dispatcher
 #   make ship-disarm                    # immediate kill (tier 1)
 #   make ship-status                    # human-readable arm state
 # ---------------------------------------------------------------------------
@@ -1118,6 +1119,7 @@ DRAFT ?= false
 DRY_RUN ?= 0
 CROSS_OWNER ?=
 STACKED ?=
+USE_EXISTING_ARM ?= 0
 TYPE ?= chore
 SLUG ?=
 LABELS ?=
@@ -1142,6 +1144,18 @@ ship-arm:
 	  --dry-run "$(DRY_RUN)" \
 	  --cross-owner "$(CROSS_OWNER)" \
 	  --stacked "$(STACKED)"
+
+ship-run:
+	@$(PYTHON) scripts/claude-hooks/_ship_run.py \
+	  --ttl "$(TTL)" \
+	  --real-eval "$(REAL_EVAL)" \
+	  --draft "$(DRAFT)" \
+	  --dry-run "$(DRY_RUN)" \
+	  --cross-owner "$(CROSS_OWNER)" \
+	  --stacked "$(STACKED)" \
+	  --use-existing-arm "$(USE_EXISTING_ARM)"
+
+codex-ship: ship-run
 
 ship-disarm:
 	@rm -f .claude/.ship-armed .claude/.ship-running.pid

--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -1,9 +1,10 @@
 # Auto-ship 파이프라인
 
-auto-ship 파이프라인은 Stop-hook 가 구동하는 시퀀스로, feature 브랜치를
-로컬 커밋에서 `main` 의 squash-merge 된 PR 까지 한 번의 ack 으로
-가져간다: `make ship-arm`. 이슈와 브랜치 생성까지 포함한 시작점은
-`make ship-start TITLE="..."` 이다. 모든 ship-arm 사이클은
+auto-ship 파이프라인은 feature 브랜치를 로컬 커밋에서 `main` 의
+squash-merge 된 PR 까지 한 번의 ack 으로 가져간다. Claude Code 세션에서는
+`make ship-arm` 이 Stop-hook 에 넘기고, Codex/non-Claude 세션에서는
+`make ship-run` 이 같은 dispatcher 를 즉시 실행한다. 이슈와 브랜치 생성까지
+포함한 시작점은 `make ship-start TITLE="..."` 이다. 모든 ship 사이클은
 단발성(single-shot) — 성공이든 실패든 트리거를 해제(disarm)한다.
 
 이 페이지는 운영 계약을 문서화한다: 어떻게 arm 하는지, 각 게이트 / 스테이지가
@@ -16,6 +17,8 @@ auto-ship 파이프라인은 Stop-hook 가 구동하는 시퀀스로, feature �
 (PR body 생성기),
 [`scripts/claude-hooks/_ship_start.py`](../../scripts/claude-hooks/_ship_start.py)
 (issue-linked branch 생성기), 그리고
+[`scripts/claude-hooks/_ship_run.py`](../../scripts/claude-hooks/_ship_run.py)
+(Codex direct runner),
 [`scripts/claude-hooks/_ship_review_gate.py`](../../scripts/claude-hooks/_ship_review_gate.py)
 (merge 전 review gate)에 있다. 등록 위치:
 [`.claude/settings.json`](../../.claude/settings.json) 의 `Stop` hook.
@@ -58,6 +61,28 @@ make ship-start TITLE="자동화 범위 설명" TYPE=chore SLUG=short-slug
 [`Makefile:289-339`](../Makefile) 와
 [`scripts/claude-hooks/_ship_arm.py`](../../scripts/claude-hooks/_ship_arm.py) 참조.
 
+## Direct run: `make ship-run`
+
+Codex Desktop 처럼 Claude Stop-hook 이 자연스럽게 발화하지 않는 세션에서는
+`make ship-run` 을 쓴다. 이 타깃은 먼저 `_ship_arm.py` 로 같은
+[`.claude/.ship-armed`](../Makefile) 상태 파일을 만든 다음,
+[`stop-ship.sh`](../../scripts/claude-hooks/stop-ship.sh)를 stdin EOF 와 함께
+즉시 1회 호출한다. 정책 우회가 아니라 같은 Gate 0 / Stage 1-5 dispatcher 를
+직접 호출하는 wrapper 다.
+
+```bash
+make ship-run DRY_RUN=1
+make ship-run REAL_EVAL=skip DRAFT=true
+USE_EXISTING_ARM=1 make ship-run
+make codex-ship DRY_RUN=1
+```
+
+`USE_EXISTING_ARM=1` 은 이미 존재하는 `.claude/.ship-armed` 를 덮어쓰지 않고
+그 arm 상태를 그대로 dispatch 한다. 기본값은 fail-closed: arm 파일이 이미
+있으면 새 arm 을 만들지 않고 거부한다. `make codex-ship` 은 `ship-run` 의
+alias 이다. `make ship-arm` 은 계속 arm-only 이므로 Claude Code Stop-hook
+워크플로와 호환된다.
+
 `make ship-arm` 은 승인된 end-to-end shipping 경로다. Agent-loop 의
 `auto-ship-prepare` / `auto-ship-plan` 은 이 경로를 준비·설명하는 명시적
 planning command 이며, local Stop hook 의 lightweight status refresh 는 이
@@ -74,6 +99,8 @@ edit + local verification
 make ship-arm  (writes .claude/.ship-armed)
     ↓
 Claude Stop event  →  scripts/claude-hooks/stop-ship.sh fires
+    ↓
+or: make ship-run / make codex-ship  (writes .ship-armed + invokes stop-ship.sh now)
     ↓
 Gate 0 — 8 pre-checks (silent exit on any failure)
     ↓
@@ -101,7 +128,7 @@ Stop hook 은 모든 Claude 턴마다 발화한다. 지배적 케이스는 no-op
 | 3 | 만료되지 않음 | TTL 초과 → 조용히 disarm | [`stop-ship.sh:71-81`](../../scripts/claude-hooks/stop-ship.sh) |
 | 4 | 브랜치가 arm 과 일치 | 브랜치 전환됨 → 조용히 disarm | [`stop-ship.sh:83-91`](../../scripts/claude-hooks/stop-ship.sh) |
 | 5 | 보호 브랜치가 아님 | main/master/develop/HEAD/release/* → **hard abort** (tier-3 firewall) | [`stop-ship.sh:93-98`](../../scripts/claude-hooks/stop-ship.sh) |
-| 6 | ship 할 작업이 있음 | clean tree + unpushed 커밋 없음 → 조용히 exit | [`stop-ship.sh:100-108`](../../scripts/claude-hooks/stop-ship.sh) |
+| 6 | ship 할 작업이 있음 | clean tree + unpushed 커밋 없음 + 기존 PR 없음 → 조용히 exit. 기존 PR 이 있으면 CI/review/merge 재개 | [`stop-ship.sh:100-108`](../../scripts/claude-hooks/stop-ship.sh) |
 | 7 | 진행 중인 git transition 없음 | merge / rebase / cherry-pick / revert 감지 → 조용히 exit | [`stop-ship.sh:110-119`](../../scripts/claude-hooks/stop-ship.sh) |
 | 8 | live pid 없음 | 이전 실행이 아직 살아있음 → 조용히 exit | [`stop-ship.sh:121-131`](../../scripts/claude-hooks/stop-ship.sh) |
 

--- a/docs/plans/T-2026-0018-codex-runnable-auto-ship.md
+++ b/docs/plans/T-2026-0018-codex-runnable-auto-ship.md
@@ -1,0 +1,156 @@
+# Plan: T-2026-0018 Codex-runnable auto-ship
+
+- Status: review
+- Owner role: Maintainer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0018`
+- Related issue / PR: issue #1547, draft PR #1548
+- Related ADR: N/A - no decision-level change
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+## Problem Statement
+
+`make ship-arm` writes `.claude/.ship-armed` and relies on Claude Code's Stop
+hook to run `scripts/claude-hooks/stop-ship.sh`. Codex Desktop sessions can
+write the arm file but do not naturally fire that Stop hook, so the implemented
+auto-ship loop looks armed while no shipping pipeline runs.
+
+## Current Behavior
+
+- `make ship-start` creates the issue-linked branch.
+- `make ship-arm` writes `.claude/.ship-armed` through `_ship_arm.py`.
+- `.claude/settings.json` wires Claude Stop events to `stop-ship.sh`.
+- `agent_loop.py auto-ship-plan` and `auto-ship-prepare` explain the path but
+  do not push, create PRs, wait for checks, or merge.
+
+## Desired Behavior
+
+Codex/non-Claude sessions have one explicit command that arms the same state
+file and immediately invokes the same dispatcher. Existing Claude Stop-hook
+behavior remains unchanged.
+
+## Constraints
+
+- Scope constraints: do not change merge policy, branch deletion policy, review
+  gate policy, or PR body §5b policy.
+- Architecture constraints: reuse `_ship_arm.py` and `stop-ship.sh`; do not
+  duplicate Stage 1-5 logic.
+- Compatibility constraints: `make ship-arm` remains arm-only.
+- Eval/privacy constraints: no private data or real-eval execution required.
+- Tooling/CI constraints: tests must avoid remote mutations.
+- Non-goals: no new scheduler, no draft/CI/review bypass, no policy change.
+
+## Architecture Impact
+
+- Affected modules or docs: `Makefile`, `scripts/claude-hooks/`,
+  `docs/operations/auto-ship.md`, tests.
+- Affected contracts or invariants: auto-ship still has one dispatcher and one
+  arm file contract.
+- Load-bearing paths: none.
+- ADR required: no, this wires an existing operational path for another client.
+- Backward compatibility expectation: existing `make ship-arm` and Stop-hook
+  users behave the same.
+
+## Affected Interfaces
+
+- CLI/API/config: add `make ship-run`, `make codex-ship`, and
+  `USE_EXISTING_ARM=1`.
+- Input data: `.claude/.ship-armed`.
+- Output artifacts: unchanged `.claude/.ship-history.log` and
+  `.claude/.ship-dryrun.log`.
+- Docs/review surfaces: auto-ship operations doc and hook helper inventory.
+- Tests/eval entrypoints: focused pytest for runner and dispatcher gates.
+
+## Data / Eval Impact
+
+- Surface: none
+- Data boundary: no data touched
+- Allowed claim: Codex can invoke the existing auto-ship dispatcher directly.
+- Disallowed claim: no claim that CI, review, or merge policy was relaxed.
+- Baseline or control affected: no.
+- Benchmark/eval auditor required: no.
+
+## Task Breakdown
+
+1. Add `_ship_run.py` and Make targets that arm then immediately invoke
+   `stop-ship.sh`.
+2. Let the dispatcher continue when a clean branch already has an open PR, so
+   direct runs can resume CI/review/merge.
+3. Update tests and docs for direct runner semantics.
+
+## Acceptance Criteria
+
+- [x] `make ship-run` arms and dispatches through the existing shell pipeline.
+- [x] Existing arm files are fail-closed unless `USE_EXISTING_ARM=1` is set.
+- [x] Clean branches with an existing PR continue through dry-run CI/review/merge.
+- [x] Docs distinguish `make ship-arm` from `make ship-run`.
+- [x] Focused tests and branch checks pass.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 -m pytest tests/test_ship_run.py tests/test_ship_dispatcher_gates.py tests/test_ship_arm_mutex.py -q
+python3 -m py_compile scripts/claude-hooks/_ship_run.py scripts/claude-hooks/_ship_arm.py
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/auto-ship.md docs/plans/T-2026-0018-codex-runnable-auto-ship.md tasks/queue.md scripts/claude-hooks/README.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: focused pytest return code 0.
+- Generated or updated artifact: plan and queue entries for T-2026-0018.
+- Reviewer checklist or manual inspection: direct runner reuses existing
+  dispatcher; no new remote mutation path.
+- Explicitly not validated, with reason: no live merge; dry-run tests avoid
+  remote mutation.
+
+## Rollback Strategy
+
+Revert `_ship_run.py`, the Make targets, the clean-existing-PR gate change, and
+the docs/tests updates. Existing `make ship-arm` behavior is independent and
+should continue working because Stop-hook wiring is not changed.
+
+## Failure Modes
+
+- Failure mode: direct runner overwrites an active arm.
+- Detection signal: `_ship_run.py` refuses when `.claude/.ship-armed` exists
+  unless `USE_EXISTING_ARM=1`.
+- Stop condition or fallback: run `make ship-disarm`, inspect
+  `.claude/.ship-history.log`, and use `make ship-arm` in Claude Code.
+
+- Failure mode: dispatcher no-ops after PR creation because the local branch is
+  clean and has no unpushed commits.
+- Detection signal: `stop-ship.sh` logs `nothing to ship` instead of reusing
+  the existing PR.
+- Stop condition or fallback: run `USE_EXISTING_ARM=1 make ship-run` after the
+  existing-PR gate is fixed.
+
+## Observability
+
+- `.claude/.ship-history.log`
+- `.claude/.ship-dryrun.log`
+- `make ship-status`
+- `gh pr list --head <branch>`
+
+## Reviewer Notes
+
+Attack the wrapper/dispatcher boundary first: `_ship_run.py` must not duplicate
+shipping policy, and `stop-ship.sh` must only resume clean branches when an
+existing PR for the armed branch is visible.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-27 00:00 KST
+
+- Role: Maintainer
+- Branch / worktree: chore/issue-1547-codex-ship-run /
+  /Users/hskim/.codex/worktrees/1547/BidMate-DocAgent
+- Current status: implementation complete; focused validation passed after rebasing on origin/main; draft PR #1548 open.
+- Commands run: python3 -m pytest tests/test_ship_run.py tests/test_ship_dispatcher_gates.py tests/test_ship_arm_mutex.py -q; python3 -m py_compile scripts/claude-hooks/_ship_run.py scripts/claude-hooks/_ship_arm.py; python3 scripts/check_doc_links.py --check-all --paths docs/operations/auto-ship.md docs/plans/T-2026-0018-codex-runnable-auto-ship.md tasks/queue.md scripts/claude-hooks/README.md; git diff --check; make check-branch
+- Results: passed
+- Next safe command: gh pr checks 1548 --watch --interval 30
+```

--- a/scripts/claude-hooks/README.md
+++ b/scripts/claude-hooks/README.md
@@ -55,6 +55,7 @@ Claude Code 의 PreToolUse / Stop / UserPromptSubmit 훅 모음. `.claude/settin
 - `_ship_lock_check.py` — ship 표면 lock 검사 (PR6 후 본격 활용 예정)
 - `_ship_private_preserve.py` — auto-ship private-path 필터가 제외한 untracked 산출물을 canonical local checkout 으로 이동
 - `_ship_pr_body.py` — stop-ship 의 PR body 빌드 헬퍼
+- `_ship_run.py` — Codex/non-Claude 세션용 `make ship-run` direct runner
 
 ## Telemetry 포맷
 

--- a/scripts/claude-hooks/_ship_run.py
+++ b/scripts/claude-hooks/_ship_run.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Arm auto-ship and immediately run the dispatcher.
+
+`make ship-arm` intentionally only writes `.claude/.ship-armed`; Claude Code's
+Stop hook later invokes `stop-ship.sh`. Codex and other non-Claude sessions do
+not naturally fire that Stop hook, so this wrapper keeps the same arm file and
+dispatcher contract but runs the dispatcher immediately.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ARMED_FILE = Path(".claude/.ship-armed")
+HOOK_DIR = Path(__file__).resolve().parent
+SHIP_ARM = HOOK_DIR / "_ship_arm.py"
+DISPATCHER = HOOK_DIR / "stop-ship.sh"
+
+TRUTHY = {"1", "true", "yes", "y", "on", "ack"}
+
+
+def is_truthy(value: str) -> bool:
+    return value.strip().lower() in TRUTHY
+
+
+def build_arm_command(args: argparse.Namespace) -> list[str]:
+    return [
+        sys.executable,
+        str(SHIP_ARM),
+        "--ttl",
+        args.ttl,
+        "--real-eval",
+        args.real_eval,
+        "--draft",
+        args.draft,
+        "--dry-run",
+        args.dry_run,
+        "--cross-owner",
+        args.cross_owner,
+        "--stacked",
+        args.stacked,
+    ]
+
+
+def repo_root(runner=subprocess.run) -> Path:
+    result = runner(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip())
+    return Path(os.getcwd())
+
+
+def run_dispatcher(runner=subprocess.run, root: Path | None = None) -> int:
+    root = root or repo_root(runner=runner)
+    result = runner(
+        ["bash", str(DISPATCHER)],
+        input="",
+        text=True,
+        check=False,
+        cwd=root,
+    )
+    return result.returncode
+
+
+def run_ship(args: argparse.Namespace, runner=subprocess.run) -> int:
+    root = repo_root(runner=runner)
+    use_existing_arm = is_truthy(args.use_existing_arm)
+    if (root / ARMED_FILE).exists() and not use_existing_arm:
+        sys.stderr.write(
+            "ship-run: refuse - .claude/.ship-armed already exists.\n"
+            "   Use USE_EXISTING_ARM=1 make ship-run to dispatch it, or "
+            "make ship-disarm before re-arming.\n"
+        )
+        return 1
+
+    if not use_existing_arm:
+        arm_result = runner(build_arm_command(args), check=False, cwd=root)
+        if arm_result.returncode != 0:
+            return arm_result.returncode
+
+    return run_dispatcher(runner=runner, root=root)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ttl", default="2h")
+    parser.add_argument("--real-eval", default="auto",
+                        choices=["auto", "skip", "async"])
+    parser.add_argument("--draft", default="false")
+    parser.add_argument("--dry-run", default="0")
+    parser.add_argument("--cross-owner", default="")
+    parser.add_argument("--stacked", default="")
+    parser.add_argument(
+        "--use-existing-arm",
+        default="0",
+        help="1/true/yes/ack to dispatch an existing .claude/.ship-armed.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return run_ship(parse_args(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -104,10 +104,15 @@ gate_0_branch_firewall() {
 }
 
 gate_0_has_work() {
-  local porcelain ahead
+  local porcelain ahead existing
   porcelain=$(git status --porcelain 2>/dev/null)
   ahead=$(git rev-list --count "@{upstream}..HEAD" 2>/dev/null || echo 0)
   if [[ -z "$porcelain" && "$ahead" == "0" ]]; then
+    existing=$(gh pr list --head "$ARM_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+    if [[ -n "$existing" && "$existing" != "null" ]]; then
+      log "gate" "clean tree with existing PR #$existing for $ARM_BRANCH — continuing"
+      return 0
+    fi
     log "gate" "nothing to ship (clean tree, no unpushed commits)"
     exit 0
   fi

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -27,6 +27,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 14 | `T-2026-0014` | `done` | Maintainer -> Reviewer | merged in PR #1532. |
 | 15 | `T-2026-0015` | `done` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1536. |
 | 16 | `T-2026-0016` | `review` | Maintainer -> Reviewer | overlap preflight implemented; PR #1543. |
+| 17 | `T-2026-0018` | `review` | Maintainer -> Reviewer | issue #1547 implemented; draft PR #1548. |
 
 ## Examples
 
@@ -119,6 +120,58 @@ make check-branch
 - Next safe command: git diff --stat
 - Reviewer focus: false-clear risk, report-only behavior, GitHub/Git failures fail closed.
 ```
+
+## T-2026-0018 — Codex-runnable auto-ship
+
+- ID: T-2026-0018
+- Title: Codex-runnable auto-ship
+- Status: review
+- Owner role: Maintainer -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Make the existing auto-ship pipeline usable from Codex/non-Claude sessions
+without relying on a Claude Stop-hook event.
+
+### Scope
+
+- Add a direct runner that reuses `_ship_arm.py` and `stop-ship.sh`.
+- Add `make ship-run` and `make codex-ship`.
+- Preserve `make ship-arm` as arm-only.
+- Let clean branches with an existing PR resume CI/review/merge instead of
+  exiting before Stage 1.
+
+### Non-Goals
+
+- Do not relax review, CI, merge, branch deletion, or §5b policy.
+- Do not introduce a scheduler or background daemon.
+- Do not run private real-eval.
+
+### Acceptance Criteria
+
+- [x] `make ship-run` arms and immediately dispatches the existing pipeline.
+- [x] `USE_EXISTING_ARM=1 make ship-run` dispatches an existing arm.
+- [x] Existing arm files fail closed by default.
+- [x] Focused tests cover runner behavior and clean existing-PR resume.
+- [x] Operations docs distinguish Stop-hook arming from direct Codex runs.
+
+### Validation Commands
+
+```bash
+python3 -m pytest tests/test_ship_run.py tests/test_ship_dispatcher_gates.py tests/test_ship_arm_mutex.py -q
+python3 -m py_compile scripts/claude-hooks/_ship_run.py scripts/claude-hooks/_ship_arm.py
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/auto-ship.md docs/plans/T-2026-0018-codex-runnable-auto-ship.md tasks/queue.md scripts/claude-hooks/README.md
+git diff --check
+make check-branch
+```
+
+### Links
+
+- Issue: #1547
+- PR: #1548
+- Plan: [`docs/plans/T-2026-0018-codex-runnable-auto-ship.md`](../docs/plans/T-2026-0018-codex-runnable-auto-ship.md)
 
 ## T-2026-0014 — Agent gate surface alignment
 

--- a/tests/test_ship_dispatcher_gates.py
+++ b/tests/test_ship_dispatcher_gates.py
@@ -10,9 +10,9 @@ Each test creates a throwaway git repo in a tmpdir, drops a synthetic
 The "no arm" path is also timed to enforce the <100ms no-op SLA — the
 Stop hook fires on every Claude reply and must not impose latency.
 
-We do NOT test stages 1-5 here (they need a real remote, gh, and CI).
-Those are exercised via the dry-run + single-PR live test described in
-the plan's Verification section.
+Most tests stop at Gate 0. The existing-PR resume regression intentionally
+continues through dry-run stages 1-5 with fake `gh` and helper scripts so it
+can prove a clean branch with an open PR no longer no-ops before CI/review.
 """
 
 from __future__ import annotations
@@ -78,11 +78,16 @@ def _arm(repo: Path, *, branch: str, ttl_seconds: int = 7200, **overrides):
     (repo / ".claude" / ".ship-armed").write_text(json.dumps(state) + "\n")
 
 
-def _run_dispatcher(repo: Path, timeout: float = 10) -> subprocess.CompletedProcess:
+def _run_dispatcher(
+    repo: Path,
+    timeout: float = 10,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
     return subprocess.run(
         ["bash", str(DISPATCHER)],
         cwd=repo, input="", capture_output=True, text=True,
         timeout=timeout,
+        env={**os.environ, **(env or {})},
     )
 
 
@@ -167,6 +172,45 @@ def test_clean_tree_silent_exit(fake_repo):
     # not a failure).
     assert (fake_repo / ".claude" / ".ship-armed").exists()
     assert "nothing to ship" in r.stderr.lower()
+
+
+def test_clean_tree_with_existing_pr_continues_dry_run(fake_repo):
+    _git("checkout", "-b", "feat/issue-9999-foo", cwd=fake_repo)
+
+    scripts = fake_repo / "scripts"
+    scripts.mkdir()
+    (scripts / "check_branch_and_issue.py").write_text(
+        "import sys\nsys.exit(0)\n",
+        encoding="utf-8",
+    )
+    _git("add", "scripts/check_branch_and_issue.py", cwd=fake_repo)
+    _git("commit", "-qm", "test helper", cwd=fake_repo)
+    _arm(fake_repo, branch="feat/issue-9999-foo", dry_run=1)
+
+    bin_dir = fake_repo.parent / "fake-gh-bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$1\" == \"pr\" && \"$2\" == \"list\" ]]; then\n"
+        "  echo 123\n"
+        "  exit 0\n"
+        "fi\n"
+        "echo \"unexpected gh call: $*\" >&2\n"
+        "exit 2\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+
+    r = _run_dispatcher(
+        fake_repo,
+        env={"PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"},
+    )
+    assert r.returncode == 0
+    assert "existing PR #123" in r.stderr
+    assert "continuing" in r.stderr
+    assert "Ship complete" in r.stderr
+    assert not (fake_repo / ".claude" / ".ship-armed").exists()
 
 
 # ---- gate 0: live PID guard ----

--- a/tests/test_ship_run.py
+++ b/tests/test_ship_run.py
@@ -1,0 +1,115 @@
+"""Tests for the Codex-runnable auto-ship entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIP_RUN_PATH = REPO_ROOT / "scripts" / "claude-hooks" / "_ship_run.py"
+
+
+def _load_ship_run():
+    spec = importlib.util.spec_from_file_location("_ship_run_mod", SHIP_RUN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def _args(**overrides):
+    values = {
+        "ttl": "30m",
+        "real_eval": "skip",
+        "draft": "true",
+        "dry_run": "1",
+        "cross_owner": "ack",
+        "stacked": "ack",
+        "use_existing_arm": "0",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_run_ship_arms_then_invokes_dispatcher(tmp_path, monkeypatch):
+    ship_run = _load_ship_run()
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{tmp_path}\n")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    assert ship_run.run_ship(_args(), runner=fake_run) == 0
+    assert len(calls) == 3
+    assert calls[0][0][:3] == ["git", "rev-parse", "--show-toplevel"]
+    assert calls[1][0][1].endswith("_ship_arm.py")
+    assert "--real-eval" in calls[1][0]
+    assert "skip" in calls[1][0]
+    assert calls[1][1] == {"check": False, "cwd": tmp_path}
+    assert calls[2][0][0] == "bash"
+    assert calls[2][0][1].endswith("stop-ship.sh")
+    assert calls[2][1]["input"] == ""
+    assert calls[2][1]["text"] is True
+    assert calls[2][1]["check"] is False
+    assert calls[2][1]["cwd"] == tmp_path
+
+
+def test_run_ship_refuses_existing_arm_without_reuse(tmp_path, monkeypatch, capsys):
+    ship_run = _load_ship_run()
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / ".ship-armed").write_text("{}\n")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{tmp_path}\n")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    assert ship_run.run_ship(_args(), runner=fake_run) == 1
+    assert len(calls) == 1
+    assert calls[0][0][:3] == ["git", "rev-parse", "--show-toplevel"]
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_run_ship_reuses_existing_arm(tmp_path, monkeypatch):
+    ship_run = _load_ship_run()
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / ".ship-armed").write_text("{}\n")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{tmp_path}\n")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    assert ship_run.run_ship(_args(use_existing_arm="1"), runner=fake_run) == 0
+    assert len(calls) == 2
+    assert calls[0][0][:3] == ["git", "rev-parse", "--show-toplevel"]
+    assert calls[1][0][0] == "bash"
+    assert calls[1][0][1].endswith("stop-ship.sh")
+
+
+def test_run_ship_returns_arm_failure(tmp_path, monkeypatch):
+    ship_run = _load_ship_run()
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{tmp_path}\n")
+        return subprocess.CompletedProcess(cmd, 7)
+
+    assert ship_run.run_ship(_args(), runner=fake_run) == 7
+    assert len(calls) == 2
+    assert calls[1][0][1].endswith("_ship_arm.py")


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Codex/non-Claude 세션에서도 Claude Stop-hook 없이 기존 auto-ship dispatcher를 직접 실행할 수 있게 `make ship-run` / `make codex-ship` 경로를 추가했습니다. 기존 `make ship-arm`은 arm-only로 유지하고, 새 runner는 `_ship_arm.py`와 `stop-ship.sh`를 그대로 재사용합니다.

Closes #1547

## 2. 영향 파일

- `Makefile`: `ship-run`, `codex-ship`, `USE_EXISTING_ARM` 추가.
- `scripts/claude-hooks/_ship_run.py`: Codex direct runner 추가.
- `scripts/claude-hooks/stop-ship.sh`: clean branch에 기존 PR이 있으면 CI/review/merge 재개.
- `tests/test_ship_run.py`, `tests/test_ship_dispatcher_gates.py`: runner와 existing-PR resume 회귀 테스트.
- `docs/operations/auto-ship.md`, `scripts/claude-hooks/README.md`, `docs/plans/T-2026-0018-codex-runnable-auto-ship.md`, `tasks/queue.md`: 운영 문서와 task 상태 업데이트.

## 3. 리스크

가장 큰 리스크는 direct runner가 기존 정책을 우회하거나, clean tree no-op 동작을 과하게 바꾸는 것입니다. runner는 `_ship_arm.py`와 `stop-ship.sh`만 호출하게 했고, dispatcher는 armed branch에 기존 PR이 있을 때만 clean 상태에서 진행하도록 제한했습니다.

## 4. 테스트

- `python3 -m pytest tests/test_ship_run.py tests/test_ship_dispatcher_gates.py tests/test_ship_arm_mutex.py -q`
- `python3 -m py_compile scripts/claude-hooks/_ship_run.py scripts/claude-hooks/_ship_arm.py`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/auto-ship.md docs/plans/T-2026-0018-codex-runnable-auto-ship.md tasks/queue.md scripts/claude-hooks/README.md`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `N/A` - workflow/tooling 변경이며 RAG 검색(retrieval), 재순위(reranking), 답변, eval metric 경로를 변경하지 않습니다.

### 5b. Real-data delta

N/A - load-bearing path 변경이 아닙니다. 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

`make ship-arm`과 `.claude/settings.json` Stop-hook wiring은 그대로 유지됩니다. 새 CLI는 opt-in이며 `USE_EXISTING_ARM=1` 없이 기존 arm 파일을 덮어쓰지 않습니다.

## 7. 범위 외

스케줄러/daemon 추가, review/CI/merge policy 완화, live merge 검증은 범위 밖입니다.