### PR TITLE
Render real100_v2 retrieval diagnostics

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -101,6 +101,7 @@ ALLOWED_PATTERNS=(
   '^reports/real100_v2/benchmark_tiers\.aggregate\.json$'
   '^reports/real100_v2/metric_suite\.aggregate\.json$'
   '^reports/real100_v2/metric_suite\.md$'
+  '^reports/real100_v2/retrieval_diagnostics\.aggregate\.json$'
 )
 
 # Guard: ADR file deletion/rename (CLAUDE.md Prohibited).

--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,7 @@ reports/real100_v2/*
 !reports/real100_v2/baseline.aggregate.json
 !reports/real100_v2/metric_suite.aggregate.json
 !reports/real100_v2/metric_suite.md
+!reports/real100_v2/retrieval_diagnostics.aggregate.json
 !reports/real100_v2/README.md
 # Issue #1021 — variance source inspection (Issue J, ADR 0059 audit
 # follow-up, script: scripts/measure_variance.py). N=5 same-HEAD runs →

--- a/docs/evaluation/real100_v2-retrieval-diagnostics.md
+++ b/docs/evaluation/real100_v2-retrieval-diagnostics.md
@@ -1,0 +1,140 @@
+# real100_v2 Retrieval Diagnostics
+
+Issue: [#1622](https://github.com/hskim-solv/BidMate-DocAgent/issues/1622)
+
+Task: `T-2026-0029`
+
+Status: aggregate-only diagnostic report; no runtime behavior change and no performance-improvement claim.
+
+## Boundary
+
+This report uses only `real100_v2` local private eval diagnostics and emits aggregate counts. It does not include raw questions, answers, evidence text, filenames, local paths, document IDs, chunk IDs, sections, or per-case rows. Legacy `real100`/v1/221/kordoc evidence is not used.
+
+## Source Provenance
+
+| Field | Value |
+|---|---|
+| Input artifact | `external_private/real100_v2_eval_summary` |
+| Input redacted | `True` |
+| Input SHA-256 prefix | `355da92b368c` |
+
+## Population
+
+| Metric | Count |
+|---|---:|
+| Predictions | 300 |
+| Answerable | 272 |
+| Unanswerable | 28 |
+| Single-chunk gold | 232 |
+| Multi-chunk gold | 40 |
+| No gold evidence | 28 |
+
+## Retrieval Metrics
+
+| Metric | Value |
+|---|---:|
+| Coverage cases | 272 |
+| Recall@5 | 0.369485 |
+| Recall@10 | 0.433824 |
+| Recall@20 | 0.433824 |
+| Hit@5 | 0.375 |
+| Hit@10 | 0.441176 |
+| All-gold@5 | 0.363971 |
+| All-gold@10 | 0.426471 |
+| MRR@5 | 0.25674 |
+| nDCG@5 | 0.282578 |
+| nDCG@10 | 0.304372 |
+
+## Exclusive Retrieval Status
+
+Dominant bucket: `not_observable_limited_depth`
+
+| Bucket | Count |
+|---|---:|
+| `unanswerable_no_gold` | 28 |
+| `no_gold_evidence` | 0 |
+| `all_gold_top5` | 99 |
+| `all_gold_top10_not_top5` | 17 |
+| `all_gold_observed_after_top10` | 0 |
+| `partial_candidate_pool` | 4 |
+| `not_in_candidate_pool` | 0 |
+| `not_observable_limited_depth` | 152 |
+
+## Failure Buckets
+
+| Bucket | Count |
+|---|---:|
+| `answer_generation_or_abstention` | 3 |
+| `boundary_or_window_candidate` | 3 |
+| `duplicate_or_near_duplicate_candidate` | 199 |
+| `evaluation_label_gap` | 0 |
+| `metadata_filter_candidate` | 43 |
+| `multi_evidence_failure` | 40 |
+| `not_in_candidate_pool` | 0 |
+| `page_metadata_blocked` | 300 |
+| `ranked_too_low_after_top5` | 21 |
+| `verifier_false_negative` | 17 |
+| `verifier_false_positive` | 2 |
+
+## Candidate Pool And Evidence Shape
+
+| Signal | Count / Rate |
+|---|---:|
+| Any gold observed | 120 |
+| All gold observed | 116 |
+| No gold observed | 152 |
+| Partial gold observed | 4 |
+| Retrieval depth < 10 | 272 |
+| Any-gold observed rate | 0.441176 |
+| All-gold observed rate | 0.426471 |
+| No-gold observed rate | 0.558824 |
+| Multi-chunk same-doc | 27 |
+| Multi-chunk multi-doc | 13 |
+| Multi-chunk unknown-doc | 0 |
+
+## Duplicate And Metadata Signals
+
+| Signal | Count |
+|---|---:|
+| Duplicate chunk-id cases | 0 |
+| Repeated document in top 5 | 146 |
+| Repeated document in top 10 | 53 |
+| Metadata candidate cases | 77 |
+| Metadata candidate doc misses | 42 |
+| Metadata ambiguous cases | 1 |
+| Reduced/relaxed filter stage cases | 297 |
+
+## Query Type Slices
+
+| Query type | Cases | Recall@5 | Recall@10 | Hit@5 | MRR@5 | Dominant status |
+|---|---:|---:|---:|---:|---:|---|
+| `single_doc` | 259 | 0.388031 | 0.453668 | 0.393822 | 0.269627 | `not_observable_limited_depth` |
+| `comparison` | 13 | 0.0 | 0.038462 | 0.0 | 0.0 | `not_observable_limited_depth` |
+| `abstention` | 28 | None | None | 0.0 | None | `unanswerable_no_gold` |
+| `unknown` | 0 | None | None | 0.0 | None | `none` |
+
+## Page Metadata Blocker
+
+| Field | Value |
+|---|---|
+| Status | `blocked_for_page_and_window_claims` |
+| Chunks total | 21800 |
+| Chunks with page span | 0 |
+| Page-span coverage | 0.0 |
+| Coverage reason | `index_lacks_page_region_metadata` |
+
+Claim-bearing page/citation or section-window work remains blocked while the v2 page metadata ready rate is 0.0. This report preserves that blocker instead of substituting old evidence.
+
+## Next Task Decision
+
+- Preferred next task: `T-2026-0032`
+- Reason: `ranked_too_low_signal_points_to_candidate_budget_or_reranker_measurement`
+- Blocked task: `T-2026-0031`
+- Blocker: `claim_bearing_page_or_window_work_blocked`
+
+## Non-Claims
+
+- No retrieval, reranking, verifier, answer, ingestion, chunking, or eval scoring behavior changed.
+- No paired delta was produced.
+- No performance improvement is claimed.
+- No legacy `real100`/v1/221/kordoc evidence is used.

--- a/docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md
+++ b/docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md
@@ -1,0 +1,177 @@
+# Plan: T-2026-0029 real100_v2 retrieval diagnostic workbench
+
+- Status: review
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0029`
+- Related issue / PR: [#1622](https://github.com/hskim-solv/BidMate-DocAgent/issues/1622)
+- Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0076](../adr/0076-multi-chunk-evidence-failure-analysis-surface.md)
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+## Problem Statement
+
+`real100_v2` is now the only valid private eval surface, but the next retrieval
+step is not yet explainable enough to choose between candidate-pool expansion,
+same-document/window work, or follow-up query decomposition. The current
+baseline packet reports top-line metrics and a page metadata blocker, but it
+does not provide a compact aggregate diagnostic that separates not-in-pool,
+ranked-too-low, duplicate, metadata-filter, verifier, label, and multi-evidence
+failure buckets for reviewers.
+
+## Current Behavior
+
+`reports/real100_v2/baseline.aggregate.json` is aggregate-only and commit-safe,
+but per-case retrieval failure categorization exists only in ignored private
+`reports/real100_v2/eval_summary.json`. Older multi-chunk scripts default to
+`reports/real100/` and are archive-only for this task. They cannot be used as
+current evidence under the v2-only policy from T-2026-0028.
+
+The known `real100_v2` page metadata ready rate is 0.0, so page/citation claims
+remain blocked. Diagnostic work may carry this blocker forward but must not
+replace it with legacy `real100`/v1/221/kordoc evidence.
+
+## Desired Behavior
+
+Add a read-only renderer that consumes local private `real100_v2` eval summary
+rows and emits only aggregate JSON/Markdown. The report should make the next
+retrieval decision observable without exposing raw private text, document IDs,
+chunk IDs, filenames, or local paths.
+
+## Constraints
+
+- Scope constraints: diagnostic/reporting only.
+- Architecture constraints: no runtime retrieval, reranking, verifier, answer,
+  ingestion, chunking, or eval scoring behavior changes.
+- Compatibility constraints: no CLI contract removal; new script is additive.
+- Eval/privacy constraints: `real100_v2` only; aggregate-only committed output.
+- Tooling/CI constraints: keep local command runnable without external services.
+- Non-goals: page metadata repair, retrieval behavior change, performance claim.
+
+## Architecture Impact
+
+- Affected modules or docs: `scripts/`, `tests/`, `reports/real100_v2/`,
+  `docs/evaluation/`, `tasks/queue.md`.
+- Affected contracts or invariants: private raw artifacts stay ignored; v2-only
+  evidence policy is preserved.
+- Load-bearing paths: none.
+- ADR required: no; this is an additive diagnostic surface under existing
+  eval/privacy ADRs.
+- Backward compatibility expectation: existing commands and reports continue to
+  work.
+
+## Affected Interfaces
+
+- CLI/API/config: new renderer CLI only.
+- Input data: ignored local `reports/real100_v2/eval_summary.json`.
+- Output artifacts: aggregate JSON and Markdown report.
+- Docs/review surfaces: queue, plan, report, real100_v2 README.
+- Tests/eval entrypoints: focused pytest plus v2 guard.
+
+## Data / Eval Impact
+
+- Surface: private real-eval.
+- Data boundary: aggregate-only private output.
+- Allowed claim: diagnostic bucket counts and next-task recommendation based on
+  the specific v2 aggregate.
+- Disallowed claim: performance improvement, page/citation readiness, or any
+  conclusion based on legacy `real100`/v1/221/kordoc evidence.
+- Baseline or control affected: no; read-only renderer.
+- Benchmark/eval auditor required: yes.
+
+## Task Breakdown
+
+1. Add `scripts/render_real100_v2_retrieval_diagnostics.py`.
+2. Add focused tests for bucket classification, privacy boundary, and fail-closed
+   legacy input handling.
+3. Render aggregate JSON/Markdown from the canonical private `real100_v2`
+   summary.
+4. Update queue, README, and guard coverage so the next task can proceed from
+   current v2 evidence.
+
+## Acceptance Criteria
+
+- [x] Diagnostics distinguish not-in-candidate-pool, ranked-too-low,
+  boundary/window, duplicate, metadata-filter, and multi-evidence failures.
+- [x] Output is aggregate-only and commit-safe.
+- [x] The report can decide whether `T-2026-0031` or `T-2026-0032` is the next
+  best experiment.
+- [x] The report explicitly carries forward the v2 page metadata blocker and
+  does not use old `real100` evidence as a substitute.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 -m py_compile scripts/render_real100_v2_retrieval_diagnostics.py scripts/check_real100_v2_only.py
+python3 -m pytest -q tests/test_render_real100_v2_retrieval_diagnostics.py tests/test_real100_v2_guard.py tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py
+REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent python3 scripts/render_real100_v2_retrieval_diagnostics.py
+make real-eval-v2-guard
+bash -n .githooks/pre-commit
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md docs/evaluation/real100_v2-retrieval-diagnostics.md reports/real100_v2/README.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: focused tests pass.
+- Generated or updated artifact: `reports/real100_v2/retrieval_diagnostics.aggregate.json`,
+  `docs/evaluation/real100_v2-retrieval-diagnostics.md`.
+- Reviewer checklist or manual inspection: privacy and claim audits pass.
+- Explicitly not validated, with reason: no retrieval performance delta because
+  runtime behavior does not change.
+
+## Rollback Strategy
+
+Revert the renderer, tests, report, and queue/doc updates. Do not delete local
+private `real100_v2` raw summaries or indexes during rollback.
+
+## Failure Modes
+
+- Failure mode: renderer accidentally accepts legacy `real100` input.
+- Detection signal: focused test and `make real-eval-v2-guard` fail.
+- Stop condition or fallback: stop before PR and tighten input path checks.
+
+- Failure mode: aggregate output leaks raw identifiers or local paths.
+- Detection signal: privacy test or agent-loop privacy audit fails.
+- Stop condition or fallback: strip fields to closed enums/counts only.
+
+- Failure mode: report reads page metadata blocker as solved.
+- Detection signal: claim audit or report review flags page readiness language.
+- Stop condition or fallback: reword as no-go blocker for page/citation claims.
+
+## Observability
+
+- `reports/real100_v2/retrieval_diagnostics.aggregate.json`
+- `docs/evaluation/real100_v2-retrieval-diagnostics.md`
+- `make real-eval-v2-guard`
+- `python3 scripts/agent_loop.py privacy-audit-output`
+- `python3 scripts/agent_loop.py claim-audit --from-git`
+
+## Reviewer Notes
+
+Attack privacy boundary first, then claim wording. This PR must not change
+runtime behavior and must not cite legacy `real100`/v1/221/kordoc evidence as
+current support.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 09:20 KST
+
+- Role: Implementer
+- Branch / worktree: eval/issue-1622-build-real100-v2-retrieval-diagnostic-workbench / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1622 / PR TBD
+- Task: T-2026-0029
+- Current status: real100_v2 retrieval diagnostics rendered and ready for review.
+- Files touched: .gitignore, .githooks/pre-commit, scripts/render_real100_v2_retrieval_diagnostics.py, scripts/check_real100_v2_only.py, tests/test_render_real100_v2_retrieval_diagnostics.py, docs/evaluation/real100_v2-retrieval-diagnostics.md, reports/real100_v2/retrieval_diagnostics.aggregate.json, reports/real100_v2/README.md, docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md, tasks/queue.md
+- Decisions made: use only real100_v2 local summary as raw input and emit aggregate-only committed artifacts.
+- Commands run: make ship-start TITLE="Build real100 v2 retrieval diagnostic workbench" TYPE=eval; make check-branch; python3 scripts/agent_loop.py next; REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent python3 scripts/render_real100_v2_retrieval_diagnostics.py; python3 -m py_compile scripts/render_real100_v2_retrieval_diagnostics.py scripts/check_real100_v2_only.py; python3 -m pytest -q tests/test_render_real100_v2_retrieval_diagnostics.py tests/test_real100_v2_guard.py tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py; make real-eval-v2-guard; bash -n .githooks/pre-commit; python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md docs/evaluation/real100_v2-retrieval-diagnostics.md reports/real100_v2/README.md; python3 scripts/agent_loop.py privacy-audit-output; python3 scripts/agent_loop.py claim-audit --from-git.
+- Results: renderer generated aggregate JSON/Markdown; focused tests, v2 guard, hook syntax check, doc links, privacy audit, and claim audit passed.
+- Next safe command: git diff --check && make check-branch
+- Open questions: none.
+- Risks: duplicate/near-duplicate signal counts repeated top documents as aggregate near-duplicates, not semantic duplicates.
+```

--- a/reports/real100_v2/README.md
+++ b/reports/real100_v2/README.md
@@ -10,6 +10,7 @@ Allowed files:
 - `baseline.aggregate.json`
 - `metric_suite.aggregate.json`
 - `metric_suite.md`
+- `retrieval_diagnostics.aggregate.json`
 - `README.md`
 
 Raw eval summaries, traces, questions, answers, evidence, document IDs, chunk IDs, filenames, paths, parsed Markdown, converted PDFs, and per-case rows must remain ignored.

--- a/reports/real100_v2/retrieval_diagnostics.aggregate.json
+++ b/reports/real100_v2/retrieval_diagnostics.aggregate.json
@@ -1,0 +1,198 @@
+{
+  "candidate_pool_coverage": {
+    "all_gold_observed": 116,
+    "all_gold_observed_rate": 0.426471,
+    "any_gold_observed": 120,
+    "any_gold_observed_rate": 0.441176,
+    "no_gold_observed": 152,
+    "no_gold_observed_rate": 0.558824,
+    "partial_gold_observed": 4,
+    "retrieval_depth_lt_10": 272
+  },
+  "duplicate_or_near_duplicate": {
+    "duplicate_chunk_id_cases": 0,
+    "repeated_doc_top10_cases": 53,
+    "repeated_doc_top5_cases": 146
+  },
+  "evidence_shape": {
+    "counts": {
+      "multi_chunk": 40,
+      "no_gold": 28,
+      "single_chunk": 232
+    },
+    "multi_chunk_doc_split": {
+      "multi_doc": 13,
+      "same_doc": 27,
+      "unknown": 0
+    },
+    "multi_chunk_rate": 0.133333
+  },
+  "exclusive_retrieval_status": {
+    "counts": {
+      "all_gold_observed_after_top10": 0,
+      "all_gold_top10_not_top5": 17,
+      "all_gold_top5": 99,
+      "no_gold_evidence": 0,
+      "not_in_candidate_pool": 0,
+      "not_observable_limited_depth": 152,
+      "partial_candidate_pool": 4,
+      "unanswerable_no_gold": 28
+    },
+    "dominant": "not_observable_limited_depth"
+  },
+  "failure_buckets": {
+    "answer_generation_or_abstention": 3,
+    "boundary_or_window_candidate": 3,
+    "duplicate_or_near_duplicate_candidate": 199,
+    "evaluation_label_gap": 0,
+    "metadata_filter_candidate": 43,
+    "multi_evidence_failure": 40,
+    "not_in_candidate_pool": 0,
+    "page_metadata_blocked": 300,
+    "ranked_too_low_after_top5": 21,
+    "verifier_false_negative": 17,
+    "verifier_false_positive": 2
+  },
+  "metadata_filter": {
+    "metadata_ambiguous_cases": 1,
+    "metadata_candidate_cases": 77,
+    "metadata_candidate_doc_miss_cases": 42,
+    "reduced_or_relaxed_filter_stage_cases": 297
+  },
+  "next_task_decision": {
+    "blocked_task": "T-2026-0031",
+    "blocker": "claim_bearing_page_or_window_work_blocked",
+    "preferred_next_task": "T-2026-0032",
+    "reason": "ranked_too_low_signal_points_to_candidate_budget_or_reranker_measurement"
+  },
+  "non_claims": {
+    "legacy_real100_evidence_used": false,
+    "paired_delta": false,
+    "performance_improvement_claim": false,
+    "runtime_behavior_changed": false
+  },
+  "page_metadata_blocker": {
+    "chunks_total": 21800,
+    "chunks_with_page_span": 0,
+    "coverage_reason": "index_lacks_page_region_metadata",
+    "page_span_coverage": 0.0,
+    "status": "blocked_for_page_and_window_claims"
+  },
+  "population": {
+    "answerable": 272,
+    "failure_category_counts": {
+      "abstention_failure": 3,
+      "answer_synthesis_issue": 0,
+      "citation_or_page_metadata_issue": 0,
+      "evaluation_label_issue": 0,
+      "none": 85,
+      "parse_or_metadata_issue": 193,
+      "retrieval_miss": 0,
+      "unknown": 0,
+      "verifier_false_negative": 17,
+      "verifier_false_positive": 2
+    },
+    "num_predictions": 300,
+    "query_type_counts": {
+      "abstention": 28,
+      "comparison": 13,
+      "single_doc": 259,
+      "unknown": 0
+    },
+    "unanswerable": 28
+  },
+  "privacy": {
+    "aggregate_only": true,
+    "chunk_ids_omitted": true,
+    "doc_ids_omitted": true,
+    "filenames_omitted": true,
+    "paths_omitted": true,
+    "per_case_rows_omitted": true,
+    "raw_answers_omitted": true,
+    "raw_evidence_omitted": true,
+    "raw_questions_omitted": true
+  },
+  "profile_type": "private_real100_v2_retrieval_diagnostics",
+  "query_type_slices": {
+    "abstention": {
+      "answerable": 0,
+      "cases": 28,
+      "chunk_recall_at_10": null,
+      "chunk_recall_at_20": null,
+      "chunk_recall_at_5": null,
+      "dominant_exclusive_status": "unanswerable_no_gold",
+      "hit_at_10": 0.0,
+      "hit_at_5": 0.0,
+      "mrr_at_5": null,
+      "ndcg_at_10": null,
+      "ndcg_at_5": null
+    },
+    "comparison": {
+      "answerable": 13,
+      "cases": 13,
+      "chunk_recall_at_10": 0.038462,
+      "chunk_recall_at_20": 0.038462,
+      "chunk_recall_at_5": 0.0,
+      "dominant_exclusive_status": "not_observable_limited_depth",
+      "hit_at_10": 0.076923,
+      "hit_at_5": 0.0,
+      "mrr_at_5": 0.0,
+      "ndcg_at_10": 0.016801,
+      "ndcg_at_5": 0.0
+    },
+    "single_doc": {
+      "answerable": 259,
+      "cases": 259,
+      "chunk_recall_at_10": 0.453668,
+      "chunk_recall_at_20": 0.453668,
+      "chunk_recall_at_5": 0.388031,
+      "dominant_exclusive_status": "not_observable_limited_depth",
+      "hit_at_10": 0.459459,
+      "hit_at_5": 0.393822,
+      "mrr_at_5": 0.269627,
+      "ndcg_at_10": 0.318806,
+      "ndcg_at_5": 0.296762
+    },
+    "unknown": {
+      "answerable": 0,
+      "cases": 0,
+      "chunk_recall_at_10": null,
+      "chunk_recall_at_20": null,
+      "chunk_recall_at_5": null,
+      "dominant_exclusive_status": "none",
+      "hit_at_10": 0.0,
+      "hit_at_5": 0.0,
+      "mrr_at_5": null,
+      "ndcg_at_10": null,
+      "ndcg_at_5": null
+    }
+  },
+  "retrieval_metrics": {
+    "all_gold_at_k": {
+      "10": 0.426471,
+      "20": 0.426471,
+      "5": 0.363971
+    },
+    "chunk_recall_at_10": 0.433824,
+    "chunk_recall_at_20": 0.433824,
+    "chunk_recall_at_5": 0.369485,
+    "context_precision_at_5": 0.075,
+    "context_recall_at_5": 0.369485,
+    "coverage_cases": 272,
+    "hit_at_k": {
+      "10": 0.441176,
+      "20": 0.441176,
+      "5": 0.375
+    },
+    "mrr": 0.266457,
+    "mrr_at_5": 0.25674,
+    "ndcg_at_10": 0.304372,
+    "ndcg_at_5": 0.282578
+  },
+  "schema_version": 1,
+  "source": {
+    "input_artifact": "external_private/real100_v2_eval_summary",
+    "input_location_redacted": true,
+    "input_sha256_12": "355da92b368c"
+  }
+}

--- a/scripts/check_real100_v2_only.py
+++ b/scripts/check_real100_v2_only.py
@@ -12,8 +12,11 @@ DEFAULT_PATHS = (
     Path("CLAUDE.md"),
     Path("tasks/queue.md"),
     Path("docs/plans/T-2026-0028-refresh-private-coverage-semantic-baselines.md"),
+    Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
     Path("docs/evaluation/surface-map.md"),
     Path("docs/evaluation/private_real_eval_workflow.md"),
+    Path("docs/evaluation/real100_v2-retrieval-diagnostics.md"),
+    Path("reports/real100_v2/README.md"),
 )
 
 STALE_PATH_RE = re.compile(r"\b(?:data/index|reports|outputs)/real100(?!_v2)\b")
@@ -26,12 +29,14 @@ BAN_CONTEXT_RE = re.compile(
 )
 
 
-def _t2026_0028_block(text: str) -> str:
-    marker = "## T-2026-0028"
+def _task_block(text: str, task_id: str, next_task_id: str | None) -> str:
+    marker = f"## {task_id}"
     start = text.find(marker)
     if start == -1:
-        return text
-    next_task = text.find("\n## T-2026-0029", start + len(marker))
+        return ""
+    next_task = -1
+    if next_task_id:
+        next_task = text.find(f"\n## {next_task_id}", start + len(marker))
     return text[start:] if next_task == -1 else text[start:next_task]
 
 
@@ -54,12 +59,29 @@ def _is_ban_context(line: str) -> bool:
 def check_path(path: Path) -> list[str]:
     full_path = ROOT / path
     text = full_path.read_text(encoding="utf-8")
-    scoped = _t2026_0028_block(text) if path == Path("tasks/queue.md") else text
+    if path == Path("tasks/queue.md"):
+        scoped = "\n".join(
+            block
+            for block in (
+                _task_block(text, "T-2026-0028", "T-2026-0029"),
+                _task_block(text, "T-2026-0029", "T-2026-0030"),
+            )
+            if block
+        )
+    else:
+        scoped = text
     findings: list[str] = []
 
     if "real100_v2" not in scoped:
         findings.append(f"{path}: missing required real100_v2 reference")
-    if "real-eval-v2" not in scoped and path != Path("CLAUDE.md"):
+    guard_required_paths = {
+        Path("tasks/queue.md"),
+        Path("docs/plans/T-2026-0028-refresh-private-coverage-semantic-baselines.md"),
+        Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
+        Path("docs/evaluation/surface-map.md"),
+        Path("docs/evaluation/private_real_eval_workflow.md"),
+    }
+    if "real-eval-v2" not in scoped and path in guard_required_paths:
         findings.append(f"{path}: missing required real-eval-v2 guard/check reference")
 
     if path == Path("CLAUDE.md"):
@@ -82,6 +104,8 @@ def check_path(path: Path) -> list[str]:
     if path in {
         Path("tasks/queue.md"),
         Path("docs/plans/T-2026-0028-refresh-private-coverage-semantic-baselines.md"),
+        Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
+        Path("docs/evaluation/real100_v2-retrieval-diagnostics.md"),
     }:
         for lineno, line in enumerate(scoped.splitlines(), start=1):
             if _is_ban_context(line):

--- a/scripts/render_real100_v2_retrieval_diagnostics.py
+++ b/scripts/render_real100_v2_retrieval_diagnostics.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""Render aggregate-only real100_v2 retrieval diagnostics.
+
+This script reads the ignored local ``real100_v2`` eval summary and writes
+commit-safe aggregate JSON/Markdown. It does not import or change retrieval,
+reranking, verifier, answer, ingestion, chunking, or eval scoring behavior.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+K_VALUES: tuple[int, ...] = (5, 10, 20)
+SAFE_QUERY_TYPES: tuple[str, ...] = ("single_doc", "comparison", "abstention", "unknown")
+SAFE_FAILURE_CATEGORIES: tuple[str, ...] = (
+    "retrieval_miss",
+    "citation_or_page_metadata_issue",
+    "verifier_false_negative",
+    "verifier_false_positive",
+    "answer_synthesis_issue",
+    "abstention_failure",
+    "evaluation_label_issue",
+    "parse_or_metadata_issue",
+    "unknown",
+    "none",
+)
+EXCLUSIVE_STATUS: tuple[str, ...] = (
+    "unanswerable_no_gold",
+    "no_gold_evidence",
+    "all_gold_top5",
+    "all_gold_top10_not_top5",
+    "all_gold_observed_after_top10",
+    "partial_candidate_pool",
+    "not_in_candidate_pool",
+    "not_observable_limited_depth",
+)
+
+
+def _default_summary() -> Path:
+    root = Path(os.environ.get("REAL_EVAL_ROOT") or ROOT)
+    return root / "reports" / "real100_v2" / "eval_summary.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return payload
+
+
+def _require_real100_v2(path: Path) -> None:
+    parts = set(path.parts)
+    if "real100_v2" not in parts:
+        raise ValueError(f"input must be under a real100_v2 path: {path}")
+    if "real100" in parts:
+        raise ValueError(f"legacy real100 input is not allowed: {path}")
+
+
+def _source_provenance(path: Path) -> dict[str, Any]:
+    resolved_root = ROOT.resolve()
+    resolved_path = path.resolve()
+    try:
+        location = str(resolved_path.relative_to(resolved_root))
+        redacted = False
+    except ValueError:
+        location = "external_private/real100_v2_eval_summary"
+        redacted = True
+    return {
+        "input_artifact": location,
+        "input_location_redacted": redacted,
+        "input_sha256_12": hashlib.sha256(path.read_bytes()).hexdigest()[:12],
+    }
+
+
+def _case_results(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = summary.get("case_results")
+    if not isinstance(raw, list):
+        raise ValueError("real100_v2 eval_summary.json must include case_results")
+    return [case for case in raw if isinstance(case, dict)]
+
+
+def _safe_query_type(value: Any) -> str:
+    text = str(value or "").strip()
+    return text if text in SAFE_QUERY_TYPES else "unknown"
+
+
+def _safe_failure_category(value: Any) -> str:
+    if value is None or value == "":
+        return "none"
+    text = str(value)
+    return text if text in SAFE_FAILURE_CATEGORIES else "unknown"
+
+
+def _bool(value: Any) -> bool:
+    return bool(value) if isinstance(value, bool) else False
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _mean(values: Iterable[float]) -> float | None:
+    clean = list(values)
+    if not clean:
+        return None
+    return round(sum(clean) / len(clean), 6)
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 6)
+
+
+def _unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def _gold_chunk_ids(case: Mapping[str, Any]) -> list[str]:
+    explicit = [str(item) for item in case.get("gold_chunk_ids") or [] if item]
+    evidence_ids = [
+        str(item.get("chunk_id") or "")
+        for item in case.get("gold_evidence") or []
+        if isinstance(item, Mapping) and item.get("chunk_id")
+    ]
+    return _unique([*explicit, *evidence_ids])
+
+
+def _gold_doc_split(case: Mapping[str, Any], gold_ids: list[str]) -> str:
+    gold_set = set(gold_ids)
+    docs: set[str] = set()
+    for item in case.get("gold_evidence") or []:
+        if not isinstance(item, Mapping):
+            continue
+        chunk_id = str(item.get("chunk_id") or "")
+        doc_id = str(item.get("doc_id") or "")
+        if chunk_id in gold_set and doc_id:
+            docs.add(doc_id)
+    if len(docs) == 1:
+        return "same_doc"
+    if len(docs) > 1:
+        return "multi_doc"
+    return "unknown"
+
+
+def _retrieved_rows(case: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = case.get("retrieved_chunks")
+    if isinstance(rows, list):
+        clean: list[tuple[int, int, dict[str, Any]]] = []
+        for ordinal, item in enumerate(rows):
+            if not isinstance(item, dict):
+                continue
+            chunk_id = str(item.get("chunk_id") or "")
+            if not chunk_id:
+                continue
+            try:
+                rank = int(item.get("rank") or ordinal + 1)
+            except (TypeError, ValueError):
+                rank = ordinal + 1
+            clean.append((rank, ordinal, item))
+        return [item for _, _, item in sorted(clean)]
+
+    ids = case.get("retrieved_chunk_ids")
+    if isinstance(ids, list):
+        return [
+            {"rank": rank, "chunk_id": str(chunk_id)}
+            for rank, chunk_id in enumerate(ids, start=1)
+            if chunk_id
+        ]
+    return []
+
+
+def _retrieved_chunk_ids(case: Mapping[str, Any]) -> list[str]:
+    return _unique(str(item.get("chunk_id") or "") for item in _retrieved_rows(case))
+
+
+def _doc_ids(rows: list[dict[str, Any]], k: int) -> list[str]:
+    return [str(item.get("doc_id") or "") for item in rows[:k] if item.get("doc_id")]
+
+
+def _topk_hit(gold: set[str], retrieved: list[str], k: int) -> bool:
+    return bool(gold & set(retrieved[:k]))
+
+
+def _topk_all(gold: set[str], retrieved: list[str], k: int) -> bool:
+    return bool(gold) and gold.issubset(set(retrieved[:k]))
+
+
+def _exclusive_status(case: Mapping[str, Any], gold: list[str], retrieved: list[str]) -> str:
+    if case.get("answerable") is False:
+        return "unanswerable_no_gold"
+    if not gold:
+        return "no_gold_evidence"
+
+    gold_set = set(gold)
+    observed = set(retrieved)
+    if _topk_all(gold_set, retrieved, 5):
+        return "all_gold_top5"
+    if _topk_all(gold_set, retrieved, 10):
+        return "all_gold_top10_not_top5"
+    if gold_set.issubset(observed):
+        return "all_gold_observed_after_top10"
+    if gold_set & observed:
+        return "partial_candidate_pool"
+    if len(retrieved) >= 10:
+        return "not_in_candidate_pool"
+    return "not_observable_limited_depth"
+
+
+def _empty_slice() -> dict[str, Any]:
+    return {
+        "cases": 0,
+        "answerable": 0,
+        "chunk_recall_at_5": None,
+        "chunk_recall_at_10": None,
+        "chunk_recall_at_20": None,
+        "hit_at_5": 0.0,
+        "hit_at_10": 0.0,
+        "mrr_at_5": None,
+        "ndcg_at_5": None,
+        "ndcg_at_10": None,
+        "dominant_exclusive_status": "none",
+    }
+
+
+def _metric_block(cases: list[Mapping[str, Any]]) -> dict[str, Any]:
+    answerable = [
+        case
+        for case in cases
+        if case.get("answerable") is True and _gold_chunk_ids(case)
+    ]
+    hits = {str(k): 0 for k in K_VALUES}
+    all_hits = {str(k): 0 for k in K_VALUES}
+    for case in answerable:
+        gold = set(_gold_chunk_ids(case))
+        retrieved = _retrieved_chunk_ids(case)
+        for k in K_VALUES:
+            if _topk_hit(gold, retrieved, k):
+                hits[str(k)] += 1
+            if _topk_all(gold, retrieved, k):
+                all_hits[str(k)] += 1
+
+    return {
+        "coverage_cases": len(answerable),
+        "chunk_recall_at_5": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("chunk_recall_at_5"))) is not None
+        ),
+        "chunk_recall_at_10": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("chunk_recall_at_10"))) is not None
+        ),
+        "chunk_recall_at_20": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("chunk_recall_at_20"))) is not None
+        ),
+        "hit_at_k": {k: _rate(v, len(answerable)) for k, v in hits.items()},
+        "all_gold_at_k": {k: _rate(v, len(answerable)) for k, v in all_hits.items()},
+        "mrr_at_5": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("chunk_mrr_at_5"))) is not None
+        ),
+        "mrr": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("chunk_mrr"))) is not None
+        ),
+        "ndcg_at_5": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("chunk_ndcg_at_5"))) is not None
+        ),
+        "ndcg_at_10": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("chunk_ndcg_at_10"))) is not None
+        ),
+        "context_precision_at_5": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("context_precision_at_5"))) is not None
+        ),
+        "context_recall_at_5": _mean(
+            value
+            for case in answerable
+            if (value := _number(case.get("context_recall_at_5"))) is not None
+        ),
+    }
+
+
+def _dominant(counter: Mapping[str, int]) -> str:
+    if not counter:
+        return "none"
+    return sorted(counter.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _recommend_next_task(
+    *,
+    page_span_coverage: float | None,
+    failure_buckets: Mapping[str, int],
+) -> dict[str, Any]:
+    if page_span_coverage == 0.0:
+        page_blocker = "claim_bearing_page_or_window_work_blocked"
+    else:
+        page_blocker = "page_metadata_available"
+
+    if failure_buckets.get("ranked_too_low_after_top5", 0) >= failure_buckets.get(
+        "not_in_candidate_pool", 0
+    ):
+        preferred = "T-2026-0032"
+        reason = "ranked_too_low_signal_points_to_candidate_budget_or_reranker_measurement"
+    else:
+        preferred = "T-2026-0031"
+        reason = "not_in_candidate_pool_signal_points_to_parent_or_section_window_experiment"
+
+    if page_span_coverage == 0.0 and preferred == "T-2026-0031":
+        return {
+            "preferred_next_task": "T-2026-0032",
+            "reason": "T-2026-0031 depends on page/window evidence; v2 page metadata is still absent",
+            "blocked_task": "T-2026-0031",
+            "blocker": page_blocker,
+        }
+    return {
+        "preferred_next_task": preferred,
+        "reason": reason,
+        "blocked_task": "T-2026-0031" if page_span_coverage == 0.0 else None,
+        "blocker": page_blocker,
+    }
+
+
+def build_diagnostics(summary: Mapping[str, Any], *, source: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    cases = _case_results(summary)
+    exclusive = Counter({key: 0 for key in EXCLUSIVE_STATUS})
+    query_types = Counter({key: 0 for key in SAFE_QUERY_TYPES})
+    failure_categories = Counter({key: 0 for key in SAFE_FAILURE_CATEGORIES})
+    evidence_split = Counter({"single_chunk": 0, "multi_chunk": 0, "no_gold": 0})
+    multi_doc_split = Counter({"same_doc": 0, "multi_doc": 0, "unknown": 0})
+    failure_buckets = Counter(
+        {
+            "not_in_candidate_pool": 0,
+            "ranked_too_low_after_top5": 0,
+            "boundary_or_window_candidate": 0,
+            "duplicate_or_near_duplicate_candidate": 0,
+            "metadata_filter_candidate": 0,
+            "multi_evidence_failure": 0,
+            "verifier_false_negative": 0,
+            "verifier_false_positive": 0,
+            "evaluation_label_gap": 0,
+            "answer_generation_or_abstention": 0,
+            "page_metadata_blocked": 0,
+        }
+    )
+    candidate_pool = {
+        "any_gold_observed": 0,
+        "all_gold_observed": 0,
+        "no_gold_observed": 0,
+        "partial_gold_observed": 0,
+        "retrieval_depth_lt_10": 0,
+    }
+    duplicate_counts = {
+        "duplicate_chunk_id_cases": 0,
+        "repeated_doc_top5_cases": 0,
+        "repeated_doc_top10_cases": 0,
+    }
+    metadata_filter = {
+        "metadata_candidate_cases": 0,
+        "metadata_candidate_doc_miss_cases": 0,
+        "metadata_ambiguous_cases": 0,
+        "reduced_or_relaxed_filter_stage_cases": 0,
+    }
+    slice_cases: dict[str, list[Mapping[str, Any]]] = {key: [] for key in SAFE_QUERY_TYPES}
+
+    for case in cases:
+        query_type = _safe_query_type(case.get("query_type") or case.get("slice"))
+        query_types[query_type] += 1
+        slice_cases[query_type].append(case)
+        failure_category = _safe_failure_category(case.get("failure_category"))
+        failure_categories[failure_category] += 1
+
+        gold = _gold_chunk_ids(case)
+        gold_set = set(gold)
+        rows = _retrieved_rows(case)
+        retrieved = _retrieved_chunk_ids(case)
+        observed = gold_set & set(retrieved)
+        status = _exclusive_status(case, gold, retrieved)
+        exclusive[status] += 1
+
+        if len(gold) == 0:
+            evidence_split["no_gold"] += 1
+        elif len(gold) == 1:
+            evidence_split["single_chunk"] += 1
+        else:
+            evidence_split["multi_chunk"] += 1
+            multi_doc_split[_gold_doc_split(case, gold)] += 1
+
+        if case.get("answerable") is True and gold:
+            if observed:
+                candidate_pool["any_gold_observed"] += 1
+            else:
+                candidate_pool["no_gold_observed"] += 1
+            if gold_set and gold_set.issubset(set(retrieved)):
+                candidate_pool["all_gold_observed"] += 1
+            elif observed:
+                candidate_pool["partial_gold_observed"] += 1
+            if len(retrieved) < 10:
+                candidate_pool["retrieval_depth_lt_10"] += 1
+
+            if not observed and len(retrieved) >= 10:
+                failure_buckets["not_in_candidate_pool"] += 1
+            if not _topk_all(gold_set, retrieved, 5) and observed:
+                failure_buckets["ranked_too_low_after_top5"] += 1
+            if len(gold) > 1 and not _topk_all(gold_set, retrieved, 5):
+                failure_buckets["multi_evidence_failure"] += 1
+                if _gold_doc_split(case, gold) == "same_doc" and observed:
+                    failure_buckets["boundary_or_window_candidate"] += 1
+
+        if len(retrieved) != len(set(retrieved)):
+            duplicate_counts["duplicate_chunk_id_cases"] += 1
+            failure_buckets["duplicate_or_near_duplicate_candidate"] += 1
+        for k, key in ((5, "repeated_doc_top5_cases"), (10, "repeated_doc_top10_cases")):
+            docs = _doc_ids(rows, k)
+            if docs and len(docs) != len(set(docs)):
+                duplicate_counts[key] += 1
+                failure_buckets["duplicate_or_near_duplicate_candidate"] += 1
+                break
+
+        metadata_count = _number(case.get("metadata_candidate_count")) or 0
+        if metadata_count > 0:
+            metadata_filter["metadata_candidate_cases"] += 1
+            if not _bool(case.get("doc_match")):
+                metadata_filter["metadata_candidate_doc_miss_cases"] += 1
+                failure_buckets["metadata_filter_candidate"] += 1
+        if _bool(case.get("metadata_ambiguous")):
+            metadata_filter["metadata_ambiguous_cases"] += 1
+            failure_buckets["metadata_filter_candidate"] += 1
+        if str(case.get("filter_stage") or "") in {"reduced", "relaxed"}:
+            metadata_filter["reduced_or_relaxed_filter_stage_cases"] += 1
+
+        if failure_category == "verifier_false_negative":
+            failure_buckets["verifier_false_negative"] += 1
+        elif failure_category == "verifier_false_positive":
+            failure_buckets["verifier_false_positive"] += 1
+        elif failure_category == "evaluation_label_issue":
+            failure_buckets["evaluation_label_gap"] += 1
+        elif failure_category in {"answer_synthesis_issue", "abstention_failure"}:
+            failure_buckets["answer_generation_or_abstention"] += 1
+
+    page_meta = summary.get("index_citation_metadata_coverage")
+    page_meta = page_meta if isinstance(page_meta, Mapping) else {}
+    page_span_coverage = _number(page_meta.get("page_span_coverage"))
+    if page_span_coverage == 0.0:
+        failure_buckets["page_metadata_blocked"] = int(summary.get("num_predictions") or len(cases))
+
+    slices: dict[str, Any] = {}
+    for query_type, items in slice_cases.items():
+        if not items:
+            slices[query_type] = _empty_slice()
+            continue
+        status_counts = Counter(_exclusive_status(case, _gold_chunk_ids(case), _retrieved_chunk_ids(case)) for case in items)
+        metrics = _metric_block(list(items))
+        slices[query_type] = {
+            "cases": len(items),
+            "answerable": sum(1 for case in items if case.get("answerable") is True),
+            "chunk_recall_at_5": metrics["chunk_recall_at_5"],
+            "chunk_recall_at_10": metrics["chunk_recall_at_10"],
+            "chunk_recall_at_20": metrics["chunk_recall_at_20"],
+            "hit_at_5": metrics["hit_at_k"]["5"],
+            "hit_at_10": metrics["hit_at_k"]["10"],
+            "mrr_at_5": metrics["mrr_at_5"],
+            "ndcg_at_5": metrics["ndcg_at_5"],
+            "ndcg_at_10": metrics["ndcg_at_10"],
+            "dominant_exclusive_status": _dominant(status_counts),
+        }
+
+    metric_block = _metric_block(cases)
+    recommendation = _recommend_next_task(
+        page_span_coverage=page_span_coverage,
+        failure_buckets=failure_buckets,
+    )
+
+    return {
+        "schema_version": 1,
+        "profile_type": "private_real100_v2_retrieval_diagnostics",
+        "source": dict(source or {}),
+        "population": {
+            "num_predictions": int(summary.get("num_predictions") or len(cases)),
+            "answerable": sum(1 for case in cases if case.get("answerable") is True),
+            "unanswerable": sum(1 for case in cases if case.get("answerable") is False),
+            "query_type_counts": dict(query_types),
+            "failure_category_counts": dict(failure_categories),
+        },
+        "retrieval_metrics": metric_block,
+        "exclusive_retrieval_status": {
+            "counts": dict(exclusive),
+            "dominant": _dominant(exclusive),
+        },
+        "candidate_pool_coverage": {
+            **candidate_pool,
+            "any_gold_observed_rate": _rate(candidate_pool["any_gold_observed"], metric_block["coverage_cases"]),
+            "all_gold_observed_rate": _rate(candidate_pool["all_gold_observed"], metric_block["coverage_cases"]),
+            "no_gold_observed_rate": _rate(candidate_pool["no_gold_observed"], metric_block["coverage_cases"]),
+        },
+        "evidence_shape": {
+            "counts": dict(evidence_split),
+            "multi_chunk_doc_split": dict(multi_doc_split),
+            "multi_chunk_rate": _rate(evidence_split["multi_chunk"], len(cases)),
+        },
+        "failure_buckets": dict(failure_buckets),
+        "duplicate_or_near_duplicate": duplicate_counts,
+        "metadata_filter": metadata_filter,
+        "query_type_slices": slices,
+        "page_metadata_blocker": {
+            "status": (
+                "blocked_for_page_and_window_claims"
+                if page_span_coverage == 0.0
+                else "available"
+            ),
+            "chunks_total": int(page_meta.get("chunks_total") or 0),
+            "chunks_with_page_span": int(page_meta.get("chunks_with_page_span") or 0),
+            "page_span_coverage": page_span_coverage,
+            "coverage_reason": str(page_meta.get("coverage_reason") or "unknown"),
+        },
+        "next_task_decision": recommendation,
+        "privacy": {
+            "aggregate_only": True,
+            "raw_questions_omitted": True,
+            "raw_answers_omitted": True,
+            "raw_evidence_omitted": True,
+            "doc_ids_omitted": True,
+            "chunk_ids_omitted": True,
+            "filenames_omitted": True,
+            "paths_omitted": True,
+            "per_case_rows_omitted": True,
+        },
+        "non_claims": {
+            "runtime_behavior_changed": False,
+            "performance_improvement_claim": False,
+            "paired_delta": False,
+            "legacy_real100_evidence_used": False,
+        },
+    }
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    source = _mapping(report.get("source"))
+    population = _mapping(report.get("population"))
+    metrics = _mapping(report.get("retrieval_metrics"))
+    status = _mapping(report.get("exclusive_retrieval_status"))
+    status_counts = _mapping(status.get("counts"))
+    candidate_pool = _mapping(report.get("candidate_pool_coverage"))
+    evidence = _mapping(report.get("evidence_shape"))
+    evidence_counts = _mapping(evidence.get("counts"))
+    doc_split = _mapping(evidence.get("multi_chunk_doc_split"))
+    failure_buckets = _mapping(report.get("failure_buckets"))
+    duplicate = _mapping(report.get("duplicate_or_near_duplicate"))
+    metadata = _mapping(report.get("metadata_filter"))
+    blocker = _mapping(report.get("page_metadata_blocker"))
+    next_task = _mapping(report.get("next_task_decision"))
+    slices = _mapping(report.get("query_type_slices"))
+
+    lines = [
+        "# real100_v2 Retrieval Diagnostics",
+        "",
+        "Issue: [#1622](https://github.com/hskim-solv/BidMate-DocAgent/issues/1622)",
+        "",
+        "Task: `T-2026-0029`",
+        "",
+        "Status: aggregate-only diagnostic report; no runtime behavior change and no performance-improvement claim.",
+        "",
+        "## Boundary",
+        "",
+        "This report uses only `real100_v2` local private eval diagnostics and emits aggregate counts. It does not include raw questions, answers, evidence text, filenames, local paths, document IDs, chunk IDs, sections, or per-case rows. Legacy `real100`/v1/221/kordoc evidence is not used.",
+        "",
+        "## Source Provenance",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Input artifact | `{source.get('input_artifact') or ''}` |",
+        f"| Input redacted | `{source.get('input_location_redacted')}` |",
+        f"| Input SHA-256 prefix | `{source.get('input_sha256_12') or ''}` |",
+        "",
+        "## Population",
+        "",
+        "| Metric | Count |",
+        "|---|---:|",
+        f"| Predictions | {population.get('num_predictions', 0)} |",
+        f"| Answerable | {population.get('answerable', 0)} |",
+        f"| Unanswerable | {population.get('unanswerable', 0)} |",
+        f"| Single-chunk gold | {evidence_counts.get('single_chunk', 0)} |",
+        f"| Multi-chunk gold | {evidence_counts.get('multi_chunk', 0)} |",
+        f"| No gold evidence | {evidence_counts.get('no_gold', 0)} |",
+        "",
+        "## Retrieval Metrics",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Coverage cases | {metrics.get('coverage_cases', 0)} |",
+        f"| Recall@5 | {metrics.get('chunk_recall_at_5')} |",
+        f"| Recall@10 | {metrics.get('chunk_recall_at_10')} |",
+        f"| Recall@20 | {metrics.get('chunk_recall_at_20')} |",
+        f"| Hit@5 | {_mapping(metrics.get('hit_at_k')).get('5')} |",
+        f"| Hit@10 | {_mapping(metrics.get('hit_at_k')).get('10')} |",
+        f"| All-gold@5 | {_mapping(metrics.get('all_gold_at_k')).get('5')} |",
+        f"| All-gold@10 | {_mapping(metrics.get('all_gold_at_k')).get('10')} |",
+        f"| MRR@5 | {metrics.get('mrr_at_5')} |",
+        f"| nDCG@5 | {metrics.get('ndcg_at_5')} |",
+        f"| nDCG@10 | {metrics.get('ndcg_at_10')} |",
+        "",
+        "## Exclusive Retrieval Status",
+        "",
+        f"Dominant bucket: `{status.get('dominant')}`",
+        "",
+        "| Bucket | Count |",
+        "|---|---:|",
+    ]
+    for bucket in EXCLUSIVE_STATUS:
+        lines.append(f"| `{bucket}` | {status_counts.get(bucket, 0)} |")
+
+    lines.extend(
+        [
+            "",
+            "## Failure Buckets",
+            "",
+            "| Bucket | Count |",
+            "|---|---:|",
+        ]
+    )
+    for bucket in sorted(failure_buckets):
+        lines.append(f"| `{bucket}` | {failure_buckets.get(bucket, 0)} |")
+
+    lines.extend(
+        [
+            "",
+            "## Candidate Pool And Evidence Shape",
+            "",
+            "| Signal | Count / Rate |",
+            "|---|---:|",
+            f"| Any gold observed | {candidate_pool.get('any_gold_observed', 0)} |",
+            f"| All gold observed | {candidate_pool.get('all_gold_observed', 0)} |",
+            f"| No gold observed | {candidate_pool.get('no_gold_observed', 0)} |",
+            f"| Partial gold observed | {candidate_pool.get('partial_gold_observed', 0)} |",
+            f"| Retrieval depth < 10 | {candidate_pool.get('retrieval_depth_lt_10', 0)} |",
+            f"| Any-gold observed rate | {candidate_pool.get('any_gold_observed_rate')} |",
+            f"| All-gold observed rate | {candidate_pool.get('all_gold_observed_rate')} |",
+            f"| No-gold observed rate | {candidate_pool.get('no_gold_observed_rate')} |",
+            f"| Multi-chunk same-doc | {doc_split.get('same_doc', 0)} |",
+            f"| Multi-chunk multi-doc | {doc_split.get('multi_doc', 0)} |",
+            f"| Multi-chunk unknown-doc | {doc_split.get('unknown', 0)} |",
+            "",
+            "## Duplicate And Metadata Signals",
+            "",
+            "| Signal | Count |",
+            "|---|---:|",
+            f"| Duplicate chunk-id cases | {duplicate.get('duplicate_chunk_id_cases', 0)} |",
+            f"| Repeated document in top 5 | {duplicate.get('repeated_doc_top5_cases', 0)} |",
+            f"| Repeated document in top 10 | {duplicate.get('repeated_doc_top10_cases', 0)} |",
+            f"| Metadata candidate cases | {metadata.get('metadata_candidate_cases', 0)} |",
+            f"| Metadata candidate doc misses | {metadata.get('metadata_candidate_doc_miss_cases', 0)} |",
+            f"| Metadata ambiguous cases | {metadata.get('metadata_ambiguous_cases', 0)} |",
+            f"| Reduced/relaxed filter stage cases | {metadata.get('reduced_or_relaxed_filter_stage_cases', 0)} |",
+            "",
+            "## Query Type Slices",
+            "",
+            "| Query type | Cases | Recall@5 | Recall@10 | Hit@5 | MRR@5 | Dominant status |",
+            "|---|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for query_type in SAFE_QUERY_TYPES:
+        row = _mapping(slices.get(query_type))
+        lines.append(
+            f"| `{query_type}` | {row.get('cases', 0)} | "
+            f"{row.get('chunk_recall_at_5')} | {row.get('chunk_recall_at_10')} | "
+            f"{row.get('hit_at_5')} | {row.get('mrr_at_5')} | "
+            f"`{row.get('dominant_exclusive_status')}` |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Page Metadata Blocker",
+            "",
+            "| Field | Value |",
+            "|---|---|",
+            f"| Status | `{blocker.get('status')}` |",
+            f"| Chunks total | {blocker.get('chunks_total', 0)} |",
+            f"| Chunks with page span | {blocker.get('chunks_with_page_span', 0)} |",
+            f"| Page-span coverage | {blocker.get('page_span_coverage')} |",
+            f"| Coverage reason | `{blocker.get('coverage_reason')}` |",
+            "",
+            "Claim-bearing page/citation or section-window work remains blocked while the v2 page metadata ready rate is 0.0. This report preserves that blocker instead of substituting old evidence.",
+            "",
+            "## Next Task Decision",
+            "",
+            f"- Preferred next task: `{next_task.get('preferred_next_task')}`",
+            f"- Reason: `{next_task.get('reason')}`",
+            f"- Blocked task: `{next_task.get('blocked_task')}`",
+            f"- Blocker: `{next_task.get('blocker')}`",
+            "",
+            "## Non-Claims",
+            "",
+            "- No retrieval, reranking, verifier, answer, ingestion, chunking, or eval scoring behavior changed.",
+            "- No paired delta was produced.",
+            "- No performance improvement is claimed.",
+            "- No legacy `real100`/v1/221/kordoc evidence is used.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render aggregate-only real100_v2 retrieval diagnostics.",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=_default_summary(),
+        help="Path to ignored real100_v2 eval_summary.json.",
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        default=ROOT / "reports" / "real100_v2" / "retrieval_diagnostics.aggregate.json",
+        help="Aggregate JSON output path.",
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        default=ROOT / "docs" / "evaluation" / "real100_v2-retrieval-diagnostics.md",
+        help="Aggregate Markdown output path.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        _require_real100_v2(args.summary)
+        summary = _load_json(args.summary)
+        report = build_diagnostics(summary, source=_source_provenance(args.summary))
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Failed to render real100_v2 retrieval diagnostics: {exc}", file=sys.stderr)
+        return 1
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(
+        json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.out_md.write_text(render_markdown(report), encoding="utf-8")
+    print(f"[OK] Wrote {args.out_json}")
+    print(f"[OK] Wrote {args.out_md}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -39,10 +39,10 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 26 | `T-2026-0026` | `todo` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1580; Chroma vector-store baseline separated from embedding-model baselines. |
 | 27 | `T-2026-0027` | `review` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1584; prioritized RAG performance experiment stack captured. |
 | 28 | `T-2026-0028` | `done` | Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1619; real100_v2-only guard and aggregate packet landed. |
-| 29 | `T-2026-0029` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0 diagnostic-only; use real100_v2 aggregate/index evidence and preserve page-metadata blocker. |
+| 29 | `T-2026-0029` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1622; real100_v2 retrieval diagnostics rendered; next experiment points to T-2026-0032 while T-2026-0031 remains page-metadata blocked. |
 | 30 | `T-2026-0030` | `backlog` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | P0; blocked on T-2026-0028 latency provenance. |
-| 31 | `T-2026-0031` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on retrieval diagnostics from T-2026-0029. |
-| 32 | `T-2026-0032` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on candidate-pool diagnostics from T-2026-0029. |
+| 31 | `T-2026-0031` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | real100_v2 page metadata coverage is 0.0; no claim-bearing page/window experiment yet. |
+| 32 | `T-2026-0032` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | T-2026-0029 diagnostics point here next; run after or with T-2026-0030 latency/cost guardrail. |
 | 33 | `T-2026-0033` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on retrieval/reranker evidence and token budget from T-2026-0030. |
 | 34 | `T-2026-0034` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on query-slice attribution from T-2026-0029. |
 | 35 | `T-2026-0035` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | P1 guardrail; should run before agentic/tool-using retrieval. |
@@ -2586,7 +2586,7 @@ make check-branch
 
 - ID: T-2026-0029
 - Title: Build retrieval diagnostic workbench
-- Status: ready
+- Status: review
 - Priority: P0
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
@@ -2621,12 +2621,12 @@ or explicitly scoped out.
 
 ### Acceptance Criteria
 
-- [ ] Diagnostics distinguish not-in-candidate-pool, ranked-too-low,
+- [x] Diagnostics distinguish not-in-candidate-pool, ranked-too-low,
   boundary/window, duplicate, metadata-filter, and multi-evidence failures.
-- [ ] Output is aggregate-only and commit-safe.
-- [ ] The report can decide whether `T-2026-0031` or `T-2026-0032` is the next
+- [x] Output is aggregate-only and commit-safe.
+- [x] The report can decide whether `T-2026-0031` or `T-2026-0032` is the next
   best experiment.
-- [ ] The report explicitly carries forward the v2 page metadata blocker and
+- [x] The report explicitly carries forward the v2 page metadata blocker and
   does not use old `real100` evidence as a substitute.
 
 ### Validation Commands
@@ -2634,8 +2634,8 @@ or explicitly scoped out.
 ```bash
 python3 -m pytest -q tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py
 make real-eval-v2-guard
-python3 <new-or-existing-retrieval-diagnostic-script> --summary reports/real100_v2/baseline.aggregate.json --out <aggregate-output>
-python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md <plan-path> <report-path>
+REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent python3 scripts/render_real100_v2_retrieval_diagnostics.py
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md docs/evaluation/real100_v2-retrieval-diagnostics.md reports/real100_v2/README.md
 git diff --check
 make check-branch
 ```
@@ -2650,9 +2650,28 @@ make check-branch
 
 ### Related Plan / Issue / PR Links
 
-- Plan: TBD - create when the task starts.
-- Issue: TBD
+- Plan: [`docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md`](../docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md)
+- Issue: [#1622](https://github.com/hskim-solv/BidMate-DocAgent/issues/1622)
 - PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 09:35 KST
+
+- Role: Implementer
+- Branch / worktree: eval/issue-1622-build-real100-v2-retrieval-diagnostic-workbench / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1622 / PR TBD
+- Task: T-2026-0029
+- Current status: real100_v2 retrieval diagnostics rendered and ready for benchmark/privacy review.
+- Files touched: .gitignore, .githooks/pre-commit, scripts/render_real100_v2_retrieval_diagnostics.py, scripts/check_real100_v2_only.py, tests/test_render_real100_v2_retrieval_diagnostics.py, docs/evaluation/real100_v2-retrieval-diagnostics.md, reports/real100_v2/retrieval_diagnostics.aggregate.json, reports/real100_v2/README.md, docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md, tasks/queue.md
+- Decisions made: dominant exclusive retrieval status is not_observable_limited_depth; T-2026-0031 remains blocked by real100_v2 page metadata coverage 0.0; next experiment candidate is T-2026-0032.
+- Commands run: REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent python3 scripts/render_real100_v2_retrieval_diagnostics.py; python3 -m pytest -q tests/test_render_real100_v2_retrieval_diagnostics.py.
+- Results: aggregate JSON and Markdown report generated; focused renderer tests passed.
+- Next safe command: python3 -m py_compile scripts/render_real100_v2_retrieval_diagnostics.py scripts/check_real100_v2_only.py && python3 -m pytest -q tests/test_render_real100_v2_retrieval_diagnostics.py tests/test_real100_v2_guard.py tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py && bash -n .githooks/pre-commit
+- Open questions: none.
+- Risks: duplicate/near-duplicate signal counts repeated top documents as aggregate near-duplicates, not semantic duplicates.
+```
 
 ## T-2026-0030 — Define latency and cost budget envelope
 
@@ -2714,16 +2733,20 @@ make check-branch
 
 - ID: T-2026-0031
 - Title: Parent and section-window retrieval experiment
-- Status: backlog
+- Status: blocked
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
-- Last updated: 2026-05-27
+- Last updated: 2026-05-28
 
 ### Goal
 
 Test whether small-to-big retrieval improves multi-chunk and same-document
 evidence failures now that page-aware metadata exists.
+
+Current blocker: `real100_v2` page metadata coverage is 0.0, so
+claim-bearing page/window work must wait until page metadata is repaired or the
+experiment is explicitly rescoped away from page/window claims.
 
 ### Scope
 
@@ -2741,6 +2764,8 @@ evidence failures now that page-aware metadata exists.
 
 ### Acceptance Criteria
 
+- [ ] real100_v2 page metadata blocker is cleared or this task is explicitly
+  rescoped before implementation.
 - [ ] Opt-in preset leaves ADR 0001 baseline byte-identical.
 - [ ] Aggregate delta reports Recall@K, MRR, nDCG, citation/page coverage,
   answer quality, abstention, and latency.
@@ -2772,16 +2797,20 @@ make check-branch
 
 - ID: T-2026-0032
 - Title: Reranker candidate-budget experiment
-- Status: backlog
+- Status: ready
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
-- Last updated: 2026-05-27
+- Last updated: 2026-05-28
 
 ### Goal
 
 Measure whether reranking improves early precision without hiding candidate-pool
 recall or causing unacceptable latency.
+
+Current trigger: `T-2026-0029` real100_v2 diagnostics selected this as the next
+experiment candidate because T-2026-0031 remains blocked by page metadata 0.0.
+Run with or after the latency/cost guardrail from `T-2026-0030`.
 
 ### Scope
 

--- a/tests/test_render_real100_v2_retrieval_diagnostics.py
+++ b/tests/test_render_real100_v2_retrieval_diagnostics.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.render_real100_v2_retrieval_diagnostics import (
+    build_diagnostics,
+    main,
+    render_markdown,
+)
+
+
+def _retrieved(ids: list[str], docs: list[str] | None = None) -> list[dict[str, object]]:
+    docs = docs or [f"doc-{idx}" for idx, _ in enumerate(ids, start=1)]
+    return [
+        {
+            "rank": rank,
+            "chunk_id": chunk_id,
+            "doc_id": doc_id,
+            "section": "PRIVATE SECTION",
+            "text_preview": "PRIVATE TEXT",
+        }
+        for rank, (chunk_id, doc_id) in enumerate(zip(ids, docs), start=1)
+    ]
+
+
+def _case(
+    *,
+    gold_ids: list[str],
+    retrieved_ids: list[str],
+    answerable: bool = True,
+    gold_docs: list[str] | None = None,
+    retrieved_docs: list[str] | None = None,
+    query_type: str = "single_doc",
+    failure_category: str | None = None,
+    metadata_candidate_count: int = 0,
+    doc_match: bool = True,
+    metadata_ambiguous: bool = False,
+    filter_stage: str = "strict",
+    recall5: float | None = None,
+    recall10: float | None = None,
+    mrr5: float | None = None,
+    ndcg5: float | None = None,
+) -> dict[str, object]:
+    evidence = [
+        {"doc_id": doc_id, "chunk_id": chunk_id}
+        for doc_id, chunk_id in zip(gold_docs or [], gold_ids)
+    ]
+    return {
+        "answerable": answerable,
+        "gold_chunk_ids": gold_ids,
+        "gold_evidence": evidence,
+        "retrieved_chunks": _retrieved(retrieved_ids, retrieved_docs),
+        "query_type": query_type,
+        "failure_category": failure_category,
+        "metadata_candidate_count": metadata_candidate_count,
+        "doc_match": doc_match,
+        "metadata_ambiguous": metadata_ambiguous,
+        "filter_stage": filter_stage,
+        "chunk_recall_at_5": recall5,
+        "chunk_recall_at_10": recall10,
+        "chunk_recall_at_20": recall10,
+        "chunk_mrr_at_5": mrr5,
+        "chunk_mrr": mrr5,
+        "chunk_ndcg_at_5": ndcg5,
+        "chunk_ndcg_at_10": ndcg5,
+        "context_precision_at_5": 0.25,
+        "context_recall_at_5": recall5,
+        "query": "PRIVATE QUERY",
+        "answer": "PRIVATE ANSWER",
+    }
+
+
+def _summary(cases: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "num_predictions": len(cases),
+        "case_results": cases,
+        "index_citation_metadata_coverage": {
+            "chunks_total": 100,
+            "chunks_with_page_span": 0,
+            "page_span_coverage": 0.0,
+            "coverage_reason": "index_lacks_page_region_metadata",
+        },
+    }
+
+
+def test_build_diagnostics_classifies_retrieval_buckets() -> None:
+    all_top5 = _case(
+        gold_ids=["g1", "g2"],
+        gold_docs=["doc-a", "doc-a"],
+        retrieved_ids=["g1", "g2", "x1"],
+        retrieved_docs=["doc-a", "doc-a", "doc-x"],
+        recall5=1.0,
+        recall10=1.0,
+        mrr5=1.0,
+        ndcg5=1.0,
+    )
+    ranked_low = _case(
+        gold_ids=["low-a", "low-b"],
+        gold_docs=["doc-b", "doc-b"],
+        retrieved_ids=["low-a", "x2", "x3", "x4", "x5", "low-b"],
+        retrieved_docs=["doc-b", "doc-x", "doc-y", "doc-z", "doc-w", "doc-b"],
+        metadata_candidate_count=2,
+        doc_match=False,
+        filter_stage="relaxed",
+        recall5=0.5,
+        recall10=1.0,
+        mrr5=0.5,
+        ndcg5=0.5,
+    )
+    not_in_pool = _case(
+        gold_ids=["miss-a"],
+        gold_docs=["doc-c"],
+        retrieved_ids=[f"x{i}" for i in range(10)],
+        retrieved_docs=[f"doc-{i}" for i in range(10)],
+        failure_category="verifier_false_negative",
+        recall5=0.0,
+        recall10=0.0,
+        mrr5=0.0,
+        ndcg5=0.0,
+    )
+    duplicate = _case(
+        gold_ids=["dup-g"],
+        gold_docs=["doc-d"],
+        retrieved_ids=["dup-g", "x11", "x12"],
+        retrieved_docs=["doc-d", "doc-d", "doc-e"],
+        metadata_ambiguous=True,
+        failure_category="verifier_false_positive",
+        recall5=1.0,
+        recall10=1.0,
+        mrr5=1.0,
+        ndcg5=1.0,
+    )
+    unanswerable = _case(
+        gold_ids=[],
+        retrieved_ids=[],
+        answerable=False,
+        query_type="abstention",
+        failure_category="abstention_failure",
+    )
+
+    report = build_diagnostics(_summary([all_top5, ranked_low, not_in_pool, duplicate, unanswerable]))
+
+    assert report["population"]["num_predictions"] == 5
+    assert report["exclusive_retrieval_status"]["counts"]["all_gold_top5"] == 2
+    assert report["exclusive_retrieval_status"]["counts"]["all_gold_top10_not_top5"] == 1
+    assert report["exclusive_retrieval_status"]["counts"]["not_in_candidate_pool"] == 1
+    assert report["failure_buckets"]["not_in_candidate_pool"] == 1
+    assert report["failure_buckets"]["ranked_too_low_after_top5"] == 1
+    assert report["failure_buckets"]["boundary_or_window_candidate"] == 1
+    assert report["failure_buckets"]["metadata_filter_candidate"] == 2
+    assert report["failure_buckets"]["duplicate_or_near_duplicate_candidate"] == 3
+    assert report["failure_buckets"]["multi_evidence_failure"] == 1
+    assert report["failure_buckets"]["verifier_false_negative"] == 1
+    assert report["failure_buckets"]["verifier_false_positive"] == 1
+    assert report["failure_buckets"]["answer_generation_or_abstention"] == 1
+    assert report["page_metadata_blocker"]["status"] == "blocked_for_page_and_window_claims"
+    assert report["next_task_decision"]["preferred_next_task"] == "T-2026-0032"
+
+
+def test_markdown_and_json_do_not_copy_private_strings() -> None:
+    secret = "SECRET_DOC_ID"
+    report = build_diagnostics(
+        _summary(
+            [
+                _case(
+                    gold_ids=["SECRET_CHUNK_ID"],
+                    gold_docs=[secret],
+                    retrieved_ids=["SECRET_CHUNK_ID"],
+                    retrieved_docs=[secret],
+                )
+            ]
+        ),
+        source={
+            "input_artifact": "external_private/eval_summary.json",
+            "input_location_redacted": True,
+            "input_basename": "eval_summary.json",
+            "input_sha256_12": "abc123def456",
+        },
+    )
+    rendered = json.dumps(report, ensure_ascii=False) + render_markdown(report)
+
+    for forbidden in (
+        "SECRET_DOC_ID",
+        "SECRET_CHUNK_ID",
+        "PRIVATE QUERY",
+        "PRIVATE ANSWER",
+        "PRIVATE TEXT",
+        "PRIVATE SECTION",
+    ):
+        assert forbidden not in rendered
+    assert "real100_v2" in rendered
+    assert "Legacy `real100`/v1/221/kordoc evidence is not used" in rendered
+
+
+def test_cli_writes_aggregate_outputs_and_rejects_legacy_input(tmp_path: Path) -> None:
+    v2_dir = tmp_path / "reports" / "real100_v2"
+    v2_dir.mkdir(parents=True)
+    summary = v2_dir / "eval_summary.json"
+    out_json = tmp_path / "retrieval.aggregate.json"
+    out_md = tmp_path / "retrieval.md"
+    summary.write_text(json.dumps(_summary([])), encoding="utf-8")
+
+    rc = main(["--summary", str(summary), "--out-json", str(out_json), "--out-md", str(out_md)])
+
+    assert rc == 0
+    written = json.loads(out_json.read_text(encoding="utf-8"))
+    assert written["profile_type"] == "private_real100_v2_retrieval_diagnostics"
+    assert written["privacy"]["aggregate_only"] is True
+    assert "`T-2026-0029`" in out_md.read_text(encoding="utf-8")
+
+    legacy_dir = tmp_path / "reports" / "real100"
+    legacy_dir.mkdir(parents=True)
+    legacy_summary = legacy_dir / "eval_summary.json"
+    legacy_summary.write_text(json.dumps(_summary([])), encoding="utf-8")
+
+    assert main(["--summary", str(legacy_summary), "--out-json", str(out_json), "--out-md", str(out_md)]) == 1


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1622

`real100_v2` 전용 retrieval diagnostic renderer를 추가했습니다. ignored private `real100_v2` eval summary를 로컬에서 읽고, commit-safe aggregate JSON/Markdown만 남깁니다. 결과는 dominant exclusive status가 `not_observable_limited_depth`이고, page metadata coverage 0.0 때문에 `T-2026-0031`은 계속 blocked, 다음 실험 후보는 `T-2026-0032`입니다.

## 2. 영향 파일

- `scripts/render_real100_v2_retrieval_diagnostics.py`: aggregate-only renderer
- `tests/test_render_real100_v2_retrieval_diagnostics.py`: bucket/privacy/legacy-input guard
- `reports/real100_v2/retrieval_diagnostics.aggregate.json`: aggregate-only diagnostic output
- `docs/evaluation/real100_v2-retrieval-diagnostics.md`: reviewer-facing report
- `docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md`, `tasks/queue.md`: plan/queue sync
- `.gitignore`, `.githooks/pre-commit`, `reports/real100_v2/README.md`: aggregate artifact allowlist
- `scripts/check_real100_v2_only.py`: guard coverage extended to T-2026-0029/report surfaces

## 3. 리스크

가장 큰 리스크는 private raw fields가 aggregate boundary를 넘는 것입니다. renderer는 counts/closed enums만 emit하고, output은 raw question/answer/evidence/doc_id/chunk_id/path/filename/per-case rows를 포함하지 않습니다. 또 legacy `real100` input은 fail-closed로 막았습니다.

## 4. 테스트

- `python3 -m py_compile scripts/render_real100_v2_retrieval_diagnostics.py scripts/check_real100_v2_only.py`
- `python3 -m pytest -q tests/test_render_real100_v2_retrieval_diagnostics.py tests/test_real100_v2_guard.py tests/test_render_multi_chunk_evidence_failures.py tests/test_render_multi_chunk_retrieval_strategy.py`
- `REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent python3 scripts/render_real100_v2_retrieval_diagnostics.py`
- `make real-eval-v2-guard`
- `bash -n .githooks/pre-commit`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md docs/evaluation/real100_v2-retrieval-diagnostics.md reports/real100_v2/README.md`
- `python3 scripts/agent_loop.py privacy-audit-output`
- `python3 scripts/agent_loop.py claim-audit --from-git`
- `git diff --cached --check`
- `make check-branch`

## 5. Eval 영향

Private real-eval aggregate-only diagnostic surface only. No retrieval/reranking/verifier/answer/ingestion/chunking/eval scoring behavior changed. No paired delta and no performance-improvement claim.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. This PR adds an aggregate-only diagnostic renderer and report; it does not change runtime behavior.

## 6. 하위 호환

Additive only. Existing CLI/config/schema/answer contract remain unchanged. Legacy private eval evidence remains banned unless explicitly re-enabled by the maintainer.

## 7. 범위 외

- `T-2026-0032` reranker/candidate-budget experiment implementation
- `T-2026-0030` latency/cost guardrail implementation
- `T-2026-0031` page/window retrieval experiment while v2 page metadata coverage is 0.0
- Any runtime retrieval behavior change
