### PR TITLE
fix: keep continue loop recursive

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1961,6 +1961,7 @@ def write_continue_loop(
         loop_out=loop_out,
         task_id=chosen_task_id,
         apply_result=apply_result,
+        apply_queue_plan=apply_queue_plan,
         repo_root=repo_root,
     )
     out = _default_output(out, DEFAULT_CONTINUE_LOOP, "continue_loop.md", repo_root=repo_root)
@@ -1992,8 +1993,12 @@ def render_continue_loop(
     loop_out: Path,
     task_id: str,
     apply_result: str,
+    apply_queue_plan: bool,
     repo_root: Path,
 ) -> str:
+    next_command = "python3 scripts/agent_loop.py continue-loop"
+    if not apply_queue_plan:
+        next_command += " --no-apply-queue-plan"
     lines = [
         "# Continue Loop",
         "",
@@ -2020,7 +2025,7 @@ def render_continue_loop(
         "## Next Safe Command",
         "",
         "```bash",
-        "python3 scripts/agent_loop.py loop-state --from-git",
+        next_command,
         "```",
         "",
     ]

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1014,6 +1014,8 @@ def test_continue_loop_advances_pr_corpus_to_queue_plan_and_loop_state(tmp_path:
     assert out == repo / "reports" / "agent_loop" / "continue_loop.md"
     assert "Queue/plan application: `applied`" in rendered
     assert "PR corpus planning command" in rendered
+    assert "python3 scripts/agent_loop.py continue-loop\n" in rendered
+    assert "loop-state --from-git" not in rendered
     assert (repo / "reports" / "agent_loop" / "batch_plan.json").exists()
     assert (repo / "reports" / "agent_loop" / "role_dispatch.md").exists()
     assert (repo / "reports" / "agent_loop" / "loop_state.json").exists()
@@ -1027,6 +1029,23 @@ def test_continue_loop_advances_pr_corpus_to_queue_plan_and_loop_state(tmp_path:
     batch = json.loads((repo / "reports" / "agent_loop" / "batch_plan.json").read_text(encoding="utf-8"))
     assert batch[0]["title"] == "Triage blocked PR lane"
     assert batch[0]["source_prs"] == ["#13"]
+
+
+def test_continue_loop_preserves_dry_run_in_next_command(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, task_id="T-2026-0001")
+    pr_state = repo / "reports" / "agent_loop" / "pr_state.json"
+    pr_state.parent.mkdir(parents=True, exist_ok=True)
+    pr_state.write_text("[]", encoding="utf-8")
+
+    _, rendered = agent_loop.write_continue_loop(
+        pr_json=pr_state,
+        task_id="T-2026-1000",
+        apply_queue_plan=False,
+        repo_root=repo,
+    )
+
+    assert "Queue/plan application: `skipped`" in rendered
+    assert "python3 scripts/agent_loop.py continue-loop --no-apply-queue-plan" in rendered
 
 
 def test_batch_plan_rejects_output_outside_agent_loop_reports(tmp_path: Path) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Make `continue-loop` point its next safe command back to `continue-loop` instead of stopping at `loop-state`, so a completed loop pass naturally advances into the next local planning pass. Closes #1559

## 2. 영향 파일

- `scripts/agent_loop.py`: `render_continue_loop` now emits recursive `continue-loop` next commands and preserves dry-run mode with `--no-apply-queue-plan`.
- `tests/test_agent_loop.py`: covers recursive next command behavior for applied and dry-run continuation.

## 3. 리스크

The change is limited to local report guidance text. It does not add remote mutation, branch mutation, PR creation/merge, private eval, or benchmark claim behavior. Main risk is accidentally suggesting a mutating command after a dry run; the new test covers preserving `--no-apply-queue-plan`.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q`
- `python3 -m py_compile scripts/agent_loop.py`
- `git diff --check`
- `make check-branch`
- `python3 scripts/agent_loop.py continue-loop --no-apply-queue-plan`

## 5. Eval 영향

N/A. Agent-loop reporting only; no eval, retrieval, verifier, scoring, ingestion, or answer behavior changes.

### 5b. Real-data delta

N/A. No load-bearing eval behavior change and no performance, benchmark, regression, or RFP quality claim.

## 6. 하위 호환

Existing `continue-loop` command behavior and output paths are preserved. Only the rendered next safe command changes from `loop-state --from-git` to `continue-loop`, with dry-run mode preserved.

## 7. 범위 외

- Running private real-eval.
- Automatically pushing, creating, merging, closing PRs, or deleting branches from `continue-loop`.
- Changing planner prioritization or task selection semantics.

