### PR TITLE
fix: advance continue loop to task preflight

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -1975,6 +1975,21 @@ def write_continue_loop(
 
     loop_task = chosen_task_id if apply_queue_plan or existing_task is not None else None
     loop_out, _ = write_loop_state(task_id=loop_task, batch=batch_json, repo_root=repo_root)
+    next_command = (
+        f"python3 scripts/agent_loop.py preflight --task {loop_task} --from-git --write-prompts"
+        if loop_task is not None
+        else _continue_loop_next_command(
+            state=state,
+            limit=limit,
+            include_body=include_body,
+            readiness_summaries=resolved_readiness_summaries,
+            readiness_reports=resolved_readiness_reports,
+            real100_dir=resolved_real100_dir,
+            page_metadata_index_dir=resolved_page_metadata_index_dir,
+            apply_queue_plan=apply_queue_plan,
+            repo_root=repo_root,
+        )
+    )
     rendered = render_continue_loop(
         pr_state=pr_state,
         ai_next=ai_next,
@@ -1991,17 +2006,7 @@ def write_continue_loop(
         task_id=chosen_task_id,
         apply_result=apply_result,
         apply_queue_plan=apply_queue_plan,
-        next_command=_continue_loop_next_command(
-            state=state,
-            limit=limit,
-            include_body=include_body,
-            readiness_summaries=resolved_readiness_summaries,
-            readiness_reports=resolved_readiness_reports,
-            real100_dir=resolved_real100_dir,
-            page_metadata_index_dir=resolved_page_metadata_index_dir,
-            apply_queue_plan=apply_queue_plan,
-            repo_root=repo_root,
-        ),
+        next_command=next_command,
         repo_root=repo_root,
     )
     out = _default_output(out, DEFAULT_CONTINUE_LOOP, "continue_loop.md", repo_root=repo_root)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1014,7 +1014,10 @@ def test_continue_loop_advances_pr_corpus_to_queue_plan_and_loop_state(tmp_path:
     assert out == repo / "reports" / "agent_loop" / "continue_loop.md"
     assert "Queue/plan application: `applied`" in rendered
     assert "PR corpus planning command" in rendered
-    assert "python3 scripts/agent_loop.py continue-loop\n" in rendered
+    assert (
+        "python3 scripts/agent_loop.py preflight --task T-2026-1000 --from-git --write-prompts"
+        in rendered
+    )
     assert "loop-state --from-git" not in rendered
     assert (repo / "reports" / "agent_loop" / "batch_plan.json").exists()
     assert (repo / "reports" / "agent_loop" / "role_dispatch.md").exists()
@@ -1151,6 +1154,11 @@ def test_continue_loop_skips_applying_existing_queued_candidate(tmp_path: Path) 
     queue = queue_path.read_text(encoding="utf-8")
     assert "Queue/plan application: `skipped-existing-task`" in rendered
     assert "Task id: `T-2026-0002`" in rendered
+    assert (
+        "python3 scripts/agent_loop.py preflight --task T-2026-0002 --from-git --write-prompts"
+        in rendered
+    )
+    assert "python3 scripts/agent_loop.py continue-loop --real100-dir reports/real100" not in rendered
     assert queue.count("Use multi-chunk evidence analysis for the next retrieval follow-up") == 2
 
 


### PR DESCRIPTION
## Summary
- Point continue-loop reports at task-specific preflight once a task is applied or reused.
- Add regression coverage for skipped existing queued candidates so they do not recurse into continue-loop again.

## Validation
- python3 -m pytest tests/test_agent_loop.py -q
- python3 -m py_compile scripts/agent_loop.py
- python3 scripts/agent_loop.py continue-loop --real100-dir reports/real100 --no-apply-queue-plan
- git diff --check
- make check-branch

## Data / Eval Impact
- Surface: agent-loop orchestration only.
- Real-data delta: N/A, no runtime retrieval or eval scoring behavior changed.

Closes #1567