### PR TITLE
Record multi-chunk retrieval no-go

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -68,6 +68,10 @@ ALLOWED_PATTERNS=(
   # scripts/render_multi_chunk_evidence_failures.py). Aggregate-only
   # counts/buckets for gold/retrieved chunk coverage and expected impact.
   '^reports/real100/multi_chunk_evidence_failures\.aggregate\.json$'
+  # Multi-chunk retrieval strategy decision (script:
+  # scripts/render_multi_chunk_retrieval_strategy.py). Mirrors the `!`-rule in
+  # `.gitignore`; aggregate-only recommendation/provenance, no raw case rows.
+  '^reports/real100/multi_chunk_retrieval_strategy\.aggregate\.json$'
   # Issue #1469 — difficulty profiler (script:
   # scripts/render_difficulty_profile.py, ADR 0077). Aggregate-only
   # difficulty buckets and outcome means; raw case rows and index text stay

--- a/docs/evaluation/multi_chunk_retrieval_strategy.md
+++ b/docs/evaluation/multi_chunk_retrieval_strategy.md
@@ -2,6 +2,16 @@
 
 This report is aggregate-only. It uses counts from `reports/real100/multi_chunk_evidence_failures.aggregate.json` and does not include raw questions, answers, document IDs, chunk IDs, paths, sections, or source text.
 
+## Source Provenance
+
+| Field | Value |
+|---|---|
+| Input artifact | `reports/real100/multi_chunk_evidence_failures.aggregate.json` |
+| Source basename | `eval_summary.json` |
+| Source SHA-256 prefix | `714c08f9996d` |
+
+Freshness boundary: this decision applies only to the aggregate above. If a newer private index or eval surface exists, render the matching multi-chunk aggregate before choosing a retrieval change.
+
 ## Recommendation
 
 - Recommended next strategy: `defer_until_page_metadata_recovery`

--- a/docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md
+++ b/docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md
@@ -1,6 +1,6 @@
 # Plan: T-2026-0022 Use multi-chunk evidence analysis for the next retrieval follow-up
 
-- Status: draft
+- Status: review
 - Owner role: Planner -> Implementer -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0022`
 - Related issue / PR: [#1563](https://github.com/hskim-solv/BidMate-DocAgent/issues/1563) / PR TBD
@@ -9,23 +9,32 @@
 
 ## Problem
 
-multi-chunk aggregate is available: 97/99 top-10 failures; 97 limited-depth cases
+multi-chunk aggregate is available: 97/99 top-10 failures; 97 limited-depth cases.
+The current strategy source is the older `reports/real100/` aggregate with source
+SHA-256 prefix `714c08f9996d`; it is not a fresh `real100_v2` multi-chunk
+measurement.
 
 ## Desired Outcome
 
-Turn the aggregate multi-chunk evidence split into one scoped measurement follow-up.
+Turn the aggregate multi-chunk evidence split into one scoped measurement
+follow-up, while preventing a stale aggregate from being mistaken for current
+`real100_v2` retrieval evidence.
 
 ## Scope
 
 - Convert the planner brief into one narrow, reviewable Codex task.
+- Render a public-safe strategy decision from the existing aggregate.
+- Record the current `real100_v2` freshness check: 100 parsed Markdown exports
+  exist, but the current `real100_v2` index has 0% chunk page metadata coverage.
 - Reuse existing BidMate operating docs, queue, plans, validation commands, and reviewer prompts.
-- Keep generated artifacts local unless a human promotes a redacted artifact.
+- Keep generated artifacts aggregate-only and public-safe.
 
 ## Out of Scope
 
 - Auto-merge, auto-push, PR creation/close/merge, branch deletion, or force-push.
 - Benchmark, performance, private real-eval, or architecture tradeoff decisions without ADR 0079 agent-gate evidence.
 - Raw private question, answer, evidence, doc_id, chunk_id, filenames, or exact local paths.
+- Retrieval, reranker, chunking, prompt, verifier, or answer runtime changes.
 
 ## Surface / Claim Boundary
 
@@ -36,19 +45,38 @@ Turn the aggregate multi-chunk evidence split into one scoped measurement follow
 - Eval surface: classify again after implementation if changed files touch eval, benchmark, metrics, reports, configs, or claims.
 - Disallowed claim: do not claim product quality, benchmark lift, or private real-eval success from this draft alone.
 
+## Freshness Check
+
+- `data/private/real100_v2/parsed_md` exists locally with 100 Markdown files
+  plus `export_manifest.local.json` listing 100 documents.
+- `data/private/real100_v2/converted_pdfs` exists locally with 94 converted
+  PDFs; raw filenames and paths stay private.
+- `data/index/real100_v2/index.json` reports `text_source=pdf_pymupdf4llm` for
+  21,800 chunks, but `scripts/page_metadata_recovery_audit.py` reports 0.0
+  coverage for chunk page metadata, `page_span`, and `regions.page_number`.
+- The `real100_v2` index embedding is currently `hashing` /
+  `local-hashing-bow`, so it is not MiniLM semantic evidence.
+
+Conclusion: the Markdown conversion exists, but page-aware retrieval evidence
+still requires a page-aware re-index before making a concrete multi-chunk
+retrieval change.
+
 ## Implementation Steps
 
 1. Read the required operating docs and this plan.
 2. Inspect the cited workflow surface and existing tests.
-3. Make the smallest scoped change.
-4. Add or update focused tests.
+3. Render the aggregate-only strategy decision.
+4. Add focused tests for strategy provenance/freshness wording.
 5. Run focused validation and `git diff --check`.
 6. Leave a handoff with required fields and reviewer focus.
 
 ## Validation
 
 ```bash
-python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py
+python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py
+python3 scripts/render_multi_chunk_retrieval_strategy.py
+export REAL_EVAL_ROOT=/path/to/private/BidMate-DocAgent
+python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_v2" --format markdown
 git diff --check
 ```
 
@@ -57,23 +85,26 @@ git diff --check
 - Scope control against the source brief.
 - Completion proof: Focused validation passes and the follow-up evidence is recorded.
 - Privacy boundary and claim wording.
+- Freshness boundary: no claim that the older `real100/` strategy report is a
+  current `real100_v2` result.
 - Conservative eval surface classification.
 - Validation evidence matches commands actually run.
 
 ## Session Handoff
 
-- Role: Planner
-- Lifecycle stage: preflight repair
-- Branch / worktree: docs/issue-1571-repair-t0022-handoff / Codex worktree
+- Role: Planner -> Implementer
+- Lifecycle stage: implementation
+- Branch / worktree: eval/issue-1563-multi-chunk-followup-implementation / Codex worktree
 - Task: T-2026-0022
-- Current status: preflight handoff fields repaired; implementation not started.
-- Files touched: docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md
-- Commands run: python3 scripts/agent_loop.py preflight --task T-2026-0022 --from-git --write-prompts
-- Results: preflight previously failed because required handoff fields were blank.
-- Validation evidence: preflight reported missing handoff fields and generated local prompts.
-- Blockers: none after this handoff repair is validated.
-- Open risks: next implementation must still choose one scoped multi-chunk retrieval measurement follow-up and avoid performance claims without aggregate paired evidence.
-- Next action: rerun preflight and then start the scoped measurement follow-up.
-- Next safe command: python3 scripts/agent_loop.py preflight --task T-2026-0022 --from-git --write-prompts
-- Reviewer focus: handoff completeness, privacy-safe aggregate-only wording, and no RAG performance claim.
-- Eval surface: next_experiment_candidate planning; classify again before runtime, eval, benchmark, report, config, or claim changes.
+- Current status: aggregate-only strategy decision implemented; concrete retrieval
+  change deferred until page-aware re-index evidence exists.
+- Files touched: .githooks/pre-commit, scripts/render_multi_chunk_retrieval_strategy.py, tests/test_render_multi_chunk_retrieval_strategy.py, docs/evaluation/multi_chunk_retrieval_strategy.md, reports/real100/multi_chunk_retrieval_strategy.aggregate.json, docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md, tasks/queue.md
+- Commands run: python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py; python3 scripts/render_multi_chunk_retrieval_strategy.py; export REAL_EVAL_ROOT=/path/to/private/BidMate-DocAgent; python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_v2" --format markdown; python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md docs/evaluation/multi_chunk_retrieval_strategy.md tasks/queue.md; bash -n .githooks/pre-commit; git diff --check; make check-branch
+- Results: strategy recommendation is `defer_until_page_metadata_recovery`; `real100_v2` has 100 parsed Markdown exports but current index page metadata coverage is 0.0.
+- Validation evidence: focused tests, doc-link check, whitespace check, branch check, and page metadata recovery audit completed.
+- Blockers: concrete retrieval implementation is blocked on page-aware re-index evidence, not on missing Markdown conversion.
+- Open risks: `real100_v2` parsed Markdown exists but lacks structured page metadata in the current index; MiniLM semantic baseline evidence is also absent from this task.
+- Next action: review this aggregate-only no-go decision, then run page-aware re-index / MiniLM baseline follow-ups separately (#1573, #1575).
+- Next safe command: python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py
+- Reviewer focus: source freshness, privacy-safe aggregate-only wording, and no RAG performance claim.
+- Eval surface: report/measurement decision only; no retrieval, reranker, verifier, prompt, answer, or eval runtime behavior change.

--- a/reports/real100/multi_chunk_retrieval_strategy.aggregate.json
+++ b/reports/real100/multi_chunk_retrieval_strategy.aggregate.json
@@ -1,0 +1,137 @@
+{
+  "candidate_pool_expansion": {
+    "all_missing_gold_seen_after_top10": 0,
+    "missing_gold_seen_after_top10": 0,
+    "not_observable_due_to_depth": 97
+  },
+  "decision_reasons": [
+    "evidence_split_unknown_dominant"
+  ],
+  "evidence_split": {
+    "counts": {
+      "multi_doc": 0,
+      "same_doc": 0,
+      "unknown": 99
+    },
+    "ratios": {
+      "multi_doc": 0.0,
+      "same_doc": 0.0,
+      "unknown": 1.0
+    }
+  },
+  "expected_impact": {
+    "pool_or_rerank_candidate": 0,
+    "query_decomposition_candidate": 0,
+    "section_expansion_candidate": 0,
+    "unknown_due_to_limited_depth": 97
+  },
+  "population": {
+    "multi_chunk_gold_cases": 99,
+    "multi_chunk_top10_evidence_failure_rate": 0.979798,
+    "multi_chunk_top10_evidence_failures": 97,
+    "num_predictions": 221
+  },
+  "privacy": {
+    "aggregate_only": true,
+    "raw_case_fields_copied": false,
+    "raw_text_or_identifiers_copied": false
+  },
+  "recommendation": "defer_until_page_metadata_recovery",
+  "recommendation_set": [
+    "defer_until_page_metadata_recovery"
+  ],
+  "retrieval_outcome_by_k": {
+    "10": {
+      "all_gold_retrieved": 2,
+      "no_gold_retrieved": 14,
+      "not_observable": 83,
+      "partial_gold_retrieved": 0
+    },
+    "20": {
+      "all_gold_retrieved": 2,
+      "no_gold_retrieved": 14,
+      "not_observable": 83,
+      "partial_gold_retrieved": 0
+    },
+    "5": {
+      "all_gold_retrieved": 2,
+      "no_gold_retrieved": 57,
+      "not_observable": 5,
+      "partial_gold_retrieved": 35
+    }
+  },
+  "run_order": "after_page_metadata_recovery",
+  "schema_version": 1,
+  "source": {
+    "input_artifact": "reports/real100/multi_chunk_evidence_failures.aggregate.json",
+    "input_schema_version": 1,
+    "source_basename": "eval_summary.json",
+    "source_location_redacted": true,
+    "source_sha256_12": "714c08f9996d"
+  },
+  "strategy_assessment": {
+    "candidate_pool_expansion": {
+      "all_missing_gold_seen_after_top10": 0,
+      "likely_help": false,
+      "missing_gold_seen_after_top10": 0,
+      "not_observable_due_to_depth": 97,
+      "verdict": "not_supported"
+    },
+    "query_decomposition": {
+      "multi_doc_cases": 0,
+      "query_decomposition_candidate": 0,
+      "required": false,
+      "verdict": "not_assessable_without_doc_split"
+    },
+    "reranker": {
+      "pool_or_rerank_candidate": 0,
+      "required": false,
+      "verdict": "insufficient_basis_without_gold_in_candidate_pool"
+    },
+    "same_doc_neighbor_expansion": {
+      "likely_help": false,
+      "same_doc_cases": 0,
+      "unknown_doc_split_cases": 99,
+      "verdict": "not_assessable_without_doc_split"
+    },
+    "section_expansion": {
+      "likely_help": false,
+      "section_expansion_candidate": 0,
+      "verdict": "not_assessable_without_same_doc_split"
+    }
+  },
+  "structured_overlap": {
+    "multi_chunk_gold_cases": {
+      "case_source_format": {
+        "csv": 0,
+        "docx": 0,
+        "hwp": 0,
+        "json": 0,
+        "other": 99,
+        "pdf": 0,
+        "pptx": 0,
+        "txt": 0,
+        "unknown": 0,
+        "xlsx": 0
+      },
+      "hardcase_table_heavy": 0,
+      "metadata_field_structured": 0
+    },
+    "top10_evidence_failures": {
+      "case_source_format": {
+        "csv": 0,
+        "docx": 0,
+        "hwp": 0,
+        "json": 0,
+        "other": 97,
+        "pdf": 0,
+        "pptx": 0,
+        "txt": 0,
+        "unknown": 0,
+        "xlsx": 0
+      },
+      "hardcase_table_heavy": 0,
+      "metadata_field_structured": 0
+    }
+  }
+}

--- a/scripts/render_multi_chunk_retrieval_strategy.py
+++ b/scripts/render_multi_chunk_retrieval_strategy.py
@@ -334,6 +334,7 @@ def build_strategy_report(
 
 
 def render_markdown(report: Mapping[str, Any]) -> str:
+    source = _mapping(report.get("source"))
     population = _mapping(report.get("population"))
     retrieval = _mapping(report.get("retrieval_outcome_by_k"))
     evidence = _mapping(report.get("evidence_split"))
@@ -355,6 +356,18 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         "`reports/real100/multi_chunk_evidence_failures.aggregate.json` and does "
         "not include raw questions, answers, document IDs, chunk IDs, paths, "
         "sections, or source text.",
+        "",
+        "## Source Provenance",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Input artifact | `{source.get('input_artifact') or ''}` |",
+        f"| Source basename | `{source.get('source_basename') or ''}` |",
+        f"| Source SHA-256 prefix | `{source.get('source_sha256_12') or ''}` |",
+        "",
+        "Freshness boundary: this decision applies only to the aggregate above. "
+        "If a newer private index or eval surface exists, render the matching "
+        "multi-chunk aggregate before choosing a retrieval change.",
         "",
         "## Recommendation",
         "",

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -32,7 +32,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 19 | `T-2026-0019` | `review` | Maintainer -> CI Reviewer -> Reviewer | local implementation ready on issue #1549 branch. |
 | 20 | `T-2026-0020` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1544; v0 metric-suite report implementation ready for review. |
 | 21 | `T-2026-0021` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 implemented; draft PR #1552. |
-| 22 | `T-2026-0022` | `backlog` | Planner -> Implementer -> Reviewer | issue #1563; choose one scoped multi-chunk retrieval measurement follow-up. |
+| 22 | `T-2026-0022` | `review` | Planner -> Implementer -> Reviewer | issue #1563; aggregate strategy decision implemented; retrieval change deferred until page-aware re-index evidence. |
 | 23 | `T-2026-0023` | `review` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | issue #1569; PR #1570. |
 
 ## Examples
@@ -1895,12 +1895,14 @@ make check-branch
 
 - ID: T-2026-0022
 - Title: Use multi-chunk evidence analysis for the next retrieval follow-up
-- Status: backlog
+- Status: review
 - Owner role: Planner -> Implementer -> Reviewer
 
 ### Goal
 
-Turn the aggregate multi-chunk evidence split into one scoped measurement follow-up.
+Turn the aggregate multi-chunk evidence split into one scoped measurement
+follow-up without mistaking a stale `real100/` aggregate for current
+`real100_v2` retrieval evidence.
 
 ### Context
 
@@ -1910,36 +1912,70 @@ Turn the aggregate multi-chunk evidence split into one scoped measurement follow
 - Workset: `general`
 - Lane: `parallel-safe`
 - Role hints: `Planner, Implementer, Reviewer`
-- Reason: multi-chunk aggregate is available: 97/99 top-10 failures; 97 limited-depth cases
+- Reason: multi-chunk aggregate is available: 97/99 top-10 failures; 97 limited-depth cases; source SHA-256 prefix `714c08f9996d` is the older `real100/` aggregate, not a fresh `real100_v2` multi-chunk measurement.
+- Freshness check: `real100_v2` has 100 parsed Markdown exports and 94 converted PDFs in ignored private storage, but the current `real100_v2` index has 21,800 `pdf_pymupdf4llm` chunks with 0.0 chunk page metadata / `page_span` / `regions.page_number` coverage.
 - Source brief: `reports/agent_loop/codex_tasks/001-multi-chunk-follow-up.md`
 - Suggested plan path: `docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md`
 
 ### Acceptance Criteria
 
-- [ ] Scope stays limited to the cited workflow surface.
-- [ ] Public-safe evidence or no-go rationale is captured without raw private data.
-- [ ] Reviewer prompt covers any eval, benchmark, privacy, or architecture surface touched.
+- [x] Scope stays limited to the cited workflow surface.
+- [x] Public-safe evidence or no-go rationale is captured without raw private data.
+- [x] Reviewer prompt covers any eval, benchmark, privacy, or architecture surface touched.
+- [x] Strategy report exposes source provenance so stale aggregate use is visible.
 
 ### Validation Commands
 
 ```bash
-python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py
+python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py
+python3 scripts/render_multi_chunk_retrieval_strategy.py
+export REAL_EVAL_ROOT=/path/to/private/BidMate-DocAgent
+python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_v2" --format markdown
 git diff --check
 ```
 
 ### Evidence Required
 
-The follow-up chooses pool/rerank, decomposition, or section-expansion measurement using aggregate counts only.
+The follow-up chooses `defer_until_page_metadata_recovery` using aggregate counts
+only. Pool/rerank, decomposition, and section expansion remain unsupported until
+a page-aware `real100_v2` aggregate can distinguish same-document versus
+multi-document evidence splits.
 
 ### Completion Proof
 
-Focused validation passes and the follow-up evidence is recorded.
+Focused validation passes and the follow-up evidence is recorded in
+`docs/evaluation/multi_chunk_retrieval_strategy.md` plus
+`reports/real100/multi_chunk_retrieval_strategy.aggregate.json`.
 
 ### Related Plan / Issue / PR Links
 
 - Plan: [`docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md`](../docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md)
 - Issue: [#1563](https://github.com/hskim-solv/BidMate-DocAgent/issues/1563)
 - PR: TBD
+
+### Session Handoff
+
+- Role: Planner -> Implementer
+- Lifecycle stage: review
+- Branch / worktree: `eval/issue-1563-multi-chunk-followup-implementation` / Codex worktree
+- Current status: aggregate-only strategy decision implemented; concrete retrieval
+  change deferred until page-aware re-index evidence exists.
+- Files touched: `.githooks/pre-commit`,
+  `scripts/render_multi_chunk_retrieval_strategy.py`,
+  `tests/test_render_multi_chunk_retrieval_strategy.py`,
+  `docs/evaluation/multi_chunk_retrieval_strategy.md`,
+  `reports/real100/multi_chunk_retrieval_strategy.aggregate.json`,
+  `docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md`,
+  `tasks/queue.md`.
+- Commands run: `python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py`; `python3 scripts/render_multi_chunk_retrieval_strategy.py`; `export REAL_EVAL_ROOT=/path/to/private/BidMate-DocAgent`; `python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_v2" --format markdown`; `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md docs/evaluation/multi_chunk_retrieval_strategy.md tasks/queue.md`; `bash -n .githooks/pre-commit`; `git diff --check`; `make check-branch`.
+- Results: strategy recommendation is `defer_until_page_metadata_recovery`; `real100_v2` has 100 parsed Markdown exports, but current index page metadata coverage is 0.0.
+- Validation evidence: focused tests, doc-link check, whitespace check, branch check, and page metadata recovery audit completed.
+- Blockers: concrete retrieval implementation is blocked on page-aware re-index evidence, not on missing Markdown conversion.
+- Open risks: MiniLM semantic baseline evidence is absent from this task; keep #1575 separate.
+- Next action: run final validation, then open the issue-linked PR for #1563.
+- Next safe command: `python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py`
+- Reviewer focus: source freshness, privacy-safe aggregate-only wording, and no RAG performance claim.
+- Eval surface: report/measurement decision only; no retrieval, reranker, verifier, prompt, answer, or eval runtime behavior change.
 
 ## T-2026-0023 — RAG performance agent operating goal
 

--- a/tests/test_render_multi_chunk_retrieval_strategy.py
+++ b/tests/test_render_multi_chunk_retrieval_strategy.py
@@ -122,6 +122,9 @@ def test_renderer_emits_json_and_markdown(tmp_path: Path) -> None:
     md = out_md.read_text(encoding="utf-8")
     assert "`defer_until_page_metadata_recovery`" in md
     assert "after page metadata recovery" in md
+    assert "Source Provenance" in md
+    assert "`external_private/multi_chunk.aggregate.json`" in md
+    assert "`abc123def456`" in md
 
 
 def test_defer_priority_beats_pool_section_query_and_reranker_signals() -> None:
@@ -203,3 +206,10 @@ def test_private_like_input_fields_are_not_rendered() -> None:
         "비공개",
     ):
         assert forbidden not in rendered
+
+
+def test_markdown_warns_that_strategy_is_bound_to_source_aggregate() -> None:
+    md = render_markdown(build_strategy_report(_aggregate()))
+
+    assert "Freshness boundary" in md
+    assert "render the matching multi-chunk aggregate" in md


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Multi-chunk failure aggregate를 바로 retrieval 변경으로 연결하지 않고, source provenance와 freshness boundary를 노출하는 aggregate-only strategy decision으로 고정했습니다. 확인 결과 기존 strategy source는 `reports/real100/` SHA prefix `714c08f9996d`이고, `real100_v2`에는 100 parsed Markdown exports가 있지만 current index page metadata coverage는 0.0이라 concrete retrieval change는 page-aware re-index 이후로 미룹니다.

Closes #1563

## 2. 영향 파일

- `.githooks/pre-commit`: `.gitignore`의 aggregate allowlist와 hook allowlist 불일치 수정
- `scripts/render_multi_chunk_retrieval_strategy.py`: rendered Markdown에 source provenance와 freshness boundary 추가
- `tests/test_render_multi_chunk_retrieval_strategy.py`: provenance/freshness wording regression coverage
- `docs/evaluation/multi_chunk_retrieval_strategy.md`: aggregate-only no-go report
- `reports/real100/multi_chunk_retrieval_strategy.aggregate.json`: aggregate-only recommendation/provenance artifact
- `docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md`, `tasks/queue.md`: handoff and validation evidence

## 3. 리스크

가장 큰 리스크는 stale `real100/` aggregate를 current `real100_v2` retrieval evidence로 오해하는 것입니다. Report에 input artifact, source basename, hash prefix, freshness boundary를 추가해 오해를 차단했습니다. Hook allowlist 변경은 `.gitignore`에 이미 존재하는 동일 aggregate 예외와 맞추는 범위입니다.

## 4. 테스트

- `python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py`
- `python3 scripts/render_multi_chunk_retrieval_strategy.py`
- `REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent bash -lc 'python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_v2" --format markdown'`\n- `python3 scripts/check_doc_links.py --check-all --paths docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md docs/evaluation/multi_chunk_retrieval_strategy.md tasks/queue.md`\n- `bash -n .githooks/pre-commit`\n- `git diff --check`\n- `make check-branch`\n\n## 5. Eval 영향\n\nNo retrieval, reranker, verifier, prompt, answer, chunking, or eval runtime behavior change. This is a report/provenance decision surface only and makes no RAG quality or performance claim.\n\n### 5b. Real-data delta\n\n검색/검증 path 동작 변화 없음. Real-data delta was not run because this PR does not change load-bearing retrieval/eval runtime behavior. The private `real100_v2` audit was used only as aggregate readiness evidence and reported citation page claim `NO-GO`, 100 documents / 21,800 chunks, and 0.0 chunk page metadata coverage.\n\n## 6. 하위 호환\n\nNo CLI contract, answer schema, or runtime behavior change. The strategy aggregate remains schema version 1; Markdown output only gains provenance/freshness text.\n\n## 7. 범위 외\n\n- Page-aware re-index / page metadata recovery remains separate (#1573).\n- MiniLM vs hashing vs BGE-M3 baseline audit remains separate (#1575).\n- No concrete retrieval, reranking, section expansion, or query decomposition change in this PR.\n