### PR TITLE
docs: expand RAG experiment task stack

### DIFF
--- a/docs/evaluation/rag-performance-experiment-stack.md
+++ b/docs/evaluation/rag-performance-experiment-stack.md
@@ -15,11 +15,15 @@ Start with the weakest measurable links:
    metadata and MiniLM target work.
 2. Make retrieval diagnostics explain candidate-pool recall, rank quality, and
    evidence split before changing retrieval behavior.
-3. Run small-to-big retrieval, reranking, context packing, and query
-   decomposition as separate opt-in experiments with paired aggregate deltas.
-4. Add security, abstention, conflict, metadata, freshness, latency, and cost
+3. Run small-to-big retrieval, reranking, retrieval-depth/fusion, context
+   packing, query decomposition, parser/layout, embedding, and generator
+   grounding as separate opt-in experiments with paired aggregate deltas.
+4. Insert replanning gates after each measurement round so weak hypotheses are
+   retired and strong ones are promoted to end-to-end bakeoff.
+5. Add security, abstention, conflict, metadata, freshness, latency, and cost
    guardrails before any production-facing claim.
-5. Gate advanced architectures behind no-go/go feasibility evidence.
+6. Gate advanced architectures behind no-go/go feasibility evidence and a final
+   optimization decision packet.
 
 ## Selection Rules
 
@@ -35,6 +39,8 @@ Start with the weakest measurable links:
   context length must carry a stage latency and cost guardrail.
 - If Recall@K improves but MRR, nDCG, citation, abstention, or latency regresses,
   the result is not a winner by default.
+- Isolated experiment winners do not become default behavior. They must pass an
+  end-to-end bakeoff and final decision gate before default-change work starts.
 
 ## Existing Evidence To Respect
 
@@ -53,11 +59,11 @@ Start with the weakest measurable links:
 
 | Priority | Task | Status | Why this order |
 |---|---|---|---|
-| P0 | `T-2026-0028` Private coverage and semantic baseline refresh | ready after this PR | Establish the current baseline and coverage before experiments. |
-| P0 | `T-2026-0029` Retrieval diagnostic workbench | backlog | Explain recall/rank/candidate-pool failures before behavior changes. |
-| P0 | `T-2026-0030` Latency and cost budget envelope | backlog | Prevent multi-query/rerank/compression experiments from winning on quality while breaking operations. |
-| P1 | `T-2026-0031` Parent/section-window retrieval experiment | backlog | Highest-value retrieval change after page-aware evidence. |
-| P1 | `T-2026-0032` Reranker candidate-budget experiment | backlog | Improve precision only after candidate-pool recall is observable. |
+| P0 | `T-2026-0028` Private coverage and semantic baseline refresh | done | Establish the current baseline and coverage before experiments. |
+| P0 | `T-2026-0029` Retrieval diagnostic workbench | review | Explain recall/rank/candidate-pool failures before behavior changes. |
+| P0 | `T-2026-0030` Latency and cost budget envelope | ready | Prevent multi-query/rerank/compression experiments from winning on quality while breaking operations. |
+| P1 | `T-2026-0031` Parent/section-window retrieval experiment | blocked | Highest-value retrieval change after page-aware evidence. |
+| P1 | `T-2026-0032` Reranker candidate-budget experiment | blocked | Improve precision only after candidate-pool recall is observable. |
 | P1 | `T-2026-0033` Context packing and citation ordering experiment | backlog | Use found evidence better without changing corpus or embeddings. |
 | P1 | `T-2026-0034` Query rewrite and decomposition experiment | backlog | Target comparison, multi-hop, abbreviation, and mixed Korean/English queries. |
 | P1 | `T-2026-0035` Prompt-injection and data/command boundary guardrail | backlog | Security must be a guardrail before more agentic or tool-using retrieval. |
@@ -65,6 +71,46 @@ Start with the weakest measurable links:
 | P2 | `T-2026-0037` Metadata, authority, and freshness ranking experiment | backlog | Use RFP metadata only after coverage and missing-field behavior are measured. |
 | P2 | `T-2026-0038` Contextual retrieval and sentence-window proof of concept | backlog | Test chunk-context enrichment after simpler small-to-big retrieval. |
 | P3 | `T-2026-0039` Advanced architecture feasibility gate | backlog | Evaluate RAPTOR, GraphRAG, LightRAG, Agentic RAG, late chunking, multi-vector, and long-context only after P0/P1 evidence. |
+| P0 planning | `T-2026-0046` RAG experiment task expansion | review | Adds the executable experiment tasks and replanning gates. |
+| P0 | `T-2026-0047` Page metadata blocker repair/rescope | backlog | Unblock or rescope claim-bearing page/window experiments. |
+| P0 | `T-2026-0048` Candidate-depth and fusion-budget sweep | backlog | Attack `not_observable_limited_depth` before adding expensive reranking/query calls. |
+| P0 replanning | `T-2026-0049` Round 1 synthesis and plan adjustment | backlog | Reorder the next experiments after latency, page metadata, retrieval-depth, and reranker evidence. |
+| P1 | `T-2026-0050` Parser/layout/table coverage experiment | backlog | Decide whether misses are parser/layout failures rather than retrieval failures. |
+| P1 | `T-2026-0051` Embedding and representation controlled sweep | backlog | Measure embedding effects without mixing vector DB backend or prompt changes. |
+| P1 | `T-2026-0052` Generator grounding and citation calibration | backlog | Measure prompt/model/decoding effects after retrieval/context evidence stabilizes. |
+| P1 replanning | `T-2026-0053` Round 2 synthesis and plan adjustment | backlog | Promote at most three isolated winners to bakeoff and retire weak hypotheses. |
+| P2 | `T-2026-0054` End-to-end winning-variant bakeoff | backlog | Test combined winners under one aggregate latency/cost/privacy guardrail. |
+| P2 decision | `T-2026-0055` Final optimization decision packet | backlog | Decide default-change-ready, more-experiment-needed, or no-go. |
+
+## Experiment Cadence
+
+The stack is intentionally iterative. Do not execute every experiment just
+because it appears in the queue.
+
+1. Measurement foundation: complete `T-2026-0030` and keep `T-2026-0028` /
+   `T-2026-0029` evidence current.
+2. Early retrieval round: run `T-2026-0032`, `T-2026-0047`, and
+   `T-2026-0048` as separate PRs. `T-2026-0031` remains blocked until page or
+   window evidence is repaired or explicitly rescoped.
+3. Round 1 replanning: run `T-2026-0049` to update queue status and select the
+   next two to four experiments. No runtime change is allowed in the replanning
+   task.
+4. Full P1 experiment round: run selected tasks from `T-2026-0031`,
+   `T-2026-0033` through `T-2026-0038`, and `T-2026-0050` through
+   `T-2026-0052`.
+5. Round 2 replanning: run `T-2026-0053` to retire low-signal branches and
+   select at most three variants for `T-2026-0054`.
+6. End-to-end bakeoff: run `T-2026-0054` with matched `real100_v2` provenance.
+7. Decision: run `T-2026-0055`. Only this task can say whether a later
+   default-change implementation should be opened.
+
+## Replanning Gates
+
+| Gate | Inputs | Required decision |
+|---|---|---|
+| `T-2026-0049` Round 1 | `T-2026-0030`, `T-2026-0032`, `T-2026-0047`, `T-2026-0048` | Choose the next experiments, keep/rescope `T-2026-0031`, and set budget caps. |
+| `T-2026-0053` Round 2 | Selected P1 experiments, parser/layout, embedding, generator evidence | Promote at most three variants to bakeoff; retire no-go hypotheses; decide whether `T-2026-0039` is justified. |
+| `T-2026-0055` Final decision | Baseline, diagnostics, all synthesis gates, `T-2026-0054` bakeoff | Call default-change-ready, more-experiment-needed, or no-go. |
 
 ## Deferred Techniques
 
@@ -89,6 +135,11 @@ Start with the weakest measurable links:
 | Query rewrite/decomposition | slice delta by query type | extra LLM calls, rewrite drift, no private egress without approval |
 | Abstention/conflict | no-answer accuracy, conflict precedence accuracy | false abstention, citation, freshness provenance |
 | Security | injection detection, instruction/data isolation checks | false positives, privacy redaction, tool-call policy |
+| Parser/layout | searchable evidence coverage, page/section/table coverage | parser latency, privacy, no raw layout/text artifacts |
+| Embedding/representation | Recall@K, MRR, nDCG, citation/answer delta | matched corpus/config/index, build time, index size, backend separation |
+| Generator grounding | answer correctness, groundedness, citation accuracy | no-answer, conflict handling, provider/payload provenance, latency/cost |
+| Replanning | bottleneck ranking, task promotion/retirement | no runtime change, no incompatible aggregate averaging |
+| End-to-end bakeoff | answer/citation/abstention paired delta | latency/cost, privacy, rollback, interaction effects |
 | Advanced architecture | feasibility score and no-go/go rationale | build cost, latency, privacy, rollback path |
 
 ## Execution Rules
@@ -101,9 +152,14 @@ Start with the weakest measurable links:
 - Record whether real private eval ran and whether any performance claim is
   made in every PR body.
 - Prefer no-go reports over premature implementation when evidence is missing.
+- After each replanning gate, update blocked/backlog/ready status before
+  starting another experiment PR.
+- Keep integrated variants out of default runtime until `T-2026-0055` produces
+  a decision packet and any required ADR work is reserved.
 
 ## First Next Task
 
-Start with `T-2026-0028`. It should refresh the aggregate baseline after page
-metadata recovery and MiniLM target separation, then decide which diagnostic
-task is truly ready.
+Current main has completed the baseline refresh and retrieval diagnostics. The
+next execution task is `T-2026-0030`; after that, run the early retrieval round
+and `T-2026-0049` before widening into parser, embedding, query, context, or
+generator experiments.

--- a/docs/plans/T-2026-0046-rag-experiment-task-expansion.md
+++ b/docs/plans/T-2026-0046-rag-experiment-task-expansion.md
@@ -1,0 +1,176 @@
+# Plan: T-2026-0046 RAG experiment task expansion
+
+- Status: review
+- Owner role: Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Related task: `tasks/queue.md::T-2026-0046`
+- Related issue / PR: [#1627](https://github.com/hskim-solv/BidMate-DocAgent/issues/1627) / PR TBD
+- Related ADR: N/A - no runtime or eval contract change
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+## Problem Statement
+
+The current RAG performance stack has implementation-oriented backlog items,
+but it does not yet give future sessions enough experiment tasks to reach a
+final optimization decision. It also lacks explicit replanning checkpoints, so a
+session could keep executing stale hypotheses after early measurements already
+show a better direction.
+
+## Current Behavior
+
+Current main has:
+
+- `T-2026-0028`: `real100_v2` aggregate baseline and stale-evidence guard.
+- `T-2026-0029`: retrieval diagnostics showing dominant
+  `not_observable_limited_depth`, page metadata coverage `0.0`, and
+  `T-2026-0032` as the next candidate while `T-2026-0031` remains blocked.
+- `T-2026-0030`: ready latency/cost envelope task.
+- `T-2026-0031` through `T-2026-0039`: broad experiment and feasibility
+  backlog, but without experiment-round synthesis gates or final decision
+  packet tasks.
+
+## Desired Behavior
+
+The queue should guide performance work through measured rounds:
+
+1. Complete latency/cost and early retrieval measurements.
+2. Replan from evidence.
+3. Run the most relevant P1 experiments.
+4. Replan again.
+5. Run an end-to-end bakeoff.
+6. Produce a final default-change, further-experiment, or no-go decision.
+
+## Constraints
+
+- Scope constraints: docs, task queue, and evaluation note only.
+- Architecture constraints: no retrieval, reranking, parser, prompt, eval
+  runtime, or index behavior changes.
+- Compatibility constraints: preserve existing task IDs and existing experiment
+  scopes.
+- Eval/privacy constraints: no private real-eval run; no raw private content,
+  filenames, local paths, `doc_id`, or `chunk_id`.
+- Tooling/CI constraints: doc-link check, whitespace check, and branch/issue
+  check only.
+- Non-goals: do not create implementation issues for every future task now.
+
+## Architecture Impact
+
+- Affected modules or docs: `tasks/queue.md`,
+  `docs/evaluation/rag-performance-experiment-stack.md`, and this plan doc.
+- Affected contracts or invariants: planning workflow only.
+- Load-bearing paths: none.
+- ADR required: no, because this is docs/planning only.
+- Backward compatibility expectation: all existing runtime and eval commands
+  remain unchanged.
+
+## Affected Interfaces
+
+- CLI/API/config: none.
+- Input data: none.
+- Output artifacts: planning docs only.
+- Docs/review surfaces: task queue and experiment stack.
+- Tests/eval entrypoints: doc-link validation only.
+
+## Data / Eval Impact
+
+- Surface: none.
+- Data boundary: no data touched.
+- Allowed claim: the experiment queue now has explicit measurement and
+  replanning gates.
+- Disallowed claim: retrieval quality, answer quality, latency, citation,
+  security, or production performance improved.
+- Baseline or control affected: no.
+- Benchmark/eval auditor required: yes, to review whether experiment order and
+  claim boundaries are coherent.
+
+## Task Breakdown
+
+1. Add `T-2026-0046` through `T-2026-0055` queue entries for experiment
+   expansion, page metadata unblock, retrieval depth/fusion, two replanning
+   gates, parser/layout, embedding, generator grounding, bakeoff, and final
+   decision.
+2. Update `docs/evaluation/rag-performance-experiment-stack.md` with cadence,
+   replanning gates, metrics, and execution rules.
+3. Add this plan document and validate links.
+
+## Acceptance Criteria
+
+- [x] The queue contains experiment tasks that cover data/parser, retrieval,
+  reranking, context, query, metadata, embedding, generator, advanced
+  architecture, and end-to-end bakeoff surfaces.
+- [x] The queue includes replanning tasks after early retrieval evidence and
+  after the full P1 experiment round.
+- [x] The final optimization decision is separated from the implementation of a
+  default behavior change.
+
+## Validation Strategy
+
+Commands that must be run:
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md docs/plans/T-2026-0046-rag-experiment-task-expansion.md
+git diff --check
+make check-branch
+```
+
+Expected evidence:
+
+- Test/eval output: N/A - no runtime or eval behavior changed.
+- Generated or updated artifact: docs and queue entries only.
+- Reviewer checklist or manual inspection: task ordering, replanning gates,
+  private boundary, and no-claim wording.
+- Explicitly not validated, with reason: no private real-eval because this PR
+  only creates task structure.
+
+## Rollback Strategy
+
+Revert this docs/planning PR if the expanded stack makes execution order less
+clear or creates overlapping task scopes. Do not delete existing experiment
+reports, private local runs, or prior plan docs.
+
+## Failure Modes
+
+- Failure mode: future agents treat isolated experiment winners as default-ready.
+- Detection signal: a PR flips runtime defaults without `T-2026-0054` bakeoff
+  and `T-2026-0055` decision evidence.
+- Stop condition or fallback: block the default-change PR and route it through
+  bakeoff and decision packet tasks.
+
+- Failure mode: future sessions execute stale backlog order after measurements
+  identify a different bottleneck.
+- Detection signal: `T-2026-0049` or `T-2026-0053` is skipped while later
+  experiment tasks proceed.
+- Stop condition or fallback: pause implementation and run the relevant
+  replanning gate.
+
+## Observability
+
+- `tasks/queue.md` ready/backlog/blocked statuses.
+- `docs/evaluation/rag-performance-experiment-stack.md` cadence and gates.
+- Future aggregate-only synthesis reports from `T-2026-0049`,
+  `T-2026-0053`, and `T-2026-0055`.
+
+## Reviewer Notes
+
+Attack overlap and claim boundaries first. The new tasks should make the path
+to final optimization more rigorous, but they must not imply any current RAG
+performance improvement.
+
+## Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 KST
+
+- Role: Planner
+- Branch / worktree: docs/issue-1627-rag-experiment-task-stack / /Users/hskim/.codex/worktrees/de70/BidMate-DocAgent
+- Issue / PR: issue #1627 / PR TBD
+- Task: T-2026-0046
+- Current status: queue, experiment stack, and plan doc drafted.
+- Files touched: tasks/queue.md, docs/evaluation/rag-performance-experiment-stack.md, docs/plans/T-2026-0046-rag-experiment-task-expansion.md
+- Decisions made: add experiment execution tasks plus replanning gates; keep final default-change decision as its own task.
+- Commands run: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md docs/plans/T-2026-0046-rag-experiment-task-expansion.md; git diff --check; make check-branch.
+- Results: passed.
+- Next safe command: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md docs/plans/T-2026-0046-rag-experiment-task-expansion.md
+- Open questions: none.
+- Risks: future agents may over-combine variants before the bakeoff task.
+```

--- a/tasks/queue.md
+++ b/tasks/queue.md
@@ -56,6 +56,16 @@ PR이 생기면 각 task에 링크를 추가한다. 예제 task는 `tasks/exampl
 | 43 | `T-2026-0043` | `backlog` | Implementer -> Reviewer | issue #1588 PR4; mutating-writer + claimed-files enforcement hook; blocked on T-2026-0042. |
 | 44 | `T-2026-0044` | `backlog` | Implementer -> Deep Reviewer -> Reviewer | issue #1588 PR5; Orchestrator-only ship-executor + gate evidence (promote agent_loop.py to LOAD_BEARING); blocked on T-2026-0043. |
 | 45 | `T-2026-0045` | `backlog` | Implementer -> Reviewer | issue #1588 PR6; full active-agent-loop.md ops-doc rewrite; blocked on T-2026-0044. |
+| 46 | `T-2026-0046` | `review` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | issue #1627; expands the RAG experiment task stack and inserts measurement-driven replanning gates. |
+| 47 | `T-2026-0047` | `backlog` | Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0; repair or explicitly rescope the real100_v2 page metadata blocker before claim-bearing page/window experiments. |
+| 48 | `T-2026-0048` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0; candidate-depth and fusion-budget sweep for the `not_observable_limited_depth` retrieval failure bucket. |
+| 49 | `T-2026-0049` | `backlog` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P0 replanning gate after T-2026-0030, T-2026-0032, T-2026-0047, and T-2026-0048 evidence. |
+| 50 | `T-2026-0050` | `backlog` | Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; parser/layout/table coverage experiment for RFP evidence that is not text-searchable enough. |
+| 51 | `T-2026-0051` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; controlled embedding and representation sweep without mixing vector DB backend effects. |
+| 52 | `T-2026-0052` | `backlog` | Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1; generator grounding, citation, prompt, and model-choice calibration after retrieval/context evidence stabilizes. |
+| 53 | `T-2026-0053` | `backlog` | Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer | P1 replanning gate after context, query, metadata, parser, embedding, and generator experiments. |
+| 54 | `T-2026-0054` | `backlog` | Implementer -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | P2; end-to-end bakeoff of the best isolated experiment winners under one aggregate guardrail. |
+| 55 | `T-2026-0055` | `backlog` | Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer | P2; final optimization decision packet and default-change or no-go proposal. |
 
 ## Examples
 
@@ -3566,4 +3576,625 @@ make check-branch
 
 - Plan: TBD - create when the task starts.
 - Issue: [#1588](https://github.com/hskim-solv/BidMate-DocAgent/issues/1588)
+- PR: TBD
+
+## T-2026-0046 — Expand RAG experiment task stack and replanning gates
+
+- ID: T-2026-0046
+- Title: Expand RAG experiment task stack and replanning gates
+- Status: review
+- Priority: P0 planning
+- Owner role: Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Turn the broad RAG optimization backlog into executable experiment tasks that
+can reach a final performance decision through measured iteration rather than a
+single fixed implementation plan.
+
+### Scope
+
+- Add experiment tasks for page metadata unblock, retrieval depth/fusion,
+  parser/layout coverage, embedding/representation, generator grounding,
+  end-to-end bakeoff, and final decision.
+- Insert explicit replanning gates after early retrieval/latency evidence and
+  after the first full P1 experiment round.
+- Keep this PR docs/planning only: no runtime, eval, retrieval, prompt, parser,
+  or index behavior changes.
+
+### Non-Goals
+
+- Do not run private real-eval.
+- Do not claim performance, latency, citation, or production quality improved.
+- Do not create all future GitHub issues before each implementation task starts.
+
+### Acceptance Criteria
+
+- [x] `tasks/queue.md` names concrete experiment tasks and replanning gates.
+- [x] `docs/evaluation/rag-performance-experiment-stack.md` explains the
+  experiment cadence and go/no-go rules.
+- [x] Every new task keeps private outputs aggregate-only and explicitly
+  separates isolated experiment wins from final default-change evidence.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md docs/plans/T-2026-0046-rag-experiment-task-expansion.md
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Doc-link validation.
+- Whitespace validation.
+- Branch/issue validation.
+- PR body says planning only, no private real-eval run, and no performance
+  claim.
+
+### Related Plan / Issue / PR Links
+
+- Plan: [`docs/plans/T-2026-0046-rag-experiment-task-expansion.md`](../docs/plans/T-2026-0046-rag-experiment-task-expansion.md)
+- Issue: [#1627](https://github.com/hskim-solv/BidMate-DocAgent/issues/1627)
+- PR: TBD
+
+### Handoff Notes
+
+```markdown
+## Session Handoff - 2026-05-28 KST
+
+- Role: Planner
+- Branch / worktree: docs/issue-1627-rag-experiment-task-stack / /Users/hskim/.codex/worktrees/de70/BidMate-DocAgent
+- Issue / PR: issue #1627 / PR TBD
+- Task: T-2026-0046
+- Current status: experiment task expansion drafted for review.
+- Files touched: tasks/queue.md, docs/evaluation/rag-performance-experiment-stack.md, docs/plans/T-2026-0046-rag-experiment-task-expansion.md
+- Decisions made: keep existing implementation backlog, add explicit experiment execution tasks and replanning gates before final default-change decisions.
+- Commands run: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md docs/plans/T-2026-0046-rag-experiment-task-expansion.md; git diff --check; make check-branch.
+- Results: passed.
+- Next safe command: python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md docs/plans/T-2026-0046-rag-experiment-task-expansion.md
+- Open questions: none.
+- Risks: future agents may skip replanning gates and combine isolated experiment winners prematurely.
+```
+
+## T-2026-0047 — Repair or rescope real100_v2 page metadata blocker
+
+- ID: T-2026-0047
+- Title: Repair or rescope real100_v2 page metadata blocker
+- Status: backlog
+- Priority: P0
+- Owner role: Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Unblock claim-bearing page/window experiments by either repairing `real100_v2`
+page metadata coverage or explicitly proving that the next retrieval experiment
+does not depend on page/window claims.
+
+### Scope
+
+- Audit why `reports/real100_v2/retrieval_diagnostics.aggregate.json` reports
+  page-span coverage `0.0`.
+- Rebuild or repair the private v2 index only if the parser/index provenance can
+  be recorded aggregate-only.
+- Emit a page metadata readiness packet with counts for page span, section, and
+  citation-ready evidence coverage.
+
+### Non-Goals
+
+- Do not change retrieval ranking.
+- Do not use legacy `real100`/v1/221/kordoc evidence as a substitute.
+- Do not claim answer quality improved from metadata repair alone.
+
+### Acceptance Criteria
+
+- [ ] The task either clears the page/window blocker or records an explicit
+  no-go/rescope decision for `T-2026-0031`.
+- [ ] Page metadata coverage is reported as aggregate counts only.
+- [ ] Any index rebuild records parser, embedding, and vector backend
+  provenance.
+
+### Validation Commands
+
+```bash
+REAL_EVAL_ROOT=/Users/hskim/Desktop/projects/BidMate-DocAgent make real-eval-v2-check
+python3 <page-metadata-readiness-script> --index-dir <private-v2-index> --out <aggregate-output>
+make real-eval-v2-guard
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate page metadata readiness report.
+- Explicit `T-2026-0031` unblock, keep-blocked, or rescope recommendation.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0048 — Candidate-depth and fusion-budget retrieval experiment
+
+- ID: T-2026-0048
+- Title: Candidate-depth and fusion-budget retrieval experiment
+- Status: backlog
+- Priority: P0
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Measure whether the dominant `not_observable_limited_depth` failure bucket is
+fixed by candidate-pool depth, dense/BM25 fusion parameters, or retrieval
+budget, before adding more expensive reranking or query expansion.
+
+### Scope
+
+- Sweep `dense_top_k`, `bm25_top_k`, RRF/fusion parameters, final candidate
+  pool size, and duplicate caps on `real100_v2`.
+- Report Recall@K, Hit@K, all-gold coverage, MRR, nDCG, duplicate rate,
+  metadata-filter candidates, and stage latency.
+- Compare against `T-2026-0032` reranker evidence without combining both changes
+  in one experiment.
+
+### Non-Goals
+
+- Do not reopen hybrid retrieval as a broad "add BM25" claim.
+- Do not change default retrieval behavior.
+- Do not hide citation or answer regressions behind recall-only gains.
+
+### Acceptance Criteria
+
+- [ ] Output classifies each sweep cell as winner, recall-only gain, rank
+  regression, duplicate regression, metadata-filter regression, latency
+  regression, or no-go.
+- [ ] The recommended candidate budget is usable by reranker, query rewrite, and
+  context-packing experiments.
+- [ ] Paired aggregate delta uses only comparable `real100_v2` inputs.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_retrieval*.py tests/test_naive_baseline_ranking_invariance.py <focused-new-tests>
+python3 <candidate-depth-sweep-script> --config <local-v2-config> --out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <variant-aggregate>
+make real-eval-v2-guard
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate sweep matrix and go/no-go classification.
+- Explicit latency/cost result from `T-2026-0030`.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0049 — Round 1 experiment synthesis and plan adjustment
+
+- ID: T-2026-0049
+- Title: Round 1 experiment synthesis and plan adjustment
+- Status: backlog
+- Priority: P0 replanning
+- Owner role: Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Reorder the experiment stack after the first measurement round instead of
+blindly executing every backlog item in its original order.
+
+### Scope
+
+- Synthesize evidence from `T-2026-0030`, `T-2026-0032`, `T-2026-0047`, and
+  `T-2026-0048`.
+- Decide whether to run `T-2026-0031`, `T-2026-0033`, `T-2026-0034`,
+  `T-2026-0035`, `T-2026-0037`, or `T-2026-0050` next.
+- Update queue statuses, blockers, and next-safe commands without changing
+  runtime behavior.
+
+### Non-Goals
+
+- Do not average incompatible experiment outputs.
+- Do not promote a default behavior.
+- Do not treat no-go results as failures; they are valid pruning evidence.
+
+### Acceptance Criteria
+
+- [ ] The synthesis identifies the dominant remaining bottleneck and the next
+  two executable experiments.
+- [ ] Any blocked task names its exact missing evidence.
+- [ ] Queue and experiment-stack docs are updated with no performance claim.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md <synthesis-report-path>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate-only synthesis report.
+- Queue diff that promotes, blocks, or retires follow-up experiments.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0050 — Parser, layout, and table coverage experiment
+
+- ID: T-2026-0050
+- Title: Parser, layout, and table coverage experiment
+- Status: backlog
+- Priority: P1
+- Owner role: Evaluator -> Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Test whether answer misses are caused by parser/layout/table extraction limits
+rather than retriever or generator behavior.
+
+### Scope
+
+- Audit private aggregate slices for table-heavy, clause-numbered, multi-column,
+  scanned/OCR, and attachment-like RFP evidence.
+- Compare current parser/index output against one opt-in parser or layout
+  extraction variant.
+- Record coverage, citation-readiness, retrieval metrics, answer metrics,
+  parser latency, and failure-mode movement.
+
+### Non-Goals
+
+- Do not replace the default ingestion pipeline.
+- Do not commit raw private document text, filenames, page images, or local
+  paths.
+- Do not combine parser changes with reranking, query rewrite, or prompt
+  changes.
+
+### Acceptance Criteria
+
+- [ ] Aggregate report separates parser coverage failures from retrieval ranking
+  failures.
+- [ ] Any parser variant is opt-in and has isolated index/report paths.
+- [ ] If parser evidence is weak, the task records no-go and returns focus to
+  retrieval/context experiments.
+
+### Validation Commands
+
+```bash
+python3 <parser-coverage-audit> --config <local-v2-config> --out <aggregate-output>
+python3 -m pytest -q <focused-parser-tests>
+python3 <parser-variant-runner> --variant <name> --summary-out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <variant-aggregate>
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Parser/layout aggregate report.
+- Privacy audit result for any committed aggregate.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0051 — Embedding and representation controlled sweep
+
+- ID: T-2026-0051
+- Title: Embedding and representation controlled sweep
+- Status: backlog
+- Priority: P1
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Measure embedding and retrieval representation effects without mixing them with
+vector DB backend, parser, reranker, or prompt changes.
+
+### Scope
+
+- Compare approved embedding surfaces such as hashing, MiniLM, BGE-M3, and one
+  explicitly approved additional model or sparse representation when available.
+- Rebuild isolated indexes with matched corpus/config and record model,
+  dimension, instruction prefix, similarity metric, normalization, and backend.
+- Report Recall@K, MRR, nDCG, citation, answer, abstention, build time, index
+  size, and query latency.
+
+### Non-Goals
+
+- Do not change the canonical baseline.
+- Do not compare different vector DB backends in this task.
+- Do not use external/private egress without an approved payload boundary.
+
+### Acceptance Criteria
+
+- [ ] Every compared index has matched dataset/config and explicit provenance.
+- [ ] Ranking deltas are separated from backend latency/ops deltas.
+- [ ] The result recommends keep-current, adopt-new-model, or no-go with
+  guardrail rationale.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_embedding*.py tests/test_naive_baseline_ranking_invariance.py <focused-new-tests>
+python3 <embedding-sweep-runner> --config <local-v2-config> --out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <variant-aggregate>
+make real-eval-v2-guard
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate embedding sweep report.
+- Provenance table for model/backend/index dimensions and cost/latency.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0052 — Generator grounding and citation calibration experiment
+
+- ID: T-2026-0052
+- Title: Generator grounding and citation calibration experiment
+- Status: backlog
+- Priority: P1
+- Owner role: Implementer -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Measure whether answer quality is limited by generator evidence-use behavior
+after retrieval, reranking, and context packing evidence is stable enough to
+avoid masking retrieval misses.
+
+### Scope
+
+- Test opt-in prompt, decoding, citation formatting, answer-structure, and
+  approved model/provider variants.
+- Measure answer correctness, groundedness, citation accuracy, no-answer,
+  conflict handling, token count, latency, and cost.
+- Keep ADR 0003 answer schema stable unless a separate ADR is reserved.
+
+### Non-Goals
+
+- Do not repair retrieval misses through prompt wording.
+- Do not send private context to external providers without approved online
+  payload provenance.
+- Do not change default answer behavior from a synthetic-only result.
+
+### Acceptance Criteria
+
+- [ ] Generator improvements are reported separately from retrieval/context
+  availability.
+- [ ] Citation regression, missed abstention, or privacy risk is a no-go even if
+  answer correctness improves.
+- [ ] The result recommends a default-change candidate, a follow-up slice, or
+  no-go.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q tests/test_answer_contract_snapshot.py tests/test_eval_metrics.py <focused-new-tests>
+python3 <generator-calibration-runner> --variant <name> --summary-out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <variant-aggregate>
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate generator calibration report.
+- Explicit provider/payload and decoding provenance.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0053 — Round 2 experiment synthesis and plan adjustment
+
+- ID: T-2026-0053
+- Title: Round 2 experiment synthesis and plan adjustment
+- Status: backlog
+- Priority: P1 replanning
+- Owner role: Planner -> Benchmark Auditor -> Privacy Auditor -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Recompute the optimization roadmap after the second experiment round, when
+retrieval, context, query, metadata, parser, embedding, and generator evidence
+can be compared as separate bottleneck surfaces.
+
+### Scope
+
+- Synthesize `T-2026-0031` through `T-2026-0038` plus `T-2026-0050` through
+  `T-2026-0052` when available.
+- Retire experiments whose guardrails failed, promote the strongest isolated
+  winners to end-to-end bakeoff, and decide whether `T-2026-0039` advanced
+  architecture feasibility is justified.
+- Update queue status and next-safe commands.
+
+### Non-Goals
+
+- Do not merge isolated winners into a runtime default.
+- Do not create a new metric surface without ADR review.
+- Do not keep running low-signal experiments just because they were listed.
+
+### Acceptance Criteria
+
+- [ ] Synthesis report names no more than three variants for end-to-end bakeoff.
+- [ ] Any advanced architecture recommendation cites measured residual
+  bottlenecks and expected failure-mode reduction.
+- [ ] Queue updates make the next task unambiguous.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md <synthesis-report-path>
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate-only round-2 synthesis.
+- Explicit go/no-go list for bakeoff and advanced architecture.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0054 — End-to-end winning-variant bakeoff
+
+- ID: T-2026-0054
+- Title: End-to-end winning-variant bakeoff
+- Status: backlog
+- Priority: P2
+- Owner role: Implementer -> Architect -> Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Test whether the best isolated experiment winners still improve the full RAG
+pipeline when combined under one latency, cost, privacy, and answer-contract
+guardrail.
+
+### Scope
+
+- Build at most three integrated opt-in variants from `T-2026-0053` outputs.
+- Run paired `real100_v2` aggregate deltas against the canonical baseline.
+- Report interaction effects: retrieval gain lost by reranking, context gain
+  lost by token budget, prompt gain lost by citation regression, or latency
+  overrun.
+
+### Non-Goals
+
+- Do not flip defaults.
+- Do not combine more than three moving parts in one variant.
+- Do not include advanced architecture unless `T-2026-0039` and `T-2026-0053`
+  recommend it.
+
+### Acceptance Criteria
+
+- [ ] Bakeoff compares baseline, isolated winners, and integrated variants with
+  matched provenance.
+- [ ] Winner requires answer/citation/abstention improvement and latency/cost
+  guardrail pass.
+- [ ] Negative interaction effects are recorded as follow-up blockers or no-go.
+
+### Validation Commands
+
+```bash
+python3 -m pytest -q <focused-integration-tests>
+python3 <end-to-end-bakeoff-runner> --config <local-v2-config> --out <aggregate-output>
+python3 scripts/run_real_eval_delta.py --base <real100_v2-base-aggregate> --head <variant-aggregate>
+make real-eval-v2-guard
+python3 scripts/agent_loop.py privacy-audit-output
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Aggregate bakeoff report.
+- Integrated variant provenance and rollback plan.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
+- PR: TBD
+
+## T-2026-0055 — Final optimization decision packet
+
+- ID: T-2026-0055
+- Title: Final optimization decision packet
+- Status: backlog
+- Priority: P2 decision
+- Owner role: Benchmark Auditor -> Privacy Auditor -> Deep Reviewer -> Reviewer
+- Created: 2026-05-28
+- Last updated: 2026-05-28
+
+### Goal
+
+Convert the experiment program into a final optimization decision: default
+change proposal, additional targeted experiment, or explicit no-go.
+
+### Scope
+
+- Summarize the full evidence chain from baseline, diagnostics, latency/cost,
+  isolated experiments, replanning gates, and end-to-end bakeoff.
+- If a default change is recommended, name required ADR updates, load-bearing
+  paths, rollout flags, rollback command, and PR body §5b evidence.
+- If no-go, identify the residual blocker and next evidence needed.
+
+### Non-Goals
+
+- Do not implement the default flip in this task.
+- Do not weaken ADR 0001 baseline protections.
+- Do not hide failed experiments; failed/no-go evidence is part of the decision.
+
+### Acceptance Criteria
+
+- [ ] Decision packet makes one of three calls: default-change-ready,
+  more-experiment-needed, or no-go.
+- [ ] Any default-change-ready call cites paired private aggregate delta,
+  latency/cost guardrail, privacy audit, claim audit, and rollback plan.
+- [ ] Reviewer can trace every claim to aggregate-safe evidence.
+
+### Validation Commands
+
+```bash
+python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md <decision-packet-path>
+python3 scripts/agent_loop.py claim-audit --from-git
+git diff --check
+make check-branch
+```
+
+### Evidence Required
+
+- Final decision packet.
+- Explicit follow-up issue recommendation for implementation or no-go.
+
+### Related Plan / Issue / PR Links
+
+- Plan: TBD - create when the task starts.
+- Issue: TBD
 - PR: TBD


### PR DESCRIPTION
## 1. 무엇을 왜 바꿨는가

RAG 성능 최적화 backlog가 구현 후보 중심으로 남아 있어, 충분한 실험과 측정 후 재계획을 거쳐 최종 최적화 결정까지 갈 수 있도록 experiment task stack을 확장했다. `T-2026-0046`부터 `T-2026-0055`까지 page metadata unblock, candidate-depth/fusion sweep, parser/layout, embedding, generator grounding, two replanning gates, end-to-end bakeoff, final decision packet을 추가하고, evaluation stack 문서에 cadence와 go/no-go gate를 명시했다.

Closes #1627

## 2. 영향 파일

- `tasks/queue.md` — 실험 task 및 replanning gate 추가
- `docs/evaluation/rag-performance-experiment-stack.md` — 실험 cadence, replanning gate, metric surface 확장
- `docs/plans/T-2026-0046-rag-experiment-task-expansion.md` — planning task 문서 추가

Load-bearing 파일 변경 없음.

## 3. 리스크

가장 큰 리스크는 future agent가 isolated experiment winner를 default-ready로 오해하는 것이다. 이를 막기 위해 `T-2026-0054` end-to-end bakeoff와 `T-2026-0055` final decision packet을 별도 gate로 명시했다.

## 4. 테스트

- `python3 scripts/check_doc_links.py --check-all --paths tasks/queue.md docs/evaluation/rag-performance-experiment-stack.md docs/plans/T-2026-0046-rag-experiment-task-expansion.md`
- `git diff --check`
- `make check-branch`

Runtime behavior change 없음이라 신규 unit test는 추가하지 않았다.

## 5. Eval 영향

Docs/planning only. Retrieval, reranking, parser, prompt, eval runtime, index behavior 변화 없음. Private real-eval 실행 없음. Performance claim 없음.

### 5b. Real-data delta

검색/검증 path 동작 변화 없음.

## 6. 하위 호환

기존 CLI, schema, answer contract, eval command 변경 없음. ADR 0001 baseline 및 ADR 0005 private boundary 유지.

## 7. 범위 외

- `T-2026-0030` latency/cost envelope 구현은 별도 issue #1626 범위다.
- 실제 실험 실행, private real-eval run, default behavior flip은 이번 PR 범위가 아니다.
- orphan worktree 정리는 push hook 경고로 확인했지만 이번 PR 범위 밖이다.
