### PR TITLE
feat: enforce lease claimed_files scope on codex patch lane (#1612)

### DIFF
--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -10235,6 +10235,24 @@ def _write_active_codex_patch(
                                 if getattr(diff_proc, "returncode", 1) == 0:
                                     diff_text = getattr(diff_proc, "stdout", "") or ""
                                     verdict = "proposed" if diff_text.strip() else "empty"
+                                    # claimed_files scope guard (issue #1612): the write lane must
+                                    # stay within the lease's declared files. An out-of-scope patch
+                                    # is downgraded to "blocked" so apply (PR-B) refuses it. An empty
+                                    # claim leaves scope unenforced (exploratory tasks).
+                                    if verdict == "proposed":
+                                        lease_items = _load_active_leases(_active_path(DEFAULT_ACTIVE_LEASES, repo_root=repo_root))
+                                        write_lease = _find_active_write_lease(lease_items, lease_id=None)
+                                        claimed_raw = write_lease.get("claimed_files") if isinstance(write_lease, dict) else None
+                                        claimed = {str(f) for f in claimed_raw} if isinstance(claimed_raw, list) else set()
+                                        if claimed:
+                                            out_of_scope = sorted(f for f in _diff_files(diff_text) if f not in claimed)
+                                            if out_of_scope:
+                                                verdict = "blocked"
+                                                blockers.append(
+                                                    "patch touches files outside the lease claim: " + ", ".join(out_of_scope[:5])
+                                                )
+                                        else:
+                                            warnings.append("lease has no claimed_files; patch scope is unenforced")
                                 else:
                                     blockers.append("git diff capture failed in scratch worktree")
                         elif rc is not None:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3989,27 +3989,20 @@ def test_agent_turn_redacts_real100_path_and_proceeds(monkeypatch, tmp_path: Pat
 # --- Phase 3 PR-A: write-lease active_agent borrow (issue #1604) ---
 
 
-def _seed_write_lease(repo: Path, *, lease_id: str = "impl", active_agent=None) -> Path:
+def _seed_write_lease(repo: Path, *, lease_id: str = "impl", active_agent=None, claimed_files=None) -> Path:
     active = repo / "reports" / "agent_loop" / "active"
     active.mkdir(parents=True, exist_ok=True)
     path = active / "leases.json"
-    path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "leases": [
-                    {
-                        "lease_id": lease_id,
-                        "status": "active",
-                        "lease_type": "write",
-                        "active_agent": active_agent,
-                        "owner_session": "implementer",
-                    }
-                ],
-            }
-        ),
-        encoding="utf-8",
-    )
+    lease = {
+        "lease_id": lease_id,
+        "status": "active",
+        "lease_type": "write",
+        "active_agent": active_agent,
+        "owner_session": "implementer",
+    }
+    if claimed_files is not None:
+        lease["claimed_files"] = list(claimed_files)
+    path.write_text(json.dumps({"schema_version": 1, "leases": [lease]}), encoding="utf-8")
     return path
 
 
@@ -4265,6 +4258,59 @@ def test_codex_runner_patch_mode_embeds_assignment_in_prompt(tmp_path: Path) -> 
     ).read_text(encoding="utf-8")
     assert "## Assignment" in prompt
     assert "ASSIGNMENT-MARKER: refactor foo." in prompt
+
+
+# --- Phase 4: claimed_files scope enforcement on the codex patch lane (issue #1612) ---
+
+
+def test_codex_runner_patch_mode_blocks_out_of_scope_files(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo, claimed_files=["allowed.py"])
+    _seed_patch_assignment(repo)
+    diff = "diff --git a/foo.py b/foo.py\n+x\n"  # foo.py is NOT in the claim
+
+    result = agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        repo_root=repo,
+        popen_factory=lambda cmd, **kw: _FakeCodexProc(),
+        which_func=lambda exe: "/usr/bin/codex",
+        git_runner=_fake_git_runner(diff_stdout=diff),
+    )
+
+    assert result.decision == "blocked"
+    assert any("outside the lease claim" in b for b in result.blockers)
+    artifact = json.loads(
+        (repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json").read_text(encoding="utf-8")
+    )
+    assert artifact["verdict"] == "blocked"
+    assert artifact["wu"] == 0
+
+
+def test_codex_runner_patch_mode_allows_in_scope_files(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_patch_registry(repo)
+    _seed_write_lease(repo, claimed_files=["foo.py"])
+    _seed_patch_assignment(repo)
+    diff = "diff --git a/foo.py b/foo.py\n+x\n"  # foo.py IS in the claim
+
+    result = agent_loop.write_active_codex_runner(
+        mode="patch",
+        execute=True,
+        task_id="T-2026-0042",
+        repo_root=repo,
+        popen_factory=lambda cmd, **kw: _FakeCodexProc(),
+        which_func=lambda exe: "/usr/bin/codex",
+        git_runner=_fake_git_runner(diff_stdout=diff),
+    )
+
+    assert result.decision == "completed"
+    artifact = json.loads(
+        (repo / "reports" / "agent_loop" / "active" / "patch_runs" / "implementer" / "patch_artifact.json").read_text(encoding="utf-8")
+    )
+    assert artifact["verdict"] == "proposed"
 
 
 # --- Phase 3 PR-B: active-apply (Orchestrator applies patch to integration branch, #1607) ---


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

write lease는 `claimed_files`를 기록하지만 **강제하지 않았다**. Phase 4는 codex patch write-lane이 claim **밖** 파일을 건드리면 verdict를 `blocked`로 강등 → apply(#1608)가 `proposed`만 적용하므로 범위 밖 패치는 **적용 불가**. write-lane이 선언 범위를 넘는 변경을 제안하는 것을 방지.

Closes #1612

## 2. 영향 파일

- `scripts/agent_loop.py` (**load-bearing 아님**) — `_write_active_codex_patch`: diff 캡처 후 `_load_active_leases`/`_find_active_write_lease`로 write lease의 `claimed_files`를 읽어 `_diff_files`와 대조. out-of-scope → `blocked` + blocker. empty claim → 미강제 + warning.
- `tests/test_agent_loop.py` — `_seed_write_lease`에 `claimed_files` + 신규 2개(out-of-scope 차단 / in-scope 허용).

## 3. 리스크

- **정상 패치 오차단**: claim과 diff 경로 형식이 일치(둘 다 repo-relative). claim 비어있으면 미강제(탐색적 task 허용)라 기존 동작 보존.
- **우회**: scope-blocked 패치는 `verdict=blocked`로 저장 → apply가 거부. 강제는 propose 단계 + apply 거부 2중.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q` → **163 passed**.
- out-of-scope(claim=[allowed.py], diff=foo.py) → blocked, wu 0, blocker / in-scope(claim=[foo.py]) → proposed / empty claim(기존 테스트) → 미강제. injected seam.

## 5. Eval 영향

All `·` — RAG 경로 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing path 변경 없음. real-eval delta 불필요.

## 6. 하위 호환

- 기존 verb/flag/계약 불변. claimed_files 없는 lease는 미강제(이전과 동일 동작). patch 동작은 scope 위반 시 blocked로 강화.

## 7. 범위 외

- pretooluse-bash-guard/lane-guard shell hook 확장(별도 follow-up). ship-executor, claude write-lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)