### PR TITLE
Recover PyMuPDF4LLM page metadata in fixed chunks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 .PHONY: eval smoke reproduce benchmark pareto cost-frontier korean-public-fetch korean-public-eval harness-smoke harness-ablation harness-compare
 
 # Real-data eval cycle (private; ADR 0005 commit boundary).
-.PHONY: real-eval real-eval-check real-eval-inventory real-eval-semantic real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
+.PHONY: real-eval real-eval-check real-eval-inventory real-eval-semantic real-eval-page-aware real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
 
 # Real-data case proposer cycle (ADR 0029; gitignored I/O).
 .PHONY: case-propose case-propose-metadata case-review case-promote
@@ -1004,6 +1004,18 @@ real-eval-semantic:
 	  REAL_EVAL_INDEX_DIR=data/index/real100_m3 \
 	  OUTPUT_DIR=outputs/real100_m3 \
 	  REAL_EVAL_REPORT_DIR=reports/real100_m3 \
+	  bash scripts/smoke_real.sh
+
+# Page-aware citation readiness variant for issue #1573. Keeps the canonical
+# hashing real100 index untouched while rebuilding into a separate section-
+# chunked index that can preserve PyMuPDF4LLM page sections on chunks.
+real-eval-page-aware:
+	CHUNKING_STRATEGY=section \
+	  HWP_PDF_ARTIFACT_DIR=data/private/real100_v2/converted_pdfs \
+	  BIDMATE_HWP_PDF_ARTIFACT_REUSE=1 \
+	  REAL_EVAL_INDEX_DIR=data/index/real100_pageaware \
+	  OUTPUT_DIR=outputs/real100_pageaware \
+	  REAL_EVAL_REPORT_DIR=reports/real100_pageaware \
 	  bash scripts/smoke_real.sh
 
 # Render an aggregate-only markdown delta between the current

--- a/docs/plans/T-2026-0024-page-metadata-reindex.md
+++ b/docs/plans/T-2026-0024-page-metadata-reindex.md
@@ -1,0 +1,105 @@
+# Plan: T-2026-0024 Page Metadata Reindex
+
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0024`
+- Related issue / PR: [#1573](https://github.com/hskim-solv/BidMate-DocAgent/issues/1573) / PR TBD
+
+## Problem
+
+The page metadata blocker was misdiagnosed as missing conversion output. The
+local `real100_v2` private artifacts include 100 parsed Markdown exports, 94
+converted PDFs, and 100 parse checkpoints. The useful recovery source is the
+checkpointed parser document shape: sections already carry explicit
+`page_span`. The stale index lost that metadata because fixed chunking built a
+document-wide parent section from section text while only aggregating
+`regions`, not `page_span`.
+
+## Desired Outcome
+
+Rebuild private indexes with page metadata available on chunks before choosing
+multi-chunk retrieval changes, without changing retrieval ranking, verifier,
+prompt, answer, or eval scoring behavior.
+
+## Scope
+
+- Preserve explicit section-level `page_span` through `fixed_parent_section`.
+- Keep the existing `make real-eval` defaults unchanged.
+- Add an isolated `real-eval-page-aware` target for local page-aware rebuilds
+  that reuse private converted PDFs and write to separate output paths.
+- Record only aggregate validation evidence.
+
+## Out Of Scope
+
+- No MiniLM/BGE-M3 baseline decision; issue #1575 covers embedding baseline
+  separation.
+- No retrieval, reranking, query decomposition, section expansion, verifier, or
+  answer runtime change.
+- No raw private text, filenames, doc IDs, chunk IDs, checkpoint payloads, or
+  local paths in committed artifacts.
+
+## Implementation Notes
+
+- `ingestion._sections_from_pymupdf4llm_output()` already creates page sections
+  with `page_span`.
+- `ingestion._sections_from_loader()` and `normalize_ingestion_row()` already
+  preserve loader sections into document payloads.
+- `rag_indexing.make_chunk()` already copies parent `page_span` into chunks.
+- The smallest lossy boundary is `rag_metadata_processing.fixed_parent_section`;
+  it now aggregates explicit section page spans when fixed chunking builds a
+  document parent section.
+
+## Validation
+
+```bash
+bash -n scripts/smoke_real.sh
+python3 -m pytest -q tests/test_smoke_real_script.py tests/test_page_aware_parser_contract.py tests/test_page_metadata_recovery_audit.py tests/test_build_private_real100_v2_parallel.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_export_private_index_markdown.py
+python3 -m py_compile ingestion.py rag_metadata_processing.py rag_indexing.py scripts/build_private_real100_v2_parallel.py scripts/build_index.py
+python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_pageaware" --format markdown
+python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_fixed_pageaware" --format markdown
+git diff --check
+make check-branch
+```
+
+## Evidence
+
+- Local section page-aware rebuild from cached checkpoints completed with 100
+  documents and 24,613 chunks.
+- Local fixed rebuild from the same cached checkpoints completed with 100
+  documents and 21,800 chunks.
+- Aggregate-only page metadata audit for both isolated rebuilds reported
+  citation page claim `GO`, chunk page metadata coverage 1.0, and chunk
+  `page_span` coverage 1.0.
+
+## Reviewer Focus
+
+- Confirm the change is metadata propagation only; retrieval ranking inputs and
+  answer generation are unchanged.
+- Confirm aggregate-only reporting and no private path/raw text leakage.
+- Confirm the PR does not claim performance improvement.
+- Confirm the documentation distinguishes coarse fixed chunk page ranges from
+  section/page-aware citation precision.
+
+## Session Handoff
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: `fix/issue-1573-page-metadata-reindex` / Codex worktree
+- Current status: implementation done; final validation and PR still needed.
+- Files touched: `Makefile`, `scripts/smoke_real.sh`,
+  `rag_metadata_processing.py`, `tests/test_page_aware_parser_contract.py`,
+  `tests/test_smoke_real_script.py`, `docs/plans/T-2026-0024-page-metadata-reindex.md`,
+  `tasks/queue.md`.
+- Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_page_aware_parser_contract.py tests/test_page_metadata_recovery_audit.py tests/test_build_private_real100_v2_parallel.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_export_private_index_markdown.py`; `python3 -m py_compile ingestion.py rag_metadata_processing.py rag_indexing.py scripts/build_private_real100_v2_parallel.py scripts/build_index.py`; `python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_pageaware" --format markdown`; `python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_fixed_pageaware" --format markdown`.
+- Results: section page-aware local rebuild from checkpoints reports 100
+  documents / 24,613 chunks / 1.0 chunk page-span coverage. Fixed rebuild
+  reports 100 documents / 21,800 chunks / 1.0 chunk page-span coverage.
+- Blockers: none known.
+- Open risks: fixed chunking produces coarse document-range page spans; precise
+  page citation quality still needs separate evaluation before claims.
+- Next action: run final validation and open PR.
+- Next safe command: `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_page_aware_parser_contract.py tests/test_page_metadata_recovery_audit.py tests/test_build_private_real100_v2_parallel.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_export_private_index_markdown.py`
+- Reviewer focus: page metadata propagation, privacy-safe evidence, no
+  performance claim.
+- Eval surface: ingestion/index metadata propagation; no retrieval ranking or
+  answer behavior change intended.

--- a/rag_metadata_processing.py
+++ b/rag_metadata_processing.py
@@ -170,10 +170,15 @@ def document_has_section_structure(doc: dict[str, Any]) -> bool:
 def fixed_parent_section(doc: dict[str, Any], sections: list[dict[str, Any]]) -> dict[str, Any]:
     parts = []
     regions = []
+    page_numbers = []
     for section in sections:
         heading = str(section.get("section") or "").strip()
         text = str(section.get("text") or "").strip()
-        regions.extend(normalize_regions(section.get("regions")))
+        section_regions = normalize_regions(section.get("regions"))
+        regions.extend(section_regions)
+        section_page_span = normalize_page_span(section.get("page_span"), section_regions)
+        if section_page_span:
+            page_numbers.extend(section_page_span)
         if heading and heading not in WEAK_SECTION_HEADINGS:
             parts.append(f"{heading}\n{text}")
         else:
@@ -190,7 +195,7 @@ def fixed_parent_section(doc: dict[str, Any], sections: list[dict[str, Any]]) ->
         "section_path": ["문서 전체"],
         "text": "\n\n".join(part for part in parts if part).strip(),
     }
-    page_span = normalize_page_span(None, regions)
+    page_span = [min(page_numbers), max(page_numbers)] if page_numbers else normalize_page_span(None, regions)
     if regions:
         parent["regions"] = regions
     if page_span:

--- a/scripts/smoke_real.sh
+++ b/scripts/smoke_real.sh
@@ -47,6 +47,8 @@ MODEL="${MODEL:-}"
 INGESTION_MODE="${INGESTION_MODE:-csv-text}"
 HWP_LOADER="${HWP_LOADER:-pdf_pymupdf4llm}"
 PDF_LOADER="${PDF_LOADER:-pdf_pymupdf4llm}"
+CHUNKING_STRATEGY="${CHUNKING_STRATEGY:-fixed}"
+HWP_PDF_ARTIFACT_DIR="${HWP_PDF_ARTIFACT_DIR:-}"
 
 log() {
   printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$1"
@@ -104,6 +106,10 @@ MODEL_ARGS=()
 if [[ -n "$MODEL" ]]; then
   MODEL_ARGS=(--model "$MODEL")
 fi
+HWP_PDF_ARTIFACT_ARGS=()
+if [[ -n "$HWP_PDF_ARTIFACT_DIR" ]]; then
+  HWP_PDF_ARTIFACT_ARGS=(--hwp_pdf_artifact_dir "$HWP_PDF_ARTIFACT_DIR")
+fi
 python3 scripts/build_index.py \
   --metadata_csv "$METADATA_CSV" \
   --files_dir "$FILES_DIR" \
@@ -112,6 +118,8 @@ python3 scripts/build_index.py \
   --pdf_loader "$PDF_LOADER" \
   --output_dir "$INDEX_DIR" \
   --embedding_backend "$EMBEDDING_BACKEND" \
+  --chunking_strategy "$CHUNKING_STRATEGY" \
+  "${HWP_PDF_ARTIFACT_ARGS[@]+"${HWP_PDF_ARTIFACT_ARGS[@]}"}" \
   "${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"}"
 
 log "Running real-data sample query"

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -34,6 +34,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 21 | `T-2026-0021` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 implemented; draft PR #1552. |
 | 22 | `T-2026-0022` | `review` | Planner -> Implementer -> Reviewer | issue #1563; aggregate strategy decision implemented; retrieval change deferred until page-aware re-index evidence. |
 | 23 | `T-2026-0023` | `review` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | issue #1569; PR #1570. |
+| 24 | `T-2026-0024` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1573; page metadata recovery patch implemented and local page-aware re-index audit passes. |
 
 ## Examples
 
@@ -2052,3 +2053,117 @@ make check-branch
 - Plan: [`docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md`](../docs/plans/T-2026-0023-rag-performance-agent-operating-goal.md)
 - Issue: [#1569](https://github.com/hskim-solv/BidMate-DocAgent/issues/1569)
 - PR: [#1570](https://github.com/hskim-solv/BidMate-DocAgent/pull/1570)
+
+## T-2026-0024 — Recover PyMuPDF4LLM page metadata at index build
+
+- ID: T-2026-0024
+- Title: Recover PyMuPDF4LLM page metadata at index build
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Fix the page metadata recovery blocker before multi-chunk retrieval changes:
+PyMuPDF4LLM parser checkpoints already contain section-level `page_span`, but
+the current fixed-chunk build drops page-span-only metadata before chunks reach
+the index.
+
+### Context
+
+- Issue: #1573
+- Related blocker: T-2026-0022 deferred retrieval changes until page-aware
+  evidence exists.
+- Discovery: `real100_v2` has 100 parsed Markdown exports, 94 converted PDFs,
+  and 100 parse checkpoints. The checkpoints already contain page-aware
+  `document.sections[].page_span`; `parsed_md` is text-only and not the recovery
+  source.
+- Current stale index symptom: `text_source=pdf_pymupdf4llm`, but chunk
+  `page_span` / `regions.page_number` coverage is 0.0.
+
+### Scope
+
+- Preserve explicit section-level `page_span` when fixed chunking builds a
+  document-wide parent section.
+- Add an isolated `real-eval-page-aware` local target that reuses private
+  converted PDFs and writes to separate local output paths.
+- Keep canonical `make real-eval` default hashing/fixed behavior unchanged
+  except for additive page metadata fields on chunks.
+- Record aggregate-only validation evidence; do not commit raw private
+  checkpoints, converted PDFs, indexes, reports, doc IDs, filenames, or paths.
+
+### Non-Goals
+
+- Do not change retrieval, reranking, prompt, verifier, answer, or eval scoring
+  behavior.
+- Do not claim RAG quality, recall, latency, or production performance improved.
+- Do not switch the canonical baseline to MiniLM or BGE-M3; issue #1575 tracks
+  embedding baseline separation.
+
+### Acceptance Criteria
+
+- [x] Fixed chunking preserves explicit parser-owned page spans from sections.
+- [x] `scripts/smoke_real.sh` exposes `CHUNKING_STRATEGY` and optional
+  `HWP_PDF_ARTIFACT_DIR` without changing defaults.
+- [x] `make real-eval-page-aware` writes to isolated local paths and enables
+  converted-PDF reuse.
+- [x] Synthetic tests cover fixed page-span propagation and script wiring.
+- [x] Local aggregate-only page metadata audit reports 1.0 page-span coverage on
+  isolated section and fixed rebuilds.
+
+### Validation Commands
+
+```bash
+bash -n scripts/smoke_real.sh
+python3 -m pytest -q tests/test_smoke_real_script.py tests/test_page_aware_parser_contract.py tests/test_page_metadata_recovery_audit.py tests/test_build_private_real100_v2_parallel.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_export_private_index_markdown.py
+python3 -m py_compile ingestion.py rag_metadata_processing.py rag_indexing.py scripts/build_private_real100_v2_parallel.py scripts/build_index.py
+python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_pageaware" --format markdown
+python3 scripts/page_metadata_recovery_audit.py --index-dir "$REAL_EVAL_ROOT/data/index/real100_fixed_pageaware" --format markdown
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Local page-aware rebuild uses cached private parse checkpoints, not raw
+  reparse, unless checkpoint fingerprints miss.
+- Audit output stays aggregate-only: document/chunk counts, source groups, and
+  coverage rates only.
+
+### Completion Proof
+
+Focused tests and syntax checks pass; local audits report citation page claim
+`GO` and chunk page-span coverage 1.0 for both isolated section
+`real100_pageaware` and fixed `real100_fixed_pageaware` rebuilds.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0024-page-metadata-reindex.md`](../docs/plans/T-2026-0024-page-metadata-reindex.md)
+- Issue: [#1573](https://github.com/hskim-solv/BidMate-DocAgent/issues/1573)
+- PR: TBD
+
+### Session Handoff
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: `fix/issue-1573-page-metadata-reindex` / Codex worktree
+- Current status: implementation done; final validation and PR still needed.
+- Files touched: `Makefile`, `scripts/smoke_real.sh`,
+  `rag_metadata_processing.py`, `tests/test_page_aware_parser_contract.py`,
+  `tests/test_smoke_real_script.py`, `docs/plans/T-2026-0024-page-metadata-reindex.md`,
+  `tasks/queue.md`.
+- Results: section page-aware local rebuild from checkpoints reports 100
+  documents / 24,613 chunks / 1.0 chunk page-span coverage. Fixed rebuild
+  reports 100 documents / 21,800 chunks / 1.0 chunk page-span coverage.
+- Blockers: none known.
+- Open risks: fixed chunking produces coarse document-range page spans; precise
+  page citation quality still needs section/page-aware evaluation before
+  performance claims.
+- Next action: run final validation, then open PR
+  for #1573.
+- Next safe command: `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_page_aware_parser_contract.py tests/test_page_metadata_recovery_audit.py tests/test_build_private_real100_v2_parallel.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_export_private_index_markdown.py`
+- Reviewer focus: no private path/raw text leakage, no performance claim, and
+  explicit distinction between coarse fixed spans and section page spans.
+- Eval surface: ingestion/index metadata propagation and private real-eval
+  readiness; no retrieval ranking or answer behavior change intended.

--- a/tests/test_page_aware_parser_contract.py
+++ b/tests/test_page_aware_parser_contract.py
@@ -161,6 +161,26 @@ def test_public_fixture_roundtrip_preserves_page_metadata() -> None:
     assert chunks[1]["regions"][0]["bbox"] == [10.0, 20.0, 110.0, 160.0]
 
 
+def test_fixed_chunking_preserves_explicit_section_page_span() -> None:
+    document = normalize_json_document(
+        {
+            "doc_id": "page-aware-fixed",
+            "title": "synthetic",
+            "sections": [
+                {"heading": "page-1", "text": "First page text.", "page_span": [1, 1]},
+                {"heading": "page-2", "text": "Second page text.", "page_span": [2, 2]},
+            ],
+        },
+        FIXTURE_DIR / "synthetic_fixed_sections.json",
+    )
+
+    chunks = build_chunks([document], chunking_strategy="fixed", max_chars=1000)
+
+    assert chunks[0]["chunking_strategy"] == "fixed"
+    assert chunks[0]["page_span"] == [1, 2]
+    assert "regions" not in chunks[0]
+
+
 @pytest.mark.parametrize(
     ("fixture_name", "malformed_key"),
     [

--- a/tests/test_smoke_real_script.py
+++ b/tests/test_smoke_real_script.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_smoke_real_exposes_chunking_strategy_without_changing_default() -> None:
+    script = (ROOT / "scripts" / "smoke_real.sh").read_text(encoding="utf-8")
+
+    assert 'CHUNKING_STRATEGY="${CHUNKING_STRATEGY:-fixed}"' in script
+    assert '--chunking_strategy "$CHUNKING_STRATEGY"' in script
+
+
+def test_smoke_real_can_pass_hwp_pdf_artifact_dir_for_reuse() -> None:
+    script = (ROOT / "scripts" / "smoke_real.sh").read_text(encoding="utf-8")
+
+    assert 'HWP_PDF_ARTIFACT_DIR="${HWP_PDF_ARTIFACT_DIR:-}"' in script
+    assert 'HWP_PDF_ARTIFACT_ARGS=(--hwp_pdf_artifact_dir "$HWP_PDF_ARTIFACT_DIR")' in script
+    assert '"${HWP_PDF_ARTIFACT_ARGS[@]+"${HWP_PDF_ARTIFACT_ARGS[@]}"}"' in script
+
+
+def test_makefile_has_isolated_page_aware_real_eval_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+
+    assert "real-eval-page-aware:" in makefile
+    assert "CHUNKING_STRATEGY=section" in makefile
+    assert "BIDMATE_HWP_PDF_ARTIFACT_REUSE=1" in makefile
+    assert "REAL_EVAL_INDEX_DIR=data/index/real100_pageaware" in makefile


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PyMuPDF4LLM parser/checkpoint에는 section-level `page_span`이 이미 있었지만, fixed 청킹(chunking)이 document-wide parent section을 만들 때 `regions`만 모으고 `page_span`은 버려서 current `real100_v2` index의 page metadata coverage가 0.0이었습니다. `fixed_parent_section()`이 explicit section `page_span`도 aggregate하도록 고치고, local-only `real-eval-page-aware` target을 추가해 page-aware rebuild를 canonical real100 경로와 분리했습니다.

Fixes #1573

## 2. 영향 파일

- `rag_metadata_processing.py`: fixed parent section이 explicit section `page_span`을 chunk까지 전달하도록 보존
- `scripts/smoke_real.sh`: `CHUNKING_STRATEGY`, optional `HWP_PDF_ARTIFACT_DIR` pass-through 추가, 기본값은 `fixed` 유지
- `Makefile`: isolated `real-eval-page-aware` target 추가
- `tests/test_page_aware_parser_contract.py`, `tests/test_smoke_real_script.py`: fixed page-span propagation and script wiring tests
- `docs/plans/T-2026-0024-page-metadata-reindex.md`, `tasks/queue.md`: plan/queue/handoff evidence

## 3. 리스크

가장 큰 리스크는 fixed chunk의 page span이 precise page citation처럼 오해되는 것입니다. 이 변경은 text-offset 추론 없이 parser-owned section page spans의 min/max만 document parent에 올리는 coarse range입니다. PR/plan/queue에 coarse fixed spans와 section page spans를 분리해서 적었습니다. Retrieval ranking input, verifier, prompt, answer generation은 바꾸지 않습니다.

## 4. 테스트

- `bash -n scripts/smoke_real.sh`
- `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_page_aware_parser_contract.py tests/test_page_metadata_recovery_audit.py tests/test_build_private_real100_v2_parallel.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_export_private_index_markdown.py`
- `python3 -m py_compile ingestion.py rag_metadata_processing.py rag_indexing.py scripts/build_private_real100_v2_parallel.py scripts/build_index.py`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0024-page-metadata-reindex.md`
- `git diff --check`
- `make check-branch`

Local aggregate-only private audits:
- section rebuild from cached checkpoints: citation page claim `GO`, 100 docs, 24,613 chunks, chunk page-span coverage 1.0
- fixed rebuild from cached checkpoints: citation page claim `GO`, 100 docs, 21,800 chunks, chunk page-span coverage 1.0

## 5. Eval 영향

No retrieval ranking, reranking, verifier, prompt, answer, or eval scoring behavior change. This is additive index metadata propagation and local workflow wiring only. No RAG quality, recall, latency, or production performance claim.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. `make real-eval-delta` was not run because the PR does not change retrieval/eval scoring behavior. Instead, local aggregate-only page metadata audits were run against isolated private rebuilds to verify readiness: both section and fixed rebuilds report citation page claim `GO` and chunk page-span coverage 1.0. Raw private indexes/checkpoints/reports are not committed.

## 6. 하위 호환

`make real-eval` remains hashing + fixed by default. `scripts/smoke_real.sh` default `CHUNKING_STRATEGY` is `fixed`, and `HWP_PDF_ARTIFACT_DIR` is optional. Added chunk `page_span` metadata is additive.

## 7. 범위 외

- MiniLM/BGE-M3/hash baseline separation remains #1575.
- Multi-chunk retrieval strategy changes remain blocked on follow-up measurement.
- Precise page citation quality and region/bbox grounding are not claimed here.
