### PR TITLE
Plan reranker candidate-budget experiment

### DIFF
--- a/docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md
+++ b/docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md
@@ -1,0 +1,196 @@
+# Plan: T-2026-0032 reranker candidate-budget experiment
+
+- Status: proposed
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0032`
+- Related issue / PR: [#1624](https://github.com/hskim-solv/BidMate-DocAgent/issues/1624)
+- Related ADR: [ADR 0001](../adr/0001-preserve-naive-baseline.md), [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md), [ADR 0026](../adr/0026-cross-encoder-reranker-deferral.md)
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+## Problem Statement
+
+`T-2026-0029` selected `T-2026-0032` as the next experiment candidate because
+`T-2026-0031` remains blocked by `real100_v2` page metadata coverage 0.0.
+However, a reranker candidate-budget sweep can easily trade quality for latency
+or hide candidate-pool recall failures. The experiment needs a fixed plan that
+separates candidate-pool recall from reranker precision and refuses headline
+claims without the latency/cost guardrail from `T-2026-0030`.
+
+## Current Behavior
+
+The repo already has a cross-encoder reranker surface:
+
+- `rag_reranker.py` exposes the `Reranker` protocol and default
+  `CrossEncoderReranker`.
+- `rag_retrieval.py` applies reranking before the final `top_k` cut when the
+  plan enables rerank.
+- `eval/run_eval.py` aggregates `rerank_delta_mrr`, `rerank_delta_ndcg_at_10`,
+  `reranker_backend`, stage latency, and run config provenance.
+- `docs/retrieval/cross-encoder-reranker.md` documents the existing backend
+  choices and the historical synthetic finding that reranker quality gains must
+  be treated carefully.
+- `reports/real100_v2/retrieval_diagnostics.aggregate.json` shows the current
+  v2 diagnostic trigger: dominant exclusive retrieval status is
+  `not_observable_limited_depth`, page metadata coverage is 0.0, and
+  `T-2026-0032` is preferred while `T-2026-0031` is blocked.
+
+## Desired Behavior
+
+Run an opt-in private `real100_v2` candidate-budget sweep that compares
+candidate pool settings and reranker top-N limits without changing default
+runtime behavior. The output should classify the result as winner,
+recall-only gain, ranking regression, citation regression, latency regression,
+or failed experiment.
+
+## Constraints
+
+- Scope constraints: experiment-only; no default runtime change.
+- Architecture constraints: preserve ADR 0001 `naive_baseline`; do not mix
+  reranking with query rewrite, parent expansion, or context packing.
+- Compatibility constraints: additive config/script/report only.
+- Eval/privacy constraints: `real100_v2` only; aggregate-only committed output;
+  no raw questions, answers, evidence, filenames, local paths, `doc_id`, or
+  `chunk_id`.
+- Tooling/CI constraints: local reranker dependencies must be explicit; CI may
+  use stub backend only.
+- Non-goals: page metadata repair, LLM reranking, production default flip,
+  improvement claim without paired private aggregate delta.
+
+## Architecture Impact
+
+- Affected modules or docs: likely `scripts/`, `tests/`, `docs/evaluation/`,
+  `reports/real100_v2/`, and `tasks/queue.md`.
+- Affected contracts or invariants: ADR 0001 baseline unchanged; ADR 0005
+  private boundary preserved.
+- Load-bearing paths: no runtime paths unless a later implementation adds an
+  opt-in eval runner under `eval/`.
+- ADR required: no for an additive experiment; yes if a later PR changes default
+  retrieval or reranker behavior.
+- Backward compatibility expectation: existing `full_reranker` and stub backend
+  behavior remain unchanged.
+
+## Affected Interfaces
+
+- CLI/API/config: new or existing local experiment runner with explicit backend,
+  candidate budget, and top-N options.
+- Input data: ignored local `real100_v2` config/index/eval summaries.
+- Output artifacts: aggregate-only sweep JSON/Markdown.
+- Docs/review surfaces: plan, queue, sweep report, PR body §5b.
+- Tests/eval entrypoints: focused unit tests plus private runner command.
+
+## Data / Eval Impact
+
+- Surface: private real-eval.
+- Data boundary: aggregate-only private output.
+- Allowed claim: experiment classification tied to a specific v2 paired
+  aggregate and latency/cost envelope.
+- Disallowed claim: global reranker improvement, page/citation readiness, or any
+  comparison based on legacy `real100`/v1/221/kordoc evidence.
+- Baseline or control affected: no default baseline change; paired control must
+  be a matching `real100_v2` base aggregate.
+- Benchmark/eval auditor required: yes.
+
+## Task Breakdown
+
+1. Complete or cite `T-2026-0030` latency/cost budget envelope before treating a
+   reranker run as PR-ready evidence.
+2. Define candidate budget matrix: retriever candidate count, reranker top-N,
+   final `top_k`, backend/model, and expected local dependency.
+3. Implement or reuse a local runner that emits paired aggregate outputs without
+   raw private fields.
+4. Render a reviewer-facing report that separates candidate-pool recall from
+   reranker precision and classifies the result.
+5. Run benchmark/privacy/claim audits before PR.
+
+## Acceptance Criteria
+
+- [ ] Sweep output classifies winner, recall-only gain, ranking regression,
+  citation regression, latency regression, or failed experiment.
+- [ ] Candidate-pool recall and reranker precision are reported separately.
+- [ ] Reranker provenance is present in aggregate output.
+- [ ] Latency/cost guardrail from `T-2026-0030` is present or this task remains
+  blocked.
+- [ ] No legacy `real100`/v1/221/kordoc evidence is used.
+
+## Validation Strategy
+
+Commands that must be run by the implementation PR:
+
+```bash
+python3 -m pytest -q tests/test_reranker*.py <focused-new-tests>
+python3 <reranker-sweep-script> --config <local-v2-config> --out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <real100_v2-variant-aggregate>
+make real-eval-v2-guard
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md <report-path>
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: focused tests and local private sweep command pass.
+- Generated or updated artifact: aggregate-only sweep report.
+- Reviewer checklist or manual inspection: benchmark validity, latency/cost, and
+  privacy checks pass.
+- Explicitly not validated, with reason: no default runtime improvement unless
+  paired private delta and latency/cost guardrail support it.
+
+## Rollback Strategy
+
+Revert the experiment runner/report/config additions. Do not delete local
+private `real100_v2` raw run artifacts or indexes during rollback.
+
+## Failure Modes
+
+- Failure mode: reranker appears to improve top-line quality but candidate-pool
+  recall falls.
+- Detection signal: report classifies `recall_only_gain` or
+  `ranking_regression` rather than `winner`.
+- Stop condition or fallback: do not claim improvement; move to candidate-pool
+  or retrieval-depth work.
+
+- Failure mode: latency/cost guardrail is missing.
+- Detection signal: no `T-2026-0030` envelope in the report.
+- Stop condition or fallback: keep T-2026-0032 blocked and run T-2026-0030.
+
+- Failure mode: raw private fields leak into aggregate output.
+- Detection signal: privacy audit or focused test fails.
+- Stop condition or fallback: strip to closed enums/counts only.
+
+## Observability
+
+- `reports/real100_v2/retrieval_diagnostics.aggregate.json`
+- Future sweep aggregate and Markdown report
+- `rerank_delta_mrr`, `rerank_delta_ndcg_at_10`, `retrieval_metrics`, and
+  `stage_latency`
+- `make real-eval-v2-guard`
+- `python3 scripts/agent_loop.py privacy-audit-output`
+- `python3 scripts/agent_loop.py claim-audit --from-git`
+
+## Reviewer Notes
+
+Attack the claim wording first. A reranker experiment is not a success if it
+wins only by hiding candidate-pool recall, regresses citation behavior, or
+exceeds the latency/cost envelope.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 09:55 KST
+
+- Role: Planner
+- Branch / worktree: eval/issue-1624-plan-reranker-candidate-budget-experiment / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1624 / PR TBD
+- Task: T-2026-0032
+- Current status: plan drafted; implementation should wait for or include T-2026-0030 latency/cost guardrail.
+- Files touched: docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md
+- Decisions made: no reranker claim without paired real100_v2 delta and latency/cost envelope; legacy real100/v1/221/kordoc evidence remains banned.
+- Commands run: make ship-start TITLE="Plan reranker candidate budget experiment" TYPE=eval; make check-branch; python3 scripts/agent_loop.py next.
+- Results: issue #1624 and branch created; branch gate passed; next task is T-2026-0032.
+- Next safe command: update tasks/queue.md to link this plan and mark the T-2026-0030 dependency explicitly.
+- Open questions: none.
+- Risks: implementing the sweep before a latency/cost envelope would produce unusable review evidence.
+```

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -40,9 +40,9 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 27 | `T-2026-0027` | `review` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1584; prioritized RAG performance experiment stack captured. |
 | 28 | `T-2026-0028` | `done` | Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1619; real100_v2-only guard and aggregate packet landed. |
 | 29 | `T-2026-0029` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1622; real100_v2 retrieval diagnostics rendered; next experiment points to T-2026-0032 while T-2026-0031 remains page-metadata blocked. |
-| 30 | `T-2026-0030` | `backlog` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | P0; blocked on T-2026-0028 latency provenance. |
+| 30 | `T-2026-0030` | `ready` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | needed before T-2026-0032 implementation; use real100_v2 latency/stage aggregate only. |
 | 31 | `T-2026-0031` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | real100_v2 page metadata coverage is 0.0; no claim-bearing page/window experiment yet. |
-| 32 | `T-2026-0032` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | T-2026-0029 diagnostics point here next; run after or with T-2026-0030 latency/cost guardrail. |
+| 32 | `T-2026-0032` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1624; plan drafted, but implementation needs T-2026-0030 latency/cost guardrail. |
 | 33 | `T-2026-0033` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on retrieval/reranker evidence and token budget from T-2026-0030. |
 | 34 | `T-2026-0034` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on query-slice attribution from T-2026-0029. |
 | 35 | `T-2026-0035` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | P1 guardrail; should run before agentic/tool-using retrieval. |
@@ -2677,16 +2677,20 @@ make check-branch
 
 - ID: T-2026-0030
 - Title: Define latency and cost budget envelope
-- Status: backlog
+- Status: ready
 - Priority: P0
 - Owner role: Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer
 - Created: 2026-05-27
-- Last updated: 2026-05-27
+- Last updated: 2026-05-28
 
 ### Goal
 
 Set the latency/cost guardrails that every multi-query, reranker, compression,
 or long-context experiment must satisfy.
+
+Current trigger: `T-2026-0032` is planned but blocked until this envelope exists.
+Use `real100_v2` aggregate latency/stage evidence only; do not use legacy
+`real100`/v1/221/kordoc evidence.
 
 ### Scope
 
@@ -2797,7 +2801,7 @@ make check-branch
 
 - ID: T-2026-0032
 - Title: Reranker candidate-budget experiment
-- Status: ready
+- Status: blocked
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
@@ -2810,7 +2814,8 @@ recall or causing unacceptable latency.
 
 Current trigger: `T-2026-0029` real100_v2 diagnostics selected this as the next
 experiment candidate because T-2026-0031 remains blocked by page metadata 0.0.
-Run with or after the latency/cost guardrail from `T-2026-0030`.
+Run with or after the latency/cost guardrail from `T-2026-0030`; until that
+guardrail exists, this task is planned but blocked for implementation.
 
 ### Scope
 
@@ -2830,6 +2835,8 @@ Run with or after the latency/cost guardrail from `T-2026-0030`.
   citation regression, latency regression, or failed experiment.
 - [ ] Candidate-pool recall and reranker precision are reported separately.
 - [ ] Reranker provenance is present in aggregate output.
+- [ ] Latency/cost guardrail from `T-2026-0030` is present or this task remains
+  blocked.
 
 ### Validation Commands
 
@@ -2848,9 +2855,28 @@ make check-branch
 
 ### Related Plan / Issue / PR Links
 
-- Plan: TBD - create when the task starts.
-- Issue: TBD
+- Plan: [`docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md`](../docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md)
+- Issue: [#1624](https://github.com/hskim-solv/BidMate-DocAgent/issues/1624)
 - PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 09:55 KST
+
+- Role: Planner
+- Branch / worktree: eval/issue-1624-plan-reranker-candidate-budget-experiment / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1624 / PR TBD
+- Task: T-2026-0032
+- Current status: plan drafted; implementation blocked on T-2026-0030 latency/cost guardrail.
+- Files touched: docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md, tasks/queue.md
+- Decisions made: no reranker candidate-budget claim without paired real100_v2 delta and latency/cost envelope.
+- Commands run: make ship-start TITLE="Plan reranker candidate budget experiment" TYPE=eval; make check-branch; python3 scripts/agent_loop.py next.
+- Results: issue #1624 and branch created; branch gate passed; T-2026-0032 plan drafted.
+- Next safe command: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md
+- Open questions: none.
+- Risks: implementing the sweep before a latency/cost envelope would produce unusable review evidence.
+```
 
 ## T-2026-0033 — Context packing and citation ordering experiment
 


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1624

`T-2026-0032` reranker candidate-budget experiment plan을 추가했습니다. `T-2026-0029` 진단 결과는 T-2026-0032를 다음 실험 후보로 가리키지만, latency/cost guardrail 없이는 review 가능한 실험 증거가 되지 않으므로 `T-2026-0030`을 ready로 올리고 T-2026-0032 구현은 blocked로 둡니다.

## 2. 영향 파일

- `docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md`: experiment plan
- `tasks/queue.md`: T-2026-0030 ready, T-2026-0032 planned-but-blocked 상태 반영

## 3. 리스크

리스크는 reranker 실험이 latency/cost 없이 quality-only 주장으로 읽히는 것입니다. plan과 queue에 no claim without paired real100_v2 delta and latency/cost envelope를 명시했습니다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md`
- `make real-eval-v2-guard`
- `python3 scripts/agent_loop.py next`
- `git diff --check`
- `make check-branch`

테스트 추가 없음: docs-only planning PR이며 runtime behavior 변경이 없습니다.

## 5. Eval 영향

Private real-eval planning only. No runtime/eval scoring/retrieval/reranking behavior changed. No paired delta and no performance-improvement claim.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음. This PR changes plan/queue only.

## 6. 하위 호환

N/A: CLI, schema, answer contract, and default runtime behavior unchanged.

## 7. 범위 외

- T-2026-0030 latency/cost budget implementation
- T-2026-0032 reranker sweep implementation
- Any legacy real100/v1/221/kordoc evidence usage
