### PR TITLE
Run Codex runner from active-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@
 # they render prompts, classify surfaces, check handoffs, suggest or run
 # allowlisted local validation, and write ignored local planning drafts. They
 # do not perform GitHub mutations.
-.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-issue-scan agent-loop-maintenance-plan agent-loop-issue-close agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-active-start agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
+.PHONY: agent-loop-next agent-loop-status agent-loop-prompt agent-loop-handoff agent-loop-review agent-loop-surface agent-loop-validation agent-loop-validate agent-loop-preflight agent-loop-pr-scan agent-loop-issue-scan agent-loop-maintenance-plan agent-loop-issue-close agent-loop-next-from-prs agent-loop-pr-health agent-loop-draft-task agent-loop-draft-next agent-loop-batch-plan agent-loop-review-followup agent-loop-review-ingest agent-loop-decision-brief agent-loop-promote-draft agent-loop-gate-status agent-loop-claim-audit agent-loop-privacy-audit-output agent-loop-auto-pass agent-loop-dashboard agent-loop-mcp-config agent-loop-safe-fix agent-loop-approval-packet agent-loop-propose-queue-plan agent-loop-pr-body agent-loop-review-plan agent-loop-stale-reports agent-loop-context-pack agent-loop-architecture-brief agent-loop-ship-simulate agent-loop-auto-ship-prepare agent-loop-auto-ship-plan agent-loop-gate-brief agent-loop-manifest agent-loop-pr-body-check agent-loop-ci-ingest agent-loop-stacked-risk agent-loop-patch-proposal agent-loop-adr-reserve agent-loop-dashboard-html agent-loop-ship-command-pack agent-loop-apply-queue-plan agent-loop-review-threads agent-loop-ci-summary agent-loop-readiness-score agent-loop-artifact-freshness agent-loop-review-patch-plan agent-loop-queue-plan-sync agent-loop-dependency-graph agent-loop-branch-issue-hygiene agent-loop-integration-pack agent-loop-scheduled-status agent-loop-validation-history agent-loop-privacy-regression agent-loop-claim-policy agent-loop-architecture-decision agent-loop-workset-recommend agent-loop-automation-coverage agent-loop-active-start agent-loop-active-codex-runner 시작 agent-loop-human-gated-exec agent-loop-loop-state agent-loop-map agent-loop-mcp
 
 # Auto-ship pipeline (Stop hook driven). See scripts/claude-hooks/stop-ship.sh
 # and the plan at /Users/hskim/.claude/plans/prci-synchronous-newell.md.
@@ -422,6 +422,8 @@ ACTIVE_REPAIR_BRANCH ?= 1
 ACTIVE_REPAIR_BRANCH_TYPE ?= chore
 ACTIVE_REPAIR_SLUG ?= active-start
 ACTIVE_REPAIR_TITLE ?= Agent loop active start
+ACTIVE_START_RUNNER ?= 1
+ACTIVE_START_RUNNER_EXECUTE ?= 1
 ACTIVE_CODEX_RUNNER_OUT ?= reports/agent_loop/active/codex_runner.md
 ACTIVE_CODEX_RUNNER_STATE ?= reports/agent_loop/active/codex_runner_state.json
 ACTIVE_CODEX_RUNS_DIR ?= reports/agent_loop/active/codex_runs
@@ -933,6 +935,7 @@ agent-loop-active-start:
 	  --repair-slug "$(ACTIVE_REPAIR_SLUG)" \
 	  --repair-title "$(ACTIVE_REPAIR_TITLE)" \
 	  --out "$(ACTIVE_START_OUT)"
+	$(if $(filter 1 true yes,$(ACTIVE_START_RUNNER)),$(MAKE) agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE="$(ACTIVE_START_RUNNER_EXECUTE)",)
 
 agent-loop-active-codex-runner:
 	$(PYTHON) scripts/agent_loop.py active-codex-runner \
@@ -944,6 +947,8 @@ agent-loop-active-codex-runner:
 	  --runs-dir "$(ACTIVE_CODEX_RUNS_DIR)" \
 	  --state "$(ACTIVE_CODEX_RUNNER_STATE)" \
 	  --out "$(ACTIVE_CODEX_RUNNER_OUT)"
+
+시작: agent-loop-active-start
 
 agent-loop-human-gated-exec:
 	@if [ -z "$(HUMAN_GATED_ACTION)" ]; then \

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -133,10 +133,33 @@ Make wrapper:
 make agent-loop-active-start
 ```
 
+Make wrapper는 여기서 멈추지 않고 기본적으로 `agent-loop-active-codex-runner`를
+`ACTIVE_CODEX_EXECUTE=1`로 이어서 호출한다. 즉 `make agent-loop-active-start` 한
+번이면 start pack 생성 후 8-session Codex runner spawn까지 진행한다.
+
+준비만 하고 process를 띄우지 않으려면 다음처럼 끈다.
+
+```bash
+make agent-loop-active-start ACTIVE_START_RUNNER=0
+```
+
+runner report까지만 보고 실제 spawn을 막으려면 다음처럼 dry-run으로 낮춘다.
+
+```bash
+make agent-loop-active-start ACTIVE_START_RUNNER_EXECUTE=0
+```
+
+Korean alias도 같은 동작을 한다.
+
+```bash
+make 시작
+```
+
 ## Codex Runner
 
-`active-start`는 ledger와 assignment를 만들지만 agent process를 spawn하지 않는다.
-8-session을 실제 별도 Codex process로 띄우는 표면은 별도 runner다.
+Python `active-start` CLI는 ledger와 assignment만 만들지만, Make wrapper는 runner를
+이어 실행한다. 8-session을 별도 Codex process로 띄우는 standalone 표면은 다음
+target이다.
 
 ```bash
 make agent-loop-active-codex-runner

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3666,6 +3666,45 @@ def test_active_codex_runner_cli_accepts_execute_and_session_filter() -> None:
     assert args.sessions == "reviewer,ci-regression-auditor"
 
 
+def test_make_active_start_spawns_codex_runner_by_default() -> None:
+    result = subprocess.run(
+        ["make", "-n", "agent-loop-active-start"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "scripts/agent_loop.py active-start" in result.stdout
+    assert 'make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE="1"' in result.stdout
+    assert "scripts/agent_loop.py active-codex-runner" in result.stdout
+    assert "--execute" in result.stdout
+
+
+def test_make_active_start_can_disable_runner_and_has_korean_alias() -> None:
+    no_runner = subprocess.run(
+        ["make", "-n", "agent-loop-active-start", "ACTIVE_START_RUNNER=0"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    alias = subprocess.run(
+        ["make", "-n", "시작"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert no_runner.returncode == 0
+    assert "scripts/agent_loop.py active-start" in no_runner.stdout
+    assert "agent-loop-active-codex-runner" not in no_runner.stdout
+    assert alias.returncode == 0
+    assert 'make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE="1"' in alias.stdout
+
+
 def test_codex_lane_adapter_maps_verdict_severity_and_errors(monkeypatch, tmp_path: Path) -> None:
     from scripts import agent_loop_codex_turn as cx
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make agent-loop-active-start`가 start pack 생성에서 멈추지 않고, 기본적으로 `agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE=1`까지 이어 실행하도록 바꿨습니다. 사용자가 말한 "시작" 한 번으로 branch repair/start ledger/8-session Codex runner spawn까지 연결됩니다. 준비만 원하면 `ACTIVE_START_RUNNER=0`, runner dry-run만 원하면 `ACTIVE_START_RUNNER_EXECUTE=0`으로 낮출 수 있습니다.

Closes #1599

## 2. 영향 파일

- `Makefile` - `agent-loop-active-start`에서 runner execute를 기본 호출, `make 시작` alias 추가
- `docs/operations/active-agent-loop.md` - start wrapper가 runner까지 실행하는 실제 UX와 override 문서화
- `tests/test_agent_loop.py` - `make -n` 기반으로 start target 기본 runner execute, disable flag, Korean alias 검증

## 3. 리스크

- `make agent-loop-active-start`가 이제 기본적으로 8개 Codex process spawn을 시도합니다. 의도적 UX 변경이며, process를 띄우지 않을 때는 `ACTIVE_START_RUNNER=0` 또는 `ACTIVE_START_RUNNER_EXECUTE=0`을 사용합니다.
- Codex executable이 없으면 runner execute가 fail-closed합니다. 기존 runner의 missing executable guard를 그대로 사용합니다.

## 4. 테스트

- `make -n agent-loop-active-start`
- `make -n agent-loop-active-start ACTIVE_START_RUNNER=0`
- `make -n 시작`
- `python3 -m pytest tests/test_agent_loop.py -q`
- `python3 -m py_compile scripts/ai_next_actions.py scripts/agent_loop.py scripts/agent_loop_codex_turn.py scripts/agent_loop_claude_turn.py`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/active-agent-loop.md`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `make check-branch`
- `make agent-loop-active-start ACTIVE_START_RUNNER_EXECUTE=0`
- `python3 scripts/agent_loop.py pr-body-check --body reports/agent_loop/pr_body.md --from-git --out reports/agent_loop/pr_body_check.md`
- `python3 scripts/agent_loop.py privacy-audit-output --path reports/agent_loop/active/codex_runner.md --out reports/agent_loop/active/codex_runner_privacy.md`

## 5. Eval 영향

All `N/A` - Make wrapper/docs/test 변경입니다. RAG 검색(retrieval), 재순위(reranking), 답변(answer), 평가(eval) metric surface 동작 변경이나 성능(performance) claim은 없습니다.

### 5b. Real-data delta

N/A - private real-data path, 검색/검증(retrieval/verification), 답변(answer), 평가(eval) 동작 변경 없음. `make real-eval-delta`는 실행하지 않았고, 이 PR은 private/internal eval 개선을 주장하지 않습니다.

## 6. 하위 호환

Python `active-start` CLI는 계속 ledger/assignment 생성만 합니다. 변경된 것은 Make wrapper 기본 UX입니다. 기존 준비-only 흐름은 `ACTIVE_START_RUNNER=0`으로 유지됩니다.

## 7. 범위 외

- Spawn된 Codex process 결과를 자동 `passed/clear` heartbeat로 승격
- `active-loop --execute` ship gate 변경
- real Codex process 8개를 검증 중 실제로 띄우기
