### PR TITLE
feat: active-codex-runner patch mode (codex write-lane, #1604)

### DIFF
--- a/schemas/patch_artifact.schema.json
+++ b/schemas/patch_artifact.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/patch_artifact.schema.json",
+  "title": "Active-loop patch-proposal artifact",
+  "description": "A patch PROPOSAL produced by a write-lane (codex) in an isolated scratch worktree (issue #1604, ADR 0080 Phase 3). The lane edits inside the scratch worktree; the agent-patch-turn adapter captures the unified diff, privacy-scrubs it (ADR 0005), and authoritatively sets the meta fields. NO apply to the integration branch — that is a separate Orchestrator step (PR-B). No raw private question/answer text, doc_id, chunk_id, filenames, or absolute private paths.",
+  "type": "object",
+  "required": ["agent", "verdict", "diff"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "task_id": {
+      "type": ["string", "null"]
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "agent": {
+      "type": "string",
+      "enum": ["codex", "claude"]
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "base": {
+      "type": "string"
+    },
+    "integration_branch": {
+      "type": "string"
+    },
+    "scratch_branch": {
+      "type": "string"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["proposed", "empty", "blocked", "error"]
+    },
+    "summary": {
+      "type": "string"
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "diffstat": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "files_changed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "insertions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deletions": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "diff": {
+      "type": "string"
+    },
+    "wu": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "privacy_scrubbed": {
+      "type": "boolean"
+    }
+  }
+}

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -9611,12 +9611,18 @@ def write_active_codex_runner(
     repo_root: Path = ROOT_DIR,
     popen_factory=None,
     which_func=None,
+    git_runner=None,
+    mode: str = "read-only",
+    task_id: str | None = None,
+    base: str = "origin/main",
 ) -> ActiveCodexRunnerResult:
-    """Plan or spawn one Codex process per active-loop session.
+    """Plan or spawn Codex processes for the active loop.
 
-    This is intentionally separate from ``active-start`` and ``active-loop --execute``:
-    it creates read-only Codex processes for role assignments, but it never marks a
-    role as passed and never calls the shipping path.
+    ``mode="read-only"`` (default) spawns one read-only Codex process per session — this is
+    intentionally separate from ``active-start`` / ``active-loop --execute`` and never marks
+    a role passed or calls ship. ``mode="patch"`` runs a single codex write-lane on the
+    Implementer (write-lease owner) inside a scratch worktree and captures a patch proposal
+    (issue #1604); it borrows the write lease (claude XOR codex) and never applies the patch.
     """
     if max_parallel < 1:
         raise ValueError("--max-parallel must be at least 1")
@@ -9624,11 +9630,31 @@ def write_active_codex_runner(
         raise ValueError("--timeout-seconds must be >= 0")
     if sandbox not in {"read-only", "workspace-write", "danger-full-access"}:
         raise ValueError("--sandbox must be read-only, workspace-write, or danger-full-access")
+    if mode not in {"read-only", "patch"}:
+        raise ValueError("--mode must be read-only or patch")
     registry_path = _active_path(registry, repo_root=repo_root)
     assignments_path = _active_path(assignments_dir, repo_root=repo_root)
     runs_path = _active_path(runs_dir, repo_root=repo_root)
     state_path = _active_path(state, repo_root=repo_root)
     out_path = _active_path(out, repo_root=repo_root)
+
+    if mode == "patch":
+        return _write_active_codex_patch(
+            registry_path=registry_path,
+            patch_runs_path=runs_path.parent / "patch_runs",
+            state_path=state_path,
+            out_path=out_path,
+            assignments_path=assignments_path,
+            task_id=task_id,
+            base=base,
+            execute=execute,
+            timeout_seconds=timeout_seconds,
+            codex_executable=codex_executable,
+            repo_root=repo_root,
+            popen_factory=popen_factory,
+            which_func=which_func,
+            git_runner=git_runner,
+        )
 
     blockers: list[str] = []
     warnings: list[str] = []
@@ -9811,6 +9837,281 @@ def write_active_codex_runner(
         runs_dir=runs_path,
         decision=decision,
         sessions=tuple(planned),
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+    )
+
+
+def _write_active_codex_patch(
+    *,
+    registry_path: Path,
+    patch_runs_path: Path,
+    state_path: Path,
+    out_path: Path,
+    assignments_path: Path,
+    task_id: str | None,
+    base: str,
+    execute: bool,
+    timeout_seconds: int,
+    codex_executable: str,
+    repo_root: Path,
+    popen_factory=None,
+    which_func=None,
+    git_runner=None,
+    now: datetime | None = None,
+) -> ActiveCodexRunnerResult:
+    """Patch mode: a single codex write-lane on the Implementer (write-lease owner).
+
+    Borrows the write lease (claude XOR codex), edits inside an isolated scratch worktree
+    under ``--sandbox workspace-write``, captures ``git diff`` as a privacy-scrubbed patch
+    artifact, then tears the worktree down and releases the lease. NO integration apply
+    (that is PR-B). Codex-only (claude headless Edit-tool is unusable — issue #1598/#1604).
+    """
+    now = now or datetime.now(timezone.utc)
+    agent = "codex"
+    blockers: list[str] = []
+    warnings: list[str] = []
+    verdict = "error"
+    diff_text = ""
+    scratch_branch = ""
+    command_display = ""
+    session_id = "implementer"
+    resolved_task: str | None = None
+    acquired = False
+
+    if not registry_path.exists():
+        blockers.append("active session registry is missing; run make agent-loop-active-start first")
+    else:
+        raw = _load_active_registry(registry_path).get("sessions")
+        raw_sessions = raw if isinstance(raw, list) else []
+        implementer = next((s for s in raw_sessions if isinstance(s, dict) and s.get("role") == "Implementer"), None)
+        if implementer is None:
+            blockers.append("no Implementer session in registry; patch mode targets the write-lease owner")
+        else:
+            session_id = _validate_session_id(str(implementer.get("session_id") or "implementer"))
+            candidate = task_id or (str(implementer.get("task_id")) if implementer.get("task_id") else None)
+            if candidate and TASK_ID_RE.fullmatch(candidate):
+                resolved_task = candidate
+            else:
+                blockers.append("patch mode requires a task id (pass --task T-YYYY-NNNN or run active-start --task)")
+
+    which = which_func if which_func is not None else shutil.which
+    resolved_executable = which(codex_executable) if execute else codex_executable
+    if execute and not resolved_executable:
+        blockers.append(f"codex executable not found: {codex_executable}")
+    if not execute:
+        warnings.append("dry-run only; pass --execute (or ACTIVE_CODEX_EXECUTE=1) with --mode patch to run the write lane")
+
+    run_dir = patch_runs_path / session_id
+    artifact_path = run_dir / "patch_artifact.json"
+    last_message_path = run_dir / "last_message.md"
+    prompt_path = run_dir / "prompt.md"
+    stdout_path = run_dir / "stdout.jsonl"
+    stderr_path = run_dir / "stderr.log"
+
+    scratch_path: Path | None = None
+    if resolved_task is not None:
+        scratch_path, scratch_branch = _scratch_worktree_paths(resolved_task, agent, repo_root=repo_root)
+        command_display = _sanitize_command_text(
+            shlex.join(
+                _active_codex_display_command(
+                    _active_codex_exec_command(
+                        codex_executable=str(resolved_executable or codex_executable),
+                        sandbox="workspace-write",
+                        last_message_path=last_message_path,
+                        repo_root=repo_root,
+                        cd=str(scratch_path),
+                    )
+                )
+            )
+        )
+
+    can_run = execute and resolved_task is not None and scratch_path is not None and not blockers
+    if can_run:
+        ok, msg, _lease = acquire_active_agent(agent=agent, repo_root=repo_root, now=now)
+        if not ok:
+            blockers.append(f"write-lease borrow failed: {msg}")
+        else:
+            acquired = True
+            try:
+                created_path, scratch_branch, wt_blockers = create_scratch_worktree(
+                    resolved_task, agent, base=base, repo_root=repo_root, runner=git_runner
+                )
+                blockers.extend(wt_blockers)
+                if not wt_blockers:
+                    run_dir.mkdir(parents=True, exist_ok=True)
+                    prompt = _render_active_patch_prompt(
+                        session_id=session_id,
+                        task_id=resolved_task,
+                        scratch=_repo_path(created_path, repo_root),
+                        repo_root=repo_root,
+                    )
+                    prompt_path.write_text(prompt, encoding="utf-8")
+                    command = _active_codex_exec_command(
+                        codex_executable=str(resolved_executable),
+                        sandbox="workspace-write",
+                        last_message_path=last_message_path,
+                        repo_root=repo_root,
+                        cd=str(created_path),
+                    )
+                    factory = popen_factory if popen_factory is not None else subprocess.Popen
+                    proc = None
+                    try:
+                        with stdout_path.open("w", encoding="utf-8") as so, stderr_path.open("w", encoding="utf-8") as se:
+                            proc = factory(command, cwd=repo_root, stdin=subprocess.PIPE, stdout=so, stderr=se, text=True)
+                            stdin = getattr(proc, "stdin", None)
+                            if stdin is not None:
+                                stdin.write(prompt)
+                                stdin.close()
+                    except OSError as exc:
+                        blockers.append(f"failed to spawn codex patch session {session_id}: {exc}")
+                    if proc is not None and not blockers:
+                        wait = getattr(proc, "wait", None)
+                        try:
+                            rc = wait(timeout=timeout_seconds or None) if callable(wait) else getattr(proc, "returncode", 0)
+                        except subprocess.TimeoutExpired:
+                            rc = None
+                            blockers.append(f"codex patch session {session_id} timed out after {timeout_seconds} seconds")
+                        if rc == 0:
+                            run = git_runner or _git_worktree_runner
+                            # Stage everything first: codex often CREATES files, and plain
+                            # `git diff` omits untracked files. `add -A` + `diff --cached`
+                            # captures new files + modifications as one applyable patch.
+                            add_proc = run(["git", "-C", str(created_path), "add", "-A"])
+                            if getattr(add_proc, "returncode", 1) != 0:
+                                blockers.append("git add failed in scratch worktree")
+                            else:
+                                diff_proc = run(["git", "-C", str(created_path), "diff", "--cached"])
+                                if getattr(diff_proc, "returncode", 1) == 0:
+                                    diff_text = getattr(diff_proc, "stdout", "") or ""
+                                    verdict = "proposed" if diff_text.strip() else "empty"
+                                else:
+                                    blockers.append("git diff capture failed in scratch worktree")
+                        elif rc is not None:
+                            blockers.append(f"codex patch session {session_id} exited with code {rc}")
+            finally:
+                warnings.extend(teardown_scratch_worktree(resolved_task, agent, repo_root=repo_root, runner=git_runner))
+                release_ok, release_msg = release_active_agent(agent=agent, repo_root=repo_root, now=now)
+                if not release_ok:
+                    warnings.append(f"active_agent release warning: {release_msg}")
+
+    if acquired and resolved_task is not None:
+        artifact = {
+            "schema_version": 1,
+            "task_id": resolved_task,
+            "session_id": session_id,
+            "role": "Implementer",
+            "agent": agent,
+            "generated_at": _isoformat(now),
+            "base": base,
+            "scratch_branch": scratch_branch,
+            "verdict": verdict,
+            "summary": _patch_summary(verdict, diff_text),
+            "files": _diff_files(diff_text),
+            "diffstat": _diffstat(diff_text),
+            "diff": diff_text,
+            "wu": 1 if verdict == "proposed" else 0,
+            "privacy_scrubbed": True,
+        }
+        run_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(
+            json.dumps(_redact_private_json(_sanitize_json_value(artifact)), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        privacy_findings = audit_privacy_output(artifact_path, out_path=None, repo_root=repo_root)
+        if privacy_findings:
+            issues = sorted({finding.issue for finding in privacy_findings})
+            verdict = "blocked"
+            redacted = {
+                "schema_version": 1,
+                "task_id": resolved_task,
+                "session_id": session_id,
+                "role": "Implementer",
+                "agent": agent,
+                "generated_at": _isoformat(now),
+                "base": base,
+                "scratch_branch": scratch_branch,
+                "verdict": "blocked",
+                "summary": f"privacy scrub rejected patch ({len(issues)} issue type(s))",
+                "files": [],
+                "diffstat": {"files_changed": 0, "insertions": 0, "deletions": 0},
+                "diff": "",
+                "wu": 0,
+                "privacy_scrubbed": False,
+            }
+            artifact_path.write_text(json.dumps(redacted, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            blockers.extend(f"privacy: {issue}" for issue in issues)
+
+    if not execute:
+        decision = "blocked" if blockers else "planned"
+    elif blockers:
+        decision = "blocked"
+    else:
+        decision = "completed"
+
+    sessions_out = [
+        {
+            "session_id": session_id,
+            "role": "Implementer",
+            "status": verdict if execute else "planned",
+            "pid": None,
+            "assignment": _repo_path(artifact_path, repo_root),
+            "last_message": _repo_path(last_message_path, repo_root),
+            "command": command_display,
+        }
+    ]
+    state_payload = {
+        "schema_version": 1,
+        "generated_at": _isoformat(now),
+        "execute": execute,
+        "mode": "patch",
+        "decision": decision,
+        "sandbox": "workspace-write",
+        "task_id": resolved_task,
+        "verdict": verdict,
+        "patch_runs_dir": _repo_path(patch_runs_path, repo_root),
+        "sessions": sessions_out,
+        "blockers": _dedupe_preserve_order(blockers),
+        "warnings": _dedupe_preserve_order(warnings),
+    }
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(_sanitize_json_value(state_payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _append_active_event(
+        _active_path(DEFAULT_ACTIVE_EVENTS, repo_root=repo_root),
+        {
+            "event": "active-codex-runner",
+            "mode": "patch",
+            "execute": execute,
+            "decision": decision,
+            "sandbox": "workspace-write",
+            "task_id": resolved_task,
+            "verdict": verdict,
+            "sessions": [session_id],
+            "blockers": blockers,
+            "warnings": warnings,
+        },
+    )
+    rendered = render_active_codex_runner(
+        decision=decision,
+        execute=execute,
+        sandbox="workspace-write",
+        sessions=sessions_out,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+        registry_path=registry_path,
+        assignments_path=assignments_path,
+        runs_path=patch_runs_path,
+        state_path=state_path,
+        repo_root=repo_root,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered, encoding="utf-8")
+    return ActiveCodexRunnerResult(
+        report_path=out_path,
+        state_path=state_path,
+        runs_dir=patch_runs_path,
+        decision=decision,
+        sessions=tuple(sessions_out),
         blockers=tuple(_dedupe_preserve_order(blockers)),
         warnings=tuple(_dedupe_preserve_order(warnings)),
     )
@@ -10202,6 +10503,66 @@ def _inspect_active_worktree(worktree: str, *, repo_root: Path) -> dict[str, obj
     return {"state": "clean", "branch": _sanitize_inline_text(branch_name), "worktree": _display_path(str(path), repo_root=repo_root)}
 
 
+def _scratch_worktree_paths(task_id: str, agent: str, *, repo_root: Path) -> tuple[Path, str]:
+    """Return (worktree_path, scratch_branch) for a write-lane scratch worktree (issue #1604)."""
+    if not TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("task id must match T-YYYY-NNNN")
+    if agent not in ACTIVE_LANE_AGENTS:
+        raise ValueError(f"agent must be one of: {', '.join(ACTIVE_LANE_AGENTS)}")
+    path = repo_root / ".claude" / "worktrees" / f"{task_id}-{agent}"
+    branch = f"agent/{task_id}/{agent}-scratch"
+    return path, branch
+
+
+def _git_worktree_runner(cmd: list[str]) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def create_scratch_worktree(
+    task_id: str,
+    agent: str,
+    *,
+    base: str = "origin/main",
+    repo_root: Path = ROOT_DIR,
+    runner=None,
+) -> tuple[Path, str, list[str]]:
+    """Create an isolated scratch worktree + branch for a write lane (issue #1604).
+
+    The lane edits inside this worktree; the patch is later captured as a diff. No
+    integration-branch apply here (that is PR-B). Returns (worktree_path, scratch_branch,
+    blockers). The git subprocess is injectable so tests never create real worktrees.
+    """
+    run = runner or _git_worktree_runner
+    path, branch = _scratch_worktree_paths(task_id, agent, repo_root=repo_root)
+    blockers: list[str] = []
+    path.parent.mkdir(parents=True, exist_ok=True)
+    proc = run(["git", "-C", str(repo_root), "worktree", "add", "-b", branch, str(path), base])
+    if proc.returncode != 0:
+        tail = next((line for line in reversed((proc.stderr or "").splitlines()) if line.strip()), "")
+        blockers.append(f"scratch worktree create failed for {branch}: {tail}".strip())
+    return path, branch, blockers
+
+
+def teardown_scratch_worktree(
+    task_id: str,
+    agent: str,
+    *,
+    repo_root: Path = ROOT_DIR,
+    runner=None,
+) -> list[str]:
+    """Best-effort removal of a scratch worktree + its branch. Returns warnings (never raises)."""
+    run = runner or _git_worktree_runner
+    path, branch = _scratch_worktree_paths(task_id, agent, repo_root=repo_root)
+    warnings: list[str] = []
+    rm = run(["git", "-C", str(repo_root), "worktree", "remove", "--force", str(path)])
+    if rm.returncode != 0:
+        warnings.append(f"scratch worktree remove warning for {branch}")
+    br = run(["git", "-C", str(repo_root), "branch", "-D", branch])
+    if br.returncode != 0:
+        warnings.append(f"scratch branch delete warning for {branch}")
+    return warnings
+
+
 def _active_role_status_ok(sessions: Sequence[dict[str, object]], role: str) -> bool:
     passing = {"pass", "passed", "approved", "ready-for-ship", "done", "clear"}
     for session in sessions:
@@ -10258,12 +10619,13 @@ def _active_codex_exec_command(
     sandbox: str,
     last_message_path: Path,
     repo_root: Path,
+    cd: str = ".",
 ) -> list[str]:
     return [
         codex_executable,
         "exec",
         "--cd",
-        ".",
+        cd,
         "--sandbox",
         sandbox,
         "--json",
@@ -10302,6 +10664,67 @@ def _render_active_codex_prompt(
             ]
         )
     )
+
+
+def _render_active_patch_prompt(
+    *,
+    session_id: str,
+    task_id: str,
+    scratch: str,
+    repo_root: Path,
+) -> str:
+    """Write-lane prompt: codex MAY edit files in the scratch worktree, but never commits,
+    pushes, ships, or touches anything outside it. The orchestrator captures the diff."""
+    return _sanitize_dynamic_text(
+        "\n".join(
+            [
+                f"You are the Codex write-lane for active-loop session `{session_id}`, task `{task_id}`.",
+                f"You are in an isolated scratch worktree at `{scratch}` — the current working directory.",
+                "Make the smallest correct code change for the task IN THIS WORKTREE ONLY (you may edit/create files).",
+                "Do NOT commit, push, create/ready/merge PRs, close issues, delete branches, force-push, or run ship/make commands.",
+                "Do NOT touch any path outside this scratch worktree.",
+                "Leave the change uncommitted in the working tree; the orchestrator will capture `git diff` as a patch proposal.",
+                "Return a concise final message: task id, files changed, a one-line rationale, and any blockers.",
+                "Do not include absolute local paths, raw private question/answer/evidence text, doc_id, chunk_id, filename, or prompt/response body.",
+                "",
+            ]
+        )
+    )
+
+
+def _diff_files(diff_text: str) -> list[str]:
+    """Extract changed file paths from a unified diff (the `b/<path>` side of each header)."""
+    files: list[str] = []
+    for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split(" b/", 1)
+            if len(parts) == 2 and parts[1] not in files:
+                files.append(parts[1])
+    return files
+
+
+def _diffstat(diff_text: str) -> dict[str, int]:
+    """Count files_changed / insertions / deletions from a unified diff."""
+    files = _diff_files(diff_text)
+    insertions = 0
+    deletions = 0
+    for line in diff_text.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            insertions += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            deletions += 1
+    return {"files_changed": len(files), "insertions": insertions, "deletions": deletions}
+
+
+def _patch_summary(verdict: str, diff_text: str) -> str:
+    if verdict == "proposed":
+        stat = _diffstat(diff_text)
+        return f"codex proposed a patch: {stat['files_changed']} file(s), +{stat['insertions']}/-{stat['deletions']}"
+    if verdict == "empty":
+        return "codex produced no changes in the scratch worktree"
+    if verdict == "blocked":
+        return "patch blocked by the privacy backstop"
+    return "codex patch lane did not complete"
 
 
 def _write_active_assignment(
@@ -11958,6 +12381,9 @@ def build_parser() -> argparse.ArgumentParser:
     codex_runner.add_argument("--timeout-seconds", type=int, default=0, help="Per-session wait timeout; 0 means no timeout.")
     codex_runner.add_argument("--codex-executable", default="codex")
     codex_runner.add_argument("--sandbox", choices=("read-only", "workspace-write", "danger-full-access"), default="read-only")
+    codex_runner.add_argument("--mode", choices=("read-only", "patch"), default="read-only", help="read-only spawns per-session review processes; patch runs one codex write-lane in a scratch worktree.")
+    codex_runner.add_argument("--task", help="Task id for patch mode (T-YYYY-NNNN); defaults to the Implementer session's task.")
+    codex_runner.add_argument("--base", default="origin/main", help="Base ref the patch-mode scratch worktree forks from.")
 
     active_prepare = sub.add_parser("active-worktree-prepare", help="Prepare an issue-linked worktree for an active-loop role.")
     active_prepare.add_argument("--issue")
@@ -12873,6 +13299,9 @@ def main(argv: list[str] | None = None) -> int:
                 timeout_seconds=args.timeout_seconds,
                 codex_executable=args.codex_executable,
                 sandbox=args.sandbox,
+                mode=args.mode,
+                task_id=args.task,
+                base=args.base,
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")
             return 0 if result.decision in {"planned", "running", "completed"} else 1

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -10088,6 +10088,86 @@ def _build_active_leases(
     )
 
 
+def _write_active_leases(path: Path, *, leases: list[dict[str, object]], now: datetime) -> Path:
+    payload = {
+        "schema_version": 1,
+        "generated_at": _isoformat(now),
+        "leases": [_sanitize_json_value(item) for item in leases],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _find_active_write_lease(leases: Sequence[dict[str, object]], *, lease_id: str | None) -> dict[str, object] | None:
+    for lease in leases:
+        if lease.get("lease_type") != "write" or lease.get("status") != "active":
+            continue
+        if lease_id is None or str(lease.get("lease_id")) == lease_id:
+            return lease
+    return None
+
+
+def acquire_active_agent(
+    *,
+    agent: str,
+    lease_id: str | None = None,
+    leases: Path = DEFAULT_ACTIVE_LEASES,
+    now: datetime | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[bool, str, str | None]:
+    """Borrow the write lease for one agent lane. Claude and Codex are mutually exclusive.
+
+    Returns ``(ok, message, lease_id)``. Re-acquiring by the same agent is idempotent;
+    acquiring while the other agent holds it fails (no clobber).
+    """
+    if agent not in ACTIVE_LANE_AGENTS:
+        raise ValueError(f"agent must be one of: {', '.join(ACTIVE_LANE_AGENTS)}")
+    now = now or datetime.now(timezone.utc)
+    path = _active_path(leases, repo_root=repo_root)
+    items = _load_active_leases(path)
+    lease = _find_active_write_lease(items, lease_id=lease_id)
+    if lease is None:
+        return (False, "no active write lease to borrow", None)
+    holder = lease.get("active_agent")
+    resolved_id = str(lease.get("lease_id"))
+    if holder is not None and str(holder) != agent:
+        return (False, f"write lease held by {holder}", resolved_id)
+    lease["active_agent"] = agent
+    lease["active_agent_since"] = _isoformat(now)
+    _write_active_leases(path, leases=items, now=now)
+    return (True, "acquired", resolved_id)
+
+
+def release_active_agent(
+    *,
+    agent: str,
+    lease_id: str | None = None,
+    leases: Path = DEFAULT_ACTIVE_LEASES,
+    now: datetime | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[bool, str]:
+    """Release the write lease held by ``agent``. No-op if already free; refuses to release
+    a lease another agent holds."""
+    if agent not in ACTIVE_LANE_AGENTS:
+        raise ValueError(f"agent must be one of: {', '.join(ACTIVE_LANE_AGENTS)}")
+    now = now or datetime.now(timezone.utc)
+    path = _active_path(leases, repo_root=repo_root)
+    items = _load_active_leases(path)
+    lease = _find_active_write_lease(items, lease_id=lease_id)
+    if lease is None:
+        return (False, "no active write lease")
+    holder = lease.get("active_agent")
+    if holder is None:
+        return (True, "already free")
+    if str(holder) != agent:
+        return (False, f"held by {holder}, not releasing")
+    lease["active_agent"] = None
+    lease.pop("active_agent_since", None)
+    _write_active_leases(path, leases=items, now=now)
+    return (True, "released")
+
+
 def _refresh_active_lease(lease: dict[str, object], *, now: datetime, repo_root: Path) -> dict[str, object]:
     rendered = dict(lease)
     expires = _parse_timestamp(rendered.get("expires_at"))

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3911,6 +3911,169 @@ def test_acquire_active_agent_rejects_unknown_agent(tmp_path: Path) -> None:
         agent_loop.acquire_active_agent(agent="gpt", repo_root=repo)
 
 
+# --- Phase 3 PR-A: scratch worktree helpers + active-codex-runner patch mode (issue #1604) ---
+
+
+class _FakeCodexProc:
+    def __init__(self) -> None:
+        self.pid = 4242
+        self.returncode = 0
+        self.stdin = self
+        self.written: list[str] = []
+
+    def write(self, s: str) -> None:
+        self.written.append(s)
+
+    def close(self) -> None:
+        pass
+
+    def wait(self, timeout=None) -> int:
+        return 0
+
+
+def _fake_git_runner(diff_stdout: str = ""):
+    calls: list[list[str]] = []
+
+    def run(cmd):
+        calls.append(cmd)
+        if "diff" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=diff_stdout, stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    run.calls = calls  # type: ignore[attr-defined]
+    return run
+
+
+def _seed_patch_registry(repo: Path, *, task: str = "T-2026-0042") -> None:
+    active = repo / "reports" / "agent_loop" / "active"
+    active.mkdir(parents=True, exist_ok=True)
+    (active / "session_registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "topology": "four-role",
+                "gate_policy": "conservative",
+                "agent_mix": agent_loop._parse_agent_mix(None),
+                "sessions": [
+                    {
+                        "session_id": "implementer",
+                        "role": "Implementer",
+                        "status": "running",
+                        "task_id": task,
+                        "lanes": agent_loop._build_active_lanes(None),
+                        "write_lease_owner": True,
+                        "ship_gate": "lease-owner",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_scratch_worktree_paths_naming(tmp_path: Path) -> None:
+    path, branch = agent_loop._scratch_worktree_paths("T-2026-0042", "codex", repo_root=tmp_path)
+    assert path == tmp_path / ".claude" / "worktrees" / "T-2026-0042-codex"
+    assert branch == "agent/T-2026-0042/codex-scratch"
+    with pytest.raises(ValueError):
+        agent_loop._scratch_worktree_paths("nope", "codex", repo_root=tmp_path)
+    with pytest.raises(ValueError):
+        agent_loop._scratch_worktree_paths("T-2026-0042", "gpt", repo_root=tmp_path)
+
+
+def test_create_and_teardown_scratch_worktree(tmp_path: Path) -> None:
+    runner = _fake_git_runner()
+    path, branch, blockers = agent_loop.create_scratch_worktree(
+        "T-2026-0042", "codex", base="origin/main", repo_root=tmp_path, runner=runner
+    )
+    assert blockers == []
+    assert branch == "agent/T-2026-0042/codex-scratch"
+    assert runner.calls[0] == ["git", "-C", str(tmp_path), "worktree", "add", "-b", branch, str(path), "origin/main"]
+    warnings = agent_loop.teardown_scratch_worktree("T-2026-0042", "codex", repo_root=tmp_path, runner=runner)
+    assert warnings == []
+    assert runner.calls[1] == ["git", "-C", str(tmp_path), "worktree", "remove", "--force", str(path)]
+    assert runner.calls[2] == ["git", "-C", str(tmp_path), "branch", "-D", branch]
+
+
+def test_create_scratch_worktree_surfaces_failure(tmp_path: Path) -> None:
+    def runner(cmd):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="fatal: already exists")
+
+    _, _, blockers = agent_loop.create_scratch_worktree("T-2026-0042", "codex", repo_root=tmp_path, runner=runner)
+    assert blockers and "already exists" in blockers[0]
+
+
+def test_codex_runner_patch_mode_dry_run_plans_without_borrow(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo)
+
+    result = agent_loop.write_active_codex_runner(mode="patch", task_id="T-2026-0042", repo_root=repo)
+
+    assert result.decision == "planned"
+    leases = json.loads((repo / "reports" / "agent_loop" / "active" / "leases.json").read_text(encoding="utf-8"))
+    assert leases["leases"][0]["active_agent"] is None  # dry-run borrows nothing
+    assert not (repo / "reports" / "agent_loop" / "active" / "patch_runs").exists()
+
+
+def test_codex_runner_patch_mode_execute_captures_patch_and_releases_lease(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo)
+    diff = "diff --git a/foo.py b/foo.py\n--- a/foo.py\n+++ b/foo.py\n@@ -1 +1,2 @@\n line\n+new line\n"
+    git_runner = _fake_git_runner(diff_stdout=diff)
+
+    result = agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        repo_root=repo,
+        popen_factory=lambda cmd, **kw: _FakeCodexProc(),
+        which_func=lambda exe: "/usr/bin/codex",
+        git_runner=git_runner,
+    )
+
+    assert result.decision == "completed"
+    artifact = json.loads(
+        (repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json").read_text(encoding="utf-8")
+    )
+    assert artifact["verdict"] == "proposed"
+    assert artifact["agent"] == "codex"
+    assert artifact["files"] == ["foo.py"]
+    assert artifact["wu"] == 1
+    assert artifact["diff"] == diff
+    cmds = [" ".join(c) for c in git_runner.calls]
+    assert any("worktree add -b agent/T-2026-0042/codex-scratch" in c for c in cmds)
+    assert any("worktree remove --force" in c for c in cmds)
+    # write lease released back to free after the run.
+    leases = json.loads((repo / "reports" / "agent_loop" / "active" / "leases.json").read_text(encoding="utf-8"))
+    assert leases["leases"][0]["active_agent"] is None
+
+
+def test_codex_runner_patch_mode_redacts_private_path_in_diff(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo)
+    diff = "diff --git a/x.py b/x.py\n+# see reports/real100/baseline.aggregate.json\n"
+
+    result = agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        repo_root=repo,
+        popen_factory=lambda cmd, **kw: _FakeCodexProc(),
+        which_func=lambda exe: "/usr/bin/codex",
+        git_runner=_fake_git_runner(diff_stdout=diff),
+    )
+
+    artifact_text = (
+        repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json"
+    ).read_text(encoding="utf-8")
+    assert "reports/real100/[redacted-private-artifact]" in artifact_text  # redact-and-proceed
+    assert "baseline.aggregate.json" not in artifact_text
+    assert result.decision == "completed"
+
+
 def test_stop_ship_skips_remote_branch_delete_when_stacked_dependents_exist() -> None:
     text = (ROOT / "scripts" / "claude-hooks" / "stop-ship.sh").read_text(encoding="utf-8")
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3851,6 +3851,66 @@ def test_agent_turn_redacts_real100_path_and_proceeds(monkeypatch, tmp_path: Pat
     assert session["status"] == "approved"
 
 
+# --- Phase 3 PR-A: write-lease active_agent borrow (issue #1604) ---
+
+
+def _seed_write_lease(repo: Path, *, lease_id: str = "impl", active_agent=None) -> Path:
+    active = repo / "reports" / "agent_loop" / "active"
+    active.mkdir(parents=True, exist_ok=True)
+    path = active / "leases.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "leases": [
+                    {
+                        "lease_id": lease_id,
+                        "status": "active",
+                        "lease_type": "write",
+                        "active_agent": active_agent,
+                        "owner_session": "implementer",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_active_agent_borrow_is_mutually_exclusive(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_write_lease(repo)
+    ok, _, lid = agent_loop.acquire_active_agent(agent="codex", repo_root=repo)
+    assert ok is True and lid == "impl"
+    # claude is blocked while codex holds the lease (mutual exclusion).
+    ok2, msg2, _ = agent_loop.acquire_active_agent(agent="claude", repo_root=repo)
+    assert ok2 is False and "held by codex" in msg2
+    # re-acquire by the same agent is idempotent.
+    assert agent_loop.acquire_active_agent(agent="codex", repo_root=repo)[0] is True
+    leases = json.loads((repo / "reports" / "agent_loop" / "active" / "leases.json").read_text(encoding="utf-8"))
+    assert leases["leases"][0]["active_agent"] == "codex"
+    # release by codex frees it; then claude can acquire.
+    assert agent_loop.release_active_agent(agent="codex", repo_root=repo)[0] is True
+    assert agent_loop.acquire_active_agent(agent="claude", repo_root=repo)[0] is True
+    # codex cannot release a lease claude holds.
+    okr, msgr = agent_loop.release_active_agent(agent="codex", repo_root=repo)
+    assert okr is False and "held by claude" in msgr
+
+
+def test_acquire_active_agent_without_write_lease_fails(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    ok, msg, lid = agent_loop.acquire_active_agent(agent="codex", repo_root=repo)
+    assert ok is False and lid is None and "no active write lease" in msg
+
+
+def test_acquire_active_agent_rejects_unknown_agent(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_write_lease(repo)
+    with pytest.raises(ValueError):
+        agent_loop.acquire_active_agent(agent="gpt", repo_root=repo)
+
+
 def test_stop_ship_skips_remote_branch_delete_when_stacked_dependents_exist() -> None:
     text = (ROOT / "scripts" / "claude-hooks" / "stop-ship.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

read-only 계층(#1589/#1594/#1602) 위에 dual-agent active loop의 **첫 mutating 표면**을 얹는다. 별도 verb 대신 머지된 `active-codex-runner`를 **opt-in `--mode patch`**(codex 전용 write-lane)로 확장 — `active-start`/`active-codex-runner`(#1592/#1597/#1600/#1603)와 호환되게 codex-exec·spawn/wait 머신을 재사용. **integration apply 없음**(PR-B). codex-only인 이유: claude `-p` headless는 모든 permission 모드에서 Edit-tool 크래시(#1598 실측).

Closes #1604

## 2. 영향 파일

- `scripts/agent_loop.py` (**load-bearing 아님**) — `write_active_codex_runner`에 `mode` 분기 + `_write_active_codex_patch`(lease borrow→scratch worktree→codex `--sandbox workspace-write --cd <scratch>`→`git add -A`+`diff --cached` 캡처→patch artifact→teardown→release); `_active_codex_exec_command`에 `--cd` 인자; `_render_active_patch_prompt`(write 변형); scratch worktree 헬퍼(`create_scratch_worktree`/`teardown_scratch_worktree`); write-lease `acquire_active_agent`/`release_active_agent`(claude XOR codex); parser `--mode/--task/--base` + dispatch.
- `schemas/patch_artifact.schema.json` (신규) — apply-free patch-proposal 계약.
- `tests/test_agent_loop.py` — borrow XOR / scratch 헬퍼 / patch dry-run·execute·privacy / read-only 회귀.

## 3. 리스크

- **read-only runner 회귀**: `mode="read-only"`(기본)는 코드 경로 불변(patch는 별도 분기로 early-return). active-start 자동경로는 `--mode` 미전달 → read-only 유지. 기존 runner 테스트 전부 통과로 고정.
- **codex가 real 저장소를 편집?**: scratch worktree로 격리 + `--cd <scratch>` 실측 확인(codex 0.132.0 probe: 편집이 scratch에만, spawn cwd로 누수 없음). teardown은 `finally`.
- **새 파일 누락**: codex는 untracked 파일을 만든다 → `git diff`만으론 누락. `add -A` + `diff --cached`로 신규 포함 완전 캡처(probe가 이 버그를 잡음).
- **privacy 누수**: patch artifact는 `_redact_private_json` + `audit_privacy_output` fail-closed(ADR 0005, redact-and-proceed).
- **write-lease 경쟁**: `active_agent` claude XOR codex, `finally`에서 release.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q` → **150 passed**(read-only runner 회귀 포함). 각 동작에 회귀 테스트.
- patch: dry-run(차용 없음) / execute(injected popen_factory+git runner: lease acquire→scratch→spawn→add+diff capture→artifact proposed→teardown→release) / privacy(real100 경로 redact-and-proceed) / scratch 헬퍼 argv·naming·실패 / borrow XOR.
- **실측(codex 0.132.0)**: `exec --sandbox workspace-write --cd <scratch>`가 scratch에서 파일 생성(편집 격리 확인) → 신규파일 캡처 위해 `add -A`+`diff --cached` 채택. (verb 레벨 orchestration은 실제 Popen/ git 인터페이스를 충실히 모사하는 seam 주입으로 단위 검증; read-only runner의 동일 Popen 패턴은 이미 머지·검증됨.)

## 5. Eval 영향

All `·` — RAG 검색/검증/답변 경로 무관. active-loop runner 확장만.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. 변경 파일 중 load-bearing path 없음(agent_loop.py는 ADR 0080에 따라 후속 phase에서 LOAD_BEARING 승격 예정, 현 시점 비-load-bearing). real-eval delta 불필요.

## 6. 하위 호환

- `active-codex-runner` 기본 `mode=read-only` = 기존 동작 완전 불변(신규 분기는 opt-in). 신규 flag(`--mode/--task/--base`) 추가만, 기존 flag 불변.
- `patch_artifact` 신규 `schema_version 1`. registry/lease 계약 불변(lease에 `active_agent` 토글만, 기존 필드 보존).

## 7. 범위 외

- integration 브랜치 `git apply`(PR-B).
- patch 프롬프트에 assignment **본문** 주입(현재 task_id만 — 실제 task-driven 편집은 follow-up; 이 PR은 mechanism scaffold).
- claude write-lane(claude CLI headless tool-use 버그 해소 또는 diff-output 우회 후).

🤖 Generated with [Claude Code](https://claude.com/claude-code)