### PR TITLE
feat: embed session assignment in active-codex-runner patch prompt (#1610)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -10127,6 +10127,23 @@ def _write_active_codex_patch(
             else:
                 blockers.append("patch mode requires a task id (pass --task T-YYYY-NNNN or run active-start --task)")
 
+    # The write-lane needs a concrete assignment — never let codex edit with workspace-write
+    # against a vague prompt. Embed the assignment in the prompt (the sandboxed codex must not
+    # read outside the scratch worktree); a missing/empty assignment is fail-closed (issue #1610).
+    assignment_text = ""
+    if resolved_task is not None:
+        assignment_file = assignments_path / f"{session_id}.md"
+        if assignment_file.exists():
+            try:
+                assignment_text = _read_text(assignment_file).strip()
+            except OSError:
+                assignment_text = ""
+        if not assignment_text:
+            blockers.append(
+                f"patch mode requires an assignment for session {session_id} "
+                f"({_repo_path(assignment_file, repo_root)}); run active-loop/active-start to generate it"
+            )
+
     which = which_func if which_func is not None else shutil.which
     resolved_executable = which(codex_executable) if execute else codex_executable
     if execute and not resolved_executable:
@@ -10176,6 +10193,7 @@ def _write_active_codex_patch(
                         session_id=session_id,
                         task_id=resolved_task,
                         scratch=_repo_path(created_path, repo_root),
+                        assignment_text=assignment_text,
                         repo_root=repo_root,
                     )
                     prompt_path.write_text(prompt, encoding="utf-8")
@@ -11166,21 +11184,28 @@ def _render_active_patch_prompt(
     session_id: str,
     task_id: str,
     scratch: str,
+    assignment_text: str,
     repo_root: Path,
 ) -> str:
-    """Write-lane prompt: codex MAY edit files in the scratch worktree, but never commits,
-    pushes, ships, or touches anything outside it. The orchestrator captures the diff."""
+    """Write-lane prompt: codex implements the embedded assignment IN the scratch worktree
+    but never commits, pushes, ships, or touches anything outside it. The orchestrator
+    captures the diff. The assignment is embedded (not a file reference) so the sandboxed
+    codex never has to read outside the scratch worktree (issue #1610)."""
     return _sanitize_dynamic_text(
         "\n".join(
             [
                 f"You are the Codex write-lane for active-loop session `{session_id}`, task `{task_id}`.",
                 f"You are in an isolated scratch worktree at `{scratch}` — the current working directory.",
-                "Make the smallest correct code change for the task IN THIS WORKTREE ONLY (you may edit/create files).",
+                "Implement the assignment below as the smallest correct code change IN THIS WORKTREE ONLY (you may edit/create files).",
                 "Do NOT commit, push, create/ready/merge PRs, close issues, delete branches, force-push, or run ship/make commands.",
                 "Do NOT touch any path outside this scratch worktree.",
                 "Leave the change uncommitted in the working tree; the orchestrator will capture `git diff` as a patch proposal.",
                 "Return a concise final message: task id, files changed, a one-line rationale, and any blockers.",
                 "Do not include absolute local paths, raw private question/answer/evidence text, doc_id, chunk_id, filename, or prompt/response body.",
+                "",
+                "## Assignment",
+                "",
+                assignment_text.strip(),
                 "",
             ]
         )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4106,6 +4106,14 @@ def _seed_patch_registry(repo: Path, *, task: str = "T-2026-0042") -> None:
     )
 
 
+def _seed_patch_assignment(repo: Path, *, session: str = "implementer", text: str = "Add a one-line docstring to foo.py.") -> Path:
+    adir = repo / "reports" / "agent_loop" / "active" / "assignments"
+    adir.mkdir(parents=True, exist_ok=True)
+    path = adir / f"{session}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
 def test_scratch_worktree_paths_naming(tmp_path: Path) -> None:
     path, branch = agent_loop._scratch_worktree_paths("T-2026-0042", "codex", repo_root=tmp_path)
     assert path == tmp_path / ".claude" / "worktrees" / "T-2026-0042-codex"
@@ -4142,6 +4150,7 @@ def test_codex_runner_patch_mode_dry_run_plans_without_borrow(tmp_path: Path) ->
     repo = _write_repo(tmp_path)
     _seed_patch_registry(repo)
     _seed_write_lease(repo)
+    _seed_patch_assignment(repo)
 
     result = agent_loop.write_active_codex_runner(mode="patch", task_id="T-2026-0042", repo_root=repo)
 
@@ -4155,6 +4164,7 @@ def test_codex_runner_patch_mode_execute_captures_patch_and_releases_lease(tmp_p
     repo = _write_repo(tmp_path)
     _seed_patch_registry(repo)
     _seed_write_lease(repo)
+    _seed_patch_assignment(repo)
     diff = "diff --git a/foo.py b/foo.py\n--- a/foo.py\n+++ b/foo.py\n@@ -1 +1,2 @@\n line\n+new line\n"
     git_runner = _fake_git_runner(diff_stdout=diff)
 
@@ -4189,6 +4199,7 @@ def test_codex_runner_patch_mode_redacts_private_path_in_diff(tmp_path: Path) ->
     repo = _write_repo(tmp_path)
     _seed_patch_registry(repo)
     _seed_write_lease(repo)
+    _seed_patch_assignment(repo)
     diff = "diff --git a/x.py b/x.py\n+# see reports/real100/baseline.aggregate.json\n"
 
     result = agent_loop.write_active_codex_runner(
@@ -4207,6 +4218,53 @@ def test_codex_runner_patch_mode_redacts_private_path_in_diff(tmp_path: Path) ->
     assert "reports/real100/[redacted-private-artifact]" in artifact_text  # redact-and-proceed
     assert "baseline.aggregate.json" not in artifact_text
     assert result.decision == "completed"
+
+
+def test_codex_runner_patch_mode_blocks_without_assignment(tmp_path: Path) -> None:
+    # Fail-closed (#1610): never run a workspace-write codex lane without a concrete assignment.
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo)
+    # no assignment seeded
+
+    result = agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        repo_root=repo,
+        popen_factory=lambda cmd, **kw: _FakeCodexProc(),
+        which_func=lambda exe: "/usr/bin/codex",
+        git_runner=_fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n"),
+    )
+
+    assert result.decision == "blocked"
+    assert any("assignment" in b for b in result.blockers)
+    leases = json.loads((repo / "reports" / "agent_loop" / "active" / "leases.json").read_text(encoding="utf-8"))
+    assert leases["leases"][0]["active_agent"] is None  # lease never borrowed
+    assert not (repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json").exists()
+
+
+def test_codex_runner_patch_mode_embeds_assignment_in_prompt(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo)
+    _seed_patch_assignment(repo, text="ASSIGNMENT-MARKER: refactor foo.")
+
+    agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        repo_root=repo,
+        popen_factory=lambda cmd, **kw: _FakeCodexProc(),
+        which_func=lambda exe: "/usr/bin/codex",
+        git_runner=_fake_git_runner(diff_stdout="diff --git a/foo.py b/foo.py\n+x\n"),
+    )
+
+    prompt = (
+        repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "prompt.md"
+    ).read_text(encoding="utf-8")
+    assert "## Assignment" in prompt
+    assert "ASSIGNMENT-MARKER: refactor foo." in prompt
 
 
 # --- Phase 3 PR-B: active-apply (Orchestrator applies patch to integration branch, #1607) ---


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

PR-A(#1606)의 patch write-lane은 codex에 **task_id만** 줘서 실제 task 내용을 몰랐다(mechanism scaffold). 이 follow-up이 Implementer 세션의 assignment를 프롬프트에 **embed**해 codex가 구체적 task를 받게 한다. assignment 없으면 **fail-closed**(workspace-write codex가 모호한 프롬프트로 임의 편집하는 것을 방지).

Closes #1610

## 2. 영향 파일

- `scripts/agent_loop.py` (**load-bearing 아님**) — `_render_active_patch_prompt`에 `assignment_text`(## Assignment 섹션); `_write_active_codex_patch`가 `assignments/<session>.md`를 읽어 embed + 없으면 blocker. 프롬프트는 기존대로 `_sanitize_dynamic_text` 통과(ADR 0005).
- `tests/test_agent_loop.py` — 기존 patch 테스트에 assignment seed + 신규 2개(no-assignment 차단 / prompt embed).

## 3. 리스크

- **codex가 scratch 밖 파일 읽기?**: assignment를 파일 참조가 아니라 프롬프트에 **본문 embed** → sandboxed codex가 scratch 밖을 읽을 필요 없음.
- **privacy**: assignment 본문이 prompt.md(gitignored, active dir)에 들어가나 `_sanitize_dynamic_text`로 absolute path/inline field 값 scrub. assignment 자체는 active-loop가 이미 scrub해 생성.
- **빈/누락 assignment**: fail-closed blocker — lease 차용·spawn·artifact 없음.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q` → **161 passed**.
- patch: assignment 있으면 dry-run planned / execute proposed / redact / **no-assignment → blocked(차용·artifact 없음)** / **prompt에 assignment embed 확인**. injected seam으로 실제 codex/git 미호출.

## 5. Eval 영향

All `·` — RAG 경로 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing path 변경 없음. real-eval delta 불필요.

## 6. 하위 호환

- `_render_active_patch_prompt`에 인자 추가(내부 함수). 외부 verb/flag/계약 불변. patch 동작은 "assignment 필수"로 강화(이전엔 task_id만으로도 진행했으나 실용성·안전성 위해 assignment 요구).

## 7. 범위 외

- ship-executor(후속 Phase), claude write-lane, integration→PR 자동화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)