### PR TITLE
Fix active-start Codex runner execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,7 @@ ACTIVE_CODEX_RUNNER_STATE ?= reports/agent_loop/active/codex_runner_state.json
 ACTIVE_CODEX_RUNS_DIR ?= reports/agent_loop/active/codex_runs
 ACTIVE_CODEX_SESSIONS ?=
 ACTIVE_CODEX_MAX_PARALLEL ?= 8
+ACTIVE_CODEX_TIMEOUT_SECONDS ?= 0
 ACTIVE_CODEX_EXECUTABLE ?= codex
 ACTIVE_CODEX_SANDBOX ?= read-only
 ACTIVE_CODEX_EXECUTE ?=
@@ -943,6 +944,7 @@ agent-loop-active-codex-runner:
 	  --codex-executable "$(ACTIVE_CODEX_EXECUTABLE)" \
 	  --sandbox "$(ACTIVE_CODEX_SANDBOX)" \
 	  --max-parallel "$(ACTIVE_CODEX_MAX_PARALLEL)" \
+	  --timeout-seconds "$(ACTIVE_CODEX_TIMEOUT_SECONDS)" \
 	  $(if $(ACTIVE_CODEX_SESSIONS),--sessions "$(ACTIVE_CODEX_SESSIONS)",) \
 	  --runs-dir "$(ACTIVE_CODEX_RUNS_DIR)" \
 	  --state "$(ACTIVE_CODEX_RUNNER_STATE)" \

--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -177,10 +177,11 @@ make agent-loop-active-codex-runner ACTIVE_CODEX_EXECUTE=1
 runner는 session마다 `reports/agent_loop/active/codex_runs/<session_id>/` 아래에
 `prompt.md`, `stdout.jsonl`, `stderr.log`, `last_message.md`를 둔다. 기본 sandbox는
 `read-only`이고, 각 prompt는 assignment의 read-only 부분만 실행하게 제한한다.
-이 runner는 `session-heartbeat`를 pass로 승격하지 않고, `active-loop --execute`의
-ship gate나 `make ship-run`도 호출하지 않는다. 따라서 agent process가 끝났다는
-사실은 reviewer/auditor gate 통과 근거가 아니며, gate status는 별도 heartbeat나
-검토 표면에서 유지한다.
+Execute mode는 8개 process를 spawn한 뒤 종료 코드와 last message artifact가 남도록
+각 process를 wait한다. 이 runner는 `session-heartbeat`를 pass로 승격하지 않고,
+`active-loop --execute`의 ship gate나 `make ship-run`도 호출하지 않는다. 따라서
+agent process가 끝났다는 사실은 reviewer/auditor gate 통과 근거가 아니며, gate
+status는 별도 heartbeat나 검토 표면에서 유지한다.
 
 ## Full Ship Gate
 

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -9540,6 +9540,7 @@ def write_active_codex_runner(
     out: Path = DEFAULT_ACTIVE_CODEX_RUNNER,
     sessions: str | None = None,
     max_parallel: int = 8,
+    timeout_seconds: int = 0,
     codex_executable: str = "codex",
     sandbox: str = "read-only",
     repo_root: Path = ROOT_DIR,
@@ -9554,6 +9555,8 @@ def write_active_codex_runner(
     """
     if max_parallel < 1:
         raise ValueError("--max-parallel must be at least 1")
+    if timeout_seconds < 0:
+        raise ValueError("--timeout-seconds must be >= 0")
     if sandbox not in {"read-only", "workspace-write", "danger-full-access"}:
         raise ValueError("--sandbox must be read-only, workspace-write, or danger-full-access")
     registry_path = _active_path(registry, repo_root=repo_root)
@@ -9619,6 +9622,7 @@ def write_active_codex_runner(
         warnings.append("dry-run only; pass --execute or ACTIVE_CODEX_EXECUTE=1 to spawn Codex processes")
 
     decision = "blocked" if blockers else ("running" if execute else "planned")
+    spawned: list[tuple[dict[str, object], object]] = []
     if execute and not blockers:
         factory = popen_factory if popen_factory is not None else subprocess.Popen
         for item in planned:
@@ -9667,6 +9671,31 @@ def write_active_codex_runner(
                 break
             item["status"] = "running"
             item["pid"] = getattr(proc, "pid", None)
+            spawned.append((item, proc))
+        for item, proc in spawned:
+            if blockers:
+                break
+            wait = getattr(proc, "wait", None)
+            try:
+                if callable(wait):
+                    rc = wait(timeout=timeout_seconds or None)
+                else:
+                    rc = getattr(proc, "returncode", 0)
+            except subprocess.TimeoutExpired:
+                item["status"] = "timeout"
+                item["returncode"] = None
+                blockers.append(f"session {item['session_id']} timed out after {timeout_seconds} seconds")
+                decision = "blocked"
+                continue
+            item["returncode"] = rc
+            if rc == 0:
+                item["status"] = "completed"
+            else:
+                item["status"] = "failed"
+                blockers.append(f"session {item['session_id']} exited with code {rc}")
+                decision = "blocked"
+        if spawned and not blockers:
+            decision = "completed"
 
     state_payload = {
         "schema_version": 1,
@@ -9674,6 +9703,7 @@ def write_active_codex_runner(
         "execute": execute,
         "decision": decision,
         "sandbox": sandbox,
+        "timeout_seconds": timeout_seconds,
         "registry": _repo_path(registry_path, repo_root),
         "assignments_dir": _repo_path(assignments_path, repo_root),
         "runs_dir": _repo_path(runs_path, repo_root),
@@ -10091,8 +10121,6 @@ def _active_codex_exec_command(
         ".",
         "--sandbox",
         sandbox,
-        "--ask-for-approval",
-        "never",
         "--json",
         "--output-last-message",
         _repo_path(last_message_path, repo_root),
@@ -11782,6 +11810,7 @@ def build_parser() -> argparse.ArgumentParser:
     codex_runner.add_argument("--out", type=Path, default=DEFAULT_ACTIVE_CODEX_RUNNER)
     codex_runner.add_argument("--sessions", help="Comma-separated session ids; default is every session in registry order.")
     codex_runner.add_argument("--max-parallel", type=int, default=8)
+    codex_runner.add_argument("--timeout-seconds", type=int, default=0, help="Per-session wait timeout; 0 means no timeout.")
     codex_runner.add_argument("--codex-executable", default="codex")
     codex_runner.add_argument("--sandbox", choices=("read-only", "workspace-write", "danger-full-access"), default="read-only")
 
@@ -12696,11 +12725,12 @@ def main(argv: list[str] | None = None) -> int:
                 out=args.out,
                 sessions=args.sessions,
                 max_parallel=args.max_parallel,
+                timeout_seconds=args.timeout_seconds,
                 codex_executable=args.codex_executable,
                 sandbox=args.sandbox,
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")
-            return 0 if result.decision in {"planned", "running"} else 1
+            return 0 if result.decision in {"planned", "running", "completed"} else 1
         if args.command == "active-worktree-prepare":
             out, _, _ = write_active_worktree_prepare(
                 issue=args.issue,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3548,7 +3548,7 @@ def test_active_codex_runner_dry_run_renders_eight_commands_without_spawning(tmp
     assert result.decision == "planned"
     assert len(result.sessions) == 8
     assert not (active / "codex_runs").exists()
-    assert all("codex exec --cd . --sandbox read-only --ask-for-approval never --json" in item["command"] for item in result.sessions)
+    assert all("codex exec --cd . --sandbox read-only --json" in item["command"] for item in result.sessions)
     report = result.report_path.read_text(encoding="utf-8")
     state = result.state_path.read_text(encoding="utf-8")
     assert str(repo) not in report
@@ -3574,6 +3574,9 @@ def test_active_codex_runner_execute_spawns_all_eight_processes_and_preserves_le
             self.pid = pid
             self.stdin = DummyStdin()
 
+        def wait(self, timeout=None):  # type: ignore[no-untyped-def]
+            return 0
+
     def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
         calls.append(
             {
@@ -3594,7 +3597,7 @@ def test_active_codex_runner_execute_spawns_all_eight_processes_and_preserves_le
         which_func=lambda exe: "/opt/codex/bin/codex",
     )
 
-    assert result.decision == "running"
+    assert result.decision == "completed"
     assert len(calls) == 8
     assert len(prompts) == 8
     for call in calls:
@@ -3602,8 +3605,6 @@ def test_active_codex_runner_execute_spawns_all_eight_processes_and_preserves_le
         assert cmd[:4] == ["/opt/codex/bin/codex", "exec", "--cd", "."]
         assert "--sandbox" in cmd
         assert cmd[cmd.index("--sandbox") + 1] == "read-only"
-        assert "--ask-for-approval" in cmd
-        assert cmd[cmd.index("--ask-for-approval") + 1] == "never"
         assert "--json" in cmd
         assert "--output-last-message" in cmd
         assert str(cmd[cmd.index("--output-last-message") + 1]).startswith("reports/agent_loop/active/codex_runs/")
@@ -3615,7 +3616,8 @@ def test_active_codex_runner_execute_spawns_all_eight_processes_and_preserves_le
     leases = json.loads((active / "leases.json").read_text(encoding="utf-8"))
     assert leases["leases"][0]["active_agent"] is None
     state = json.loads(result.state_path.read_text(encoding="utf-8"))
-    assert {item["status"] for item in state["sessions"]} == {"running"}
+    assert {item["status"] for item in state["sessions"]} == {"completed"}
+    assert {item["returncode"] for item in state["sessions"]} == {0}
     assert all(item["pid"] for item in state["sessions"])
     assert str(repo) not in result.state_path.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

`make agent-loop-active-start`가 실제 `codex exec` 8개를 띄울 때 현재 Codex CLI에 없는 `--ask-for-approval` flag 때문에 즉시 종료되던 문제를 고쳤습니다. 또한 runner가 process를 spawn만 하고 부모가 바로 끝나면 Codex turn이 시작 직후 끊기는 것을 확인해, execute mode에서 8개 process를 spawn한 뒤 각 process 종료 코드와 last-message artifact가 남을 때까지 wait하도록 변경했습니다.

Closes #1601

## 2. 영향 파일

- `scripts/agent_loop.py` - Codex exec command를 현재 CLI flag에 맞추고, execute runner가 process completion을 wait/record
- `Makefile` - `ACTIVE_CODEX_TIMEOUT_SECONDS` 변수와 runner timeout 전달 추가
- `tests/test_agent_loop.py` - runner command expectation 및 completed/returncode state 검증 갱신
- `docs/operations/active-agent-loop.md` - execute mode가 spawn 후 wait한다는 실제 동작 문서화

## 3. 리스크

- `make agent-loop-active-start`가 이제 runner completion을 기다리므로 즉시 반환하지 않습니다. 필요 시 `ACTIVE_CODEX_TIMEOUT_SECONDS=<N>`으로 per-session timeout을 둘 수 있고, `0`은 timeout 없음입니다.
- Codex process completion은 runner lifecycle evidence일 뿐, reviewer/auditor pass gate로 자동 승격하지 않습니다.

## 4. 테스트

- `python3 -m py_compile scripts/agent_loop.py`
- `python3 -m py_compile scripts/agent_loop.py scripts/agent_loop_codex_turn.py scripts/agent_loop_claude_turn.py`
- `python3 -m pytest tests/test_agent_loop.py -q`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `make -n agent-loop-active-start`
- `make check-branch`
- `python3 scripts/check_doc_links.py --check-all --paths docs/operations/active-agent-loop.md`
- `make agent-loop-active-start ACTIVE_CODEX_TIMEOUT_SECONDS=180` - completed 8/8, exit code 0 for all sessions
- `python3 scripts/agent_loop.py privacy-audit-output --path reports/agent_loop/active/codex_runner.md --out reports/agent_loop/active/codex_runner_privacy.md`
- `python3 scripts/agent_loop.py pr-body-check --body reports/agent_loop/pr_body.md --from-git --out reports/agent_loop/pr_body_check.md`

## 5. Eval 영향

All `N/A` - agent-loop runner CLI/Make/docs/test 변경입니다. RAG 검색(retrieval), 재순위(reranking), 답변(answer), 평가(eval) metric surface 동작 변경이나 성능(performance) claim은 없습니다.

### 5b. Real-data delta

N/A - private real-data path, 검색/검증(retrieval/verification), 답변(answer), 평가(eval) 동작 변경 없음. `make real-eval-delta`는 실행하지 않았고, 이 PR은 private/internal eval 개선을 주장하지 않습니다.

## 6. 하위 호환

`active-codex-runner --execute`의 decision은 성공 시 `completed`를 반환합니다. 기존 dry-run은 그대로 `planned`입니다. `active-loop --execute` ship gate와 heartbeat pass/clear 계약은 변경하지 않습니다.

## 7. 범위 외

- Completed runner session을 자동 `passed/clear` heartbeat로 승격
- ship gate 또는 PR shipping 자동화 변경
- generated `reports/agent_loop/active/codex_runs/` artifact 커밋
