### PR TITLE
Add active agent loop start command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@
 # they render prompts, classify surfaces, check handoffs, suggest or run
 # allowlisted local validation, and write ignored local planning drafts. They
 # do not perform GitHub mutations.
-.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-issue-scan agent-loop-maintenance-plan agent-loop-issue-close agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
+.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-issue-scan agent-loop-maintenance-plan agent-loop-issue-close agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-active-start agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
 
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
@@ -299,6 +299,7 @@ test-regression:
 #   make agent-loop-dashboard-html
 #   make agent-loop-ship-command-pack
 #   make agent-loop-apply-queue-plan CONFIRM_HUMAN_APPROVED=1
+#   make agent-loop-active-start
 #   make agent-loop-loop-state TASK=T-2026-0003
 #   make agent-loop-status TASK=T-2026-0003
 #   make agent-loop-preflight TASK=T-2026-0003
@@ -413,6 +414,10 @@ ARCHITECTURE_DECISION_OUT ?= reports/agent_loop/architecture_decision.md
 WORKSET_RECOMMENDATION_OUT ?= reports/agent_loop/workset_recommendation.md
 DEPENDENCY_GRAPH_OUT ?= reports/agent_loop/dependency_graph.md
 AUTOMATION_COVERAGE_OUT ?= reports/agent_loop/automation_coverage.md
+ACTIVE_START_OUT ?= reports/agent_loop/active/start.md
+ACTIVE_TOPOLOGY ?= expanded-eight
+ACTIVE_AGENT_MIX ?= claude=5,codex=5
+ACTIVE_LEASE_TTL_MINUTES ?= 30
 HUMAN_GATED_ACTION ?=
 HUMAN_GATED_EXEC_OUT ?= reports/agent_loop/human_gated_exec.md
 HUMAN_GATED_DRY_RUN ?=
@@ -898,6 +903,20 @@ agent-loop-workset-recommend:
 agent-loop-automation-coverage:
 	$(PYTHON) scripts/agent_loop.py automation-coverage \
 	  --out "$(AUTOMATION_COVERAGE_OUT)"
+
+agent-loop-active-start:
+	$(PYTHON) scripts/agent_loop.py active-start \
+	  --topology "$(ACTIVE_TOPOLOGY)" \
+	  --agent-mix "$(ACTIVE_AGENT_MIX)" \
+	  --lease-ttl-minutes "$(ACTIVE_LEASE_TTL_MINUTES)" \
+	  $(if $(TASK),--task "$(TASK)",) \
+	  $(if $(ISSUE),--issue "$(ISSUE)",) \
+	  $(if $(BRANCH),--branch "$(BRANCH)",) \
+	  $(if $(CHANGED_FILES),--changed-files "$(CHANGED_FILES)",--from-git) \
+	  $(if $(CLAIM_TEXT),--claim-text "$(CLAIM_TEXT)",) \
+	  $(if $(PR_BODY_OUT),--pr-body "$(PR_BODY_OUT)",) \
+	  $(if $(DECISION_BATCH),--batch "$(DECISION_BATCH)",) \
+	  --out "$(ACTIVE_START_OUT)"
 
 agent-loop-human-gated-exec:
 	@if [ -z "$(HUMAN_GATED_ACTION)" ]; then \

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -107,6 +107,27 @@ python3 scripts/agent_loop.py active-loop --mode full-ship --dry-run --from-git
 5. `Implementer` write lease와 각 role assignment를 갱신한다.
 6. Full ship gate 결과를 report한다.
 
+## One-command Start
+
+사람이 "시작"만 눌러도 local orchestration surface가 한 번에 만들어져야 할 때는
+`active-start`를 사용한다.
+
+```bash
+python3 scripts/agent_loop.py active-start --from-git
+```
+
+이 명령은 remote mutation을 하지 않는다. 대신 `reports/agent_loop/active/` 아래에
+expanded-eight ledger, role assignment, dashboard, approval packet, readiness score,
+privacy audit, ship simulation, auto-ship dry-run plan을 한 번에 쓴다. 현재 branch가
+detached HEAD이거나 ADR 0007 issue branch가 아니면 blocked start report와 다음 안전
+명령을 남긴다.
+
+Make wrapper:
+
+```bash
+make agent-loop-active-start
+```
+
 ## Full Ship Gate
 
 `--execute`는 gate가 통과할 때만 기존 ship runner를 호출한다.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -127,6 +127,7 @@ DEFAULT_ACTIVE_LEASES = DEFAULT_ACTIVE_DIR / "leases.json"
 DEFAULT_ACTIVE_EVENTS = DEFAULT_ACTIVE_DIR / "events.jsonl"
 DEFAULT_ACTIVE_ASSIGNMENTS_DIR = DEFAULT_ACTIVE_DIR / "assignments"
 DEFAULT_ACTIVE_LOOP = DEFAULT_ACTIVE_DIR / "active_loop.md"
+DEFAULT_ACTIVE_START = DEFAULT_ACTIVE_DIR / "start.md"
 DEFAULT_ACTIVE_AGENT_MIX = DEFAULT_ACTIVE_DIR / "agent_mix.json"
 DEFAULT_ACTIVE_WORKTREE_PREPARE = DEFAULT_ACTIVE_DIR / "active_worktree_prepare.md"
 DEFAULT_ISSUE_STATE = DEFAULT_REPORT_DIR / "issue_state.json"
@@ -529,6 +530,17 @@ class ActiveLoopResult:
     blockers: tuple[str, ...]
     warnings: tuple[str, ...]
     executed_commands: tuple[tuple[str, ...], ...] = ()
+
+
+@dataclass(frozen=True)
+class ActiveStartResult:
+    report_path: Path
+    active_loop: ActiveLoopResult
+    outputs: tuple[Path, ...]
+    decision: str
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    next_safe_command: str
 
 
 def _repo_path(path: Path, repo_root: Path) -> str:
@@ -8504,6 +8516,230 @@ def write_active_loop(
     )
 
 
+def write_active_start(
+    *,
+    mode: str = "full-ship",
+    topology: str = "expanded-eight",
+    task_id: str | None = None,
+    issue: str | None = None,
+    branch: str | None = None,
+    changed_files: Sequence[str] = (),
+    claim_text: Path | None = None,
+    pr_body: Path | None = None,
+    lease_ttl_minutes: int = 30,
+    batch: Path | None = None,
+    agent_mix: dict[str, object] | None = None,
+    out: Path = DEFAULT_ACTIVE_START,
+    repo_root: Path = ROOT_DIR,
+) -> ActiveStartResult:
+    files = tuple(sorted(_normalize_changed_file(path, repo_root=repo_root) for path in changed_files if path))
+    active_dir = repo_root / "reports" / "agent_loop" / "active"
+    outputs: list[Path] = []
+    warnings: list[str] = []
+    blockers: list[str] = []
+
+    active_loop = write_active_loop(
+        mode=mode,
+        topology=topology,
+        execute=False,
+        task_id=task_id,
+        issue=issue,
+        branch=branch,
+        changed_files=files,
+        claim_text=claim_text,
+        pr_body=pr_body,
+        lease_ttl_minutes=lease_ttl_minutes,
+        batch=batch,
+        agent_mix=agent_mix,
+        out=active_dir / "active_loop.md",
+        repo_root=repo_root,
+    )
+    outputs.append(active_loop.report_path)
+    blockers.extend(active_loop.blockers)
+    warnings.extend(active_loop.warnings)
+
+    branch_name = branch or _current_branch(repo_root) or "unknown"
+
+    def capture(label: str, writer) -> None:  # type: ignore[no-untyped-def]
+        try:
+            written = writer()
+            outputs.append(written[0] if isinstance(written, tuple) else written)
+        except ValueError as exc:
+            warnings.append(f"{label} skipped: {exc}")
+
+    capture(
+        "dashboard",
+        lambda: write_dashboard(
+            task_id=task_id,
+            batch=batch,
+            changed_files=files,
+            out=active_dir / "dashboard.md",
+            repo_root=repo_root,
+        ),
+    )
+    capture(
+        "branch-issue-hygiene",
+        lambda: write_branch_issue_hygiene(
+            branch=branch_name,
+            body=pr_body,
+            task_id=task_id,
+            out=active_dir / "branch_issue_hygiene.md",
+            repo_root=repo_root,
+        ),
+    )
+    capture(
+        "approval-packet",
+        lambda: write_approval_packet(
+            task_id=task_id,
+            changed_files=files,
+            claim_text=claim_text,
+            out=active_dir / "approval_packet.md",
+            repo_root=repo_root,
+        ),
+    )
+    capture(
+        "ship-simulate",
+        lambda: write_ship_simulation(
+            task_id=task_id,
+            changed_files=files,
+            branch=branch_name,
+            out=active_dir / "ship_simulation.md",
+            repo_root=repo_root,
+        ),
+    )
+    capture(
+        "auto-ship-plan",
+        lambda: write_auto_ship_plan(
+            task_id=task_id,
+            changed_files=files,
+            branch=branch_name,
+            real_eval="skip",
+            draft=True,
+            dry_run=True,
+            out=active_dir / "auto_ship_plan.md",
+            repo_root=repo_root,
+        ),
+    )
+    try:
+        privacy_out, privacy_rc, _ = write_privacy_audit_output(
+            path=repo_root / "reports" / "agent_loop",
+            out=active_dir / "privacy_audit.md",
+            repo_root=repo_root,
+        )
+        outputs.append(privacy_out)
+        if privacy_rc:
+            blockers.append("privacy audit found generated artifact issue(s)")
+    except ValueError as exc:
+        warnings.append(f"privacy-audit-output skipped: {exc}")
+
+    decision = "blocked" if blockers else "started"
+    if blockers:
+        next_safe = "python3 scripts/agent_loop.py decision-brief --from-git --gate task"
+        if issue:
+            next_safe = (
+                "python3 scripts/agent_loop.py active-worktree-prepare "
+                f"--issue {shlex.quote(_validate_issue_selector(issue))} --role Implementer "
+                "--slug active-agent-loop --dry-run"
+            )
+    else:
+        next_safe = (
+            "python3 scripts/agent_loop.py active-loop "
+            f"--mode {mode} --topology {topology} --execute --from-git"
+        )
+
+    out_path = _active_path(out, repo_root=repo_root)
+    rendered = render_active_start(
+        mode=mode,
+        topology=topology,
+        task_id=task_id,
+        issue=issue,
+        branch=branch_name,
+        changed_files=files,
+        decision=decision,
+        active_loop=active_loop,
+        outputs=tuple(outputs),
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        next_safe_command=next_safe,
+        repo_root=repo_root,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered, encoding="utf-8")
+    return ActiveStartResult(
+        report_path=out_path,
+        active_loop=active_loop,
+        outputs=tuple(outputs),
+        decision=decision,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        next_safe_command=next_safe,
+    )
+
+
+def render_active_start(
+    *,
+    mode: str,
+    topology: str,
+    task_id: str | None,
+    issue: str | None,
+    branch: str,
+    changed_files: Sequence[str],
+    decision: str,
+    active_loop: ActiveLoopResult,
+    outputs: Sequence[Path],
+    blockers: Sequence[str],
+    warnings: Sequence[str],
+    next_safe_command: str,
+    repo_root: Path,
+) -> str:
+    lines = [
+        "# Active Agent Loop Start",
+        "",
+        "- One-command local start pack for the active agent loop.",
+        "- This command writes local reports only; it does not push, create/merge PRs, delete branches, force-push, or call external model APIs.",
+        "- It starts the ledger, role assignments, readiness evidence, privacy audit, and ship simulation in one tick.",
+        "",
+        "## Inputs",
+        "",
+        f"- Mode: `{_sanitize_inline_text(mode)}`",
+        f"- Topology: `{_sanitize_inline_text(topology)}`",
+        f"- Task: `{task_id or 'N/A'}`",
+        f"- Issue: `{_validate_issue_selector(issue) if issue else 'N/A'}`",
+        f"- Branch: `{_sanitize_inline_text(branch)}`",
+        f"- Changed files: `{len(changed_files)}`",
+        "",
+        "## Decision",
+        "",
+        f"- Start decision: `{decision}`",
+        f"- Active-loop decision: `{active_loop.decision}`",
+        "",
+        "## Artifacts",
+        "",
+    ]
+    lines.extend(f"- `{_repo_path(path, repo_root)}`" for path in outputs)
+    lines.extend(["", "## Blockers", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in blockers) if blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in warnings) if warnings else lines.append("- None")
+    lines.extend(
+        [
+            "",
+            "## Next Safe Command",
+            "",
+            "```bash",
+            _sanitize_command_text(next_safe_command),
+            "```",
+            "",
+            "## Role Assignments",
+            "",
+            f"- Directory: `{_repo_path(active_loop.assignments_dir, repo_root)}`",
+            "- Run the blocking role commands from each assignment, then record pass/clear with `session-heartbeat`.",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
 def render_active_loop(
     *,
     mode: str,
@@ -8635,6 +8871,8 @@ def _active_path(path: Path, *, repo_root: Path) -> Path:
         path = repo_root / "reports" / "agent_loop" / "active" / "assignments"
     elif path == DEFAULT_ACTIVE_LOOP:
         path = repo_root / "reports" / "agent_loop" / "active" / "active_loop.md"
+    elif path == DEFAULT_ACTIVE_START:
+        path = repo_root / "reports" / "agent_loop" / "active" / "start.md"
     elif path == DEFAULT_ACTIVE_AGENT_MIX:
         path = repo_root / "reports" / "agent_loop" / "active" / "agent_mix.json"
     elif path == DEFAULT_ACTIVE_WORKTREE_PREPARE:
@@ -10559,6 +10797,21 @@ def build_parser() -> argparse.ArgumentParser:
     role_dispatch.add_argument("--workset")
     role_dispatch.add_argument("--out", type=Path, default=DEFAULT_ROLE_DISPATCH)
 
+    active_start = sub.add_parser("active-start", help="Create a one-command local start pack for the active loop.")
+    active_start.add_argument("--mode", choices=("full-ship",), default="full-ship")
+    active_start.add_argument("--topology", choices=ACTIVE_TOPOLOGY_CHOICES, default="expanded-eight")
+    active_start.add_argument("--task")
+    active_start.add_argument("--issue")
+    active_start.add_argument("--branch")
+    active_start.add_argument("--changed-files", type=Path)
+    active_start.add_argument("--from-git", action="store_true")
+    active_start.add_argument("--claim-text", type=Path)
+    active_start.add_argument("--pr-body", type=Path)
+    active_start.add_argument("--lease-ttl-minutes", type=int, default=30)
+    active_start.add_argument("--batch", type=Path)
+    active_start.add_argument("--agent-mix", help="Work-unit mix target, e.g. claude=5,codex=5")
+    active_start.add_argument("--out", type=Path, default=DEFAULT_ACTIVE_START)
+
     active_loop = sub.add_parser("active-loop", help="Run the active orchestrator tick.")
     active_loop.add_argument("--mode", choices=("full-ship",), default="full-ship")
     active_loop.add_argument("--topology", choices=ACTIVE_TOPOLOGY_CHOICES, default="four-role")
@@ -11398,6 +11651,29 @@ def main(argv: list[str] | None = None) -> int:
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(out, ROOT_DIR)}\n")
             return 0
+        if args.command == "active-start":
+            files = _read_changed_files(
+                args.changed_files,
+                from_git=args.from_git,
+                pr=None,
+                repo_root=ROOT_DIR,
+            )
+            result = write_active_start(
+                mode=args.mode,
+                topology=args.topology,
+                task_id=args.task,
+                issue=args.issue,
+                branch=args.branch,
+                changed_files=files,
+                claim_text=args.claim_text,
+                pr_body=args.pr_body,
+                lease_ttl_minutes=args.lease_ttl_minutes,
+                batch=args.batch,
+                agent_mix=_parse_agent_mix(args.agent_mix),
+                out=args.out,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")
+            return 0 if result.decision == "started" else 1
         if args.command == "active-loop":
             files = _read_changed_files(
                 args.changed_files,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2845,8 +2845,10 @@ def test_active_loop_cli_accepts_expanded_eight_and_rejects_unknown_topology() -
     parser = agent_loop.build_parser()
 
     args = parser.parse_args(["active-loop", "--topology", "expanded-eight"])
+    start_args = parser.parse_args(["active-start"])
 
     assert args.topology == "expanded-eight"
+    assert start_args.topology == "expanded-eight"
     with pytest.raises(SystemExit):
         parser.parse_args(["active-loop", "--topology", "unknown-topology"])
 
@@ -2921,6 +2923,51 @@ def test_active_loop_agent_mix_flag_overrides_target(monkeypatch, tmp_path: Path
 
     assert registry["agent_mix"]["target"] == {"claude": 7, "codex": 3}
     assert agent_mix["policy"]["target"] == {"claude": 7, "codex": 3}
+
+
+def test_active_start_creates_local_start_pack_without_remote_mutation(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _patch_active_loop_clear(monkeypatch)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    result = agent_loop.write_active_start(
+        changed_files=["docs/operations/active-agent-loop.md"],
+        repo_root=repo,
+    )
+
+    assert result.decision == "started"
+    assert result.report_path == repo / "reports" / "agent_loop" / "active" / "start.md"
+    assert result.active_loop.decision == "planned"
+    assert (repo / "reports" / "agent_loop" / "active" / "active_loop.md").exists()
+    assert (repo / "reports" / "agent_loop" / "active" / "dashboard.md").exists()
+    assert (repo / "reports" / "agent_loop" / "active" / "approval_packet.md").exists()
+    assert (repo / "reports" / "agent_loop" / "active" / "ship_simulation.md").exists()
+    assert (repo / "reports" / "agent_loop" / "active" / "auto_ship_plan.md").exists()
+    assert (repo / "reports" / "agent_loop" / "active" / "privacy_audit.md").exists()
+    assert not any(call[0] in {"gh", "make"} for call in calls)
+    assert "active-loop --mode full-ship --topology expanded-eight --execute --from-git" in result.next_safe_command
+
+
+def test_active_start_blocks_on_detached_head_and_suggests_prepare(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "HEAD")
+    monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
+
+    result = agent_loop.write_active_start(
+        issue="9999",
+        changed_files=["docs/operations/active-agent-loop.md"],
+        repo_root=repo,
+    )
+
+    assert result.decision == "blocked"
+    assert any("current branch is not an issue-linked feature branch" in blocker for blocker in result.blockers)
+    assert "active-worktree-prepare --issue 9999" in result.next_safe_command
 
 
 def test_active_loop_four_role_v2_shape_is_unchanged(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Active agent loop를 "시작" 한 번으로 굴릴 수 있도록 `active-start` local-only entrypoint를 추가했습니다. 이 명령은 expanded-eight ledger, role assignment, readiness evidence, privacy audit, ship simulation, auto-ship dry-run plan을 한 번에 생성하지만 push/PR/merge/delete 같은 remote mutation은 수행하지 않습니다.

Closes #1591

## 2. 영향 파일

- `scripts/agent_loop.py` — `active-start` CLI, local start pack renderer/writer 추가
- `Makefile` — `make agent-loop-active-start` wrapper 추가
- `docs/operations/active-agent-loop.md` — one-command start 사용법 문서화
- `tests/test_agent_loop.py` — local-only start pack과 detached HEAD blocker 검증 추가

## 3. 리스크

가장 큰 리스크는 시작 명령이 remote mutation으로 오해되거나, detached/protected branch에서 ship 단계로 넘어가는 것입니다. `active-start`는 local report만 쓰고 blocked 상태에서는 다음 안전 명령만 남기도록 제한했습니다.

## 4. 테스트

- `python3 -m py_compile scripts/agent_loop.py`
- `python3 -m pytest tests/test_agent_loop.py -q -k active_start`
- `git diff --check`
- `make check-branch`

## 5. Eval 영향

All `N/A` — RAG 검색(retrieval), 재순위(reranking), 답변(answer), eval scorer 동작 변경 없음. Agent-loop orchestration CLI와 문서/테스트 변경입니다.

### 5b. Real-data delta

N/A — load-bearing path 변경 없음. 검색/검증 path 동작 변화 없음.

## 6. 하위 호환

기존 `active-loop`, `session-heartbeat`, `active-worktree-prepare` CLI flag는 유지했습니다. 새 `active-start`는 additive command이며 기본 topology만 `expanded-eight`입니다.

## 7. 범위 외

- 실제 Claude/Codex worker 자동 실행(spawn)은 추가하지 않았습니다.
- Push/PR/merge/delete 자동 실행은 기존 conservative gate와 `make ship-run` 경로에 남겼습니다.
