### PR TITLE
[codex] Plan tasks from PR corpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -901,7 +901,7 @@ agent-loop-automation-coverage:
 
 agent-loop-human-gated-exec:
 	@if [ -z "$(HUMAN_GATED_ACTION)" ]; then \
-	  echo "Usage: make agent-loop-human-gated-exec HUMAN_GATED_ACTION=push|pr-create|pr-merge|pr-close|branch-delete|force-push CONFIRM_HUMAN_APPROVED=1"; \
+	  echo "Usage: make agent-loop-human-gated-exec HUMAN_GATED_ACTION=push|pr-create|pr-ready|pr-merge|pr-close|branch-delete|force-push CONFIRM_HUMAN_APPROVED=1"; \
 	  exit 1; \
 	fi
 	$(PYTHON) scripts/agent_loop.py human-gated-exec \

--- a/docs/operations/ai-codex-workflow.md
+++ b/docs/operations/ai-codex-workflow.md
@@ -8,7 +8,7 @@ Codex 작업을 손으로 고르는 비용을 줄이는 것이다.
 
 | Role | Responsibility |
 |---|---|
-| ChatGPT | Planner/reviewer. repo 상태, readiness aggregate, PR 상태를 읽고 다음 작업을 고른다. |
+| ChatGPT | Planner/reviewer. repo 상태, readiness aggregate, PR corpus를 읽고 다음 workset/task lane을 계획한다. |
 | Codex | Scoped executor. 한 번에 하나의 좁은 task를 구현하고 focused verification을 남긴다. |
 | GitHub | State store. issue, PR, review, CI, merge state를 보관한다. |
 | Conservative agent gate | [ADR 0079](../adr/0079-agent-gated-offline-online-rfp-eval-loop.md)의 정책을 집행한다. routine merge, claim, private eval, cleanup 판단은 사람에게 매번 묻지 않고 보수적으로 처리한다. |
@@ -27,9 +27,9 @@ python3 scripts/ai_next_actions.py \
   --pr-json tmp/open-prs.json
 ```
 
-- `reports/ai_next_actions.md`: 현재 상태와 최우선 Codex task
+- `reports/ai_next_actions.md`: 현재 상태와 최우선 Codex workset task
 - `reports/ai_next_actions.html`: 사람이 빠르게 보는 현재 상태판
-- `reports/codex_tasks/*.md`: Codex에게 넘길 scoped task briefs
+- `reports/codex_tasks/*.md`: Codex에게 넘길 scoped workset task briefs
 
 `reports/*`는 기본 gitignore 대상이므로 이 산출물은 로컬 workflow artifact다.
 committable evidence가 필요하면 별도 redacted aggregate 산출물로 승격해야 한다.
@@ -44,11 +44,12 @@ ADR 0079 이후 이 화면은 매번 사용자 승인을 받기 위한 human gat
 Codex가 보수적 agent gate를 집행하기 위한 evidence board다. 애매한 경우 기본값은
 `draft`, `no performance claim`, `follow-up issue`, `fail closed`다.
 
-HTML 화면에서 먼저 볼 항목은 다음 네 가지다.
+HTML 화면에서 먼저 볼 항목은 다음 네 가지다. 여기서 `Top task`는 open PR 중
+하나를 고르는 값이 아니라, PR corpus 전체에서 합성된 운영 workset이다.
 
 | Area | What to decide |
 |---|---|
-| Top task | 지금 검토하거나 실행할 단일 작업 |
+| Top task | 지금 검토하거나 실행할 workset task |
 | Page citation claim | page-level claim을 해도 되는지 여부 |
 | Private delta needed | load-bearing 변경의 private delta evidence 필요 여부 |
 | Privacy guard | 입력 artifact가 aggregate/redacted boundary를 지켰는지 여부 |
@@ -79,16 +80,64 @@ python3 scripts/agent_loop.py overlap-preflight \
 
 ## Classification Contract
 
-Planner는 다음 순서로 active work를 분류한다.
+Planner는 open PR을 선택 후보 목록으로 다루지 않는다. PR의 CI, draft 여부,
+review 상태, merge blocker, stale/superseded 신호를 corpus/evidence로 읽고
+다음 순서로 active workset을 분류한다. PR별 1:1 task 생성을 기본값으로 삼지
+않고, 같은 운영 문제를 공유하는 PR들을 하나의 lane task로 묶는다.
 
 | Classification | Meaning |
 |---|---|
-| `failed_experiment` | NO-GO 또는 negative experiment 신호가 있다. |
-| `close_superseded` | stale/superseded draft PR을 active review 후보에서 제거해야 한다. |
-| `blocked` | readiness blocker, requested changes, merge blocker, failing check가 있다. |
-| `needs_private_delta` | private delta evidence가 필요한 PR 또는 load-bearing change가 있다. |
-| `ready_for_review` | blocker-free 상태라 reviewer handoff가 가능하다. |
-| `next_experiment_candidate` | 위 신호가 없으므로 다음 측정 후보를 고른다. |
+| `failed_experiment` | NO-GO 또는 negative experiment 신호가 있는 PR lane을 문서화한다. |
+| `close_superseded` | stale/superseded draft PR lane을 cleanup task로 묶는다. |
+| `blocked` | requested changes, merge blocker, failing check, missing PR JSON field가 있는 blocked lane을 triage한다. |
+| `needs_private_delta` | private delta evidence가 필요한 PR 또는 load-bearing claim lane을 준비한다. |
+| `ready_for_review` | blocker-free PR들을 ship/review lane으로 묶는다. |
+| `next_experiment_candidate` | draft/measurement 후보들을 다음 workset으로 이어간다. |
+
+각 task brief는 `Source PRs`, `Workset`, `Lane`, `Role Hints`,
+`Completion Proof`를 포함한다. `Source PRs`는 근거가 된 PR 번호 목록이며,
+그 PR 중 하나를 선택했다는 뜻이 아니다.
+
+## Batch And Role Dispatch
+
+`scripts/agent_loop.py batch-plan`은 `reports/agent_loop/codex_tasks/*.md`를
+읽어 workset 단위 JSON을 만든다.
+
+```bash
+python3 scripts/agent_loop.py batch-plan
+```
+
+`batch_plan.json`의 각 item은 `workset_id`, `lane`, `source_prs`,
+`role_hints`, `completion_proof`를 포함한다. lane은 다음 네 종류다.
+
+| Lane | Meaning |
+|---|---|
+| `serial` | 같은 file/surface/dependency 또는 blocker를 공유해 순차 처리한다. |
+| `parallel-safe` | 독립 surface라 병렬 구현 또는 탐색이 가능하다. |
+| `review-only` | 구현보다 review/ship evidence 확인이 우선이다. |
+| `manual-gated` | 내부적으로는 agent-gated lane이며 private eval, claim, remote mutation 같은 보수 gate를 요구한다. |
+
+`role-dispatch --batch reports/agent_loop/batch_plan.json`은 workset별
+Planner, Implementer, Reviewer, CI Reviewer, Benchmark Auditor, Privacy
+Auditor, Deep Reviewer prompt source를 만든다. root session은 integration,
+validation, ship gate만 맡고, 이 보고서는 subagent를 실행하거나 remote mutation을
+하지 않는다.
+
+## Continue Loop
+
+`continue-loop`는 정상 루프에서 사람이 다음 일을 고르지 않도록 상위 command를
+제공한다.
+
+```bash
+python3 scripts/agent_loop.py continue-loop
+```
+
+흐름은 `pr-scan -> next-from-prs -> batch-plan -> role-dispatch ->
+draft/apply queue-plan -> loop-state`다. 기본 동작은 내부 agent gate가 통과한
+queue/plan draft를 tracked queue/plan docs에 반영한다. 이 command는 push, PR
+create/merge/close, issue close, branch delete, force-push, private eval 실행,
+benchmark/performance claim 승인을 하지 않는다. remote mutation은 기존 ship
+gate와 `make ship-arm` 경로로 넘긴다.
 
 Page citation claim은 readiness summary의 page metadata gate가 `NO-GO`이거나
 missing page metadata rate가 `1.0`이면 NO-GO로 취급한다. 이 경우 planner는

--- a/docs/operations/ai-engineering-operating-system.md
+++ b/docs/operations/ai-engineering-operating-system.md
@@ -94,7 +94,7 @@
 
 | 질문 | 답하는 문서 |
 |---|---|
-| What should I work on next? | [`tasks/queue.md`](../../tasks/queue.md)의 `Ready Order` |
+| What should I work on next? | [`tasks/queue.md`](../../tasks/queue.md)의 `Ready Order` 또는 `python3 scripts/agent_loop.py continue-loop` |
 | What role am I acting as? | 이 문서의 [Agent Role Model](#agent-role-model) |
 | What plan should I follow? | task의 plan link 또는 [`docs/plans/TEMPLATE.md`](../plans/TEMPLATE.md) |
 | What evidence must I produce? | task의 `Evidence Required`와 plan의 `Validation Strategy` |
@@ -135,6 +135,8 @@ Minimum viable operating system은 다음 조건을 만족하면 충분하다.
 
 ```text
 idea / issue
+  -> PR corpus scan when the next work is unclear
+  -> workset task brief
   -> task queue entry
   -> plan doc when required
   -> ready task
@@ -145,6 +147,19 @@ idea / issue
   -> merge-ready evidence
   -> done
 ```
+
+`next-from-prs`는 open PR 중 하나를 선택하지 않는다. PR 전체를 상태 corpus로
+읽고 blocked lane, ready ship lane, stale draft cleanup lane, private delta lane
+같은 상위 운영 task를 만든다. `batch-plan`은 이 task들을 workset으로 묶고
+`serial`, `parallel-safe`, `review-only`, `agent-gated` lane을 정한다.
+`role-dispatch`는 workset별 Planner, Implementer, Reviewer, CI Reviewer,
+Benchmark Auditor, Privacy Auditor, Deep Reviewer prompt source를 만든다.
+
+`continue-loop`는 `pr-scan -> next-from-prs -> batch-plan -> role-dispatch ->
+draft/apply queue-plan -> loop-state`를 한 번에 실행하는 local continuation
+surface다. 이 command는 queue/plan docs까지 자동 반영할 수 있지만 remote mutation
+(push, PR create/merge/close, issue close, branch delete, force-push), private
+real-eval 실행, benchmark/performance claim 승인은 하지 않는다.
 
 ### Granularity Guardrails
 
@@ -166,6 +181,9 @@ Agent에게 맡기는 work package는 충분히 커야 하지만, review surface
   command가 통과해도 PR-ready가 아니다.
 - `loop-state`의 `continuation` block은 detached HEAD, stale manifest, task
   linkage 누락을 감지해 다음 복구 command를 machine-readable하게 제공한다.
+- PR corpus 기반 task는 `Source PRs`, `Workset`, `Lane`, `Role Hints`,
+  `Completion Proof`를 남긴다. `Source PRs`는 선택된 PR이 아니라 그 task를
+  만든 evidence set이다.
 
 ### Planning Required
 
@@ -305,7 +323,8 @@ handoff block을 남긴다.
 2. 새 작업부터 `tasks/queue.md`와 plan doc를 사용한다.
 3. 기존 open PR/issue를 모두 이 시스템으로 retro-fit하지 않는다.
 4. eval/benchmark claim이 있는 새 PR부터 Benchmark Auditor checklist를 적용한다.
-5. 불편한 항목만 automation으로 승격한다. 처음부터 새 CI gate를 만들지 않는다.
+5. 불편한 항목만 local automation으로 승격한다. 처음부터 새 CI gate나 remote
+   mutation automation을 만들지 않는다.
 
 ## Incremental Rollout
 
@@ -318,8 +337,9 @@ handoff block을 남긴다.
 
 ## Risks And Tradeoffs
 
-- 문서가 늘어나는 비용이 있다. 그래서 task queue, plan, review, eval map만 최소로
-  추가하고, 새 code automation은 만들지 않는다.
+- 문서와 local automation이 늘어나는 비용이 있다. 그래서 task queue, plan, review,
+  eval map, agent-loop helper만 최소 surface로 유지하고 새 remote mutation
+  automation은 만들지 않는다.
 - Queue가 GitHub issue와 중복될 수 있다. Queue는 issue tracker가 아니라 AI-agent
   handoff index로 한정한다.
 - Checklist가 형식적으로 채워질 위험이 있다. Reviewer는 checklist의 "N/A" 사유가

--- a/docs/operations/auto-ship.md
+++ b/docs/operations/auto-ship.md
@@ -107,7 +107,7 @@ Gate 0 — 8 pre-checks (silent exit on any failure)
 Stage 1: commit   (private-path filter → multi-agent lock → tier-7 prefix gate → bash scripts/test.sh → git commit)
 Stage 2: push     (ADR 0007 branch check → git push)
 Stage 3: PR       (_ship_pr_body.py → §5b cascade → gh pr create)
-Stage 4: CI/review gate  (gh pr checks --watch → requested-changes/unresolved-thread gate)
+Stage 4: CI/review gate  (gh pr checks --watch → ready-mode draft promotion → requested-changes/unresolved-thread gate)
 Stage 5: merge    (gh pr merge --squash --admin → git push origin --delete <branch> → checkout main → disarm)
 ```
 
@@ -190,11 +190,19 @@ merge 직전에 다음을 fail-closed 로 검사한다:
 - `reviewDecision` 이 `CHANGES_REQUESTED` 가 아님.
 - unresolved 이고 outdated 가 아닌 review thread 가 없음.
 
+`DRAFT=false` 로 armed 된 ready-mode run 에서 기존 head PR 이 아직 draft 라면,
+Stage 4 는 review gate 직전에 `gh pr ready <N>` 를 실행한다. 즉, 이미 draft
+PR 이 열린 브랜치를 재사용하더라도 ready-mode arm 은 draft→ready→review
+gate→merge 흐름을 이어간다. 반대로 `DRAFT=true` 는 의도적으로 draft PR 을
+열어두는 모드이므로 review gate 의 `PR is draft` blocker 에서 멈춘다.
+
 review gate 가 막으면 PR 을 열린 채로 두고 disarm 한다. 그 상태에서 Codex 의
 GitHub review-fix 루프를 실행해 코멘트를 처리하고, fix 커밋을 push 한 뒤
-다시 `make ship-arm` 한다. Shell hook 은 reviewer 코멘트를 임의로 수정하지
-않는다; patch 선택은 코드 맥락과 reviewer 의도를 읽어야 하므로 agent 판단
-단계로 남긴다.
+다시 `make ship-arm` 한다. draft 상태만 blocker 라면
+`python3 scripts/agent_loop.py human-gated-exec --action pr-ready --pr <N> --confirm-human-approved`
+로 draft 를 ready 로 바꾼 뒤 `make ship-arm DRAFT=false` 로 ready-mode 를
+재무장한다. Shell hook 은 reviewer 코멘트를 임의로 수정하지 않는다; patch
+선택은 코드 맥락과 reviewer 의도를 읽어야 하므로 agent 판단 단계로 남긴다.
 
 ### Stage 5 — squash-merge ([`stop-ship.sh:374-424`](../../scripts/claude-hooks/stop-ship.sh))
 

--- a/docs/plans/T-2026-0020-pr-corpus-workset-planning.md
+++ b/docs/plans/T-2026-0020-pr-corpus-workset-planning.md
@@ -1,0 +1,103 @@
+# Plan: T-2026-0020 PR corpus workset planning
+
+- Status: review
+- Owner role: Maintainer -> CI Reviewer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0020`
+- Related issue: #1551
+
+## Problem
+
+`next-from-prs` sounded like it selected one open PR to continue. That is the
+wrong operating model for the agent loop. Open PRs should be read as a corpus:
+draft state, CI state, review state, merge blockers, stale signals, and claim
+evidence together should produce the next task list.
+
+The downstream commands also need to preserve that corpus-level decision.
+`batch-plan` should group task briefs into worksets and lanes, and
+`role-dispatch` should produce role-specific prompt inputs from that workset
+plan. The root session should keep integration, validation, and ship gates.
+
+## Desired Behavior
+
+- `next-from-prs` treats open PRs as evidence, not as a PR selection list.
+- Generated tasks are operational worksets such as blocked PR triage, ready PR
+  ship lane, stale draft cleanup, private delta evidence, or draft workset
+  continuation.
+- Each task brief records `Source PRs`, `Workset`, `Lane`, `Role Hints`, and
+  `Completion Proof`.
+- `batch-plan` writes JSON with `workset_id`, `lane`, `source_prs`,
+  `role_hints`, and `completion_proof`.
+- `role-dispatch --batch` turns those worksets into Planner, Implementer,
+  Reviewer, CI Reviewer, Benchmark Auditor, Privacy Auditor, and Deep Reviewer
+  prompt source.
+- `continue-loop` advances `pr-scan -> next-from-prs -> batch-plan ->
+  role-dispatch -> draft/apply queue-plan -> loop-state` locally.
+
+## Non-Goals
+
+- Do not push, create/merge/close PRs, close issues, delete branches, force-push,
+  run private real-eval, or approve benchmark/performance claims.
+- Do not change retrieval, ingestion, eval scoring, answer contracts, or runtime
+  behavior.
+- Do not expose private raw values or PR body/title text as required evidence.
+
+## Affected Interfaces
+
+- `python3 scripts/agent_loop.py next-from-prs`
+- `python3 scripts/agent_loop.py batch-plan`
+- `python3 scripts/agent_loop.py role-dispatch --batch`
+- `python3 scripts/agent_loop.py continue-loop`
+- `scripts/ai_next_actions.py` generated Markdown, HTML, and task briefs
+- `reports/agent_loop/batch_plan.json` local schema
+- `tasks/queue.md` and `docs/plans/` operating docs
+
+## Implementation Steps
+
+1. Replace per-PR task generation with PR corpus signal classification.
+2. Emit workset task briefs with source PR lists and completion proof.
+3. Parse the new brief fields in `agent_loop.py`.
+4. Extend `batch-plan` Markdown and JSON with workset metadata.
+5. Wire `role-dispatch` to batch/workset inputs.
+6. Add `continue-loop` to run the local planning chain and apply queue/plan
+   only after internal agent-gate checks.
+7. Update docs and persistent queue state.
+8. Add focused tests for corpus planning, workset JSON, role dispatch, and
+   local continuation.
+
+## Validation Strategy
+
+```bash
+python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py
+python3 -m pytest tests/test_ai_next_actions.py tests/test_agent_loop.py -q
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0020-pr-corpus-workset-planning.md
+python3 scripts/agent_loop.py continue-loop --pr-json reports/agent_loop/pr_state.json --no-apply-queue-plan
+git diff --check
+make check-branch
+```
+
+## Acceptance Criteria
+
+- Multiple PRs produce task/workset briefs from the corpus rather than a single
+  PR selection.
+- Blocked, ready, stale draft, private-delta, and draft continuation lanes can
+  be represented with `Source PRs`.
+- `batch-plan` separates serial, parallel-safe, review-only, and agent-gated
+  lanes while preserving workset metadata.
+- `role-dispatch` can render workset inputs from `batch_plan.json`.
+- `continue-loop` creates local reports, drafts/apply queue-plan, and writes
+  loop state without remote mutation.
+
+## Rollback
+
+Revert the `scripts/ai_next_actions.py`, `scripts/agent_loop.py`, tests, docs,
+and queue/plan changes from this task. Generated `reports/agent_loop/*`
+artifacts are gitignored and do not need rollback.
+
+## Reviewer Focus
+
+- Confirm `next-from-prs` no longer selects a single PR.
+- Confirm task briefs do not leak private raw values or require raw PR text.
+- Confirm `continue-loop` does not perform remote mutation.
+- Confirm batch/workset lanes preserve serial dependencies and gate-sensitive
+  surfaces.
+- Confirm no benchmark, product quality, or private real-eval claim is implied.

--- a/docs/plans/T-2026-0021-pr-corpus-workset-planning.md
+++ b/docs/plans/T-2026-0021-pr-corpus-workset-planning.md
@@ -16,6 +16,9 @@ The downstream commands also need to preserve that corpus-level decision.
 `batch-plan` should group task briefs into worksets and lanes, and
 `role-dispatch` should produce role-specific prompt inputs from that workset
 plan. The root session should keep integration, validation, and ship gates.
+The ship gate also needs a continuous ready-mode path when a branch already has
+a draft PR: otherwise the loop reaches review gate, fails on `PR is draft`, and
+never reaches merge even when the agent has armed ready shipping.
 
 ## Desired Behavior
 
@@ -32,6 +35,9 @@ plan. The root session should keep integration, validation, and ship gates.
   prompt source.
 - `continue-loop` advances `pr-scan -> next-from-prs -> batch-plan ->
   role-dispatch -> draft/apply queue-plan -> loop-state` locally.
+- Ready-mode auto-ship (`DRAFT=false`) promotes an existing draft PR to ready
+  before the review gate, then continues to merge only if CI and review gates
+  pass.
 
 ## Non-Goals
 
@@ -48,6 +54,8 @@ plan. The root session should keep integration, validation, and ship gates.
 - `python3 scripts/agent_loop.py role-dispatch --batch`
 - `python3 scripts/agent_loop.py continue-loop`
 - `scripts/ai_next_actions.py` generated Markdown, HTML, and task briefs
+- `scripts/claude-hooks/stop-ship.sh` Stage 4 ready-mode bridge
+- `scripts/claude-hooks/_ship_review_gate.py` draft blocker recovery guidance
 - `reports/agent_loop/batch_plan.json` local schema
 - `tasks/queue.md` and `docs/plans/` operating docs
 
@@ -63,13 +71,15 @@ plan. The root session should keep integration, validation, and ship gates.
 7. Update docs and persistent queue state.
 8. Add focused tests for corpus planning, workset JSON, role dispatch, and
    local continuation.
+9. Add a focused draft→ready bridge so ready-mode shipping does not stop at an
+   existing draft PR before merge.
 
 ## Validation Strategy
 
 ```bash
 python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py
-python3 -m pytest tests/test_ai_next_actions.py tests/test_agent_loop.py -q
-python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0021-pr-corpus-workset-planning.md
+python3 -m pytest tests/test_ai_next_actions.py tests/test_agent_loop.py tests/test_ship_start_review_gate.py tests/test_ship_dispatcher_gates.py -q
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md docs/operations/ai-engineering-operating-system.md docs/operations/auto-ship.md tasks/queue.md docs/plans/T-2026-0021-pr-corpus-workset-planning.md
 python3 scripts/agent_loop.py continue-loop --pr-json reports/agent_loop/pr_state.json --no-apply-queue-plan
 git diff --check
 make check-branch
@@ -86,6 +96,8 @@ make check-branch
 - `role-dispatch` can render workset inputs from `batch_plan.json`.
 - `continue-loop` creates local reports, drafts/apply queue-plan, and writes
   loop state without remote mutation.
+- `make ship-arm DRAFT=false` can reuse an existing draft PR by marking it
+  ready before review gate; `DRAFT=true` still intentionally stops as draft.
 
 ## Rollback
 

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -2189,7 +2189,7 @@ def render_batch_plan(briefs: Sequence[BriefSummary], *, tasks_dir: Path, repo_r
             "## Agent Gate Stop Points",
             "",
             "- Applying any draft to `tasks/queue.md` or `docs/plans/*.md`.",
-            "- Any push, PR create/merge/close, branch delete, or force-push without explicit confirmation command/flag.",
+            "- Any push, PR create/ready/merge/close, branch delete, or force-push without explicit confirmation command/flag.",
             "- Benchmark/performance/private real-eval claims.",
             "- Architecture tradeoff decisions.",
             "",
@@ -3752,7 +3752,7 @@ def render_approval_packet(
             "## Conservative Agent Gate Required Before",
             "",
             "- Applying queue/plan drafts to tracked docs.",
-            "- Running push, PR create/merge/close, branch delete, or force-push.",
+            "- Running push, PR create/ready/merge/close, branch delete, or force-push.",
             "- Making benchmark/performance/private real-eval claims.",
             "- Choosing architecture tradeoffs.",
             "",
@@ -3893,7 +3893,7 @@ Closes #{issue_number or '<ISSUE_NUMBER>'}
 
 ## 3. 리스크
 
-- Conservative-agent-gated decisions remain outside this CLI: push, PR create/merge/close, branch delete, force-push, private real-eval decisions, benchmark/performance claims, and architecture tradeoffs.
+- Conservative-agent-gated decisions remain outside this CLI: push, PR create/ready/merge/close, branch delete, force-push, private real-eval decisions, benchmark/performance claims, and architecture tradeoffs.
 - Disallowed claims to avoid:
 {chr(10).join(f'  - {claim}' for claim in surface.disallowed_claims)}
 
@@ -4579,6 +4579,7 @@ def render_auto_ship_plan(
         "- The existing Stop hook then runs the repository auto-ship pipeline once and disarms.",
         "- `DRY_RUN=1` echoes mutating commands to `.claude/.ship-dryrun.log` instead of executing them.",
         "- `DRAFT=true` creates a draft PR so the review gate stops before ready merge.",
+        "- `DRAFT=false` ready-mode marks an existing draft PR ready before the review gate, then continues to merge only if the gate passes.",
         "",
         "## Recommended Command",
         "",
@@ -6139,6 +6140,7 @@ def render_ship_command_pack(*, pr: str | None, branch: str | None, repo_root: P
         "",
         "```bash",
         f"# create PR after agent gate: python3 scripts/agent_loop.py human-gated-exec --action pr-create --branch {shell_branch} --body reports/agent_loop/pr_body.md --confirm-human-approved",
+        f"# mark draft PR ready after agent gate: python3 scripts/agent_loop.py human-gated-exec --action pr-ready --pr {safe_pr} --confirm-human-approved",
         f"# review gate before merge/close/delete: make ship-review-gate PR={safe_pr}",
         f"# push after agent gate: python3 scripts/agent_loop.py human-gated-exec --action push --branch {shell_branch} --confirm-human-approved",
         f"# merge after agent gate: python3 scripts/agent_loop.py human-gated-exec --action pr-merge --pr {safe_pr} --confirm-review-gate-passed --confirm-human-approved",
@@ -6157,7 +6159,16 @@ def render_ship_command_pack(*, pr: str | None, branch: str | None, repo_root: P
     return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
 
 
-HUMAN_GATED_ACTIONS = {"push", "pr-create", "pr-merge", "pr-close", "branch-delete", "force-push", "issue-close"}
+HUMAN_GATED_ACTIONS = {
+    "push",
+    "pr-create",
+    "pr-ready",
+    "pr-merge",
+    "pr-close",
+    "branch-delete",
+    "force-push",
+    "issue-close",
+}
 
 
 def write_human_gated_exec(
@@ -6283,6 +6294,10 @@ def build_human_gated_exec_plan(
         if title:
             command_parts.extend(["--title", _sanitize_inline_text(title)])
         command = tuple(command_parts)
+    elif action == "pr-ready":
+        safe_pr = _validate_pr_selector(pr or "")
+        command = ("gh", "pr", "ready", safe_pr)
+        warnings.append("pr-ready only clears GitHub draft state; CI, review, claim, and dependency gates still run before merge")
     elif action == "pr-merge":
         safe_pr = _validate_pr_selector(pr or "")
         if not confirm_review_gate_passed:
@@ -7408,7 +7423,7 @@ def render_automation_coverage() -> str:
             "",
             "- Queue/plan tracked-doc application requires either the explicit compatibility flag or the `continue-loop` internal agent gate.",
             "- Running existing `make ship-arm` remains a conservative shipping gate; `auto-ship-plan` only prepares a plan.",
-            "- Push, PR create/merge/close, issue close, branch delete, force-push require `human-gated-exec --confirm-human-approved` plus action-specific gates.",
+            "- Push, PR create/ready/merge/close, issue close, branch delete, force-push require `human-gated-exec --confirm-human-approved` plus action-specific gates.",
             "- Private real-eval decisions, benchmark/performance claims, and architecture tradeoffs follow ADR 0079 defaults.",
             "- Role dispatch is report-only; it does not execute subagents or remote mutations.",
             "",
@@ -8343,10 +8358,11 @@ flowchart TD
   INT --> MCP
   ISS --> F
   ROLE --> F
-  Q --> R{"Agent gate: review, claims, merge, close issue/PR, push, delete?"}
+  Q --> R{"Agent gate: review, claims, ready PR, merge, close issue/PR, push, delete?"}
   R -->|policy passes| SHIP["make ship-arm: conservative single end-to-end ship pipeline"]
   R -->|fallback policy passes| EXEC["human-gated-exec: legacy-named conservative remote mutation fallback"]
-  SHIP --> S["Existing ship workflow"]
+  SHIP --> READYPR["Ready-mode bridge: existing draft PR -> gh pr ready before review gate"]
+  READYPR --> S["Existing ship workflow"]
   EXEC --> S["Manual fallback workflow"]
   R -->|more work| A
 ```
@@ -8385,7 +8401,7 @@ Automation points:
 - auto-ship-prepare: prepare or create a local ADR 0007 branch for the primary `make ship-arm` pipeline; branch creation requires `--confirm-human-approved`.
 - auto-ship-plan: render a readiness-backed bridge to the primary `make ship-arm` Stop-hook pipeline without arming it.
 - ship-command-pack: render conservative shipping commands without executing them.
-- human-gated-exec: legacy command name for conservative remote mutation fallback; executes push/PR create/merge/close, issue close, remote branch delete, or force-with-lease only with `--confirm-human-approved` and action-specific gates.
+- human-gated-exec: legacy command name for conservative remote mutation fallback; executes push/PR create/ready/merge/close, issue close, remote branch delete, or force-with-lease only with `--confirm-human-approved` and action-specific gates.
 - dependency-graph: render stacked PR graph without merge/delete mutation.
 - stacked-risk: detect dependent PR risk before merge/delete cleanup.
 - pr-body-check: verify `Closes`, §5b, claim, and privacy boundaries before PR creation.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -115,6 +115,7 @@ DEFAULT_WORKSET_RECOMMENDATION = DEFAULT_REPORT_DIR / "workset_recommendation.md
 DEFAULT_DEPENDENCY_GRAPH = DEFAULT_REPORT_DIR / "dependency_graph.md"
 DEFAULT_AUTOMATION_COVERAGE = DEFAULT_REPORT_DIR / "automation_coverage.md"
 DEFAULT_ROLE_DISPATCH = DEFAULT_REPORT_DIR / "role_dispatch.md"
+DEFAULT_CONTINUE_LOOP = DEFAULT_REPORT_DIR / "continue_loop.md"
 DEFAULT_OVERLAP_PREFLIGHT = DEFAULT_REPORT_DIR / "overlap_preflight.md"
 DEFAULT_HUMAN_GATED_EXEC = DEFAULT_REPORT_DIR / "human_gated_exec.md"
 DEFAULT_AUTO_SHIP_PLAN = DEFAULT_REPORT_DIR / "auto_ship_plan.md"
@@ -261,11 +262,15 @@ class BriefSummary:
     title: str
     classification: str
     source: str
+    source_prs: tuple[str, ...]
+    workset: str
     reason: str
     goal: str
     verification: str
     lane: str
     gate_reason: str
+    completion_proof: str
+    role_hints: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -1813,6 +1818,11 @@ def _sanitize_work_item(ai_next_actions, item):  # type: ignore[no-untyped-def]
         goal=_sanitize_dynamic_text(item.goal),
         expected_evidence=_sanitize_dynamic_text(item.expected_evidence),
         verification=_sanitize_command_text(item.verification),
+        source_prs=tuple(int(number) for number in getattr(item, "source_prs", ()) if str(number).isdigit()),
+        workset=_slugify(str(getattr(item, "workset", "general"))) or "general",
+        lane=_sanitize_inline_text(str(getattr(item, "lane", "parallel-safe"))),
+        completion_proof=_sanitize_dynamic_text(str(getattr(item, "completion_proof", ""))),
+        role_hints=tuple(_sanitize_inline_text(str(role)) for role in getattr(item, "role_hints", ()) if str(role).strip()),
     )
 
 
@@ -1879,6 +1889,133 @@ def draft_next_from_prs(
     return pr_state, tasks_dir, draft
 
 
+def write_continue_loop(
+    *,
+    pr_json: Path | None = None,
+    state: str = "open",
+    limit: int = 30,
+    include_body: bool = False,
+    task_id: str = DEFAULT_DRAFT_TASK_ID,
+    max_items: int = 12,
+    apply_queue_plan: bool = True,
+    out: Path = DEFAULT_CONTINUE_LOOP,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, str]:
+    if pr_json is None:
+        pr_state = scan_pr_state(
+            out=repo_root / "reports" / "agent_loop" / "pr_state.json",
+            state=state,
+            limit=limit,
+            include_body=include_body,
+            repo_root=repo_root,
+        )
+    else:
+        pr_state = _resolve_input_path(pr_json, repo_root=repo_root)
+        if not pr_state.exists():
+            raise ValueError("PR state JSON not found; run pr-scan first or pass an existing --pr-json")
+
+    ai_next, tasks_dir = run_next_from_prs(pr_json=pr_state, repo_root=repo_root)
+    batch_md, batch_json, _ = write_batch_plan(tasks_dir=tasks_dir, max_items=max_items, repo_root=repo_root)
+    if batch_json is None:
+        raise ValueError("continue-loop requires batch JSON metadata")
+    workset_out, _ = write_workset_recommendation(batch=batch_json, repo_root=repo_root)
+    role_out, _ = write_role_dispatch(batch=batch_json, repo_root=repo_root)
+
+    briefs = sorted(tasks_dir.glob("*.md"))
+    if not briefs:
+        raise ValueError("planner did not produce a task brief")
+    chosen_task_id = _next_task_id(repo_root) if task_id == DEFAULT_DRAFT_TASK_ID else task_id
+    draft = draft_task_from_brief(task_brief=briefs[0], task_id=chosen_task_id, repo_root=repo_root)
+    promote_out, _ = write_promote_draft(repo_root=repo_root)
+    apply_out: Path | None = None
+    apply_result = "skipped"
+    if apply_queue_plan:
+        apply_out, _ = write_apply_queue_plan(confirm_human_approved=True, repo_root=repo_root)
+        apply_result = "applied"
+
+    loop_task = chosen_task_id if apply_queue_plan else None
+    loop_out, _ = write_loop_state(task_id=loop_task, batch=batch_json, repo_root=repo_root)
+    rendered = render_continue_loop(
+        pr_state=pr_state,
+        ai_next=ai_next,
+        tasks_dir=tasks_dir,
+        batch_md=batch_md,
+        batch_json=batch_json,
+        workset_out=workset_out,
+        role_out=role_out,
+        queue_draft=draft.queue_path,
+        plan_draft=draft.plan_path,
+        promote_out=promote_out,
+        apply_out=apply_out,
+        loop_out=loop_out,
+        task_id=chosen_task_id,
+        apply_result=apply_result,
+        repo_root=repo_root,
+    )
+    out = _default_output(out, DEFAULT_CONTINUE_LOOP, "continue_loop.md", repo_root=repo_root)
+    safe_out = _safe_output_path(out, repo_root=repo_root)
+    safe_out.parent.mkdir(parents=True, exist_ok=True)
+    safe_out.write_text(rendered, encoding="utf-8")
+    return safe_out, rendered
+
+
+def _next_task_id(repo_root: Path) -> str:
+    queue = repo_root / QUEUE_PATH
+    existing = [int(match.group(1)) for match in re.finditer(r"\bT-2026-(\d{4})\b", _read_text(queue) if queue.exists() else "")]
+    return f"T-2026-{(max(existing) + 1 if existing else 1):04d}"
+
+
+def render_continue_loop(
+    *,
+    pr_state: Path,
+    ai_next: Path,
+    tasks_dir: Path,
+    batch_md: Path,
+    batch_json: Path,
+    workset_out: Path,
+    role_out: Path,
+    queue_draft: Path,
+    plan_draft: Path,
+    promote_out: Path,
+    apply_out: Path | None,
+    loop_out: Path,
+    task_id: str,
+    apply_result: str,
+    repo_root: Path,
+) -> str:
+    lines = [
+        "# Continue Loop",
+        "",
+        "- PR corpus planning command. It treats PRs as evidence for workset planning, not as a single PR selection list.",
+        "- It does not push, create/merge/close PRs, delete branches, force-push, run private eval, or approve benchmark claims.",
+        f"- Queue/plan application: `{apply_result}`",
+        f"- Task id: `{task_id}`",
+        "",
+        "## Outputs",
+        "",
+        f"- PR state: `{_display_path(_repo_path(pr_state, repo_root), repo_root=repo_root)}`",
+        f"- Next actions: `{_display_path(_repo_path(ai_next, repo_root), repo_root=repo_root)}`",
+        f"- Task briefs: `{_display_path(_repo_path(tasks_dir, repo_root), repo_root=repo_root)}`",
+        f"- Batch plan: `{_display_path(_repo_path(batch_md, repo_root), repo_root=repo_root)}`",
+        f"- Batch JSON: `{_display_path(_repo_path(batch_json, repo_root), repo_root=repo_root)}`",
+        f"- Workset recommendation: `{_display_path(_repo_path(workset_out, repo_root), repo_root=repo_root)}`",
+        f"- Role dispatch: `{_display_path(_repo_path(role_out, repo_root), repo_root=repo_root)}`",
+        f"- Queue draft: `{_display_path(_repo_path(queue_draft, repo_root), repo_root=repo_root)}`",
+        f"- Plan draft: `{_display_path(_repo_path(plan_draft, repo_root), repo_root=repo_root)}`",
+        f"- Promote diff: `{_display_path(_repo_path(promote_out, repo_root), repo_root=repo_root)}`",
+        f"- Apply report: `{_display_path(_repo_path(apply_out, repo_root), repo_root=repo_root) if apply_out else 'N/A'}`",
+        f"- Loop state: `{_display_path(_repo_path(loop_out, repo_root), repo_root=repo_root)}`",
+        "",
+        "## Next Safe Command",
+        "",
+        "```bash",
+        "python3 scripts/agent_loop.py loop-state --from-git",
+        "```",
+        "",
+    ]
+    return _sanitize_dynamic_text("\n".join(lines))
+
+
 def write_batch_plan(
     *,
     tasks_dir: Path = DEFAULT_CODEX_TASKS_DIR,
@@ -1928,17 +2065,33 @@ def _load_brief_summaries(tasks_dir: Path, *, max_items: int, repo_root: Path) -
                 title=_sanitize_inline_text(brief["title"]),
                 classification=_sanitize_inline_text(brief["classification"]),
                 source=_sanitize_inline_text(brief["source"]),
+                source_prs=tuple(_split_csv_field(brief["source_prs"])),
+                workset=_sanitize_inline_text(brief["workset"] or "general"),
                 reason=_sanitize_inline_text(brief["reason"]),
                 goal=_sanitize_inline_text(brief["goal"]),
                 verification=_sanitize_command_text(brief["verification"]),
                 lane=lane,
                 gate_reason=reason,
+                completion_proof=_sanitize_inline_text(brief["completion_proof"]),
+                role_hints=tuple(_split_csv_field(brief["role_hints"])),
             )
         )
     return summaries
 
 
+def _split_csv_field(value: str) -> list[str]:
+    cleaned = value.strip().strip("`")
+    if not cleaned or cleaned.upper() == "N/A":
+        return []
+    return [_sanitize_inline_text(part.strip()) for part in cleaned.split(",") if part.strip()]
+
+
 def _lane_for_brief(brief: dict[str, str]) -> tuple[str, str]:
+    lane_hint = brief.get("lane", "").strip()
+    valid_lanes = {"serial", "parallel-safe", "review-only", "agent-gated", "manual-gated"}
+    if lane_hint in valid_lanes:
+        normalized = "manual-gated" if lane_hint == "agent-gated" else lane_hint
+        return normalized, f"brief declares `{lane_hint}` lane"
     classification = brief["classification"].lower()
     haystack = "\n".join(
         [brief["title"], brief["classification"], brief["source"], brief["reason"], brief["goal"], brief["verification"]]
@@ -1992,6 +2145,17 @@ def render_batch_plan(briefs: Sequence[BriefSummary], *, tasks_dir: Path, repo_r
         lines.append(f"| `{lane}` | {count} | {label[lane]} |")
     lines.append("")
 
+    worksets: dict[str, list[BriefSummary]] = {}
+    for item in briefs:
+        worksets.setdefault(item.workset or "general", []).append(item)
+    lines.extend(["## Workset Summary", "", "| Workset | Lane(s) | Source PRs | Role hints |", "|---|---|---|---|"])
+    for workset, items in sorted(worksets.items()):
+        workset_lanes = ", ".join(sorted({item.lane for item in items}))
+        prs = ", ".join(sorted({pr for item in items for pr in item.source_prs})) or "N/A"
+        roles = ", ".join(sorted({role for item in items for role in item.role_hints})) or "N/A"
+        lines.append(f"| `{_sanitize_inline_text(workset)}` | `{workset_lanes}` | `{prs}` | `{roles}` |")
+    lines.append("")
+
     for lane in lanes:
         lines.extend([f"## {label[lane]}", ""])
         items = [item for item in briefs if item.lane == lane]
@@ -2006,8 +2170,12 @@ def render_batch_plan(briefs: Sequence[BriefSummary], *, tasks_dir: Path, repo_r
                     f"- Brief: `{_display_path(_repo_path(item.path, repo_root), repo_root=repo_root)}`",
                     f"- Classification: `{item.classification}`",
                     f"- Source: `{item.source}`",
+                    f"- Source PRs: `{', '.join(item.source_prs) if item.source_prs else 'N/A'}`",
+                    f"- Workset: `{item.workset}`",
+                    f"- Role hints: `{', '.join(item.role_hints) if item.role_hints else 'N/A'}`",
                     f"- Gate reason: {item.gate_reason}",
                     f"- Reason: {item.reason}",
+                    f"- Completion proof: {item.completion_proof}",
                     "- Suggested next safe command:",
                     "",
                     "```bash",
@@ -2036,9 +2204,14 @@ def _brief_summary_payload(item: BriefSummary, *, repo_root: Path) -> dict[str, 
         "title": item.title,
         "classification": item.classification,
         "source": item.source,
+        "source_prs": list(item.source_prs),
+        "workset": item.workset,
+        "workset_id": _slugify(item.workset or item.title),
         "lane": item.lane,
         "gate_reason": item.gate_reason,
         "brief": _display_path(_repo_path(item.path, repo_root), repo_root=repo_root),
+        "role_hints": list(item.role_hints),
+        "completion_proof": item.completion_proof,
         "verification": _ensure_git_diff_check(item.verification).splitlines(),
     }
 
@@ -6254,7 +6427,7 @@ def render_apply_queue_plan(*, confirm_human_approved: bool, target_queue: str, 
 - Result: `{'applied' if confirm_human_approved else 'blocked'}`
 - Queue target: `{target_queue}`
 - Plan target: `{target_plan}`
-- This command writes tracked queue/plan docs only when `--confirm-human-approved` is present.
+- This command writes tracked queue/plan docs only when `--confirm-human-approved` is present, or when `continue-loop` calls it after its internal agent gate.
 - It does not push, create/merge/close PRs, delete branches, force-push, run private eval, or approve claims.
 """
     )
@@ -7212,12 +7385,12 @@ def render_automation_coverage() -> str:
         ("14", "privacy regression corpus", "privacy-regression, privacy-audit-output"),
         ("15", "claim policy engine", "claim-policy, claim-audit"),
         ("16", "architecture decision detector", "architecture-decision, architecture-brief, adr-reserve"),
-        ("17", "next work-set recommender", "workset-recommend, batch-plan"),
+        ("17", "PR corpus workset planner", "pr-scan, next-from-prs, batch-plan, workset-recommend, continue-loop"),
         ("18", "auto-pass strict profiles", "auto-pass-check --profile ..."),
         ("19", "conservative remote execution", "human-gated-exec --confirm-human-approved"),
         ("20", "existing auto-ship bridge", "auto-ship-prepare, auto-ship-plan, ship-simulate, ship-command-pack"),
         ("21", "conservative issue cleanup", "issue-scan, maintenance-plan, human-gated-exec --action issue-close"),
-        ("22", "role-separated subagent dispatch", "role-dispatch"),
+        ("22", "role-separated subagent dispatch", "role-dispatch --batch"),
     )
     lines = [
         "# Agent Loop Automation Coverage",
@@ -7233,7 +7406,7 @@ def render_automation_coverage() -> str:
             "",
             "## Still Agent-Gated",
             "",
-            "- Queue/plan actual tracked-doc application unless `--confirm-human-approved` is explicit.",
+            "- Queue/plan tracked-doc application requires either the explicit compatibility flag or the `continue-loop` internal agent gate.",
             "- Running existing `make ship-arm` remains a conservative shipping gate; `auto-ship-plan` only prepares a plan.",
             "- Push, PR create/merge/close, issue close, branch delete, force-push require `human-gated-exec --confirm-human-approved` plus action-specific gates.",
             "- Private real-eval decisions, benchmark/performance claims, and architecture tradeoffs follow ADR 0079 defaults.",
@@ -7248,10 +7421,18 @@ def write_role_dispatch(
     *,
     changed_files: Sequence[str] = (),
     owner_role: str | None = None,
+    batch: Path | None = None,
+    workset: str | None = None,
     out: Path = DEFAULT_ROLE_DISPATCH,
     repo_root: Path = ROOT_DIR,
 ) -> tuple[Path, str]:
-    rendered = render_role_dispatch(changed_files=changed_files, owner_role=owner_role, repo_root=repo_root)
+    rendered = render_role_dispatch(
+        changed_files=changed_files,
+        owner_role=owner_role,
+        batch=batch,
+        workset=workset,
+        repo_root=repo_root,
+    )
     out = _default_output(out, DEFAULT_ROLE_DISPATCH, "role_dispatch.md", repo_root=repo_root)
     safe_out = _safe_output_path(out, repo_root=repo_root)
     safe_out.parent.mkdir(parents=True, exist_ok=True)
@@ -7259,11 +7440,15 @@ def write_role_dispatch(
     return safe_out, rendered
 
 
-def _role_dispatch_chain(owner_role: str | None, surface: SurfaceReport) -> list[str]:
+def _role_dispatch_chain(owner_role: str | None, surface: SurfaceReport, extra_roles: Sequence[str] = ()) -> list[str]:
     raw_roles = re.split(r"\s*(?:->|\+|,)\s*", owner_role or "Planner -> Implementer -> Reviewer")
     roles = [_sanitize_inline_text(role).strip() for role in raw_roles if role.strip()]
     if not roles:
         roles = ["Planner", "Implementer", "Reviewer"]
+    for role in extra_roles:
+        safe_role = _sanitize_inline_text(role).strip()
+        if safe_role:
+            roles.append(safe_role)
 
     reviewer_roles: list[str] = []
     if "Benchmark Auditor" in surface.reviewer_type:
@@ -7338,12 +7523,20 @@ def render_role_dispatch(
     *,
     changed_files: Sequence[str] = (),
     owner_role: str | None = None,
+    batch: Path | None = None,
+    workset: str | None = None,
     repo_root: Path = ROOT_DIR,
 ) -> str:
     normalized_files = tuple(_normalize_changed_file(path, repo_root=repo_root) for path in changed_files)
     normalized_files = tuple(path for path in normalized_files if path)
     surface = classify_changed_files(normalized_files)
-    roles = _role_dispatch_chain(owner_role, surface)
+    batch_items = _role_dispatch_batch_items(batch=batch, workset=workset, repo_root=repo_root)
+    extra_roles = tuple(
+        str(role)
+        for item in batch_items
+        for role in (item.get("role_hints") if isinstance(item.get("role_hints"), list) else [])
+    )
+    roles = _role_dispatch_chain(owner_role, surface, extra_roles=extra_roles)
     owner = _sanitize_inline_text(owner_role or "Planner -> Implementer -> Reviewer")
 
     lines = [
@@ -7365,6 +7558,10 @@ def render_role_dispatch(
         lines.extend(f"  - `{_sanitize_inline_text(path)}`" for path in normalized_files)
     else:
         lines.append("- Changed files: `none supplied`")
+    if batch is not None:
+        lines.append(f"- Batch: `{_display_path(_repo_path(_resolve_input_path(batch, repo_root=repo_root), repo_root), repo_root=repo_root)}`")
+        lines.append(f"- Workset filter: `{_sanitize_inline_text(workset or 'all')}`")
+        lines.append(f"- Workset item count: `{len(batch_items)}`")
 
     lines.extend(
         [
@@ -7388,6 +7585,24 @@ def render_role_dispatch(
             + " |"
         )
 
+    if batch_items:
+        lines.extend(["", "## Workset Inputs", "", "| Workset | Lane | Source PRs | Task |", "|---|---|---|---|"])
+        for item in batch_items:
+            source_prs = item.get("source_prs") if isinstance(item.get("source_prs"), list) else []
+            lines.append(
+                "| "
+                + " | ".join(
+                    _sanitize_dynamic_text(str(value)).replace("\n", " ")
+                    for value in (
+                        item.get("workset_id") or item.get("workset") or "general",
+                        item.get("lane") or "unknown",
+                        ", ".join(str(pr) for pr in source_prs) or "N/A",
+                        item.get("title") or "Untitled",
+                    )
+                )
+                + " |"
+            )
+
     lines.extend(
         [
             "",
@@ -7401,6 +7616,21 @@ def render_role_dispatch(
         ]
     )
     return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
+def _role_dispatch_batch_items(*, batch: Path | None, workset: str | None, repo_root: Path) -> list[dict[str, object]]:
+    if batch is None:
+        return []
+    path = _resolve_input_path(batch, repo_root=repo_root)
+    payload = _load_batch_payload(path)
+    if not workset:
+        return payload
+    wanted = _slugify(workset)
+    return [
+        item
+        for item in payload
+        if _slugify(str(item.get("workset_id") or item.get("workset") or "")) == wanted
+    ]
 
 
 def write_loop_state(
@@ -7612,6 +7842,7 @@ def _loop_artifact_state(repo_root: Path) -> dict[str, bool]:
         "reports/agent_loop/dependency_graph.md",
         "reports/agent_loop/automation_coverage.md",
         "reports/agent_loop/human_gated_exec.md",
+        "reports/agent_loop/continue_loop.md",
     )
     return {rel: (repo_root / rel).exists() for rel in rels}
 
@@ -8069,8 +8300,8 @@ flowchart TD
   A --> ISS["issue-scan and maintenance-plan: conservative issue cleanup and queue migration"]
   A --> MCP["agent-loop-mcp: expose safe local loop tools to MCP clients"]
   MCP --> D
-  B --> C["next-from-prs: generate next-action report and task briefs"]
-  C --> D["batch-plan: group serial, parallel, review, and agent-gated lanes"]
+  B --> C["next-from-prs: plan workset tasks from PR state corpus"]
+  C --> D["batch-plan: group worksets into serial, parallel, review, and agent-gated lanes"]
   D --> E["decision-brief: explain options, trade-offs, severity, and safe commands"]
   E --> F["draft-task: generate queue and plan drafts"]
   F --> G["promote-draft: dry-run queue/plan diff only"]
@@ -8105,6 +8336,9 @@ flowchart TD
   ARCH --> ADR["adr-reserve: draft-only ADR reservation"]
   C --> WORKSET["workset-recommend: serial/parallel/review/agent-gated sets"]
   WORKSET --> ROLE["role-dispatch: role-separated subagent dispatch plan (max 12, depth 2)"]
+  C --> CONT["continue-loop: pr-scan -> next-from-prs -> batch-plan -> role-dispatch -> queue/plan -> loop-state"]
+  CONT --> ROLE
+  CONT --> Q
   A --> INT["integration-pack and scheduled-status recipes"]
   INT --> MCP
   ISS --> F
@@ -8122,9 +8356,10 @@ Automation points:
 - issue-scan: read-only `gh issue list` JSON export plus conservative close/queue/in-flight/manual classification.
 - overlap-preflight: read-only start-of-task check for issue, branch, PR, worktree, remote branch, and freshness overlap.
 - maintenance-plan: generate issue cleanup, queue migration, worktree cleanup, and branch deletion gate recommendations without executing them.
-- next-from-prs: deterministic wrapper around `scripts/ai_next_actions.py`.
+- next-from-prs: deterministic wrapper around `scripts/ai_next_actions.py`; treats open PRs as a corpus, not a single PR selection list.
 - pr-health: group exported PR state into CI, review, stale, draft, blocked, and ready lanes.
-- batch-plan: group local task briefs into serial, parallel-safe, review-only, and agent-gated lanes.
+- batch-plan: group local task briefs into worksets with serial, parallel-safe, review-only, and agent-gated lanes.
+- continue-loop: run PR-corpus planning through batch plan, role dispatch, queue/plan draft/application, and loop-state without remote mutation.
 - decision-brief: explain agent-gate options, trade-offs, severity, reversibility, evidence, and next safe commands.
 - draft-task: local queue/plan drafts under `reports/agent_loop/`.
 - promote-draft: local dry-run diff for queue/plan promotion; no tracked files are changed.
@@ -8169,7 +8404,7 @@ Automation points:
 - dashboard: render a human-readable loop report from loop-state signals.
 - dashboard-html: render static local HTML view of the dashboard.
 - stale-reports: separate current vs stale local report artifacts; dry-run by default.
-- apply-queue-plan: apply queue/plan drafts only with explicit `--confirm-human-approved`.
+- apply-queue-plan: compatibility command that applies queue/plan drafts only with explicit `--confirm-human-approved`; `continue-loop` may invoke the same writer after its internal agent gate passes.
 - mcp-config: render placeholder-based MCP client config samples.
 - review-followup: parse reviewer findings into local follow-up task briefs.
 - review-ingest: normalize local or PR review text into review-followup briefs.
@@ -8186,6 +8421,7 @@ Conservative agent gate policy:
 - Prefer `make ship-arm` for policy-passing end-to-end shipping; use `human-gated-exec` only as a legacy-named manual fallback after action-specific preflight.
 - Treat informational reviews as advisory unless they produce unresolved review threads, requested changes, or concrete failing evidence.
 - Treat role dispatch as a planning surface only; it does not execute subagents or remote mutations.
+- Treat `continue-loop` as a local continuation surface only; it may update tracked queue/plan docs, but never pushes, creates/merges/closes PRs, deletes branches, runs private eval, or approves claims.
 """
 
 
@@ -8227,14 +8463,20 @@ def _parse_task_brief(text: str) -> dict[str, str]:
         )
     if not verification:
         verification = "git diff --check"
+    completion_proof = _clean_section(_section_text(text, "Completion Proof"))
     return {
         "title": _sanitize_dynamic_text(title),
         "classification": _clean_scalar(fields.get(_normalize_field("Classification"), "unknown")),
         "source": _clean_scalar(fields.get(_normalize_field("Source"), "planner")),
+        "source_prs": _clean_scalar(fields.get(_normalize_field("Source PRs"), "N/A")),
+        "workset": _clean_scalar(fields.get(_normalize_field("Workset"), "general")),
+        "lane": _clean_scalar(fields.get(_normalize_field("Lane"), "")),
+        "role_hints": _clean_scalar(fields.get(_normalize_field("Role Hints"), "Planner, Implementer, Reviewer")),
         "reason": _clean_scalar(fields.get(_normalize_field("Reason"), "no reason captured")),
         "goal": _clean_section(_section_text(text, "Goal")) or "Define the smallest safe follow-up from the planner brief.",
         "expected_evidence": _clean_section(_section_text(text, "Expected Evidence"))
         or "Public-safe evidence or a documented no-go decision.",
+        "completion_proof": completion_proof or "Focused validation passes and the follow-up evidence is recorded.",
         "verification": _sanitize_command_text(verification),
     }
 
@@ -8277,6 +8519,10 @@ def _render_task_drafts(
 
 - Classification: `{brief["classification"]}`
 - Source: `{brief["source"]}`
+- Source PRs: `{brief["source_prs"]}`
+- Workset: `{brief["workset"]}`
+- Lane: `{brief["lane"] or 'auto'}`
+- Role hints: `{brief["role_hints"]}`
 - Reason: {brief["reason"]}
 - Source brief: `{source_brief}`
 - Suggested plan path: `{suggested_plan}`
@@ -8296,6 +8542,10 @@ def _render_task_drafts(
 ### Evidence Required
 
 {brief["expected_evidence"]}
+
+### Completion Proof
+
+{brief["completion_proof"]}
 
 ### Related Plan / Issue / PR Links
 
@@ -8332,6 +8582,9 @@ def _render_task_drafts(
 ## Surface / Claim Boundary
 
 - Initial classification: `{brief["classification"]}`
+- Workset: `{brief["workset"]}`
+- Source PRs: `{brief["source_prs"]}`
+- Lane: `{brief["lane"] or 'auto'}`
 - Eval surface: classify again after implementation if changed files touch eval, benchmark, metrics, reports, configs, or claims.
 - Disallowed claim: do not claim product quality, benchmark lift, or private real-eval success from this draft alone.
 
@@ -8353,6 +8606,7 @@ def _render_task_drafts(
 ## Reviewer Focus
 
 - Scope control against the source brief.
+- Completion proof: {brief["completion_proof"]}
 - Privacy boundary and claim wording.
 - Conservative eval surface classification.
 - Validation evidence matches commands actually run.
@@ -8507,7 +8761,7 @@ def build_parser() -> argparse.ArgumentParser:
     maintenance.add_argument("--json-out", type=Path, default=DEFAULT_MAINTENANCE_PLAN_JSON)
     maintenance.add_argument("--tasks-dir", type=Path, default=DEFAULT_ISSUE_QUEUE_TASKS_DIR)
 
-    next_prs = sub.add_parser("next-from-prs", help="Generate next-action briefs from PR state JSON.")
+    next_prs = sub.add_parser("next-from-prs", help="Plan workset task briefs from the PR state corpus.")
     next_prs.add_argument("--pr-json", type=Path, default=DEFAULT_PR_STATE)
     next_prs.add_argument("--out-md", type=Path, default=DEFAULT_AI_NEXT_ACTIONS)
     next_prs.add_argument("--tasks-dir", type=Path, default=DEFAULT_CODEX_TASKS_DIR)
@@ -8538,6 +8792,16 @@ def build_parser() -> argparse.ArgumentParser:
     batch.add_argument("--json-out", type=Path, default=DEFAULT_BATCH_PLAN_JSON)
     batch.add_argument("--no-json", action="store_true")
     batch.add_argument("--max-items", type=int, default=12)
+
+    continue_loop = sub.add_parser("continue-loop", help="Advance PR-corpus planning through batch, role dispatch, queue/plan, and loop-state.")
+    continue_loop.add_argument("--pr-json", type=Path)
+    continue_loop.add_argument("--state", choices=("open", "closed", "all"), default="open")
+    continue_loop.add_argument("--limit", type=int, default=30)
+    continue_loop.add_argument("--include-body", action="store_true")
+    continue_loop.add_argument("--task-id", default=DEFAULT_DRAFT_TASK_ID)
+    continue_loop.add_argument("--max-items", type=int, default=12)
+    continue_loop.add_argument("--no-apply-queue-plan", action="store_true")
+    continue_loop.add_argument("--out", type=Path, default=DEFAULT_CONTINUE_LOOP)
 
     followup = sub.add_parser("review-followup", help="Convert reviewer findings into local follow-up briefs.")
     followup.add_argument("--review", required=True, type=Path)
@@ -8866,6 +9130,8 @@ def build_parser() -> argparse.ArgumentParser:
     role_dispatch.add_argument("--changed-files", type=Path)
     role_dispatch.add_argument("--from-git", action="store_true")
     role_dispatch.add_argument("--pr")
+    role_dispatch.add_argument("--batch", type=Path)
+    role_dispatch.add_argument("--workset")
     role_dispatch.add_argument("--out", type=Path, default=DEFAULT_ROLE_DISPATCH)
 
     gated = sub.add_parser("human-gated-exec", help="Legacy-named conservative remote mutation executor after explicit gate acknowledgment.")
@@ -9089,6 +9355,19 @@ def main(argv: list[str] | None = None) -> int:
                 sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
             else:
                 sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)} and {_repo_path(json_out, ROOT_DIR)}\n")
+            return 0
+        if args.command == "continue-loop":
+            out, _ = write_continue_loop(
+                pr_json=args.pr_json,
+                state=args.state,
+                limit=args.limit,
+                include_body=args.include_body,
+                task_id=args.task_id,
+                max_items=args.max_items,
+                apply_queue_plan=not args.no_apply_queue_plan,
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
             return 0
         if args.command == "review-followup":
             out, tasks_dir, count, _ = write_review_followups(
@@ -9630,6 +9909,8 @@ def main(argv: list[str] | None = None) -> int:
             out, _ = write_role_dispatch(
                 changed_files=files,
                 owner_role=args.owner_role,
+                batch=args.batch,
+                workset=args.workset,
                 out=args.out,
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")

--- a/scripts/ai_next_actions.py
+++ b/scripts/ai_next_actions.py
@@ -95,6 +95,11 @@ class WorkItem:
     goal: str
     expected_evidence: str
     verification: str
+    source_prs: tuple[int, ...] = ()
+    workset: str = "general"
+    lane: str = "parallel-safe"
+    completion_proof: str = "Focused validation passes and the follow-up evidence is recorded."
+    role_hints: tuple[str, ...] = ("Planner", "Implementer", "Reviewer")
 
     @property
     def priority(self) -> tuple[int, str, str]:
@@ -334,12 +339,17 @@ def _summary_work_items(summary: Mapping[str, Any], source: SourceState) -> list
     return items
 
 
-def _pr_work_items(prs: Sequence[Mapping[str, Any]], readiness_blocked: bool) -> list[WorkItem]:
-    items: list[WorkItem] = []
+@dataclass(frozen=True)
+class PrCorpusSignal:
+    number: int
+    classification: str
+    reason: str
+
+
+def _pr_corpus_signals(prs: Sequence[Mapping[str, Any]], readiness_blocked: bool) -> list[PrCorpusSignal]:
+    signals: list[PrCorpusSignal] = []
     for pr in sorted(prs, key=lambda p: _as_int(p.get("number"), 999999)):
         number = _as_int(pr.get("number"), 0)
-        source = f"PR #{number}" if number else "PR"
-        title = str(pr.get("title") or "(untitled)")
         missing_fields = [field for field in REQUIRED_PR_FIELDS if field not in pr]
         review = str(pr.get("reviewDecision") or "").upper()
         merge_state = str(pr.get("mergeStateStatus") or "").upper()
@@ -360,91 +370,149 @@ def _pr_work_items(prs: Sequence[Mapping[str, Any]], readiness_blocked: bool) ->
             not_ready_reason = "PR reports NO-GO/not claim-ready failed measurement"
             if merge_state:
                 not_ready_reason += f"; not merge-ready (merge state is {merge_state})"
-            items.append(
-                WorkItem(
-                    classification="failed_experiment",
-                    title=f"Do not merge {source}: {title}",
-                    reason=not_ready_reason,
-                    source=source,
-                    slug="failed-measurement-pr",
-                    goal="Convert the failed measurement into a documented no-go or a narrower follow-up task.",
-                    expected_evidence="The PR remains draft or explicitly documents NO-GO aggregate evidence without claiming improvement.",
-                    verification=f"gh pr view {number} --json isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,body",
-                )
-            )
+            signals.append(PrCorpusSignal(number, "failed_experiment", not_ready_reason))
             continue
 
         if draft and STALE_SUPERSEDED_RE.search(text):
-            items.append(
-                WorkItem(
-                    classification="close_superseded",
-                    title=f"Close superseded {source}: {title}",
-                    reason="draft PR appears stale or superseded; do not treat as an unblock candidate",
-                    source=source,
-                    slug="close-superseded-pr",
-                    goal="Close or clearly mark the stale draft so active next-action planning is not polluted.",
-                    expected_evidence="The PR is closed, or its body explicitly points to the replacement work.",
-                    verification=f"gh pr view {number} --json state,isDraft,title,body,updatedAt",
+            signals.append(
+                PrCorpusSignal(
+                    number,
+                    "close_superseded",
+                    "draft PR appears stale or superseded; do not treat as an unblock candidate",
                 )
             )
             continue
 
         if blocked_reasons:
-            items.append(
-                WorkItem(
-                    classification="blocked",
-                    title=f"Unblock {source}: {title}",
-                    reason="; ".join(blocked_reasons),
-                    source=source,
-                    slug="unblock-pr",
-                    goal="Resolve review, merge, or CI blockers before asking for review or merge.",
-                    expected_evidence="The PR has no requested changes, merge blocker, or failing required check.",
-                    verification=f"gh pr view {number} --json reviewDecision,mergeStateStatus,statusCheckRollup",
-                )
-            )
+            signals.append(PrCorpusSignal(number, "blocked", "; ".join(blocked_reasons)))
             continue
 
         if not readiness_blocked and (PRIVATE_DELTA_RE.search(text) or LOAD_BEARING_RE.search(text)):
-            items.append(
-                WorkItem(
-                    classification="needs_private_delta",
-                    title=f"Run private delta for {source}",
-                    reason="PR context indicates pending private delta evidence",
-                    source=source,
-                    slug="run-private-delta",
-                    goal="Produce public-safe private delta evidence before final review.",
-                    expected_evidence="PR body or reviewer note includes the redacted aggregate delta result.",
-                    verification="make real-eval-delta",
-                )
-            )
+            signals.append(PrCorpusSignal(number, "needs_private_delta", "PR context indicates pending private delta evidence"))
             continue
 
         if not draft:
-            items.append(
-                WorkItem(
-                    classification="ready_for_review",
-                    title=f"Review {source}: {title}",
-                    reason="PR has no detected blocker in exported GitHub state",
-                    source=source,
-                    slug="review-pr",
-                    goal="Perform a focused reviewer pass and identify any scoped Codex follow-up.",
-                    expected_evidence="Reviewer notes are either resolved or converted into a scoped follow-up task.",
-                    verification=f"gh pr view {number} --json reviewDecision,mergeStateStatus,statusCheckRollup",
-                )
-            )
+            signals.append(PrCorpusSignal(number, "ready_for_review", "PR has no detected blocker in exported GitHub state"))
         else:
-            items.append(
-                WorkItem(
-                    classification="next_experiment_candidate",
-                    title=f"Continue draft {source}: {title}",
-                    reason="draft PR has no exported hard blocker",
-                    source=source,
-                    slug="continue-draft-pr",
-                    goal="Narrow the draft PR to its next verifiable milestone.",
-                    expected_evidence="Focused tests and updated PR notes describe the remaining gap.",
-                    verification=f"gh pr view {number} --json isDraft,reviewDecision,mergeStateStatus",
-                )
+            signals.append(PrCorpusSignal(number, "next_experiment_candidate", "draft PR has no exported hard blocker"))
+    return signals
+
+
+def _source_prs_text(numbers: Sequence[int]) -> str:
+    return ", ".join(f"#{number}" for number in numbers if number) or "PR corpus"
+
+
+def _reason_summary(signals: Sequence[PrCorpusSignal]) -> str:
+    counts: dict[str, int] = {}
+    for signal in signals:
+        counts[signal.reason] = counts.get(signal.reason, 0) + 1
+    return "; ".join(f"{reason} ({count})" for reason, count in sorted(counts.items())) or "no reason captured"
+
+
+def _pr_corpus_work_items(prs: Sequence[Mapping[str, Any]], readiness_blocked: bool) -> list[WorkItem]:
+    signals = _pr_corpus_signals(prs, readiness_blocked)
+    grouped: dict[str, list[PrCorpusSignal]] = {}
+    for signal in signals:
+        grouped.setdefault(signal.classification, []).append(signal)
+
+    specs = (
+        (
+            "failed_experiment",
+            "Document failed measurement PR lane",
+            "failed-measurement-lane",
+            "failed-measurement",
+            "serial",
+            "Convert failed or NO-GO measurement PR evidence into documented no-go notes or narrower follow-up tasks.",
+            "Each source PR remains draft/closed or explicitly documents aggregate-only NO-GO evidence without claiming improvement.",
+            "gh pr list --state open --json number,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,body",
+            "Source PRs have no unqualified benchmark or performance claim after the no-go decision is recorded.",
+            ("Planner", "Benchmark Auditor", "Reviewer"),
+        ),
+        (
+            "close_superseded",
+            "Clean stale draft PR lane",
+            "stale-draft-cleanup",
+            "stale-draft-cleanup",
+            "agent-gated",
+            "Close or clearly mark stale/superseded draft PRs so active planning is not polluted by obsolete branches.",
+            "Each source PR is closed, retitled, or updated with a replacement pointer and no active merge expectation.",
+            "gh pr list --state open --json number,isDraft,title,body,updatedAt,mergeStateStatus",
+            "No source PR remains an ambiguous stale draft in the open PR corpus.",
+            ("Planner", "Maintainer", "Reviewer"),
+        ),
+        (
+            "blocked",
+            "Triage blocked PR lane",
+            "blocked-pr-triage",
+            "blocked-pr-triage",
+            "serial",
+            "Resolve shared CI, review, or merge blockers before selecting implementation or shipping work.",
+            "The source PR corpus has no requested changes, failing required checks, missing required JSON fields, or blocking merge state.",
+            "gh pr list --state open --json number,reviewDecision,mergeStateStatus,statusCheckRollup",
+            "All source PRs leave the blocked lane or have focused follow-up tasks with validation evidence.",
+            ("Planner", "CI Reviewer", "Implementer", "Reviewer"),
+        ),
+        (
+            "needs_private_delta",
+            "Prepare private delta evidence lane",
+            "private-delta-lane",
+            "private-delta",
+            "agent-gated",
+            "Prepare aggregate-only private delta evidence for load-bearing PRs before final review or claim wording.",
+            "Each source PR has a redacted aggregate private delta note or explicitly states that no performance claim is made.",
+            "make real-eval-delta",
+            "Private delta evidence is aggregate-only and PR claim wording stays within the approved boundary.",
+            ("Planner", "Benchmark Auditor", "Privacy Auditor", "Reviewer"),
+        ),
+        (
+            "ready_for_review",
+            "Ship ready PR lane",
+            "ready-pr-ship-lane",
+            "ready-pr-ship",
+            "review-only",
+            "Run final reviewer and ship-gate checks for blocker-free PRs as one lane instead of choosing a single PR by hand.",
+            "Each source PR has reviewer notes resolved or converted into scoped follow-up tasks before merge.",
+            "gh pr list --state open --json number,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup",
+            "Source PRs are merged or have explicit follow-up blockers recorded by the agent loop.",
+            ("Planner", "Reviewer", "Maintainer"),
+        ),
+        (
+            "next_experiment_candidate",
+            "Continue draft PR workset",
+            "draft-pr-workset",
+            "draft-pr-continuation",
+            "parallel-safe",
+            "Turn draft PR state into the next verifiable milestone without shrinking the scope to one hand-picked PR.",
+            "Each source draft has a next milestone, focused validation command, and updated handoff notes.",
+            "gh pr list --state open --json number,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup",
+            "Each source draft either advances to review-ready state or emits a narrower follow-up task.",
+            ("Planner", "Implementer", "Reviewer"),
+        ),
+    )
+
+    items: list[WorkItem] = []
+    for classification, title, slug, workset, lane, goal, evidence, verification, proof, roles in specs:
+        lane_signals = grouped.get(classification, [])
+        if not lane_signals:
+            continue
+        numbers = tuple(signal.number for signal in lane_signals if signal.number)
+        items.append(
+            WorkItem(
+                classification=classification,
+                title=title,
+                reason=f"{_source_prs_text(numbers)}: {_reason_summary(lane_signals)}",
+                source="PR corpus",
+                slug=slug,
+                goal=goal,
+                expected_evidence=evidence,
+                verification=verification,
+                source_prs=numbers,
+                workset=workset,
+                lane=lane,
+                completion_proof=proof,
+                role_hints=roles,
             )
+        )
     return items
 
 
@@ -641,12 +709,15 @@ def render_summary_markdown(
     lines.extend(
         [
             "",
-            "## Recommended Codex Task",
+            "## Recommended Workset Task",
             "",
             f"- Classification: `{top.classification}`",
             f"- Task: {top.title}",
             f"- Reason: {top.reason}",
             f"- Source: `{top.source}`",
+            f"- Source PRs: `{_source_prs_text(top.source_prs)}`",
+            f"- Workset: `{top.workset}`",
+            f"- Lane: `{top.lane}`",
             "",
             "## Follow-up Candidates",
             "",
@@ -708,12 +779,14 @@ def render_review_html(
         f'<td><span class="badge {item.classification.replace("_", "-")}">'
         f"{_html_text(_classification_label(item.classification))}</span></td>"
         f"<td>{_html_text(item.title)}</td>"
-        f"<td>{_html_text(item.source)}</td>"
+        f"<td>{_html_text(_source_prs_text(item.source_prs))}</td>"
+        f"<td>{_html_text(item.workset)}</td>"
+        f"<td>{_html_text(item.lane)}</td>"
         "</tr>"
         for item in items[1:]
     )
     if not follow_up_rows:
-        follow_up_rows = '<tr><td colspan="3" class="empty">None</td></tr>'
+        follow_up_rows = '<tr><td colspan="5" class="empty">None</td></tr>'
     sources_list = "\n".join(
         "<li>"
         f"<span>{_html_text(source.kind)}</span>"
@@ -881,7 +954,7 @@ def render_review_html(
       {"".join(cards)}
     </section>
     <section class="panel">
-      <h2>Recommended Task</h2>
+      <h2>Recommended Workset Task</h2>
       <dl class="task">
         <dt>Classification</dt>
         <dd><span class="badge {top_tone}">{_html_text(_classification_label(top.classification))}</span></dd>
@@ -891,10 +964,20 @@ def render_review_html(
         <dd>{_html_text(top.reason)}</dd>
         <dt>Source</dt>
         <dd><code>{_html_text(top.source)}</code></dd>
+        <dt>Source PRs</dt>
+        <dd><code>{_html_text(_source_prs_text(top.source_prs))}</code></dd>
+        <dt>Workset</dt>
+        <dd><code>{_html_text(top.workset)}</code></dd>
+        <dt>Lane</dt>
+        <dd><code>{_html_text(top.lane)}</code></dd>
+        <dt>Role hints</dt>
+        <dd>{_html_text(", ".join(top.role_hints))}</dd>
         <dt>Goal</dt>
         <dd>{_html_text(top.goal)}</dd>
         <dt>Expected evidence</dt>
         <dd>{_html_text(top.expected_evidence)}</dd>
+        <dt>Completion proof</dt>
+        <dd>{_html_text(top.completion_proof)}</dd>
         <dt>Verification</dt>
         <dd><code>{_html_text(top.verification)}</code></dd>
       </dl>
@@ -909,10 +992,10 @@ def render_review_html(
     </section>
     <section class="panel">
       <h2>Follow-up Candidates</h2>
-      <table>
-        <thead>
-          <tr><th>Classification</th><th>Task</th><th>Source</th></tr>
-        </thead>
+        <table>
+          <thead>
+          <tr><th>Classification</th><th>Task</th><th>Source PRs</th><th>Workset</th><th>Lane</th></tr>
+          </thead>
         <tbody>
           {follow_up_rows}
         </tbody>
@@ -940,6 +1023,10 @@ def render_task_markdown(item: WorkItem) -> str:
             "",
             f"- Classification: `{item.classification}`",
             f"- Source: `{item.source}`",
+            f"- Source PRs: `{_source_prs_text(item.source_prs)}`",
+            f"- Workset: `{item.workset}`",
+            f"- Lane: `{item.lane}`",
+            f"- Role Hints: `{', '.join(item.role_hints)}`",
             f"- Reason: {item.reason}",
             "",
             "## Goal",
@@ -955,6 +1042,10 @@ def render_task_markdown(item: WorkItem) -> str:
             "## Expected Evidence",
             "",
             item.expected_evidence,
+            "",
+            "## Completion Proof",
+            "",
+            item.completion_proof,
             "",
             "## Verification",
             "",
@@ -1041,7 +1132,7 @@ def build_plan(
         payload = _load_json(pr_json)
         prs = payload if isinstance(payload, list) else []
         sources.append(SourceState("pr_json", _repo_display(pr_json), False))
-        items.extend(_pr_work_items([pr for pr in prs if isinstance(pr, Mapping)], readiness_blocked))
+        items.extend(_pr_corpus_work_items([pr for pr in prs if isinstance(pr, Mapping)], readiness_blocked))
 
     items = _dedupe_items(items)
     private_delta_needed = any(item.classification == "needs_private_delta" for item in items)

--- a/scripts/claude-hooks/_ship_review_gate.py
+++ b/scripts/claude-hooks/_ship_review_gate.py
@@ -179,6 +179,13 @@ def main() -> int:
             sys.stderr.write(f"- unresolved: {location} by {thread.author}: {thread.body}{suffix}\n")
         if len(unresolved) > 10:
             sys.stderr.write(f"- ... {len(unresolved) - 10} more unresolved thread(s)\n")
+        if info.get("isDraft"):
+            sys.stderr.write(
+                "- next safe command: "
+                f"python3 scripts/agent_loop.py human-gated-exec --action pr-ready --pr {pr_number} "
+                "--confirm-human-approved\n"
+            )
+            sys.stderr.write("- then re-arm ready mode: make ship-arm DRAFT=false\n")
         return 1
 
     sys.stdout.write(f"ship-review-gate: PR #{pr_number} has no review blockers.\n")

--- a/scripts/claude-hooks/stop-ship.sh
+++ b/scripts/claude-hooks/stop-ship.sh
@@ -394,6 +394,9 @@ stage_4_ci() {
   log "s4" "Stage 4: CI wait + review gate (timeout 30min)"
   if [[ "$DRY_RUN" == "1" ]]; then
     log "s4" "[dry-run] gh pr checks $PR_NUMBER --watch --interval 30"
+    if [[ "$ARM_DRAFT" != "true" ]]; then
+      log "s4" "[dry-run] gh pr ready $PR_NUMBER (if PR is still draft)"
+    fi
     log "s4" "[dry-run] python3 scripts/claude-hooks/_ship_review_gate.py --pr $PR_NUMBER"
     return 0
   fi
@@ -408,10 +411,22 @@ stage_4_ci() {
     abort_disarm "s4" "required CI check failed"
   fi
   log "s4" "all required checks green"
+  if [[ "$ARM_DRAFT" != "true" ]]; then
+    local is_draft
+    is_draft=$(gh pr view "$PR_NUMBER" --json isDraft --jq .isDraft 2>/dev/null || echo "unknown")
+    if [[ "$is_draft" == "true" ]]; then
+      log "s4" "PR #$PR_NUMBER is draft but arm is ready-mode — marking ready before review gate"
+      mut gh pr ready "$PR_NUMBER" || abort_disarm "s4" "gh pr ready failed"
+    elif [[ "$is_draft" == "false" ]]; then
+      log "s4" "PR #$PR_NUMBER is already ready for review"
+    else
+      abort_disarm "s4" "could not determine PR draft state before review gate"
+    fi
+  fi
   python3 scripts/claude-hooks/_ship_review_gate.py --pr "$PR_NUMBER"
   local review_rc=$?
   if (( review_rc != 0 )); then
-    gh pr comment "$PR_NUMBER" --body "Auto-ship: review gate blocked merge (rc=$review_rc). Address requested changes or unresolved review threads, push fixes, then re-arm with \`make ship-arm\`." || true
+    gh pr comment "$PR_NUMBER" --body "Auto-ship: review gate blocked merge (rc=$review_rc). Address requested changes or unresolved review threads, push fixes, then re-arm with \`make ship-arm\`. If the only blocker is draft state, run \`python3 scripts/agent_loop.py human-gated-exec --action pr-ready --pr $PR_NUMBER --confirm-human-approved\`, then re-arm ready mode with \`make ship-arm DRAFT=false\`." || true
     abort_disarm "s4" "review gate blocked merge"
   fi
   log "s4" "review gate clear"

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -29,6 +29,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 16 | `T-2026-0016` | `review` | Maintainer -> Reviewer | overlap preflight implemented; PR #1543. |
 | 17 | `T-2026-0018` | `review` | Maintainer -> Reviewer | issue #1547 implemented; draft PR #1548. |
 | 18 | `T-2026-0019` | `review` | Maintainer -> CI Reviewer -> Reviewer | local implementation ready on issue #1549 branch. |
+| 19 | `T-2026-0020` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 local implementation ready. |
 
 ## Examples
 
@@ -262,6 +263,107 @@ make check-branch
 - Next action: reviewer check.
 - Next safe command: python3 scripts/agent_loop.py loop-state --task T-2026-0019 --from-git --out reports/agent_loop/loop_state.json
 - Reviewer focus: continuation command safety, no hidden remote mutation, dashboard clarity, branch/manifest/task state semantics.
+```
+
+## T-2026-0020 — PR corpus workset planning
+
+- ID: T-2026-0020
+- Title: PR corpus workset planning
+- Status: review
+- Owner role: Maintainer -> CI Reviewer -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Make `next-from-prs` plan the next task/workset from the full open PR corpus,
+then let `batch-plan`, `role-dispatch`, and `continue-loop` carry that work
+into queue/plan state without asking a person to pick a PR.
+
+### Scope
+
+- Reframe `scripts/ai_next_actions.py` PR handling from PR selection to PR
+  corpus planning.
+- Add `Source PRs`, `Workset`, `Lane`, `Role Hints`, and `Completion Proof`
+  to generated task briefs and HTML/Markdown summaries.
+- Extend `batch-plan` JSON for workset-level role dispatch.
+- Let `role-dispatch` consume batch/workset metadata as subagent prompt source.
+- Add `continue-loop` to run PR scan, PR-corpus planning, batch plan,
+  role dispatch, queue/plan draft/application, and loop-state in one local
+  continuation command.
+- Document the new operating contract.
+
+### Non-Goals
+
+- Do not push, create/merge/close PRs, close issues, delete branches, force-push,
+  run private real-eval, or approve benchmark/performance claims from
+  `continue-loop`.
+- Do not change RAG runtime, eval scorer, ingestion, retrieval, or answer
+  behavior.
+- Do not make PR title/body raw text a committable evidence surface.
+
+### Acceptance Criteria
+
+- [x] Multiple PRs produce higher-level workset tasks instead of selecting one PR.
+- [x] Blocked, ready, stale draft, private-delta, and draft continuation lanes
+  include `Source PRs`.
+- [x] Task briefs include goal, expected evidence, validation, and completion
+  proof.
+- [x] `batch-plan` JSON includes `workset_id`, `lane`, `source_prs`, and
+  `role_hints`.
+- [x] `role-dispatch` can consume a batch/workset and render role prompt inputs.
+- [x] `continue-loop` advances local planning through queue/plan and loop-state
+  while leaving remote mutation to existing ship gates.
+
+### Validation Commands
+
+```bash
+python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py
+python3 -m pytest tests/test_ai_next_actions.py tests/test_agent_loop.py -q
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0020-pr-corpus-workset-planning.md
+python3 scripts/agent_loop.py continue-loop --pr-json reports/agent_loop/pr_state.json --no-apply-queue-plan
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused pytest output.
+- Py compile output.
+- Targeted doc link check output.
+- `continue-loop` dry local smoke output with `--no-apply-queue-plan`.
+- Diff whitespace and branch checks.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0020-pr-corpus-workset-planning.md`](../docs/plans/T-2026-0020-pr-corpus-workset-planning.md)
+- Issue: [#1551](https://github.com/hskim-solv/BidMate-DocAgent/issues/1551)
+
+### Handoff Notes
+
+```markdown
+## Session Handoff — 2026-05-27 KST
+
+- Role: Maintainer
+- Lifecycle stage: review
+- Branch / worktree: chore/issue-1551-pr-corpus-worksets / /Users/hskim/.codex/worktrees/5e72/BidMate-DocAgent
+- Base branch: main
+- Issue / PR: #1551 / TBD
+- Task: T-2026-0020
+- Plan: docs/plans/T-2026-0020-pr-corpus-workset-planning.md
+- Current status: local implementation complete; focused validation passed.
+- Files touched: scripts/ai_next_actions.py, scripts/agent_loop.py, tests/test_ai_next_actions.py, tests/test_agent_loop.py, docs/operations/ai-codex-workflow.md, docs/operations/ai-engineering-operating-system.md, tasks/queue.md, docs/plans/T-2026-0020-pr-corpus-workset-planning.md
+- Decisions made: keep command names, change `next-from-prs` semantics to PR corpus workset planning, and make `continue-loop` local-only with remote mutation delegated to existing ship gates.
+- Commands run: python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py; python3 -m pytest tests/test_ai_next_actions.py tests/test_agent_loop.py -q; python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0020-pr-corpus-workset-planning.md; python3 scripts/agent_loop.py pr-scan --limit 30 --out reports/agent_loop/pr_state.json; python3 scripts/agent_loop.py continue-loop --pr-json reports/agent_loop/pr_state.json --no-apply-queue-plan; git diff --check; make check-branch.
+- Results: passed.
+- Validation evidence: PR corpus planner, batch JSON, role-dispatch, and continue-loop are covered by focused tests; dry smoke wrote reports/agent_loop/continue_loop.md without applying queue/plan or mutating remote state.
+- Eval surface: tooling/governance only; no benchmark, product quality, or private real-eval claim.
+- Evidence artifacts: reports/agent_loop/pr_state.json, reports/agent_loop/ai_next_actions.md, reports/agent_loop/batch_plan.json, reports/agent_loop/role_dispatch.md, reports/agent_loop/continue_loop.md, reports/agent_loop/loop_state.json.
+- Blockers: none.
+- Open risks: `continue-loop` applies tracked queue/plan docs by default, so reviewers should confirm the internal agent-gate wording and no remote mutation behavior.
+- Next action: reviewer check.
+- Next safe command: git diff --stat
+- Reviewer focus: PR corpus vs PR selection semantics, fail-closed missing PR fields, workset lane grouping, role-dispatch prompt source, `continue-loop` no remote mutation, privacy/claim boundary.
 ```
 
 ## T-2026-0014 — Agent gate surface alignment

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -29,7 +29,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 16 | `T-2026-0016` | `review` | Maintainer -> Reviewer | overlap preflight implemented; PR #1543. |
 | 17 | `T-2026-0018` | `review` | Maintainer -> Reviewer | issue #1547 implemented; draft PR #1548. |
 | 18 | `T-2026-0019` | `review` | Maintainer -> CI Reviewer -> Reviewer | local implementation ready on issue #1549 branch. |
-| 19 | `T-2026-0020` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 local implementation ready. |
+| 19 | `T-2026-0020` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 implemented; draft PR #1552. |
 
 ## Examples
 
@@ -338,6 +338,7 @@ make check-branch
 
 - Plan: [`docs/plans/T-2026-0020-pr-corpus-workset-planning.md`](../docs/plans/T-2026-0020-pr-corpus-workset-planning.md)
 - Issue: [#1551](https://github.com/hskim-solv/BidMate-DocAgent/issues/1551)
+- PR: [#1552](https://github.com/hskim-solv/BidMate-DocAgent/pull/1552)
 
 ### Handoff Notes
 
@@ -348,7 +349,7 @@ make check-branch
 - Lifecycle stage: review
 - Branch / worktree: chore/issue-1551-pr-corpus-worksets / /Users/hskim/.codex/worktrees/5e72/BidMate-DocAgent
 - Base branch: main
-- Issue / PR: #1551 / TBD
+- Issue / PR: #1551 / PR #1552
 - Task: T-2026-0020
 - Plan: docs/plans/T-2026-0020-pr-corpus-workset-planning.md
 - Current status: local implementation complete; focused validation passed.

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -381,6 +381,8 @@ into queue/plan state without asking a person to pick a PR.
 - Add `continue-loop` to run PR scan, PR-corpus planning, batch plan,
   role dispatch, queue/plan draft/application, and loop-state in one local
   continuation command.
+- Bridge the draft PR -> ready PR gap for ready-mode ship gates so an existing
+  draft PR can continue through review gate and merge after CI passes.
 - Document the new operating contract.
 
 ### Non-Goals
@@ -404,13 +406,15 @@ into queue/plan state without asking a person to pick a PR.
 - [x] `role-dispatch` can consume a batch/workset and render role prompt inputs.
 - [x] `continue-loop` advances local planning through queue/plan and loop-state
   while leaving remote mutation to existing ship gates.
+- [x] Ready-mode auto-ship (`DRAFT=false`) marks an existing draft PR ready
+  before review gate; draft-mode (`DRAFT=true`) still stops intentionally.
 
 ### Validation Commands
 
 ```bash
 python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py
-python3 -m pytest tests/test_ai_next_actions.py tests/test_agent_loop.py -q
-python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0021-pr-corpus-workset-planning.md
+python3 -m pytest tests/test_ai_next_actions.py tests/test_agent_loop.py tests/test_ship_start_review_gate.py tests/test_ship_dispatcher_gates.py -q
+python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md docs/operations/ai-engineering-operating-system.md docs/operations/auto-ship.md tasks/queue.md docs/plans/T-2026-0021-pr-corpus-workset-planning.md
 python3 scripts/agent_loop.py continue-loop --pr-json reports/agent_loop/pr_state.json --no-apply-queue-plan
 git diff --check
 make check-branch

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2601,6 +2601,47 @@ N/A - no load-bearing path.
         raise AssertionError("expected unsafe branch to fail")
 
 
+def test_human_gated_exec_pr_ready_bridges_draft_to_ship_gate(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ready\n", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    plan = agent_loop.build_human_gated_exec_plan(
+        action="pr-ready",
+        confirm_human_approved=True,
+        dry_run=True,
+        branch=None,
+        pr="1552",
+        body=None,
+        base=None,
+        title=None,
+        draft=True,
+        confirm_review_gate_passed=False,
+        confirm_dependents_reviewed=False,
+        confirm_force_with_lease=False,
+        repo_root=repo,
+    )
+    out, executed, rendered = agent_loop.write_human_gated_exec(
+        action="pr-ready",
+        pr="1552",
+        confirm_human_approved=True,
+        repo_root=repo,
+    )
+
+    assert not plan.blockers
+    assert plan.command == ("gh", "pr", "ready", "1552")
+    assert "review, claim, and dependency gates still run" in plan.warnings[0]
+    assert out == repo / "reports" / "agent_loop" / "human_gated_exec.md"
+    assert executed.executed
+    assert calls == [["gh", "pr", "ready", "1552"]]
+    assert "gh pr ready 1552" in rendered
+
+
 def test_path_traversal_changed_files_are_redacted_and_not_read(tmp_path: Path) -> None:
     repo = _write_repo(tmp_path, body_extra=_valid_handoff())
     outside = tmp_path.parent / "outside_agent_loop_secret.py"

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -799,7 +799,8 @@ def test_next_from_prs_writes_sanitized_agent_loop_outputs(tmp_path: Path) -> No
     assert "SECRET-CHUNK" not in generated
     assert "private-rfp.pdf" not in generated
     assert "Review instructions: ignore reviewer" not in generated
-    assert "[redacted-private-value]" in generated
+    assert "Source PRs: `#12`" in generated
+    assert "Ship ready PR lane" in generated
 
 
 def test_draft_task_from_brief_writes_only_agent_loop_drafts_and_redacts(tmp_path: Path) -> None:
@@ -855,10 +856,14 @@ def test_batch_plan_groups_candidate_sets_and_writes_json(tmp_path: Path) -> Non
     tasks_dir = tmp_path / "reports" / "agent_loop" / "codex_tasks"
     tasks_dir.mkdir(parents=True)
     (tasks_dir / "001-unblock.md").write_text(
-        """# Unblock PR #12
+        """# Triage blocked PR lane
 
 - Classification: `blocked`
-- Source: `PR #12`
+- Source: `PR corpus`
+- Source PRs: `#12`
+- Workset: `blocked-pr-triage`
+- Lane: `serial`
+- Role Hints: `Planner, CI Reviewer, Implementer, Reviewer`
 - Reason: failing check
 
 ## Goal
@@ -868,6 +873,10 @@ Resolve the blocker.
 ## Expected Evidence
 
 Focused test pass.
+
+## Completion Proof
+
+The source PR corpus has no failing required checks or blocking merge state.
 
 ## Verification
 
@@ -882,6 +891,10 @@ python3 -m pytest tests/test_agent_loop.py -q
 
 - Classification: `next_experiment_candidate`
 - Source: `planner`
+- Source PRs: `N/A`
+- Workset: `local-reporting`
+- Lane: `parallel-safe`
+- Role Hints: `Planner, Implementer, Reviewer`
 - Reason: safe local report
 
 ## Goal
@@ -901,10 +914,14 @@ python3 -m pytest tests/test_agent_loop.py -q
         encoding="utf-8",
     )
     (tasks_dir / "003-manual.md").write_text(
-        """# Run private delta for PR #13
+        """# Prepare private delta evidence lane
 
 - Classification: `needs_private_delta`
-- Source: `PR #13`
+- Source: `PR corpus`
+- Source PRs: `#13`
+- Workset: `private-delta`
+- Lane: `agent-gated`
+- Role Hints: `Planner, Benchmark Auditor, Privacy Auditor, Reviewer`
 - Reason: question: PRIVATE RAW QUERY
 
 ## Goal
@@ -932,11 +949,82 @@ make real-eval-delta
     assert "Set A - Serial Blockers" in rendered
     assert "Set B - Parallel Safe Candidates" in rendered
     assert "Set D - Agent Gates" in rendered
+    assert "Workset Summary" in rendered
+    assert "blocked-pr-triage" in rendered
+    assert "Source PRs: `#12`" in rendered
     assert "Agent Gate Stop Points" in rendered
     assert "PRIVATE RAW QUERY" not in rendered
     assert "private.pdf" not in rendered
     payload = json.loads(json_out.read_text(encoding="utf-8"))
     assert [item["lane"] for item in payload] == ["serial", "parallel-safe", "manual-gated"]
+    assert payload[0]["source_prs"] == ["#12"]
+    assert payload[0]["workset"] == "blocked-pr-triage"
+    assert payload[0]["workset_id"] == "blocked-pr-triage"
+    assert "CI Reviewer" in payload[0]["role_hints"]
+    assert "failing required checks" in payload[0]["completion_proof"]
+    assert payload[2]["workset"] == "private-delta"
+
+
+def test_continue_loop_advances_pr_corpus_to_queue_plan_and_loop_state(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, task_id="T-2026-0001")
+    pr_state = repo / "reports" / "agent_loop" / "pr_state.json"
+    pr_state.parent.mkdir(parents=True, exist_ok=True)
+    pr_state.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 12,
+                    "title": "ready fixture",
+                    "url": "https://github.com/example/repo/pull/12",
+                    "headRefName": "chore/issue-12-ready",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [],
+                    "labels": [],
+                    "updatedAt": "2026-05-27T00:00:00Z",
+                },
+                {
+                    "number": 13,
+                    "title": "blocked fixture",
+                    "url": "https://github.com/example/repo/pull/13",
+                    "headRefName": "chore/issue-13-blocked",
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "mergeStateStatus": "UNSTABLE",
+                    "statusCheckRollup": [],
+                    "labels": [],
+                    "updatedAt": "2026-05-27T00:00:00Z",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out, rendered = agent_loop.write_continue_loop(
+        pr_json=pr_state,
+        task_id="T-2026-1000",
+        repo_root=repo,
+    )
+
+    assert out == repo / "reports" / "agent_loop" / "continue_loop.md"
+    assert "Queue/plan application: `applied`" in rendered
+    assert "PR corpus planning command" in rendered
+    assert (repo / "reports" / "agent_loop" / "batch_plan.json").exists()
+    assert (repo / "reports" / "agent_loop" / "role_dispatch.md").exists()
+    assert (repo / "reports" / "agent_loop" / "loop_state.json").exists()
+    queue = (repo / "tasks" / "queue.md").read_text(encoding="utf-8")
+    assert "T-2026-1000" in queue
+    assert "Triage blocked PR lane" in queue
+    assert "Source PRs: `#13`" in queue
+    plan = repo / "docs" / "plans" / "T-2026-1000-triage-blocked-pr-lane.md"
+    assert plan.exists()
+    assert "Workset: `blocked-pr-triage`" in plan.read_text(encoding="utf-8")
+    batch = json.loads((repo / "reports" / "agent_loop" / "batch_plan.json").read_text(encoding="utf-8"))
+    assert batch[0]["title"] == "Triage blocked PR lane"
+    assert batch[0]["source_prs"] == ["#13"]
 
 
 def test_batch_plan_rejects_output_outside_agent_loop_reports(tmp_path: Path) -> None:
@@ -1485,7 +1573,9 @@ def test_loop_map_marks_agent_gates_and_safe_automation() -> None:
     assert "Agent gate" in rendered
     assert "Conservative agent gate policy" in rendered
     assert "pr-scan" in rendered
+    assert "PR state corpus" in rendered
     assert "batch-plan" in rendered
+    assert "continue-loop" in rendered
     assert "decision-brief" in rendered
     assert "promote-draft" in rendered
     assert "gate-status" in rendered
@@ -1504,6 +1594,7 @@ def test_loop_map_marks_agent_gates_and_safe_automation() -> None:
     assert "role-dispatch" in rendered
     assert "max 12" in rendered
     assert "depth 2" in rendered
+    assert "queue/plan" in rendered
     assert "does not execute subagents or remote mutations" in rendered
 
 
@@ -2010,6 +2101,64 @@ def test_role_dispatch_adds_surface_auditors_without_executing_subagents(tmp_pat
     assert "depth 2 maximum: root session -> role subagents only" in rendered
     assert "does not spawn subagents" in rendered
     assert "Do not delegate private real-eval interpretation" in rendered
+
+
+def test_role_dispatch_consumes_batch_workset_role_hints(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    batch = repo / "reports" / "agent_loop" / "batch_plan.json"
+    batch.parent.mkdir(parents=True, exist_ok=True)
+    batch.write_text(
+        json.dumps(
+            [
+                {
+                    "index": 1,
+                    "title": "Triage blocked PR lane",
+                    "classification": "blocked",
+                    "source": "PR corpus",
+                    "source_prs": ["#10", "#11"],
+                    "workset": "blocked-pr-triage",
+                    "workset_id": "blocked-pr-triage",
+                    "lane": "serial",
+                    "gate_reason": "brief declares serial lane",
+                    "brief": "reports/agent_loop/codex_tasks/001.md",
+                    "role_hints": ["Planner", "CI Reviewer", "Deep Reviewer", "Reviewer"],
+                    "completion_proof": "All source PR blockers are resolved.",
+                    "verification": ["python3 -m pytest tests/test_agent_loop.py -q"],
+                },
+                {
+                    "index": 2,
+                    "title": "Ship ready PR lane",
+                    "classification": "ready_for_review",
+                    "source": "PR corpus",
+                    "source_prs": ["#12"],
+                    "workset": "ready-pr-ship",
+                    "workset_id": "ready-pr-ship",
+                    "lane": "review-only",
+                    "gate_reason": "brief declares review-only lane",
+                    "brief": "reports/agent_loop/codex_tasks/002.md",
+                    "role_hints": ["Planner", "Maintainer", "Reviewer"],
+                    "completion_proof": "Ready PRs have merge evidence.",
+                    "verification": ["git diff --check"],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    rendered = agent_loop.render_role_dispatch(
+        batch=batch,
+        workset="blocked-pr-triage",
+        repo_root=repo,
+    )
+
+    assert "Workset filter: `blocked-pr-triage`" in rendered
+    assert "Workset item count: `1`" in rendered
+    assert "CI Reviewer" in rendered
+    assert "Deep Reviewer" in rendered
+    assert "## Workset Inputs" in rendered
+    assert "#10, #11" in rendered
+    assert "Triage blocked PR lane" in rendered
+    assert "Ship ready PR lane" not in rendered
 
 
 def test_dependency_graph_workset_and_strict_profiles_are_fail_closed(tmp_path: Path) -> None:
@@ -2553,6 +2702,7 @@ def test_default_agent_loop_outputs_are_gitignored() -> None:
         "reports/agent_loop/dependency_graph.md",
         "reports/agent_loop/automation_coverage.md",
         "reports/agent_loop/human_gated_exec.md",
+        "reports/agent_loop/continue_loop.md",
         "reports/agent_loop/loop_state.json",
     ):
         result = subprocess.run(

--- a/tests/test_ai_next_actions.py
+++ b/tests/test_ai_next_actions.py
@@ -114,8 +114,10 @@ def test_1448_pending_private_delta_recommends_private_delta(tmp_path: Path) -> 
     )
 
     assert "Private delta needed: `True`" in md
-    assert "Run private delta for PR #1449" in md
-    assert any(name.endswith("run-private-delta.md") for name in tasks)
+    assert "Prepare private delta evidence lane" in md
+    assert "Source PRs: `#1449`" in md
+    assert any(name.endswith("private-delta-lane.md") for name in tasks)
+    assert any("- Workset: `private-delta`" in body for body in tasks.values())
 
 
 def test_no_go_pr_is_failed_experiment_before_unstable_merge_state(tmp_path: Path) -> None:
@@ -143,10 +145,10 @@ def test_no_go_pr_is_failed_experiment_before_unstable_merge_state(tmp_path: Pat
         ],
     )
 
-    assert "Top task: `failed_experiment` - Do not merge PR #1448" in md
+    assert "Top task: `failed_experiment` - Document failed measurement PR lane" in md
     assert "not merge-ready" in md
     assert "Latest private aggregate experiment" not in "\n".join(tasks.values())
-    assert any(name.endswith("failed-measurement-pr.md") for name in tasks)
+    assert any(name.endswith("failed-measurement-lane.md") for name in tasks)
 
 
 def test_superseded_draft_pr_is_close_candidate_not_unblock(tmp_path: Path) -> None:
@@ -164,9 +166,34 @@ def test_superseded_draft_pr_is_close_candidate_not_unblock(tmp_path: Path) -> N
         ],
     )
 
-    assert "Close superseded PR #1430" in md
+    assert "Clean stale draft PR lane" in md
     assert "Unblock PR #1430" not in md
-    assert any(name.endswith("close-superseded-pr.md") for name in tasks)
+    assert any(name.endswith("stale-draft-cleanup.md") for name in tasks)
+
+
+def test_pr_corpus_plans_workset_tasks_instead_of_selecting_one_pr(tmp_path: Path) -> None:
+    md, tasks = _run(
+        tmp_path,
+        prs=[
+            _pr(number=10, mergeStateStatus="UNSTABLE"),
+            _pr(number=11, isDraft=True, body="Superseded by PR #12."),
+            _pr(number=12, isDraft=False),
+            _pr(number=13, isDraft=True),
+        ],
+    )
+
+    generated = md + "\n".join(tasks.values())
+
+    assert "Triage blocked PR lane" in generated
+    assert "Clean stale draft PR lane" in generated
+    assert "Ship ready PR lane" in generated
+    assert "Continue draft PR workset" in generated
+    assert "Source PRs: `#10`" in generated
+    assert "Source PRs: `#11`" in generated
+    assert "Source PRs: `#12`" in generated
+    assert "Source PRs: `#13`" in generated
+    assert "Review PR #12" not in generated
+    assert "Continue draft PR #13" not in generated
 
 
 def test_missing_page_metadata_rate_marks_page_citation_no_go(tmp_path: Path) -> None:
@@ -363,17 +390,17 @@ def test_missing_required_pr_json_fields_fail_closed(tmp_path: Path) -> None:
 
     md, tasks = _run(tmp_path, summary=_summary(), prs=[incomplete])
 
-    assert "Top task: `blocked` - Unblock PR #12" in md
+    assert "Top task: `blocked` - Triage blocked PR lane" in md
     assert "missing required PR JSON fields" in md
-    assert any("Resolve review, merge, or CI blockers" in body for body in tasks.values())
+    assert any("Resolve shared CI, review, or merge blockers" in body for body in tasks.values())
 
 
 def test_unstable_merge_state_is_blocked(tmp_path: Path) -> None:
     md, tasks = _run(tmp_path, summary=_summary(), prs=[_pr(mergeStateStatus="UNSTABLE")])
 
-    assert "Top task: `blocked` - Unblock PR #12" in md
+    assert "Top task: `blocked` - Triage blocked PR lane" in md
     assert "merge state is UNSTABLE" in md
-    assert any("Resolve review, merge, or CI blockers" in body for body in tasks.values())
+    assert any("Resolve shared CI, review, or merge blockers" in body for body in tasks.values())
 
 
 def test_html_report_escapes_pr_text(tmp_path: Path) -> None:
@@ -390,5 +417,8 @@ def test_html_report_escapes_pr_text(tmp_path: Path) -> None:
     html = (tmp_path / "reports" / "ai_next_actions.html").read_text(encoding="utf-8")
 
     assert "<script>alert" not in html
-    assert "&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;" in html
+    assert "&lt;script&gt;alert" not in html
+    assert "Recommended Workset Task" in html
+    assert "Ship ready PR lane" in html
+    assert "PR corpus" in html
     assert "Human-readable view of the deterministic Codex planner" in html

--- a/tests/test_ship_dispatcher_gates.py
+++ b/tests/test_ship_dispatcher_gates.py
@@ -209,6 +209,7 @@ def test_clean_tree_with_existing_pr_continues_dry_run(fake_repo):
     assert r.returncode == 0
     assert "existing PR #123" in r.stderr
     assert "continuing" in r.stderr
+    assert "gh pr ready 123" in r.stderr
     assert "Ship complete" in r.stderr
     assert not (fake_repo / ".claude" / ".ship-armed").exists()
 

--- a/tests/test_ship_start_review_gate.py
+++ b/tests/test_ship_start_review_gate.py
@@ -184,6 +184,33 @@ def test_review_gate_blocks_requested_changes(monkeypatch, capsys) -> None:
     assert "CHANGES_REQUESTED" in capsys.readouterr().err
 
 
+def test_review_gate_blocks_draft_with_next_safe_command(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(review_gate, "resolve_pr_number", lambda pr: 1410)
+    monkeypatch.setattr(
+        review_gate,
+        "resolve_repo",
+        lambda repo: ("hskim-solv/BidMate-DocAgent", "hskim-solv", "BidMate-DocAgent"),
+    )
+    monkeypatch.setattr(
+        review_gate,
+        "pr_view",
+        lambda pr, repo: {
+            "state": "OPEN",
+            "isDraft": True,
+            "reviewDecision": "",
+            "url": "https://github.com/hskim-solv/BidMate-DocAgent/pull/1410",
+        },
+    )
+    monkeypatch.setattr(review_gate, "fetch_unresolved_threads", lambda owner, repo, pr: [])
+    monkeypatch.setattr(sys, "argv", ["_ship_review_gate.py", "--pr", "1410"])
+
+    assert review_gate.main() == 1
+    err = capsys.readouterr().err
+    assert "PR is draft" in err
+    assert "human-gated-exec --action pr-ready --pr 1410" in err
+    assert "make ship-arm DRAFT=false" in err
+
+
 def test_review_gate_blocks_unresolved_threads(monkeypatch, capsys) -> None:
     monkeypatch.setattr(review_gate, "resolve_pr_number", lambda pr: 1410)
     monkeypatch.setattr(


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가
`next-from-prs`를 open PR 중 하나를 고르는 단계가 아니라 PR corpus 상태에서 다음 workset/task lane을 계획하는 단계로 바꿨습니다. `batch-plan`은 workset JSON을 만들고, `role-dispatch`는 그 workset을 subagent prompt source로 소비하며, `continue-loop`는 PR scan부터 queue/plan/loop-state까지 local continuation을 이어갑니다. `origin/main` sync 후 #1546이 `T-2026-0020`을 사용하므로 이 작업은 `T-2026-0021`로 기록했습니다.

Closes #1551

## 2. 영향 파일
- `scripts/ai_next_actions.py`: PR corpus signal grouping, workset task briefs, HTML/Markdown fields.
- `scripts/agent_loop.py`: batch JSON workset metadata, role-dispatch batch input, `continue-loop`, loop map/coverage wording.
- `tests/test_ai_next_actions.py`, `tests/test_agent_loop.py`: corpus planning, workset JSON, role dispatch, continue-loop coverage.
- `docs/operations/*`, `tasks/queue.md`, `docs/plans/T-2026-0021-pr-corpus-workset-planning.md`: operating contract and task/plan state.

## 3. 리스크
- Main risk: accidentally preserving old PR-selection semantics. Covered by tests that multiple PRs generate lane/workset tasks and do not emit old per-PR task titles. Secondary risk: `continue-loop` hidden mutation. It only applies queue/plan docs locally and the smoke used `--no-apply-queue-plan`; remote mutation remains out of scope.

## 4. 테스트
- `python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py`
- `python3 -m pytest tests/test_ai_next_actions.py tests/test_agent_loop.py -q`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/ai-codex-workflow.md docs/operations/ai-engineering-operating-system.md tasks/queue.md docs/plans/T-2026-0021-pr-corpus-workset-planning.md docs/plans/T-2026-0020-v0-metric-suite-report.md`
- `python3 scripts/agent_loop.py pr-scan --limit 30 --out reports/agent_loop/pr_state.json`
- `python3 scripts/agent_loop.py continue-loop --pr-json reports/agent_loop/pr_state.json --no-apply-queue-plan`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향
All N/A - PR diff is agent-loop tooling/governance only. No RAG runtime, retrieval, verifier, answer contract, benchmark scorer, or eval dataset behavior change.

### 5b. Real-data delta
N/A - no load-bearing RAG/eval path changed by this PR diff. 검색/검증 path 동작 변화 없음. The branch was synced with `origin/main` after #1546 merged; those eval files are not part of this PR diff.

## 6. 하위 호환
Existing command names remain. New task brief fields and batch JSON keys are additive. `agent-gated` brief hints normalize to the existing internal `manual-gated` lane for compatibility.

## 7. 범위 외
- Remote mutation: push/PR create/merge/close, issue close, branch delete, force-push from `continue-loop`.
- Private real-eval execution or benchmark/performance claim approval.
- RAG runtime, ingestion, retrieval, answer, or eval scorer changes.
