### PR TITLE
feat: active-apply — apply codex patch to integration branch (#1607)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -586,6 +586,17 @@ class ActiveCodexRunnerResult:
     warnings: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class ActiveApplyResult:
+    report_path: Path
+    state_path: Path
+    decision: str
+    integration_branch: str
+    applied: bool
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
 def _repo_path(path: Path, repo_root: Path) -> str:
     try:
         return path.resolve().relative_to(repo_root.resolve()).as_posix()
@@ -10563,6 +10574,165 @@ def teardown_scratch_worktree(
     return warnings
 
 
+def _integration_worktree_paths(task_id: str, *, repo_root: Path) -> tuple[Path, str]:
+    """Return (worktree_path, branch) for a task's integration target (issue #1607)."""
+    if not TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("task id must match T-YYYY-NNNN")
+    path = repo_root / ".claude" / "worktrees" / f"{task_id}-integration"
+    branch = f"feature/{task_id}-integration"
+    return path, branch
+
+
+def write_active_apply(
+    *,
+    patch: Path | None = None,
+    base: str = "origin/main",
+    execute: bool = False,
+    out: Path | None = None,
+    state: Path | None = None,
+    repo_root: Path = ROOT_DIR,
+    git_runner=None,
+) -> ActiveApplyResult:
+    """Orchestrator-only: apply a codex patch artifact to its integration branch.
+
+    Reads the (already privacy-scrubbed) patch artifact produced by PR-A, ensures the
+    integration worktree exists, and gates on ``git apply --check``. Only on ``--execute``
+    AND a clean check does it apply + commit to ``feature/T-N-integration``. It NEVER
+    touches main and never pushes/ships. Fail-closed: a check failure blocks with no
+    mutation (issue #1607). The git subprocess is injectable for tests.
+    """
+    run = git_runner or _git_worktree_runner
+    now = datetime.now(timezone.utc)
+    active_dir = repo_root / "reports" / "agent_loop" / "active"
+    patch_path = patch if patch is not None else active_dir / "patch_runs" / "implementer" / "patch_artifact.json"
+    out_path = out if out is not None else active_dir / "active_apply.md"
+    state_path = state if state is not None else active_dir / "active_apply_state.json"
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    task_id: str | None = None
+    integration_branch = ""
+    diff_text = ""
+    applied = False
+    decision = "blocked"
+
+    if not patch_path.exists():
+        blockers.append(f"patch artifact not found: {_repo_path(patch_path, repo_root)}")
+    else:
+        artifact: object = None
+        try:
+            artifact = json.loads(_read_text(patch_path))
+        except (json.JSONDecodeError, OSError):
+            blockers.append("patch artifact is not valid JSON")
+        if isinstance(artifact, dict):
+            verdict = str(artifact.get("verdict") or "")
+            diff_text = str(artifact.get("diff") or "")
+            raw_task = str(artifact.get("task_id") or "")
+            if verdict != "proposed":
+                blockers.append(f"patch artifact verdict is '{verdict}', expected 'proposed'")
+            if not diff_text.strip():
+                blockers.append("patch artifact has an empty diff")
+            if TASK_ID_RE.fullmatch(raw_task):
+                task_id = raw_task
+            else:
+                blockers.append("patch artifact has no valid task id")
+        elif artifact is not None:
+            blockers.append("patch artifact is not a JSON object")
+
+    if not execute:
+        warnings.append("dry-run only; pass --execute to apply the patch after a clean --check")
+
+    if task_id is not None and diff_text.strip() and not blockers:
+        integration_path, integration_branch = _integration_worktree_paths(task_id, repo_root=repo_root)
+        if not integration_path.exists():
+            integration_path.parent.mkdir(parents=True, exist_ok=True)
+            created = run(["git", "-C", str(repo_root), "worktree", "add", "-b", integration_branch, str(integration_path), base])
+            if getattr(created, "returncode", 1) != 0:
+                attached = run(["git", "-C", str(repo_root), "worktree", "add", str(integration_path), integration_branch])
+                if getattr(attached, "returncode", 1) != 0:
+                    blockers.append(f"could not create integration worktree for {integration_branch}")
+        if not blockers:
+            diff_file = active_dir / "active_apply.patch"
+            diff_file.parent.mkdir(parents=True, exist_ok=True)
+            diff_file.write_text(diff_text if diff_text.endswith("\n") else diff_text + "\n", encoding="utf-8")
+            check = run(["git", "-C", str(integration_path), "apply", "--check", str(diff_file)])
+            if getattr(check, "returncode", 1) != 0:
+                tail = next((line for line in reversed((getattr(check, "stderr", "") or "").splitlines()) if line.strip()), "")
+                blockers.append(f"patch does not apply cleanly to {integration_branch}: {tail}".strip())
+            elif execute:
+                applied_proc = run(["git", "-C", str(integration_path), "apply", str(diff_file)])
+                if getattr(applied_proc, "returncode", 1) != 0:
+                    blockers.append("git apply failed after a clean --check (unexpected)")
+                else:
+                    run(["git", "-C", str(integration_path), "add", "-A"])
+                    commit = run(
+                        ["git", "-C", str(integration_path), "commit", "-m", f"feat({task_id}): apply codex patch proposal"]
+                    )
+                    if getattr(commit, "returncode", 1) != 0:
+                        blockers.append("git commit failed in integration worktree")
+                    else:
+                        applied = True
+                        decision = "applied"
+            else:
+                decision = "checked"
+
+    state_payload = {
+        "schema_version": 1,
+        "generated_at": _isoformat(now),
+        "execute": execute,
+        "decision": decision,
+        "task_id": task_id,
+        "integration_branch": integration_branch,
+        "patch": _repo_path(patch_path, repo_root),
+        "applied": applied,
+        "blockers": _dedupe_preserve_order(blockers),
+        "warnings": _dedupe_preserve_order(warnings),
+    }
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(_sanitize_json_value(state_payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _append_active_event(
+        _active_path(DEFAULT_ACTIVE_EVENTS, repo_root=repo_root),
+        {
+            "event": "active-apply",
+            "execute": execute,
+            "decision": decision,
+            "task_id": task_id,
+            "integration_branch": integration_branch,
+            "applied": applied,
+            "blockers": blockers,
+        },
+    )
+    lines = [
+        "# Active Apply",
+        "",
+        "- Applies a codex patch proposal to its integration branch after `git apply --check`.",
+        "- Never touches main; no ship/push. Fail-closed on a check failure (no partial apply).",
+        f"- Requested execution: `{execute}`",
+        f"- Decision: `{decision}`",
+        f"- Task: `{task_id or 'N/A'}`",
+        f"- Integration branch: `{_sanitize_inline_text(integration_branch or 'N/A')}`",
+        f"- Patch: `{_repo_path(patch_path, repo_root)}`",
+        f"- Applied: `{applied}`",
+        "",
+        "## Blockers",
+        "",
+    ]
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in blockers) if blockers else lines.append("- None")
+    lines.extend(["", "## Warnings", ""])
+    lines.extend(f"- {_sanitize_dynamic_text(item)}" for item in warnings) if warnings else lines.append("- None")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(_sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n", encoding="utf-8")
+    return ActiveApplyResult(
+        report_path=out_path,
+        state_path=state_path,
+        decision=decision,
+        integration_branch=integration_branch,
+        applied=applied,
+        blockers=tuple(_dedupe_preserve_order(blockers)),
+        warnings=tuple(_dedupe_preserve_order(warnings)),
+    )
+
+
 def _active_role_status_ok(sessions: Sequence[dict[str, object]], role: str) -> bool:
     passing = {"pass", "passed", "approved", "ready-for-ship", "done", "clear"}
     for session in sessions:
@@ -12385,6 +12555,14 @@ def build_parser() -> argparse.ArgumentParser:
     codex_runner.add_argument("--task", help="Task id for patch mode (T-YYYY-NNNN); defaults to the Implementer session's task.")
     codex_runner.add_argument("--base", default="origin/main", help="Base ref the patch-mode scratch worktree forks from.")
 
+    active_apply = sub.add_parser("active-apply", help="Apply a codex patch artifact to its integration branch after git apply --check (never touches main).")
+    active_apply.add_argument("--patch", type=Path, help="Patch artifact JSON; defaults to the Implementer session's patch_artifact.json.")
+    active_apply.add_argument("--base", default="origin/main", help="Base ref the integration branch forks from when created.")
+    active_apply.add_argument("--dry-run", dest="execute", action="store_false", default=False)
+    active_apply.add_argument("--execute", dest="execute", action="store_true")
+    active_apply.add_argument("--out", type=Path)
+    active_apply.add_argument("--state", type=Path)
+
     active_prepare = sub.add_parser("active-worktree-prepare", help="Prepare an issue-linked worktree for an active-loop role.")
     active_prepare.add_argument("--issue")
     active_prepare.add_argument("--title")
@@ -13305,6 +13483,19 @@ def main(argv: list[str] | None = None) -> int:
             )
             sys.stdout.write(f"[OK] wrote {_repo_path(result.report_path, ROOT_DIR)}\n")
             return 0 if result.decision in {"planned", "running", "completed"} else 1
+        if args.command == "active-apply":
+            apply_result = write_active_apply(
+                patch=args.patch,
+                base=args.base,
+                execute=args.execute,
+                out=args.out,
+                state=args.state,
+            )
+            sys.stdout.write(
+                f"[OK] {apply_result.decision} {apply_result.integration_branch or '(no branch)'} "
+                f"-> {_repo_path(apply_result.report_path, ROOT_DIR)}\n"
+            )
+            return 0 if apply_result.decision in {"checked", "applied"} else 1
         if args.command == "active-worktree-prepare":
             out, _, _ = write_active_worktree_prepare(
                 issue=args.issue,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4074,6 +4074,109 @@ def test_codex_runner_patch_mode_redacts_private_path_in_diff(tmp_path: Path) ->
     assert result.decision == "completed"
 
 
+# --- Phase 3 PR-B: active-apply (Orchestrator applies patch to integration branch, #1607) ---
+
+
+def _fake_apply_git_runner(check_rc: int = 0):
+    calls: list[list[str]] = []
+
+    def run(cmd):
+        calls.append(cmd)
+        if "--check" in cmd:
+            return subprocess.CompletedProcess(cmd, check_rc, stdout="", stderr=("" if check_rc == 0 else "error: patch failed to apply"))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    run.calls = calls  # type: ignore[attr-defined]
+    return run
+
+
+def _seed_patch_artifact(
+    repo: Path,
+    *,
+    verdict: str = "proposed",
+    task: str = "T-2026-0042",
+    session: str = "implementer",
+    diff: str = "diff --git a/foo.py b/foo.py\n+x\n",
+) -> Path:
+    run_dir = repo / "reports" / "agent_loop" / "active" / "patch_runs" / session
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / "patch_artifact.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "task_id": task,
+                "session_id": session,
+                "role": "Implementer",
+                "agent": "codex",
+                "verdict": verdict,
+                "diff": diff,
+                "files": ["foo.py"],
+                "privacy_scrubbed": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_active_apply_dry_run_checks_only(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_artifact(repo)
+    runner = _fake_apply_git_runner(check_rc=0)
+
+    result = agent_loop.write_active_apply(repo_root=repo, git_runner=runner)
+
+    assert result.decision == "checked"
+    assert result.applied is False
+    assert result.integration_branch == "feature/T-2026-0042-integration"
+    # Inspect the command LISTS (exact tokens) — the repo tmp path itself contains "apply".
+    assert any("--check" in c for c in runner.calls)
+    assert not any("commit" in c for c in runner.calls)  # dry-run never commits
+    assert not any(("apply" in c and "--check" not in c) for c in runner.calls)  # no real apply
+
+
+def test_active_apply_execute_applies_and_commits(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_artifact(repo)
+    runner = _fake_apply_git_runner(check_rc=0)
+
+    result = agent_loop.write_active_apply(repo_root=repo, execute=True, git_runner=runner)
+
+    assert result.decision == "applied"
+    assert result.applied is True
+    assert any("--check" in c for c in runner.calls)
+    assert any(("apply" in c and "--check" not in c) for c in runner.calls)  # the real apply
+    assert any("commit" in c for c in runner.calls)
+    # every git op runs under the repo tree (repo_root or the integration worktree) — never a separate main checkout.
+    assert all(c[2].startswith(str(repo)) for c in runner.calls if len(c) > 2 and c[1] == "-C")
+
+
+def test_active_apply_blocks_when_check_fails(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_artifact(repo)
+    runner = _fake_apply_git_runner(check_rc=1)
+
+    result = agent_loop.write_active_apply(repo_root=repo, execute=True, git_runner=runner)
+
+    assert result.decision == "blocked"
+    assert result.applied is False
+    assert any("--check" in c for c in runner.calls)
+    assert not any("commit" in c for c in runner.calls)  # fail-closed: no apply/commit after a failed check
+    assert not any(("apply" in c and "--check" not in c) for c in runner.calls)
+
+
+def test_active_apply_blocks_on_missing_or_unproposed_artifact(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    # missing artifact
+    r1 = agent_loop.write_active_apply(repo_root=repo, execute=True, git_runner=_fake_apply_git_runner())
+    assert r1.decision == "blocked" and any("not found" in b for b in r1.blockers)
+    # present but verdict != proposed (and empty diff)
+    _seed_patch_artifact(repo, verdict="empty", diff="")
+    r2 = agent_loop.write_active_apply(repo_root=repo, execute=True, git_runner=_fake_apply_git_runner())
+    assert r2.decision == "blocked" and r2.applied is False
+
+
 def test_stop_ship_skips_remote_branch_delete_when_stacked_dependents_exist() -> None:
     text = (ROOT / "scripts" / "claude-hooks" / "stop-ship.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Phase 3 propose→apply 루프 완성. PR-A(#1606)의 write-lane이 privacy-scrubbed **patch artifact**를 만들고, 이 PR-B가 그것을 integration 브랜치에 **적용**한다 — dual-agent active loop가 integration 브랜치를 실제로 mutate하는 첫 지점. **main은 절대 건드리지 않음**, push/ship 없음.

Closes #1607

## 2. 영향 파일

- `scripts/agent_loop.py` (**load-bearing 아님**) — `write_active_apply` + `active-apply` verb: patch artifact(verdict `proposed` + non-empty diff) 읽기 → integration worktree(`feature/T-N-integration` @ `.claude/worktrees/T-N-integration`) 보장 → `git apply --check` 게이트 → `--execute` + clean check일 때만 `apply` + `add -A` + `commit`. `_integration_worktree_paths` 헬퍼, `ActiveApplyResult`, parser/dispatch(dry-run 기본). injectable git runner.
- `tests/test_agent_loop.py` — 4 테스트.

## 3. 리스크

- **main mutation?** 모든 git op는 `repo_root`(worktree add) 또는 integration worktree(`-C <integration>`) 대상 — main checkout을 절대 건드리지 않음(테스트로 `-C` 인자가 repo tree 내부임을 고정).
- **부분 apply**: `git apply --check` 실패 시 fail-closed(blocker, apply/commit 없음). check 통과 후에만 apply.
- **redacted diff 적용**: patch artifact의 diff는 PR-A에서 privacy-scrub됨. scrub이 발동한 경우(드문 false-positive, 예: real100 경로 언급) redacted 텍스트가 적용될 수 있으나, scrub이 diff를 깨뜨리면 `apply --check`가 실패→fail-closed로 안전. (코드 diff는 보통 private 패턴 미포함.)
- **idempotency**: integration worktree 없으면 base에서 생성, 있으면 재사용.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q` → **154 passed**.
- active-apply: dry-run(check만, commit 없음) / execute(check→apply→commit, applied=True, 모든 op가 repo tree 내부) / check 실패(blocked, mutation 없음) / 누락·non-proposed artifact(blocked). injected git runner로 실제 git/worktree 미호출.

## 5. Eval 영향

All `·` — RAG 검색/검증/답변 경로 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing path 변경 없음(agent_loop.py는 후속 phase에서 LOAD_BEARING 승격 예정). real-eval delta 불필요.

## 6. 하위 호환

- 신규 verb `active-apply`(dry-run 기본) 추가만. 기존 verb/flag/계약 불변. patch_artifact `schema_version 1` 소비만.

## 7. 범위 외

- ship/push/PR (Orchestrator-only ship-executor는 후속 Phase).
- patch 프롬프트에 assignment 본문 주입(별도 follow-up — 현재 mechanism scaffold).
- integration 브랜치 → PR/머지 자동화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)