### PR TITLE
chore: add agent loop continuation repair

### DIFF
--- a/docs/operations/ai-engineering-operating-system.md
+++ b/docs/operations/ai-engineering-operating-system.md
@@ -146,6 +146,27 @@ idea / issue
   -> done
 ```
 
+### Granularity Guardrails
+
+Agent에게 맡기는 work package는 충분히 커야 하지만, review surface는 작고
+검증 가능해야 한다. 이 저장소에서 "scope를 키운다"는 말은 senior engineer가
+며칠에서 몇 주 걸릴 목표를 task와 plan으로 self-contained하게 만든다는 뜻이지,
+여러 concern을 한 PR에 섞는다는 뜻이 아니다.
+
+- Task/plan은 큰 outcome을 잡는다: 목표, non-goals, affected interfaces,
+  validation strategy, handoff를 한곳에 둔다.
+- PR은 한 concern만 담는다: eval scorer 변경, retrieval algorithm 변경, ADR
+  상태 변경, docs narrative rewrite를 같은 PR에 섞지 않는다.
+- 긴 session은 transcript가 아니라 queue, plan, handoff로 유지한다. context
+  compaction이 일어나도 새 agent가 같은 결정을 다시 추측하지 않아야 한다.
+- Reviewer/Benchmark Auditor/Deep Reviewer는 Implementer가 직접 수행하지 않은
+  독립 검증 역할이다. 자동화가 PR 생성, 테스트 실행, CI 확인을 대신해도
+  claim boundary와 merge readiness 판단은 evidence로 남긴다.
+- Detached HEAD, issue 없는 branch, plan 없는 load-bearing diff는 validation
+  command가 통과해도 PR-ready가 아니다.
+- `loop-state`의 `continuation` block은 detached HEAD, stale manifest, task
+  linkage 누락을 감지해 다음 복구 command를 machine-readable하게 제공한다.
+
 ### Planning Required
 
 Plan doc가 필요한 경우:

--- a/docs/plans/T-2026-0019-agent-loop-continuation-repair.md
+++ b/docs/plans/T-2026-0019-agent-loop-continuation-repair.md
@@ -1,0 +1,64 @@
+# Plan: T-2026-0019 Agent loop continuation repair
+
+- Status: review
+- Owner role: Maintainer -> CI Reviewer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0019`
+- Issue: #1549
+
+## Problem
+
+`loop-state` records the current gate, surface, manifest freshness, and task
+state, but it does not provide a single machine-readable continuation plan when
+the loop is interrupted by detached HEAD, missing task linkage, or a stale
+manifest. The result is a safe stop, but not an obvious next automated recovery
+step.
+
+## Desired Outcome
+
+`loop-state` should expose a `continuation` block that names blockers, warnings,
+whether automation can continue, and the next safe command sequence. The
+dashboard should render the same status for human review.
+
+## Scope
+
+- Add continuation metadata to `scripts/agent_loop.py` loop-state output.
+- Render continuation status in the dashboard.
+- Add focused regression coverage for detached HEAD repair and ready issue
+  branch continuation.
+- Document the continuation block in the operating-system doc.
+
+## Non-Goals
+
+- Do not execute push, PR creation, merge, branch deletion, force-push, or
+  private real-eval from `loop-state`.
+- Do not remove `make ship-arm` single-shot behavior.
+- Do not hide task/plan linkage gaps.
+
+## Validation Strategy
+
+```bash
+python3 -m py_compile scripts/agent_loop.py
+python3 -m pytest tests/test_agent_loop.py -q
+python3 -m pytest tests/test_agent_loop_claude_integration.py -q
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0019-agent-loop-continuation-repair.md
+git diff --check
+make check-branch
+```
+
+## Rollback Strategy
+
+Revert the `continuation` helper, dashboard section, tests, and documentation.
+Existing gate-status, manifest, and auto-ship commands remain independent.
+
+## Failure Modes
+
+- Recovery command could imply bypassing conservative gates.
+- Detached HEAD repair could create an issue-linked branch but still lack a task
+  id.
+- A stale manifest could make automation believe the current diff is older than
+  it is.
+
+## Reviewer Notes
+
+This is tooling/governance only. It does not change retrieval, answer behavior,
+eval scoring, private data handling, or shipping mutation behavior.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -2979,6 +2979,7 @@ def render_dashboard(state: dict[str, object], *, repo_root: Path = ROOT_DIR) ->
     artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
     freshness = state.get("freshness") if isinstance(state.get("freshness"), list) else []
     manifest = state.get("manifest") if isinstance(state.get("manifest"), dict) else {}
+    continuation = state.get("continuation") if isinstance(state.get("continuation"), dict) else {}
     validation = state.get("validation_suggestions") if isinstance(state.get("validation_suggestions"), list) else []
     lines = [
         "# Agent Loop Dashboard",
@@ -3024,6 +3025,26 @@ def render_dashboard(state: dict[str, object], *, repo_root: Path = ROOT_DIR) ->
     else:
         lines.append("- No stale local artifact detected by the 7-day report threshold.")
     lines.append(f"- Manifest current: `{bool(manifest.get('current', False))}` ({_sanitize_inline_text(str(manifest.get('reason', 'not checked')))})")
+
+    if continuation:
+        lines.extend(
+            [
+                "",
+                "## Continuation",
+                "",
+                f"- Status: `{continuation.get('status', 'unknown')}`",
+                f"- Can auto-continue: `{bool(continuation.get('can_auto_continue', False))}`",
+                f"- Current branch: `{_sanitize_inline_text(str(continuation.get('current_branch', 'unknown')))}`",
+            ]
+        )
+        blockers = continuation.get("blockers") if isinstance(continuation.get("blockers"), list) else []
+        warnings = continuation.get("warnings") if isinstance(continuation.get("warnings"), list) else []
+        if blockers:
+            lines.append("- Blockers: " + ", ".join(f"`{_sanitize_inline_text(str(item))}`" for item in blockers))
+        if warnings:
+            lines.append("- Warnings: " + ", ".join(f"`{_sanitize_inline_text(str(item))}`" for item in warnings))
+        command = str(continuation.get("next_safe_command", "python3 scripts/agent_loop.py map"))
+        lines.extend(["", "```bash", _sanitize_command_text(command), "```"])
 
     lines.extend(["", "## Suggested Validation", ""])
     if validation:
@@ -7418,6 +7439,7 @@ def build_loop_state(
     repo_root: Path,
 ) -> dict[str, object]:
     surface = classify_changed_files(changed_files)
+    manifest = _manifest_freshness(changed_files=changed_files, repo_root=repo_root)
     gate = build_gate_status(
         task_id=task_id,
         batch=batch,
@@ -7442,7 +7464,7 @@ def build_loop_state(
         "validation_suggestions": suggest_validation_commands(changed_files),
         "artifacts": _loop_artifact_state(repo_root),
         "freshness": _report_freshness(repo_root=repo_root, max_age_days=7),
-        "manifest": _manifest_freshness(changed_files=changed_files, repo_root=repo_root),
+        "manifest": manifest,
     }
     if task_id:
         task = load_task(task_id, repo_root)
@@ -7456,7 +7478,87 @@ def build_loop_state(
             "handoff_missing": list(handoff.missing_fields),
             "handoff_invalid": list(handoff.invalid_fields),
         }
+    payload["continuation"] = _loop_continuation_plan(
+        task_id=task_id,
+        changed_files=changed_files,
+        pr=pr,
+        surface=surface,
+        manifest=manifest,
+        repo_root=repo_root,
+    )
     return payload
+
+
+def _loop_continuation_plan(
+    *,
+    task_id: str | None,
+    changed_files: Sequence[str],
+    pr: str | None,
+    surface: SurfaceReport,
+    manifest: dict[str, object],
+    repo_root: Path,
+) -> dict[str, object]:
+    current_branch = _current_branch(repo_root) or "unknown"
+    branch_issue = _issue_from_branch(current_branch)
+    branch_ready = bool(
+        branch_issue
+        and current_branch not in {"HEAD", "main", "master"}
+        and not current_branch.startswith("release/")
+    )
+    blockers: list[str] = []
+    warnings: list[str] = []
+    commands: list[str] = []
+
+    if not branch_ready:
+        blockers.append("branch-not-ready")
+        commands.append(
+            "ISSUE=$(gh issue create --title \"Agent loop continuation\" "
+            "--body \"Public-safe continuation issue for the current local agent-loop diff.\" "
+            "| awk -F/ '{print $NF}') && "
+            "python3 scripts/agent_loop.py auto-ship-prepare --issue \"$ISSUE\" "
+            "--slug agent-loop-continuation --create-branch --confirm-human-approved"
+        )
+    else:
+        commands.append(
+            f"python3 scripts/agent_loop.py branch-issue-hygiene --branch {shlex.quote(current_branch)}"
+        )
+
+    if not task_id:
+        warnings.append("task-not-linked")
+        commands.append("python3 scripts/agent_loop.py decision-brief --from-git --gate task")
+
+    if not manifest.get("current"):
+        warnings.append("manifest-stale")
+        commands.append(
+            "python3 scripts/agent_loop.py manifest --from-git --source-command loop-state "
+            "--output reports/agent_loop/loop_state.json"
+        )
+
+    if task_id:
+        commands.append(f"python3 scripts/agent_loop.py preflight --task {task_id} --from-git --write-prompts")
+    else:
+        commands.append("python3 scripts/agent_loop.py preflight --task <TASK_ID> --from-git --write-prompts")
+
+    status = "blocked" if blockers else "ready-for-preflight"
+    if not blockers and warnings:
+        status = "repair-needed"
+    if not blockers and task_id:
+        next_safe = f"python3 scripts/agent_loop.py preflight --task {task_id} --from-git --write-prompts"
+    else:
+        next_safe = commands[0] if commands else "python3 scripts/agent_loop.py map"
+    return {
+        "status": status,
+        "can_auto_continue": not blockers,
+        "current_branch": _sanitize_inline_text(current_branch),
+        "branch_issue": branch_issue or None,
+        "task_id": task_id or None,
+        "pr": _validate_pr_selector(pr) if pr else None,
+        "surface": surface.surface,
+        "blockers": blockers,
+        "warnings": warnings,
+        "next_safe_command": next_safe,
+        "commands": commands,
+    }
 
 
 def _loop_artifact_state(repo_root: Path) -> dict[str, bool]:

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -9095,6 +9095,7 @@ def main(argv: list[str] | None = None) -> int:
                 review=args.review,
                 out=args.out,
                 tasks_dir=args.tasks_dir,
+                repo_root=ROOT_DIR,
             )
             sys.stdout.write(
                 f"[OK] wrote {_repo_path(out, ROOT_DIR)} and {count} follow-up brief(s) under "

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -28,6 +28,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 15 | `T-2026-0015` | `done` | Maintainer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1536. |
 | 16 | `T-2026-0016` | `review` | Maintainer -> Reviewer | overlap preflight implemented; PR #1543. |
 | 17 | `T-2026-0018` | `review` | Maintainer -> Reviewer | issue #1547 implemented; draft PR #1548. |
+| 18 | `T-2026-0019` | `review` | Maintainer -> CI Reviewer -> Reviewer | local implementation ready on issue #1549 branch. |
 
 ## Examples
 
@@ -172,6 +173,96 @@ make check-branch
 - Issue: #1547
 - PR: #1548
 - Plan: [`docs/plans/T-2026-0018-codex-runnable-auto-ship.md`](../docs/plans/T-2026-0018-codex-runnable-auto-ship.md)
+
+## T-2026-0019 — Agent loop continuation repair
+
+- ID: T-2026-0019
+- Title: Agent loop continuation repair
+- Status: review
+- Owner role: Maintainer -> CI Reviewer -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Make `loop-state` expose the next automatic continuation step when branch,
+manifest, or task linkage is incomplete, so the loop can recover without
+removing conservative gates.
+
+### Scope
+
+- Add a machine-readable `continuation` block to `scripts/agent_loop.py`
+  `loop-state` output.
+- Surface continuation status in the generated dashboard.
+- Document the continuation block in the agent operating-system doc.
+- Cover detached HEAD repair and ready issue-branch continuation with focused
+  tests.
+
+### Non-Goals
+
+- Do not auto-push, create PRs, merge, delete branches, force-push, or run
+  private real-eval.
+- Do not remove `make ship-arm` single-shot behavior.
+- Do not make missing task/plan linkage invisible.
+
+### Acceptance Criteria
+
+- [x] Detached HEAD loop state contains a concrete issue+branch recovery command.
+- [x] Issue-linked branch with fresh manifest can report `can_auto_continue`.
+- [x] Dashboard renders continuation status and next command.
+- [x] Branch is issue-linked to #1549 and passes branch check.
+
+### Validation Commands
+
+```bash
+python3 -m py_compile scripts/agent_loop.py
+python3 -m pytest tests/test_agent_loop.py -q
+python3 -m pytest tests/test_agent_loop_claude_integration.py -q
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0019-agent-loop-continuation-repair.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Py compile output.
+- Doc link check output.
+- Branch check output.
+- `loop-state` continuation sample.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0019-agent-loop-continuation-repair.md`](../docs/plans/T-2026-0019-agent-loop-continuation-repair.md)
+- Issue: [#1549](https://github.com/hskim-solv/BidMate-DocAgent/issues/1549)
+- PR: [#1550](https://github.com/hskim-solv/BidMate-DocAgent/pull/1550)
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-27 KST
+
+- Role: Maintainer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1549-agent-loop-continuation / /Users/hskim/.codex/worktrees/380f/BidMate-DocAgent
+- Base branch: main
+- Issue / PR: #1549 / PR #1550
+- Task: T-2026-0019
+- Plan: docs/plans/T-2026-0019-agent-loop-continuation-repair.md
+- Current status: local implementation complete; focused validation passed; draft PR #1550 open.
+- Files touched: scripts/agent_loop.py, tests/test_agent_loop.py, docs/operations/ai-engineering-operating-system.md, tasks/queue.md, docs/plans/T-2026-0019-agent-loop-continuation-repair.md
+- Decisions made: keep Stop hook report-only; expose continuation commands in loop-state/dashboard instead of mutating automatically from the hook.
+- Commands run: python3 -m py_compile scripts/agent_loop.py; python3 -m pytest tests/test_agent_loop.py -q; python3 -m pytest tests/test_agent_loop_claude_integration.py -q; python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0019-agent-loop-continuation-repair.md; git diff --check; make check-branch.
+- Results: passed.
+- Validation evidence: focused tests and branch check passed; loop-state reports branch issue #1549 with can_auto_continue true after manifest refresh.
+- Eval surface: tooling/governance only; no benchmark or performance claim.
+- Evidence artifacts: reports/agent_loop/loop_state.json, reports/agent_loop/manifest.json, reports/agent_loop/branch_issue_hygiene.md.
+- Blockers: none.
+- Open risks: task/plan linkage remains explicit so automation still needs a task id for preflight prompts.
+- Next action: reviewer check.
+- Next safe command: python3 scripts/agent_loop.py loop-state --task T-2026-0019 --from-git --out reports/agent_loop/loop_state.json
+- Reviewer focus: continuation command safety, no hidden remote mutation, dashboard clarity, branch/manifest/task state semantics.
+```
 
 ## T-2026-0014 — Agent gate surface alignment
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -988,8 +988,9 @@ Needs changes
     assert "python3 scripts/_governance.py --check-eval-privacy" in generated
 
 
-def test_review_followup_cli_smoke(capsys) -> None:
-    review = ROOT / "reports" / "agent_loop" / "review_output.md"
+def test_review_followup_cli_smoke(capsys, monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(agent_loop, "ROOT_DIR", tmp_path)
+    review = tmp_path / "reports" / "agent_loop" / "review_output.md"
     review.parent.mkdir(parents=True, exist_ok=True)
     review.write_text(
         """## Findings

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1427,6 +1427,54 @@ def test_loop_state_writes_machine_readable_safe_state(tmp_path: Path) -> None:
     assert state["surface"]["surface"] == "ci-validation"  # type: ignore[index]
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["validation_suggestions"][-1] == "git diff --check"
+    assert "continuation" in payload
+
+
+def test_loop_state_reports_detached_head_continuation_repair(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "HEAD")
+
+    _out, state = agent_loop.write_loop_state(
+        changed_files=["docs/operations/ai-engineering-operating-system.md"],
+        repo_root=repo,
+    )
+
+    continuation = state["continuation"]  # type: ignore[index]
+    assert continuation["status"] == "blocked"  # type: ignore[index]
+    assert continuation["can_auto_continue"] is False  # type: ignore[index]
+    assert "branch-not-ready" in continuation["blockers"]  # type: ignore[index]
+    assert "task-not-linked" in continuation["warnings"]  # type: ignore[index]
+    assert "manifest-stale" in continuation["warnings"]  # type: ignore[index]
+    commands = "\n".join(continuation["commands"])  # type: ignore[index]
+    assert "gh issue create" in commands
+    assert "auto-ship-prepare --issue" in commands
+    assert "manifest --from-git" in commands
+
+
+def test_loop_state_can_auto_continue_on_issue_branch_with_fresh_manifest(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, body_extra=_valid_handoff())
+    changed_files = ["scripts/agent_loop.py", "tests/test_agent_loop.py"]
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-agent-loop")
+    agent_loop.write_manifest(
+        changed_files=changed_files,
+        command="test",
+        outputs=[Path("reports/agent_loop/loop_state.json")],
+        repo_root=repo,
+    )
+
+    _out, state = agent_loop.write_loop_state(
+        task_id="T-2026-9999",
+        changed_files=changed_files,
+        repo_root=repo,
+    )
+
+    continuation = state["continuation"]  # type: ignore[index]
+    assert continuation["status"] == "ready-for-preflight"  # type: ignore[index]
+    assert continuation["can_auto_continue"] is True  # type: ignore[index]
+    assert continuation["branch_issue"] == "9999"  # type: ignore[index]
+    assert continuation["next_safe_command"] == (
+        "python3 scripts/agent_loop.py preflight --task T-2026-9999 --from-git --write-prompts"
+    )  # type: ignore[index]
 
 
 def test_loop_map_marks_agent_gates_and_safe_automation() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`loop-state`가 끊긴 루프의 다음 복구 단계를 machine-readable `continuation` block으로 내보내도록 했습니다. detached HEAD, issue-linked branch 누락, stale manifest, task linkage 누락을 구분하고, 안전장치를 우회하지 않는 다음 command를 제안합니다.

Closes #1549

## 2. 영향 파일

- `scripts/agent_loop.py` — `loop-state` continuation block 추가, dashboard 렌더링 추가
- `tests/test_agent_loop.py` — detached HEAD 복구와 ready issue-branch continuation 회귀 테스트 추가
- `tasks/queue.md` — `T-2026-0019` task 및 handoff 추가
- `docs/plans/T-2026-0019-agent-loop-continuation-repair.md` — plan 추가
- `docs/operations/ai-engineering-operating-system.md` — granularity/continuation guardrail 보완

## 3. 리스크

- 복구 command가 remote mutation 우회처럼 보일 수 있음: `loop-state`는 실행하지 않고 command만 제안하며, push/PR/merge/delete/private eval은 기존 gate 밖으로 옮기지 않았습니다.
- task linkage 누락을 숨길 수 있음: task가 없으면 `task-not-linked` warning을 유지합니다.
- stale manifest가 잘못된 상태 판단을 만들 수 있음: manifest mismatch를 `manifest-stale` warning으로 노출합니다.

## 4. 테스트

- `python3 -m py_compile scripts/agent_loop.py`
- `python3 -m pytest tests/test_agent_loop.py -q`
- `python3 -m pytest tests/test_agent_loop_claude_integration.py -q`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0019-agent-loop-continuation-repair.md`
- `git diff --check`
- `make check-branch`
- `python3 scripts/agent_loop.py preflight --task T-2026-0019 --from-git --write-prompts`

## 5. Eval 영향

Tooling/governance only. Retrieval, answer generation, ingestion, eval scoring, benchmark data, and private real-eval behavior are unchanged.

### 5b. Real-data delta

N/A — no load-bearing RAG/eval/runtime path changed. No benchmark or performance claim.

## 6. 하위 호환

Existing `loop-state` keys remain present. Consumers can ignore the additive `continuation` block. Stop hook remains report-only and `make ship-arm` remains single-shot.

## 7. 범위 외

- Auto-push/PR/merge execution from `loop-state`
- Removing conservative gates
- Private real-eval execution
- Retrieval/answer/eval behavior changes
