### PR TITLE
docs: set RAG performance agent operating goal

### DIFF
--- a/docs/agent-utilization.md
+++ b/docs/agent-utilization.md
@@ -86,6 +86,26 @@
 - agent-delegation-gate false-positive 비율 (트리거 키워드 정확성)
 - Q3 self-review 5축 재진단 — 4△ → ✓ 회복 측정 (`/self-review-quarterly Q3-2026`)
 
+## RAG Performance Loop Application
+
+`T-2026-0023`은 5축 KPI를 RAG 성능 개선 loop에 적용하는 장기 목표다. 큰 scope는
+program-level queue/plan에 두고, 실제 PR은 한 concern만 담는다.
+
+| 8원칙 | 기존 축 / 도구 | RAG 성능 개선 loop에서의 적용 |
+|---|---|---|
+| 1. 스코프는 크게 잡아라 | #1 컨텍스트 효율 + plan doc | RAG performance goal은 queue/plan에 크게 보존하고 PR은 concern별로 분리 |
+| 2. 세션을 길게 유지하라 | #5 메모리 위생 + long-session workflow | session continuity는 transcript가 아니라 task, plan, handoff로 유지 |
+| 3. 할 일 목록을 파일로 남겨라 | tasks/queue.md | next action, blocker, completion proof는 tracked queue/plan에 기록 |
+| 4. Plan Doc 작성에 공을 들여라 | #2 Agent 위임 + docs/plans | multi-file, eval, load-bearing work는 구현 전 plan 필수 |
+| 5. 적대적 리뷰어를 붙여라 | Review Escalation | Benchmark/Privacy/Deep Reviewer가 claim, data boundary, architecture drift를 공격 |
+| 6. 역할별 세션을 분리하라 | Subagents + multi-agent ownership | Planner, Implementer, Tester/CI Reviewer, Issue Triage, Deep Reviewer를 분리 |
+| 7. 사람을 loop 밖으로 빼라 | `continue-loop`, ship gates | agent가 evidence를 만들고 사람은 double-check와 conservative gate만 수행 |
+| 8. 시간의 20%를 process 개선에 써라 | #3 자동화 ROI + #4 cycle time | 반복 miss는 instruction, harness, review prompt, queue/plan 개선 issue로 전환 |
+
+성능(performance) 주장은 이 표로 승인되지 않는다. private real-eval aggregate paired
+delta와 provenance가 없는 PR은 operating-goal alignment 또는 measurement setup만
+claim할 수 있다.
+
 ### Out-of-scope (별도 작업)
 
 - Agent/Skill 호출도 `.hook-fires.log` 에 기록 (PreToolUse matcher 를 `Agent|Skill|Task` 까지 확장) — 별도 PR

--- a/docs/operations/ai-codex-workflow.md
+++ b/docs/operations/ai-codex-workflow.md
@@ -139,6 +139,11 @@ create/merge/close, issue close, branch delete, force-push, private eval 실행,
 benchmark/performance claim 승인을 하지 않는다. remote mutation은 기존 ship
 gate와 `make ship-arm` 경로로 넘긴다.
 
+RAG 성능 개선 loop에서는 `continue-loop`를 사람이 다음 일을 고르는 UI가 아니라
+agent가 다음 queue/plan/preflight 증거를 만드는 표면으로 본다. 사람의 역할은
+실행자가 아니라 claim boundary, conservative gate, merge readiness를 double-check하는
+검증자다.
+
 Page citation claim은 readiness summary의 page metadata gate가 `NO-GO`이거나
 missing page metadata rate가 `1.0`이면 NO-GO로 취급한다. 이 경우 planner는
 page-aware parser/index rebuild 작업을 Codex 후보로 만든다.

--- a/docs/operations/ai-engineering-operating-system.md
+++ b/docs/operations/ai-engineering-operating-system.md
@@ -185,6 +185,31 @@ Agent에게 맡기는 work package는 충분히 커야 하지만, review surface
   `Completion Proof`를 남긴다. `Source PRs`는 선택된 PR이 아니라 그 task를
   만든 evidence set이다.
 
+### Long-Running RAG Performance Goal
+
+RAG system performance improvement는 단일 bug fix가 아니라 여러 session과 여러
+역할이 이어가는 program-level 목표다. Queue와 plan은 큰 목표를 보존하고, PR은
+한 concern만 ship한다.
+
+운영 원칙:
+
+1. Broad outcome scope: `tasks/queue.md`와 plan doc에는 RAG 성능 개선의 큰
+   outcome을 둔다.
+2. Long sessions: 하루 단위가 아니라 task/plan/handoff 단위로 이어간다.
+3. Todo/file queue: 다음 action, blocker, completion proof는 tracked file에 남긴다.
+4. Plan docs: broad, multi-file, eval, load-bearing work는 구현 전에 plan을 만든다.
+5. Adversarial review: Reviewer, Deep Reviewer, Benchmark Auditor, Privacy Auditor가
+   독립적으로 공격할 표면을 남긴다.
+6. Role-separated sessions: Planner, Implementer, Tester/CI Reviewer, Issue Triage,
+   Deep Reviewer, Benchmark Auditor, Privacy Auditor, Reviewer를 필요할 때 분리한다.
+7. Human outside the loop: agent가 PR 생성, validation, CI 확인, evidence 작성까지
+   스스로 증명하고, 사람은 증거 double-check와 conservative gate만 맡는다.
+8. Process improvement: 반복 실수가 보이면 loop time의 최소 20%를 instruction,
+   harness, review prompt, queue/plan 품질 개선에 쓴다.
+
+이 원칙은 performance claim이 아니다. 성능(performance) 주장은 private real-eval
+aggregate paired delta, provenance, claim boundary 검토가 있을 때만 허용한다.
+
 ### Planning Required
 
 Plan doc가 필요한 경우:

--- a/docs/operations/long-session-workflow.md
+++ b/docs/operations/long-session-workflow.md
@@ -36,6 +36,23 @@ eval validity를 유지하며, reviewer가 검증 가능한 근거(evidence)를 
   쓰지 않는다.
 - ADR 번호, PR base, stacked dependency, private artifact 위치는 handoff마다 갱신한다.
 
+## RAG Performance Loop Check
+
+RAG 성능 개선 관련 long session은 handoff마다 8개 운영 원칙을 짧게 점검한다.
+
+- Broad scope: program-level RAG outcome과 현재 PR concern이 분리되어 있는가?
+- Long session: 다음 session이 queue/plan/handoff만 읽고 이어갈 수 있는가?
+- File-backed todo: next action, blocker, completion proof가 tracked file에 있는가?
+- Plan doc: broad, multi-file, eval, 또는 load-bearing work라면 plan이 있는가?
+- Adversarial review: Reviewer, Deep Reviewer, Benchmark Auditor, Privacy Auditor 중
+  필요한 역할이 지정됐는가?
+- Role split: Planner, Implementer, Tester/CI Reviewer, Issue Triage 역할이 한
+  session에 과하게 몰려 있지 않은가?
+- Human outside loop: 사람이 직접 실행한 terminal/PR/CI 단계가 있으면 agent가
+  증거를 double-check했는가?
+- Process improvement: 반복 실수는 instruction, harness, review prompt, queue/plan
+  개선으로 이어졌는가?
+
 ## Handoff Template
 
 세션 종료, context compaction 전, blocked 전환, review 요청 전에 아래 block을 남긴다.

--- a/docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md
+++ b/docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md
@@ -1,0 +1,192 @@
+# Plan: T-2026-0023 RAG performance agent operating goal
+
+- Status: running
+- Owner role: Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0023`
+- Related issue / PR: [#1569](https://github.com/hskim-solv/BidMate-DocAgent/issues/1569) / PR TBD
+- Related ADR: N/A - no decision-level runtime or eval contract change
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+## Problem Statement
+
+The agent loop can make progress by fixing small orchestration bugs, but the
+longer goal is to improve RAG system performance. Without a tracked operating
+goal, future sessions can over-optimize for tiny local fixes, skip role
+separation, or forget to invest in process improvements that make larger RAG
+work reliable.
+
+## Current Behavior
+
+The repository already has the core operating surfaces:
+
+- `tasks/queue.md` stores persistent task state.
+- `docs/plans/TEMPLATE.md` defines plan docs for non-trivial work.
+- `docs/operations/ai-engineering-operating-system.md` defines role and review
+  escalation.
+- `docs/operations/long-session-workflow.md` preserves handoff state.
+- `docs/agent-utilization.md` maps rules, skills, subagents, and commands.
+- `scripts/agent_loop.py continue-loop` generates queue/plan/role-dispatch
+  artifacts.
+
+The missing part is an explicit long-running RAG performance goal that binds
+these surfaces to the 8 operating principles.
+
+## Desired Behavior
+
+New sessions should treat RAG performance improvement as a broad, multi-session
+program while still shipping one concern per PR. The first screen for future
+agents should make the expected operating shape clear: queue-backed work,
+plan-backed scope, role-separated sessions, adversarial review, conservative
+human gates, and periodic process improvement.
+
+## Constraints
+
+- Scope constraints: docs/governance only for this PR.
+- Architecture constraints: do not change retrieval, reranking, answer,
+  ingestion, API, or eval runtime behavior.
+- Compatibility constraints: preserve existing task queue and plan doc formats.
+- Eval/privacy constraints: no private real-eval run, no raw private artifact
+  content, and no exact local private path in tracked docs.
+- Tooling/CI constraints: use targeted doc-link checks plus branch/issue checks.
+- Non-goals: do not add code automation, CI gates, metrics, or benchmark
+  outputs in this PR.
+
+## Architecture Impact
+
+- Affected modules or docs: `tasks/queue.md`,
+  `docs/operations/ai-engineering-operating-system.md`,
+  `docs/operations/long-session-workflow.md`,
+  `docs/operations/ai-codex-workflow.md`, `docs/agent-utilization.md`.
+- Affected contracts or invariants: operating workflow only.
+- Load-bearing paths: none.
+- ADR required: no, this does not change a load-bearing runtime or eval
+  contract.
+- Backward compatibility expectation: existing queue, plan, review, and
+  continue-loop workflows remain valid.
+
+## Affected Interfaces
+
+- CLI/API/config: none.
+- Input data: none.
+- Output artifacts: docs and task queue only.
+- Docs/review surfaces: agent-loop operating docs and handoff checklist.
+- Tests/eval entrypoints: doc-link validation only.
+
+## Data / Eval Impact
+
+- Surface: none.
+- Data boundary: no data touched.
+- Allowed claim: operating-goal alignment for future RAG performance work.
+- Disallowed claim: RAG quality, retrieval quality, answer quality, latency,
+  recall, nDCG, or production performance improved.
+- Baseline or control affected: no.
+- Benchmark/eval auditor required: yes for future performance claims; this PR
+  only records that requirement.
+
+## Task Breakdown
+
+1. Add a ready queue entry for the long-running RAG performance operating goal.
+2. Add this plan doc with the 8 operating principles as acceptance criteria.
+3. Update operating docs so future sessions know how to apply the principles.
+4. Validate links, branch/issue convention, and claim wording.
+
+## Operating Principles
+
+1. Broad outcome scope: set RAG performance improvement as the program-level
+   goal, then split implementation into one concern per PR.
+2. Long sessions: keep work alive through queue, plan, handoff, and follow-up
+   tasks instead of transcript memory.
+3. Todo/file queue: put next actions, blockers, and completion proof in tracked
+   docs.
+4. Plan docs: use plan docs before broad, multi-file, eval, or load-bearing work.
+5. Adversarial review: attach Reviewer, Deep Reviewer, Benchmark Auditor, and
+   Privacy Auditor when the surface requires them.
+6. Role-separated sessions: split Planner, Implementer, Tester/CI Reviewer,
+   Issue Triage, Deep Reviewer, Benchmark Auditor, and Privacy Auditor when
+   work can proceed independently.
+7. Human outside the loop: automation should execute and produce evidence;
+   humans double-check evidence and approve conservative gates only.
+8. Process improvement: when repeated misses appear, spend at least 20% of loop
+   time improving instructions, harnesses, queue quality, or review prompts.
+
+## Acceptance Criteria
+
+- [ ] `tasks/queue.md` contains a ready task for the long-running RAG performance
+  goal.
+- [ ] The 8 principles are reflected in operating docs, not only in this plan.
+- [ ] Role separation explicitly includes Planner, Implementer, Tester/CI
+  Reviewer, Issue Triage, Deep Reviewer, Benchmark Auditor, Privacy Auditor,
+  and Reviewer.
+- [ ] Claim wording says this PR is docs/governance only and makes no RAG
+  performance claim.
+- [ ] Validation evidence is recorded without private raw data.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md docs/operations/ai-engineering-operating-system.md docs/operations/long-session-workflow.md docs/operations/ai-codex-workflow.md docs/agent-utilization.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: N/A - no runtime or eval behavior changed.
+- Generated or updated artifact: docs and queue entries only.
+- Reviewer checklist or manual inspection: claim boundary and role separation.
+- Explicitly not validated, with reason: no private real-eval because this PR
+  does not change RAG runtime behavior or make a performance claim.
+
+## Rollback Strategy
+
+Revert this docs/governance PR if the operating wording causes workflow
+confusion. Do not delete any unrelated task queue entries or plan docs during
+rollback.
+
+## Failure Modes
+
+- Failure mode: future agents treat broad scope as permission to mix concerns in
+  one PR.
+- Detection signal: PR contains unrelated runtime, eval, ADR, and docs changes.
+- Stop condition or fallback: split work into issue-linked PRs and keep only one
+  concern per branch.
+
+- Failure mode: governance wording is mistaken for a performance claim.
+- Detection signal: PR body or docs imply RAG quality improved.
+- Stop condition or fallback: remove the claim and require private real-eval
+  aggregate paired delta before performance wording.
+
+## Observability
+
+- `tasks/queue.md` Ready Order shows the long-running operating goal.
+- Future task entries link back to this plan when they are part of the RAG
+  performance program.
+- PR bodies include whether the change is docs/governance only or includes a
+  validated performance claim.
+
+## Reviewer Notes
+
+Attack claim wording first. This PR should make future RAG performance work more
+operable, but it must not claim any current RAG performance improvement.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-27 15:16 KST
+
+- Role: Planner / Implementer
+- Branch / worktree: docs/issue-1569-rag-performance-agent-goal / /Users/hskim/.codex/worktrees/3165/BidMate-DocAgent
+- Issue / PR: #1569 / PR TBD
+- Task: T-2026-0023
+- Current status: queue and plan drafted; operating docs next.
+- Files touched: tasks/queue.md, docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md
+- Decisions made: keep this as docs/governance only; no runtime or eval changes.
+- Commands run: pending validation.
+- Results: pending.
+- Next safe command: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md docs/operations/ai-engineering-operating-system.md docs/operations/long-session-workflow.md docs/operations/ai-codex-workflow.md docs/agent-utilization.md
+- Open questions: none.
+- Risks: claim wording could be overread as a performance result.
+```

--- a/docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md
+++ b/docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md
@@ -1,9 +1,9 @@
 # Plan: T-2026-0023 RAG performance agent operating goal
 
-- Status: running
+- Status: review
 - Owner role: Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0023`
-- Related issue / PR: [#1569](https://github.com/hskim-solv/BidMate-DocAgent/issues/1569) / PR TBD
+- Related issue / PR: [#1569](https://github.com/hskim-solv/BidMate-DocAgent/issues/1569) / [#1570](https://github.com/hskim-solv/BidMate-DocAgent/pull/1570)
 - Related ADR: N/A - no decision-level runtime or eval contract change
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -179,14 +179,14 @@ operable, but it must not claim any current RAG performance improvement.
 
 - Role: Planner / Implementer
 - Branch / worktree: docs/issue-1569-rag-performance-agent-goal / /Users/hskim/.codex/worktrees/3165/BidMate-DocAgent
-- Issue / PR: #1569 / PR TBD
+- Issue / PR: #1569 / PR #1570
 - Task: T-2026-0023
-- Current status: queue and plan drafted; operating docs next.
-- Files touched: tasks/queue.md, docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md
+- Current status: docs/governance implementation opened as PR #1570.
+- Files touched: tasks/queue.md, docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md, docs/operations/ai-engineering-operating-system.md, docs/operations/long-session-workflow.md, docs/operations/ai-codex-workflow.md, docs/agent-utilization.md
 - Decisions made: keep this as docs/governance only; no runtime or eval changes.
-- Commands run: pending validation.
-- Results: pending.
-- Next safe command: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md docs/operations/ai-engineering-operating-system.md docs/operations/long-session-workflow.md docs/operations/ai-codex-workflow.md docs/agent-utilization.md
+- Commands run: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md docs/operations/ai-engineering-operating-system.md docs/operations/long-session-workflow.md docs/operations/ai-codex-workflow.md docs/agent-utilization.md; git diff --check; make check-branch
+- Results: passed.
+- Next safe command: make ship-review-gate PR=1570
 - Open questions: none.
 - Risks: claim wording could be overread as a performance result.
 ```

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -33,6 +33,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 20 | `T-2026-0020` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1544; v0 metric-suite report implementation ready for review. |
 | 21 | `T-2026-0021` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 implemented; draft PR #1552. |
 | 22 | `T-2026-0022` | `backlog` | Planner -> Implementer -> Reviewer | issue #1563; choose one scoped multi-chunk retrieval measurement follow-up. |
+| 23 | `T-2026-0023` | `ready` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | issue #1569; long-running RAG performance goal with 8 agent operating principles. |
 
 ## Examples
 
@@ -1938,4 +1939,80 @@ Focused validation passes and the follow-up evidence is recorded.
 
 - Plan: [`docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md`](../docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md)
 - Issue: [#1563](https://github.com/hskim-solv/BidMate-DocAgent/issues/1563)
+- PR: TBD
+
+## T-2026-0023 — RAG performance agent operating goal
+
+- ID: T-2026-0023
+- Title: RAG performance agent operating goal
+- Status: ready
+- Owner role: Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Make RAG system performance improvement the long-running agent-loop goal, with
+the 8 operating principles written into the queue, plan, and operating docs so
+future sessions do not collapse into only small local fixes.
+
+### Context
+
+- Issue: #1569
+- Surface: docs/governance only.
+- Operating principles:
+  1. Hold a broad outcome scope.
+  2. Maintain long sessions through queue, plan, and handoff artifacts.
+  3. Keep todo state in tracked files.
+  4. Invest in plan docs before broad changes.
+  5. Attach adversarial, deep, benchmark, and privacy reviewers.
+  6. Split Planner, Implementer, Tester/CI Reviewer, Issue Triage, Deep Reviewer,
+     Benchmark Auditor, and Privacy Auditor into separate sessions when useful.
+  7. Keep the human out of the execution loop except evidence double-checks and
+     explicit conservative gates.
+  8. Spend at least 20% of loop time on process improvement when repeated misses
+     appear.
+
+### Scope
+
+- Add this queue entry and a self-contained plan doc.
+- Link the principles from the operating-system, long-session, utilization, and
+  Codex workflow docs.
+- Keep the change as an operating-goal alignment PR.
+
+### Non-Goals
+
+- Do not change retrieval, reranking, answer, ingestion, or eval runtime behavior.
+- Do not run private real-eval.
+- Do not claim RAG quality, recall, latency, or production performance improved.
+- Do not add new automation until a repeated omission proves it is needed.
+
+### Acceptance Criteria
+
+- [ ] The 8 principles are recorded as enforceable operating criteria, not a chat-only preference.
+- [ ] RAG performance improvement is represented as a multi-session goal with
+  role separation and reviewer escalation.
+- [ ] The docs explicitly separate this governance change from any performance claim.
+- [ ] Follow-up implementation work can start from `T-2026-0022` or later
+  measurement tasks without rediscovering the operating model.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md docs/operations/ai-engineering-operating-system.md docs/operations/long-session-workflow.md docs/operations/ai-codex-workflow.md docs/agent-utilization.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Targeted doc-link check passes.
+- Branch/issue convention passes.
+- PR body states: docs/governance only; no RAG runtime/eval behavior changed;
+  no private real-eval run; no performance claim.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md`](../docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md)
+- Issue: [#1569](https://github.com/hskim-solv/BidMate-DocAgent/issues/1569)
 - PR: TBD

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -33,7 +33,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 20 | `T-2026-0020` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1544; v0 metric-suite report implementation ready for review. |
 | 21 | `T-2026-0021` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 implemented; draft PR #1552. |
 | 22 | `T-2026-0022` | `backlog` | Planner -> Implementer -> Reviewer | issue #1563; choose one scoped multi-chunk retrieval measurement follow-up. |
-| 23 | `T-2026-0023` | `ready` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | issue #1569; long-running RAG performance goal with 8 agent operating principles. |
+| 23 | `T-2026-0023` | `review` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | issue #1569; PR #1570. |
 
 ## Examples
 
@@ -1945,7 +1945,7 @@ Focused validation passes and the follow-up evidence is recorded.
 
 - ID: T-2026-0023
 - Title: RAG performance agent operating goal
-- Status: ready
+- Status: review
 - Owner role: Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -2015,4 +2015,4 @@ make check-branch
 
 - Plan: [`docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md`](../docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md)
 - Issue: [#1569](https://github.com/hskim-solv/BidMate-DocAgent/issues/1569)
-- PR: TBD
+- PR: [#1570](https://github.com/hskim-solv/BidMate-DocAgent/pull/1570)


### PR DESCRIPTION
## Summary
- Add T-2026-0023 as the long-running RAG performance agent operating goal.
- Add a plan doc that records the 8 operating principles as acceptance criteria.
- Link the principles from the operating-system, long-session, Codex workflow, and agent-utilization docs.

## Validation
- python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md docs/operations/ai-engineering-operating-system.md docs/operations/long-session-workflow.md docs/operations/ai-codex-workflow.md docs/agent-utilization.md
- git diff --check
- make check-branch

## Data / Eval Impact
- Surface: docs/governance only.
- Real-data delta: N/A; no RAG runtime/eval behavior changed.
- Private real-eval: not run.
- Performance claim: none.

Closes #1569