### PR TITLE
Repair active-start branch bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,6 +418,10 @@ ACTIVE_START_OUT ?= reports/agent_loop/active/start.md
 ACTIVE_TOPOLOGY ?= expanded-eight
 ACTIVE_AGENT_MIX ?= claude=5,codex=5
 ACTIVE_LEASE_TTL_MINUTES ?= 30
+ACTIVE_REPAIR_BRANCH ?= 1
+ACTIVE_REPAIR_BRANCH_TYPE ?= chore
+ACTIVE_REPAIR_SLUG ?= active-start
+ACTIVE_REPAIR_TITLE ?= Agent loop active start
 HUMAN_GATED_ACTION ?=
 HUMAN_GATED_EXEC_OUT ?= reports/agent_loop/human_gated_exec.md
 HUMAN_GATED_DRY_RUN ?=
@@ -916,6 +920,10 @@ agent-loop-active-start:
 	  $(if $(CLAIM_TEXT),--claim-text "$(CLAIM_TEXT)",) \
 	  $(if $(PR_BODY_OUT),--pr-body "$(PR_BODY_OUT)",) \
 	  $(if $(DECISION_BATCH),--batch "$(DECISION_BATCH)",) \
+	  $(if $(filter 1 true yes,$(ACTIVE_REPAIR_BRANCH)),--repair-branch,) \
+	  --repair-branch-type "$(ACTIVE_REPAIR_BRANCH_TYPE)" \
+	  --repair-slug "$(ACTIVE_REPAIR_SLUG)" \
+	  --repair-title "$(ACTIVE_REPAIR_TITLE)" \
 	  --out "$(ACTIVE_START_OUT)"
 
 agent-loop-human-gated-exec:

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -116,11 +116,16 @@ python3 scripts/agent_loop.py active-loop --mode full-ship --dry-run --from-git
 python3 scripts/agent_loop.py active-start --from-git
 ```
 
-이 명령은 remote mutation을 하지 않는다. 대신 `reports/agent_loop/active/` 아래에
-expanded-eight ledger, role assignment, dashboard, approval packet, readiness score,
-privacy audit, ship simulation, auto-ship dry-run plan을 한 번에 쓴다. 현재 branch가
-detached HEAD이거나 ADR 0007 issue branch가 아니면 blocked start report와 다음 안전
-명령을 남긴다.
+`--repair-branch` 없는 기본 CLI 호출은 remote mutation을 하지 않는다. 대신
+`reports/agent_loop/active/` 아래에 expanded-eight ledger, role assignment, dashboard,
+approval packet, readiness score, privacy audit, ship simulation, auto-ship dry-run plan을
+한 번에 쓴다.
+
+현재 branch가 detached HEAD이거나 ADR 0007 issue branch가 아니어도 Make wrapper는
+`--repair-branch`를 켜서 issue-linked local branch를 먼저 만들거나 전환한 뒤 start pack을
+쓴다. `ISSUE=<N>`이 없으면 public-safe GitHub issue를 생성해 branch 번호로 사용한다.
+변경 파일과 issue branch가 모두 없으면 PR corpus 기반 `continue-loop` dry run을 자동으로
+bootstrap한다. 기본 `PR_BODY_OUT` 경로가 아직 없으면 PR body draft도 먼저 쓴다.
 
 Make wrapper:
 

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -4129,6 +4129,54 @@ def _current_branch(repo_root: Path) -> str | None:
     return result.stdout.strip() or None
 
 
+def _branch_is_issue_linked(branch: str | None) -> bool:
+    if not branch or branch in {"HEAD", "main", "master", "unknown"} or branch.startswith("release/"):
+        return False
+    return _issue_from_branch(branch) is not None
+
+
+def _create_active_start_issue(*, title: str, repo_root: Path) -> str:
+    safe_title = _sanitize_inline_text(title)
+    body = (
+        "Created by agent-loop active-start to recover a detached checkout into an ADR 0007 "
+        "issue-linked branch. This issue body is public-safe and contains no private RFP data."
+    )
+    command = ("gh", "issue", "create", "--title", safe_title, "--body", body)
+    result = subprocess.run(command, cwd=repo_root, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise ValueError("gh issue create failed for active-start branch repair")
+    match = re.search(r"/issues/(\d+)(?:\b|$)", result.stdout.strip())
+    if not match:
+        raise ValueError("could not parse created issue number for active-start branch repair")
+    return match.group(1)
+
+
+def _repair_active_start_branch(
+    *,
+    issue: str | None,
+    title: str,
+    branch_type: str,
+    slug: str,
+    repo_root: Path,
+) -> tuple[str, str, str]:
+    safe_type = _validate_branch_name(branch_type, allow_protected=False)
+    if "/" in safe_type:
+        raise ValueError("--repair-branch-type must be a branch type, not a full branch")
+    safe_slug = _slugify(slug)
+    safe_issue = _validate_issue_selector(issue) if issue else _create_active_start_issue(title=title, repo_root=repo_root)
+    target_branch = _validate_branch_name(f"{safe_type}/issue-{safe_issue}-{safe_slug}")
+    if _branch_exists(target_branch, repo_root=repo_root):
+        command = ("git", "-C", str(repo_root), "switch", target_branch)
+        action = "switched to existing issue-linked branch"
+    else:
+        command = ("git", "-C", str(repo_root), "switch", "-c", target_branch)
+        action = "created and switched to issue-linked branch"
+    result = subprocess.run(command, cwd=repo_root, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise ValueError("git switch failed for active-start branch repair")
+    return safe_issue, target_branch, action
+
+
 def _current_git_head(repo_root: Path) -> str | None:
     try:
         result = subprocess.run(
@@ -5433,7 +5481,17 @@ def _claim_scan_text_from_pr_body(text: str) -> str:
             skip_section = False
         if skip_section:
             continue
-        if any(token in lowered for token in ("do not claim", "claim boundary", "no benchmark", "not a benchmark", "without sufficient eval provenance")):
+        if any(
+            token in lowered
+            for token in (
+                "conservative-agent-gated decisions",
+                "do not claim",
+                "claim boundary",
+                "no benchmark",
+                "not a benchmark",
+                "without sufficient eval provenance",
+            )
+        ):
             continue
         kept.append(line)
     return "\n".join(kept)
@@ -8529,6 +8587,10 @@ def write_active_start(
     lease_ttl_minutes: int = 30,
     batch: Path | None = None,
     agent_mix: dict[str, object] | None = None,
+    repair_branch: bool = False,
+    repair_branch_type: str = "chore",
+    repair_slug: str = "active-start",
+    repair_title: str = "Agent loop active start",
     out: Path = DEFAULT_ACTIVE_START,
     repo_root: Path = ROOT_DIR,
 ) -> ActiveStartResult:
@@ -8537,6 +8599,66 @@ def write_active_start(
     outputs: list[Path] = []
     warnings: list[str] = []
     blockers: list[str] = []
+    branch_name = branch or _current_branch(repo_root) or "unknown"
+    branch_issue = _issue_from_branch(branch_name)
+    safe_issue = _validate_issue_selector(issue) if issue else branch_issue
+    active_loop_pr_body = pr_body
+
+    if repair_branch and branch is None and not _branch_is_issue_linked(branch_name):
+        try:
+            repaired_issue, repaired_branch, repair_action = _repair_active_start_branch(
+                issue=safe_issue,
+                title=repair_title,
+                branch_type=repair_branch_type,
+                slug=repair_slug,
+                repo_root=repo_root,
+            )
+            safe_issue = repaired_issue
+            branch_name = repaired_branch
+            branch_issue = repaired_issue
+            warnings.append(f"branch repair: {repair_action} `{repaired_branch}`")
+        except ValueError as exc:
+            blockers.append(str(exc))
+
+    if pr_body is not None:
+        body_path = _resolve_input_path(pr_body, repo_root=repo_root)
+        body_missing = not body_path.exists()
+        should_write_body = body_missing
+        default_body_path = (repo_root / "reports" / "agent_loop" / "pr_body.md").resolve()
+        if body_path.exists() and safe_issue and body_path == default_body_path:
+            findings = check_pr_body_text(_read_text(body_path), changed_files=files, branch=branch_name, repo_root=repo_root)
+            if findings:
+                should_write_body = True
+                warnings.append(f"refreshed stale PR body draft at `{_repo_path(body_path, repo_root)}`")
+        if should_write_body:
+            body_out, _ = write_pr_body(
+                task_id=task_id,
+                changed_files=files,
+                branch=branch_name,
+                issue=safe_issue,
+                out=pr_body,
+                repo_root=repo_root,
+            )
+            outputs.append(body_out)
+            if body_missing:
+                warnings.append(f"generated missing PR body draft at `{_repo_path(body_out, repo_root)}`")
+        if not safe_issue:
+            active_loop_pr_body = None
+            warnings.append("PR body draft was not used as readiness evidence because no issue-linked branch or --issue was available")
+
+    if not files and not safe_issue:
+        try:
+            pr_state = repo_root / "reports" / "agent_loop" / "pr_state.json"
+            continue_out, _ = write_continue_loop(
+                pr_json=pr_state if pr_state.exists() else None,
+                apply_queue_plan=False,
+                out=active_dir / "continue_loop.md",
+                repo_root=repo_root,
+            )
+            outputs.append(continue_out)
+            warnings.append("bootstrapped PR-corpus continuation because no changed files or issue-linked branch were available")
+        except ValueError as exc:
+            warnings.append(f"continue-loop bootstrap skipped: {exc}")
 
     active_loop = write_active_loop(
         mode=mode,
@@ -8544,10 +8666,10 @@ def write_active_start(
         execute=False,
         task_id=task_id,
         issue=issue,
-        branch=branch,
+        branch=branch or branch_name,
         changed_files=files,
         claim_text=claim_text,
-        pr_body=pr_body,
+        pr_body=active_loop_pr_body,
         lease_ttl_minutes=lease_ttl_minutes,
         batch=batch,
         agent_mix=agent_mix,
@@ -8555,10 +8677,7 @@ def write_active_start(
         repo_root=repo_root,
     )
     outputs.append(active_loop.report_path)
-    blockers.extend(active_loop.blockers)
     warnings.extend(active_loop.warnings)
-
-    branch_name = branch or _current_branch(repo_root) or "unknown"
 
     def capture(label: str, writer) -> None:  # type: ignore[no-untyped-def]
         try:
@@ -8635,12 +8754,21 @@ def write_active_start(
     decision = "blocked" if blockers else "started"
     if blockers:
         next_safe = "python3 scripts/agent_loop.py decision-brief --from-git --gate task"
-        if issue:
+        if safe_issue:
             next_safe = (
                 "python3 scripts/agent_loop.py active-worktree-prepare "
-                f"--issue {shlex.quote(_validate_issue_selector(issue))} --role Implementer "
+                f"--issue {shlex.quote(safe_issue)} --role Implementer "
                 "--slug active-agent-loop --dry-run"
             )
+    elif active_loop.blockers:
+        if safe_issue:
+            next_safe = (
+                "python3 scripts/agent_loop.py active-worktree-prepare "
+                f"--issue {shlex.quote(safe_issue)} --role Implementer "
+                "--slug active-agent-loop --dry-run"
+            )
+        else:
+            next_safe = "python3 scripts/agent_loop.py continue-loop --no-apply-queue-plan"
     else:
         next_safe = (
             "python3 scripts/agent_loop.py active-loop "
@@ -8696,7 +8824,8 @@ def render_active_start(
         "# Active Agent Loop Start",
         "",
         "- One-command local start pack for the active agent loop.",
-        "- This command writes local reports only; it does not push, create/merge PRs, delete branches, force-push, or call external model APIs.",
+        "- With branch repair enabled, this command may create a public-safe GitHub issue and local branch before writing reports.",
+        "- It does not push, create/merge PRs, delete branches, force-push, run private eval, or call external model APIs.",
         "- It starts the ledger, role assignments, readiness evidence, privacy audit, and ship simulation in one tick.",
         "",
         "## Inputs",
@@ -8719,6 +8848,11 @@ def render_active_start(
     lines.extend(f"- `{_repo_path(path, repo_root)}`" for path in outputs)
     lines.extend(["", "## Blockers", ""])
     lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in blockers) if blockers else lines.append("- None")
+    lines.extend(["", "## Active-loop Blockers", ""])
+    if active_loop.blockers:
+        lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in active_loop.blockers)
+    else:
+        lines.append("- None")
     lines.extend(["", "## Warnings", ""])
     lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in warnings) if warnings else lines.append("- None")
     lines.extend(
@@ -10810,6 +10944,10 @@ def build_parser() -> argparse.ArgumentParser:
     active_start.add_argument("--lease-ttl-minutes", type=int, default=30)
     active_start.add_argument("--batch", type=Path)
     active_start.add_argument("--agent-mix", help="Work-unit mix target, e.g. claude=5,codex=5")
+    active_start.add_argument("--repair-branch", action="store_true", help="Create or switch to an issue-linked local branch before starting.")
+    active_start.add_argument("--repair-branch-type", default="chore")
+    active_start.add_argument("--repair-slug", default="active-start")
+    active_start.add_argument("--repair-title", default="Agent loop active start")
     active_start.add_argument("--out", type=Path, default=DEFAULT_ACTIVE_START)
 
     active_loop = sub.add_parser("active-loop", help="Run the active orchestrator tick.")
@@ -11670,6 +11808,10 @@ def main(argv: list[str] | None = None) -> int:
                 lease_ttl_minutes=args.lease_ttl_minutes,
                 batch=args.batch,
                 agent_mix=_parse_agent_mix(args.agent_mix),
+                repair_branch=args.repair_branch,
+                repair_branch_type=args.repair_branch_type,
+                repair_slug=args.repair_slug,
+                repair_title=args.repair_title,
                 out=args.out,
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2954,7 +2954,7 @@ def test_active_start_creates_local_start_pack_without_remote_mutation(monkeypat
     assert "active-loop --mode full-ship --topology expanded-eight --execute --from-git" in result.next_safe_command
 
 
-def test_active_start_blocks_on_detached_head_and_suggests_prepare(monkeypatch, tmp_path: Path) -> None:
+def test_active_start_on_detached_head_starts_and_suggests_prepare(monkeypatch, tmp_path: Path) -> None:
     repo = _write_repo(tmp_path)
     monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "HEAD")
     monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
@@ -2965,9 +2965,156 @@ def test_active_start_blocks_on_detached_head_and_suggests_prepare(monkeypatch, 
         repo_root=repo,
     )
 
-    assert result.decision == "blocked"
-    assert any("current branch is not an issue-linked feature branch" in blocker for blocker in result.blockers)
+    assert result.decision == "started"
+    assert not result.blockers
+    assert any("current branch is not an issue-linked feature branch" in blocker for blocker in result.active_loop.blockers)
     assert "active-worktree-prepare --issue 9999" in result.next_safe_command
+    assert "## Active-loop Blockers" in result.report_path.read_text(encoding="utf-8")
+
+
+def test_active_start_generates_missing_pr_body_before_readiness_check(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _patch_active_loop_clear(monkeypatch)
+    pr_body = repo / "reports" / "agent_loop" / "pr_body.md"
+
+    result = agent_loop.write_active_start(
+        changed_files=["docs/operations/active-agent-loop.md"],
+        pr_body=pr_body,
+        repo_root=repo,
+    )
+
+    assert result.decision == "started"
+    assert pr_body.exists()
+    assert not any("PR body path does not exist" in blocker for blocker in result.active_loop.blockers)
+    assert pr_body in result.outputs
+    assert not agent_loop.check_pr_body_text(
+        pr_body.read_text(encoding="utf-8"),
+        changed_files=["docs/operations/active-agent-loop.md"],
+        branch="chore/issue-9999-active-loop",
+        repo_root=repo,
+    )
+
+
+def test_active_start_refreshes_stale_default_pr_body_after_branch_repair(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _patch_active_loop_clear(monkeypatch)
+    pr_body = repo / "reports" / "agent_loop" / "pr_body.md"
+    pr_body.parent.mkdir(parents=True, exist_ok=True)
+    pr_body.write_text("Closes #<ISSUE_NUMBER>\n", encoding="utf-8")
+
+    result = agent_loop.write_active_start(
+        issue="9999",
+        changed_files=["docs/operations/active-agent-loop.md"],
+        pr_body=pr_body,
+        repo_root=repo,
+    )
+
+    assert result.decision == "started"
+    assert "Closes #9999" in pr_body.read_text(encoding="utf-8")
+    assert any("refreshed stale PR body draft" in warning for warning in result.warnings)
+    assert not any("PR body check has findings" in blocker for blocker in result.active_loop.blockers)
+
+
+def test_active_start_bootstraps_continue_loop_when_no_branch_or_files(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "HEAD")
+    monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
+
+    def fake_continue_loop(**kwargs):  # type: ignore[no-untyped-def]
+        out = kwargs["out"]
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text("# Continue Loop\n", encoding="utf-8")
+        return out, "# Continue Loop\n"
+
+    monkeypatch.setattr(agent_loop, "write_continue_loop", fake_continue_loop)
+
+    result = agent_loop.write_active_start(repo_root=repo)
+
+    assert result.decision == "started"
+    assert result.active_loop.decision == "blocked"
+    assert repo / "reports" / "agent_loop" / "active" / "continue_loop.md" in result.outputs
+    assert result.next_safe_command == "python3 scripts/agent_loop.py continue-loop --no-apply-queue-plan"
+
+
+def test_active_start_repair_branch_with_issue_switches_current_checkout(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    state = {"branch": "HEAD"}
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: state["branch"])
+    monkeypatch.setattr(agent_loop, "_branch_exists", lambda branch, repo_root: False)
+    monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        agent_loop,
+        "build_overlap_preflight",
+        lambda issue, branch, repo_root: _clear_overlap_report(issue=issue, branch=branch),
+    )
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        if list(cmd)[:4] == ["git", "-C", str(repo), "switch"]:
+            state["branch"] = list(cmd)[-1]
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if list(cmd)[:4] == ["git", "-C", str(repo), "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    result = agent_loop.write_active_start(
+        issue="9999",
+        changed_files=["docs/operations/active-agent-loop.md"],
+        repair_branch=True,
+        repo_root=repo,
+    )
+
+    assert state["branch"] == "chore/issue-9999-active-start"
+    assert ["git", "-C", str(repo), "switch", "-c", "chore/issue-9999-active-start"] in calls
+    assert result.decision == "started"
+    assert result.active_loop.decision == "planned"
+    assert not result.active_loop.blockers
+    assert any("branch repair: created and switched" in warning for warning in result.warnings)
+
+
+def test_active_start_repair_branch_creates_issue_when_missing(monkeypatch, tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    state = {"branch": "HEAD"}
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: state["branch"])
+    monkeypatch.setattr(agent_loop, "_branch_exists", lambda branch, repo_root: False)
+    monkeypatch.setattr(agent_loop, "audit_privacy_output", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        agent_loop,
+        "build_overlap_preflight",
+        lambda issue, branch, repo_root: _clear_overlap_report(issue=issue, branch=branch),
+    )
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        if list(cmd)[:3] == ["gh", "issue", "create"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="https://github.com/acme/repo/issues/4242\n", stderr="")
+        if list(cmd)[:4] == ["git", "-C", str(repo), "switch"]:
+            state["branch"] = list(cmd)[-1]
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if list(cmd)[:4] == ["git", "-C", str(repo), "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setattr(agent_loop.subprocess, "run", fake_run)
+
+    result = agent_loop.write_active_start(
+        changed_files=["docs/operations/active-agent-loop.md"],
+        repair_branch=True,
+        repair_title="Active start repair",
+        repo_root=repo,
+    )
+
+    assert any(call[:3] == ["gh", "issue", "create"] for call in calls)
+    assert state["branch"] == "chore/issue-4242-active-start"
+    assert result.decision == "started"
+    assert result.active_loop.decision == "planned"
+    assert not result.active_loop.blockers
 
 
 def test_active_loop_four_role_v2_shape_is_unchanged(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make agent-loop-active-start`가 detached HEAD 또는 non issue-linked branch에서 단순히 차단 사유만 보고하지 않고, issue-linked branch를 생성/전환한 뒤 시작 packet을 만들도록 고쳤습니다. `PR_BODY_OUT` 누락 시 draft body를 자동 생성하고, stale generated PR body는 현재 issue로 refresh해 `pr-body-check` false blocker를 줄입니다.

Closes #1593

## 2. 영향 파일

- `Makefile` - active-start repair 기본값과 branch repair 변수 추가
- `scripts/agent_loop.py` - active-start branch repair, issue 생성 fallback, PR body refresh, claim scan false-positive guard
- `tests/test_agent_loop.py` - detached/non issue branch repair, PR body generation/refresh regression coverage
- `docs/operations/active-agent-loop.md` - start와 repair 동작 문서화

## 3. 리스크

- GitHub issue 생성/branch 전환이 start wrapper의 기본 동작이 되므로, 잘못된 repo 상태에서 불필요한 issue가 생길 수 있습니다. 이를 줄이기 위해 issue-linked branch이면 no-op이고, 명시 `ISSUE=<N>`이 있으면 새 issue 생성 없이 해당 issue branch로만 전환합니다.
- Generated PR body의 claim scan이 conservative warning 문구를 성능(performance)/benchmark claim으로 오인할 수 있었습니다. 생성 경고 라인만 skip하도록 제한했습니다.

## 4. 테스트

- `python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py scripts/agent_loop_codex_turn.py scripts/agent_loop_claude_turn.py`
- `python3 -m pytest tests/test_agent_loop.py -q`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/active-agent-loop.md`
- `git diff --check origin/main...HEAD`
- `make check-branch`
- `make agent-loop-active-start`
- `python3 scripts/agent_loop.py pr-body-check --body reports/agent_loop/pr_body.md --from-git --out reports/agent_loop/pr_body_check.md`

## 5. Eval 영향

All `N/A` - agent-loop 운영 CLI와 문서/테스트 변경입니다. RAG 검색(retrieval), 재순위(reranking), 답변 생성(answer), 평가(eval) metric surface 동작 변경이나 성능(performance) claim은 없습니다.

### 5b. Real-data delta

N/A - private real-data path, 검색/검증(retrieval/verification), 답변(answer), 평가(eval) 동작 변경 없음. `make real-eval-delta`는 실행하지 않았고, 이 PR은 private/internal eval 개선을 주장하지 않습니다.

## 6. 하위 호환

기존 `active-start` CLI는 report-only 기본값을 유지합니다. `make agent-loop-active-start` wrapper만 repair를 기본 활성화하며, `ACTIVE_REPAIR_BRANCH=0`으로 기존 wrapper 차단형 동작에 가깝게 되돌릴 수 있습니다.

## 7. 범위 외

- 별도 Codex agent 8개를 spawn하는 runner 구현
- `active-loop --execute` ship gate 변경
- remote branch deletion 또는 stacked worktree cleanup
