### PR TITLE
fix: skip queued loop candidates

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1954,16 +1954,26 @@ def write_continue_loop(
     briefs = sorted(tasks_dir.glob("*.md"))
     if not briefs:
         raise ValueError("planner did not produce a task brief")
-    chosen_task_id = _next_task_id(repo_root) if task_id == DEFAULT_DRAFT_TASK_ID else task_id
+    first_brief = _parse_task_brief(_sanitize_dynamic_text(_read_text(briefs[0])))
+    existing_task = _find_existing_task_by_title(first_brief["title"], repo_root=repo_root)
+    chosen_task_id = (
+        existing_task.task_id
+        if existing_task is not None
+        else _next_task_id(repo_root)
+        if task_id == DEFAULT_DRAFT_TASK_ID
+        else task_id
+    )
     draft = draft_task_from_brief(task_brief=briefs[0], task_id=chosen_task_id, repo_root=repo_root)
     promote_out, _ = write_promote_draft(repo_root=repo_root)
     apply_out: Path | None = None
     apply_result = "skipped"
-    if apply_queue_plan:
+    if existing_task is not None:
+        apply_result = "skipped-existing-task"
+    elif apply_queue_plan:
         apply_out, _ = write_apply_queue_plan(confirm_human_approved=True, repo_root=repo_root)
         apply_result = "applied"
 
-    loop_task = chosen_task_id if apply_queue_plan else None
+    loop_task = chosen_task_id if apply_queue_plan or existing_task is not None else None
     loop_out, _ = write_loop_state(task_id=loop_task, batch=batch_json, repo_root=repo_root)
     rendered = render_continue_loop(
         pr_state=pr_state,
@@ -2005,6 +2015,17 @@ def _next_task_id(repo_root: Path) -> str:
     queue = repo_root / QUEUE_PATH
     existing = [int(match.group(1)) for match in re.finditer(r"\bT-2026-(\d{4})\b", _read_text(queue) if queue.exists() else "")]
     return f"T-2026-{(max(existing) + 1 if existing else 1):04d}"
+
+
+def _find_existing_task_by_title(title: str, *, repo_root: Path) -> TaskEntry | None:
+    queue = repo_root / QUEUE_PATH
+    if not queue.exists():
+        return None
+    normalized_title = _sanitize_inline_text(title).casefold()
+    for task in parse_task_entries(_read_text(queue)):
+        if _sanitize_inline_text(task.title).casefold() == normalized_title:
+            return task
+    return None
 
 
 def _continue_loop_next_command(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1113,6 +1113,47 @@ def test_continue_loop_redacts_real100_source_when_applying_queue_plan(tmp_path:
     assert "multi_chunk_evidence_failures.aggregate.json" in queue
 
 
+def test_continue_loop_skips_applying_existing_queued_candidate(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, task_id="T-2026-0001")
+    queue_path = repo / "tasks" / "queue.md"
+    queue_path.write_text(
+        queue_path.read_text(encoding="utf-8")
+        + "\n## T-2026-0002 — Use multi-chunk evidence analysis for the next retrieval follow-up\n\n"
+        + "- ID: T-2026-0002\n"
+        + "- Title: Use multi-chunk evidence analysis for the next retrieval follow-up\n"
+        + "- Status: backlog\n",
+        encoding="utf-8",
+    )
+    pr_state = repo / "reports" / "agent_loop" / "pr_state.json"
+    pr_state.parent.mkdir(parents=True, exist_ok=True)
+    pr_state.write_text("[]", encoding="utf-8")
+    real100 = repo / "reports" / "real100"
+    real100.mkdir(parents=True)
+    (real100 / "multi_chunk_evidence_failures.aggregate.json").write_text(
+        json.dumps(
+            {
+                "population": {
+                    "multi_chunk_gold_cases": 9,
+                    "multi_chunk_top10_evidence_failures": 7,
+                },
+                "expected_impact": {"unknown_due_to_limited_depth": 6},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, rendered = agent_loop.write_continue_loop(
+        pr_json=pr_state,
+        real100_dir=Path("reports/real100"),
+        repo_root=repo,
+    )
+
+    queue = queue_path.read_text(encoding="utf-8")
+    assert "Queue/plan application: `skipped-existing-task`" in rendered
+    assert "Task id: `T-2026-0002`" in rendered
+    assert queue.count("Use multi-chunk evidence analysis for the next retrieval follow-up") == 2
+
+
 def test_batch_plan_rejects_output_outside_agent_loop_reports(tmp_path: Path) -> None:
     tasks_dir = tmp_path / "reports" / "agent_loop" / "codex_tasks"
     tasks_dir.mkdir(parents=True)


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Prevent recursive `continue-loop` passes from re-applying the same planner candidate after it has already been promoted into `tasks/queue.md`. Closes #1565

## 2. 영향 파일

- `scripts/agent_loop.py`: detects an existing queued task with the same planner brief title, skips queue/plan apply, and carries the existing task id into loop-state.
- `tests/test_agent_loop.py`: covers existing queued candidate detection and no duplicate queue append.

## 3. 리스크

This changes local planning behavior only. It does not change retrieval/eval behavior or perform remote mutation. Main risk is an over-broad title match; matching is limited to sanitized exact title equality.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q`
- `python3 -m py_compile scripts/agent_loop.py`
- `git diff --check`
- `make check-branch`
- `python3 scripts/agent_loop.py continue-loop --real100-dir reports/real100 --no-apply-queue-plan`

## 5. Eval 영향

N/A. Agent-loop queue planning only; no eval, retrieval, verifier, scorer, ingestion, or answer behavior changes.

### 5b. Real-data delta

N/A. No load-bearing eval behavior change and no performance, benchmark, regression, or RFP quality claim.

## 6. 하위 호환

If no matching queued task exists, `continue-loop` behaves as before. If a matching queued task exists, it avoids duplicate tracked queue/plan writes and reports `skipped-existing-task`.

## 7. 범위 외

- Planner prioritization changes.
- Implementing T-2026-0022 retrieval follow-up behavior.
- Private real-eval execution.
