### PR TITLE
Add named MiniLM real-eval target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 .PHONY: eval smoke reproduce benchmark pareto cost-frontier korean-public-fetch korean-public-eval harness-smoke harness-ablation harness-compare
 
 # Real-data eval cycle (private; ADR 0005 commit boundary).
-.PHONY: real-eval real-eval-check real-eval-inventory real-eval-semantic real-eval-page-aware real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
+.PHONY: real-eval real-eval-check real-eval-inventory real-eval-minilm real-eval-semantic real-eval-page-aware real-eval-delta real-eval-baseline-update real-eval-history-render real-eval-with-judge harness-real
 
 # Real-data case proposer cycle (ADR 0029; gitignored I/O).
 .PHONY: case-propose case-propose-metadata case-review case-promote
@@ -995,10 +995,21 @@ real-eval:
 	bash scripts/smoke_real.sh
 
 # Semantic variant of real-eval (issue #1295): builds a sentence-transformers
-# BGE-M3 index into a SEPARATE dir (real100_m3) so the canonical hashing
-# real100 index is untouched. Requires the model to be downloadable/cached
-# (not offline/CI-safe). Use this — not `real-eval` — when measuring dense or
-# hybrid retrieval recall, since hashing embeddings carry no semantic signal.
+# MiniLM index into a SEPARATE dir (real100_minilm) so the canonical hashing
+# real100 index is untouched. Requires the model to be downloadable/cached.
+real-eval-minilm:
+	EMBEDDING_BACKEND=sentence-transformers \
+	  MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 \
+	  REAL_EVAL_INDEX_DIR=data/index/real100_minilm \
+	  OUTPUT_DIR=outputs/real100_minilm \
+	  REAL_EVAL_REPORT_DIR=reports/real100_minilm \
+	  bash scripts/smoke_real.sh
+
+# Semantic comparison variant of real-eval (issue #1295): builds a BGE-M3 index
+# into a SEPARATE dir (real100_m3) so the canonical hashing real100 index is
+# untouched. Requires the model to be downloadable/cached (not offline/CI-safe).
+# Use semantic targets — not `real-eval` — when measuring dense or hybrid
+# retrieval recall, since hashing embeddings carry no semantic signal.
 real-eval-semantic:
 	EMBEDDING_BACKEND=sentence-transformers MODEL=BAAI/bge-m3 \
 	  REAL_EVAL_INDEX_DIR=data/index/real100_m3 \

--- a/docs/evaluation/private_real_eval_workflow.md
+++ b/docs/evaluation/private_real_eval_workflow.md
@@ -156,8 +156,9 @@ names, or absolute local paths.
 
 The contract runner builds the index when `index_build.mode: build_if_missing`
 and `<index_dir>/index.json` is absent. It loads the existing index when
-`index.json` is present. The template uses the project MiniLM default so the
-private run measures dense semantic retrieval, not the hashing smoke fallback.
+`index.json` is present. Do not infer the embedding model from
+`DEFAULT_EMBEDDING_MODEL` alone: the build surface is determined by both
+`--embedding_backend` and `--model`.
 
 The readiness scaffold also prints the expected build command shape when local
 private documents and manifest are present:
@@ -171,6 +172,20 @@ python3 scripts/build_index.py \
   --pdf_loader pdf_pymupdf4llm \
   --embedding_backend hashing
 ```
+
+That command is the deterministic offline hashing surface. It records
+`embedding.backend=hashing` and `embedding.model=local-hashing-bow`; it is not a
+MiniLM semantic run even though the CLI default model constant is MiniLM.
+
+Use separate named targets for semantic private runs:
+
+```bash
+make real-eval-minilm    # MiniLM sentence-transformers baseline
+make real-eval-semantic  # BGE-M3 semantic comparison
+```
+
+These write to separate local index/output/report directories and do not update
+the canonical hashing `real100` path.
 
 ## Validate Private Naive RAG Inputs
 
@@ -201,6 +216,11 @@ Or use the Make target:
 ```bash
 make real-eval
 ```
+
+`make real-eval` is the hashing/offline workflow-validation run. Do not use it
+as a dense semantic retrieval baseline or performance claim. Use
+`make real-eval-minilm` for the named MiniLM baseline, and `make
+real-eval-semantic` for the BGE-M3 comparison surface.
 
 To write the committable aggregate candidate after review:
 

--- a/docs/evaluation/surface-map.md
+++ b/docs/evaluation/surface-map.md
@@ -26,7 +26,7 @@ agent gate behavior is [Agent-Gated RFP Evaluation Loop](./agent-gated-rfp-eval-
 |---|---|---|---|---|---|
 | Public fixture smoke | `eval/fixtures/smoke_rfp/raw/`, `eval/config.yaml` | CI wiring, schema, deterministic regression, latency SLO | `make smoke`, `make harness-smoke`, `python3 eval/run_eval.py --index_dir data/index --output_dir reports --config eval/config.yaml` | raw run은 local/generated, small fixture는 commit 가능 | "eval harness가 동작한다", "regression guard 통과" |
 | Public synthetic benchmark | `data/eval/benchmark/`, `configs/eval/benchmark_naive_rag_v1.yaml` | controlled failure discovery, ablation setup | `python3 eval/naive_rag/validate_benchmark_dataset.py --config configs/eval/benchmark_naive_rag_v1.yaml --report reports/benchmark/naive_rag_v1_validation.json`, `python3 -m eval.naive_rag.benchmark --config configs/eval/benchmark_naive_rag_v1.yaml` | synthetic corpus/config/gold는 public; generated run artifacts는 local | "synthetic v1에서 failure mode X 관측" |
-| Private real-eval | `eval/real_config.local.yaml`, private corpus/index, `reports/real100/` local outputs | real RFP aggregate evidence, hardcase stress, paired delta | `make real-eval-check`, `make real-eval`, `make real-eval-semantic`, `make real-eval-delta` | raw/per-case local-only; allowlisted aggregate-only artifact만 commit | "private aggregate에서 delta X, provenance Y" |
+| Private real-eval | `eval/real_config.local.yaml`, private corpus/index, `reports/real100/` local outputs | real RFP aggregate evidence, hardcase stress, paired delta | `make real-eval-check`, `make real-eval`, `make real-eval-minilm`, `make real-eval-semantic`, `make real-eval-delta` | raw/per-case local-only; allowlisted aggregate-only artifact만 commit | "private aggregate에서 delta X, provenance Y" |
 | PR fixture eval | `.github/workflows/pr-eval.yml` | PR마다 public fixture delta와 tests 검증 | GitHub Actions `PR Eval Delta` | PR comment/check only | "CI smoke delta passed/failed" |
 | Slow tests | `pytest -m slow`, `.github/workflows/slow-tests.yml` | real-model/full-corpus risk 확인 | `PYTEST_ADDOPTS="-m slow" bash scripts/test.sh` | generated outputs local | "slow gate passed on date/SHA" |
 
@@ -93,7 +93,7 @@ agent gate behavior is [Agent-Gated RFP Evaluation Loop](./agent-gated-rfp-eval-
   dataset/config/index/provenance.
 - `make real-eval` uses the deterministic offline hashing path unless overridden. It is useful for
   repeatable private eval plumbing, but semantic dense/hybrid retrieval quality claims require
-  `make real-eval-semantic` or equivalent semantic index provenance.
+  `make real-eval-minilm`, `make real-eval-semantic`, or equivalent semantic index provenance.
 - CI green means non-slow tests plus fixture smoke gate passed. It does not mean private real-eval passed.
 
 ## Benchmark Auditor Checklist

--- a/docs/plans/T-2026-0025-minilm-baseline-target.md
+++ b/docs/plans/T-2026-0025-minilm-baseline-target.md
@@ -1,0 +1,82 @@
+# Plan: T-2026-0025 MiniLM Baseline Target
+
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0025`
+- Related issue / PR: [#1575](https://github.com/hskim-solv/BidMate-DocAgent/issues/1575) / PR TBD
+
+## Problem
+
+The private real-eval surface used ambiguous naming: `DEFAULT_EMBEDDING_MODEL`
+is MiniLM, but `make real-eval` forces `EMBEDDING_BACKEND=hashing`, so the
+actual index records `embedding.backend=hashing` and
+`embedding.model=local-hashing-bow`. Operators could reasonably mistake that
+hashing run for a MiniLM semantic baseline.
+
+## Desired Outcome
+
+Make the three baseline surfaces explicit:
+
+- `make real-eval`: hashing/offline workflow-validation surface.
+- `make real-eval-minilm`: MiniLM sentence-transformers private baseline.
+- `make real-eval-semantic`: BGE-M3 semantic comparison surface.
+
+## Scope
+
+- Add a named MiniLM target with isolated local index/output/report paths.
+- Update docs so backend/model selection is explicit.
+- Add focused tests that lock the Makefile target and script comment wording.
+
+## Out Of Scope
+
+- Do not run MiniLM or BGE-M3 private eval.
+- Do not update aggregate baselines or performance reports.
+- Do not claim any quality, recall, latency, or production improvement.
+- Do not change retrieval, reranking, verifier, prompt, answer, or eval scoring.
+
+## Validation
+
+```bash
+bash -n scripts/smoke_real.sh
+python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md
+git diff --check
+make check-branch
+```
+
+## Evidence
+
+- `make real-eval-minilm` sets `EMBEDDING_BACKEND=sentence-transformers`,
+  `MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`, and
+  separate `real100_minilm` local paths.
+- Private workflow docs state that `make real-eval` is hashing/offline and not a
+  MiniLM semantic run.
+
+## Reviewer Focus
+
+- Confirm target naming matches actual backend/model behavior.
+- Confirm no performance claim is made.
+- Confirm no private raw artifact or path is committed.
+
+## Session Handoff
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: `eval/issue-1575-minilm-baseline-target` / Codex worktree
+- Current status: implementation validated; PR still needed.
+- Files touched: `Makefile`, `scripts/smoke_real.sh`,
+  `docs/evaluation/private_real_eval_workflow.md`,
+  `docs/private-real-eval-inventory.md`, `tests/test_smoke_real_script.py`,
+  `docs/plans/T-2026-0025-minilm-baseline-target.md`, `tasks/queue.md`.
+- Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md`; `git diff --check`; `make check-branch`.
+- Results: named MiniLM target added; docs now separate hashing, MiniLM, and
+  BGE-M3 surfaces.
+- Blockers: none known.
+- Open risks: MiniLM target existence does not prove model availability or
+  performance; actual private eval remains a separate local run.
+- Next action: open PR.
+- Next safe command: `gh pr create --draft --base main --head eval/issue-1575-minilm-baseline-target`
+- Reviewer focus: baseline wording, no performance claim, and actual
+  backend/model naming.
+- Eval surface: workflow/docs only; no retrieval or eval runtime behavior change
+  except new opt-in target.

--- a/docs/plans/T-2026-0025-minilm-baseline-target.md
+++ b/docs/plans/T-2026-0025-minilm-baseline-target.md
@@ -55,7 +55,8 @@ make check-branch
 - Private workflow docs state that `make real-eval` is hashing/offline and not a
   MiniLM semantic run.
 - Aggregate `run_manifest` extraction keeps `embedding_backend`,
-  `embedding_model_id`, and `embedding_dim` while still dropping `config_path`.
+  `embedding_model_id`, and `embedding_dim` while still dropping `config_path`
+  and redacting local embedding model paths.
 
 ## Reviewer Focus
 
@@ -78,7 +79,7 @@ make check-branch
 - Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`; `python3 -m pytest -q tests/test_run_real_eval_delta.py -k run_manifest`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md docs/evaluation/surface-map.md`; `git diff --check`; `make check-branch`.
 - Results: named MiniLM target added; docs now separate hashing, MiniLM, and
   BGE-M3 surfaces; aggregate run-manifest extraction preserves embedding
-  provenance without private path leakage.
+  provenance without private path leakage, including local model paths.
 - Blockers: none known.
 - Open risks: MiniLM target existence does not prove model availability or
   performance; actual private eval remains a separate local run.

--- a/docs/plans/T-2026-0025-minilm-baseline-target.md
+++ b/docs/plans/T-2026-0025-minilm-baseline-target.md
@@ -3,7 +3,7 @@
 - Status: review
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0025`
-- Related issue / PR: [#1575](https://github.com/hskim-solv/BidMate-DocAgent/issues/1575) / PR TBD
+- Related issue / PR: [#1575](https://github.com/hskim-solv/BidMate-DocAgent/issues/1575) / [#1579](https://github.com/hskim-solv/BidMate-DocAgent/pull/1579)
 
 ## Problem
 
@@ -26,11 +26,13 @@ Make the three baseline surfaces explicit:
 - Add a named MiniLM target with isolated local index/output/report paths.
 - Update docs so backend/model selection is explicit.
 - Add focused tests that lock the Makefile target and script comment wording.
+- Keep aggregate run-manifest provenance explicit for embedding backend/model.
 
 ## Out Of Scope
 
 - Do not run MiniLM or BGE-M3 private eval.
 - Do not update aggregate baselines or performance reports.
+- Do not expose private paths or raw private artifacts in aggregate reports.
 - Do not claim any quality, recall, latency, or production improvement.
 - Do not change retrieval, reranking, verifier, prompt, answer, or eval scoring.
 
@@ -39,7 +41,8 @@ Make the three baseline surfaces explicit:
 ```bash
 bash -n scripts/smoke_real.sh
 python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py
-python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md
+python3 -m pytest -q tests/test_run_real_eval_delta.py -k run_manifest
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md docs/evaluation/surface-map.md
 git diff --check
 make check-branch
 ```
@@ -51,6 +54,8 @@ make check-branch
   separate `real100_minilm` local paths.
 - Private workflow docs state that `make real-eval` is hashing/offline and not a
   MiniLM semantic run.
+- Aggregate `run_manifest` extraction keeps `embedding_backend`,
+  `embedding_model_id`, and `embedding_dim` while still dropping `config_path`.
 
 ## Reviewer Focus
 
@@ -65,17 +70,20 @@ make check-branch
 - Branch / worktree: `eval/issue-1575-minilm-baseline-target` / Codex worktree
 - Current status: implementation validated; PR still needed.
 - Files touched: `Makefile`, `scripts/smoke_real.sh`,
+  `scripts/run_real_eval_delta.py`,
   `docs/evaluation/private_real_eval_workflow.md`,
-  `docs/private-real-eval-inventory.md`, `tests/test_smoke_real_script.py`,
+  `docs/evaluation/surface-map.md`, `docs/private-real-eval-inventory.md`,
+  `tests/test_smoke_real_script.py`, `tests/test_run_real_eval_delta.py`,
   `docs/plans/T-2026-0025-minilm-baseline-target.md`, `tasks/queue.md`.
-- Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md`; `git diff --check`; `make check-branch`.
+- Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`; `python3 -m pytest -q tests/test_run_real_eval_delta.py -k run_manifest`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md docs/evaluation/surface-map.md`; `git diff --check`; `make check-branch`.
 - Results: named MiniLM target added; docs now separate hashing, MiniLM, and
-  BGE-M3 surfaces.
+  BGE-M3 surfaces; aggregate run-manifest extraction preserves embedding
+  provenance without private path leakage.
 - Blockers: none known.
 - Open risks: MiniLM target existence does not prove model availability or
   performance; actual private eval remains a separate local run.
-- Next action: open PR.
-- Next safe command: `gh pr create --draft --base main --head eval/issue-1575-minilm-baseline-target`
+- Next action: push and mark PR ready.
+- Next safe command: `git status --short`
 - Reviewer focus: baseline wording, no performance claim, and actual
   backend/model naming.
 - Eval surface: workflow/docs only; no retrieval or eval runtime behavior change

--- a/docs/private-real-eval-inventory.md
+++ b/docs/private-real-eval-inventory.md
@@ -16,8 +16,9 @@ deprecated/dead reference 로 분리한다. 조사 기준은 repo-wide `rg` 로
 | `data/files/` | required input | `scripts/build_index.py --files_dir`, `scripts/validate_data_list.py --files_dir`, kordoc source hashing | yes | no | `REAL_EVAL_DATA_DIR`, `real_eval.document_dirs.default` |
 | `data/files_kordoc/` | regenerable cache | `ingestion._resolve_kordoc_cache_dir`, `scripts/build_kordoc_manifest.py`, `BIDMATE_KORDOC_CACHE_DIR` | no | yes | `REAL_EVAL_KORDOC_DATA_DIR`, `real_eval.document_dirs.kordoc` |
 | `.cache/real_eval/` | regenerable cache | resolver-owned root for OCR/parsed/layout/embedding cache placement | no | yes | `REAL_EVAL_CACHE_DIR`, `real_eval.cache.root` |
-| `data/index/real100/` | regenerable cache | `app.py --input_dir`, `eval/run_eval.py --index_dir`, `scripts/smoke_real.sh` | no | yes | `REAL_EVAL_INDEX_DIR`, `real_eval.index.root` |
-| `data/index/real100_m3/` | deprecated / removed artifact when 898 chunks | `scripts/phase35_m3_ablation.py --index_dir_m3`, old Phase 3.5 reports | no | yes | `REAL_EVAL_INDEX_DIR` for current rebuilds |
+| `data/index/real100/` | regenerable cache | `app.py --input_dir`, `eval/run_eval.py --index_dir`, `scripts/smoke_real.sh`, `make real-eval` | no | yes | `REAL_EVAL_INDEX_DIR`, `real_eval.index.root`; hashing/offline surface |
+| `data/index/real100_minilm/` | regenerable cache | `make real-eval-minilm` | no | yes | `REAL_EVAL_INDEX_DIR`; MiniLM sentence-transformers baseline |
+| `data/index/real100_m3/` | regenerable cache | `make real-eval-semantic`, `scripts/phase35_m3_ablation.py --index_dir_m3` | no | yes | `REAL_EVAL_INDEX_DIR`; BGE-M3 semantic comparison |
 | `data/index/real100_kordoc/` | regenerable cache | Phase 4 metadata retrieval reports and docs | no | yes | `REAL_EVAL_INDEX_DIR` for kordoc-only runs |
 | `outputs/real100/` | output artifact | `scripts/smoke_real.sh`, `app.py --output_dir` | no | yes | `OUTPUT_DIR` |
 | `reports/real100/` | output artifact | `eval/run_eval.py --output_dir`, `scripts/run_real_eval_delta.py` | no | yes | `REAL_EVAL_REPORT_DIR`, `real_eval.reports.output_dir` |

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -277,7 +277,15 @@ SAFE_RETRY_EFFECTIVENESS_CI_KEYS = ("recovery_rate", "residual_failure_rate")
 # (filesystem layout is not committable); ``config_sha256`` is the
 # canonical config identifier. Nested offline/online provenance fields are
 # scalar-only and contain no case payload or exact local path.
-SAFE_RUN_MANIFEST_KEYS = ("git_commit", "git_dirty", "config_sha256", "generated_at")
+SAFE_RUN_MANIFEST_KEYS = (
+    "git_commit",
+    "git_dirty",
+    "config_sha256",
+    "generated_at",
+    "embedding_backend",
+    "embedding_model_id",
+    "embedding_dim",
+)
 SAFE_RUN_MANIFEST_NESTED_KEYS = {
     "environment": (
         "mode",

--- a/scripts/run_real_eval_delta.py
+++ b/scripts/run_real_eval_delta.py
@@ -301,6 +301,29 @@ SAFE_RUN_MANIFEST_NESTED_KEYS = {
 ABSOLUTE_LOCAL_PATH_RE = re.compile(
     r"(?<![A-Za-z0-9_-])(?:/Users|/private|/var/folders|/Volumes)/[^\s)`'\"]+"
 )
+LOCAL_MODEL_PATH_PREFIXES = frozenset(
+    {
+        ".cache",
+        "artifacts",
+        "cache",
+        "checkpoints",
+        "data",
+        "eval",
+        "models",
+        "outputs",
+        "private",
+        "reports",
+        "tmp",
+    }
+)
+MODEL_ARTIFACT_SUFFIXES = (
+    ".bin",
+    ".gguf",
+    ".onnx",
+    ".pt",
+    ".pth",
+    ".safetensors",
+)
 PRIVATE_INLINE_VALUE_RE = re.compile(
     r"\b(?:(?:raw\s+)?(?:question|answer|evidence)|doc[_ -]?id|"
     r"chunk[_ -]?id|file\s*name|filename)\s*[:=]\s*[^\n;,]+",
@@ -570,7 +593,7 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
             # Drop config_path (filesystem layout, not committable).
             # Keep reproducibility fields and scalar offline/online provenance.
             manifest_out = {
-                sub: _safe_run_manifest_value(value.get(sub))
+                sub: _safe_run_manifest_field(sub, value.get(sub))
                 for sub in SAFE_RUN_MANIFEST_KEYS
                 if value.get(sub) is not None
             }
@@ -579,7 +602,7 @@ def extract_aggregate(summary: dict[str, Any]) -> dict[str, Any]:
                 if not isinstance(raw_section, dict):
                     continue
                 section_out = {
-                    sub: _safe_run_manifest_value(raw_section.get(sub))
+                    sub: _safe_run_manifest_field(sub, raw_section.get(sub))
                     for sub in allowed
                     if raw_section.get(sub) is not None
                 }
@@ -779,6 +802,26 @@ def _safe_run_manifest_value(value: Any) -> Any:
     if PRIVATE_INLINE_VALUE_RE.search(text):
         return "[redacted-private-value]"
     return text
+
+
+def _safe_run_manifest_field(field: str, value: Any) -> Any:
+    safe_value = _safe_run_manifest_value(value)
+    if field == "embedding_model_id" and isinstance(safe_value, str):
+        if _looks_like_local_model_path(safe_value):
+            return "[redacted-local-path]"
+    return safe_value
+
+
+def _looks_like_local_model_path(value: str) -> bool:
+    text = value.strip().replace("\\", "/")
+    if not text:
+        return False
+    if text.startswith(("/", "./", "../", "~/")):
+        return True
+    first_segment = text.split("/", 1)[0].lower()
+    if first_segment in LOCAL_MODEL_PATH_PREFIXES:
+        return True
+    return text.lower().endswith(MODEL_ARTIFACT_SUFFIXES)
 
 
 def _assert_no_forbidden(obj: Any, path: str = "") -> None:

--- a/scripts/smoke_real.sh
+++ b/scripts/smoke_real.sh
@@ -37,9 +37,9 @@ QUERY="${QUERY:-한영대학교 특성화 맞춤형 교육환경 구축 사업�
 # the CI-safe SSoT baseline (ADR 0061). BUT it is *semantic-blind*: dense/hybrid
 # retrieval recall measured on a hashing index is meaningless (issue #1295).
 # For semantic retrieval measurement build with sentence-transformers + a real
-# model, e.g. `make real-eval-semantic` (EMBEDDING_BACKEND=sentence-transformers
-# MODEL=BAAI/bge-m3). The #1212 provenance banner WARNs at run start when an
-# index is hashing-backed.
+# model, e.g. `make real-eval-minilm` for the named MiniLM baseline or
+# `make real-eval-semantic` for the BGE-M3 comparison. The #1212 provenance
+# banner WARNs at run start when an index is hashing-backed.
 EMBEDDING_BACKEND="${EMBEDDING_BACKEND:-hashing}"
 # MODEL empty → build_index.py uses its DEFAULT_EMBEDDING_MODEL; pass-through
 # only when set so the default `make real-eval` invocation stays byte-identical.

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -35,6 +35,7 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 22 | `T-2026-0022` | `review` | Planner -> Implementer -> Reviewer | issue #1563; aggregate strategy decision implemented; retrieval change deferred until page-aware re-index evidence. |
 | 23 | `T-2026-0023` | `review` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | issue #1569; PR #1570. |
 | 24 | `T-2026-0024` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1573; page metadata recovery patch implemented and local page-aware re-index audit passes. |
+| 25 | `T-2026-0025` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1575; named MiniLM target and baseline-surface wording implemented. |
 
 ## Examples
 
@@ -2167,3 +2168,100 @@ Focused tests and syntax checks pass; local audits report citation page claim
   explicit distinction between coarse fixed spans and section page spans.
 - Eval surface: ingestion/index metadata propagation and private real-eval
   readiness; no retrieval ranking or answer behavior change intended.
+
+## T-2026-0025 — Separate hashing, MiniLM, and BGE-M3 real-eval surfaces
+
+- ID: T-2026-0025
+- Title: Separate hashing, MiniLM, and BGE-M3 real-eval surfaces
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Remove the ambiguity where operators saw the MiniLM default model name but the
+actual canonical private run used `EMBEDDING_BACKEND=hashing` and therefore
+produced `local-hashing-bow` vectors.
+
+### Context
+
+- Issue: #1575
+- `make real-eval` is deterministic/offline hashing and should be treated as a
+  workflow-validation surface, not semantic retrieval evidence.
+- `make real-eval-semantic` currently means BGE-M3 comparison.
+- There was no named MiniLM private real-eval target even though
+  `DEFAULT_EMBEDDING_MODEL` is MiniLM.
+
+### Scope
+
+- Add `make real-eval-minilm` as the named sentence-transformers MiniLM private
+  baseline target.
+- Keep `make real-eval` hashing/offline and `make real-eval-semantic` BGE-M3.
+- Update private workflow/inventory docs so backend/model surfaces are explicit.
+- Add focused tests for target wiring and comments.
+
+### Non-Goals
+
+- Do not run MiniLM or BGE-M3 private eval in this PR.
+- Do not update committed baselines or performance numbers.
+- Do not change retrieval, reranking, verifier, prompt, answer, or eval scoring.
+
+### Acceptance Criteria
+
+- [x] `make real-eval-minilm` writes to separate local paths:
+  `data/index/real100_minilm`, `outputs/real100_minilm`,
+  `reports/real100_minilm`.
+- [x] Docs state that `make real-eval` is hashing/offline and not MiniLM.
+- [x] Docs distinguish MiniLM baseline from BGE-M3 comparison.
+- [x] No performance claim is made from hashing runs.
+
+### Validation Commands
+
+```bash
+bash -n scripts/smoke_real.sh
+python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused tests pass.
+- Docs and Makefile name actual backend/model surfaces.
+- PR body says no private real-eval was run and no performance claim is made.
+
+### Completion Proof
+
+Focused tests and doc-link checks pass; `make real-eval-minilm` exists as the
+named MiniLM sentence-transformers target.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0025-minilm-baseline-target.md`](../docs/plans/T-2026-0025-minilm-baseline-target.md)
+- Issue: [#1575](https://github.com/hskim-solv/BidMate-DocAgent/issues/1575)
+- PR: TBD
+
+### Session Handoff
+
+- Role: Implementer
+- Lifecycle stage: review
+- Branch / worktree: `eval/issue-1575-minilm-baseline-target` / Codex worktree
+- Current status: implementation validated; PR still needed.
+- Files touched: `Makefile`, `scripts/smoke_real.sh`,
+  `docs/evaluation/private_real_eval_workflow.md`,
+  `docs/private-real-eval-inventory.md`, `tests/test_smoke_real_script.py`,
+  `docs/plans/T-2026-0025-minilm-baseline-target.md`, `tasks/queue.md`.
+- Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md`; `git diff --check`; `make check-branch`.
+- Results: named MiniLM target added; docs now state `make real-eval` is
+  hashing/offline and not MiniLM. Focused validation passed.
+- Blockers: none known.
+- Open risks: target existence does not prove MiniLM model cache/download or
+  performance; actual MiniLM private eval remains a separate run.
+- Next action: open PR for #1575.
+- Next safe command: `gh pr create --draft --base main --head eval/issue-1575-minilm-baseline-target`
+- Reviewer focus: baseline wording, no performance claim, and actual
+  backend/model naming.
+- Eval surface: workflow/docs only; no retrieval or eval runtime behavior change
+  except new opt-in target.

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -1953,7 +1953,7 @@ Focused validation passes and the follow-up evidence is recorded in
 
 - Plan: [`docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md`](../docs/plans/T-2026-0022-use-multi-chunk-evidence-analysis-for-the-next-retrieval-fol.md)
 - Issue: [#1563](https://github.com/hskim-solv/BidMate-DocAgent/issues/1563)
-- PR: TBD
+- PR: [#1576](https://github.com/hskim-solv/BidMate-DocAgent/pull/1576)
 
 ### Session Handoff
 
@@ -2200,11 +2200,14 @@ produced `local-hashing-bow` vectors.
 - Keep `make real-eval` hashing/offline and `make real-eval-semantic` BGE-M3.
 - Update private workflow/inventory docs so backend/model surfaces are explicit.
 - Add focused tests for target wiring and comments.
+- Preserve `embedding_backend`, `embedding_model_id`, and `embedding_dim` in
+  aggregate `run_manifest` extraction so reviewers can see what actually ran.
 
 ### Non-Goals
 
 - Do not run MiniLM or BGE-M3 private eval in this PR.
 - Do not update committed baselines or performance numbers.
+- Do not expose private paths or raw private artifacts in aggregate reports.
 - Do not change retrieval, reranking, verifier, prompt, answer, or eval scoring.
 
 ### Acceptance Criteria
@@ -2214,6 +2217,8 @@ produced `local-hashing-bow` vectors.
   `reports/real100_minilm`.
 - [x] Docs state that `make real-eval` is hashing/offline and not MiniLM.
 - [x] Docs distinguish MiniLM baseline from BGE-M3 comparison.
+- [x] Aggregate run-manifest extraction keeps embedding backend/model/dim while
+  still dropping local config paths.
 - [x] No performance claim is made from hashing runs.
 
 ### Validation Commands
@@ -2221,7 +2226,8 @@ produced `local-hashing-bow` vectors.
 ```bash
 bash -n scripts/smoke_real.sh
 python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py
-python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md
+python3 -m pytest -q tests/test_run_real_eval_delta.py -k run_manifest
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md docs/evaluation/surface-map.md
 git diff --check
 make check-branch
 ```
@@ -2230,18 +2236,20 @@ make check-branch
 
 - Focused tests pass.
 - Docs and Makefile name actual backend/model surfaces.
+- Aggregate reports retain embedding provenance without private path leakage.
 - PR body says no private real-eval was run and no performance claim is made.
 
 ### Completion Proof
 
 Focused tests and doc-link checks pass; `make real-eval-minilm` exists as the
-named MiniLM sentence-transformers target.
+named MiniLM sentence-transformers target, and aggregate `run_manifest`
+extraction preserves embedding provenance.
 
 ### Related Plan / Issue / PR Links
 
 - Plan: [`docs/plans/T-2026-0025-minilm-baseline-target.md`](../docs/plans/T-2026-0025-minilm-baseline-target.md)
 - Issue: [#1575](https://github.com/hskim-solv/BidMate-DocAgent/issues/1575)
-- PR: TBD
+- PR: [#1579](https://github.com/hskim-solv/BidMate-DocAgent/pull/1579)
 
 ### Session Handoff
 
@@ -2250,17 +2258,20 @@ named MiniLM sentence-transformers target.
 - Branch / worktree: `eval/issue-1575-minilm-baseline-target` / Codex worktree
 - Current status: implementation validated; PR still needed.
 - Files touched: `Makefile`, `scripts/smoke_real.sh`,
+  `scripts/run_real_eval_delta.py`,
   `docs/evaluation/private_real_eval_workflow.md`,
-  `docs/private-real-eval-inventory.md`, `tests/test_smoke_real_script.py`,
+  `docs/evaluation/surface-map.md`, `docs/private-real-eval-inventory.md`,
+  `tests/test_smoke_real_script.py`, `tests/test_run_real_eval_delta.py`,
   `docs/plans/T-2026-0025-minilm-baseline-target.md`, `tasks/queue.md`.
-- Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md`; `git diff --check`; `make check-branch`.
+- Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`; `python3 -m pytest -q tests/test_run_real_eval_delta.py -k run_manifest`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md docs/evaluation/surface-map.md`; `git diff --check`; `make check-branch`.
 - Results: named MiniLM target added; docs now state `make real-eval` is
-  hashing/offline and not MiniLM. Focused validation passed.
+  hashing/offline and not MiniLM; aggregate run-manifest extraction preserves
+  embedding provenance without private path leakage.
 - Blockers: none known.
 - Open risks: target existence does not prove MiniLM model cache/download or
   performance; actual MiniLM private eval remains a separate run.
-- Next action: open PR for #1575.
-- Next safe command: `gh pr create --draft --base main --head eval/issue-1575-minilm-baseline-target`
+- Next action: push and mark PR #1579 ready.
+- Next safe command: `git status --short`
 - Reviewer focus: baseline wording, no performance claim, and actual
   backend/model naming.
 - Eval surface: workflow/docs only; no retrieval or eval runtime behavior change

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -2218,7 +2218,7 @@ produced `local-hashing-bow` vectors.
 - [x] Docs state that `make real-eval` is hashing/offline and not MiniLM.
 - [x] Docs distinguish MiniLM baseline from BGE-M3 comparison.
 - [x] Aggregate run-manifest extraction keeps embedding backend/model/dim while
-  still dropping local config paths.
+  still dropping local config paths and redacting local model paths.
 - [x] No performance claim is made from hashing runs.
 
 ### Validation Commands
@@ -2243,7 +2243,7 @@ make check-branch
 
 Focused tests and doc-link checks pass; `make real-eval-minilm` exists as the
 named MiniLM sentence-transformers target, and aggregate `run_manifest`
-extraction preserves embedding provenance.
+extraction preserves embedding provenance without local model path leakage.
 
 ### Related Plan / Issue / PR Links
 
@@ -2266,7 +2266,7 @@ extraction preserves embedding provenance.
 - Commands run: `bash -n scripts/smoke_real.sh`; `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`; `python3 -m pytest -q tests/test_run_real_eval_delta.py -k run_manifest`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md docs/evaluation/surface-map.md`; `git diff --check`; `make check-branch`.
 - Results: named MiniLM target added; docs now state `make real-eval` is
   hashing/offline and not MiniLM; aggregate run-manifest extraction preserves
-  embedding provenance without private path leakage.
+  embedding provenance without private path leakage, including local model paths.
 - Blockers: none known.
 - Open risks: target existence does not prove MiniLM model cache/download or
   performance; actual MiniLM private eval remains a separate run.

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -381,6 +381,9 @@ class ExtractAggregateTest(unittest.TestCase):
                 "config_path": "/Users/hskim/private/real_config.local.yaml",
                 "config_sha256": "0123456789abcdef",
                 "generated_at": "2026-05-11T10:30:00Z",
+                "embedding_backend": "sentence-transformers",
+                "embedding_model_id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+                "embedding_dim": 384,
                 "environment": {
                     "mode": "online",
                     "network": "non-closed",
@@ -407,6 +410,12 @@ class ExtractAggregateTest(unittest.TestCase):
         manifest = agg["run_manifest"]
         self.assertEqual("abc123def456", manifest["git_commit"])
         self.assertEqual("0123456789abcdef", manifest["config_sha256"])
+        self.assertEqual("sentence-transformers", manifest["embedding_backend"])
+        self.assertEqual(
+            "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+            manifest["embedding_model_id"],
+        )
+        self.assertEqual(384, manifest["embedding_dim"])
         self.assertEqual("online", manifest["environment"]["mode"])
         self.assertEqual("[redacted-local-path]", manifest["environment"]["hardware"])
         self.assertEqual("private-raw", manifest["payload"]["private_data_egress"])

--- a/tests/test_run_real_eval_delta.py
+++ b/tests/test_run_real_eval_delta.py
@@ -424,6 +424,22 @@ class ExtractAggregateTest(unittest.TestCase):
         # The dropped path should not appear anywhere in the serialized output.
         self.assertNotIn("hskim", json.dumps(agg))
 
+    def test_run_manifest_redacts_local_embedding_model_path(self) -> None:
+        summary = {
+            **FULL_SUMMARY,
+            "run_manifest": {
+                "embedding_backend": "sentence-transformers",
+                "embedding_model_id": "data/private/model.bin",
+                "embedding_dim": 384,
+            },
+        }
+        agg = extract_aggregate(summary)
+        manifest = agg["run_manifest"]
+        self.assertEqual("sentence-transformers", manifest["embedding_backend"])
+        self.assertEqual("[redacted-local-path]", manifest["embedding_model_id"])
+        self.assertEqual(384, manifest["embedding_dim"])
+        self.assertNotIn("data/private/model.bin", json.dumps(agg))
+
     def test_render_includes_retry_effectiveness_section(self) -> None:
         summary_with_re = {
             **FULL_SUMMARY,

--- a/tests/test_smoke_real_script.py
+++ b/tests/test_smoke_real_script.py
@@ -28,3 +28,19 @@ def test_makefile_has_isolated_page_aware_real_eval_target() -> None:
     assert "CHUNKING_STRATEGY=section" in makefile
     assert "BIDMATE_HWP_PDF_ARTIFACT_REUSE=1" in makefile
     assert "REAL_EVAL_INDEX_DIR=data/index/real100_pageaware" in makefile
+
+
+def test_makefile_has_named_minilm_real_eval_target() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+
+    assert "real-eval-minilm:" in makefile
+    assert "MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2" in makefile
+    assert "REAL_EVAL_INDEX_DIR=data/index/real100_minilm" in makefile
+    assert "REAL_EVAL_REPORT_DIR=reports/real100_minilm" in makefile
+
+
+def test_smoke_real_comment_separates_minilm_and_bge_m3_targets() -> None:
+    script = (ROOT / "scripts" / "smoke_real.sh").read_text(encoding="utf-8")
+
+    assert "`make real-eval-minilm` for the named MiniLM baseline" in script
+    assert "`make real-eval-semantic` for the BGE-M3 comparison" in script


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`DEFAULT_EMBEDDING_MODEL`가 MiniLM이라도 `make real-eval`은 `EMBEDDING_BACKEND=hashing`을 강제해서 실제 index는 `local-hashing-bow`였습니다. 이 오해를 없애기 위해 `make real-eval-minilm`을 별도 target으로 추가하고, hashing/offline, MiniLM baseline, BGE-M3 comparison surface를 문서와 inventory에서 명시적으로 분리했습니다.

또한 aggregate-only 리포트의 `run_manifest`가 실제 embedding backend/model/dim을 보존하게 해서, 나중에 reviewer가 hashing run을 MiniLM run으로 오해하지 않도록 했습니다. `config_path` 같은 local path는 계속 제거되고, `embedding_model_id`가 `data/private/model.bin` 같은 local model path처럼 보이면 `[redacted-local-path]`로 redaction됩니다.

Fixes #1575

## 2. 영향 파일

- `Makefile`: `real-eval-minilm` target 추가, `real-eval-semantic`을 BGE-M3 comparison으로 명확화
- `scripts/smoke_real.sh`: comment에서 MiniLM/BGE-M3 semantic targets 분리
- `scripts/run_real_eval_delta.py`: aggregate `run_manifest` allowlist에 `embedding_backend`, `embedding_model_id`, `embedding_dim` 추가, local model path redaction 추가
- `docs/evaluation/private_real_eval_workflow.md`, `docs/evaluation/surface-map.md`: hashing/MiniLM/BGE-M3 surface 분리
- `docs/private-real-eval-inventory.md`: `real100`, `real100_minilm`, `real100_m3` index surfaces 분리
- `tests/test_smoke_real_script.py`, `tests/test_run_real_eval_delta.py`: target wiring과 path-safe embedding provenance regression tests
- `docs/plans/T-2026-0025-minilm-baseline-target.md`, `tasks/queue.md`: plan/queue/handoff evidence

## 3. 리스크

가장 큰 리스크는 target 추가를 성능 개선으로 오해하는 것입니다. 이 PR은 실제 MiniLM/BGE-M3 eval을 돌리지 않고, target/wiring/docs/provenance만 정리합니다. `make real-eval` 기본 hashing/offline behavior는 유지됩니다.

## 4. 테스트

- `bash -n scripts/smoke_real.sh`
- `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_provenance_banner.py`
- `python3 -m pytest -q tests/test_run_real_eval_delta.py -k run_manifest`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0025-minilm-baseline-target.md docs/evaluation/private_real_eval_workflow.md docs/private-real-eval-inventory.md docs/evaluation/surface-map.md`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

No retrieval, reranking, verifier, prompt, answer, or eval scoring behavior change. Adds an opt-in MiniLM workflow target and aggregate provenance guard only. No RAG quality, recall, latency, or production performance claim.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. `make real-eval-delta` was not run because this PR only adds an opt-in target, wording guard, and aggregate provenance allowlist/redaction. Actual MiniLM private eval remains a separate local run before any performance claim.

## 6. 하위 호환

`make real-eval` remains hashing/offline and writes to the canonical `real100` local paths. Existing `make real-eval-semantic` remains BGE-M3 and writes to `real100_m3`. New `make real-eval-minilm` writes to separate `real100_minilm` local paths.

## 7. 범위 외

- No MiniLM/BGE-M3 private eval was run.
- No committed baseline/report numbers changed.
- No performance claim from hashing, MiniLM, or BGE-M3.
- Chroma vector DB baseline is separated into follow-up issue #1580 so vector DB effects do not mix with embedding-model effects.
