### PR TITLE
feat: active-loop read-only agent-turn lanes + Work Unit accounting

### DIFF
--- a/schemas/review_artifact.schema.json
+++ b/schemas/review_artifact.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/review_artifact.schema.json",
+  "title": "Active-loop read-only lane review artifact",
+  "description": "Shared contract for a read-only agent-turn artifact produced by a Claude or Codex lane. The model fills verdict/summary/findings/next_steps; the agent-turn adapter authoritatively sets the remaining meta fields (schema_version, task_id, session_id, role, agent, generated_at, wu, privacy_scrubbed) after parsing and privacy-scrubbing. No raw private question/answer text, doc_id, chunk_id, filenames, prompt bodies, or absolute private paths (ADR 0005).",
+  "type": "object",
+  "required": ["verdict", "summary", "findings"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "task_id": {
+      "type": ["string", "null"]
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "agent": {
+      "type": "string",
+      "enum": ["claude", "codex"]
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["approved", "clear", "needs-attention", "blocked", "error"]
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    },
+    "next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "wu": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "privacy_scrubbed": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "required": ["severity", "title"],
+      "additionalProperties": false,
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": ["blocker", "warning", "info"]
+        },
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "recommendation": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -129,6 +129,8 @@ DEFAULT_ACTIVE_ASSIGNMENTS_DIR = DEFAULT_ACTIVE_DIR / "assignments"
 DEFAULT_ACTIVE_LOOP = DEFAULT_ACTIVE_DIR / "active_loop.md"
 DEFAULT_ACTIVE_START = DEFAULT_ACTIVE_DIR / "start.md"
 DEFAULT_ACTIVE_AGENT_MIX = DEFAULT_ACTIVE_DIR / "agent_mix.json"
+DEFAULT_ACTIVE_AGENT_MIX_REPORT = DEFAULT_ACTIVE_DIR / "agent_mix_report.md"
+DEFAULT_ACTIVE_ARTIFACTS_DIR = DEFAULT_ACTIVE_DIR / "artifacts"
 DEFAULT_ACTIVE_WORKTREE_PREPARE = DEFAULT_ACTIVE_DIR / "active_worktree_prepare.md"
 DEFAULT_ISSUE_STATE = DEFAULT_REPORT_DIR / "issue_state.json"
 DEFAULT_ISSUE_TRIAGE = DEFAULT_REPORT_DIR / "issue_triage.md"
@@ -179,6 +181,20 @@ DEFAULT_AGENT_MIX = {
     "unit": "work_unit",
     "window": {"type": "rolling_tasks", "size": 20},
     "max_allowed_skew_wu": 2,
+}
+# Read-only review/analysis lane contract (issue #1590, ADR 0080 Phase 2).
+REVIEW_ARTIFACT_SCHEMA = Path("schemas/review_artifact.schema.json")
+# Per-role lane capability prior. Adversarial/regression review favors the Codex
+# companion (ADR 0066); claim/privacy/planning/scouting favor the Claude lane.
+# choose_agent adds rolling Work-Unit mix debt on top of these priors.
+_ROLE_CAPABILITY = {
+    "Reviewer": {"codex": 1.0},
+    "Deep Reviewer": {"codex": 1.0},
+    "CI / Regression Auditor": {"codex": 1.0},
+    "CI/Eval Auditor": {"codex": 1.0},
+    "Eval / Claim / Privacy Auditor": {"claude": 1.0},
+    "Planner / Issue Triage": {"claude": 1.0},
+    "Experiment Scout": {"claude": 1.0},
 }
 
 GH_PR_JSON_FIELDS = (
@@ -541,6 +557,18 @@ class ActiveStartResult:
     blockers: tuple[str, ...]
     warnings: tuple[str, ...]
     next_safe_command: str
+
+
+@dataclass(frozen=True)
+class AgentTurnResult:
+    decision: str
+    role: str
+    agent: str
+    verdict: str
+    artifact_path: Path | None
+    registry_path: Path | None
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
 
 
 def _repo_path(path: Path, repo_root: Path) -> str:
@@ -8875,6 +8903,10 @@ def _active_path(path: Path, *, repo_root: Path) -> Path:
         path = repo_root / "reports" / "agent_loop" / "active" / "start.md"
     elif path == DEFAULT_ACTIVE_AGENT_MIX:
         path = repo_root / "reports" / "agent_loop" / "active" / "agent_mix.json"
+    elif path == DEFAULT_ACTIVE_AGENT_MIX_REPORT:
+        path = repo_root / "reports" / "agent_loop" / "active" / "agent_mix_report.md"
+    elif path == DEFAULT_ACTIVE_ARTIFACTS_DIR:
+        path = repo_root / "reports" / "agent_loop" / "active" / "artifacts"
     elif path == DEFAULT_ACTIVE_WORKTREE_PREPARE:
         path = repo_root / "reports" / "agent_loop" / "active" / "active_worktree_prepare.md"
     return _safe_output_path(path, repo_root=repo_root)
@@ -9026,6 +9058,375 @@ def _write_active_agent_mix(
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(_sanitize_json_value(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
+
+
+def _agent_turn_roles() -> set[str]:
+    """Read-only review/analysis roles eligible for an agent-turn lane.
+
+    Orchestrator (control plane) and Implementer (write-lease owner) are excluded —
+    they are not read-only review lanes.
+    """
+    roles: set[str] = set()
+    for entries in ACTIVE_TOPOLOGY_ROLES.values():
+        for _session_id, role in entries:
+            if role not in {"Orchestrator", "Implementer"}:
+                roles.add(role)
+    return roles
+
+
+def choose_agent(role: str, *, agent_mix: dict[str, object], rolling: dict[str, object]) -> str:
+    """Pick a lane deterministically from role capability + rolling Work-Unit mix debt.
+
+    score(agent) = capability_prior + (target_share - actual_share). The lane that is
+    most under its target share (most Work Units "owed") gets a boost, so the rolling
+    Claude:Codex split converges to the configured mix. Ties break to Claude.
+    """
+    capability = _ROLE_CAPABILITY.get(role, {})
+    target_raw = agent_mix.get("target") if isinstance(agent_mix.get("target"), dict) else {}
+    targets = {agent: _coerce_wu(target_raw.get(agent)) for agent in ACTIVE_LANE_AGENTS}
+    target_total = sum(targets.values())
+    rolling_wu = {agent: _coerce_wu(rolling.get(agent)) for agent in ACTIVE_LANE_AGENTS}
+    rolling_total = sum(rolling_wu.values())
+    scores: dict[str, float] = {}
+    for agent in ACTIVE_LANE_AGENTS:
+        target_share = (targets[agent] / target_total) if target_total else 0.5
+        actual_share = (rolling_wu[agent] / rolling_total) if rolling_total else 0.0
+        scores[agent] = float(capability.get(agent, 0.0)) + (target_share - actual_share)
+    return max(ACTIVE_LANE_AGENTS, key=lambda a: (scores[a], a == "claude"))
+
+
+def _record_agent_wu(
+    path: Path,
+    *,
+    agent: str,
+    task_id: str | None,
+    wu: int,
+    policy: dict[str, object],
+    now: datetime,
+) -> dict[str, int]:
+    """Append a Work-Unit entry to the agent-mix ledger and recompute rolling totals.
+
+    The ledger is trimmed to the policy rolling-window size; rolling per-agent WU is
+    the sum over the trimmed window. Returns the recomputed rolling map.
+    """
+    existing = _load_active_agent_mix(path)
+    ledger_raw = existing.get("ledger") if isinstance(existing.get("ledger"), list) else []
+    ledger = [dict(item) for item in ledger_raw if isinstance(item, dict)]
+    ledger.append({"agent": agent, "task_id": task_id, "wu": _coerce_wu(wu), "at": _isoformat(now)})
+    window = policy.get("window") if isinstance(policy.get("window"), dict) else {}
+    size = window.get("size")
+    if isinstance(size, int) and not isinstance(size, bool) and size > 0:
+        ledger = ledger[-size:]
+    rolling = {a: 0 for a in ACTIVE_LANE_AGENTS}
+    for item in ledger:
+        name = str(item.get("agent") or "")
+        if name in rolling:
+            rolling[name] += _coerce_wu(item.get("wu"))
+    payload = {
+        "schema_version": ACTIVE_REGISTRY_SCHEMA_VERSION,
+        "generated_at": _isoformat(now),
+        "policy": policy,
+        "rolling": rolling,
+        "ledger": ledger,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_sanitize_json_value(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return rolling
+
+
+def _agent_turn_artifact_path(
+    artifacts_dir: Path,
+    *,
+    task_id: str | None,
+    session_id: str,
+    agent: str,
+    repo_root: Path,
+) -> Path:
+    base = _active_path(artifacts_dir, repo_root=repo_root)
+    task_segment = task_id if task_id else "no-task"
+    return base / task_segment / session_id / f"{agent}.json"
+
+
+def _build_agent_turn_prompt(role: str, *, task_id: str | None, pr: str | None, base: str) -> str:
+    scope_bits = [f"role={role}"]
+    if task_id:
+        scope_bits.append(f"task={task_id}")
+    if pr:
+        scope_bits.append(f"PR=#{pr}")
+    scope = ", ".join(scope_bits)
+    return (
+        "You are a read-only reviewer in the BidMate-DocAgent active loop. "
+        f"Scope: {scope}. Diff base: {base}. "
+        "Review the current branch changes WITHOUT editing, writing, committing, pushing, or shipping. "
+        "Use only Read/Grep/Glob and read-only git (diff/log/status). "
+        "Return JSON conforming to the review_artifact schema: a verdict "
+        "(approved|clear|needs-attention|blocked), a one-line summary, a findings array "
+        "(each with severity blocker|warning|info, a title, and optional body/recommendation), "
+        "and an optional next_steps array. Do NOT include raw private question/answer text, "
+        "doc_id, chunk_id, filenames, or absolute private paths (ADR 0005)."
+    )
+
+
+def _run_agent_lane(
+    agent: str,
+    *,
+    role: str,
+    task_id: str | None,
+    pr: str | None,
+    base: str,
+    schema_path: Path,
+    repo_root: Path,
+    claude_runner=None,
+    codex_runner=None,
+) -> dict[str, object]:
+    """Dispatch one read-only lane and return the shared review-artifact core."""
+    try:
+        from scripts import agent_loop_claude_turn as claude_turn, agent_loop_codex_turn as codex_turn
+    except ImportError:  # pragma: no cover - direct-script invocation fallback
+        import agent_loop_claude_turn as claude_turn  # type: ignore[no-redef]
+        import agent_loop_codex_turn as codex_turn  # type: ignore[no-redef]
+    if agent == "codex":
+        focus = f"{role} read-only review"
+        return codex_turn.run_turn(base=base, scope="branch", focus=focus, runner=codex_runner)
+    prompt = _build_agent_turn_prompt(role, task_id=task_id, pr=pr, base=base)
+    resolved_schema = schema_path if schema_path.is_absolute() else (repo_root / schema_path)
+    return claude_turn.run_turn(prompt=prompt, schema_path=resolved_schema, runner=claude_runner)
+
+
+def write_agent_turn(
+    *,
+    session_id: str,
+    role: str,
+    agent: str | None = None,
+    task_id: str | None = None,
+    pr: str | None = None,
+    base: str = "origin/main",
+    execute: bool = False,
+    registry: Path = DEFAULT_ACTIVE_REGISTRY,
+    events: Path = DEFAULT_ACTIVE_EVENTS,
+    agent_mix_path: Path = DEFAULT_ACTIVE_AGENT_MIX,
+    artifacts_dir: Path = DEFAULT_ACTIVE_ARTIFACTS_DIR,
+    schema_path: Path = REVIEW_ARTIFACT_SCHEMA,
+    claude_runner=None,
+    codex_runner=None,
+    repo_root: Path = ROOT_DIR,
+) -> AgentTurnResult:
+    """Run one read-only Claude/Codex review lane; persist artifact + lane heartbeat.
+
+    Read-only contract: no writes, patches, or ship. The model fills the review-artifact
+    core (verdict/summary/findings/next_steps); this function authoritatively sets the
+    meta fields, runs a fail-closed privacy scrub (ADR 0005), records the Work Unit, and
+    drives ``write_session_heartbeat`` so the conservative gate sees the lane verdict.
+    """
+    safe_session = _validate_session_id(session_id)
+    safe_role = _sanitize_inline_text(role)
+    if safe_role not in _agent_turn_roles():
+        raise ValueError("agent-turn role must be a read-only review/analysis role (not Orchestrator/Implementer)")
+    if task_id and not TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("--task must match T-YYYY-NNNN")
+    safe_pr: str | None = None
+    if pr:
+        if not re.fullmatch(r"\d{1,7}", str(pr)):
+            raise ValueError("--pr must be a numeric PR id")
+        safe_pr = str(pr)
+    now = datetime.now(timezone.utc)
+    registry_path = _active_path(registry, repo_root=repo_root)
+    registry_payload = _load_active_registry(registry_path)
+    policy = registry_payload.get("agent_mix") if isinstance(registry_payload.get("agent_mix"), dict) else _parse_agent_mix(None)
+    mix_path = _active_path(agent_mix_path, repo_root=repo_root)
+    mix_state = _load_active_agent_mix(mix_path)
+    rolling = mix_state.get("rolling") if isinstance(mix_state.get("rolling"), dict) else {}
+    if agent:
+        chosen = agent.strip().casefold()
+        if chosen not in ACTIVE_LANE_AGENTS:
+            raise ValueError(f"--agent must be one of: {', '.join(ACTIVE_LANE_AGENTS)}")
+    else:
+        chosen = choose_agent(safe_role, agent_mix=policy, rolling=rolling)
+    if not execute:
+        return AgentTurnResult(
+            decision="planned",
+            role=safe_role,
+            agent=chosen,
+            verdict="",
+            artifact_path=None,
+            registry_path=None,
+            blockers=(),
+            warnings=(),
+        )
+    core = _run_agent_lane(
+        chosen,
+        role=safe_role,
+        task_id=task_id,
+        pr=safe_pr,
+        base=base,
+        schema_path=schema_path,
+        repo_root=repo_root,
+        claude_runner=claude_runner,
+        codex_runner=codex_runner,
+    )
+    verdict = str(core.get("verdict") or "needs-attention")
+    artifact_path = _agent_turn_artifact_path(
+        artifacts_dir, task_id=task_id, session_id=safe_session, agent=chosen, repo_root=repo_root
+    )
+    raw_findings = core.get("findings")
+    raw_steps = core.get("next_steps")
+    artifact = {
+        "schema_version": 1,
+        "task_id": task_id,
+        "session_id": safe_session,
+        "role": safe_role,
+        "agent": chosen,
+        "generated_at": _isoformat(now),
+        "verdict": verdict,
+        "summary": str(core.get("summary") or ""),
+        "findings": raw_findings if isinstance(raw_findings, list) else [],
+        "next_steps": raw_steps if isinstance(raw_steps, list) else [],
+        "wu": 1,
+        "privacy_scrubbed": True,
+    }
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text(json.dumps(_sanitize_json_value(artifact), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    events_path = _active_path(events, repo_root=repo_root)
+    # Fail-closed privacy gate (ADR 0005): if the lane output leaked raw private values
+    # into the artifact, rewrite it as a redacted error and record neither a pass-class
+    # heartbeat nor a Work Unit.
+    privacy_findings = audit_privacy_output(artifact_path, out_path=None, repo_root=repo_root)
+    if privacy_findings:
+        issues = sorted({finding.issue for finding in privacy_findings})
+        redacted = {
+            "schema_version": 1,
+            "task_id": task_id,
+            "session_id": safe_session,
+            "role": safe_role,
+            "agent": chosen,
+            "generated_at": _isoformat(now),
+            "verdict": "blocked",
+            "summary": f"privacy scrub rejected lane output ({len(issues)} issue type(s))",
+            "findings": [],
+            "next_steps": [],
+            "wu": 0,
+            "privacy_scrubbed": False,
+        }
+        artifact_path.write_text(json.dumps(redacted, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        _append_active_event(
+            events_path,
+            {
+                "event": "agent-turn",
+                "session_id": safe_session,
+                "role": safe_role,
+                "agent": chosen,
+                "verdict": "blocked",
+                "task_id": task_id,
+                "privacy_blocked": issues,
+            },
+        )
+        write_session_heartbeat(
+            session_id=safe_session,
+            role=safe_role,
+            task_id=task_id,
+            status="blocked",
+            agent=chosen,
+            registry=registry,
+            events=events,
+            repo_root=repo_root,
+        )
+        return AgentTurnResult(
+            decision="blocked",
+            role=safe_role,
+            agent=chosen,
+            verdict="blocked",
+            artifact_path=artifact_path,
+            registry_path=registry_path,
+            blockers=tuple(f"privacy: {issue}" for issue in issues),
+            warnings=(),
+        )
+    _record_agent_wu(mix_path, agent=chosen, task_id=task_id, wu=1, policy=policy, now=now)
+    write_session_heartbeat(
+        session_id=safe_session,
+        role=safe_role,
+        task_id=task_id,
+        status=verdict,
+        agent=chosen,
+        registry=registry,
+        events=events,
+        repo_root=repo_root,
+    )
+    _append_active_event(
+        events_path,
+        {
+            "event": "agent-turn",
+            "session_id": safe_session,
+            "role": safe_role,
+            "agent": chosen,
+            "verdict": verdict,
+            "task_id": task_id,
+            "wu": 1,
+        },
+    )
+    return AgentTurnResult(
+        decision="executed",
+        role=safe_role,
+        agent=chosen,
+        verdict=verdict,
+        artifact_path=artifact_path,
+        registry_path=registry_path,
+        blockers=(),
+        warnings=(),
+    )
+
+
+def write_agent_mix_report(
+    *,
+    agent_mix_path: Path = DEFAULT_ACTIVE_AGENT_MIX,
+    out: Path = DEFAULT_ACTIVE_AGENT_MIX_REPORT,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, dict[str, object]]:
+    """Render the rolling Claude/Codex Work-Unit mix and a rebalance recommendation."""
+    now = datetime.now(timezone.utc)
+    mix_path = _active_path(agent_mix_path, repo_root=repo_root)
+    state = _load_active_agent_mix(mix_path)
+    policy = state.get("policy") if isinstance(state.get("policy"), dict) else _parse_agent_mix(None)
+    rolling_raw = state.get("rolling") if isinstance(state.get("rolling"), dict) else {}
+    rolling = {agent: _coerce_wu(rolling_raw.get(agent)) for agent in ACTIVE_LANE_AGENTS}
+    total = sum(rolling.values())
+    target_raw = policy.get("target") if isinstance(policy.get("target"), dict) else {}
+    targets = {agent: _coerce_wu(target_raw.get(agent)) for agent in ACTIVE_LANE_AGENTS}
+    target_total = sum(targets.values())
+    skew = abs(rolling["claude"] - rolling["codex"])
+    max_skew_raw = policy.get("max_allowed_skew_wu")
+    max_skew = max_skew_raw if isinstance(max_skew_raw, int) and not isinstance(max_skew_raw, bool) else 2
+    within = skew <= max_skew
+
+    def debt(a: str) -> float:
+        target_share = (targets[a] / target_total) if target_total else 0.5
+        actual_share = (rolling[a] / total) if total else 0.0
+        return target_share - actual_share
+
+    recommended = max(ACTIVE_LANE_AGENTS, key=lambda a: (debt(a), a == "claude"))
+    summary: dict[str, object] = {
+        "rolling": rolling,
+        "target": targets,
+        "skew_wu": skew,
+        "max_allowed_skew_wu": max_skew,
+        "within_tolerance": within,
+        "recommended_next_agent": recommended,
+    }
+    lines = [
+        "# Active-loop agent-mix report",
+        "",
+        f"- Generated: {_isoformat(now)}",
+        f"- Rolling Work Units — claude: {rolling['claude']}, codex: {rolling['codex']} (total {total})",
+        f"- Target mix — claude: {targets['claude']}, codex: {targets['codex']}",
+        f"- Skew: {skew} WU (max allowed {max_skew}) — {'within tolerance' if within else 'REBALANCE'}",
+        f"- Recommended next lane: **{recommended}**",
+    ]
+    if not within:
+        lines.append("")
+        lines.append(f"Skew exceeds tolerance; route upcoming read-only turns to **{recommended}** until balanced.")
+    out_path = _active_path(out, repo_root=repo_root)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return out_path, summary
 
 
 def _load_active_leases(path: Path) -> list[dict[str, object]]:
@@ -10837,6 +11238,19 @@ def build_parser() -> argparse.ArgumentParser:
     heartbeat.add_argument("--agent", choices=ACTIVE_LANE_AGENTS)
     heartbeat.add_argument("--lease-ttl-minutes", type=int, default=30)
 
+    agent_turn = sub.add_parser("agent-turn", help="Run one read-only Claude/Codex review lane and record its artifact + heartbeat.")
+    agent_turn.add_argument("--session-id", required=True)
+    agent_turn.add_argument("--role", required=True)
+    agent_turn.add_argument("--agent", choices=ACTIVE_LANE_AGENTS)
+    agent_turn.add_argument("--task")
+    agent_turn.add_argument("--pr")
+    agent_turn.add_argument("--base", default="origin/main")
+    agent_turn.add_argument("--dry-run", dest="execute", action="store_false", default=False)
+    agent_turn.add_argument("--execute", dest="execute", action="store_true")
+
+    agent_mix_report = sub.add_parser("agent-mix-report", help="Render the rolling Claude/Codex Work-Unit mix and rebalance recommendation.")
+    agent_mix_report.add_argument("--out", type=Path, default=DEFAULT_ACTIVE_AGENT_MIX_REPORT)
+
     active_prepare = sub.add_parser("active-worktree-prepare", help="Prepare an issue-linked worktree for an active-loop role.")
     active_prepare.add_argument("--issue")
     active_prepare.add_argument("--title")
@@ -11708,6 +12122,31 @@ def main(argv: list[str] | None = None) -> int:
                 lease_ttl_minutes=args.lease_ttl_minutes,
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(registry, ROOT_DIR)}\n")
+            return 0
+        if args.command == "agent-turn":
+            result = write_agent_turn(
+                session_id=args.session_id,
+                role=args.role,
+                agent=args.agent,
+                task_id=args.task,
+                pr=args.pr,
+                base=args.base,
+                execute=args.execute,
+            )
+            if result.artifact_path is not None:
+                sys.stdout.write(
+                    f"[OK] {result.decision} {result.agent} lane -> "
+                    f"{_repo_path(result.artifact_path, ROOT_DIR)} (verdict={result.verdict})\n"
+                )
+            else:
+                sys.stdout.write(f"[OK] {result.decision} {result.agent} lane (dry-run)\n")
+            return 0 if result.decision in {"planned", "executed"} else 1
+        if args.command == "agent-mix-report":
+            out_path, summary = write_agent_mix_report(out=args.out)
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(out_path, ROOT_DIR)} "
+                f"(recommended={summary['recommended_next_agent']}, skew={summary['skew_wu']})\n"
+            )
             return 0
         if args.command == "active-worktree-prepare":
             out, _, _ = write_active_worktree_prepare(

--- a/scripts/agent_loop_claude_turn.py
+++ b/scripts/agent_loop_claude_turn.py
@@ -1,0 +1,152 @@
+"""Read-only Claude lane adapter for the active-loop `agent-turn` (issue #1590).
+
+Invokes `claude -p` in plan permission mode with a read-only tool allowlist and a
+write/ship denylist, asking for output that conforms to
+`schemas/review_artifact.schema.json`. Parses the `--output-format json` wrapper
+into the shared review-artifact core (verdict / summary / findings / next_steps).
+No writes, no patches, no ship.
+
+The agent-turn caller (scripts/agent_loop.py) owns privacy scrubbing, artifact
+persistence, Work Unit accounting, and the session heartbeat. This module never
+raises on tool failure — it returns a ``verdict="error"`` core so the caller can
+record a deterministic non-pass heartbeat. The subprocess call is injectable via
+``runner`` so tests never shell out to the real `claude` binary.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Callable, Sequence
+
+# Read-only lane: plan mode already blocks mutation; the denylist is belt-and-suspenders.
+DEFAULT_ALLOWED_TOOLS = (
+    "Read",
+    "Grep",
+    "Glob",
+    "Bash(git diff:*)",
+    "Bash(git log:*)",
+    "Bash(git status:*)",
+)
+DEFAULT_DISALLOWED_TOOLS = (
+    "Edit",
+    "Write",
+    "NotebookEdit",
+    "Bash(git push:*)",
+    "Bash(git commit:*)",
+    "Bash(git merge:*)",
+    "Bash(gh:*)",
+    "Bash(make:*)",
+)
+_VERDICTS = {"approved", "clear", "needs-attention", "blocked", "error"}
+_SEVERITIES = {"blocker", "warning", "info"}
+
+# runner(cmd) -> CompletedProcess; injectable for tests.
+ClaudeRunner = Callable[[list[str]], "subprocess.CompletedProcess[str]"]
+
+
+def build_command(
+    *,
+    prompt: str,
+    schema_path: Path,
+    allowed_tools: Sequence[str] = DEFAULT_ALLOWED_TOOLS,
+    disallowed_tools: Sequence[str] = DEFAULT_DISALLOWED_TOOLS,
+) -> list[str]:
+    return [
+        "claude",
+        "-p",
+        prompt,
+        "--output-format",
+        "json",
+        "--json-schema",
+        str(schema_path),
+        "--permission-mode",
+        "plan",
+        "--allowedTools",
+        " ".join(allowed_tools),
+        "--disallowedTools",
+        " ".join(disallowed_tools),
+    ]
+
+
+def _default_runner(cmd: list[str]) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def run_turn(
+    *,
+    prompt: str,
+    schema_path: Path,
+    allowed_tools: Sequence[str] = DEFAULT_ALLOWED_TOOLS,
+    disallowed_tools: Sequence[str] = DEFAULT_DISALLOWED_TOOLS,
+    runner: ClaudeRunner | None = None,
+) -> dict[str, object]:
+    """Return the core review-artifact fields from a read-only Claude turn."""
+    run = runner or _default_runner
+    cmd = build_command(
+        prompt=prompt,
+        schema_path=schema_path,
+        allowed_tools=allowed_tools,
+        disallowed_tools=disallowed_tools,
+    )
+    try:
+        proc = run(cmd)
+    except OSError as exc:
+        return _error(f"claude invocation failed: {exc}")
+    if proc.returncode != 0:
+        tail = next((line for line in reversed((proc.stderr or "").splitlines()) if line.strip()), "")
+        return _error(f"claude rc={proc.returncode}: {tail}".strip())
+    core = _extract_core(proc.stdout or "")
+    return core if core is not None else _error("claude emitted unparseable output")
+
+
+def _extract_core(stdout: str) -> dict[str, object] | None:
+    try:
+        outer = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    candidate: object = outer
+    if isinstance(outer, dict) and "result" in outer:
+        candidate = outer["result"]
+    if isinstance(candidate, str):
+        try:
+            candidate = json.loads(candidate)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if not isinstance(candidate, dict):
+        return None
+    return _normalize_core(candidate)
+
+
+def _normalize_core(obj: dict[str, object]) -> dict[str, object]:
+    verdict = str(obj.get("verdict") or "needs-attention")
+    if verdict not in _VERDICTS:
+        verdict = "needs-attention"
+    summary = str(obj.get("summary") or "").strip() or "Claude review complete."
+    raw_findings = obj.get("findings")
+    findings = [
+        _normalize_finding(item)
+        for item in (raw_findings if isinstance(raw_findings, list) else [])
+        if isinstance(item, dict)
+    ]
+    raw_steps = obj.get("next_steps")
+    next_steps = [str(step) for step in (raw_steps if isinstance(raw_steps, list) else []) if isinstance(step, str)]
+    return {"verdict": verdict, "summary": summary, "findings": findings, "next_steps": next_steps}
+
+
+def _normalize_finding(finding: dict[str, object]) -> dict[str, object]:
+    severity = str(finding.get("severity") or "info")
+    if severity not in _SEVERITIES:
+        severity = "info"
+    out: dict[str, object] = {"severity": severity, "title": str(finding.get("title") or "(untitled)")}
+    body = str(finding.get("body") or "").strip()
+    if body:
+        out["body"] = body
+    recommendation = str(finding.get("recommendation") or "").strip()
+    if recommendation:
+        out["recommendation"] = recommendation
+    return out
+
+
+def _error(message: str) -> dict[str, object]:
+    return {"verdict": "error", "summary": message, "findings": [], "next_steps": []}

--- a/scripts/agent_loop_codex_turn.py
+++ b/scripts/agent_loop_codex_turn.py
@@ -1,0 +1,135 @@
+"""Read-only Codex lane adapter for the active-loop `agent-turn` (issue #1590).
+
+Runs the Codex companion `adversarial-review` (ADR 0066) in read-only mode and
+maps its JSON output into the shared review-artifact core
+(`schemas/review_artifact.schema.json`): verdict / summary / findings / next_steps.
+No writes, no patches, no ship — review only. The companion path is resolved by
+glob over the plugin cache (the ADR 0066 "symlink/glob follow-up"), not the
+version-pinned literal the CI workflow uses.
+
+The agent-turn caller (scripts/agent_loop.py) owns privacy scrubbing, artifact
+persistence, Work Unit accounting, and the session heartbeat. This module only
+produces the core review fields and never raises on tool failure — it returns a
+``verdict="error"`` core instead, so the caller can record a deterministic
+non-pass heartbeat.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+HOME = Path(os.path.expanduser("~"))
+COMPANION_GLOB = ".claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs"
+
+# Codex adversarial-review severity -> review_artifact severity (plan collapse).
+_SEVERITY_COLLAPSE = {
+    "critical": "blocker",
+    "high": "blocker",
+    "medium": "warning",
+    "low": "info",
+}
+# Codex verdict -> review_artifact verdict.
+_VERDICT_MAP = {
+    "approve": "approved",
+    "needs-attention": "needs-attention",
+}
+
+# runner(companion, base, scope, focus) -> CompletedProcess; injectable for tests.
+CodexRunner = Callable[[Path, str, str, str], "subprocess.CompletedProcess[str]"]
+
+
+def resolve_companion(explicit: str | None = None, *, home: Path = HOME) -> Path | None:
+    """Resolve codex-companion.mjs: explicit arg > $CODEX_COMPANION > newest glob match."""
+    if explicit:
+        candidate = Path(explicit)
+        return candidate if candidate.is_file() else None
+    env = os.environ.get("CODEX_COMPANION")
+    if env and Path(env).is_file():
+        return Path(env)
+    matches = sorted(glob.glob(str(home / COMPANION_GLOB)))
+    return Path(matches[-1]) if matches else None
+
+
+def _default_runner(companion: Path, base: str, scope: str, focus: str) -> "subprocess.CompletedProcess[str]":
+    cmd = ["node", str(companion), "adversarial-review", "--json", "--base", base, "--scope", scope]
+    if focus:
+        cmd.append(focus)
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def run_turn(
+    *,
+    base: str = "origin/main",
+    scope: str = "branch",
+    focus: str = "",
+    companion_path: str | None = None,
+    runner: CodexRunner | None = None,
+    home: Path = HOME,
+) -> dict[str, object]:
+    """Return the core review-artifact fields from a read-only Codex review."""
+    companion = resolve_companion(companion_path, home=home)
+    if companion is None:
+        return _error("codex companion not found (plugin cache glob miss)")
+    run = runner or _default_runner
+    try:
+        proc = run(companion, base, scope, focus)
+    except OSError as exc:
+        return _error(f"codex companion invocation failed: {exc}")
+    if proc.returncode != 0:
+        tail = next((line for line in reversed((proc.stderr or "").splitlines()) if line.strip()), "")
+        return _error(f"codex companion rc={proc.returncode}: {tail}".strip())
+    try:
+        payload = json.loads(proc.stdout or "")
+    except (json.JSONDecodeError, TypeError):
+        return _error("codex companion emitted non-JSON output")
+    if not isinstance(payload, dict):
+        return _error("codex companion output is not a JSON object")
+    if payload.get("parseError"):
+        return _error(f"codex structured-output rejected: {payload.get('parseError')}")
+    raw_result = payload.get("result")
+    result: dict[str, object] = raw_result if isinstance(raw_result, dict) else {}
+    verdict = _VERDICT_MAP.get(str(result.get("verdict") or ""), "needs-attention")
+    summary = str(result.get("summary") or "").strip() or "Codex adversarial review complete."
+    raw_findings = result.get("findings")
+    findings = [
+        _collapse_finding(f)
+        for f in (raw_findings if isinstance(raw_findings, list) else [])
+        if isinstance(f, dict)
+    ]
+    raw_steps = result.get("next_steps")
+    next_steps = [
+        str(step) for step in (raw_steps if isinstance(raw_steps, list) else []) if isinstance(step, str)
+    ]
+    return {
+        "verdict": verdict,
+        "summary": summary,
+        "findings": findings,
+        "next_steps": next_steps,
+    }
+
+
+def _collapse_finding(finding: dict[str, object]) -> dict[str, object]:
+    severity = _SEVERITY_COLLAPSE.get(str(finding.get("severity") or "low"), "info")
+    out: dict[str, object] = {"severity": severity, "title": str(finding.get("title") or "(untitled)")}
+    body = str(finding.get("body") or "").strip()
+    file = str(finding.get("file") or "").strip()
+    if file:
+        location = file
+        line_start, line_end = finding.get("line_start"), finding.get("line_end")
+        if isinstance(line_start, int):
+            location += f":{line_start}" + (f"-{line_end}" if isinstance(line_end, int) else "")
+        body = f"[{location}] {body}".strip()
+    if body:
+        out["body"] = body
+    recommendation = str(finding.get("recommendation") or "").strip()
+    if recommendation:
+        out["recommendation"] = recommendation
+    return out
+
+
+def _error(message: str) -> dict[str, object]:
+    return {"verdict": "error", "summary": message, "findings": [], "next_steps": []}

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -3292,7 +3292,7 @@ python3 scripts/agent_loop.py agent-mix-report
 
 - Plan: [`docs/plans/T-2026-0040-active-dual-agent-lanes.md`](../docs/plans/T-2026-0040-active-dual-agent-lanes.md) (umbrella roadmap; PR2 = Phase 2).
 - Issue: [#1590](https://github.com/hskim-solv/BidMate-DocAgent/issues/1590) (umbrella [#1588](https://github.com/hskim-solv/BidMate-DocAgent/issues/1588)).
-- PR: TBD
+- PR: [#1594](https://github.com/hskim-solv/BidMate-DocAgent/pull/1594)
 
 ## T-2026-0042 — Patch-proposal + lease active_agent borrow + scratch worktree
 

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -50,8 +50,8 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 37 | `T-2026-0037` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on metadata coverage evidence from T-2026-0028. |
 | 38 | `T-2026-0038` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P2; blocked on small-to-big retrieval evidence from T-2026-0031. |
 | 39 | `T-2026-0039` | `backlog` | Planner -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | P3; advanced architecture feasibility after P0/P1 evidence. |
-| 40 | `T-2026-0040` | `review` | Implementer -> Reviewer | issue #1588 PR1 (#1589); active-loop registry v2 + per-session Claude/Codex lanes scaffold; in review. |
-| 41 | `T-2026-0041` | `backlog` | Implementer -> Reviewer | issue #1588 PR2; read-only Claude/Codex lane adapters + WU accounting; blocked on T-2026-0040. |
+| 40 | `T-2026-0040` | `done` | Implementer -> Reviewer | issue #1588 PR1 (#1589 merged); active-loop registry v2 + per-session Claude/Codex lanes scaffold. |
+| 41 | `T-2026-0041` | `review` | Implementer -> Reviewer | issue #1590 PR2; read-only Claude/Codex lane adapters + WU accounting; in review. |
 | 42 | `T-2026-0042` | `backlog` | Implementer -> Reviewer | issue #1588 PR3; patch-proposal + lease active_agent borrow + scratch worktree; re-confirm scope after Phase 1-2. |
 | 43 | `T-2026-0043` | `backlog` | Implementer -> Reviewer | issue #1588 PR4; mutating-writer + claimed-files enforcement hook; blocked on T-2026-0042. |
 | 44 | `T-2026-0044` | `backlog` | Implementer -> Deep Reviewer -> Reviewer | issue #1588 PR5; Orchestrator-only ship-executor + gate evidence (promote agent_loop.py to LOAD_BEARING); blocked on T-2026-0043. |
@@ -3250,7 +3250,7 @@ make check-branch
 
 - ID: T-2026-0041
 - Title: Read-only Claude/Codex lane adapters + WU accounting
-- Status: backlog
+- Status: review
 - Priority: P1
 - Owner role: Implementer -> Reviewer
 - Created: 2026-05-27
@@ -3274,7 +3274,7 @@ Unit accounting (`agent-mix-report`, deterministic `choose_agent`).
 
 ### Acceptance Criteria
 
-- [ ] Read-only reviewer artifacts produced + privacy-clean; WU recorded per lane;
+- [x] Read-only reviewer artifacts produced + privacy-clean; WU recorded per lane;
   skew>threshold -> rebalance recommendation.
 
 ### Validation Commands
@@ -3290,8 +3290,8 @@ python3 scripts/agent_loop.py agent-mix-report
 
 ### Related Plan / Issue / PR Links
 
-- Plan: TBD - create when the task starts.
-- Issue: [#1588](https://github.com/hskim-solv/BidMate-DocAgent/issues/1588)
+- Plan: [`docs/plans/T-2026-0040-active-dual-agent-lanes.md`](../docs/plans/T-2026-0040-active-dual-agent-lanes.md) (umbrella roadmap; PR2 = Phase 2).
+- Issue: [#1590](https://github.com/hskim-solv/BidMate-DocAgent/issues/1590) (umbrella [#1588](https://github.com/hskim-solv/BidMate-DocAgent/issues/1588)).
 - PR: TBD
 
 ## T-2026-0042 — Patch-proposal + lease active_agent borrow + scratch worktree

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3066,6 +3066,380 @@ def test_session_heartbeat_cli_accepts_agent_and_rejects_unknown() -> None:
         )
 
 
+# --- Phase 2: read-only agent-turn lanes + Work-Unit accounting (issue #1590) ---
+
+
+def _claude_lane_runner(core: dict[str, object]):
+    payload = json.dumps({"result": core})
+
+    def run(cmd):
+        return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+
+    return run
+
+
+def _codex_lane_runner(core: dict[str, object]):
+    payload = json.dumps({"result": core})
+
+    def run(companion, base, scope, focus):
+        return subprocess.CompletedProcess([str(companion)], 0, stdout=payload, stderr="")
+
+    return run
+
+
+def _active_dir(repo: Path) -> Path:
+    return repo / "reports" / "agent_loop" / "active"
+
+
+def test_agent_turn_claude_lane_writes_artifact_heartbeat_and_wu(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "feat/issue-1590-active-lane-adapters")
+    core = {
+        "verdict": "needs-attention",
+        "summary": "Review found a coverage gap",
+        "findings": [{"severity": "warning", "title": "Add regression test", "body": "missing coverage"}],
+        "next_steps": ["write a regression test"],
+    }
+
+    result = agent_loop.write_agent_turn(
+        session_id="eval-auditor",
+        role="Eval / Claim / Privacy Auditor",
+        agent="claude",
+        task_id="T-2026-9999",
+        execute=True,
+        claude_runner=_claude_lane_runner(core),
+        repo_root=repo,
+    )
+
+    assert result.decision == "executed"
+    assert result.agent == "claude"
+    assert result.verdict == "needs-attention"
+    assert result.artifact_path == _active_dir(repo) / "artifacts" / "T-2026-9999" / "eval-auditor" / "claude.json"
+    artifact = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    assert artifact["schema_version"] == 1
+    assert artifact["agent"] == "claude"
+    assert artifact["role"] == "Eval / Claim / Privacy Auditor"
+    assert artifact["privacy_scrubbed"] is True
+    assert artifact["wu"] == 1
+    assert artifact["findings"][0]["title"] == "Add regression test"
+    # Heartbeat: session + lane status reflect the verdict; non-pass blocks the gate.
+    registry = json.loads((_active_dir(repo) / "session_registry.json").read_text(encoding="utf-8"))
+    session = next(item for item in registry["sessions"] if item["session_id"] == "eval-auditor")
+    assert session["status"] == "needs-attention"
+    assert session["lanes"]["claude"]["status"] == "needs-attention"
+    assert agent_loop._active_role_status_ok(registry["sessions"], "Eval / Claim / Privacy Auditor") is False
+    # WU ledger records exactly one claude unit.
+    mix = json.loads((_active_dir(repo) / "agent_mix.json").read_text(encoding="utf-8"))
+    assert mix["rolling"] == {"claude": 1, "codex": 0}
+    assert len(mix["ledger"]) == 1
+    assert mix["ledger"][0]["agent"] == "claude"
+
+
+def test_agent_turn_approved_verdict_satisfies_conservative_gate(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "feat/issue-1590")
+    core = {"verdict": "approved", "summary": "looks good", "findings": [], "next_steps": []}
+
+    result = agent_loop.write_agent_turn(
+        session_id="reviewer",
+        role="Reviewer",
+        agent="claude",
+        task_id="T-2026-9999",
+        execute=True,
+        claude_runner=_claude_lane_runner(core),
+        repo_root=repo,
+    )
+
+    registry = json.loads((_active_dir(repo) / "session_registry.json").read_text(encoding="utf-8"))
+    assert result.verdict == "approved"
+    assert agent_loop._active_role_status_ok(registry["sessions"], "Reviewer") is True
+
+
+def test_agent_turn_codex_lane_maps_verdict_via_companion(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "feat/issue-1590")
+    companion = tmp_path / "codex-companion.mjs"
+    companion.write_text("// stub", encoding="utf-8")
+    monkeypatch.setenv("CODEX_COMPANION", str(companion))
+    core = {"verdict": "approve", "summary": "no blockers", "findings": [], "next_steps": []}
+
+    result = agent_loop.write_agent_turn(
+        session_id="reviewer",
+        role="Reviewer",
+        agent="codex",
+        task_id="T-2026-9999",
+        execute=True,
+        codex_runner=_codex_lane_runner(core),
+        repo_root=repo,
+    )
+
+    assert result.decision == "executed"
+    assert result.agent == "codex"
+    assert result.verdict == "approved"  # codex "approve" -> review_artifact "approved"
+    assert result.artifact_path.name == "codex.json"
+    artifact = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    assert artifact["agent"] == "codex"
+    mix = json.loads((_active_dir(repo) / "agent_mix.json").read_text(encoding="utf-8"))
+    assert mix["rolling"] == {"claude": 0, "codex": 1}
+
+
+def test_agent_turn_scrubs_private_field_values_from_artifact(monkeypatch, tmp_path: Path) -> None:
+    # Common-path privacy protection: the artifact writer redacts private field values
+    # in place (ADR 0005), so a leaked doc_id never persists — the turn still executes.
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "feat/issue-1590")
+    leaky = {
+        "verdict": "approved",
+        "summary": "leaked doc_id: SECRET-XYZ from the corpus",
+        "findings": [],
+        "next_steps": [],
+    }
+
+    result = agent_loop.write_agent_turn(
+        session_id="reviewer",
+        role="Reviewer",
+        agent="claude",
+        task_id="T-2026-9999",
+        execute=True,
+        claude_runner=_claude_lane_runner(leaky),
+        repo_root=repo,
+    )
+
+    assert result.decision == "executed"
+    artifact_text = result.artifact_path.read_text(encoding="utf-8")
+    assert "SECRET-XYZ" not in artifact_text  # raw value never persisted
+    assert "[redacted-private-value]" in artifact_text
+    assert json.loads(artifact_text)["privacy_scrubbed"] is True
+
+
+def test_agent_turn_failclosed_blocks_when_audit_finds_leak(monkeypatch, tmp_path: Path) -> None:
+    # Fail-closed secondary net: if the privacy audit flags anything that slipped past the
+    # proactive scrub, the turn is blocked, no Work Unit is recorded, and the heartbeat is
+    # non-pass — never a pass-class gate on leaked output.
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "feat/issue-1590")
+    monkeypatch.setattr(
+        agent_loop,
+        "audit_privacy_output",
+        lambda *a, **k: [agent_loop.PrivacyFinding(path="artifact", issue="absolute local path")],
+    )
+    core = {"verdict": "approved", "summary": "clean summary", "findings": [], "next_steps": []}
+
+    result = agent_loop.write_agent_turn(
+        session_id="reviewer",
+        role="Reviewer",
+        agent="claude",
+        task_id="T-2026-9999",
+        execute=True,
+        claude_runner=_claude_lane_runner(core),
+        repo_root=repo,
+    )
+
+    assert result.decision == "blocked"
+    assert result.verdict == "blocked"
+    assert result.blockers  # the privacy issue surfaced as a blocker
+    artifact = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    assert artifact["privacy_scrubbed"] is False
+    assert artifact["wu"] == 0
+    assert artifact["findings"] == []
+    # No Work Unit recorded; heartbeat marks the session blocked.
+    mix_path = _active_dir(repo) / "agent_mix.json"
+    if mix_path.exists():
+        assert json.loads(mix_path.read_text(encoding="utf-8"))["rolling"] == {"claude": 0, "codex": 0}
+    registry = json.loads((_active_dir(repo) / "session_registry.json").read_text(encoding="utf-8"))
+    session = next(item for item in registry["sessions"] if item["session_id"] == "reviewer")
+    assert session["status"] == "blocked"
+
+
+def test_choose_agent_capability_then_mix_debt() -> None:
+    policy = agent_loop._parse_agent_mix(None)
+    # Capability prior: review -> codex, planning -> claude when rolling is empty.
+    assert agent_loop.choose_agent("Reviewer", agent_mix=policy, rolling={}) == "codex"
+    assert agent_loop.choose_agent("Planner / Issue Triage", agent_mix=policy, rolling={}) == "claude"
+    # Mix debt overrides the capability prior once codex is over-used past target share.
+    assert agent_loop.choose_agent("Reviewer", agent_mix=policy, rolling={"claude": 0, "codex": 10}) == "claude"
+
+
+def test_agent_mix_report_flags_skew_and_recommends_underused(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    active = _active_dir(repo)
+    active.mkdir(parents=True, exist_ok=True)
+    (active / "agent_mix.json").write_text(
+        json.dumps(
+            {
+                "policy": agent_loop._parse_agent_mix(None),
+                "rolling": {"claude": 5, "codex": 0},
+                "ledger": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    out_path, summary = agent_loop.write_agent_mix_report(repo_root=repo)
+
+    assert summary["skew_wu"] == 5
+    assert summary["within_tolerance"] is False
+    assert summary["recommended_next_agent"] == "codex"
+    assert "REBALANCE" in out_path.read_text(encoding="utf-8")
+
+
+def test_agent_turn_dry_run_plans_without_writing(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+
+    result = agent_loop.write_agent_turn(
+        session_id="reviewer",
+        role="Reviewer",
+        task_id="T-2026-9999",
+        execute=False,
+        repo_root=repo,
+    )
+
+    assert result.decision == "planned"
+    assert result.agent == "codex"  # capability prior; no lane invoked in dry-run
+    assert result.artifact_path is None
+    assert not (_active_dir(repo) / "artifacts").exists()
+
+
+def test_agent_turn_rejects_non_review_roles(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    for role in ("Orchestrator", "Implementer"):
+        with pytest.raises(ValueError):
+            agent_loop.write_agent_turn(session_id="x", role=role, repo_root=repo)
+
+
+def test_agent_turn_wu_accumulates_per_agent(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "feat/issue-1590")
+    companion = tmp_path / "codex-companion.mjs"
+    companion.write_text("// stub", encoding="utf-8")
+    monkeypatch.setenv("CODEX_COMPANION", str(companion))
+    clean = {"verdict": "clear", "summary": "ok", "findings": [], "next_steps": []}
+
+    for _ in range(2):
+        agent_loop.write_agent_turn(
+            session_id="eval-auditor",
+            role="Eval / Claim / Privacy Auditor",
+            agent="claude",
+            task_id="T-2026-9999",
+            execute=True,
+            claude_runner=_claude_lane_runner(clean),
+            repo_root=repo,
+        )
+    agent_loop.write_agent_turn(
+        session_id="reviewer",
+        role="Reviewer",
+        agent="codex",
+        task_id="T-2026-9999",
+        execute=True,
+        codex_runner=_codex_lane_runner({"verdict": "approve", "summary": "ok", "findings": [], "next_steps": []}),
+        repo_root=repo,
+    )
+
+    mix = json.loads((_active_dir(repo) / "agent_mix.json").read_text(encoding="utf-8"))
+    assert mix["rolling"] == {"claude": 2, "codex": 1}
+    assert len(mix["ledger"]) == 3
+
+
+def test_agent_turn_cli_accepts_and_rejects_agent() -> None:
+    parser = agent_loop.build_parser()
+    args = parser.parse_args(["agent-turn", "--session-id", "reviewer", "--role", "Reviewer", "--agent", "codex"])
+    assert args.agent == "codex"
+    assert args.execute is False
+    exec_args = parser.parse_args(["agent-turn", "--session-id", "reviewer", "--role", "Reviewer", "--execute"])
+    assert exec_args.execute is True
+    with pytest.raises(SystemExit):
+        parser.parse_args(["agent-turn", "--session-id", "reviewer", "--role", "Reviewer", "--agent", "gpt"])
+    parser.parse_args(["agent-mix-report"])  # parser exists
+
+
+def test_codex_lane_adapter_maps_verdict_severity_and_errors(monkeypatch, tmp_path: Path) -> None:
+    from scripts import agent_loop_codex_turn as cx
+
+    monkeypatch.delenv("CODEX_COMPANION", raising=False)
+    companion = tmp_path / "codex-companion.mjs"
+    companion.write_text("// stub", encoding="utf-8")
+
+    def ok_runner(comp, base, scope, focus):
+        payload = {
+            "result": {
+                "verdict": "needs-attention",
+                "summary": "found issues",
+                "findings": [
+                    {"severity": "critical", "title": "C", "body": "b", "file": "rag_core.py", "line_start": 10, "line_end": 12},
+                    {"severity": "medium", "title": "M"},
+                    {"severity": "low", "title": "L"},
+                ],
+                "next_steps": ["fix C"],
+            }
+        }
+        return subprocess.CompletedProcess([str(comp)], 0, stdout=json.dumps(payload), stderr="")
+
+    core = cx.run_turn(companion_path=str(companion), runner=ok_runner)
+    assert core["verdict"] == "needs-attention"
+    assert [f["severity"] for f in core["findings"]] == ["blocker", "warning", "info"]
+    assert "[rag_core.py:10-12]" in core["findings"][0]["body"]  # file:line folded into body
+    assert core["next_steps"] == ["fix C"]
+
+    def approve_runner(comp, base, scope, focus):
+        return subprocess.CompletedProcess(
+            [str(comp)], 0, stdout=json.dumps({"result": {"verdict": "approve", "summary": "ok"}}), stderr=""
+        )
+
+    assert cx.run_turn(companion_path=str(companion), runner=approve_runner)["verdict"] == "approved"
+
+    # Error paths never raise: missing companion, non-zero rc, non-JSON.
+    assert cx.run_turn(companion_path=None, home=tmp_path)["verdict"] == "error"
+
+    def fail_runner(comp, base, scope, focus):
+        return subprocess.CompletedProcess([str(comp)], 2, stdout="", stderr="boom")
+
+    assert cx.run_turn(companion_path=str(companion), runner=fail_runner)["verdict"] == "error"
+
+    def junk_runner(comp, base, scope, focus):
+        return subprocess.CompletedProcess([str(comp)], 0, stdout="not json", stderr="")
+
+    assert cx.run_turn(companion_path=str(companion), runner=junk_runner)["verdict"] == "error"
+
+
+def test_claude_lane_adapter_command_and_core(tmp_path: Path) -> None:
+    from scripts import agent_loop_claude_turn as cl
+
+    schema = tmp_path / "schema.json"
+    schema.write_text("{}", encoding="utf-8")
+    cmd = cl.build_command(prompt="review", schema_path=schema)
+    assert cmd[:3] == ["claude", "-p", "review"]
+    assert cmd[cmd.index("--permission-mode") + 1] == "plan"
+    assert "--json-schema" in cmd
+    allowed = cmd[cmd.index("--allowedTools") + 1]
+    disallowed = cmd[cmd.index("--disallowedTools") + 1]
+    assert "Read" in allowed
+    assert "Edit" in disallowed and "Bash(git push:*)" in disallowed
+
+    def dict_runner(c):
+        payload = {"result": {"verdict": "clear", "summary": "ok", "findings": [], "next_steps": []}}
+        return subprocess.CompletedProcess(c, 0, stdout=json.dumps(payload), stderr="")
+
+    assert cl.run_turn(prompt="x", schema_path=schema, runner=dict_runner)["verdict"] == "clear"
+
+    def str_runner(c):
+        inner = json.dumps({"verdict": "needs-attention", "summary": "s", "findings": [{"severity": "warning", "title": "T"}]})
+        return subprocess.CompletedProcess(c, 0, stdout=json.dumps({"result": inner}), stderr="")
+
+    core = cl.run_turn(prompt="x", schema_path=schema, runner=str_runner)
+    assert core["verdict"] == "needs-attention"
+    assert core["findings"][0]["severity"] == "warning"
+
+    def fail_runner(c):
+        return subprocess.CompletedProcess(c, 1, stdout="", stderr="err")
+
+    assert cl.run_turn(prompt="x", schema_path=schema, runner=fail_runner)["verdict"] == "error"
+
+    def junk_runner(c):
+        return subprocess.CompletedProcess(c, 0, stdout="<<not json>>", stderr="")
+
+    assert cl.run_turn(prompt="x", schema_path=schema, runner=junk_runner)["verdict"] == "error"
+
+
 def test_stop_ship_skips_remote_branch_delete_when_stacked_dependents_exist() -> None:
     text = (ROOT / "scripts" / "claude-hooks" / "stop-ship.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Merged active-loop(registry v2 + lane scaffold, #1589) 위에 Claude/Codex가 실제로 일하는 **read-only 실행 계층**을 얹는다. session마다 Claude lane / Codex lane이 read-only 리뷰 turn을 돌리고, review_artifact를 남긴 뒤 conservative gate가 보는 session heartbeat를 갱신한다. dual-agent는 topology가 아니라 lane policy이므로 새 topology enum은 없다. 쓰기/패치/ship 없음 — Phase 3+가 mutation 담당. 8-session dual-agent active loop 6-PR 로드맵(umbrella #1588)의 PR2.

Closes #1590

## 2. 영향 파일

- `scripts/agent_loop.py` — `agent-turn`/`agent-mix-report` verb, `AgentTurnResult`, `write_agent_turn`, `choose_agent`, `_record_agent_wu`, `_run_agent_lane`, `write_agent_mix_report`, `_active_path` artifacts/report 경로 2개. (**load-bearing 아님** — ADR 0080에 따라 Phase 5에서 `LOAD_BEARING_PATHS` 승격 예정.)
- `scripts/agent_loop_claude_turn.py` (신규) — Claude lane 어댑터(`claude -p --permission-mode plan` + read-only allowlist / write·ship denylist).
- `scripts/agent_loop_codex_turn.py` (신규) — Codex lane 어댑터(`adversarial-review --json`, severity/verdict collapse, companion glob 해석).
- `schemas/review_artifact.schema.json` (신규) — 공유 review-artifact 코어 계약.
- `tests/test_agent_loop.py` — 12 신규 테스트.
- `tasks/queue.md` — T-2026-0040 done / T-2026-0041 review 동기화.

## 3. 리스크

- **테스트가 실제 `claude`/`node` 서브프로세스 호출** → 느림·비결정성. 두 어댑터 모두 `runner` 주입 seam, 테스트는 fake runner만 사용(서브프로세스 0). 어댑터는 tool 실패 시 raise 대신 `verdict="error"`.
- **privacy 누수(ADR 0005)**: lane 출력이 raw private 값을 artifact에 흘릴 위험. `_sanitize_json_value`가 기록 시점에 private field 값 in-place redact + `audit_privacy_output` fail-closed 2차 게이트(누수 적발 시 block + WU 0 + non-pass heartbeat). 두 경로 테스트.
- **gate 회귀**: verdict→pass-class 매핑을 `_active_role_status_ok`와 정렬(approved/clear=pass, needs-attention/blocked=non-pass), 테스트로 고정.

## 4. 테스트

`tests/test_agent_loop.py` 12개 추가(변경 전 함수 부재로 fail → 추가 후 pass):
- agent-turn: Claude lane artifact+heartbeat+WU / Codex lane verdict 매핑 / approved→gate 통과 / dry-run 무기록 / non-review role 거부 / WU per-agent 누적 / CLI accept·reject.
- privacy: 능동 scrub(raw 값 미기록) + fail-closed block(audit 적발 시 WU 0·heartbeat blocked).
- choose_agent: capability prior(Reviewer→codex, Planner→claude) + mix-debt 역전(codex 초과 시 claude).
- agent-mix-report: skew>tolerance → rebalance 추천.
- 어댑터 단위: codex severity collapse·verdict map·error / claude command 구성·result 래퍼(dict/str)·error.

`python3 -m pytest tests/test_agent_loop.py -q` → **127 passed** (post-rebase onto #1592).

## 5. Eval 영향

All \`·\` — RAG 검색/검증/답변 경로 무변경. agent-loop 오케스트레이션 + 신규 어댑터/스키마/테스트만 변경.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. 변경 파일 중 load-bearing path(rag_*, ingestion, visual_ingestion, eval/, api/, docs/adr/, scripts/build_index.py) 없음 — agent_loop.py는 ADR 0080에 따라 Phase 5 승격 예정이나 이 PR 시점엔 비-load-bearing. real-eval delta 불필요.

## 6. 하위 호환

- registry/agent_mix 계약은 #1589의 `schema_version 2` 유지(bump 없음). review_artifact는 신규 `schema_version 1`.
- 신규 verb(`agent-turn`, `agent-mix-report`)만 추가, 기존 verb·flag 불변. four-role/expanded-eight 동작 불변(테스트 고정).
- ADR 0003 답변 계약 무관.

## 7. 범위 외

- 쓰기/패치/mutating-writer/ship-executor (Phase 3-5).
- agent_loop.py의 `LOAD_BEARING_PATHS` 승격 (Phase 5, ADR 0080).
- patch-proposal lease `active_agent` borrow + scratch worktree (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)