### PR TITLE
Add active Codex runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,6 +422,14 @@ ACTIVE_REPAIR_BRANCH ?= 1
 ACTIVE_REPAIR_BRANCH_TYPE ?= chore
 ACTIVE_REPAIR_SLUG ?= active-start
 ACTIVE_REPAIR_TITLE ?= Agent loop active start
+ACTIVE_CODEX_RUNNER_OUT ?= reports/agent_loop/active/codex_runner.md
+ACTIVE_CODEX_RUNNER_STATE ?= reports/agent_loop/active/codex_runner_state.json
+ACTIVE_CODEX_RUNS_DIR ?= reports/agent_loop/active/codex_runs
+ACTIVE_CODEX_SESSIONS ?=
+ACTIVE_CODEX_MAX_PARALLEL ?= 8
+ACTIVE_CODEX_EXECUTABLE ?= codex
+ACTIVE_CODEX_SANDBOX ?= read-only
+ACTIVE_CODEX_EXECUTE ?=
 HUMAN_GATED_ACTION ?=
 HUMAN_GATED_EXEC_OUT ?= reports/agent_loop/human_gated_exec.md
 HUMAN_GATED_DRY_RUN ?=
@@ -925,6 +933,17 @@ agent-loop-active-start:
 	  --repair-slug "$(ACTIVE_REPAIR_SLUG)" \
 	  --repair-title "$(ACTIVE_REPAIR_TITLE)" \
 	  --out "$(ACTIVE_START_OUT)"
+
+agent-loop-active-codex-runner:
+	$(PYTHON) scripts/agent_loop.py active-codex-runner \
+	  $(if $(filter 1 true yes,$(ACTIVE_CODEX_EXECUTE)),--execute,--dry-run) \
+	  --codex-executable "$(ACTIVE_CODEX_EXECUTABLE)" \
+	  --sandbox "$(ACTIVE_CODEX_SANDBOX)" \
+	  --max-parallel "$(ACTIVE_CODEX_MAX_PARALLEL)" \
+	  $(if $(ACTIVE_CODEX_SESSIONS),--sessions "$(ACTIVE_CODEX_SESSIONS)",) \
+	  --runs-dir "$(ACTIVE_CODEX_RUNS_DIR)" \
+	  --state "$(ACTIVE_CODEX_RUNNER_STATE)" \
+	  --out "$(ACTIVE_CODEX_RUNNER_OUT)"
 
 agent-loop-human-gated-exec:
 	@if [ -z "$(HUMAN_GATED_ACTION)" ]; then \

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -133,6 +133,32 @@ Make wrapper:
 make agent-loop-active-start
 ```
 
+## Codex Runner
+
+`active-start`는 ledger와 assignment를 만들지만 agent process를 spawn하지 않는다.
+8-session을 실제 별도 Codex process로 띄우는 표면은 별도 runner다.
+
+```bash
+make agent-loop-active-codex-runner
+```
+
+기본값은 dry-run이며, `reports/agent_loop/active/session_registry.json`과
+`assignments/<session_id>.md`를 읽어 8개 `codex exec` command와 출력 경로를
+`reports/agent_loop/active/codex_runner.md`에 렌더링한다. 실제 spawn은 다음처럼
+명시한다.
+
+```bash
+make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE=1
+```
+
+runner는 session마다 `reports/agent_loop/active/codex_runs/<session_id>/` 아래에
+`prompt.md`, `stdout.jsonl`, `stderr.log`, `last_message.md`를 둔다. 기본 sandbox는
+`read-only`이고, 각 prompt는 assignment의 read-only 부분만 실행하게 제한한다.
+이 runner는 `session-heartbeat`를 pass로 승격하지 않고, `active-loop --execute`의
+ship gate나 `make ship-run`도 호출하지 않는다. 따라서 agent process가 끝났다는
+사실은 reviewer/auditor gate 통과 근거가 아니며, gate status는 별도 heartbeat나
+검토 표면에서 유지한다.
+
 ## Full Ship Gate
 
 `--execute`는 gate가 통과할 때만 기존 ship runner를 호출한다.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -18,6 +18,7 @@ import json
 from pathlib import Path
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 from typing import Iterable, Sequence
@@ -132,6 +133,9 @@ DEFAULT_ACTIVE_AGENT_MIX = DEFAULT_ACTIVE_DIR / "agent_mix.json"
 DEFAULT_ACTIVE_AGENT_MIX_REPORT = DEFAULT_ACTIVE_DIR / "agent_mix_report.md"
 DEFAULT_ACTIVE_ARTIFACTS_DIR = DEFAULT_ACTIVE_DIR / "artifacts"
 DEFAULT_ACTIVE_WORKTREE_PREPARE = DEFAULT_ACTIVE_DIR / "active_worktree_prepare.md"
+DEFAULT_ACTIVE_CODEX_RUNNER = DEFAULT_ACTIVE_DIR / "codex_runner.md"
+DEFAULT_ACTIVE_CODEX_RUNNER_STATE = DEFAULT_ACTIVE_DIR / "codex_runner_state.json"
+DEFAULT_ACTIVE_CODEX_RUNS_DIR = DEFAULT_ACTIVE_DIR / "codex_runs"
 DEFAULT_ISSUE_STATE = DEFAULT_REPORT_DIR / "issue_state.json"
 DEFAULT_ISSUE_TRIAGE = DEFAULT_REPORT_DIR / "issue_triage.md"
 DEFAULT_ISSUE_QUEUE_TASKS_DIR = DEFAULT_REPORT_DIR / "issue_queue_tasks"
@@ -567,6 +571,17 @@ class AgentTurnResult:
     verdict: str
     artifact_path: Path | None
     registry_path: Path | None
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ActiveCodexRunnerResult:
+    report_path: Path
+    state_path: Path
+    runs_dir: Path
+    decision: str
+    sessions: tuple[dict[str, object], ...]
     blockers: tuple[str, ...]
     warnings: tuple[str, ...]
 
@@ -9043,6 +9058,12 @@ def _active_path(path: Path, *, repo_root: Path) -> Path:
         path = repo_root / "reports" / "agent_loop" / "active" / "artifacts"
     elif path == DEFAULT_ACTIVE_WORKTREE_PREPARE:
         path = repo_root / "reports" / "agent_loop" / "active" / "active_worktree_prepare.md"
+    elif path == DEFAULT_ACTIVE_CODEX_RUNNER:
+        path = repo_root / "reports" / "agent_loop" / "active" / "codex_runner.md"
+    elif path == DEFAULT_ACTIVE_CODEX_RUNNER_STATE:
+        path = repo_root / "reports" / "agent_loop" / "active" / "codex_runner_state.json"
+    elif path == DEFAULT_ACTIVE_CODEX_RUNS_DIR:
+        path = repo_root / "reports" / "agent_loop" / "active" / "codex_runs"
     return _safe_output_path(path, repo_root=repo_root)
 
 
@@ -9509,6 +9530,271 @@ def write_agent_turn(
     )
 
 
+def write_active_codex_runner(
+    *,
+    execute: bool = False,
+    registry: Path = DEFAULT_ACTIVE_REGISTRY,
+    assignments_dir: Path = DEFAULT_ACTIVE_ASSIGNMENTS_DIR,
+    runs_dir: Path = DEFAULT_ACTIVE_CODEX_RUNS_DIR,
+    state: Path = DEFAULT_ACTIVE_CODEX_RUNNER_STATE,
+    out: Path = DEFAULT_ACTIVE_CODEX_RUNNER,
+    sessions: str | None = None,
+    max_parallel: int = 8,
+    codex_executable: str = "codex",
+    sandbox: str = "read-only",
+    repo_root: Path = ROOT_DIR,
+    popen_factory=None,
+    which_func=None,
+) -> ActiveCodexRunnerResult:
+    """Plan or spawn one Codex process per active-loop session.
+
+    This is intentionally separate from ``active-start`` and ``active-loop --execute``:
+    it creates read-only Codex processes for role assignments, but it never marks a
+    role as passed and never calls the shipping path.
+    """
+    if max_parallel < 1:
+        raise ValueError("--max-parallel must be at least 1")
+    if sandbox not in {"read-only", "workspace-write", "danger-full-access"}:
+        raise ValueError("--sandbox must be read-only, workspace-write, or danger-full-access")
+    registry_path = _active_path(registry, repo_root=repo_root)
+    assignments_path = _active_path(assignments_dir, repo_root=repo_root)
+    runs_path = _active_path(runs_dir, repo_root=repo_root)
+    state_path = _active_path(state, repo_root=repo_root)
+    out_path = _active_path(out, repo_root=repo_root)
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    planned: list[dict[str, object]] = []
+    requested_sessions = _parse_active_session_filter(sessions)
+    registry_payload: dict[str, object] = {}
+
+    if not registry_path.exists():
+        blockers.append("active session registry is missing; run make agent-loop-active-start first")
+    else:
+        registry_payload = _load_active_registry(registry_path)
+        selected, selection_blockers = _select_active_codex_sessions(registry_payload, requested_sessions)
+        blockers.extend(selection_blockers)
+        if len(selected) > max_parallel:
+            blockers.append(f"selected session count {len(selected)} exceeds --max-parallel {max_parallel}")
+        for session in selected:
+            session_id = _validate_session_id(str(session.get("session_id") or ""))
+            role = _sanitize_inline_text(str(session.get("role") or "unknown"))
+            assignment_path = assignments_path / f"{session_id}.md"
+            run_dir = runs_path / session_id
+            prompt_path = run_dir / "prompt.md"
+            stdout_path = run_dir / "stdout.jsonl"
+            stderr_path = run_dir / "stderr.log"
+            last_message_path = run_dir / "last_message.md"
+            if not assignment_path.exists():
+                blockers.append(f"assignment missing for session {session_id}")
+            command = _active_codex_exec_command(
+                codex_executable=codex_executable,
+                sandbox=sandbox,
+                last_message_path=last_message_path,
+                repo_root=repo_root,
+            )
+            planned.append(
+                {
+                    "session_id": session_id,
+                    "role": role,
+                    "status": "planned",
+                    "pid": None,
+                    "assignment": _repo_path(assignment_path, repo_root),
+                    "run_dir": _repo_path(run_dir, repo_root),
+                    "prompt": _repo_path(prompt_path, repo_root),
+                    "stdout": _repo_path(stdout_path, repo_root),
+                    "stderr": _repo_path(stderr_path, repo_root),
+                    "last_message": _repo_path(last_message_path, repo_root),
+                    "command": _sanitize_command_text(shlex.join(_active_codex_display_command(command))),
+                }
+            )
+
+    resolved_executable = None
+    if execute:
+        which = which_func if which_func is not None else shutil.which
+        resolved_executable = which(codex_executable)
+        if not resolved_executable:
+            blockers.append(f"codex executable not found: {codex_executable}")
+    else:
+        warnings.append("dry-run only; pass --execute or ACTIVE_CODEX_EXECUTE=1 to spawn Codex processes")
+
+    decision = "blocked" if blockers else ("running" if execute else "planned")
+    if execute and not blockers:
+        factory = popen_factory if popen_factory is not None else subprocess.Popen
+        for item in planned:
+            session_id = str(item["session_id"])
+            role = str(item["role"])
+            run_dir = runs_path / session_id
+            assignment_path = assignments_path / f"{session_id}.md"
+            prompt_path = run_dir / "prompt.md"
+            stdout_path = run_dir / "stdout.jsonl"
+            stderr_path = run_dir / "stderr.log"
+            last_message_path = run_dir / "last_message.md"
+            run_dir.mkdir(parents=True, exist_ok=True)
+            prompt = _render_active_codex_prompt(
+                session_id=session_id,
+                role=role,
+                assignment_path=assignment_path,
+                repo_root=repo_root,
+            )
+            prompt_path.write_text(prompt, encoding="utf-8")
+            command = _active_codex_exec_command(
+                codex_executable=str(resolved_executable or codex_executable),
+                sandbox=sandbox,
+                last_message_path=last_message_path,
+                repo_root=repo_root,
+            )
+            try:
+                with stdout_path.open("w", encoding="utf-8") as stdout_file, stderr_path.open(
+                    "w", encoding="utf-8"
+                ) as stderr_file:
+                    proc = factory(
+                        command,
+                        cwd=repo_root,
+                        stdin=subprocess.PIPE,
+                        stdout=stdout_file,
+                        stderr=stderr_file,
+                        text=True,
+                    )
+                    stdin = getattr(proc, "stdin", None)
+                    if stdin is not None:
+                        stdin.write(prompt)
+                        stdin.close()
+            except OSError as exc:
+                item["status"] = "spawn-failed"
+                blockers.append(f"failed to spawn session {session_id}: {exc}")
+                decision = "blocked"
+                break
+            item["status"] = "running"
+            item["pid"] = getattr(proc, "pid", None)
+
+    state_payload = {
+        "schema_version": 1,
+        "generated_at": _isoformat(datetime.now(timezone.utc)),
+        "execute": execute,
+        "decision": decision,
+        "sandbox": sandbox,
+        "registry": _repo_path(registry_path, repo_root),
+        "assignments_dir": _repo_path(assignments_path, repo_root),
+        "runs_dir": _repo_path(runs_path, repo_root),
+        "sessions": planned,
+        "blockers": _dedupe_preserve_order(blockers),
+        "warnings": _dedupe_preserve_order(warnings),
+    }
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(_sanitize_json_value(state_payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _append_active_event(
+        _active_path(DEFAULT_ACTIVE_EVENTS, repo_root=repo_root),
+        {
+            "event": "active-codex-runner",
+            "execute": execute,
+            "decision": decision,
+            "sandbox": sandbox,
+            "sessions": [item["session_id"] for item in planned],
+            "blockers": blockers,
+            "warnings": warnings,
+        },
+    )
+    rendered = render_active_codex_runner(
+        decision=decision,
+        execute=execute,
+        sandbox=sandbox,
+        sessions=planned,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        registry_path=registry_path,
+        assignments_path=assignments_path,
+        runs_path=runs_path,
+        state_path=state_path,
+        repo_root=repo_root,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered, encoding="utf-8")
+    return ActiveCodexRunnerResult(
+        report_path=out_path,
+        state_path=state_path,
+        runs_dir=runs_path,
+        decision=decision,
+        sessions=tuple(planned),
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+    )
+
+
+def render_active_codex_runner(
+    *,
+    decision: str,
+    execute: bool,
+    sandbox: str,
+    sessions: Sequence[dict[str, object]],
+    blockers: Sequence[str],
+    warnings: Sequence[str],
+    registry_path: Path,
+    assignments_path: Path,
+    runs_path: Path,
+    state_path: Path,
+    repo_root: Path,
+) -> str:
+    lines = [
+        "# Active Codex Runner",
+        "",
+        "- Spawns one separate `codex exec` process per active-loop assignment.",
+        "- Separate from `active-start` and `active-loop --execute`; it never marks role gates passed and never calls ship.",
+        "- Default sandbox is read-only. Use stronger sandboxes only after lease and scope review.",
+        f"- Requested execution: `{execute}`",
+        f"- Decision: `{decision}`",
+        f"- Sandbox: `{_sanitize_inline_text(sandbox)}`",
+        "",
+        "## Inputs",
+        "",
+        f"- Registry: `{_repo_path(registry_path, repo_root)}`",
+        f"- Assignments: `{_repo_path(assignments_path, repo_root)}`",
+        f"- Runs: `{_repo_path(runs_path, repo_root)}`",
+        f"- State: `{_repo_path(state_path, repo_root)}`",
+        "",
+        "## Sessions",
+        "",
+        "| Session | Role | Status | PID | Assignment | Last message | Command |",
+        "|---|---|---|---:|---|---|---|",
+    ]
+    if sessions:
+        for item in sessions:
+            lines.append(
+                "| "
+                + " | ".join(
+                    _sanitize_inline_text(str(value))
+                    for value in (
+                        item.get("session_id", ""),
+                        item.get("role", ""),
+                        item.get("status", ""),
+                        item.get("pid") if item.get("pid") is not None else "",
+                        item.get("assignment", ""),
+                        item.get("last_message", ""),
+                        item.get("command", ""),
+                    )
+                )
+                + " |"
+            )
+    else:
+        lines.append("| N/A | N/A | no sessions |  | N/A | N/A | N/A |")
+    lines.extend(["", "## Blockers", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in blockers) if blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in warnings) if warnings else lines.append("- None")
+    lines.extend(
+        [
+            "",
+            "## Execute",
+            "",
+            "```bash",
+            "make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE=1",
+            "```",
+            "",
+        ]
+    )
+    return _sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n"
+
+
 def write_agent_mix_report(
     *,
     agent_mix_path: Path = DEFAULT_ACTIVE_AGENT_MIX,
@@ -9747,6 +10033,102 @@ def _active_role_status_ok(sessions: Sequence[dict[str, object]], role: str) -> 
         if session.get("role") == role:
             return str(session.get("status") or "").casefold() in passing
     return False
+
+
+def _parse_active_session_filter(spec: str | None) -> tuple[str, ...] | None:
+    if not spec:
+        return None
+    sessions = tuple(_validate_session_id(part.strip()) for part in spec.split(",") if part.strip())
+    if not sessions:
+        raise ValueError("--sessions must contain at least one session id")
+    return sessions
+
+
+def _select_active_codex_sessions(
+    registry_payload: dict[str, object],
+    requested_sessions: Sequence[str] | None,
+) -> tuple[list[dict[str, object]], list[str]]:
+    raw_sessions = registry_payload.get("sessions")
+    if not isinstance(raw_sessions, list) or not raw_sessions:
+        return [], ["active session registry has no sessions; run active-start or active-loop first"]
+    valid_sessions: list[dict[str, object]] = []
+    blockers: list[str] = []
+    for item in raw_sessions:
+        if not isinstance(item, dict):
+            blockers.append("active session registry contains a non-object session")
+            continue
+        session_id = str(item.get("session_id") or "")
+        try:
+            _validate_session_id(session_id)
+        except ValueError:
+            blockers.append("active session registry contains an unsafe session id")
+            continue
+        valid_sessions.append(dict(item))
+    if requested_sessions is None:
+        return valid_sessions, blockers
+    by_id = {str(item.get("session_id")): item for item in valid_sessions}
+    selected: list[dict[str, object]] = []
+    for session_id in requested_sessions:
+        item = by_id.get(session_id)
+        if item is None:
+            blockers.append(f"requested session is not in active registry: {session_id}")
+            continue
+        selected.append(item)
+    return selected, blockers
+
+
+def _active_codex_exec_command(
+    *,
+    codex_executable: str,
+    sandbox: str,
+    last_message_path: Path,
+    repo_root: Path,
+) -> list[str]:
+    return [
+        codex_executable,
+        "exec",
+        "--cd",
+        ".",
+        "--sandbox",
+        sandbox,
+        "--ask-for-approval",
+        "never",
+        "--json",
+        "--output-last-message",
+        _repo_path(last_message_path, repo_root),
+        "-",
+    ]
+
+
+def _active_codex_display_command(command: Sequence[str]) -> list[str]:
+    display = list(command)
+    if display:
+        display[0] = Path(display[0]).name or "codex"
+    return display
+
+
+def _render_active_codex_prompt(
+    *,
+    session_id: str,
+    role: str,
+    assignment_path: Path,
+    repo_root: Path,
+) -> str:
+    assignment = _repo_path(assignment_path, repo_root)
+    return _sanitize_dynamic_text(
+        "\n".join(
+            [
+                f"You are the Codex active-loop session `{session_id}` for role `{role}`.",
+                "Repository root is the current working directory.",
+                f"Read the assignment at `{assignment}` and execute the read-only parts of that role.",
+                "Do not edit files, commit, push, create/ready/merge PRs, close issues, delete branches, force-push, or run ship commands.",
+                "If the assignment's next command would write, mutate remote state, or require a missing placeholder, report the blocker and the next safe command instead.",
+                "Return a concise final message with: session id, role, commands inspected, blockers, warnings, evidence, and next safe command.",
+                "Do not include absolute local paths, raw private question/answer/evidence text, doc_id, chunk_id, filename, or prompt/response body.",
+                "",
+            ]
+        )
+    )
 
 
 def _write_active_assignment(
@@ -10572,6 +10954,7 @@ Automation points:
 - validation-history: summarize local JSONL validation history.
 - workset-recommend: recommend serial, parallel-safe, review-only, and agent-gated task sets.
 - role-dispatch: render role-separated subagent dispatch cards with max 12 and depth 2; report-only, does not spawn subagents.
+- active-codex-runner: spawn one separate read-only Codex process per active-loop assignment; does not mark gates passed or ship.
 - automation-coverage: map implemented automation candidates to command surfaces.
 - auto-pass-check: fail-closed low-risk gate check; named strict profiles require high-confidence docs/CI/tooling surfaces and passed validation.
 - loop-state: write machine-readable current loop state JSON.
@@ -11388,6 +11771,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     agent_mix_report = sub.add_parser("agent-mix-report", help="Render the rolling Claude/Codex Work-Unit mix and rebalance recommendation.")
     agent_mix_report.add_argument("--out", type=Path, default=DEFAULT_ACTIVE_AGENT_MIX_REPORT)
+
+    codex_runner = sub.add_parser("active-codex-runner", help="Plan or spawn one read-only Codex process per active-loop session.")
+    codex_runner.add_argument("--dry-run", dest="execute", action="store_false", default=False)
+    codex_runner.add_argument("--execute", dest="execute", action="store_true")
+    codex_runner.add_argument("--registry", type=Path, default=DEFAULT_ACTIVE_REGISTRY)
+    codex_runner.add_argument("--assignments-dir", type=Path, default=DEFAULT_ACTIVE_ASSIGNMENTS_DIR)
+    codex_runner.add_argument("--runs-dir", type=Path, default=DEFAULT_ACTIVE_CODEX_RUNS_DIR)
+    codex_runner.add_argument("--state", type=Path, default=DEFAULT_ACTIVE_CODEX_RUNNER_STATE)
+    codex_runner.add_argument("--out", type=Path, default=DEFAULT_ACTIVE_CODEX_RUNNER)
+    codex_runner.add_argument("--sessions", help="Comma-separated session ids; default is every session in registry order.")
+    codex_runner.add_argument("--max-parallel", type=int, default=8)
+    codex_runner.add_argument("--codex-executable", default="codex")
+    codex_runner.add_argument("--sandbox", choices=("read-only", "workspace-write", "danger-full-access"), default="read-only")
 
     active_prepare = sub.add_parser("active-worktree-prepare", help="Prepare an issue-linked worktree for an active-loop role.")
     active_prepare.add_argument("--issue")
@@ -12290,6 +12686,21 @@ def main(argv: list[str] | None = None) -> int:
                 f"(recommended={summary['recommended_next_agent']}, skew={summary['skew_wu']})\n"
             )
             return 0
+        if args.command == "active-codex-runner":
+            result = write_active_codex_runner(
+                execute=args.execute,
+                registry=args.registry,
+                assignments_dir=args.assignments_dir,
+                runs_dir=args.runs_dir,
+                state=args.state,
+                out=args.out,
+                sessions=args.sessions,
+                max_parallel=args.max_parallel,
+                codex_executable=args.codex_executable,
+                sandbox=args.sandbox,
+            )
+            sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")
+            return 0 if result.decision in {"planned", "running"} else 1
         if args.command == "active-worktree-prepare":
             out, _, _ = write_active_worktree_prepare(
                 issue=args.issue,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3499,6 +3499,173 @@ def test_agent_turn_cli_accepts_and_rejects_agent() -> None:
     parser.parse_args(["agent-mix-report"])  # parser exists
 
 
+def _write_expanded_active_runner_fixture(repo: Path) -> Path:
+    active = _active_dir(repo)
+    assignments = active / "assignments"
+    assignments.mkdir(parents=True, exist_ok=True)
+    sessions = []
+    for session_id, role in agent_loop.ACTIVE_TOPOLOGY_ROLES["expanded-eight"]:
+        sessions.append(
+            {
+                "session_id": session_id,
+                "role": role,
+                "status": "idle",
+                "last_heartbeat": "2999-01-01T00:00:00Z",
+                "lanes": {"claude": {"status": "idle"}, "codex": {"status": "idle"}},
+                "write_lease_owner": role == "Implementer",
+                "ship_gate": agent_loop._active_ship_gate(role, topology="expanded-eight"),
+            }
+        )
+        (assignments / f"{session_id}.md").write_text(
+            f"# Active Assignment: {role}\n\n- Session: `{session_id}`\n- Next command: `status`\n",
+            encoding="utf-8",
+        )
+    (active / "session_registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "topology": "expanded-eight",
+                "gate_policy": "conservative",
+                "agent_mix": agent_loop._parse_agent_mix(None),
+                "sessions": sessions,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (active / "leases.json").write_text(
+        json.dumps({"schema_version": 1, "leases": [{"lease_id": "lease", "active_agent": None}]}),
+        encoding="utf-8",
+    )
+    return active
+
+
+def test_active_codex_runner_dry_run_renders_eight_commands_without_spawning(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    active = _write_expanded_active_runner_fixture(repo)
+
+    result = agent_loop.write_active_codex_runner(repo_root=repo)
+
+    assert result.decision == "planned"
+    assert len(result.sessions) == 8
+    assert not (active / "codex_runs").exists()
+    assert all("codex exec --cd . --sandbox read-only --ask-for-approval never --json" in item["command"] for item in result.sessions)
+    report = result.report_path.read_text(encoding="utf-8")
+    state = result.state_path.read_text(encoding="utf-8")
+    assert str(repo) not in report
+    assert str(repo) not in state
+    assert "role-dispatch" not in report  # runner is a separate spawn surface, not the report-only dispatcher.
+
+
+def test_active_codex_runner_execute_spawns_all_eight_processes_and_preserves_lease(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    active = _write_expanded_active_runner_fixture(repo)
+    calls: list[dict[str, object]] = []
+    prompts: list[str] = []
+
+    class DummyStdin:
+        def write(self, text: str) -> None:
+            prompts.append(text)
+
+        def close(self) -> None:
+            pass
+
+    class DummyProc:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+            self.stdin = DummyStdin()
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(
+            {
+                "cmd": list(cmd),
+                "cwd": kwargs["cwd"],
+                "stdin": kwargs["stdin"],
+                "stdout": kwargs["stdout"].name,
+                "stderr": kwargs["stderr"].name,
+                "text": kwargs["text"],
+            }
+        )
+        return DummyProc(7000 + len(calls))
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True,
+        repo_root=repo,
+        popen_factory=fake_popen,
+        which_func=lambda exe: "/opt/codex/bin/codex",
+    )
+
+    assert result.decision == "running"
+    assert len(calls) == 8
+    assert len(prompts) == 8
+    for call in calls:
+        cmd = call["cmd"]
+        assert cmd[:4] == ["/opt/codex/bin/codex", "exec", "--cd", "."]
+        assert "--sandbox" in cmd
+        assert cmd[cmd.index("--sandbox") + 1] == "read-only"
+        assert "--ask-for-approval" in cmd
+        assert cmd[cmd.index("--ask-for-approval") + 1] == "never"
+        assert "--json" in cmd
+        assert "--output-last-message" in cmd
+        assert str(cmd[cmd.index("--output-last-message") + 1]).startswith("reports/agent_loop/active/codex_runs/")
+        assert cmd[-1] == "-"
+        assert call["cwd"] == repo
+        assert call["stdin"] == subprocess.PIPE
+        assert call["text"] is True
+    assert (active / "codex_runs" / "reviewer" / "prompt.md").exists()
+    leases = json.loads((active / "leases.json").read_text(encoding="utf-8"))
+    assert leases["leases"][0]["active_agent"] is None
+    state = json.loads(result.state_path.read_text(encoding="utf-8"))
+    assert {item["status"] for item in state["sessions"]} == {"running"}
+    assert all(item["pid"] for item in state["sessions"])
+    assert str(repo) not in result.state_path.read_text(encoding="utf-8")
+
+
+def test_active_codex_runner_execute_fails_closed_without_codex(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _write_expanded_active_runner_fixture(repo)
+    calls: list[list[str]] = []
+
+    result = agent_loop.write_active_codex_runner(
+        execute=True,
+        repo_root=repo,
+        popen_factory=lambda cmd, **kwargs: calls.append(list(cmd)),  # type: ignore[arg-type]
+        which_func=lambda exe: None,
+    )
+
+    assert result.decision == "blocked"
+    assert any("codex executable not found" in blocker for blocker in result.blockers)
+    assert calls == []
+
+
+def test_active_codex_runner_fails_closed_on_missing_registry_or_assignment(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+
+    missing_registry = agent_loop.write_active_codex_runner(execute=True, repo_root=repo, which_func=lambda exe: "/bin/codex")
+
+    assert missing_registry.decision == "blocked"
+    assert any("registry is missing" in blocker for blocker in missing_registry.blockers)
+
+    active = _write_expanded_active_runner_fixture(repo)
+    (active / "assignments" / "reviewer.md").unlink()
+
+    missing_assignment = agent_loop.write_active_codex_runner(
+        execute=True,
+        sessions="reviewer",
+        repo_root=repo,
+        which_func=lambda exe: "/bin/codex",
+    )
+
+    assert missing_assignment.decision == "blocked"
+    assert any("assignment missing for session reviewer" in blocker for blocker in missing_assignment.blockers)
+
+
+def test_active_codex_runner_cli_accepts_execute_and_session_filter() -> None:
+    parser = agent_loop.build_parser()
+    args = parser.parse_args(["active-codex-runner", "--execute", "--sessions", "reviewer,ci-regression-auditor"])
+    assert args.execute is True
+    assert args.sessions == "reviewer,ci-regression-auditor"
+
+
 def test_codex_lane_adapter_maps_verdict_severity_and_errors(monkeypatch, tmp_path: Path) -> None:
     from scripts import agent_loop_codex_turn as cx
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`active-start`가 만든 expanded-eight registry/assignment를 읽어, 8개 역할을 별도 `codex exec` process로 spawn할 수 있는 `active-codex-runner` CLI와 Make target을 추가했습니다. 기본은 dry-run이며, 실제 spawn은 `ACTIVE_CODEX_EXECUTE=1`일 때만 수행합니다. Runner는 gate 통과나 ship을 대신하지 않고, read-only sandbox와 repo-local output artifact만 남깁니다.

Closes #1596

## 2. 영향 파일

- `scripts/agent_loop.py` - `active-codex-runner` planner/executor, state/report rendering, fail-closed validation
- `Makefile` - `agent-loop-active-codex-runner` target 및 실행 변수 추가
- `tests/test_agent_loop.py` - dry-run 8-session rendering, execute Popen spawn, missing codex/registry/assignment fail-closed coverage
- `docs/operations/active-agent-loop.md` - start와 runner 분리, execute command, gate non-escalation 문서화

## 3. 리스크

- 실제 `ACTIVE_CODEX_EXECUTE=1`은 Codex process 8개를 동시에 spawn할 수 있습니다. 기본값을 dry-run으로 두고, `ACTIVE_CODEX_MAX_PARALLEL`과 `ACTIVE_CODEX_SESSIONS`로 범위를 제한할 수 있게 했습니다.
- Process 종료를 gate 통과로 오인할 위험이 있습니다. Runner는 `session-heartbeat` pass/clear를 쓰지 않고 `active-loop --execute`나 `make ship-run`도 호출하지 않도록 분리했습니다.
- Local path/private artifact leakage 위험은 runner state/report에 repo-relative path만 저장하고, prompt에는 private raw field 금지 문구를 넣었습니다.

## 4. 테스트

- `python3 -m py_compile scripts/agent_loop.py`
- `python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py scripts/agent_loop_codex_turn.py scripts/agent_loop_claude_turn.py`
- `python3 -m pytest tests/test_agent_loop.py -q`
- `make agent-loop-active-start`
- `make agent-loop-active-codex-runner`
- `python3 scripts/agent_loop.py privacy-audit-output --path reports/agent_loop/active/codex_runner.md --out reports/agent_loop/active/codex_runner_privacy.md`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/active-agent-loop.md`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `make check-branch`
- `python3 scripts/agent_loop.py pr-body-check --body reports/agent_loop/pr_body.md --from-git --out reports/agent_loop/pr_body_check.md`

## 5. Eval 영향

All `N/A` - agent-loop 운영 CLI, ignored report artifact, docs/test 변경입니다. RAG 검색(retrieval), 재순위(reranking), 답변(answer), 평가(eval) metric surface 동작 변경이나 성능(performance) claim은 없습니다.

### 5b. Real-data delta

N/A - private real-data path, 검색/검증(retrieval/verification), 답변(answer), 평가(eval) 동작 변경 없음. `make real-eval-delta`는 실행하지 않았고, 이 PR은 private/internal eval 개선을 주장하지 않습니다.

## 6. 하위 호환

기존 `active-start`, `active-loop`, `role-dispatch`, `agent-turn`, `session-heartbeat` 계약은 유지합니다. 새 runner는 별도 subcommand/Make target입니다. `role-dispatch`의 report-only 계약도 유지합니다.

## 7. 범위 외

- Spawn된 Codex process 결과를 자동으로 `passed/clear` heartbeat로 승격
- write lease를 Codex process에 배정하거나 구현 patch를 자동 적용
- `active-loop --execute` ship gate 변경
- remote branch deletion 또는 orphan worktree cleanup
