### PR TITLE
feat: task-scoped gate_evidence bundle for the active loop (#1616)

### DIFF
--- a/docs/operations/active-agent-loop.md
+++ b/docs/operations/active-agent-loop.md
@@ -233,6 +233,22 @@ python3 scripts/agent_loop.py active-apply --task T-2026-00NN --execute
 - `--execute` + clean check일 때만 `git apply` + `git add -A` + `git commit`한다.
 - dry-run(기본)은 check만 수행한다.
 
+## Gate Evidence
+
+`gate-evidence`는 한 task의 Conservative-Gate 통과 근거를 **감사 기록**으로 묶는다.
+**ship/push/merge를 트리거하지 않는다** — 실제 ship은 기존 human-gated 경로(`ship-pr` /
+`make ship-arm`)가 담당한다.
+
+```bash
+python3 scripts/agent_loop.py gate-evidence --task T-2026-00NN
+```
+
+`reports/agent_loop/active/gate_evidence/<task>/`에 `evidence.json` + 요약 `evidence.md`를
+쓴다. 묶는 내용: topology + gate_policy, 필수 gate role의 pass 여부와 overall ready bool,
+patch artifact(verdict/files/diffstat), apply state(decision/applied/integration_branch),
+agent_mix Work Unit, privacy audit(clean/issue 수). raw private 값은 포함하지 않는다
+(요약 메타만, ADR 0005). 누락 아티팩트는 `null`로 graceful 처리한다.
+
 ## Full Ship Gate
 
 `--execute`는 gate가 통과할 때만 기존 ship runner를 호출한다.

--- a/scripts/agent_loop.py
+++ b/scripts/agent_loop.py
@@ -11082,6 +11082,128 @@ def write_active_apply(
     )
 
 
+def write_active_gate_evidence(
+    *,
+    task_id: str,
+    registry: Path = DEFAULT_ACTIVE_REGISTRY,
+    out_dir: Path | None = None,
+    repo_root: Path = ROOT_DIR,
+) -> tuple[Path, dict[str, object]]:
+    """Bundle the active loop's Conservative-Gate evidence for one task.
+
+    Read-only audit record written to reports/agent_loop/active/gate_evidence/<task>/ —
+    it NEVER ships, pushes, or merges (issue #1616). The actual ship stays with the
+    existing human-gated path (ship-pr / make ship-arm). Returns (evidence_json, summary).
+    """
+    if not TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("--task must match T-YYYY-NNNN")
+    now = datetime.now(timezone.utc)
+    active_dir = repo_root / "reports" / "agent_loop" / "active"
+    registry_path = _active_path(registry, repo_root=repo_root)
+
+    topology = "four-role"
+    sessions: list[dict[str, object]] = []
+    if registry_path.exists():
+        payload = _load_active_registry(registry_path)
+        topology = str(payload.get("topology") or "four-role")
+        if topology not in ACTIVE_TOPOLOGY_ROLES:
+            topology = "four-role"
+        raw = payload.get("sessions")
+        sessions = [s for s in raw if isinstance(s, dict)] if isinstance(raw, list) else []
+
+    required_roles = _active_required_gate_roles(topology, load_bearing_touched=False)
+    gate_roles: list[dict[str, object]] = []
+    for role in required_roles:
+        status = next((str(s.get("status")) for s in sessions if s.get("role") == role), "missing")
+        gate_roles.append({"role": role, "status": status, "ok": _active_role_status_ok(sessions, role)})
+    ready = bool(required_roles) and all(bool(item["ok"]) for item in gate_roles)
+
+    implementer = next((s for s in sessions if s.get("role") == "Implementer"), None)
+    impl_session = str(implementer.get("session_id")) if implementer else "implementer"
+    patch_path = active_dir / "patch_runs" / impl_session / "patch_artifact.json"
+    patch_summary: dict[str, object] | None = None
+    if patch_path.exists():
+        try:
+            pa = json.loads(_read_text(patch_path))
+            if isinstance(pa, dict):
+                patch_summary = {"verdict": pa.get("verdict"), "files": pa.get("files"), "diffstat": pa.get("diffstat")}
+        except (json.JSONDecodeError, OSError):
+            patch_summary = {"verdict": "unreadable"}
+
+    apply_path = active_dir / "active_apply_state.json"
+    apply_summary: dict[str, object] | None = None
+    if apply_path.exists():
+        try:
+            ap = json.loads(_read_text(apply_path))
+            if isinstance(ap, dict):
+                apply_summary = {
+                    "decision": ap.get("decision"),
+                    "applied": ap.get("applied"),
+                    "integration_branch": ap.get("integration_branch"),
+                }
+        except (json.JSONDecodeError, OSError):
+            apply_summary = {"decision": "unreadable"}
+
+    mix = _load_active_agent_mix(_active_path(DEFAULT_ACTIVE_AGENT_MIX, repo_root=repo_root))
+    rolling_raw = mix.get("rolling") if isinstance(mix.get("rolling"), dict) else {}
+    rolling = {agent: _coerce_wu(rolling_raw.get(agent)) for agent in ACTIVE_LANE_AGENTS}
+
+    privacy_findings = audit_privacy_output(active_dir, out_path=None, repo_root=repo_root) if active_dir.exists() else []
+    privacy = {"clean": not privacy_findings, "issue_count": len(privacy_findings)}
+
+    evidence = {
+        "schema_version": 1,
+        "task_id": task_id,
+        "generated_at": _isoformat(now),
+        "topology": topology,
+        "gate_policy": "conservative",
+        "conservative_gate": {"ready": ready, "required_roles": gate_roles},
+        "patch": patch_summary,
+        "apply": apply_summary,
+        "work_units": rolling,
+        "privacy": privacy,
+        "ship": "not-triggered (use the existing human-gated ship path: ship-pr / make ship-arm)",
+    }
+    gate_dir = out_dir if out_dir is not None else active_dir / "gate_evidence" / task_id
+    gate_dir.mkdir(parents=True, exist_ok=True)
+    evidence_path = gate_dir / "evidence.json"
+    evidence_path.write_text(json.dumps(_sanitize_json_value(evidence), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    lines = [
+        f"# Gate evidence — {task_id}",
+        "",
+        f"- Generated: {_isoformat(now)}",
+        f"- Topology: `{topology}` (gate_policy: conservative)",
+        f"- Conservative gate: **{'READY' if ready else 'NOT READY'}**",
+        "",
+        "## Required gate roles",
+        "",
+        "| Role | Status | OK |",
+        "|---|---|---|",
+    ]
+    for item in gate_roles:
+        lines.append(f"| {item['role']} | {_sanitize_inline_text(str(item['status']))} | {'yes' if item['ok'] else 'no'} |")
+    if not gate_roles:
+        lines.append("| (none) | | |")
+    lines.extend(
+        [
+            "",
+            f"- Patch: `{patch_summary or 'none'}`",
+            f"- Apply: `{apply_summary or 'none'}`",
+            f"- Work units: claude {rolling['claude']}, codex {rolling['codex']}",
+            f"- Privacy: {'clean' if privacy['clean'] else str(privacy['issue_count']) + ' issue(s)'}",
+            "",
+            "Ship is NOT triggered here — use the existing human-gated path (`ship-pr` / `make ship-arm`).",
+        ]
+    )
+    (gate_dir / "evidence.md").write_text(_sanitize_dynamic_text("\n".join(lines)).rstrip() + "\n", encoding="utf-8")
+    _append_active_event(
+        _active_path(DEFAULT_ACTIVE_EVENTS, repo_root=repo_root),
+        {"event": "gate-evidence", "task_id": task_id, "ready": ready, "privacy_clean": privacy["clean"]},
+    )
+    return evidence_path, {"ready": ready, "required_roles": [str(i["role"]) for i in gate_roles], "privacy_clean": privacy["clean"]}
+
+
 def _active_role_status_ok(sessions: Sequence[dict[str, object]], role: str) -> bool:
     passing = {"pass", "passed", "approved", "ready-for-ship", "done", "clear"}
     for session in sessions:
@@ -12932,6 +13054,10 @@ def build_parser() -> argparse.ArgumentParser:
     active_apply.add_argument("--out", type=Path)
     active_apply.add_argument("--state", type=Path)
 
+    gate_evidence = sub.add_parser("gate-evidence", help="Bundle the active loop's Conservative-Gate evidence for a task (audit record; never ships).")
+    gate_evidence.add_argument("--task", required=True)
+    gate_evidence.add_argument("--out-dir", dest="out_dir", type=Path)
+
     active_prepare = sub.add_parser("active-worktree-prepare", help="Prepare an issue-linked worktree for an active-loop role.")
     active_prepare.add_argument("--issue")
     active_prepare.add_argument("--title")
@@ -13866,6 +13992,13 @@ def main(argv: list[str] | None = None) -> int:
                 f"-> {_repo_path(apply_result.report_path, ROOT_DIR)}\n"
             )
             return 0 if apply_result.decision in {"checked", "applied"} else 1
+        if args.command == "gate-evidence":
+            evidence_path, gate_summary = write_active_gate_evidence(task_id=args.task, out_dir=args.out_dir)
+            sys.stdout.write(
+                f"[OK] wrote {_repo_path(evidence_path, ROOT_DIR)} "
+                f"(ready={gate_summary['ready']}, privacy_clean={gate_summary['privacy_clean']})\n"
+            )
+            return 0
         if args.command == "active-worktree-prepare":
             out, _, _ = write_active_worktree_prepare(
                 issue=args.issue,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4416,6 +4416,77 @@ def test_active_apply_blocks_on_missing_or_unproposed_artifact(tmp_path: Path) -
     assert r2.decision == "blocked" and r2.applied is False
 
 
+# --- Phase 5: task-scoped gate_evidence bundle (issue #1616) ---
+
+
+def _seed_gate_registry(repo: Path, *, reviewer_status: str = "approved", ci_status: str = "approved") -> None:
+    active = repo / "reports" / "agent_loop" / "active"
+    active.mkdir(parents=True, exist_ok=True)
+    (active / "session_registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "topology": "four-role",
+                "gate_policy": "conservative",
+                "agent_mix": agent_loop._parse_agent_mix(None),
+                "sessions": [
+                    {"session_id": "orchestrator", "role": "Orchestrator", "status": "running"},
+                    {"session_id": "implementer", "role": "Implementer", "status": "running"},
+                    {"session_id": "reviewer", "role": "Reviewer", "status": reviewer_status},
+                    {"session_id": "ci-eval-auditor", "role": "CI/Eval Auditor", "status": ci_status},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_gate_evidence_ready_when_required_gates_pass(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_gate_registry(repo)
+
+    path, summary = agent_loop.write_active_gate_evidence(task_id="T-2026-0042", repo_root=repo)
+
+    assert summary["ready"] is True
+    assert path == repo / "reports" / "agent_loop" / "active" / "gate_evidence" / "T-2026-0042" / "evidence.json"
+    ev = json.loads(path.read_text(encoding="utf-8"))
+    assert ev["conservative_gate"]["ready"] is True
+    roles = {r["role"]: r["ok"] for r in ev["conservative_gate"]["required_roles"]}
+    assert roles == {"Reviewer": True, "CI/Eval Auditor": True}
+    assert ev["patch"] is None and ev["apply"] is None  # no patch/apply artifacts present
+    assert ev["ship"].startswith("not-triggered")
+
+
+def test_gate_evidence_not_ready_when_a_gate_is_unmet(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_gate_registry(repo, reviewer_status="idle")
+
+    _, summary = agent_loop.write_active_gate_evidence(task_id="T-2026-0042", repo_root=repo)
+
+    assert summary["ready"] is False
+
+
+def test_gate_evidence_bundles_patch_and_apply(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path)
+    _seed_gate_registry(repo)
+    _seed_patch_artifact(repo)  # patch_runs/implementer/patch_artifact.json (verdict proposed)
+    (repo / "reports" / "agent_loop" / "active" / "active_apply_state.json").write_text(
+        json.dumps({"decision": "applied", "applied": True, "integration_branch": "feature/T-2026-0042-integration"}),
+        encoding="utf-8",
+    )
+
+    path, _ = agent_loop.write_active_gate_evidence(task_id="T-2026-0042", repo_root=repo)
+
+    ev = json.loads(path.read_text(encoding="utf-8"))
+    assert ev["patch"]["verdict"] == "proposed"
+    assert ev["apply"]["decision"] == "applied" and ev["apply"]["applied"] is True
+
+
+def test_gate_evidence_rejects_bad_task(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        agent_loop.write_active_gate_evidence(task_id="nope", repo_root=tmp_path)
+
+
 def test_stop_ship_skips_remote_branch_delete_when_stacked_dependents_exist() -> None:
     text = (ROOT / "scripts" / "claude-hooks" / "stop-ship.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Phase 5. Conservative-Gate 통과 근거를 task별 **감사 기록**으로 묶는 `gate-evidence` verb. **ship/push/merge를 트리거하지 않는다** — 실제 ship은 기존 human-gated 경로(`ship-pr`/`make ship-arm`). 새 ship-executor 대신 이걸 택한 이유: ship-executor는 `approval-packet`/`human-gated-exec`와 중복 + 3번째 ship surface(CLAUDE.md commit-0 가드).

Closes #1616

## 2. 영향 파일

- `scripts/agent_loop.py` (**load-bearing 아님**) — `write_active_gate_evidence` + `gate-evidence --task` verb: registry(topology + 필수 gate role pass via `_active_role_status_ok`) / patch artifact / apply state / agent_mix WU / privacy audit를 읽어 `gate_evidence/<task>/`에 evidence.json + evidence.md.
- `tests/test_agent_loop.py` — 4 테스트.
- `docs/operations/active-agent-loop.md` — Gate Evidence 섹션.

## 3. 리스크

- **실수로 ship?**: ship/push/merge 호출 없음(코드에 make ship/git push 부재). audit 기록만.
- **privacy**: raw private 값 미포함(요약 메타만). `audit_privacy_output`로 active dir clean 여부만 기록.
- **누락 아티팩트**: patch/apply 없으면 null로 graceful.

## 4. 테스트

- `python3 -m pytest tests/test_agent_loop.py -q` → **167 passed**.
- ready(필수 gate pass) / not-ready(gate 미충족) / patch+apply 번들 / bad task ValueError. CLI smoke: registry 없으면 ready=False.

## 5. Eval 영향

All `·` — RAG 경로 무관.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. load-bearing path 변경 없음. real-eval delta 불필요.

## 6. 하위 호환

신규 verb `gate-evidence`만 추가. 기존 verb/flag/계약/ship 경로 불변.

## 7. 범위 외

- 실제 ship(기존 human-gated 경로). 새 ship surface 없음.
- pretooluse-bash-guard shell hook 확장(별도 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)