### PR TITLE
chore: add expanded active loop topology

### DIFF
--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -1,13 +1,13 @@
 # Active Agent Loop
 
-이 문서는 `agent_loop.py active-loop`가 운영하는 4-session active
+이 문서는 `agent_loop.py active-loop`가 운영하는 active
 orchestrator 계약이다. 목적은 사람이 다음 세션을 계속 수동 배정하지 않아도,
 repo-local ledger가 작업권(lease), 하트비트(heartbeat), 할당(assignment), ship
 gate를 보존하게 하는 것이다.
 
 ## Topology
 
-기본 topology는 고정 4개 session이다.
+기본 topology는 backward-compatible 4개 session이다.
 
 | Session | Role | Write authority |
 |---|---|---|
@@ -15,6 +15,23 @@ gate를 보존하게 하는 것이다.
 | `implementer` | Implementer | assigned issue branch/worktree only |
 | `reviewer` | Reviewer | read-only review report |
 | `ci-eval-auditor` | CI/Eval Auditor | read-only CI/eval/claim report |
+
+장기 RAG/eval governance 작업은 optional 8-session topology를 사용할 수 있다.
+
+```bash
+python3 scripts/agent_loop.py active-loop --mode full-ship --topology expanded-eight --dry-run --from-git
+```
+
+| Session | Role | Write authority |
+|---|---|---|
+| `orchestrator` | Orchestrator | ledger, queue/plan proposal, gate decision |
+| `planner-triage` | Planner / Issue Triage | read-only queue/plan/workset proposal |
+| `experiment-scout` | Experiment Scout | read-only hypothesis, ablation, aggregate evidence |
+| `implementer` | Implementer | assigned issue branch/worktree only |
+| `reviewer` | Reviewer | read-only review report |
+| `deep-reviewer` | Deep Reviewer | read-only architecture/load-bearing review |
+| `ci-regression-auditor` | CI / Regression Auditor | read-only CI/regression report |
+| `eval-claim-privacy-auditor` | Eval / Claim / Privacy Auditor | read-only eval/claim/privacy report |
 
 Worker 간 direct communication은 필요 조건이 아니다. 모든 이어받기는
 `reports/agent_loop/active/` ledger와 기존 handoff block으로 복구 가능해야 한다.
@@ -67,7 +84,15 @@ Gate 조건:
 - overlap preflight가 blocked가 아니다.
 - generated `reports/agent_loop/` artifact privacy audit가 clear다.
 - load-bearing/eval surface는 claim text 또는 PR body evidence가 있다.
-- `Reviewer`와 `CI/Eval Auditor` session heartbeat status가 pass 계열이다.
+- `four-role`: `Reviewer`와 `CI/Eval Auditor` session heartbeat status가 pass 계열이다.
+- `expanded-eight`: `Reviewer`, `CI / Regression Auditor`,
+  `Eval / Claim / Privacy Auditor` status가 pass 계열이다.
+- `expanded-eight`에서 load-bearing file이 바뀌면 `Deep Reviewer` status도 pass
+  계열이어야 한다.
+
+`Planner / Issue Triage`와 `Experiment Scout`는 Conservative Gate에서 ship을
+막지 않는다. 둘은 다음 work 후보, 실험 가설, aggregate-only evidence를 만들고,
+Orchestrator가 tracked queue/plan으로 승격할 때만 구현 lane으로 넘어간다.
 
 통과하면 primary ship command는 다음이다.
 
@@ -88,6 +113,16 @@ python3 scripts/agent_loop.py session-heartbeat \
   --role Reviewer \
   --task T-2026-0000 \
   --status passed
+```
+
+Expanded topology 예시:
+
+```bash
+python3 scripts/agent_loop.py session-heartbeat \
+  --session-id eval-claim-privacy-auditor \
+  --role "Eval / Claim / Privacy Auditor" \
+  --task T-2026-0000 \
+  --status clear
 ```
 
 기본 TTL은 30분이다. TTL을 넘은 session은 다음 orchestrator tick에서 `stale`로

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -8008,6 +8008,9 @@ def write_session_heartbeat(
         raise ValueError("--task must match T-YYYY-NNNN")
     registry_path = _active_path(registry, repo_root=repo_root)
     payload = _load_active_registry(registry_path)
+    topology = str(payload.get("topology") or "four-role")
+    if topology not in ACTIVE_TOPOLOGY_ROLES:
+        topology = "four-role"
     sessions = payload.get("sessions") if isinstance(payload.get("sessions"), list) else []
     by_id = {str(item.get("session_id")): dict(item) for item in sessions if isinstance(item, dict)}
     session = by_id.get(safe_session, {})
@@ -8022,14 +8025,14 @@ def write_session_heartbeat(
             "last_heartbeat": _isoformat(now),
             "heartbeat_state": "fresh",
             "lease_expires_at": _isoformat(now + timedelta(minutes=lease_ttl_minutes)),
-            "next_command": "python3 scripts/agent_loop.py active-loop --mode full-ship --dry-run",
+            "next_command": _active_next_command(safe_role, task_id=task_id, topology=topology),
         }
     )
     by_id[safe_session] = session
     rendered_payload = {
         "schema_version": 1,
         "generated_at": _isoformat(now),
-        "topology": payload.get("topology") or "four-role",
+        "topology": topology,
         "sessions": [_sanitize_json_value(by_id[key]) for key in sorted(by_id)],
     }
     registry_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -136,12 +136,36 @@ DEFAULT_MAINTENANCE_PLAN_JSON = DEFAULT_REPORT_DIR / "maintenance_plan.json"
 DEFAULT_DRAFT_TASK_ID = "T-2026-0000"
 QUEUE_PATH = Path("tasks/queue.md")
 PLAN_DIR = Path("docs/plans")
-ACTIVE_TOPOLOGY_ROLES = (
-    ("orchestrator", "Orchestrator"),
-    ("implementer", "Implementer"),
-    ("reviewer", "Reviewer"),
-    ("ci-eval-auditor", "CI/Eval Auditor"),
-)
+ACTIVE_TOPOLOGY_ROLES = {
+    "four-role": (
+        ("orchestrator", "Orchestrator"),
+        ("implementer", "Implementer"),
+        ("reviewer", "Reviewer"),
+        ("ci-eval-auditor", "CI/Eval Auditor"),
+    ),
+    "expanded-eight": (
+        ("orchestrator", "Orchestrator"),
+        ("planner-triage", "Planner / Issue Triage"),
+        ("experiment-scout", "Experiment Scout"),
+        ("implementer", "Implementer"),
+        ("reviewer", "Reviewer"),
+        ("deep-reviewer", "Deep Reviewer"),
+        ("ci-regression-auditor", "CI / Regression Auditor"),
+        ("eval-claim-privacy-auditor", "Eval / Claim / Privacy Auditor"),
+    ),
+}
+ACTIVE_TOPOLOGY_CHOICES = tuple(ACTIVE_TOPOLOGY_ROLES)
+ACTIVE_TOPOLOGY_DESCRIPTIONS = {
+    "four-role": "Default 4-session topology: Orchestrator, Implementer, Reviewer, CI/Eval Auditor",
+    "expanded-eight": "Expanded 8-session topology for long-running RAG/eval governance",
+}
+ACTIVE_REQUIRED_GATES = {
+    "four-role": ("Reviewer", "CI/Eval Auditor"),
+    "expanded-eight": ("Reviewer", "CI / Regression Auditor", "Eval / Claim / Privacy Auditor"),
+}
+ACTIVE_LOAD_BEARING_GATES = {
+    "expanded-eight": ("Deep Reviewer",),
+}
 
 GH_PR_JSON_FIELDS = (
     "number",
@@ -8181,8 +8205,8 @@ def write_active_loop(
 ) -> ActiveLoopResult:
     if mode != "full-ship":
         raise ValueError("--mode currently supports only full-ship")
-    if topology != "four-role":
-        raise ValueError("--topology currently supports only four-role")
+    if topology not in ACTIVE_TOPOLOGY_ROLES:
+        raise ValueError(f"--topology must be one of: {', '.join(ACTIVE_TOPOLOGY_CHOICES)}")
     if lease_ttl_minutes < 1:
         raise ValueError("--lease-ttl-minutes must be at least 1")
     if task_id and not TASK_ID_RE.fullmatch(task_id):
@@ -8252,7 +8276,8 @@ def write_active_loop(
     surfaces = {surface.surface, *surface.additional_surfaces}
     if files:
         evidence.append(f"surface={surface.surface}")
-    if any(is_load_bearing(path) for path in files) or surfaces & {
+    load_bearing_touched = any(is_load_bearing(path) for path in files)
+    if load_bearing_touched or surfaces & {
         "private-real-eval",
         "privacy-sensitive-artifact",
         "benchmark-reporting",
@@ -8283,17 +8308,14 @@ def write_active_loop(
         else:
             evidence.append("PR body check clear")
 
-    reviewer_ok = _active_role_status_ok(sessions, "Reviewer")
-    ci_ok = _active_role_status_ok(sessions, "CI/Eval Auditor")
+    required_gate_roles = _active_required_gate_roles(topology, load_bearing_touched=load_bearing_touched)
+    missing_gate_roles = [role for role in required_gate_roles if not _active_role_status_ok(sessions, role)]
     if execute:
-        if not reviewer_ok:
-            blockers.append("Reviewer session has not passed")
-        if not ci_ok:
-            blockers.append("CI/Eval Auditor session has not passed")
-    elif not reviewer_ok:
-        warnings.append("Reviewer session has not passed yet")
-    if not ci_ok:
-        warnings.append("CI/Eval Auditor session has not passed yet")
+        blockers.extend(f"{role} session has not passed" for role in missing_gate_roles)
+    else:
+        warnings.extend(f"{role} session has not passed yet" for role in missing_gate_roles)
+    if required_gate_roles:
+        evidence.append("ship gate roles=" + ", ".join(required_gate_roles))
 
     refresh_outputs: list[Path] = []
     try:
@@ -8469,7 +8491,7 @@ def render_active_loop(
         "# Active Agent Loop",
         "",
         "- Hybrid active orchestrator ledger. Repo-local reports are the source of truth; Codex heartbeat can call these commands later.",
-        "- Fixed topology: Orchestrator, Implementer, Reviewer, CI/Eval Auditor.",
+        f"- Topology contract: {ACTIVE_TOPOLOGY_DESCRIPTIONS.get(topology, topology)}.",
         "- Full ship uses the existing `make ship-run DRAFT=false REAL_EVAL=auto` path after conservative agent gates pass.",
         "- Force-push is excluded from this active loop.",
         f"- Mode: `{mode}`",
@@ -8597,6 +8619,20 @@ def _load_active_leases(path: Path) -> list[dict[str, object]]:
     raise ValueError("active leases must be a JSON object with a leases array")
 
 
+def _active_topology_roles(topology: str) -> tuple[tuple[str, str], ...]:
+    roles = ACTIVE_TOPOLOGY_ROLES.get(topology)
+    if roles is None:
+        raise ValueError(f"unknown active-loop topology: {topology}")
+    return roles
+
+
+def _active_required_gate_roles(topology: str, *, load_bearing_touched: bool) -> tuple[str, ...]:
+    roles = list(ACTIVE_REQUIRED_GATES.get(topology, ()))
+    if load_bearing_touched:
+        roles.extend(ACTIVE_LOAD_BEARING_GATES.get(topology, ()))
+    return tuple(_dedupe_preserve_order(roles))
+
+
 def _build_active_sessions(
     *,
     old_registry: dict[str, object],
@@ -8609,7 +8645,7 @@ def _build_active_sessions(
     old_sessions = old_registry.get("sessions") if isinstance(old_registry.get("sessions"), list) else []
     old_by_id = {str(item.get("session_id")): dict(item) for item in old_sessions if isinstance(item, dict)}
     sessions: list[dict[str, object]] = []
-    for session_id, role in ACTIVE_TOPOLOGY_ROLES:
+    for session_id, role in _active_topology_roles(topology):
         old = old_by_id.get(session_id, {})
         last_heartbeat = _parse_timestamp(old.get("last_heartbeat")) or now
         age_seconds = max(0.0, (now - last_heartbeat).total_seconds())
@@ -8628,19 +8664,30 @@ def _build_active_sessions(
                 "last_heartbeat": _isoformat(last_heartbeat),
                 "heartbeat_state": heartbeat_state,
                 "lease_expires_at": _isoformat(now + timedelta(minutes=lease_ttl_minutes)),
-                "next_command": _active_next_command(role, task_id=task_id),
+                "next_command": _active_next_command(role, task_id=task_id, topology=topology),
             }
         )
     return sessions
 
 
-def _active_next_command(role: str, *, task_id: str | None) -> str:
+def _active_next_command(role: str, *, task_id: str | None, topology: str = "four-role") -> str:
     if role == "Orchestrator":
-        return "python3 scripts/agent_loop.py active-loop --mode full-ship --dry-run"
+        topology_arg = "" if topology == "four-role" else f" --topology {topology}"
+        return f"python3 scripts/agent_loop.py active-loop --mode full-ship{topology_arg} --dry-run"
+    if role == "Planner / Issue Triage":
+        return "python3 scripts/agent_loop.py continue-loop --pr-json reports/agent_loop/pr_state.json --no-apply-queue-plan"
+    if role == "Experiment Scout":
+        return "python3 scripts/agent_loop.py workset-recommend"
     if role == "Implementer":
         return f"python3 scripts/agent_loop.py preflight --task {task_id or '<TASK_ID>'} --from-git --write-prompts"
     if role == "Reviewer":
         return "python3 scripts/agent_loop.py review-plan --pr <PR>"
+    if role == "Deep Reviewer":
+        return "python3 scripts/agent_loop.py architecture-decision --from-git"
+    if role == "CI / Regression Auditor":
+        return "python3 scripts/agent_loop.py ci-summary --pr <PR>"
+    if role == "Eval / Claim / Privacy Auditor":
+        return "python3 scripts/agent_loop.py claim-policy --from-git"
     return "python3 scripts/agent_loop.py ci-summary --pr <PR>"
 
 
@@ -10323,9 +10370,9 @@ def build_parser() -> argparse.ArgumentParser:
     role_dispatch.add_argument("--workset")
     role_dispatch.add_argument("--out", type=Path, default=DEFAULT_ROLE_DISPATCH)
 
-    active_loop = sub.add_parser("active-loop", help="Run the 4-session active orchestrator tick.")
+    active_loop = sub.add_parser("active-loop", help="Run the active orchestrator tick.")
     active_loop.add_argument("--mode", choices=("full-ship",), default="full-ship")
-    active_loop.add_argument("--topology", choices=("four-role",), default="four-role")
+    active_loop.add_argument("--topology", choices=ACTIVE_TOPOLOGY_CHOICES, default="four-role")
     active_loop.add_argument("--dry-run", dest="execute", action="store_false", default=False)
     active_loop.add_argument("--execute", dest="execute", action="store_true")
     active_loop.add_argument("--task")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2412,6 +2412,16 @@ def _clear_overlap_report(issue: str = "9999", branch: str = "chore/issue-9999-a
     )
 
 
+def _write_active_registry(repo: Path, *, topology: str, sessions: list[dict[str, str]]) -> Path:
+    registry = repo / "reports" / "agent_loop" / "active" / "session_registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps({"schema_version": 1, "topology": topology, "sessions": sessions}),
+        encoding="utf-8",
+    )
+    return registry
+
+
 def test_active_loop_dry_run_creates_four_session_ledger_without_remote_mutation(monkeypatch, tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     calls: list[list[str]] = []
@@ -2444,6 +2454,46 @@ def test_active_loop_dry_run_creates_four_session_ledger_without_remote_mutation
     assert leases["leases"][0]["status"] == "active"
     assert (result.assignments_dir / "orchestrator.md").exists()
     assert result.events_path.exists()
+    assert calls == []
+
+
+def test_active_loop_expanded_eight_dry_run_creates_sessions_and_assignments(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
+
+    result = agent_loop.write_active_loop(
+        topology="expanded-eight",
+        changed_files=["docs/operations/active-agent-loop.md"],
+        repo_root=repo,
+    )
+
+    registry = json.loads(result.registry_path.read_text(encoding="utf-8"))
+    leases = json.loads(result.leases_path.read_text(encoding="utf-8"))
+
+    assert result.decision == "planned"
+    assert len(registry["sessions"]) == 8
+    assert {item["session_id"] for item in registry["sessions"]} == {
+        "orchestrator",
+        "planner-triage",
+        "experiment-scout",
+        "implementer",
+        "reviewer",
+        "deep-reviewer",
+        "ci-regression-auditor",
+        "eval-claim-privacy-auditor",
+    }
+    assert leases["leases"][0]["owner_session"] == "implementer"
+    assert len(list(result.assignments_dir.glob("*.md"))) == 8
+    assert "workset-recommend" in (result.assignments_dir / "experiment-scout.md").read_text(encoding="utf-8")
     assert calls == []
 
 
@@ -2485,6 +2535,124 @@ def test_active_loop_execute_runs_ship_only_after_reviewer_and_ci_pass(monkeypat
     assert result.decision == "executed"
     assert result.executed_commands == (("make", "ship-run", "DRAFT=false", "REAL_EVAL=auto"),)
     assert calls == [["make", "ship-run", "DRAFT=false", "REAL_EVAL=auto"]]
+
+
+def test_active_loop_expanded_eight_execute_uses_conservative_gate(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    now = "2999-01-01T00:00:00Z"
+    _write_active_registry(
+        repo,
+        topology="expanded-eight",
+        sessions=[
+            {"session_id": "reviewer", "role": "Reviewer", "status": "passed", "last_heartbeat": now},
+            {"session_id": "ci-regression-auditor", "role": "CI / Regression Auditor", "status": "passed", "last_heartbeat": now},
+            {"session_id": "eval-claim-privacy-auditor", "role": "Eval / Claim / Privacy Auditor", "status": "clear", "last_heartbeat": now},
+            {"session_id": "planner-triage", "role": "Planner / Issue Triage", "status": "idle", "last_heartbeat": "2020-01-01T00:00:00Z"},
+            {"session_id": "experiment-scout", "role": "Experiment Scout", "status": "idle", "last_heartbeat": "2020-01-01T00:00:00Z"},
+        ],
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
+
+    result = agent_loop.write_active_loop(
+        topology="expanded-eight",
+        execute=True,
+        changed_files=["docs/operations/active-agent-loop.md"],
+        lease_ttl_minutes=1,
+        repo_root=repo,
+    )
+
+    registry = json.loads(result.registry_path.read_text(encoding="utf-8"))
+    planner = next(item for item in registry["sessions"] if item["session_id"] == "planner-triage")
+    experiment = next(item for item in registry["sessions"] if item["session_id"] == "experiment-scout")
+
+    assert result.decision == "executed"
+    assert planner["status"] == "stale"
+    assert experiment["status"] == "stale"
+    assert not any("Planner / Issue Triage" in blocker for blocker in result.blockers)
+    assert not any("Experiment Scout" in blocker for blocker in result.blockers)
+    assert calls == [["make", "ship-run", "DRAFT=false", "REAL_EVAL=auto"]]
+
+
+def test_active_loop_expanded_eight_blocks_when_required_auditor_missing(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    now = "2999-01-01T00:00:00Z"
+    _write_active_registry(
+        repo,
+        topology="expanded-eight",
+        sessions=[
+            {"session_id": "reviewer", "role": "Reviewer", "status": "passed", "last_heartbeat": now},
+            {"session_id": "ci-regression-auditor", "role": "CI / Regression Auditor", "status": "passed", "last_heartbeat": now},
+        ],
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
+
+    result = agent_loop.write_active_loop(
+        topology="expanded-eight",
+        execute=True,
+        changed_files=["docs/operations/active-agent-loop.md"],
+        repo_root=repo,
+    )
+
+    assert result.decision == "blocked"
+    assert any("Eval / Claim / Privacy Auditor session has not passed" in blocker for blocker in result.blockers)
+    assert calls == []
+
+
+def test_active_loop_expanded_eight_requires_deep_reviewer_for_load_bearing(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    now = "2999-01-01T00:00:00Z"
+    _write_active_registry(
+        repo,
+        topology="expanded-eight",
+        sessions=[
+            {"session_id": "reviewer", "role": "Reviewer", "status": "passed", "last_heartbeat": now},
+            {"session_id": "ci-regression-auditor", "role": "CI / Regression Auditor", "status": "passed", "last_heartbeat": now},
+            {"session_id": "eval-claim-privacy-auditor", "role": "Eval / Claim / Privacy Auditor", "status": "clear", "last_heartbeat": now},
+        ],
+    )
+    body = repo / "pr_body.md"
+    body.write_text("N/A\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "chore/issue-9999-active-loop")
+    monkeypatch.setattr(agent_loop, "build_overlap_preflight", lambda issue, branch, repo_root: _clear_overlap_report(issue, branch))
+    monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
+    monkeypatch.setattr(agent_loop, "check_pr_body_text", lambda *args, **kwargs: [])
+
+    result = agent_loop.write_active_loop(
+        topology="expanded-eight",
+        execute=True,
+        changed_files=["rag_core.py"],
+        pr_body=body,
+        repo_root=repo,
+    )
+
+    assert result.decision == "blocked"
+    assert any("Deep Reviewer session has not passed" in blocker for blocker in result.blockers)
+    assert calls == []
 
 
 def test_active_loop_blocks_ship_when_reviewer_or_ci_has_not_passed(monkeypatch, tmp_path: Path) -> None:
@@ -2644,6 +2812,16 @@ def test_session_heartbeat_refreshes_registry_and_stale_sessions_are_marked(monk
     assert events.exists()
     assert reviewer["heartbeat_state"] == "stale"
     assert reviewer["status"] == "stale"
+
+
+def test_active_loop_cli_accepts_expanded_eight_and_rejects_unknown_topology() -> None:
+    parser = agent_loop.build_parser()
+
+    args = parser.parse_args(["active-loop", "--topology", "expanded-eight"])
+
+    assert args.topology == "expanded-eight"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["active-loop", "--topology", "unknown-topology"])
 
 
 def test_stop_ship_skips_remote_branch_delete_when_stacked_dependents_exist() -> None:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2814,6 +2814,33 @@ def test_session_heartbeat_refreshes_registry_and_stale_sessions_are_marked(monk
     assert reviewer["status"] == "stale"
 
 
+def test_session_heartbeat_preserves_expanded_eight_next_command(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _write_active_registry(
+        repo,
+        topology="expanded-eight",
+        sessions=[
+            {
+                "session_id": "orchestrator",
+                "role": "Orchestrator",
+                "status": "running",
+                "last_heartbeat": "2999-01-01T00:00:00Z",
+            }
+        ],
+    )
+
+    _, _, payload = agent_loop.write_session_heartbeat(
+        session_id="orchestrator",
+        role="Orchestrator",
+        status="running",
+        repo_root=repo,
+    )
+
+    session = payload["sessions"][0]
+    assert payload["topology"] == "expanded-eight"
+    assert "--topology expanded-eight" in session["next_command"]
+
+
 def test_active_loop_cli_accepts_expanded_eight_and_rejects_unknown_topology() -> None:
     parser = agent_loop.build_parser()
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`active-loop`의 기본 `four-role` topology는 유지하면서, 장기 RAG/eval governance용 optional `expanded-eight` topology를 추가합니다. Expanded mode는 planning/experiment 세션을 ledger에 올리되 Conservative Gate로 핵심 reviewer/auditor만 `--execute` ship을 막게 합니다.

Closes #1585

## 2. 영향 파일

- `scripts/agent_loop.py` — active topology map, expanded-eight CLI choice, Conservative Gate, role별 next command.
- `tests/test_agent_loop.py` — expanded-eight ledger/gate/CLI coverage.
- `docs/operations/active-agent-loop.md` — 4-session default와 8-session expanded 운영 문서.

## 3. 리스크

가장 큰 리스크는 기존 `four-role` 자동 ship gate가 바뀌는 것입니다. 기본값과 기존 required role 이름을 유지했고, 기존 four-role 테스트와 새 expanded-eight 테스트로 분리 검증했습니다.

## 4. 테스트

- `python3 -m py_compile scripts/agent_loop.py scripts/ai_next_actions.py`
- `python3 -m pytest tests/test_agent_loop.py -q`
- `python3 scripts/agent_loop.py active-loop --mode full-ship --topology expanded-eight --dry-run --from-git`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

RAG retrieval/answer/eval runtime 변경이 아닙니다. Active loop orchestration, docs, tests만 변경합니다.

### 5b. Real-data delta

N/A — load-bearing path 변경이 아니며 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

`four-role`이 계속 기본값이고 기존 CLI invocation은 그대로 동작합니다. `session_registry.json` schema shape도 유지됩니다. 새 동작은 `--topology expanded-eight`를 명시할 때만 활성화됩니다.

## 7. 범위 외

Experiment Scout 산출물을 tracked queue/plan으로 승격하는 별도 command는 이번 PR 범위에 포함하지 않았습니다. Expanded topology는 operational ledger/assignment 표면까지만 추가합니다.
