### PR TITLE
fix: active-loop read-only lanes against real claude/codex CLIs (F1-F4)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -3074,6 +3074,42 @@ def _privacy_audit_patterns() -> dict[str, re.Pattern[str]]:
     }
 
 
+# Redaction counterparts to _privacy_audit_patterns. Each masks the span the matching
+# detector would flag while preserving its structural prefix, so a read-only lane artifact
+# stays usable (verdict + findings survive) and no raw private value persists. The caller
+# re-runs audit_privacy_output after redaction as the fail-closed backstop (issue #1598 F1:
+# code-review prose legitimately mentions repo paths / field names that the RFP-data
+# patterns would otherwise hard-block). Keep these in sync with _privacy_audit_patterns.
+_REAL100_PATH_REDACT_RE = re.compile(r"reports/real100/(?!\[redacted-private-artifact\])\S+", re.IGNORECASE)
+_JSON_PRIVATE_FIELD_REDACT_RE = re.compile(
+    r'"(?P<key>question|answer|evidence|doc_id|chunk_id|filename)"\s*:\s*"(?!\[redacted-private-value\])[^"]*"',
+    re.IGNORECASE,
+)
+_RAW_DOC_CHUNK_TOKEN_REDACT_RE = re.compile(r"\b(?:doc|chunk)[_-]?id[-_:][A-Za-z0-9][A-Za-z0-9._-]*", re.IGNORECASE)
+
+
+def _redact_private_text(text: str) -> str:
+    """Mask every span audit_privacy_output would flag, preserving structural prefixes."""
+    text = ABSOLUTE_LOCAL_PATH_RE.sub("[redacted-local-path]", text)
+    text = _REAL100_PATH_REDACT_RE.sub("reports/real100/[redacted-private-artifact]", text)
+    text = PRIVATE_INLINE_VALUE_RE.sub(lambda m: f"{m.group('label')}: [redacted-private-value]", text)
+    text = PRIVATE_FLAG_VALUE_RE.sub(lambda m: f"{m.group('flag')}[redacted-private-value]", text)
+    text = _JSON_PRIVATE_FIELD_REDACT_RE.sub(lambda m: f'"{m.group("key")}": "[redacted-private-value]"', text)
+    text = _RAW_DOC_CHUNK_TOKEN_REDACT_RE.sub("[redacted-private-token]", text)
+    return text
+
+
+def _redact_private_json(value):  # type: ignore[no-untyped-def]
+    """Recursively apply _redact_private_text to every string in a JSON-like value."""
+    if isinstance(value, dict):
+        return {key: _redact_private_json(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_private_json(item) for item in value]
+    if isinstance(value, str):
+        return _redact_private_text(value)
+    return value
+
+
 def _dedupe_privacy_findings(findings: Iterable[PrivacyFinding]) -> list[PrivacyFinding]:
     seen: set[tuple[str, str]] = set()
     out: list[PrivacyFinding] = []
@@ -9302,24 +9338,48 @@ def _agent_turn_artifact_path(
     return base / task_segment / session_id / f"{agent}.json"
 
 
-def _build_agent_turn_prompt(role: str, *, task_id: str | None, pr: str | None, base: str) -> str:
+def _agent_turn_diff(base: str, *, repo_root: Path, max_chars: int = 60000) -> str:
+    """Return ``git diff <base>`` text (capped) for embedding in a read-only lane prompt.
+
+    The Claude lane embeds the diff instead of letting claude run git itself: in headless
+    ``-p`` mode claude's tool use crashes the API (issue #1598 F4). Only tracked changes
+    are diffed, so no gitignored private data (ADR 0005) is included.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "diff", base], cwd=repo_root, capture_output=True, text=True, check=False
+        )
+    except OSError:
+        return ""
+    if proc.returncode != 0:
+        return ""
+    text = proc.stdout or ""
+    if len(text) > max_chars:
+        text = text[:max_chars] + "\n... [diff truncated]"
+    return text
+
+
+def _build_agent_turn_prompt(role: str, *, task_id: str | None, pr: str | None, base: str, diff: str = "") -> str:
     scope_bits = [f"role={role}"]
     if task_id:
         scope_bits.append(f"task={task_id}")
     if pr:
         scope_bits.append(f"PR=#{pr}")
     scope = ", ".join(scope_bits)
-    return (
+    instructions = (
         "You are a read-only reviewer in the BidMate-DocAgent active loop. "
         f"Scope: {scope}. Diff base: {base}. "
-        "Review the current branch changes WITHOUT editing, writing, committing, pushing, or shipping. "
-        "Use only Read/Grep/Glob and read-only git (diff/log/status). "
-        "Return JSON conforming to the review_artifact schema: a verdict "
-        "(approved|clear|needs-attention|blocked), a one-line summary, a findings array "
-        "(each with severity blocker|warning|info, a title, and optional body/recommendation), "
-        "and an optional next_steps array. Do NOT include raw private question/answer text, "
-        "doc_id, chunk_id, filenames, or absolute private paths (ADR 0005)."
+        "Review the unified diff below WITHOUT proposing edits, writing, committing, pushing, or shipping. "
+        "Output ONLY a raw JSON object (no markdown code fences, no prose before or after) "
+        "with exactly these keys: \"verdict\" (one of approved|clear|needs-attention|blocked), "
+        "\"summary\" (one line), \"findings\" (array; each object has \"severity\" one of "
+        "blocker|warning|info, \"title\", and optional \"body\"/\"recommendation\"), and "
+        "\"next_steps\" (array of strings, may be empty). Do NOT include raw private "
+        "question/answer text, doc_id, chunk_id, filenames, or absolute private paths (ADR 0005)."
     )
+    if diff:
+        return f"{instructions}\n\nUNIFIED DIFF (base {base}):\n{diff}"
+    return f"{instructions}\n\n(No diff content available; review based on scope metadata only.)"
 
 
 def _run_agent_lane(
@@ -9343,7 +9403,8 @@ def _run_agent_lane(
     if agent == "codex":
         focus = f"{role} read-only review"
         return codex_turn.run_turn(base=base, scope="branch", focus=focus, runner=codex_runner)
-    prompt = _build_agent_turn_prompt(role, task_id=task_id, pr=pr, base=base)
+    diff = _agent_turn_diff(base, repo_root=repo_root)
+    prompt = _build_agent_turn_prompt(role, task_id=task_id, pr=pr, base=base, diff=diff)
     resolved_schema = schema_path if schema_path.is_absolute() else (repo_root / schema_path)
     return claude_turn.run_turn(prompt=prompt, schema_path=resolved_schema, runner=claude_runner)
 
@@ -9440,11 +9501,15 @@ def write_agent_turn(
         "privacy_scrubbed": True,
     }
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
-    artifact_path.write_text(json.dumps(_sanitize_json_value(artifact), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    # Privacy (ADR 0005): redact-and-proceed. _redact_private_json masks every span the
+    # audit would flag (repo paths, field values, raw tokens) in place, so a legitimate
+    # code review stays usable (verdict + findings survive) without persisting raw private
+    # values. audit_privacy_output then re-runs as a fail-closed backstop: if anything
+    # un-redactable slips through, the turn is blocked with no Work Unit and a non-pass
+    # heartbeat (issue #1598 F1).
+    safe_artifact = _redact_private_json(_sanitize_json_value(artifact))
+    artifact_path.write_text(json.dumps(safe_artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     events_path = _active_path(events, repo_root=repo_root)
-    # Fail-closed privacy gate (ADR 0005): if the lane output leaked raw private values
-    # into the artifact, rewrite it as a redacted error and record neither a pass-class
-    # heartbeat nor a Work Unit.
     privacy_findings = audit_privacy_output(artifact_path, out_path=None, repo_root=repo_root)
     if privacy_findings:
         issues = sorted({finding.issue for finding in privacy_findings})

--- a/scripts/agent_loop_claude_turn.py
+++ b/scripts/agent_loop_claude_turn.py
@@ -1,10 +1,12 @@
 """Read-only Claude lane adapter for the active-loop `agent-turn` (issue #1590).
 
-Invokes `claude -p` in plan permission mode with a read-only tool allowlist and a
-write/ship denylist, asking for output that conforms to
-`schemas/review_artifact.schema.json`. Parses the `--output-format json` wrapper
-into the shared review-artifact core (verdict / summary / findings / next_steps).
-No writes, no patches, no ship.
+Invokes `claude -p` with the unified diff embedded in the prompt (the caller runs
+`git diff`), an inline `--json-schema`, a read-only tool allowlist, and a write/ship
+denylist. The diff is embedded rather than fetched via claude's own tools because
+headless `-p` tool use crashes the API ("tool_use ids must be unique", issue #1598
+F4); plan mode is likewise dropped. Parses the `--output-format json` wrapper (the
+model's result may be fenced) into the shared review-artifact core
+(verdict / summary / findings / next_steps). No writes, no patches, no ship.
 
 The agent-turn caller (scripts/agent_loop.py) owns privacy scrubbing, artifact
 persistence, Work Unit accounting, and the session heartbeat. This module never
@@ -15,6 +17,7 @@ record a deterministic non-pass heartbeat. The subprocess call is injectable via
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Callable, Sequence
@@ -52,21 +55,24 @@ def build_command(
     allowed_tools: Sequence[str] = DEFAULT_ALLOWED_TOOLS,
     disallowed_tools: Sequence[str] = DEFAULT_DISALLOWED_TOOLS,
 ) -> list[str]:
-    return [
-        "claude",
-        "-p",
-        prompt,
-        "--output-format",
-        "json",
-        "--json-schema",
-        str(schema_path),
-        "--permission-mode",
-        "plan",
-        "--allowedTools",
-        " ".join(allowed_tools),
-        "--disallowedTools",
-        " ".join(disallowed_tools),
-    ]
+    cmd = ["claude", "-p", prompt, "--output-format", "json"]
+    # `--json-schema` expects the schema JSON *inline*, not a file path — passing a path
+    # crashes the claude binary (issue #1598 F2). Inline the file content; omit the flag if
+    # the schema is unreadable so the lane still runs (the prompt carries the required shape).
+    try:
+        schema_text = schema_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        schema_text = ""
+    if schema_text:
+        cmd += ["--json-schema", schema_text]
+    # No --permission-mode plan: in headless `-p`, plan mode + tool use crashes the API with
+    # "tool_use ids must be unique" (issue #1598 F4). The diff is embedded in the prompt so
+    # the lane needs no tools; the read-only allowlist + mutation denylist stay as defense.
+    if allowed_tools:
+        cmd += ["--allowedTools", " ".join(allowed_tools)]
+    if disallowed_tools:
+        cmd += ["--disallowedTools", " ".join(disallowed_tools)]
+    return cmd
 
 
 def _default_runner(cmd: list[str]) -> "subprocess.CompletedProcess[str]":
@@ -110,12 +116,21 @@ def _extract_core(stdout: str) -> dict[str, object] | None:
         candidate = outer["result"]
     if isinstance(candidate, str):
         try:
-            candidate = json.loads(candidate)
+            candidate = json.loads(_strip_code_fences(candidate))
         except (json.JSONDecodeError, TypeError):
             return None
     if not isinstance(candidate, dict):
         return None
     return _normalize_core(candidate)
+
+
+def _strip_code_fences(text: str) -> str:
+    """Strip a leading/trailing markdown code fence (claude 2.1.3 wraps result JSON; F3)."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```[A-Za-z0-9_-]*\s*\n?", "", stripped)
+        stripped = re.sub(r"\n?```\s*$", "", stripped)
+    return stripped.strip()
 
 
 def _normalize_core(obj: dict[str, object]) -> dict[str, object]:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3761,8 +3761,11 @@ def test_claude_lane_adapter_command_and_core(tmp_path: Path) -> None:
     schema.write_text("{}", encoding="utf-8")
     cmd = cl.build_command(prompt="review", schema_path=schema)
     assert cmd[:3] == ["claude", "-p", "review"]
-    assert cmd[cmd.index("--permission-mode") + 1] == "plan"
-    assert "--json-schema" in cmd
+    # F4: no --permission-mode plan (headless plan-mode tool use crashes the API).
+    assert "--permission-mode" not in cmd
+    # F2: --json-schema must carry the inline schema CONTENT, not the file path.
+    assert cmd[cmd.index("--json-schema") + 1] == "{}"
+    assert str(schema) not in cmd
     allowed = cmd[cmd.index("--allowedTools") + 1]
     disallowed = cmd[cmd.index("--disallowedTools") + 1]
     assert "Read" in allowed
@@ -3782,6 +3785,13 @@ def test_claude_lane_adapter_command_and_core(tmp_path: Path) -> None:
     assert core["verdict"] == "needs-attention"
     assert core["findings"][0]["severity"] == "warning"
 
+    # F3: claude 2.1.3 wraps the result JSON in a ```json code fence; _extract_core strips it.
+    def fenced_runner(c):
+        inner = "```json\n" + json.dumps({"verdict": "approved", "summary": "ok", "findings": []}) + "\n```"
+        return subprocess.CompletedProcess(c, 0, stdout=json.dumps({"result": inner}), stderr="")
+
+    assert cl.run_turn(prompt="x", schema_path=schema, runner=fenced_runner)["verdict"] == "approved"
+
     def fail_runner(c):
         return subprocess.CompletedProcess(c, 1, stdout="", stderr="err")
 
@@ -3791,6 +3801,52 @@ def test_claude_lane_adapter_command_and_core(tmp_path: Path) -> None:
         return subprocess.CompletedProcess(c, 0, stdout="<<not json>>", stderr="")
 
     assert cl.run_turn(prompt="x", schema_path=schema, runner=junk_runner)["verdict"] == "error"
+
+
+def test_claude_lane_adapter_omits_schema_when_unreadable(tmp_path: Path) -> None:
+    from scripts import agent_loop_claude_turn as cl
+
+    missing = tmp_path / "nope.json"  # does not exist
+    cmd = cl.build_command(prompt="review", schema_path=missing)
+    # F2 safety: unreadable schema -> omit --json-schema so the lane still runs.
+    assert "--json-schema" not in cmd
+    assert cmd[:5] == ["claude", "-p", "review", "--output-format", "json"]
+
+
+def test_agent_turn_redacts_real100_path_and_proceeds(monkeypatch, tmp_path: Path) -> None:
+    # F1: a code review legitimately mentioning a public repo path (reports/real100/...)
+    # must be redacted-and-proceeded, NOT false-positive-blocked.
+    repo = _write_repo(tmp_path)
+    monkeypatch.setattr(agent_loop, "_current_branch", lambda repo_root: "fix/issue-1598")
+    core = {
+        "verdict": "approved",
+        "summary": "Baseline lives in reports/real100/baseline.aggregate.json; the change looks safe.",
+        "findings": [],
+        "next_steps": [],
+    }
+
+    result = agent_loop.write_agent_turn(
+        session_id="reviewer",
+        role="Reviewer",
+        agent="claude",
+        task_id="T-2026-9999",
+        execute=True,
+        claude_runner=_claude_lane_runner(core),
+        repo_root=repo,
+    )
+
+    assert result.decision == "executed"  # redact-and-proceed, not blocked
+    assert result.verdict == "approved"
+    text = result.artifact_path.read_text(encoding="utf-8")
+    assert "reports/real100/[redacted-private-artifact]" in text
+    assert "baseline.aggregate.json" not in text  # raw artifact name masked
+    assert json.loads(text)["privacy_scrubbed"] is True
+    # WU recorded + heartbeat reflects the pass-class verdict (not blocked).
+    mix = json.loads((_active_dir(repo) / "agent_mix.json").read_text(encoding="utf-8"))
+    assert mix["rolling"] == {"claude": 1, "codex": 0}
+    registry = json.loads((_active_dir(repo) / "session_registry.json").read_text(encoding="utf-8"))
+    session = next(item for item in registry["sessions"] if item["session_id"] == "reviewer")
+    assert session["status"] == "approved"
 
 
 def test_stop_ship_skips_remote_branch_delete_when_stacked_dependents_exist() -> None:


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

머지된 read-only Claude/Codex lane(#1594)을 **실제** `claude`/`codex` CLI 상대로 end-to-end 검증한 결과, mock-runner 테스트(완벽한 JSON 주입)가 못 잡은 4개 통합 버그(F1–F4)를 수정한다. read-only 계약·범위는 불변 — 동작을 실제로 돌게 만드는 fix.

Closes #1598

## 2. 영향 파일

- `scripts/agent_loop.py` — F1 redact-and-proceed(`_redact_private_text`/`_redact_private_json` + `write_agent_turn`이 redact→재감사, audit는 fail-closed backstop), F4 diff 임베딩(`_agent_turn_diff` + `_build_agent_turn_prompt`가 `git diff <base>`를 프롬프트에 삽입), F3b 프롬프트 강화. (**load-bearing 아님** — Phase 5에서 승격 예정, ADR 0080.)
- `scripts/agent_loop_claude_turn.py` — F2 `--json-schema` 본문 인라인, F3 코드펜스 제거(`_strip_code_fences`), F4 `--permission-mode plan` 제거(headless tool-use 크래시 회피).
- `tests/test_agent_loop.py` — 버그별 회귀 테스트(펜스 출력 파싱 / inline-not-path schema / schema 부재 시 flag omit / real100 mention redact-and-proceed).

## 3. 리스크

- **read-only 약화?** F4로 plan mode를 뺐지만 diff를 프롬프트에 넣어 lane이 tool을 쓸 필요가 없고(실측 1-turn, no tool), write/ship denylist + read-only allowlist가 방어. tracked-file diff만 임베딩 → gitignored 비공개 데이터 미포함(ADR 0005).
- **privacy 약화?** redact-and-proceed는 raw span을 마스킹 후 **재감사**하여 그래도 남으면 block — fail-closed 유지. raw 비공개 값은 절대 persist 안 됨.
- **redactor/detector drift**: `_redact_private_text`는 `_privacy_audit_patterns`와 짝(주석 명시); 어긋나도 재감사 backstop이 차단.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q` → **141 passed**. 각 fix에 변경 전 실패/변경 후 통과하는 회귀 테스트.
- **실측 e2e**: `agent-turn --agent claude --execute`가 실제 claude로 `verdict=approved` + 실제 findings 반환(수정 전엔 `rc=1` 크래시). F1(codex)은 unit-verified(redactor가 정확히 `reports/real100/` 패턴 무력화 + 재감사 `[]`); codex 플러밍은 #1594 검증 세션에서 실측됨.

## 5. Eval 영향

All `·` — RAG 검색/검증/답변 경로 무관. agent-loop lane 어댑터 + privacy 게이트만 변경.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. 변경 파일 중 load-bearing path 없음(agent_loop.py는 ADR 0080에 따라 Phase 5 승격 예정, 현 시점 비-load-bearing). real-eval delta 불필요.

## 6. 하위 호환

- `review_artifact` 계약(`schema_version 1`) 불변. registry/agent_mix 불변.
- 신규 CLI verb/flag 추가 없음; claude lane **내부** 호출 방식만 변경(plan-mode tool-use → diff 임베딩). codex lane 불변.

## 7. 범위 외

- codex lane F1 실측 재확인(5분 소요, unit-proven으로 갈음).
- Phase 3+ (mutating/patch/ship).
- claude `--json-schema` 미강제(advisory) — 프롬프트 + fence-strip + 파서로 대응, schema 강제 자체는 claude CLI 한계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)