### PR TITLE
eval: define real100 v2 latency cost budget

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -99,6 +99,7 @@ ALLOWED_PATTERNS=(
   '^reports/real100_v2/question_distribution\.aggregate\.json$'
   '^reports/real100_v2/baseline\.aggregate\.json$'
   '^reports/real100_v2/benchmark_tiers\.aggregate\.json$'
+  '^reports/real100_v2/latency_cost_budget\.aggregate\.json$'
   '^reports/real100_v2/metric_suite\.aggregate\.json$'
   '^reports/real100_v2/metric_suite\.md$'
   '^reports/real100_v2/retrieval_diagnostics\.aggregate\.json$'

--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ reports/real100_v2/*
 !reports/real100_v2/question_distribution.aggregate.json
 !reports/real100_v2/benchmark_tiers.aggregate.json
 !reports/real100_v2/baseline.aggregate.json
+!reports/real100_v2/latency_cost_budget.aggregate.json
 !reports/real100_v2/metric_suite.aggregate.json
 !reports/real100_v2/metric_suite.md
 !reports/real100_v2/retrieval_diagnostics.aggregate.json

--- a/docs/evaluation/real100_v2-latency-cost-budget.md
+++ b/docs/evaluation/real100_v2-latency-cost-budget.md
@@ -1,0 +1,85 @@
+# real100_v2 Latency And Cost Budget
+
+Issue: [#1626](https://github.com/hskim-solv/BidMate-DocAgent/issues/1626)
+
+Task: `T-2026-0030`
+
+Status: aggregate-only budget envelope; no runtime behavior change and no performance-improvement claim.
+
+## Boundary
+
+This report uses only committed `real100_v2` aggregate latency fields. It does not include raw questions, answers, evidence, filenames, local paths, document IDs, chunk IDs, or per-case rows. Legacy `real100`/v1/221/kordoc evidence is not used.
+
+## Source Provenance
+
+| Field | Value |
+|---|---|
+| Input artifact | `reports/real100_v2/baseline.aggregate.json` |
+| Input redacted | `False` |
+| Input SHA-256 prefix | `a73a99987064` |
+
+## Baseline Population
+
+| Field | Value |
+|---|---|
+| Predictions | 300 |
+| Pipeline | `agentic_full` |
+| Primary run | `full` |
+| Prompt profile | `structured_grounded_claims` |
+
+## Overall Latency Envelope
+
+| Metric | Value |
+|---|---:|
+| Mean ms | 2206.346667 |
+| p50 ms | 2216.985 |
+| p95 ms | 3199.0625 |
+| p99 ms | None |
+| Soft ceiling ms | 3999.0 |
+| Hard no-go ceiling ms | 4799.0 |
+
+p99 is named but not observed in the committed source aggregate.
+
+## Stage Latency Envelope
+
+| Stage | Mean | p50 | p95 | p99 | Soft ceiling | Hard ceiling |
+|---|---:|---:|---:|---:|---:|---:|
+| `query_analysis_ms` | 160.83699 | 116.77 | 388.67 | None | 486.0 | 584.0 |
+| `context_resolution_ms` | 0.018227 | 0.02 | 0.03 | None | 1.0 | 1.0 |
+| `retrieve_ms` | 995.162387 | 1036.72 | 1553.274 | None | 1942.0 | 2330.0 |
+| `verify_ms` | 19.963689 | 19.14 | 34.561 | None | 44.0 | 52.0 |
+| `answer_generation_ms` | 1.366187 | 1.14 | 3.536 | None | 5.0 | 6.0 |
+
+## Cost Envelope
+
+| Field | Value |
+|---|---|
+| Status | `not_observable_from_committed_aggregate` |
+| Synthesis cost present | `False` |
+| Synthesis tokens present | `False` |
+| Paid API rule | paid or external reranker/synthesis cost must be reported separately before claim |
+| Local CPU rule | local reranker latency must be counted even when direct API cost is zero |
+
+## Guardrail Rules
+
+- Soft regression: variant p95 above soft_ceiling_ms requires explicit reviewer justification
+- Hard no-go: variant p95 above hard_ceiling_ms cannot be called a winner
+- Quality-only no-go: quality gain without latency and cost evidence is not sufficient
+- p99 rule: p99 must be added when the source aggregate exposes it; currently not observed
+
+## Caveats
+
+- Scope: `local private real100_v2 baseline aggregate`
+- Warm/cold status: `not_split_in_committed_aggregate`
+- Production SLO claim: `False`
+
+## Downstream Use
+
+`T-2026-0032` and later candidate-pool, query rewrite, and context-packing experiments can cite this envelope. A quality-only gain is no-go unless latency stays under the hard ceiling and cost evidence is present or explicitly not applicable.
+
+## Non-Claims
+
+- No runtime retrieval, reranking, verifier, answer, ingestion, chunking, or eval scoring behavior changed.
+- No paired delta was produced.
+- No performance improvement is claimed.
+- No legacy `real100`/v1/221/kordoc evidence is used.

--- a/docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md
+++ b/docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md
@@ -1,0 +1,161 @@
+# Plan: T-2026-0030 real100_v2 latency and cost budget envelope
+
+- Status: review
+- Owner role: Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0030`
+- Related issue / PR: [#1626](https://github.com/hskim-solv/BidMate-DocAgent/issues/1626)
+- Related ADR: [ADR 0005](../adr/0005-eval-split-public-synthetic-private-local.md)
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+## Problem Statement
+
+`T-2026-0032` needs a latency/cost guardrail before a reranker candidate-budget
+experiment can make any quality claim. Without a shared envelope, a future PR
+could report retrieval quality gains while hiding local reranker latency or
+missing paid/API cost evidence.
+
+## Current Behavior
+
+`reports/real100_v2/baseline.aggregate.json` already contains aggregate p50,
+p95, mean latency and stage latency for the current private baseline. It does
+not expose p99, synthesis token totals, or synthesis cost totals in the
+committed aggregate.
+
+## Desired Behavior
+
+Create a committed aggregate-only budget packet that names p50, p95, p99
+status, stage-level latency, soft ceilings, hard no-go ceilings, cost evidence
+availability, warm/cold caveats, and downstream no-go rules.
+
+## Constraints
+
+- Scope constraints: measurement/reporting only.
+- Architecture constraints: no runtime retrieval, reranking, verifier, answer,
+  ingestion, chunking, or eval scoring behavior changes.
+- Compatibility constraints: additive script/report only.
+- Eval/privacy constraints: `real100_v2` committed aggregate only; no raw
+  private rows or identifiers.
+- Tooling/CI constraints: report must be reproducible from committed aggregate.
+- Non-goals: latency optimization, production SLO, paired quality delta.
+
+## Architecture Impact
+
+- Affected modules or docs: `scripts/`, `tests/`, `docs/evaluation/`,
+  `reports/real100_v2/`, `tasks/queue.md`.
+- Affected contracts or invariants: ADR 0005 private boundary and v2-only
+  evidence policy.
+- Load-bearing paths: none.
+- ADR required: no; this is additive reporting.
+- Backward compatibility expectation: existing eval/runtime behavior unchanged.
+
+## Affected Interfaces
+
+- CLI/API/config: new renderer CLI only.
+- Input data: `reports/real100_v2/baseline.aggregate.json`.
+- Output artifacts: `reports/real100_v2/latency_cost_budget.aggregate.json` and
+  `docs/evaluation/real100_v2-latency-cost-budget.md`.
+- Docs/review surfaces: plan, queue, report, README.
+- Tests/eval entrypoints: focused renderer tests and doc/guard checks.
+
+## Data / Eval Impact
+
+- Surface: private real-eval.
+- Data boundary: aggregate-only private output.
+- Allowed claim: latency/cost guardrail derived from the current committed
+  `real100_v2` aggregate.
+- Disallowed claim: production SLO, performance improvement, or
+  legacy `real100`/v1/221/kordoc comparison.
+- Baseline or control affected: no.
+- Benchmark/eval auditor required: yes.
+
+## Task Breakdown
+
+1. Add `scripts/render_real100_v2_latency_budget.py`.
+2. Add focused tests for budget math, privacy boundary, and legacy input
+   rejection.
+3. Render aggregate JSON and Markdown budget report.
+4. Allowlist the new aggregate artifact and update queue/README/guard coverage.
+
+## Acceptance Criteria
+
+- [x] Budget report names p50, p95, p99 status, and stage-level components.
+- [x] Candidate-pool, reranker, query-rewrite, and context-packing tasks can cite
+  the same latency/cost envelope.
+- [x] The report states warm/cold and local hardware caveats.
+- [x] Cost evidence availability is explicit and quality-only gains are no-go.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 -m py_compile scripts/render_real100_v2_latency_budget.py scripts/check_real100_v2_only.py
+python3 -m pytest -q tests/test_render_real100_v2_latency_budget.py tests/test_real100_v2_guard.py
+python3 scripts/render_real100_v2_latency_budget.py
+make real-eval-v2-guard
+bash -n .githooks/pre-commit
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md docs/evaluation/real100_v2-latency-cost-budget.md reports/real100_v2/README.md
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: focused tests pass.
+- Generated or updated artifact: latency/cost aggregate JSON and Markdown.
+- Reviewer checklist or manual inspection: privacy and claim audits pass.
+- Explicitly not validated, with reason: no paired delta because runtime
+  behavior does not change.
+
+## Rollback Strategy
+
+Revert the renderer, tests, allowlist entries, report, and queue/doc updates.
+Do not delete private raw `real100_v2` runs or indexes during rollback.
+
+## Failure Modes
+
+- Failure mode: a future quality-only experiment cites the budget as a success
+  claim.
+- Detection signal: claim audit or reviewer sees no paired delta.
+- Stop condition or fallback: classify as no-go until paired quality and
+  latency/cost evidence exist.
+
+- Failure mode: cost is missing but treated as zero.
+- Detection signal: report status is `not_observable_from_committed_aggregate`.
+- Stop condition or fallback: require explicit not-applicable or fresh aggregate
+  with cost fields.
+
+## Observability
+
+- `reports/real100_v2/latency_cost_budget.aggregate.json`
+- `docs/evaluation/real100_v2-latency-cost-budget.md`
+- `make real-eval-v2-guard`
+- `python3 scripts/agent_loop.py privacy-audit-output`
+- `python3 scripts/agent_loop.py claim-audit --from-git`
+
+## Reviewer Notes
+
+Attack the no-go wording first. This PR should make it harder, not easier, to
+claim a quality win without latency and cost evidence.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 10:15 KST
+
+- Role: Implementer
+- Branch / worktree: eval/issue-1626-define-real100-v2-latency-and-cost-budget-envelo / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1626 / PR TBD
+- Task: T-2026-0030
+- Current status: latency/cost budget report rendered and ready for review.
+- Files touched: .gitignore, .githooks/pre-commit, scripts/render_real100_v2_latency_budget.py, tests/test_render_real100_v2_latency_budget.py, docs/evaluation/real100_v2-latency-cost-budget.md, reports/real100_v2/latency_cost_budget.aggregate.json, reports/real100_v2/README.md, docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md, tasks/queue.md
+- Decisions made: p99 and cost are not observable from the committed aggregate; quality-only gains are no-go unless cost is present or explicitly not applicable.
+- Commands run: make ship-start TITLE="Define real100 v2 latency and cost budget envelope" TYPE=eval; make check-branch; python3 scripts/render_real100_v2_latency_budget.py; python3 -m pytest -q tests/test_render_real100_v2_latency_budget.py.
+- Results: issue #1626 and branch created; renderer generated aggregate JSON/Markdown; focused tests passed.
+- Next safe command: python3 -m py_compile scripts/render_real100_v2_latency_budget.py scripts/check_real100_v2_only.py && python3 -m pytest -q tests/test_render_real100_v2_latency_budget.py tests/test_real100_v2_guard.py
+- Open questions: none.
+- Risks: p99 and cost are named but not available in the current committed source aggregate.
+```

--- a/reports/real100_v2/README.md
+++ b/reports/real100_v2/README.md
@@ -8,6 +8,7 @@ Allowed files:
 - `question_distribution.aggregate.json`
 - `benchmark_tiers.aggregate.json`
 - `baseline.aggregate.json`
+- `latency_cost_budget.aggregate.json`
 - `metric_suite.aggregate.json`
 - `metric_suite.md`
 - `retrieval_diagnostics.aggregate.json`

--- a/reports/real100_v2/latency_cost_budget.aggregate.json
+++ b/reports/real100_v2/latency_cost_budget.aggregate.json
@@ -1,0 +1,120 @@
+{
+  "baseline_latency": {
+    "hard_ceiling_ms": 4799.0,
+    "mean_ms": 2206.346667,
+    "p50_ms": 2216.985,
+    "p95_ms": 3199.0625,
+    "p99_ms": null,
+    "p99_status": "not_observed_in_source_aggregate",
+    "soft_ceiling_ms": 3999.0
+  },
+  "budget_rules": {
+    "hard_no_go": "variant p95 above hard_ceiling_ms cannot be called a winner",
+    "p99_rule": "p99 must be added when the source aggregate exposes it; currently not observed",
+    "quality_only_no_go": "quality gain without latency and cost evidence is not sufficient",
+    "soft_regression": "variant p95 above soft_ceiling_ms requires explicit reviewer justification"
+  },
+  "cost_envelope": {
+    "local_cpu_rule": "local reranker latency must be counted even when direct API cost is zero",
+    "paid_api_rule": "paid or external reranker/synthesis cost must be reported separately before claim",
+    "status": "not_observable_from_committed_aggregate",
+    "synthesis_cost_present": false,
+    "synthesis_tokens_present": false
+  },
+  "downstream_use": {
+    "applies_to": [
+      "T-2026-0032 reranker candidate-budget experiment",
+      "candidate-pool sweeps",
+      "query rewrite experiments",
+      "context packing experiments"
+    ],
+    "winner_requires": [
+      "paired real100_v2 quality delta",
+      "no hard latency breach",
+      "cost evidence present or explicitly not applicable",
+      "privacy audit pass"
+    ]
+  },
+  "hardware_caveats": {
+    "production_slo_claim": false,
+    "scope": "local private real100_v2 baseline aggregate",
+    "warm_cold_status": "not_split_in_committed_aggregate"
+  },
+  "non_claims": {
+    "legacy_real100_evidence_used": false,
+    "paired_delta": false,
+    "performance_improvement_claim": false,
+    "runtime_behavior_changed": false
+  },
+  "population": {
+    "num_predictions": 300,
+    "pipeline": "agentic_full",
+    "primary_run": "full",
+    "prompt_profile": "structured_grounded_claims"
+  },
+  "privacy": {
+    "aggregate_only": true,
+    "chunk_ids_omitted": true,
+    "doc_ids_omitted": true,
+    "filenames_omitted": true,
+    "paths_omitted": true,
+    "per_case_rows_omitted": true,
+    "raw_answers_omitted": true,
+    "raw_evidence_omitted": true,
+    "raw_questions_omitted": true
+  },
+  "profile_type": "private_real100_v2_latency_cost_budget",
+  "schema_version": 1,
+  "source": {
+    "input_artifact": "reports/real100_v2/baseline.aggregate.json",
+    "input_location_redacted": false,
+    "input_sha256_12": "a73a99987064"
+  },
+  "stage_latency": {
+    "answer_generation_ms": {
+      "hard_ceiling_ms": 6.0,
+      "mean_ms": 1.366187,
+      "p50_ms": 1.14,
+      "p95_ms": 3.536,
+      "p99_ms": null,
+      "p99_status": "not_observed_in_source_aggregate",
+      "soft_ceiling_ms": 5.0
+    },
+    "context_resolution_ms": {
+      "hard_ceiling_ms": 1.0,
+      "mean_ms": 0.018227,
+      "p50_ms": 0.02,
+      "p95_ms": 0.03,
+      "p99_ms": null,
+      "p99_status": "not_observed_in_source_aggregate",
+      "soft_ceiling_ms": 1.0
+    },
+    "query_analysis_ms": {
+      "hard_ceiling_ms": 584.0,
+      "mean_ms": 160.83699,
+      "p50_ms": 116.77,
+      "p95_ms": 388.67,
+      "p99_ms": null,
+      "p99_status": "not_observed_in_source_aggregate",
+      "soft_ceiling_ms": 486.0
+    },
+    "retrieve_ms": {
+      "hard_ceiling_ms": 2330.0,
+      "mean_ms": 995.162387,
+      "p50_ms": 1036.72,
+      "p95_ms": 1553.274,
+      "p99_ms": null,
+      "p99_status": "not_observed_in_source_aggregate",
+      "soft_ceiling_ms": 1942.0
+    },
+    "verify_ms": {
+      "hard_ceiling_ms": 52.0,
+      "mean_ms": 19.963689,
+      "p50_ms": 19.14,
+      "p95_ms": 34.561,
+      "p99_ms": null,
+      "p99_status": "not_observed_in_source_aggregate",
+      "soft_ceiling_ms": 44.0
+    }
+  }
+}

--- a/scripts/check_real100_v2_only.py
+++ b/scripts/check_real100_v2_only.py
@@ -13,9 +13,12 @@ DEFAULT_PATHS = (
     Path("tasks/queue.md"),
     Path("docs/plans/T-2026-0028-refresh-private-coverage-semantic-baselines.md"),
     Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
+    Path("docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md"),
+    Path("docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md"),
     Path("docs/evaluation/surface-map.md"),
     Path("docs/evaluation/private_real_eval_workflow.md"),
     Path("docs/evaluation/real100_v2-retrieval-diagnostics.md"),
+    Path("docs/evaluation/real100_v2-latency-cost-budget.md"),
     Path("reports/real100_v2/README.md"),
 )
 
@@ -65,6 +68,9 @@ def check_path(path: Path) -> list[str]:
             for block in (
                 _task_block(text, "T-2026-0028", "T-2026-0029"),
                 _task_block(text, "T-2026-0029", "T-2026-0030"),
+                _task_block(text, "T-2026-0030", "T-2026-0031"),
+                _task_block(text, "T-2026-0031", "T-2026-0032"),
+                _task_block(text, "T-2026-0032", "T-2026-0033"),
             )
             if block
         )
@@ -78,6 +84,8 @@ def check_path(path: Path) -> list[str]:
         Path("tasks/queue.md"),
         Path("docs/plans/T-2026-0028-refresh-private-coverage-semantic-baselines.md"),
         Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
+        Path("docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md"),
+        Path("docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md"),
         Path("docs/evaluation/surface-map.md"),
         Path("docs/evaluation/private_real_eval_workflow.md"),
     }
@@ -105,7 +113,10 @@ def check_path(path: Path) -> list[str]:
         Path("tasks/queue.md"),
         Path("docs/plans/T-2026-0028-refresh-private-coverage-semantic-baselines.md"),
         Path("docs/plans/T-2026-0029-real100-v2-retrieval-diagnostic-workbench.md"),
+        Path("docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md"),
+        Path("docs/plans/T-2026-0032-reranker-candidate-budget-experiment.md"),
         Path("docs/evaluation/real100_v2-retrieval-diagnostics.md"),
+        Path("docs/evaluation/real100_v2-latency-cost-budget.md"),
     }:
         for lineno, line in enumerate(scoped.splitlines(), start=1):
             if _is_ban_context(line):

--- a/scripts/render_real100_v2_latency_budget.py
+++ b/scripts/render_real100_v2_latency_budget.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Render aggregate-only real100_v2 latency/cost budget envelope."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INPUT = ROOT / "reports" / "real100_v2" / "baseline.aggregate.json"
+DEFAULT_OUT_JSON = ROOT / "reports" / "real100_v2" / "latency_cost_budget.aggregate.json"
+DEFAULT_OUT_MD = ROOT / "docs" / "evaluation" / "real100_v2-latency-cost-budget.md"
+STAGE_KEYS: tuple[str, ...] = (
+    "query_analysis_ms",
+    "context_resolution_ms",
+    "retrieve_ms",
+    "verify_ms",
+    "answer_generation_ms",
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return payload
+
+
+def _require_real100_v2(path: Path) -> None:
+    parts = set(path.parts)
+    if "real100_v2" not in parts:
+        raise ValueError(f"input must be under a real100_v2 path: {path}")
+    if "real100" in parts:
+        raise ValueError(f"legacy real100 input is not allowed: {path}")
+
+
+def _source(path: Path) -> dict[str, Any]:
+    resolved_root = ROOT.resolve()
+    resolved_path = path.resolve()
+    try:
+        label = str(resolved_path.relative_to(resolved_root))
+        redacted = False
+    except ValueError:
+        label = "external_private/real100_v2_baseline_aggregate"
+        redacted = True
+    return {
+        "input_artifact": label,
+        "input_location_redacted": redacted,
+        "input_sha256_12": hashlib.sha256(path.read_bytes()).hexdigest()[:12],
+    }
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return round(float(value), 6)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _ceil_ms(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return float(math.ceil(value))
+
+
+def _budget_from_p95(p95: float | None) -> dict[str, float | None]:
+    if p95 is None:
+        return {"soft_ceiling_ms": None, "hard_ceiling_ms": None}
+    return {
+        "soft_ceiling_ms": _ceil_ms(p95 * 1.25),
+        "hard_ceiling_ms": _ceil_ms(p95 * 1.5),
+    }
+
+
+def _latency_block(raw: Mapping[str, Any]) -> dict[str, Any]:
+    p95 = _number(raw.get("p95"))
+    return {
+        "mean_ms": _number(raw.get("mean")),
+        "p50_ms": _number(raw.get("p50")),
+        "p95_ms": p95,
+        "p99_ms": None,
+        "p99_status": "not_observed_in_source_aggregate",
+        **_budget_from_p95(p95),
+    }
+
+
+def build_budget(payload: Mapping[str, Any], *, source: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    latency = _latency_block(_mapping(payload.get("latency")))
+    stages: dict[str, Any] = {}
+    stage_raw = _mapping(payload.get("stage_latency"))
+    for stage in STAGE_KEYS:
+        stages[stage] = _latency_block(_mapping(stage_raw.get(stage)))
+
+    cost_raw = payload.get("synthesis_cost")
+    token_raw = payload.get("synthesis_tokens")
+    cost_observable = isinstance(cost_raw, Mapping)
+    token_observable = isinstance(token_raw, Mapping)
+
+    return {
+        "schema_version": 1,
+        "profile_type": "private_real100_v2_latency_cost_budget",
+        "source": dict(source or {}),
+        "population": {
+            "num_predictions": int(payload.get("num_predictions") or 0),
+            "pipeline": str(payload.get("pipeline") or ""),
+            "primary_run": str(payload.get("primary_run") or ""),
+            "prompt_profile": str(payload.get("prompt_profile") or ""),
+        },
+        "baseline_latency": latency,
+        "stage_latency": stages,
+        "budget_rules": {
+            "soft_regression": "variant p95 above soft_ceiling_ms requires explicit reviewer justification",
+            "hard_no_go": "variant p95 above hard_ceiling_ms cannot be called a winner",
+            "quality_only_no_go": "quality gain without latency and cost evidence is not sufficient",
+            "p99_rule": "p99 must be added when the source aggregate exposes it; currently not observed",
+        },
+        "cost_envelope": {
+            "status": "not_observable_from_committed_aggregate"
+            if not (cost_observable or token_observable)
+            else "observable",
+            "synthesis_cost_present": cost_observable,
+            "synthesis_tokens_present": token_observable,
+            "paid_api_rule": "paid or external reranker/synthesis cost must be reported separately before claim",
+            "local_cpu_rule": "local reranker latency must be counted even when direct API cost is zero",
+        },
+        "hardware_caveats": {
+            "scope": "local private real100_v2 baseline aggregate",
+            "warm_cold_status": "not_split_in_committed_aggregate",
+            "production_slo_claim": False,
+        },
+        "downstream_use": {
+            "applies_to": [
+                "T-2026-0032 reranker candidate-budget experiment",
+                "candidate-pool sweeps",
+                "query rewrite experiments",
+                "context packing experiments",
+            ],
+            "winner_requires": [
+                "paired real100_v2 quality delta",
+                "no hard latency breach",
+                "cost evidence present or explicitly not applicable",
+                "privacy audit pass",
+            ],
+        },
+        "privacy": {
+            "aggregate_only": True,
+            "raw_questions_omitted": True,
+            "raw_answers_omitted": True,
+            "raw_evidence_omitted": True,
+            "doc_ids_omitted": True,
+            "chunk_ids_omitted": True,
+            "filenames_omitted": True,
+            "paths_omitted": True,
+            "per_case_rows_omitted": True,
+        },
+        "non_claims": {
+            "runtime_behavior_changed": False,
+            "performance_improvement_claim": False,
+            "paired_delta": False,
+            "legacy_real100_evidence_used": False,
+        },
+    }
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    source = _mapping(report.get("source"))
+    population = _mapping(report.get("population"))
+    latency = _mapping(report.get("baseline_latency"))
+    stages = _mapping(report.get("stage_latency"))
+    cost = _mapping(report.get("cost_envelope"))
+    caveats = _mapping(report.get("hardware_caveats"))
+    rules = _mapping(report.get("budget_rules"))
+
+    lines = [
+        "# real100_v2 Latency And Cost Budget",
+        "",
+        "Issue: [#1626](https://github.com/hskim-solv/BidMate-DocAgent/issues/1626)",
+        "",
+        "Task: `T-2026-0030`",
+        "",
+        "Status: aggregate-only budget envelope; no runtime behavior change and no performance-improvement claim.",
+        "",
+        "## Boundary",
+        "",
+        "This report uses only committed `real100_v2` aggregate latency fields. It does not include raw questions, answers, evidence, filenames, local paths, document IDs, chunk IDs, or per-case rows. Legacy `real100`/v1/221/kordoc evidence is not used.",
+        "",
+        "## Source Provenance",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Input artifact | `{source.get('input_artifact') or ''}` |",
+        f"| Input redacted | `{source.get('input_location_redacted')}` |",
+        f"| Input SHA-256 prefix | `{source.get('input_sha256_12') or ''}` |",
+        "",
+        "## Baseline Population",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Predictions | {population.get('num_predictions', 0)} |",
+        f"| Pipeline | `{population.get('pipeline')}` |",
+        f"| Primary run | `{population.get('primary_run')}` |",
+        f"| Prompt profile | `{population.get('prompt_profile')}` |",
+        "",
+        "## Overall Latency Envelope",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Mean ms | {latency.get('mean_ms')} |",
+        f"| p50 ms | {latency.get('p50_ms')} |",
+        f"| p95 ms | {latency.get('p95_ms')} |",
+        f"| p99 ms | {latency.get('p99_ms')} |",
+        f"| Soft ceiling ms | {latency.get('soft_ceiling_ms')} |",
+        f"| Hard no-go ceiling ms | {latency.get('hard_ceiling_ms')} |",
+        "",
+        "p99 is named but not observed in the committed source aggregate.",
+        "",
+        "## Stage Latency Envelope",
+        "",
+        "| Stage | Mean | p50 | p95 | p99 | Soft ceiling | Hard ceiling |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for stage in STAGE_KEYS:
+        row = _mapping(stages.get(stage))
+        lines.append(
+            f"| `{stage}` | {row.get('mean_ms')} | {row.get('p50_ms')} | "
+            f"{row.get('p95_ms')} | {row.get('p99_ms')} | "
+            f"{row.get('soft_ceiling_ms')} | {row.get('hard_ceiling_ms')} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Cost Envelope",
+            "",
+            "| Field | Value |",
+            "|---|---|",
+            f"| Status | `{cost.get('status')}` |",
+            f"| Synthesis cost present | `{cost.get('synthesis_cost_present')}` |",
+            f"| Synthesis tokens present | `{cost.get('synthesis_tokens_present')}` |",
+            f"| Paid API rule | {cost.get('paid_api_rule')} |",
+            f"| Local CPU rule | {cost.get('local_cpu_rule')} |",
+            "",
+            "## Guardrail Rules",
+            "",
+            f"- Soft regression: {rules.get('soft_regression')}",
+            f"- Hard no-go: {rules.get('hard_no_go')}",
+            f"- Quality-only no-go: {rules.get('quality_only_no_go')}",
+            f"- p99 rule: {rules.get('p99_rule')}",
+            "",
+            "## Caveats",
+            "",
+            f"- Scope: `{caveats.get('scope')}`",
+            f"- Warm/cold status: `{caveats.get('warm_cold_status')}`",
+            f"- Production SLO claim: `{caveats.get('production_slo_claim')}`",
+            "",
+            "## Downstream Use",
+            "",
+            "`T-2026-0032` and later candidate-pool, query rewrite, and context-packing experiments can cite this envelope. A quality-only gain is no-go unless latency stays under the hard ceiling and cost evidence is present or explicitly not applicable.",
+            "",
+            "## Non-Claims",
+            "",
+            "- No runtime retrieval, reranking, verifier, answer, ingestion, chunking, or eval scoring behavior changed.",
+            "- No paired delta was produced.",
+            "- No performance improvement is claimed.",
+            "- No legacy `real100`/v1/221/kordoc evidence is used.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render aggregate-only real100_v2 latency/cost budget envelope.",
+    )
+    parser.add_argument("--summary", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--out-json", type=Path, default=DEFAULT_OUT_JSON)
+    parser.add_argument("--out-md", type=Path, default=DEFAULT_OUT_MD)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        _require_real100_v2(args.summary)
+        payload = _load_json(args.summary)
+        report = build_budget(payload, source=_source(args.summary))
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Failed to render real100_v2 latency budget: {exc}", file=sys.stderr)
+        return 1
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(
+        json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.out_md.write_text(render_markdown(report), encoding="utf-8")
+    print(f"[OK] Wrote {args.out_json}")
+    print(f"[OK] Wrote {args.out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -40,9 +40,9 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 27 | `T-2026-0027` | `review` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1584; prioritized RAG performance experiment stack captured. |
 | 28 | `T-2026-0028` | `done` | Evaluator -> Benchmark Auditor -> Privacy Auditor -> Reviewer | merged in PR #1619; real100_v2-only guard and aggregate packet landed. |
 | 29 | `T-2026-0029` | `review` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1622; real100_v2 retrieval diagnostics rendered; next experiment points to T-2026-0032 while T-2026-0031 remains page-metadata blocked. |
-| 30 | `T-2026-0030` | `ready` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | needed before T-2026-0032 implementation; use real100_v2 latency/stage aggregate only. |
+| 30 | `T-2026-0030` | `review` | Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer | issue #1626; real100_v2 latency/cost envelope rendered for review. |
 | 31 | `T-2026-0031` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | real100_v2 page metadata coverage is 0.0; no claim-bearing page/window experiment yet. |
-| 32 | `T-2026-0032` | `blocked` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1624; plan drafted, but implementation needs T-2026-0030 latency/cost guardrail. |
+| 32 | `T-2026-0032` | `ready` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1624; plan drafted and T-2026-0030 guardrail is ready for review. |
 | 33 | `T-2026-0033` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on retrieval/reranker evidence and token budget from T-2026-0030. |
 | 34 | `T-2026-0034` | `backlog` | Planner -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; blocked on query-slice attribution from T-2026-0029. |
 | 35 | `T-2026-0035` | `backlog` | Security Reviewer -> Implementer -> Privacy Auditor -> Reviewer | P1 guardrail; should run before agentic/tool-using retrieval. |
@@ -2677,7 +2677,7 @@ make check-branch
 
 - ID: T-2026-0030
 - Title: Define latency and cost budget envelope
-- Status: ready
+- Status: review
 - Priority: P0
 - Owner role: Implementer -> CI Reviewer -> Benchmark Auditor -> Reviewer
 - Created: 2026-05-27
@@ -2689,8 +2689,8 @@ Set the latency/cost guardrails that every multi-query, reranker, compression,
 or long-context experiment must satisfy.
 
 Current trigger: `T-2026-0032` is planned but blocked until this envelope exists.
-Use `real100_v2` aggregate latency/stage evidence only; do not use legacy
-`real100`/v1/221/kordoc evidence.
+Use `real100_v2` aggregate latency/stage evidence only; do not use
+legacy `real100`/v1/221/kordoc evidence.
 
 ### Scope
 
@@ -2708,16 +2708,16 @@ Use `real100_v2` aggregate latency/stage evidence only; do not use legacy
 
 ### Acceptance Criteria
 
-- [ ] Budget report names p50/p95/p99 and stage-level components.
-- [ ] Candidate-pool, reranker, query-rewrite, and context-packing tasks can cite
+- [x] Budget report names p50/p95/p99 and stage-level components.
+- [x] Candidate-pool, reranker, query-rewrite, and context-packing tasks can cite
   the same latency/cost envelope.
-- [ ] The report states warm/cold and local hardware caveats.
+- [x] The report states warm/cold and local hardware caveats.
 
 ### Validation Commands
 
 ```bash
-python3 <new-or-existing-latency-budget-script> --summary <aggregate-input> --out <aggregate-output>
-python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md <plan-path> <report-path>
+python3 scripts/render_real100_v2_latency_budget.py
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md docs/evaluation/real100_v2-latency-cost-budget.md reports/real100_v2/README.md
 git diff --check
 make check-branch
 ```
@@ -2729,15 +2729,34 @@ make check-branch
 
 ### Related Plan / Issue / PR Links
 
-- Plan: TBD - create when the task starts.
-- Issue: TBD
+- Plan: [`docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md`](../docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md)
+- Issue: [#1626](https://github.com/hskim-solv/BidMate-DocAgent/issues/1626)
 - PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 10:15 KST
+
+- Role: Implementer
+- Branch / worktree: eval/issue-1626-define-real100-v2-latency-and-cost-budget-envelo / /Users/hskim/.codex/worktrees/0ebc/BidMate-DocAgent
+- Issue / PR: issue #1626 / PR TBD
+- Task: T-2026-0030
+- Current status: real100_v2 latency/cost budget envelope rendered and ready for review.
+- Files touched: .gitignore, .githooks/pre-commit, scripts/render_real100_v2_latency_budget.py, scripts/check_real100_v2_only.py, tests/test_render_real100_v2_latency_budget.py, docs/evaluation/real100_v2-latency-cost-budget.md, reports/real100_v2/latency_cost_budget.aggregate.json, reports/real100_v2/README.md, docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md, tasks/queue.md
+- Decisions made: p99 and cost are named but not observable in committed aggregate; quality-only gains are no-go without latency/cost evidence.
+- Commands run: python3 scripts/render_real100_v2_latency_budget.py; python3 -m pytest -q tests/test_render_real100_v2_latency_budget.py.
+- Results: aggregate JSON and Markdown report generated; focused renderer tests passed.
+- Next safe command: python3 -m py_compile scripts/render_real100_v2_latency_budget.py scripts/check_real100_v2_only.py && python3 -m pytest -q tests/test_render_real100_v2_latency_budget.py tests/test_real100_v2_guard.py
+- Open questions: none.
+- Risks: cost and p99 require fresh aggregate fields before they can be enforced quantitatively.
+```
 
 ## T-2026-0031 — Parent and section-window retrieval experiment
 
 - ID: T-2026-0031
 - Title: Parent and section-window retrieval experiment
-- Status: blocked
+- Status: ready
 - Priority: P1
 - Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
 - Created: 2026-05-27
@@ -2814,8 +2833,7 @@ recall or causing unacceptable latency.
 
 Current trigger: `T-2026-0029` real100_v2 diagnostics selected this as the next
 experiment candidate because T-2026-0031 remains blocked by page metadata 0.0.
-Run with or after the latency/cost guardrail from `T-2026-0030`; until that
-guardrail exists, this task is planned but blocked for implementation.
+Run with or after the latency/cost guardrail from `T-2026-0030`.
 
 ### Scope
 
@@ -2835,7 +2853,7 @@ guardrail exists, this task is planned but blocked for implementation.
   citation regression, latency regression, or failed experiment.
 - [ ] Candidate-pool recall and reranker precision are reported separately.
 - [ ] Reranker provenance is present in aggregate output.
-- [ ] Latency/cost guardrail from `T-2026-0030` is present or this task remains
+- [x] Latency/cost guardrail from `T-2026-0030` is present or this task remains
   blocked.
 
 ### Validation Commands

--- a/tests/test_render_real100_v2_latency_budget.py
+++ b/tests/test_render_real100_v2_latency_budget.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.render_real100_v2_latency_budget import build_budget, main, render_markdown
+
+
+def _baseline() -> dict[str, object]:
+    return {
+        "num_predictions": 3,
+        "pipeline": "agentic_full",
+        "primary_run": "full",
+        "prompt_profile": "structured_grounded_claims",
+        "latency": {"mean": 100.4, "p50": 90.2, "p95": 200.1},
+        "stage_latency": {
+            "query_analysis_ms": {"mean": 10.0, "p50": 9.0, "p95": 20.1},
+            "context_resolution_ms": {"mean": 1.0, "p50": 1.0, "p95": 2.0},
+            "retrieve_ms": {"mean": 50.0, "p50": 45.0, "p95": 80.1},
+            "verify_ms": {"mean": 5.0, "p50": 4.0, "p95": 10.0},
+            "answer_generation_ms": {"mean": 2.0, "p50": 1.0, "p95": 4.0},
+        },
+    }
+
+
+def test_build_budget_sets_latency_thresholds_and_cost_status() -> None:
+    report = build_budget(_baseline(), source={"input_artifact": "reports/real100_v2/baseline.aggregate.json"})
+
+    assert report["profile_type"] == "private_real100_v2_latency_cost_budget"
+    assert report["baseline_latency"]["p50_ms"] == 90.2
+    assert report["baseline_latency"]["p95_ms"] == 200.1
+    assert report["baseline_latency"]["p99_status"] == "not_observed_in_source_aggregate"
+    assert report["baseline_latency"]["soft_ceiling_ms"] == 251.0
+    assert report["baseline_latency"]["hard_ceiling_ms"] == 301.0
+    assert report["stage_latency"]["retrieve_ms"]["hard_ceiling_ms"] == 121.0
+    assert report["cost_envelope"]["status"] == "not_observable_from_committed_aggregate"
+    assert report["downstream_use"]["applies_to"][0] == "T-2026-0032 reranker candidate-budget experiment"
+    assert report["privacy"]["aggregate_only"] is True
+    assert report["non_claims"]["performance_improvement_claim"] is False
+
+
+def test_rendered_output_has_no_private_fields() -> None:
+    payload = _baseline()
+    payload["query"] = "PRIVATE QUERY"
+    payload["doc_id"] = "SECRET_DOC_ID"
+    payload["chunk_id"] = "SECRET_CHUNK_ID"
+    report = build_budget(payload, source={"input_artifact": "external_private/real100_v2_baseline_aggregate"})
+    rendered = json.dumps(report, ensure_ascii=False) + render_markdown(report)
+
+    for forbidden in (
+        "PRIVATE QUERY",
+        "SECRET_DOC_ID",
+        "SECRET_CHUNK_ID",
+        "/Users/",
+    ):
+        assert forbidden not in rendered
+    assert "p99 is named but not observed" in rendered
+    assert "Legacy `real100`/v1/221/kordoc" in rendered
+
+
+def test_cli_writes_outputs_and_rejects_legacy_input(tmp_path: Path) -> None:
+    v2_dir = tmp_path / "reports" / "real100_v2"
+    v2_dir.mkdir(parents=True)
+    summary = v2_dir / "baseline.aggregate.json"
+    out_json = tmp_path / "budget.aggregate.json"
+    out_md = tmp_path / "budget.md"
+    summary.write_text(json.dumps(_baseline()), encoding="utf-8")
+
+    assert main(["--summary", str(summary), "--out-json", str(out_json), "--out-md", str(out_md)]) == 0
+    written = json.loads(out_json.read_text(encoding="utf-8"))
+    assert written["schema_version"] == 1
+    assert written["source"]["input_location_redacted"] is True
+    assert "`T-2026-0030`" in out_md.read_text(encoding="utf-8")
+
+    legacy_dir = tmp_path / "reports" / "real100"
+    legacy_dir.mkdir(parents=True)
+    legacy_summary = legacy_dir / "baseline.aggregate.json"
+    legacy_summary.write_text(json.dumps(_baseline()), encoding="utf-8")
+
+    assert main(["--summary", str(legacy_summary), "--out-json", str(out_json), "--out-md", str(out_md)]) == 1


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

Closes #1626

`real100_v2` committed aggregate에서 latency/cost budget envelope를 aggregate-only evidence packet으로 렌더링합니다. 다음 `T-2026-0032` reranker candidate budget 실험이 성능 주장 없이 사용할 수 있도록 observed p50/p95, p95 기반 soft/hard ceiling, p99/cost not-observable 상태, privacy boundary를 문서와 JSON으로 고정했습니다.

## 2. 영향 파일

- `scripts/render_real100_v2_latency_budget.py` — aggregate-only budget renderer 추가
- `tests/test_render_real100_v2_latency_budget.py` — budget math, privacy boundary, legacy input rejection 검증
- `reports/real100_v2/latency_cost_budget.aggregate.json` — aggregate-only output 추가
- `docs/evaluation/real100_v2-latency-cost-budget.md` — reviewer-facing summary 추가
- `docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md` — plan doc 추가
- `tasks/queue.md` — T-2026-0030 review 상태와 T-2026-0032 unblock 연결
- `.gitignore`, `.githooks/pre-commit`, `reports/real100_v2/README.md`, `scripts/check_real100_v2_only.py` — allowed aggregate output 및 v2-only guard 업데이트

## 3. 리스크

가장 큰 리스크는 private raw artifact나 legacy `real100`/v1/221/kordoc evidence를 실수로 baseline 근거에 섞는 것입니다. renderer는 legacy `reports/real100` 입력을 거부하고, output은 committed aggregate fields만 사용하며, `make real-eval-v2-guard`와 privacy audit를 통과했습니다.

## 4. 테스트

- `python3 -m py_compile scripts/render_real100_v2_latency_budget.py scripts/check_real100_v2_only.py`
- `python3 -m pytest -q tests/test_render_real100_v2_latency_budget.py tests/test_real100_v2_guard.py`
- `python3 scripts/render_real100_v2_latency_budget.py`
- `make real-eval-v2-guard`
- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/plans/T-2026-0030-real100-v2-latency-cost-budget-envelope.md docs/evaluation/real100_v2-latency-cost-budget.md reports/real100_v2/README.md`
- `git diff --cached --check && make check-branch`
- `python3 scripts/agent_loop.py privacy-audit-output`
- `python3 scripts/agent_loop.py claim-audit --from-git`
- `bash -n .githooks/pre-commit`

## 5. Eval 영향

No runtime behavior change. This PR defines a reviewer budget envelope from existing `real100_v2` aggregate evidence only; it does not rerun retrieval/answer/verifier/eval scoring and does not claim benchmark improvement.

### 5b. Real-data delta

| Surface | Result |
| --- | --- |
| real private eval execution | Not rerun in this PR |
| paired delta validity | Not applicable; no runtime behavior change and no new paired run |
| eval surface | `real100_v2`, aggregate-only committed baseline |
| observed latency basis | p50/p95 only from committed aggregate |
| p99 status | Not observed in source aggregate |
| cost status | Not observable from committed aggregate because token/cost fields are absent |
| privacy audit | `python3 scripts/agent_loop.py privacy-audit-output` passed with 0 findings |

검색/검증 path 동작 변화 없음.

## 6. 하위 호환

No answer-contract, CLI contract, ingestion, retrieval, reranking, answer, verifier, or eval scoring behavior changes. The legacy real100/v1 evidence ban remains enforced for this task surface.

## 7. 범위 외

- No candidate-budget experiment execution; that is `T-2026-0032`.
- No BGE-M3 or embedding backend comparison.
- No cost estimate beyond explicitly marking current aggregate cost evidence as not observable.
- No cleanup of unrelated orphan worktrees reported by the push hook.
