### PR TITLE
docs: plan RAG performance experiment stack

### DIFF
--- a/docs/evaluation/rag-performance-experiment-stack.md
+++ b/docs/evaluation/rag-performance-experiment-stack.md
@@ -1,0 +1,109 @@
+# RAG Performance Experiment Stack
+
+This document selects the next RAG performance experiments from the broad RAG
+technique space and orders them for BidMate-DocAgent. It is a planning surface,
+not a performance claim. It contains no private raw questions, answers,
+evidence text, filenames, exact local paths, document identifiers, or chunk
+identifiers.
+
+## TL;DR
+
+Do not start with GraphRAG, Agentic RAG, late chunking, or multi-vector search.
+Start with the weakest measurable links:
+
+1. Refresh private real-eval coverage and semantic baselines after the page
+   metadata and MiniLM target work.
+2. Make retrieval diagnostics explain candidate-pool recall, rank quality, and
+   evidence split before changing retrieval behavior.
+3. Run small-to-big retrieval, reranking, context packing, and query
+   decomposition as separate opt-in experiments with paired aggregate deltas.
+4. Add security, abstention, conflict, metadata, freshness, latency, and cost
+   guardrails before any production-facing claim.
+5. Gate advanced architectures behind no-go/go feasibility evidence.
+
+## Selection Rules
+
+- A performance claim requires private real-eval aggregate paired delta with
+  matched dataset, config, index provenance, command, and embedding/backend
+  provenance.
+- Public fixture smoke can prove wiring or regression behavior only.
+- Public synthetic benchmark can expose a controlled failure mode only.
+- Private raw artifacts stay local and ignored.
+- Experiments must state the expected primary metric and guardrails before
+  implementation.
+- Any experiment that increases candidate count, reranking, LLM calls, or
+  context length must carry a stage latency and cost guardrail.
+- If Recall@K improves but MRR, nDCG, citation, abstention, or latency regresses,
+  the result is not a winner by default.
+
+## Existing Evidence To Respect
+
+- Page metadata recovery is available on current main through `T-2026-0024`.
+- MiniLM and BGE-M3 semantic private real-eval targets are separated through
+  `T-2026-0025`.
+- The hybrid sweep report found recall-only gains but ranking and latency
+  regressions; do not reopen hybrid as a broad "just add BM25" change.
+- The multi-chunk strategy report deferred retrieval changes until page-aware
+  evidence can distinguish same-document from multi-document evidence splits.
+- `T-2026-0026` tracks Chroma as a vector DB backend baseline. Treat it as
+  backend parity, provenance, latency, and operations work unless paired
+  same-embedding deltas prove ranking drift.
+
+## Priority Stack
+
+| Priority | Task | Status | Why this order |
+|---|---|---|---|
+| P0 | `T-2026-0028` Private coverage and semantic baseline refresh | ready after this PR | Establish the current baseline and coverage before experiments. |
+| P0 | `T-2026-0029` Retrieval diagnostic workbench | backlog | Explain recall/rank/candidate-pool failures before behavior changes. |
+| P0 | `T-2026-0030` Latency and cost budget envelope | backlog | Prevent multi-query/rerank/compression experiments from winning on quality while breaking operations. |
+| P1 | `T-2026-0031` Parent/section-window retrieval experiment | backlog | Highest-value retrieval change after page-aware evidence. |
+| P1 | `T-2026-0032` Reranker candidate-budget experiment | backlog | Improve precision only after candidate-pool recall is observable. |
+| P1 | `T-2026-0033` Context packing and citation ordering experiment | backlog | Use found evidence better without changing corpus or embeddings. |
+| P1 | `T-2026-0034` Query rewrite and decomposition experiment | backlog | Target comparison, multi-hop, abbreviation, and mixed Korean/English queries. |
+| P1 | `T-2026-0035` Prompt-injection and data/command boundary guardrail | backlog | Security must be a guardrail before more agentic or tool-using retrieval. |
+| P2 | `T-2026-0036` Abstention, conflict, and freshness calibration | backlog | Improve no-answer and precedence behavior after retrieval evidence is stable. |
+| P2 | `T-2026-0037` Metadata, authority, and freshness ranking experiment | backlog | Use RFP metadata only after coverage and missing-field behavior are measured. |
+| P2 | `T-2026-0038` Contextual retrieval and sentence-window proof of concept | backlog | Test chunk-context enrichment after simpler small-to-big retrieval. |
+| P3 | `T-2026-0039` Advanced architecture feasibility gate | backlog | Evaluate RAPTOR, GraphRAG, LightRAG, Agentic RAG, late chunking, multi-vector, and long-context only after P0/P1 evidence. |
+
+## Deferred Techniques
+
+| Technique | Default decision | Reason |
+|---|---|---|
+| GraphRAG / LightRAG | defer to `T-2026-0039` | Expensive build/eval surface; best for corpus-level sensemaking, not first-line RFP QA failures. |
+| RAPTOR | defer to `T-2026-0039` | Requires summary-tree build and summary faithfulness checks. |
+| Agentic RAG / Self-RAG / CRAG / FLARE | defer to `T-2026-0039` | Adds loop/tool/security complexity before retrieval and context baselines are stable. |
+| Late chunking | defer to `T-2026-0039` | Requires long-context embedding model and index rebuild provenance. |
+| ColBERT / multi-vector retrieval | defer to `T-2026-0039` | Storage and latency profile are large; candidate-pool diagnostics must justify it. |
+| Broad hybrid BM25 rerun | do not reopen without a new hypothesis | Prior sweep showed recall-only gains with rank/latency regressions. |
+| Long-context "put everything in prompt" | do not use as default | Token cost, lost-in-middle risk, ACL/privacy boundary, and citation traceability remain unresolved. |
+
+## Metrics Required By Experiment Type
+
+| Experiment type | Primary metric | Guardrails |
+|---|---|---|
+| Coverage/baseline | explicit gold coverage, parse/page coverage, run provenance | privacy, no raw IDs, no performance claim without paired delta |
+| Retrieval | Recall@K, Hit@K, MRR, nDCG, candidate-pool coverage | citation, abstention, latency, same corpus/index provenance |
+| Reranking | MRR@K, nDCG@K, answer containment, precision@K | candidate recall, p50/p95 latency, cost |
+| Context packing | citation accuracy, faithfulness, completeness | lost-in-middle placement, token count, no hallucination increase |
+| Query rewrite/decomposition | slice delta by query type | extra LLM calls, rewrite drift, no private egress without approval |
+| Abstention/conflict | no-answer accuracy, conflict precedence accuracy | false abstention, citation, freshness provenance |
+| Security | injection detection, instruction/data isolation checks | false positives, privacy redaction, tool-call policy |
+| Advanced architecture | feasibility score and no-go/go rationale | build cost, latency, privacy, rollback path |
+
+## Execution Rules
+
+- Create a GitHub issue and ADR 0007 branch for each implementation task when
+  that task starts.
+- Keep each PR to one task ID and one concern.
+- Put private raw runs under ignored local paths only.
+- Commit only aggregate reports that pass privacy checks.
+- Record whether real private eval ran and whether any performance claim is
+  made in every PR body.
+- Prefer no-go reports over premature implementation when evidence is missing.
+
+## First Next Task
+
+Start with `T-2026-0028`. It should refresh the aggregate baseline after page
+metadata recovery and MiniLM target separation, then decide which diagnostic
+task is truly ready.

--- a/docs/evaluation/surface-map.md
+++ b/docs/evaluation/surface-map.md
@@ -117,3 +117,4 @@ Before accepting an eval/benchmark claim, verify:
 - [Private Real-Eval Workflow](./private_real_eval_workflow.md)
 - [Agent-Gated RFP Evaluation Loop](./agent-gated-rfp-eval-loop.md)
 - [Pre-Improvement Readiness Checklist](./pre_improvement_readiness_checklist.md)
+- [RAG Performance Experiment Stack](./rag-performance-experiment-stack.md)

--- a/docs/plans/T-2026-0027-rag-performance-experiment-stack.md
+++ b/docs/plans/T-2026-0027-rag-performance-experiment-stack.md
@@ -189,7 +189,7 @@ or latency improvement.
 ## Session Handoff - 2026-05-27 20:00 KST
 
 - Role: Planner
-- Branch / worktree: docs/issue-1584-rag-performance-experiment-stack / /Users/hskim/.codex/worktrees/3005/BidMate-DocAgent
+- Branch / worktree: docs/issue-1584-rag-performance-experiment-stack / Codex worktree
 - Issue / PR: #1584 / #1587
 - Task: T-2026-0027
 - Current status: task stack docs implemented and validation passed.

--- a/docs/plans/T-2026-0027-rag-performance-experiment-stack.md
+++ b/docs/plans/T-2026-0027-rag-performance-experiment-stack.md
@@ -3,7 +3,7 @@
 - Status: review
 - Owner role: Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Related task: `tasks/queue.md::T-2026-0027`
-- Related issue / PR: [#1584](https://github.com/hskim-solv/BidMate-DocAgent/issues/1584) / PR TBD
+- Related issue / PR: [#1584](https://github.com/hskim-solv/BidMate-DocAgent/issues/1584) / [#1587](https://github.com/hskim-solv/BidMate-DocAgent/pull/1587)
 - Related ADR: N/A - no runtime or eval contract change
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -190,7 +190,7 @@ or latency improvement.
 
 - Role: Planner
 - Branch / worktree: docs/issue-1584-rag-performance-experiment-stack / /Users/hskim/.codex/worktrees/3005/BidMate-DocAgent
-- Issue / PR: #1584 / PR TBD
+- Issue / PR: #1584 / #1587
 - Task: T-2026-0027
 - Current status: task stack docs implemented and validation passed.
 - Files touched: tasks/queue.md, docs/plans/T-2026-0027-rag-performance-experiment-stack.md, docs/evaluation/rag-performance-experiment-stack.md, docs/evaluation/surface-map.md

--- a/docs/plans/T-2026-0027-rag-performance-experiment-stack.md
+++ b/docs/plans/T-2026-0027-rag-performance-experiment-stack.md
@@ -1,0 +1,203 @@
+# Plan: T-2026-0027 RAG performance experiment stack
+
+- Status: review
+- Owner role: Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0027`
+- Related issue / PR: [#1584](https://github.com/hskim-solv/BidMate-DocAgent/issues/1584) / PR TBD
+- Related ADR: N/A - no runtime or eval contract change
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+## Problem Statement
+
+The RAG performance goal is now explicit, but the next work is still too broad
+to execute safely. A generic list of RAG techniques can push the project toward
+expensive experiments before the private real-eval baseline, failure taxonomy,
+latency envelope, and privacy boundaries are strong enough to support a real
+performance claim.
+
+Without a concrete stack, future sessions can mix data readiness, retrieval,
+reranking, context packing, generator behavior, security, and advanced
+architecture work in one PR. That would violate the one-concern rule and make
+paired delta evidence hard to trust.
+
+## Current Behavior
+
+The current main branch already contains important prerequisites:
+
+- `T-2026-0022` recorded the multi-chunk retrieval no-go until page-aware
+  evidence can distinguish same-document and multi-document evidence splits.
+- `T-2026-0023` set the long-running RAG performance operating goal.
+- `T-2026-0024` recovered page metadata at index build time.
+- `T-2026-0025` separated hashing, MiniLM, and BGE-M3 private real-eval
+  surfaces.
+- `T-2026-0026` split Chroma vector-store work into a backend-axis task rather
+  than a quality-improvement experiment.
+- `docs/evaluation/surface-map.md` already requires private real-eval aggregate
+  paired deltas for real performance claims.
+- `docs/evaluation/pre_improvement_readiness_checklist.md` already requires
+  parse audit -> eval dataset audit -> validate-only -> baseline run -> failure
+  taxonomy -> improvement hypothesis.
+
+The missing piece is a repo-native task stack that converts the broad RAG
+performance checklist into ordered, scoped, measurable tasks.
+
+## Desired Behavior
+
+Future sessions should start from a prioritized queue:
+
+1. Build or refresh measurement evidence before changing behavior.
+2. Run retrieval experiments only when the candidate pool and gold evidence
+   diagnostics can explain the expected metric movement.
+3. Add reranking, context packing, query rewriting, no-answer, conflict, and
+   metadata changes behind opt-in experiment surfaces.
+4. Treat GraphRAG, RAPTOR, LightRAG, Agentic RAG, late chunking, multi-vector
+   retrieval, and long-context RAG as feasibility work until private aggregate
+   evidence shows the simpler stack is exhausted.
+
+The observable output is a queue-backed stack plus a durable evaluation note,
+not a runtime quality change.
+
+## Constraints
+
+- Scope constraints: docs, task queue, and planning surfaces only.
+- Architecture constraints: do not change retrieval, reranking, answer,
+  ingestion, API, eval runtime, or index-building behavior in this PR.
+- Compatibility constraints: preserve existing task and plan formats.
+- Eval/privacy constraints: no private real-eval run, no raw private content,
+  no exact local private path, no `doc_id` or `chunk_id` in committed docs.
+- Tooling/CI constraints: validate doc links, whitespace, and branch/issue
+  convention.
+- Non-goals: do not create all future GitHub issues now; create issue-linked
+  branches when each task starts.
+
+## Architecture Impact
+
+- Affected modules or docs: `tasks/queue.md`,
+  `docs/evaluation/rag-performance-experiment-stack.md`,
+  `docs/evaluation/surface-map.md`, and this plan doc.
+- Affected contracts or invariants: planning and review workflow only.
+- Load-bearing paths: none.
+- ADR required: no, this does not introduce a new metric contract or runtime
+  architecture decision.
+- Backward compatibility expectation: existing eval, retrieval, and agent-loop
+  commands remain unchanged.
+
+## Affected Interfaces
+
+- CLI/API/config: none.
+- Input data: none.
+- Output artifacts: planning docs only.
+- Docs/review surfaces: task queue, evaluation surface map, experiment stack.
+- Tests/eval entrypoints: doc-link validation only.
+
+## Data / Eval Impact
+
+- Surface: none.
+- Data boundary: no data touched.
+- Allowed claim: a prioritized experiment backlog was created.
+- Disallowed claim: retrieval quality, answer quality, latency, citation,
+  abstention, security, or production performance improved.
+- Baseline or control affected: no.
+- Benchmark/eval auditor required: yes, to review the selected experiment order
+  and claim boundaries.
+
+## Task Breakdown
+
+1. Sync prerequisite queue entries whose merge state is already visible on
+   current main.
+2. Add a selected experiment stack document that maps broad RAG levers to
+   concrete BidMate tasks and defers low-evidence techniques.
+3. Add queue entries for P0/P1/P2/P3 tasks with dependencies, surfaces,
+   validation commands, and evidence requirements.
+4. Link the stack from the evaluation surface map.
+5. Validate links and branch hygiene.
+
+## Acceptance Criteria
+
+- [x] `tasks/queue.md` contains a current planning task and a concrete
+  prioritized follow-up stack.
+- [x] Every follow-up task has a priority, dependency, scope, non-goal,
+  acceptance criteria, validation command, and evidence boundary.
+- [x] The stack explains why some advanced RAG techniques are deferred.
+- [x] Wording clearly says this PR is docs/planning only and makes no RAG
+  performance claim.
+- [x] Validation evidence is recorded without private raw data.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0027-rag-performance-experiment-stack.md docs/evaluation/rag-performance-experiment-stack.md docs/evaluation/surface-map.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: N/A - no runtime or eval behavior changed.
+- Generated or updated artifact: docs and queue entries only.
+- Reviewer checklist or manual inspection: priority order, dependency order,
+  no-claim wording, and private boundary.
+- Explicitly not validated, with reason: no private real-eval because this PR
+  only creates the task stack.
+
+## Rollback Strategy
+
+Revert this docs/planning PR if the stack confuses execution order or pushes
+too much work into one PR. Do not delete unrelated existing task entries or
+plan docs during rollback.
+
+## Failure Modes
+
+- Failure mode: future agents treat the stack as permission to implement
+  multiple experiment tasks in one branch.
+- Detection signal: a PR changes retrieval, reranking, context packing, prompt,
+  security, and eval metrics together.
+- Stop condition or fallback: split the PR by task ID and keep only one concern
+  per branch.
+
+- Failure mode: a task claims performance from public fixture or synthetic
+  output.
+- Detection signal: PR body lacks private aggregate paired delta provenance.
+- Stop condition or fallback: downgrade the claim to regression or measurement
+  only.
+
+- Failure mode: a task commits raw private identifiers.
+- Detection signal: committed artifact includes raw question, answer, evidence,
+  filename, exact local path, `doc_id`, or `chunk_id`.
+- Stop condition or fallback: remove the artifact and replace it with
+  aggregate-only evidence.
+
+## Observability
+
+- `tasks/queue.md` shows the next executable P0 task.
+- `docs/evaluation/rag-performance-experiment-stack.md` explains why each task
+  is selected or deferred.
+- Future PR bodies can cite a task ID and state the allowed claim surface.
+
+## Reviewer Notes
+
+Attack priority order and claim boundaries first. This PR should make future
+RAG performance work more executable, but it must not imply any current quality
+or latency improvement.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-27 20:00 KST
+
+- Role: Planner
+- Branch / worktree: docs/issue-1584-rag-performance-experiment-stack / /Users/hskim/.codex/worktrees/3005/BidMate-DocAgent
+- Issue / PR: #1584 / PR TBD
+- Task: T-2026-0027
+- Current status: task stack docs implemented and validation passed.
+- Files touched: tasks/queue.md, docs/plans/T-2026-0027-rag-performance-experiment-stack.md, docs/evaluation/rag-performance-experiment-stack.md, docs/evaluation/surface-map.md
+- Decisions made: prioritize measurement readiness and retrieval diagnostics before advanced architectures; keep Chroma as a separate backend-axis task.
+- Commands run: python3 scripts/agent_loop.py overlap-preflight --issue 1584 --branch docs/issue-1584-rag-performance-experiment-stack; python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0027-rag-performance-experiment-stack.md docs/evaluation/rag-performance-experiment-stack.md docs/evaluation/surface-map.md; git diff --check; make check-branch.
+- Results: passed.
+- Next safe command: git diff --stat
+- Open questions: none.
+- Risks: task stack may need issue split before implementation starts.
+```

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -32,11 +32,24 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 19 | `T-2026-0019` | `review` | Maintainer -> CI Reviewer -> Reviewer | local implementation ready on issue #1549 branch. |
 | 20 | `T-2026-0020` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1544; v0 metric-suite report implementation ready for review. |
 | 21 | `T-2026-0021` | `review` | Maintainer -> CI Reviewer -> Reviewer | issue #1551 implemented; draft PR #1552. |
-| 22 | `T-2026-0022` | `review` | Planner -> Implementer -> Reviewer | issue #1563; aggregate strategy decision implemented; retrieval change deferred until page-aware re-index evidence. |
-| 23 | `T-2026-0023` | `review` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | issue #1569; PR #1570. |
-| 24 | `T-2026-0024` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1573; page metadata recovery patch implemented and local page-aware re-index audit passes. |
-| 25 | `T-2026-0025` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1575; named MiniLM target and baseline-surface wording implemented. |
+| 22 | `T-2026-0022` | `done` | Planner -> Implementer -> Reviewer | merged in PR #1576; retrieval change deferred until page-aware re-index evidence. |
+| 23 | `T-2026-0023` | `done` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | merged in PR #1570. |
+| 24 | `T-2026-0024` | `done` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1577; page metadata recovery landed. |
+| 25 | `T-2026-0025` | `done` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1579; named MiniLM target landed. |
 | 26 | `T-2026-0026` | `todo` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1580; Chroma vector-store baseline separated from embedding-model baselines. |
+| 27 | `T-2026-0027` | `review` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1584; prioritized RAG performance experiment stack captured. |
+| 28 | `T-2026-0028` | `ready` | Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0; refresh private coverage and semantic baselines before behavior changes. |
+| 29 | `T-2026-0029` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0; blocked on T-2026-0028 baseline refresh. |
+| 30 | `T-2026-0030` | `backlog` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | P0; blocked on T-2026-0028 latency provenance. |
+| 31 | `T-2026-0031` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on retrieval diagnostics from T-2026-0029. |
+| 32 | `T-2026-0032` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on candidate-pool diagnostics from T-2026-0029. |
+| 33 | `T-2026-0033` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on retrieval/reranker evidence and token budget from T-2026-0030. |
+| 34 | `T-2026-0034` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on query-slice attribution from T-2026-0029. |
+| 35 | `T-2026-0035` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | P1 guardrail; should run before agentic/tool-using retrieval. |
+| 36 | `T-2026-0036` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on stable retrieval/context evidence from P0/P1 tasks. |
+| 37 | `T-2026-0037` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on metadata coverage evidence from T-2026-0028. |
+| 38 | `T-2026-0038` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on small-to-big retrieval evidence from T-2026-0031. |
+| 39 | `T-2026-0039` | `backlog` | Planner -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | P3; advanced architecture feasibility after P0/P1 evidence. |
 
 ## Examples
 
@@ -1898,7 +1911,7 @@ make check-branch
 
 - ID: T-2026-0022
 - Title: Use multi-chunk evidence analysis for the next retrieval follow-up
-- Status: review
+- Status: done
 - Owner role: Planner -> Implementer -> Reviewer
 
 ### Goal
@@ -1961,8 +1974,8 @@ Focused validation passes and the follow-up evidence is recorded in
 - Role: Planner -> Implementer
 - Lifecycle stage: review
 - Branch / worktree: `eval/issue-1563-multi-chunk-followup-implementation` / Codex worktree
-- Current status: aggregate-only strategy decision implemented; concrete retrieval
-  change deferred until page-aware re-index evidence exists.
+- Current status: merged in PR #1576; concrete retrieval change deferred until
+  page-aware re-index evidence exists.
 - Files touched: `.githooks/pre-commit`,
   `scripts/render_multi_chunk_retrieval_strategy.py`,
   `tests/test_render_multi_chunk_retrieval_strategy.py`,
@@ -1975,8 +1988,9 @@ Focused validation passes and the follow-up evidence is recorded in
 - Validation evidence: focused tests, doc-link check, whitespace check, branch check, and page metadata recovery audit completed.
 - Blockers: concrete retrieval implementation is blocked on page-aware re-index evidence, not on missing Markdown conversion.
 - Open risks: MiniLM semantic baseline evidence is absent from this task; keep #1575 separate.
-- Next action: run final validation, then open the issue-linked PR for #1563.
-- Next safe command: `python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py`
+- Next action: start a separate page-aware retrieval follow-up after refreshed
+  aggregate evidence exists.
+- Next safe command: `git status --short`
 - Reviewer focus: source freshness, privacy-safe aggregate-only wording, and no RAG performance claim.
 - Eval surface: report/measurement decision only; no retrieval, reranker, verifier, prompt, answer, or eval runtime behavior change.
 
@@ -1984,7 +1998,7 @@ Focused validation passes and the follow-up evidence is recorded in
 
 - ID: T-2026-0023
 - Title: RAG performance agent operating goal
-- Status: review
+- Status: done
 - Owner role: Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -2028,11 +2042,11 @@ future sessions do not collapse into only small local fixes.
 
 ### Acceptance Criteria
 
-- [ ] The 8 principles are recorded as enforceable operating criteria, not a chat-only preference.
-- [ ] RAG performance improvement is represented as a multi-session goal with
+- [x] The 8 principles are recorded as enforceable operating criteria, not a chat-only preference.
+- [x] RAG performance improvement is represented as a multi-session goal with
   role separation and reviewer escalation.
-- [ ] The docs explicitly separate this governance change from any performance claim.
-- [ ] Follow-up implementation work can start from `T-2026-0022` or later
+- [x] The docs explicitly separate this governance change from any performance claim.
+- [x] Follow-up implementation work can start from `T-2026-0022` or later
   measurement tasks without rediscovering the operating model.
 
 ### Validation Commands
@@ -2060,7 +2074,7 @@ make check-branch
 
 - ID: T-2026-0024
 - Title: Recover PyMuPDF4LLM page metadata at index build
-- Status: review
+- Status: done
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -2143,14 +2157,14 @@ Focused tests and syntax checks pass; local audits report citation page claim
 
 - Plan: [`docs/plans/T-2026-0024-page-metadata-reindex.md`](../docs/plans/T-2026-0024-page-metadata-reindex.md)
 - Issue: [#1573](https://github.com/hskim-solv/BidMate-DocAgent/issues/1573)
-- PR: TBD
+- PR: [#1577](https://github.com/hskim-solv/BidMate-DocAgent/pull/1577)
 
 ### Session Handoff
 
 - Role: Implementer
 - Lifecycle stage: review
 - Branch / worktree: `fix/issue-1573-page-metadata-reindex` / Codex worktree
-- Current status: implementation done; final validation and PR still needed.
+- Current status: merged in PR #1577.
 - Files touched: `Makefile`, `scripts/smoke_real.sh`,
   `rag_metadata_processing.py`, `tests/test_page_aware_parser_contract.py`,
   `tests/test_smoke_real_script.py`, `docs/plans/T-2026-0024-page-metadata-reindex.md`,
@@ -2162,9 +2176,9 @@ Focused tests and syntax checks pass; local audits report citation page claim
 - Open risks: fixed chunking produces coarse document-range page spans; precise
   page citation quality still needs section/page-aware evaluation before
   performance claims.
-- Next action: run final validation, then open PR
-  for #1573.
-- Next safe command: `python3 -m pytest -q tests/test_smoke_real_script.py tests/test_page_aware_parser_contract.py tests/test_page_metadata_recovery_audit.py tests/test_build_private_real100_v2_parallel.py tests/test_hwp_pdf_pymupdf4llm_loader.py tests/test_export_private_index_markdown.py`
+- Next action: use page-aware aggregate evidence for follow-up retrieval
+  diagnostics.
+- Next safe command: `git status --short`
 - Reviewer focus: no private path/raw text leakage, no performance claim, and
   explicit distinction between coarse fixed spans and section page spans.
 - Eval surface: ingestion/index metadata propagation and private real-eval
@@ -2174,7 +2188,7 @@ Focused tests and syntax checks pass; local audits report citation page claim
 
 - ID: T-2026-0025
 - Title: Separate hashing, MiniLM, and BGE-M3 real-eval surfaces
-- Status: review
+- Status: done
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
 - Last updated: 2026-05-27
@@ -2257,7 +2271,7 @@ extraction preserves embedding provenance without local model path leakage.
 - Role: Implementer
 - Lifecycle stage: review
 - Branch / worktree: `eval/issue-1575-minilm-baseline-target` / Codex worktree
-- Current status: implementation validated; PR still needed.
+- Current status: merged in PR #1579.
 - Files touched: `Makefile`, `scripts/smoke_real.sh`,
   `scripts/run_real_eval_delta.py`,
   `docs/evaluation/private_real_eval_workflow.md`,
@@ -2271,7 +2285,8 @@ extraction preserves embedding provenance without local model path leakage.
 - Blockers: none known.
 - Open risks: target existence does not prove MiniLM model cache/download or
   performance; actual MiniLM private eval remains a separate run.
-- Next action: push and mark PR #1579 ready.
+- Next action: run the named MiniLM/BGE-M3 surfaces only in a separate
+  aggregate-only eval task.
 - Next safe command: `git status --short`
 - Reviewer focus: baseline wording, no performance claim, and actual
   backend/model naming.
@@ -2371,3 +2386,801 @@ make check-branch
 - Next safe command: `git status --short`
 - Reviewer focus: backend axis separation, parity guard, no mixed embedding
   claim.
+
+## T-2026-0027 — RAG performance experiment stack
+
+- ID: T-2026-0027
+- Title: RAG performance experiment stack
+- Status: review
+- Priority: P0 planning
+- Owner role: Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Convert the broad RAG performance checklist into a repo-native, prioritized
+experiment stack that future sessions can execute one task and one PR at a
+time.
+
+### Context
+
+- Issue: #1584
+- Current branch: `docs/issue-1584-rag-performance-experiment-stack`
+- Current main already has page metadata recovery and named MiniLM/BGE-M3
+  private real-eval surfaces.
+- Existing hybrid sweep evidence says recall-only gains are not enough when
+  MRR, nDCG, citation, or latency regress.
+
+### Scope
+
+- Add a durable evaluation note that selects and defers RAG techniques.
+- Add concrete queue tasks for P0/P1/P2/P3 experiment execution.
+- Link the stack from the evaluation surface map.
+- Keep existing runtime, eval, retrieval, reranking, and answer behavior
+  unchanged.
+
+### Non-Goals
+
+- Do not implement retrieval, reranking, context packing, generator, security,
+  or advanced architecture behavior in this PR.
+- Do not run private real-eval.
+- Do not claim RAG quality, latency, citation, or production performance
+  improved.
+- Do not create all future GitHub issues before each task starts.
+
+### Acceptance Criteria
+
+- [x] Experiment tasks are ordered by priority and dependency.
+- [x] Each task states surface, validation, evidence, and no-claim boundary.
+- [x] Advanced techniques are explicitly deferred behind feasibility gates.
+- [x] The stack starts with private coverage and baseline refresh rather than
+  speculative architecture work.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0027-rag-performance-experiment-stack.md docs/evaluation/rag-performance-experiment-stack.md docs/evaluation/surface-map.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Doc-link check, whitespace check, and branch/issue check pass.
+- PR body says docs/planning only, no private real-eval run, and no performance
+  claim.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0027-rag-performance-experiment-stack.md`](../docs/plans/T-2026-0027-rag-performance-experiment-stack.md)
+- Evaluation note: [`docs/evaluation/rag-performance-experiment-stack.md`](../docs/evaluation/rag-performance-experiment-stack.md)
+- Issue: [#1584](https://github.com/hskim-solv/BidMate-DocAgent/issues/1584)
+- PR: TBD
+
+### Session Handoff
+
+- Role: Planner
+- Lifecycle stage: review
+- Branch / worktree: `docs/issue-1584-rag-performance-experiment-stack` / Codex worktree
+- Current status: task stack implemented and validation passed.
+- Files touched: `tasks/queue.md`,
+  `docs/plans/T-2026-0027-rag-performance-experiment-stack.md`,
+  `docs/evaluation/rag-performance-experiment-stack.md`,
+  `docs/evaluation/surface-map.md`.
+- Decisions made: prioritize measurement readiness, retrieval diagnostics,
+  latency/cost guardrails, and small-to-big retrieval before GraphRAG/Agentic
+  RAG.
+- Commands run: `python3 scripts/agent_loop.py overlap-preflight --issue 1584 --branch docs/issue-1584-rag-performance-experiment-stack`; `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0027-rag-performance-experiment-stack.md docs/evaluation/rag-performance-experiment-stack.md docs/evaluation/surface-map.md`; `git diff --check`; `make check-branch`.
+- Results: passed.
+- Next safe command: `git diff --stat`
+- Reviewer focus: priority order, no-claim wording, and private boundary.
+
+## T-2026-0028 — Refresh private coverage and semantic baselines
+
+- ID: T-2026-0028
+- Title: Refresh private coverage and semantic baselines
+- Status: ready
+- Priority: P0
+- Owner role: Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Create the first current aggregate-only baseline packet after page metadata
+recovery and MiniLM target separation, so later experiments compare against the
+right corpus, index, backend, and metric surface.
+
+### Scope
+
+- Run or document the local-only sequence: parse/data audit, validate-only,
+  hashing baseline, MiniLM baseline, and optional BGE-M3 comparison.
+- Preserve aggregate-only outputs that summarize case counts, evidence coverage,
+  page metadata coverage, retrieval metrics, answer metrics, abstention, stage
+  latency, embedding backend/model/dim, and vector DB backend.
+- Produce a no-go/go note naming which P0/P1 task should run next.
+
+### Non-Goals
+
+- Do not change ingestion, retrieval, reranking, answer, prompt, verifier, or
+  eval scoring behavior.
+- Do not commit raw private outputs.
+- Do not claim performance improvement from a single run without paired delta.
+
+### Acceptance Criteria
+
+- [ ] Aggregate packet reports answerable/unanswerable counts, explicit gold
+  evidence coverage, multi-document/multi-chunk counts, page/page_span coverage,
+  and embedding/backend provenance.
+- [ ] Hashing, MiniLM, and BGE-M3 surfaces are not compared unless dataset,
+  config, index, command, and provenance match the claim wording.
+- [ ] Any committed artifact passes privacy checks and omits raw questions,
+  answers, evidence, filenames, local paths, `doc_id`, and `chunk_id`.
+- [ ] The handoff names the next task: `T-2026-0029`, `T-2026-0030`, or a no-go
+  blocker.
+
+### Validation Commands
+
+```bash
+python3 scripts/audit_private_data_readiness.py --config eval/real_config.local.yaml --out-dir experiments/private_runs/readiness_audit
+python3 scripts/check_private_real_eval_readiness.py --config eval/real_config.local.yaml
+make real-eval
+make real-eval-minilm
+make real-eval-semantic
+python3 scripts/run_real_eval_delta.py --base <aggregate-baseline> --head <aggregate-head>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate-only baseline packet and command transcript summary.
+- Explicit statement whether real private eval ran and whether any paired delta
+  is valid.
+- Privacy audit result for any committed aggregate.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0029 — Build retrieval diagnostic workbench
+
+- ID: T-2026-0029
+- Title: Build retrieval diagnostic workbench
+- Status: backlog
+- Priority: P0
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Make retrieval failures explainable before changing retrieval behavior.
+
+### Scope
+
+- Add or harden an aggregate-only diagnostic that reports Recall@K, Hit@K, MRR,
+  nDCG, candidate-pool coverage, same-document versus multi-document evidence
+  split, rank-too-low cases, not-in-pool cases, duplicate/near-duplicate
+  candidate counts, and query-type slices.
+- Separate retrieval misses from evaluation-label gaps and answer-generation
+  failures.
+- Use page-aware private indexes from the refreshed baseline when available.
+
+### Non-Goals
+
+- Do not change ranking behavior.
+- Do not add reranking, query rewrite, or context packing.
+- Do not expose private case text or raw identifiers.
+
+### Acceptance Criteria
+
+- [ ] Diagnostics distinguish not-in-candidate-pool, ranked-too-low,
+  boundary/window, duplicate, metadata-filter, and multi-evidence failures.
+- [ ] Output is aggregate-only and commit-safe.
+- [ ] The report can decide whether `T-2026-0031` or `T-2026-0032` is the next
+  best experiment.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py
+python3 <new-or-existing-retrieval-diagnostic-script> --summary <aggregate-input> --out <aggregate-output>
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md <plan-path> <report-path>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate diagnostic report with no raw private text, IDs, filenames, or
+  paths.
+- Reviewer note explaining which failure bucket is dominant.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0030 — Define latency and cost budget envelope
+
+- ID: T-2026-0030
+- Title: Define latency and cost budget envelope
+- Status: backlog
+- Priority: P0
+- Owner role: Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Set the latency/cost guardrails that every multi-query, reranker, compression,
+or long-context experiment must satisfy.
+
+### Scope
+
+- Use existing `stage_latency`, p50/p95/p99, token counts, reranker candidate
+  counts, context token counts, and cache indicators where available.
+- Add a report or gate that classifies quality-only gains as no-go when latency
+  or cost exceeds the agreed envelope.
+- Keep the report aggregate-only and hardware-caveated.
+
+### Non-Goals
+
+- Do not optimize latency yet.
+- Do not introduce caching behavior.
+- Do not infer production SLOs from public fixture smoke.
+
+### Acceptance Criteria
+
+- [ ] Budget report names p50/p95/p99 and stage-level components.
+- [ ] Candidate-pool, reranker, query-rewrite, and context-packing tasks can cite
+  the same latency/cost envelope.
+- [ ] The report states warm/cold and local hardware caveats.
+
+### Validation Commands
+
+```bash
+python3 <new-or-existing-latency-budget-script> --summary <aggregate-input> --out <aggregate-output>
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md <plan-path> <report-path>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate latency/cost budget report.
+- Explicit guardrail thresholds or no-go classification rules.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0031 — Parent and section-window retrieval experiment
+
+- ID: T-2026-0031
+- Title: Parent and section-window retrieval experiment
+- Status: backlog
+- Priority: P1
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Test whether small-to-big retrieval improves multi-chunk and same-document
+evidence failures now that page-aware metadata exists.
+
+### Scope
+
+- Add an opt-in experiment preset that retrieves small chunks but expands
+  selected hits to parent section, page window, or sentence window context.
+- Deduplicate parent expansions and cap token/context growth.
+- Compare against the refreshed private baseline with paired aggregate delta.
+
+### Non-Goals
+
+- Do not change default `naive_baseline`.
+- Do not combine with reranker or query rewrite changes.
+- Do not claim improvement unless private paired delta shows primary metric
+  movement without guardrail regressions.
+
+### Acceptance Criteria
+
+- [ ] Opt-in preset leaves ADR 0001 baseline byte-identical.
+- [ ] Aggregate delta reports Recall@K, MRR, nDCG, citation/page coverage,
+  answer quality, abstention, and latency.
+- [ ] Same-document multi-chunk cases are reported separately from
+  multi-document cases.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_naive_baseline_ranking_invariance.py <focused-new-tests>
+python3 <experiment-runner> --variant parent_section_window --summary-out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Paired private aggregate delta or explicit no-go.
+- Token/latency guardrail result.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0032 — Reranker candidate-budget experiment
+
+- ID: T-2026-0032
+- Title: Reranker candidate-budget experiment
+- Status: backlog
+- Priority: P1
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Measure whether reranking improves early precision without hiding candidate-pool
+recall or causing unacceptable latency.
+
+### Scope
+
+- Sweep retriever candidate counts and reranker top-N limits.
+- Keep reranker model/provider provenance explicit.
+- Report rank movement, answer containment, citation effect, and stage latency.
+
+### Non-Goals
+
+- Do not increase candidate pools blindly.
+- Do not use LLM reranking until cross-encoder budget is measured.
+- Do not mix reranking with query rewrite, parent expansion, or prompt changes.
+
+### Acceptance Criteria
+
+- [ ] Sweep output classifies winner, recall-only gain, ranking regression,
+  citation regression, latency regression, or failed experiment.
+- [ ] Candidate-pool recall and reranker precision are reported separately.
+- [ ] Reranker provenance is present in aggregate output.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_reranker*.py <focused-new-tests>
+python3 <reranker-sweep-script> --config <local-or-public-config> --out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate sweep summary with no raw private content.
+- Latency/cost guardrail from `T-2026-0030`.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0033 — Context packing and citation ordering experiment
+
+- ID: T-2026-0033
+- Title: Context packing and citation ordering experiment
+- Status: backlog
+- Priority: P1
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Improve how selected evidence is assembled for generation without changing the
+retriever.
+
+### Scope
+
+- Test evidence-first ordering, duplicate suppression, conflicting evidence
+  grouping, page/section citation formatting, and lost-in-the-middle mitigation.
+- Measure token count, citation grounding, completeness, abstention, and
+  latency.
+- Preserve ADR 0003 answer contract unless an ADR explicitly changes it.
+
+### Non-Goals
+
+- Do not change retrieval ranking or reranker behavior.
+- Do not summarize private context into committed artifacts.
+- Do not increase context length without a token/latency budget.
+
+### Acceptance Criteria
+
+- [ ] Context assembly variant is opt-in and separately named.
+- [ ] Citation and answer metrics move together; citation regression is no-go.
+- [ ] Conflict grouping is visible to the generator without raw conflict text in
+  committed reports.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_answer_contract_snapshot.py <focused-context-tests>
+python3 <context-packing-experiment> --variant evidence_first --summary-out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Paired aggregate delta for citation, answer, abstention, token, and latency
+  metrics.
+- Explicit no-change statement for retrieval behavior.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0034 — Query rewrite and decomposition experiment
+
+- ID: T-2026-0034
+- Title: Query rewrite and decomposition experiment
+- Status: backlog
+- Priority: P1
+- Owner role: Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Test query rewrite, multi-query, and decomposition only on slices where query
+form is the measured bottleneck.
+
+### Scope
+
+- Target comparison, multi-hop, abbreviation, typo, mixed Korean/English, and
+  date/entity questions.
+- Keep rewrite outputs local-only for private cases.
+- Measure extra LLM/API calls, latency, rewrite drift, retrieval delta, and
+  answer delta.
+
+### Non-Goals
+
+- Do not turn on rewrite globally.
+- Do not send private queries to external providers without an approved online
+  payload boundary.
+- Do not combine with reranker or context-packing changes in the same PR.
+
+### Acceptance Criteria
+
+- [ ] Query-slice report justifies which slices receive rewrite/decomposition.
+- [ ] Identity expansion remains the default for `naive_baseline`.
+- [ ] Multi-query is no-go if recall gains are erased by reranking budget,
+  context truncation, latency, or answer regressions.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_query_expansion*.py tests/test_naive_baseline_ranking_invariance.py <focused-new-tests>
+python3 <query-experiment-runner> --variant rewrite_or_decompose --summary-out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate slice deltas and provider/payload provenance.
+- Explicit private egress statement.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0035 — Prompt-injection and data boundary guardrail
+
+- ID: T-2026-0035
+- Title: Prompt-injection and data boundary guardrail
+- Status: backlog
+- Priority: P1 guardrail
+- Owner role: Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Ensure retrieved text is treated as data, not instructions, before adding more
+agentic retrieval, tool routing, or external provider workflows.
+
+### Scope
+
+- Add or extend red-team fixtures for indirect prompt injection, instruction
+  override strings, secret/PII leakage attempts, and citation-only answer
+  constraints.
+- Verify retrieval context isolation, verifier neutralization, and tool-call
+  policy boundaries.
+- Record false positive/false negative counts without private raw payloads.
+
+### Non-Goals
+
+- Do not add broad new security architecture.
+- Do not block legitimate RFP text with overbroad filters without measuring
+  false positives.
+- Do not expose private documents in red-team artifacts.
+
+### Acceptance Criteria
+
+- [ ] Security fixtures cover malicious retrieved-document instructions.
+- [ ] Tests verify system/developer instructions remain higher priority than
+  retrieved data.
+- [ ] Aggregate report separates detection, neutralization, and answer behavior.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_verifier*.py tests/test_security*.py <focused-new-tests>
+python3 <security-redteam-runner> --out <aggregate-output>
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md <plan-path> <report-path>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Focused security test output.
+- Aggregate red-team report with false positive and false negative counts.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0036 — Abstention, conflict, and freshness calibration
+
+- ID: T-2026-0036
+- Title: Abstention, conflict, and freshness calibration
+- Status: backlog
+- Priority: P2
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Improve no-answer, conflicting evidence, and effective-date behavior after the
+retrieval evidence surface is stable.
+
+### Scope
+
+- Add or harden evaluation slices for unanswerable questions, stale/deprecated
+  documents, conflicting policy versions, and freshness/authority precedence.
+- Measure false abstention, missed abstention, citation support, and freshness
+  precedence accuracy.
+- Keep policy precedence rules explicit and testable.
+
+### Non-Goals
+
+- Do not mask retrieval misses as answer abstention improvements.
+- Do not change answer contract without ADR review.
+- Do not claim production policy correctness from synthetic-only cases.
+
+### Acceptance Criteria
+
+- [ ] Abstention and conflict metrics are reported separately from retrieval
+  recall.
+- [ ] Freshness/authority rules use metadata fields with missing-field behavior
+  defined.
+- [ ] Private aggregate evidence is required before real-world claim wording.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_answer_contract_snapshot.py tests/test_eval_metrics.py <focused-new-tests>
+python3 <abstention-conflict-runner> --summary-out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate no-answer/conflict/freshness report.
+- Clear separation between answer behavior and retrieval availability.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0037 — Metadata, authority, and freshness ranking experiment
+
+- ID: T-2026-0037
+- Title: Metadata, authority, and freshness ranking experiment
+- Status: backlog
+- Priority: P2
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Measure whether document metadata can improve ranking for RFP-specific
+questions without excluding valid evidence through missing or stale fields.
+
+### Scope
+
+- Audit metadata coverage for document type, issue date, effective date,
+  expiry/deprecated state, section title, page number, authority/source class,
+  customer/region/product fields when available.
+- Add opt-in freshness/authority boosts or filters only after coverage supports
+  them.
+- Report missing-field effects separately from ranking effects.
+
+### Non-Goals
+
+- Do not require metadata fields that private corpus does not reliably contain.
+- Do not change ACL or permission behavior in this task.
+- Do not introduce a vector DB payload-index dependency unless scoped as a
+  separate backend task.
+
+### Acceptance Criteria
+
+- [ ] Metadata coverage report determines which fields are safe to rank/filter
+  on.
+- [ ] Ranking variant has fail-open/fail-closed behavior documented for missing
+  fields.
+- [ ] Paired aggregate delta includes freshness, citation, retrieval, and
+  latency metrics.
+
+### Validation Commands
+
+```bash
+python3 <metadata-coverage-script> --index-dir <private-index> --out <aggregate-output>
+python3 -m pytest -q <focused-metadata-tests>
+python3 <metadata-ranking-experiment> --summary-out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Metadata coverage aggregate.
+- Ranking delta with missing-field analysis.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0038 — Contextual retrieval and sentence-window proof of concept
+
+- ID: T-2026-0038
+- Title: Contextual retrieval and sentence-window proof of concept
+- Status: backlog
+- Priority: P2
+- Owner role: Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Test chunk-context enrichment and sentence-window retrieval after simpler
+parent/section-window retrieval has been measured.
+
+### Scope
+
+- Prototype an opt-in contextual chunk prefix or sentence-window replacement
+  surface.
+- Record how contextual text was generated, whether external providers were
+  used, payload class, and private egress mode.
+- Compare against parent/section-window results before choosing a larger
+  ingestion/index rebuild.
+
+### Non-Goals
+
+- Do not rewrite the default ingestion pipeline.
+- Do not generate contextual prefixes for private chunks with an external model
+  unless explicitly approved under the online payload boundary.
+- Do not combine with GraphRAG/RAPTOR.
+
+### Acceptance Criteria
+
+- [ ] POC is opt-in and has isolated index/report paths.
+- [ ] Contextual text provenance and private egress mode are recorded.
+- [ ] Aggregate delta beats or clearly fails against the simpler small-to-big
+  retrieval baseline.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q <focused-contextual-retrieval-tests> tests/test_naive_baseline_ranking_invariance.py
+python3 <contextual-retrieval-experiment> --summary-out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <baseline-aggregate> --head <variant-aggregate>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate POC report and provenance.
+- Explicit go/no-go recommendation for broader contextual retrieval work.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0039 — Advanced architecture feasibility gate
+
+- ID: T-2026-0039
+- Title: Advanced architecture feasibility gate
+- Status: backlog
+- Priority: P3
+- Owner role: Planner -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
+- Created: 2026-05-27
+- Last updated: 2026-05-27
+
+### Goal
+
+Decide whether RAPTOR, GraphRAG, LightRAG, Agentic RAG, Self-RAG, CRAG, FLARE,
+late chunking, multi-vector retrieval, or long-context RAG is justified for
+BidMate-DocAgent.
+
+### Scope
+
+- Use P0/P1/P2 aggregate evidence to identify bottlenecks that simpler changes
+  could not solve.
+- Produce a feasibility matrix with build cost, index size, latency, privacy
+  risk, evaluation burden, rollback plan, and expected failure mode reduction.
+- Recommend at most one advanced architecture follow-up issue.
+
+### Non-Goals
+
+- Do not implement advanced architecture in this task.
+- Do not create a new graph/tree/index contract without ADR reservation.
+- Do not replace the existing RAG pipeline or baseline.
+
+### Acceptance Criteria
+
+- [ ] Feasibility report compares advanced options against measured bottlenecks,
+  not generic industry trend value.
+- [ ] Any recommended architecture names the exact eval surface and ADR need.
+- [ ] No-go is acceptable and preferred when evidence is weak.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md <plan-path> <feasibility-report-path>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Feasibility matrix and one recommended next issue or explicit no-go.
+- Reviewer notes for architecture, privacy, eval, and rollback risk.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -2456,7 +2456,7 @@ make check-branch
 - Plan: [`docs/plans/T-2026-0027-rag-performance-experiment-stack.md`](../docs/plans/T-2026-0027-rag-performance-experiment-stack.md)
 - Evaluation note: [`docs/evaluation/rag-performance-experiment-stack.md`](../docs/evaluation/rag-performance-experiment-stack.md)
 - Issue: [#1584](https://github.com/hskim-solv/BidMate-DocAgent/issues/1584)
-- PR: TBD
+- PR: [#1587](https://github.com/hskim-solv/BidMate-DocAgent/pull/1587)
 
 ### Session Handoff
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

RAG 성능 고도화 요청을 바로 runtime 변경으로 시작하지 않고, private real-eval aggregate 기준의 측정(measurement) -> 검색(retrieval) 진단 -> 실험(experiment) -> guardrail 순서로 실행할 수 있는 task stack으로 정리했습니다. `tasks/queue.md`에 P0/P1/P2/P3 우선순위 task를 추가하고, `docs/evaluation/rag-performance-experiment-stack.md`와 plan 문서에 선택/보류 기준을 남겼습니다.

Closes #1584

## 2. 영향 파일

- `tasks/queue.md` — T-2026-0027~T-2026-0039 task stack 추가, 최근 merge된 prerequisite task 상태 sync.
- `docs/plans/T-2026-0027-rag-performance-experiment-stack.md` — 이번 planning PR의 실행 기록.
- `docs/evaluation/rag-performance-experiment-stack.md` — 실험 우선순위, deferred technique, metric/guardrail 기준.
- `docs/evaluation/surface-map.md` — 새 experiment stack 문서 링크 추가.

## 3. 리스크

- 가장 큰 리스크는 이 문서가 성능(performance) 개선 claim처럼 읽히는 것입니다. 문서와 queue 모두 docs/planning only, private real-eval 미실행, no performance claim 경계를 명시했습니다.
- 또 다른 리스크는 task가 너무 많아 scope가 섞이는 것입니다. 각 task에 priority, dependency, scope, non-goal, validation, evidence boundary를 넣어 one PR / one concern으로 쪼갰습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0027-rag-performance-experiment-stack.md docs/evaluation/rag-performance-experiment-stack.md docs/evaluation/surface-map.md`
- `git diff --check`
- `make check-branch`

신규 runtime 동작이 없는 docs/planning 변경이라 unit test는 추가하지 않았습니다.

## 5. Eval 영향

Eval runtime, metric 계산, retrieval, reranking, answer generation 동작은 변경하지 않았습니다. 이번 PR은 future eval/experiment task ordering만 추가합니다.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. Private real-eval은 실행하지 않았고, real-data delta 또는 RAG 성능 claim도 없습니다.

## 6. 하위 호환

기존 CLI, schema, answer contract, eval artifact contract 변경 없음. 문서 링크는 targeted doc-link check로 확인했습니다.

## 7. 범위 외

- T-2026-0028 이후의 private baseline refresh는 별도 issue-linked PR에서 실행합니다.
- Parent/section-window retrieval, reranker, query rewrite, context packing, GraphRAG/RAPTOR/Agentic RAG 등은 이번 PR에서 구현하지 않습니다.
- Chroma vector-store baseline은 기존 T-2026-0026에 남겨 backend-axis task로 분리했습니다.
